### PR TITLE
test(cli): use supported native output policy in optimization fixture

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -79,7 +79,8 @@ jobs:
       - name: verify -g additivity of the compiler itself
         run: |
           set -euo pipefail
-          tmp=$(mktemp -d)
+          mkdir -p out
+          tmp=$(mktemp -d out/self-additive.XXXXXX)
           trap 'rm -rf "$tmp"' EXIT
           g="$tmp/mach.g"; nog="$tmp/mach.nog"
           # section-table bookkeeping (e_shoff @40 8B, e_shnum @60 2B, e_shstrndx @62 2B)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,7 @@ The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 #### Driver and build
 
+- Initialization stops on inventory path allocation failure instead of publishing a file above its intended nested destination (#3171).
 - Initialization preserves Windows drive and UNC roots and converts native path components to canonical transaction-relative paths (#3169).
 - Manifest dependency editing allocates escaped TOML strings at their exact owned size, so ordinary values release their full allocation (#3160).
 - Build steps inherit the planner environment and apply declared overrides with host-correct name identity. Target variables remain authoritative, environment changes invalidate cached steps, and allocating failures release exact owned extents (#3146).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -202,6 +202,7 @@ The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 #### Driver and build
 
+- Initialization preserves Windows drive and UNC roots and converts native path components to canonical transaction-relative paths (#3169).
 - Manifest dependency editing allocates escaped TOML strings at their exact owned size, so ordinary values release their full allocation (#3160).
 - Build steps inherit the planner environment and apply declared overrides with host-correct name identity. Target variables remain authoritative, environment changes invalidate cached steps, and allocating failures release exact owned extents (#3146).
 - CI's vendored-version and checked-type fixtures use contained source snapshots at the compiler's std pin, and release additivity builds use project-relative output paths (#3135).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -158,6 +158,7 @@ The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 #### Middle end
 
+- Floating remainder preserves negative zero when a negative exact multiple is reduced to zero, matching comptime evaluation at both float widths (#3164).
 - The vectorizer could mutate the function and then decline, and its remainder guard hardcoded a signed compare over a wrapping bound.
 - Loop versioning's disjointness check authorized the fast path on aliasing memory when a bound wrapped.
 - A once-called callee whose address escapes was inlined as free, and a small callee could be duplicated without bound.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@ The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 ### Changed
 
+- The unshipped initialization journal uses a single `.machinit.*` layout without protocol versioning.
+
 #### Language
 
 - `$mach.abi.sysv` resolves to `sysv64` with a deprecation warning naming the registry spelling.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,7 @@ The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 #### Driver and build
 
+- Manifest dependency editing allocates escaped TOML strings at their exact owned size, so ordinary values release their full allocation (#3160).
 - Build steps inherit the planner environment and apply declared overrides with host-correct name identity. Target variables remain authoritative, environment changes invalidate cached steps, and allocating failures release exact owned extents (#3146).
 - CI's vendored-version and checked-type fixtures use contained source snapshots at the compiler's std pin, and release additivity builds use project-relative output paths (#3135).
 - Root dependency overrides select the realization's source kind, URL and exact selector before verification, including when a transitive edge is visited first (#3138).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@ The pin moves from 0.28.1 to 0.37.1.
 
 #### Driver and build
 
+- CI's vendored-version and checked-type fixtures use contained source snapshots at the compiler's std pin, and release additivity builds use project-relative output paths (#3135).
 - A required artifact planned under `mach test` was built as a test cell.
 - `--quiet` on `mach build` was ignored.
 - `BuildPlan` borrowed its request.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -200,6 +200,8 @@ The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 #### Driver and build
 
+- Build steps inherit the planner environment and apply declared overrides with host-correct name identity. Target variables remain authoritative, environment changes invalidate cached steps, and allocating failures release exact owned extents (#3146).
+
 - Root dependency overrides select the realization's source kind, URL and exact selector before verification, including when a transitive edge is visited first (#3138).
 - A required artifact planned under `mach test` was built as a test cell.
 - `--quiet` on `mach build` was ignored.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -196,6 +196,7 @@ The pin moves from 0.28.1 to 0.37.1.
 
 #### Driver and build
 
+- Link fixture build steps preserve the harness-selected toolchain PATH, including CI's versioned LLVM directory and native Windows compiler paths (#3141).
 - A required artifact planned under `mach test` was built as a test cell.
 - `--quiet` on `mach build` was ignored.
 - `BuildPlan` borrowed its request.

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -856,7 +856,9 @@ without threading it through the template — e.g. `cc --target=$MACH_TARGET_ISA
 The step inherits the planner's environment, then applies its declared `env`
 values, then assigns those three target variables. Names use host identity:
 case-sensitive on Unix and ordinal case-insensitive on Windows, including Unicode
-names. Each name has one value. A `MACH_TARGET_*` value inherited from an enclosing
+names. A declaration cannot contain names differing only in ASCII case on any
+host, or names that alias under Windows Unicode comparison on Windows. Each name
+has one value. A `MACH_TARGET_*` value inherited from an enclosing
 build or declared by the step is overwritten by the cell's own. The same three values are
 available in the `argv` templates as the `{target.*}` keys (see
 [Path templates](#path-templates)).

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -795,9 +795,10 @@ Because a step has no filter of its own, the condition for running it lives in t
 link entry that demands it: on a build cell where that entry filters out, the step
 is never demanded and never runs.
 
-A step is cached by content: its `in` contents plus its expanded `argv` fingerprint
-the step (the query engine's `Q_LINK_CONFIG` pattern). An unchanged step whose
-outputs still exist is skipped; change an input or the command and it re-runs.
+A step is cached by content: its declared inputs, resolved executable, expanded
+arguments, and effective environment contribute to its fingerprint. An unchanged
+step whose outputs still exist is skipped. Changing an inherited environment
+value received by the child also invalidates the step.
 
 **Bounding a step.** `timeout_seconds` gives the step a deadline measured from
 the moment it is spawned. When the deadline passes, the step's whole process
@@ -852,9 +853,11 @@ distinct sibling such as `{project.out}/vendor/<library>/`.
 build cell's target tuple as `MACH_TARGET_ISA`, `MACH_TARGET_OS`, and
 `MACH_TARGET_ABI`, so the script `argv` invokes can branch on the target
 without threading it through the template — e.g. `cc --target=$MACH_TARGET_ISA-…`.
-The step's environment is the planner's environment with those three variables
-**replaced**, never appended: a `MACH_TARGET_*` value inherited from an
-enclosing build is overwritten by the cell's own. The same three values are
+The step inherits the planner's environment, then applies its declared `env`
+values, then assigns those three target variables. Names use host identity:
+case-sensitive on Unix and ordinal case-insensitive on Windows, including Unicode
+names. Each name has one value. A `MACH_TARGET_*` value inherited from an enclosing
+build or declared by the step is overwritten by the cell's own. The same three values are
 available in the `argv` templates as the `{target.*}` keys (see
 [Path templates](#path-templates)).
 

--- a/mach.toml
+++ b/mach.toml
@@ -66,4 +66,4 @@ need = []
 
 [dep.std]
 git = "https://github.com/briar-systems/mach-std"
-ref = "commit/aac7012d2c6b01dfcb7c7d1db677b0d762a4f955"
+ref = "commit/17bf1f7b5b9521482adefaf7aa08fba14f5cbc24"

--- a/mach.toml
+++ b/mach.toml
@@ -66,4 +66,4 @@ need = []
 
 [dep.std]
 git = "https://github.com/briar-systems/mach-std"
-ref = "branch/main"
+ref = "commit/aac7012d2c6b01dfcb7c7d1db677b0d762a4f955"

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -324,7 +324,7 @@ test "mach.cli.cmd.build.run_typed:a_glob_requirement_builds_first_and_the_bin_e
 }
 
 test "mach.cli.cmd.build.run_typed:rejects_o1_before_any_side_effect_o0_and_o2_still_build" {
-    val toml_body: str = "[project]\nid = \"rem102fx\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out\"\n\n[artifact.rem102fx]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/rem102fx.a\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+    val toml_body: str = "[project]\nid = \"rem102fx\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out\"\n\n[profile.test]\nopt = 0\ndebug = false\n\n[artifact.rem102fx]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/rem102fx.a\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
     val src_body: str = "pub fun value() i64 {\n    ret 42;\n}\n";
 
     var a: A.Allocator;

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -324,7 +324,7 @@ test "mach.cli.cmd.build.run_typed:a_glob_requirement_builds_first_and_the_bin_e
 }
 
 test "mach.cli.cmd.build.run_typed:rejects_o1_before_any_side_effect_o0_and_o2_still_build" {
-    val toml_body: str = "[project]\nid = \"rem102fx\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out\"\n\n[profile.test]\nopt = 0\ndebug = false\n\n[artifact.rem102fx]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/rem102fx.a\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
+    val toml_body: str = "[project]\nid = \"rem102fx\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out\"\n\n[profile.test]\nopt = 0\ndebug = false\nsimd = \"scalarize\"\n\n[artifact.rem102fx]\nkind = \"static\"\nentry = \"lib.mach\"\nout = \"lib/rem102fx.a\"\ntargets = [\"*\"]\nlink = []\nneed = []\n";
     val src_body: str = "pub fun value() i64 {\n    ret 42;\n}\n";
 
     var a: A.Allocator;

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -7,7 +7,6 @@ use txn: std.filesystem.transaction;
 use os: std.system.os;
 use std.format;
 use std.print;
-use std.process.env;
 use std.process.exec;
 use std.text.string.str_dup;
 use std.text.string.str_free;
@@ -49,33 +48,6 @@ rec DepReq {
     is_git:    bool;
 }
 
-fun forward_git_config_env() {
-    val environ: **u8 = env.environ();
-    if (environ == nil) { ret; }
-    var n: usize = 0;
-    var i: usize = 0;
-    for (environ[i] != nil) {
-        if (str_starts_with(environ[i]::str, "GIT_CONFIG_COUNT=") || str_starts_with(environ[i]::str, "GIT_CONFIG_KEY_")
-            || str_starts_with(environ[i]::str, "GIT_CONFIG_VALUE_")) { n = n + 1; }
-        i = i + 1;
-    }
-    if (n == 0) { ret; }
-    var a: A.Allocator;
-    if (O.is_some[str](page.make(?a))) { ret; }
-    val ar: R.Result[**u8, str] = A.allocate[*u8](?a, n + 1);
-    if (R.is_err[**u8, str](ar)) { ret; }
-    val out: **u8 = R.unwrap_ok[**u8, str](ar);
-    var k: usize = 0;
-    i = 0;
-    for (environ[i] != nil) {
-        if (str_starts_with(environ[i]::str, "GIT_CONFIG_COUNT=") || str_starts_with(environ[i]::str, "GIT_CONFIG_KEY_")
-            || str_starts_with(environ[i]::str, "GIT_CONFIG_VALUE_")) { out[k] = environ[i]; k = k + 1; }
-        i = i + 1;
-    }
-    out[k] = nil;
-    deps.set_git_config_env(out);
-}
-
 # `mach dep`: route to one action: list, add, remove, update, pull, verify, or the
 # deprecated sync, which runs pull after a note
 # ---
@@ -83,7 +55,6 @@ fun forward_git_config_env() {
 # inv: the parsed invocation for this command
 # ret: 0 success, 1 missing or unknown action, unknown flag, or a failed action, 2 setup failure
 pub fun run_typed(argv: **u8, inv: *args.ParsedInvocation) i64 {
-    forward_git_config_env();
     if (!inv.has_action) {
         if (inv.argc < 3) {
             print.eprint("error: missing dep action\n");

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -1130,9 +1130,7 @@ fun t_lib_module(a: *A.Allocator, dir: str) bool {
 }
 
 fun t_dep_table(a: *A.Allocator, name: str, url: str) str {
-    val r: R.Result[str, str] = format.sprint(a, "\n[dep.{}]\ngit = \"{}\"\nref = \"branch/main\"\n", name, url);
-    if (R.is_err[str, str](r)) { ret ""; }
-    ret R.unwrap_ok[str, str](r);
+    ret t_dep_table_ref(a, name, url, "branch/main");
 }
 
 fun t_dep_verify_cli(a: *A.Allocator, root: str) i64 {
@@ -1450,9 +1448,9 @@ fun t_tagged_b(a: *A.Allocator) str {
 }
 
 fun t_requirer_of_b(a: *A.Allocator, prefix: str, id: str, fix_b: str, ref: str, with_gitlink: bool) str {
-    val table_r: R.Result[str, str] = format.sprint(a, "\n[dep.b]\ngit = \"{}\"\nref = \"{}\"\n", fix_b, ref);
-    if (R.is_err[str, str](table_r)) { ret ""; }
-    val dir: str = t_package_repo(a, prefix, id, R.unwrap_ok[str, str](table_r));
+    val table: str = t_dep_table_ref(a, "b", fix_b, ref);
+    if (str_empty(table)) { ret ""; }
+    val dir: str = t_package_repo(a, prefix, id, table);
     if (str_empty(dir)) { ret ""; }
     if (with_gitlink) {
         if (!t_git_submodule_add(a, dir, fix_b, "dep/b")) { ret ""; }
@@ -1462,7 +1460,12 @@ fun t_requirer_of_b(a: *A.Allocator, prefix: str, id: str, fix_b: str, ref: str,
 }
 
 fun t_dep_table_ref(a: *A.Allocator, name: str, url: str, ref: str) str {
-    val r: R.Result[str, str] = format.sprint(a, "\n[dep.{}]\ngit = \"{}\"\nref = \"{}\"\n", name, url, ref);
+    var spec: manifest.DepTableSpec;
+    spec.name = name;
+    spec.source = manifest.DEP_SOURCE_GIT;
+    spec.value = url;
+    spec.ref = ref;
+    val r: R.Result[str, str] = manifest.manifest_add_dep_table(a, "", ?spec);
     if (R.is_err[str, str](r)) { ret ""; }
     ret R.unwrap_ok[str, str](r);
 }
@@ -1741,5 +1744,23 @@ test "mach.cli.cmd.dep.pull_and_verify:a_stale_lock_file_is_noted_not_read" {
     val before_quiet: usize = deps.stale_lock_notes_printed;
     if (pull_project(root, true) != 0 || deps.stale_lock_notes_printed != before_quiet) { fs.remove_all(?a, root); ret 8; }
     fs.remove_all(?a, root);
+    ret 0;
+}
+
+
+test "mach.cli.cmd.dep: generated dependency fixtures preserve TOML string values" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    val url: str = "C:\\Users\\fixture\\quoted\" repo";
+    val ref: str = "branch/quoted\"\\line\nnext\tpart";
+    val text: str = t_dep_table_ref(?a, "fixture", url, ref);
+    if (str_empty(text)) { ret 2; }
+    fin { str_free(?a, text); }
+    val parsed: R.Result[toml.Table, str] = toml.parse(?a, text);
+    if (R.is_err[toml.Table, str](parsed)) { ret 3; }
+    var table: toml.Table = R.unwrap_ok[toml.Table, str](parsed);
+    fin { toml.dnit(?a, ?table); }
+    if (!str_equals(toml.get_str(?table, "dep.fixture.git"), url)) { ret 4; }
+    if (!str_equals(toml.get_str(?table, "dep.fixture.ref"), ref)) { ret 5; }
     ret 0;
 }

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -339,17 +339,15 @@ fun run_absent_branch(a: *A.Allocator, mp: *txn.Descent, id: *u8, is_lib: bool,
     ret 0;
 }
 
-val JOURNAL_LEAF:     str = ".machinit1.journal";
-val BACKUP_MANIFEST:  str = ".machinit1.mach.toml.backup";
-val BACKUP_ENTRY_BIN: str = ".machinit1.root.mach.backup";
-val BACKUP_ENTRY_LIB: str = ".machinit1.lib.mach.backup";
+val JOURNAL_LEAF:     str = ".machinit.journal";
+val BACKUP_MANIFEST:  str = ".machinit.mach.toml.backup";
+val BACKUP_ENTRY_BIN: str = ".machinit.root.mach.backup";
+val BACKUP_ENTRY_LIB: str = ".machinit.lib.mach.backup";
 
-val INIT_JOURNAL_MAGIC:   u32 = 0x494e4a31;
-val INIT_JOURNAL_VERSION: u32 = 1;
+val INIT_JOURNAL_MAGIC: u32 = 0x494e4954;
 
 rec InitJournal {
     magic:                 u32;
-    version:                u32;
     root_device:            u64;
     root_file:              u64;
     manifest_had_identity:  bool;
@@ -484,8 +482,8 @@ fun journal_read(a: *A.Allocator, root_cap: *txn.Root) R.Result[O.Option[InitJou
     val got: O.Option[usize] = R.unwrap_ok[O.Option[usize], txn.Error](read_r);
     if (O.is_none[usize](got)) { ret R.ok[O.Option[InitJournal], str](O.none[InitJournal]()); }
     if (O.unwrap[usize](got) != jsize) { ret R.err[O.Option[InitJournal], str]("init journal has an unexpected size"); }
-    if (j.magic != INIT_JOURNAL_MAGIC || j.version != INIT_JOURNAL_VERSION) {
-        ret R.err[O.Option[InitJournal], str]("init journal has an unrecognized version");
+    if (j.magic != INIT_JOURNAL_MAGIC) {
+        ret R.err[O.Option[InitJournal], str]("init journal has an invalid signature");
     }
     ret R.ok[O.Option[InitJournal], str](O.some[InitJournal](j));
 }
@@ -496,7 +494,6 @@ fun journal_create(a: *A.Allocator, root_cap: *txn.Root, root_id: txn.Identity,
                    is_lib: bool, src_dir_created: bool) R.Result[R.Void, str] {
     var j: InitJournal;
     j.magic                 = INIT_JOURNAL_MAGIC;
-    j.version                = INIT_JOURNAL_VERSION;
     j.root_device             = root_id.device;
     j.root_file               = root_id.file;
     j.manifest_had_identity   = manifest_probe.present;

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -253,21 +253,36 @@ fun split_for_discovery(alloc: *A.Allocator, cwd: str, dir: str) R.Result[DestSp
     val cleaned_r: R.Result[str, str] = path.clean(alloc, dir);
     if (R.is_err[str, str](cleaned_r)) { ret R.err[DestSplit, str](R.unwrap_err[str, str](cleaned_r)); }
     val cleaned: str = R.unwrap_ok[str, str](cleaned_r);
+    fin { str_free(alloc, cleaned); }
 
-    var ds: DestSplit;
+    var root_source: str = cwd;
+    var root_len: usize = str_len(cwd);
+    var relative_start: usize = 0;
+    val cleaned_len: usize = str_len(cleaned);
     if (path.is_abs(cleaned)) {
-        ds.root = "/";
-        ds.dest_rel = "";
-        if (str_len(cleaned) > 1) {
-            val stripped_r: R.Result[str, str] = str_copy_slice(alloc, cleaned, 1, str_len(cleaned) - 1);
-            if (R.is_err[str, str](stripped_r)) { ret R.err[DestSplit, str](R.unwrap_err[str, str](stripped_r)); }
-            ds.dest_rel = R.unwrap_ok[str, str](stripped_r);
+        root_source = cleaned;
+        root_len = path.root(cleaned).len;
+        relative_start = root_len;
+        for (relative_start < cleaned_len && path.is_separator(cleaned[relative_start])) {
+            relative_start = relative_start + 1;
         }
     }
-    or {
-        ds.root = cwd;
-        ds.dest_rel = cleaned;
-        if (str_equals(cleaned, ".")) { ds.dest_rel = ""; }
+    or (str_equals(cleaned, ".")) { relative_start = cleaned_len; }
+
+    val root_r: R.Result[str, str] = str_copy_slice(alloc, root_source, 0, root_len);
+    if (R.is_err[str, str](root_r)) { ret R.err[DestSplit, str](R.unwrap_err[str, str](root_r)); }
+    var ds: DestSplit;
+    ds.root = R.unwrap_ok[str, str](root_r);
+    val relative_r: R.Result[str, str] = str_copy_slice(alloc, cleaned, relative_start, cleaned_len - relative_start);
+    if (R.is_err[str, str](relative_r)) {
+        str_free(alloc, ds.root);
+        ret R.err[DestSplit, str](R.unwrap_err[str, str](relative_r));
+    }
+    ds.dest_rel = R.unwrap_ok[str, str](relative_r);
+    var i: usize = 0;
+    for (ds.dest_rel[i] != 0) {
+        if (path.is_separator(ds.dest_rel[i])) { ds.dest_rel[i] = '/'; }
+        i = i + 1;
     }
     ret R.ok[DestSplit, str](ds);
 }
@@ -462,7 +477,8 @@ fun sweep_root(a: *A.Allocator, cap: *txn.Root) {
 }
 
 fun src_dir_rel(a: *A.Allocator, dir_rel: str) R.Result[str, str] {
-    ret path.join(a, dir_rel, "src");
+    if (str_empty(dir_rel)) { ret str_copy_slice(a, "src", 0, 3); }
+    ret format.sprint(a, "{}/src", dir_rel);
 }
 
 fun open_src_cap(a: *A.Allocator, root: str, dir_rel: str) R.Result[txn.Root, str] {
@@ -1332,6 +1348,7 @@ test "mach.cli.cmd.init.split_for_discovery:relative_stays_under_cwd_absolute_us
     if (R.is_err[DestSplit, str](rel_r)) { bad = 1; }
     or {
         val ds: DestSplit = R.unwrap_ok[DestSplit, str](rel_r);
+        fin { str_free(?alloc, ds.root); str_free(?alloc, ds.dest_rel); }
         if (!str_equals(ds.root, "/home/x") || !str_equals(ds.dest_rel, "myproj")) { bad = 1; }
     }
 
@@ -1339,6 +1356,7 @@ test "mach.cli.cmd.init.split_for_discovery:relative_stays_under_cwd_absolute_us
     if (R.is_err[DestSplit, str](dotrel_r)) { bad = 1; }
     or {
         val ds: DestSplit = R.unwrap_ok[DestSplit, str](dotrel_r);
+        fin { str_free(?alloc, ds.root); str_free(?alloc, ds.dest_rel); }
         if (!str_equals(ds.dest_rel, "myproj")) { bad = 1; }
     }
 
@@ -1346,17 +1364,77 @@ test "mach.cli.cmd.init.split_for_discovery:relative_stays_under_cwd_absolute_us
     if (R.is_err[DestSplit, str](abs_r)) { bad = 1; }
     or {
         val ds: DestSplit = R.unwrap_ok[DestSplit, str](abs_r);
-        if (!str_equals(ds.root, "/") || !str_equals(ds.dest_rel, "tmp/other/myproj")) { bad = 1; }
+        fin { str_free(?alloc, ds.root); str_free(?alloc, ds.dest_rel); }
+        var expected_root: str = "/";
+        $if ($mach.build.os == $mach.os.windows) { expected_root = "\\"; }
+        if (!str_equals(ds.root, expected_root) || !str_equals(ds.dest_rel, "tmp/other/myproj")) { bad = 1; }
     }
 
     val dot_r: R.Result[DestSplit, str] = split_for_discovery(?alloc, "/home/x", ".");
     if (R.is_err[DestSplit, str](dot_r)) { bad = 1; }
     or {
         val ds: DestSplit = R.unwrap_ok[DestSplit, str](dot_r);
+        fin { str_free(?alloc, ds.root); str_free(?alloc, ds.dest_rel); }
         if (!str_empty(ds.dest_rel) && !str_equals(ds.dest_rel, ".")) { bad = 1; }
     }
 
     ret bad;
+}
+
+
+test "mach.cli.cmd.init.split_for_discovery:native_roots_and_canonical_relative_components" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var cwd: str = "/work";
+    var root: str = "/";
+    $if ($mach.build.os == $mach.os.windows) { cwd = "C:\\work"; root = "\\"; }
+    var inputs: [9]str;
+    var roots: [9]str;
+    var relatives: [9]str;
+    inputs[0] = "nested/./proj"; roots[0] = cwd; relatives[0] = "nested/proj";
+    inputs[1] = "."; roots[1] = cwd; relatives[1] = "";
+    inputs[2] = "/"; roots[2] = root; relatives[2] = "";
+    var count: usize = 3;
+    $if ($mach.build.os == $mach.os.windows) {
+        inputs[3] = "D:\\nested\\proj"; roots[3] = "D:\\"; relatives[3] = "nested/proj";
+        inputs[4] = "D:/nested/../proj"; roots[4] = "D:\\"; relatives[4] = "proj";
+        inputs[5] = "\\\\server\\share\\nested\\proj"; roots[5] = "\\\\server\\share"; relatives[5] = "nested/proj";
+        inputs[6] = "D:\\"; roots[6] = "D:\\"; relatives[6] = "";
+        inputs[7] = "nested\\child/../proj"; roots[7] = cwd; relatives[7] = "nested/proj";
+        inputs[8] = "//server/share"; roots[8] = "\\\\server\\share"; relatives[8] = "";
+        count = 9;
+    }
+    var i: usize = 0;
+    for (i < count) {
+        val r: R.Result[DestSplit, str] = split_for_discovery(?alloc, cwd, inputs[i]);
+        if (R.is_err[DestSplit, str](r)) { ret 2; }
+        val ds: DestSplit = R.unwrap_ok[DestSplit, str](r);
+        fin { str_free(?alloc, ds.root); str_free(?alloc, ds.dest_rel); }
+        if (!str_equals(ds.root, roots[i])) { ret 10 + i::i32; }
+        if (!str_equals(ds.dest_rel, relatives[i])) { ret 30 + i::i32; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+test "mach.cli.cmd.init.src_dir_rel:preserves_canonical_transaction_separators" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var dirs: [3]str;
+    var expected: [3]str;
+    dirs[0] = ""; expected[0] = "src";
+    dirs[1] = "project"; expected[1] = "project/src";
+    dirs[2] = "nested/project"; expected[2] = "nested/project/src";
+    var i: usize = 0;
+    for (i < 3) {
+        val r: R.Result[str, str] = src_dir_rel(?alloc, dirs[i]);
+        if (R.is_err[str, str](r)) { ret 2; }
+        val rel: str = R.unwrap_ok[str, str](r);
+        fin { str_free(?alloc, rel); }
+        if (!str_equals(rel, expected[i])) { ret 3 + i::i32; }
+        i = i + 1;
+    }
+    ret 0;
 }
 
 test "mach.cli.cmd.init.default_project_id:is_the_final_component_of_the_resolved_destination" {

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -1,6 +1,7 @@
 use fs: std.filesystem;
 use std.allocator.arena;
 use std.allocator.page;
+use std.allocator.fixed;
 use std.format;
 use std.print;
 use std.process.env;
@@ -293,11 +294,9 @@ fun split_for_discovery(alloc: *A.Allocator, cwd: str, dir: str) R.Result[DestSp
 # levels below the deepest existing directory, everything the scaffold contains
 # has to be addressed relative to that one component rather than to the
 # destination itself.
-fun under_remainder(a: *A.Allocator, remainder: str, rel: str) str {
-    if (str_empty(remainder)) { ret rel; }
-    val r: R.Result[str, str] = format.sprint(a, "{}/{}", remainder, rel);
-    if (R.is_err[str, str](r)) { ret rel; }
-    ret R.unwrap_ok[str, str](r);
+fun under_remainder(a: *A.Allocator, remainder: str, rel: str) R.Result[str, str] {
+    if (str_empty(remainder)) { ret str_copy_slice(a, rel, 0, str_len(rel)); }
+    ret format.sprint(a, "{}/{}", remainder, rel);
 }
 
 fun run_absent_branch(a: *A.Allocator, mp: *txn.Descent, id: *u8, is_lib: bool,
@@ -310,8 +309,24 @@ fun run_absent_branch(a: *A.Allocator, mp: *txn.Descent, id: *u8, is_lib: bool,
     }
     val text: str = R.unwrap_ok[str, str](text_r);
 
+    val manifest_rel_r: R.Result[str, str] = under_remainder(a, mp.remainder, "mach.toml");
+    if (R.is_err[str, str](manifest_rel_r)) {
+        print.eprint("error: cannot plan mach.toml path\n");
+        txn.descent_dnit(a, mp);
+        ret 2;
+    }
+    val manifest_rel: str = R.unwrap_ok[str, str](manifest_rel_r);
+    fin { str_free(a, manifest_rel); }
+    val entry_rel_r: R.Result[str, str] = under_remainder(a, mp.remainder, entry_label::str);
+    if (R.is_err[str, str](entry_rel_r)) {
+        print.eprint("error: cannot plan source entry path\n");
+        txn.descent_dnit(a, mp);
+        ret 2;
+    }
+    val entry_rel: str = R.unwrap_ok[str, str](entry_rel_r);
+    fin { str_free(a, entry_rel); }
+
     var inv: txn.Inventory = txn.inventory_init(a);
-    val manifest_rel: str = under_remainder(a, mp.remainder, "mach.toml");
     val push1: O.Option[txn.Error] = txn.inventory_push(?inv,
         txn.entry_file(manifest_rel, text::*u8, str_len(text), FILE_MODE));
     if (O.is_some[txn.Error](push1)) {
@@ -322,7 +337,6 @@ fun run_absent_branch(a: *A.Allocator, mp: *txn.Descent, id: *u8, is_lib: bool,
     }
 
     val src_text: str = source_template(is_lib)::str;
-    val entry_rel: str = under_remainder(a, mp.remainder, entry_label::str);
     val push2: O.Option[txn.Error] = txn.inventory_push(?inv,
         txn.entry_file(entry_rel, src_text::*u8, str_len(src_text), FILE_MODE));
     if (O.is_some[txn.Error](push2)) {
@@ -1926,4 +1940,22 @@ test "mach.cli.cmd.init.recover_existing:rollback_deletes_a_freshly_committed_ou
     fs.remove_all(?alloc, root);
     str_free(?alloc, root);
     ret bad;
+}
+
+
+test "mach.cli.cmd.init.under_remainder:allocation_failure_cannot_drop_the_destination_prefix" {
+    var state: fixed.FixedState;
+    var alloc: A.Allocator;
+    var storage: [128]u8;
+    if (O.is_some[*u8](fixed.make(?alloc, ?state, ?storage[0], 0))) { ret 1; }
+    val refused: R.Result[str, str] = under_remainder(?alloc, "nested/project", "mach.toml");
+    if (R.is_ok[str, str](refused)) { ret 2; }
+    if (O.is_some[*u8](fixed.make(?alloc, ?state, ?storage[0], 128))) { ret 3; }
+    val planned: R.Result[str, str] = under_remainder(?alloc, "nested/project", "mach.toml");
+    if (R.is_err[str, str](planned)) { ret 4; }
+    if (!str_equals(R.unwrap_ok[str, str](planned), "nested/project/mach.toml")) { ret 5; }
+    val leaf: R.Result[str, str] = under_remainder(?alloc, "", "mach.toml");
+    if (R.is_err[str, str](leaf)) { ret 6; }
+    if (!str_equals(R.unwrap_ok[str, str](leaf), "mach.toml")) { ret 7; }
+    ret 0;
 }

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -1806,13 +1806,8 @@ fun validate_request(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
         if (row.sec != req.text_section || row.text_offset > text_len) {
             ret R.err[R.Void, str]("dwarf.produce: line row lies outside the selected text section");
         }
-        var row_j: u32 = 0;
-        for (row_j < row_i) {
-            if (req.rows[row_j].sec == row.sec
-                && req.rows[row_j].text_offset > row.text_offset) {
-                ret R.err[R.Void, str]("dwarf.produce: line rows are not monotonic within a section");
-            }
-            row_j = row_j + 1;
+        if (row_i > 0 && req.rows[row_i - 1].text_offset > row.text_offset) {
+            ret R.err[R.Void, str]("dwarf.produce: line rows are not monotonic within a section");
         }
         row_i = row_i + 1;
     }
@@ -1822,13 +1817,8 @@ fun validate_request(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
         if (pc.sec != req.text_section || pc.text_offset >= text_len) {
             ret R.err[R.Void, str]("dwarf.produce: inline PC lies outside the selected text section");
         }
-        var inline_j: u32 = 0;
-        for (inline_j < inline_i) {
-            if (req.inline_pcs[inline_j].sec == pc.sec
-                && req.inline_pcs[inline_j].text_offset > pc.text_offset) {
-                ret R.err[R.Void, str]("dwarf.produce: inline PCs are not monotonic within a section");
-            }
-            inline_j = inline_j + 1;
+        if (inline_i > 0 && req.inline_pcs[inline_i - 1].text_offset > pc.text_offset) {
+            ret R.err[R.Void, str]("dwarf.produce: inline PCs are not monotonic within a section");
         }
         val fn: *ir.Function = ir_function_at(image, s.ir_module, pc.sec, pc.text_offset);
         if (!inline_tree_valid(fn) || (pc.inline_site != 0 && pc.inline_site > fn.inline_site_len)) {
@@ -4117,4 +4107,185 @@ test "mach.lang.be.codegen.dwarf.inline_caps:reflects_nested_depth" {
     ir.dnit(?m);
     session.dnit(?s);
     ret bad;
+}
+
+fun t_stream_request(check: fun(*of.DebugProduceRequest) i32) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    val nr: R.Result[intern.StrId, str] = intern.intern(?s.interner, "stream_order");
+    if (R.is_err[intern.StrId, str](nr)) { session.dnit(?s); ret 1; }
+    val name: intern.StrId = R.unwrap_ok[intern.StrId, str](nr);
+    val mr: R.Result[ir.Module, str] = ir.init(?alloc, name);
+    if (R.is_err[ir.Module, str](mr)) { session.dnit(?s); ret 1; }
+    var irmod: ir.Module = R.unwrap_ok[ir.Module, str](mr);
+    val fr: R.Result[u32, str] = ir.function_add(?irmod, name, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](fr)) { ir.dnit(?irmod); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, str](ir.function_register(?irmod, name, R.unwrap_ok[u32, str](fr)))) {
+        ir.dnit(?irmod); session.dnit(?s); ret 1;
+    }
+    var mirmod: mir.MirModule;
+    mirmod.alloc = ?alloc;
+    mirmod.interner = ?s.interner;
+    mirmod.srcmap = ?s.sources;
+    val image_r: R.Result[of.ObjectImage, str] = obj.init(?alloc, ?s.interner, name);
+    if (R.is_err[of.ObjectImage, str](image_r)) { ir.dnit(?irmod); session.dnit(?s); ret 1; }
+    var image: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](image_r);
+    val br: R.Result[*u8, str] = A.allocate[u8](?alloc, 8::usize);
+    if (R.is_err[*u8, str](br)) { obj.dnit(?image); ir.dnit(?irmod); session.dnit(?s); ret 1; }
+    var section: of.Section;
+    section.name = name;
+    section.kind = of.SK_TEXT;
+    section.bytes = R.unwrap_ok[*u8, str](br);
+    section.len = 8;
+    section.align = 1;
+    if (R.is_err[u32, str](obj.install_section(?image, ?section))) {
+        obj.dnit(?image); ir.dnit(?irmod); session.dnit(?s); ret 1;
+    }
+    var symbol: of.Symbol;
+    symbol.name = name;
+    symbol.section = 0;
+    symbol.offset = 0;
+    symbol.size = 8;
+    symbol.flags = of.SYM_OBJ_FLAG_FUNCTION;
+    symbol.fallback = of.SYMBOL_NONE;
+    symbol.align = 1;
+    if (R.is_err[u32, str](obj.add_symbol(?image, symbol))) {
+        obj.dnit(?image); ir.dnit(?irmod); session.dnit(?s); ret 1;
+    }
+    var req: of.DebugProduceRequest;
+    req.program = t_debug_program(?s);
+    req.program.ir_module = ?irmod;
+    req.program.mir_module = ?mirmod;
+    req.program.dwarf_reg = t_debug_reg;
+    req.image = ?image;
+    req.producer = name;
+    req.comp_dir = name;
+    val bad: i32 = check(?req);
+    obj.dnit(?image);
+    ir.dnit(?irmod);
+    session.dnit(?s);
+    ret bad;
+}
+
+fun t_request_error_is(req: *of.DebugProduceRequest, expected: str) bool {
+    val r: R.Result[R.Void, str] = validate_request(req);
+    ret R.is_err[R.Void, str](r) && str_equals(R.unwrap_err[R.Void, str](r), expected);
+}
+
+fun t_stream_order_contract(req: *of.DebugProduceRequest) i32 {
+    var rows: [6]debug_input.LineRow;
+    var pcs: [6]debug_input.InlinePc;
+    var i: u32 = 0;
+    for (i < 6) {
+        rows[i].sec = 0;
+        rows[i].text_offset = i;
+        rows[i].loc = source.loc_nil();
+        pcs[i].sec = 0;
+        pcs[i].text_offset = i;
+        pcs[i].inline_site = 0;
+        i = i + 1;
+    }
+    rows[2].text_offset = 1;
+    rows[5].text_offset = 8;
+    pcs[2].text_offset = 1;
+    pcs[5].text_offset = 7;
+    if (t_request_rejected(req)) { ret 2; }
+    req.rows = ?rows[0]; req.row_count = 1;
+    req.inline_pcs = ?pcs[0]; req.inline_pc_count = 1;
+    if (t_request_rejected(req)) { ret 3; }
+    req.row_count = 6; req.inline_pc_count = 6;
+    if (t_request_rejected(req)) { ret 4; }
+    i = 1;
+    for (i < 6) {
+        val saved: u32 = rows[i].text_offset;
+        rows[i].text_offset = 0;
+        if (i == 1) { rows[0].text_offset = 2; }
+        if (!t_request_error_is(req, "dwarf.produce: line rows are not monotonic within a section")) { ret 5; }
+        if (rows[i].text_offset != 0) { ret 6; }
+        rows[i].text_offset = saved;
+        rows[0].text_offset = 0;
+        i = i + 1;
+    }
+    i = 0;
+    for (i < 6) {
+        rows[i].sec = 1;
+        if (!t_request_error_is(req, "dwarf.produce: line row lies outside the selected text section")) { ret 7; }
+        if (rows[i].sec != 1) { ret 8; }
+        rows[i].sec = 0;
+        i = i + 1;
+    }
+    rows[5].text_offset = 9;
+    if (!t_request_error_is(req, "dwarf.produce: line row lies outside the selected text section")) { ret 9; }
+    rows[5].text_offset = 8;
+    i = 1;
+    for (i < 6) {
+        val saved: u32 = pcs[i].text_offset;
+        pcs[i].text_offset = 0;
+        if (i == 1) { pcs[0].text_offset = 2; }
+        if (!t_request_error_is(req, "dwarf.produce: inline PCs are not monotonic within a section")) { ret 10; }
+        if (pcs[i].text_offset != 0) { ret 11; }
+        pcs[i].text_offset = saved;
+        pcs[0].text_offset = 0;
+        i = i + 1;
+    }
+    i = 0;
+    for (i < 6) {
+        pcs[i].sec = 1;
+        if (!t_request_error_is(req, "dwarf.produce: inline PC lies outside the selected text section")) { ret 12; }
+        if (pcs[i].sec != 1) { ret 13; }
+        pcs[i].sec = 0;
+        i = i + 1;
+    }
+    pcs[5].text_offset = 8;
+    if (!t_request_error_is(req, "dwarf.produce: inline PC lies outside the selected text section")) { ret 14; }
+    pcs[5].text_offset = 7;
+    if (t_request_rejected(req)) { ret 15; }
+    ret 0;
+}
+
+fun t_large_ordered_streams(req: *of.DebugProduceRequest) i32 {
+    val count: usize = 100000;
+    val alloc: *A.Allocator = req.program.alloc;
+    val rr: R.Result[*debug_input.LineRow, str] = A.allocate[debug_input.LineRow](alloc, count);
+    if (R.is_err[*debug_input.LineRow, str](rr)) { ret 2; }
+    val rows: *debug_input.LineRow = R.unwrap_ok[*debug_input.LineRow, str](rr);
+    val pr: R.Result[*debug_input.InlinePc, str] = A.allocate[debug_input.InlinePc](alloc, count);
+    if (R.is_err[*debug_input.InlinePc, str](pr)) {
+        A.deallocate[debug_input.LineRow](alloc, rows, count); ret 3;
+    }
+    val pcs: *debug_input.InlinePc = R.unwrap_ok[*debug_input.InlinePc, str](pr);
+    var i: usize = 0;
+    for (i < count) {
+        val offset: u32 = (i / 20000)::u32;
+        rows[i].sec = 0; rows[i].text_offset = offset; rows[i].loc = source.loc_nil();
+        pcs[i].sec = 0; pcs[i].text_offset = offset; pcs[i].inline_site = 0;
+        i = i + 1;
+    }
+    req.rows = rows; req.row_count = count::u32;
+    req.inline_pcs = pcs; req.inline_pc_count = count::u32;
+    var bad: i32 = 0;
+    if (t_request_rejected(req)) { bad = 4; }
+    i = 0;
+    for (i < count) {
+        val offset: u32 = (i / 20000)::u32;
+        if (rows[i].sec != 0 || rows[i].text_offset != offset
+            || pcs[i].sec != 0 || pcs[i].text_offset != offset || pcs[i].inline_site != 0) { bad = 5; }
+        i = i + 1;
+    }
+    A.deallocate[debug_input.LineRow](alloc, rows, count);
+    A.deallocate[debug_input.InlinePc](alloc, pcs, count);
+    req.rows = nil; req.row_count = 0;
+    req.inline_pcs = nil; req.inline_pc_count = 0;
+    ret bad;
+}
+
+test "mach.lang.be.codegen.dwarf.validate_request:stream_order_contract" {
+    ret t_stream_request(t_stream_order_contract);
+}
+
+test "mach.lang.be.codegen.dwarf.validate_request:large_ordered_streams" {
+    ret t_stream_request(t_large_ordered_streams);
 }

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -39,6 +39,7 @@ use mach.lang.diagnostic;
 use mach.lang.fe.token;
 use mach.lang.embed;
 use mach.lang.intern;
+use mach.lang.session;
 use mach.lang.manifest;
 use mach.subprocess;
 use src: mach.lang.source;
@@ -48,6 +49,7 @@ use std.process.events;
 use tm: std.chrono.time;
 
 use mach.lang.driver.project;
+use step_env: mach.lang.driver.environment;
 use mach.lang.driver.load;
 use ddep: mach.lang.driver.deps;
 use mach.lang.driver.union;
@@ -1549,17 +1551,18 @@ fun expand_step_strings(a: *A.Allocator, p: *project.Project, ids: *intern.StrId
     val ar: R.Result[**u8, str] = A.allocate[*u8](a, count::usize + 1);
     if (R.is_err[**u8, str](ar)) { ret R.err[StepStrings, str](R.unwrap_err[**u8, str](ar)); }
     out.items = R.unwrap_ok[**u8, str](ar);
+    out.count = count;
+    var cleared: usize = 0;
+    for (cleared <= count::usize) { out.items[cleared] = nil; cleared = cleared + 1; }
     var i: u32 = 0;
     for (i < count) {
         val raw_opt: O.Option[str] = intern.lookup(?p.s.interner, ids[i]);
         if (O.is_none[str](raw_opt)) {
-            out.count = i;
             step_strings_free(a, ?out);
             ret R.err[StepStrings, str]("internal: build step field not interned");
         }
         val er: R.Result[str, str] = manifest.expand_step_value(a, O.unwrap[str](raw_opt), project_out, v);
         if (R.is_err[str, str](er)) {
-            out.count = i;
             step_strings_free(a, ?out);
             ret R.err[StepStrings, str](R.unwrap_err[str, str](er));
         }
@@ -1585,64 +1588,55 @@ fun expand_step_invocation(a: *A.Allocator, p: *project.Project, step: *manifest
         ret R.err[StepInvocation, str]("mach.toml: expanded build step argv[0] must name an executable");
     }
 
-    val env_r: R.Result[**u8, str] = A.allocate[*u8](a, step.env_count::usize + TARGET_ENV_N + 1);
-    if (R.is_err[**u8, str](env_r)) {
+    val inherited: **u8 = env.environ();
+    if (inherited == nil) {
         step_strings_free(a, ?invocation.argv);
-        ret R.err[StepInvocation, str](R.unwrap_err[**u8, str](env_r));
+        ret R.err[StepInvocation, str]("planner environment unavailable");
     }
-    invocation.env.items = R.unwrap_ok[**u8, str](env_r);
-
-    var out: u32 = 0;
-    var ti: usize = 0;
-    for (ti < TARGET_ENV_N) {
-        val entry_r: R.Result[str, str] = format.sprint(a, "{}={}", TARGET_ENV_KEYS[ti], target_env_value(v, ti));
-        if (R.is_err[str, str](entry_r)) {
-            invocation.env.count = out;
-            step_strings_free(a, ?invocation.env);
-            step_strings_free(a, ?invocation.argv);
-            ret R.err[StepInvocation, str](R.unwrap_err[str, str](entry_r));
-        }
-        invocation.env.items[out] = R.unwrap_ok[str, str](entry_r)::*u8;
-        out = out + 1;
-        ti = ti + 1;
+    val environment_r: R.Result[StepStrings, str] = expand_step_environment(a, p, step, project_out, v, inherited);
+    if (R.is_err[StepStrings, str](environment_r)) {
+        step_strings_free(a, ?invocation.argv);
+        ret R.err[StepInvocation, str](R.unwrap_err[StepStrings, str](environment_r));
     }
+    invocation.env = R.unwrap_ok[StepStrings, str](environment_r);
+    ret R.ok[StepInvocation, str](invocation);
+}
 
+fun expand_step_environment(a: *A.Allocator, p: *project.Project, step: *manifest.StepDef,
+                            project_out: str, v: *manifest.TmplVars, inherited: **u8) R.Result[StepStrings, str] {
+    val captured: R.Result[step_env.Environment, str] = step_env.capture(a, inherited);
+    if (R.is_err[step_env.Environment, str](captured)) { ret R.err[StepStrings, str](R.unwrap_err[step_env.Environment, str](captured)); }
+    var environment: step_env.Environment = R.unwrap_ok[step_env.Environment, str](captured);
+    fin { step_env.dnit(?environment); }
     var i: u32 = 0;
     for (i < step.env_count) {
         val key_opt: O.Option[str] = intern.lookup(?p.s.interner, step.env_keys[i]);
         val value_opt: O.Option[str] = intern.lookup(?p.s.interner, step.env_values[i]);
         if (O.is_none[str](key_opt) || O.is_none[str](value_opt)) {
-            invocation.env.count = out;
-            step_strings_free(a, ?invocation.env);
-            step_strings_free(a, ?invocation.argv);
-            ret R.err[StepInvocation, str]("internal: build step environment not interned");
+            ret R.err[StepStrings, str]("internal: build step environment not interned");
         }
         val key: str = O.unwrap[str](key_opt);
-        if (is_target_env_key(key)) { i = i + 1; cnt; }
-
+        val reserved: R.Result[bool, str] = is_target_env_key(key);
+        if (R.is_err[bool, str](reserved)) { ret R.err[StepStrings, str](R.unwrap_err[bool, str](reserved)); }
+        if (R.unwrap_ok[bool, str](reserved)) { i = i + 1; cnt; }
         val value_r: R.Result[str, str] = manifest.expand_step_value(a, O.unwrap[str](value_opt), project_out, v);
-        if (R.is_err[str, str](value_r)) {
-            invocation.env.count = out;
-            step_strings_free(a, ?invocation.env);
-            step_strings_free(a, ?invocation.argv);
-            ret R.err[StepInvocation, str](R.unwrap_err[str, str](value_r));
-        }
+        if (R.is_err[str, str](value_r)) { ret R.err[StepStrings, str](R.unwrap_err[str, str](value_r)); }
         val value: str = R.unwrap_ok[str, str](value_r);
-        val entry_r: R.Result[str, str] = format.sprint(a, "{}={}", key, value);
+        val added: R.Result[R.Void, str] = step_env.put(?environment, key, value, true);
         str_free(a, value);
-        if (R.is_err[str, str](entry_r)) {
-            invocation.env.count = out;
-            step_strings_free(a, ?invocation.env);
-            step_strings_free(a, ?invocation.argv);
-            ret R.err[StepInvocation, str](R.unwrap_err[str, str](entry_r));
-        }
-        invocation.env.items[out] = R.unwrap_ok[str, str](entry_r)::*u8;
-        out = out + 1;
+        if (R.is_err[R.Void, str](added)) { ret R.err[StepStrings, str](R.unwrap_err[R.Void, str](added)); }
         i = i + 1;
     }
-    invocation.env.items[out] = nil;
-    invocation.env.count = out;
-    ret R.ok[StepInvocation, str](invocation);
+    var ti: usize = 0;
+    for (ti < TARGET_ENV_N) {
+        val added: R.Result[R.Void, str] = step_env.put(?environment, TARGET_ENV_KEYS[ti], target_env_value(v, ti), true);
+        if (R.is_err[R.Void, str](added)) { ret R.err[StepStrings, str](R.unwrap_err[R.Void, str](added)); }
+        ti = ti + 1;
+    }
+    val exported: R.Result[step_env.Strings, str] = step_env.to_strings(?environment);
+    if (R.is_err[step_env.Strings, str](exported)) { ret R.err[StepStrings, str](R.unwrap_err[step_env.Strings, str](exported)); }
+    val strings: step_env.Strings = R.unwrap_ok[step_env.Strings, str](exported);
+    ret R.ok[StepStrings, str](StepStrings{items: strings.items, count: strings.count});
 }
 
 val TARGET_ENV_N: usize = 3;
@@ -1658,13 +1652,15 @@ fun target_env_value(v: *manifest.TmplVars, idx: usize) str {
     ret v.abi;
 }
 
-fun is_target_env_key(key: str) bool {
+fun is_target_env_key(key: str) R.Result[bool, str] {
     var i: usize = 0;
     for (i < TARGET_ENV_N) {
-        if (str_equals(key, TARGET_ENV_KEYS[i])) { ret true; }
+        val order: R.Result[i32, str] = env.compare_names(key, TARGET_ENV_KEYS[i]);
+        if (R.is_err[i32, str](order)) { ret R.err[bool, str](R.unwrap_err[i32, str](order)); }
+        if (R.unwrap_ok[i32, str](order) == 0) { ret R.ok[bool, str](true); }
         i = i + 1;
     }
-    ret false;
+    ret R.ok[bool, str](false);
 }
 
 fun step_invocation_free(a: *A.Allocator, invocation: *StepInvocation) {
@@ -3839,5 +3835,80 @@ test "mach.lang.driver.config.execute_step_invocation:an_unbounded_step_is_never
     val unbounded: R.Result[R.Void, str] = execute_step_invocation(?alloc, "/", program, ?invocation, "slow-step", 0);
     str_free(?alloc, program);
     if (R.is_err[R.Void, str](unbounded)) { ret 2; }
+    ret 0;
+}
+
+
+test "mach.lang.driver.config: expanded step environment inherits overlays and owns target identity" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?a);
+    if (R.is_err[session.Session, str](sr)) { ret 2; }
+    var owned_session: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?owned_session); }
+    var p: project.Project;
+    p.s = ?owned_session;
+    var keys: [2]intern.StrId;
+    var values: [2]intern.StrId;
+    val key: R.Result[intern.StrId, str] = intern.intern(?owned_session.interner, "MACH_3146_OVERRIDE");
+    val value: R.Result[intern.StrId, str] = intern.intern(?owned_session.interner, "{profile}={isa}");
+    val target_key: R.Result[intern.StrId, str] = intern.intern(?owned_session.interner, "MACH_TARGET_OS");
+    val target_value: R.Result[intern.StrId, str] = intern.intern(?owned_session.interner, "ignored {unsupported}");
+    if (R.is_err[intern.StrId, str](key) || R.is_err[intern.StrId, str](value) || R.is_err[intern.StrId, str](target_key) || R.is_err[intern.StrId, str](target_value)) { ret 3; }
+    keys[0] = R.unwrap_ok[intern.StrId, str](key);
+    keys[1] = R.unwrap_ok[intern.StrId, str](target_key);
+    values[0] = R.unwrap_ok[intern.StrId, str](value);
+    values[1] = R.unwrap_ok[intern.StrId, str](target_value);
+    var step: manifest.StepDef;
+    step.env_keys = ?keys[0];
+    step.env_values = ?values[0];
+    step.env_count = 2;
+    var v: manifest.TmplVars;
+    v.target = "probe";
+    v.profile = "release";
+    v.isa = "x86_64";
+    v.os = "windows";
+    v.abi = "win64";
+    var inherited: [6]usize;
+    inherited[0] = ("PATH=/planner/compiler-tools")::usize;
+    inherited[1] = ("MACH_3146_KEEP=unchanged")::usize;
+    inherited[2] = ("MACH_3146_OVERRIDE=old")::usize;
+    inherited[3] = ("MACH_TARGET_OS=wrong")::usize;
+    inherited[4] = ("MACH_TARGET_ABI=wrong")::usize;
+    inherited[5] = 0;
+    $if ($mach.build.os == $mach.os.windows) {
+        val folded_key: R.Result[intern.StrId, str] = intern.intern(?owned_session.interner, "mach_target_os");
+        if (R.is_err[intern.StrId, str](folded_key)) { ret 8; }
+        keys[1] = R.unwrap_ok[intern.StrId, str](folded_key);
+        inherited[4] = ("mach_target_abi=wrong")::usize;
+    }
+    val er: R.Result[StepStrings, str] = expand_step_environment(?a, ?p, ?step, "out", ?v, (?inherited[0])::**u8);
+    if (R.is_err[StepStrings, str](er)) { ret 4; }
+    var environment: StepStrings = R.unwrap_ok[StepStrings, str](er);
+    fin { step_strings_free(?a, ?environment); }
+    if (environment.count != 6 || environment.items[6] != nil) { ret 5; }
+    var expected: [6]str;
+    expected[0] = "MACH_3146_KEEP=unchanged";
+    expected[1] = "MACH_3146_OVERRIDE=release=x86_64";
+    expected[2] = "MACH_TARGET_ABI=win64";
+    expected[3] = "MACH_TARGET_ISA=x86_64";
+    expected[4] = "MACH_TARGET_OS=windows";
+    expected[5] = "PATH=/planner/compiler-tools";
+    var i: usize = 0;
+    for (i < 6) {
+        if (!str_equals(environment.items[i]::str, expected[i])) { ret 6; }
+        i = i + 1;
+    }
+    $if ($mach.build.os != $mach.os.windows) {
+        var argv: [4]usize;
+        argv[0] = ("sh")::usize;
+        argv[1] = ("-c")::usize;
+        argv[2] = ("test \"$PATH\" = /planner/compiler-tools && test \"$MACH_3146_KEEP\" = unchanged && test \"$MACH_3146_OVERRIDE\" = release=x86_64 && test \"$MACH_TARGET_OS\" = windows")::usize;
+        argv[3] = 0;
+        var invocation: StepInvocation;
+        invocation.argv = StepStrings{items: (?argv[0])::**u8, count: 3};
+        invocation.env = environment;
+        if (R.is_err[R.Void, str](execute_step_invocation(?a, "/", "/bin/sh", ?invocation, "environment inheritance", 0))) { ret 7; }
+    }
     ret 0;
 }

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -3851,7 +3851,7 @@ test "mach.lang.driver.config: expanded step environment inherits overlays and o
     var keys: [2]intern.StrId;
     var values: [2]intern.StrId;
     val key: R.Result[intern.StrId, str] = intern.intern(?owned_session.interner, "MACH_3146_OVERRIDE");
-    val value: R.Result[intern.StrId, str] = intern.intern(?owned_session.interner, "{profile}={isa}");
+    val value: R.Result[intern.StrId, str] = intern.intern(?owned_session.interner, "{profile.name}={target.isa}");
     val target_key: R.Result[intern.StrId, str] = intern.intern(?owned_session.interner, "MACH_TARGET_OS");
     val target_value: R.Result[intern.StrId, str] = intern.intern(?owned_session.interner, "ignored {unsupported}");
     if (R.is_err[intern.StrId, str](key) || R.is_err[intern.StrId, str](value) || R.is_err[intern.StrId, str](target_key) || R.is_err[intern.StrId, str](target_value)) { ret 3; }

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -6,6 +6,7 @@ use std.collections.vector.Vector;
 use fs: std.filesystem;
 use std.format;
 use std.process.exec;
+use std.process.env;
 use std.text.string.str_free;
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -16,6 +17,7 @@ use std.types.string.str_empty;
 use std.types.string.str_equals;
 use std.types.string.str_len;
 use std.types.string.str_compare;
+use std.types.string.str_contains;
 use std.types.string.str_copy_slice;
 use std.types.string.str_starts_with;
 use std.types.path;
@@ -36,17 +38,19 @@ use std.print;
 
 rec GitInspector {
     program: str;
+    inherited_env: **u8;
 }
 
 fun git_inspector_init(alloc: *A.Allocator) R.Result[GitInspector, str] {
     val rr: R.Result[str, str] = exec.resolve(alloc, "git");
     if (R.is_err[str, str](rr)) { ret R.err[GitInspector, str]("git not found on PATH; dependency verification requires Git"); }
-    ret R.ok[GitInspector, str](GitInspector{program: R.unwrap_ok[str, str](rr)});
+    ret R.ok[GitInspector, str](GitInspector{program: R.unwrap_ok[str, str](rr), inherited_env: env.environ()});
 }
 
 fun git_inspector_dnit(alloc: *A.Allocator, gi: *GitInspector) {
     str_free(alloc, gi.program);
     gi.program = nil;
+    gi.inherited_env = nil;
 }
 
 fun captured_text(alloc: *A.Allocator, p: *subprocess.OwnedSubprocess, trim_line_end: bool) R.Result[str, str] {
@@ -82,9 +86,30 @@ pub fun set_git_config_env(env: **u8) {
     git_config_env = env;
 }
 
+fun git_env_prefix(entry: *u8, prefix: str) bool {
+    var i: usize = 0;
+    for (prefix[i] != 0) {
+        var c: u8 = entry[i];
+        $if ($mach.build.os == $mach.os.windows) {
+            if (c >= 'a' && c <= 'z') { c = c - 32; }
+        }
+        if (c != prefix[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
 fun env_names_git_config(entry: *u8) bool {
-    ret str_starts_with(entry::str, "GIT_CONFIG_COUNT=") || str_starts_with(entry::str, "GIT_CONFIG_KEY_")
-        || str_starts_with(entry::str, "GIT_CONFIG_VALUE_");
+    ret git_env_prefix(entry, "GIT_CONFIG_COUNT=") || git_env_prefix(entry, "GIT_CONFIG_KEY_")
+        || git_env_prefix(entry, "GIT_CONFIG_VALUE_");
+}
+
+fun git_inherits_env(entry: *u8, config_override: bool) bool {
+    if (!git_env_prefix(entry, "GIT_")) { ret true; }
+    if (env_names_git_config(entry)) { ret !config_override; }
+    ret git_env_prefix(entry, "GIT_CONFIG_GLOBAL=") || git_env_prefix(entry, "GIT_CONFIG_SYSTEM=")
+        || git_env_prefix(entry, "GIT_CONFIG_NOSYSTEM=") || git_env_prefix(entry, "GIT_ATTR_NOSYSTEM=")
+        || (!config_override && git_env_prefix(entry, "GIT_CONFIG_PARAMETERS="));
 }
 
 fun git_run_capture(alloc: *A.Allocator, gi: *GitInspector, argv: **u8, trim_line_end: bool, extra_env: **u8) R.Result[str, str] {
@@ -105,44 +130,49 @@ fun git_run_capture(alloc: *A.Allocator, gi: *GitInspector, argv: **u8, trim_lin
     for (ci < extra_n) { if (env_names_git_config(extra_env[ci])) { config_n = extra_n; } ci = ci + 1; }
     var forward_n: usize = 0;
     if (config_n == 0) { forward_n = count_nil_terminated(git_config_env); }
-    val env_ar: R.Result[**u8, str] = A.allocate[*u8](alloc, 5 + extra_n + forward_n);
+    val inherited_n: usize = count_nil_terminated(gi.inherited_env);
+    val env_capacity: usize = 3 + extra_n + forward_n + inherited_n;
+    val env_ar: R.Result[**u8, str] = A.allocate[*u8](alloc, env_capacity);
     if (R.is_err[**u8, str](env_ar)) {
         fs.temp_remove(?temp);
         str_free(alloc, fs.temp_path(?temp));
         ret R.err[str, str](R.unwrap_err[**u8, str](env_ar));
     }
     val git_env: **u8 = R.unwrap_ok[**u8, str](env_ar);
-    git_env[0] = "GIT_CONFIG_NOSYSTEM=1";
-    $if ($mach.build.os == $mach.os.windows) {
-        git_env[1] = "GIT_CONFIG_GLOBAL=NUL";
+    git_env[0] = "GIT_OPTIONAL_LOCKS=0";
+    git_env[1] = "GIT_TERMINAL_PROMPT=0";
+    var used: usize = 2;
+    var inherited_i: usize = 0;
+    for (inherited_i < inherited_n) {
+        val entry: *u8 = gi.inherited_env[inherited_i];
+        if (git_inherits_env(entry, config_n != 0 || forward_n != 0)) {
+            git_env[used] = entry;
+            used = used + 1;
+        }
+        inherited_i = inherited_i + 1;
     }
-    $or {
-        git_env[1] = "GIT_CONFIG_GLOBAL=/dev/null";
-    }
-    git_env[2] = "GIT_OPTIONAL_LOCKS=0";
-    git_env[3] = "GIT_TERMINAL_PROMPT=0";
     var ei: usize = 0;
-    for (ei < extra_n) { git_env[4 + ei] = extra_env[ei]; ei = ei + 1; }
+    for (ei < extra_n) { git_env[used + ei] = extra_env[ei]; ei = ei + 1; }
     var fi: usize = 0;
-    for (fi < forward_n) { git_env[4 + extra_n + fi] = git_config_env[fi]; fi = fi + 1; }
-    git_env[4 + extra_n + forward_n] = nil;
+    for (fi < forward_n) { git_env[used + extra_n + fi] = git_config_env[fi]; fi = fi + 1; }
+    git_env[used + extra_n + forward_n] = nil;
     val sr: R.Result[R.Void, str] = subprocess.spawn_captured(alloc, ?child, gi.program, argv,
         git_env, fs.temp_path(?temp), 1048576);
     if (R.is_err[R.Void, str](sr)) {
-        A.deallocate[*u8](alloc, git_env, 5 + extra_n + forward_n);
+        A.deallocate[*u8](alloc, git_env, env_capacity);
         git_capture_cleanup(alloc, ?temp, ?child, false);
         ret R.err[str, str](R.unwrap_err[R.Void, str](sr));
     }
     val wr: R.Result[subprocess.SubprocessTerminal, str] = subprocess.wait(alloc, ?child);
     if (R.is_err[subprocess.SubprocessTerminal, str](wr)) {
         subprocess.abandon_capture(?child);
-        A.deallocate[*u8](alloc, git_env, 5 + extra_n + forward_n);
+        A.deallocate[*u8](alloc, git_env, env_capacity);
         git_capture_cleanup(alloc, ?temp, ?child, false);
         ret R.err[str, str](R.unwrap_err[subprocess.SubprocessTerminal, str](wr));
     }
     val terminal: subprocess.SubprocessTerminal = R.unwrap_ok[subprocess.SubprocessTerminal, str](wr);
     val cr: R.Result[subprocess.CaptureIoResult, str] = subprocess.finish_capture(alloc, ?child, true);
-    A.deallocate[*u8](alloc, git_env, 5 + extra_n + forward_n);
+    A.deallocate[*u8](alloc, git_env, env_capacity);
     if (R.is_err[subprocess.CaptureIoResult, str](cr)) {
         git_capture_cleanup(alloc, ?temp, ?child, false);
         ret R.err[str, str](R.unwrap_err[subprocess.CaptureIoResult, str](cr));
@@ -2798,4 +2828,120 @@ test "mach.lang.driver.deps.realized_content:nested_project_verifies_checkout" {
     str_free(?alloc, fixture);
     git_inspector_dnit(?alloc, ?gi);
     ret bad;
+}
+
+test "mach.lang.driver.deps.git_environment:configuration_survives_repository_redirection_does_not" {
+    if (!git_inherits_env("HOME=/checkout-owner", false)) { ret 1; }
+    if (!git_inherits_env("XDG_CONFIG_HOME=/checkout-config", false)) { ret 2; }
+    if (!git_inherits_env("GIT_CONFIG_GLOBAL=/checkout-config/git", false)) { ret 3; }
+    if (!git_inherits_env("GIT_CONFIG_SYSTEM=/system-config/git", false)) { ret 4; }
+    if (!git_inherits_env("GIT_CONFIG_NOSYSTEM=1", false)) { ret 5; }
+    if (!git_inherits_env("GIT_CONFIG_COUNT=1", false)) { ret 6; }
+    if (git_inherits_env("GIT_CONFIG_COUNT=1", true)) { ret 7; }
+    if (git_inherits_env("GIT_CONFIG_KEY_0=core.autocrlf", true)) { ret 8; }
+    if (git_inherits_env("GIT_CONFIG_VALUE_0=true", true)) { ret 9; }
+    if (git_inherits_env("GIT_DIR=/another/repo", false)) { ret 10; }
+    if (git_inherits_env("GIT_WORK_TREE=/another/tree", false)) { ret 11; }
+    if (git_inherits_env("GIT_INDEX_FILE=/another/index", false)) { ret 12; }
+    if (git_inherits_env("GIT_COMMON_DIR=/another/repo", false)) { ret 13; }
+    if (git_inherits_env("GIT_OBJECT_DIRECTORY=/another/objects", false)) { ret 14; }
+    if (git_inherits_env("GIT_OPTIONAL_LOCKS=1", false)) { ret 15; }
+    if (git_inherits_env("GIT_TERMINAL_PROMPT=1", false)) { ret 16; }
+    $if ($mach.build.os == $mach.os.windows) {
+        if (git_inherits_env("git_dir=C:/another/repo", false)) { ret 17; }
+    }
+    ret 0;
+}
+
+test "mach.lang.driver.deps.git_environment:clean_crlf_checkout_verifies_and_real_edit_is_refused" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val gi_r: R.Result[GitInspector, str] = git_inspector_init(?alloc);
+    if (R.is_err[GitInspector, str](gi_r)) { ret 2; }
+    var gi: GitInspector = R.unwrap_ok[GitInspector, str](gi_r);
+    fin { git_inspector_dnit(?alloc, ?gi); }
+    val fixture_r: R.Result[str, str] = t_make_fixture_repo(?alloc, ?gi, "std");
+    if (R.is_err[str, str](fixture_r)) { ret 3; }
+    val fixture: str = R.unwrap_ok[str, str](fixture_r);
+    fin { fs.remove_all(?alloc, fixture); str_free(?alloc, fixture); }
+    val root_r: R.Result[str, str] = t_scratch_dir(?alloc, "mach_git_config");
+    if (R.is_err[str, str](root_r)) { ret 4; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+    if (O.is_some[str](t_write_file(?alloc, root, "global",
+        "[core]\n\tautocrlf = true\n\tfsmonitor = missing-mach-test-monitor\n\tuntrackedCache = true\n"))) { ret 5; }
+    val config_r: R.Result[str, str] = format.sprint(?alloc, "GIT_CONFIG_GLOBAL={}/global", root);
+    if (R.is_err[str, str](config_r)) { ret 6; }
+    val config: str = R.unwrap_ok[str, str](config_r);
+    fin { str_free(?alloc, config); }
+    val ambient_n: usize = count_nil_terminated(gi.inherited_env);
+    val env_r: R.Result[**u8, str] = A.allocate[*u8](?alloc, ambient_n + 6);
+    if (R.is_err[**u8, str](env_r)) { ret 7; }
+    val inherited: **u8 = R.unwrap_ok[**u8, str](env_r);
+    fin { A.deallocate[*u8](?alloc, inherited, ambient_n + 6); }
+    var count: usize = 0;
+    var i: usize = 0;
+    for (i < ambient_n) {
+        if (!git_env_prefix(gi.inherited_env[i], "GIT_")) {
+            inherited[count] = gi.inherited_env[i];
+            count = count + 1;
+        }
+        i = i + 1;
+    }
+    inherited[count] = config::*u8;
+    inherited[count + 1] = "GIT_CONFIG_NOSYSTEM=1";
+    inherited[count + 2] = "GIT_DIR=/missing-mach-test-repository";
+    inherited[count + 3] = "GIT_WORK_TREE=/missing-mach-test-worktree";
+    inherited[count + 4] = "GIT_INDEX_FILE=/missing-mach-test-index";
+    inherited[count + 5] = nil;
+    gi.inherited_env = inherited;
+    var clone_args: [3]str;
+    clone_args[0] = "clone"; clone_args[1] = fixture; clone_args[2] = "std";
+    val cloned: R.Result[str, str] = git_op(?alloc, ?gi, root, ?clone_args[0], 3, nil);
+    if (R.is_err[str, str](cloned)) { ret 8; }
+    str_free(?alloc, R.unwrap_ok[str, str](cloned));
+    val clone_r: R.Result[str, str] = path.join(?alloc, root, "std");
+    if (R.is_err[str, str](clone_r)) { ret 9; }
+    val clone: str = R.unwrap_ok[str, str](clone_r);
+    fin { str_free(?alloc, clone); }
+    val toml_r: R.Result[str, str] = path.join(?alloc, clone, "mach.toml");
+    if (R.is_err[str, str](toml_r)) { ret 10; }
+    val toml_path: str = R.unwrap_ok[str, str](toml_r);
+    fin { str_free(?alloc, toml_path); }
+    val text_r: R.Result[str, str] = fs.read_string(?alloc, toml_path);
+    if (R.is_err[str, str](text_r)) { ret 11; }
+    val text: str = R.unwrap_ok[str, str](text_r);
+    fin { str_free(?alloc, text); }
+    if (!str_contains(text, "\r\n")) { ret 12; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 13; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
+    var d: manifest.DepDef;
+    d.ref = project.intern_unwrap(?s.interner, "branch/main");
+    val clean: R.Result[intern.StrId, str] = verify_git_checkout(?s, ?gi, "std", root, clone, "dep", ?d, DEP_AUTHORITY_NESTED);
+    if (R.is_err[intern.StrId, str](clean)) { ret 14; }
+    var config_args: [3]str;
+    config_args[0] = "config"; config_args[1] = "--get"; config_args[2] = "core.fsmonitor";
+    val monitor_r: R.Result[str, str] = git_query(?alloc, ?gi, clone, ?config_args[0], 3);
+    if (R.is_err[str, str](monitor_r)) { ret 18; }
+    val monitor: str = R.unwrap_ok[str, str](monitor_r);
+    val monitor_disabled: bool = str_equals(monitor, "false");
+    str_free(?alloc, monitor);
+    if (!monitor_disabled) { ret 19; }
+    config_args[2] = "core.untrackedCache";
+    val cache_r: R.Result[str, str] = git_query(?alloc, ?gi, clone, ?config_args[0], 3);
+    if (R.is_err[str, str](cache_r)) { ret 20; }
+    val cache: str = R.unwrap_ok[str, str](cache_r);
+    val cache_disabled: bool = str_equals(cache, "false");
+    str_free(?alloc, cache);
+    if (!cache_disabled) { ret 21; }
+    if (O.is_some[str](t_write_file(?alloc, clone, "mach.toml", "edited\r\n"))) { ret 15; }
+    val dirty: R.Result[intern.StrId, str] = verify_git_checkout(?s, ?gi, "std", root, clone, "dep", ?d, DEP_AUTHORITY_NESTED);
+    if (R.is_ok[intern.StrId, str](dirty)) { ret 16; }
+    val error: str = R.unwrap_err[intern.StrId, str](dirty);
+    val named: bool = str_contains(error, "checkout is dirty:") && str_contains(error, "mach.toml");
+    str_free(?alloc, error);
+    if (!named) { ret 17; }
+    ret 0;
 }

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -183,7 +183,6 @@ fun git_run_capture(alloc: *A.Allocator, gi: *GitInspector, argv: **u8, trim_lin
         ret R.err[str, str]("Git dependency inspection output could not be captured completely");
     }
     if (terminal.kind != subprocess.STATE_EXITED || terminal.code != 0) {
-        val dbg: R.Result[str, str] = captured_text(alloc, ?child, false);
         git_capture_cleanup(alloc, ?temp, ?child, true);
         ret R.err[str, str]("Git dependency inspection command failed");
     }

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -2868,7 +2868,7 @@ test "mach.lang.driver.deps.git_environment:clean_crlf_checkout_verifies_and_rea
     val root: str = R.unwrap_ok[str, str](root_r);
     fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
     if (O.is_some[str](t_write_file(?alloc, root, "global",
-        "[core]\n\tautocrlf = true\n\tfsmonitor = missing-mach-test-monitor\n\tuntrackedCache = true\n"))) { ret 5; }
+        "[core]\n\tautocrlf = true\n"))) { ret 5; }
     val config_r: R.Result[str, str] = format.sprint(?alloc, "GIT_CONFIG_GLOBAL={}/global", root);
     if (R.is_err[str, str](config_r)) { ret 6; }
     val config: str = R.unwrap_ok[str, str](config_r);
@@ -2889,20 +2889,25 @@ test "mach.lang.driver.deps.git_environment:clean_crlf_checkout_verifies_and_rea
     }
     inherited[count] = config::*u8;
     inherited[count + 1] = "GIT_CONFIG_NOSYSTEM=1";
-    inherited[count + 2] = "GIT_DIR=/missing-mach-test-repository";
-    inherited[count + 3] = "GIT_WORK_TREE=/missing-mach-test-worktree";
-    inherited[count + 4] = "GIT_INDEX_FILE=/missing-mach-test-index";
-    inherited[count + 5] = nil;
-    gi.inherited_env = inherited;
-    var clone_args: [3]str;
-    clone_args[0] = "clone"; clone_args[1] = fixture; clone_args[2] = "std";
-    val cloned: R.Result[str, str] = git_op(?alloc, ?gi, root, ?clone_args[0], 3, nil);
-    if (R.is_err[str, str](cloned)) { ret 8; }
-    str_free(?alloc, R.unwrap_ok[str, str](cloned));
+    inherited[count + 2] = nil;
+    var ordinary_args: [7]*u8;
+    ordinary_args[0] = gi.program::*u8; ordinary_args[1] = "-C";
+    ordinary_args[2] = root::*u8; ordinary_args[3] = "clone";
+    ordinary_args[4] = fixture::*u8; ordinary_args[5] = "std"; ordinary_args[6] = nil;
+    val cloned: R.Result[exec.ExitStatus, str] = exec.run(gi.program, ?ordinary_args[0], inherited);
+    if (R.is_err[exec.ExitStatus, str](cloned)) { ret 8; }
+    val clone_status: exec.ExitStatus = R.unwrap_ok[exec.ExitStatus, str](cloned);
+    if (!exec.exited(clone_status) || exec.code(clone_status) != 0) { ret 8; }
     val clone_r: R.Result[str, str] = path.join(?alloc, root, "std");
     if (R.is_err[str, str](clone_r)) { ret 9; }
     val clone: str = R.unwrap_ok[str, str](clone_r);
     fin { str_free(?alloc, clone); }
+    ordinary_args[2] = clone::*u8; ordinary_args[3] = "diff";
+    ordinary_args[4] = "--exit-code"; ordinary_args[5] = "--quiet";
+    val ordinary_clean: R.Result[exec.ExitStatus, str] = exec.run(gi.program, ?ordinary_args[0], inherited);
+    if (R.is_err[exec.ExitStatus, str](ordinary_clean)) { ret 22; }
+    val ordinary_status: exec.ExitStatus = R.unwrap_ok[exec.ExitStatus, str](ordinary_clean);
+    if (!exec.exited(ordinary_status) || exec.code(ordinary_status) != 0) { ret 22; }
     val toml_r: R.Result[str, str] = path.join(?alloc, clone, "mach.toml");
     if (R.is_err[str, str](toml_r)) { ret 10; }
     val toml_path: str = R.unwrap_ok[str, str](toml_r);
@@ -2912,6 +2917,13 @@ test "mach.lang.driver.deps.git_environment:clean_crlf_checkout_verifies_and_rea
     val text: str = R.unwrap_ok[str, str](text_r);
     fin { str_free(?alloc, text); }
     if (!str_contains(text, "\r\n")) { ret 12; }
+    if (O.is_some[str](t_write_file(?alloc, root, "global",
+        "[core]\n\tautocrlf = true\n\tfsmonitor = missing-mach-test-monitor\n\tuntrackedCache = true\n"))) { ret 23; }
+    inherited[count + 2] = "GIT_DIR=/missing-mach-test-repository";
+    inherited[count + 3] = "GIT_WORK_TREE=/missing-mach-test-worktree";
+    inherited[count + 4] = "GIT_INDEX_FILE=/missing-mach-test-index";
+    inherited[count + 5] = nil;
+    gi.inherited_env = inherited;
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 13; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -112,6 +112,31 @@ fun git_inherits_env(entry: *u8, config_override: bool) bool {
         || (!config_override && git_env_prefix(entry, "GIT_CONFIG_PARAMETERS="));
 }
 
+fun git_env_same_name(a: *u8, b: *u8) bool {
+    var i: usize = 0;
+    for (a[i] != 0 && a[i] != '=') {
+        var ac: u8 = a[i];
+        var bc: u8 = b[i];
+        $if ($mach.build.os == $mach.os.windows) {
+            if (ac >= 'a' && ac <= 'z') { ac = ac - 32; }
+            if (bc >= 'a' && bc <= 'z') { bc = bc - 32; }
+        }
+        if (ac != bc) { ret false; }
+        i = i + 1;
+    }
+    ret a[i] == '=' && b[i] == '=';
+}
+
+fun git_env_put(entries: **u8, count: *usize, entry: *u8) {
+    var i: usize = 0;
+    for (i < @count) {
+        if (git_env_same_name(entries[i], entry)) { entries[i] = entry; ret; }
+        i = i + 1;
+    }
+    entries[@count] = entry;
+    @count = @count + 1;
+}
+
 fun git_run_capture(alloc: *A.Allocator, gi: *GitInspector, argv: **u8, trim_line_end: bool, extra_env: **u8) R.Result[str, str] {
     val tr: R.Result[fs.TempFile, str] = fs.temp_create(alloc, "mach_dep_verify");
     if (R.is_err[fs.TempFile, str](tr)) { ret R.err[str, str](R.unwrap_err[fs.TempFile, str](tr)); }
@@ -146,16 +171,21 @@ fun git_run_capture(alloc: *A.Allocator, gi: *GitInspector, argv: **u8, trim_lin
     for (inherited_i < inherited_n) {
         val entry: *u8 = gi.inherited_env[inherited_i];
         if (git_inherits_env(entry, config_n != 0 || forward_n != 0)) {
-            git_env[used] = entry;
-            used = used + 1;
+            git_env_put(git_env, ?used, entry);
         }
         inherited_i = inherited_i + 1;
     }
     var ei: usize = 0;
-    for (ei < extra_n) { git_env[used + ei] = extra_env[ei]; ei = ei + 1; }
+    for (ei < extra_n) {
+        if (git_inherits_env(extra_env[ei], false)) { git_env_put(git_env, ?used, extra_env[ei]); }
+        ei = ei + 1;
+    }
     var fi: usize = 0;
-    for (fi < forward_n) { git_env[used + extra_n + fi] = git_config_env[fi]; fi = fi + 1; }
-    git_env[used + extra_n + forward_n] = nil;
+    for (fi < forward_n) {
+        if (git_inherits_env(git_config_env[fi], false)) { git_env_put(git_env, ?used, git_config_env[fi]); }
+        fi = fi + 1;
+    }
+    git_env[used] = nil;
     val sr: R.Result[R.Void, str] = subprocess.spawn_captured(alloc, ?child, gi.program, argv,
         git_env, fs.temp_path(?temp), 1048576);
     if (R.is_err[R.Void, str](sr)) {
@@ -2874,10 +2904,10 @@ test "mach.lang.driver.deps.git_environment:clean_crlf_checkout_verifies_and_rea
     val config: str = R.unwrap_ok[str, str](config_r);
     fin { str_free(?alloc, config); }
     val ambient_n: usize = count_nil_terminated(gi.inherited_env);
-    val env_r: R.Result[**u8, str] = A.allocate[*u8](?alloc, ambient_n + 6);
+    val env_r: R.Result[**u8, str] = A.allocate[*u8](?alloc, ambient_n + 7);
     if (R.is_err[**u8, str](env_r)) { ret 7; }
     val inherited: **u8 = R.unwrap_ok[**u8, str](env_r);
-    fin { A.deallocate[*u8](?alloc, inherited, ambient_n + 6); }
+    fin { A.deallocate[*u8](?alloc, inherited, ambient_n + 7); }
     var count: usize = 0;
     var i: usize = 0;
     for (i < ambient_n) {
@@ -2922,7 +2952,8 @@ test "mach.lang.driver.deps.git_environment:clean_crlf_checkout_verifies_and_rea
     inherited[count + 2] = "GIT_DIR=/missing-mach-test-repository";
     inherited[count + 3] = "GIT_WORK_TREE=/missing-mach-test-worktree";
     inherited[count + 4] = "GIT_INDEX_FILE=/missing-mach-test-index";
-    inherited[count + 5] = nil;
+    inherited[count + 5] = "MACH_ENV_PROBE=inherited";
+    inherited[count + 6] = nil;
     gi.inherited_env = inherited;
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 13; }
@@ -2954,5 +2985,30 @@ test "mach.lang.driver.deps.git_environment:clean_crlf_checkout_verifies_and_rea
     val named: bool = str_contains(error, "checkout is dirty:") && str_contains(error, "mach.toml");
     str_free(?alloc, error);
     if (!named) { ret 17; }
+    if (O.is_some[str](t_write_file(?alloc, root, "override", "[mach]\n\torigin = explicit\n"))) { ret 24; }
+    val override_r: R.Result[str, str] = format.sprint(?alloc, "GIT_CONFIG_GLOBAL={}/override", root);
+    if (R.is_err[str, str](override_r)) { ret 25; }
+    val override: str = R.unwrap_ok[str, str](override_r);
+    fin { str_free(?alloc, override); }
+    var extras: [9]*u8;
+    extras[0] = override::*u8;
+    extras[1] = "GIT_OPTIONAL_LOCKS=1";
+    extras[2] = "GIT_TERMINAL_PROMPT=1";
+    extras[3] = "GIT_DIR=/missing-mach-test-repository";
+    extras[4] = "GIT_WORK_TREE=/missing-mach-test-worktree";
+    extras[5] = "GIT_INDEX_FILE=/missing-mach-test-index";
+    extras[6] = "MACH_ENV_PROBE=first";
+    extras[7] = "MACH_ENV_PROBE=explicit";
+    extras[8] = nil;
+    var probe_args: [3]str;
+    probe_args[0] = "-c";
+    probe_args[1] = "alias.mach-env=!test \"$GIT_OPTIONAL_LOCKS\" = 0 && test \"$GIT_TERMINAL_PROMPT\" = 0 && test \"$MACH_ENV_PROBE\" = explicit && git config --get mach.origin";
+    probe_args[2] = "mach-env";
+    val probe_r: R.Result[str, str] = git_op(?alloc, ?gi, clone, ?probe_args[0], 3, ?extras[0]);
+    if (R.is_err[str, str](probe_r)) { ret 26; }
+    val probe: str = R.unwrap_ok[str, str](probe_r);
+    val override_seen: bool = str_equals(probe, "explicit");
+    str_free(?alloc, probe);
+    if (!override_seen) { ret 27; }
     ret 0;
 }

--- a/src/lang/driver/deps.mach
+++ b/src/lang/driver/deps.mach
@@ -7,6 +7,7 @@ use fs: std.filesystem;
 use std.format;
 use std.process.exec;
 use std.process.env;
+use child_env: mach.lang.driver.environment;
 use std.text.string.str_free;
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -44,7 +45,12 @@ rec GitInspector {
 fun git_inspector_init(alloc: *A.Allocator) R.Result[GitInspector, str] {
     val rr: R.Result[str, str] = exec.resolve(alloc, "git");
     if (R.is_err[str, str](rr)) { ret R.err[GitInspector, str]("git not found on PATH; dependency verification requires Git"); }
-    ret R.ok[GitInspector, str](GitInspector{program: R.unwrap_ok[str, str](rr), inherited_env: env.environ()});
+    val inherited: **u8 = env.environ();
+    if (inherited == nil) {
+        str_free(alloc, R.unwrap_ok[str, str](rr));
+        ret R.err[GitInspector, str]("Git dependency environment unavailable");
+    }
+    ret R.ok[GitInspector, str](GitInspector{program: R.unwrap_ok[str, str](rr), inherited_env: inherited});
 }
 
 fun git_inspector_dnit(alloc: *A.Allocator, gi: *GitInspector) {
@@ -86,55 +92,109 @@ pub fun set_git_config_env(env: **u8) {
     git_config_env = env;
 }
 
-fun git_env_prefix(entry: *u8, prefix: str) bool {
+# compare reserved key segments through the host's environment name identity
+fun git_env_prefix(alloc: *A.Allocator, entry: *u8, prefix: str) R.Result[bool, str] {
+    val prefix_size: usize = str_len(prefix);
+    val exact: bool = prefix[prefix_size - 1] == '=';
+    var wanted: usize = 0;
     var i: usize = 0;
-    for (prefix[i] != 0) {
-        var c: u8 = entry[i];
-        $if ($mach.build.os == $mach.os.windows) {
-            if (c >= 'a' && c <= 'z') { c = c - 32; }
+    for (i < prefix_size) {
+        if (prefix[i] == '_') { wanted = wanted + 1; }
+        i = i + 1;
+    }
+    var size: usize = 0;
+    var parts: usize = 0;
+    for (entry[size] != 0 && entry[size] != '=') {
+        if (!exact && entry[size] == '_') {
+            parts = parts + 1;
+            if (parts == wanted) { size = size + 1; brk; }
         }
-        if (c != prefix[i]) { ret false; }
+        size = size + 1;
+    }
+    var compared: usize = prefix_size;
+    if (exact) {
+        if (entry[size] != '=') { ret R.ok[bool, str](false); }
+        compared = compared - 1;
+    } or (parts != wanted) { ret R.ok[bool, str](false); }
+    val lr: R.Result[str, str] = str_copy_slice(alloc, entry::str, 0, size);
+    if (R.is_err[str, str](lr)) { ret R.err[bool, str](R.unwrap_err[str, str](lr)); }
+    val left: str = R.unwrap_ok[str, str](lr);
+    fin { str_free(alloc, left); }
+    val rr: R.Result[str, str] = str_copy_slice(alloc, prefix, 0, compared);
+    if (R.is_err[str, str](rr)) { ret R.err[bool, str](R.unwrap_err[str, str](rr)); }
+    val right: str = R.unwrap_ok[str, str](rr);
+    fin { str_free(alloc, right); }
+    val order: R.Result[i32, str] = env.compare_names(left, right);
+    if (R.is_err[i32, str](order)) { ret R.err[bool, str](R.unwrap_err[i32, str](order)); }
+    ret R.ok[bool, str](R.unwrap_ok[i32, str](order) == 0);
+}
+
+fun env_names_git_config(alloc: *A.Allocator, entry: *u8) R.Result[bool, str] {
+    var prefixes: [3]str = [3]str{"GIT_CONFIG_COUNT=", "GIT_CONFIG_KEY_", "GIT_CONFIG_VALUE_"};
+    var i: usize = 0;
+    for (i < 3) {
+        val found: R.Result[bool, str] = git_env_prefix(alloc, entry, prefixes[i]);
+        if (R.is_err[bool, str](found) || R.unwrap_ok[bool, str](found)) { ret found; }
         i = i + 1;
     }
-    ret true;
+    ret R.ok[bool, str](false);
 }
 
-fun env_names_git_config(entry: *u8) bool {
-    ret git_env_prefix(entry, "GIT_CONFIG_COUNT=") || git_env_prefix(entry, "GIT_CONFIG_KEY_")
-        || git_env_prefix(entry, "GIT_CONFIG_VALUE_");
-}
-
-fun git_inherits_env(entry: *u8, config_override: bool) bool {
-    if (!git_env_prefix(entry, "GIT_")) { ret true; }
-    if (env_names_git_config(entry)) { ret !config_override; }
-    ret git_env_prefix(entry, "GIT_CONFIG_GLOBAL=") || git_env_prefix(entry, "GIT_CONFIG_SYSTEM=")
-        || git_env_prefix(entry, "GIT_CONFIG_NOSYSTEM=") || git_env_prefix(entry, "GIT_ATTR_NOSYSTEM=")
-        || (!config_override && git_env_prefix(entry, "GIT_CONFIG_PARAMETERS="));
-}
-
-fun git_env_same_name(a: *u8, b: *u8) bool {
+fun git_inherits_env(alloc: *A.Allocator, entry: *u8, config_override: bool) R.Result[bool, str] {
+    val family: R.Result[bool, str] = git_env_prefix(alloc, entry, "GIT_");
+    if (R.is_err[bool, str](family)) { ret family; }
+    if (!R.unwrap_ok[bool, str](family)) { ret R.ok[bool, str](true); }
+    val config: R.Result[bool, str] = env_names_git_config(alloc, entry);
+    if (R.is_err[bool, str](config)) { ret config; }
+    if (R.unwrap_ok[bool, str](config)) { ret R.ok[bool, str](!config_override); }
+    var allowed: [5]str = [5]str{"GIT_CONFIG_GLOBAL=", "GIT_CONFIG_SYSTEM=", "GIT_CONFIG_NOSYSTEM=", "GIT_ATTR_NOSYSTEM=", "GIT_CONFIG_PARAMETERS="};
+    var count: usize = 5;
+    if (config_override) { count = 4; }
     var i: usize = 0;
-    for (a[i] != 0 && a[i] != '=') {
-        var ac: u8 = a[i];
-        var bc: u8 = b[i];
-        $if ($mach.build.os == $mach.os.windows) {
-            if (ac >= 'a' && ac <= 'z') { ac = ac - 32; }
-            if (bc >= 'a' && bc <= 'z') { bc = bc - 32; }
+    for (i < count) {
+        val found: R.Result[bool, str] = git_env_prefix(alloc, entry, allowed[i]);
+        if (R.is_err[bool, str](found) || R.unwrap_ok[bool, str](found)) { ret found; }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](false);
+}
+
+fun git_environment(alloc: *A.Allocator, inherited: **u8, extras: **u8) R.Result[child_env.Strings, str] {
+    var values: child_env.Environment = child_env.init(alloc);
+    fin { child_env.dnit(?values); }
+    var override: bool = false;
+    var i: usize = 0;
+    for (extras != nil && extras[i] != nil) {
+        val config: R.Result[bool, str] = env_names_git_config(alloc, extras[i]);
+        if (R.is_err[bool, str](config)) { ret R.err[child_env.Strings, str](R.unwrap_err[bool, str](config)); }
+        if (R.unwrap_ok[bool, str](config)) { override = true; }
+        i = i + 1;
+    }
+    var configured: **u8 = git_config_env;
+    if (override) { configured = nil; }
+    val inherited_override: bool = override || count_nil_terminated(configured) != 0;
+    val locks: R.Result[R.Void, str] = child_env.put(?values, "GIT_OPTIONAL_LOCKS", "0", true);
+    if (R.is_err[R.Void, str](locks)) { ret R.err[child_env.Strings, str](R.unwrap_err[R.Void, str](locks)); }
+    val prompt: R.Result[R.Void, str] = child_env.put(?values, "GIT_TERMINAL_PROMPT", "0", true);
+    if (R.is_err[R.Void, str](prompt)) { ret R.err[child_env.Strings, str](R.unwrap_err[R.Void, str](prompt)); }
+    var layers: [3]**u8 = [3]**u8{inherited, extras, configured};
+    var layer: usize = 0;
+    for (layer < 3) {
+        val entries: **u8 = layers[layer];
+        i = 0;
+        for (entries != nil && entries[i] != nil) {
+            val suppress_config: bool = layer == 0 && inherited_override;
+            val keep: R.Result[bool, str] = git_inherits_env(alloc, entries[i], suppress_config);
+            if (R.is_err[bool, str](keep)) { ret R.err[child_env.Strings, str](R.unwrap_err[bool, str](keep)); }
+            if (R.unwrap_ok[bool, str](keep)) {
+                val added: R.Result[R.Void, str] = child_env.put_entry(?values, entries[i]::str, layer != 0);
+                if (R.is_err[R.Void, str](added)) { ret R.err[child_env.Strings, str](R.unwrap_err[R.Void, str](added)); }
+            }
+            i = i + 1;
         }
-        if (ac != bc) { ret false; }
-        i = i + 1;
+        layer = layer + 1;
     }
-    ret a[i] == '=' && b[i] == '=';
-}
-
-fun git_env_put(entries: **u8, count: *usize, entry: *u8) {
-    var i: usize = 0;
-    for (i < @count) {
-        if (git_env_same_name(entries[i], entry)) { entries[i] = entry; ret; }
-        i = i + 1;
-    }
-    entries[@count] = entry;
-    @count = @count + 1;
+    ret child_env.to_strings(?values);
 }
 
 fun git_run_capture(alloc: *A.Allocator, gi: *GitInspector, argv: **u8, trim_line_end: bool, extra_env: **u8) R.Result[str, str] {
@@ -149,60 +209,27 @@ fun git_run_capture(alloc: *A.Allocator, gi: *GitInspector, argv: **u8, trim_lin
 
     var child: subprocess.OwnedSubprocess;
     subprocess.init(?child);
-    val extra_n: usize = count_nil_terminated(extra_env);
-    var config_n: usize = 0;
-    var ci: usize = 0;
-    for (ci < extra_n) { if (env_names_git_config(extra_env[ci])) { config_n = extra_n; } ci = ci + 1; }
-    var forward_n: usize = 0;
-    if (config_n == 0) { forward_n = count_nil_terminated(git_config_env); }
-    val inherited_n: usize = count_nil_terminated(gi.inherited_env);
-    val env_capacity: usize = 3 + extra_n + forward_n + inherited_n;
-    val env_ar: R.Result[**u8, str] = A.allocate[*u8](alloc, env_capacity);
-    if (R.is_err[**u8, str](env_ar)) {
-        fs.temp_remove(?temp);
-        str_free(alloc, fs.temp_path(?temp));
-        ret R.err[str, str](R.unwrap_err[**u8, str](env_ar));
+    val env_r: R.Result[child_env.Strings, str] = git_environment(alloc, gi.inherited_env, extra_env);
+    if (R.is_err[child_env.Strings, str](env_r)) {
+        git_capture_cleanup(alloc, ?temp, ?child, false);
+        ret R.err[str, str](R.unwrap_err[child_env.Strings, str](env_r));
     }
-    val git_env: **u8 = R.unwrap_ok[**u8, str](env_ar);
-    git_env[0] = "GIT_OPTIONAL_LOCKS=0";
-    git_env[1] = "GIT_TERMINAL_PROMPT=0";
-    var used: usize = 2;
-    var inherited_i: usize = 0;
-    for (inherited_i < inherited_n) {
-        val entry: *u8 = gi.inherited_env[inherited_i];
-        if (git_inherits_env(entry, config_n != 0 || forward_n != 0)) {
-            git_env_put(git_env, ?used, entry);
-        }
-        inherited_i = inherited_i + 1;
-    }
-    var ei: usize = 0;
-    for (ei < extra_n) {
-        if (git_inherits_env(extra_env[ei], false)) { git_env_put(git_env, ?used, extra_env[ei]); }
-        ei = ei + 1;
-    }
-    var fi: usize = 0;
-    for (fi < forward_n) {
-        if (git_inherits_env(git_config_env[fi], false)) { git_env_put(git_env, ?used, git_config_env[fi]); }
-        fi = fi + 1;
-    }
-    git_env[used] = nil;
+    var git_env: child_env.Strings = R.unwrap_ok[child_env.Strings, str](env_r);
+    fin { child_env.strings_free(alloc, ?git_env); }
     val sr: R.Result[R.Void, str] = subprocess.spawn_captured(alloc, ?child, gi.program, argv,
-        git_env, fs.temp_path(?temp), 1048576);
+        git_env.items, fs.temp_path(?temp), 1048576);
     if (R.is_err[R.Void, str](sr)) {
-        A.deallocate[*u8](alloc, git_env, env_capacity);
         git_capture_cleanup(alloc, ?temp, ?child, false);
         ret R.err[str, str](R.unwrap_err[R.Void, str](sr));
     }
     val wr: R.Result[subprocess.SubprocessTerminal, str] = subprocess.wait(alloc, ?child);
     if (R.is_err[subprocess.SubprocessTerminal, str](wr)) {
         subprocess.abandon_capture(?child);
-        A.deallocate[*u8](alloc, git_env, env_capacity);
         git_capture_cleanup(alloc, ?temp, ?child, false);
         ret R.err[str, str](R.unwrap_err[subprocess.SubprocessTerminal, str](wr));
     }
     val terminal: subprocess.SubprocessTerminal = R.unwrap_ok[subprocess.SubprocessTerminal, str](wr);
     val cr: R.Result[subprocess.CaptureIoResult, str] = subprocess.finish_capture(alloc, ?child, true);
-    A.deallocate[*u8](alloc, git_env, env_capacity);
     if (R.is_err[subprocess.CaptureIoResult, str](cr)) {
         git_capture_cleanup(alloc, ?temp, ?child, false);
         ret R.err[str, str](R.unwrap_err[subprocess.CaptureIoResult, str](cr));
@@ -2862,26 +2889,62 @@ test "mach.lang.driver.deps.realized_content:nested_project_verifies_checkout" {
     ret bad;
 }
 
+fun git_test_inheritance(alloc: *A.Allocator, entry: *u8, override: bool, expected: bool) bool {
+    val result: R.Result[bool, str] = git_inherits_env(alloc, entry, override);
+    ret R.is_ok[bool, str](result) && R.unwrap_ok[bool, str](result) == expected;
+}
+
 test "mach.lang.driver.deps.git_environment:configuration_survives_repository_redirection_does_not" {
-    if (!git_inherits_env("HOME=/checkout-owner", false)) { ret 1; }
-    if (!git_inherits_env("XDG_CONFIG_HOME=/checkout-config", false)) { ret 2; }
-    if (!git_inherits_env("GIT_CONFIG_GLOBAL=/checkout-config/git", false)) { ret 3; }
-    if (!git_inherits_env("GIT_CONFIG_SYSTEM=/system-config/git", false)) { ret 4; }
-    if (!git_inherits_env("GIT_CONFIG_NOSYSTEM=1", false)) { ret 5; }
-    if (!git_inherits_env("GIT_CONFIG_COUNT=1", false)) { ret 6; }
-    if (git_inherits_env("GIT_CONFIG_COUNT=1", true)) { ret 7; }
-    if (git_inherits_env("GIT_CONFIG_KEY_0=core.autocrlf", true)) { ret 8; }
-    if (git_inherits_env("GIT_CONFIG_VALUE_0=true", true)) { ret 9; }
-    if (git_inherits_env("GIT_DIR=/another/repo", false)) { ret 10; }
-    if (git_inherits_env("GIT_WORK_TREE=/another/tree", false)) { ret 11; }
-    if (git_inherits_env("GIT_INDEX_FILE=/another/index", false)) { ret 12; }
-    if (git_inherits_env("GIT_COMMON_DIR=/another/repo", false)) { ret 13; }
-    if (git_inherits_env("GIT_OBJECT_DIRECTORY=/another/objects", false)) { ret 14; }
-    if (git_inherits_env("GIT_OPTIONAL_LOCKS=1", false)) { ret 15; }
-    if (git_inherits_env("GIT_TERMINAL_PROMPT=1", false)) { ret 16; }
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 20; }
+    if (!git_test_inheritance(?alloc, "HOME=/checkout-owner", false, true)) { ret 1; }
+    if (!git_test_inheritance(?alloc, "XDG_CONFIG_HOME=/checkout-config", false, true)) { ret 2; }
+    if (!git_test_inheritance(?alloc, "GIT_CONFIG_GLOBAL=/checkout-config/git", false, true)) { ret 3; }
+    if (!git_test_inheritance(?alloc, "GIT_CONFIG_SYSTEM=/system-config/git", false, true)) { ret 4; }
+    if (!git_test_inheritance(?alloc, "GIT_CONFIG_NOSYSTEM=1", false, true)) { ret 5; }
+    if (!git_test_inheritance(?alloc, "GIT_CONFIG_COUNT=1", false, true)) { ret 6; }
+    if (!git_test_inheritance(?alloc, "GIT_CONFIG_COUNT=1", true, false)) { ret 7; }
+    if (!git_test_inheritance(?alloc, "GIT_CONFIG_KEY_0=core.autocrlf", true, false)) { ret 8; }
+    if (!git_test_inheritance(?alloc, "GIT_CONFIG_VALUE_0=true", true, false)) { ret 9; }
+    if (!git_test_inheritance(?alloc, "GIT_DIR=/another/repo", false, false)) { ret 10; }
+    if (!git_test_inheritance(?alloc, "GIT_WORK_TREE=/another/tree", false, false)) { ret 11; }
+    if (!git_test_inheritance(?alloc, "GIT_INDEX_FILE=/another/index", false, false)) { ret 12; }
+    if (!git_test_inheritance(?alloc, "GIT_COMMON_DIR=/another/repo", false, false)) { ret 13; }
+    if (!git_test_inheritance(?alloc, "GIT_OBJECT_DIRECTORY=/another/objects", false, false)) { ret 14; }
+    if (!git_test_inheritance(?alloc, "GIT_OPTIONAL_LOCKS=1", false, false)) { ret 15; }
+    if (!git_test_inheritance(?alloc, "GIT_TERMINAL_PROMPT=1", false, false)) { ret 16; }
     $if ($mach.build.os == $mach.os.windows) {
-        if (git_inherits_env("git_dir=C:/another/repo", false)) { ret 17; }
+        if (!git_test_inheritance(?alloc, "git_dir=C:/another/repo", false, false)) { ret 17; }
+        val ordinal: R.Result[i32, str] = env.compare_names("gıt", "GIT");
+        if (R.is_err[i32, str](ordinal)) { ret 18; }
+        val ordinary: bool = R.unwrap_ok[i32, str](ordinal) != 0;
+        if (!git_test_inheritance(?alloc, "gıt_dir=C:/another/repo", false, ordinary)) { ret 19; }
     }
+    ret 0;
+}
+
+test "mach.lang.driver.deps.git_environment:inherited_configuration_keeps_first_native_name" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var inherited: [7]*u8 = [7]*u8{"GIT_CONFIG_COUNT=1", "GIT_CONFIG_COUNT=0",
+        "GIT_CONFIG_KEY_0=mach.probe", "GIT_CONFIG_VALUE_0=first",
+        "GIT_CONFIG_VALUE_0=ignored", "MACH_PROBE=inherited", nil};
+    $if ($mach.build.os == $mach.os.windows) {
+        inherited[1] = "git_config_count=0";
+        inherited[2] = "git_config_key_0=mach.probe";
+        inherited[3] = "git_config_value_0=first";
+    }
+    val result: R.Result[child_env.Strings, str] = git_environment(?alloc, ?inherited[0], nil);
+    if (R.is_err[child_env.Strings, str](result)) { ret 2; }
+    var strings: child_env.Strings = R.unwrap_ok[child_env.Strings, str](result);
+    fin { child_env.strings_free(?alloc, ?strings); }
+    if (strings.count != 6) { ret 3; }
+    if (!str_equals(strings.items[0]::str, inherited[0]::str)) { ret 4; }
+    if (!str_equals(strings.items[1]::str, inherited[2]::str)) { ret 5; }
+    if (!str_equals(strings.items[2]::str, inherited[3]::str)) { ret 6; }
+    if (!str_equals(strings.items[3]::str, "GIT_OPTIONAL_LOCKS=0")) { ret 7; }
+    if (!str_equals(strings.items[4]::str, "GIT_TERMINAL_PROMPT=0")) { ret 8; }
+    if (!str_equals(strings.items[5]::str, "MACH_PROBE=inherited")) { ret 9; }
     ret 0;
 }
 
@@ -2914,7 +2977,9 @@ test "mach.lang.driver.deps.git_environment:clean_crlf_checkout_verifies_and_rea
     var count: usize = 0;
     var i: usize = 0;
     for (i < ambient_n) {
-        if (!git_env_prefix(gi.inherited_env[i], "GIT_")) {
+        val reserved: R.Result[bool, str] = git_env_prefix(?alloc, gi.inherited_env[i], "GIT_");
+        if (R.is_err[bool, str](reserved)) { ret 41; }
+        if (!R.unwrap_ok[bool, str](reserved)) {
             inherited[count] = gi.inherited_env[i];
             count = count + 1;
         }

--- a/src/lang/driver/environment.mach
+++ b/src/lang/driver/environment.mach
@@ -1,0 +1,303 @@
+use std.collections.vector;
+use std.collections.vector.Vector;
+use std.format;
+use std.process.env;
+use std.text.string.str_dup;
+use std.text.string.str_free;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_copy_slice;
+use std.types.string.str_len;
+
+use A: std.allocator;
+use std.allocator.page;
+use O: std.types.option;
+use std.types.string.str_equals;
+use R: std.types.result;
+
+pub rec Entry {
+    name: str;
+    value: str;
+}
+
+pub rec Environment {
+    entries: Vector[Entry];
+}
+
+pub rec Strings {
+    items: **u8;
+    count: u32;
+}
+
+pub fun init(a: *A.Allocator) Environment {
+    ret Environment{entries: vector.init[Entry](a)};
+}
+
+pub fun dnit(values: *Environment) {
+    var i: usize = 0;
+    for (i < values.entries.len) {
+        str_free(values.entries.a, values.entries.data[i].name);
+        str_free(values.entries.a, values.entries.data[i].value);
+        i = i + 1;
+    }
+    vector.dnit[Entry](?values.entries);
+}
+
+# entries own both strings and use host identity before any overlay is applied
+pub fun put(values: *Environment, name: str, value: str, replace: bool) R.Result[R.Void, str] {
+    val n: usize = str_len(name);
+    if (n == 0) { ret R.err[R.Void, str]("environment variable name is empty"); }
+    var i: usize = 0;
+    for (i < n) {
+        if (name[i] == '=') { ret R.err[R.Void, str]("environment variable name contains '='"); }
+        i = i + 1;
+    }
+    val valid: R.Result[i32, str] = env.compare_names(name, name);
+    if (R.is_err[i32, str](valid)) { ret R.err[R.Void, str](R.unwrap_err[i32, str](valid)); }
+    var found: usize = values.entries.len;
+    i = 0;
+    for (i < values.entries.len) {
+        val order: R.Result[i32, str] = env.compare_names(values.entries.data[i].name, name);
+        if (R.is_err[i32, str](order)) { ret R.err[R.Void, str](R.unwrap_err[i32, str](order)); }
+        if (R.unwrap_ok[i32, str](order) == 0) { found = i; brk; }
+        i = i + 1;
+    }
+    if (found < values.entries.len && !replace) { ret R.ok_void[str](); }
+    val a: *A.Allocator = values.entries.a;
+    val nr: R.Result[str, str] = str_dup(a, name);
+    if (R.is_err[str, str](nr)) { ret R.err[R.Void, str](R.unwrap_err[str, str](nr)); }
+    val owned_name: str = R.unwrap_ok[str, str](nr);
+    val vr: R.Result[str, str] = str_dup(a, value);
+    if (R.is_err[str, str](vr)) { str_free(a, owned_name); ret R.err[R.Void, str](R.unwrap_err[str, str](vr)); }
+    val entry: Entry = Entry{name: owned_name, value: R.unwrap_ok[str, str](vr)};
+    if (found < values.entries.len) {
+        str_free(a, values.entries.data[found].name);
+        str_free(a, values.entries.data[found].value);
+        values.entries.data[found] = entry;
+    } or {
+        val pushed: R.Result[usize, str] = vector.push[Entry](?values.entries, entry);
+        if (R.is_err[usize, str](pushed)) {
+            str_free(a, entry.name);
+            str_free(a, entry.value);
+            ret R.err[R.Void, str](R.unwrap_err[usize, str](pushed));
+        }
+    }
+    ret R.ok_void[str]();
+}
+
+pub fun put_entry(values: *Environment, entry: str, replace: bool) R.Result[R.Void, str] {
+    var split: usize = 0;
+    if (entry == nil) { ret R.err[R.Void, str]("environment entry is nil"); }
+    for (entry[split] != 0 && entry[split] != '=') { split = split + 1; }
+    if (split == 0 || entry[split] != '=') {
+        ret R.err[R.Void, str]("environment entry must have a name and '='");
+    }
+    val a: *A.Allocator = values.entries.a;
+    val nr: R.Result[str, str] = str_copy_slice(a, entry, 0, split);
+    if (R.is_err[str, str](nr)) { ret R.err[R.Void, str](R.unwrap_err[str, str](nr)); }
+    val name: str = R.unwrap_ok[str, str](nr);
+    val added: R.Result[R.Void, str] = put(values, name, ?entry[split + 1], replace);
+    str_free(a, name);
+    ret added;
+}
+
+# inherited duplicate names retain the first value, matching native lookup
+pub fun capture(a: *A.Allocator, inherited: **u8) R.Result[Environment, str] {
+    var values: Environment = init(a);
+    var i: usize = 0;
+    for (inherited != nil && inherited[i] != nil) {
+        val added: R.Result[R.Void, str] = put_entry(?values, inherited[i]::str, false);
+        if (R.is_err[R.Void, str](added)) { dnit(?values); ret R.err[Environment, str](R.unwrap_err[R.Void, str](added)); }
+        i = i + 1;
+    }
+    ret R.ok[Environment, str](values);
+}
+
+pub fun canonicalize(values: *Environment) R.Result[R.Void, str] {
+    var i: usize = 1;
+    for (i < values.entries.len) {
+        var j: usize = i;
+        for (j > 0) {
+            val order: R.Result[i32, str] = env.compare_names(values.entries.data[j - 1].name, values.entries.data[j].name);
+            if (R.is_err[i32, str](order)) { ret R.err[R.Void, str](R.unwrap_err[i32, str](order)); }
+            if (R.unwrap_ok[i32, str](order) <= 0) { brk; }
+            val previous: Entry = values.entries.data[j - 1];
+            values.entries.data[j - 1] = values.entries.data[j];
+            values.entries.data[j] = previous;
+            j = j - 1;
+        }
+        i = i + 1;
+    }
+    ret R.ok_void[str]();
+}
+
+pub fun strings_free(a: *A.Allocator, strings: *Strings) {
+    if (strings.items == nil) { ret; }
+    var i: u32 = 0;
+    for (i < strings.count) { str_free(a, strings.items[i]::str); i = i + 1; }
+    A.deallocate[*u8](a, strings.items, strings.count::usize + 1);
+    strings.items = nil;
+    strings.count = 0;
+}
+
+pub fun to_strings(values: *Environment) R.Result[Strings, str] {
+    val sorted: R.Result[R.Void, str] = canonicalize(values);
+    if (R.is_err[R.Void, str](sorted)) { ret R.err[Strings, str](R.unwrap_err[R.Void, str](sorted)); }
+    val count: usize = values.entries.len;
+    if (count > 0xffffffff) { ret R.err[Strings, str]("environment has too many entries"); }
+    val a: *A.Allocator = values.entries.a;
+    val ar: R.Result[**u8, str] = A.allocate[*u8](a, count + 1);
+    if (R.is_err[**u8, str](ar)) { ret R.err[Strings, str](R.unwrap_err[**u8, str](ar)); }
+    val items: **u8 = R.unwrap_ok[**u8, str](ar);
+    var i: usize = 0;
+    for (i < count) {
+        val entry: Entry = values.entries.data[i];
+        val sr: R.Result[str, str] = format.sprint(a, "{}={}", entry.name, entry.value);
+        if (R.is_err[str, str](sr)) {
+            var j: usize = 0;
+            for (j < i) { str_free(a, items[j]::str); j = j + 1; }
+            A.deallocate[*u8](a, items, count + 1);
+            ret R.err[Strings, str](R.unwrap_err[str, str](sr));
+        }
+        items[i] = R.unwrap_ok[str, str](sr)::*u8;
+        i = i + 1;
+    }
+    items[count] = nil;
+    ret R.ok[Strings, str](Strings{items: items, count: count::u32});
+}
+
+
+pub fun capture_planner(a: *A.Allocator) R.Result[Environment, str] {
+    val inherited: **u8 = env.environ();
+    if (inherited == nil) { ret R.err[Environment, str]("planner environment unavailable"); }
+    ret capture(a, inherited);
+}
+
+
+test "mach.lang.driver.environment: owned overlays use host name identity" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    var entry: [11]u8;
+    val initial: str = "MACH_X=one";
+    var i: usize = 0;
+    for (i <= 10) { entry[i] = initial[i]; i = i + 1; }
+    var inherited: [3]usize;
+    inherited[0] = (?entry[0])::usize;
+    inherited[1] = ("MACH_X=ignored")::usize;
+    inherited[2] = 0;
+    val cr: R.Result[Environment, str] = capture(?a, (?inherited[0])::**u8);
+    if (R.is_err[Environment, str](cr)) { ret 2; }
+    var values: Environment = R.unwrap_ok[Environment, str](cr);
+    fin { dnit(?values); }
+    entry[7] = 'X';
+    if (values.entries.len != 1 || !str_equals(values.entries.data[0].value, "one")) { ret 3; }
+    if (R.is_err[R.Void, str](put(?values, "MACH_X", "declared=value", true))) { ret 4; }
+    if (R.is_err[R.Void, str](put(?values, "MACH_ÄΩ", "first", true))) { ret 5; }
+    if (R.is_err[R.Void, str](put(?values, "mach_äω", "second", true))) { ret 6; }
+    $if ($mach.build.os == $mach.os.windows) { if (values.entries.len != 2) { ret 7; } }
+    $or { if (values.entries.len != 3) { ret 8; } }
+    val sr: R.Result[Strings, str] = to_strings(?values);
+    if (R.is_err[Strings, str](sr)) { ret 9; }
+    var strings: Strings = R.unwrap_ok[Strings, str](sr);
+    fin { strings_free(?a, ?strings); }
+    if (!str_equals(strings.items[0]::str, "MACH_X=declared=value") || strings.items[strings.count] != nil) { ret 10; }
+    if (R.is_ok[R.Void, str](put_entry(?values, "=bad", true))) { ret 11; }
+    if (R.is_ok[R.Void, str](put_entry(?values, "missing", true))) { ret 12; }
+    ret 0;
+}
+
+rec EnvProbe {
+    backing: A.Allocator;
+    pointers: [128]ptr;
+    sizes: [128]usize;
+    count: usize;
+    calls: usize;
+    fail_at: usize;
+    bad: bool;
+}
+
+fun t_env_allocate(ctx: ptr, size: usize, align: usize) O.Option[ptr] {
+    val probe: *EnvProbe = ctx::*EnvProbe;
+    probe.calls = probe.calls + 1;
+    if (probe.calls == probe.fail_at) { ret O.none[ptr](); }
+    if (probe.count == 128) { probe.bad = true; ret O.none[ptr](); }
+    val r: O.Option[ptr] = probe.backing.fn_allocate(probe.backing.ctx, size, align);
+    if (O.is_some[ptr](r)) {
+        probe.pointers[probe.count] = O.unwrap[ptr](r);
+        probe.sizes[probe.count] = size;
+        probe.count = probe.count + 1;
+    }
+    ret r;
+}
+
+fun t_env_reallocate(ctx: ptr, pointer: ptr, old_size: usize, new_size: usize, align: usize) O.Option[ptr] {
+    val probe: *EnvProbe = ctx::*EnvProbe;
+    probe.calls = probe.calls + 1;
+    if (probe.calls == probe.fail_at) { ret O.none[ptr](); }
+    var i: usize = 0;
+    for (i < probe.count && probe.pointers[i] != pointer) { i = i + 1; }
+    if (i == probe.count) { probe.bad = true; ret O.none[ptr](); }
+    if (probe.sizes[i] != old_size) { probe.bad = true; }
+    val r: O.Option[ptr] = probe.backing.fn_reallocate(probe.backing.ctx, pointer, probe.sizes[i], new_size, align);
+    if (O.is_some[ptr](r)) { probe.pointers[i] = O.unwrap[ptr](r); probe.sizes[i] = new_size; }
+    ret r;
+}
+
+fun t_env_deallocate(ctx: ptr, pointer: ptr, size: usize, align: usize) i64 {
+    val probe: *EnvProbe = ctx::*EnvProbe;
+    var i: usize = 0;
+    for (i < probe.count && probe.pointers[i] != pointer) { i = i + 1; }
+    if (i == probe.count) { probe.bad = true; ret -1; }
+    if (probe.sizes[i] != size) { probe.bad = true; }
+    val result: i64 = probe.backing.fn_deallocate(probe.backing.ctx, pointer, probe.sizes[i], align);
+    probe.count = probe.count - 1;
+    probe.pointers[i] = probe.pointers[probe.count];
+    probe.sizes[i] = probe.sizes[probe.count];
+    ret result;
+}
+
+fun t_env_attempt(a: *A.Allocator) bool {
+    var inherited: [3]usize;
+    inherited[0] = ("MACH_Z=initial")::usize;
+    inherited[1] = ("MACH_A=retained")::usize;
+    inherited[2] = 0;
+    val cr: R.Result[Environment, str] = capture(a, (?inherited[0])::**u8);
+    if (R.is_err[Environment, str](cr)) { ret false; }
+    var values: Environment = R.unwrap_ok[Environment, str](cr);
+    fin { dnit(?values); }
+    if (R.is_err[R.Void, str](put_entry(?values, "MACH_Z=replacement", true))) { ret false; }
+    val sr: R.Result[Strings, str] = to_strings(?values);
+    if (R.is_err[Strings, str](sr)) { ret false; }
+    var strings: Strings = R.unwrap_ok[Strings, str](sr);
+    strings_free(a, ?strings);
+    ret true;
+}
+
+test "mach.lang.driver.environment: allocation failures release exact owned extents" {
+    var fail_at: usize = 1;
+    for (fail_at < 128) {
+        var probe: EnvProbe;
+        if (O.is_some[str](page.make(?probe.backing))) { ret 1; }
+        probe.fail_at = fail_at;
+        probe.calls = 0;
+        probe.count = 0;
+        probe.bad = false;
+        var a: A.Allocator;
+        a.ctx = (?probe)::ptr;
+        a.fn_allocate = t_env_allocate;
+        a.fn_reallocate = t_env_reallocate;
+        a.fn_deallocate = t_env_deallocate;
+        val completed: bool = t_env_attempt(?a);
+        if (probe.bad || probe.count != 0) { ret 2; }
+        if (completed) {
+            if (probe.calls >= fail_at) { ret 3; }
+            ret 0;
+        }
+        if (probe.calls < fail_at) { ret 4; }
+        fail_at = fail_at + 1;
+    }
+    ret 5;
+}

--- a/src/lang/driver/environment.mach
+++ b/src/lang/driver/environment.mach
@@ -261,10 +261,18 @@ fun t_env_deallocate(ctx: ptr, pointer: ptr, size: usize, align: usize) i64 {
 }
 
 fun t_env_attempt(a: *A.Allocator) bool {
-    var inherited: [3]usize;
+    var inherited: [11]usize;
     inherited[0] = ("MACH_Z=initial")::usize;
     inherited[1] = ("MACH_A=retained")::usize;
-    inherited[2] = 0;
+    inherited[2] = ("MACH_B=retained")::usize;
+    inherited[3] = ("MACH_C=retained")::usize;
+    inherited[4] = ("MACH_D=retained")::usize;
+    inherited[5] = ("MACH_E=retained")::usize;
+    inherited[6] = ("MACH_F=retained")::usize;
+    inherited[7] = ("MACH_G=retained")::usize;
+    inherited[8] = ("MACH_H=retained")::usize;
+    inherited[9] = ("MACH_I=retained")::usize;
+    inherited[10] = 0;
     val cr: R.Result[Environment, str] = capture(a, (?inherited[0])::**u8);
     if (R.is_err[Environment, str](cr)) { ret false; }
     var values: Environment = R.unwrap_ok[Environment, str](cr);

--- a/src/lang/driver/environment.mach
+++ b/src/lang/driver/environment.mach
@@ -234,6 +234,7 @@ fun t_env_allocate(ctx: ptr, size: usize, align: usize) O.Option[ptr] {
 }
 
 fun t_env_reallocate(ctx: ptr, pointer: ptr, old_size: usize, new_size: usize, align: usize) O.Option[ptr] {
+    if (pointer == nil) { ret t_env_allocate(ctx, new_size, align); }
     val probe: *EnvProbe = ctx::*EnvProbe;
     probe.calls = probe.calls + 1;
     if (probe.calls == probe.fail_at) { ret O.none[ptr](); }

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -21,6 +21,7 @@ use ctime: std.chrono.time;
 use cdur:  std.chrono.duration;
 use std.sync.atomic;
 use std.sync.thread;
+use std.process.env;
 
 use mach.lang.be.codegen;
 use mach.lang.be.codegen.unit;
@@ -55,6 +56,7 @@ use mach.lang.target.of;
 use mach.lang.type;
 
 use mach.lang.driver.project;
+use step_env: mach.lang.driver.environment;
 use mach.lang.driver.union;
 use dq: mach.lang.driver.query;
 use mach.lang.driver.load;
@@ -2070,6 +2072,31 @@ fun write_step_environment(fb: *dq.FpBuf, p: *project.Project) R.Result[R.Void, 
         }
         si = si + 1;
     }
+    if (p.config.step_count == 0 && p.config.dep_count == 0) { ret dq.fp_u32(fb, 0); }
+    val inherited: **u8 = env.environ();
+    if (inherited == nil) { ret R.err[R.Void, str]("planner environment unavailable"); }
+    ret write_planner_environment(fb, inherited);
+}
+
+
+# planner inputs cover child inheritance and executable lookup for root and dependency steps
+fun write_planner_environment(fb: *dq.FpBuf, inherited: **u8) R.Result[R.Void, str] {
+    val captured: R.Result[step_env.Environment, str] = step_env.capture(fb.alloc, inherited);
+    if (R.is_err[step_env.Environment, str](captured)) { ret R.err[R.Void, str](R.unwrap_err[step_env.Environment, str](captured)); }
+    var environment: step_env.Environment = R.unwrap_ok[step_env.Environment, str](captured);
+    fin { step_env.dnit(?environment); }
+    val exported: R.Result[step_env.Strings, str] = step_env.to_strings(?environment);
+    if (R.is_err[step_env.Strings, str](exported)) { ret R.err[R.Void, str](R.unwrap_err[step_env.Strings, str](exported)); }
+    var strings: step_env.Strings = R.unwrap_ok[step_env.Strings, str](exported);
+    fin { step_env.strings_free(fb.alloc, ?strings); }
+    val count: R.Result[R.Void, str] = dq.fp_u32(fb, strings.count);
+    if (R.is_err[R.Void, str](count)) { ret count; }
+    var i: u32 = 0;
+    for (i < strings.count) {
+        val entry: R.Result[R.Void, str] = dq.fp_cstr(fb, strings.items[i]);
+        if (R.is_err[R.Void, str](entry)) { ret entry; }
+        i = i + 1;
+    }
     ret R.ok_void[str]();
 }
 
@@ -2421,5 +2448,42 @@ test "mach.lang.driver.passes.write_build_config:every_tuple_field_moves_the_fin
         }
         i = i + 1;
     }
+    ret 0;
+}
+
+
+fun t_planner_environment_digest(a: *A.Allocator, inherited: **u8, digest: *u8) bool {
+    var fb: dq.FpBuf;
+    fb.alloc = a;
+    fb.buf = nil;
+    fb.len = 0;
+    fb.cap = 0;
+    fin { dq.fp_free(?fb); }
+    val written: R.Result[R.Void, str] = write_planner_environment(?fb, inherited);
+    if (R.is_err[R.Void, str](written)) { ret false; }
+    sha256.hash(fb.buf, fb.len, digest);
+    ret true;
+}
+
+test "mach.lang.driver.passes: planner environment cache input tracks values and ignores entry order" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    var entries: [4]usize;
+    entries[0] = ("MACH_3146_B=two")::usize;
+    entries[1] = ("MACH_3146_A=one")::usize;
+    entries[2] = ("MACH_3146_A=ignored duplicate")::usize;
+    entries[3] = 0;
+    var initial: [32]u8;
+    if (!t_planner_environment_digest(?a, (?entries[0])::**u8, ?initial[0])) { ret 2; }
+    entries[0] = ("MACH_3146_A=one")::usize;
+    entries[1] = ("MACH_3146_B=two")::usize;
+    entries[2] = 0;
+    var reordered: [32]u8;
+    if (!t_planner_environment_digest(?a, (?entries[0])::**u8, ?reordered[0])) { ret 3; }
+    if (ut_digest_differs(?initial[0], ?reordered[0])) { ret 4; }
+    entries[1] = ("MACH_3146_B=changed inherited value")::usize;
+    var changed: [32]u8;
+    if (!t_planner_environment_digest(?a, (?entries[0])::**u8, ?changed[0])) { ret 5; }
+    if (!ut_digest_differs(?initial[0], ?changed[0])) { ret 6; }
     ret 0;
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -19955,3 +19955,35 @@ test "mach.lang.driver:deprecated_manifest_keys_warn_for_the_root_and_each_depen
     session.dnit(?s);
     ret bad;
 }
+
+fun ut_spirv_float_remainder(src: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str; texts[0] = src;
+    val pr: R.Result[project.Project, outcome.Fail] = ut_spv_lower(?s, ?alloc, ?names[0], ?texts[0], 1, "", nil, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    var image: of.ObjectImage;
+    var err: str = nil;
+    var bad: i32 = 0;
+    if (!ut_spv_codegen(?p, ?s, "spvcase.main", ?image, ?err)) {
+        print.println(err);
+        bad = 2;
+    }
+    or { obj.dnit(?image); }
+    project.dnit_project(?p);
+    session.dnit(?s);
+    ret bad;
+}
+
+test "mach.lang.driver:spirv_float_remainder_f32_has_structured_control_flow" {
+    ret ut_spirv_float_remainder("pub fun remainder(a: f32, b: f32) f32 { ret a % b; }\n");
+}
+
+test "mach.lang.driver:spirv_float_remainder_f64_has_structured_control_flow" {
+    ret ut_spirv_float_remainder("pub fun remainder(a: f64, b: f64) f64 { ret a % b; }\n");
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1,4 +1,5 @@
 use std.allocator.page;
+use std.allocator.arena;
 use std.collections.map;
 use std.collections.vector;
 use fs: std.filesystem;
@@ -19986,4 +19987,65 @@ test "mach.lang.driver:spirv_float_remainder_f32_has_structured_control_flow" {
 
 test "mach.lang.driver:spirv_float_remainder_f64_has_structured_control_flow" {
     ret ut_spirv_float_remainder("pub fun remainder(a: f64, b: f64) f64 { ret a % b; }\n");
+}
+
+
+fun ut_float_zero_program() str {
+    ret "val CT_N_D64: u64 = (-6.0f64 % 3.0f64):~u64;\nval CT_N_ND64: u64 = (-6.0f64 % -3.0f64):~u64;\nval CT_P_D64: u64 = (6.0f64 % 3.0f64):~u64;\nval CT_P_ND64: u64 = (6.0f64 % -3.0f64):~u64;\nval CT_NZ_D64: u64 = (-0.0f64 % 3.0f64):~u64;\nval CT_NZ_ND64: u64 = (-0.0f64 % -3.0f64):~u64;\nval CT_Z_D64: u64 = (0.0f64 % 3.0f64):~u64;\nval CT_Z_ND64: u64 = (0.0f64 % -3.0f64):~u64;\nval CT_N_D32: u32 = (-6.0f32 % 3.0f32):~u32;\nval CT_N_ND32: u32 = (-6.0f32 % -3.0f32):~u32;\nval CT_P_D32: u32 = (6.0f32 % 3.0f32):~u32;\nval CT_P_ND32: u32 = (6.0f32 % -3.0f32):~u32;\nval CT_NZ_D32: u32 = (-0.0f32 % 3.0f32):~u32;\nval CT_NZ_ND32: u32 = (-0.0f32 % -3.0f32):~u32;\nval CT_Z_D32: u32 = (0.0f32 % 3.0f32):~u32;\nval CT_Z_ND32: u32 = (0.0f32 % -3.0f32):~u32;\npub var N64: f64 = -6.0f64;\npub var P64: f64 = 6.0f64;\npub var Z64: f64 = 0.0f64;\npub var NZ64: f64 = -0.0f64;\npub var D64: f64 = 3.0f64;\npub var ND64: f64 = -3.0f64;\npub var N32: f32 = -6.0f32;\npub var P32: f32 = 6.0f32;\npub var Z32: f32 = 0.0f32;\npub var NZ32: f32 = -0.0f32;\npub var D32: f32 = 3.0f32;\npub var ND32: f32 = -3.0f32;\nfun check64(a: f64, b: f64, bits: u64) i32 {\n    if ((a % b):~u64 != bits) { ret 1; }\n    ret 0;\n}\nfun check32(a: f32, b: f32, bits: u32) i32 {\n    if ((a % b):~u32 != bits) { ret 1; }\n    ret 0;\n}\n#[symbol(\"probe\")]\nfun probe() i32 {\n    if (CT_N_D64 != 0x8000000000000000) { ret 1; }\n    if (check64(N64, D64, CT_N_D64) != 0) { ret 2; }\n    if (CT_N_ND64 != 0x8000000000000000) { ret 3; }\n    if (check64(N64, ND64, CT_N_ND64) != 0) { ret 4; }\n    if (CT_P_D64 != 0) { ret 5; }\n    if (check64(P64, D64, CT_P_D64) != 0) { ret 6; }\n    if (CT_P_ND64 != 0) { ret 7; }\n    if (check64(P64, ND64, CT_P_ND64) != 0) { ret 8; }\n    if (CT_NZ_D64 != 0x8000000000000000) { ret 9; }\n    if (check64(NZ64, D64, CT_NZ_D64) != 0) { ret 10; }\n    if (CT_NZ_ND64 != 0x8000000000000000) { ret 11; }\n    if (check64(NZ64, ND64, CT_NZ_ND64) != 0) { ret 12; }\n    if (CT_Z_D64 != 0) { ret 13; }\n    if (check64(Z64, D64, CT_Z_D64) != 0) { ret 14; }\n    if (CT_Z_ND64 != 0) { ret 15; }\n    if (check64(Z64, ND64, CT_Z_ND64) != 0) { ret 16; }\n    if (CT_N_D32 != 0x80000000) { ret 17; }\n    if (check32(N32, D32, CT_N_D32) != 0) { ret 18; }\n    if (CT_N_ND32 != 0x80000000) { ret 19; }\n    if (check32(N32, ND32, CT_N_ND32) != 0) { ret 20; }\n    if (CT_P_D32 != 0) { ret 21; }\n    if (check32(P32, D32, CT_P_D32) != 0) { ret 22; }\n    if (CT_P_ND32 != 0) { ret 23; }\n    if (check32(P32, ND32, CT_P_ND32) != 0) { ret 24; }\n    if (CT_NZ_D32 != 0x80000000) { ret 25; }\n    if (check32(NZ32, D32, CT_NZ_D32) != 0) { ret 26; }\n    if (CT_NZ_ND32 != 0x80000000) { ret 27; }\n    if (check32(NZ32, ND32, CT_NZ_ND32) != 0) { ret 28; }\n    if (CT_Z_D32 != 0) { ret 29; }\n    if (check32(Z32, D32, CT_Z_D32) != 0) { ret 30; }\n    if (CT_Z_ND32 != 0) { ret 31; }\n    if (check32(Z32, ND32, CT_Z_ND32) != 0) { ret 32; }\n    ret 0;\n}\n$if ($mach.build.os == $mach.os.windows) {\n    #[symbol(\"mainCRTStartup\")]\n    fun start() i32 { ret probe(); }\n}\n$or {\n    #[symbol(\"_start\")]\n    pub fun start() {\n        $if ($mach.build.arch == $mach.arch.x86_64) {\n            asm x86_64 {\n                and rsp, -16\n                call probe\n                mov edi, eax\n                mov rax, 60\n                syscall\n            }\n        }\n        $or ($mach.build.arch == $mach.arch.aarch64) {\n            asm aarch64 {\n                bl probe\n                mov x8, 93\n                svc 0\n            }\n        }\n        $or {\n            asm riscv64 {\n                call probe\n                li a7, 93\n                ecall\n            }\n        }\n    }\n}\n";
+}
+
+fun ut_float_zero_manifest() str {
+    ret "[project]\nid=\"remainder\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out/{target.name}/{profile.name}\"\n[target.linux]\nisa=\"x86_64\"\nos=\"linux\"\nabi=\"sysv64\"\n[target.windows]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n[target.linux-arm64]\nisa=\"aarch64\"\nos=\"linux\"\nabi=\"aapcs64\"\n[target.linux-riscv64]\nisa=\"riscv64\"\nos=\"linux\"\nabi=\"lp64d\"\n[profile.debug]\nopt=0\ndebug=false\nsimd=\"scalarize\"\n[profile.release]\nopt=2\ndebug=false\nsimd=\"scalarize\"\n[artifact.probe]\nkind=\"bin\"\nentry=\"main.mach\"\nout=\"bin/probe.exe\"\ntargets=[\"*\"]\nlink=[]\nneed=[]\n";
+}
+
+fun ut_float_zero_profile(alloc: *A.Allocator, root: str, profile_name: str) i32 {
+    val sr: R.Result[session.Session, str] = session.init(alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { ret 2; }
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) { ret 3; }
+    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = root;
+    rq.target = "native";
+    rq.profile = profile_name;
+    val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, ?s.registry, ?m, rq);
+    if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { ret 4; }
+    var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
+    val br: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, alloc, nil);
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](br)) { ret 5; }
+    val bo: outcome.BuildOutcome = R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](br);
+    if (bo.severity != outcome.BUILD_OK || bo.artifacts.len != 1) { ret 6; }
+    var trapped: bool = false;
+    var code: i32 = 0;
+    if (!ut_run_with_argc(alloc, "", bo.artifacts.data[0].path, 1, ?trapped, ?code)) { ret 7; }
+    if (trapped || code != 0) {
+        print.printf("float remainder {} child exit {}\n", profile_name, code);
+        ret 8;
+    }
+    ret 0;
+}
+
+test "mach.lang.driver: floating remainder preserves signed zero in emitted native programs" {
+    $if ($mach.build.os != $mach.os.linux && $mach.build.os != $mach.os.windows) { ret 0; }
+    var backing: A.Allocator;
+    var ar: arena.Arena;
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    if (O.is_some[str](arena.init(?ar, ?backing, 0))) { ret 2; }
+    fin { arena.dnit(?ar); }
+    if (O.is_some[str](arena.make(?alloc, ?ar))) { ret 3; }
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str; texts[0] = ut_float_zero_program();
+    val root_r: R.Result[str, str] = ut_scaffold_m(?alloc, ut_float_zero_manifest(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { ret 4; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    fin { fs.remove_all(?alloc, root); }
+    val debug: i32 = ut_float_zero_profile(?alloc, root, "debug");
+    if (debug != 0) { print.printf("float remainder debug build/run exit {}\n", debug); ret 5; }
+    val release: i32 = ut_float_zero_profile(?alloc, root, "release");
+    if (release != 0) { print.printf("float remainder release build/run exit {}\n", release); ret 6; }
+    ret 0;
 }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2,6 +2,7 @@ use std.allocator.arena;
 use std.allocator.page;
 use std.data.toml;
 use std.format;
+use process_env: std.process.env;
 use std.system.panic.panic;
 use std.memory;
 use std.text.string.str_free;
@@ -1835,6 +1836,21 @@ fun env_key_compare(a: str, b: str) i64 {
     ret str_compare(a, b);
 }
 
+fun env_keys_ambiguous(left: str, right: str) R.Result[bool, str] {
+    val length: usize = str_len(left);
+    if (length == str_len(right)) {
+        var i: usize = 0;
+        for (i < length && char_to_lower(left[i]::char) == char_to_lower(right[i]::char)) { i = i + 1; }
+        if (i == length) { ret R.ok[bool, str](true); }
+    }
+    $if ($mach.build.os == $mach.os.windows) {
+        val order: R.Result[i32, str] = process_env.compare_names(left, right);
+        if (R.is_err[i32, str](order)) { ret R.err[bool, str](R.unwrap_err[i32, str](order)); }
+        ret R.ok[bool, str](R.unwrap_ok[i32, str](order) == 0);
+    }
+    $or { ret R.ok[bool, str](false); }
+}
+
 fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *Manifest, as_root: bool) R.Result[R.Void, str] {
     val tab: *toml.Table = toml.get_table(t, "step");
     if (tab == nil) { ret R.ok_void[str](); }
@@ -1934,12 +1950,10 @@ fun parse_steps(alloc: *A.Allocator, itn: *intern.Interner, t: *toml.Table, m: *
                     var ej: usize = 0;
                     for (ej < ei) {
                         val prior: str = idstr(itn, d.env_keys[ej]);
-                        if (str_len(prior) == str_len(env_key)) {
-                            var ek: usize = 0;
-                            for (ek < str_len(env_key) && char_to_lower(prior[ek]::char) == char_to_lower(env_key[ek]::char)) { ek = ek + 1; }
-                            if (ek == str_len(env_key)) {
-                                ret step_parse_error(alloc, label, sfmt(alloc, "mach.toml: {}.env has ambiguous keys '{}' and '{}'", label, prior, env_key));
-                            }
+                        val ambiguous: R.Result[bool, str] = env_keys_ambiguous(prior, env_key);
+                        if (R.is_err[bool, str](ambiguous)) { ret step_parse_error(alloc, label, R.unwrap_err[bool, str](ambiguous)); }
+                        if (R.unwrap_ok[bool, str](ambiguous)) {
+                            ret step_parse_error(alloc, label, sfmt(alloc, "mach.toml: {}.env has ambiguous keys '{}' and '{}'", label, prior, env_key));
                         }
                         ej = ej + 1;
                     }
@@ -7348,4 +7362,26 @@ test "mach.lang.manifest.parse:env_is_a_target_key_carried_verbatim" {
     if (R.is_ok[Manifest, str](bad) || !str_contains(R.unwrap_err[Manifest, str](bad), "env must be a non-empty string")) { code = 1; }
     arena.dnit(?ar);
     ret code;
+}
+
+
+test "mach.lang.manifest.parse: Windows Unicode environment names cannot alias" {
+    var backing: A.Allocator;
+    var ar: arena.Arena;
+    var alloc: A.Allocator;
+    var itn: intern.Interner;
+    if (!tinit(?backing, ?ar, ?alloc, ?itn)) { ret 1; }
+    fin { arena.dnit(?ar); }
+    val source: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n[step.s]\nargv=[\"true\"]\nin=[]\nout=[]\nneed=[]\n[step.s.env]\n\"MACH_ÄΩ\"=\"first\"\n\"mach_äω\"=\"second\"\n";
+    val parsed: R.Result[Manifest, str] = tparse(?alloc, ?itn, source);
+    $if ($mach.build.os == $mach.os.windows) {
+        if (R.is_ok[Manifest, str](parsed)) { ret 2; }
+        if (!str_contains(R.unwrap_err[Manifest, str](parsed), "ambiguous keys")) { ret 3; }
+    }
+    $or {
+        if (R.is_err[Manifest, str](parsed)) { ret 4; }
+        val manifest: Manifest = R.unwrap_ok[Manifest, str](parsed);
+        if (manifest.step_count != 1 || manifest.steps[0].env_count != 2) { ret 5; }
+    }
+    ret 0;
 }

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -7199,10 +7199,16 @@ test "mach.lang.manifest.resolve_target:native_without_a_host_match_uses_the_sol
 
     val head: str = "[project]\nid=\"x\"\nversion=\"1\"\nsrc=\"src\"\nout=\"out\"\n";
     val art: str = "[artifact.app]\nkind=\"bin\"\nentry=\"a.mach\"\nout=\"bin/app\"\ntargets=[\"*\"]\nlink=[]\nneed=[]\n";
-    val w1: str = "[target.w1]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n";
-    val w2: str = "[target.w2]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\n";
-    val w2_default: str = "[target.w2]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\ndefault=true\n";
-    val w1_default: str = "[target.w1]\nisa=\"x86_64\"\nos=\"windows\"\nabi=\"win64\"\ndefault=true\n";
+    var foreign_os: str = "windows";
+    var foreign_abi: str = "win64";
+    $if ($mach.build.os == $mach.os.windows) {
+        foreign_os = "linux";
+        foreign_abi = "sysv64";
+    }
+    val w1: str = sfmt(?alloc, "[target.w1]\nisa=\"x86_64\"\nos=\"{}\"\nabi=\"{}\"\n", foreign_os, foreign_abi);
+    val w2: str = sfmt(?alloc, "[target.w2]\nisa=\"x86_64\"\nos=\"{}\"\nabi=\"{}\"\n", foreign_os, foreign_abi);
+    val w2_default: str = sfmt(?alloc, "{}default=true\n", w2);
+    val w1_default: str = sfmt(?alloc, "{}default=true\n", w1);
     val native: Selection = mk_sel("native", "", "", false, false);
 
     val sr: R.Result[Manifest, str] = tparse(?alloc, ?itn, sfmt(?alloc, "{}{}{}", head, w1, art));

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -4208,7 +4208,18 @@ fun hex_digit(v: u8) u8 {
 
 fun toml_escape_value(alloc: *A.Allocator, s: str) R.Result[str, str] {
     val n: usize = str_len(s);
-    val cap: usize = n * 6 + 1;
+    var cap: usize = 1;
+    var offset: usize = 0;
+    for (offset < n) {
+        val c: u8 = s[offset];
+        var width: usize = 1;
+        if (c == '\\'::u8 || c == '"'::u8 || c == '\n'::u8 || c == '\r'::u8
+            || c == '\t'::u8 || c == 8::u8 || c == 12::u8) { width = 2; }
+        or (c < 32::u8 || c == 127::u8) { width = 6; }
+        if (cap > 0xffffffffffffffff::usize - width) { ret R.err[str, str]("escaped TOML value is too long"); }
+        cap = cap + width;
+        offset = offset + 1;
+    }
     val r: R.Result[*u8, str] = A.allocate[u8](alloc, cap);
     if (R.is_err[*u8, str](r)) { ret R.err[str, str](R.unwrap_err[*u8, str](r)); }
     val buf: *u8 = R.unwrap_ok[*u8, str](r);
@@ -7382,6 +7393,44 @@ test "mach.lang.manifest.parse: Windows Unicode environment names cannot alias" 
         if (R.is_err[Manifest, str](parsed)) { ret 4; }
         val manifest: Manifest = R.unwrap_ok[Manifest, str](parsed);
         if (manifest.step_count != 1 || manifest.steps[0].env_count != 2) { ret 5; }
+    }
+    ret 0;
+}
+
+
+test "mach.lang.manifest: escaped TOML strings retain exact allocation ownership" {
+    var large: [1025]u8;
+    var i: usize = 0;
+    for (i < 1024) { large[i] = 'x'; i = i + 1; }
+    large[1024] = 0;
+    var control: [3]u8;
+    control[0] = 1;
+    control[1] = 127;
+    control[2] = 0;
+    var inputs: [6]str;
+    var expected: [6]str;
+    inputs[0] = ""; expected[0] = "";
+    inputs[1] = "x"; expected[1] = "x";
+    inputs[2] = "\\\"\n\r\t\x08\x0c"; expected[2] = "\\\\\\\"\\n\\r\\t\\b\\f";
+    inputs[3] = (?control[0])::str; expected[3] = "\\u0001\\u007f";
+    inputs[4] = "ÄΩ"; expected[4] = "ÄΩ";
+    inputs[5] = (?large[0])::str; expected[5] = (?large[0])::str;
+    i = 0;
+    for (i < 6) {
+        var probe: PlanAllocProbe;
+        var alloc: A.Allocator;
+        if (!plan_probe_make(?probe, ?alloc, 0)) { ret 1; }
+        val escaped: R.Result[str, str] = toml_escape_value(?alloc, inputs[i]);
+        if (R.is_err[str, str](escaped)) { ret 2; }
+        val text: str = R.unwrap_ok[str, str](escaped);
+        val correct: bool = str_equals(text, expected[i]);
+        str_free(?alloc, text);
+        if (!correct || probe.live != 0 || probe.mismatch || probe.calls != 1) { ret 3; }
+        if (!plan_probe_make(?probe, ?alloc, 1)) { ret 4; }
+        val refused: R.Result[str, str] = toml_escape_value(?alloc, inputs[i]);
+        if (R.is_ok[str, str](refused)) { str_free(?alloc, R.unwrap_ok[str, str](refused)); ret 5; }
+        if (probe.live != 0 || probe.mismatch || probe.calls != 1) { ret 6; }
+        i = i + 1;
     }
     ret 0;
 }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1905,7 +1905,7 @@ fun float_rem_general(ctx: *context.LowerContext, lhs: value.Value, rhs: value.V
     if (R.is_err[R.Void, str](res_cbr)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_cbr))); }
 
     builder.set_block(?ctx.builder, blk_neg);
-    val res_negr: R.Result[value.Value, str] = builder.emit_sub(?ctx.builder, zero, reduced);
+    val res_negr: R.Result[value.Value, str] = builder.emit_neg(?ctx.builder, reduced);
     if (R.is_err[value.Value, str](res_negr)) { ret fail.lift[value.Value](res_negr); }
     val neg_reduced: value.Value = R.unwrap_ok[value.Value, str](res_negr);
     val res_br1: R.Result[R.Void, str] = builder.emit_br(?ctx.builder, blk_merge);

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1927,54 +1927,84 @@ fun float_rem_general(ctx: *context.LowerContext, lhs: value.Value, rhs: value.V
     ret R.ok[value.Value, fail.Fail](phi);
 }
 
-fun lower_float_rem(ctx: *context.LowerContext, lhs: value.Value, rhs: value.Value) R.Result[value.Value, fail.Fail] {
-    val zero: value.Value = value.const_float(0.0, lhs.ty);
-    val two:  value.Value = value.const_float(2.0, lhs.ty);
-
+fun float_rem_needs_narrow(ctx: *context.LowerContext, lhs: value.Value, rhs: value.Value, zero: value.Value, two: value.Value) R.Result[value.Value, fail.Fail] {
     val res_bzero: R.Result[value.Value, str] = builder.emit_cmp_eq(?ctx.builder, rhs, zero);
     if (R.is_err[value.Value, str](res_bzero)) { ret fail.lift[value.Value](res_bzero); }
     val b_zero: value.Value = R.unwrap_ok[value.Value, str](res_bzero);
+    val blk_entry: ir.BlockId = ctx.builder.block;
 
-    val res_bn: R.Result[ir.BlockId, str] = builder.new_block(?ctx.builder);
-    if (R.is_err[ir.BlockId, str](res_bn)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[ir.BlockId, str](res_bn))); }
-    val blk_narrow: ir.BlockId = R.unwrap_ok[ir.BlockId, str](res_bn);
+    val res_check: R.Result[ir.BlockId, str] = builder.new_block(?ctx.builder);
+    if (R.is_err[ir.BlockId, str](res_check)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[ir.BlockId, str](res_check))); }
+    val blk_check: ir.BlockId = R.unwrap_ok[ir.BlockId, str](res_check);
+    val res_nonzero: R.Result[ir.BlockId, str] = builder.new_block(?ctx.builder);
+    if (R.is_err[ir.BlockId, str](res_nonzero)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[ir.BlockId, str](res_nonzero))); }
+    val blk_nonzero: ir.BlockId = R.unwrap_ok[ir.BlockId, str](res_nonzero);
+    val res_inner: R.Result[ir.BlockId, str] = builder.new_block(?ctx.builder);
+    if (R.is_err[ir.BlockId, str](res_inner)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[ir.BlockId, str](res_inner))); }
+    val blk_inner: ir.BlockId = R.unwrap_ok[ir.BlockId, str](res_inner);
+    val res_outer: R.Result[ir.BlockId, str] = builder.new_block(?ctx.builder);
+    if (R.is_err[ir.BlockId, str](res_outer)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[ir.BlockId, str](res_outer))); }
+    val blk_outer: ir.BlockId = R.unwrap_ok[ir.BlockId, str](res_outer);
 
-    val res_bci: R.Result[ir.BlockId, str] = builder.new_block(?ctx.builder);
-    if (R.is_err[ir.BlockId, str](res_bci)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[ir.BlockId, str](res_bci))); }
-    val blk_chk_inf: ir.BlockId = R.unwrap_ok[ir.BlockId, str](res_bci);
-
-    val res_cbr0: R.Result[R.Void, str] = builder.emit_cbr(?ctx.builder, b_zero, blk_narrow, blk_chk_inf);
+    val res_cbr0: R.Result[R.Void, str] = builder.emit_cbr(?ctx.builder, b_zero, blk_outer, blk_check);
     if (R.is_err[R.Void, str](res_cbr0)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_cbr0))); }
-
-    builder.set_block(?ctx.builder, blk_chk_inf);
+    builder.set_block(?ctx.builder, blk_check);
     val res_a2: R.Result[value.Value, str] = builder.emit_mul(?ctx.builder, lhs, two);
     if (R.is_err[value.Value, str](res_a2)) { ret fail.lift[value.Value](res_a2); }
     val a2: value.Value = R.unwrap_ok[value.Value, str](res_a2);
     val res_eqa2: R.Result[value.Value, str] = builder.emit_cmp_eq(?ctx.builder, lhs, a2);
     if (R.is_err[value.Value, str](res_eqa2)) { ret fail.lift[value.Value](res_eqa2); }
     val a_eq_2a: value.Value = R.unwrap_ok[value.Value, str](res_eqa2);
+    val res_cbr1: R.Result[R.Void, str] = builder.emit_cbr(?ctx.builder, a_eq_2a, blk_nonzero, blk_inner);
+    if (R.is_err[R.Void, str](res_cbr1)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_cbr1))); }
 
-    val res_bci2: R.Result[ir.BlockId, str] = builder.new_block(?ctx.builder);
-    if (R.is_err[ir.BlockId, str](res_bci2)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[ir.BlockId, str](res_bci2))); }
-    val blk_chk_inf2: ir.BlockId = R.unwrap_ok[ir.BlockId, str](res_bci2);
+    builder.set_block(?ctx.builder, blk_nonzero);
+    val res_ne: R.Result[value.Value, str] = builder.emit_cmp_ne(?ctx.builder, lhs, zero);
+    if (R.is_err[value.Value, str](res_ne)) { ret fail.lift[value.Value](res_ne); }
+    val a_ne_zero: value.Value = R.unwrap_ok[value.Value, str](res_ne);
+    val res_br_inner: R.Result[R.Void, str] = builder.emit_br(?ctx.builder, blk_inner);
+    if (R.is_err[R.Void, str](res_br_inner)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_br_inner))); }
 
+    builder.set_block(?ctx.builder, blk_inner);
+    val res_iphi: R.Result[value.Value, str] = builder.emit_phi(?ctx.builder, b_zero.ty);
+    if (R.is_err[value.Value, str](res_iphi)) { ret fail.lift[value.Value](res_iphi); }
+    val inner: value.Value = R.unwrap_ok[value.Value, str](res_iphi);
+    val res_i0: R.Result[R.Void, str] = builder.phi_add_incoming(?ctx.builder, inner, blk_check, a_eq_2a);
+    if (R.is_err[R.Void, str](res_i0)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_i0))); }
+    val res_i1: R.Result[R.Void, str] = builder.phi_add_incoming(?ctx.builder, inner, blk_nonzero, a_ne_zero);
+    if (R.is_err[R.Void, str](res_i1)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_i1))); }
+    val res_br_outer: R.Result[R.Void, str] = builder.emit_br(?ctx.builder, blk_outer);
+    if (R.is_err[R.Void, str](res_br_outer)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_br_outer))); }
+
+    builder.set_block(?ctx.builder, blk_outer);
+    val res_ophi: R.Result[value.Value, str] = builder.emit_phi(?ctx.builder, b_zero.ty);
+    if (R.is_err[value.Value, str](res_ophi)) { ret fail.lift[value.Value](res_ophi); }
+    val outer: value.Value = R.unwrap_ok[value.Value, str](res_ophi);
+    val res_o0: R.Result[R.Void, str] = builder.phi_add_incoming(?ctx.builder, outer, blk_entry, b_zero);
+    if (R.is_err[R.Void, str](res_o0)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_o0))); }
+    val res_o1: R.Result[R.Void, str] = builder.phi_add_incoming(?ctx.builder, outer, blk_inner, inner);
+    if (R.is_err[R.Void, str](res_o1)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_o1))); }
+    ret R.ok[value.Value, fail.Fail](outer);
+}
+
+fun lower_float_rem(ctx: *context.LowerContext, lhs: value.Value, rhs: value.Value) R.Result[value.Value, fail.Fail] {
+    val zero: value.Value = value.const_float(0.0, lhs.ty);
+    val two: value.Value = value.const_float(2.0, lhs.ty);
+    val res_narrow_needed: R.Result[value.Value, fail.Fail] = float_rem_needs_narrow(ctx, lhs, rhs, zero, two);
+    if (R.is_err[value.Value, fail.Fail](res_narrow_needed)) { ret res_narrow_needed; }
+    val narrow_needed: value.Value = R.unwrap_ok[value.Value, fail.Fail](res_narrow_needed);
+
+    val res_bn: R.Result[ir.BlockId, str] = builder.new_block(?ctx.builder);
+    if (R.is_err[ir.BlockId, str](res_bn)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[ir.BlockId, str](res_bn))); }
+    val blk_narrow: ir.BlockId = R.unwrap_ok[ir.BlockId, str](res_bn);
     val res_bg: R.Result[ir.BlockId, str] = builder.new_block(?ctx.builder);
     if (R.is_err[ir.BlockId, str](res_bg)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[ir.BlockId, str](res_bg))); }
     val blk_general: ir.BlockId = R.unwrap_ok[ir.BlockId, str](res_bg);
-
     val res_bj: R.Result[ir.BlockId, str] = builder.new_block(?ctx.builder);
     if (R.is_err[ir.BlockId, str](res_bj)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[ir.BlockId, str](res_bj))); }
     val blk_join: ir.BlockId = R.unwrap_ok[ir.BlockId, str](res_bj);
-
-    val res_cbr1: R.Result[R.Void, str] = builder.emit_cbr(?ctx.builder, a_eq_2a, blk_chk_inf2, blk_general);
-    if (R.is_err[R.Void, str](res_cbr1)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_cbr1))); }
-
-    builder.set_block(?ctx.builder, blk_chk_inf2);
-    val res_ane0: R.Result[value.Value, str] = builder.emit_cmp_ne(?ctx.builder, lhs, zero);
-    if (R.is_err[value.Value, str](res_ane0)) { ret fail.lift[value.Value](res_ane0); }
-    val a_ne_zero: value.Value = R.unwrap_ok[value.Value, str](res_ane0);
-    val res_cbr2: R.Result[R.Void, str] = builder.emit_cbr(?ctx.builder, a_ne_zero, blk_narrow, blk_general);
-    if (R.is_err[R.Void, str](res_cbr2)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_cbr2))); }
+    val res_cbr: R.Result[R.Void, str] = builder.emit_cbr(?ctx.builder, narrow_needed, blk_narrow, blk_general);
+    if (R.is_err[R.Void, str](res_cbr)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_cbr))); }
 
     builder.set_block(?ctx.builder, blk_narrow);
     val res_narrow: R.Result[value.Value, fail.Fail] = float_rem_narrow(ctx, lhs, rhs);

--- a/src/lang/publication.mach
+++ b/src/lang/publication.mach
@@ -147,7 +147,7 @@ pub fun writer[W](itn: *intern.Interner, a: *A.Allocator, path: str, ctx: *W,
 
 pub fun subtree(a: *A.Allocator, d: *txn.Descent, inv: *txn.Inventory, dir_mode: i32) R.Result[R.Void, str] {
     val prep_r: R.Result[txn.Transaction, txn.Error] =
-        txn.prepare_subtree(a, ?d.root, d.root_abs, d.first_missing, inv, dir_mode);
+        txn.prepare_subtree(a, ?d.root, d.first_missing, inv, dir_mode);
     if (R.is_err[txn.Transaction, txn.Error](prep_r)) {
         ret R.err[R.Void, str](txn.error_message(R.unwrap_err[txn.Transaction, txn.Error](prep_r)));
     }

--- a/test/census/real-bools.txt
+++ b/test/census/real-bools.txt
@@ -10,6 +10,7 @@ src/lang/build/plan.mach:steps_demanded
 src/lang/diagnostic.mach:gate_commit
 src/lang/diagnostic.mach:gate_error
 src/lang/diagnostic.mach:gate_error_named
+src/lang/driver/config.mach:is_target_env_key
 src/lang/driver/deps.mach:git_symlink_tracked
 src/lang/driver/deps.mach:module_file_present
 src/lang/driver/load.mach:has_deferred_dependency
@@ -30,13 +31,14 @@ src/lang/fe/comptime.mach:gate_depends_on_pair
 src/lang/fe/comptime.mach:gate_needs_typed_selection
 src/lang/fe/comptime.mach:gate_walk
 src/lang/fe/resolve.mach:gate_chain_defers_to_instantiation
-src/lang/fe/sema/infer.mach:reaches_nominal
 src/lang/fe/sema.mach:comptime_branch_active
 src/lang/fe/sema.mach:decl_gate_is_active
 src/lang/fe/sema.mach:gate_chain_depends
 src/lang/fe/sema.mach:prune_type_comparison_chain
 src/lang/fe/sema.mach:stmt_comptime_branch_active
+src/lang/fe/sema/infer.mach:reaches_nominal
 src/lang/manifest.mach:cell_supported
+src/lang/manifest.mach:env_keys_ambiguous
 src/lang/manifest.mach:parse_debug_flag
 src/lang/manifest.mach:parse_default_flag
 src/lang/manifest.mach:parse_float_reassoc_flag

--- a/test/census/real-bools.txt
+++ b/test/census/real-bools.txt
@@ -10,6 +10,10 @@ src/lang/build/plan.mach:steps_demanded
 src/lang/diagnostic.mach:gate_commit
 src/lang/diagnostic.mach:gate_error
 src/lang/diagnostic.mach:gate_error_named
+src/lang/driver/config.mach:is_target_env_key
+src/lang/driver/deps.mach:env_names_git_config
+src/lang/driver/deps.mach:git_env_prefix
+src/lang/driver/deps.mach:git_inherits_env
 src/lang/driver/deps.mach:git_symlink_tracked
 src/lang/driver/deps.mach:module_file_present
 src/lang/driver/load.mach:has_deferred_dependency
@@ -37,6 +41,7 @@ src/lang/fe/sema.mach:gate_chain_depends
 src/lang/fe/sema.mach:prune_type_comparison_chain
 src/lang/fe/sema.mach:stmt_comptime_branch_active
 src/lang/manifest.mach:cell_supported
+src/lang/manifest.mach:env_keys_ambiguous
 src/lang/manifest.mach:parse_debug_flag
 src/lang/manifest.mach:parse_default_flag
 src/lang/manifest.mach:parse_float_reassoc_flag

--- a/test/checked-types/verify.sh
+++ b/test/checked-types/verify.sh
@@ -38,8 +38,13 @@ trap 'rm -rf "$work"' EXIT
 git init -q "$work"
 mkdir -p "$work/project" "$work/provider" "$work/std"
 sed 's|path = "provider"|path = "../provider"|' "$here/mach.toml" > "$work/project/mach.toml"
+cat >> "$work/project/mach.toml" <<'EOF'
+
+[dep.std]
+path = "../std"
+EOF
 cp -R "$here/src" "$work/project/"
-sed 's|path = "../../../dep/std"|path = "../std"|' "$here/provider/mach.toml" > "$work/provider/mach.toml"
+cp "$here/provider/mach.toml" "$work/provider/"
 cp -R "$root/src" "$work/provider/"
 cp "$root/dep/std/mach.toml" "$work/std/"
 cp -R "$root/dep/std/src" "$work/std/"

--- a/test/checked-types/verify.sh
+++ b/test/checked-types/verify.sh
@@ -33,16 +33,23 @@ if [ ! -f "$compiler" ]; then
     exit 2
 fi
 
-if [ ! -e "$here/provider/src" ]; then
-    ln -s ../../../src "$here/provider/src"
-fi
-"$compiler" dep pull "$here" >/dev/null
+work=$(mktemp -d)
+trap 'rm -rf "$work"' EXIT
+git init -q "$work"
+mkdir -p "$work/project" "$work/provider" "$work/std"
+sed 's|path = "provider"|path = "../provider"|' "$here/mach.toml" > "$work/project/mach.toml"
+cp -R "$here/src" "$work/project/"
+sed 's|path = "../../../dep/std"|path = "../std"|' "$here/provider/mach.toml" > "$work/provider/mach.toml"
+cp -R "$root/src" "$work/provider/"
+cp "$root/dep/std/mach.toml" "$work/std/"
+cp -R "$root/dep/std/src" "$work/std/"
+"$compiler" dep pull "$work/project" >/dev/null
 
 verify_rejection() {
     artifact=$1
     first_type=$2
     second_type=$3
-    if output=$("$compiler" build "$here" --lib "$artifact" --emit obj 2>&1); then
+    if output=$("$compiler" build "$work/project" --lib "$artifact" --emit obj 2>&1); then
         echo "checked-types: $artifact unexpectedly compiled" >&2
         exit 1
     fi

--- a/test/golden/aarch64-darwin/float/arith_f32.dis
+++ b/test/golden/aarch64-darwin/float/arith_f32.dis
@@ -401,8 +401,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d6, d4
                	b	 <L76>
 <L75>:
-               	fmov	s31, wzr
-               	fsub	s6, s31, s4
+               	fneg	s6, s4
 <L76>:
                	b	 <L82>
 <L77>:
@@ -505,8 +504,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d7, d5
                	b	 <L98>
 <L97>:
-               	fmov	s31, wzr
-               	fsub	s7, s31, s5
+               	fneg	s7, s5
 <L98>:
                	b	 <L104>
 <L99>:
@@ -609,8 +607,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d7, d5
                	b	 <L120>
 <L119>:
-               	fmov	s31, wzr
-               	fsub	s7, s31, s5
+               	fneg	s7, s5
 <L120>:
                	b	 <L126>
 <L121>:
@@ -715,8 +712,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d16, d6
                	b	 <L142>
 <L141>:
-               	fmov	s31, wzr
-               	fsub	s16, s31, s6
+               	fneg	s16, s6
 <L142>:
                	b	 <L148>
 <L143>:
@@ -822,8 +818,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d7, d5
                	b	 <L164>
 <L163>:
-               	fmov	s31, wzr
-               	fsub	s7, s31, s5
+               	fneg	s7, s5
 <L164>:
                	b	 <L170>
 <L165>:
@@ -926,8 +921,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d6, d4
                	b	 <L186>
 <L185>:
-               	fmov	s31, wzr
-               	fsub	s6, s31, s4
+               	fneg	s6, s4
 <L186>:
                	b	 <L192>
 <L187>:
@@ -1028,8 +1022,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d6, d4
                	b	 <L208>
 <L207>:
-               	fmov	s31, wzr
-               	fsub	s6, s31, s4
+               	fneg	s6, s4
 <L208>:
                	b	 <L214>
 <L209>:
@@ -1133,8 +1126,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d7, d5
                	b	 <L230>
 <L229>:
-               	fmov	s31, wzr
-               	fsub	s7, s31, s5
+               	fneg	s7, s5
 <L230>:
                	b	 <L236>
 <L231>:

--- a/test/golden/aarch64-darwin/float/arith_f32.dis
+++ b/test/golden/aarch64-darwin/float/arith_f32.dis
@@ -123,758 +123,740 @@ Disassembly of section __TEXT,__text:
                	mov	x20, x0
 <L16>:
                	fdiv	s0, s9, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L18>
                	mov	x0, x20
 <L17>:
                	bl	 <L17>
-               	mov	x19, x0
-               	b	 <L20>
+               	fdiv	s0, s10, s9
 <L18>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L18>
+               	fneg	s0, s9
 <L19>:
                	bl	 <L19>
-               	mov	x19, x0
+               	fmov	s31, wzr
+               	fsub	s10, s31, s9
+               	fmov	s0, s10
 <L20>:
-               	fdiv	s0, s10, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L22>
-               	mov	x0, x19
+               	bl	 <L20>
+               	fsub	s0, s9, s9
 <L21>:
                	bl	 <L21>
-               	mov	x20, x0
-               	b	 <L24>
+               	fadd	s0, s10, s9
 <L22>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L23>:
-               	bl	 <L23>
-               	mov	x20, x0
-<L24>:
-               	fneg	s0, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L26>
-               	mov	x0, x20
-<L25>:
-               	bl	 <L25>
-               	mov	x19, x0
-               	b	 <L28>
-<L26>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L27>:
-               	bl	 <L27>
-               	mov	x19, x0
-<L28>:
-               	fmov	s31, wzr
-               	fsub	s0, s31, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L30>
-               	mov	x0, x19
-<L29>:
-               	bl	 <L29>
-               	mov	x20, x0
-               	b	 <L32>
-<L30>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L31>:
-               	bl	 <L31>
-               	mov	x20, x0
-<L32>:
-               	fsub	s0, s9, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L34>
-               	mov	x0, x20
-<L33>:
-               	bl	 <L33>
-               	mov	x19, x0
-               	b	 <L36>
-<L34>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L35>:
-               	bl	 <L35>
-               	mov	x19, x0
-<L36>:
-               	fmov	s31, wzr
-               	fsub	s0, s31, s9
-               	fadd	s1, s0, s9
-               	fcmp	s1, s1
-               	cset	w0, ne
-               	cbnz	w0,  <L38>
-               	mov	x0, x19
-               	fmov	s0, s1
-<L37>:
-               	bl	 <L37>
-               	mov	x20, x0
-               	b	 <L40>
-<L38>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L39>:
-               	bl	 <L39>
-               	mov	x20, x0
-<L40>:
+               	bl	 <L22>
                	fmov	s31, #3.00000000
                	fmul	s9, s31, s8
                	fdiv	s10, s8, s9
-               	fcmp	s10, s10
-               	cset	w0, ne
-               	cbnz	w0,  <L42>
-               	mov	x0, x20
                	fmov	s0, s10
-<L41>:
-               	bl	 <L41>
-               	mov	x19, x0
-               	b	 <L44>
-<L42>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L43>:
-               	bl	 <L43>
-               	mov	x19, x0
-<L44>:
+<L23>:
+               	bl	 <L23>
                	fmul	s0, s10, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L46>
-               	mov	x0, x19
-<L45>:
-               	bl	 <L45>
-               	mov	x20, x0
-               	b	 <L48>
-<L46>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L47>:
-               	bl	 <L47>
-               	mov	x20, x0
-<L48>:
+<L24>:
+               	bl	 <L24>
                	fsub	s0, s8, s10
                	fsub	s1, s0, s10
                	fsub	s0, s1, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L50>
-               	mov	x0, x20
-<L49>:
-               	bl	 <L49>
-               	mov	x19, x0
-               	b	 <L52>
-<L50>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L51>:
-               	bl	 <L51>
-               	mov	x19, x0
-<L52>:
+<L25>:
+               	bl	 <L25>
                	mov	w16, #0x42440000        ; =1111752704
                	fmov	s30, w16
                	fdiv	s0, s8, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L54>
-               	mov	x0, x19
-<L53>:
-               	bl	 <L53>
-               	mov	x20, x0
-               	b	 <L56>
-<L54>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L55>:
-               	bl	 <L55>
-               	mov	x20, x0
-<L56>:
+<L26>:
+               	bl	 <L26>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f32.opaque_f32>
                	ldr	s30, [x16]
                	fdiv	s0, s8, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L58>
-               	mov	x0, x20
-<L57>:
-               	bl	 <L57>
-               	mov	x19, x0
-               	b	 <L60>
-<L58>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L59>:
-               	bl	 <L59>
-               	mov	x19, x0
-<L60>:
+<L27>:
+               	bl	 <L27>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f32.opaque_f32>
                	ldr	s31, [x16]
                	fdiv	s0, s31, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L62>
-               	mov	x0, x19
-<L61>:
-               	bl	 <L61>
-               	mov	x20, x0
-               	b	 <L64>
-<L62>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L63>:
-               	bl	 <L63>
-               	mov	x20, x0
-<L64>:
+<L28>:
+               	bl	 <L28>
                	mov	w16, #0x4b800000        ; =1266679808
                	fmov	s31, w16
                	fmul	s9, s31, s8
-               	fadd	s0, s9, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L66>
-               	mov	x0, x20
-<L65>:
-               	bl	 <L65>
-               	mov	x19, x0
-               	b	 <L68>
-<L66>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L67>:
-               	bl	 <L67>
-               	mov	x19, x0
-<L68>:
-               	fadd	s0, s9, s8
-               	fadd	s1, s0, s8
-               	fcmp	s1, s1
-               	cset	w0, ne
-               	cbnz	w0,  <L70>
-               	mov	x0, x19
-               	fmov	s0, s1
-<L69>:
-               	bl	 <L69>
-               	mov	x20, x0
-               	b	 <L72>
-<L70>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L71>:
-               	bl	 <L71>
-               	mov	x20, x0
-<L72>:
+               	fadd	s11, s9, s8
+               	fmov	s0, s11
+<L29>:
+               	bl	 <L29>
+               	fadd	s0, s11, s8
+<L30>:
+               	bl	 <L30>
                	fadd	s0, s8, s8
                	fadd	s1, s9, s0
-               	fcmp	s1, s1
-               	cset	w0, ne
-               	cbnz	w0,  <L74>
-               	mov	x0, x20
                	fmov	s0, s1
-<L73>:
-               	bl	 <L73>
-               	mov	x19, x0
-               	b	 <L76>
-<L74>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L75>:
-               	bl	 <L75>
-               	mov	x19, x0
-<L76>:
+<L31>:
+               	bl	 <L31>
                	fsub	s0, s9, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L78>
-               	mov	x0, x19
-<L77>:
-               	bl	 <L77>
-               	mov	x20, x0
-               	b	 <L80>
-<L78>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L79>:
-               	bl	 <L79>
-               	mov	x20, x0
-<L80>:
-               	fadd	s0, s9, s8
-               	fsub	s1, s0, s9
-               	fcmp	s1, s1
-               	cset	w0, ne
-               	cbnz	w0,  <L82>
-               	mov	x0, x20
-               	fmov	s0, s1
-<L81>:
-               	bl	 <L81>
-               	mov	x19, x0
-               	b	 <L84>
-<L82>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L83>:
-               	bl	 <L83>
-               	mov	x19, x0
-<L84>:
+<L32>:
+               	bl	 <L32>
+               	fsub	s0, s11, s9
+<L33>:
+               	bl	 <L33>
                	fmov	s31, wzr
                	fmul	s0, s31, s8
+               	mov	x19, x0
                	fmov	d9, d0
                	mov	w20, #0x0               ; =0
                	cmp	w20, #0x18
-               	b.lo	 <L85>
-               	b	 <L90>
-<L85>:
+               	b.lo	 <L34>
+               	b	 <L39>
+<L34>:
                	fadd	s0, s9, s10
                	fmov	s30, #1.50000000
                	fmul	s11, s0, s30
                	fcmp	s11, s11
                	cset	w0, ne
-               	cbnz	w0,  <L87>
+               	cbnz	w0,  <L36>
                	mov	x0, x19
                	fmov	s0, s11
-<L86>:
-               	bl	 <L86>
+<L35>:
+               	bl	 <L35>
                	mov	x22, x0
-               	b	 <L89>
-<L87>:
+               	b	 <L38>
+<L36>:
                	mov	x0, x19
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L88>:
-               	bl	 <L88>
+<L37>:
+               	bl	 <L37>
                	mov	x22, x0
-<L89>:
+<L38>:
                	add	w20, w20, #0x1
                	mov	x19, x22
                	fmov	d9, d11
                	cmp	w20, #0x18
-               	b.lo	 <L85>
-<L90>:
+               	b.lo	 <L34>
+<L39>:
                	mov	w17, #0xffff            ; =65535
                	movk	w17, #0x7f7f, lsl #16
                	add	w0, w17, w21
                	fmov	s9, w0
                	fcmp	s9, s9
                	cset	w0, ne
-               	cbnz	w0,  <L92>
+               	cbnz	w0,  <L41>
                	mov	x0, x19
                	fmov	s0, s9
-<L91>:
-               	bl	 <L91>
+<L40>:
+               	bl	 <L40>
                	mov	x20, x0
-               	b	 <L94>
-<L92>:
+               	b	 <L43>
+<L41>:
                	mov	x0, x19
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L93>:
-               	bl	 <L93>
+<L42>:
+               	bl	 <L42>
                	mov	x20, x0
-<L94>:
+<L43>:
                	fmov	s30, #2.00000000
                	fdiv	s0, s9, s30
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L96>
+               	cbnz	w0,  <L45>
                	mov	x0, x20
-<L95>:
-               	bl	 <L95>
+<L44>:
+               	bl	 <L44>
                	mov	x19, x0
-               	b	 <L98>
-<L96>:
+               	b	 <L47>
+<L45>:
                	mov	x0, x20
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L97>:
-               	bl	 <L97>
+<L46>:
+               	bl	 <L46>
                	mov	x19, x0
-<L98>:
+<L47>:
                	fadd	s0, s9, s9
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L100>
+               	cbnz	w0,  <L49>
                	mov	x0, x19
-<L99>:
-               	bl	 <L99>
+<L48>:
+               	bl	 <L48>
                	mov	x20, x0
-               	b	 <L102>
-<L100>:
+               	b	 <L51>
+<L49>:
                	mov	x0, x19
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L101>:
-               	bl	 <L101>
+<L50>:
+               	bl	 <L50>
                	mov	x20, x0
-<L102>:
+<L51>:
                	fmov	s30, #2.00000000
-               	fmul	s0, s9, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L104>
+               	fmul	s10, s9, s30
                	mov	x0, x20
-<L103>:
-               	bl	 <L103>
-               	mov	x19, x0
-               	b	 <L106>
-<L104>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L105>:
-               	bl	 <L105>
-               	mov	x19, x0
-<L106>:
-               	fmov	s30, #2.00000000
-               	fmul	s0, s9, s30
+               	fmov	s0, s10
+<L52>:
+               	bl	 <L52>
                	fmov	s31, wzr
-               	fsub	s1, s31, s0
-               	fcmp	s1, s1
-               	cset	w0, ne
-               	cbnz	w0,  <L108>
-               	mov	x0, x19
-               	fmov	s0, s1
-<L107>:
-               	bl	 <L107>
-               	mov	x20, x0
-               	b	 <L110>
-<L108>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L109>:
-               	bl	 <L109>
-               	mov	x20, x0
-<L110>:
+               	fsub	s0, s31, s10
+<L53>:
+               	bl	 <L53>
                	fmul	s0, s9, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L112>
-               	mov	x0, x20
-<L111>:
-               	bl	 <L111>
-               	mov	x19, x0
-               	b	 <L114>
-<L112>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L113>:
-               	bl	 <L113>
-               	mov	x19, x0
-<L114>:
+<L54>:
+               	bl	 <L54>
                	fsub	s0, s9, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L116>
-               	mov	x0, x19
-<L115>:
-               	bl	 <L115>
-               	mov	x20, x0
-               	b	 <L118>
-<L116>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L117>:
-               	bl	 <L117>
-               	mov	x20, x0
-<L118>:
+<L55>:
+               	bl	 <L55>
                	mov	w17, #0x800000          ; =8388608
-               	add	w0, w17, w21
-               	fmov	s9, w0
+               	add	w1, w17, w21
+               	fmov	s9, w1
                	mov	w17, #0x1               ; =1
-               	add	w0, w17, w21
-               	fmov	s10, w0
+               	add	w1, w17, w21
+               	fmov	s10, w1
                	fmov	s30, #0.50000000
                	fmul	s0, s9, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L120>
-               	mov	x0, x20
-<L119>:
-               	bl	 <L119>
-               	mov	x19, x0
-               	b	 <L122>
-<L120>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L121>:
-               	bl	 <L121>
-               	mov	x19, x0
-<L122>:
+<L56>:
+               	bl	 <L56>
                	fmov	s30, #2.00000000
                	fdiv	s0, s9, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L124>
-               	mov	x0, x19
-<L123>:
-               	bl	 <L123>
-               	mov	x20, x0
-               	b	 <L126>
-<L124>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L125>:
-               	bl	 <L125>
-               	mov	x20, x0
-<L126>:
+<L57>:
+               	bl	 <L57>
                	fsub	s0, s9, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L128>
-               	mov	x0, x20
-<L127>:
-               	bl	 <L127>
-               	mov	x19, x0
-               	b	 <L130>
-<L128>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L129>:
-               	bl	 <L129>
-               	mov	x19, x0
-<L130>:
+<L58>:
+               	bl	 <L58>
                	fmul	s0, s9, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L132>
-               	mov	x0, x19
-<L131>:
-               	bl	 <L131>
-               	mov	x20, x0
-               	b	 <L134>
-<L132>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L133>:
-               	bl	 <L133>
-               	mov	x20, x0
-<L134>:
+<L59>:
+               	bl	 <L59>
                	fadd	s0, s10, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L136>
-               	mov	x0, x20
-<L135>:
-               	bl	 <L135>
-               	mov	x19, x0
-               	b	 <L138>
-<L136>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L137>:
-               	bl	 <L137>
-               	mov	x19, x0
-<L138>:
+<L60>:
+               	bl	 <L60>
                	fmov	s30, #0.50000000
                	fmul	s0, s10, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L140>
-               	mov	x0, x19
-<L139>:
-               	bl	 <L139>
-               	mov	x20, x0
-               	b	 <L142>
-<L140>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L141>:
-               	bl	 <L141>
-               	mov	x20, x0
-<L142>:
+<L61>:
+               	bl	 <L61>
                	fmov	s30, #0.75000000
                	fmul	s0, s10, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L144>
-               	mov	x0, x20
-<L143>:
-               	bl	 <L143>
-               	mov	x19, x0
-               	b	 <L146>
-<L144>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L145>:
-               	bl	 <L145>
-               	mov	x19, x0
-<L146>:
+<L62>:
+               	bl	 <L62>
                	mov	w16, #0x4b800000        ; =1266679808
                	fmov	s30, w16
                	fmul	s0, s10, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L148>
-               	mov	x0, x19
-<L147>:
-               	bl	 <L147>
-               	mov	x20, x0
-               	b	 <L150>
-<L148>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L149>:
-               	bl	 <L149>
-               	mov	x20, x0
-<L150>:
+<L63>:
+               	bl	 <L63>
                	fdiv	s0, s10, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L152>
-               	mov	x0, x20
-<L151>:
-               	bl	 <L151>
+<L64>:
+               	bl	 <L64>
                	mov	x19, x0
-               	b	 <L154>
-<L152>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L153>:
-               	bl	 <L153>
-               	mov	x19, x0
-<L154>:
                	fmov	s31, #5.50000000
                	fmul	s9, s31, s8
                	fmov	s31, #3.00000000
                	fmul	s10, s31, s8
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L67>
+               	fmov	s30, #2.00000000
+               	fmul	s0, s9, s30
+               	fcmp	s9, s0
+               	cset	w1, eq
+               	cbnz	w1,  <L65>
+               	b	 <L66>
+<L65>:
+               	fmov	s30, wzr
+               	fcmp	s9, s30
+               	cset	w1, ne
+<L66>:
+               	b	 <L68>
+<L67>:
+               	mov	x1, x0
+<L68>:
+               	cbnz	w1,  <L81>
+               	fmov	s30, wzr
+               	fcmp	s9, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L69>
+               	fmov	d0, d9
+               	b	 <L70>
+<L69>:
+               	fmov	s31, wzr
+               	fsub	s0, s31, s9
+<L70>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L71>
+               	fmov	d1, d10
+               	b	 <L72>
+<L71>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s10
+<L72>:
+               	fmov	s30, #2.00000000
+               	fdiv	s2, s0, s30
+               	fmov	d3, d1
+<L73>:
+               	fcmp	s3, s2
+               	cset	w1, ls
+               	cbnz	w1,  <L80>
+               	fmov	d4, d0
+               	fmov	d5, d3
+<L74>:
+               	fcmp	s1, s5
+               	cset	w1, ls
+               	cbnz	w1,  <L77>
+               	cbnz	w0,  <L75>
+               	fmov	d6, d4
+               	b	 <L76>
+<L75>:
+               	fmov	s31, wzr
+               	fsub	s6, s31, s4
+<L76>:
+               	b	 <L82>
+<L77>:
+               	fcmp	s5, s4
+               	cset	w1, ls
+               	cbnz	w1,  <L78>
+               	fmov	d7, d4
+               	b	 <L79>
+<L78>:
+               	fsub	s7, s4, s5
+<L79>:
+               	fmov	s30, #2.00000000
+               	fdiv	s5, s5, s30
+               	fmov	d4, d7
+               	b	 <L74>
+<L80>:
+               	fmov	s30, #2.00000000
+               	fmul	s3, s3, s30
+               	b	 <L73>
+<L81>:
                	fdiv	s0, s9, s10
                	fcvtzs	x0, s0
                	scvtf	s0, x0
                	fmul	s1, s0, s10
-               	fsub	s0, s9, s1
-               	fcmp	s0, s0
+               	fsub	s6, s9, s1
+<L82>:
+               	fcmp	s6, s6
                	cset	w0, ne
-               	cbnz	w0,  <L156>
+               	cbnz	w0,  <L84>
                	mov	x0, x19
-<L155>:
-               	bl	 <L155>
+               	fmov	s0, s6
+<L83>:
+               	bl	 <L83>
                	mov	x20, x0
-               	b	 <L158>
-<L156>:
+               	b	 <L86>
+<L84>:
                	mov	x0, x19
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L157>:
-               	bl	 <L157>
+<L85>:
+               	bl	 <L85>
                	mov	x20, x0
-<L158>:
+<L86>:
                	fmov	s31, wzr
                	fsub	s0, s31, s9
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L89>
+               	fmov	s30, #2.00000000
+               	fmul	s1, s0, s30
+               	fcmp	s0, s1
+               	cset	w1, eq
+               	cbnz	w1,  <L87>
+               	b	 <L88>
+<L87>:
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w1, ne
+<L88>:
+               	b	 <L90>
+<L89>:
+               	mov	x1, x0
+<L90>:
+               	cbnz	w1,  <L103>
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L91>
+               	fmov	d1, d0
+               	b	 <L92>
+<L91>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s0
+<L92>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L93>
+               	fmov	d2, d10
+               	b	 <L94>
+<L93>:
+               	fmov	s31, wzr
+               	fsub	s2, s31, s10
+<L94>:
+               	fmov	s30, #2.00000000
+               	fdiv	s3, s1, s30
+               	fmov	d4, d2
+<L95>:
+               	fcmp	s4, s3
+               	cset	w1, ls
+               	cbnz	w1,  <L102>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L96>:
+               	fcmp	s2, s6
+               	cset	w1, ls
+               	cbnz	w1,  <L99>
+               	cbnz	w0,  <L97>
+               	fmov	d7, d5
+               	b	 <L98>
+<L97>:
+               	fmov	s31, wzr
+               	fsub	s7, s31, s5
+<L98>:
+               	b	 <L104>
+<L99>:
+               	fcmp	s6, s5
+               	cset	w1, ls
+               	cbnz	w1,  <L100>
+               	fmov	d16, d5
+               	b	 <L101>
+<L100>:
+               	fsub	s16, s5, s6
+<L101>:
+               	fmov	s30, #2.00000000
+               	fdiv	s6, s6, s30
+               	fmov	d5, d16
+               	b	 <L96>
+<L102>:
+               	fmov	s30, #2.00000000
+               	fmul	s4, s4, s30
+               	b	 <L95>
+<L103>:
                	fdiv	s1, s0, s10
                	fcvtzs	x0, s1
                	scvtf	s1, x0
                	fmul	s2, s1, s10
-               	fsub	s1, s0, s2
-               	fcmp	s1, s1
+               	fsub	s7, s0, s2
+<L104>:
+               	fcmp	s7, s7
                	cset	w0, ne
-               	cbnz	w0,  <L160>
+               	cbnz	w0,  <L106>
                	mov	x0, x20
-               	fmov	s0, s1
-<L159>:
-               	bl	 <L159>
+               	fmov	s0, s7
+<L105>:
+               	bl	 <L105>
                	mov	x19, x0
-               	b	 <L162>
-<L160>:
+               	b	 <L108>
+<L106>:
                	mov	x0, x20
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L161>:
-               	bl	 <L161>
+<L107>:
+               	bl	 <L107>
                	mov	x19, x0
-<L162>:
+<L108>:
                	fmov	s31, wzr
                	fsub	s0, s31, s10
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L111>
+               	fmov	s30, #2.00000000
+               	fmul	s1, s9, s30
+               	fcmp	s9, s1
+               	cset	w1, eq
+               	cbnz	w1,  <L109>
+               	b	 <L110>
+<L109>:
+               	fmov	s30, wzr
+               	fcmp	s9, s30
+               	cset	w1, ne
+<L110>:
+               	b	 <L112>
+<L111>:
+               	mov	x1, x0
+<L112>:
+               	cbnz	w1,  <L125>
+               	fmov	s30, wzr
+               	fcmp	s9, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L113>
+               	fmov	d1, d9
+               	b	 <L114>
+<L113>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s9
+<L114>:
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L115>
+               	fmov	d2, d0
+               	b	 <L116>
+<L115>:
+               	fmov	s31, wzr
+               	fsub	s2, s31, s0
+<L116>:
+               	fmov	s30, #2.00000000
+               	fdiv	s3, s1, s30
+               	fmov	d4, d2
+<L117>:
+               	fcmp	s4, s3
+               	cset	w1, ls
+               	cbnz	w1,  <L124>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L118>:
+               	fcmp	s2, s6
+               	cset	w1, ls
+               	cbnz	w1,  <L121>
+               	cbnz	w0,  <L119>
+               	fmov	d7, d5
+               	b	 <L120>
+<L119>:
+               	fmov	s31, wzr
+               	fsub	s7, s31, s5
+<L120>:
+               	b	 <L126>
+<L121>:
+               	fcmp	s6, s5
+               	cset	w1, ls
+               	cbnz	w1,  <L122>
+               	fmov	d16, d5
+               	b	 <L123>
+<L122>:
+               	fsub	s16, s5, s6
+<L123>:
+               	fmov	s30, #2.00000000
+               	fdiv	s6, s6, s30
+               	fmov	d5, d16
+               	b	 <L118>
+<L124>:
+               	fmov	s30, #2.00000000
+               	fmul	s4, s4, s30
+               	b	 <L117>
+<L125>:
                	fdiv	s1, s9, s0
                	fcvtzs	x0, s1
                	scvtf	s1, x0
                	fmul	s2, s1, s0
-               	fsub	s0, s9, s2
-               	fcmp	s0, s0
+               	fsub	s7, s9, s2
+<L126>:
+               	fcmp	s7, s7
                	cset	w0, ne
-               	cbnz	w0,  <L164>
+               	cbnz	w0,  <L128>
                	mov	x0, x19
-<L163>:
-               	bl	 <L163>
+               	fmov	s0, s7
+<L127>:
+               	bl	 <L127>
                	mov	x20, x0
-               	b	 <L166>
-<L164>:
+               	b	 <L130>
+<L128>:
                	mov	x0, x19
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L165>:
-               	bl	 <L165>
+<L129>:
+               	bl	 <L129>
                	mov	x20, x0
-<L166>:
+<L130>:
                	fmov	s31, wzr
                	fsub	s0, s31, s9
                	fmov	s31, wzr
                	fsub	s1, s31, s10
+               	fmov	s30, wzr
+               	fcmp	s1, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L133>
+               	fmov	s30, #2.00000000
+               	fmul	s2, s0, s30
+               	fcmp	s0, s2
+               	cset	w1, eq
+               	cbnz	w1,  <L131>
+               	b	 <L132>
+<L131>:
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w1, ne
+<L132>:
+               	b	 <L134>
+<L133>:
+               	mov	x1, x0
+<L134>:
+               	cbnz	w1,  <L147>
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L135>
+               	fmov	d2, d0
+               	b	 <L136>
+<L135>:
+               	fmov	s31, wzr
+               	fsub	s2, s31, s0
+<L136>:
+               	fmov	s30, wzr
+               	fcmp	s1, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L137>
+               	fmov	d3, d1
+               	b	 <L138>
+<L137>:
+               	fmov	s31, wzr
+               	fsub	s3, s31, s1
+<L138>:
+               	fmov	s30, #2.00000000
+               	fdiv	s4, s2, s30
+               	fmov	d5, d3
+<L139>:
+               	fcmp	s5, s4
+               	cset	w1, ls
+               	cbnz	w1,  <L146>
+               	fmov	d6, d2
+               	fmov	d7, d5
+<L140>:
+               	fcmp	s3, s7
+               	cset	w1, ls
+               	cbnz	w1,  <L143>
+               	cbnz	w0,  <L141>
+               	fmov	d16, d6
+               	b	 <L142>
+<L141>:
+               	fmov	s31, wzr
+               	fsub	s16, s31, s6
+<L142>:
+               	b	 <L148>
+<L143>:
+               	fcmp	s7, s6
+               	cset	w1, ls
+               	cbnz	w1,  <L144>
+               	fmov	d17, d6
+               	b	 <L145>
+<L144>:
+               	fsub	s17, s6, s7
+<L145>:
+               	fmov	s30, #2.00000000
+               	fdiv	s7, s7, s30
+               	fmov	d6, d17
+               	b	 <L140>
+<L146>:
+               	fmov	s30, #2.00000000
+               	fmul	s5, s5, s30
+               	b	 <L139>
+<L147>:
                	fdiv	s2, s0, s1
                	fcvtzs	x0, s2
                	scvtf	s2, x0
                	fmul	s3, s2, s1
-               	fsub	s1, s0, s3
-               	fcmp	s1, s1
+               	fsub	s16, s0, s3
+<L148>:
+               	fcmp	s16, s16
                	cset	w0, ne
-               	cbnz	w0,  <L168>
+               	cbnz	w0,  <L150>
                	mov	x0, x20
-               	fmov	s0, s1
-<L167>:
-               	bl	 <L167>
+               	fmov	s0, s16
+<L149>:
+               	bl	 <L149>
                	mov	x19, x0
-               	b	 <L170>
-<L168>:
+               	b	 <L152>
+<L150>:
                	mov	x0, x20
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L169>:
-               	bl	 <L169>
+<L151>:
+               	bl	 <L151>
                	mov	x19, x0
-<L170>:
+<L152>:
                	fmov	s31, #7.00000000
                	fmul	s0, s31, s8
+               	fmov	s31, #0.50000000
+               	fmov	s30, wzr
+               	fcmp	s31, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L155>
+               	fmov	s30, #2.00000000
+               	fmul	s1, s0, s30
+               	fcmp	s0, s1
+               	cset	w1, eq
+               	cbnz	w1,  <L153>
+               	b	 <L154>
+<L153>:
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w1, ne
+<L154>:
+               	b	 <L156>
+<L155>:
+               	mov	x1, x0
+<L156>:
+               	cbnz	w1,  <L169>
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L157>
+               	fmov	d1, d0
+               	b	 <L158>
+<L157>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s0
+<L158>:
+               	fmov	s31, #0.50000000
+               	fmov	s30, wzr
+               	fcmp	s31, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L159>
+               	fmov	s2, #0.50000000
+               	b	 <L160>
+<L159>:
+               	fmov	s31, wzr
+               	fmov	s30, #0.50000000
+               	fsub	s2, s31, s30
+<L160>:
+               	fmov	s30, #2.00000000
+               	fdiv	s3, s1, s30
+               	fmov	d4, d2
+<L161>:
+               	fcmp	s4, s3
+               	cset	w1, ls
+               	cbnz	w1,  <L168>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L162>:
+               	fcmp	s2, s6
+               	cset	w1, ls
+               	cbnz	w1,  <L165>
+               	cbnz	w0,  <L163>
+               	fmov	d7, d5
+               	b	 <L164>
+<L163>:
+               	fmov	s31, wzr
+               	fsub	s7, s31, s5
+<L164>:
+               	b	 <L170>
+<L165>:
+               	fcmp	s6, s5
+               	cset	w1, ls
+               	cbnz	w1,  <L166>
+               	fmov	d16, d5
+               	b	 <L167>
+<L166>:
+               	fsub	s16, s5, s6
+<L167>:
+               	fmov	s30, #2.00000000
+               	fdiv	s6, s6, s30
+               	fmov	d5, d16
+               	b	 <L162>
+<L168>:
+               	fmov	s30, #2.00000000
+               	fmul	s4, s4, s30
+               	b	 <L161>
+<L169>:
                	fmov	s30, #0.50000000
                	fdiv	s1, s0, s30
                	fcvtzs	x0, s1
                	scvtf	s1, x0
                	fmov	s30, #0.50000000
                	fmul	s2, s1, s30
-               	fsub	s1, s0, s2
-               	fcmp	s1, s1
+               	fsub	s7, s0, s2
+<L170>:
+               	fcmp	s7, s7
                	cset	w0, ne
                	cbnz	w0,  <L172>
                	mov	x0, x19
-               	fmov	s0, s1
+               	fmov	s0, s7
 <L171>:
                	bl	 <L171>
                	mov	x20, x0
@@ -887,73 +869,315 @@ Disassembly of section __TEXT,__text:
                	bl	 <L173>
                	mov	x20, x0
 <L174>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L177>
+               	fmov	s30, #2.00000000
+               	fmul	s0, s8, s30
+               	fcmp	s8, s0
+               	cset	w1, eq
+               	cbnz	w1,  <L175>
+               	b	 <L176>
+<L175>:
+               	fmov	s30, wzr
+               	fcmp	s8, s30
+               	cset	w1, ne
+<L176>:
+               	b	 <L178>
+<L177>:
+               	mov	x1, x0
+<L178>:
+               	cbnz	w1,  <L191>
+               	fmov	s30, wzr
+               	fcmp	s8, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L179>
+               	fmov	d0, d8
+               	b	 <L180>
+<L179>:
+               	fmov	s31, wzr
+               	fsub	s0, s31, s8
+<L180>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L181>
+               	fmov	d1, d10
+               	b	 <L182>
+<L181>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s10
+<L182>:
+               	fmov	s30, #2.00000000
+               	fdiv	s2, s0, s30
+               	fmov	d3, d1
+<L183>:
+               	fcmp	s3, s2
+               	cset	w1, ls
+               	cbnz	w1,  <L190>
+               	fmov	d4, d0
+               	fmov	d5, d3
+<L184>:
+               	fcmp	s1, s5
+               	cset	w1, ls
+               	cbnz	w1,  <L187>
+               	cbnz	w0,  <L185>
+               	fmov	d6, d4
+               	b	 <L186>
+<L185>:
+               	fmov	s31, wzr
+               	fsub	s6, s31, s4
+<L186>:
+               	b	 <L192>
+<L187>:
+               	fcmp	s5, s4
+               	cset	w1, ls
+               	cbnz	w1,  <L188>
+               	fmov	d7, d4
+               	b	 <L189>
+<L188>:
+               	fsub	s7, s4, s5
+<L189>:
+               	fmov	s30, #2.00000000
+               	fdiv	s5, s5, s30
+               	fmov	d4, d7
+               	b	 <L184>
+<L190>:
+               	fmov	s30, #2.00000000
+               	fmul	s3, s3, s30
+               	b	 <L183>
+<L191>:
                	fdiv	s0, s8, s10
                	fcvtzs	x0, s0
                	scvtf	s0, x0
                	fmul	s1, s0, s10
-               	fsub	s0, s8, s1
-               	fcmp	s0, s0
+               	fsub	s6, s8, s1
+<L192>:
+               	fcmp	s6, s6
                	cset	w0, ne
-               	cbnz	w0,  <L176>
+               	cbnz	w0,  <L194>
                	mov	x0, x20
-<L175>:
-               	bl	 <L175>
+               	fmov	s0, s6
+<L193>:
+               	bl	 <L193>
                	mov	x19, x0
-               	b	 <L178>
-<L176>:
+               	b	 <L196>
+<L194>:
                	mov	x0, x20
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L177>:
-               	bl	 <L177>
+<L195>:
+               	bl	 <L195>
                	mov	x19, x0
-<L178>:
+<L196>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L199>
+               	fmov	s30, #2.00000000
+               	fmul	s0, s10, s30
+               	fcmp	s10, s0
+               	cset	w1, eq
+               	cbnz	w1,  <L197>
+               	b	 <L198>
+<L197>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w1, ne
+<L198>:
+               	b	 <L200>
+<L199>:
+               	mov	x1, x0
+<L200>:
+               	cbnz	w1,  <L213>
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L201>
+               	fmov	d0, d10
+               	b	 <L202>
+<L201>:
+               	fmov	s31, wzr
+               	fsub	s0, s31, s10
+<L202>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L203>
+               	fmov	d1, d10
+               	b	 <L204>
+<L203>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s10
+<L204>:
+               	fmov	s30, #2.00000000
+               	fdiv	s2, s0, s30
+               	fmov	d3, d1
+<L205>:
+               	fcmp	s3, s2
+               	cset	w1, ls
+               	cbnz	w1,  <L212>
+               	fmov	d4, d0
+               	fmov	d5, d3
+<L206>:
+               	fcmp	s1, s5
+               	cset	w1, ls
+               	cbnz	w1,  <L209>
+               	cbnz	w0,  <L207>
+               	fmov	d6, d4
+               	b	 <L208>
+<L207>:
+               	fmov	s31, wzr
+               	fsub	s6, s31, s4
+<L208>:
+               	b	 <L214>
+<L209>:
+               	fcmp	s5, s4
+               	cset	w1, ls
+               	cbnz	w1,  <L210>
+               	fmov	d7, d4
+               	b	 <L211>
+<L210>:
+               	fsub	s7, s4, s5
+<L211>:
+               	fmov	s30, #2.00000000
+               	fdiv	s5, s5, s30
+               	fmov	d4, d7
+               	b	 <L206>
+<L212>:
+               	fmov	s30, #2.00000000
+               	fmul	s3, s3, s30
+               	b	 <L205>
+<L213>:
                	fdiv	s0, s10, s10
                	fcvtzs	x0, s0
                	scvtf	s0, x0
                	fmul	s1, s0, s10
-               	fsub	s0, s10, s1
-               	fcmp	s0, s0
+               	fsub	s6, s10, s1
+<L214>:
+               	fcmp	s6, s6
                	cset	w0, ne
-               	cbnz	w0,  <L180>
+               	cbnz	w0,  <L216>
                	mov	x0, x19
-<L179>:
-               	bl	 <L179>
+               	fmov	s0, s6
+<L215>:
+               	bl	 <L215>
                	mov	x20, x0
-               	b	 <L182>
-<L180>:
+               	b	 <L218>
+<L216>:
                	mov	x0, x19
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L181>:
-               	bl	 <L181>
+<L217>:
+               	bl	 <L217>
                	mov	x20, x0
-<L182>:
+<L218>:
                	mov	w16, #0x49800000        ; =1233125376
                	fmov	s31, w16
                	fmul	s0, s31, s8
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w0, eq
+               	cbnz	w0,  <L221>
+               	fmov	s30, #2.00000000
+               	fmul	s1, s0, s30
+               	fcmp	s0, s1
+               	cset	w1, eq
+               	cbnz	w1,  <L219>
+               	b	 <L220>
+<L219>:
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w1, ne
+<L220>:
+               	b	 <L222>
+<L221>:
+               	mov	x1, x0
+<L222>:
+               	cbnz	w1,  <L235>
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w0, mi
+               	cbnz	w0,  <L223>
+               	fmov	d1, d0
+               	b	 <L224>
+<L223>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s0
+<L224>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L225>
+               	fmov	d2, d10
+               	b	 <L226>
+<L225>:
+               	fmov	s31, wzr
+               	fsub	s2, s31, s10
+<L226>:
+               	fmov	s30, #2.00000000
+               	fdiv	s3, s1, s30
+               	fmov	d4, d2
+<L227>:
+               	fcmp	s4, s3
+               	cset	w1, ls
+               	cbnz	w1,  <L234>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L228>:
+               	fcmp	s2, s6
+               	cset	w1, ls
+               	cbnz	w1,  <L231>
+               	cbnz	w0,  <L229>
+               	fmov	d7, d5
+               	b	 <L230>
+<L229>:
+               	fmov	s31, wzr
+               	fsub	s7, s31, s5
+<L230>:
+               	b	 <L236>
+<L231>:
+               	fcmp	s6, s5
+               	cset	w1, ls
+               	cbnz	w1,  <L232>
+               	fmov	d16, d5
+               	b	 <L233>
+<L232>:
+               	fsub	s16, s5, s6
+<L233>:
+               	fmov	s30, #2.00000000
+               	fdiv	s6, s6, s30
+               	fmov	d5, d16
+               	b	 <L228>
+<L234>:
+               	fmov	s30, #2.00000000
+               	fmul	s4, s4, s30
+               	b	 <L227>
+<L235>:
                	fdiv	s1, s0, s10
                	fcvtzs	x0, s1
                	scvtf	s1, x0
                	fmul	s2, s1, s10
-               	fsub	s1, s0, s2
-               	fcmp	s1, s1
+               	fsub	s7, s0, s2
+<L236>:
+               	fcmp	s7, s7
                	cset	w0, ne
-               	cbnz	w0,  <L184>
+               	cbnz	w0,  <L238>
                	mov	x0, x20
-               	fmov	s0, s1
-<L183>:
-               	bl	 <L183>
+               	fmov	s0, s7
+<L237>:
+               	bl	 <L237>
                	mov	x19, x0
-               	b	 <L186>
-<L184>:
+               	b	 <L240>
+<L238>:
                	mov	x0, x20
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L185>:
-               	bl	 <L185>
+<L239>:
+               	bl	 <L239>
                	mov	x19, x0
-<L186>:
+<L240>:
                	mov	x0, x19
                	ldp	d8, d9, [x29, #-0x30]
                	ldp	d10, d11, [x29, #-0x40]

--- a/test/golden/aarch64-darwin/float/arith_f64.dis
+++ b/test/golden/aarch64-darwin/float/arith_f64.dis
@@ -420,8 +420,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d6, d4
                	b	 <L76>
 <L75>:
-               	fmov	d31, xzr
-               	fsub	d6, d31, d4
+               	fneg	d6, d4
 <L76>:
                	b	 <L82>
 <L77>:
@@ -526,8 +525,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d7, d5
                	b	 <L98>
 <L97>:
-               	fmov	d31, xzr
-               	fsub	d7, d31, d5
+               	fneg	d7, d5
 <L98>:
                	b	 <L104>
 <L99>:
@@ -632,8 +630,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d7, d5
                	b	 <L120>
 <L119>:
-               	fmov	d31, xzr
-               	fsub	d7, d31, d5
+               	fneg	d7, d5
 <L120>:
                	b	 <L126>
 <L121>:
@@ -740,8 +737,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d16, d6
                	b	 <L142>
 <L141>:
-               	fmov	d31, xzr
-               	fsub	d16, d31, d6
+               	fneg	d16, d6
 <L142>:
                	b	 <L148>
 <L143>:
@@ -829,8 +825,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d6, d4
                	b	 <L160>
 <L159>:
-               	fmov	d31, xzr
-               	fsub	d6, d31, d4
+               	fneg	d6, d4
 <L160>:
                	b	 <L166>
 <L161>:
@@ -935,8 +930,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d6, d4
                	b	 <L182>
 <L181>:
-               	fmov	d31, xzr
-               	fsub	d6, d31, d4
+               	fneg	d6, d4
 <L182>:
                	b	 <L188>
 <L183>:
@@ -1039,8 +1033,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d6, d4
                	b	 <L204>
 <L203>:
-               	fmov	d31, xzr
-               	fsub	d6, d31, d4
+               	fneg	d6, d4
 <L204>:
                	b	 <L210>
 <L205>:
@@ -1146,8 +1139,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d7, d5
                	b	 <L226>
 <L225>:
-               	fmov	d31, xzr
-               	fsub	d7, d31, d5
+               	fneg	d7, d5
 <L226>:
                	b	 <L232>
 <L227>:

--- a/test/golden/aarch64-darwin/float/arith_f64.dis
+++ b/test/golden/aarch64-darwin/float/arith_f64.dis
@@ -132,388 +132,113 @@ Disassembly of section __TEXT,__text:
                	mov	x20, x0
 <L16>:
                	fdiv	d0, d9, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L18>
                	mov	x0, x20
 <L17>:
                	bl	 <L17>
-               	mov	x21, x0
-               	b	 <L20>
+               	fdiv	d0, d10, d9
 <L18>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L18>
+               	fneg	d0, d9
 <L19>:
                	bl	 <L19>
-               	mov	x21, x0
+               	fmov	d31, xzr
+               	fsub	d10, d31, d9
+               	fmov	d0, d10
 <L20>:
-               	fdiv	d0, d10, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L22>
-               	mov	x0, x21
+               	bl	 <L20>
+               	fsub	d0, d9, d9
 <L21>:
                	bl	 <L21>
-               	mov	x20, x0
-               	b	 <L24>
+               	fadd	d0, d10, d9
 <L22>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L23>:
-               	bl	 <L23>
-               	mov	x20, x0
-<L24>:
-               	fneg	d0, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L26>
-               	mov	x0, x20
-<L25>:
-               	bl	 <L25>
-               	mov	x21, x0
-               	b	 <L28>
-<L26>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L27>:
-               	bl	 <L27>
-               	mov	x21, x0
-<L28>:
-               	fmov	d31, xzr
-               	fsub	d0, d31, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L30>
-               	mov	x0, x21
-<L29>:
-               	bl	 <L29>
-               	mov	x20, x0
-               	b	 <L32>
-<L30>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L31>:
-               	bl	 <L31>
-               	mov	x20, x0
-<L32>:
-               	fsub	d0, d9, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L34>
-               	mov	x0, x20
-<L33>:
-               	bl	 <L33>
-               	mov	x21, x0
-               	b	 <L36>
-<L34>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L35>:
-               	bl	 <L35>
-               	mov	x21, x0
-<L36>:
-               	fmov	d31, xzr
-               	fsub	d0, d31, d9
-               	fadd	d1, d0, d9
-               	fcmp	d1, d1
-               	cset	w0, ne
-               	cbnz	w0,  <L38>
-               	mov	x0, x21
-               	fmov	d0, d1
-<L37>:
-               	bl	 <L37>
-               	mov	x20, x0
-               	b	 <L40>
-<L38>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L39>:
-               	bl	 <L39>
-               	mov	x20, x0
-<L40>:
+               	bl	 <L22>
                	fmov	d31, #3.00000000
                	fmul	d9, d31, d8
                	fdiv	d10, d8, d9
-               	fcmp	d10, d10
-               	cset	w0, ne
-               	cbnz	w0,  <L42>
-               	mov	x0, x20
                	fmov	d0, d10
-<L41>:
-               	bl	 <L41>
-               	mov	x21, x0
-               	b	 <L44>
-<L42>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L43>:
-               	bl	 <L43>
-               	mov	x21, x0
-<L44>:
+<L23>:
+               	bl	 <L23>
                	fmul	d0, d10, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L46>
-               	mov	x0, x21
-<L45>:
-               	bl	 <L45>
-               	mov	x20, x0
-               	b	 <L48>
-<L46>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L47>:
-               	bl	 <L47>
-               	mov	x20, x0
-<L48>:
+<L24>:
+               	bl	 <L24>
                	fsub	d0, d8, d10
                	fsub	d1, d0, d10
                	fsub	d0, d1, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L50>
-               	mov	x0, x20
-<L49>:
-               	bl	 <L49>
-               	mov	x21, x0
-               	b	 <L52>
-<L50>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L51>:
-               	bl	 <L51>
-               	mov	x21, x0
-<L52>:
+<L25>:
+               	bl	 <L25>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f64.opaque_f64>
                	ldr	d30, [x16]
                	fdiv	d0, d8, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L54>
-               	mov	x0, x21
-<L53>:
-               	bl	 <L53>
-               	mov	x20, x0
-               	b	 <L56>
-<L54>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L55>:
-               	bl	 <L55>
-               	mov	x20, x0
-<L56>:
+<L26>:
+               	bl	 <L26>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f64.opaque_f64>
                	ldr	d30, [x16]
                	fdiv	d0, d8, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L58>
-               	mov	x0, x20
-<L57>:
-               	bl	 <L57>
-               	mov	x21, x0
-               	b	 <L60>
-<L58>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L59>:
-               	bl	 <L59>
-               	mov	x21, x0
-<L60>:
+<L27>:
+               	bl	 <L27>
                	adrp	x16, 0x0 <corpus.cases.float.arith_f64.opaque_f64>
                	ldr	d31, [x16]
                	fdiv	d0, d31, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L62>
-               	mov	x0, x21
-<L61>:
-               	bl	 <L61>
-               	mov	x20, x0
-               	b	 <L64>
-<L62>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L63>:
-               	bl	 <L63>
-               	mov	x20, x0
-<L64>:
+<L28>:
+               	bl	 <L28>
                	mov	x16, #0x4340000000000000 ; =4845873199050653696
                	fmov	d31, x16
                	fmul	d9, d31, d8
-               	fadd	d0, d9, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L66>
-               	mov	x0, x20
-<L65>:
-               	bl	 <L65>
-               	mov	x21, x0
-               	b	 <L68>
-<L66>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L67>:
-               	bl	 <L67>
-               	mov	x21, x0
-<L68>:
-               	fadd	d0, d9, d8
-               	fadd	d1, d0, d8
-               	fcmp	d1, d1
-               	cset	w0, ne
-               	cbnz	w0,  <L70>
-               	mov	x0, x21
-               	fmov	d0, d1
-<L69>:
-               	bl	 <L69>
-               	mov	x20, x0
-               	b	 <L72>
-<L70>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L71>:
-               	bl	 <L71>
-               	mov	x20, x0
-<L72>:
+               	fadd	d11, d9, d8
+               	fmov	d0, d11
+<L29>:
+               	bl	 <L29>
+               	fadd	d0, d11, d8
+<L30>:
+               	bl	 <L30>
                	fadd	d0, d8, d8
                	fadd	d1, d9, d0
-               	fcmp	d1, d1
-               	cset	w0, ne
-               	cbnz	w0,  <L74>
-               	mov	x0, x20
                	fmov	d0, d1
-<L73>:
-               	bl	 <L73>
-               	mov	x21, x0
-               	b	 <L76>
-<L74>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L75>:
-               	bl	 <L75>
-               	mov	x21, x0
-<L76>:
+<L31>:
+               	bl	 <L31>
                	fsub	d0, d9, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L78>
-               	mov	x0, x21
-<L77>:
-               	bl	 <L77>
-               	mov	x20, x0
-               	b	 <L80>
-<L78>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L79>:
-               	bl	 <L79>
-               	mov	x20, x0
-<L80>:
-               	fadd	d0, d9, d8
-               	fsub	d1, d0, d9
-               	fcmp	d1, d1
-               	cset	w0, ne
-               	cbnz	w0,  <L82>
-               	mov	x0, x20
-               	fmov	d0, d1
-<L81>:
-               	bl	 <L81>
-               	mov	x21, x0
-               	b	 <L84>
-<L82>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L83>:
-               	bl	 <L83>
-               	mov	x21, x0
-<L84>:
+<L32>:
+               	bl	 <L32>
+               	fsub	d0, d11, d9
+<L33>:
+               	bl	 <L33>
                	fmov	d31, xzr
                	fmul	d0, d31, d8
+               	mov	x20, x0
                	fmov	d9, d0
-               	mov	x20, #0x0               ; =0
-               	cmp	x20, #0x18
-               	b.lo	 <L85>
-               	b	 <L90>
-<L85>:
+               	mov	x21, #0x0               ; =0
+               	cmp	x21, #0x18
+               	b.lo	 <L34>
+               	b	 <L39>
+<L34>:
                	fadd	d0, d9, d10
                	fmov	d30, #1.50000000
                	fmul	d11, d0, d30
                	fcmp	d11, d11
                	cset	w0, ne
-               	cbnz	w0,  <L87>
-               	mov	x0, x21
+               	cbnz	w0,  <L36>
+               	mov	x0, x20
                	fmov	d0, d11
-<L86>:
-               	bl	 <L86>
+<L35>:
+               	bl	 <L35>
                	mov	x22, x0
-               	b	 <L89>
-<L87>:
-               	mov	x0, x21
+               	b	 <L38>
+<L36>:
+               	mov	x0, x20
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L88>:
-               	bl	 <L88>
+<L37>:
+               	bl	 <L37>
                	mov	x22, x0
-<L89>:
-               	add	x20, x20, #0x1
-               	mov	x21, x22
+<L38>:
+               	add	x21, x21, #0x1
+               	mov	x20, x22
                	fmov	d9, d11
-               	cmp	x20, #0x18
-               	b.lo	 <L85>
-<L90>:
+               	cmp	x21, #0x18
+               	b.lo	 <L34>
+<L39>:
                	mov	x17, #0xffff            ; =65535
                	movk	x17, #0xffff, lsl #16
                	movk	x17, #0xffff, lsl #32
@@ -522,533 +247,952 @@ Disassembly of section __TEXT,__text:
                	fmov	d9, x0
                	fcmp	d9, d9
                	cset	w0, ne
-               	cbnz	w0,  <L92>
-               	mov	x0, x21
+               	cbnz	w0,  <L41>
+               	mov	x0, x20
                	fmov	d0, d9
-<L91>:
-               	bl	 <L91>
-               	mov	x20, x0
-               	b	 <L94>
-<L92>:
-               	mov	x0, x21
+<L40>:
+               	bl	 <L40>
+               	mov	x21, x0
+               	b	 <L43>
+<L41>:
+               	mov	x0, x20
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L93>:
-               	bl	 <L93>
-               	mov	x20, x0
-<L94>:
+<L42>:
+               	bl	 <L42>
+               	mov	x21, x0
+<L43>:
                	fmov	d30, #2.00000000
                	fdiv	d0, d9, d30
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L96>
-               	mov	x0, x20
-<L95>:
-               	bl	 <L95>
-               	mov	x21, x0
-               	b	 <L98>
-<L96>:
-               	mov	x0, x20
+               	cbnz	w0,  <L45>
+               	mov	x0, x21
+<L44>:
+               	bl	 <L44>
+               	mov	x20, x0
+               	b	 <L47>
+<L45>:
+               	mov	x0, x21
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L97>:
-               	bl	 <L97>
-               	mov	x21, x0
-<L98>:
+<L46>:
+               	bl	 <L46>
+               	mov	x20, x0
+<L47>:
                	fadd	d0, d9, d9
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L100>
-               	mov	x0, x21
-<L99>:
-               	bl	 <L99>
-               	mov	x20, x0
-               	b	 <L102>
-<L100>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L101>:
-               	bl	 <L101>
-               	mov	x20, x0
-<L102>:
-               	fmov	d30, #2.00000000
-               	fmul	d0, d9, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L104>
+               	cbnz	w0,  <L49>
                	mov	x0, x20
-<L103>:
-               	bl	 <L103>
+<L48>:
+               	bl	 <L48>
                	mov	x21, x0
-               	b	 <L106>
-<L104>:
+               	b	 <L51>
+<L49>:
                	mov	x0, x20
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L105>:
-               	bl	 <L105>
+<L50>:
+               	bl	 <L50>
                	mov	x21, x0
-<L106>:
+<L51>:
                	fmov	d30, #2.00000000
-               	fmul	d0, d9, d30
+               	fmul	d10, d9, d30
+               	mov	x0, x21
+               	fmov	d0, d10
+<L52>:
+               	bl	 <L52>
                	fmov	d31, xzr
-               	fsub	d1, d31, d0
-               	fcmp	d1, d1
-               	cset	w0, ne
-               	cbnz	w0,  <L108>
-               	mov	x0, x21
-               	fmov	d0, d1
-<L107>:
-               	bl	 <L107>
-               	mov	x20, x0
-               	b	 <L110>
-<L108>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L109>:
-               	bl	 <L109>
-               	mov	x20, x0
-<L110>:
+               	fsub	d0, d31, d10
+<L53>:
+               	bl	 <L53>
                	fmul	d0, d9, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L112>
-               	mov	x0, x20
-<L111>:
-               	bl	 <L111>
-               	mov	x21, x0
-               	b	 <L114>
-<L112>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L113>:
-               	bl	 <L113>
-               	mov	x21, x0
-<L114>:
+<L54>:
+               	bl	 <L54>
                	fsub	d0, d9, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L116>
-               	mov	x0, x21
-<L115>:
-               	bl	 <L115>
-               	mov	x20, x0
-               	b	 <L118>
-<L116>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L117>:
-               	bl	 <L117>
-               	mov	x20, x0
-<L118>:
+<L55>:
+               	bl	 <L55>
                	mov	x17, #0x10000000000000  ; =4503599627370496
-               	add	x0, x17, x19
-               	fmov	d9, x0
+               	add	x1, x17, x19
+               	fmov	d9, x1
                	mov	x17, #0x1               ; =1
-               	add	x0, x17, x19
-               	fmov	d10, x0
+               	add	x1, x17, x19
+               	fmov	d10, x1
                	fmov	d30, #0.50000000
                	fmul	d0, d9, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L120>
-               	mov	x0, x20
-<L119>:
-               	bl	 <L119>
-               	mov	x19, x0
-               	b	 <L122>
-<L120>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L121>:
-               	bl	 <L121>
-               	mov	x19, x0
-<L122>:
+<L56>:
+               	bl	 <L56>
                	fmov	d30, #2.00000000
                	fdiv	d0, d9, d30
-               	fcmp	d0, d0
+<L57>:
+               	bl	 <L57>
+               	fsub	d0, d9, d10
+<L58>:
+               	bl	 <L58>
+               	fmul	d0, d9, d8
+<L59>:
+               	bl	 <L59>
+               	fadd	d0, d10, d10
+<L60>:
+               	bl	 <L60>
+               	fmov	d30, #0.50000000
+               	fmul	d0, d10, d30
+<L61>:
+               	bl	 <L61>
+               	fmov	d30, #0.75000000
+               	fmul	d0, d10, d30
+<L62>:
+               	bl	 <L62>
+               	mov	x16, #0x4340000000000000 ; =4845873199050653696
+               	fmov	d30, x16
+               	fmul	d0, d10, d30
+<L63>:
+               	bl	 <L63>
+               	fdiv	d0, d10, d9
+<L64>:
+               	bl	 <L64>
+               	mov	x19, x0
+               	fmov	d31, #5.50000000
+               	fmul	d9, d31, d8
+               	fmov	d31, #3.00000000
+               	fmul	d10, d31, d8
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w0, eq
+               	cbnz	w0,  <L67>
+               	fmov	d30, #2.00000000
+               	fmul	d0, d9, d30
+               	fcmp	d9, d0
+               	cset	w1, eq
+               	cbnz	w1,  <L65>
+               	b	 <L66>
+<L65>:
+               	fmov	d30, xzr
+               	fcmp	d9, d30
+               	cset	w1, ne
+<L66>:
+               	b	 <L68>
+<L67>:
+               	mov	x1, x0
+<L68>:
+               	cbnz	w1,  <L81>
+               	fmov	d30, xzr
+               	fcmp	d9, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L69>
+               	fmov	d0, d9
+               	b	 <L70>
+<L69>:
+               	fmov	d31, xzr
+               	fsub	d0, d31, d9
+<L70>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L71>
+               	fmov	d1, d10
+               	b	 <L72>
+<L71>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d10
+<L72>:
+               	fmov	d30, #2.00000000
+               	fdiv	d2, d0, d30
+               	fmov	d3, d1
+<L73>:
+               	fcmp	d3, d2
+               	cset	w1, ls
+               	cbnz	w1,  <L80>
+               	fmov	d4, d0
+               	fmov	d5, d3
+<L74>:
+               	fcmp	d1, d5
+               	cset	w1, ls
+               	cbnz	w1,  <L77>
+               	cbnz	w0,  <L75>
+               	fmov	d6, d4
+               	b	 <L76>
+<L75>:
+               	fmov	d31, xzr
+               	fsub	d6, d31, d4
+<L76>:
+               	b	 <L82>
+<L77>:
+               	fcmp	d5, d4
+               	cset	w1, ls
+               	cbnz	w1,  <L78>
+               	fmov	d7, d4
+               	b	 <L79>
+<L78>:
+               	fsub	d7, d4, d5
+<L79>:
+               	fmov	d30, #2.00000000
+               	fdiv	d5, d5, d30
+               	fmov	d4, d7
+               	b	 <L74>
+<L80>:
+               	fmov	d30, #2.00000000
+               	fmul	d3, d3, d30
+               	b	 <L73>
+<L81>:
+               	fdiv	d0, d9, d10
+               	fcvtzs	x0, d0
+               	scvtf	d0, x0
+               	fmul	d1, d0, d10
+               	fsub	d6, d9, d1
+<L82>:
+               	fcmp	d6, d6
                	cset	w0, ne
-               	cbnz	w0,  <L124>
+               	cbnz	w0,  <L84>
                	mov	x0, x19
-<L123>:
-               	bl	 <L123>
+               	fmov	d0, d6
+<L83>:
+               	bl	 <L83>
                	mov	x20, x0
-               	b	 <L126>
-<L124>:
+               	b	 <L86>
+<L84>:
                	mov	x0, x19
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L125>:
-               	bl	 <L125>
+<L85>:
+               	bl	 <L85>
                	mov	x20, x0
+<L86>:
+               	fmov	d31, xzr
+               	fsub	d0, d31, d9
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w0, eq
+               	cbnz	w0,  <L89>
+               	fmov	d30, #2.00000000
+               	fmul	d1, d0, d30
+               	fcmp	d0, d1
+               	cset	w1, eq
+               	cbnz	w1,  <L87>
+               	b	 <L88>
+<L87>:
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w1, ne
+<L88>:
+               	b	 <L90>
+<L89>:
+               	mov	x1, x0
+<L90>:
+               	cbnz	w1,  <L103>
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L91>
+               	fmov	d1, d0
+               	b	 <L92>
+<L91>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d0
+<L92>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L93>
+               	fmov	d2, d10
+               	b	 <L94>
+<L93>:
+               	fmov	d31, xzr
+               	fsub	d2, d31, d10
+<L94>:
+               	fmov	d30, #2.00000000
+               	fdiv	d3, d1, d30
+               	fmov	d4, d2
+<L95>:
+               	fcmp	d4, d3
+               	cset	w1, ls
+               	cbnz	w1,  <L102>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L96>:
+               	fcmp	d2, d6
+               	cset	w1, ls
+               	cbnz	w1,  <L99>
+               	cbnz	w0,  <L97>
+               	fmov	d7, d5
+               	b	 <L98>
+<L97>:
+               	fmov	d31, xzr
+               	fsub	d7, d31, d5
+<L98>:
+               	b	 <L104>
+<L99>:
+               	fcmp	d6, d5
+               	cset	w1, ls
+               	cbnz	w1,  <L100>
+               	fmov	d16, d5
+               	b	 <L101>
+<L100>:
+               	fsub	d16, d5, d6
+<L101>:
+               	fmov	d30, #2.00000000
+               	fdiv	d6, d6, d30
+               	fmov	d5, d16
+               	b	 <L96>
+<L102>:
+               	fmov	d30, #2.00000000
+               	fmul	d4, d4, d30
+               	b	 <L95>
+<L103>:
+               	fdiv	d1, d0, d10
+               	fcvtzs	x0, d1
+               	scvtf	d1, x0
+               	fmul	d2, d1, d10
+               	fsub	d7, d0, d2
+<L104>:
+               	fcmp	d7, d7
+               	cset	w0, ne
+               	cbnz	w0,  <L106>
+               	mov	x0, x20
+               	fmov	d0, d7
+<L105>:
+               	bl	 <L105>
+               	mov	x19, x0
+               	b	 <L108>
+<L106>:
+               	mov	x0, x20
+               	mov	x1, #0xffff             ; =65535
+               	movk	x1, #0xffff, lsl #16
+               	movk	x1, #0xffff, lsl #32
+               	movk	x1, #0xffff, lsl #48
+<L107>:
+               	bl	 <L107>
+               	mov	x19, x0
+<L108>:
+               	fmov	d31, xzr
+               	fsub	d0, d31, d10
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, eq
+               	cbnz	w0,  <L111>
+               	fmov	d30, #2.00000000
+               	fmul	d1, d9, d30
+               	fcmp	d9, d1
+               	cset	w1, eq
+               	cbnz	w1,  <L109>
+               	b	 <L110>
+<L109>:
+               	fmov	d30, xzr
+               	fcmp	d9, d30
+               	cset	w1, ne
+<L110>:
+               	b	 <L112>
+<L111>:
+               	mov	x1, x0
+<L112>:
+               	cbnz	w1,  <L125>
+               	fmov	d30, xzr
+               	fcmp	d9, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L113>
+               	fmov	d1, d9
+               	b	 <L114>
+<L113>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d9
+<L114>:
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L115>
+               	fmov	d2, d0
+               	b	 <L116>
+<L115>:
+               	fmov	d31, xzr
+               	fsub	d2, d31, d0
+<L116>:
+               	fmov	d30, #2.00000000
+               	fdiv	d3, d1, d30
+               	fmov	d4, d2
+<L117>:
+               	fcmp	d4, d3
+               	cset	w1, ls
+               	cbnz	w1,  <L124>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L118>:
+               	fcmp	d2, d6
+               	cset	w1, ls
+               	cbnz	w1,  <L121>
+               	cbnz	w0,  <L119>
+               	fmov	d7, d5
+               	b	 <L120>
+<L119>:
+               	fmov	d31, xzr
+               	fsub	d7, d31, d5
+<L120>:
+               	b	 <L126>
+<L121>:
+               	fcmp	d6, d5
+               	cset	w1, ls
+               	cbnz	w1,  <L122>
+               	fmov	d16, d5
+               	b	 <L123>
+<L122>:
+               	fsub	d16, d5, d6
+<L123>:
+               	fmov	d30, #2.00000000
+               	fdiv	d6, d6, d30
+               	fmov	d5, d16
+               	b	 <L118>
+<L124>:
+               	fmov	d30, #2.00000000
+               	fmul	d4, d4, d30
+               	b	 <L117>
+<L125>:
+               	fdiv	d1, d9, d0
+               	fcvtzs	x0, d1
+               	scvtf	d1, x0
+               	fmul	d2, d1, d0
+               	fsub	d7, d9, d2
 <L126>:
-               	fsub	d0, d9, d10
-               	fcmp	d0, d0
+               	fcmp	d7, d7
                	cset	w0, ne
                	cbnz	w0,  <L128>
-               	mov	x0, x20
+               	mov	x0, x19
+               	fmov	d0, d7
 <L127>:
                	bl	 <L127>
-               	mov	x19, x0
+               	mov	x20, x0
                	b	 <L130>
 <L128>:
-               	mov	x0, x20
+               	mov	x0, x19
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
 <L129>:
                	bl	 <L129>
-               	mov	x19, x0
+               	mov	x20, x0
 <L130>:
-               	fmul	d0, d9, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L132>
-               	mov	x0, x19
-<L131>:
-               	bl	 <L131>
-               	mov	x20, x0
-               	b	 <L134>
-<L132>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L133>:
-               	bl	 <L133>
-               	mov	x20, x0
-<L134>:
-               	fadd	d0, d10, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L136>
-               	mov	x0, x20
-<L135>:
-               	bl	 <L135>
-               	mov	x19, x0
-               	b	 <L138>
-<L136>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L137>:
-               	bl	 <L137>
-               	mov	x19, x0
-<L138>:
-               	fmov	d30, #0.50000000
-               	fmul	d0, d10, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L140>
-               	mov	x0, x19
-<L139>:
-               	bl	 <L139>
-               	mov	x20, x0
-               	b	 <L142>
-<L140>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L141>:
-               	bl	 <L141>
-               	mov	x20, x0
-<L142>:
-               	fmov	d30, #0.75000000
-               	fmul	d0, d10, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L144>
-               	mov	x0, x20
-<L143>:
-               	bl	 <L143>
-               	mov	x19, x0
-               	b	 <L146>
-<L144>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L145>:
-               	bl	 <L145>
-               	mov	x19, x0
-<L146>:
-               	mov	x16, #0x4340000000000000 ; =4845873199050653696
-               	fmov	d30, x16
-               	fmul	d0, d10, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L148>
-               	mov	x0, x19
-<L147>:
-               	bl	 <L147>
-               	mov	x20, x0
-               	b	 <L150>
-<L148>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L149>:
-               	bl	 <L149>
-               	mov	x20, x0
-<L150>:
-               	fdiv	d0, d10, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L152>
-               	mov	x0, x20
-<L151>:
-               	bl	 <L151>
-               	mov	x19, x0
-               	b	 <L154>
-<L152>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L153>:
-               	bl	 <L153>
-               	mov	x19, x0
-<L154>:
-               	fmov	d31, #5.50000000
-               	fmul	d9, d31, d8
-               	fmov	d31, #3.00000000
-               	fmul	d10, d31, d8
-               	fdiv	d0, d9, d10
-               	fcvtzs	x0, d0
-               	scvtf	d0, x0
-               	fmul	d1, d0, d10
-               	fsub	d0, d9, d1
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L156>
-               	mov	x0, x19
-<L155>:
-               	bl	 <L155>
-               	mov	x20, x0
-               	b	 <L158>
-<L156>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L157>:
-               	bl	 <L157>
-               	mov	x20, x0
-<L158>:
-               	fmov	d31, xzr
-               	fsub	d0, d31, d9
-               	fdiv	d1, d0, d10
-               	fcvtzs	x0, d1
-               	scvtf	d1, x0
-               	fmul	d2, d1, d10
-               	fsub	d1, d0, d2
-               	fcmp	d1, d1
-               	cset	w0, ne
-               	cbnz	w0,  <L160>
-               	mov	x0, x20
-               	fmov	d0, d1
-<L159>:
-               	bl	 <L159>
-               	mov	x19, x0
-               	b	 <L162>
-<L160>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L161>:
-               	bl	 <L161>
-               	mov	x19, x0
-<L162>:
-               	fmov	d31, xzr
-               	fsub	d0, d31, d10
-               	fdiv	d1, d9, d0
-               	fcvtzs	x0, d1
-               	scvtf	d1, x0
-               	fmul	d2, d1, d0
-               	fsub	d0, d9, d2
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L164>
-               	mov	x0, x19
-<L163>:
-               	bl	 <L163>
-               	mov	x20, x0
-               	b	 <L166>
-<L164>:
-               	mov	x0, x19
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L165>:
-               	bl	 <L165>
-               	mov	x20, x0
-<L166>:
                	fmov	d31, xzr
                	fsub	d0, d31, d9
                	fmov	d31, xzr
                	fsub	d1, d31, d10
+               	fmov	d30, xzr
+               	fcmp	d1, d30
+               	cset	w0, eq
+               	cbnz	w0,  <L133>
+               	fmov	d30, #2.00000000
+               	fmul	d2, d0, d30
+               	fcmp	d0, d2
+               	cset	w1, eq
+               	cbnz	w1,  <L131>
+               	b	 <L132>
+<L131>:
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w1, ne
+<L132>:
+               	b	 <L134>
+<L133>:
+               	mov	x1, x0
+<L134>:
+               	cbnz	w1,  <L147>
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L135>
+               	fmov	d2, d0
+               	b	 <L136>
+<L135>:
+               	fmov	d31, xzr
+               	fsub	d2, d31, d0
+<L136>:
+               	fmov	d30, xzr
+               	fcmp	d1, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L137>
+               	fmov	d3, d1
+               	b	 <L138>
+<L137>:
+               	fmov	d31, xzr
+               	fsub	d3, d31, d1
+<L138>:
+               	fmov	d30, #2.00000000
+               	fdiv	d4, d2, d30
+               	fmov	d5, d3
+<L139>:
+               	fcmp	d5, d4
+               	cset	w1, ls
+               	cbnz	w1,  <L146>
+               	fmov	d6, d2
+               	fmov	d7, d5
+<L140>:
+               	fcmp	d3, d7
+               	cset	w1, ls
+               	cbnz	w1,  <L143>
+               	cbnz	w0,  <L141>
+               	fmov	d16, d6
+               	b	 <L142>
+<L141>:
+               	fmov	d31, xzr
+               	fsub	d16, d31, d6
+<L142>:
+               	b	 <L148>
+<L143>:
+               	fcmp	d7, d6
+               	cset	w1, ls
+               	cbnz	w1,  <L144>
+               	fmov	d17, d6
+               	b	 <L145>
+<L144>:
+               	fsub	d17, d6, d7
+<L145>:
+               	fmov	d30, #2.00000000
+               	fdiv	d7, d7, d30
+               	fmov	d6, d17
+               	b	 <L140>
+<L146>:
+               	fmov	d30, #2.00000000
+               	fmul	d5, d5, d30
+               	b	 <L139>
+<L147>:
                	fdiv	d2, d0, d1
                	fcvtzs	x0, d2
                	scvtf	d2, x0
                	fmul	d3, d2, d1
-               	fsub	d1, d0, d3
-               	fcmp	d1, d1
+               	fsub	d16, d0, d3
+<L148>:
+               	fcmp	d16, d16
                	cset	w0, ne
-               	cbnz	w0,  <L168>
+               	cbnz	w0,  <L150>
                	mov	x0, x20
-               	fmov	d0, d1
-<L167>:
-               	bl	 <L167>
+               	fmov	d0, d16
+<L149>:
+               	bl	 <L149>
                	mov	x19, x0
-               	b	 <L170>
-<L168>:
+               	b	 <L152>
+<L150>:
                	mov	x0, x20
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L169>:
-               	bl	 <L169>
+<L151>:
+               	bl	 <L151>
                	mov	x19, x0
-<L170>:
+<L152>:
                	fmov	d31, #7.00000000
                	fmul	d0, d31, d8
+               	fmov	d30, #2.00000000
+               	fmul	d1, d0, d30
+               	fcmp	d0, d1
+               	cset	w0, eq
+               	cbnz	w0,  <L153>
+               	b	 <L154>
+<L153>:
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, ne
+<L154>:
+               	cbnz	w0,  <L165>
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L155>
+               	fmov	d1, d0
+               	b	 <L156>
+<L155>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d0
+<L156>:
+               	fmov	d30, #2.00000000
+               	fdiv	d2, d1, d30
+               	fmov	d3, #0.50000000
+<L157>:
+               	fcmp	d3, d2
+               	cset	w1, ls
+               	cbnz	w1,  <L164>
+               	fmov	d4, d1
+               	fmov	d5, d3
+<L158>:
+               	fmov	d31, #0.50000000
+               	fcmp	d31, d5
+               	cset	w1, ls
+               	cbnz	w1,  <L161>
+               	cbnz	w0,  <L159>
+               	fmov	d6, d4
+               	b	 <L160>
+<L159>:
+               	fmov	d31, xzr
+               	fsub	d6, d31, d4
+<L160>:
+               	b	 <L166>
+<L161>:
+               	fcmp	d5, d4
+               	cset	w1, ls
+               	cbnz	w1,  <L162>
+               	fmov	d7, d4
+               	b	 <L163>
+<L162>:
+               	fsub	d7, d4, d5
+<L163>:
+               	fmov	d30, #2.00000000
+               	fdiv	d5, d5, d30
+               	fmov	d4, d7
+               	b	 <L158>
+<L164>:
+               	fmov	d30, #2.00000000
+               	fmul	d3, d3, d30
+               	b	 <L157>
+<L165>:
                	fmov	d30, #0.50000000
                	fdiv	d1, d0, d30
                	fcvtzs	x0, d1
                	scvtf	d1, x0
                	fmov	d30, #0.50000000
                	fmul	d2, d1, d30
-               	fsub	d1, d0, d2
-               	fcmp	d1, d1
+               	fsub	d6, d0, d2
+<L166>:
+               	fcmp	d6, d6
                	cset	w0, ne
-               	cbnz	w0,  <L172>
+               	cbnz	w0,  <L168>
                	mov	x0, x19
-               	fmov	d0, d1
-<L171>:
-               	bl	 <L171>
+               	fmov	d0, d6
+<L167>:
+               	bl	 <L167>
                	mov	x20, x0
-               	b	 <L174>
-<L172>:
+               	b	 <L170>
+<L168>:
                	mov	x0, x19
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L173>:
-               	bl	 <L173>
+<L169>:
+               	bl	 <L169>
                	mov	x20, x0
+<L170>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w0, eq
+               	cbnz	w0,  <L173>
+               	fmov	d30, #2.00000000
+               	fmul	d0, d8, d30
+               	fcmp	d8, d0
+               	cset	w1, eq
+               	cbnz	w1,  <L171>
+               	b	 <L172>
+<L171>:
+               	fmov	d30, xzr
+               	fcmp	d8, d30
+               	cset	w1, ne
+<L172>:
+               	b	 <L174>
+<L173>:
+               	mov	x1, x0
 <L174>:
+               	cbnz	w1,  <L187>
+               	fmov	d30, xzr
+               	fcmp	d8, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L175>
+               	fmov	d0, d8
+               	b	 <L176>
+<L175>:
+               	fmov	d31, xzr
+               	fsub	d0, d31, d8
+<L176>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L177>
+               	fmov	d1, d10
+               	b	 <L178>
+<L177>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d10
+<L178>:
+               	fmov	d30, #2.00000000
+               	fdiv	d2, d0, d30
+               	fmov	d3, d1
+<L179>:
+               	fcmp	d3, d2
+               	cset	w1, ls
+               	cbnz	w1,  <L186>
+               	fmov	d4, d0
+               	fmov	d5, d3
+<L180>:
+               	fcmp	d1, d5
+               	cset	w1, ls
+               	cbnz	w1,  <L183>
+               	cbnz	w0,  <L181>
+               	fmov	d6, d4
+               	b	 <L182>
+<L181>:
+               	fmov	d31, xzr
+               	fsub	d6, d31, d4
+<L182>:
+               	b	 <L188>
+<L183>:
+               	fcmp	d5, d4
+               	cset	w1, ls
+               	cbnz	w1,  <L184>
+               	fmov	d7, d4
+               	b	 <L185>
+<L184>:
+               	fsub	d7, d4, d5
+<L185>:
+               	fmov	d30, #2.00000000
+               	fdiv	d5, d5, d30
+               	fmov	d4, d7
+               	b	 <L180>
+<L186>:
+               	fmov	d30, #2.00000000
+               	fmul	d3, d3, d30
+               	b	 <L179>
+<L187>:
                	fdiv	d0, d8, d10
                	fcvtzs	x0, d0
                	scvtf	d0, x0
                	fmul	d1, d0, d10
-               	fsub	d0, d8, d1
-               	fcmp	d0, d0
+               	fsub	d6, d8, d1
+<L188>:
+               	fcmp	d6, d6
                	cset	w0, ne
-               	cbnz	w0,  <L176>
+               	cbnz	w0,  <L190>
                	mov	x0, x20
-<L175>:
-               	bl	 <L175>
+               	fmov	d0, d6
+<L189>:
+               	bl	 <L189>
                	mov	x19, x0
-               	b	 <L178>
-<L176>:
+               	b	 <L192>
+<L190>:
                	mov	x0, x20
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L177>:
-               	bl	 <L177>
+<L191>:
+               	bl	 <L191>
                	mov	x19, x0
-<L178>:
+<L192>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w0, eq
+               	cbnz	w0,  <L195>
+               	fmov	d30, #2.00000000
+               	fmul	d0, d10, d30
+               	fcmp	d10, d0
+               	cset	w1, eq
+               	cbnz	w1,  <L193>
+               	b	 <L194>
+<L193>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w1, ne
+<L194>:
+               	b	 <L196>
+<L195>:
+               	mov	x1, x0
+<L196>:
+               	cbnz	w1,  <L209>
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L197>
+               	fmov	d0, d10
+               	b	 <L198>
+<L197>:
+               	fmov	d31, xzr
+               	fsub	d0, d31, d10
+<L198>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L199>
+               	fmov	d1, d10
+               	b	 <L200>
+<L199>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d10
+<L200>:
+               	fmov	d30, #2.00000000
+               	fdiv	d2, d0, d30
+               	fmov	d3, d1
+<L201>:
+               	fcmp	d3, d2
+               	cset	w1, ls
+               	cbnz	w1,  <L208>
+               	fmov	d4, d0
+               	fmov	d5, d3
+<L202>:
+               	fcmp	d1, d5
+               	cset	w1, ls
+               	cbnz	w1,  <L205>
+               	cbnz	w0,  <L203>
+               	fmov	d6, d4
+               	b	 <L204>
+<L203>:
+               	fmov	d31, xzr
+               	fsub	d6, d31, d4
+<L204>:
+               	b	 <L210>
+<L205>:
+               	fcmp	d5, d4
+               	cset	w1, ls
+               	cbnz	w1,  <L206>
+               	fmov	d7, d4
+               	b	 <L207>
+<L206>:
+               	fsub	d7, d4, d5
+<L207>:
+               	fmov	d30, #2.00000000
+               	fdiv	d5, d5, d30
+               	fmov	d4, d7
+               	b	 <L202>
+<L208>:
+               	fmov	d30, #2.00000000
+               	fmul	d3, d3, d30
+               	b	 <L201>
+<L209>:
                	fdiv	d0, d10, d10
                	fcvtzs	x0, d0
                	scvtf	d0, x0
                	fmul	d1, d0, d10
-               	fsub	d0, d10, d1
-               	fcmp	d0, d0
+               	fsub	d6, d10, d1
+<L210>:
+               	fcmp	d6, d6
                	cset	w0, ne
-               	cbnz	w0,  <L180>
+               	cbnz	w0,  <L212>
                	mov	x0, x19
-<L179>:
-               	bl	 <L179>
+               	fmov	d0, d6
+<L211>:
+               	bl	 <L211>
                	mov	x20, x0
-               	b	 <L182>
-<L180>:
+               	b	 <L214>
+<L212>:
                	mov	x0, x19
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L181>:
-               	bl	 <L181>
+<L213>:
+               	bl	 <L213>
                	mov	x20, x0
-<L182>:
+<L214>:
                	mov	x16, #0x4130000000000000 ; =4697254411347427328
                	fmov	d31, x16
                	fmul	d0, d31, d8
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w0, eq
+               	cbnz	w0,  <L217>
+               	fmov	d30, #2.00000000
+               	fmul	d1, d0, d30
+               	fcmp	d0, d1
+               	cset	w1, eq
+               	cbnz	w1,  <L215>
+               	b	 <L216>
+<L215>:
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w1, ne
+<L216>:
+               	b	 <L218>
+<L217>:
+               	mov	x1, x0
+<L218>:
+               	cbnz	w1,  <L231>
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w0, mi
+               	cbnz	w0,  <L219>
+               	fmov	d1, d0
+               	b	 <L220>
+<L219>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d0
+<L220>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L221>
+               	fmov	d2, d10
+               	b	 <L222>
+<L221>:
+               	fmov	d31, xzr
+               	fsub	d2, d31, d10
+<L222>:
+               	fmov	d30, #2.00000000
+               	fdiv	d3, d1, d30
+               	fmov	d4, d2
+<L223>:
+               	fcmp	d4, d3
+               	cset	w1, ls
+               	cbnz	w1,  <L230>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L224>:
+               	fcmp	d2, d6
+               	cset	w1, ls
+               	cbnz	w1,  <L227>
+               	cbnz	w0,  <L225>
+               	fmov	d7, d5
+               	b	 <L226>
+<L225>:
+               	fmov	d31, xzr
+               	fsub	d7, d31, d5
+<L226>:
+               	b	 <L232>
+<L227>:
+               	fcmp	d6, d5
+               	cset	w1, ls
+               	cbnz	w1,  <L228>
+               	fmov	d16, d5
+               	b	 <L229>
+<L228>:
+               	fsub	d16, d5, d6
+<L229>:
+               	fmov	d30, #2.00000000
+               	fdiv	d6, d6, d30
+               	fmov	d5, d16
+               	b	 <L224>
+<L230>:
+               	fmov	d30, #2.00000000
+               	fmul	d4, d4, d30
+               	b	 <L223>
+<L231>:
                	fdiv	d1, d0, d10
                	fcvtzs	x0, d1
                	scvtf	d1, x0
                	fmul	d2, d1, d10
-               	fsub	d1, d0, d2
-               	fcmp	d1, d1
+               	fsub	d7, d0, d2
+<L232>:
+               	fcmp	d7, d7
                	cset	w0, ne
-               	cbnz	w0,  <L184>
+               	cbnz	w0,  <L234>
                	mov	x0, x20
-               	fmov	d0, d1
-<L183>:
-               	bl	 <L183>
+               	fmov	d0, d7
+<L233>:
+               	bl	 <L233>
                	mov	x19, x0
-               	b	 <L186>
-<L184>:
+               	b	 <L236>
+<L234>:
                	mov	x0, x20
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L185>:
-               	bl	 <L185>
+<L235>:
+               	bl	 <L235>
                	mov	x19, x0
-<L186>:
+<L236>:
                	mov	x0, x19
                	ldp	d8, d9, [x29, #-0x30]
                	ldp	d10, d11, [x29, #-0x40]

--- a/test/golden/aarch64-linux/float/arith_f32.dis
+++ b/test/golden/aarch64-linux/float/arith_f32.dis
@@ -401,8 +401,7 @@ Disassembly of section .text:
                	fmov	d6, d4
                	b	 <L76>
 <L75>:
-               	fmov	s31, wzr
-               	fsub	s6, s31, s4
+               	fneg	s6, s4
 <L76>:
                	b	 <L82>
 <L77>:
@@ -505,8 +504,7 @@ Disassembly of section .text:
                	fmov	d7, d5
                	b	 <L98>
 <L97>:
-               	fmov	s31, wzr
-               	fsub	s7, s31, s5
+               	fneg	s7, s5
 <L98>:
                	b	 <L104>
 <L99>:
@@ -609,8 +607,7 @@ Disassembly of section .text:
                	fmov	d7, d5
                	b	 <L120>
 <L119>:
-               	fmov	s31, wzr
-               	fsub	s7, s31, s5
+               	fneg	s7, s5
 <L120>:
                	b	 <L126>
 <L121>:
@@ -715,8 +712,7 @@ Disassembly of section .text:
                	fmov	d16, d6
                	b	 <L142>
 <L141>:
-               	fmov	s31, wzr
-               	fsub	s16, s31, s6
+               	fneg	s16, s6
 <L142>:
                	b	 <L148>
 <L143>:
@@ -822,8 +818,7 @@ Disassembly of section .text:
                	fmov	d7, d5
                	b	 <L164>
 <L163>:
-               	fmov	s31, wzr
-               	fsub	s7, s31, s5
+               	fneg	s7, s5
 <L164>:
                	b	 <L170>
 <L165>:
@@ -926,8 +921,7 @@ Disassembly of section .text:
                	fmov	d6, d4
                	b	 <L186>
 <L185>:
-               	fmov	s31, wzr
-               	fsub	s6, s31, s4
+               	fneg	s6, s4
 <L186>:
                	b	 <L192>
 <L187>:
@@ -1028,8 +1022,7 @@ Disassembly of section .text:
                	fmov	d6, d4
                	b	 <L208>
 <L207>:
-               	fmov	s31, wzr
-               	fsub	s6, s31, s4
+               	fneg	s6, s4
 <L208>:
                	b	 <L214>
 <L209>:
@@ -1133,8 +1126,7 @@ Disassembly of section .text:
                	fmov	d7, d5
                	b	 <L230>
 <L229>:
-               	fmov	s31, wzr
-               	fsub	s7, s31, s5
+               	fneg	s7, s5
 <L230>:
                	b	 <L236>
 <L231>:

--- a/test/golden/aarch64-linux/float/arith_f32.dis
+++ b/test/golden/aarch64-linux/float/arith_f32.dis
@@ -347,301 +347,313 @@ Disassembly of section .text:
                	fmov	s30, wzr
                	fcmp	s10, s30
                	cset	w0, eq
-               	cbnz	w0,  <L79>
+               	cbnz	w0,  <L67>
                	fmov	s30, #2.00000000
                	fmul	s0, s9, s30
                	fcmp	s9, s0
-               	cset	w0, eq
-               	cbnz	w0,  <L65>
+               	cset	w1, eq
+               	cbnz	w1,  <L65>
                	b	 <L66>
 <L65>:
                	fmov	s30, wzr
                	fcmp	s9, s30
-               	cset	w0, ne
-               	cbnz	w0,  <L79>
+               	cset	w1, ne
 <L66>:
+               	b	 <L68>
+<L67>:
+               	mov	x1, x0
+<L68>:
+               	cbnz	w1,  <L81>
                	fmov	s30, wzr
                	fcmp	s9, s30
                	cset	w0, mi
-               	cbnz	w0,  <L67>
+               	cbnz	w0,  <L69>
                	fmov	d0, d9
-               	b	 <L68>
-<L67>:
-               	fmov	s31, wzr
-               	fsub	s0, s31, s9
-<L68>:
-               	fmov	s30, wzr
-               	fcmp	s10, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L69>
-               	fmov	d1, d10
                	b	 <L70>
 <L69>:
                	fmov	s31, wzr
-               	fsub	s1, s31, s10
+               	fsub	s0, s31, s9
 <L70>:
+               	fmov	s30, wzr
+               	fcmp	s10, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L71>
+               	fmov	d1, d10
+               	b	 <L72>
+<L71>:
+               	fmov	s31, wzr
+               	fsub	s1, s31, s10
+<L72>:
                	fmov	s30, #2.00000000
                	fdiv	s2, s0, s30
                	fmov	d3, d1
-<L71>:
+<L73>:
                	fcmp	s3, s2
                	cset	w1, ls
-               	cbnz	w1,  <L78>
+               	cbnz	w1,  <L80>
                	fmov	d4, d0
                	fmov	d5, d3
-<L72>:
+<L74>:
                	fcmp	s1, s5
                	cset	w1, ls
-               	cbnz	w1,  <L75>
-               	cbnz	w0,  <L73>
+               	cbnz	w1,  <L77>
+               	cbnz	w0,  <L75>
                	fmov	d6, d4
-               	b	 <L74>
-<L73>:
+               	b	 <L76>
+<L75>:
                	fmov	s31, wzr
                	fsub	s6, s31, s4
-<L74>:
-               	b	 <L80>
-<L75>:
+<L76>:
+               	b	 <L82>
+<L77>:
                	fcmp	s5, s4
                	cset	w1, ls
-               	cbnz	w1,  <L76>
+               	cbnz	w1,  <L78>
                	fmov	d7, d4
-               	b	 <L77>
-<L76>:
+               	b	 <L79>
+<L78>:
                	fsub	s7, s4, s5
-<L77>:
+<L79>:
                	fmov	s30, #2.00000000
                	fdiv	s5, s5, s30
                	fmov	d4, d7
-               	b	 <L72>
-<L78>:
+               	b	 <L74>
+<L80>:
                	fmov	s30, #2.00000000
                	fmul	s3, s3, s30
-               	b	 <L71>
-<L79>:
+               	b	 <L73>
+<L81>:
                	fdiv	s0, s9, s10
                	fcvtzs	x0, s0
                	scvtf	s0, x0
                	fmul	s1, s0, s10
                	fsub	s6, s9, s1
-<L80>:
+<L82>:
                	fcmp	s6, s6
                	cset	w0, ne
-               	cbnz	w0,  <L82>
+               	cbnz	w0,  <L84>
                	mov	x0, x19
                	fmov	s0, s6
-<L81>:
-               	bl	 <L81>
-               	mov	x20, x0
-               	b	 <L84>
-<L82>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             // =65535
-               	movk	w1, #0xffff, lsl #16
 <L83>:
                	bl	 <L83>
                	mov	x20, x0
+               	b	 <L86>
 <L84>:
+               	mov	x0, x19
+               	mov	w1, #0xffff             // =65535
+               	movk	w1, #0xffff, lsl #16
+<L85>:
+               	bl	 <L85>
+               	mov	x20, x0
+<L86>:
                	fmov	s31, wzr
                	fsub	s0, s31, s9
                	fmov	s30, wzr
                	fcmp	s10, s30
                	cset	w0, eq
-               	cbnz	w0,  <L99>
+               	cbnz	w0,  <L89>
                	fmov	s30, #2.00000000
                	fmul	s1, s0, s30
                	fcmp	s0, s1
-               	cset	w0, eq
-               	cbnz	w0,  <L85>
-               	b	 <L86>
-<L85>:
+               	cset	w1, eq
+               	cbnz	w1,  <L87>
+               	b	 <L88>
+<L87>:
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w0, ne
-               	cbnz	w0,  <L99>
-<L86>:
+               	cset	w1, ne
+<L88>:
+               	b	 <L90>
+<L89>:
+               	mov	x1, x0
+<L90>:
+               	cbnz	w1,  <L103>
                	fmov	s30, wzr
                	fcmp	s0, s30
                	cset	w0, mi
-               	cbnz	w0,  <L87>
+               	cbnz	w0,  <L91>
                	fmov	d1, d0
-               	b	 <L88>
-<L87>:
+               	b	 <L92>
+<L91>:
                	fmov	s31, wzr
                	fsub	s1, s31, s0
-<L88>:
+<L92>:
                	fmov	s30, wzr
                	fcmp	s10, s30
                	cset	w1, mi
-               	cbnz	w1,  <L89>
+               	cbnz	w1,  <L93>
                	fmov	d2, d10
-               	b	 <L90>
-<L89>:
-               	fmov	s31, wzr
-               	fsub	s2, s31, s10
-<L90>:
-               	fmov	s30, #2.00000000
-               	fdiv	s3, s1, s30
-               	fmov	d4, d2
-<L91>:
-               	fcmp	s4, s3
-               	cset	w1, ls
-               	cbnz	w1,  <L98>
-               	fmov	d5, d1
-               	fmov	d6, d4
-<L92>:
-               	fcmp	s2, s6
-               	cset	w1, ls
-               	cbnz	w1,  <L95>
-               	cbnz	w0,  <L93>
-               	fmov	d7, d5
                	b	 <L94>
 <L93>:
                	fmov	s31, wzr
-               	fsub	s7, s31, s5
+               	fsub	s2, s31, s10
 <L94>:
-               	b	 <L100>
+               	fmov	s30, #2.00000000
+               	fdiv	s3, s1, s30
+               	fmov	d4, d2
 <L95>:
+               	fcmp	s4, s3
+               	cset	w1, ls
+               	cbnz	w1,  <L102>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L96>:
+               	fcmp	s2, s6
+               	cset	w1, ls
+               	cbnz	w1,  <L99>
+               	cbnz	w0,  <L97>
+               	fmov	d7, d5
+               	b	 <L98>
+<L97>:
+               	fmov	s31, wzr
+               	fsub	s7, s31, s5
+<L98>:
+               	b	 <L104>
+<L99>:
                	fcmp	s6, s5
                	cset	w1, ls
-               	cbnz	w1,  <L96>
+               	cbnz	w1,  <L100>
                	fmov	d16, d5
-               	b	 <L97>
-<L96>:
+               	b	 <L101>
+<L100>:
                	fsub	s16, s5, s6
-<L97>:
+<L101>:
                	fmov	s30, #2.00000000
                	fdiv	s6, s6, s30
                	fmov	d5, d16
-               	b	 <L92>
-<L98>:
+               	b	 <L96>
+<L102>:
                	fmov	s30, #2.00000000
                	fmul	s4, s4, s30
-               	b	 <L91>
-<L99>:
+               	b	 <L95>
+<L103>:
                	fdiv	s1, s0, s10
                	fcvtzs	x0, s1
                	scvtf	s1, x0
                	fmul	s2, s1, s10
                	fsub	s7, s0, s2
-<L100>:
+<L104>:
                	fcmp	s7, s7
                	cset	w0, ne
-               	cbnz	w0,  <L102>
+               	cbnz	w0,  <L106>
                	mov	x0, x20
                	fmov	s0, s7
-<L101>:
-               	bl	 <L101>
+<L105>:
+               	bl	 <L105>
                	mov	x19, x0
-               	b	 <L104>
-<L102>:
+               	b	 <L108>
+<L106>:
                	mov	x0, x20
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L103>:
-               	bl	 <L103>
+<L107>:
+               	bl	 <L107>
                	mov	x19, x0
-<L104>:
+<L108>:
                	fmov	s31, wzr
                	fsub	s0, s31, s10
                	fmov	s30, wzr
                	fcmp	s0, s30
                	cset	w0, eq
-               	cbnz	w0,  <L119>
+               	cbnz	w0,  <L111>
                	fmov	s30, #2.00000000
                	fmul	s1, s9, s30
                	fcmp	s9, s1
-               	cset	w0, eq
-               	cbnz	w0,  <L105>
-               	b	 <L106>
-<L105>:
+               	cset	w1, eq
+               	cbnz	w1,  <L109>
+               	b	 <L110>
+<L109>:
                	fmov	s30, wzr
                	fcmp	s9, s30
-               	cset	w0, ne
-               	cbnz	w0,  <L119>
-<L106>:
+               	cset	w1, ne
+<L110>:
+               	b	 <L112>
+<L111>:
+               	mov	x1, x0
+<L112>:
+               	cbnz	w1,  <L125>
                	fmov	s30, wzr
                	fcmp	s9, s30
                	cset	w0, mi
-               	cbnz	w0,  <L107>
-               	fmov	d1, d9
-               	b	 <L108>
-<L107>:
-               	fmov	s31, wzr
-               	fsub	s1, s31, s9
-<L108>:
-               	fmov	s30, wzr
-               	fcmp	s0, s30
-               	cset	w1, mi
-               	cbnz	w1,  <L109>
-               	fmov	d2, d0
-               	b	 <L110>
-<L109>:
-               	fmov	s31, wzr
-               	fsub	s2, s31, s0
-<L110>:
-               	fmov	s30, #2.00000000
-               	fdiv	s3, s1, s30
-               	fmov	d4, d2
-<L111>:
-               	fcmp	s4, s3
-               	cset	w1, ls
-               	cbnz	w1,  <L118>
-               	fmov	d5, d1
-               	fmov	d6, d4
-<L112>:
-               	fcmp	s2, s6
-               	cset	w1, ls
-               	cbnz	w1,  <L115>
                	cbnz	w0,  <L113>
-               	fmov	d7, d5
+               	fmov	d1, d9
                	b	 <L114>
 <L113>:
                	fmov	s31, wzr
-               	fsub	s7, s31, s5
+               	fsub	s1, s31, s9
 <L114>:
-               	b	 <L120>
+               	fmov	s30, wzr
+               	fcmp	s0, s30
+               	cset	w1, mi
+               	cbnz	w1,  <L115>
+               	fmov	d2, d0
+               	b	 <L116>
 <L115>:
+               	fmov	s31, wzr
+               	fsub	s2, s31, s0
+<L116>:
+               	fmov	s30, #2.00000000
+               	fdiv	s3, s1, s30
+               	fmov	d4, d2
+<L117>:
+               	fcmp	s4, s3
+               	cset	w1, ls
+               	cbnz	w1,  <L124>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L118>:
+               	fcmp	s2, s6
+               	cset	w1, ls
+               	cbnz	w1,  <L121>
+               	cbnz	w0,  <L119>
+               	fmov	d7, d5
+               	b	 <L120>
+<L119>:
+               	fmov	s31, wzr
+               	fsub	s7, s31, s5
+<L120>:
+               	b	 <L126>
+<L121>:
                	fcmp	s6, s5
                	cset	w1, ls
-               	cbnz	w1,  <L116>
+               	cbnz	w1,  <L122>
                	fmov	d16, d5
-               	b	 <L117>
-<L116>:
+               	b	 <L123>
+<L122>:
                	fsub	s16, s5, s6
-<L117>:
+<L123>:
                	fmov	s30, #2.00000000
                	fdiv	s6, s6, s30
                	fmov	d5, d16
-               	b	 <L112>
-<L118>:
+               	b	 <L118>
+<L124>:
                	fmov	s30, #2.00000000
                	fmul	s4, s4, s30
-               	b	 <L111>
-<L119>:
+               	b	 <L117>
+<L125>:
                	fdiv	s1, s9, s0
                	fcvtzs	x0, s1
                	scvtf	s1, x0
                	fmul	s2, s1, s0
                	fsub	s7, s9, s2
-<L120>:
+<L126>:
                	fcmp	s7, s7
                	cset	w0, ne
-               	cbnz	w0,  <L122>
+               	cbnz	w0,  <L128>
                	mov	x0, x19
                	fmov	s0, s7
-<L121>:
-               	bl	 <L121>
+<L127>:
+               	bl	 <L127>
                	mov	x20, x0
-               	b	 <L124>
-<L122>:
+               	b	 <L130>
+<L128>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L123>:
-               	bl	 <L123>
+<L129>:
+               	bl	 <L129>
                	mov	x20, x0
-<L124>:
+<L130>:
                	fmov	s31, wzr
                	fsub	s0, s31, s9
                	fmov	s31, wzr
@@ -649,181 +661,189 @@ Disassembly of section .text:
                	fmov	s30, wzr
                	fcmp	s1, s30
                	cset	w0, eq
-               	cbnz	w0,  <L139>
+               	cbnz	w0,  <L133>
                	fmov	s30, #2.00000000
                	fmul	s2, s0, s30
                	fcmp	s0, s2
-               	cset	w0, eq
-               	cbnz	w0,  <L125>
-               	b	 <L126>
-<L125>:
+               	cset	w1, eq
+               	cbnz	w1,  <L131>
+               	b	 <L132>
+<L131>:
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w0, ne
-               	cbnz	w0,  <L139>
-<L126>:
+               	cset	w1, ne
+<L132>:
+               	b	 <L134>
+<L133>:
+               	mov	x1, x0
+<L134>:
+               	cbnz	w1,  <L147>
                	fmov	s30, wzr
                	fcmp	s0, s30
                	cset	w0, mi
-               	cbnz	w0,  <L127>
+               	cbnz	w0,  <L135>
                	fmov	d2, d0
-               	b	 <L128>
-<L127>:
+               	b	 <L136>
+<L135>:
                	fmov	s31, wzr
                	fsub	s2, s31, s0
-<L128>:
+<L136>:
                	fmov	s30, wzr
                	fcmp	s1, s30
                	cset	w1, mi
-               	cbnz	w1,  <L129>
+               	cbnz	w1,  <L137>
                	fmov	d3, d1
-               	b	 <L130>
-<L129>:
+               	b	 <L138>
+<L137>:
                	fmov	s31, wzr
                	fsub	s3, s31, s1
-<L130>:
+<L138>:
                	fmov	s30, #2.00000000
                	fdiv	s4, s2, s30
                	fmov	d5, d3
-<L131>:
+<L139>:
                	fcmp	s5, s4
                	cset	w1, ls
-               	cbnz	w1,  <L138>
+               	cbnz	w1,  <L146>
                	fmov	d6, d2
                	fmov	d7, d5
-<L132>:
+<L140>:
                	fcmp	s3, s7
                	cset	w1, ls
-               	cbnz	w1,  <L135>
-               	cbnz	w0,  <L133>
+               	cbnz	w1,  <L143>
+               	cbnz	w0,  <L141>
                	fmov	d16, d6
-               	b	 <L134>
-<L133>:
+               	b	 <L142>
+<L141>:
                	fmov	s31, wzr
                	fsub	s16, s31, s6
-<L134>:
-               	b	 <L140>
-<L135>:
+<L142>:
+               	b	 <L148>
+<L143>:
                	fcmp	s7, s6
                	cset	w1, ls
-               	cbnz	w1,  <L136>
+               	cbnz	w1,  <L144>
                	fmov	d17, d6
-               	b	 <L137>
-<L136>:
+               	b	 <L145>
+<L144>:
                	fsub	s17, s6, s7
-<L137>:
+<L145>:
                	fmov	s30, #2.00000000
                	fdiv	s7, s7, s30
                	fmov	d6, d17
-               	b	 <L132>
-<L138>:
+               	b	 <L140>
+<L146>:
                	fmov	s30, #2.00000000
                	fmul	s5, s5, s30
-               	b	 <L131>
-<L139>:
+               	b	 <L139>
+<L147>:
                	fdiv	s2, s0, s1
                	fcvtzs	x0, s2
                	scvtf	s2, x0
                	fmul	s3, s2, s1
                	fsub	s16, s0, s3
-<L140>:
+<L148>:
                	fcmp	s16, s16
                	cset	w0, ne
-               	cbnz	w0,  <L142>
+               	cbnz	w0,  <L150>
                	mov	x0, x20
                	fmov	s0, s16
-<L141>:
-               	bl	 <L141>
+<L149>:
+               	bl	 <L149>
                	mov	x19, x0
-               	b	 <L144>
-<L142>:
+               	b	 <L152>
+<L150>:
                	mov	x0, x20
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L143>:
-               	bl	 <L143>
+<L151>:
+               	bl	 <L151>
                	mov	x19, x0
-<L144>:
+<L152>:
                	fmov	s31, #7.00000000
                	fmul	s0, s31, s8
                	fmov	s31, #0.50000000
                	fmov	s30, wzr
                	fcmp	s31, s30
                	cset	w0, eq
-               	cbnz	w0,  <L159>
+               	cbnz	w0,  <L155>
                	fmov	s30, #2.00000000
                	fmul	s1, s0, s30
                	fcmp	s0, s1
-               	cset	w0, eq
-               	cbnz	w0,  <L145>
-               	b	 <L146>
-<L145>:
+               	cset	w1, eq
+               	cbnz	w1,  <L153>
+               	b	 <L154>
+<L153>:
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w0, ne
-               	cbnz	w0,  <L159>
-<L146>:
+               	cset	w1, ne
+<L154>:
+               	b	 <L156>
+<L155>:
+               	mov	x1, x0
+<L156>:
+               	cbnz	w1,  <L169>
                	fmov	s30, wzr
                	fcmp	s0, s30
                	cset	w0, mi
-               	cbnz	w0,  <L147>
+               	cbnz	w0,  <L157>
                	fmov	d1, d0
-               	b	 <L148>
-<L147>:
+               	b	 <L158>
+<L157>:
                	fmov	s31, wzr
                	fsub	s1, s31, s0
-<L148>:
+<L158>:
                	fmov	s31, #0.50000000
                	fmov	s30, wzr
                	fcmp	s31, s30
                	cset	w1, mi
-               	cbnz	w1,  <L149>
+               	cbnz	w1,  <L159>
                	fmov	s2, #0.50000000
-               	b	 <L150>
-<L149>:
+               	b	 <L160>
+<L159>:
                	fmov	s31, wzr
                	fmov	s30, #0.50000000
                	fsub	s2, s31, s30
-<L150>:
+<L160>:
                	fmov	s30, #2.00000000
                	fdiv	s3, s1, s30
                	fmov	d4, d2
-<L151>:
+<L161>:
                	fcmp	s4, s3
                	cset	w1, ls
-               	cbnz	w1,  <L158>
+               	cbnz	w1,  <L168>
                	fmov	d5, d1
                	fmov	d6, d4
-<L152>:
+<L162>:
                	fcmp	s2, s6
                	cset	w1, ls
-               	cbnz	w1,  <L155>
-               	cbnz	w0,  <L153>
+               	cbnz	w1,  <L165>
+               	cbnz	w0,  <L163>
                	fmov	d7, d5
-               	b	 <L154>
-<L153>:
+               	b	 <L164>
+<L163>:
                	fmov	s31, wzr
                	fsub	s7, s31, s5
-<L154>:
-               	b	 <L160>
-<L155>:
+<L164>:
+               	b	 <L170>
+<L165>:
                	fcmp	s6, s5
                	cset	w1, ls
-               	cbnz	w1,  <L156>
+               	cbnz	w1,  <L166>
                	fmov	d16, d5
-               	b	 <L157>
-<L156>:
+               	b	 <L167>
+<L166>:
                	fsub	s16, s5, s6
-<L157>:
+<L167>:
                	fmov	s30, #2.00000000
                	fdiv	s6, s6, s30
                	fmov	d5, d16
-               	b	 <L152>
-<L158>:
+               	b	 <L162>
+<L168>:
                	fmov	s30, #2.00000000
                	fmul	s4, s4, s30
-               	b	 <L151>
-<L159>:
+               	b	 <L161>
+<L169>:
                	fmov	s30, #0.50000000
                	fdiv	s1, s0, s30
                	fcvtzs	x0, s1
@@ -831,122 +851,126 @@ Disassembly of section .text:
                	fmov	s30, #0.50000000
                	fmul	s2, s1, s30
                	fsub	s7, s0, s2
-<L160>:
+<L170>:
                	fcmp	s7, s7
                	cset	w0, ne
-               	cbnz	w0,  <L162>
+               	cbnz	w0,  <L172>
                	mov	x0, x19
                	fmov	s0, s7
-<L161>:
-               	bl	 <L161>
+<L171>:
+               	bl	 <L171>
                	mov	x20, x0
-               	b	 <L164>
-<L162>:
+               	b	 <L174>
+<L172>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L163>:
-               	bl	 <L163>
+<L173>:
+               	bl	 <L173>
                	mov	x20, x0
-<L164>:
+<L174>:
                	fmov	s30, wzr
                	fcmp	s10, s30
                	cset	w0, eq
-               	cbnz	w0,  <L179>
+               	cbnz	w0,  <L177>
                	fmov	s30, #2.00000000
                	fmul	s0, s8, s30
                	fcmp	s8, s0
-               	cset	w0, eq
-               	cbnz	w0,  <L165>
-               	b	 <L166>
-<L165>:
+               	cset	w1, eq
+               	cbnz	w1,  <L175>
+               	b	 <L176>
+<L175>:
                	fmov	s30, wzr
                	fcmp	s8, s30
-               	cset	w0, ne
-               	cbnz	w0,  <L179>
-<L166>:
+               	cset	w1, ne
+<L176>:
+               	b	 <L178>
+<L177>:
+               	mov	x1, x0
+<L178>:
+               	cbnz	w1,  <L191>
                	fmov	s30, wzr
                	fcmp	s8, s30
                	cset	w0, mi
-               	cbnz	w0,  <L167>
+               	cbnz	w0,  <L179>
                	fmov	d0, d8
-               	b	 <L168>
-<L167>:
+               	b	 <L180>
+<L179>:
                	fmov	s31, wzr
                	fsub	s0, s31, s8
-<L168>:
+<L180>:
                	fmov	s30, wzr
                	fcmp	s10, s30
                	cset	w1, mi
-               	cbnz	w1,  <L169>
+               	cbnz	w1,  <L181>
                	fmov	d1, d10
-               	b	 <L170>
-<L169>:
+               	b	 <L182>
+<L181>:
                	fmov	s31, wzr
                	fsub	s1, s31, s10
-<L170>:
+<L182>:
                	fmov	s30, #2.00000000
                	fdiv	s2, s0, s30
                	fmov	d3, d1
-<L171>:
+<L183>:
                	fcmp	s3, s2
                	cset	w1, ls
-               	cbnz	w1,  <L178>
+               	cbnz	w1,  <L190>
                	fmov	d4, d0
                	fmov	d5, d3
-<L172>:
+<L184>:
                	fcmp	s1, s5
                	cset	w1, ls
-               	cbnz	w1,  <L175>
-               	cbnz	w0,  <L173>
+               	cbnz	w1,  <L187>
+               	cbnz	w0,  <L185>
                	fmov	d6, d4
-               	b	 <L174>
-<L173>:
+               	b	 <L186>
+<L185>:
                	fmov	s31, wzr
                	fsub	s6, s31, s4
-<L174>:
-               	b	 <L180>
-<L175>:
+<L186>:
+               	b	 <L192>
+<L187>:
                	fcmp	s5, s4
                	cset	w1, ls
-               	cbnz	w1,  <L176>
+               	cbnz	w1,  <L188>
                	fmov	d7, d4
-               	b	 <L177>
-<L176>:
+               	b	 <L189>
+<L188>:
                	fsub	s7, s4, s5
-<L177>:
+<L189>:
                	fmov	s30, #2.00000000
                	fdiv	s5, s5, s30
                	fmov	d4, d7
-               	b	 <L172>
-<L178>:
+               	b	 <L184>
+<L190>:
                	fmov	s30, #2.00000000
                	fmul	s3, s3, s30
-               	b	 <L171>
-<L179>:
+               	b	 <L183>
+<L191>:
                	fdiv	s0, s8, s10
                	fcvtzs	x0, s0
                	scvtf	s0, x0
                	fmul	s1, s0, s10
                	fsub	s6, s8, s1
-<L180>:
+<L192>:
                	fcmp	s6, s6
                	cset	w0, ne
-               	cbnz	w0,  <L182>
+               	cbnz	w0,  <L194>
                	mov	x0, x20
                	fmov	s0, s6
-<L181>:
-               	bl	 <L181>
+<L193>:
+               	bl	 <L193>
                	mov	x19, x0
-               	b	 <L184>
-<L182>:
+               	b	 <L196>
+<L194>:
                	mov	x0, x20
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L183>:
-               	bl	 <L183>
+<L195>:
+               	bl	 <L195>
                	mov	x19, x0
-<L184>:
+<L196>:
                	fmov	s30, wzr
                	fcmp	s10, s30
                	cset	w0, eq
@@ -954,198 +978,206 @@ Disassembly of section .text:
                	fmov	s30, #2.00000000
                	fmul	s0, s10, s30
                	fcmp	s10, s0
-               	cset	w0, eq
-               	cbnz	w0,  <L185>
-               	b	 <L186>
-<L185>:
+               	cset	w1, eq
+               	cbnz	w1,  <L197>
+               	b	 <L198>
+<L197>:
                	fmov	s30, wzr
                	fcmp	s10, s30
-               	cset	w0, ne
-               	cbnz	w0,  <L199>
-<L186>:
+               	cset	w1, ne
+<L198>:
+               	b	 <L200>
+<L199>:
+               	mov	x1, x0
+<L200>:
+               	cbnz	w1,  <L213>
                	fmov	s30, wzr
                	fcmp	s10, s30
                	cset	w0, mi
-               	cbnz	w0,  <L187>
+               	cbnz	w0,  <L201>
                	fmov	d0, d10
-               	b	 <L188>
-<L187>:
+               	b	 <L202>
+<L201>:
                	fmov	s31, wzr
                	fsub	s0, s31, s10
-<L188>:
+<L202>:
                	fmov	s30, wzr
                	fcmp	s10, s30
                	cset	w1, mi
-               	cbnz	w1,  <L189>
+               	cbnz	w1,  <L203>
                	fmov	d1, d10
-               	b	 <L190>
-<L189>:
+               	b	 <L204>
+<L203>:
                	fmov	s31, wzr
                	fsub	s1, s31, s10
-<L190>:
+<L204>:
                	fmov	s30, #2.00000000
                	fdiv	s2, s0, s30
                	fmov	d3, d1
-<L191>:
+<L205>:
                	fcmp	s3, s2
                	cset	w1, ls
-               	cbnz	w1,  <L198>
+               	cbnz	w1,  <L212>
                	fmov	d4, d0
                	fmov	d5, d3
-<L192>:
+<L206>:
                	fcmp	s1, s5
                	cset	w1, ls
-               	cbnz	w1,  <L195>
-               	cbnz	w0,  <L193>
+               	cbnz	w1,  <L209>
+               	cbnz	w0,  <L207>
                	fmov	d6, d4
-               	b	 <L194>
-<L193>:
+               	b	 <L208>
+<L207>:
                	fmov	s31, wzr
                	fsub	s6, s31, s4
-<L194>:
-               	b	 <L200>
-<L195>:
+<L208>:
+               	b	 <L214>
+<L209>:
                	fcmp	s5, s4
                	cset	w1, ls
-               	cbnz	w1,  <L196>
+               	cbnz	w1,  <L210>
                	fmov	d7, d4
-               	b	 <L197>
-<L196>:
+               	b	 <L211>
+<L210>:
                	fsub	s7, s4, s5
-<L197>:
+<L211>:
                	fmov	s30, #2.00000000
                	fdiv	s5, s5, s30
                	fmov	d4, d7
-               	b	 <L192>
-<L198>:
+               	b	 <L206>
+<L212>:
                	fmov	s30, #2.00000000
                	fmul	s3, s3, s30
-               	b	 <L191>
-<L199>:
+               	b	 <L205>
+<L213>:
                	fdiv	s0, s10, s10
                	fcvtzs	x0, s0
                	scvtf	s0, x0
                	fmul	s1, s0, s10
                	fsub	s6, s10, s1
-<L200>:
+<L214>:
                	fcmp	s6, s6
                	cset	w0, ne
-               	cbnz	w0,  <L202>
+               	cbnz	w0,  <L216>
                	mov	x0, x19
                	fmov	s0, s6
-<L201>:
-               	bl	 <L201>
+<L215>:
+               	bl	 <L215>
                	mov	x20, x0
-               	b	 <L204>
-<L202>:
+               	b	 <L218>
+<L216>:
                	mov	x0, x19
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L203>:
-               	bl	 <L203>
+<L217>:
+               	bl	 <L217>
                	mov	x20, x0
-<L204>:
+<L218>:
                	mov	w16, #0x49800000        // =1233125376
                	fmov	s31, w16
                	fmul	s0, s31, s8
                	fmov	s30, wzr
                	fcmp	s10, s30
                	cset	w0, eq
-               	cbnz	w0,  <L219>
+               	cbnz	w0,  <L221>
                	fmov	s30, #2.00000000
                	fmul	s1, s0, s30
                	fcmp	s0, s1
-               	cset	w0, eq
-               	cbnz	w0,  <L205>
-               	b	 <L206>
-<L205>:
+               	cset	w1, eq
+               	cbnz	w1,  <L219>
+               	b	 <L220>
+<L219>:
                	fmov	s30, wzr
                	fcmp	s0, s30
-               	cset	w0, ne
-               	cbnz	w0,  <L219>
-<L206>:
+               	cset	w1, ne
+<L220>:
+               	b	 <L222>
+<L221>:
+               	mov	x1, x0
+<L222>:
+               	cbnz	w1,  <L235>
                	fmov	s30, wzr
                	fcmp	s0, s30
                	cset	w0, mi
-               	cbnz	w0,  <L207>
+               	cbnz	w0,  <L223>
                	fmov	d1, d0
-               	b	 <L208>
-<L207>:
+               	b	 <L224>
+<L223>:
                	fmov	s31, wzr
                	fsub	s1, s31, s0
-<L208>:
+<L224>:
                	fmov	s30, wzr
                	fcmp	s10, s30
                	cset	w1, mi
-               	cbnz	w1,  <L209>
+               	cbnz	w1,  <L225>
                	fmov	d2, d10
-               	b	 <L210>
-<L209>:
+               	b	 <L226>
+<L225>:
                	fmov	s31, wzr
                	fsub	s2, s31, s10
-<L210>:
+<L226>:
                	fmov	s30, #2.00000000
                	fdiv	s3, s1, s30
                	fmov	d4, d2
-<L211>:
+<L227>:
                	fcmp	s4, s3
                	cset	w1, ls
-               	cbnz	w1,  <L218>
+               	cbnz	w1,  <L234>
                	fmov	d5, d1
                	fmov	d6, d4
-<L212>:
+<L228>:
                	fcmp	s2, s6
                	cset	w1, ls
-               	cbnz	w1,  <L215>
-               	cbnz	w0,  <L213>
+               	cbnz	w1,  <L231>
+               	cbnz	w0,  <L229>
                	fmov	d7, d5
-               	b	 <L214>
-<L213>:
+               	b	 <L230>
+<L229>:
                	fmov	s31, wzr
                	fsub	s7, s31, s5
-<L214>:
-               	b	 <L220>
-<L215>:
+<L230>:
+               	b	 <L236>
+<L231>:
                	fcmp	s6, s5
                	cset	w1, ls
-               	cbnz	w1,  <L216>
+               	cbnz	w1,  <L232>
                	fmov	d16, d5
-               	b	 <L217>
-<L216>:
+               	b	 <L233>
+<L232>:
                	fsub	s16, s5, s6
-<L217>:
+<L233>:
                	fmov	s30, #2.00000000
                	fdiv	s6, s6, s30
                	fmov	d5, d16
-               	b	 <L212>
-<L218>:
+               	b	 <L228>
+<L234>:
                	fmov	s30, #2.00000000
                	fmul	s4, s4, s30
-               	b	 <L211>
-<L219>:
+               	b	 <L227>
+<L235>:
                	fdiv	s1, s0, s10
                	fcvtzs	x0, s1
                	scvtf	s1, x0
                	fmul	s2, s1, s10
                	fsub	s7, s0, s2
-<L220>:
+<L236>:
                	fcmp	s7, s7
                	cset	w0, ne
-               	cbnz	w0,  <L222>
+               	cbnz	w0,  <L238>
                	mov	x0, x20
                	fmov	s0, s7
-<L221>:
-               	bl	 <L221>
+<L237>:
+               	bl	 <L237>
                	mov	x19, x0
-               	b	 <L224>
-<L222>:
+               	b	 <L240>
+<L238>:
                	mov	x0, x20
                	mov	w1, #0xffff             // =65535
                	movk	w1, #0xffff, lsl #16
-<L223>:
-               	bl	 <L223>
+<L239>:
+               	bl	 <L239>
                	mov	x19, x0
-<L224>:
+<L240>:
                	mov	x0, x19
                	ldp	d8, d9, [x29, #-0x30]
                	ldp	d10, d11, [x29, #-0x40]

--- a/test/golden/aarch64-linux/float/arith_f64.dis
+++ b/test/golden/aarch64-linux/float/arith_f64.dis
@@ -366,307 +366,319 @@ Disassembly of section .text:
                	fmov	d30, xzr
                	fcmp	d10, d30
                	cset	w0, eq
-               	cbnz	w0,  <L79>
+               	cbnz	w0,  <L67>
                	fmov	d30, #2.00000000
                	fmul	d0, d9, d30
                	fcmp	d9, d0
-               	cset	w0, eq
-               	cbnz	w0,  <L65>
+               	cset	w1, eq
+               	cbnz	w1,  <L65>
                	b	 <L66>
 <L65>:
                	fmov	d30, xzr
                	fcmp	d9, d30
-               	cset	w0, ne
-               	cbnz	w0,  <L79>
+               	cset	w1, ne
 <L66>:
+               	b	 <L68>
+<L67>:
+               	mov	x1, x0
+<L68>:
+               	cbnz	w1,  <L81>
                	fmov	d30, xzr
                	fcmp	d9, d30
                	cset	w0, mi
-               	cbnz	w0,  <L67>
+               	cbnz	w0,  <L69>
                	fmov	d0, d9
-               	b	 <L68>
-<L67>:
-               	fmov	d31, xzr
-               	fsub	d0, d31, d9
-<L68>:
-               	fmov	d30, xzr
-               	fcmp	d10, d30
-               	cset	w1, mi
-               	cbnz	w1,  <L69>
-               	fmov	d1, d10
                	b	 <L70>
 <L69>:
                	fmov	d31, xzr
-               	fsub	d1, d31, d10
+               	fsub	d0, d31, d9
 <L70>:
+               	fmov	d30, xzr
+               	fcmp	d10, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L71>
+               	fmov	d1, d10
+               	b	 <L72>
+<L71>:
+               	fmov	d31, xzr
+               	fsub	d1, d31, d10
+<L72>:
                	fmov	d30, #2.00000000
                	fdiv	d2, d0, d30
                	fmov	d3, d1
-<L71>:
+<L73>:
                	fcmp	d3, d2
                	cset	w1, ls
-               	cbnz	w1,  <L78>
+               	cbnz	w1,  <L80>
                	fmov	d4, d0
                	fmov	d5, d3
-<L72>:
+<L74>:
                	fcmp	d1, d5
                	cset	w1, ls
-               	cbnz	w1,  <L75>
-               	cbnz	w0,  <L73>
+               	cbnz	w1,  <L77>
+               	cbnz	w0,  <L75>
                	fmov	d6, d4
-               	b	 <L74>
-<L73>:
+               	b	 <L76>
+<L75>:
                	fmov	d31, xzr
                	fsub	d6, d31, d4
-<L74>:
-               	b	 <L80>
-<L75>:
+<L76>:
+               	b	 <L82>
+<L77>:
                	fcmp	d5, d4
                	cset	w1, ls
-               	cbnz	w1,  <L76>
+               	cbnz	w1,  <L78>
                	fmov	d7, d4
-               	b	 <L77>
-<L76>:
+               	b	 <L79>
+<L78>:
                	fsub	d7, d4, d5
-<L77>:
+<L79>:
                	fmov	d30, #2.00000000
                	fdiv	d5, d5, d30
                	fmov	d4, d7
-               	b	 <L72>
-<L78>:
+               	b	 <L74>
+<L80>:
                	fmov	d30, #2.00000000
                	fmul	d3, d3, d30
-               	b	 <L71>
-<L79>:
+               	b	 <L73>
+<L81>:
                	fdiv	d0, d9, d10
                	fcvtzs	x0, d0
                	scvtf	d0, x0
                	fmul	d1, d0, d10
                	fsub	d6, d9, d1
-<L80>:
+<L82>:
                	fcmp	d6, d6
                	cset	w0, ne
-               	cbnz	w0,  <L82>
+               	cbnz	w0,  <L84>
                	mov	x0, x19
                	fmov	d0, d6
-<L81>:
-               	bl	 <L81>
+<L83>:
+               	bl	 <L83>
                	mov	x20, x0
-               	b	 <L84>
-<L82>:
+               	b	 <L86>
+<L84>:
                	mov	x0, x19
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L83>:
-               	bl	 <L83>
+<L85>:
+               	bl	 <L85>
                	mov	x20, x0
-<L84>:
+<L86>:
                	fmov	d31, xzr
                	fsub	d0, d31, d9
                	fmov	d30, xzr
                	fcmp	d10, d30
                	cset	w0, eq
-               	cbnz	w0,  <L99>
+               	cbnz	w0,  <L89>
                	fmov	d30, #2.00000000
                	fmul	d1, d0, d30
                	fcmp	d0, d1
-               	cset	w0, eq
-               	cbnz	w0,  <L85>
-               	b	 <L86>
-<L85>:
+               	cset	w1, eq
+               	cbnz	w1,  <L87>
+               	b	 <L88>
+<L87>:
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, ne
-               	cbnz	w0,  <L99>
-<L86>:
+               	cset	w1, ne
+<L88>:
+               	b	 <L90>
+<L89>:
+               	mov	x1, x0
+<L90>:
+               	cbnz	w1,  <L103>
                	fmov	d30, xzr
                	fcmp	d0, d30
                	cset	w0, mi
-               	cbnz	w0,  <L87>
+               	cbnz	w0,  <L91>
                	fmov	d1, d0
-               	b	 <L88>
-<L87>:
+               	b	 <L92>
+<L91>:
                	fmov	d31, xzr
                	fsub	d1, d31, d0
-<L88>:
+<L92>:
                	fmov	d30, xzr
                	fcmp	d10, d30
                	cset	w1, mi
-               	cbnz	w1,  <L89>
+               	cbnz	w1,  <L93>
                	fmov	d2, d10
-               	b	 <L90>
-<L89>:
-               	fmov	d31, xzr
-               	fsub	d2, d31, d10
-<L90>:
-               	fmov	d30, #2.00000000
-               	fdiv	d3, d1, d30
-               	fmov	d4, d2
-<L91>:
-               	fcmp	d4, d3
-               	cset	w1, ls
-               	cbnz	w1,  <L98>
-               	fmov	d5, d1
-               	fmov	d6, d4
-<L92>:
-               	fcmp	d2, d6
-               	cset	w1, ls
-               	cbnz	w1,  <L95>
-               	cbnz	w0,  <L93>
-               	fmov	d7, d5
                	b	 <L94>
 <L93>:
                	fmov	d31, xzr
-               	fsub	d7, d31, d5
+               	fsub	d2, d31, d10
 <L94>:
-               	b	 <L100>
+               	fmov	d30, #2.00000000
+               	fdiv	d3, d1, d30
+               	fmov	d4, d2
 <L95>:
+               	fcmp	d4, d3
+               	cset	w1, ls
+               	cbnz	w1,  <L102>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L96>:
+               	fcmp	d2, d6
+               	cset	w1, ls
+               	cbnz	w1,  <L99>
+               	cbnz	w0,  <L97>
+               	fmov	d7, d5
+               	b	 <L98>
+<L97>:
+               	fmov	d31, xzr
+               	fsub	d7, d31, d5
+<L98>:
+               	b	 <L104>
+<L99>:
                	fcmp	d6, d5
                	cset	w1, ls
-               	cbnz	w1,  <L96>
+               	cbnz	w1,  <L100>
                	fmov	d16, d5
-               	b	 <L97>
-<L96>:
+               	b	 <L101>
+<L100>:
                	fsub	d16, d5, d6
-<L97>:
+<L101>:
                	fmov	d30, #2.00000000
                	fdiv	d6, d6, d30
                	fmov	d5, d16
-               	b	 <L92>
-<L98>:
+               	b	 <L96>
+<L102>:
                	fmov	d30, #2.00000000
                	fmul	d4, d4, d30
-               	b	 <L91>
-<L99>:
+               	b	 <L95>
+<L103>:
                	fdiv	d1, d0, d10
                	fcvtzs	x0, d1
                	scvtf	d1, x0
                	fmul	d2, d1, d10
                	fsub	d7, d0, d2
-<L100>:
+<L104>:
                	fcmp	d7, d7
                	cset	w0, ne
-               	cbnz	w0,  <L102>
+               	cbnz	w0,  <L106>
                	mov	x0, x20
                	fmov	d0, d7
-<L101>:
-               	bl	 <L101>
+<L105>:
+               	bl	 <L105>
                	mov	x19, x0
-               	b	 <L104>
-<L102>:
+               	b	 <L108>
+<L106>:
                	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L103>:
-               	bl	 <L103>
+<L107>:
+               	bl	 <L107>
                	mov	x19, x0
-<L104>:
+<L108>:
                	fmov	d31, xzr
                	fsub	d0, d31, d10
                	fmov	d30, xzr
                	fcmp	d0, d30
                	cset	w0, eq
-               	cbnz	w0,  <L119>
+               	cbnz	w0,  <L111>
                	fmov	d30, #2.00000000
                	fmul	d1, d9, d30
                	fcmp	d9, d1
-               	cset	w0, eq
-               	cbnz	w0,  <L105>
-               	b	 <L106>
-<L105>:
+               	cset	w1, eq
+               	cbnz	w1,  <L109>
+               	b	 <L110>
+<L109>:
                	fmov	d30, xzr
                	fcmp	d9, d30
-               	cset	w0, ne
-               	cbnz	w0,  <L119>
-<L106>:
+               	cset	w1, ne
+<L110>:
+               	b	 <L112>
+<L111>:
+               	mov	x1, x0
+<L112>:
+               	cbnz	w1,  <L125>
                	fmov	d30, xzr
                	fcmp	d9, d30
                	cset	w0, mi
-               	cbnz	w0,  <L107>
-               	fmov	d1, d9
-               	b	 <L108>
-<L107>:
-               	fmov	d31, xzr
-               	fsub	d1, d31, d9
-<L108>:
-               	fmov	d30, xzr
-               	fcmp	d0, d30
-               	cset	w1, mi
-               	cbnz	w1,  <L109>
-               	fmov	d2, d0
-               	b	 <L110>
-<L109>:
-               	fmov	d31, xzr
-               	fsub	d2, d31, d0
-<L110>:
-               	fmov	d30, #2.00000000
-               	fdiv	d3, d1, d30
-               	fmov	d4, d2
-<L111>:
-               	fcmp	d4, d3
-               	cset	w1, ls
-               	cbnz	w1,  <L118>
-               	fmov	d5, d1
-               	fmov	d6, d4
-<L112>:
-               	fcmp	d2, d6
-               	cset	w1, ls
-               	cbnz	w1,  <L115>
                	cbnz	w0,  <L113>
-               	fmov	d7, d5
+               	fmov	d1, d9
                	b	 <L114>
 <L113>:
                	fmov	d31, xzr
-               	fsub	d7, d31, d5
+               	fsub	d1, d31, d9
 <L114>:
-               	b	 <L120>
+               	fmov	d30, xzr
+               	fcmp	d0, d30
+               	cset	w1, mi
+               	cbnz	w1,  <L115>
+               	fmov	d2, d0
+               	b	 <L116>
 <L115>:
+               	fmov	d31, xzr
+               	fsub	d2, d31, d0
+<L116>:
+               	fmov	d30, #2.00000000
+               	fdiv	d3, d1, d30
+               	fmov	d4, d2
+<L117>:
+               	fcmp	d4, d3
+               	cset	w1, ls
+               	cbnz	w1,  <L124>
+               	fmov	d5, d1
+               	fmov	d6, d4
+<L118>:
+               	fcmp	d2, d6
+               	cset	w1, ls
+               	cbnz	w1,  <L121>
+               	cbnz	w0,  <L119>
+               	fmov	d7, d5
+               	b	 <L120>
+<L119>:
+               	fmov	d31, xzr
+               	fsub	d7, d31, d5
+<L120>:
+               	b	 <L126>
+<L121>:
                	fcmp	d6, d5
                	cset	w1, ls
-               	cbnz	w1,  <L116>
+               	cbnz	w1,  <L122>
                	fmov	d16, d5
-               	b	 <L117>
-<L116>:
+               	b	 <L123>
+<L122>:
                	fsub	d16, d5, d6
-<L117>:
+<L123>:
                	fmov	d30, #2.00000000
                	fdiv	d6, d6, d30
                	fmov	d5, d16
-               	b	 <L112>
-<L118>:
+               	b	 <L118>
+<L124>:
                	fmov	d30, #2.00000000
                	fmul	d4, d4, d30
-               	b	 <L111>
-<L119>:
+               	b	 <L117>
+<L125>:
                	fdiv	d1, d9, d0
                	fcvtzs	x0, d1
                	scvtf	d1, x0
                	fmul	d2, d1, d0
                	fsub	d7, d9, d2
-<L120>:
+<L126>:
                	fcmp	d7, d7
                	cset	w0, ne
-               	cbnz	w0,  <L122>
+               	cbnz	w0,  <L128>
                	mov	x0, x19
                	fmov	d0, d7
-<L121>:
-               	bl	 <L121>
+<L127>:
+               	bl	 <L127>
                	mov	x20, x0
-               	b	 <L124>
-<L122>:
+               	b	 <L130>
+<L128>:
                	mov	x0, x19
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L123>:
-               	bl	 <L123>
+<L129>:
+               	bl	 <L129>
                	mov	x20, x0
-<L124>:
+<L130>:
                	fmov	d31, xzr
                	fsub	d0, d31, d9
                	fmov	d31, xzr
@@ -674,167 +686,171 @@ Disassembly of section .text:
                	fmov	d30, xzr
                	fcmp	d1, d30
                	cset	w0, eq
-               	cbnz	w0,  <L139>
+               	cbnz	w0,  <L133>
                	fmov	d30, #2.00000000
                	fmul	d2, d0, d30
                	fcmp	d0, d2
-               	cset	w0, eq
-               	cbnz	w0,  <L125>
-               	b	 <L126>
-<L125>:
+               	cset	w1, eq
+               	cbnz	w1,  <L131>
+               	b	 <L132>
+<L131>:
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, ne
-               	cbnz	w0,  <L139>
-<L126>:
+               	cset	w1, ne
+<L132>:
+               	b	 <L134>
+<L133>:
+               	mov	x1, x0
+<L134>:
+               	cbnz	w1,  <L147>
                	fmov	d30, xzr
                	fcmp	d0, d30
                	cset	w0, mi
-               	cbnz	w0,  <L127>
+               	cbnz	w0,  <L135>
                	fmov	d2, d0
-               	b	 <L128>
-<L127>:
+               	b	 <L136>
+<L135>:
                	fmov	d31, xzr
                	fsub	d2, d31, d0
-<L128>:
+<L136>:
                	fmov	d30, xzr
                	fcmp	d1, d30
                	cset	w1, mi
-               	cbnz	w1,  <L129>
+               	cbnz	w1,  <L137>
                	fmov	d3, d1
-               	b	 <L130>
-<L129>:
+               	b	 <L138>
+<L137>:
                	fmov	d31, xzr
                	fsub	d3, d31, d1
-<L130>:
+<L138>:
                	fmov	d30, #2.00000000
                	fdiv	d4, d2, d30
                	fmov	d5, d3
-<L131>:
+<L139>:
                	fcmp	d5, d4
                	cset	w1, ls
-               	cbnz	w1,  <L138>
+               	cbnz	w1,  <L146>
                	fmov	d6, d2
                	fmov	d7, d5
-<L132>:
+<L140>:
                	fcmp	d3, d7
                	cset	w1, ls
-               	cbnz	w1,  <L135>
-               	cbnz	w0,  <L133>
+               	cbnz	w1,  <L143>
+               	cbnz	w0,  <L141>
                	fmov	d16, d6
-               	b	 <L134>
-<L133>:
+               	b	 <L142>
+<L141>:
                	fmov	d31, xzr
                	fsub	d16, d31, d6
-<L134>:
-               	b	 <L140>
-<L135>:
+<L142>:
+               	b	 <L148>
+<L143>:
                	fcmp	d7, d6
                	cset	w1, ls
-               	cbnz	w1,  <L136>
+               	cbnz	w1,  <L144>
                	fmov	d17, d6
-               	b	 <L137>
-<L136>:
+               	b	 <L145>
+<L144>:
                	fsub	d17, d6, d7
-<L137>:
+<L145>:
                	fmov	d30, #2.00000000
                	fdiv	d7, d7, d30
                	fmov	d6, d17
-               	b	 <L132>
-<L138>:
+               	b	 <L140>
+<L146>:
                	fmov	d30, #2.00000000
                	fmul	d5, d5, d30
-               	b	 <L131>
-<L139>:
+               	b	 <L139>
+<L147>:
                	fdiv	d2, d0, d1
                	fcvtzs	x0, d2
                	scvtf	d2, x0
                	fmul	d3, d2, d1
                	fsub	d16, d0, d3
-<L140>:
+<L148>:
                	fcmp	d16, d16
                	cset	w0, ne
-               	cbnz	w0,  <L142>
+               	cbnz	w0,  <L150>
                	mov	x0, x20
                	fmov	d0, d16
-<L141>:
-               	bl	 <L141>
+<L149>:
+               	bl	 <L149>
                	mov	x19, x0
-               	b	 <L144>
-<L142>:
+               	b	 <L152>
+<L150>:
                	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L143>:
-               	bl	 <L143>
+<L151>:
+               	bl	 <L151>
                	mov	x19, x0
-<L144>:
+<L152>:
                	fmov	d31, #7.00000000
                	fmul	d0, d31, d8
                	fmov	d30, #2.00000000
                	fmul	d1, d0, d30
                	fcmp	d0, d1
                	cset	w0, eq
-               	cbnz	w0,  <L145>
-               	b	 <L146>
-<L145>:
+               	cbnz	w0,  <L153>
+               	b	 <L154>
+<L153>:
                	fmov	d30, xzr
                	fcmp	d0, d30
                	cset	w0, ne
-               	cbnz	w0,  <L157>
-<L146>:
+<L154>:
+               	cbnz	w0,  <L165>
                	fmov	d30, xzr
                	fcmp	d0, d30
                	cset	w0, mi
-               	cbnz	w0,  <L147>
+               	cbnz	w0,  <L155>
                	fmov	d1, d0
-               	b	 <L148>
-<L147>:
+               	b	 <L156>
+<L155>:
                	fmov	d31, xzr
                	fsub	d1, d31, d0
-<L148>:
+<L156>:
                	fmov	d30, #2.00000000
                	fdiv	d2, d1, d30
                	fmov	d3, #0.50000000
-<L149>:
+<L157>:
                	fcmp	d3, d2
                	cset	w1, ls
-               	cbnz	w1,  <L156>
+               	cbnz	w1,  <L164>
                	fmov	d4, d1
                	fmov	d5, d3
-<L150>:
+<L158>:
                	fmov	d31, #0.50000000
                	fcmp	d31, d5
                	cset	w1, ls
-               	cbnz	w1,  <L153>
-               	cbnz	w0,  <L151>
+               	cbnz	w1,  <L161>
+               	cbnz	w0,  <L159>
                	fmov	d6, d4
-               	b	 <L152>
-<L151>:
+               	b	 <L160>
+<L159>:
                	fmov	d31, xzr
                	fsub	d6, d31, d4
-<L152>:
-               	b	 <L158>
-<L153>:
+<L160>:
+               	b	 <L166>
+<L161>:
                	fcmp	d5, d4
                	cset	w1, ls
-               	cbnz	w1,  <L154>
+               	cbnz	w1,  <L162>
                	fmov	d7, d4
-               	b	 <L155>
-<L154>:
+               	b	 <L163>
+<L162>:
                	fsub	d7, d4, d5
-<L155>:
+<L163>:
                	fmov	d30, #2.00000000
                	fdiv	d5, d5, d30
                	fmov	d4, d7
-               	b	 <L150>
-<L156>:
+               	b	 <L158>
+<L164>:
                	fmov	d30, #2.00000000
                	fmul	d3, d3, d30
-               	b	 <L149>
-<L157>:
+               	b	 <L157>
+<L165>:
                	fmov	d30, #0.50000000
                	fdiv	d1, d0, d30
                	fcvtzs	x0, d1
@@ -842,226 +858,234 @@ Disassembly of section .text:
                	fmov	d30, #0.50000000
                	fmul	d2, d1, d30
                	fsub	d6, d0, d2
-<L158>:
+<L166>:
                	fcmp	d6, d6
                	cset	w0, ne
-               	cbnz	w0,  <L160>
+               	cbnz	w0,  <L168>
                	mov	x0, x19
                	fmov	d0, d6
-<L159>:
-               	bl	 <L159>
+<L167>:
+               	bl	 <L167>
                	mov	x20, x0
-               	b	 <L162>
-<L160>:
+               	b	 <L170>
+<L168>:
                	mov	x0, x19
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L161>:
-               	bl	 <L161>
+<L169>:
+               	bl	 <L169>
                	mov	x20, x0
-<L162>:
+<L170>:
                	fmov	d30, xzr
                	fcmp	d10, d30
                	cset	w0, eq
-               	cbnz	w0,  <L177>
+               	cbnz	w0,  <L173>
                	fmov	d30, #2.00000000
                	fmul	d0, d8, d30
                	fcmp	d8, d0
-               	cset	w0, eq
-               	cbnz	w0,  <L163>
-               	b	 <L164>
-<L163>:
+               	cset	w1, eq
+               	cbnz	w1,  <L171>
+               	b	 <L172>
+<L171>:
                	fmov	d30, xzr
                	fcmp	d8, d30
-               	cset	w0, ne
-               	cbnz	w0,  <L177>
-<L164>:
+               	cset	w1, ne
+<L172>:
+               	b	 <L174>
+<L173>:
+               	mov	x1, x0
+<L174>:
+               	cbnz	w1,  <L187>
                	fmov	d30, xzr
                	fcmp	d8, d30
                	cset	w0, mi
-               	cbnz	w0,  <L165>
+               	cbnz	w0,  <L175>
                	fmov	d0, d8
-               	b	 <L166>
-<L165>:
+               	b	 <L176>
+<L175>:
                	fmov	d31, xzr
                	fsub	d0, d31, d8
-<L166>:
+<L176>:
                	fmov	d30, xzr
                	fcmp	d10, d30
                	cset	w1, mi
-               	cbnz	w1,  <L167>
+               	cbnz	w1,  <L177>
                	fmov	d1, d10
-               	b	 <L168>
-<L167>:
+               	b	 <L178>
+<L177>:
                	fmov	d31, xzr
                	fsub	d1, d31, d10
-<L168>:
+<L178>:
                	fmov	d30, #2.00000000
                	fdiv	d2, d0, d30
                	fmov	d3, d1
-<L169>:
+<L179>:
                	fcmp	d3, d2
                	cset	w1, ls
-               	cbnz	w1,  <L176>
+               	cbnz	w1,  <L186>
                	fmov	d4, d0
                	fmov	d5, d3
-<L170>:
+<L180>:
                	fcmp	d1, d5
                	cset	w1, ls
-               	cbnz	w1,  <L173>
-               	cbnz	w0,  <L171>
+               	cbnz	w1,  <L183>
+               	cbnz	w0,  <L181>
                	fmov	d6, d4
-               	b	 <L172>
-<L171>:
+               	b	 <L182>
+<L181>:
                	fmov	d31, xzr
                	fsub	d6, d31, d4
-<L172>:
-               	b	 <L178>
-<L173>:
+<L182>:
+               	b	 <L188>
+<L183>:
                	fcmp	d5, d4
                	cset	w1, ls
-               	cbnz	w1,  <L174>
+               	cbnz	w1,  <L184>
                	fmov	d7, d4
-               	b	 <L175>
-<L174>:
+               	b	 <L185>
+<L184>:
                	fsub	d7, d4, d5
-<L175>:
+<L185>:
                	fmov	d30, #2.00000000
                	fdiv	d5, d5, d30
                	fmov	d4, d7
-               	b	 <L170>
-<L176>:
+               	b	 <L180>
+<L186>:
                	fmov	d30, #2.00000000
                	fmul	d3, d3, d30
-               	b	 <L169>
-<L177>:
+               	b	 <L179>
+<L187>:
                	fdiv	d0, d8, d10
                	fcvtzs	x0, d0
                	scvtf	d0, x0
                	fmul	d1, d0, d10
                	fsub	d6, d8, d1
-<L178>:
+<L188>:
                	fcmp	d6, d6
                	cset	w0, ne
-               	cbnz	w0,  <L180>
+               	cbnz	w0,  <L190>
                	mov	x0, x20
                	fmov	d0, d6
-<L179>:
-               	bl	 <L179>
+<L189>:
+               	bl	 <L189>
                	mov	x19, x0
-               	b	 <L182>
-<L180>:
+               	b	 <L192>
+<L190>:
                	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L181>:
-               	bl	 <L181>
+<L191>:
+               	bl	 <L191>
                	mov	x19, x0
-<L182>:
+<L192>:
                	fmov	d30, xzr
                	fcmp	d10, d30
                	cset	w0, eq
-               	cbnz	w0,  <L197>
+               	cbnz	w0,  <L195>
                	fmov	d30, #2.00000000
                	fmul	d0, d10, d30
                	fcmp	d10, d0
-               	cset	w0, eq
-               	cbnz	w0,  <L183>
-               	b	 <L184>
-<L183>:
+               	cset	w1, eq
+               	cbnz	w1,  <L193>
+               	b	 <L194>
+<L193>:
                	fmov	d30, xzr
                	fcmp	d10, d30
-               	cset	w0, ne
-               	cbnz	w0,  <L197>
-<L184>:
+               	cset	w1, ne
+<L194>:
+               	b	 <L196>
+<L195>:
+               	mov	x1, x0
+<L196>:
+               	cbnz	w1,  <L209>
                	fmov	d30, xzr
                	fcmp	d10, d30
                	cset	w0, mi
-               	cbnz	w0,  <L185>
+               	cbnz	w0,  <L197>
                	fmov	d0, d10
-               	b	 <L186>
-<L185>:
+               	b	 <L198>
+<L197>:
                	fmov	d31, xzr
                	fsub	d0, d31, d10
-<L186>:
+<L198>:
                	fmov	d30, xzr
                	fcmp	d10, d30
                	cset	w1, mi
-               	cbnz	w1,  <L187>
+               	cbnz	w1,  <L199>
                	fmov	d1, d10
-               	b	 <L188>
-<L187>:
+               	b	 <L200>
+<L199>:
                	fmov	d31, xzr
                	fsub	d1, d31, d10
-<L188>:
+<L200>:
                	fmov	d30, #2.00000000
                	fdiv	d2, d0, d30
                	fmov	d3, d1
-<L189>:
+<L201>:
                	fcmp	d3, d2
                	cset	w1, ls
-               	cbnz	w1,  <L196>
+               	cbnz	w1,  <L208>
                	fmov	d4, d0
                	fmov	d5, d3
-<L190>:
+<L202>:
                	fcmp	d1, d5
                	cset	w1, ls
-               	cbnz	w1,  <L193>
-               	cbnz	w0,  <L191>
+               	cbnz	w1,  <L205>
+               	cbnz	w0,  <L203>
                	fmov	d6, d4
-               	b	 <L192>
-<L191>:
+               	b	 <L204>
+<L203>:
                	fmov	d31, xzr
                	fsub	d6, d31, d4
-<L192>:
-               	b	 <L198>
-<L193>:
+<L204>:
+               	b	 <L210>
+<L205>:
                	fcmp	d5, d4
                	cset	w1, ls
-               	cbnz	w1,  <L194>
+               	cbnz	w1,  <L206>
                	fmov	d7, d4
-               	b	 <L195>
-<L194>:
+               	b	 <L207>
+<L206>:
                	fsub	d7, d4, d5
-<L195>:
+<L207>:
                	fmov	d30, #2.00000000
                	fdiv	d5, d5, d30
                	fmov	d4, d7
-               	b	 <L190>
-<L196>:
+               	b	 <L202>
+<L208>:
                	fmov	d30, #2.00000000
                	fmul	d3, d3, d30
-               	b	 <L189>
-<L197>:
+               	b	 <L201>
+<L209>:
                	fdiv	d0, d10, d10
                	fcvtzs	x0, d0
                	scvtf	d0, x0
                	fmul	d1, d0, d10
                	fsub	d6, d10, d1
-<L198>:
+<L210>:
                	fcmp	d6, d6
                	cset	w0, ne
-               	cbnz	w0,  <L200>
+               	cbnz	w0,  <L212>
                	mov	x0, x19
                	fmov	d0, d6
-<L199>:
-               	bl	 <L199>
+<L211>:
+               	bl	 <L211>
                	mov	x20, x0
-               	b	 <L202>
-<L200>:
+               	b	 <L214>
+<L212>:
                	mov	x0, x19
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L201>:
-               	bl	 <L201>
+<L213>:
+               	bl	 <L213>
                	mov	x20, x0
-<L202>:
+<L214>:
                	mov	x16, #0x4130000000000000 // =4697254411347427328
                	fmov	d31, x16
                	fmul	d0, d31, d8
@@ -1072,99 +1096,103 @@ Disassembly of section .text:
                	fmov	d30, #2.00000000
                	fmul	d1, d0, d30
                	fcmp	d0, d1
-               	cset	w0, eq
-               	cbnz	w0,  <L203>
-               	b	 <L204>
-<L203>:
+               	cset	w1, eq
+               	cbnz	w1,  <L215>
+               	b	 <L216>
+<L215>:
                	fmov	d30, xzr
                	fcmp	d0, d30
-               	cset	w0, ne
-               	cbnz	w0,  <L217>
-<L204>:
+               	cset	w1, ne
+<L216>:
+               	b	 <L218>
+<L217>:
+               	mov	x1, x0
+<L218>:
+               	cbnz	w1,  <L231>
                	fmov	d30, xzr
                	fcmp	d0, d30
                	cset	w0, mi
-               	cbnz	w0,  <L205>
+               	cbnz	w0,  <L219>
                	fmov	d1, d0
-               	b	 <L206>
-<L205>:
+               	b	 <L220>
+<L219>:
                	fmov	d31, xzr
                	fsub	d1, d31, d0
-<L206>:
+<L220>:
                	fmov	d30, xzr
                	fcmp	d10, d30
                	cset	w1, mi
-               	cbnz	w1,  <L207>
+               	cbnz	w1,  <L221>
                	fmov	d2, d10
-               	b	 <L208>
-<L207>:
+               	b	 <L222>
+<L221>:
                	fmov	d31, xzr
                	fsub	d2, d31, d10
-<L208>:
+<L222>:
                	fmov	d30, #2.00000000
                	fdiv	d3, d1, d30
                	fmov	d4, d2
-<L209>:
+<L223>:
                	fcmp	d4, d3
                	cset	w1, ls
-               	cbnz	w1,  <L216>
+               	cbnz	w1,  <L230>
                	fmov	d5, d1
                	fmov	d6, d4
-<L210>:
+<L224>:
                	fcmp	d2, d6
                	cset	w1, ls
-               	cbnz	w1,  <L213>
-               	cbnz	w0,  <L211>
+               	cbnz	w1,  <L227>
+               	cbnz	w0,  <L225>
                	fmov	d7, d5
-               	b	 <L212>
-<L211>:
+               	b	 <L226>
+<L225>:
                	fmov	d31, xzr
                	fsub	d7, d31, d5
-<L212>:
-               	b	 <L218>
-<L213>:
+<L226>:
+               	b	 <L232>
+<L227>:
                	fcmp	d6, d5
                	cset	w1, ls
-               	cbnz	w1,  <L214>
+               	cbnz	w1,  <L228>
                	fmov	d16, d5
-               	b	 <L215>
-<L214>:
+               	b	 <L229>
+<L228>:
                	fsub	d16, d5, d6
-<L215>:
+<L229>:
                	fmov	d30, #2.00000000
                	fdiv	d6, d6, d30
                	fmov	d5, d16
-               	b	 <L210>
-<L216>:
+               	b	 <L224>
+<L230>:
                	fmov	d30, #2.00000000
                	fmul	d4, d4, d30
-               	b	 <L209>
-<L217>:
+               	b	 <L223>
+<L231>:
                	fdiv	d1, d0, d10
                	fcvtzs	x0, d1
                	scvtf	d1, x0
                	fmul	d2, d1, d10
                	fsub	d7, d0, d2
-<L218>:
+<L232>:
                	fcmp	d7, d7
                	cset	w0, ne
-               	cbnz	w0,  <L220>
+               	cbnz	w0,  <L234>
                	mov	x0, x20
                	fmov	d0, d7
-<L219>:
-               	bl	 <L219>
+<L233>:
+               	bl	 <L233>
                	mov	x19, x0
-               	b	 <L222>
-<L220>:
+               	b	 <L236>
+<L234>:
                	mov	x0, x20
                	mov	x1, #0xffff             // =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L221>:
-               	bl	 <L221>
+<L235>:
+               	bl	 <L235>
                	mov	x19, x0
-<L222>:
+<L236>:
                	mov	x0, x19
                	ldp	d8, d9, [x29, #-0x30]
                	ldp	d10, d11, [x29, #-0x40]

--- a/test/golden/aarch64-linux/float/arith_f64.dis
+++ b/test/golden/aarch64-linux/float/arith_f64.dis
@@ -420,8 +420,7 @@ Disassembly of section .text:
                	fmov	d6, d4
                	b	 <L76>
 <L75>:
-               	fmov	d31, xzr
-               	fsub	d6, d31, d4
+               	fneg	d6, d4
 <L76>:
                	b	 <L82>
 <L77>:
@@ -526,8 +525,7 @@ Disassembly of section .text:
                	fmov	d7, d5
                	b	 <L98>
 <L97>:
-               	fmov	d31, xzr
-               	fsub	d7, d31, d5
+               	fneg	d7, d5
 <L98>:
                	b	 <L104>
 <L99>:
@@ -632,8 +630,7 @@ Disassembly of section .text:
                	fmov	d7, d5
                	b	 <L120>
 <L119>:
-               	fmov	d31, xzr
-               	fsub	d7, d31, d5
+               	fneg	d7, d5
 <L120>:
                	b	 <L126>
 <L121>:
@@ -740,8 +737,7 @@ Disassembly of section .text:
                	fmov	d16, d6
                	b	 <L142>
 <L141>:
-               	fmov	d31, xzr
-               	fsub	d16, d31, d6
+               	fneg	d16, d6
 <L142>:
                	b	 <L148>
 <L143>:
@@ -829,8 +825,7 @@ Disassembly of section .text:
                	fmov	d6, d4
                	b	 <L160>
 <L159>:
-               	fmov	d31, xzr
-               	fsub	d6, d31, d4
+               	fneg	d6, d4
 <L160>:
                	b	 <L166>
 <L161>:
@@ -935,8 +930,7 @@ Disassembly of section .text:
                	fmov	d6, d4
                	b	 <L182>
 <L181>:
-               	fmov	d31, xzr
-               	fsub	d6, d31, d4
+               	fneg	d6, d4
 <L182>:
                	b	 <L188>
 <L183>:
@@ -1039,8 +1033,7 @@ Disassembly of section .text:
                	fmov	d6, d4
                	b	 <L204>
 <L203>:
-               	fmov	d31, xzr
-               	fsub	d6, d31, d4
+               	fneg	d6, d4
 <L204>:
                	b	 <L210>
 <L205>:
@@ -1146,8 +1139,7 @@ Disassembly of section .text:
                	fmov	d7, d5
                	b	 <L226>
 <L225>:
-               	fmov	d31, xzr
-               	fsub	d7, d31, d5
+               	fneg	d7, d5
 <L226>:
                	b	 <L232>
 <L227>:

--- a/test/golden/riscv64-linux/float/arith_f32.dis
+++ b/test/golden/riscv64-linux/float/arith_f32.dis
@@ -124,580 +124,247 @@ Disassembly of section .text:
                	jalr	ra <corpus.cases.float.arith_f32.checksum+0x14c>
                	mv	s2, a0
                	fdiv.s	ft0, fs1, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x1f8 <corpus.cases.float.arith_f32.checksum+0x180>
                	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x170>
-               	mv	s1, a0
-               	j	0x20c <corpus.cases.float.arith_f32.checksum+0x194>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x188>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x164>
                	fdiv.s	ft0, fs2, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x234 <corpus.cases.float.arith_f32.checksum+0x1bc>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x1ac>
-               	mv	s2, a0
-               	j	0x248 <corpus.cases.float.arith_f32.checksum+0x1d0>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x1c4>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x174>
                	fneg.s	ft0, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x270 <corpus.cases.float.arith_f32.checksum+0x1f8>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x1e8>
-               	mv	s1, a0
-               	j	0x284 <corpus.cases.float.arith_f32.checksum+0x20c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x200>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x184>
                	fmv.w.x	ft11, zero
-               	fsub.s	ft0, ft11, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x2b0 <corpus.cases.float.arith_f32.checksum+0x238>
-               	mv	a0, s1
-               	fmv.s	fa0, ft0
+               	fsub.s	fs2, ft11, fs1
+               	fmv.s	fa0, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x228>
-               	mv	s2, a0
-               	j	0x2c4 <corpus.cases.float.arith_f32.checksum+0x24c>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x240>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x198>
                	fsub.s	ft0, fs1, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x2ec <corpus.cases.float.arith_f32.checksum+0x274>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x264>
-               	mv	s1, a0
-               	j	0x300 <corpus.cases.float.arith_f32.checksum+0x288>
-               	mv	a0, s2
-               	li	a1, -0x1
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x1a8>
+               	fadd.s	ft0, fs2, fs1
+               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x27c>
-               	mv	s1, a0
-               	fmv.w.x	ft11, zero
-               	fsub.s	ft0, ft11, fs1
-               	fadd.s	ft1, ft0, fs1
-               	feq.s	a0, ft1, ft1
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x330 <corpus.cases.float.arith_f32.checksum+0x2b8>
-               	mv	a0, s1
-               	fmv.s	fa0, ft1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x2a8>
-               	mv	s2, a0
-               	j	0x344 <corpus.cases.float.arith_f32.checksum+0x2cc>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x2c0>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x1b8>
                	lui	t0, 0x40400
                	fmv.w.x	ft11, t0
                	fmul.s	fs1, ft11, fs0
                	fdiv.s	fs2, fs0, fs1
-               	feq.s	a0, fs2, fs2
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x378 <corpus.cases.float.arith_f32.checksum+0x300>
-               	mv	a0, s2
                	fmv.s	fa0, fs2
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x2f0>
-               	mv	s1, a0
-               	j	0x38c <corpus.cases.float.arith_f32.checksum+0x314>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x308>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x1d4>
                	fmul.s	ft0, fs2, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x3b4 <corpus.cases.float.arith_f32.checksum+0x33c>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x32c>
-               	mv	s2, a0
-               	j	0x3c8 <corpus.cases.float.arith_f32.checksum+0x350>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x344>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x1e4>
                	fsub.s	ft0, fs0, fs2
                	fsub.s	ft1, ft0, fs2
                	fsub.s	ft0, ft1, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x3f8 <corpus.cases.float.arith_f32.checksum+0x380>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x370>
-               	mv	s1, a0
-               	j	0x40c <corpus.cases.float.arith_f32.checksum+0x394>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x388>
-               	mv	s1, a0
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x1fc>
                	lui	t0, 0x42440
                	fmv.w.x	ft10, t0
                	fdiv.s	ft0, fs0, ft10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x43c <corpus.cases.float.arith_f32.checksum+0x3c4>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x3b4>
-               	mv	s2, a0
-               	j	0x450 <.Lpcrel_hi.0>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x3cc>
-               	mv	s2, a0
+               	jalr	ra <corpus.cases.float.arith_f32.checksum+0x214>
 
 <.Lpcrel_hi.0>:
                	auipc	t0, 0x0
                	flw	ft10, 0x0(t0)
                	fdiv.s	ft0, fs0, ft10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x480 <.Lpcrel_hi.0+0x30>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x20>
-               	mv	s1, a0
-               	j	0x494 <.Lpcrel_hi.1>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.0+0x38>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.0+0x10>
 
 <.Lpcrel_hi.1>:
                	auipc	t0, 0x0
                	flw	ft11, 0x0(t0)
                	fdiv.s	ft0, ft11, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x4c4 <.Lpcrel_hi.1+0x30>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x20>
-               	mv	s2, a0
-               	j	0x4d8 <.Lpcrel_hi.1+0x44>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x38>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x10>
                	lui	t0, 0x4b800
                	fmv.w.x	ft11, t0
                	fmul.s	fs1, ft11, fs0
-               	fadd.s	ft0, fs1, fs0
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x50c <.Lpcrel_hi.1+0x78>
-               	mv	a0, s2
+               	fadd.s	fs3, fs1, fs0
+               	fmv.s	fa0, fs3
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.1+0x2c>
+               	fadd.s	ft0, fs3, fs0
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x68>
-               	mv	s1, a0
-               	j	0x520 <.Lpcrel_hi.1+0x8c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x80>
-               	mv	s1, a0
-               	fadd.s	ft0, fs1, fs0
-               	fadd.s	ft1, ft0, fs0
-               	feq.s	a0, ft1, ft1
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x54c <.Lpcrel_hi.1+0xb8>
-               	mv	a0, s1
-               	fmv.s	fa0, ft1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xa8>
-               	mv	s2, a0
-               	j	0x560 <.Lpcrel_hi.1+0xcc>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xc0>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x3c>
                	fadd.s	ft0, fs0, fs0
                	fadd.s	ft1, fs1, ft0
-               	feq.s	a0, ft1, ft1
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x58c <.Lpcrel_hi.1+0xf8>
-               	mv	a0, s2
                	fmv.s	fa0, ft1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xe8>
-               	mv	s1, a0
-               	j	0x5a0 <.Lpcrel_hi.1+0x10c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x100>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.1+0x50>
                	fsub.s	ft0, fs1, fs0
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x5c8 <.Lpcrel_hi.1+0x134>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x124>
-               	mv	s2, a0
-               	j	0x5dc <.Lpcrel_hi.1+0x148>
-               	mv	a0, s1
-               	li	a1, -0x1
+               	jalr	ra <.Lpcrel_hi.1+0x60>
+               	fsub.s	ft0, fs3, fs1
+               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x13c>
-               	mv	s2, a0
-               	fadd.s	ft0, fs1, fs0
-               	fsub.s	ft1, ft0, fs1
-               	feq.s	a0, ft1, ft1
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x608 <.Lpcrel_hi.1+0x174>
-               	mv	a0, s2
-               	fmv.s	fa0, ft1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x164>
-               	mv	s1, a0
-               	j	0x61c <.Lpcrel_hi.1+0x188>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x17c>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.1+0x70>
                	fmv.w.x	ft11, zero
                	fmul.s	ft0, ft11, fs0
+               	mv	s1, a0
                	fmv.d	fs1, ft0
                	li	s2, 0x0
                	li	t0, 0x18
-               	bltu	s2, t0, 0x638 <.Lpcrel_hi.1+0x1a4>
-               	j	0x694 <.Lpcrel_hi.1+0x200>
+               	bltu	s2, t0, 0x344 <.Lpcrel_hi.1+0x98>
+               	j	0x3a0 <.Lpcrel_hi.1+0xf4>
                	fadd.s	ft0, fs1, fs2
                	lui	t0, 0x3fc00
                	fmv.w.x	ft10, t0
                	fmul.s	fs3, ft0, ft10
                	feq.s	a0, fs3, fs3
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x66c <.Lpcrel_hi.1+0x1d8>
+               	bnez	a0, 0x378 <.Lpcrel_hi.1+0xcc>
                	mv	a0, s1
                	fmv.s	fa0, fs3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x1c8>
+               	jalr	ra <.Lpcrel_hi.1+0xbc>
                	mv	s4, a0
-               	j	0x680 <.Lpcrel_hi.1+0x1ec>
+               	j	0x38c <.Lpcrel_hi.1+0xe0>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x1e0>
+               	jalr	ra <.Lpcrel_hi.1+0xd4>
                	mv	s4, a0
                	addiw	s2, s2, 0x1
                	mv	s1, s4
                	fmv.d	fs1, fs3
                	li	t0, 0x18
-               	bltu	s2, t0, 0x638 <.Lpcrel_hi.1+0x1a4>
+               	bltu	s2, t0, 0x344 <.Lpcrel_hi.1+0x98>
                	lui	t1, 0x7f800
                	addiw	t1, t1, -0x1
                	addw	a0, t1, s3
                	fmv.w.x	fs1, a0
                	feq.s	a0, fs1, fs1
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x6c8 <.Lpcrel_hi.1+0x234>
+               	bnez	a0, 0x3d4 <.Lpcrel_hi.1+0x128>
                	mv	a0, s1
                	fmv.s	fa0, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x224>
+               	jalr	ra <.Lpcrel_hi.1+0x118>
                	mv	s2, a0
-               	j	0x6dc <.Lpcrel_hi.1+0x248>
+               	j	0x3e8 <.Lpcrel_hi.1+0x13c>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x23c>
+               	jalr	ra <.Lpcrel_hi.1+0x130>
                	mv	s2, a0
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft0, fs1, ft10
                	feq.s	a0, ft0, ft0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x70c <.Lpcrel_hi.1+0x278>
+               	bnez	a0, 0x418 <.Lpcrel_hi.1+0x16c>
                	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x268>
+               	jalr	ra <.Lpcrel_hi.1+0x15c>
                	mv	s1, a0
-               	j	0x720 <.Lpcrel_hi.1+0x28c>
+               	j	0x42c <.Lpcrel_hi.1+0x180>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x280>
+               	jalr	ra <.Lpcrel_hi.1+0x174>
                	mv	s1, a0
                	fadd.s	ft0, fs1, fs1
                	feq.s	a0, ft0, ft0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x748 <.Lpcrel_hi.1+0x2b4>
+               	bnez	a0, 0x454 <.Lpcrel_hi.1+0x1a8>
                	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x2a4>
+               	jalr	ra <.Lpcrel_hi.1+0x198>
                	mv	s2, a0
-               	j	0x75c <.Lpcrel_hi.1+0x2c8>
+               	j	0x468 <.Lpcrel_hi.1+0x1bc>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x2bc>
+               	jalr	ra <.Lpcrel_hi.1+0x1b0>
                	mv	s2, a0
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
-               	fmul.s	ft0, fs1, ft10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x78c <.Lpcrel_hi.1+0x2f8>
+               	fmul.s	fs2, fs1, ft10
                	mv	a0, s2
-               	fmv.s	fa0, ft0
+               	fmv.s	fa0, fs2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x2e8>
-               	mv	s1, a0
-               	j	0x7a0 <.Lpcrel_hi.1+0x30c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x300>
-               	mv	s1, a0
-               	lui	t0, 0x40000
-               	fmv.w.x	ft10, t0
-               	fmul.s	ft0, fs1, ft10
+               	jalr	ra <.Lpcrel_hi.1+0x1d0>
                	fmv.w.x	ft11, zero
-               	fsub.s	ft1, ft11, ft0
-               	feq.s	a0, ft1, ft1
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x7d8 <.Lpcrel_hi.1+0x344>
-               	mv	a0, s1
-               	fmv.s	fa0, ft1
+               	fsub.s	ft0, ft11, fs2
+               	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x334>
-               	mv	s2, a0
-               	j	0x7ec <.Lpcrel_hi.1+0x358>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x34c>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x1e4>
                	fmul.s	ft0, fs1, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x814 <.Lpcrel_hi.1+0x380>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x370>
-               	mv	s1, a0
-               	j	0x828 <.Lpcrel_hi.1+0x394>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x388>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.1+0x1f4>
                	fsub.s	ft0, fs1, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x850 <.Lpcrel_hi.1+0x3bc>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x3ac>
-               	mv	s2, a0
-               	j	0x864 <.Lpcrel_hi.1+0x3d0>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x3c4>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x204>
                	lui	t1, 0x800
-               	addw	a0, t1, s3
-               	fmv.w.x	fs1, a0
+               	addw	a1, t1, s3
+               	fmv.w.x	fs1, a1
                	li	t1, 0x1
-               	addw	a0, t1, s3
-               	fmv.w.x	fs2, a0
+               	addw	a1, t1, s3
+               	fmv.w.x	fs2, a1
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs1, ft10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x8ac <.Lpcrel_hi.1+0x418>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x408>
-               	mv	s1, a0
-               	j	0x8c0 <.Lpcrel_hi.1+0x42c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x420>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.1+0x234>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft0, fs1, ft10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x8f0 <.Lpcrel_hi.1+0x45c>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x44c>
-               	mv	s2, a0
-               	j	0x904 <.Lpcrel_hi.1+0x470>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x464>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x24c>
                	fsub.s	ft0, fs1, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x92c <.Lpcrel_hi.1+0x498>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x488>
-               	mv	s1, a0
-               	j	0x940 <.Lpcrel_hi.1+0x4ac>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x4a0>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.1+0x25c>
                	fmul.s	ft0, fs1, fs0
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x968 <.Lpcrel_hi.1+0x4d4>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x4c4>
-               	mv	s2, a0
-               	j	0x97c <.Lpcrel_hi.1+0x4e8>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x4dc>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x26c>
                	fadd.s	ft0, fs2, fs2
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x9a4 <.Lpcrel_hi.1+0x510>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x500>
-               	mv	s1, a0
-               	j	0x9b8 <.Lpcrel_hi.1+0x524>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x518>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.1+0x27c>
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs2, ft10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x9e8 <.Lpcrel_hi.1+0x554>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x544>
-               	mv	s2, a0
-               	j	0x9fc <.Lpcrel_hi.1+0x568>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x55c>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x294>
                	lui	t0, 0x3f400
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs2, ft10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa2c <.Lpcrel_hi.1+0x598>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x588>
-               	mv	s1, a0
-               	j	0xa40 <.Lpcrel_hi.1+0x5ac>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x5a0>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.1+0x2ac>
                	lui	t0, 0x4b800
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs2, ft10
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa70 <.Lpcrel_hi.1+0x5dc>
-               	mv	a0, s1
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x5cc>
-               	mv	s2, a0
-               	j	0xa84 <.Lpcrel_hi.1+0x5f0>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x5e4>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.1+0x2c4>
                	fdiv.s	ft0, fs2, fs1
-               	feq.s	a0, ft0, ft0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xaac <.Lpcrel_hi.1+0x618>
-               	mv	a0, s2
                	fmv.s	fa0, ft0
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x608>
-               	mv	s1, a0
-               	j	0xac0 <.Lpcrel_hi.1+0x62c>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x620>
+               	jalr	ra <.Lpcrel_hi.1+0x2d4>
                	mv	s1, a0
                	lui	t0, 0x40b00
                	fmv.w.x	ft11, t0
@@ -705,93 +372,394 @@ Disassembly of section .text:
                	lui	t0, 0x40400
                	fmv.w.x	ft11, t0
                	fmul.s	fs2, ft11, fs0
+               	fmv.w.x	ft10, zero
+               	feq.s	a0, fs2, ft10
+               	bnez	a0, 0x5d8 <.Lpcrel_hi.1+0x32c>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft0, fs1, ft10
+               	feq.s	a1, fs1, ft0
+               	bnez	a1, 0x5c8 <.Lpcrel_hi.1+0x31c>
+               	j	0x5d4 <.Lpcrel_hi.1+0x328>
+               	fmv.w.x	ft10, zero
+               	feq.s	a1, fs1, ft10
+               	xori	a1, a1, 0x1
+               	j	0x5dc <.Lpcrel_hi.1+0x330>
+               	mv	a1, a0
+               	bnez	a1, 0x690 <.Lpcrel_hi.1+0x3e4>
+               	fmv.w.x	ft10, zero
+               	flt.s	a0, fs1, ft10
+               	bnez	a0, 0x5f4 <.Lpcrel_hi.1+0x348>
+               	fmv.d	ft0, fs1
+               	j	0x5fc <.Lpcrel_hi.1+0x350>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft0, ft11, fs1
+               	fmv.w.x	ft10, zero
+               	flt.s	a1, fs2, ft10
+               	bnez	a1, 0x610 <.Lpcrel_hi.1+0x364>
+               	fmv.d	ft1, fs2
+               	j	0x618 <.Lpcrel_hi.1+0x36c>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft1, ft11, fs2
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft2, ft0, ft10
+               	fmv.d	ft3, ft1
+               	fle.s	a1, ft3, ft2
+               	bnez	a1, 0x680 <.Lpcrel_hi.1+0x3d4>
+               	fmv.d	ft4, ft0
+               	fmv.d	ft5, ft3
+               	fle.s	a1, ft1, ft5
+               	bnez	a1, 0x658 <.Lpcrel_hi.1+0x3ac>
+               	bnez	a0, 0x64c <.Lpcrel_hi.1+0x3a0>
+               	fmv.d	ft6, ft4
+               	j	0x654 <.Lpcrel_hi.1+0x3a8>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft6, ft11, ft4
+               	j	0x6a4 <.Lpcrel_hi.1+0x3f8>
+               	fle.s	a1, ft5, ft4
+               	bnez	a1, 0x668 <.Lpcrel_hi.1+0x3bc>
+               	fmv.d	ft7, ft4
+               	j	0x66c <.Lpcrel_hi.1+0x3c0>
+               	fsub.s	ft7, ft4, ft5
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft5, ft5, ft10
+               	fmv.d	ft4, ft7
+               	j	0x638 <.Lpcrel_hi.1+0x38c>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft3, ft3, ft10
+               	j	0x628 <.Lpcrel_hi.1+0x37c>
                	fdiv.s	ft0, fs1, fs2
                	fcvt.l.s	a0, ft0, rtz
                	fcvt.s.l	ft0, a0
                	fmul.s	ft1, ft0, fs2
-               	fsub.s	ft0, fs1, ft1
-               	feq.s	a0, ft0, ft0
+               	fsub.s	ft6, fs1, ft1
+               	feq.s	a0, ft6, ft6
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xb10 <.Lpcrel_hi.1+0x67c>
+               	bnez	a0, 0x6c8 <.Lpcrel_hi.1+0x41c>
                	mv	a0, s1
-               	fmv.s	fa0, ft0
+               	fmv.s	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x66c>
+               	jalr	ra <.Lpcrel_hi.1+0x40c>
                	mv	s2, a0
-               	j	0xb24 <.Lpcrel_hi.1+0x690>
+               	j	0x6dc <.Lpcrel_hi.1+0x430>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x684>
+               	jalr	ra <.Lpcrel_hi.1+0x424>
                	mv	s2, a0
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs1
+               	fmv.w.x	ft10, zero
+               	feq.s	a0, fs2, ft10
+               	bnez	a0, 0x718 <.Lpcrel_hi.1+0x46c>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft1, ft0, ft10
+               	feq.s	a1, ft0, ft1
+               	bnez	a1, 0x708 <.Lpcrel_hi.1+0x45c>
+               	j	0x714 <.Lpcrel_hi.1+0x468>
+               	fmv.w.x	ft10, zero
+               	feq.s	a1, ft0, ft10
+               	xori	a1, a1, 0x1
+               	j	0x71c <.Lpcrel_hi.1+0x470>
+               	mv	a1, a0
+               	bnez	a1, 0x7d0 <.Lpcrel_hi.1+0x524>
+               	fmv.w.x	ft10, zero
+               	flt.s	a0, ft0, ft10
+               	bnez	a0, 0x734 <.Lpcrel_hi.1+0x488>
+               	fmv.d	ft1, ft0
+               	j	0x73c <.Lpcrel_hi.1+0x490>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft1, ft11, ft0
+               	fmv.w.x	ft10, zero
+               	flt.s	a1, fs2, ft10
+               	bnez	a1, 0x750 <.Lpcrel_hi.1+0x4a4>
+               	fmv.d	ft2, fs2
+               	j	0x758 <.Lpcrel_hi.1+0x4ac>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft2, ft11, fs2
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft3, ft1, ft10
+               	fmv.d	ft4, ft2
+               	fle.s	a1, ft4, ft3
+               	bnez	a1, 0x7c0 <.Lpcrel_hi.1+0x514>
+               	fmv.d	ft5, ft1
+               	fmv.d	ft6, ft4
+               	fle.s	a1, ft2, ft6
+               	bnez	a1, 0x798 <.Lpcrel_hi.1+0x4ec>
+               	bnez	a0, 0x78c <.Lpcrel_hi.1+0x4e0>
+               	fmv.d	ft7, ft5
+               	j	0x794 <.Lpcrel_hi.1+0x4e8>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft7, ft11, ft5
+               	j	0x7e4 <.Lpcrel_hi.1+0x538>
+               	fle.s	a1, ft6, ft5
+               	bnez	a1, 0x7a8 <.Lpcrel_hi.1+0x4fc>
+               	fmv.d	fa0, ft5
+               	j	0x7ac <.Lpcrel_hi.1+0x500>
+               	fsub.s	fa0, ft5, ft6
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft6, ft6, ft10
+               	fmv.d	ft5, fa0
+               	j	0x778 <.Lpcrel_hi.1+0x4cc>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft4, ft4, ft10
+               	j	0x768 <.Lpcrel_hi.1+0x4bc>
                	fdiv.s	ft1, ft0, fs2
                	fcvt.l.s	a0, ft1, rtz
                	fcvt.s.l	ft1, a0
                	fmul.s	ft2, ft1, fs2
-               	fsub.s	ft1, ft0, ft2
-               	feq.s	a0, ft1, ft1
+               	fsub.s	ft7, ft0, ft2
+               	feq.s	a0, ft7, ft7
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xb64 <.Lpcrel_hi.1+0x6d0>
+               	bnez	a0, 0x808 <.Lpcrel_hi.1+0x55c>
                	mv	a0, s2
-               	fmv.s	fa0, ft1
+               	fmv.s	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x6c0>
+               	jalr	ra <.Lpcrel_hi.1+0x54c>
                	mv	s1, a0
-               	j	0xb78 <.Lpcrel_hi.1+0x6e4>
+               	j	0x81c <.Lpcrel_hi.1+0x570>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x6d8>
+               	jalr	ra <.Lpcrel_hi.1+0x564>
                	mv	s1, a0
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs2
+               	fmv.w.x	ft10, zero
+               	feq.s	a0, ft0, ft10
+               	bnez	a0, 0x858 <.Lpcrel_hi.1+0x5ac>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft1, fs1, ft10
+               	feq.s	a1, fs1, ft1
+               	bnez	a1, 0x848 <.Lpcrel_hi.1+0x59c>
+               	j	0x854 <.Lpcrel_hi.1+0x5a8>
+               	fmv.w.x	ft10, zero
+               	feq.s	a1, fs1, ft10
+               	xori	a1, a1, 0x1
+               	j	0x85c <.Lpcrel_hi.1+0x5b0>
+               	mv	a1, a0
+               	bnez	a1, 0x910 <.Lpcrel_hi.1+0x664>
+               	fmv.w.x	ft10, zero
+               	flt.s	a0, fs1, ft10
+               	bnez	a0, 0x874 <.Lpcrel_hi.1+0x5c8>
+               	fmv.d	ft1, fs1
+               	j	0x87c <.Lpcrel_hi.1+0x5d0>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft1, ft11, fs1
+               	fmv.w.x	ft10, zero
+               	flt.s	a1, ft0, ft10
+               	bnez	a1, 0x890 <.Lpcrel_hi.1+0x5e4>
+               	fmv.d	ft2, ft0
+               	j	0x898 <.Lpcrel_hi.1+0x5ec>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft2, ft11, ft0
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft3, ft1, ft10
+               	fmv.d	ft4, ft2
+               	fle.s	a1, ft4, ft3
+               	bnez	a1, 0x900 <.Lpcrel_hi.1+0x654>
+               	fmv.d	ft5, ft1
+               	fmv.d	ft6, ft4
+               	fle.s	a1, ft2, ft6
+               	bnez	a1, 0x8d8 <.Lpcrel_hi.1+0x62c>
+               	bnez	a0, 0x8cc <.Lpcrel_hi.1+0x620>
+               	fmv.d	ft7, ft5
+               	j	0x8d4 <.Lpcrel_hi.1+0x628>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft7, ft11, ft5
+               	j	0x924 <.Lpcrel_hi.1+0x678>
+               	fle.s	a1, ft6, ft5
+               	bnez	a1, 0x8e8 <.Lpcrel_hi.1+0x63c>
+               	fmv.d	fa0, ft5
+               	j	0x8ec <.Lpcrel_hi.1+0x640>
+               	fsub.s	fa0, ft5, ft6
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft6, ft6, ft10
+               	fmv.d	ft5, fa0
+               	j	0x8b8 <.Lpcrel_hi.1+0x60c>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft4, ft4, ft10
+               	j	0x8a8 <.Lpcrel_hi.1+0x5fc>
                	fdiv.s	ft1, fs1, ft0
                	fcvt.l.s	a0, ft1, rtz
                	fcvt.s.l	ft1, a0
                	fmul.s	ft2, ft1, ft0
-               	fsub.s	ft0, fs1, ft2
-               	feq.s	a0, ft0, ft0
+               	fsub.s	ft7, fs1, ft2
+               	feq.s	a0, ft7, ft7
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xbb8 <.Lpcrel_hi.1+0x724>
+               	bnez	a0, 0x948 <.Lpcrel_hi.1+0x69c>
                	mv	a0, s1
-               	fmv.s	fa0, ft0
+               	fmv.s	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x714>
+               	jalr	ra <.Lpcrel_hi.1+0x68c>
                	mv	s2, a0
-               	j	0xbcc <.Lpcrel_hi.1+0x738>
+               	j	0x95c <.Lpcrel_hi.1+0x6b0>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x72c>
+               	jalr	ra <.Lpcrel_hi.1+0x6a4>
                	mv	s2, a0
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs1
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, fs2
+               	fmv.w.x	ft10, zero
+               	feq.s	a0, ft1, ft10
+               	bnez	a0, 0x9a0 <.Lpcrel_hi.1+0x6f4>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft2, ft0, ft10
+               	feq.s	a1, ft0, ft2
+               	bnez	a1, 0x990 <.Lpcrel_hi.1+0x6e4>
+               	j	0x99c <.Lpcrel_hi.1+0x6f0>
+               	fmv.w.x	ft10, zero
+               	feq.s	a1, ft0, ft10
+               	xori	a1, a1, 0x1
+               	j	0x9a4 <.Lpcrel_hi.1+0x6f8>
+               	mv	a1, a0
+               	bnez	a1, 0xa58 <.Lpcrel_hi.1+0x7ac>
+               	fmv.w.x	ft10, zero
+               	flt.s	a0, ft0, ft10
+               	bnez	a0, 0x9bc <.Lpcrel_hi.1+0x710>
+               	fmv.d	ft2, ft0
+               	j	0x9c4 <.Lpcrel_hi.1+0x718>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft2, ft11, ft0
+               	fmv.w.x	ft10, zero
+               	flt.s	a1, ft1, ft10
+               	bnez	a1, 0x9d8 <.Lpcrel_hi.1+0x72c>
+               	fmv.d	ft3, ft1
+               	j	0x9e0 <.Lpcrel_hi.1+0x734>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft3, ft11, ft1
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft4, ft2, ft10
+               	fmv.d	ft5, ft3
+               	fle.s	a1, ft5, ft4
+               	bnez	a1, 0xa48 <.Lpcrel_hi.1+0x79c>
+               	fmv.d	ft6, ft2
+               	fmv.d	ft7, ft5
+               	fle.s	a1, ft3, ft7
+               	bnez	a1, 0xa20 <.Lpcrel_hi.1+0x774>
+               	bnez	a0, 0xa14 <.Lpcrel_hi.1+0x768>
+               	fmv.d	fa0, ft6
+               	j	0xa1c <.Lpcrel_hi.1+0x770>
+               	fmv.w.x	ft11, zero
+               	fsub.s	fa0, ft11, ft6
+               	j	0xa6c <.Lpcrel_hi.1+0x7c0>
+               	fle.s	a1, ft7, ft6
+               	bnez	a1, 0xa30 <.Lpcrel_hi.1+0x784>
+               	fmv.d	fa1, ft6
+               	j	0xa34 <.Lpcrel_hi.1+0x788>
+               	fsub.s	fa1, ft6, ft7
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft7, ft7, ft10
+               	fmv.d	ft6, fa1
+               	j	0xa00 <.Lpcrel_hi.1+0x754>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft5, ft5, ft10
+               	j	0x9f0 <.Lpcrel_hi.1+0x744>
                	fdiv.s	ft2, ft0, ft1
                	fcvt.l.s	a0, ft2, rtz
                	fcvt.s.l	ft2, a0
                	fmul.s	ft3, ft2, ft1
-               	fsub.s	ft1, ft0, ft3
-               	feq.s	a0, ft1, ft1
+               	fsub.s	fa0, ft0, ft3
+               	feq.s	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xc14 <.Lpcrel_hi.1+0x780>
+               	bnez	a0, 0xa8c <.Lpcrel_hi.1+0x7e0>
                	mv	a0, s2
-               	fmv.s	fa0, ft1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x770>
+               	jalr	ra <.Lpcrel_hi.1+0x7d0>
                	mv	s1, a0
-               	j	0xc28 <.Lpcrel_hi.1+0x794>
+               	j	0xaa0 <.Lpcrel_hi.1+0x7f4>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x788>
+               	jalr	ra <.Lpcrel_hi.1+0x7e8>
                	mv	s1, a0
                	lui	t0, 0x40e00
                	fmv.w.x	ft11, t0
                	fmul.s	ft0, ft11, fs0
+               	lui	t0, 0x3f000
+               	fmv.w.x	ft11, t0
+               	fmv.w.x	ft10, zero
+               	feq.s	a0, ft11, ft10
+               	bnez	a0, 0xae8 <.Lpcrel_hi.1+0x83c>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft1, ft0, ft10
+               	feq.s	a1, ft0, ft1
+               	bnez	a1, 0xad8 <.Lpcrel_hi.1+0x82c>
+               	j	0xae4 <.Lpcrel_hi.1+0x838>
+               	fmv.w.x	ft10, zero
+               	feq.s	a1, ft0, ft10
+               	xori	a1, a1, 0x1
+               	j	0xaec <.Lpcrel_hi.1+0x840>
+               	mv	a1, a0
+               	bnez	a1, 0xbb4 <.Lpcrel_hi.1+0x908>
+               	fmv.w.x	ft10, zero
+               	flt.s	a0, ft0, ft10
+               	bnez	a0, 0xb04 <.Lpcrel_hi.1+0x858>
+               	fmv.d	ft1, ft0
+               	j	0xb0c <.Lpcrel_hi.1+0x860>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft1, ft11, ft0
+               	lui	t0, 0x3f000
+               	fmv.w.x	ft11, t0
+               	fmv.w.x	ft10, zero
+               	flt.s	a1, ft11, ft10
+               	bnez	a1, 0xb2c <.Lpcrel_hi.1+0x880>
+               	lui	t0, 0x3f000
+               	fmv.w.x	ft2, t0
+               	j	0xb3c <.Lpcrel_hi.1+0x890>
+               	fmv.w.x	ft11, zero
+               	lui	t0, 0x3f000
+               	fmv.w.x	ft10, t0
+               	fsub.s	ft2, ft11, ft10
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft3, ft1, ft10
+               	fmv.d	ft4, ft2
+               	fle.s	a1, ft4, ft3
+               	bnez	a1, 0xba4 <.Lpcrel_hi.1+0x8f8>
+               	fmv.d	ft5, ft1
+               	fmv.d	ft6, ft4
+               	fle.s	a1, ft2, ft6
+               	bnez	a1, 0xb7c <.Lpcrel_hi.1+0x8d0>
+               	bnez	a0, 0xb70 <.Lpcrel_hi.1+0x8c4>
+               	fmv.d	ft7, ft5
+               	j	0xb78 <.Lpcrel_hi.1+0x8cc>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft7, ft11, ft5
+               	j	0xbd8 <.Lpcrel_hi.1+0x92c>
+               	fle.s	a1, ft6, ft5
+               	bnez	a1, 0xb8c <.Lpcrel_hi.1+0x8e0>
+               	fmv.d	fa0, ft5
+               	j	0xb90 <.Lpcrel_hi.1+0x8e4>
+               	fsub.s	fa0, ft5, ft6
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft6, ft6, ft10
+               	fmv.d	ft5, fa0
+               	j	0xb5c <.Lpcrel_hi.1+0x8b0>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft4, ft4, ft10
+               	j	0xb4c <.Lpcrel_hi.1+0x8a0>
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft1, ft0, ft10
@@ -800,80 +768,257 @@ Disassembly of section .text:
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
                	fmul.s	ft2, ft1, ft10
-               	fsub.s	ft1, ft0, ft2
-               	feq.s	a0, ft1, ft1
+               	fsub.s	ft7, ft0, ft2
+               	feq.s	a0, ft7, ft7
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xc7c <.Lpcrel_hi.1+0x7e8>
+               	bnez	a0, 0xbfc <.Lpcrel_hi.1+0x950>
                	mv	a0, s1
-               	fmv.s	fa0, ft1
+               	fmv.s	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x7d8>
+               	jalr	ra <.Lpcrel_hi.1+0x940>
                	mv	s2, a0
-               	j	0xc90 <.Lpcrel_hi.1+0x7fc>
+               	j	0xc10 <.Lpcrel_hi.1+0x964>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x7f0>
+               	jalr	ra <.Lpcrel_hi.1+0x958>
                	mv	s2, a0
+               	fmv.w.x	ft10, zero
+               	feq.s	a0, fs2, ft10
+               	bnez	a0, 0xc44 <.Lpcrel_hi.1+0x998>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft0, fs0, ft10
+               	feq.s	a1, fs0, ft0
+               	bnez	a1, 0xc34 <.Lpcrel_hi.1+0x988>
+               	j	0xc40 <.Lpcrel_hi.1+0x994>
+               	fmv.w.x	ft10, zero
+               	feq.s	a1, fs0, ft10
+               	xori	a1, a1, 0x1
+               	j	0xc48 <.Lpcrel_hi.1+0x99c>
+               	mv	a1, a0
+               	bnez	a1, 0xcfc <.Lpcrel_hi.1+0xa50>
+               	fmv.w.x	ft10, zero
+               	flt.s	a0, fs0, ft10
+               	bnez	a0, 0xc60 <.Lpcrel_hi.1+0x9b4>
+               	fmv.d	ft0, fs0
+               	j	0xc68 <.Lpcrel_hi.1+0x9bc>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft0, ft11, fs0
+               	fmv.w.x	ft10, zero
+               	flt.s	a1, fs2, ft10
+               	bnez	a1, 0xc7c <.Lpcrel_hi.1+0x9d0>
+               	fmv.d	ft1, fs2
+               	j	0xc84 <.Lpcrel_hi.1+0x9d8>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft1, ft11, fs2
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft2, ft0, ft10
+               	fmv.d	ft3, ft1
+               	fle.s	a1, ft3, ft2
+               	bnez	a1, 0xcec <.Lpcrel_hi.1+0xa40>
+               	fmv.d	ft4, ft0
+               	fmv.d	ft5, ft3
+               	fle.s	a1, ft1, ft5
+               	bnez	a1, 0xcc4 <.Lpcrel_hi.1+0xa18>
+               	bnez	a0, 0xcb8 <.Lpcrel_hi.1+0xa0c>
+               	fmv.d	ft6, ft4
+               	j	0xcc0 <.Lpcrel_hi.1+0xa14>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft6, ft11, ft4
+               	j	0xd10 <.Lpcrel_hi.1+0xa64>
+               	fle.s	a1, ft5, ft4
+               	bnez	a1, 0xcd4 <.Lpcrel_hi.1+0xa28>
+               	fmv.d	ft7, ft4
+               	j	0xcd8 <.Lpcrel_hi.1+0xa2c>
+               	fsub.s	ft7, ft4, ft5
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft5, ft5, ft10
+               	fmv.d	ft4, ft7
+               	j	0xca4 <.Lpcrel_hi.1+0x9f8>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft3, ft3, ft10
+               	j	0xc94 <.Lpcrel_hi.1+0x9e8>
                	fdiv.s	ft0, fs0, fs2
                	fcvt.l.s	a0, ft0, rtz
                	fcvt.s.l	ft0, a0
                	fmul.s	ft1, ft0, fs2
-               	fsub.s	ft0, fs0, ft1
-               	feq.s	a0, ft0, ft0
+               	fsub.s	ft6, fs0, ft1
+               	feq.s	a0, ft6, ft6
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xcc8 <.Lpcrel_hi.1+0x834>
+               	bnez	a0, 0xd34 <.Lpcrel_hi.1+0xa88>
                	mv	a0, s2
-               	fmv.s	fa0, ft0
+               	fmv.s	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x824>
+               	jalr	ra <.Lpcrel_hi.1+0xa78>
                	mv	s1, a0
-               	j	0xcdc <.Lpcrel_hi.1+0x848>
+               	j	0xd48 <.Lpcrel_hi.1+0xa9c>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x83c>
+               	jalr	ra <.Lpcrel_hi.1+0xa90>
                	mv	s1, a0
+               	fmv.w.x	ft10, zero
+               	feq.s	a0, fs2, ft10
+               	bnez	a0, 0xd7c <.Lpcrel_hi.1+0xad0>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft0, fs2, ft10
+               	feq.s	a1, fs2, ft0
+               	bnez	a1, 0xd6c <.Lpcrel_hi.1+0xac0>
+               	j	0xd78 <.Lpcrel_hi.1+0xacc>
+               	fmv.w.x	ft10, zero
+               	feq.s	a1, fs2, ft10
+               	xori	a1, a1, 0x1
+               	j	0xd80 <.Lpcrel_hi.1+0xad4>
+               	mv	a1, a0
+               	bnez	a1, 0xe34 <.Lpcrel_hi.1+0xb88>
+               	fmv.w.x	ft10, zero
+               	flt.s	a0, fs2, ft10
+               	bnez	a0, 0xd98 <.Lpcrel_hi.1+0xaec>
+               	fmv.d	ft0, fs2
+               	j	0xda0 <.Lpcrel_hi.1+0xaf4>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft0, ft11, fs2
+               	fmv.w.x	ft10, zero
+               	flt.s	a1, fs2, ft10
+               	bnez	a1, 0xdb4 <.Lpcrel_hi.1+0xb08>
+               	fmv.d	ft1, fs2
+               	j	0xdbc <.Lpcrel_hi.1+0xb10>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft1, ft11, fs2
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft2, ft0, ft10
+               	fmv.d	ft3, ft1
+               	fle.s	a1, ft3, ft2
+               	bnez	a1, 0xe24 <.Lpcrel_hi.1+0xb78>
+               	fmv.d	ft4, ft0
+               	fmv.d	ft5, ft3
+               	fle.s	a1, ft1, ft5
+               	bnez	a1, 0xdfc <.Lpcrel_hi.1+0xb50>
+               	bnez	a0, 0xdf0 <.Lpcrel_hi.1+0xb44>
+               	fmv.d	ft6, ft4
+               	j	0xdf8 <.Lpcrel_hi.1+0xb4c>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft6, ft11, ft4
+               	j	0xe48 <.Lpcrel_hi.1+0xb9c>
+               	fle.s	a1, ft5, ft4
+               	bnez	a1, 0xe0c <.Lpcrel_hi.1+0xb60>
+               	fmv.d	ft7, ft4
+               	j	0xe10 <.Lpcrel_hi.1+0xb64>
+               	fsub.s	ft7, ft4, ft5
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft5, ft5, ft10
+               	fmv.d	ft4, ft7
+               	j	0xddc <.Lpcrel_hi.1+0xb30>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft3, ft3, ft10
+               	j	0xdcc <.Lpcrel_hi.1+0xb20>
                	fdiv.s	ft0, fs2, fs2
                	fcvt.l.s	a0, ft0, rtz
                	fcvt.s.l	ft0, a0
                	fmul.s	ft1, ft0, fs2
-               	fsub.s	ft0, fs2, ft1
-               	feq.s	a0, ft0, ft0
+               	fsub.s	ft6, fs2, ft1
+               	feq.s	a0, ft6, ft6
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xd14 <.Lpcrel_hi.1+0x880>
+               	bnez	a0, 0xe6c <.Lpcrel_hi.1+0xbc0>
                	mv	a0, s1
-               	fmv.s	fa0, ft0
+               	fmv.s	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x870>
+               	jalr	ra <.Lpcrel_hi.1+0xbb0>
                	mv	s2, a0
-               	j	0xd28 <.Lpcrel_hi.1+0x894>
+               	j	0xe80 <.Lpcrel_hi.1+0xbd4>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x888>
+               	jalr	ra <.Lpcrel_hi.1+0xbc8>
                	mv	s2, a0
                	lui	t0, 0x49800
                	fmv.w.x	ft11, t0
                	fmul.s	ft0, ft11, fs0
+               	fmv.w.x	ft10, zero
+               	feq.s	a0, fs2, ft10
+               	bnez	a0, 0xec0 <.Lpcrel_hi.1+0xc14>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft1, ft0, ft10
+               	feq.s	a1, ft0, ft1
+               	bnez	a1, 0xeb0 <.Lpcrel_hi.1+0xc04>
+               	j	0xebc <.Lpcrel_hi.1+0xc10>
+               	fmv.w.x	ft10, zero
+               	feq.s	a1, ft0, ft10
+               	xori	a1, a1, 0x1
+               	j	0xec4 <.Lpcrel_hi.1+0xc18>
+               	mv	a1, a0
+               	bnez	a1, 0xf78 <.Lpcrel_hi.1+0xccc>
+               	fmv.w.x	ft10, zero
+               	flt.s	a0, ft0, ft10
+               	bnez	a0, 0xedc <.Lpcrel_hi.1+0xc30>
+               	fmv.d	ft1, ft0
+               	j	0xee4 <.Lpcrel_hi.1+0xc38>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft1, ft11, ft0
+               	fmv.w.x	ft10, zero
+               	flt.s	a1, fs2, ft10
+               	bnez	a1, 0xef8 <.Lpcrel_hi.1+0xc4c>
+               	fmv.d	ft2, fs2
+               	j	0xf00 <.Lpcrel_hi.1+0xc54>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft2, ft11, fs2
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft3, ft1, ft10
+               	fmv.d	ft4, ft2
+               	fle.s	a1, ft4, ft3
+               	bnez	a1, 0xf68 <.Lpcrel_hi.1+0xcbc>
+               	fmv.d	ft5, ft1
+               	fmv.d	ft6, ft4
+               	fle.s	a1, ft2, ft6
+               	bnez	a1, 0xf40 <.Lpcrel_hi.1+0xc94>
+               	bnez	a0, 0xf34 <.Lpcrel_hi.1+0xc88>
+               	fmv.d	ft7, ft5
+               	j	0xf3c <.Lpcrel_hi.1+0xc90>
+               	fmv.w.x	ft11, zero
+               	fsub.s	ft7, ft11, ft5
+               	j	0xf8c <.Lpcrel_hi.1+0xce0>
+               	fle.s	a1, ft6, ft5
+               	bnez	a1, 0xf50 <.Lpcrel_hi.1+0xca4>
+               	fmv.d	fa0, ft5
+               	j	0xf54 <.Lpcrel_hi.1+0xca8>
+               	fsub.s	fa0, ft5, ft6
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fdiv.s	ft6, ft6, ft10
+               	fmv.d	ft5, fa0
+               	j	0xf20 <.Lpcrel_hi.1+0xc74>
+               	lui	t0, 0x40000
+               	fmv.w.x	ft10, t0
+               	fmul.s	ft4, ft4, ft10
+               	j	0xf10 <.Lpcrel_hi.1+0xc64>
                	fdiv.s	ft1, ft0, fs2
                	fcvt.l.s	a0, ft1, rtz
                	fcvt.s.l	ft1, a0
                	fmul.s	ft2, ft1, fs2
-               	fsub.s	ft1, ft0, ft2
-               	feq.s	a0, ft1, ft1
+               	fsub.s	ft7, ft0, ft2
+               	feq.s	a0, ft7, ft7
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xd6c <.Lpcrel_hi.1+0x8d8>
+               	bnez	a0, 0xfb0 <.Lpcrel_hi.1+0xd04>
                	mv	a0, s2
-               	fmv.s	fa0, ft1
+               	fmv.s	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x8c8>
+               	jalr	ra <.Lpcrel_hi.1+0xcf4>
                	mv	s1, a0
-               	j	0xd80 <.Lpcrel_hi.1+0x8ec>
+               	j	0xfc4 <.Lpcrel_hi.1+0xd18>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x8e0>
+               	jalr	ra <.Lpcrel_hi.1+0xd0c>
                	mv	s1, a0
                	mv	a0, s1
                	ld	s1, 0x38(sp)

--- a/test/golden/riscv64-linux/float/arith_f32.dis
+++ b/test/golden/riscv64-linux/float/arith_f32.dis
@@ -386,7 +386,7 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	j	0x5dc <.Lpcrel_hi.1+0x330>
                	mv	a1, a0
-               	bnez	a1, 0x690 <.Lpcrel_hi.1+0x3e4>
+               	bnez	a1, 0x68c <.Lpcrel_hi.1+0x3e0>
                	fmv.w.x	ft10, zero
                	flt.s	a0, fs1, ft10
                	bnez	a0, 0x5f4 <.Lpcrel_hi.1+0x348>
@@ -406,21 +406,20 @@ Disassembly of section .text:
                	fdiv.s	ft2, ft0, ft10
                	fmv.d	ft3, ft1
                	fle.s	a1, ft3, ft2
-               	bnez	a1, 0x680 <.Lpcrel_hi.1+0x3d4>
+               	bnez	a1, 0x67c <.Lpcrel_hi.1+0x3d0>
                	fmv.d	ft4, ft0
                	fmv.d	ft5, ft3
                	fle.s	a1, ft1, ft5
-               	bnez	a1, 0x658 <.Lpcrel_hi.1+0x3ac>
+               	bnez	a1, 0x654 <.Lpcrel_hi.1+0x3a8>
                	bnez	a0, 0x64c <.Lpcrel_hi.1+0x3a0>
                	fmv.d	ft6, ft4
-               	j	0x654 <.Lpcrel_hi.1+0x3a8>
-               	fmv.w.x	ft11, zero
-               	fsub.s	ft6, ft11, ft4
-               	j	0x6a4 <.Lpcrel_hi.1+0x3f8>
+               	j	0x650 <.Lpcrel_hi.1+0x3a4>
+               	fneg.s	ft6, ft4
+               	j	0x6a0 <.Lpcrel_hi.1+0x3f4>
                	fle.s	a1, ft5, ft4
-               	bnez	a1, 0x668 <.Lpcrel_hi.1+0x3bc>
+               	bnez	a1, 0x664 <.Lpcrel_hi.1+0x3b8>
                	fmv.d	ft7, ft4
-               	j	0x66c <.Lpcrel_hi.1+0x3c0>
+               	j	0x668 <.Lpcrel_hi.1+0x3bc>
                	fsub.s	ft7, ft4, ft5
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
@@ -438,47 +437,47 @@ Disassembly of section .text:
                	fsub.s	ft6, fs1, ft1
                	feq.s	a0, ft6, ft6
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x6c8 <.Lpcrel_hi.1+0x41c>
+               	bnez	a0, 0x6c4 <.Lpcrel_hi.1+0x418>
                	mv	a0, s1
                	fmv.s	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x40c>
+               	jalr	ra <.Lpcrel_hi.1+0x408>
                	mv	s2, a0
-               	j	0x6dc <.Lpcrel_hi.1+0x430>
+               	j	0x6d8 <.Lpcrel_hi.1+0x42c>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x424>
+               	jalr	ra <.Lpcrel_hi.1+0x420>
                	mv	s2, a0
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs1
                	fmv.w.x	ft10, zero
                	feq.s	a0, fs2, ft10
-               	bnez	a0, 0x718 <.Lpcrel_hi.1+0x46c>
+               	bnez	a0, 0x714 <.Lpcrel_hi.1+0x468>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft1, ft0, ft10
                	feq.s	a1, ft0, ft1
-               	bnez	a1, 0x708 <.Lpcrel_hi.1+0x45c>
-               	j	0x714 <.Lpcrel_hi.1+0x468>
+               	bnez	a1, 0x704 <.Lpcrel_hi.1+0x458>
+               	j	0x710 <.Lpcrel_hi.1+0x464>
                	fmv.w.x	ft10, zero
                	feq.s	a1, ft0, ft10
                	xori	a1, a1, 0x1
-               	j	0x71c <.Lpcrel_hi.1+0x470>
+               	j	0x718 <.Lpcrel_hi.1+0x46c>
                	mv	a1, a0
-               	bnez	a1, 0x7d0 <.Lpcrel_hi.1+0x524>
+               	bnez	a1, 0x7c8 <.Lpcrel_hi.1+0x51c>
                	fmv.w.x	ft10, zero
                	flt.s	a0, ft0, ft10
-               	bnez	a0, 0x734 <.Lpcrel_hi.1+0x488>
+               	bnez	a0, 0x730 <.Lpcrel_hi.1+0x484>
                	fmv.d	ft1, ft0
-               	j	0x73c <.Lpcrel_hi.1+0x490>
+               	j	0x738 <.Lpcrel_hi.1+0x48c>
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, ft0
                	fmv.w.x	ft10, zero
                	flt.s	a1, fs2, ft10
-               	bnez	a1, 0x750 <.Lpcrel_hi.1+0x4a4>
+               	bnez	a1, 0x74c <.Lpcrel_hi.1+0x4a0>
                	fmv.d	ft2, fs2
-               	j	0x758 <.Lpcrel_hi.1+0x4ac>
+               	j	0x754 <.Lpcrel_hi.1+0x4a8>
                	fmv.w.x	ft11, zero
                	fsub.s	ft2, ft11, fs2
                	lui	t0, 0x40000
@@ -486,31 +485,30 @@ Disassembly of section .text:
                	fdiv.s	ft3, ft1, ft10
                	fmv.d	ft4, ft2
                	fle.s	a1, ft4, ft3
-               	bnez	a1, 0x7c0 <.Lpcrel_hi.1+0x514>
+               	bnez	a1, 0x7b8 <.Lpcrel_hi.1+0x50c>
                	fmv.d	ft5, ft1
                	fmv.d	ft6, ft4
                	fle.s	a1, ft2, ft6
-               	bnez	a1, 0x798 <.Lpcrel_hi.1+0x4ec>
-               	bnez	a0, 0x78c <.Lpcrel_hi.1+0x4e0>
+               	bnez	a1, 0x790 <.Lpcrel_hi.1+0x4e4>
+               	bnez	a0, 0x788 <.Lpcrel_hi.1+0x4dc>
                	fmv.d	ft7, ft5
-               	j	0x794 <.Lpcrel_hi.1+0x4e8>
-               	fmv.w.x	ft11, zero
-               	fsub.s	ft7, ft11, ft5
-               	j	0x7e4 <.Lpcrel_hi.1+0x538>
+               	j	0x78c <.Lpcrel_hi.1+0x4e0>
+               	fneg.s	ft7, ft5
+               	j	0x7dc <.Lpcrel_hi.1+0x530>
                	fle.s	a1, ft6, ft5
-               	bnez	a1, 0x7a8 <.Lpcrel_hi.1+0x4fc>
+               	bnez	a1, 0x7a0 <.Lpcrel_hi.1+0x4f4>
                	fmv.d	fa0, ft5
-               	j	0x7ac <.Lpcrel_hi.1+0x500>
+               	j	0x7a4 <.Lpcrel_hi.1+0x4f8>
                	fsub.s	fa0, ft5, ft6
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft6, ft6, ft10
                	fmv.d	ft5, fa0
-               	j	0x778 <.Lpcrel_hi.1+0x4cc>
+               	j	0x774 <.Lpcrel_hi.1+0x4c8>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft4, ft4, ft10
-               	j	0x768 <.Lpcrel_hi.1+0x4bc>
+               	j	0x764 <.Lpcrel_hi.1+0x4b8>
                	fdiv.s	ft1, ft0, fs2
                	fcvt.l.s	a0, ft1, rtz
                	fcvt.s.l	ft1, a0
@@ -518,47 +516,47 @@ Disassembly of section .text:
                	fsub.s	ft7, ft0, ft2
                	feq.s	a0, ft7, ft7
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x808 <.Lpcrel_hi.1+0x55c>
+               	bnez	a0, 0x800 <.Lpcrel_hi.1+0x554>
                	mv	a0, s2
                	fmv.s	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x54c>
+               	jalr	ra <.Lpcrel_hi.1+0x544>
                	mv	s1, a0
-               	j	0x81c <.Lpcrel_hi.1+0x570>
+               	j	0x814 <.Lpcrel_hi.1+0x568>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x564>
+               	jalr	ra <.Lpcrel_hi.1+0x55c>
                	mv	s1, a0
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs2
                	fmv.w.x	ft10, zero
                	feq.s	a0, ft0, ft10
-               	bnez	a0, 0x858 <.Lpcrel_hi.1+0x5ac>
+               	bnez	a0, 0x850 <.Lpcrel_hi.1+0x5a4>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft1, fs1, ft10
                	feq.s	a1, fs1, ft1
-               	bnez	a1, 0x848 <.Lpcrel_hi.1+0x59c>
-               	j	0x854 <.Lpcrel_hi.1+0x5a8>
+               	bnez	a1, 0x840 <.Lpcrel_hi.1+0x594>
+               	j	0x84c <.Lpcrel_hi.1+0x5a0>
                	fmv.w.x	ft10, zero
                	feq.s	a1, fs1, ft10
                	xori	a1, a1, 0x1
-               	j	0x85c <.Lpcrel_hi.1+0x5b0>
+               	j	0x854 <.Lpcrel_hi.1+0x5a8>
                	mv	a1, a0
-               	bnez	a1, 0x910 <.Lpcrel_hi.1+0x664>
+               	bnez	a1, 0x904 <.Lpcrel_hi.1+0x658>
                	fmv.w.x	ft10, zero
                	flt.s	a0, fs1, ft10
-               	bnez	a0, 0x874 <.Lpcrel_hi.1+0x5c8>
+               	bnez	a0, 0x86c <.Lpcrel_hi.1+0x5c0>
                	fmv.d	ft1, fs1
-               	j	0x87c <.Lpcrel_hi.1+0x5d0>
+               	j	0x874 <.Lpcrel_hi.1+0x5c8>
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, fs1
                	fmv.w.x	ft10, zero
                	flt.s	a1, ft0, ft10
-               	bnez	a1, 0x890 <.Lpcrel_hi.1+0x5e4>
+               	bnez	a1, 0x888 <.Lpcrel_hi.1+0x5dc>
                	fmv.d	ft2, ft0
-               	j	0x898 <.Lpcrel_hi.1+0x5ec>
+               	j	0x890 <.Lpcrel_hi.1+0x5e4>
                	fmv.w.x	ft11, zero
                	fsub.s	ft2, ft11, ft0
                	lui	t0, 0x40000
@@ -566,31 +564,30 @@ Disassembly of section .text:
                	fdiv.s	ft3, ft1, ft10
                	fmv.d	ft4, ft2
                	fle.s	a1, ft4, ft3
-               	bnez	a1, 0x900 <.Lpcrel_hi.1+0x654>
+               	bnez	a1, 0x8f4 <.Lpcrel_hi.1+0x648>
                	fmv.d	ft5, ft1
                	fmv.d	ft6, ft4
                	fle.s	a1, ft2, ft6
-               	bnez	a1, 0x8d8 <.Lpcrel_hi.1+0x62c>
-               	bnez	a0, 0x8cc <.Lpcrel_hi.1+0x620>
+               	bnez	a1, 0x8cc <.Lpcrel_hi.1+0x620>
+               	bnez	a0, 0x8c4 <.Lpcrel_hi.1+0x618>
                	fmv.d	ft7, ft5
-               	j	0x8d4 <.Lpcrel_hi.1+0x628>
-               	fmv.w.x	ft11, zero
-               	fsub.s	ft7, ft11, ft5
-               	j	0x924 <.Lpcrel_hi.1+0x678>
+               	j	0x8c8 <.Lpcrel_hi.1+0x61c>
+               	fneg.s	ft7, ft5
+               	j	0x918 <.Lpcrel_hi.1+0x66c>
                	fle.s	a1, ft6, ft5
-               	bnez	a1, 0x8e8 <.Lpcrel_hi.1+0x63c>
+               	bnez	a1, 0x8dc <.Lpcrel_hi.1+0x630>
                	fmv.d	fa0, ft5
-               	j	0x8ec <.Lpcrel_hi.1+0x640>
+               	j	0x8e0 <.Lpcrel_hi.1+0x634>
                	fsub.s	fa0, ft5, ft6
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft6, ft6, ft10
                	fmv.d	ft5, fa0
-               	j	0x8b8 <.Lpcrel_hi.1+0x60c>
+               	j	0x8b0 <.Lpcrel_hi.1+0x604>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft4, ft4, ft10
-               	j	0x8a8 <.Lpcrel_hi.1+0x5fc>
+               	j	0x8a0 <.Lpcrel_hi.1+0x5f4>
                	fdiv.s	ft1, fs1, ft0
                	fcvt.l.s	a0, ft1, rtz
                	fcvt.s.l	ft1, a0
@@ -598,17 +595,17 @@ Disassembly of section .text:
                	fsub.s	ft7, fs1, ft2
                	feq.s	a0, ft7, ft7
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x948 <.Lpcrel_hi.1+0x69c>
+               	bnez	a0, 0x93c <.Lpcrel_hi.1+0x690>
                	mv	a0, s1
                	fmv.s	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x68c>
+               	jalr	ra <.Lpcrel_hi.1+0x680>
                	mv	s2, a0
-               	j	0x95c <.Lpcrel_hi.1+0x6b0>
+               	j	0x950 <.Lpcrel_hi.1+0x6a4>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x6a4>
+               	jalr	ra <.Lpcrel_hi.1+0x698>
                	mv	s2, a0
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs1
@@ -616,31 +613,31 @@ Disassembly of section .text:
                	fsub.s	ft1, ft11, fs2
                	fmv.w.x	ft10, zero
                	feq.s	a0, ft1, ft10
-               	bnez	a0, 0x9a0 <.Lpcrel_hi.1+0x6f4>
+               	bnez	a0, 0x994 <.Lpcrel_hi.1+0x6e8>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft2, ft0, ft10
                	feq.s	a1, ft0, ft2
-               	bnez	a1, 0x990 <.Lpcrel_hi.1+0x6e4>
-               	j	0x99c <.Lpcrel_hi.1+0x6f0>
+               	bnez	a1, 0x984 <.Lpcrel_hi.1+0x6d8>
+               	j	0x990 <.Lpcrel_hi.1+0x6e4>
                	fmv.w.x	ft10, zero
                	feq.s	a1, ft0, ft10
                	xori	a1, a1, 0x1
-               	j	0x9a4 <.Lpcrel_hi.1+0x6f8>
+               	j	0x998 <.Lpcrel_hi.1+0x6ec>
                	mv	a1, a0
-               	bnez	a1, 0xa58 <.Lpcrel_hi.1+0x7ac>
+               	bnez	a1, 0xa48 <.Lpcrel_hi.1+0x79c>
                	fmv.w.x	ft10, zero
                	flt.s	a0, ft0, ft10
-               	bnez	a0, 0x9bc <.Lpcrel_hi.1+0x710>
+               	bnez	a0, 0x9b0 <.Lpcrel_hi.1+0x704>
                	fmv.d	ft2, ft0
-               	j	0x9c4 <.Lpcrel_hi.1+0x718>
+               	j	0x9b8 <.Lpcrel_hi.1+0x70c>
                	fmv.w.x	ft11, zero
                	fsub.s	ft2, ft11, ft0
                	fmv.w.x	ft10, zero
                	flt.s	a1, ft1, ft10
-               	bnez	a1, 0x9d8 <.Lpcrel_hi.1+0x72c>
+               	bnez	a1, 0x9cc <.Lpcrel_hi.1+0x720>
                	fmv.d	ft3, ft1
-               	j	0x9e0 <.Lpcrel_hi.1+0x734>
+               	j	0x9d4 <.Lpcrel_hi.1+0x728>
                	fmv.w.x	ft11, zero
                	fsub.s	ft3, ft11, ft1
                	lui	t0, 0x40000
@@ -648,31 +645,30 @@ Disassembly of section .text:
                	fdiv.s	ft4, ft2, ft10
                	fmv.d	ft5, ft3
                	fle.s	a1, ft5, ft4
-               	bnez	a1, 0xa48 <.Lpcrel_hi.1+0x79c>
+               	bnez	a1, 0xa38 <.Lpcrel_hi.1+0x78c>
                	fmv.d	ft6, ft2
                	fmv.d	ft7, ft5
                	fle.s	a1, ft3, ft7
-               	bnez	a1, 0xa20 <.Lpcrel_hi.1+0x774>
-               	bnez	a0, 0xa14 <.Lpcrel_hi.1+0x768>
+               	bnez	a1, 0xa10 <.Lpcrel_hi.1+0x764>
+               	bnez	a0, 0xa08 <.Lpcrel_hi.1+0x75c>
                	fmv.d	fa0, ft6
-               	j	0xa1c <.Lpcrel_hi.1+0x770>
-               	fmv.w.x	ft11, zero
-               	fsub.s	fa0, ft11, ft6
-               	j	0xa6c <.Lpcrel_hi.1+0x7c0>
+               	j	0xa0c <.Lpcrel_hi.1+0x760>
+               	fneg.s	fa0, ft6
+               	j	0xa5c <.Lpcrel_hi.1+0x7b0>
                	fle.s	a1, ft7, ft6
-               	bnez	a1, 0xa30 <.Lpcrel_hi.1+0x784>
+               	bnez	a1, 0xa20 <.Lpcrel_hi.1+0x774>
                	fmv.d	fa1, ft6
-               	j	0xa34 <.Lpcrel_hi.1+0x788>
+               	j	0xa24 <.Lpcrel_hi.1+0x778>
                	fsub.s	fa1, ft6, ft7
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft7, ft7, ft10
                	fmv.d	ft6, fa1
-               	j	0xa00 <.Lpcrel_hi.1+0x754>
+               	j	0x9f4 <.Lpcrel_hi.1+0x748>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft5, ft5, ft10
-               	j	0x9f0 <.Lpcrel_hi.1+0x744>
+               	j	0x9e4 <.Lpcrel_hi.1+0x738>
                	fdiv.s	ft2, ft0, ft1
                	fcvt.l.s	a0, ft2, rtz
                	fcvt.s.l	ft2, a0
@@ -680,16 +676,16 @@ Disassembly of section .text:
                	fsub.s	fa0, ft0, ft3
                	feq.s	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xa8c <.Lpcrel_hi.1+0x7e0>
+               	bnez	a0, 0xa7c <.Lpcrel_hi.1+0x7d0>
                	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x7d0>
+               	jalr	ra <.Lpcrel_hi.1+0x7c0>
                	mv	s1, a0
-               	j	0xaa0 <.Lpcrel_hi.1+0x7f4>
+               	j	0xa90 <.Lpcrel_hi.1+0x7e4>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x7e8>
+               	jalr	ra <.Lpcrel_hi.1+0x7d8>
                	mv	s1, a0
                	lui	t0, 0x40e00
                	fmv.w.x	ft11, t0
@@ -698,34 +694,34 @@ Disassembly of section .text:
                	fmv.w.x	ft11, t0
                	fmv.w.x	ft10, zero
                	feq.s	a0, ft11, ft10
-               	bnez	a0, 0xae8 <.Lpcrel_hi.1+0x83c>
+               	bnez	a0, 0xad8 <.Lpcrel_hi.1+0x82c>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft1, ft0, ft10
                	feq.s	a1, ft0, ft1
-               	bnez	a1, 0xad8 <.Lpcrel_hi.1+0x82c>
-               	j	0xae4 <.Lpcrel_hi.1+0x838>
+               	bnez	a1, 0xac8 <.Lpcrel_hi.1+0x81c>
+               	j	0xad4 <.Lpcrel_hi.1+0x828>
                	fmv.w.x	ft10, zero
                	feq.s	a1, ft0, ft10
                	xori	a1, a1, 0x1
-               	j	0xaec <.Lpcrel_hi.1+0x840>
+               	j	0xadc <.Lpcrel_hi.1+0x830>
                	mv	a1, a0
-               	bnez	a1, 0xbb4 <.Lpcrel_hi.1+0x908>
+               	bnez	a1, 0xba0 <.Lpcrel_hi.1+0x8f4>
                	fmv.w.x	ft10, zero
                	flt.s	a0, ft0, ft10
-               	bnez	a0, 0xb04 <.Lpcrel_hi.1+0x858>
+               	bnez	a0, 0xaf4 <.Lpcrel_hi.1+0x848>
                	fmv.d	ft1, ft0
-               	j	0xb0c <.Lpcrel_hi.1+0x860>
+               	j	0xafc <.Lpcrel_hi.1+0x850>
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, ft0
                	lui	t0, 0x3f000
                	fmv.w.x	ft11, t0
                	fmv.w.x	ft10, zero
                	flt.s	a1, ft11, ft10
-               	bnez	a1, 0xb2c <.Lpcrel_hi.1+0x880>
+               	bnez	a1, 0xb1c <.Lpcrel_hi.1+0x870>
                	lui	t0, 0x3f000
                	fmv.w.x	ft2, t0
-               	j	0xb3c <.Lpcrel_hi.1+0x890>
+               	j	0xb2c <.Lpcrel_hi.1+0x880>
                	fmv.w.x	ft11, zero
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
@@ -735,31 +731,30 @@ Disassembly of section .text:
                	fdiv.s	ft3, ft1, ft10
                	fmv.d	ft4, ft2
                	fle.s	a1, ft4, ft3
-               	bnez	a1, 0xba4 <.Lpcrel_hi.1+0x8f8>
+               	bnez	a1, 0xb90 <.Lpcrel_hi.1+0x8e4>
                	fmv.d	ft5, ft1
                	fmv.d	ft6, ft4
                	fle.s	a1, ft2, ft6
-               	bnez	a1, 0xb7c <.Lpcrel_hi.1+0x8d0>
-               	bnez	a0, 0xb70 <.Lpcrel_hi.1+0x8c4>
+               	bnez	a1, 0xb68 <.Lpcrel_hi.1+0x8bc>
+               	bnez	a0, 0xb60 <.Lpcrel_hi.1+0x8b4>
                	fmv.d	ft7, ft5
-               	j	0xb78 <.Lpcrel_hi.1+0x8cc>
-               	fmv.w.x	ft11, zero
-               	fsub.s	ft7, ft11, ft5
-               	j	0xbd8 <.Lpcrel_hi.1+0x92c>
+               	j	0xb64 <.Lpcrel_hi.1+0x8b8>
+               	fneg.s	ft7, ft5
+               	j	0xbc4 <.Lpcrel_hi.1+0x918>
                	fle.s	a1, ft6, ft5
-               	bnez	a1, 0xb8c <.Lpcrel_hi.1+0x8e0>
+               	bnez	a1, 0xb78 <.Lpcrel_hi.1+0x8cc>
                	fmv.d	fa0, ft5
-               	j	0xb90 <.Lpcrel_hi.1+0x8e4>
+               	j	0xb7c <.Lpcrel_hi.1+0x8d0>
                	fsub.s	fa0, ft5, ft6
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft6, ft6, ft10
                	fmv.d	ft5, fa0
-               	j	0xb5c <.Lpcrel_hi.1+0x8b0>
+               	j	0xb4c <.Lpcrel_hi.1+0x8a0>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft4, ft4, ft10
-               	j	0xb4c <.Lpcrel_hi.1+0x8a0>
+               	j	0xb3c <.Lpcrel_hi.1+0x890>
                	lui	t0, 0x3f000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft1, ft0, ft10
@@ -771,45 +766,45 @@ Disassembly of section .text:
                	fsub.s	ft7, ft0, ft2
                	feq.s	a0, ft7, ft7
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xbfc <.Lpcrel_hi.1+0x950>
+               	bnez	a0, 0xbe8 <.Lpcrel_hi.1+0x93c>
                	mv	a0, s1
                	fmv.s	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x940>
+               	jalr	ra <.Lpcrel_hi.1+0x92c>
                	mv	s2, a0
-               	j	0xc10 <.Lpcrel_hi.1+0x964>
+               	j	0xbfc <.Lpcrel_hi.1+0x950>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x958>
+               	jalr	ra <.Lpcrel_hi.1+0x944>
                	mv	s2, a0
                	fmv.w.x	ft10, zero
                	feq.s	a0, fs2, ft10
-               	bnez	a0, 0xc44 <.Lpcrel_hi.1+0x998>
+               	bnez	a0, 0xc30 <.Lpcrel_hi.1+0x984>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs0, ft10
                	feq.s	a1, fs0, ft0
-               	bnez	a1, 0xc34 <.Lpcrel_hi.1+0x988>
-               	j	0xc40 <.Lpcrel_hi.1+0x994>
+               	bnez	a1, 0xc20 <.Lpcrel_hi.1+0x974>
+               	j	0xc2c <.Lpcrel_hi.1+0x980>
                	fmv.w.x	ft10, zero
                	feq.s	a1, fs0, ft10
                	xori	a1, a1, 0x1
-               	j	0xc48 <.Lpcrel_hi.1+0x99c>
+               	j	0xc34 <.Lpcrel_hi.1+0x988>
                	mv	a1, a0
-               	bnez	a1, 0xcfc <.Lpcrel_hi.1+0xa50>
+               	bnez	a1, 0xce4 <.Lpcrel_hi.1+0xa38>
                	fmv.w.x	ft10, zero
                	flt.s	a0, fs0, ft10
-               	bnez	a0, 0xc60 <.Lpcrel_hi.1+0x9b4>
+               	bnez	a0, 0xc4c <.Lpcrel_hi.1+0x9a0>
                	fmv.d	ft0, fs0
-               	j	0xc68 <.Lpcrel_hi.1+0x9bc>
+               	j	0xc54 <.Lpcrel_hi.1+0x9a8>
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs0
                	fmv.w.x	ft10, zero
                	flt.s	a1, fs2, ft10
-               	bnez	a1, 0xc7c <.Lpcrel_hi.1+0x9d0>
+               	bnez	a1, 0xc68 <.Lpcrel_hi.1+0x9bc>
                	fmv.d	ft1, fs2
-               	j	0xc84 <.Lpcrel_hi.1+0x9d8>
+               	j	0xc70 <.Lpcrel_hi.1+0x9c4>
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, fs2
                	lui	t0, 0x40000
@@ -817,31 +812,30 @@ Disassembly of section .text:
                	fdiv.s	ft2, ft0, ft10
                	fmv.d	ft3, ft1
                	fle.s	a1, ft3, ft2
-               	bnez	a1, 0xcec <.Lpcrel_hi.1+0xa40>
+               	bnez	a1, 0xcd4 <.Lpcrel_hi.1+0xa28>
                	fmv.d	ft4, ft0
                	fmv.d	ft5, ft3
                	fle.s	a1, ft1, ft5
-               	bnez	a1, 0xcc4 <.Lpcrel_hi.1+0xa18>
-               	bnez	a0, 0xcb8 <.Lpcrel_hi.1+0xa0c>
+               	bnez	a1, 0xcac <.Lpcrel_hi.1+0xa00>
+               	bnez	a0, 0xca4 <.Lpcrel_hi.1+0x9f8>
                	fmv.d	ft6, ft4
-               	j	0xcc0 <.Lpcrel_hi.1+0xa14>
-               	fmv.w.x	ft11, zero
-               	fsub.s	ft6, ft11, ft4
-               	j	0xd10 <.Lpcrel_hi.1+0xa64>
+               	j	0xca8 <.Lpcrel_hi.1+0x9fc>
+               	fneg.s	ft6, ft4
+               	j	0xcf8 <.Lpcrel_hi.1+0xa4c>
                	fle.s	a1, ft5, ft4
-               	bnez	a1, 0xcd4 <.Lpcrel_hi.1+0xa28>
+               	bnez	a1, 0xcbc <.Lpcrel_hi.1+0xa10>
                	fmv.d	ft7, ft4
-               	j	0xcd8 <.Lpcrel_hi.1+0xa2c>
+               	j	0xcc0 <.Lpcrel_hi.1+0xa14>
                	fsub.s	ft7, ft4, ft5
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft5, ft5, ft10
                	fmv.d	ft4, ft7
-               	j	0xca4 <.Lpcrel_hi.1+0x9f8>
+               	j	0xc90 <.Lpcrel_hi.1+0x9e4>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft3, ft3, ft10
-               	j	0xc94 <.Lpcrel_hi.1+0x9e8>
+               	j	0xc80 <.Lpcrel_hi.1+0x9d4>
                	fdiv.s	ft0, fs0, fs2
                	fcvt.l.s	a0, ft0, rtz
                	fcvt.s.l	ft0, a0
@@ -849,45 +843,45 @@ Disassembly of section .text:
                	fsub.s	ft6, fs0, ft1
                	feq.s	a0, ft6, ft6
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xd34 <.Lpcrel_hi.1+0xa88>
+               	bnez	a0, 0xd1c <.Lpcrel_hi.1+0xa70>
                	mv	a0, s2
                	fmv.s	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xa78>
+               	jalr	ra <.Lpcrel_hi.1+0xa60>
                	mv	s1, a0
-               	j	0xd48 <.Lpcrel_hi.1+0xa9c>
+               	j	0xd30 <.Lpcrel_hi.1+0xa84>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xa90>
+               	jalr	ra <.Lpcrel_hi.1+0xa78>
                	mv	s1, a0
                	fmv.w.x	ft10, zero
                	feq.s	a0, fs2, ft10
-               	bnez	a0, 0xd7c <.Lpcrel_hi.1+0xad0>
+               	bnez	a0, 0xd64 <.Lpcrel_hi.1+0xab8>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft0, fs2, ft10
                	feq.s	a1, fs2, ft0
-               	bnez	a1, 0xd6c <.Lpcrel_hi.1+0xac0>
-               	j	0xd78 <.Lpcrel_hi.1+0xacc>
+               	bnez	a1, 0xd54 <.Lpcrel_hi.1+0xaa8>
+               	j	0xd60 <.Lpcrel_hi.1+0xab4>
                	fmv.w.x	ft10, zero
                	feq.s	a1, fs2, ft10
                	xori	a1, a1, 0x1
-               	j	0xd80 <.Lpcrel_hi.1+0xad4>
+               	j	0xd68 <.Lpcrel_hi.1+0xabc>
                	mv	a1, a0
-               	bnez	a1, 0xe34 <.Lpcrel_hi.1+0xb88>
+               	bnez	a1, 0xe18 <.Lpcrel_hi.1+0xb6c>
                	fmv.w.x	ft10, zero
                	flt.s	a0, fs2, ft10
-               	bnez	a0, 0xd98 <.Lpcrel_hi.1+0xaec>
+               	bnez	a0, 0xd80 <.Lpcrel_hi.1+0xad4>
                	fmv.d	ft0, fs2
-               	j	0xda0 <.Lpcrel_hi.1+0xaf4>
+               	j	0xd88 <.Lpcrel_hi.1+0xadc>
                	fmv.w.x	ft11, zero
                	fsub.s	ft0, ft11, fs2
                	fmv.w.x	ft10, zero
                	flt.s	a1, fs2, ft10
-               	bnez	a1, 0xdb4 <.Lpcrel_hi.1+0xb08>
+               	bnez	a1, 0xd9c <.Lpcrel_hi.1+0xaf0>
                	fmv.d	ft1, fs2
-               	j	0xdbc <.Lpcrel_hi.1+0xb10>
+               	j	0xda4 <.Lpcrel_hi.1+0xaf8>
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, fs2
                	lui	t0, 0x40000
@@ -895,31 +889,30 @@ Disassembly of section .text:
                	fdiv.s	ft2, ft0, ft10
                	fmv.d	ft3, ft1
                	fle.s	a1, ft3, ft2
-               	bnez	a1, 0xe24 <.Lpcrel_hi.1+0xb78>
+               	bnez	a1, 0xe08 <.Lpcrel_hi.1+0xb5c>
                	fmv.d	ft4, ft0
                	fmv.d	ft5, ft3
                	fle.s	a1, ft1, ft5
-               	bnez	a1, 0xdfc <.Lpcrel_hi.1+0xb50>
-               	bnez	a0, 0xdf0 <.Lpcrel_hi.1+0xb44>
+               	bnez	a1, 0xde0 <.Lpcrel_hi.1+0xb34>
+               	bnez	a0, 0xdd8 <.Lpcrel_hi.1+0xb2c>
                	fmv.d	ft6, ft4
-               	j	0xdf8 <.Lpcrel_hi.1+0xb4c>
-               	fmv.w.x	ft11, zero
-               	fsub.s	ft6, ft11, ft4
-               	j	0xe48 <.Lpcrel_hi.1+0xb9c>
+               	j	0xddc <.Lpcrel_hi.1+0xb30>
+               	fneg.s	ft6, ft4
+               	j	0xe2c <.Lpcrel_hi.1+0xb80>
                	fle.s	a1, ft5, ft4
-               	bnez	a1, 0xe0c <.Lpcrel_hi.1+0xb60>
+               	bnez	a1, 0xdf0 <.Lpcrel_hi.1+0xb44>
                	fmv.d	ft7, ft4
-               	j	0xe10 <.Lpcrel_hi.1+0xb64>
+               	j	0xdf4 <.Lpcrel_hi.1+0xb48>
                	fsub.s	ft7, ft4, ft5
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft5, ft5, ft10
                	fmv.d	ft4, ft7
-               	j	0xddc <.Lpcrel_hi.1+0xb30>
+               	j	0xdc4 <.Lpcrel_hi.1+0xb18>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft3, ft3, ft10
-               	j	0xdcc <.Lpcrel_hi.1+0xb20>
+               	j	0xdb4 <.Lpcrel_hi.1+0xb08>
                	fdiv.s	ft0, fs2, fs2
                	fcvt.l.s	a0, ft0, rtz
                	fcvt.s.l	ft0, a0
@@ -927,48 +920,48 @@ Disassembly of section .text:
                	fsub.s	ft6, fs2, ft1
                	feq.s	a0, ft6, ft6
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xe6c <.Lpcrel_hi.1+0xbc0>
+               	bnez	a0, 0xe50 <.Lpcrel_hi.1+0xba4>
                	mv	a0, s1
                	fmv.s	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xbb0>
+               	jalr	ra <.Lpcrel_hi.1+0xb94>
                	mv	s2, a0
-               	j	0xe80 <.Lpcrel_hi.1+0xbd4>
+               	j	0xe64 <.Lpcrel_hi.1+0xbb8>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xbc8>
+               	jalr	ra <.Lpcrel_hi.1+0xbac>
                	mv	s2, a0
                	lui	t0, 0x49800
                	fmv.w.x	ft11, t0
                	fmul.s	ft0, ft11, fs0
                	fmv.w.x	ft10, zero
                	feq.s	a0, fs2, ft10
-               	bnez	a0, 0xec0 <.Lpcrel_hi.1+0xc14>
+               	bnez	a0, 0xea4 <.Lpcrel_hi.1+0xbf8>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft1, ft0, ft10
                	feq.s	a1, ft0, ft1
-               	bnez	a1, 0xeb0 <.Lpcrel_hi.1+0xc04>
-               	j	0xebc <.Lpcrel_hi.1+0xc10>
+               	bnez	a1, 0xe94 <.Lpcrel_hi.1+0xbe8>
+               	j	0xea0 <.Lpcrel_hi.1+0xbf4>
                	fmv.w.x	ft10, zero
                	feq.s	a1, ft0, ft10
                	xori	a1, a1, 0x1
-               	j	0xec4 <.Lpcrel_hi.1+0xc18>
+               	j	0xea8 <.Lpcrel_hi.1+0xbfc>
                	mv	a1, a0
-               	bnez	a1, 0xf78 <.Lpcrel_hi.1+0xccc>
+               	bnez	a1, 0xf58 <.Lpcrel_hi.1+0xcac>
                	fmv.w.x	ft10, zero
                	flt.s	a0, ft0, ft10
-               	bnez	a0, 0xedc <.Lpcrel_hi.1+0xc30>
+               	bnez	a0, 0xec0 <.Lpcrel_hi.1+0xc14>
                	fmv.d	ft1, ft0
-               	j	0xee4 <.Lpcrel_hi.1+0xc38>
+               	j	0xec8 <.Lpcrel_hi.1+0xc1c>
                	fmv.w.x	ft11, zero
                	fsub.s	ft1, ft11, ft0
                	fmv.w.x	ft10, zero
                	flt.s	a1, fs2, ft10
-               	bnez	a1, 0xef8 <.Lpcrel_hi.1+0xc4c>
+               	bnez	a1, 0xedc <.Lpcrel_hi.1+0xc30>
                	fmv.d	ft2, fs2
-               	j	0xf00 <.Lpcrel_hi.1+0xc54>
+               	j	0xee4 <.Lpcrel_hi.1+0xc38>
                	fmv.w.x	ft11, zero
                	fsub.s	ft2, ft11, fs2
                	lui	t0, 0x40000
@@ -976,31 +969,30 @@ Disassembly of section .text:
                	fdiv.s	ft3, ft1, ft10
                	fmv.d	ft4, ft2
                	fle.s	a1, ft4, ft3
-               	bnez	a1, 0xf68 <.Lpcrel_hi.1+0xcbc>
+               	bnez	a1, 0xf48 <.Lpcrel_hi.1+0xc9c>
                	fmv.d	ft5, ft1
                	fmv.d	ft6, ft4
                	fle.s	a1, ft2, ft6
-               	bnez	a1, 0xf40 <.Lpcrel_hi.1+0xc94>
-               	bnez	a0, 0xf34 <.Lpcrel_hi.1+0xc88>
+               	bnez	a1, 0xf20 <.Lpcrel_hi.1+0xc74>
+               	bnez	a0, 0xf18 <.Lpcrel_hi.1+0xc6c>
                	fmv.d	ft7, ft5
-               	j	0xf3c <.Lpcrel_hi.1+0xc90>
-               	fmv.w.x	ft11, zero
-               	fsub.s	ft7, ft11, ft5
-               	j	0xf8c <.Lpcrel_hi.1+0xce0>
+               	j	0xf1c <.Lpcrel_hi.1+0xc70>
+               	fneg.s	ft7, ft5
+               	j	0xf6c <.Lpcrel_hi.1+0xcc0>
                	fle.s	a1, ft6, ft5
-               	bnez	a1, 0xf50 <.Lpcrel_hi.1+0xca4>
+               	bnez	a1, 0xf30 <.Lpcrel_hi.1+0xc84>
                	fmv.d	fa0, ft5
-               	j	0xf54 <.Lpcrel_hi.1+0xca8>
+               	j	0xf34 <.Lpcrel_hi.1+0xc88>
                	fsub.s	fa0, ft5, ft6
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fdiv.s	ft6, ft6, ft10
                	fmv.d	ft5, fa0
-               	j	0xf20 <.Lpcrel_hi.1+0xc74>
+               	j	0xf04 <.Lpcrel_hi.1+0xc58>
                	lui	t0, 0x40000
                	fmv.w.x	ft10, t0
                	fmul.s	ft4, ft4, ft10
-               	j	0xf10 <.Lpcrel_hi.1+0xc64>
+               	j	0xef4 <.Lpcrel_hi.1+0xc48>
                	fdiv.s	ft1, ft0, fs2
                	fcvt.l.s	a0, ft1, rtz
                	fcvt.s.l	ft1, a0
@@ -1008,17 +1000,17 @@ Disassembly of section .text:
                	fsub.s	ft7, ft0, ft2
                	feq.s	a0, ft7, ft7
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xfb0 <.Lpcrel_hi.1+0xd04>
+               	bnez	a0, 0xf90 <.Lpcrel_hi.1+0xce4>
                	mv	a0, s2
                	fmv.s	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xcf4>
+               	jalr	ra <.Lpcrel_hi.1+0xcd4>
                	mv	s1, a0
-               	j	0xfc4 <.Lpcrel_hi.1+0xd18>
+               	j	0xfa4 <.Lpcrel_hi.1+0xcf8>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0xd0c>
+               	jalr	ra <.Lpcrel_hi.1+0xcec>
                	mv	s1, a0
                	mv	a0, s1
                	ld	s1, 0x38(sp)

--- a/test/golden/riscv64-linux/float/arith_f64.dis
+++ b/test/golden/riscv64-linux/float/arith_f64.dis
@@ -125,281 +125,94 @@ Disassembly of section .text:
                	jalr	ra <.Lpcrel_hi.1+0xe0>
                	mv	s2, a0
                	fdiv.d	fa0, fs1, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x1e8 <.Lpcrel_hi.1+0x110>
                	mv	a0, s2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.1+0xf4>
+               	fdiv.d	fa0, fs2, fs1
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.1+0x100>
-               	mv	s3, a0
-               	j	0x1fc <.Lpcrel_hi.1+0x124>
-               	mv	a0, s2
-               	li	a1, -0x1
+               	fneg.d	fa0, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x118>
-               	mv	s3, a0
-               	fdiv.d	fa0, fs2, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x220 <.Lpcrel_hi.1+0x148>
-               	mv	a0, s3
+               	jalr	ra <.Lpcrel_hi.1+0x10c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	fs2, ft11, fs1
+               	fmv.d	fa0, fs2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.1+0x120>
+               	fsub.d	fa0, fs1, fs1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.1+0x12c>
+               	fadd.d	fa0, fs2, fs1
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.1+0x138>
-               	mv	s2, a0
-               	j	0x234 <.Lpcrel_hi.1+0x15c>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x150>
-               	mv	s2, a0
-               	fneg.d	fa0, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x258 <.Lpcrel_hi.1+0x180>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x170>
-               	mv	s3, a0
-               	j	0x26c <.Lpcrel_hi.1+0x194>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x188>
-               	mv	s3, a0
-               	fmv.d.x	ft11, zero
-               	fsub.d	fa0, ft11, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x294 <.Lpcrel_hi.1+0x1bc>
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x1ac>
-               	mv	s2, a0
-               	j	0x2a8 <.Lpcrel_hi.1+0x1d0>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x1c4>
-               	mv	s2, a0
-               	fsub.d	fa0, fs1, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x2cc <.Lpcrel_hi.1+0x1f4>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x1e4>
-               	mv	s3, a0
-               	j	0x2e0 <.Lpcrel_hi.1+0x208>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x1fc>
-               	mv	s3, a0
-               	fmv.d.x	ft11, zero
-               	fsub.d	ft0, ft11, fs1
-               	fadd.d	fa0, ft0, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x30c <.Lpcrel_hi.1+0x234>
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x224>
-               	mv	s2, a0
-               	j	0x320 <.Lpcrel_hi.2>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.1+0x23c>
-               	mv	s2, a0
 
 <.Lpcrel_hi.2>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
                	fmul.d	fs1, ft11, fs0
                	fdiv.d	fs2, fs0, fs1
-               	feq.d	a0, fs2, fs2
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x354 <.Lpcrel_hi.2+0x34>
-               	mv	a0, s2
                	fmv.d	fa0, fs2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x24>
-               	mv	s3, a0
-               	j	0x368 <.Lpcrel_hi.2+0x48>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x3c>
-               	mv	s3, a0
+               	jalr	ra <.Lpcrel_hi.2+0x14>
                	fmul.d	fa0, fs2, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x38c <.Lpcrel_hi.2+0x6c>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x5c>
-               	mv	s2, a0
-               	j	0x3a0 <.Lpcrel_hi.2+0x80>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x74>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.2+0x20>
                	fsub.d	ft0, fs0, fs2
                	fsub.d	ft1, ft0, fs2
                	fsub.d	fa0, ft1, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x3cc <.Lpcrel_hi.2+0xac>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0x9c>
-               	mv	s3, a0
-               	j	0x3e0 <.Lpcrel_hi.3>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.2+0xb4>
-               	mv	s3, a0
+               	jalr	ra <.Lpcrel_hi.2+0x34>
 
 <.Lpcrel_hi.3>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fdiv.d	fa0, fs0, ft10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x40c <.Lpcrel_hi.3+0x2c>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x1c>
-               	mv	s2, a0
-               	j	0x420 <.Lpcrel_hi.4>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.3+0x34>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.3+0xc>
 
 <.Lpcrel_hi.4>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fdiv.d	fa0, fs0, ft10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x44c <.Lpcrel_hi.4+0x2c>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.4+0x1c>
-               	mv	s3, a0
-               	j	0x460 <.Lpcrel_hi.5>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.4+0x34>
-               	mv	s3, a0
+               	jalr	ra <.Lpcrel_hi.4+0xc>
 
 <.Lpcrel_hi.5>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
                	fdiv.d	fa0, ft11, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x48c <.Lpcrel_hi.5+0x2c>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.5+0x1c>
-               	mv	s2, a0
-               	j	0x4a0 <.Lpcrel_hi.6>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.5+0x34>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.5+0xc>
 
 <.Lpcrel_hi.6>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
                	fmul.d	fs1, ft11, fs0
-               	fadd.d	fa0, fs1, fs0
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x4d0 <.Lpcrel_hi.6+0x30>
-               	mv	a0, s2
+               	fadd.d	fs3, fs1, fs0
+               	fmv.d	fa0, fs3
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.6+0x14>
+               	fadd.d	fa0, fs3, fs0
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.6+0x20>
-               	mv	s3, a0
-               	j	0x4e4 <.Lpcrel_hi.6+0x44>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x38>
-               	mv	s3, a0
-               	fadd.d	ft0, fs1, fs0
-               	fadd.d	fa0, ft0, fs0
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x50c <.Lpcrel_hi.6+0x6c>
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x5c>
-               	mv	s2, a0
-               	j	0x520 <.Lpcrel_hi.6+0x80>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x74>
-               	mv	s2, a0
                	fadd.d	ft0, fs0, fs0
                	fadd.d	fa0, fs1, ft0
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x548 <.Lpcrel_hi.6+0xa8>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x98>
-               	mv	s3, a0
-               	j	0x55c <.Lpcrel_hi.6+0xbc>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0xb0>
-               	mv	s3, a0
+               	jalr	ra <.Lpcrel_hi.6+0x30>
                	fsub.d	fa0, fs1, fs0
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x580 <.Lpcrel_hi.6+0xe0>
-               	mv	a0, s3
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0xd0>
-               	mv	s2, a0
-               	j	0x594 <.Lpcrel_hi.6+0xf4>
-               	mv	a0, s3
-               	li	a1, -0x1
+               	jalr	ra <.Lpcrel_hi.6+0x3c>
+               	fsub.d	fa0, fs3, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0xe8>
-               	mv	s2, a0
-               	fadd.d	ft0, fs1, fs0
-               	fsub.d	fa0, ft0, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x5bc <.Lpcrel_hi.6+0x11c>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x10c>
-               	mv	s3, a0
-               	j	0x5d0 <.Lpcrel_hi.6+0x130>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.6+0x124>
-               	mv	s3, a0
+               	jalr	ra <.Lpcrel_hi.6+0x48>
                	fmv.d.x	ft11, zero
                	fmul.d	ft0, ft11, fs0
+               	mv	s2, a0
                	fmv.d	fs1, ft0
-               	li	s2, 0x0
+               	li	s3, 0x0
                	li	t0, 0x18
-               	bltu	s2, t0, 0x5ec <.Lpcrel_hi.6+0x14c>
-               	j	0x648 <.Lpcrel_hi.7+0x58>
+               	bltu	s3, t0, 0x300 <.Lpcrel_hi.6+0x70>
+               	j	0x35c <.Lpcrel_hi.7+0x58>
                	fadd.d	ft0, fs1, fs2
 
 <.Lpcrel_hi.7>:
@@ -408,23 +221,23 @@ Disassembly of section .text:
                	fmul.d	fs3, ft0, ft10
                	feq.d	a0, fs3, fs3
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x620 <.Lpcrel_hi.7+0x30>
-               	mv	a0, s3
+               	bnez	a0, 0x334 <.Lpcrel_hi.7+0x30>
+               	mv	a0, s2
                	fmv.d	fa0, fs3
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.7+0x20>
                	mv	s4, a0
-               	j	0x634 <.Lpcrel_hi.7+0x44>
-               	mv	a0, s3
+               	j	0x348 <.Lpcrel_hi.7+0x44>
+               	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.7+0x38>
                	mv	s4, a0
-               	addi	s2, s2, 0x1
-               	mv	s3, s4
+               	addi	s3, s3, 0x1
+               	mv	s2, s4
                	fmv.d	fs1, fs3
                	li	t0, 0x18
-               	bltu	s2, t0, 0x5ec <.Lpcrel_hi.6+0x14c>
+               	bltu	s3, t0, 0x300 <.Lpcrel_hi.6+0x70>
                	lui	t1, 0x7ff0
                	slli	t1, t1, 0xc
                	slli	t1, t1, 0xc
@@ -434,18 +247,18 @@ Disassembly of section .text:
                	fmv.d.x	fs1, a0
                	feq.d	a0, fs1, fs1
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x688 <.Lpcrel_hi.7+0x98>
-               	mv	a0, s3
+               	bnez	a0, 0x39c <.Lpcrel_hi.7+0x98>
+               	mv	a0, s2
                	fmv.d	fa0, fs1
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.7+0x88>
-               	mv	s2, a0
-               	j	0x69c <.Lpcrel_hi.8>
-               	mv	a0, s3
+               	mv	s3, a0
+               	j	0x3b0 <.Lpcrel_hi.8>
+               	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.7+0xa0>
-               	mv	s2, a0
+               	mv	s3, a0
 
 <.Lpcrel_hi.8>:
                	auipc	t0, 0x0
@@ -453,323 +266,449 @@ Disassembly of section .text:
                	fdiv.d	fa0, fs1, ft10
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x6c8 <.Lpcrel_hi.8+0x2c>
-               	mv	a0, s2
+               	bnez	a0, 0x3dc <.Lpcrel_hi.8+0x2c>
+               	mv	a0, s3
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.8+0x1c>
-               	mv	s3, a0
-               	j	0x6dc <.Lpcrel_hi.8+0x40>
-               	mv	a0, s2
+               	mv	s2, a0
+               	j	0x3f0 <.Lpcrel_hi.8+0x40>
+               	mv	a0, s3
                	li	a1, -0x1
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.8+0x34>
-               	mv	s3, a0
+               	mv	s2, a0
                	fadd.d	fa0, fs1, fs1
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x700 <.Lpcrel_hi.8+0x64>
-               	mv	a0, s3
+               	bnez	a0, 0x414 <.Lpcrel_hi.8+0x64>
+               	mv	a0, s2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.8+0x54>
-               	mv	s2, a0
-               	j	0x714 <.Lpcrel_hi.9>
-               	mv	a0, s3
+               	mv	s3, a0
+               	j	0x428 <.Lpcrel_hi.9>
+               	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.8+0x6c>
-               	mv	s2, a0
+               	mv	s3, a0
 
 <.Lpcrel_hi.9>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fmul.d	fa0, fs1, ft10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x740 <.Lpcrel_hi.9+0x2c>
-               	mv	a0, s2
+               	fmul.d	fs2, fs1, ft10
+               	mv	a0, s3
+               	fmv.d	fa0, fs2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x1c>
-               	mv	s3, a0
-               	j	0x754 <.Lpcrel_hi.10>
-               	mv	a0, s2
-               	li	a1, -0x1
+               	jalr	ra <.Lpcrel_hi.9+0x14>
+               	fmv.d.x	ft11, zero
+               	fsub.d	fa0, ft11, fs2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.9+0x34>
-               	mv	s3, a0
+               	jalr	ra <.Lpcrel_hi.9+0x24>
+               	fmul.d	fa0, fs1, fs1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.9+0x30>
+               	fsub.d	fa0, fs1, fs1
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.9+0x3c>
+               	lui	t1, 0x10000
+               	slli	t1, t1, 0xc
+               	slli	t1, t1, 0xc
+               	add	a1, t1, s1
+               	fmv.d.x	fs1, a1
+               	li	t1, 0x1
+               	add	a1, t1, s1
+               	fmv.d.x	fs2, a1
 
 <.Lpcrel_hi.10>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fmul.d	ft0, fs1, ft10
-               	fmv.d.x	ft11, zero
-               	fsub.d	fa0, ft11, ft0
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x788 <.Lpcrel_hi.10+0x34>
-               	mv	a0, s3
+               	fmul.d	fa0, fs1, ft10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x24>
-               	mv	s2, a0
-               	j	0x79c <.Lpcrel_hi.10+0x48>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x3c>
-               	mv	s2, a0
-               	fmul.d	fa0, fs1, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x7c0 <.Lpcrel_hi.10+0x6c>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x5c>
-               	mv	s3, a0
-               	j	0x7d4 <.Lpcrel_hi.10+0x80>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x74>
-               	mv	s3, a0
-               	fsub.d	fa0, fs1, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x7f8 <.Lpcrel_hi.10+0xa4>
-               	mv	a0, s3
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0x94>
-               	mv	s2, a0
-               	j	0x80c <.Lpcrel_hi.10+0xb8>
-               	mv	a0, s3
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.10+0xac>
-               	mv	s2, a0
-               	lui	t1, 0x10000
-               	slli	t1, t1, 0xc
-               	slli	t1, t1, 0xc
-               	add	a0, t1, s1
-               	fmv.d.x	fs1, a0
-               	li	t1, 0x1
-               	add	a0, t1, s1
-               	fmv.d.x	fs2, a0
+               	jalr	ra <.Lpcrel_hi.10+0xc>
 
 <.Lpcrel_hi.11>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fmul.d	fa0, fs1, ft10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x858 <.Lpcrel_hi.11+0x2c>
-               	mv	a0, s2
+               	fdiv.d	fa0, fs1, ft10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x1c>
-               	mv	s1, a0
-               	j	0x86c <.Lpcrel_hi.12>
-               	mv	a0, s2
-               	li	a1, -0x1
+               	jalr	ra <.Lpcrel_hi.11+0xc>
+               	fsub.d	fa0, fs1, fs2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.11+0x34>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.11+0x18>
+               	fmul.d	fa0, fs1, fs0
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.11+0x24>
+               	fadd.d	fa0, fs2, fs2
+               	auipc	ra, 0x0
+               	jalr	ra <.Lpcrel_hi.11+0x30>
 
 <.Lpcrel_hi.12>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
-               	fdiv.d	fa0, fs1, ft10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x898 <.Lpcrel_hi.12+0x2c>
-               	mv	a0, s1
+               	fmul.d	fa0, fs2, ft10
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.12+0x1c>
-               	mv	s2, a0
-               	j	0x8ac <.Lpcrel_hi.12+0x40>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.12+0x34>
-               	mv	s2, a0
-               	fsub.d	fa0, fs1, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x8d0 <.Lpcrel_hi.12+0x64>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.12+0x54>
-               	mv	s1, a0
-               	j	0x8e4 <.Lpcrel_hi.12+0x78>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.12+0x6c>
-               	mv	s1, a0
-               	fmul.d	fa0, fs1, fs0
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x908 <.Lpcrel_hi.12+0x9c>
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.12+0x8c>
-               	mv	s2, a0
-               	j	0x91c <.Lpcrel_hi.12+0xb0>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.12+0xa4>
-               	mv	s2, a0
-               	fadd.d	fa0, fs2, fs2
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x940 <.Lpcrel_hi.12+0xd4>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.12+0xc4>
-               	mv	s1, a0
-               	j	0x954 <.Lpcrel_hi.13>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.12+0xdc>
-               	mv	s1, a0
+               	jalr	ra <.Lpcrel_hi.12+0xc>
 
 <.Lpcrel_hi.13>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	fa0, fs2, ft10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x980 <.Lpcrel_hi.13+0x2c>
-               	mv	a0, s1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x1c>
-               	mv	s2, a0
-               	j	0x994 <.Lpcrel_hi.14>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.13+0x34>
-               	mv	s2, a0
+               	jalr	ra <.Lpcrel_hi.13+0xc>
 
 <.Lpcrel_hi.14>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	fa0, fs2, ft10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0x9c0 <.Lpcrel_hi.14+0x2c>
-               	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.14+0x1c>
-               	mv	s1, a0
-               	j	0x9d4 <.Lpcrel_hi.15>
-               	mv	a0, s2
-               	li	a1, -0x1
+               	jalr	ra <.Lpcrel_hi.14+0xc>
+               	fdiv.d	fa0, fs2, fs1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.14+0x34>
+               	jalr	ra <.Lpcrel_hi.14+0x18>
                	mv	s1, a0
 
 <.Lpcrel_hi.15>:
                	auipc	t0, 0x0
-               	fld	ft10, 0x0(t0)
-               	fmul.d	fa0, fs2, ft10
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa00 <.Lpcrel_hi.15+0x2c>
-               	mv	a0, s1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x1c>
-               	mv	s2, a0
-               	j	0xa14 <.Lpcrel_hi.15+0x40>
-               	mv	a0, s1
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x34>
-               	mv	s2, a0
-               	fdiv.d	fa0, fs2, fs1
-               	feq.d	a0, fa0, fa0
-               	xori	a0, a0, 0x1
-               	bnez	a0, 0xa38 <.Lpcrel_hi.15+0x64>
-               	mv	a0, s2
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x54>
-               	mv	s1, a0
-               	j	0xa4c <.Lpcrel_hi.16>
-               	mv	a0, s2
-               	li	a1, -0x1
-               	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.15+0x6c>
-               	mv	s1, a0
+               	fld	ft11, 0x0(t0)
+               	fmul.d	fs1, ft11, fs0
 
 <.Lpcrel_hi.16>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
-               	fmul.d	fs1, ft11, fs0
+               	fmul.d	fs2, ft11, fs0
+               	fmv.d.x	ft10, zero
+               	feq.d	a0, fs2, ft10
+               	bnez	a0, 0x570 <.Lpcrel_hi.17+0x28>
 
 <.Lpcrel_hi.17>:
                	auipc	t0, 0x0
-               	fld	ft11, 0x0(t0)
-               	fmul.d	fs2, ft11, fs0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft0, fs1, ft10
+               	feq.d	a1, fs1, ft0
+               	bnez	a1, 0x560 <.Lpcrel_hi.17+0x18>
+               	j	0x56c <.Lpcrel_hi.17+0x24>
+               	fmv.d.x	ft10, zero
+               	feq.d	a1, fs1, ft10
+               	xori	a1, a1, 0x1
+               	j	0x574 <.Lpcrel_hi.17+0x2c>
+               	mv	a1, a0
+               	bnez	a1, 0x628 <.Lpcrel_hi.20+0x10>
+               	fmv.d.x	ft10, zero
+               	flt.d	a0, fs1, ft10
+               	bnez	a0, 0x58c <.Lpcrel_hi.17+0x44>
+               	fmv.d	ft0, fs1
+               	j	0x594 <.Lpcrel_hi.17+0x4c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft0, ft11, fs1
+               	fmv.d.x	ft10, zero
+               	flt.d	a1, fs2, ft10
+               	bnez	a1, 0x5a8 <.Lpcrel_hi.17+0x60>
+               	fmv.d	ft1, fs2
+               	j	0x5b0 <.Lpcrel_hi.18>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft1, ft11, fs2
+
+<.Lpcrel_hi.18>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft2, ft0, ft10
+               	fmv.d	ft3, ft1
+               	fle.d	a1, ft3, ft2
+               	bnez	a1, 0x618 <.Lpcrel_hi.20>
+               	fmv.d	ft4, ft0
+               	fmv.d	ft5, ft3
+               	fle.d	a1, ft1, ft5
+               	bnez	a1, 0x5f0 <.Lpcrel_hi.18+0x40>
+               	bnez	a0, 0x5e4 <.Lpcrel_hi.18+0x34>
+               	fmv.d	ft6, ft4
+               	j	0x5ec <.Lpcrel_hi.18+0x3c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft6, ft11, ft4
+               	j	0x63c <.Lpcrel_hi.20+0x24>
+               	fle.d	a1, ft5, ft4
+               	bnez	a1, 0x600 <.Lpcrel_hi.18+0x50>
+               	fmv.d	ft7, ft4
+               	j	0x604 <.Lpcrel_hi.19>
+               	fsub.d	ft7, ft4, ft5
+
+<.Lpcrel_hi.19>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft5, ft5, ft10
+               	fmv.d	ft4, ft7
+               	j	0x5d0 <.Lpcrel_hi.18+0x20>
+
+<.Lpcrel_hi.20>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft3, ft3, ft10
+               	j	0x5c0 <.Lpcrel_hi.18+0x10>
                	fdiv.d	ft0, fs1, fs2
                	fcvt.l.d	a0, ft0, rtz
                	fcvt.d.l	ft0, a0
                	fmul.d	ft1, ft0, fs2
-               	fsub.d	fa0, fs1, ft1
-               	feq.d	a0, fa0, fa0
+               	fsub.d	ft6, fs1, ft1
+               	feq.d	a0, ft6, ft6
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xa98 <.Lpcrel_hi.17+0x40>
+               	bnez	a0, 0x660 <.Lpcrel_hi.20+0x48>
                	mv	a0, s1
+               	fmv.d	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.17+0x30>
+               	jalr	ra <.Lpcrel_hi.20+0x38>
                	mv	s2, a0
-               	j	0xaac <.Lpcrel_hi.17+0x54>
+               	j	0x674 <.Lpcrel_hi.20+0x5c>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.17+0x48>
+               	jalr	ra <.Lpcrel_hi.20+0x50>
                	mv	s2, a0
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs1
+               	fmv.d.x	ft10, zero
+               	feq.d	a0, fs2, ft10
+               	bnez	a0, 0x6b0 <.Lpcrel_hi.21+0x28>
+
+<.Lpcrel_hi.21>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft1, ft0, ft10
+               	feq.d	a1, ft0, ft1
+               	bnez	a1, 0x6a0 <.Lpcrel_hi.21+0x18>
+               	j	0x6ac <.Lpcrel_hi.21+0x24>
+               	fmv.d.x	ft10, zero
+               	feq.d	a1, ft0, ft10
+               	xori	a1, a1, 0x1
+               	j	0x6b4 <.Lpcrel_hi.21+0x2c>
+               	mv	a1, a0
+               	bnez	a1, 0x768 <.Lpcrel_hi.24+0x10>
+               	fmv.d.x	ft10, zero
+               	flt.d	a0, ft0, ft10
+               	bnez	a0, 0x6cc <.Lpcrel_hi.21+0x44>
+               	fmv.d	ft1, ft0
+               	j	0x6d4 <.Lpcrel_hi.21+0x4c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft1, ft11, ft0
+               	fmv.d.x	ft10, zero
+               	flt.d	a1, fs2, ft10
+               	bnez	a1, 0x6e8 <.Lpcrel_hi.21+0x60>
+               	fmv.d	ft2, fs2
+               	j	0x6f0 <.Lpcrel_hi.22>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft2, ft11, fs2
+
+<.Lpcrel_hi.22>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft3, ft1, ft10
+               	fmv.d	ft4, ft2
+               	fle.d	a1, ft4, ft3
+               	bnez	a1, 0x758 <.Lpcrel_hi.24>
+               	fmv.d	ft5, ft1
+               	fmv.d	ft6, ft4
+               	fle.d	a1, ft2, ft6
+               	bnez	a1, 0x730 <.Lpcrel_hi.22+0x40>
+               	bnez	a0, 0x724 <.Lpcrel_hi.22+0x34>
+               	fmv.d	ft7, ft5
+               	j	0x72c <.Lpcrel_hi.22+0x3c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft7, ft11, ft5
+               	j	0x77c <.Lpcrel_hi.24+0x24>
+               	fle.d	a1, ft6, ft5
+               	bnez	a1, 0x740 <.Lpcrel_hi.22+0x50>
+               	fmv.d	fa0, ft5
+               	j	0x744 <.Lpcrel_hi.23>
+               	fsub.d	fa0, ft5, ft6
+
+<.Lpcrel_hi.23>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft6, ft6, ft10
+               	fmv.d	ft5, fa0
+               	j	0x710 <.Lpcrel_hi.22+0x20>
+
+<.Lpcrel_hi.24>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft4, ft4, ft10
+               	j	0x700 <.Lpcrel_hi.22+0x10>
                	fdiv.d	ft1, ft0, fs2
                	fcvt.l.d	a0, ft1, rtz
                	fcvt.d.l	ft1, a0
                	fmul.d	ft2, ft1, fs2
-               	fsub.d	fa0, ft0, ft2
-               	feq.d	a0, fa0, fa0
+               	fsub.d	ft7, ft0, ft2
+               	feq.d	a0, ft7, ft7
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xae8 <.Lpcrel_hi.17+0x90>
+               	bnez	a0, 0x7a0 <.Lpcrel_hi.24+0x48>
                	mv	a0, s2
+               	fmv.d	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.17+0x80>
+               	jalr	ra <.Lpcrel_hi.24+0x38>
                	mv	s1, a0
-               	j	0xafc <.Lpcrel_hi.17+0xa4>
+               	j	0x7b4 <.Lpcrel_hi.24+0x5c>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.17+0x98>
+               	jalr	ra <.Lpcrel_hi.24+0x50>
                	mv	s1, a0
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs2
+               	fmv.d.x	ft10, zero
+               	feq.d	a0, ft0, ft10
+               	bnez	a0, 0x7f0 <.Lpcrel_hi.25+0x28>
+
+<.Lpcrel_hi.25>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft1, fs1, ft10
+               	feq.d	a1, fs1, ft1
+               	bnez	a1, 0x7e0 <.Lpcrel_hi.25+0x18>
+               	j	0x7ec <.Lpcrel_hi.25+0x24>
+               	fmv.d.x	ft10, zero
+               	feq.d	a1, fs1, ft10
+               	xori	a1, a1, 0x1
+               	j	0x7f4 <.Lpcrel_hi.25+0x2c>
+               	mv	a1, a0
+               	bnez	a1, 0x8a8 <.Lpcrel_hi.28+0x10>
+               	fmv.d.x	ft10, zero
+               	flt.d	a0, fs1, ft10
+               	bnez	a0, 0x80c <.Lpcrel_hi.25+0x44>
+               	fmv.d	ft1, fs1
+               	j	0x814 <.Lpcrel_hi.25+0x4c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft1, ft11, fs1
+               	fmv.d.x	ft10, zero
+               	flt.d	a1, ft0, ft10
+               	bnez	a1, 0x828 <.Lpcrel_hi.25+0x60>
+               	fmv.d	ft2, ft0
+               	j	0x830 <.Lpcrel_hi.26>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft2, ft11, ft0
+
+<.Lpcrel_hi.26>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft3, ft1, ft10
+               	fmv.d	ft4, ft2
+               	fle.d	a1, ft4, ft3
+               	bnez	a1, 0x898 <.Lpcrel_hi.28>
+               	fmv.d	ft5, ft1
+               	fmv.d	ft6, ft4
+               	fle.d	a1, ft2, ft6
+               	bnez	a1, 0x870 <.Lpcrel_hi.26+0x40>
+               	bnez	a0, 0x864 <.Lpcrel_hi.26+0x34>
+               	fmv.d	ft7, ft5
+               	j	0x86c <.Lpcrel_hi.26+0x3c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft7, ft11, ft5
+               	j	0x8bc <.Lpcrel_hi.28+0x24>
+               	fle.d	a1, ft6, ft5
+               	bnez	a1, 0x880 <.Lpcrel_hi.26+0x50>
+               	fmv.d	fa0, ft5
+               	j	0x884 <.Lpcrel_hi.27>
+               	fsub.d	fa0, ft5, ft6
+
+<.Lpcrel_hi.27>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft6, ft6, ft10
+               	fmv.d	ft5, fa0
+               	j	0x850 <.Lpcrel_hi.26+0x20>
+
+<.Lpcrel_hi.28>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft4, ft4, ft10
+               	j	0x840 <.Lpcrel_hi.26+0x10>
                	fdiv.d	ft1, fs1, ft0
                	fcvt.l.d	a0, ft1, rtz
                	fcvt.d.l	ft1, a0
                	fmul.d	ft2, ft1, ft0
-               	fsub.d	fa0, fs1, ft2
-               	feq.d	a0, fa0, fa0
+               	fsub.d	ft7, fs1, ft2
+               	feq.d	a0, ft7, ft7
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xb38 <.Lpcrel_hi.17+0xe0>
+               	bnez	a0, 0x8e0 <.Lpcrel_hi.28+0x48>
                	mv	a0, s1
+               	fmv.d	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.17+0xd0>
+               	jalr	ra <.Lpcrel_hi.28+0x38>
                	mv	s2, a0
-               	j	0xb4c <.Lpcrel_hi.17+0xf4>
+               	j	0x8f4 <.Lpcrel_hi.28+0x5c>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.17+0xe8>
+               	jalr	ra <.Lpcrel_hi.28+0x50>
                	mv	s2, a0
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs1
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, fs2
+               	fmv.d.x	ft10, zero
+               	feq.d	a0, ft1, ft10
+               	bnez	a0, 0x938 <.Lpcrel_hi.29+0x28>
+
+<.Lpcrel_hi.29>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft2, ft0, ft10
+               	feq.d	a1, ft0, ft2
+               	bnez	a1, 0x928 <.Lpcrel_hi.29+0x18>
+               	j	0x934 <.Lpcrel_hi.29+0x24>
+               	fmv.d.x	ft10, zero
+               	feq.d	a1, ft0, ft10
+               	xori	a1, a1, 0x1
+               	j	0x93c <.Lpcrel_hi.29+0x2c>
+               	mv	a1, a0
+               	bnez	a1, 0x9f0 <.Lpcrel_hi.32+0x10>
+               	fmv.d.x	ft10, zero
+               	flt.d	a0, ft0, ft10
+               	bnez	a0, 0x954 <.Lpcrel_hi.29+0x44>
+               	fmv.d	ft2, ft0
+               	j	0x95c <.Lpcrel_hi.29+0x4c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft2, ft11, ft0
+               	fmv.d.x	ft10, zero
+               	flt.d	a1, ft1, ft10
+               	bnez	a1, 0x970 <.Lpcrel_hi.29+0x60>
+               	fmv.d	ft3, ft1
+               	j	0x978 <.Lpcrel_hi.30>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft3, ft11, ft1
+
+<.Lpcrel_hi.30>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft4, ft2, ft10
+               	fmv.d	ft5, ft3
+               	fle.d	a1, ft5, ft4
+               	bnez	a1, 0x9e0 <.Lpcrel_hi.32>
+               	fmv.d	ft6, ft2
+               	fmv.d	ft7, ft5
+               	fle.d	a1, ft3, ft7
+               	bnez	a1, 0x9b8 <.Lpcrel_hi.30+0x40>
+               	bnez	a0, 0x9ac <.Lpcrel_hi.30+0x34>
+               	fmv.d	fa0, ft6
+               	j	0x9b4 <.Lpcrel_hi.30+0x3c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	fa0, ft11, ft6
+               	j	0xa04 <.Lpcrel_hi.32+0x24>
+               	fle.d	a1, ft7, ft6
+               	bnez	a1, 0x9c8 <.Lpcrel_hi.30+0x50>
+               	fmv.d	fa1, ft6
+               	j	0x9cc <.Lpcrel_hi.31>
+               	fsub.d	fa1, ft6, ft7
+
+<.Lpcrel_hi.31>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft7, ft7, ft10
+               	fmv.d	ft6, fa1
+               	j	0x998 <.Lpcrel_hi.30+0x20>
+
+<.Lpcrel_hi.32>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft5, ft5, ft10
+               	j	0x988 <.Lpcrel_hi.30+0x10>
                	fdiv.d	ft2, ft0, ft1
                	fcvt.l.d	a0, ft2, rtz
                	fcvt.d.l	ft2, a0
@@ -777,106 +716,373 @@ Disassembly of section .text:
                	fsub.d	fa0, ft0, ft3
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xb90 <.Lpcrel_hi.17+0x138>
+               	bnez	a0, 0xa24 <.Lpcrel_hi.32+0x44>
                	mv	a0, s2
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.17+0x128>
+               	jalr	ra <.Lpcrel_hi.32+0x34>
                	mv	s1, a0
-               	j	0xba4 <.Lpcrel_hi.18>
+               	j	0xa38 <.Lpcrel_hi.33>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.17+0x140>
+               	jalr	ra <.Lpcrel_hi.32+0x4c>
                	mv	s1, a0
 
-<.Lpcrel_hi.18>:
+<.Lpcrel_hi.33>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
                	fmul.d	ft0, ft11, fs0
 
-<.Lpcrel_hi.19>:
+<.Lpcrel_hi.34>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft1, ft0, ft10
+               	feq.d	a0, ft0, ft1
+               	bnez	a0, 0xa5c <.Lpcrel_hi.34+0x18>
+               	j	0xa68 <.Lpcrel_hi.34+0x24>
+               	fmv.d.x	ft10, zero
+               	feq.d	a0, ft0, ft10
+               	xori	a0, a0, 0x1
+               	bnez	a0, 0xb0c <.Lpcrel_hi.40>
+               	fmv.d.x	ft10, zero
+               	flt.d	a0, ft0, ft10
+               	bnez	a0, 0xa80 <.Lpcrel_hi.34+0x3c>
+               	fmv.d	ft1, ft0
+               	j	0xa88 <.Lpcrel_hi.35>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft1, ft11, ft0
+
+<.Lpcrel_hi.35>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft2, ft1, ft10
+
+<.Lpcrel_hi.36>:
+               	auipc	t0, 0x0
+               	fld	ft3, 0x0(t0)
+               	fle.d	a1, ft3, ft2
+               	bnez	a1, 0xafc <.Lpcrel_hi.39>
+               	fmv.d	ft4, ft1
+               	fmv.d	ft5, ft3
+
+<.Lpcrel_hi.37>:
+               	auipc	t0, 0x0
+               	fld	ft11, 0x0(t0)
+               	fle.d	a1, ft11, ft5
+               	bnez	a1, 0xad4 <.Lpcrel_hi.37+0x28>
+               	bnez	a0, 0xac8 <.Lpcrel_hi.37+0x1c>
+               	fmv.d	ft6, ft4
+               	j	0xad0 <.Lpcrel_hi.37+0x24>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft6, ft11, ft4
+               	j	0xb30 <.Lpcrel_hi.41+0x10>
+               	fle.d	a1, ft5, ft4
+               	bnez	a1, 0xae4 <.Lpcrel_hi.37+0x38>
+               	fmv.d	ft7, ft4
+               	j	0xae8 <.Lpcrel_hi.38>
+               	fsub.d	ft7, ft4, ft5
+
+<.Lpcrel_hi.38>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft5, ft5, ft10
+               	fmv.d	ft4, ft7
+               	j	0xaac <.Lpcrel_hi.37>
+
+<.Lpcrel_hi.39>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft3, ft3, ft10
+               	j	0xa9c <.Lpcrel_hi.36+0x8>
+
+<.Lpcrel_hi.40>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft1, ft0, ft10
                	fcvt.l.d	a0, ft1, rtz
                	fcvt.d.l	ft1, a0
 
-<.Lpcrel_hi.20>:
+<.Lpcrel_hi.41>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft2, ft1, ft10
-               	fsub.d	fa0, ft0, ft2
-               	feq.d	a0, fa0, fa0
+               	fsub.d	ft6, ft0, ft2
+               	feq.d	a0, ft6, ft6
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xbf4 <.Lpcrel_hi.20+0x30>
+               	bnez	a0, 0xb54 <.Lpcrel_hi.41+0x34>
                	mv	a0, s1
+               	fmv.d	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.20+0x20>
+               	jalr	ra <.Lpcrel_hi.41+0x24>
                	mv	s2, a0
-               	j	0xc08 <.Lpcrel_hi.20+0x44>
+               	j	0xb68 <.Lpcrel_hi.41+0x48>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.20+0x38>
+               	jalr	ra <.Lpcrel_hi.41+0x3c>
                	mv	s2, a0
+               	fmv.d.x	ft10, zero
+               	feq.d	a0, fs2, ft10
+               	bnez	a0, 0xb9c <.Lpcrel_hi.42+0x28>
+
+<.Lpcrel_hi.42>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft0, fs0, ft10
+               	feq.d	a1, fs0, ft0
+               	bnez	a1, 0xb8c <.Lpcrel_hi.42+0x18>
+               	j	0xb98 <.Lpcrel_hi.42+0x24>
+               	fmv.d.x	ft10, zero
+               	feq.d	a1, fs0, ft10
+               	xori	a1, a1, 0x1
+               	j	0xba0 <.Lpcrel_hi.42+0x2c>
+               	mv	a1, a0
+               	bnez	a1, 0xc54 <.Lpcrel_hi.45+0x10>
+               	fmv.d.x	ft10, zero
+               	flt.d	a0, fs0, ft10
+               	bnez	a0, 0xbb8 <.Lpcrel_hi.42+0x44>
+               	fmv.d	ft0, fs0
+               	j	0xbc0 <.Lpcrel_hi.42+0x4c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft0, ft11, fs0
+               	fmv.d.x	ft10, zero
+               	flt.d	a1, fs2, ft10
+               	bnez	a1, 0xbd4 <.Lpcrel_hi.42+0x60>
+               	fmv.d	ft1, fs2
+               	j	0xbdc <.Lpcrel_hi.43>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft1, ft11, fs2
+
+<.Lpcrel_hi.43>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft2, ft0, ft10
+               	fmv.d	ft3, ft1
+               	fle.d	a1, ft3, ft2
+               	bnez	a1, 0xc44 <.Lpcrel_hi.45>
+               	fmv.d	ft4, ft0
+               	fmv.d	ft5, ft3
+               	fle.d	a1, ft1, ft5
+               	bnez	a1, 0xc1c <.Lpcrel_hi.43+0x40>
+               	bnez	a0, 0xc10 <.Lpcrel_hi.43+0x34>
+               	fmv.d	ft6, ft4
+               	j	0xc18 <.Lpcrel_hi.43+0x3c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft6, ft11, ft4
+               	j	0xc68 <.Lpcrel_hi.45+0x24>
+               	fle.d	a1, ft5, ft4
+               	bnez	a1, 0xc2c <.Lpcrel_hi.43+0x50>
+               	fmv.d	ft7, ft4
+               	j	0xc30 <.Lpcrel_hi.44>
+               	fsub.d	ft7, ft4, ft5
+
+<.Lpcrel_hi.44>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft5, ft5, ft10
+               	fmv.d	ft4, ft7
+               	j	0xbfc <.Lpcrel_hi.43+0x20>
+
+<.Lpcrel_hi.45>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft3, ft3, ft10
+               	j	0xbec <.Lpcrel_hi.43+0x10>
                	fdiv.d	ft0, fs0, fs2
                	fcvt.l.d	a0, ft0, rtz
                	fcvt.d.l	ft0, a0
                	fmul.d	ft1, ft0, fs2
-               	fsub.d	fa0, fs0, ft1
-               	feq.d	a0, fa0, fa0
+               	fsub.d	ft6, fs0, ft1
+               	feq.d	a0, ft6, ft6
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xc3c <.Lpcrel_hi.20+0x78>
+               	bnez	a0, 0xc8c <.Lpcrel_hi.45+0x48>
                	mv	a0, s2
+               	fmv.d	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.20+0x68>
+               	jalr	ra <.Lpcrel_hi.45+0x38>
                	mv	s1, a0
-               	j	0xc50 <.Lpcrel_hi.20+0x8c>
+               	j	0xca0 <.Lpcrel_hi.45+0x5c>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.20+0x80>
+               	jalr	ra <.Lpcrel_hi.45+0x50>
                	mv	s1, a0
+               	fmv.d.x	ft10, zero
+               	feq.d	a0, fs2, ft10
+               	bnez	a0, 0xcd4 <.Lpcrel_hi.46+0x28>
+
+<.Lpcrel_hi.46>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft0, fs2, ft10
+               	feq.d	a1, fs2, ft0
+               	bnez	a1, 0xcc4 <.Lpcrel_hi.46+0x18>
+               	j	0xcd0 <.Lpcrel_hi.46+0x24>
+               	fmv.d.x	ft10, zero
+               	feq.d	a1, fs2, ft10
+               	xori	a1, a1, 0x1
+               	j	0xcd8 <.Lpcrel_hi.46+0x2c>
+               	mv	a1, a0
+               	bnez	a1, 0xd8c <.Lpcrel_hi.49+0x10>
+               	fmv.d.x	ft10, zero
+               	flt.d	a0, fs2, ft10
+               	bnez	a0, 0xcf0 <.Lpcrel_hi.46+0x44>
+               	fmv.d	ft0, fs2
+               	j	0xcf8 <.Lpcrel_hi.46+0x4c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft0, ft11, fs2
+               	fmv.d.x	ft10, zero
+               	flt.d	a1, fs2, ft10
+               	bnez	a1, 0xd0c <.Lpcrel_hi.46+0x60>
+               	fmv.d	ft1, fs2
+               	j	0xd14 <.Lpcrel_hi.47>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft1, ft11, fs2
+
+<.Lpcrel_hi.47>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft2, ft0, ft10
+               	fmv.d	ft3, ft1
+               	fle.d	a1, ft3, ft2
+               	bnez	a1, 0xd7c <.Lpcrel_hi.49>
+               	fmv.d	ft4, ft0
+               	fmv.d	ft5, ft3
+               	fle.d	a1, ft1, ft5
+               	bnez	a1, 0xd54 <.Lpcrel_hi.47+0x40>
+               	bnez	a0, 0xd48 <.Lpcrel_hi.47+0x34>
+               	fmv.d	ft6, ft4
+               	j	0xd50 <.Lpcrel_hi.47+0x3c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft6, ft11, ft4
+               	j	0xda0 <.Lpcrel_hi.49+0x24>
+               	fle.d	a1, ft5, ft4
+               	bnez	a1, 0xd64 <.Lpcrel_hi.47+0x50>
+               	fmv.d	ft7, ft4
+               	j	0xd68 <.Lpcrel_hi.48>
+               	fsub.d	ft7, ft4, ft5
+
+<.Lpcrel_hi.48>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft5, ft5, ft10
+               	fmv.d	ft4, ft7
+               	j	0xd34 <.Lpcrel_hi.47+0x20>
+
+<.Lpcrel_hi.49>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft3, ft3, ft10
+               	j	0xd24 <.Lpcrel_hi.47+0x10>
                	fdiv.d	ft0, fs2, fs2
                	fcvt.l.d	a0, ft0, rtz
                	fcvt.d.l	ft0, a0
                	fmul.d	ft1, ft0, fs2
-               	fsub.d	fa0, fs2, ft1
-               	feq.d	a0, fa0, fa0
+               	fsub.d	ft6, fs2, ft1
+               	feq.d	a0, ft6, ft6
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xc84 <.Lpcrel_hi.20+0xc0>
+               	bnez	a0, 0xdc4 <.Lpcrel_hi.49+0x48>
                	mv	a0, s1
+               	fmv.d	fa0, ft6
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.20+0xb0>
+               	jalr	ra <.Lpcrel_hi.49+0x38>
                	mv	s2, a0
-               	j	0xc98 <.Lpcrel_hi.21>
+               	j	0xdd8 <.Lpcrel_hi.50>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.20+0xc8>
+               	jalr	ra <.Lpcrel_hi.49+0x50>
                	mv	s2, a0
 
-<.Lpcrel_hi.21>:
+<.Lpcrel_hi.50>:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
                	fmul.d	ft0, ft11, fs0
+               	fmv.d.x	ft10, zero
+               	feq.d	a0, fs2, ft10
+               	bnez	a0, 0xe18 <.Lpcrel_hi.51+0x28>
+
+<.Lpcrel_hi.51>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft1, ft0, ft10
+               	feq.d	a1, ft0, ft1
+               	bnez	a1, 0xe08 <.Lpcrel_hi.51+0x18>
+               	j	0xe14 <.Lpcrel_hi.51+0x24>
+               	fmv.d.x	ft10, zero
+               	feq.d	a1, ft0, ft10
+               	xori	a1, a1, 0x1
+               	j	0xe1c <.Lpcrel_hi.51+0x2c>
+               	mv	a1, a0
+               	bnez	a1, 0xed0 <.Lpcrel_hi.54+0x10>
+               	fmv.d.x	ft10, zero
+               	flt.d	a0, ft0, ft10
+               	bnez	a0, 0xe34 <.Lpcrel_hi.51+0x44>
+               	fmv.d	ft1, ft0
+               	j	0xe3c <.Lpcrel_hi.51+0x4c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft1, ft11, ft0
+               	fmv.d.x	ft10, zero
+               	flt.d	a1, fs2, ft10
+               	bnez	a1, 0xe50 <.Lpcrel_hi.51+0x60>
+               	fmv.d	ft2, fs2
+               	j	0xe58 <.Lpcrel_hi.52>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft2, ft11, fs2
+
+<.Lpcrel_hi.52>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft3, ft1, ft10
+               	fmv.d	ft4, ft2
+               	fle.d	a1, ft4, ft3
+               	bnez	a1, 0xec0 <.Lpcrel_hi.54>
+               	fmv.d	ft5, ft1
+               	fmv.d	ft6, ft4
+               	fle.d	a1, ft2, ft6
+               	bnez	a1, 0xe98 <.Lpcrel_hi.52+0x40>
+               	bnez	a0, 0xe8c <.Lpcrel_hi.52+0x34>
+               	fmv.d	ft7, ft5
+               	j	0xe94 <.Lpcrel_hi.52+0x3c>
+               	fmv.d.x	ft11, zero
+               	fsub.d	ft7, ft11, ft5
+               	j	0xee4 <.Lpcrel_hi.54+0x24>
+               	fle.d	a1, ft6, ft5
+               	bnez	a1, 0xea8 <.Lpcrel_hi.52+0x50>
+               	fmv.d	fa0, ft5
+               	j	0xeac <.Lpcrel_hi.53>
+               	fsub.d	fa0, ft5, ft6
+
+<.Lpcrel_hi.53>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fdiv.d	ft6, ft6, ft10
+               	fmv.d	ft5, fa0
+               	j	0xe78 <.Lpcrel_hi.52+0x20>
+
+<.Lpcrel_hi.54>:
+               	auipc	t0, 0x0
+               	fld	ft10, 0x0(t0)
+               	fmul.d	ft4, ft4, ft10
+               	j	0xe68 <.Lpcrel_hi.52+0x10>
                	fdiv.d	ft1, ft0, fs2
                	fcvt.l.d	a0, ft1, rtz
                	fcvt.d.l	ft1, a0
                	fmul.d	ft2, ft1, fs2
-               	fsub.d	fa0, ft0, ft2
-               	feq.d	a0, fa0, fa0
+               	fsub.d	ft7, ft0, ft2
+               	feq.d	a0, ft7, ft7
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xcd8 <.Lpcrel_hi.21+0x40>
+               	bnez	a0, 0xf08 <.Lpcrel_hi.54+0x48>
                	mv	a0, s2
+               	fmv.d	fa0, ft7
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x30>
+               	jalr	ra <.Lpcrel_hi.54+0x38>
                	mv	s1, a0
-               	j	0xcec <.Lpcrel_hi.21+0x54>
+               	j	0xf1c <.Lpcrel_hi.54+0x5c>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
-               	jalr	ra <.Lpcrel_hi.21+0x48>
+               	jalr	ra <.Lpcrel_hi.54+0x50>
                	mv	s1, a0
                	mv	a0, s1
                	ld	s1, 0x38(sp)

--- a/test/golden/riscv64-linux/float/arith_f64.dis
+++ b/test/golden/riscv64-linux/float/arith_f64.dis
@@ -392,7 +392,7 @@ Disassembly of section .text:
                	xori	a1, a1, 0x1
                	j	0x574 <.Lpcrel_hi.17+0x2c>
                	mv	a1, a0
-               	bnez	a1, 0x628 <.Lpcrel_hi.20+0x10>
+               	bnez	a1, 0x624 <.Lpcrel_hi.20+0x10>
                	fmv.d.x	ft10, zero
                	flt.d	a0, fs1, ft10
                	bnez	a0, 0x58c <.Lpcrel_hi.17+0x44>
@@ -414,21 +414,20 @@ Disassembly of section .text:
                	fdiv.d	ft2, ft0, ft10
                	fmv.d	ft3, ft1
                	fle.d	a1, ft3, ft2
-               	bnez	a1, 0x618 <.Lpcrel_hi.20>
+               	bnez	a1, 0x614 <.Lpcrel_hi.20>
                	fmv.d	ft4, ft0
                	fmv.d	ft5, ft3
                	fle.d	a1, ft1, ft5
-               	bnez	a1, 0x5f0 <.Lpcrel_hi.18+0x40>
+               	bnez	a1, 0x5ec <.Lpcrel_hi.18+0x3c>
                	bnez	a0, 0x5e4 <.Lpcrel_hi.18+0x34>
                	fmv.d	ft6, ft4
-               	j	0x5ec <.Lpcrel_hi.18+0x3c>
-               	fmv.d.x	ft11, zero
-               	fsub.d	ft6, ft11, ft4
-               	j	0x63c <.Lpcrel_hi.20+0x24>
+               	j	0x5e8 <.Lpcrel_hi.18+0x38>
+               	fneg.d	ft6, ft4
+               	j	0x638 <.Lpcrel_hi.20+0x24>
                	fle.d	a1, ft5, ft4
-               	bnez	a1, 0x600 <.Lpcrel_hi.18+0x50>
+               	bnez	a1, 0x5fc <.Lpcrel_hi.18+0x4c>
                	fmv.d	ft7, ft4
-               	j	0x604 <.Lpcrel_hi.19>
+               	j	0x600 <.Lpcrel_hi.19>
                	fsub.d	ft7, ft4, ft5
 
 <.Lpcrel_hi.19>:
@@ -450,13 +449,13 @@ Disassembly of section .text:
                	fsub.d	ft6, fs1, ft1
                	feq.d	a0, ft6, ft6
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x660 <.Lpcrel_hi.20+0x48>
+               	bnez	a0, 0x65c <.Lpcrel_hi.20+0x48>
                	mv	a0, s1
                	fmv.d	fa0, ft6
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.20+0x38>
                	mv	s2, a0
-               	j	0x674 <.Lpcrel_hi.20+0x5c>
+               	j	0x670 <.Lpcrel_hi.20+0x5c>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -466,33 +465,33 @@ Disassembly of section .text:
                	fsub.d	ft0, ft11, fs1
                	fmv.d.x	ft10, zero
                	feq.d	a0, fs2, ft10
-               	bnez	a0, 0x6b0 <.Lpcrel_hi.21+0x28>
+               	bnez	a0, 0x6ac <.Lpcrel_hi.21+0x28>
 
 <.Lpcrel_hi.21>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft1, ft0, ft10
                	feq.d	a1, ft0, ft1
-               	bnez	a1, 0x6a0 <.Lpcrel_hi.21+0x18>
-               	j	0x6ac <.Lpcrel_hi.21+0x24>
+               	bnez	a1, 0x69c <.Lpcrel_hi.21+0x18>
+               	j	0x6a8 <.Lpcrel_hi.21+0x24>
                	fmv.d.x	ft10, zero
                	feq.d	a1, ft0, ft10
                	xori	a1, a1, 0x1
-               	j	0x6b4 <.Lpcrel_hi.21+0x2c>
+               	j	0x6b0 <.Lpcrel_hi.21+0x2c>
                	mv	a1, a0
-               	bnez	a1, 0x768 <.Lpcrel_hi.24+0x10>
+               	bnez	a1, 0x760 <.Lpcrel_hi.24+0x10>
                	fmv.d.x	ft10, zero
                	flt.d	a0, ft0, ft10
-               	bnez	a0, 0x6cc <.Lpcrel_hi.21+0x44>
+               	bnez	a0, 0x6c8 <.Lpcrel_hi.21+0x44>
                	fmv.d	ft1, ft0
-               	j	0x6d4 <.Lpcrel_hi.21+0x4c>
+               	j	0x6d0 <.Lpcrel_hi.21+0x4c>
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, ft0
                	fmv.d.x	ft10, zero
                	flt.d	a1, fs2, ft10
-               	bnez	a1, 0x6e8 <.Lpcrel_hi.21+0x60>
+               	bnez	a1, 0x6e4 <.Lpcrel_hi.21+0x60>
                	fmv.d	ft2, fs2
-               	j	0x6f0 <.Lpcrel_hi.22>
+               	j	0x6ec <.Lpcrel_hi.22>
                	fmv.d.x	ft11, zero
                	fsub.d	ft2, ft11, fs2
 
@@ -502,21 +501,20 @@ Disassembly of section .text:
                	fdiv.d	ft3, ft1, ft10
                	fmv.d	ft4, ft2
                	fle.d	a1, ft4, ft3
-               	bnez	a1, 0x758 <.Lpcrel_hi.24>
+               	bnez	a1, 0x750 <.Lpcrel_hi.24>
                	fmv.d	ft5, ft1
                	fmv.d	ft6, ft4
                	fle.d	a1, ft2, ft6
-               	bnez	a1, 0x730 <.Lpcrel_hi.22+0x40>
-               	bnez	a0, 0x724 <.Lpcrel_hi.22+0x34>
+               	bnez	a1, 0x728 <.Lpcrel_hi.22+0x3c>
+               	bnez	a0, 0x720 <.Lpcrel_hi.22+0x34>
                	fmv.d	ft7, ft5
-               	j	0x72c <.Lpcrel_hi.22+0x3c>
-               	fmv.d.x	ft11, zero
-               	fsub.d	ft7, ft11, ft5
-               	j	0x77c <.Lpcrel_hi.24+0x24>
+               	j	0x724 <.Lpcrel_hi.22+0x38>
+               	fneg.d	ft7, ft5
+               	j	0x774 <.Lpcrel_hi.24+0x24>
                	fle.d	a1, ft6, ft5
-               	bnez	a1, 0x740 <.Lpcrel_hi.22+0x50>
+               	bnez	a1, 0x738 <.Lpcrel_hi.22+0x4c>
                	fmv.d	fa0, ft5
-               	j	0x744 <.Lpcrel_hi.23>
+               	j	0x73c <.Lpcrel_hi.23>
                	fsub.d	fa0, ft5, ft6
 
 <.Lpcrel_hi.23>:
@@ -524,13 +522,13 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft6, ft6, ft10
                	fmv.d	ft5, fa0
-               	j	0x710 <.Lpcrel_hi.22+0x20>
+               	j	0x70c <.Lpcrel_hi.22+0x20>
 
 <.Lpcrel_hi.24>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft4, ft4, ft10
-               	j	0x700 <.Lpcrel_hi.22+0x10>
+               	j	0x6fc <.Lpcrel_hi.22+0x10>
                	fdiv.d	ft1, ft0, fs2
                	fcvt.l.d	a0, ft1, rtz
                	fcvt.d.l	ft1, a0
@@ -538,13 +536,13 @@ Disassembly of section .text:
                	fsub.d	ft7, ft0, ft2
                	feq.d	a0, ft7, ft7
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x7a0 <.Lpcrel_hi.24+0x48>
+               	bnez	a0, 0x798 <.Lpcrel_hi.24+0x48>
                	mv	a0, s2
                	fmv.d	fa0, ft7
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.24+0x38>
                	mv	s1, a0
-               	j	0x7b4 <.Lpcrel_hi.24+0x5c>
+               	j	0x7ac <.Lpcrel_hi.24+0x5c>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -554,33 +552,33 @@ Disassembly of section .text:
                	fsub.d	ft0, ft11, fs2
                	fmv.d.x	ft10, zero
                	feq.d	a0, ft0, ft10
-               	bnez	a0, 0x7f0 <.Lpcrel_hi.25+0x28>
+               	bnez	a0, 0x7e8 <.Lpcrel_hi.25+0x28>
 
 <.Lpcrel_hi.25>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft1, fs1, ft10
                	feq.d	a1, fs1, ft1
-               	bnez	a1, 0x7e0 <.Lpcrel_hi.25+0x18>
-               	j	0x7ec <.Lpcrel_hi.25+0x24>
+               	bnez	a1, 0x7d8 <.Lpcrel_hi.25+0x18>
+               	j	0x7e4 <.Lpcrel_hi.25+0x24>
                	fmv.d.x	ft10, zero
                	feq.d	a1, fs1, ft10
                	xori	a1, a1, 0x1
-               	j	0x7f4 <.Lpcrel_hi.25+0x2c>
+               	j	0x7ec <.Lpcrel_hi.25+0x2c>
                	mv	a1, a0
-               	bnez	a1, 0x8a8 <.Lpcrel_hi.28+0x10>
+               	bnez	a1, 0x89c <.Lpcrel_hi.28+0x10>
                	fmv.d.x	ft10, zero
                	flt.d	a0, fs1, ft10
-               	bnez	a0, 0x80c <.Lpcrel_hi.25+0x44>
+               	bnez	a0, 0x804 <.Lpcrel_hi.25+0x44>
                	fmv.d	ft1, fs1
-               	j	0x814 <.Lpcrel_hi.25+0x4c>
+               	j	0x80c <.Lpcrel_hi.25+0x4c>
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, fs1
                	fmv.d.x	ft10, zero
                	flt.d	a1, ft0, ft10
-               	bnez	a1, 0x828 <.Lpcrel_hi.25+0x60>
+               	bnez	a1, 0x820 <.Lpcrel_hi.25+0x60>
                	fmv.d	ft2, ft0
-               	j	0x830 <.Lpcrel_hi.26>
+               	j	0x828 <.Lpcrel_hi.26>
                	fmv.d.x	ft11, zero
                	fsub.d	ft2, ft11, ft0
 
@@ -590,21 +588,20 @@ Disassembly of section .text:
                	fdiv.d	ft3, ft1, ft10
                	fmv.d	ft4, ft2
                	fle.d	a1, ft4, ft3
-               	bnez	a1, 0x898 <.Lpcrel_hi.28>
+               	bnez	a1, 0x88c <.Lpcrel_hi.28>
                	fmv.d	ft5, ft1
                	fmv.d	ft6, ft4
                	fle.d	a1, ft2, ft6
-               	bnez	a1, 0x870 <.Lpcrel_hi.26+0x40>
-               	bnez	a0, 0x864 <.Lpcrel_hi.26+0x34>
+               	bnez	a1, 0x864 <.Lpcrel_hi.26+0x3c>
+               	bnez	a0, 0x85c <.Lpcrel_hi.26+0x34>
                	fmv.d	ft7, ft5
-               	j	0x86c <.Lpcrel_hi.26+0x3c>
-               	fmv.d.x	ft11, zero
-               	fsub.d	ft7, ft11, ft5
-               	j	0x8bc <.Lpcrel_hi.28+0x24>
+               	j	0x860 <.Lpcrel_hi.26+0x38>
+               	fneg.d	ft7, ft5
+               	j	0x8b0 <.Lpcrel_hi.28+0x24>
                	fle.d	a1, ft6, ft5
-               	bnez	a1, 0x880 <.Lpcrel_hi.26+0x50>
+               	bnez	a1, 0x874 <.Lpcrel_hi.26+0x4c>
                	fmv.d	fa0, ft5
-               	j	0x884 <.Lpcrel_hi.27>
+               	j	0x878 <.Lpcrel_hi.27>
                	fsub.d	fa0, ft5, ft6
 
 <.Lpcrel_hi.27>:
@@ -612,13 +609,13 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft6, ft6, ft10
                	fmv.d	ft5, fa0
-               	j	0x850 <.Lpcrel_hi.26+0x20>
+               	j	0x848 <.Lpcrel_hi.26+0x20>
 
 <.Lpcrel_hi.28>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft4, ft4, ft10
-               	j	0x840 <.Lpcrel_hi.26+0x10>
+               	j	0x838 <.Lpcrel_hi.26+0x10>
                	fdiv.d	ft1, fs1, ft0
                	fcvt.l.d	a0, ft1, rtz
                	fcvt.d.l	ft1, a0
@@ -626,13 +623,13 @@ Disassembly of section .text:
                	fsub.d	ft7, fs1, ft2
                	feq.d	a0, ft7, ft7
                	xori	a0, a0, 0x1
-               	bnez	a0, 0x8e0 <.Lpcrel_hi.28+0x48>
+               	bnez	a0, 0x8d4 <.Lpcrel_hi.28+0x48>
                	mv	a0, s1
                	fmv.d	fa0, ft7
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.28+0x38>
                	mv	s2, a0
-               	j	0x8f4 <.Lpcrel_hi.28+0x5c>
+               	j	0x8e8 <.Lpcrel_hi.28+0x5c>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -644,33 +641,33 @@ Disassembly of section .text:
                	fsub.d	ft1, ft11, fs2
                	fmv.d.x	ft10, zero
                	feq.d	a0, ft1, ft10
-               	bnez	a0, 0x938 <.Lpcrel_hi.29+0x28>
+               	bnez	a0, 0x92c <.Lpcrel_hi.29+0x28>
 
 <.Lpcrel_hi.29>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft2, ft0, ft10
                	feq.d	a1, ft0, ft2
-               	bnez	a1, 0x928 <.Lpcrel_hi.29+0x18>
-               	j	0x934 <.Lpcrel_hi.29+0x24>
+               	bnez	a1, 0x91c <.Lpcrel_hi.29+0x18>
+               	j	0x928 <.Lpcrel_hi.29+0x24>
                	fmv.d.x	ft10, zero
                	feq.d	a1, ft0, ft10
                	xori	a1, a1, 0x1
-               	j	0x93c <.Lpcrel_hi.29+0x2c>
+               	j	0x930 <.Lpcrel_hi.29+0x2c>
                	mv	a1, a0
-               	bnez	a1, 0x9f0 <.Lpcrel_hi.32+0x10>
+               	bnez	a1, 0x9e0 <.Lpcrel_hi.32+0x10>
                	fmv.d.x	ft10, zero
                	flt.d	a0, ft0, ft10
-               	bnez	a0, 0x954 <.Lpcrel_hi.29+0x44>
+               	bnez	a0, 0x948 <.Lpcrel_hi.29+0x44>
                	fmv.d	ft2, ft0
-               	j	0x95c <.Lpcrel_hi.29+0x4c>
+               	j	0x950 <.Lpcrel_hi.29+0x4c>
                	fmv.d.x	ft11, zero
                	fsub.d	ft2, ft11, ft0
                	fmv.d.x	ft10, zero
                	flt.d	a1, ft1, ft10
-               	bnez	a1, 0x970 <.Lpcrel_hi.29+0x60>
+               	bnez	a1, 0x964 <.Lpcrel_hi.29+0x60>
                	fmv.d	ft3, ft1
-               	j	0x978 <.Lpcrel_hi.30>
+               	j	0x96c <.Lpcrel_hi.30>
                	fmv.d.x	ft11, zero
                	fsub.d	ft3, ft11, ft1
 
@@ -680,21 +677,20 @@ Disassembly of section .text:
                	fdiv.d	ft4, ft2, ft10
                	fmv.d	ft5, ft3
                	fle.d	a1, ft5, ft4
-               	bnez	a1, 0x9e0 <.Lpcrel_hi.32>
+               	bnez	a1, 0x9d0 <.Lpcrel_hi.32>
                	fmv.d	ft6, ft2
                	fmv.d	ft7, ft5
                	fle.d	a1, ft3, ft7
-               	bnez	a1, 0x9b8 <.Lpcrel_hi.30+0x40>
-               	bnez	a0, 0x9ac <.Lpcrel_hi.30+0x34>
+               	bnez	a1, 0x9a8 <.Lpcrel_hi.30+0x3c>
+               	bnez	a0, 0x9a0 <.Lpcrel_hi.30+0x34>
                	fmv.d	fa0, ft6
-               	j	0x9b4 <.Lpcrel_hi.30+0x3c>
-               	fmv.d.x	ft11, zero
-               	fsub.d	fa0, ft11, ft6
-               	j	0xa04 <.Lpcrel_hi.32+0x24>
+               	j	0x9a4 <.Lpcrel_hi.30+0x38>
+               	fneg.d	fa0, ft6
+               	j	0x9f4 <.Lpcrel_hi.32+0x24>
                	fle.d	a1, ft7, ft6
-               	bnez	a1, 0x9c8 <.Lpcrel_hi.30+0x50>
+               	bnez	a1, 0x9b8 <.Lpcrel_hi.30+0x4c>
                	fmv.d	fa1, ft6
-               	j	0x9cc <.Lpcrel_hi.31>
+               	j	0x9bc <.Lpcrel_hi.31>
                	fsub.d	fa1, ft6, ft7
 
 <.Lpcrel_hi.31>:
@@ -702,13 +698,13 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft7, ft7, ft10
                	fmv.d	ft6, fa1
-               	j	0x998 <.Lpcrel_hi.30+0x20>
+               	j	0x98c <.Lpcrel_hi.30+0x20>
 
 <.Lpcrel_hi.32>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft5, ft5, ft10
-               	j	0x988 <.Lpcrel_hi.30+0x10>
+               	j	0x97c <.Lpcrel_hi.30+0x10>
                	fdiv.d	ft2, ft0, ft1
                	fcvt.l.d	a0, ft2, rtz
                	fcvt.d.l	ft2, a0
@@ -716,12 +712,12 @@ Disassembly of section .text:
                	fsub.d	fa0, ft0, ft3
                	feq.d	a0, fa0, fa0
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xa24 <.Lpcrel_hi.32+0x44>
+               	bnez	a0, 0xa14 <.Lpcrel_hi.32+0x44>
                	mv	a0, s2
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.32+0x34>
                	mv	s1, a0
-               	j	0xa38 <.Lpcrel_hi.33>
+               	j	0xa28 <.Lpcrel_hi.33>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -738,17 +734,17 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fmul.d	ft1, ft0, ft10
                	feq.d	a0, ft0, ft1
-               	bnez	a0, 0xa5c <.Lpcrel_hi.34+0x18>
-               	j	0xa68 <.Lpcrel_hi.34+0x24>
+               	bnez	a0, 0xa4c <.Lpcrel_hi.34+0x18>
+               	j	0xa58 <.Lpcrel_hi.34+0x24>
                	fmv.d.x	ft10, zero
                	feq.d	a0, ft0, ft10
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xb0c <.Lpcrel_hi.40>
+               	bnez	a0, 0xaf8 <.Lpcrel_hi.40>
                	fmv.d.x	ft10, zero
                	flt.d	a0, ft0, ft10
-               	bnez	a0, 0xa80 <.Lpcrel_hi.34+0x3c>
+               	bnez	a0, 0xa70 <.Lpcrel_hi.34+0x3c>
                	fmv.d	ft1, ft0
-               	j	0xa88 <.Lpcrel_hi.35>
+               	j	0xa78 <.Lpcrel_hi.35>
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, ft0
 
@@ -761,7 +757,7 @@ Disassembly of section .text:
                	auipc	t0, 0x0
                	fld	ft3, 0x0(t0)
                	fle.d	a1, ft3, ft2
-               	bnez	a1, 0xafc <.Lpcrel_hi.39>
+               	bnez	a1, 0xae8 <.Lpcrel_hi.39>
                	fmv.d	ft4, ft1
                	fmv.d	ft5, ft3
 
@@ -769,17 +765,16 @@ Disassembly of section .text:
                	auipc	t0, 0x0
                	fld	ft11, 0x0(t0)
                	fle.d	a1, ft11, ft5
-               	bnez	a1, 0xad4 <.Lpcrel_hi.37+0x28>
-               	bnez	a0, 0xac8 <.Lpcrel_hi.37+0x1c>
+               	bnez	a1, 0xac0 <.Lpcrel_hi.37+0x24>
+               	bnez	a0, 0xab8 <.Lpcrel_hi.37+0x1c>
                	fmv.d	ft6, ft4
-               	j	0xad0 <.Lpcrel_hi.37+0x24>
-               	fmv.d.x	ft11, zero
-               	fsub.d	ft6, ft11, ft4
-               	j	0xb30 <.Lpcrel_hi.41+0x10>
+               	j	0xabc <.Lpcrel_hi.37+0x20>
+               	fneg.d	ft6, ft4
+               	j	0xb1c <.Lpcrel_hi.41+0x10>
                	fle.d	a1, ft5, ft4
-               	bnez	a1, 0xae4 <.Lpcrel_hi.37+0x38>
+               	bnez	a1, 0xad0 <.Lpcrel_hi.37+0x34>
                	fmv.d	ft7, ft4
-               	j	0xae8 <.Lpcrel_hi.38>
+               	j	0xad4 <.Lpcrel_hi.38>
                	fsub.d	ft7, ft4, ft5
 
 <.Lpcrel_hi.38>:
@@ -787,13 +782,13 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft5, ft5, ft10
                	fmv.d	ft4, ft7
-               	j	0xaac <.Lpcrel_hi.37>
+               	j	0xa9c <.Lpcrel_hi.37>
 
 <.Lpcrel_hi.39>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft3, ft3, ft10
-               	j	0xa9c <.Lpcrel_hi.36+0x8>
+               	j	0xa8c <.Lpcrel_hi.36+0x8>
 
 <.Lpcrel_hi.40>:
                	auipc	t0, 0x0
@@ -809,13 +804,13 @@ Disassembly of section .text:
                	fsub.d	ft6, ft0, ft2
                	feq.d	a0, ft6, ft6
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xb54 <.Lpcrel_hi.41+0x34>
+               	bnez	a0, 0xb40 <.Lpcrel_hi.41+0x34>
                	mv	a0, s1
                	fmv.d	fa0, ft6
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.41+0x24>
                	mv	s2, a0
-               	j	0xb68 <.Lpcrel_hi.41+0x48>
+               	j	0xb54 <.Lpcrel_hi.41+0x48>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -823,33 +818,33 @@ Disassembly of section .text:
                	mv	s2, a0
                	fmv.d.x	ft10, zero
                	feq.d	a0, fs2, ft10
-               	bnez	a0, 0xb9c <.Lpcrel_hi.42+0x28>
+               	bnez	a0, 0xb88 <.Lpcrel_hi.42+0x28>
 
 <.Lpcrel_hi.42>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft0, fs0, ft10
                	feq.d	a1, fs0, ft0
-               	bnez	a1, 0xb8c <.Lpcrel_hi.42+0x18>
-               	j	0xb98 <.Lpcrel_hi.42+0x24>
+               	bnez	a1, 0xb78 <.Lpcrel_hi.42+0x18>
+               	j	0xb84 <.Lpcrel_hi.42+0x24>
                	fmv.d.x	ft10, zero
                	feq.d	a1, fs0, ft10
                	xori	a1, a1, 0x1
-               	j	0xba0 <.Lpcrel_hi.42+0x2c>
+               	j	0xb8c <.Lpcrel_hi.42+0x2c>
                	mv	a1, a0
-               	bnez	a1, 0xc54 <.Lpcrel_hi.45+0x10>
+               	bnez	a1, 0xc3c <.Lpcrel_hi.45+0x10>
                	fmv.d.x	ft10, zero
                	flt.d	a0, fs0, ft10
-               	bnez	a0, 0xbb8 <.Lpcrel_hi.42+0x44>
+               	bnez	a0, 0xba4 <.Lpcrel_hi.42+0x44>
                	fmv.d	ft0, fs0
-               	j	0xbc0 <.Lpcrel_hi.42+0x4c>
+               	j	0xbac <.Lpcrel_hi.42+0x4c>
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs0
                	fmv.d.x	ft10, zero
                	flt.d	a1, fs2, ft10
-               	bnez	a1, 0xbd4 <.Lpcrel_hi.42+0x60>
+               	bnez	a1, 0xbc0 <.Lpcrel_hi.42+0x60>
                	fmv.d	ft1, fs2
-               	j	0xbdc <.Lpcrel_hi.43>
+               	j	0xbc8 <.Lpcrel_hi.43>
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, fs2
 
@@ -859,21 +854,20 @@ Disassembly of section .text:
                	fdiv.d	ft2, ft0, ft10
                	fmv.d	ft3, ft1
                	fle.d	a1, ft3, ft2
-               	bnez	a1, 0xc44 <.Lpcrel_hi.45>
+               	bnez	a1, 0xc2c <.Lpcrel_hi.45>
                	fmv.d	ft4, ft0
                	fmv.d	ft5, ft3
                	fle.d	a1, ft1, ft5
-               	bnez	a1, 0xc1c <.Lpcrel_hi.43+0x40>
-               	bnez	a0, 0xc10 <.Lpcrel_hi.43+0x34>
+               	bnez	a1, 0xc04 <.Lpcrel_hi.43+0x3c>
+               	bnez	a0, 0xbfc <.Lpcrel_hi.43+0x34>
                	fmv.d	ft6, ft4
-               	j	0xc18 <.Lpcrel_hi.43+0x3c>
-               	fmv.d.x	ft11, zero
-               	fsub.d	ft6, ft11, ft4
-               	j	0xc68 <.Lpcrel_hi.45+0x24>
+               	j	0xc00 <.Lpcrel_hi.43+0x38>
+               	fneg.d	ft6, ft4
+               	j	0xc50 <.Lpcrel_hi.45+0x24>
                	fle.d	a1, ft5, ft4
-               	bnez	a1, 0xc2c <.Lpcrel_hi.43+0x50>
+               	bnez	a1, 0xc14 <.Lpcrel_hi.43+0x4c>
                	fmv.d	ft7, ft4
-               	j	0xc30 <.Lpcrel_hi.44>
+               	j	0xc18 <.Lpcrel_hi.44>
                	fsub.d	ft7, ft4, ft5
 
 <.Lpcrel_hi.44>:
@@ -881,13 +875,13 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft5, ft5, ft10
                	fmv.d	ft4, ft7
-               	j	0xbfc <.Lpcrel_hi.43+0x20>
+               	j	0xbe8 <.Lpcrel_hi.43+0x20>
 
 <.Lpcrel_hi.45>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft3, ft3, ft10
-               	j	0xbec <.Lpcrel_hi.43+0x10>
+               	j	0xbd8 <.Lpcrel_hi.43+0x10>
                	fdiv.d	ft0, fs0, fs2
                	fcvt.l.d	a0, ft0, rtz
                	fcvt.d.l	ft0, a0
@@ -895,13 +889,13 @@ Disassembly of section .text:
                	fsub.d	ft6, fs0, ft1
                	feq.d	a0, ft6, ft6
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xc8c <.Lpcrel_hi.45+0x48>
+               	bnez	a0, 0xc74 <.Lpcrel_hi.45+0x48>
                	mv	a0, s2
                	fmv.d	fa0, ft6
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.45+0x38>
                	mv	s1, a0
-               	j	0xca0 <.Lpcrel_hi.45+0x5c>
+               	j	0xc88 <.Lpcrel_hi.45+0x5c>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -909,33 +903,33 @@ Disassembly of section .text:
                	mv	s1, a0
                	fmv.d.x	ft10, zero
                	feq.d	a0, fs2, ft10
-               	bnez	a0, 0xcd4 <.Lpcrel_hi.46+0x28>
+               	bnez	a0, 0xcbc <.Lpcrel_hi.46+0x28>
 
 <.Lpcrel_hi.46>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft0, fs2, ft10
                	feq.d	a1, fs2, ft0
-               	bnez	a1, 0xcc4 <.Lpcrel_hi.46+0x18>
-               	j	0xcd0 <.Lpcrel_hi.46+0x24>
+               	bnez	a1, 0xcac <.Lpcrel_hi.46+0x18>
+               	j	0xcb8 <.Lpcrel_hi.46+0x24>
                	fmv.d.x	ft10, zero
                	feq.d	a1, fs2, ft10
                	xori	a1, a1, 0x1
-               	j	0xcd8 <.Lpcrel_hi.46+0x2c>
+               	j	0xcc0 <.Lpcrel_hi.46+0x2c>
                	mv	a1, a0
-               	bnez	a1, 0xd8c <.Lpcrel_hi.49+0x10>
+               	bnez	a1, 0xd70 <.Lpcrel_hi.49+0x10>
                	fmv.d.x	ft10, zero
                	flt.d	a0, fs2, ft10
-               	bnez	a0, 0xcf0 <.Lpcrel_hi.46+0x44>
+               	bnez	a0, 0xcd8 <.Lpcrel_hi.46+0x44>
                	fmv.d	ft0, fs2
-               	j	0xcf8 <.Lpcrel_hi.46+0x4c>
+               	j	0xce0 <.Lpcrel_hi.46+0x4c>
                	fmv.d.x	ft11, zero
                	fsub.d	ft0, ft11, fs2
                	fmv.d.x	ft10, zero
                	flt.d	a1, fs2, ft10
-               	bnez	a1, 0xd0c <.Lpcrel_hi.46+0x60>
+               	bnez	a1, 0xcf4 <.Lpcrel_hi.46+0x60>
                	fmv.d	ft1, fs2
-               	j	0xd14 <.Lpcrel_hi.47>
+               	j	0xcfc <.Lpcrel_hi.47>
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, fs2
 
@@ -945,21 +939,20 @@ Disassembly of section .text:
                	fdiv.d	ft2, ft0, ft10
                	fmv.d	ft3, ft1
                	fle.d	a1, ft3, ft2
-               	bnez	a1, 0xd7c <.Lpcrel_hi.49>
+               	bnez	a1, 0xd60 <.Lpcrel_hi.49>
                	fmv.d	ft4, ft0
                	fmv.d	ft5, ft3
                	fle.d	a1, ft1, ft5
-               	bnez	a1, 0xd54 <.Lpcrel_hi.47+0x40>
-               	bnez	a0, 0xd48 <.Lpcrel_hi.47+0x34>
+               	bnez	a1, 0xd38 <.Lpcrel_hi.47+0x3c>
+               	bnez	a0, 0xd30 <.Lpcrel_hi.47+0x34>
                	fmv.d	ft6, ft4
-               	j	0xd50 <.Lpcrel_hi.47+0x3c>
-               	fmv.d.x	ft11, zero
-               	fsub.d	ft6, ft11, ft4
-               	j	0xda0 <.Lpcrel_hi.49+0x24>
+               	j	0xd34 <.Lpcrel_hi.47+0x38>
+               	fneg.d	ft6, ft4
+               	j	0xd84 <.Lpcrel_hi.49+0x24>
                	fle.d	a1, ft5, ft4
-               	bnez	a1, 0xd64 <.Lpcrel_hi.47+0x50>
+               	bnez	a1, 0xd48 <.Lpcrel_hi.47+0x4c>
                	fmv.d	ft7, ft4
-               	j	0xd68 <.Lpcrel_hi.48>
+               	j	0xd4c <.Lpcrel_hi.48>
                	fsub.d	ft7, ft4, ft5
 
 <.Lpcrel_hi.48>:
@@ -967,13 +960,13 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft5, ft5, ft10
                	fmv.d	ft4, ft7
-               	j	0xd34 <.Lpcrel_hi.47+0x20>
+               	j	0xd1c <.Lpcrel_hi.47+0x20>
 
 <.Lpcrel_hi.49>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft3, ft3, ft10
-               	j	0xd24 <.Lpcrel_hi.47+0x10>
+               	j	0xd0c <.Lpcrel_hi.47+0x10>
                	fdiv.d	ft0, fs2, fs2
                	fcvt.l.d	a0, ft0, rtz
                	fcvt.d.l	ft0, a0
@@ -981,13 +974,13 @@ Disassembly of section .text:
                	fsub.d	ft6, fs2, ft1
                	feq.d	a0, ft6, ft6
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xdc4 <.Lpcrel_hi.49+0x48>
+               	bnez	a0, 0xda8 <.Lpcrel_hi.49+0x48>
                	mv	a0, s1
                	fmv.d	fa0, ft6
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.49+0x38>
                	mv	s2, a0
-               	j	0xdd8 <.Lpcrel_hi.50>
+               	j	0xdbc <.Lpcrel_hi.50>
                	mv	a0, s1
                	li	a1, -0x1
                	auipc	ra, 0x0
@@ -1000,33 +993,33 @@ Disassembly of section .text:
                	fmul.d	ft0, ft11, fs0
                	fmv.d.x	ft10, zero
                	feq.d	a0, fs2, ft10
-               	bnez	a0, 0xe18 <.Lpcrel_hi.51+0x28>
+               	bnez	a0, 0xdfc <.Lpcrel_hi.51+0x28>
 
 <.Lpcrel_hi.51>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft1, ft0, ft10
                	feq.d	a1, ft0, ft1
-               	bnez	a1, 0xe08 <.Lpcrel_hi.51+0x18>
-               	j	0xe14 <.Lpcrel_hi.51+0x24>
+               	bnez	a1, 0xdec <.Lpcrel_hi.51+0x18>
+               	j	0xdf8 <.Lpcrel_hi.51+0x24>
                	fmv.d.x	ft10, zero
                	feq.d	a1, ft0, ft10
                	xori	a1, a1, 0x1
-               	j	0xe1c <.Lpcrel_hi.51+0x2c>
+               	j	0xe00 <.Lpcrel_hi.51+0x2c>
                	mv	a1, a0
-               	bnez	a1, 0xed0 <.Lpcrel_hi.54+0x10>
+               	bnez	a1, 0xeb0 <.Lpcrel_hi.54+0x10>
                	fmv.d.x	ft10, zero
                	flt.d	a0, ft0, ft10
-               	bnez	a0, 0xe34 <.Lpcrel_hi.51+0x44>
+               	bnez	a0, 0xe18 <.Lpcrel_hi.51+0x44>
                	fmv.d	ft1, ft0
-               	j	0xe3c <.Lpcrel_hi.51+0x4c>
+               	j	0xe20 <.Lpcrel_hi.51+0x4c>
                	fmv.d.x	ft11, zero
                	fsub.d	ft1, ft11, ft0
                	fmv.d.x	ft10, zero
                	flt.d	a1, fs2, ft10
-               	bnez	a1, 0xe50 <.Lpcrel_hi.51+0x60>
+               	bnez	a1, 0xe34 <.Lpcrel_hi.51+0x60>
                	fmv.d	ft2, fs2
-               	j	0xe58 <.Lpcrel_hi.52>
+               	j	0xe3c <.Lpcrel_hi.52>
                	fmv.d.x	ft11, zero
                	fsub.d	ft2, ft11, fs2
 
@@ -1036,21 +1029,20 @@ Disassembly of section .text:
                	fdiv.d	ft3, ft1, ft10
                	fmv.d	ft4, ft2
                	fle.d	a1, ft4, ft3
-               	bnez	a1, 0xec0 <.Lpcrel_hi.54>
+               	bnez	a1, 0xea0 <.Lpcrel_hi.54>
                	fmv.d	ft5, ft1
                	fmv.d	ft6, ft4
                	fle.d	a1, ft2, ft6
-               	bnez	a1, 0xe98 <.Lpcrel_hi.52+0x40>
-               	bnez	a0, 0xe8c <.Lpcrel_hi.52+0x34>
+               	bnez	a1, 0xe78 <.Lpcrel_hi.52+0x3c>
+               	bnez	a0, 0xe70 <.Lpcrel_hi.52+0x34>
                	fmv.d	ft7, ft5
-               	j	0xe94 <.Lpcrel_hi.52+0x3c>
-               	fmv.d.x	ft11, zero
-               	fsub.d	ft7, ft11, ft5
-               	j	0xee4 <.Lpcrel_hi.54+0x24>
+               	j	0xe74 <.Lpcrel_hi.52+0x38>
+               	fneg.d	ft7, ft5
+               	j	0xec4 <.Lpcrel_hi.54+0x24>
                	fle.d	a1, ft6, ft5
-               	bnez	a1, 0xea8 <.Lpcrel_hi.52+0x50>
+               	bnez	a1, 0xe88 <.Lpcrel_hi.52+0x4c>
                	fmv.d	fa0, ft5
-               	j	0xeac <.Lpcrel_hi.53>
+               	j	0xe8c <.Lpcrel_hi.53>
                	fsub.d	fa0, ft5, ft6
 
 <.Lpcrel_hi.53>:
@@ -1058,13 +1050,13 @@ Disassembly of section .text:
                	fld	ft10, 0x0(t0)
                	fdiv.d	ft6, ft6, ft10
                	fmv.d	ft5, fa0
-               	j	0xe78 <.Lpcrel_hi.52+0x20>
+               	j	0xe5c <.Lpcrel_hi.52+0x20>
 
 <.Lpcrel_hi.54>:
                	auipc	t0, 0x0
                	fld	ft10, 0x0(t0)
                	fmul.d	ft4, ft4, ft10
-               	j	0xe68 <.Lpcrel_hi.52+0x10>
+               	j	0xe4c <.Lpcrel_hi.52+0x10>
                	fdiv.d	ft1, ft0, fs2
                	fcvt.l.d	a0, ft1, rtz
                	fcvt.d.l	ft1, a0
@@ -1072,13 +1064,13 @@ Disassembly of section .text:
                	fsub.d	ft7, ft0, ft2
                	feq.d	a0, ft7, ft7
                	xori	a0, a0, 0x1
-               	bnez	a0, 0xf08 <.Lpcrel_hi.54+0x48>
+               	bnez	a0, 0xee8 <.Lpcrel_hi.54+0x48>
                	mv	a0, s2
                	fmv.d	fa0, ft7
                	auipc	ra, 0x0
                	jalr	ra <.Lpcrel_hi.54+0x38>
                	mv	s1, a0
-               	j	0xf1c <.Lpcrel_hi.54+0x5c>
+               	j	0xefc <.Lpcrel_hi.54+0x5c>
                	mv	a0, s2
                	li	a1, -0x1
                	auipc	ra, 0x0

--- a/test/golden/spirv/float/arith_f32.dis
+++ b/test/golden/spirv/float/arith_f32.dis
@@ -1168,7 +1168,7 @@ OpStore %493 %1163
 OpBranch %84
 %82 = OpLabel
 %1164 = OpLoad %float %485
-%1165 = OpFSub %float %float_0 %1164
+%1165 = OpFNegate %float %1164
 OpStore %492 %1165
 %1166 = OpLoad %float %492
 OpStore %493 %1166
@@ -1381,7 +1381,7 @@ OpStore %525 %1255
 OpBranch %109
 %107 = OpLabel
 %1256 = OpLoad %float %517
-%1257 = OpFSub %float %float_0 %1256
+%1257 = OpFNegate %float %1256
 OpStore %524 %1257
 %1258 = OpLoad %float %524
 OpStore %525 %1258
@@ -1594,7 +1594,7 @@ OpStore %557 %1347
 OpBranch %134
 %132 = OpLabel
 %1348 = OpLoad %float %549
-%1349 = OpFSub %float %float_0 %1348
+%1349 = OpFNegate %float %1348
 OpStore %556 %1349
 %1350 = OpLoad %float %556
 OpStore %557 %1350
@@ -1810,7 +1810,7 @@ OpStore %590 %1441
 OpBranch %159
 %157 = OpLabel
 %1442 = OpLoad %float %582
-%1443 = OpFSub %float %float_0 %1442
+%1443 = OpFNegate %float %1442
 OpStore %589 %1443
 %1444 = OpLoad %float %589
 OpStore %590 %1444
@@ -2019,7 +2019,7 @@ OpStore %622 %1530
 OpBranch %184
 %182 = OpLabel
 %1531 = OpLoad %float %614
-%1532 = OpFSub %float %float_0 %1531
+%1532 = OpFNegate %float %1531
 OpStore %621 %1532
 %1533 = OpLoad %float %621
 OpStore %622 %1533
@@ -2227,7 +2227,7 @@ OpStore %653 %1618
 OpBranch %209
 %207 = OpLabel
 %1619 = OpLoad %float %645
-%1620 = OpFSub %float %float_0 %1619
+%1620 = OpFNegate %float %1619
 OpStore %652 %1620
 %1621 = OpLoad %float %652
 OpStore %653 %1621
@@ -2437,7 +2437,7 @@ OpStore %684 %1708
 OpBranch %234
 %232 = OpLabel
 %1709 = OpLoad %float %676
-%1710 = OpFSub %float %float_0 %1709
+%1710 = OpFNegate %float %1709
 OpStore %683 %1710
 %1711 = OpLoad %float %683
 OpStore %684 %1711
@@ -2650,7 +2650,7 @@ OpStore %716 %1801
 OpBranch %259
 %257 = OpLabel
 %1802 = OpLoad %float %708
-%1803 = OpFSub %float %float_0 %1802
+%1803 = OpFNegate %float %1802
 OpStore %715 %1803
 %1804 = OpLoad %float %715
 OpStore %716 %1804

--- a/test/golden/spirv/float/arith_f32.dis
+++ b/test/golden/spirv/float/arith_f32.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1499
+; Bound: 1969
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -41,9 +41,9 @@ OpDecorate %3 LinkageAttributes "corpus.cases.float.arith_f32.checksum" Export
 %float_5_5 = OpConstant %float 5.5
 %float_7 = OpConstant %float 7
 %float_1048576 = OpConstant %float 1048576
-%1399 = OpTypeFunction %ulong
+%1869 = OpTypeFunction %ulong
 %ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%1402 = OpTypeFunction %ulong %ulong %uint
+%1872 = OpTypeFunction %ulong %ulong %uint
 %ulong_0 = OpConstant %ulong 0
 %ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
@@ -108,2108 +108,2866 @@ OpFunctionEnd
 %3 = OpFunction %ulong None %54
 %55 = OpFunctionParameter %ulong
 %56 = OpLabel
-%299 = OpVariable %_ptr_Function_ulong Function
-%300 = OpVariable %_ptr_Function_ulong Function
-%301 = OpVariable %_ptr_Function_uint Function
-%302 = OpVariable %_ptr_Function_float Function
-%303 = OpVariable %_ptr_Function_float Function
-%304 = OpVariable %_ptr_Function_float Function
-%305 = OpVariable %_ptr_Function_float Function
-%306 = OpVariable %_ptr_Function_float Function
-%307 = OpVariable %_ptr_Function_float Function
-%308 = OpVariable %_ptr_Function_float Function
-%309 = OpVariable %_ptr_Function_float Function
-%310 = OpVariable %_ptr_Function_float Function
-%311 = OpVariable %_ptr_Function_float Function
-%312 = OpVariable %_ptr_Function_float Function
-%313 = OpVariable %_ptr_Function_float Function
-%314 = OpVariable %_ptr_Function_float Function
-%315 = OpVariable %_ptr_Function_float Function
-%316 = OpVariable %_ptr_Function_float Function
-%317 = OpVariable %_ptr_Function_float Function
-%318 = OpVariable %_ptr_Function_float Function
-%319 = OpVariable %_ptr_Function_float Function
-%320 = OpVariable %_ptr_Function_float Function
-%321 = OpVariable %_ptr_Function_float Function
-%322 = OpVariable %_ptr_Function_float Function
-%323 = OpVariable %_ptr_Function_float Function
-%324 = OpVariable %_ptr_Function_float Function
-%325 = OpVariable %_ptr_Function_float Function
-%326 = OpVariable %_ptr_Function_float Function
-%327 = OpVariable %_ptr_Function_float Function
-%328 = OpVariable %_ptr_Function_float Function
-%329 = OpVariable %_ptr_Function_float Function
-%330 = OpVariable %_ptr_Function_float Function
-%331 = OpVariable %_ptr_Function_float Function
-%332 = OpVariable %_ptr_Function_float Function
-%333 = OpVariable %_ptr_Function_float Function
-%334 = OpVariable %_ptr_Function_bool Function
-%335 = OpVariable %_ptr_Function_float Function
-%336 = OpVariable %_ptr_Function_float Function
-%337 = OpVariable %_ptr_Function_uint Function
-%338 = OpVariable %_ptr_Function_float Function
-%339 = OpVariable %_ptr_Function_float Function
-%340 = OpVariable %_ptr_Function_float Function
-%341 = OpVariable %_ptr_Function_float Function
-%342 = OpVariable %_ptr_Function_float Function
-%343 = OpVariable %_ptr_Function_float Function
-%344 = OpVariable %_ptr_Function_float Function
-%345 = OpVariable %_ptr_Function_float Function
-%346 = OpVariable %_ptr_Function_float Function
-%347 = OpVariable %_ptr_Function_float Function
-%348 = OpVariable %_ptr_Function_float Function
-%349 = OpVariable %_ptr_Function_float Function
-%350 = OpVariable %_ptr_Function_float Function
-%351 = OpVariable %_ptr_Function_float Function
-%352 = OpVariable %_ptr_Function_float Function
-%353 = OpVariable %_ptr_Function_float Function
-%354 = OpVariable %_ptr_Function_float Function
-%355 = OpVariable %_ptr_Function_float Function
-%356 = OpVariable %_ptr_Function_float Function
-%357 = OpVariable %_ptr_Function_ulong Function
-%358 = OpVariable %_ptr_Function_float Function
-%359 = OpVariable %_ptr_Function_float Function
-%360 = OpVariable %_ptr_Function_float Function
-%361 = OpVariable %_ptr_Function_float Function
-%362 = OpVariable %_ptr_Function_float Function
-%363 = OpVariable %_ptr_Function_ulong Function
-%364 = OpVariable %_ptr_Function_float Function
-%365 = OpVariable %_ptr_Function_float Function
-%366 = OpVariable %_ptr_Function_float Function
-%367 = OpVariable %_ptr_Function_float Function
-%368 = OpVariable %_ptr_Function_float Function
-%369 = OpVariable %_ptr_Function_ulong Function
-%370 = OpVariable %_ptr_Function_float Function
-%371 = OpVariable %_ptr_Function_float Function
-%372 = OpVariable %_ptr_Function_float Function
-%373 = OpVariable %_ptr_Function_float Function
-%374 = OpVariable %_ptr_Function_float Function
-%375 = OpVariable %_ptr_Function_float Function
-%376 = OpVariable %_ptr_Function_ulong Function
-%377 = OpVariable %_ptr_Function_float Function
-%378 = OpVariable %_ptr_Function_float Function
-%379 = OpVariable %_ptr_Function_float Function
-%380 = OpVariable %_ptr_Function_float Function
-%381 = OpVariable %_ptr_Function_float Function
+%381 = OpVariable %_ptr_Function_ulong Function
 %382 = OpVariable %_ptr_Function_ulong Function
-%383 = OpVariable %_ptr_Function_float Function
+%383 = OpVariable %_ptr_Function_uint Function
 %384 = OpVariable %_ptr_Function_float Function
 %385 = OpVariable %_ptr_Function_float Function
 %386 = OpVariable %_ptr_Function_float Function
-%387 = OpVariable %_ptr_Function_ulong Function
+%387 = OpVariable %_ptr_Function_float Function
 %388 = OpVariable %_ptr_Function_float Function
 %389 = OpVariable %_ptr_Function_float Function
 %390 = OpVariable %_ptr_Function_float Function
-%391 = OpVariable %_ptr_Function_float Function
-%392 = OpVariable %_ptr_Function_ulong Function
-%393 = OpVariable %_ptr_Function_float Function
+%391 = OpVariable %_ptr_Function_ulong Function
+%392 = OpVariable %_ptr_Function_float Function
+%393 = OpVariable %_ptr_Function_ulong Function
 %394 = OpVariable %_ptr_Function_float Function
-%395 = OpVariable %_ptr_Function_float Function
+%395 = OpVariable %_ptr_Function_ulong Function
 %396 = OpVariable %_ptr_Function_float Function
-%397 = OpVariable %_ptr_Function_float Function
-%398 = OpVariable %_ptr_Function_ulong Function
-%399 = OpVariable %_ptr_Function_float Function
+%397 = OpVariable %_ptr_Function_ulong Function
+%398 = OpVariable %_ptr_Function_float Function
+%399 = OpVariable %_ptr_Function_ulong Function
 %400 = OpVariable %_ptr_Function_float Function
-%401 = OpVariable %_ptr_Function_float Function
-%402 = OpVariable %_ptr_Function_ulong Function
+%401 = OpVariable %_ptr_Function_ulong Function
+%402 = OpVariable %_ptr_Function_float Function
 %403 = OpVariable %_ptr_Function_float Function
-%404 = OpVariable %_ptr_Function_uint Function
-%405 = OpVariable %_ptr_Function_uint Function
-%406 = OpVariable %_ptr_Function_float Function
-%407 = OpVariable %_ptr_Function_bool Function
-%408 = OpVariable %_ptr_Function_ulong Function
-%409 = OpVariable %_ptr_Function_ulong Function
+%404 = OpVariable %_ptr_Function_ulong Function
+%405 = OpVariable %_ptr_Function_float Function
+%406 = OpVariable %_ptr_Function_ulong Function
+%407 = OpVariable %_ptr_Function_float Function
+%408 = OpVariable %_ptr_Function_float Function
+%409 = OpVariable %_ptr_Function_float Function
 %410 = OpVariable %_ptr_Function_ulong Function
-%411 = OpVariable %_ptr_Function_uint Function
-%412 = OpVariable %_ptr_Function_float Function
-%413 = OpVariable %_ptr_Function_bool Function
+%411 = OpVariable %_ptr_Function_float Function
+%412 = OpVariable %_ptr_Function_ulong Function
+%413 = OpVariable %_ptr_Function_float Function
 %414 = OpVariable %_ptr_Function_ulong Function
-%415 = OpVariable %_ptr_Function_ulong Function
+%415 = OpVariable %_ptr_Function_float Function
 %416 = OpVariable %_ptr_Function_ulong Function
-%417 = OpVariable %_ptr_Function_bool Function
-%418 = OpVariable %_ptr_Function_ulong Function
+%417 = OpVariable %_ptr_Function_float Function
+%418 = OpVariable %_ptr_Function_float Function
 %419 = OpVariable %_ptr_Function_ulong Function
-%420 = OpVariable %_ptr_Function_ulong Function
-%421 = OpVariable %_ptr_Function_bool Function
-%422 = OpVariable %_ptr_Function_ulong Function
-%423 = OpVariable %_ptr_Function_ulong Function
+%420 = OpVariable %_ptr_Function_float Function
+%421 = OpVariable %_ptr_Function_ulong Function
+%422 = OpVariable %_ptr_Function_float Function
+%423 = OpVariable %_ptr_Function_float Function
 %424 = OpVariable %_ptr_Function_ulong Function
-%425 = OpVariable %_ptr_Function_bool Function
+%425 = OpVariable %_ptr_Function_float Function
 %426 = OpVariable %_ptr_Function_ulong Function
-%427 = OpVariable %_ptr_Function_ulong Function
+%427 = OpVariable %_ptr_Function_float Function
 %428 = OpVariable %_ptr_Function_ulong Function
-%429 = OpVariable %_ptr_Function_bool Function
-%430 = OpVariable %_ptr_Function_ulong Function
-%431 = OpVariable %_ptr_Function_ulong Function
-%432 = OpVariable %_ptr_Function_ulong Function
-%433 = OpVariable %_ptr_Function_bool Function
-%434 = OpVariable %_ptr_Function_ulong Function
-%435 = OpVariable %_ptr_Function_ulong Function
-%436 = OpVariable %_ptr_Function_ulong Function
-%437 = OpVariable %_ptr_Function_bool Function
-%438 = OpVariable %_ptr_Function_ulong Function
+%429 = OpVariable %_ptr_Function_float Function
+%430 = OpVariable %_ptr_Function_bool Function
+%431 = OpVariable %_ptr_Function_float Function
+%432 = OpVariable %_ptr_Function_float Function
+%433 = OpVariable %_ptr_Function_uint Function
+%434 = OpVariable %_ptr_Function_float Function
+%435 = OpVariable %_ptr_Function_float Function
+%436 = OpVariable %_ptr_Function_float Function
+%437 = OpVariable %_ptr_Function_ulong Function
+%438 = OpVariable %_ptr_Function_float Function
 %439 = OpVariable %_ptr_Function_ulong Function
-%440 = OpVariable %_ptr_Function_ulong Function
-%441 = OpVariable %_ptr_Function_bool Function
-%442 = OpVariable %_ptr_Function_ulong Function
+%440 = OpVariable %_ptr_Function_float Function
+%441 = OpVariable %_ptr_Function_ulong Function
+%442 = OpVariable %_ptr_Function_float Function
 %443 = OpVariable %_ptr_Function_ulong Function
-%444 = OpVariable %_ptr_Function_ulong Function
-%445 = OpVariable %_ptr_Function_bool Function
-%446 = OpVariable %_ptr_Function_ulong Function
+%444 = OpVariable %_ptr_Function_float Function
+%445 = OpVariable %_ptr_Function_ulong Function
+%446 = OpVariable %_ptr_Function_float Function
 %447 = OpVariable %_ptr_Function_ulong Function
-%448 = OpVariable %_ptr_Function_ulong Function
-%449 = OpVariable %_ptr_Function_bool Function
-%450 = OpVariable %_ptr_Function_ulong Function
+%448 = OpVariable %_ptr_Function_float Function
+%449 = OpVariable %_ptr_Function_ulong Function
+%450 = OpVariable %_ptr_Function_float Function
 %451 = OpVariable %_ptr_Function_ulong Function
-%452 = OpVariable %_ptr_Function_ulong Function
-%453 = OpVariable %_ptr_Function_bool Function
-%454 = OpVariable %_ptr_Function_ulong Function
+%452 = OpVariable %_ptr_Function_float Function
+%453 = OpVariable %_ptr_Function_ulong Function
+%454 = OpVariable %_ptr_Function_float Function
 %455 = OpVariable %_ptr_Function_ulong Function
-%456 = OpVariable %_ptr_Function_ulong Function
-%457 = OpVariable %_ptr_Function_bool Function
-%458 = OpVariable %_ptr_Function_ulong Function
+%456 = OpVariable %_ptr_Function_float Function
+%457 = OpVariable %_ptr_Function_ulong Function
+%458 = OpVariable %_ptr_Function_float Function
 %459 = OpVariable %_ptr_Function_ulong Function
-%460 = OpVariable %_ptr_Function_ulong Function
-%461 = OpVariable %_ptr_Function_bool Function
-%462 = OpVariable %_ptr_Function_ulong Function
-%463 = OpVariable %_ptr_Function_ulong Function
-%464 = OpVariable %_ptr_Function_ulong Function
-%465 = OpVariable %_ptr_Function_bool Function
-%466 = OpVariable %_ptr_Function_ulong Function
-%467 = OpVariable %_ptr_Function_ulong Function
-%468 = OpVariable %_ptr_Function_ulong Function
+%460 = OpVariable %_ptr_Function_float Function
+%461 = OpVariable %_ptr_Function_ulong Function
+%462 = OpVariable %_ptr_Function_float Function
+%463 = OpVariable %_ptr_Function_float Function
+%464 = OpVariable %_ptr_Function_bool Function
+%465 = OpVariable %_ptr_Function_float Function
+%466 = OpVariable %_ptr_Function_bool Function
+%467 = OpVariable %_ptr_Function_bool Function
+%468 = OpVariable %_ptr_Function_bool Function
 %469 = OpVariable %_ptr_Function_bool Function
-%470 = OpVariable %_ptr_Function_ulong Function
+%470 = OpVariable %_ptr_Function_float Function
 %471 = OpVariable %_ptr_Function_ulong Function
-%472 = OpVariable %_ptr_Function_ulong Function
-%473 = OpVariable %_ptr_Function_uint Function
+%472 = OpVariable %_ptr_Function_float Function
+%473 = OpVariable %_ptr_Function_float Function
 %474 = OpVariable %_ptr_Function_float Function
 %475 = OpVariable %_ptr_Function_bool Function
-%476 = OpVariable %_ptr_Function_ulong Function
-%477 = OpVariable %_ptr_Function_ulong Function
-%478 = OpVariable %_ptr_Function_ulong Function
-%479 = OpVariable %_ptr_Function_uint Function
+%476 = OpVariable %_ptr_Function_float Function
+%477 = OpVariable %_ptr_Function_float Function
+%478 = OpVariable %_ptr_Function_bool Function
+%479 = OpVariable %_ptr_Function_float Function
 %480 = OpVariable %_ptr_Function_float Function
-%481 = OpVariable %_ptr_Function_bool Function
-%482 = OpVariable %_ptr_Function_ulong Function
-%483 = OpVariable %_ptr_Function_ulong Function
-%484 = OpVariable %_ptr_Function_ulong Function
-%485 = OpVariable %_ptr_Function_bool Function
-%486 = OpVariable %_ptr_Function_ulong Function
-%487 = OpVariable %_ptr_Function_ulong Function
-%488 = OpVariable %_ptr_Function_ulong Function
-%489 = OpVariable %_ptr_Function_bool Function
-%490 = OpVariable %_ptr_Function_ulong Function
-%491 = OpVariable %_ptr_Function_ulong Function
-%492 = OpVariable %_ptr_Function_ulong Function
-%493 = OpVariable %_ptr_Function_bool Function
-%494 = OpVariable %_ptr_Function_ulong Function
-%495 = OpVariable %_ptr_Function_ulong Function
-%496 = OpVariable %_ptr_Function_ulong Function
-%497 = OpVariable %_ptr_Function_bool Function
-%498 = OpVariable %_ptr_Function_ulong Function
-%499 = OpVariable %_ptr_Function_ulong Function
-%500 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_float Function
+%482 = OpVariable %_ptr_Function_float Function
+%483 = OpVariable %_ptr_Function_bool Function
+%484 = OpVariable %_ptr_Function_float Function
+%485 = OpVariable %_ptr_Function_float Function
+%486 = OpVariable %_ptr_Function_float Function
+%487 = OpVariable %_ptr_Function_bool Function
+%488 = OpVariable %_ptr_Function_bool Function
+%489 = OpVariable %_ptr_Function_float Function
+%490 = OpVariable %_ptr_Function_float Function
+%491 = OpVariable %_ptr_Function_float Function
+%492 = OpVariable %_ptr_Function_float Function
+%493 = OpVariable %_ptr_Function_float Function
+%494 = OpVariable %_ptr_Function_float Function
+%495 = OpVariable %_ptr_Function_float Function
+%496 = OpVariable %_ptr_Function_bool Function
+%497 = OpVariable %_ptr_Function_float Function
+%498 = OpVariable %_ptr_Function_bool Function
+%499 = OpVariable %_ptr_Function_bool Function
+%500 = OpVariable %_ptr_Function_bool Function
 %501 = OpVariable %_ptr_Function_bool Function
-%502 = OpVariable %_ptr_Function_ulong Function
+%502 = OpVariable %_ptr_Function_float Function
 %503 = OpVariable %_ptr_Function_ulong Function
-%504 = OpVariable %_ptr_Function_ulong Function
-%505 = OpVariable %_ptr_Function_bool Function
-%506 = OpVariable %_ptr_Function_ulong Function
-%507 = OpVariable %_ptr_Function_ulong Function
-%508 = OpVariable %_ptr_Function_ulong Function
-%509 = OpVariable %_ptr_Function_bool Function
-%510 = OpVariable %_ptr_Function_ulong Function
-%511 = OpVariable %_ptr_Function_ulong Function
-%512 = OpVariable %_ptr_Function_ulong Function
-%513 = OpVariable %_ptr_Function_bool Function
-%514 = OpVariable %_ptr_Function_ulong Function
-%515 = OpVariable %_ptr_Function_ulong Function
-%516 = OpVariable %_ptr_Function_ulong Function
-%517 = OpVariable %_ptr_Function_bool Function
-%518 = OpVariable %_ptr_Function_ulong Function
-%519 = OpVariable %_ptr_Function_ulong Function
-%520 = OpVariable %_ptr_Function_ulong Function
-%521 = OpVariable %_ptr_Function_bool Function
-%522 = OpVariable %_ptr_Function_ulong Function
-%523 = OpVariable %_ptr_Function_ulong Function
-%524 = OpVariable %_ptr_Function_ulong Function
-%525 = OpVariable %_ptr_Function_bool Function
-%526 = OpVariable %_ptr_Function_ulong Function
-%527 = OpVariable %_ptr_Function_ulong Function
-%528 = OpVariable %_ptr_Function_ulong Function
-%529 = OpVariable %_ptr_Function_bool Function
-%530 = OpVariable %_ptr_Function_ulong Function
-%531 = OpVariable %_ptr_Function_ulong Function
-%532 = OpVariable %_ptr_Function_ulong Function
+%504 = OpVariable %_ptr_Function_float Function
+%505 = OpVariable %_ptr_Function_float Function
+%506 = OpVariable %_ptr_Function_float Function
+%507 = OpVariable %_ptr_Function_bool Function
+%508 = OpVariable %_ptr_Function_float Function
+%509 = OpVariable %_ptr_Function_float Function
+%510 = OpVariable %_ptr_Function_bool Function
+%511 = OpVariable %_ptr_Function_float Function
+%512 = OpVariable %_ptr_Function_float Function
+%513 = OpVariable %_ptr_Function_float Function
+%514 = OpVariable %_ptr_Function_float Function
+%515 = OpVariable %_ptr_Function_bool Function
+%516 = OpVariable %_ptr_Function_float Function
+%517 = OpVariable %_ptr_Function_float Function
+%518 = OpVariable %_ptr_Function_float Function
+%519 = OpVariable %_ptr_Function_bool Function
+%520 = OpVariable %_ptr_Function_bool Function
+%521 = OpVariable %_ptr_Function_float Function
+%522 = OpVariable %_ptr_Function_float Function
+%523 = OpVariable %_ptr_Function_float Function
+%524 = OpVariable %_ptr_Function_float Function
+%525 = OpVariable %_ptr_Function_float Function
+%526 = OpVariable %_ptr_Function_float Function
+%527 = OpVariable %_ptr_Function_float Function
+%528 = OpVariable %_ptr_Function_bool Function
+%529 = OpVariable %_ptr_Function_float Function
+%530 = OpVariable %_ptr_Function_bool Function
+%531 = OpVariable %_ptr_Function_bool Function
+%532 = OpVariable %_ptr_Function_bool Function
 %533 = OpVariable %_ptr_Function_bool Function
-%534 = OpVariable %_ptr_Function_ulong Function
+%534 = OpVariable %_ptr_Function_float Function
 %535 = OpVariable %_ptr_Function_ulong Function
-%536 = OpVariable %_ptr_Function_ulong Function
-%537 = OpVariable %_ptr_Function_bool Function
-%538 = OpVariable %_ptr_Function_ulong Function
-%539 = OpVariable %_ptr_Function_ulong Function
-%540 = OpVariable %_ptr_Function_ulong Function
-%541 = OpVariable %_ptr_Function_bool Function
-%542 = OpVariable %_ptr_Function_ulong Function
-%543 = OpVariable %_ptr_Function_ulong Function
-%544 = OpVariable %_ptr_Function_ulong Function
-%545 = OpVariable %_ptr_Function_bool Function
-%546 = OpVariable %_ptr_Function_ulong Function
-%547 = OpVariable %_ptr_Function_ulong Function
-%548 = OpVariable %_ptr_Function_ulong Function
-%549 = OpVariable %_ptr_Function_bool Function
-%550 = OpVariable %_ptr_Function_ulong Function
-%551 = OpVariable %_ptr_Function_ulong Function
-%552 = OpVariable %_ptr_Function_ulong Function
-%553 = OpVariable %_ptr_Function_bool Function
-%554 = OpVariable %_ptr_Function_ulong Function
-%555 = OpVariable %_ptr_Function_ulong Function
-%556 = OpVariable %_ptr_Function_ulong Function
-%557 = OpVariable %_ptr_Function_bool Function
-%558 = OpVariable %_ptr_Function_ulong Function
-%559 = OpVariable %_ptr_Function_ulong Function
-%560 = OpVariable %_ptr_Function_ulong Function
+%536 = OpVariable %_ptr_Function_float Function
+%537 = OpVariable %_ptr_Function_float Function
+%538 = OpVariable %_ptr_Function_float Function
+%539 = OpVariable %_ptr_Function_bool Function
+%540 = OpVariable %_ptr_Function_float Function
+%541 = OpVariable %_ptr_Function_float Function
+%542 = OpVariable %_ptr_Function_bool Function
+%543 = OpVariable %_ptr_Function_float Function
+%544 = OpVariable %_ptr_Function_float Function
+%545 = OpVariable %_ptr_Function_float Function
+%546 = OpVariable %_ptr_Function_float Function
+%547 = OpVariable %_ptr_Function_bool Function
+%548 = OpVariable %_ptr_Function_float Function
+%549 = OpVariable %_ptr_Function_float Function
+%550 = OpVariable %_ptr_Function_float Function
+%551 = OpVariable %_ptr_Function_bool Function
+%552 = OpVariable %_ptr_Function_bool Function
+%553 = OpVariable %_ptr_Function_float Function
+%554 = OpVariable %_ptr_Function_float Function
+%555 = OpVariable %_ptr_Function_float Function
+%556 = OpVariable %_ptr_Function_float Function
+%557 = OpVariable %_ptr_Function_float Function
+%558 = OpVariable %_ptr_Function_float Function
+%559 = OpVariable %_ptr_Function_float Function
+%560 = OpVariable %_ptr_Function_float Function
 %561 = OpVariable %_ptr_Function_bool Function
-%562 = OpVariable %_ptr_Function_ulong Function
-%563 = OpVariable %_ptr_Function_ulong Function
-%564 = OpVariable %_ptr_Function_ulong Function
+%562 = OpVariable %_ptr_Function_float Function
+%563 = OpVariable %_ptr_Function_bool Function
+%564 = OpVariable %_ptr_Function_bool Function
 %565 = OpVariable %_ptr_Function_bool Function
-%566 = OpVariable %_ptr_Function_ulong Function
-%567 = OpVariable %_ptr_Function_ulong Function
+%566 = OpVariable %_ptr_Function_bool Function
+%567 = OpVariable %_ptr_Function_float Function
 %568 = OpVariable %_ptr_Function_ulong Function
-%569 = OpVariable %_ptr_Function_bool Function
-%570 = OpVariable %_ptr_Function_ulong Function
-%571 = OpVariable %_ptr_Function_ulong Function
-%572 = OpVariable %_ptr_Function_ulong Function
-%573 = OpVariable %_ptr_Function_bool Function
-%574 = OpVariable %_ptr_Function_ulong Function
-%575 = OpVariable %_ptr_Function_ulong Function
-%576 = OpVariable %_ptr_Function_ulong Function
-%577 = OpVariable %_ptr_Function_bool Function
-%578 = OpVariable %_ptr_Function_ulong Function
-%579 = OpVariable %_ptr_Function_ulong Function
-%580 = OpVariable %_ptr_Function_ulong Function
-%581 = OpVariable %_ptr_Function_bool Function
-%582 = OpVariable %_ptr_Function_ulong Function
-%583 = OpVariable %_ptr_Function_ulong Function
-%584 = OpVariable %_ptr_Function_ulong Function
+%569 = OpVariable %_ptr_Function_float Function
+%570 = OpVariable %_ptr_Function_float Function
+%571 = OpVariable %_ptr_Function_float Function
+%572 = OpVariable %_ptr_Function_bool Function
+%573 = OpVariable %_ptr_Function_float Function
+%574 = OpVariable %_ptr_Function_float Function
+%575 = OpVariable %_ptr_Function_bool Function
+%576 = OpVariable %_ptr_Function_float Function
+%577 = OpVariable %_ptr_Function_float Function
+%578 = OpVariable %_ptr_Function_float Function
+%579 = OpVariable %_ptr_Function_float Function
+%580 = OpVariable %_ptr_Function_bool Function
+%581 = OpVariable %_ptr_Function_float Function
+%582 = OpVariable %_ptr_Function_float Function
+%583 = OpVariable %_ptr_Function_float Function
+%584 = OpVariable %_ptr_Function_bool Function
 %585 = OpVariable %_ptr_Function_bool Function
-%586 = OpVariable %_ptr_Function_ulong Function
-%587 = OpVariable %_ptr_Function_ulong Function
-%588 = OpVariable %_ptr_Function_ulong Function
-%589 = OpVariable %_ptr_Function_bool Function
-%590 = OpVariable %_ptr_Function_ulong Function
-%591 = OpVariable %_ptr_Function_ulong Function
-%592 = OpVariable %_ptr_Function_ulong Function
+%586 = OpVariable %_ptr_Function_float Function
+%587 = OpVariable %_ptr_Function_float Function
+%588 = OpVariable %_ptr_Function_float Function
+%589 = OpVariable %_ptr_Function_float Function
+%590 = OpVariable %_ptr_Function_float Function
+%591 = OpVariable %_ptr_Function_float Function
+%592 = OpVariable %_ptr_Function_float Function
 %593 = OpVariable %_ptr_Function_bool Function
-%594 = OpVariable %_ptr_Function_ulong Function
-%595 = OpVariable %_ptr_Function_ulong Function
-%596 = OpVariable %_ptr_Function_ulong Function
-OpStore %299 %55
-%597 = OpFunctionCall %ulong %4
-OpStore %300 %597
-%598 = OpLoad %ulong %299
-%599 = OpUConvert %uint %598
-OpStore %301 %599
-OpBranch %60
-%60 = OpLabel
-%601 = OpLoad %uint %301
-%602 = OpIAdd %uint %uint_1065353216 %601
-OpStore %405 %602
-%603 = OpLoad %uint %405
-%604 = OpBitcast %float %603
-OpStore %406 %604
-OpBranch %61
-%61 = OpLabel
-%606 = OpLoad %float %406
-%607 = OpFMul %float %float_1_5 %606
-OpStore %302 %607
-%609 = OpLoad %float %406
-%610 = OpFMul %float %float_0_25 %609
-OpStore %303 %610
-%611 = OpLoad %float %302
-%612 = OpLoad %float %303
-%613 = OpFAdd %float %611 %612
-OpStore %304 %613
-OpBranch %69
-%69 = OpLabel
-%614 = OpLoad %float %304
-%615 = OpLoad %float %304
-%616 = OpFUnordNotEqual %bool %614 %615
-OpStore %413 %616
-%617 = OpLoad %bool %413
-OpSelectionMerge %73 None
-OpBranchConditional %617 %70 %71
-%71 = OpLabel
-OpBranch %72
-%72 = OpLabel
-%618 = OpLoad %ulong %300
-%619 = OpLoad %float %304
-%620 = OpFunctionCall %ulong %6 %618 %619
-OpStore %415 %620
-%621 = OpLoad %ulong %415
-OpStore %416 %621
-OpBranch %73
-%70 = OpLabel
-%622 = OpLoad %ulong %300
-%623 = OpFunctionCall %ulong %5 %622 %uint_4294967295
-OpStore %414 %623
-%624 = OpLoad %ulong %414
-OpStore %416 %624
-OpBranch %73
-%73 = OpLabel
-%625 = OpLoad %float %302
-%626 = OpLoad %float %303
-%627 = OpFSub %float %625 %626
-OpStore %305 %627
-OpBranch %79
-%79 = OpLabel
-%628 = OpLoad %float %305
-%629 = OpLoad %float %305
-%630 = OpFUnordNotEqual %bool %628 %629
-OpStore %421 %630
-%631 = OpLoad %bool %421
-OpSelectionMerge %83 None
-OpBranchConditional %631 %80 %81
-%81 = OpLabel
-OpBranch %82
-%82 = OpLabel
-%632 = OpLoad %ulong %416
-%633 = OpLoad %float %305
-%634 = OpFunctionCall %ulong %6 %632 %633
-OpStore %423 %634
-%635 = OpLoad %ulong %423
-OpStore %424 %635
-OpBranch %83
-%80 = OpLabel
-%636 = OpLoad %ulong %416
-%637 = OpFunctionCall %ulong %5 %636 %uint_4294967295
-OpStore %422 %637
-%638 = OpLoad %ulong %422
-OpStore %424 %638
-OpBranch %83
-%83 = OpLabel
-%639 = OpLoad %float %303
-%640 = OpLoad %float %302
-%641 = OpFSub %float %639 %640
-OpStore %306 %641
-OpBranch %89
-%89 = OpLabel
-%642 = OpLoad %float %306
-%643 = OpLoad %float %306
-%644 = OpFUnordNotEqual %bool %642 %643
-OpStore %429 %644
-%645 = OpLoad %bool %429
-OpSelectionMerge %93 None
-OpBranchConditional %645 %90 %91
-%91 = OpLabel
-OpBranch %92
-%92 = OpLabel
-%646 = OpLoad %ulong %424
-%647 = OpLoad %float %306
-%648 = OpFunctionCall %ulong %6 %646 %647
-OpStore %431 %648
-%649 = OpLoad %ulong %431
-OpStore %432 %649
-OpBranch %93
-%90 = OpLabel
-%650 = OpLoad %ulong %424
-%651 = OpFunctionCall %ulong %5 %650 %uint_4294967295
-OpStore %430 %651
-%652 = OpLoad %ulong %430
-OpStore %432 %652
-OpBranch %93
-%93 = OpLabel
-%653 = OpLoad %float %302
-%654 = OpLoad %float %303
-%655 = OpFMul %float %653 %654
-OpStore %307 %655
-OpBranch %99
-%99 = OpLabel
-%656 = OpLoad %float %307
-%657 = OpLoad %float %307
-%658 = OpFUnordNotEqual %bool %656 %657
-OpStore %437 %658
-%659 = OpLoad %bool %437
-OpSelectionMerge %103 None
-OpBranchConditional %659 %100 %101
-%101 = OpLabel
-OpBranch %102
-%102 = OpLabel
-%660 = OpLoad %ulong %432
-%661 = OpLoad %float %307
-%662 = OpFunctionCall %ulong %6 %660 %661
-OpStore %439 %662
-%663 = OpLoad %ulong %439
-OpStore %440 %663
-OpBranch %103
-%100 = OpLabel
-%664 = OpLoad %ulong %432
-%665 = OpFunctionCall %ulong %5 %664 %uint_4294967295
-OpStore %438 %665
-%666 = OpLoad %ulong %438
-OpStore %440 %666
-OpBranch %103
-%103 = OpLabel
-%667 = OpLoad %float %302
-%668 = OpLoad %float %303
-%669 = OpFDiv %float %667 %668
-OpStore %308 %669
-OpBranch %109
-%109 = OpLabel
-%670 = OpLoad %float %308
-%671 = OpLoad %float %308
-%672 = OpFUnordNotEqual %bool %670 %671
-OpStore %445 %672
-%673 = OpLoad %bool %445
-OpSelectionMerge %113 None
-OpBranchConditional %673 %110 %111
-%111 = OpLabel
-OpBranch %112
-%112 = OpLabel
-%674 = OpLoad %ulong %440
-%675 = OpLoad %float %308
-%676 = OpFunctionCall %ulong %6 %674 %675
-OpStore %447 %676
-%677 = OpLoad %ulong %447
-OpStore %448 %677
-OpBranch %113
-%110 = OpLabel
-%678 = OpLoad %ulong %440
-%679 = OpFunctionCall %ulong %5 %678 %uint_4294967295
-OpStore %446 %679
-%680 = OpLoad %ulong %446
-OpStore %448 %680
-OpBranch %113
-%113 = OpLabel
-%681 = OpLoad %float %303
-%682 = OpLoad %float %302
-%683 = OpFDiv %float %681 %682
-OpStore %309 %683
-OpBranch %119
-%119 = OpLabel
-%684 = OpLoad %float %309
-%685 = OpLoad %float %309
-%686 = OpFUnordNotEqual %bool %684 %685
-OpStore %453 %686
-%687 = OpLoad %bool %453
-OpSelectionMerge %123 None
-OpBranchConditional %687 %120 %121
-%121 = OpLabel
-OpBranch %122
-%122 = OpLabel
-%688 = OpLoad %ulong %448
-%689 = OpLoad %float %309
-%690 = OpFunctionCall %ulong %6 %688 %689
-OpStore %455 %690
-%691 = OpLoad %ulong %455
-OpStore %456 %691
-OpBranch %123
-%120 = OpLabel
-%692 = OpLoad %ulong %448
-%693 = OpFunctionCall %ulong %5 %692 %uint_4294967295
-OpStore %454 %693
-%694 = OpLoad %ulong %454
-OpStore %456 %694
-OpBranch %123
-%123 = OpLabel
-%695 = OpLoad %float %302
-%696 = OpFNegate %float %695
-OpStore %310 %696
-OpBranch %129
-%129 = OpLabel
-%697 = OpLoad %float %310
-%698 = OpLoad %float %310
-%699 = OpFUnordNotEqual %bool %697 %698
-OpStore %461 %699
-%700 = OpLoad %bool %461
-OpSelectionMerge %133 None
-OpBranchConditional %700 %130 %131
-%131 = OpLabel
-OpBranch %132
-%132 = OpLabel
-%701 = OpLoad %ulong %456
-%702 = OpLoad %float %310
-%703 = OpFunctionCall %ulong %6 %701 %702
-OpStore %463 %703
-%704 = OpLoad %ulong %463
-OpStore %464 %704
-OpBranch %133
-%130 = OpLabel
-%705 = OpLoad %ulong %456
-%706 = OpFunctionCall %ulong %5 %705 %uint_4294967295
-OpStore %462 %706
-%707 = OpLoad %ulong %462
-OpStore %464 %707
-OpBranch %133
-%133 = OpLabel
-%709 = OpLoad %float %302
-%710 = OpFSub %float %float_0 %709
-OpStore %311 %710
-OpBranch %139
-%139 = OpLabel
-%711 = OpLoad %float %311
-%712 = OpLoad %float %311
-%713 = OpFUnordNotEqual %bool %711 %712
-OpStore %469 %713
-%714 = OpLoad %bool %469
-OpSelectionMerge %143 None
-OpBranchConditional %714 %140 %141
-%141 = OpLabel
-OpBranch %142
-%142 = OpLabel
-%715 = OpLoad %ulong %464
-%716 = OpLoad %float %311
-%717 = OpFunctionCall %ulong %6 %715 %716
-OpStore %471 %717
-%718 = OpLoad %ulong %471
-OpStore %472 %718
-OpBranch %143
-%140 = OpLabel
-%719 = OpLoad %ulong %464
-%720 = OpFunctionCall %ulong %5 %719 %uint_4294967295
-OpStore %470 %720
-%721 = OpLoad %ulong %470
-OpStore %472 %721
-OpBranch %143
-%143 = OpLabel
-%722 = OpLoad %float %302
-%723 = OpLoad %float %302
-%724 = OpFSub %float %722 %723
-OpStore %312 %724
-OpBranch %146
-%146 = OpLabel
-%725 = OpLoad %float %312
-%726 = OpLoad %float %312
-%727 = OpFUnordNotEqual %bool %725 %726
-OpStore %475 %727
-%728 = OpLoad %bool %475
-OpSelectionMerge %150 None
-OpBranchConditional %728 %147 %148
-%148 = OpLabel
-OpBranch %149
-%149 = OpLabel
-%729 = OpLoad %ulong %472
-%730 = OpLoad %float %312
-%731 = OpFunctionCall %ulong %6 %729 %730
-OpStore %477 %731
-%732 = OpLoad %ulong %477
-OpStore %478 %732
-OpBranch %150
-%147 = OpLabel
-%733 = OpLoad %ulong %472
-%734 = OpFunctionCall %ulong %5 %733 %uint_4294967295
-OpStore %476 %734
-%735 = OpLoad %ulong %476
-OpStore %478 %735
-OpBranch %150
-%150 = OpLabel
-%736 = OpLoad %float %302
-%737 = OpFSub %float %float_0 %736
-OpStore %313 %737
-%738 = OpLoad %float %313
-%739 = OpLoad %float %302
-%740 = OpFAdd %float %738 %739
-OpStore %314 %740
-OpBranch %153
-%153 = OpLabel
-%741 = OpLoad %float %314
-%742 = OpLoad %float %314
-%743 = OpFUnordNotEqual %bool %741 %742
-OpStore %481 %743
-%744 = OpLoad %bool %481
-OpSelectionMerge %157 None
-OpBranchConditional %744 %154 %155
-%155 = OpLabel
-OpBranch %156
-%156 = OpLabel
-%745 = OpLoad %ulong %478
-%746 = OpLoad %float %314
-%747 = OpFunctionCall %ulong %6 %745 %746
-OpStore %483 %747
-%748 = OpLoad %ulong %483
-OpStore %484 %748
-OpBranch %157
-%154 = OpLabel
-%749 = OpLoad %ulong %478
-%750 = OpFunctionCall %ulong %5 %749 %uint_4294967295
-OpStore %482 %750
-%751 = OpLoad %ulong %482
-OpStore %484 %751
-OpBranch %157
-%157 = OpLabel
-%753 = OpLoad %float %406
-%754 = OpFMul %float %float_3 %753
-OpStore %315 %754
-%755 = OpLoad %float %406
-%756 = OpLoad %float %315
-%757 = OpFDiv %float %755 %756
-OpStore %316 %757
-OpBranch %163
-%163 = OpLabel
-%758 = OpLoad %float %316
-%759 = OpLoad %float %316
-%760 = OpFUnordNotEqual %bool %758 %759
-OpStore %489 %760
-%761 = OpLoad %bool %489
-OpSelectionMerge %167 None
-OpBranchConditional %761 %164 %165
-%165 = OpLabel
-OpBranch %166
-%166 = OpLabel
-%762 = OpLoad %ulong %484
-%763 = OpLoad %float %316
-%764 = OpFunctionCall %ulong %6 %762 %763
-OpStore %491 %764
-%765 = OpLoad %ulong %491
-OpStore %492 %765
-OpBranch %167
-%164 = OpLabel
-%766 = OpLoad %ulong %484
-%767 = OpFunctionCall %ulong %5 %766 %uint_4294967295
-OpStore %490 %767
-%768 = OpLoad %ulong %490
-OpStore %492 %768
-OpBranch %167
-%167 = OpLabel
-%769 = OpLoad %float %316
-%770 = OpLoad %float %315
-%771 = OpFMul %float %769 %770
-OpStore %317 %771
-OpBranch %173
-%173 = OpLabel
-%772 = OpLoad %float %317
-%773 = OpLoad %float %317
-%774 = OpFUnordNotEqual %bool %772 %773
-OpStore %497 %774
-%775 = OpLoad %bool %497
-OpSelectionMerge %177 None
-OpBranchConditional %775 %174 %175
-%175 = OpLabel
-OpBranch %176
-%176 = OpLabel
-%776 = OpLoad %ulong %492
-%777 = OpLoad %float %317
-%778 = OpFunctionCall %ulong %6 %776 %777
-OpStore %499 %778
-%779 = OpLoad %ulong %499
-OpStore %500 %779
-OpBranch %177
-%174 = OpLabel
-%780 = OpLoad %ulong %492
-%781 = OpFunctionCall %ulong %5 %780 %uint_4294967295
-OpStore %498 %781
-%782 = OpLoad %ulong %498
-OpStore %500 %782
-OpBranch %177
-%177 = OpLabel
-%783 = OpLoad %float %406
-%784 = OpLoad %float %316
-%785 = OpFSub %float %783 %784
-OpStore %318 %785
-%786 = OpLoad %float %318
-%787 = OpLoad %float %316
-%788 = OpFSub %float %786 %787
-OpStore %319 %788
-%789 = OpLoad %float %319
-%790 = OpLoad %float %316
-%791 = OpFSub %float %789 %790
-OpStore %320 %791
-OpBranch %183
-%183 = OpLabel
-%792 = OpLoad %float %320
-%793 = OpLoad %float %320
-%794 = OpFUnordNotEqual %bool %792 %793
-OpStore %505 %794
-%795 = OpLoad %bool %505
-OpSelectionMerge %187 None
-OpBranchConditional %795 %184 %185
-%185 = OpLabel
-OpBranch %186
-%186 = OpLabel
-%796 = OpLoad %ulong %500
-%797 = OpLoad %float %320
-%798 = OpFunctionCall %ulong %6 %796 %797
-OpStore %507 %798
-%799 = OpLoad %ulong %507
-OpStore %508 %799
-OpBranch %187
-%184 = OpLabel
-%800 = OpLoad %ulong %500
-%801 = OpFunctionCall %ulong %5 %800 %uint_4294967295
-OpStore %506 %801
-%802 = OpLoad %ulong %506
-OpStore %508 %802
-OpBranch %187
-%187 = OpLabel
-%803 = OpLoad %float %406
-%805 = OpFDiv %float %803 %float_49
-OpStore %321 %805
-OpBranch %193
-%193 = OpLabel
-%806 = OpLoad %float %321
-%807 = OpLoad %float %321
-%808 = OpFUnordNotEqual %bool %806 %807
-OpStore %513 %808
-%809 = OpLoad %bool %513
-OpSelectionMerge %197 None
-OpBranchConditional %809 %194 %195
-%195 = OpLabel
-OpBranch %196
-%196 = OpLabel
-%810 = OpLoad %ulong %508
-%811 = OpLoad %float %321
-%812 = OpFunctionCall %ulong %6 %810 %811
-OpStore %515 %812
-%813 = OpLoad %ulong %515
-OpStore %516 %813
-OpBranch %197
-%194 = OpLabel
-%814 = OpLoad %ulong %508
-%815 = OpFunctionCall %ulong %5 %814 %uint_4294967295
-OpStore %514 %815
-%816 = OpLoad %ulong %514
-OpStore %516 %816
-OpBranch %197
-%197 = OpLabel
-%817 = OpLoad %float %406
-%819 = OpFDiv %float %817 %float_1048576_5
-OpStore %322 %819
-OpBranch %203
-%203 = OpLabel
-%820 = OpLoad %float %322
-%821 = OpLoad %float %322
-%822 = OpFUnordNotEqual %bool %820 %821
-OpStore %521 %822
-%823 = OpLoad %bool %521
-OpSelectionMerge %207 None
-OpBranchConditional %823 %204 %205
-%205 = OpLabel
-OpBranch %206
-%206 = OpLabel
-%824 = OpLoad %ulong %516
-%825 = OpLoad %float %322
-%826 = OpFunctionCall %ulong %6 %824 %825
-OpStore %523 %826
-%827 = OpLoad %ulong %523
-OpStore %524 %827
-OpBranch %207
-%204 = OpLabel
-%828 = OpLoad %ulong %516
-%829 = OpFunctionCall %ulong %5 %828 %uint_4294967295
-OpStore %522 %829
-%830 = OpLoad %ulong %522
-OpStore %524 %830
-OpBranch %207
-%207 = OpLabel
-%831 = OpLoad %float %315
-%832 = OpFDiv %float %float_1048576_5 %831
-OpStore %323 %832
-OpBranch %213
-%213 = OpLabel
-%833 = OpLoad %float %323
-%834 = OpLoad %float %323
-%835 = OpFUnordNotEqual %bool %833 %834
-OpStore %529 %835
-%836 = OpLoad %bool %529
-OpSelectionMerge %217 None
-OpBranchConditional %836 %214 %215
-%215 = OpLabel
-OpBranch %216
-%216 = OpLabel
-%837 = OpLoad %ulong %524
-%838 = OpLoad %float %323
-%839 = OpFunctionCall %ulong %6 %837 %838
-OpStore %531 %839
-%840 = OpLoad %ulong %531
-OpStore %532 %840
-OpBranch %217
-%214 = OpLabel
-%841 = OpLoad %ulong %524
-%842 = OpFunctionCall %ulong %5 %841 %uint_4294967295
-OpStore %530 %842
-%843 = OpLoad %ulong %530
-OpStore %532 %843
-OpBranch %217
-%217 = OpLabel
-%845 = OpLoad %float %406
-%846 = OpFMul %float %float_16777216 %845
-OpStore %324 %846
-%847 = OpLoad %float %324
-%848 = OpLoad %float %406
-%849 = OpFAdd %float %847 %848
-OpStore %325 %849
-OpBranch %223
-%223 = OpLabel
-%850 = OpLoad %float %325
-%851 = OpLoad %float %325
-%852 = OpFUnordNotEqual %bool %850 %851
-OpStore %537 %852
-%853 = OpLoad %bool %537
-OpSelectionMerge %227 None
-OpBranchConditional %853 %224 %225
-%225 = OpLabel
-OpBranch %226
-%226 = OpLabel
-%854 = OpLoad %ulong %532
-%855 = OpLoad %float %325
-%856 = OpFunctionCall %ulong %6 %854 %855
-OpStore %539 %856
-%857 = OpLoad %ulong %539
-OpStore %540 %857
-OpBranch %227
-%224 = OpLabel
-%858 = OpLoad %ulong %532
-%859 = OpFunctionCall %ulong %5 %858 %uint_4294967295
-OpStore %538 %859
-%860 = OpLoad %ulong %538
-OpStore %540 %860
-OpBranch %227
-%227 = OpLabel
-%861 = OpLoad %float %324
-%862 = OpLoad %float %406
-%863 = OpFAdd %float %861 %862
-OpStore %326 %863
-%864 = OpLoad %float %326
-%865 = OpLoad %float %406
-%866 = OpFAdd %float %864 %865
-OpStore %327 %866
-OpBranch %233
-%233 = OpLabel
-%867 = OpLoad %float %327
-%868 = OpLoad %float %327
-%869 = OpFUnordNotEqual %bool %867 %868
-OpStore %545 %869
-%870 = OpLoad %bool %545
-OpSelectionMerge %237 None
-OpBranchConditional %870 %234 %235
-%235 = OpLabel
-OpBranch %236
-%236 = OpLabel
-%871 = OpLoad %ulong %540
-%872 = OpLoad %float %327
-%873 = OpFunctionCall %ulong %6 %871 %872
-OpStore %547 %873
-%874 = OpLoad %ulong %547
-OpStore %548 %874
-OpBranch %237
-%234 = OpLabel
-%875 = OpLoad %ulong %540
-%876 = OpFunctionCall %ulong %5 %875 %uint_4294967295
-OpStore %546 %876
-%877 = OpLoad %ulong %546
-OpStore %548 %877
-OpBranch %237
-%237 = OpLabel
-%878 = OpLoad %float %406
-%879 = OpLoad %float %406
-%880 = OpFAdd %float %878 %879
-OpStore %328 %880
-%881 = OpLoad %float %324
-%882 = OpLoad %float %328
-%883 = OpFAdd %float %881 %882
-OpStore %329 %883
-OpBranch %243
-%243 = OpLabel
-%884 = OpLoad %float %329
-%885 = OpLoad %float %329
-%886 = OpFUnordNotEqual %bool %884 %885
-OpStore %553 %886
-%887 = OpLoad %bool %553
-OpSelectionMerge %247 None
-OpBranchConditional %887 %244 %245
-%245 = OpLabel
-OpBranch %246
-%246 = OpLabel
-%888 = OpLoad %ulong %548
-%889 = OpLoad %float %329
-%890 = OpFunctionCall %ulong %6 %888 %889
-OpStore %555 %890
-%891 = OpLoad %ulong %555
-OpStore %556 %891
-OpBranch %247
-%244 = OpLabel
-%892 = OpLoad %ulong %548
-%893 = OpFunctionCall %ulong %5 %892 %uint_4294967295
-OpStore %554 %893
-%894 = OpLoad %ulong %554
-OpStore %556 %894
-OpBranch %247
-%247 = OpLabel
-%895 = OpLoad %float %324
-%896 = OpLoad %float %406
-%897 = OpFSub %float %895 %896
-OpStore %330 %897
-OpBranch %253
-%253 = OpLabel
-%898 = OpLoad %float %330
-%899 = OpLoad %float %330
-%900 = OpFUnordNotEqual %bool %898 %899
-OpStore %561 %900
-%901 = OpLoad %bool %561
-OpSelectionMerge %257 None
-OpBranchConditional %901 %254 %255
-%255 = OpLabel
-OpBranch %256
-%256 = OpLabel
-%902 = OpLoad %ulong %556
-%903 = OpLoad %float %330
-%904 = OpFunctionCall %ulong %6 %902 %903
-OpStore %563 %904
-%905 = OpLoad %ulong %563
-OpStore %564 %905
-OpBranch %257
-%254 = OpLabel
-%906 = OpLoad %ulong %556
-%907 = OpFunctionCall %ulong %5 %906 %uint_4294967295
-OpStore %562 %907
-%908 = OpLoad %ulong %562
-OpStore %564 %908
-OpBranch %257
-%257 = OpLabel
-%909 = OpLoad %float %324
-%910 = OpLoad %float %406
-%911 = OpFAdd %float %909 %910
-OpStore %331 %911
-%912 = OpLoad %float %331
-%913 = OpLoad %float %324
-%914 = OpFSub %float %912 %913
-OpStore %332 %914
-OpBranch %263
-%263 = OpLabel
-%915 = OpLoad %float %332
-%916 = OpLoad %float %332
-%917 = OpFUnordNotEqual %bool %915 %916
-OpStore %569 %917
-%918 = OpLoad %bool %569
-OpSelectionMerge %267 None
-OpBranchConditional %918 %264 %265
-%265 = OpLabel
-OpBranch %266
-%266 = OpLabel
-%919 = OpLoad %ulong %564
-%920 = OpLoad %float %332
-%921 = OpFunctionCall %ulong %6 %919 %920
-OpStore %571 %921
-%922 = OpLoad %ulong %571
-OpStore %572 %922
-OpBranch %267
-%264 = OpLabel
-%923 = OpLoad %ulong %564
-%924 = OpFunctionCall %ulong %5 %923 %uint_4294967295
-OpStore %570 %924
-%925 = OpLoad %ulong %570
-OpStore %572 %925
-OpBranch %267
-%267 = OpLabel
-%926 = OpLoad %float %406
-%927 = OpFMul %float %float_0 %926
-OpStore %333 %927
-%928 = OpLoad %ulong %572
-OpStore %402 %928
-%929 = OpLoad %float %333
-OpStore %403 %929
-OpStore %404 %uint_0
-OpBranch %57
-%57 = OpLabel
-%931 = OpLoad %uint %404
-%933 = OpULessThan %bool %931 %uint_24
-OpStore %334 %933
-%934 = OpLoad %bool %334
-OpLoopMerge %59 %298 None
-OpBranchConditional %934 %58 %59
-%59 = OpLabel
-OpBranch %67
-%67 = OpLabel
-%936 = OpLoad %uint %301
-%937 = OpIAdd %uint %uint_2139095039 %936
-OpStore %411 %937
-%938 = OpLoad %uint %411
-%939 = OpBitcast %float %938
-OpStore %412 %939
-OpBranch %68
-%68 = OpLabel
-OpBranch %74
-%74 = OpLabel
-%940 = OpLoad %float %412
-%941 = OpLoad %float %412
-%942 = OpFUnordNotEqual %bool %940 %941
-OpStore %417 %942
-%943 = OpLoad %bool %417
-OpSelectionMerge %78 None
-OpBranchConditional %943 %75 %76
-%76 = OpLabel
-OpBranch %77
-%77 = OpLabel
-%944 = OpLoad %ulong %402
-%945 = OpLoad %float %412
-%946 = OpFunctionCall %ulong %6 %944 %945
-OpStore %419 %946
-%947 = OpLoad %ulong %419
-OpStore %420 %947
-OpBranch %78
-%75 = OpLabel
-%948 = OpLoad %ulong %402
-%949 = OpFunctionCall %ulong %5 %948 %uint_4294967295
-OpStore %418 %949
-%950 = OpLoad %ulong %418
-OpStore %420 %950
-OpBranch %78
-%78 = OpLabel
-%951 = OpLoad %float %412
-%953 = OpFDiv %float %951 %float_2
-OpStore %338 %953
-OpBranch %84
-%84 = OpLabel
-%954 = OpLoad %float %338
-%955 = OpLoad %float %338
-%956 = OpFUnordNotEqual %bool %954 %955
-OpStore %425 %956
-%957 = OpLoad %bool %425
-OpSelectionMerge %88 None
-OpBranchConditional %957 %85 %86
-%86 = OpLabel
-OpBranch %87
-%87 = OpLabel
-%958 = OpLoad %ulong %420
-%959 = OpLoad %float %338
-%960 = OpFunctionCall %ulong %6 %958 %959
-OpStore %427 %960
-%961 = OpLoad %ulong %427
-OpStore %428 %961
-OpBranch %88
-%85 = OpLabel
-%962 = OpLoad %ulong %420
-%963 = OpFunctionCall %ulong %5 %962 %uint_4294967295
-OpStore %426 %963
-%964 = OpLoad %ulong %426
-OpStore %428 %964
-OpBranch %88
-%88 = OpLabel
-%965 = OpLoad %float %412
-%966 = OpLoad %float %412
-%967 = OpFAdd %float %965 %966
-OpStore %339 %967
-OpBranch %94
-%94 = OpLabel
-%968 = OpLoad %float %339
-%969 = OpLoad %float %339
-%970 = OpFUnordNotEqual %bool %968 %969
-OpStore %433 %970
-%971 = OpLoad %bool %433
-OpSelectionMerge %98 None
-OpBranchConditional %971 %95 %96
-%96 = OpLabel
-OpBranch %97
-%97 = OpLabel
-%972 = OpLoad %ulong %428
-%973 = OpLoad %float %339
-%974 = OpFunctionCall %ulong %6 %972 %973
-OpStore %435 %974
-%975 = OpLoad %ulong %435
-OpStore %436 %975
-OpBranch %98
-%95 = OpLabel
-%976 = OpLoad %ulong %428
-%977 = OpFunctionCall %ulong %5 %976 %uint_4294967295
-OpStore %434 %977
-%978 = OpLoad %ulong %434
-OpStore %436 %978
-OpBranch %98
-%98 = OpLabel
-%979 = OpLoad %float %412
-%980 = OpFMul %float %979 %float_2
-OpStore %340 %980
-OpBranch %104
-%104 = OpLabel
-%981 = OpLoad %float %340
-%982 = OpLoad %float %340
-%983 = OpFUnordNotEqual %bool %981 %982
-OpStore %441 %983
-%984 = OpLoad %bool %441
-OpSelectionMerge %108 None
-OpBranchConditional %984 %105 %106
-%106 = OpLabel
-OpBranch %107
-%107 = OpLabel
-%985 = OpLoad %ulong %436
-%986 = OpLoad %float %340
-%987 = OpFunctionCall %ulong %6 %985 %986
-OpStore %443 %987
-%988 = OpLoad %ulong %443
-OpStore %444 %988
-OpBranch %108
-%105 = OpLabel
-%989 = OpLoad %ulong %436
-%990 = OpFunctionCall %ulong %5 %989 %uint_4294967295
-OpStore %442 %990
-%991 = OpLoad %ulong %442
-OpStore %444 %991
-OpBranch %108
-%108 = OpLabel
-%992 = OpLoad %float %412
-%993 = OpFMul %float %992 %float_2
-OpStore %341 %993
-%994 = OpLoad %float %341
-%995 = OpFSub %float %float_0 %994
-OpStore %342 %995
-OpBranch %114
-%114 = OpLabel
-%996 = OpLoad %float %342
-%997 = OpLoad %float %342
-%998 = OpFUnordNotEqual %bool %996 %997
-OpStore %449 %998
-%999 = OpLoad %bool %449
-OpSelectionMerge %118 None
-OpBranchConditional %999 %115 %116
-%116 = OpLabel
-OpBranch %117
-%117 = OpLabel
-%1000 = OpLoad %ulong %444
-%1001 = OpLoad %float %342
-%1002 = OpFunctionCall %ulong %6 %1000 %1001
-OpStore %451 %1002
-%1003 = OpLoad %ulong %451
-OpStore %452 %1003
-OpBranch %118
-%115 = OpLabel
-%1004 = OpLoad %ulong %444
-%1005 = OpFunctionCall %ulong %5 %1004 %uint_4294967295
-OpStore %450 %1005
-%1006 = OpLoad %ulong %450
-OpStore %452 %1006
-OpBranch %118
-%118 = OpLabel
-%1007 = OpLoad %float %412
-%1008 = OpLoad %float %412
-%1009 = OpFMul %float %1007 %1008
-OpStore %343 %1009
-OpBranch %124
-%124 = OpLabel
-%1010 = OpLoad %float %343
-%1011 = OpLoad %float %343
-%1012 = OpFUnordNotEqual %bool %1010 %1011
-OpStore %457 %1012
-%1013 = OpLoad %bool %457
-OpSelectionMerge %128 None
-OpBranchConditional %1013 %125 %126
-%126 = OpLabel
-OpBranch %127
-%127 = OpLabel
-%1014 = OpLoad %ulong %452
-%1015 = OpLoad %float %343
-%1016 = OpFunctionCall %ulong %6 %1014 %1015
-OpStore %459 %1016
-%1017 = OpLoad %ulong %459
-OpStore %460 %1017
-OpBranch %128
-%125 = OpLabel
-%1018 = OpLoad %ulong %452
-%1019 = OpFunctionCall %ulong %5 %1018 %uint_4294967295
-OpStore %458 %1019
-%1020 = OpLoad %ulong %458
-OpStore %460 %1020
-OpBranch %128
-%128 = OpLabel
-%1021 = OpLoad %float %412
-%1022 = OpLoad %float %412
-%1023 = OpFSub %float %1021 %1022
-OpStore %344 %1023
-OpBranch %134
-%134 = OpLabel
-%1024 = OpLoad %float %344
-%1025 = OpLoad %float %344
-%1026 = OpFUnordNotEqual %bool %1024 %1025
-OpStore %465 %1026
-%1027 = OpLoad %bool %465
-OpSelectionMerge %138 None
-OpBranchConditional %1027 %135 %136
-%136 = OpLabel
-OpBranch %137
-%137 = OpLabel
-%1028 = OpLoad %ulong %460
-%1029 = OpLoad %float %344
-%1030 = OpFunctionCall %ulong %6 %1028 %1029
-OpStore %467 %1030
-%1031 = OpLoad %ulong %467
-OpStore %468 %1031
-OpBranch %138
-%135 = OpLabel
-%1032 = OpLoad %ulong %460
-%1033 = OpFunctionCall %ulong %5 %1032 %uint_4294967295
-OpStore %466 %1033
-%1034 = OpLoad %ulong %466
-OpStore %468 %1034
-OpBranch %138
-%138 = OpLabel
-OpBranch %144
-%144 = OpLabel
-%1036 = OpLoad %uint %301
-%1037 = OpIAdd %uint %uint_8388608 %1036
-OpStore %473 %1037
-%1038 = OpLoad %uint %473
-%1039 = OpBitcast %float %1038
-OpStore %474 %1039
-OpBranch %145
-%145 = OpLabel
-OpBranch %151
-%151 = OpLabel
-%1041 = OpLoad %uint %301
-%1042 = OpIAdd %uint %uint_1 %1041
-OpStore %479 %1042
-%1043 = OpLoad %uint %479
-%1044 = OpBitcast %float %1043
-OpStore %480 %1044
-OpBranch %152
-%152 = OpLabel
-%1045 = OpLoad %float %474
-%1047 = OpFMul %float %1045 %float_0_5
-OpStore %345 %1047
-OpBranch %158
-%158 = OpLabel
-%1048 = OpLoad %float %345
-%1049 = OpLoad %float %345
-%1050 = OpFUnordNotEqual %bool %1048 %1049
-OpStore %485 %1050
-%1051 = OpLoad %bool %485
-OpSelectionMerge %162 None
-OpBranchConditional %1051 %159 %160
-%160 = OpLabel
-OpBranch %161
-%161 = OpLabel
-%1052 = OpLoad %ulong %468
-%1053 = OpLoad %float %345
-%1054 = OpFunctionCall %ulong %6 %1052 %1053
-OpStore %487 %1054
-%1055 = OpLoad %ulong %487
-OpStore %488 %1055
-OpBranch %162
-%159 = OpLabel
-%1056 = OpLoad %ulong %468
-%1057 = OpFunctionCall %ulong %5 %1056 %uint_4294967295
-OpStore %486 %1057
-%1058 = OpLoad %ulong %486
-OpStore %488 %1058
-OpBranch %162
-%162 = OpLabel
-%1059 = OpLoad %float %474
-%1060 = OpFDiv %float %1059 %float_2
-OpStore %346 %1060
-OpBranch %168
-%168 = OpLabel
-%1061 = OpLoad %float %346
-%1062 = OpLoad %float %346
-%1063 = OpFUnordNotEqual %bool %1061 %1062
-OpStore %493 %1063
-%1064 = OpLoad %bool %493
-OpSelectionMerge %172 None
-OpBranchConditional %1064 %169 %170
-%170 = OpLabel
-OpBranch %171
-%171 = OpLabel
-%1065 = OpLoad %ulong %488
-%1066 = OpLoad %float %346
-%1067 = OpFunctionCall %ulong %6 %1065 %1066
-OpStore %495 %1067
-%1068 = OpLoad %ulong %495
-OpStore %496 %1068
-OpBranch %172
-%169 = OpLabel
-%1069 = OpLoad %ulong %488
-%1070 = OpFunctionCall %ulong %5 %1069 %uint_4294967295
-OpStore %494 %1070
-%1071 = OpLoad %ulong %494
-OpStore %496 %1071
-OpBranch %172
-%172 = OpLabel
-%1072 = OpLoad %float %474
-%1073 = OpLoad %float %480
-%1074 = OpFSub %float %1072 %1073
-OpStore %347 %1074
-OpBranch %178
-%178 = OpLabel
-%1075 = OpLoad %float %347
-%1076 = OpLoad %float %347
-%1077 = OpFUnordNotEqual %bool %1075 %1076
-OpStore %501 %1077
-%1078 = OpLoad %bool %501
-OpSelectionMerge %182 None
-OpBranchConditional %1078 %179 %180
-%180 = OpLabel
-OpBranch %181
-%181 = OpLabel
-%1079 = OpLoad %ulong %496
-%1080 = OpLoad %float %347
-%1081 = OpFunctionCall %ulong %6 %1079 %1080
-OpStore %503 %1081
-%1082 = OpLoad %ulong %503
-OpStore %504 %1082
-OpBranch %182
-%179 = OpLabel
-%1083 = OpLoad %ulong %496
-%1084 = OpFunctionCall %ulong %5 %1083 %uint_4294967295
-OpStore %502 %1084
-%1085 = OpLoad %ulong %502
-OpStore %504 %1085
-OpBranch %182
-%182 = OpLabel
-%1086 = OpLoad %float %474
-%1087 = OpLoad %float %406
-%1088 = OpFMul %float %1086 %1087
-OpStore %348 %1088
-OpBranch %188
-%188 = OpLabel
-%1089 = OpLoad %float %348
-%1090 = OpLoad %float %348
-%1091 = OpFUnordNotEqual %bool %1089 %1090
-OpStore %509 %1091
-%1092 = OpLoad %bool %509
-OpSelectionMerge %192 None
-OpBranchConditional %1092 %189 %190
-%190 = OpLabel
-OpBranch %191
-%191 = OpLabel
-%1093 = OpLoad %ulong %504
-%1094 = OpLoad %float %348
-%1095 = OpFunctionCall %ulong %6 %1093 %1094
-OpStore %511 %1095
-%1096 = OpLoad %ulong %511
-OpStore %512 %1096
-OpBranch %192
-%189 = OpLabel
-%1097 = OpLoad %ulong %504
-%1098 = OpFunctionCall %ulong %5 %1097 %uint_4294967295
-OpStore %510 %1098
-%1099 = OpLoad %ulong %510
-OpStore %512 %1099
-OpBranch %192
-%192 = OpLabel
-%1100 = OpLoad %float %480
-%1101 = OpLoad %float %480
-%1102 = OpFAdd %float %1100 %1101
-OpStore %349 %1102
-OpBranch %198
-%198 = OpLabel
-%1103 = OpLoad %float %349
-%1104 = OpLoad %float %349
-%1105 = OpFUnordNotEqual %bool %1103 %1104
-OpStore %517 %1105
-%1106 = OpLoad %bool %517
-OpSelectionMerge %202 None
-OpBranchConditional %1106 %199 %200
-%200 = OpLabel
-OpBranch %201
-%201 = OpLabel
-%1107 = OpLoad %ulong %512
-%1108 = OpLoad %float %349
-%1109 = OpFunctionCall %ulong %6 %1107 %1108
-OpStore %519 %1109
-%1110 = OpLoad %ulong %519
-OpStore %520 %1110
-OpBranch %202
-%199 = OpLabel
-%1111 = OpLoad %ulong %512
-%1112 = OpFunctionCall %ulong %5 %1111 %uint_4294967295
-OpStore %518 %1112
-%1113 = OpLoad %ulong %518
-OpStore %520 %1113
-OpBranch %202
-%202 = OpLabel
-%1114 = OpLoad %float %480
-%1115 = OpFMul %float %1114 %float_0_5
-OpStore %350 %1115
-OpBranch %208
-%208 = OpLabel
-%1116 = OpLoad %float %350
-%1117 = OpLoad %float %350
-%1118 = OpFUnordNotEqual %bool %1116 %1117
-OpStore %525 %1118
-%1119 = OpLoad %bool %525
-OpSelectionMerge %212 None
-OpBranchConditional %1119 %209 %210
-%210 = OpLabel
-OpBranch %211
-%211 = OpLabel
-%1120 = OpLoad %ulong %520
-%1121 = OpLoad %float %350
-%1122 = OpFunctionCall %ulong %6 %1120 %1121
-OpStore %527 %1122
-%1123 = OpLoad %ulong %527
-OpStore %528 %1123
-OpBranch %212
-%209 = OpLabel
-%1124 = OpLoad %ulong %520
-%1125 = OpFunctionCall %ulong %5 %1124 %uint_4294967295
-OpStore %526 %1125
-%1126 = OpLoad %ulong %526
-OpStore %528 %1126
-OpBranch %212
-%212 = OpLabel
-%1127 = OpLoad %float %480
-%1129 = OpFMul %float %1127 %float_0_75
-OpStore %351 %1129
-OpBranch %218
-%218 = OpLabel
-%1130 = OpLoad %float %351
-%1131 = OpLoad %float %351
-%1132 = OpFUnordNotEqual %bool %1130 %1131
-OpStore %533 %1132
-%1133 = OpLoad %bool %533
-OpSelectionMerge %222 None
-OpBranchConditional %1133 %219 %220
-%220 = OpLabel
-OpBranch %221
-%221 = OpLabel
-%1134 = OpLoad %ulong %528
-%1135 = OpLoad %float %351
-%1136 = OpFunctionCall %ulong %6 %1134 %1135
-OpStore %535 %1136
-%1137 = OpLoad %ulong %535
-OpStore %536 %1137
-OpBranch %222
-%219 = OpLabel
-%1138 = OpLoad %ulong %528
-%1139 = OpFunctionCall %ulong %5 %1138 %uint_4294967295
-OpStore %534 %1139
-%1140 = OpLoad %ulong %534
-OpStore %536 %1140
-OpBranch %222
-%222 = OpLabel
-%1141 = OpLoad %float %480
-%1142 = OpFMul %float %1141 %float_16777216
-OpStore %352 %1142
-OpBranch %228
-%228 = OpLabel
-%1143 = OpLoad %float %352
-%1144 = OpLoad %float %352
-%1145 = OpFUnordNotEqual %bool %1143 %1144
-OpStore %541 %1145
-%1146 = OpLoad %bool %541
-OpSelectionMerge %232 None
-OpBranchConditional %1146 %229 %230
-%230 = OpLabel
-OpBranch %231
-%231 = OpLabel
-%1147 = OpLoad %ulong %536
-%1148 = OpLoad %float %352
-%1149 = OpFunctionCall %ulong %6 %1147 %1148
-OpStore %543 %1149
-%1150 = OpLoad %ulong %543
-OpStore %544 %1150
-OpBranch %232
-%229 = OpLabel
-%1151 = OpLoad %ulong %536
-%1152 = OpFunctionCall %ulong %5 %1151 %uint_4294967295
-OpStore %542 %1152
-%1153 = OpLoad %ulong %542
-OpStore %544 %1153
-OpBranch %232
-%232 = OpLabel
-%1154 = OpLoad %float %480
-%1155 = OpLoad %float %474
-%1156 = OpFDiv %float %1154 %1155
-OpStore %353 %1156
-OpBranch %238
-%238 = OpLabel
-%1157 = OpLoad %float %353
-%1158 = OpLoad %float %353
-%1159 = OpFUnordNotEqual %bool %1157 %1158
-OpStore %549 %1159
-%1160 = OpLoad %bool %549
-OpSelectionMerge %242 None
-OpBranchConditional %1160 %239 %240
-%240 = OpLabel
-OpBranch %241
-%241 = OpLabel
-%1161 = OpLoad %ulong %544
-%1162 = OpLoad %float %353
-%1163 = OpFunctionCall %ulong %6 %1161 %1162
-OpStore %551 %1163
-%1164 = OpLoad %ulong %551
-OpStore %552 %1164
-OpBranch %242
-%239 = OpLabel
-%1165 = OpLoad %ulong %544
-%1166 = OpFunctionCall %ulong %5 %1165 %uint_4294967295
-OpStore %550 %1166
-%1167 = OpLoad %ulong %550
-OpStore %552 %1167
-OpBranch %242
-%242 = OpLabel
-%1169 = OpLoad %float %406
-%1170 = OpFMul %float %float_5_5 %1169
-OpStore %354 %1170
-%1171 = OpLoad %float %406
-%1172 = OpFMul %float %float_3 %1171
-OpStore %355 %1172
-%1173 = OpLoad %float %354
-%1174 = OpLoad %float %355
-%1175 = OpFDiv %float %1173 %1174
-OpStore %356 %1175
-%1176 = OpLoad %float %356
-%1177 = OpConvertFToS %ulong %1176
-OpStore %357 %1177
-%1178 = OpLoad %ulong %357
-%1179 = OpConvertSToF %float %1178
-OpStore %358 %1179
-%1180 = OpLoad %float %358
-%1181 = OpLoad %float %355
-%1182 = OpFMul %float %1180 %1181
-OpStore %359 %1182
-%1183 = OpLoad %float %354
-%1184 = OpLoad %float %359
-%1185 = OpFSub %float %1183 %1184
-OpStore %360 %1185
-OpBranch %248
-%248 = OpLabel
-%1186 = OpLoad %float %360
-%1187 = OpLoad %float %360
-%1188 = OpFUnordNotEqual %bool %1186 %1187
-OpStore %557 %1188
-%1189 = OpLoad %bool %557
-OpSelectionMerge %252 None
-OpBranchConditional %1189 %249 %250
-%250 = OpLabel
-OpBranch %251
-%251 = OpLabel
-%1190 = OpLoad %ulong %552
-%1191 = OpLoad %float %360
-%1192 = OpFunctionCall %ulong %6 %1190 %1191
-OpStore %559 %1192
-%1193 = OpLoad %ulong %559
-OpStore %560 %1193
-OpBranch %252
-%249 = OpLabel
-%1194 = OpLoad %ulong %552
-%1195 = OpFunctionCall %ulong %5 %1194 %uint_4294967295
-OpStore %558 %1195
-%1196 = OpLoad %ulong %558
-OpStore %560 %1196
-OpBranch %252
-%252 = OpLabel
-%1197 = OpLoad %float %354
-%1198 = OpFSub %float %float_0 %1197
-OpStore %361 %1198
-%1199 = OpLoad %float %361
-%1200 = OpLoad %float %355
-%1201 = OpFDiv %float %1199 %1200
-OpStore %362 %1201
-%1202 = OpLoad %float %362
-%1203 = OpConvertFToS %ulong %1202
-OpStore %363 %1203
-%1204 = OpLoad %ulong %363
-%1205 = OpConvertSToF %float %1204
-OpStore %364 %1205
-%1206 = OpLoad %float %364
-%1207 = OpLoad %float %355
-%1208 = OpFMul %float %1206 %1207
-OpStore %365 %1208
-%1209 = OpLoad %float %361
-%1210 = OpLoad %float %365
-%1211 = OpFSub %float %1209 %1210
-OpStore %366 %1211
-OpBranch %258
-%258 = OpLabel
-%1212 = OpLoad %float %366
-%1213 = OpLoad %float %366
-%1214 = OpFUnordNotEqual %bool %1212 %1213
-OpStore %565 %1214
-%1215 = OpLoad %bool %565
-OpSelectionMerge %262 None
-OpBranchConditional %1215 %259 %260
+%594 = OpVariable %_ptr_Function_float Function
+%595 = OpVariable %_ptr_Function_bool Function
+%596 = OpVariable %_ptr_Function_bool Function
+%597 = OpVariable %_ptr_Function_bool Function
+%598 = OpVariable %_ptr_Function_bool Function
+%599 = OpVariable %_ptr_Function_float Function
+%600 = OpVariable %_ptr_Function_ulong Function
+%601 = OpVariable %_ptr_Function_float Function
+%602 = OpVariable %_ptr_Function_float Function
+%603 = OpVariable %_ptr_Function_float Function
+%604 = OpVariable %_ptr_Function_bool Function
+%605 = OpVariable %_ptr_Function_float Function
+%606 = OpVariable %_ptr_Function_float Function
+%607 = OpVariable %_ptr_Function_bool Function
+%608 = OpVariable %_ptr_Function_float Function
+%609 = OpVariable %_ptr_Function_float Function
+%610 = OpVariable %_ptr_Function_float Function
+%611 = OpVariable %_ptr_Function_float Function
+%612 = OpVariable %_ptr_Function_bool Function
+%613 = OpVariable %_ptr_Function_float Function
+%614 = OpVariable %_ptr_Function_float Function
+%615 = OpVariable %_ptr_Function_float Function
+%616 = OpVariable %_ptr_Function_bool Function
+%617 = OpVariable %_ptr_Function_bool Function
+%618 = OpVariable %_ptr_Function_float Function
+%619 = OpVariable %_ptr_Function_float Function
+%620 = OpVariable %_ptr_Function_float Function
+%621 = OpVariable %_ptr_Function_float Function
+%622 = OpVariable %_ptr_Function_float Function
+%623 = OpVariable %_ptr_Function_float Function
+%624 = OpVariable %_ptr_Function_bool Function
+%625 = OpVariable %_ptr_Function_float Function
+%626 = OpVariable %_ptr_Function_bool Function
+%627 = OpVariable %_ptr_Function_bool Function
+%628 = OpVariable %_ptr_Function_bool Function
+%629 = OpVariable %_ptr_Function_bool Function
+%630 = OpVariable %_ptr_Function_float Function
+%631 = OpVariable %_ptr_Function_ulong Function
+%632 = OpVariable %_ptr_Function_float Function
+%633 = OpVariable %_ptr_Function_float Function
+%634 = OpVariable %_ptr_Function_float Function
+%635 = OpVariable %_ptr_Function_bool Function
+%636 = OpVariable %_ptr_Function_float Function
+%637 = OpVariable %_ptr_Function_float Function
+%638 = OpVariable %_ptr_Function_bool Function
+%639 = OpVariable %_ptr_Function_float Function
+%640 = OpVariable %_ptr_Function_float Function
+%641 = OpVariable %_ptr_Function_float Function
+%642 = OpVariable %_ptr_Function_float Function
+%643 = OpVariable %_ptr_Function_bool Function
+%644 = OpVariable %_ptr_Function_float Function
+%645 = OpVariable %_ptr_Function_float Function
+%646 = OpVariable %_ptr_Function_float Function
+%647 = OpVariable %_ptr_Function_bool Function
+%648 = OpVariable %_ptr_Function_bool Function
+%649 = OpVariable %_ptr_Function_float Function
+%650 = OpVariable %_ptr_Function_float Function
+%651 = OpVariable %_ptr_Function_float Function
+%652 = OpVariable %_ptr_Function_float Function
+%653 = OpVariable %_ptr_Function_float Function
+%654 = OpVariable %_ptr_Function_float Function
+%655 = OpVariable %_ptr_Function_bool Function
+%656 = OpVariable %_ptr_Function_float Function
+%657 = OpVariable %_ptr_Function_bool Function
+%658 = OpVariable %_ptr_Function_bool Function
+%659 = OpVariable %_ptr_Function_bool Function
+%660 = OpVariable %_ptr_Function_bool Function
+%661 = OpVariable %_ptr_Function_float Function
+%662 = OpVariable %_ptr_Function_ulong Function
+%663 = OpVariable %_ptr_Function_float Function
+%664 = OpVariable %_ptr_Function_float Function
+%665 = OpVariable %_ptr_Function_float Function
+%666 = OpVariable %_ptr_Function_bool Function
+%667 = OpVariable %_ptr_Function_float Function
+%668 = OpVariable %_ptr_Function_float Function
+%669 = OpVariable %_ptr_Function_bool Function
+%670 = OpVariable %_ptr_Function_float Function
+%671 = OpVariable %_ptr_Function_float Function
+%672 = OpVariable %_ptr_Function_float Function
+%673 = OpVariable %_ptr_Function_float Function
+%674 = OpVariable %_ptr_Function_bool Function
+%675 = OpVariable %_ptr_Function_float Function
+%676 = OpVariable %_ptr_Function_float Function
+%677 = OpVariable %_ptr_Function_float Function
+%678 = OpVariable %_ptr_Function_bool Function
+%679 = OpVariable %_ptr_Function_bool Function
+%680 = OpVariable %_ptr_Function_float Function
+%681 = OpVariable %_ptr_Function_float Function
+%682 = OpVariable %_ptr_Function_float Function
+%683 = OpVariable %_ptr_Function_float Function
+%684 = OpVariable %_ptr_Function_float Function
+%685 = OpVariable %_ptr_Function_float Function
+%686 = OpVariable %_ptr_Function_float Function
+%687 = OpVariable %_ptr_Function_bool Function
+%688 = OpVariable %_ptr_Function_float Function
+%689 = OpVariable %_ptr_Function_bool Function
+%690 = OpVariable %_ptr_Function_bool Function
+%691 = OpVariable %_ptr_Function_bool Function
+%692 = OpVariable %_ptr_Function_bool Function
+%693 = OpVariable %_ptr_Function_float Function
+%694 = OpVariable %_ptr_Function_ulong Function
+%695 = OpVariable %_ptr_Function_float Function
+%696 = OpVariable %_ptr_Function_float Function
+%697 = OpVariable %_ptr_Function_float Function
+%698 = OpVariable %_ptr_Function_bool Function
+%699 = OpVariable %_ptr_Function_float Function
+%700 = OpVariable %_ptr_Function_float Function
+%701 = OpVariable %_ptr_Function_bool Function
+%702 = OpVariable %_ptr_Function_float Function
+%703 = OpVariable %_ptr_Function_float Function
+%704 = OpVariable %_ptr_Function_float Function
+%705 = OpVariable %_ptr_Function_float Function
+%706 = OpVariable %_ptr_Function_bool Function
+%707 = OpVariable %_ptr_Function_float Function
+%708 = OpVariable %_ptr_Function_float Function
+%709 = OpVariable %_ptr_Function_float Function
+%710 = OpVariable %_ptr_Function_bool Function
+%711 = OpVariable %_ptr_Function_bool Function
+%712 = OpVariable %_ptr_Function_float Function
+%713 = OpVariable %_ptr_Function_float Function
+%714 = OpVariable %_ptr_Function_float Function
+%715 = OpVariable %_ptr_Function_float Function
+%716 = OpVariable %_ptr_Function_float Function
+%717 = OpVariable %_ptr_Function_float Function
+%718 = OpVariable %_ptr_Function_ulong Function
+%719 = OpVariable %_ptr_Function_float Function
+%720 = OpVariable %_ptr_Function_uint Function
+%721 = OpVariable %_ptr_Function_uint Function
+%722 = OpVariable %_ptr_Function_float Function
+%723 = OpVariable %_ptr_Function_bool Function
+%724 = OpVariable %_ptr_Function_ulong Function
+%725 = OpVariable %_ptr_Function_ulong Function
+%726 = OpVariable %_ptr_Function_ulong Function
+%727 = OpVariable %_ptr_Function_uint Function
+%728 = OpVariable %_ptr_Function_float Function
+%729 = OpVariable %_ptr_Function_bool Function
+%730 = OpVariable %_ptr_Function_ulong Function
+%731 = OpVariable %_ptr_Function_ulong Function
+%732 = OpVariable %_ptr_Function_ulong Function
+%733 = OpVariable %_ptr_Function_bool Function
+%734 = OpVariable %_ptr_Function_ulong Function
+%735 = OpVariable %_ptr_Function_ulong Function
+%736 = OpVariable %_ptr_Function_ulong Function
+%737 = OpVariable %_ptr_Function_bool Function
+%738 = OpVariable %_ptr_Function_ulong Function
+%739 = OpVariable %_ptr_Function_ulong Function
+%740 = OpVariable %_ptr_Function_ulong Function
+%741 = OpVariable %_ptr_Function_bool Function
+%742 = OpVariable %_ptr_Function_ulong Function
+%743 = OpVariable %_ptr_Function_ulong Function
+%744 = OpVariable %_ptr_Function_ulong Function
+%745 = OpVariable %_ptr_Function_bool Function
+%746 = OpVariable %_ptr_Function_ulong Function
+%747 = OpVariable %_ptr_Function_ulong Function
+%748 = OpVariable %_ptr_Function_ulong Function
+%749 = OpVariable %_ptr_Function_bool Function
+%750 = OpVariable %_ptr_Function_ulong Function
+%751 = OpVariable %_ptr_Function_ulong Function
+%752 = OpVariable %_ptr_Function_ulong Function
+%753 = OpVariable %_ptr_Function_bool Function
+%754 = OpVariable %_ptr_Function_ulong Function
+%755 = OpVariable %_ptr_Function_ulong Function
+%756 = OpVariable %_ptr_Function_ulong Function
+%757 = OpVariable %_ptr_Function_bool Function
+%758 = OpVariable %_ptr_Function_ulong Function
+%759 = OpVariable %_ptr_Function_ulong Function
+%760 = OpVariable %_ptr_Function_ulong Function
+%761 = OpVariable %_ptr_Function_bool Function
+%762 = OpVariable %_ptr_Function_ulong Function
+%763 = OpVariable %_ptr_Function_ulong Function
+%764 = OpVariable %_ptr_Function_ulong Function
+%765 = OpVariable %_ptr_Function_bool Function
+%766 = OpVariable %_ptr_Function_ulong Function
+%767 = OpVariable %_ptr_Function_ulong Function
+%768 = OpVariable %_ptr_Function_ulong Function
+%769 = OpVariable %_ptr_Function_bool Function
+%770 = OpVariable %_ptr_Function_ulong Function
+%771 = OpVariable %_ptr_Function_ulong Function
+%772 = OpVariable %_ptr_Function_ulong Function
+%773 = OpVariable %_ptr_Function_bool Function
+%774 = OpVariable %_ptr_Function_ulong Function
+%775 = OpVariable %_ptr_Function_ulong Function
+%776 = OpVariable %_ptr_Function_ulong Function
+%777 = OpVariable %_ptr_Function_bool Function
+%778 = OpVariable %_ptr_Function_ulong Function
+%779 = OpVariable %_ptr_Function_ulong Function
+%780 = OpVariable %_ptr_Function_ulong Function
+%781 = OpVariable %_ptr_Function_bool Function
+%782 = OpVariable %_ptr_Function_ulong Function
+%783 = OpVariable %_ptr_Function_ulong Function
+%784 = OpVariable %_ptr_Function_ulong Function
+%785 = OpVariable %_ptr_Function_bool Function
+%786 = OpVariable %_ptr_Function_ulong Function
+%787 = OpVariable %_ptr_Function_ulong Function
+%788 = OpVariable %_ptr_Function_ulong Function
+%789 = OpVariable %_ptr_Function_uint Function
+%790 = OpVariable %_ptr_Function_float Function
+%791 = OpVariable %_ptr_Function_uint Function
+%792 = OpVariable %_ptr_Function_float Function
+OpStore %381 %55
+%793 = OpFunctionCall %ulong %4
+OpStore %382 %793
+%794 = OpLoad %ulong %381
+%795 = OpUConvert %uint %794
+OpStore %383 %795
+OpBranch %260
 %260 = OpLabel
+%797 = OpLoad %uint %383
+%798 = OpIAdd %uint %uint_1065353216 %797
+OpStore %721 %798
+%799 = OpLoad %uint %721
+%800 = OpBitcast %float %799
+OpStore %722 %800
 OpBranch %261
 %261 = OpLabel
-%1216 = OpLoad %ulong %560
-%1217 = OpLoad %float %366
-%1218 = OpFunctionCall %ulong %6 %1216 %1217
-OpStore %567 %1218
-%1219 = OpLoad %ulong %567
-OpStore %568 %1219
-OpBranch %262
-%259 = OpLabel
-%1220 = OpLoad %ulong %560
-%1221 = OpFunctionCall %ulong %5 %1220 %uint_4294967295
-OpStore %566 %1221
-%1222 = OpLoad %ulong %566
-OpStore %568 %1222
-OpBranch %262
-%262 = OpLabel
-%1223 = OpLoad %float %355
-%1224 = OpFSub %float %float_0 %1223
-OpStore %367 %1224
-%1225 = OpLoad %float %354
-%1226 = OpLoad %float %367
-%1227 = OpFDiv %float %1225 %1226
-OpStore %368 %1227
-%1228 = OpLoad %float %368
-%1229 = OpConvertFToS %ulong %1228
-OpStore %369 %1229
-%1230 = OpLoad %ulong %369
-%1231 = OpConvertSToF %float %1230
-OpStore %370 %1231
-%1232 = OpLoad %float %370
-%1233 = OpLoad %float %367
-%1234 = OpFMul %float %1232 %1233
-OpStore %371 %1234
-%1235 = OpLoad %float %354
-%1236 = OpLoad %float %371
-%1237 = OpFSub %float %1235 %1236
-OpStore %372 %1237
+%802 = OpLoad %float %722
+%803 = OpFMul %float %float_1_5 %802
+OpStore %384 %803
+%805 = OpLoad %float %722
+%806 = OpFMul %float %float_0_25 %805
+OpStore %385 %806
+%807 = OpLoad %float %384
+%808 = OpLoad %float %385
+%809 = OpFAdd %float %807 %808
+OpStore %386 %809
+OpBranch %309
+%309 = OpLabel
+%810 = OpLoad %float %386
+%811 = OpLoad %float %386
+%812 = OpFUnordNotEqual %bool %810 %811
+OpStore %761 %812
+%813 = OpLoad %bool %761
+OpSelectionMerge %313 None
+OpBranchConditional %813 %310 %311
+%311 = OpLabel
+OpBranch %312
+%312 = OpLabel
+%814 = OpLoad %ulong %382
+%815 = OpLoad %float %386
+%816 = OpFunctionCall %ulong %6 %814 %815
+OpStore %763 %816
+%817 = OpLoad %ulong %763
+OpStore %764 %817
+OpBranch %313
+%310 = OpLabel
+%818 = OpLoad %ulong %382
+%819 = OpFunctionCall %ulong %5 %818 %uint_4294967295
+OpStore %762 %819
+%820 = OpLoad %ulong %762
+OpStore %764 %820
+OpBranch %313
+%313 = OpLabel
+%821 = OpLoad %float %384
+%822 = OpLoad %float %385
+%823 = OpFSub %float %821 %822
+OpStore %387 %823
+OpBranch %319
+%319 = OpLabel
+%824 = OpLoad %float %387
+%825 = OpLoad %float %387
+%826 = OpFUnordNotEqual %bool %824 %825
+OpStore %769 %826
+%827 = OpLoad %bool %769
+OpSelectionMerge %323 None
+OpBranchConditional %827 %320 %321
+%321 = OpLabel
+OpBranch %322
+%322 = OpLabel
+%828 = OpLoad %ulong %764
+%829 = OpLoad %float %387
+%830 = OpFunctionCall %ulong %6 %828 %829
+OpStore %771 %830
+%831 = OpLoad %ulong %771
+OpStore %772 %831
+OpBranch %323
+%320 = OpLabel
+%832 = OpLoad %ulong %764
+%833 = OpFunctionCall %ulong %5 %832 %uint_4294967295
+OpStore %770 %833
+%834 = OpLoad %ulong %770
+OpStore %772 %834
+OpBranch %323
+%323 = OpLabel
+%835 = OpLoad %float %385
+%836 = OpLoad %float %384
+%837 = OpFSub %float %835 %836
+OpStore %388 %837
+OpBranch %329
+%329 = OpLabel
+%838 = OpLoad %float %388
+%839 = OpLoad %float %388
+%840 = OpFUnordNotEqual %bool %838 %839
+OpStore %777 %840
+%841 = OpLoad %bool %777
+OpSelectionMerge %333 None
+OpBranchConditional %841 %330 %331
+%331 = OpLabel
+OpBranch %332
+%332 = OpLabel
+%842 = OpLoad %ulong %772
+%843 = OpLoad %float %388
+%844 = OpFunctionCall %ulong %6 %842 %843
+OpStore %779 %844
+%845 = OpLoad %ulong %779
+OpStore %780 %845
+OpBranch %333
+%330 = OpLabel
+%846 = OpLoad %ulong %772
+%847 = OpFunctionCall %ulong %5 %846 %uint_4294967295
+OpStore %778 %847
+%848 = OpLoad %ulong %778
+OpStore %780 %848
+OpBranch %333
+%333 = OpLabel
+%849 = OpLoad %float %384
+%850 = OpLoad %float %385
+%851 = OpFMul %float %849 %850
+OpStore %389 %851
+OpBranch %339
+%339 = OpLabel
+%852 = OpLoad %float %389
+%853 = OpLoad %float %389
+%854 = OpFUnordNotEqual %bool %852 %853
+OpStore %785 %854
+%855 = OpLoad %bool %785
+OpSelectionMerge %343 None
+OpBranchConditional %855 %340 %341
+%341 = OpLabel
+OpBranch %342
+%342 = OpLabel
+%856 = OpLoad %ulong %780
+%857 = OpLoad %float %389
+%858 = OpFunctionCall %ulong %6 %856 %857
+OpStore %787 %858
+%859 = OpLoad %ulong %787
+OpStore %788 %859
+OpBranch %343
+%340 = OpLabel
+%860 = OpLoad %ulong %780
+%861 = OpFunctionCall %ulong %5 %860 %uint_4294967295
+OpStore %786 %861
+%862 = OpLoad %ulong %786
+OpStore %788 %862
+OpBranch %343
+%343 = OpLabel
+%863 = OpLoad %float %384
+%864 = OpLoad %float %385
+%865 = OpFDiv %float %863 %864
+OpStore %390 %865
+%866 = OpLoad %ulong %788
+%867 = OpLoad %float %390
+%868 = OpFunctionCall %ulong %2 %866 %867
+OpStore %391 %868
+%869 = OpLoad %float %385
+%870 = OpLoad %float %384
+%871 = OpFDiv %float %869 %870
+OpStore %392 %871
+%872 = OpLoad %ulong %391
+%873 = OpLoad %float %392
+%874 = OpFunctionCall %ulong %2 %872 %873
+OpStore %393 %874
+%875 = OpLoad %float %384
+%876 = OpFNegate %float %875
+OpStore %394 %876
+%877 = OpLoad %ulong %393
+%878 = OpLoad %float %394
+%879 = OpFunctionCall %ulong %2 %877 %878
+OpStore %395 %879
+%881 = OpLoad %float %384
+%882 = OpFSub %float %float_0 %881
+OpStore %396 %882
+%883 = OpLoad %ulong %395
+%884 = OpLoad %float %396
+%885 = OpFunctionCall %ulong %2 %883 %884
+OpStore %397 %885
+%886 = OpLoad %float %384
+%887 = OpLoad %float %384
+%888 = OpFSub %float %886 %887
+OpStore %398 %888
+%889 = OpLoad %ulong %397
+%890 = OpLoad %float %398
+%891 = OpFunctionCall %ulong %2 %889 %890
+OpStore %399 %891
+%892 = OpLoad %float %396
+%893 = OpLoad %float %384
+%894 = OpFAdd %float %892 %893
+OpStore %400 %894
+%895 = OpLoad %ulong %399
+%896 = OpLoad %float %400
+%897 = OpFunctionCall %ulong %2 %895 %896
+OpStore %401 %897
+%899 = OpLoad %float %722
+%900 = OpFMul %float %float_3 %899
+OpStore %402 %900
+%901 = OpLoad %float %722
+%902 = OpLoad %float %402
+%903 = OpFDiv %float %901 %902
+OpStore %403 %903
+%904 = OpLoad %ulong %401
+%905 = OpLoad %float %403
+%906 = OpFunctionCall %ulong %2 %904 %905
+OpStore %404 %906
+%907 = OpLoad %float %403
+%908 = OpLoad %float %402
+%909 = OpFMul %float %907 %908
+OpStore %405 %909
+%910 = OpLoad %ulong %404
+%911 = OpLoad %float %405
+%912 = OpFunctionCall %ulong %2 %910 %911
+OpStore %406 %912
+%913 = OpLoad %float %722
+%914 = OpLoad %float %403
+%915 = OpFSub %float %913 %914
+OpStore %407 %915
+%916 = OpLoad %float %407
+%917 = OpLoad %float %403
+%918 = OpFSub %float %916 %917
+OpStore %408 %918
+%919 = OpLoad %float %408
+%920 = OpLoad %float %403
+%921 = OpFSub %float %919 %920
+OpStore %409 %921
+%922 = OpLoad %ulong %406
+%923 = OpLoad %float %409
+%924 = OpFunctionCall %ulong %2 %922 %923
+OpStore %410 %924
+%925 = OpLoad %float %722
+%927 = OpFDiv %float %925 %float_49
+OpStore %411 %927
+%928 = OpLoad %ulong %410
+%929 = OpLoad %float %411
+%930 = OpFunctionCall %ulong %2 %928 %929
+OpStore %412 %930
+%931 = OpLoad %float %722
+%933 = OpFDiv %float %931 %float_1048576_5
+OpStore %413 %933
+%934 = OpLoad %ulong %412
+%935 = OpLoad %float %413
+%936 = OpFunctionCall %ulong %2 %934 %935
+OpStore %414 %936
+%937 = OpLoad %float %402
+%938 = OpFDiv %float %float_1048576_5 %937
+OpStore %415 %938
+%939 = OpLoad %ulong %414
+%940 = OpLoad %float %415
+%941 = OpFunctionCall %ulong %2 %939 %940
+OpStore %416 %941
+%943 = OpLoad %float %722
+%944 = OpFMul %float %float_16777216 %943
+OpStore %417 %944
+%945 = OpLoad %float %417
+%946 = OpLoad %float %722
+%947 = OpFAdd %float %945 %946
+OpStore %418 %947
+%948 = OpLoad %ulong %416
+%949 = OpLoad %float %418
+%950 = OpFunctionCall %ulong %2 %948 %949
+OpStore %419 %950
+%951 = OpLoad %float %418
+%952 = OpLoad %float %722
+%953 = OpFAdd %float %951 %952
+OpStore %420 %953
+%954 = OpLoad %ulong %419
+%955 = OpLoad %float %420
+%956 = OpFunctionCall %ulong %2 %954 %955
+OpStore %421 %956
+%957 = OpLoad %float %722
+%958 = OpLoad %float %722
+%959 = OpFAdd %float %957 %958
+OpStore %422 %959
+%960 = OpLoad %float %417
+%961 = OpLoad %float %422
+%962 = OpFAdd %float %960 %961
+OpStore %423 %962
+%963 = OpLoad %ulong %421
+%964 = OpLoad %float %423
+%965 = OpFunctionCall %ulong %2 %963 %964
+OpStore %424 %965
+%966 = OpLoad %float %417
+%967 = OpLoad %float %722
+%968 = OpFSub %float %966 %967
+OpStore %425 %968
+%969 = OpLoad %ulong %424
+%970 = OpLoad %float %425
+%971 = OpFunctionCall %ulong %2 %969 %970
+OpStore %426 %971
+%972 = OpLoad %float %418
+%973 = OpLoad %float %417
+%974 = OpFSub %float %972 %973
+OpStore %427 %974
+%975 = OpLoad %ulong %426
+%976 = OpLoad %float %427
+%977 = OpFunctionCall %ulong %2 %975 %976
+OpStore %428 %977
+%978 = OpLoad %float %722
+%979 = OpFMul %float %float_0 %978
+OpStore %429 %979
+%980 = OpLoad %ulong %428
+OpStore %718 %980
+%981 = OpLoad %float %429
+OpStore %719 %981
+OpStore %720 %uint_0
+OpBranch %57
+%57 = OpLabel
+%983 = OpLoad %uint %720
+%985 = OpULessThan %bool %983 %uint_24
+OpStore %430 %985
+%986 = OpLoad %bool %430
+OpLoopMerge %59 %380 None
+OpBranchConditional %986 %58 %59
+%59 = OpLabel
+OpBranch %267
+%267 = OpLabel
+%988 = OpLoad %uint %383
+%989 = OpIAdd %uint %uint_2139095039 %988
+OpStore %727 %989
+%990 = OpLoad %uint %727
+%991 = OpBitcast %float %990
+OpStore %728 %991
 OpBranch %268
 %268 = OpLabel
-%1238 = OpLoad %float %372
-%1239 = OpLoad %float %372
-%1240 = OpFUnordNotEqual %bool %1238 %1239
-OpStore %573 %1240
-%1241 = OpLoad %bool %573
-OpSelectionMerge %272 None
-OpBranchConditional %1241 %269 %270
-%270 = OpLabel
-OpBranch %271
-%271 = OpLabel
-%1242 = OpLoad %ulong %568
-%1243 = OpLoad %float %372
-%1244 = OpFunctionCall %ulong %6 %1242 %1243
-OpStore %575 %1244
-%1245 = OpLoad %ulong %575
-OpStore %576 %1245
-OpBranch %272
-%269 = OpLabel
-%1246 = OpLoad %ulong %568
-%1247 = OpFunctionCall %ulong %5 %1246 %uint_4294967295
-OpStore %574 %1247
-%1248 = OpLoad %ulong %574
-OpStore %576 %1248
-OpBranch %272
-%272 = OpLabel
-%1249 = OpLoad %float %354
-%1250 = OpFSub %float %float_0 %1249
-OpStore %373 %1250
-%1251 = OpLoad %float %355
-%1252 = OpFSub %float %float_0 %1251
-OpStore %374 %1252
-%1253 = OpLoad %float %373
-%1254 = OpLoad %float %374
-%1255 = OpFDiv %float %1253 %1254
-OpStore %375 %1255
-%1256 = OpLoad %float %375
-%1257 = OpConvertFToS %ulong %1256
-OpStore %376 %1257
-%1258 = OpLoad %ulong %376
-%1259 = OpConvertSToF %float %1258
-OpStore %377 %1259
-%1260 = OpLoad %float %377
-%1261 = OpLoad %float %374
-%1262 = OpFMul %float %1260 %1261
-OpStore %378 %1262
-%1263 = OpLoad %float %373
-%1264 = OpLoad %float %378
-%1265 = OpFSub %float %1263 %1264
-OpStore %379 %1265
-OpBranch %273
-%273 = OpLabel
-%1266 = OpLoad %float %379
-%1267 = OpLoad %float %379
-%1268 = OpFUnordNotEqual %bool %1266 %1267
-OpStore %577 %1268
-%1269 = OpLoad %bool %577
-OpSelectionMerge %277 None
-OpBranchConditional %1269 %274 %275
-%275 = OpLabel
-OpBranch %276
-%276 = OpLabel
-%1270 = OpLoad %ulong %576
-%1271 = OpLoad %float %379
-%1272 = OpFunctionCall %ulong %6 %1270 %1271
-OpStore %579 %1272
-%1273 = OpLoad %ulong %579
-OpStore %580 %1273
-OpBranch %277
-%274 = OpLabel
-%1274 = OpLoad %ulong %576
-%1275 = OpFunctionCall %ulong %5 %1274 %uint_4294967295
-OpStore %578 %1275
-%1276 = OpLoad %ulong %578
-OpStore %580 %1276
-OpBranch %277
-%277 = OpLabel
-%1278 = OpLoad %float %406
-%1279 = OpFMul %float %float_7 %1278
-OpStore %380 %1279
-%1280 = OpLoad %float %380
-%1281 = OpFDiv %float %1280 %float_0_5
-OpStore %381 %1281
-%1282 = OpLoad %float %381
-%1283 = OpConvertFToS %ulong %1282
-OpStore %382 %1283
-%1284 = OpLoad %ulong %382
-%1285 = OpConvertSToF %float %1284
-OpStore %383 %1285
-%1286 = OpLoad %float %383
-%1287 = OpFMul %float %1286 %float_0_5
-OpStore %384 %1287
-%1288 = OpLoad %float %380
-%1289 = OpLoad %float %384
-%1290 = OpFSub %float %1288 %1289
-OpStore %385 %1290
-OpBranch %278
-%278 = OpLabel
-%1291 = OpLoad %float %385
-%1292 = OpLoad %float %385
-%1293 = OpFUnordNotEqual %bool %1291 %1292
-OpStore %581 %1293
-%1294 = OpLoad %bool %581
-OpSelectionMerge %282 None
-OpBranchConditional %1294 %279 %280
-%280 = OpLabel
-OpBranch %281
-%281 = OpLabel
-%1295 = OpLoad %ulong %580
-%1296 = OpLoad %float %385
-%1297 = OpFunctionCall %ulong %6 %1295 %1296
-OpStore %583 %1297
-%1298 = OpLoad %ulong %583
-OpStore %584 %1298
-OpBranch %282
-%279 = OpLabel
-%1299 = OpLoad %ulong %580
-%1300 = OpFunctionCall %ulong %5 %1299 %uint_4294967295
-OpStore %582 %1300
-%1301 = OpLoad %ulong %582
-OpStore %584 %1301
-OpBranch %282
-%282 = OpLabel
-%1302 = OpLoad %float %406
-%1303 = OpLoad %float %355
-%1304 = OpFDiv %float %1302 %1303
-OpStore %386 %1304
-%1305 = OpLoad %float %386
-%1306 = OpConvertFToS %ulong %1305
-OpStore %387 %1306
-%1307 = OpLoad %ulong %387
-%1308 = OpConvertSToF %float %1307
-OpStore %388 %1308
-%1309 = OpLoad %float %388
-%1310 = OpLoad %float %355
-%1311 = OpFMul %float %1309 %1310
-OpStore %389 %1311
-%1312 = OpLoad %float %406
-%1313 = OpLoad %float %389
-%1314 = OpFSub %float %1312 %1313
-OpStore %390 %1314
-OpBranch %283
-%283 = OpLabel
-%1315 = OpLoad %float %390
-%1316 = OpLoad %float %390
-%1317 = OpFUnordNotEqual %bool %1315 %1316
-OpStore %585 %1317
-%1318 = OpLoad %bool %585
-OpSelectionMerge %287 None
-OpBranchConditional %1318 %284 %285
-%285 = OpLabel
-OpBranch %286
-%286 = OpLabel
-%1319 = OpLoad %ulong %584
-%1320 = OpLoad %float %390
-%1321 = OpFunctionCall %ulong %6 %1319 %1320
-OpStore %587 %1321
-%1322 = OpLoad %ulong %587
-OpStore %588 %1322
-OpBranch %287
-%284 = OpLabel
-%1323 = OpLoad %ulong %584
-%1324 = OpFunctionCall %ulong %5 %1323 %uint_4294967295
-OpStore %586 %1324
-%1325 = OpLoad %ulong %586
-OpStore %588 %1325
-OpBranch %287
-%287 = OpLabel
-%1326 = OpLoad %float %355
-%1327 = OpLoad %float %355
-%1328 = OpFDiv %float %1326 %1327
-OpStore %391 %1328
-%1329 = OpLoad %float %391
-%1330 = OpConvertFToS %ulong %1329
-OpStore %392 %1330
-%1331 = OpLoad %ulong %392
-%1332 = OpConvertSToF %float %1331
-OpStore %393 %1332
-%1333 = OpLoad %float %393
-%1334 = OpLoad %float %355
-%1335 = OpFMul %float %1333 %1334
-OpStore %394 %1335
-%1336 = OpLoad %float %355
-%1337 = OpLoad %float %394
-%1338 = OpFSub %float %1336 %1337
-OpStore %395 %1338
-OpBranch %288
-%288 = OpLabel
-%1339 = OpLoad %float %395
-%1340 = OpLoad %float %395
-%1341 = OpFUnordNotEqual %bool %1339 %1340
-OpStore %589 %1341
-%1342 = OpLoad %bool %589
-OpSelectionMerge %292 None
-OpBranchConditional %1342 %289 %290
-%290 = OpLabel
-OpBranch %291
-%291 = OpLabel
-%1343 = OpLoad %ulong %588
-%1344 = OpLoad %float %395
-%1345 = OpFunctionCall %ulong %6 %1343 %1344
-OpStore %591 %1345
-%1346 = OpLoad %ulong %591
-OpStore %592 %1346
-OpBranch %292
-%289 = OpLabel
-%1347 = OpLoad %ulong %588
-%1348 = OpFunctionCall %ulong %5 %1347 %uint_4294967295
-OpStore %590 %1348
-%1349 = OpLoad %ulong %590
-OpStore %592 %1349
-OpBranch %292
-%292 = OpLabel
-%1351 = OpLoad %float %406
-%1352 = OpFMul %float %float_1048576 %1351
-OpStore %396 %1352
-%1353 = OpLoad %float %396
-%1354 = OpLoad %float %355
-%1355 = OpFDiv %float %1353 %1354
-OpStore %397 %1355
-%1356 = OpLoad %float %397
-%1357 = OpConvertFToS %ulong %1356
-OpStore %398 %1357
-%1358 = OpLoad %ulong %398
-%1359 = OpConvertSToF %float %1358
-OpStore %399 %1359
-%1360 = OpLoad %float %399
-%1361 = OpLoad %float %355
-%1362 = OpFMul %float %1360 %1361
-OpStore %400 %1362
-%1363 = OpLoad %float %396
-%1364 = OpLoad %float %400
-%1365 = OpFSub %float %1363 %1364
-OpStore %401 %1365
-OpBranch %293
-%293 = OpLabel
-%1366 = OpLoad %float %401
-%1367 = OpLoad %float %401
-%1368 = OpFUnordNotEqual %bool %1366 %1367
-OpStore %593 %1368
-%1369 = OpLoad %bool %593
-OpSelectionMerge %297 None
-OpBranchConditional %1369 %294 %295
-%295 = OpLabel
-OpBranch %296
-%296 = OpLabel
-%1370 = OpLoad %ulong %592
-%1371 = OpLoad %float %401
-%1372 = OpFunctionCall %ulong %6 %1370 %1371
-OpStore %595 %1372
-%1373 = OpLoad %ulong %595
-OpStore %596 %1373
-OpBranch %297
-%294 = OpLabel
-%1374 = OpLoad %ulong %592
-%1375 = OpFunctionCall %ulong %5 %1374 %uint_4294967295
-OpStore %594 %1375
-%1376 = OpLoad %ulong %594
-OpStore %596 %1376
-OpBranch %297
-%297 = OpLabel
-%1377 = OpLoad %ulong %596
-OpReturnValue %1377
-%58 = OpLabel
-%1378 = OpLoad %float %403
-%1379 = OpLoad %float %316
-%1380 = OpFAdd %float %1378 %1379
-OpStore %335 %1380
-%1381 = OpLoad %float %335
-%1382 = OpFMul %float %1381 %float_1_5
-OpStore %336 %1382
+OpBranch %314
+%314 = OpLabel
+%992 = OpLoad %float %728
+%993 = OpLoad %float %728
+%994 = OpFUnordNotEqual %bool %992 %993
+OpStore %765 %994
+%995 = OpLoad %bool %765
+OpSelectionMerge %318 None
+OpBranchConditional %995 %315 %316
+%316 = OpLabel
+OpBranch %317
+%317 = OpLabel
+%996 = OpLoad %ulong %718
+%997 = OpLoad %float %728
+%998 = OpFunctionCall %ulong %6 %996 %997
+OpStore %767 %998
+%999 = OpLoad %ulong %767
+OpStore %768 %999
+OpBranch %318
+%315 = OpLabel
+%1000 = OpLoad %ulong %718
+%1001 = OpFunctionCall %ulong %5 %1000 %uint_4294967295
+OpStore %766 %1001
+%1002 = OpLoad %ulong %766
+OpStore %768 %1002
+OpBranch %318
+%318 = OpLabel
+%1003 = OpLoad %float %728
+%1005 = OpFDiv %float %1003 %float_2
+OpStore %434 %1005
+OpBranch %324
+%324 = OpLabel
+%1006 = OpLoad %float %434
+%1007 = OpLoad %float %434
+%1008 = OpFUnordNotEqual %bool %1006 %1007
+OpStore %773 %1008
+%1009 = OpLoad %bool %773
+OpSelectionMerge %328 None
+OpBranchConditional %1009 %325 %326
+%326 = OpLabel
+OpBranch %327
+%327 = OpLabel
+%1010 = OpLoad %ulong %768
+%1011 = OpLoad %float %434
+%1012 = OpFunctionCall %ulong %6 %1010 %1011
+OpStore %775 %1012
+%1013 = OpLoad %ulong %775
+OpStore %776 %1013
+OpBranch %328
+%325 = OpLabel
+%1014 = OpLoad %ulong %768
+%1015 = OpFunctionCall %ulong %5 %1014 %uint_4294967295
+OpStore %774 %1015
+%1016 = OpLoad %ulong %774
+OpStore %776 %1016
+OpBranch %328
+%328 = OpLabel
+%1017 = OpLoad %float %728
+%1018 = OpLoad %float %728
+%1019 = OpFAdd %float %1017 %1018
+OpStore %435 %1019
+OpBranch %334
+%334 = OpLabel
+%1020 = OpLoad %float %435
+%1021 = OpLoad %float %435
+%1022 = OpFUnordNotEqual %bool %1020 %1021
+OpStore %781 %1022
+%1023 = OpLoad %bool %781
+OpSelectionMerge %338 None
+OpBranchConditional %1023 %335 %336
+%336 = OpLabel
+OpBranch %337
+%337 = OpLabel
+%1024 = OpLoad %ulong %776
+%1025 = OpLoad %float %435
+%1026 = OpFunctionCall %ulong %6 %1024 %1025
+OpStore %783 %1026
+%1027 = OpLoad %ulong %783
+OpStore %784 %1027
+OpBranch %338
+%335 = OpLabel
+%1028 = OpLoad %ulong %776
+%1029 = OpFunctionCall %ulong %5 %1028 %uint_4294967295
+OpStore %782 %1029
+%1030 = OpLoad %ulong %782
+OpStore %784 %1030
+OpBranch %338
+%338 = OpLabel
+%1031 = OpLoad %float %728
+%1032 = OpFMul %float %1031 %float_2
+OpStore %436 %1032
+%1033 = OpLoad %ulong %784
+%1034 = OpLoad %float %436
+%1035 = OpFunctionCall %ulong %2 %1033 %1034
+OpStore %437 %1035
+%1036 = OpLoad %float %436
+%1037 = OpFSub %float %float_0 %1036
+OpStore %438 %1037
+%1038 = OpLoad %ulong %437
+%1039 = OpLoad %float %438
+%1040 = OpFunctionCall %ulong %2 %1038 %1039
+OpStore %439 %1040
+%1041 = OpLoad %float %728
+%1042 = OpLoad %float %728
+%1043 = OpFMul %float %1041 %1042
+OpStore %440 %1043
+%1044 = OpLoad %ulong %439
+%1045 = OpLoad %float %440
+%1046 = OpFunctionCall %ulong %2 %1044 %1045
+OpStore %441 %1046
+%1047 = OpLoad %float %728
+%1048 = OpLoad %float %728
+%1049 = OpFSub %float %1047 %1048
+OpStore %442 %1049
+%1050 = OpLoad %ulong %441
+%1051 = OpLoad %float %442
+%1052 = OpFunctionCall %ulong %2 %1050 %1051
+OpStore %443 %1052
+OpBranch %344
+%344 = OpLabel
+%1054 = OpLoad %uint %383
+%1055 = OpIAdd %uint %uint_8388608 %1054
+OpStore %789 %1055
+%1056 = OpLoad %uint %789
+%1057 = OpBitcast %float %1056
+OpStore %790 %1057
+OpBranch %345
+%345 = OpLabel
+OpBranch %346
+%346 = OpLabel
+%1059 = OpLoad %uint %383
+%1060 = OpIAdd %uint %uint_1 %1059
+OpStore %791 %1060
+%1061 = OpLoad %uint %791
+%1062 = OpBitcast %float %1061
+OpStore %792 %1062
+OpBranch %347
+%347 = OpLabel
+%1063 = OpLoad %float %790
+%1065 = OpFMul %float %1063 %float_0_5
+OpStore %444 %1065
+%1066 = OpLoad %ulong %443
+%1067 = OpLoad %float %444
+%1068 = OpFunctionCall %ulong %2 %1066 %1067
+OpStore %445 %1068
+%1069 = OpLoad %float %790
+%1070 = OpFDiv %float %1069 %float_2
+OpStore %446 %1070
+%1071 = OpLoad %ulong %445
+%1072 = OpLoad %float %446
+%1073 = OpFunctionCall %ulong %2 %1071 %1072
+OpStore %447 %1073
+%1074 = OpLoad %float %790
+%1075 = OpLoad %float %792
+%1076 = OpFSub %float %1074 %1075
+OpStore %448 %1076
+%1077 = OpLoad %ulong %447
+%1078 = OpLoad %float %448
+%1079 = OpFunctionCall %ulong %2 %1077 %1078
+OpStore %449 %1079
+%1080 = OpLoad %float %790
+%1081 = OpLoad %float %722
+%1082 = OpFMul %float %1080 %1081
+OpStore %450 %1082
+%1083 = OpLoad %ulong %449
+%1084 = OpLoad %float %450
+%1085 = OpFunctionCall %ulong %2 %1083 %1084
+OpStore %451 %1085
+%1086 = OpLoad %float %792
+%1087 = OpLoad %float %792
+%1088 = OpFAdd %float %1086 %1087
+OpStore %452 %1088
+%1089 = OpLoad %ulong %451
+%1090 = OpLoad %float %452
+%1091 = OpFunctionCall %ulong %2 %1089 %1090
+OpStore %453 %1091
+%1092 = OpLoad %float %792
+%1093 = OpFMul %float %1092 %float_0_5
+OpStore %454 %1093
+%1094 = OpLoad %ulong %453
+%1095 = OpLoad %float %454
+%1096 = OpFunctionCall %ulong %2 %1094 %1095
+OpStore %455 %1096
+%1097 = OpLoad %float %792
+%1099 = OpFMul %float %1097 %float_0_75
+OpStore %456 %1099
+%1100 = OpLoad %ulong %455
+%1101 = OpLoad %float %456
+%1102 = OpFunctionCall %ulong %2 %1100 %1101
+OpStore %457 %1102
+%1103 = OpLoad %float %792
+%1104 = OpFMul %float %1103 %float_16777216
+OpStore %458 %1104
+%1105 = OpLoad %ulong %457
+%1106 = OpLoad %float %458
+%1107 = OpFunctionCall %ulong %2 %1105 %1106
+OpStore %459 %1107
+%1108 = OpLoad %float %792
+%1109 = OpLoad %float %790
+%1110 = OpFDiv %float %1108 %1109
+OpStore %460 %1110
+%1111 = OpLoad %ulong %459
+%1112 = OpLoad %float %460
+%1113 = OpFunctionCall %ulong %2 %1111 %1112
+OpStore %461 %1113
+%1115 = OpLoad %float %722
+%1116 = OpFMul %float %float_5_5 %1115
+OpStore %462 %1116
+%1117 = OpLoad %float %722
+%1118 = OpFMul %float %float_3 %1117
+OpStore %463 %1118
+%1119 = OpLoad %float %463
+%1120 = OpFOrdEqual %bool %1119 %float_0
+OpStore %464 %1120
+%1121 = OpLoad %bool %464
+OpSelectionMerge %63 None
+OpBranchConditional %1121 %349 %60
+%60 = OpLabel
+%1122 = OpLoad %float %462
+%1123 = OpFMul %float %1122 %float_2
+OpStore %465 %1123
+%1124 = OpLoad %float %462
+%1125 = OpLoad %float %465
+%1126 = OpFOrdEqual %bool %1124 %1125
+OpStore %466 %1126
+%1127 = OpLoad %bool %466
+OpSelectionMerge %62 None
+OpBranchConditional %1127 %61 %348
+%348 = OpLabel
+%1128 = OpLoad %bool %466
+OpStore %468 %1128
+OpBranch %62
+%61 = OpLabel
+%1129 = OpLoad %float %462
+%1130 = OpFUnordNotEqual %bool %1129 %float_0
+OpStore %467 %1130
+%1131 = OpLoad %bool %467
+OpStore %468 %1131
 OpBranch %62
 %62 = OpLabel
-%1383 = OpLoad %float %336
-%1384 = OpLoad %float %336
-%1385 = OpFUnordNotEqual %bool %1383 %1384
-OpStore %407 %1385
-%1386 = OpLoad %bool %407
-OpSelectionMerge %66 None
-OpBranchConditional %1386 %63 %64
-%64 = OpLabel
-OpBranch %65
-%65 = OpLabel
-%1387 = OpLoad %ulong %402
-%1388 = OpLoad %float %336
-%1389 = OpFunctionCall %ulong %6 %1387 %1388
-OpStore %409 %1389
-%1390 = OpLoad %ulong %409
-OpStore %410 %1390
-OpBranch %66
+%1132 = OpLoad %bool %468
+OpStore %469 %1132
+OpBranch %63
+%349 = OpLabel
+%1133 = OpLoad %bool %464
+OpStore %469 %1133
+OpBranch %63
 %63 = OpLabel
-%1391 = OpLoad %ulong %402
-%1392 = OpFunctionCall %ulong %5 %1391 %uint_4294967295
-OpStore %408 %1392
-%1393 = OpLoad %ulong %408
-OpStore %410 %1393
+%1134 = OpLoad %bool %469
+OpSelectionMerge %66 None
+OpBranchConditional %1134 %64 %65
+%65 = OpLabel
+%1135 = OpLoad %float %462
+%1136 = OpFOrdLessThan %bool %1135 %float_0
+OpStore %475 %1136
+%1137 = OpLoad %bool %475
+OpSelectionMerge %69 None
+OpBranchConditional %1137 %67 %68
+%68 = OpLabel
+%1138 = OpLoad %float %462
+OpStore %477 %1138
+OpBranch %69
+%67 = OpLabel
+%1139 = OpLoad %float %462
+%1140 = OpFSub %float %float_0 %1139
+OpStore %476 %1140
+%1141 = OpLoad %float %476
+OpStore %477 %1141
+OpBranch %69
+%69 = OpLabel
+%1142 = OpLoad %float %463
+%1143 = OpFOrdLessThan %bool %1142 %float_0
+OpStore %478 %1143
+%1144 = OpLoad %bool %478
+OpSelectionMerge %72 None
+OpBranchConditional %1144 %70 %71
+%71 = OpLabel
+%1145 = OpLoad %float %463
+OpStore %480 %1145
+OpBranch %72
+%70 = OpLabel
+%1146 = OpLoad %float %463
+%1147 = OpFSub %float %float_0 %1146
+OpStore %479 %1147
+%1148 = OpLoad %float %479
+OpStore %480 %1148
+OpBranch %72
+%72 = OpLabel
+%1149 = OpLoad %float %477
+%1150 = OpFDiv %float %1149 %float_2
+OpStore %481 %1150
+%1151 = OpLoad %float %480
+OpStore %482 %1151
+OpBranch %73
+%73 = OpLabel
+%1152 = OpLoad %float %482
+%1153 = OpLoad %float %481
+%1154 = OpFOrdLessThanEqual %bool %1152 %1153
+OpStore %483 %1154
+%1155 = OpLoad %bool %483
+OpLoopMerge %75 %379 None
+OpBranchConditional %1155 %74 %75
+%75 = OpLabel
+%1156 = OpLoad %float %477
+OpStore %485 %1156
+%1157 = OpLoad %float %482
+OpStore %486 %1157
+OpBranch %76
+%76 = OpLabel
+%1158 = OpLoad %float %480
+%1159 = OpLoad %float %486
+%1160 = OpFOrdLessThanEqual %bool %1158 %1159
+OpStore %487 %1160
+%1161 = OpLoad %bool %487
+OpLoopMerge %80 %378 None
+OpBranchConditional %1161 %81 %80
+%80 = OpLabel
+%1162 = OpLoad %bool %475
+OpSelectionMerge %84 None
+OpBranchConditional %1162 %82 %83
+%83 = OpLabel
+%1163 = OpLoad %float %485
+OpStore %493 %1163
+OpBranch %84
+%82 = OpLabel
+%1164 = OpLoad %float %485
+%1165 = OpFSub %float %float_0 %1164
+OpStore %492 %1165
+%1166 = OpLoad %float %492
+OpStore %493 %1166
+OpBranch %84
+%84 = OpLabel
+%1167 = OpLoad %float %493
+OpStore %494 %1167
+OpBranch %66
+%81 = OpLabel
+%1168 = OpLoad %float %486
+%1169 = OpLoad %float %485
+%1170 = OpFOrdLessThanEqual %bool %1168 %1169
+OpStore %488 %1170
+%1171 = OpLoad %bool %488
+OpSelectionMerge %79 None
+OpBranchConditional %1171 %77 %78
+%78 = OpLabel
+%1172 = OpLoad %float %485
+OpStore %490 %1172
+OpBranch %79
+%77 = OpLabel
+%1173 = OpLoad %float %485
+%1174 = OpLoad %float %486
+%1175 = OpFSub %float %1173 %1174
+OpStore %489 %1175
+%1176 = OpLoad %float %489
+OpStore %490 %1176
+OpBranch %79
+%79 = OpLabel
+%1177 = OpLoad %float %486
+%1178 = OpFDiv %float %1177 %float_2
+OpStore %491 %1178
+%1179 = OpLoad %float %490
+OpStore %485 %1179
+%1180 = OpLoad %float %491
+OpStore %486 %1180
+OpBranch %378
+%74 = OpLabel
+%1181 = OpLoad %float %482
+%1182 = OpFMul %float %1181 %float_2
+OpStore %484 %1182
+%1183 = OpLoad %float %484
+OpStore %482 %1183
+OpBranch %379
+%64 = OpLabel
+%1184 = OpLoad %float %462
+%1185 = OpLoad %float %463
+%1186 = OpFDiv %float %1184 %1185
+OpStore %470 %1186
+%1187 = OpLoad %float %470
+%1188 = OpConvertFToS %ulong %1187
+OpStore %471 %1188
+%1189 = OpLoad %ulong %471
+%1190 = OpConvertSToF %float %1189
+OpStore %472 %1190
+%1191 = OpLoad %float %472
+%1192 = OpLoad %float %463
+%1193 = OpFMul %float %1191 %1192
+OpStore %473 %1193
+%1194 = OpLoad %float %462
+%1195 = OpLoad %float %473
+%1196 = OpFSub %float %1194 %1195
+OpStore %474 %1196
+%1197 = OpLoad %float %474
+OpStore %494 %1197
 OpBranch %66
 %66 = OpLabel
-%1394 = OpLoad %uint %404
-%1395 = OpIAdd %uint %1394 %uint_1
-OpStore %337 %1395
-%1396 = OpLoad %ulong %410
-OpStore %402 %1396
-%1397 = OpLoad %float %336
-OpStore %403 %1397
-%1398 = OpLoad %uint %337
-OpStore %404 %1398
+OpBranch %269
+%269 = OpLabel
+%1198 = OpLoad %float %494
+%1199 = OpLoad %float %494
+%1200 = OpFUnordNotEqual %bool %1198 %1199
+OpStore %729 %1200
+%1201 = OpLoad %bool %729
+OpSelectionMerge %273 None
+OpBranchConditional %1201 %270 %271
+%271 = OpLabel
+OpBranch %272
+%272 = OpLabel
+%1202 = OpLoad %ulong %461
+%1203 = OpLoad %float %494
+%1204 = OpFunctionCall %ulong %6 %1202 %1203
+OpStore %731 %1204
+%1205 = OpLoad %ulong %731
+OpStore %732 %1205
+OpBranch %273
+%270 = OpLabel
+%1206 = OpLoad %ulong %461
+%1207 = OpFunctionCall %ulong %5 %1206 %uint_4294967295
+OpStore %730 %1207
+%1208 = OpLoad %ulong %730
+OpStore %732 %1208
+OpBranch %273
+%273 = OpLabel
+%1209 = OpLoad %float %462
+%1210 = OpFSub %float %float_0 %1209
+OpStore %495 %1210
+%1211 = OpLoad %float %463
+%1212 = OpFOrdEqual %bool %1211 %float_0
+OpStore %496 %1212
+%1213 = OpLoad %bool %496
+OpSelectionMerge %88 None
+OpBranchConditional %1213 %351 %85
+%85 = OpLabel
+%1214 = OpLoad %float %495
+%1215 = OpFMul %float %1214 %float_2
+OpStore %497 %1215
+%1216 = OpLoad %float %495
+%1217 = OpLoad %float %497
+%1218 = OpFOrdEqual %bool %1216 %1217
+OpStore %498 %1218
+%1219 = OpLoad %bool %498
+OpSelectionMerge %87 None
+OpBranchConditional %1219 %86 %350
+%350 = OpLabel
+%1220 = OpLoad %bool %498
+OpStore %500 %1220
+OpBranch %87
+%86 = OpLabel
+%1221 = OpLoad %float %495
+%1222 = OpFUnordNotEqual %bool %1221 %float_0
+OpStore %499 %1222
+%1223 = OpLoad %bool %499
+OpStore %500 %1223
+OpBranch %87
+%87 = OpLabel
+%1224 = OpLoad %bool %500
+OpStore %501 %1224
+OpBranch %88
+%351 = OpLabel
+%1225 = OpLoad %bool %496
+OpStore %501 %1225
+OpBranch %88
+%88 = OpLabel
+%1226 = OpLoad %bool %501
+OpSelectionMerge %91 None
+OpBranchConditional %1226 %89 %90
+%90 = OpLabel
+%1227 = OpLoad %float %495
+%1228 = OpFOrdLessThan %bool %1227 %float_0
+OpStore %507 %1228
+%1229 = OpLoad %bool %507
+OpSelectionMerge %94 None
+OpBranchConditional %1229 %92 %93
+%93 = OpLabel
+%1230 = OpLoad %float %495
+OpStore %509 %1230
+OpBranch %94
+%92 = OpLabel
+%1231 = OpLoad %float %495
+%1232 = OpFSub %float %float_0 %1231
+OpStore %508 %1232
+%1233 = OpLoad %float %508
+OpStore %509 %1233
+OpBranch %94
+%94 = OpLabel
+%1234 = OpLoad %float %463
+%1235 = OpFOrdLessThan %bool %1234 %float_0
+OpStore %510 %1235
+%1236 = OpLoad %bool %510
+OpSelectionMerge %97 None
+OpBranchConditional %1236 %95 %96
+%96 = OpLabel
+%1237 = OpLoad %float %463
+OpStore %512 %1237
+OpBranch %97
+%95 = OpLabel
+%1238 = OpLoad %float %463
+%1239 = OpFSub %float %float_0 %1238
+OpStore %511 %1239
+%1240 = OpLoad %float %511
+OpStore %512 %1240
+OpBranch %97
+%97 = OpLabel
+%1241 = OpLoad %float %509
+%1242 = OpFDiv %float %1241 %float_2
+OpStore %513 %1242
+%1243 = OpLoad %float %512
+OpStore %514 %1243
+OpBranch %98
+%98 = OpLabel
+%1244 = OpLoad %float %514
+%1245 = OpLoad %float %513
+%1246 = OpFOrdLessThanEqual %bool %1244 %1245
+OpStore %515 %1246
+%1247 = OpLoad %bool %515
+OpLoopMerge %100 %377 None
+OpBranchConditional %1247 %99 %100
+%100 = OpLabel
+%1248 = OpLoad %float %509
+OpStore %517 %1248
+%1249 = OpLoad %float %514
+OpStore %518 %1249
+OpBranch %101
+%101 = OpLabel
+%1250 = OpLoad %float %512
+%1251 = OpLoad %float %518
+%1252 = OpFOrdLessThanEqual %bool %1250 %1251
+OpStore %519 %1252
+%1253 = OpLoad %bool %519
+OpLoopMerge %105 %376 None
+OpBranchConditional %1253 %106 %105
+%105 = OpLabel
+%1254 = OpLoad %bool %507
+OpSelectionMerge %109 None
+OpBranchConditional %1254 %107 %108
+%108 = OpLabel
+%1255 = OpLoad %float %517
+OpStore %525 %1255
+OpBranch %109
+%107 = OpLabel
+%1256 = OpLoad %float %517
+%1257 = OpFSub %float %float_0 %1256
+OpStore %524 %1257
+%1258 = OpLoad %float %524
+OpStore %525 %1258
+OpBranch %109
+%109 = OpLabel
+%1259 = OpLoad %float %525
+OpStore %526 %1259
+OpBranch %91
+%106 = OpLabel
+%1260 = OpLoad %float %518
+%1261 = OpLoad %float %517
+%1262 = OpFOrdLessThanEqual %bool %1260 %1261
+OpStore %520 %1262
+%1263 = OpLoad %bool %520
+OpSelectionMerge %104 None
+OpBranchConditional %1263 %102 %103
+%103 = OpLabel
+%1264 = OpLoad %float %517
+OpStore %522 %1264
+OpBranch %104
+%102 = OpLabel
+%1265 = OpLoad %float %517
+%1266 = OpLoad %float %518
+%1267 = OpFSub %float %1265 %1266
+OpStore %521 %1267
+%1268 = OpLoad %float %521
+OpStore %522 %1268
+OpBranch %104
+%104 = OpLabel
+%1269 = OpLoad %float %518
+%1270 = OpFDiv %float %1269 %float_2
+OpStore %523 %1270
+%1271 = OpLoad %float %522
+OpStore %517 %1271
+%1272 = OpLoad %float %523
+OpStore %518 %1272
+OpBranch %376
+%99 = OpLabel
+%1273 = OpLoad %float %514
+%1274 = OpFMul %float %1273 %float_2
+OpStore %516 %1274
+%1275 = OpLoad %float %516
+OpStore %514 %1275
+OpBranch %377
+%89 = OpLabel
+%1276 = OpLoad %float %495
+%1277 = OpLoad %float %463
+%1278 = OpFDiv %float %1276 %1277
+OpStore %502 %1278
+%1279 = OpLoad %float %502
+%1280 = OpConvertFToS %ulong %1279
+OpStore %503 %1280
+%1281 = OpLoad %ulong %503
+%1282 = OpConvertSToF %float %1281
+OpStore %504 %1282
+%1283 = OpLoad %float %504
+%1284 = OpLoad %float %463
+%1285 = OpFMul %float %1283 %1284
+OpStore %505 %1285
+%1286 = OpLoad %float %495
+%1287 = OpLoad %float %505
+%1288 = OpFSub %float %1286 %1287
+OpStore %506 %1288
+%1289 = OpLoad %float %506
+OpStore %526 %1289
+OpBranch %91
+%91 = OpLabel
+OpBranch %274
+%274 = OpLabel
+%1290 = OpLoad %float %526
+%1291 = OpLoad %float %526
+%1292 = OpFUnordNotEqual %bool %1290 %1291
+OpStore %733 %1292
+%1293 = OpLoad %bool %733
+OpSelectionMerge %278 None
+OpBranchConditional %1293 %275 %276
+%276 = OpLabel
+OpBranch %277
+%277 = OpLabel
+%1294 = OpLoad %ulong %732
+%1295 = OpLoad %float %526
+%1296 = OpFunctionCall %ulong %6 %1294 %1295
+OpStore %735 %1296
+%1297 = OpLoad %ulong %735
+OpStore %736 %1297
+OpBranch %278
+%275 = OpLabel
+%1298 = OpLoad %ulong %732
+%1299 = OpFunctionCall %ulong %5 %1298 %uint_4294967295
+OpStore %734 %1299
+%1300 = OpLoad %ulong %734
+OpStore %736 %1300
+OpBranch %278
+%278 = OpLabel
+%1301 = OpLoad %float %463
+%1302 = OpFSub %float %float_0 %1301
+OpStore %527 %1302
+%1303 = OpLoad %float %527
+%1304 = OpFOrdEqual %bool %1303 %float_0
+OpStore %528 %1304
+%1305 = OpLoad %bool %528
+OpSelectionMerge %113 None
+OpBranchConditional %1305 %353 %110
+%110 = OpLabel
+%1306 = OpLoad %float %462
+%1307 = OpFMul %float %1306 %float_2
+OpStore %529 %1307
+%1308 = OpLoad %float %462
+%1309 = OpLoad %float %529
+%1310 = OpFOrdEqual %bool %1308 %1309
+OpStore %530 %1310
+%1311 = OpLoad %bool %530
+OpSelectionMerge %112 None
+OpBranchConditional %1311 %111 %352
+%352 = OpLabel
+%1312 = OpLoad %bool %530
+OpStore %532 %1312
+OpBranch %112
+%111 = OpLabel
+%1313 = OpLoad %float %462
+%1314 = OpFUnordNotEqual %bool %1313 %float_0
+OpStore %531 %1314
+%1315 = OpLoad %bool %531
+OpStore %532 %1315
+OpBranch %112
+%112 = OpLabel
+%1316 = OpLoad %bool %532
+OpStore %533 %1316
+OpBranch %113
+%353 = OpLabel
+%1317 = OpLoad %bool %528
+OpStore %533 %1317
+OpBranch %113
+%113 = OpLabel
+%1318 = OpLoad %bool %533
+OpSelectionMerge %116 None
+OpBranchConditional %1318 %114 %115
+%115 = OpLabel
+%1319 = OpLoad %float %462
+%1320 = OpFOrdLessThan %bool %1319 %float_0
+OpStore %539 %1320
+%1321 = OpLoad %bool %539
+OpSelectionMerge %119 None
+OpBranchConditional %1321 %117 %118
+%118 = OpLabel
+%1322 = OpLoad %float %462
+OpStore %541 %1322
+OpBranch %119
+%117 = OpLabel
+%1323 = OpLoad %float %462
+%1324 = OpFSub %float %float_0 %1323
+OpStore %540 %1324
+%1325 = OpLoad %float %540
+OpStore %541 %1325
+OpBranch %119
+%119 = OpLabel
+%1326 = OpLoad %float %527
+%1327 = OpFOrdLessThan %bool %1326 %float_0
+OpStore %542 %1327
+%1328 = OpLoad %bool %542
+OpSelectionMerge %122 None
+OpBranchConditional %1328 %120 %121
+%121 = OpLabel
+%1329 = OpLoad %float %527
+OpStore %544 %1329
+OpBranch %122
+%120 = OpLabel
+%1330 = OpLoad %float %527
+%1331 = OpFSub %float %float_0 %1330
+OpStore %543 %1331
+%1332 = OpLoad %float %543
+OpStore %544 %1332
+OpBranch %122
+%122 = OpLabel
+%1333 = OpLoad %float %541
+%1334 = OpFDiv %float %1333 %float_2
+OpStore %545 %1334
+%1335 = OpLoad %float %544
+OpStore %546 %1335
+OpBranch %123
+%123 = OpLabel
+%1336 = OpLoad %float %546
+%1337 = OpLoad %float %545
+%1338 = OpFOrdLessThanEqual %bool %1336 %1337
+OpStore %547 %1338
+%1339 = OpLoad %bool %547
+OpLoopMerge %125 %375 None
+OpBranchConditional %1339 %124 %125
+%125 = OpLabel
+%1340 = OpLoad %float %541
+OpStore %549 %1340
+%1341 = OpLoad %float %546
+OpStore %550 %1341
+OpBranch %126
+%126 = OpLabel
+%1342 = OpLoad %float %544
+%1343 = OpLoad %float %550
+%1344 = OpFOrdLessThanEqual %bool %1342 %1343
+OpStore %551 %1344
+%1345 = OpLoad %bool %551
+OpLoopMerge %130 %374 None
+OpBranchConditional %1345 %131 %130
+%130 = OpLabel
+%1346 = OpLoad %bool %539
+OpSelectionMerge %134 None
+OpBranchConditional %1346 %132 %133
+%133 = OpLabel
+%1347 = OpLoad %float %549
+OpStore %557 %1347
+OpBranch %134
+%132 = OpLabel
+%1348 = OpLoad %float %549
+%1349 = OpFSub %float %float_0 %1348
+OpStore %556 %1349
+%1350 = OpLoad %float %556
+OpStore %557 %1350
+OpBranch %134
+%134 = OpLabel
+%1351 = OpLoad %float %557
+OpStore %558 %1351
+OpBranch %116
+%131 = OpLabel
+%1352 = OpLoad %float %550
+%1353 = OpLoad %float %549
+%1354 = OpFOrdLessThanEqual %bool %1352 %1353
+OpStore %552 %1354
+%1355 = OpLoad %bool %552
+OpSelectionMerge %129 None
+OpBranchConditional %1355 %127 %128
+%128 = OpLabel
+%1356 = OpLoad %float %549
+OpStore %554 %1356
+OpBranch %129
+%127 = OpLabel
+%1357 = OpLoad %float %549
+%1358 = OpLoad %float %550
+%1359 = OpFSub %float %1357 %1358
+OpStore %553 %1359
+%1360 = OpLoad %float %553
+OpStore %554 %1360
+OpBranch %129
+%129 = OpLabel
+%1361 = OpLoad %float %550
+%1362 = OpFDiv %float %1361 %float_2
+OpStore %555 %1362
+%1363 = OpLoad %float %554
+OpStore %549 %1363
+%1364 = OpLoad %float %555
+OpStore %550 %1364
+OpBranch %374
+%124 = OpLabel
+%1365 = OpLoad %float %546
+%1366 = OpFMul %float %1365 %float_2
+OpStore %548 %1366
+%1367 = OpLoad %float %548
+OpStore %546 %1367
+OpBranch %375
+%114 = OpLabel
+%1368 = OpLoad %float %462
+%1369 = OpLoad %float %527
+%1370 = OpFDiv %float %1368 %1369
+OpStore %534 %1370
+%1371 = OpLoad %float %534
+%1372 = OpConvertFToS %ulong %1371
+OpStore %535 %1372
+%1373 = OpLoad %ulong %535
+%1374 = OpConvertSToF %float %1373
+OpStore %536 %1374
+%1375 = OpLoad %float %536
+%1376 = OpLoad %float %527
+%1377 = OpFMul %float %1375 %1376
+OpStore %537 %1377
+%1378 = OpLoad %float %462
+%1379 = OpLoad %float %537
+%1380 = OpFSub %float %1378 %1379
+OpStore %538 %1380
+%1381 = OpLoad %float %538
+OpStore %558 %1381
+OpBranch %116
+%116 = OpLabel
+OpBranch %279
+%279 = OpLabel
+%1382 = OpLoad %float %558
+%1383 = OpLoad %float %558
+%1384 = OpFUnordNotEqual %bool %1382 %1383
+OpStore %737 %1384
+%1385 = OpLoad %bool %737
+OpSelectionMerge %283 None
+OpBranchConditional %1385 %280 %281
+%281 = OpLabel
+OpBranch %282
+%282 = OpLabel
+%1386 = OpLoad %ulong %736
+%1387 = OpLoad %float %558
+%1388 = OpFunctionCall %ulong %6 %1386 %1387
+OpStore %739 %1388
+%1389 = OpLoad %ulong %739
+OpStore %740 %1389
+OpBranch %283
+%280 = OpLabel
+%1390 = OpLoad %ulong %736
+%1391 = OpFunctionCall %ulong %5 %1390 %uint_4294967295
+OpStore %738 %1391
+%1392 = OpLoad %ulong %738
+OpStore %740 %1392
+OpBranch %283
+%283 = OpLabel
+%1393 = OpLoad %float %462
+%1394 = OpFSub %float %float_0 %1393
+OpStore %559 %1394
+%1395 = OpLoad %float %463
+%1396 = OpFSub %float %float_0 %1395
+OpStore %560 %1396
+%1397 = OpLoad %float %560
+%1398 = OpFOrdEqual %bool %1397 %float_0
+OpStore %561 %1398
+%1399 = OpLoad %bool %561
+OpSelectionMerge %138 None
+OpBranchConditional %1399 %355 %135
+%135 = OpLabel
+%1400 = OpLoad %float %559
+%1401 = OpFMul %float %1400 %float_2
+OpStore %562 %1401
+%1402 = OpLoad %float %559
+%1403 = OpLoad %float %562
+%1404 = OpFOrdEqual %bool %1402 %1403
+OpStore %563 %1404
+%1405 = OpLoad %bool %563
+OpSelectionMerge %137 None
+OpBranchConditional %1405 %136 %354
+%354 = OpLabel
+%1406 = OpLoad %bool %563
+OpStore %565 %1406
+OpBranch %137
+%136 = OpLabel
+%1407 = OpLoad %float %559
+%1408 = OpFUnordNotEqual %bool %1407 %float_0
+OpStore %564 %1408
+%1409 = OpLoad %bool %564
+OpStore %565 %1409
+OpBranch %137
+%137 = OpLabel
+%1410 = OpLoad %bool %565
+OpStore %566 %1410
+OpBranch %138
+%355 = OpLabel
+%1411 = OpLoad %bool %561
+OpStore %566 %1411
+OpBranch %138
+%138 = OpLabel
+%1412 = OpLoad %bool %566
+OpSelectionMerge %141 None
+OpBranchConditional %1412 %139 %140
+%140 = OpLabel
+%1413 = OpLoad %float %559
+%1414 = OpFOrdLessThan %bool %1413 %float_0
+OpStore %572 %1414
+%1415 = OpLoad %bool %572
+OpSelectionMerge %144 None
+OpBranchConditional %1415 %142 %143
+%143 = OpLabel
+%1416 = OpLoad %float %559
+OpStore %574 %1416
+OpBranch %144
+%142 = OpLabel
+%1417 = OpLoad %float %559
+%1418 = OpFSub %float %float_0 %1417
+OpStore %573 %1418
+%1419 = OpLoad %float %573
+OpStore %574 %1419
+OpBranch %144
+%144 = OpLabel
+%1420 = OpLoad %float %560
+%1421 = OpFOrdLessThan %bool %1420 %float_0
+OpStore %575 %1421
+%1422 = OpLoad %bool %575
+OpSelectionMerge %147 None
+OpBranchConditional %1422 %145 %146
+%146 = OpLabel
+%1423 = OpLoad %float %560
+OpStore %577 %1423
+OpBranch %147
+%145 = OpLabel
+%1424 = OpLoad %float %560
+%1425 = OpFSub %float %float_0 %1424
+OpStore %576 %1425
+%1426 = OpLoad %float %576
+OpStore %577 %1426
+OpBranch %147
+%147 = OpLabel
+%1427 = OpLoad %float %574
+%1428 = OpFDiv %float %1427 %float_2
+OpStore %578 %1428
+%1429 = OpLoad %float %577
+OpStore %579 %1429
+OpBranch %148
+%148 = OpLabel
+%1430 = OpLoad %float %579
+%1431 = OpLoad %float %578
+%1432 = OpFOrdLessThanEqual %bool %1430 %1431
+OpStore %580 %1432
+%1433 = OpLoad %bool %580
+OpLoopMerge %150 %373 None
+OpBranchConditional %1433 %149 %150
+%150 = OpLabel
+%1434 = OpLoad %float %574
+OpStore %582 %1434
+%1435 = OpLoad %float %579
+OpStore %583 %1435
+OpBranch %151
+%151 = OpLabel
+%1436 = OpLoad %float %577
+%1437 = OpLoad %float %583
+%1438 = OpFOrdLessThanEqual %bool %1436 %1437
+OpStore %584 %1438
+%1439 = OpLoad %bool %584
+OpLoopMerge %155 %372 None
+OpBranchConditional %1439 %156 %155
+%155 = OpLabel
+%1440 = OpLoad %bool %572
+OpSelectionMerge %159 None
+OpBranchConditional %1440 %157 %158
+%158 = OpLabel
+%1441 = OpLoad %float %582
+OpStore %590 %1441
+OpBranch %159
+%157 = OpLabel
+%1442 = OpLoad %float %582
+%1443 = OpFSub %float %float_0 %1442
+OpStore %589 %1443
+%1444 = OpLoad %float %589
+OpStore %590 %1444
+OpBranch %159
+%159 = OpLabel
+%1445 = OpLoad %float %590
+OpStore %591 %1445
+OpBranch %141
+%156 = OpLabel
+%1446 = OpLoad %float %583
+%1447 = OpLoad %float %582
+%1448 = OpFOrdLessThanEqual %bool %1446 %1447
+OpStore %585 %1448
+%1449 = OpLoad %bool %585
+OpSelectionMerge %154 None
+OpBranchConditional %1449 %152 %153
+%153 = OpLabel
+%1450 = OpLoad %float %582
+OpStore %587 %1450
+OpBranch %154
+%152 = OpLabel
+%1451 = OpLoad %float %582
+%1452 = OpLoad %float %583
+%1453 = OpFSub %float %1451 %1452
+OpStore %586 %1453
+%1454 = OpLoad %float %586
+OpStore %587 %1454
+OpBranch %154
+%154 = OpLabel
+%1455 = OpLoad %float %583
+%1456 = OpFDiv %float %1455 %float_2
+OpStore %588 %1456
+%1457 = OpLoad %float %587
+OpStore %582 %1457
+%1458 = OpLoad %float %588
+OpStore %583 %1458
+OpBranch %372
+%149 = OpLabel
+%1459 = OpLoad %float %579
+%1460 = OpFMul %float %1459 %float_2
+OpStore %581 %1460
+%1461 = OpLoad %float %581
+OpStore %579 %1461
+OpBranch %373
+%139 = OpLabel
+%1462 = OpLoad %float %559
+%1463 = OpLoad %float %560
+%1464 = OpFDiv %float %1462 %1463
+OpStore %567 %1464
+%1465 = OpLoad %float %567
+%1466 = OpConvertFToS %ulong %1465
+OpStore %568 %1466
+%1467 = OpLoad %ulong %568
+%1468 = OpConvertSToF %float %1467
+OpStore %569 %1468
+%1469 = OpLoad %float %569
+%1470 = OpLoad %float %560
+%1471 = OpFMul %float %1469 %1470
+OpStore %570 %1471
+%1472 = OpLoad %float %559
+%1473 = OpLoad %float %570
+%1474 = OpFSub %float %1472 %1473
+OpStore %571 %1474
+%1475 = OpLoad %float %571
+OpStore %591 %1475
+OpBranch %141
+%141 = OpLabel
+OpBranch %284
+%284 = OpLabel
+%1476 = OpLoad %float %591
+%1477 = OpLoad %float %591
+%1478 = OpFUnordNotEqual %bool %1476 %1477
+OpStore %741 %1478
+%1479 = OpLoad %bool %741
+OpSelectionMerge %288 None
+OpBranchConditional %1479 %285 %286
+%286 = OpLabel
+OpBranch %287
+%287 = OpLabel
+%1480 = OpLoad %ulong %740
+%1481 = OpLoad %float %591
+%1482 = OpFunctionCall %ulong %6 %1480 %1481
+OpStore %743 %1482
+%1483 = OpLoad %ulong %743
+OpStore %744 %1483
+OpBranch %288
+%285 = OpLabel
+%1484 = OpLoad %ulong %740
+%1485 = OpFunctionCall %ulong %5 %1484 %uint_4294967295
+OpStore %742 %1485
+%1486 = OpLoad %ulong %742
+OpStore %744 %1486
+OpBranch %288
+%288 = OpLabel
+%1488 = OpLoad %float %722
+%1489 = OpFMul %float %float_7 %1488
+OpStore %592 %1489
+%1490 = OpFOrdEqual %bool %float_0_5 %float_0
+OpStore %593 %1490
+%1491 = OpLoad %bool %593
+OpSelectionMerge %163 None
+OpBranchConditional %1491 %357 %160
+%160 = OpLabel
+%1492 = OpLoad %float %592
+%1493 = OpFMul %float %1492 %float_2
+OpStore %594 %1493
+%1494 = OpLoad %float %592
+%1495 = OpLoad %float %594
+%1496 = OpFOrdEqual %bool %1494 %1495
+OpStore %595 %1496
+%1497 = OpLoad %bool %595
+OpSelectionMerge %162 None
+OpBranchConditional %1497 %161 %356
+%356 = OpLabel
+%1498 = OpLoad %bool %595
+OpStore %597 %1498
+OpBranch %162
+%161 = OpLabel
+%1499 = OpLoad %float %592
+%1500 = OpFUnordNotEqual %bool %1499 %float_0
+OpStore %596 %1500
+%1501 = OpLoad %bool %596
+OpStore %597 %1501
+OpBranch %162
+%162 = OpLabel
+%1502 = OpLoad %bool %597
+OpStore %598 %1502
+OpBranch %163
+%357 = OpLabel
+%1503 = OpLoad %bool %593
+OpStore %598 %1503
+OpBranch %163
+%163 = OpLabel
+%1504 = OpLoad %bool %598
+OpSelectionMerge %166 None
+OpBranchConditional %1504 %164 %165
+%165 = OpLabel
+%1505 = OpLoad %float %592
+%1506 = OpFOrdLessThan %bool %1505 %float_0
+OpStore %604 %1506
+%1507 = OpLoad %bool %604
+OpSelectionMerge %169 None
+OpBranchConditional %1507 %167 %168
+%168 = OpLabel
+%1508 = OpLoad %float %592
+OpStore %606 %1508
+OpBranch %169
+%167 = OpLabel
+%1509 = OpLoad %float %592
+%1510 = OpFSub %float %float_0 %1509
+OpStore %605 %1510
+%1511 = OpLoad %float %605
+OpStore %606 %1511
+OpBranch %169
+%169 = OpLabel
+%1512 = OpFOrdLessThan %bool %float_0_5 %float_0
+OpStore %607 %1512
+%1513 = OpLoad %bool %607
+OpSelectionMerge %172 None
+OpBranchConditional %1513 %170 %171
+%171 = OpLabel
+OpStore %609 %float_0_5
+OpBranch %172
+%170 = OpLabel
+%1514 = OpFSub %float %float_0 %float_0_5
+OpStore %608 %1514
+%1515 = OpLoad %float %608
+OpStore %609 %1515
+OpBranch %172
+%172 = OpLabel
+%1516 = OpLoad %float %606
+%1517 = OpFDiv %float %1516 %float_2
+OpStore %610 %1517
+%1518 = OpLoad %float %609
+OpStore %611 %1518
+OpBranch %173
+%173 = OpLabel
+%1519 = OpLoad %float %611
+%1520 = OpLoad %float %610
+%1521 = OpFOrdLessThanEqual %bool %1519 %1520
+OpStore %612 %1521
+%1522 = OpLoad %bool %612
+OpLoopMerge %175 %371 None
+OpBranchConditional %1522 %174 %175
+%175 = OpLabel
+%1523 = OpLoad %float %606
+OpStore %614 %1523
+%1524 = OpLoad %float %611
+OpStore %615 %1524
+OpBranch %176
+%176 = OpLabel
+%1525 = OpLoad %float %609
+%1526 = OpLoad %float %615
+%1527 = OpFOrdLessThanEqual %bool %1525 %1526
+OpStore %616 %1527
+%1528 = OpLoad %bool %616
+OpLoopMerge %180 %370 None
+OpBranchConditional %1528 %181 %180
+%180 = OpLabel
+%1529 = OpLoad %bool %604
+OpSelectionMerge %184 None
+OpBranchConditional %1529 %182 %183
+%183 = OpLabel
+%1530 = OpLoad %float %614
+OpStore %622 %1530
+OpBranch %184
+%182 = OpLabel
+%1531 = OpLoad %float %614
+%1532 = OpFSub %float %float_0 %1531
+OpStore %621 %1532
+%1533 = OpLoad %float %621
+OpStore %622 %1533
+OpBranch %184
+%184 = OpLabel
+%1534 = OpLoad %float %622
+OpStore %623 %1534
+OpBranch %166
+%181 = OpLabel
+%1535 = OpLoad %float %615
+%1536 = OpLoad %float %614
+%1537 = OpFOrdLessThanEqual %bool %1535 %1536
+OpStore %617 %1537
+%1538 = OpLoad %bool %617
+OpSelectionMerge %179 None
+OpBranchConditional %1538 %177 %178
+%178 = OpLabel
+%1539 = OpLoad %float %614
+OpStore %619 %1539
+OpBranch %179
+%177 = OpLabel
+%1540 = OpLoad %float %614
+%1541 = OpLoad %float %615
+%1542 = OpFSub %float %1540 %1541
+OpStore %618 %1542
+%1543 = OpLoad %float %618
+OpStore %619 %1543
+OpBranch %179
+%179 = OpLabel
+%1544 = OpLoad %float %615
+%1545 = OpFDiv %float %1544 %float_2
+OpStore %620 %1545
+%1546 = OpLoad %float %619
+OpStore %614 %1546
+%1547 = OpLoad %float %620
+OpStore %615 %1547
+OpBranch %370
+%174 = OpLabel
+%1548 = OpLoad %float %611
+%1549 = OpFMul %float %1548 %float_2
+OpStore %613 %1549
+%1550 = OpLoad %float %613
+OpStore %611 %1550
+OpBranch %371
+%164 = OpLabel
+%1551 = OpLoad %float %592
+%1552 = OpFDiv %float %1551 %float_0_5
+OpStore %599 %1552
+%1553 = OpLoad %float %599
+%1554 = OpConvertFToS %ulong %1553
+OpStore %600 %1554
+%1555 = OpLoad %ulong %600
+%1556 = OpConvertSToF %float %1555
+OpStore %601 %1556
+%1557 = OpLoad %float %601
+%1558 = OpFMul %float %1557 %float_0_5
+OpStore %602 %1558
+%1559 = OpLoad %float %592
+%1560 = OpLoad %float %602
+%1561 = OpFSub %float %1559 %1560
+OpStore %603 %1561
+%1562 = OpLoad %float %603
+OpStore %623 %1562
+OpBranch %166
+%166 = OpLabel
+OpBranch %289
+%289 = OpLabel
+%1563 = OpLoad %float %623
+%1564 = OpLoad %float %623
+%1565 = OpFUnordNotEqual %bool %1563 %1564
+OpStore %745 %1565
+%1566 = OpLoad %bool %745
+OpSelectionMerge %293 None
+OpBranchConditional %1566 %290 %291
+%291 = OpLabel
+OpBranch %292
+%292 = OpLabel
+%1567 = OpLoad %ulong %744
+%1568 = OpLoad %float %623
+%1569 = OpFunctionCall %ulong %6 %1567 %1568
+OpStore %747 %1569
+%1570 = OpLoad %ulong %747
+OpStore %748 %1570
+OpBranch %293
+%290 = OpLabel
+%1571 = OpLoad %ulong %744
+%1572 = OpFunctionCall %ulong %5 %1571 %uint_4294967295
+OpStore %746 %1572
+%1573 = OpLoad %ulong %746
+OpStore %748 %1573
+OpBranch %293
+%293 = OpLabel
+%1574 = OpLoad %float %463
+%1575 = OpFOrdEqual %bool %1574 %float_0
+OpStore %624 %1575
+%1576 = OpLoad %bool %624
+OpSelectionMerge %188 None
+OpBranchConditional %1576 %359 %185
+%185 = OpLabel
+%1577 = OpLoad %float %722
+%1578 = OpFMul %float %1577 %float_2
+OpStore %625 %1578
+%1579 = OpLoad %float %722
+%1580 = OpLoad %float %625
+%1581 = OpFOrdEqual %bool %1579 %1580
+OpStore %626 %1581
+%1582 = OpLoad %bool %626
+OpSelectionMerge %187 None
+OpBranchConditional %1582 %186 %358
+%358 = OpLabel
+%1583 = OpLoad %bool %626
+OpStore %628 %1583
+OpBranch %187
+%186 = OpLabel
+%1584 = OpLoad %float %722
+%1585 = OpFUnordNotEqual %bool %1584 %float_0
+OpStore %627 %1585
+%1586 = OpLoad %bool %627
+OpStore %628 %1586
+OpBranch %187
+%187 = OpLabel
+%1587 = OpLoad %bool %628
+OpStore %629 %1587
+OpBranch %188
+%359 = OpLabel
+%1588 = OpLoad %bool %624
+OpStore %629 %1588
+OpBranch %188
+%188 = OpLabel
+%1589 = OpLoad %bool %629
+OpSelectionMerge %191 None
+OpBranchConditional %1589 %189 %190
+%190 = OpLabel
+%1590 = OpLoad %float %722
+%1591 = OpFOrdLessThan %bool %1590 %float_0
+OpStore %635 %1591
+%1592 = OpLoad %bool %635
+OpSelectionMerge %194 None
+OpBranchConditional %1592 %192 %193
+%193 = OpLabel
+%1593 = OpLoad %float %722
+OpStore %637 %1593
+OpBranch %194
+%192 = OpLabel
+%1594 = OpLoad %float %722
+%1595 = OpFSub %float %float_0 %1594
+OpStore %636 %1595
+%1596 = OpLoad %float %636
+OpStore %637 %1596
+OpBranch %194
+%194 = OpLabel
+%1597 = OpLoad %float %463
+%1598 = OpFOrdLessThan %bool %1597 %float_0
+OpStore %638 %1598
+%1599 = OpLoad %bool %638
+OpSelectionMerge %197 None
+OpBranchConditional %1599 %195 %196
+%196 = OpLabel
+%1600 = OpLoad %float %463
+OpStore %640 %1600
+OpBranch %197
+%195 = OpLabel
+%1601 = OpLoad %float %463
+%1602 = OpFSub %float %float_0 %1601
+OpStore %639 %1602
+%1603 = OpLoad %float %639
+OpStore %640 %1603
+OpBranch %197
+%197 = OpLabel
+%1604 = OpLoad %float %637
+%1605 = OpFDiv %float %1604 %float_2
+OpStore %641 %1605
+%1606 = OpLoad %float %640
+OpStore %642 %1606
+OpBranch %198
+%198 = OpLabel
+%1607 = OpLoad %float %642
+%1608 = OpLoad %float %641
+%1609 = OpFOrdLessThanEqual %bool %1607 %1608
+OpStore %643 %1609
+%1610 = OpLoad %bool %643
+OpLoopMerge %200 %369 None
+OpBranchConditional %1610 %199 %200
+%200 = OpLabel
+%1611 = OpLoad %float %637
+OpStore %645 %1611
+%1612 = OpLoad %float %642
+OpStore %646 %1612
+OpBranch %201
+%201 = OpLabel
+%1613 = OpLoad %float %640
+%1614 = OpLoad %float %646
+%1615 = OpFOrdLessThanEqual %bool %1613 %1614
+OpStore %647 %1615
+%1616 = OpLoad %bool %647
+OpLoopMerge %205 %368 None
+OpBranchConditional %1616 %206 %205
+%205 = OpLabel
+%1617 = OpLoad %bool %635
+OpSelectionMerge %209 None
+OpBranchConditional %1617 %207 %208
+%208 = OpLabel
+%1618 = OpLoad %float %645
+OpStore %653 %1618
+OpBranch %209
+%207 = OpLabel
+%1619 = OpLoad %float %645
+%1620 = OpFSub %float %float_0 %1619
+OpStore %652 %1620
+%1621 = OpLoad %float %652
+OpStore %653 %1621
+OpBranch %209
+%209 = OpLabel
+%1622 = OpLoad %float %653
+OpStore %654 %1622
+OpBranch %191
+%206 = OpLabel
+%1623 = OpLoad %float %646
+%1624 = OpLoad %float %645
+%1625 = OpFOrdLessThanEqual %bool %1623 %1624
+OpStore %648 %1625
+%1626 = OpLoad %bool %648
+OpSelectionMerge %204 None
+OpBranchConditional %1626 %202 %203
+%203 = OpLabel
+%1627 = OpLoad %float %645
+OpStore %650 %1627
+OpBranch %204
+%202 = OpLabel
+%1628 = OpLoad %float %645
+%1629 = OpLoad %float %646
+%1630 = OpFSub %float %1628 %1629
+OpStore %649 %1630
+%1631 = OpLoad %float %649
+OpStore %650 %1631
+OpBranch %204
+%204 = OpLabel
+%1632 = OpLoad %float %646
+%1633 = OpFDiv %float %1632 %float_2
+OpStore %651 %1633
+%1634 = OpLoad %float %650
+OpStore %645 %1634
+%1635 = OpLoad %float %651
+OpStore %646 %1635
+OpBranch %368
+%199 = OpLabel
+%1636 = OpLoad %float %642
+%1637 = OpFMul %float %1636 %float_2
+OpStore %644 %1637
+%1638 = OpLoad %float %644
+OpStore %642 %1638
+OpBranch %369
+%189 = OpLabel
+%1639 = OpLoad %float %722
+%1640 = OpLoad %float %463
+%1641 = OpFDiv %float %1639 %1640
+OpStore %630 %1641
+%1642 = OpLoad %float %630
+%1643 = OpConvertFToS %ulong %1642
+OpStore %631 %1643
+%1644 = OpLoad %ulong %631
+%1645 = OpConvertSToF %float %1644
+OpStore %632 %1645
+%1646 = OpLoad %float %632
+%1647 = OpLoad %float %463
+%1648 = OpFMul %float %1646 %1647
+OpStore %633 %1648
+%1649 = OpLoad %float %722
+%1650 = OpLoad %float %633
+%1651 = OpFSub %float %1649 %1650
+OpStore %634 %1651
+%1652 = OpLoad %float %634
+OpStore %654 %1652
+OpBranch %191
+%191 = OpLabel
+OpBranch %294
+%294 = OpLabel
+%1653 = OpLoad %float %654
+%1654 = OpLoad %float %654
+%1655 = OpFUnordNotEqual %bool %1653 %1654
+OpStore %749 %1655
+%1656 = OpLoad %bool %749
+OpSelectionMerge %298 None
+OpBranchConditional %1656 %295 %296
+%296 = OpLabel
+OpBranch %297
+%297 = OpLabel
+%1657 = OpLoad %ulong %748
+%1658 = OpLoad %float %654
+%1659 = OpFunctionCall %ulong %6 %1657 %1658
+OpStore %751 %1659
+%1660 = OpLoad %ulong %751
+OpStore %752 %1660
+OpBranch %298
+%295 = OpLabel
+%1661 = OpLoad %ulong %748
+%1662 = OpFunctionCall %ulong %5 %1661 %uint_4294967295
+OpStore %750 %1662
+%1663 = OpLoad %ulong %750
+OpStore %752 %1663
 OpBranch %298
 %298 = OpLabel
+%1664 = OpLoad %float %463
+%1665 = OpFOrdEqual %bool %1664 %float_0
+OpStore %655 %1665
+%1666 = OpLoad %bool %655
+OpSelectionMerge %213 None
+OpBranchConditional %1666 %361 %210
+%210 = OpLabel
+%1667 = OpLoad %float %463
+%1668 = OpFMul %float %1667 %float_2
+OpStore %656 %1668
+%1669 = OpLoad %float %463
+%1670 = OpLoad %float %656
+%1671 = OpFOrdEqual %bool %1669 %1670
+OpStore %657 %1671
+%1672 = OpLoad %bool %657
+OpSelectionMerge %212 None
+OpBranchConditional %1672 %211 %360
+%360 = OpLabel
+%1673 = OpLoad %bool %657
+OpStore %659 %1673
+OpBranch %212
+%211 = OpLabel
+%1674 = OpLoad %float %463
+%1675 = OpFUnordNotEqual %bool %1674 %float_0
+OpStore %658 %1675
+%1676 = OpLoad %bool %658
+OpStore %659 %1676
+OpBranch %212
+%212 = OpLabel
+%1677 = OpLoad %bool %659
+OpStore %660 %1677
+OpBranch %213
+%361 = OpLabel
+%1678 = OpLoad %bool %655
+OpStore %660 %1678
+OpBranch %213
+%213 = OpLabel
+%1679 = OpLoad %bool %660
+OpSelectionMerge %216 None
+OpBranchConditional %1679 %214 %215
+%215 = OpLabel
+%1680 = OpLoad %float %463
+%1681 = OpFOrdLessThan %bool %1680 %float_0
+OpStore %666 %1681
+%1682 = OpLoad %bool %666
+OpSelectionMerge %219 None
+OpBranchConditional %1682 %217 %218
+%218 = OpLabel
+%1683 = OpLoad %float %463
+OpStore %668 %1683
+OpBranch %219
+%217 = OpLabel
+%1684 = OpLoad %float %463
+%1685 = OpFSub %float %float_0 %1684
+OpStore %667 %1685
+%1686 = OpLoad %float %667
+OpStore %668 %1686
+OpBranch %219
+%219 = OpLabel
+%1687 = OpLoad %float %463
+%1688 = OpFOrdLessThan %bool %1687 %float_0
+OpStore %669 %1688
+%1689 = OpLoad %bool %669
+OpSelectionMerge %222 None
+OpBranchConditional %1689 %220 %221
+%221 = OpLabel
+%1690 = OpLoad %float %463
+OpStore %671 %1690
+OpBranch %222
+%220 = OpLabel
+%1691 = OpLoad %float %463
+%1692 = OpFSub %float %float_0 %1691
+OpStore %670 %1692
+%1693 = OpLoad %float %670
+OpStore %671 %1693
+OpBranch %222
+%222 = OpLabel
+%1694 = OpLoad %float %668
+%1695 = OpFDiv %float %1694 %float_2
+OpStore %672 %1695
+%1696 = OpLoad %float %671
+OpStore %673 %1696
+OpBranch %223
+%223 = OpLabel
+%1697 = OpLoad %float %673
+%1698 = OpLoad %float %672
+%1699 = OpFOrdLessThanEqual %bool %1697 %1698
+OpStore %674 %1699
+%1700 = OpLoad %bool %674
+OpLoopMerge %225 %367 None
+OpBranchConditional %1700 %224 %225
+%225 = OpLabel
+%1701 = OpLoad %float %668
+OpStore %676 %1701
+%1702 = OpLoad %float %673
+OpStore %677 %1702
+OpBranch %226
+%226 = OpLabel
+%1703 = OpLoad %float %671
+%1704 = OpLoad %float %677
+%1705 = OpFOrdLessThanEqual %bool %1703 %1704
+OpStore %678 %1705
+%1706 = OpLoad %bool %678
+OpLoopMerge %230 %366 None
+OpBranchConditional %1706 %231 %230
+%230 = OpLabel
+%1707 = OpLoad %bool %666
+OpSelectionMerge %234 None
+OpBranchConditional %1707 %232 %233
+%233 = OpLabel
+%1708 = OpLoad %float %676
+OpStore %684 %1708
+OpBranch %234
+%232 = OpLabel
+%1709 = OpLoad %float %676
+%1710 = OpFSub %float %float_0 %1709
+OpStore %683 %1710
+%1711 = OpLoad %float %683
+OpStore %684 %1711
+OpBranch %234
+%234 = OpLabel
+%1712 = OpLoad %float %684
+OpStore %685 %1712
+OpBranch %216
+%231 = OpLabel
+%1713 = OpLoad %float %677
+%1714 = OpLoad %float %676
+%1715 = OpFOrdLessThanEqual %bool %1713 %1714
+OpStore %679 %1715
+%1716 = OpLoad %bool %679
+OpSelectionMerge %229 None
+OpBranchConditional %1716 %227 %228
+%228 = OpLabel
+%1717 = OpLoad %float %676
+OpStore %681 %1717
+OpBranch %229
+%227 = OpLabel
+%1718 = OpLoad %float %676
+%1719 = OpLoad %float %677
+%1720 = OpFSub %float %1718 %1719
+OpStore %680 %1720
+%1721 = OpLoad %float %680
+OpStore %681 %1721
+OpBranch %229
+%229 = OpLabel
+%1722 = OpLoad %float %677
+%1723 = OpFDiv %float %1722 %float_2
+OpStore %682 %1723
+%1724 = OpLoad %float %681
+OpStore %676 %1724
+%1725 = OpLoad %float %682
+OpStore %677 %1725
+OpBranch %366
+%224 = OpLabel
+%1726 = OpLoad %float %673
+%1727 = OpFMul %float %1726 %float_2
+OpStore %675 %1727
+%1728 = OpLoad %float %675
+OpStore %673 %1728
+OpBranch %367
+%214 = OpLabel
+%1729 = OpLoad %float %463
+%1730 = OpLoad %float %463
+%1731 = OpFDiv %float %1729 %1730
+OpStore %661 %1731
+%1732 = OpLoad %float %661
+%1733 = OpConvertFToS %ulong %1732
+OpStore %662 %1733
+%1734 = OpLoad %ulong %662
+%1735 = OpConvertSToF %float %1734
+OpStore %663 %1735
+%1736 = OpLoad %float %663
+%1737 = OpLoad %float %463
+%1738 = OpFMul %float %1736 %1737
+OpStore %664 %1738
+%1739 = OpLoad %float %463
+%1740 = OpLoad %float %664
+%1741 = OpFSub %float %1739 %1740
+OpStore %665 %1741
+%1742 = OpLoad %float %665
+OpStore %685 %1742
+OpBranch %216
+%216 = OpLabel
+OpBranch %299
+%299 = OpLabel
+%1743 = OpLoad %float %685
+%1744 = OpLoad %float %685
+%1745 = OpFUnordNotEqual %bool %1743 %1744
+OpStore %753 %1745
+%1746 = OpLoad %bool %753
+OpSelectionMerge %303 None
+OpBranchConditional %1746 %300 %301
+%301 = OpLabel
+OpBranch %302
+%302 = OpLabel
+%1747 = OpLoad %ulong %752
+%1748 = OpLoad %float %685
+%1749 = OpFunctionCall %ulong %6 %1747 %1748
+OpStore %755 %1749
+%1750 = OpLoad %ulong %755
+OpStore %756 %1750
+OpBranch %303
+%300 = OpLabel
+%1751 = OpLoad %ulong %752
+%1752 = OpFunctionCall %ulong %5 %1751 %uint_4294967295
+OpStore %754 %1752
+%1753 = OpLoad %ulong %754
+OpStore %756 %1753
+OpBranch %303
+%303 = OpLabel
+%1755 = OpLoad %float %722
+%1756 = OpFMul %float %float_1048576 %1755
+OpStore %686 %1756
+%1757 = OpLoad %float %463
+%1758 = OpFOrdEqual %bool %1757 %float_0
+OpStore %687 %1758
+%1759 = OpLoad %bool %687
+OpSelectionMerge %238 None
+OpBranchConditional %1759 %363 %235
+%235 = OpLabel
+%1760 = OpLoad %float %686
+%1761 = OpFMul %float %1760 %float_2
+OpStore %688 %1761
+%1762 = OpLoad %float %686
+%1763 = OpLoad %float %688
+%1764 = OpFOrdEqual %bool %1762 %1763
+OpStore %689 %1764
+%1765 = OpLoad %bool %689
+OpSelectionMerge %237 None
+OpBranchConditional %1765 %236 %362
+%362 = OpLabel
+%1766 = OpLoad %bool %689
+OpStore %691 %1766
+OpBranch %237
+%236 = OpLabel
+%1767 = OpLoad %float %686
+%1768 = OpFUnordNotEqual %bool %1767 %float_0
+OpStore %690 %1768
+%1769 = OpLoad %bool %690
+OpStore %691 %1769
+OpBranch %237
+%237 = OpLabel
+%1770 = OpLoad %bool %691
+OpStore %692 %1770
+OpBranch %238
+%363 = OpLabel
+%1771 = OpLoad %bool %687
+OpStore %692 %1771
+OpBranch %238
+%238 = OpLabel
+%1772 = OpLoad %bool %692
+OpSelectionMerge %241 None
+OpBranchConditional %1772 %239 %240
+%240 = OpLabel
+%1773 = OpLoad %float %686
+%1774 = OpFOrdLessThan %bool %1773 %float_0
+OpStore %698 %1774
+%1775 = OpLoad %bool %698
+OpSelectionMerge %244 None
+OpBranchConditional %1775 %242 %243
+%243 = OpLabel
+%1776 = OpLoad %float %686
+OpStore %700 %1776
+OpBranch %244
+%242 = OpLabel
+%1777 = OpLoad %float %686
+%1778 = OpFSub %float %float_0 %1777
+OpStore %699 %1778
+%1779 = OpLoad %float %699
+OpStore %700 %1779
+OpBranch %244
+%244 = OpLabel
+%1780 = OpLoad %float %463
+%1781 = OpFOrdLessThan %bool %1780 %float_0
+OpStore %701 %1781
+%1782 = OpLoad %bool %701
+OpSelectionMerge %247 None
+OpBranchConditional %1782 %245 %246
+%246 = OpLabel
+%1783 = OpLoad %float %463
+OpStore %703 %1783
+OpBranch %247
+%245 = OpLabel
+%1784 = OpLoad %float %463
+%1785 = OpFSub %float %float_0 %1784
+OpStore %702 %1785
+%1786 = OpLoad %float %702
+OpStore %703 %1786
+OpBranch %247
+%247 = OpLabel
+%1787 = OpLoad %float %700
+%1788 = OpFDiv %float %1787 %float_2
+OpStore %704 %1788
+%1789 = OpLoad %float %703
+OpStore %705 %1789
+OpBranch %248
+%248 = OpLabel
+%1790 = OpLoad %float %705
+%1791 = OpLoad %float %704
+%1792 = OpFOrdLessThanEqual %bool %1790 %1791
+OpStore %706 %1792
+%1793 = OpLoad %bool %706
+OpLoopMerge %250 %365 None
+OpBranchConditional %1793 %249 %250
+%250 = OpLabel
+%1794 = OpLoad %float %700
+OpStore %708 %1794
+%1795 = OpLoad %float %705
+OpStore %709 %1795
+OpBranch %251
+%251 = OpLabel
+%1796 = OpLoad %float %703
+%1797 = OpLoad %float %709
+%1798 = OpFOrdLessThanEqual %bool %1796 %1797
+OpStore %710 %1798
+%1799 = OpLoad %bool %710
+OpLoopMerge %255 %364 None
+OpBranchConditional %1799 %256 %255
+%255 = OpLabel
+%1800 = OpLoad %bool %698
+OpSelectionMerge %259 None
+OpBranchConditional %1800 %257 %258
+%258 = OpLabel
+%1801 = OpLoad %float %708
+OpStore %716 %1801
+OpBranch %259
+%257 = OpLabel
+%1802 = OpLoad %float %708
+%1803 = OpFSub %float %float_0 %1802
+OpStore %715 %1803
+%1804 = OpLoad %float %715
+OpStore %716 %1804
+OpBranch %259
+%259 = OpLabel
+%1805 = OpLoad %float %716
+OpStore %717 %1805
+OpBranch %241
+%256 = OpLabel
+%1806 = OpLoad %float %709
+%1807 = OpLoad %float %708
+%1808 = OpFOrdLessThanEqual %bool %1806 %1807
+OpStore %711 %1808
+%1809 = OpLoad %bool %711
+OpSelectionMerge %254 None
+OpBranchConditional %1809 %252 %253
+%253 = OpLabel
+%1810 = OpLoad %float %708
+OpStore %713 %1810
+OpBranch %254
+%252 = OpLabel
+%1811 = OpLoad %float %708
+%1812 = OpLoad %float %709
+%1813 = OpFSub %float %1811 %1812
+OpStore %712 %1813
+%1814 = OpLoad %float %712
+OpStore %713 %1814
+OpBranch %254
+%254 = OpLabel
+%1815 = OpLoad %float %709
+%1816 = OpFDiv %float %1815 %float_2
+OpStore %714 %1816
+%1817 = OpLoad %float %713
+OpStore %708 %1817
+%1818 = OpLoad %float %714
+OpStore %709 %1818
+OpBranch %364
+%249 = OpLabel
+%1819 = OpLoad %float %705
+%1820 = OpFMul %float %1819 %float_2
+OpStore %707 %1820
+%1821 = OpLoad %float %707
+OpStore %705 %1821
+OpBranch %365
+%239 = OpLabel
+%1822 = OpLoad %float %686
+%1823 = OpLoad %float %463
+%1824 = OpFDiv %float %1822 %1823
+OpStore %693 %1824
+%1825 = OpLoad %float %693
+%1826 = OpConvertFToS %ulong %1825
+OpStore %694 %1826
+%1827 = OpLoad %ulong %694
+%1828 = OpConvertSToF %float %1827
+OpStore %695 %1828
+%1829 = OpLoad %float %695
+%1830 = OpLoad %float %463
+%1831 = OpFMul %float %1829 %1830
+OpStore %696 %1831
+%1832 = OpLoad %float %686
+%1833 = OpLoad %float %696
+%1834 = OpFSub %float %1832 %1833
+OpStore %697 %1834
+%1835 = OpLoad %float %697
+OpStore %717 %1835
+OpBranch %241
+%241 = OpLabel
+OpBranch %304
+%304 = OpLabel
+%1836 = OpLoad %float %717
+%1837 = OpLoad %float %717
+%1838 = OpFUnordNotEqual %bool %1836 %1837
+OpStore %757 %1838
+%1839 = OpLoad %bool %757
+OpSelectionMerge %308 None
+OpBranchConditional %1839 %305 %306
+%306 = OpLabel
+OpBranch %307
+%307 = OpLabel
+%1840 = OpLoad %ulong %756
+%1841 = OpLoad %float %717
+%1842 = OpFunctionCall %ulong %6 %1840 %1841
+OpStore %759 %1842
+%1843 = OpLoad %ulong %759
+OpStore %760 %1843
+OpBranch %308
+%305 = OpLabel
+%1844 = OpLoad %ulong %756
+%1845 = OpFunctionCall %ulong %5 %1844 %uint_4294967295
+OpStore %758 %1845
+%1846 = OpLoad %ulong %758
+OpStore %760 %1846
+OpBranch %308
+%308 = OpLabel
+%1847 = OpLoad %ulong %760
+OpReturnValue %1847
+%58 = OpLabel
+%1848 = OpLoad %float %719
+%1849 = OpLoad %float %403
+%1850 = OpFAdd %float %1848 %1849
+OpStore %431 %1850
+%1851 = OpLoad %float %431
+%1852 = OpFMul %float %1851 %float_1_5
+OpStore %432 %1852
+OpBranch %262
+%262 = OpLabel
+%1853 = OpLoad %float %432
+%1854 = OpLoad %float %432
+%1855 = OpFUnordNotEqual %bool %1853 %1854
+OpStore %723 %1855
+%1856 = OpLoad %bool %723
+OpSelectionMerge %266 None
+OpBranchConditional %1856 %263 %264
+%264 = OpLabel
+OpBranch %265
+%265 = OpLabel
+%1857 = OpLoad %ulong %718
+%1858 = OpLoad %float %432
+%1859 = OpFunctionCall %ulong %6 %1857 %1858
+OpStore %725 %1859
+%1860 = OpLoad %ulong %725
+OpStore %726 %1860
+OpBranch %266
+%263 = OpLabel
+%1861 = OpLoad %ulong %718
+%1862 = OpFunctionCall %ulong %5 %1861 %uint_4294967295
+OpStore %724 %1862
+%1863 = OpLoad %ulong %724
+OpStore %726 %1863
+OpBranch %266
+%266 = OpLabel
+%1864 = OpLoad %uint %720
+%1865 = OpIAdd %uint %1864 %uint_1
+OpStore %433 %1865
+%1866 = OpLoad %ulong %726
+OpStore %718 %1866
+%1867 = OpLoad %float %432
+OpStore %719 %1867
+%1868 = OpLoad %uint %433
+OpStore %720 %1868
+OpBranch %380
+%364 = OpLabel
+OpBranch %251
+%365 = OpLabel
+OpBranch %248
+%366 = OpLabel
+OpBranch %226
+%367 = OpLabel
+OpBranch %223
+%368 = OpLabel
+OpBranch %201
+%369 = OpLabel
+OpBranch %198
+%370 = OpLabel
+OpBranch %176
+%371 = OpLabel
+OpBranch %173
+%372 = OpLabel
+OpBranch %151
+%373 = OpLabel
+OpBranch %148
+%374 = OpLabel
+OpBranch %126
+%375 = OpLabel
+OpBranch %123
+%376 = OpLabel
+OpBranch %101
+%377 = OpLabel
+OpBranch %98
+%378 = OpLabel
+OpBranch %76
+%379 = OpLabel
+OpBranch %73
+%380 = OpLabel
 OpBranch %57
 OpFunctionEnd
-%4 = OpFunction %ulong None %1399
-%1400 = OpLabel
+%4 = OpFunction %ulong None %1869
+%1870 = OpLabel
 OpReturnValue %ulong_14695981039346656037
 OpFunctionEnd
-%5 = OpFunction %ulong None %1402
-%1403 = OpFunctionParameter %ulong
-%1404 = OpFunctionParameter %uint
-%1405 = OpLabel
-%1412 = OpVariable %_ptr_Function_ulong Function
-%1413 = OpVariable %_ptr_Function_uint Function
-%1414 = OpVariable %_ptr_Function_ulong Function
-%1415 = OpVariable %_ptr_Function_bool Function
-%1416 = OpVariable %_ptr_Function_ulong Function
-%1417 = OpVariable %_ptr_Function_ulong Function
-%1418 = OpVariable %_ptr_Function_ulong Function
-%1419 = OpVariable %_ptr_Function_ulong Function
-%1420 = OpVariable %_ptr_Function_ulong Function
-%1421 = OpVariable %_ptr_Function_ulong Function
-%1422 = OpVariable %_ptr_Function_ulong Function
-%1423 = OpVariable %_ptr_Function_ulong Function
-OpStore %1412 %1403
-OpStore %1413 %1404
-%1424 = OpLoad %uint %1413
-%1425 = OpUConvert %ulong %1424
-OpStore %1414 %1425
-OpBranch %1406
-%1406 = OpLabel
-%1426 = OpLoad %ulong %1412
-OpStore %1422 %1426
-OpStore %1423 %ulong_0
-OpBranch %1407
-%1407 = OpLabel
-%1428 = OpLoad %ulong %1423
-%1430 = OpULessThan %bool %1428 %ulong_8
-OpStore %1415 %1430
-%1431 = OpLoad %bool %1415
-OpLoopMerge %1409 %1411 None
-OpBranchConditional %1431 %1408 %1409
-%1409 = OpLabel
-OpBranch %1410
-%1410 = OpLabel
-%1432 = OpLoad %ulong %1422
-OpReturnValue %1432
-%1408 = OpLabel
-%1433 = OpLoad %ulong %1423
-%1434 = OpIMul %ulong %1433 %ulong_8
-OpStore %1416 %1434
-%1435 = OpLoad %ulong %1414
-%1436 = OpLoad %ulong %1416
-%1437 = OpShiftRightLogical %ulong %1435 %1436
-OpStore %1417 %1437
-%1438 = OpLoad %ulong %1417
-%1440 = OpBitwiseAnd %ulong %1438 %ulong_255
-OpStore %1418 %1440
-%1441 = OpLoad %ulong %1422
-%1442 = OpLoad %ulong %1418
-%1443 = OpBitwiseXor %ulong %1441 %1442
-OpStore %1419 %1443
-%1444 = OpLoad %ulong %1419
-%1446 = OpIMul %ulong %1444 %ulong_1099511628211
-OpStore %1420 %1446
-%1447 = OpLoad %ulong %1423
-%1449 = OpIAdd %ulong %1447 %ulong_1
-OpStore %1421 %1449
-%1450 = OpLoad %ulong %1420
-OpStore %1422 %1450
-%1451 = OpLoad %ulong %1421
-OpStore %1423 %1451
-OpBranch %1411
-%1411 = OpLabel
-OpBranch %1407
+%5 = OpFunction %ulong None %1872
+%1873 = OpFunctionParameter %ulong
+%1874 = OpFunctionParameter %uint
+%1875 = OpLabel
+%1882 = OpVariable %_ptr_Function_ulong Function
+%1883 = OpVariable %_ptr_Function_uint Function
+%1884 = OpVariable %_ptr_Function_ulong Function
+%1885 = OpVariable %_ptr_Function_bool Function
+%1886 = OpVariable %_ptr_Function_ulong Function
+%1887 = OpVariable %_ptr_Function_ulong Function
+%1888 = OpVariable %_ptr_Function_ulong Function
+%1889 = OpVariable %_ptr_Function_ulong Function
+%1890 = OpVariable %_ptr_Function_ulong Function
+%1891 = OpVariable %_ptr_Function_ulong Function
+%1892 = OpVariable %_ptr_Function_ulong Function
+%1893 = OpVariable %_ptr_Function_ulong Function
+OpStore %1882 %1873
+OpStore %1883 %1874
+%1894 = OpLoad %uint %1883
+%1895 = OpUConvert %ulong %1894
+OpStore %1884 %1895
+OpBranch %1876
+%1876 = OpLabel
+%1896 = OpLoad %ulong %1882
+OpStore %1892 %1896
+OpStore %1893 %ulong_0
+OpBranch %1877
+%1877 = OpLabel
+%1898 = OpLoad %ulong %1893
+%1900 = OpULessThan %bool %1898 %ulong_8
+OpStore %1885 %1900
+%1901 = OpLoad %bool %1885
+OpLoopMerge %1879 %1881 None
+OpBranchConditional %1901 %1878 %1879
+%1879 = OpLabel
+OpBranch %1880
+%1880 = OpLabel
+%1902 = OpLoad %ulong %1892
+OpReturnValue %1902
+%1878 = OpLabel
+%1903 = OpLoad %ulong %1893
+%1904 = OpIMul %ulong %1903 %ulong_8
+OpStore %1886 %1904
+%1905 = OpLoad %ulong %1884
+%1906 = OpLoad %ulong %1886
+%1907 = OpShiftRightLogical %ulong %1905 %1906
+OpStore %1887 %1907
+%1908 = OpLoad %ulong %1887
+%1910 = OpBitwiseAnd %ulong %1908 %ulong_255
+OpStore %1888 %1910
+%1911 = OpLoad %ulong %1892
+%1912 = OpLoad %ulong %1888
+%1913 = OpBitwiseXor %ulong %1911 %1912
+OpStore %1889 %1913
+%1914 = OpLoad %ulong %1889
+%1916 = OpIMul %ulong %1914 %ulong_1099511628211
+OpStore %1890 %1916
+%1917 = OpLoad %ulong %1893
+%1919 = OpIAdd %ulong %1917 %ulong_1
+OpStore %1891 %1919
+%1920 = OpLoad %ulong %1890
+OpStore %1892 %1920
+%1921 = OpLoad %ulong %1891
+OpStore %1893 %1921
+OpBranch %1881
+%1881 = OpLabel
+OpBranch %1877
 OpFunctionEnd
 %6 = OpFunction %ulong None %26
-%1452 = OpFunctionParameter %ulong
-%1453 = OpFunctionParameter %float
-%1454 = OpLabel
-%1461 = OpVariable %_ptr_Function_ulong Function
-%1462 = OpVariable %_ptr_Function_float Function
-%1463 = OpVariable %_ptr_Function_uint Function
-%1464 = OpVariable %_ptr_Function_ulong Function
-%1465 = OpVariable %_ptr_Function_bool Function
-%1466 = OpVariable %_ptr_Function_ulong Function
-%1467 = OpVariable %_ptr_Function_ulong Function
-%1468 = OpVariable %_ptr_Function_ulong Function
-%1469 = OpVariable %_ptr_Function_ulong Function
-%1470 = OpVariable %_ptr_Function_ulong Function
-%1471 = OpVariable %_ptr_Function_ulong Function
-%1472 = OpVariable %_ptr_Function_ulong Function
-%1473 = OpVariable %_ptr_Function_ulong Function
-OpStore %1461 %1452
-OpStore %1462 %1453
-%1474 = OpLoad %float %1462
-%1475 = OpBitcast %uint %1474
-OpStore %1463 %1475
-%1476 = OpLoad %uint %1463
-%1477 = OpUConvert %ulong %1476
-OpStore %1464 %1477
-OpBranch %1455
-%1455 = OpLabel
-%1478 = OpLoad %ulong %1461
-OpStore %1472 %1478
-OpStore %1473 %ulong_0
-OpBranch %1456
-%1456 = OpLabel
-%1479 = OpLoad %ulong %1473
-%1480 = OpULessThan %bool %1479 %ulong_8
-OpStore %1465 %1480
-%1481 = OpLoad %bool %1465
-OpLoopMerge %1458 %1460 None
-OpBranchConditional %1481 %1457 %1458
-%1458 = OpLabel
-OpBranch %1459
-%1459 = OpLabel
-%1482 = OpLoad %ulong %1472
-OpReturnValue %1482
-%1457 = OpLabel
-%1483 = OpLoad %ulong %1473
-%1484 = OpIMul %ulong %1483 %ulong_8
-OpStore %1466 %1484
-%1485 = OpLoad %ulong %1464
-%1486 = OpLoad %ulong %1466
-%1487 = OpShiftRightLogical %ulong %1485 %1486
-OpStore %1467 %1487
-%1488 = OpLoad %ulong %1467
-%1489 = OpBitwiseAnd %ulong %1488 %ulong_255
-OpStore %1468 %1489
-%1490 = OpLoad %ulong %1472
-%1491 = OpLoad %ulong %1468
-%1492 = OpBitwiseXor %ulong %1490 %1491
-OpStore %1469 %1492
-%1493 = OpLoad %ulong %1469
-%1494 = OpIMul %ulong %1493 %ulong_1099511628211
-OpStore %1470 %1494
-%1495 = OpLoad %ulong %1473
-%1496 = OpIAdd %ulong %1495 %ulong_1
-OpStore %1471 %1496
-%1497 = OpLoad %ulong %1470
-OpStore %1472 %1497
-%1498 = OpLoad %ulong %1471
-OpStore %1473 %1498
-OpBranch %1460
-%1460 = OpLabel
-OpBranch %1456
+%1922 = OpFunctionParameter %ulong
+%1923 = OpFunctionParameter %float
+%1924 = OpLabel
+%1931 = OpVariable %_ptr_Function_ulong Function
+%1932 = OpVariable %_ptr_Function_float Function
+%1933 = OpVariable %_ptr_Function_uint Function
+%1934 = OpVariable %_ptr_Function_ulong Function
+%1935 = OpVariable %_ptr_Function_bool Function
+%1936 = OpVariable %_ptr_Function_ulong Function
+%1937 = OpVariable %_ptr_Function_ulong Function
+%1938 = OpVariable %_ptr_Function_ulong Function
+%1939 = OpVariable %_ptr_Function_ulong Function
+%1940 = OpVariable %_ptr_Function_ulong Function
+%1941 = OpVariable %_ptr_Function_ulong Function
+%1942 = OpVariable %_ptr_Function_ulong Function
+%1943 = OpVariable %_ptr_Function_ulong Function
+OpStore %1931 %1922
+OpStore %1932 %1923
+%1944 = OpLoad %float %1932
+%1945 = OpBitcast %uint %1944
+OpStore %1933 %1945
+%1946 = OpLoad %uint %1933
+%1947 = OpUConvert %ulong %1946
+OpStore %1934 %1947
+OpBranch %1925
+%1925 = OpLabel
+%1948 = OpLoad %ulong %1931
+OpStore %1942 %1948
+OpStore %1943 %ulong_0
+OpBranch %1926
+%1926 = OpLabel
+%1949 = OpLoad %ulong %1943
+%1950 = OpULessThan %bool %1949 %ulong_8
+OpStore %1935 %1950
+%1951 = OpLoad %bool %1935
+OpLoopMerge %1928 %1930 None
+OpBranchConditional %1951 %1927 %1928
+%1928 = OpLabel
+OpBranch %1929
+%1929 = OpLabel
+%1952 = OpLoad %ulong %1942
+OpReturnValue %1952
+%1927 = OpLabel
+%1953 = OpLoad %ulong %1943
+%1954 = OpIMul %ulong %1953 %ulong_8
+OpStore %1936 %1954
+%1955 = OpLoad %ulong %1934
+%1956 = OpLoad %ulong %1936
+%1957 = OpShiftRightLogical %ulong %1955 %1956
+OpStore %1937 %1957
+%1958 = OpLoad %ulong %1937
+%1959 = OpBitwiseAnd %ulong %1958 %ulong_255
+OpStore %1938 %1959
+%1960 = OpLoad %ulong %1942
+%1961 = OpLoad %ulong %1938
+%1962 = OpBitwiseXor %ulong %1960 %1961
+OpStore %1939 %1962
+%1963 = OpLoad %ulong %1939
+%1964 = OpIMul %ulong %1963 %ulong_1099511628211
+OpStore %1940 %1964
+%1965 = OpLoad %ulong %1943
+%1966 = OpIAdd %ulong %1965 %ulong_1
+OpStore %1941 %1966
+%1967 = OpLoad %ulong %1940
+OpStore %1942 %1967
+%1968 = OpLoad %ulong %1941
+OpStore %1943 %1968
+OpBranch %1930
+%1930 = OpLabel
+OpBranch %1926
 OpFunctionEnd

--- a/test/golden/spirv/float/arith_f64.dis
+++ b/test/golden/spirv/float/arith_f64.dis
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.6
 ; Generator: Khronos; 0
-; Bound: 1484
+; Bound: 1937
 ; Schema: 0
 OpCapability Shader
 OpCapability Linkage
@@ -40,9 +40,9 @@ OpDecorate %3 LinkageAttributes "corpus.cases.float.arith_f64.checksum" Export
 %double_5_5 = OpConstant %double 5.5
 %double_7 = OpConstant %double 7
 %double_1048576 = OpConstant %double 1048576
-%1394 = OpTypeFunction %ulong
+%1847 = OpTypeFunction %ulong
 %ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
-%1397 = OpTypeFunction %ulong %ulong %ulong
+%1850 = OpTypeFunction %ulong %ulong %ulong
 %ulong_8 = OpConstant %ulong 8
 %ulong_255 = OpConstant %ulong 255
 %ulong_1099511628211 = OpConstant %ulong 1099511628211
@@ -105,2092 +105,2822 @@ OpFunctionEnd
 %3 = OpFunction %ulong None %52
 %53 = OpFunctionParameter %ulong
 %54 = OpLabel
-%297 = OpVariable %_ptr_Function_ulong Function
-%298 = OpVariable %_ptr_Function_ulong Function
-%299 = OpVariable %_ptr_Function_double Function
-%300 = OpVariable %_ptr_Function_double Function
-%301 = OpVariable %_ptr_Function_double Function
-%302 = OpVariable %_ptr_Function_double Function
-%303 = OpVariable %_ptr_Function_double Function
-%304 = OpVariable %_ptr_Function_double Function
-%305 = OpVariable %_ptr_Function_double Function
-%306 = OpVariable %_ptr_Function_double Function
-%307 = OpVariable %_ptr_Function_double Function
-%308 = OpVariable %_ptr_Function_double Function
-%309 = OpVariable %_ptr_Function_double Function
-%310 = OpVariable %_ptr_Function_double Function
-%311 = OpVariable %_ptr_Function_double Function
-%312 = OpVariable %_ptr_Function_double Function
-%313 = OpVariable %_ptr_Function_double Function
-%314 = OpVariable %_ptr_Function_double Function
-%315 = OpVariable %_ptr_Function_double Function
-%316 = OpVariable %_ptr_Function_double Function
-%317 = OpVariable %_ptr_Function_double Function
-%318 = OpVariable %_ptr_Function_double Function
-%319 = OpVariable %_ptr_Function_double Function
-%320 = OpVariable %_ptr_Function_double Function
-%321 = OpVariable %_ptr_Function_double Function
-%322 = OpVariable %_ptr_Function_double Function
-%323 = OpVariable %_ptr_Function_double Function
-%324 = OpVariable %_ptr_Function_double Function
-%325 = OpVariable %_ptr_Function_double Function
-%326 = OpVariable %_ptr_Function_double Function
-%327 = OpVariable %_ptr_Function_double Function
-%328 = OpVariable %_ptr_Function_double Function
-%329 = OpVariable %_ptr_Function_double Function
-%330 = OpVariable %_ptr_Function_double Function
-%331 = OpVariable %_ptr_Function_bool Function
-%332 = OpVariable %_ptr_Function_double Function
-%333 = OpVariable %_ptr_Function_double Function
-%334 = OpVariable %_ptr_Function_ulong Function
-%335 = OpVariable %_ptr_Function_double Function
-%336 = OpVariable %_ptr_Function_double Function
-%337 = OpVariable %_ptr_Function_double Function
-%338 = OpVariable %_ptr_Function_double Function
-%339 = OpVariable %_ptr_Function_double Function
-%340 = OpVariable %_ptr_Function_double Function
-%341 = OpVariable %_ptr_Function_double Function
-%342 = OpVariable %_ptr_Function_double Function
-%343 = OpVariable %_ptr_Function_double Function
-%344 = OpVariable %_ptr_Function_double Function
-%345 = OpVariable %_ptr_Function_double Function
-%346 = OpVariable %_ptr_Function_double Function
-%347 = OpVariable %_ptr_Function_double Function
-%348 = OpVariable %_ptr_Function_double Function
-%349 = OpVariable %_ptr_Function_double Function
-%350 = OpVariable %_ptr_Function_double Function
-%351 = OpVariable %_ptr_Function_double Function
-%352 = OpVariable %_ptr_Function_double Function
-%353 = OpVariable %_ptr_Function_double Function
-%354 = OpVariable %_ptr_Function_ulong Function
-%355 = OpVariable %_ptr_Function_double Function
-%356 = OpVariable %_ptr_Function_double Function
-%357 = OpVariable %_ptr_Function_double Function
-%358 = OpVariable %_ptr_Function_double Function
-%359 = OpVariable %_ptr_Function_double Function
-%360 = OpVariable %_ptr_Function_ulong Function
-%361 = OpVariable %_ptr_Function_double Function
-%362 = OpVariable %_ptr_Function_double Function
-%363 = OpVariable %_ptr_Function_double Function
-%364 = OpVariable %_ptr_Function_double Function
-%365 = OpVariable %_ptr_Function_double Function
-%366 = OpVariable %_ptr_Function_ulong Function
-%367 = OpVariable %_ptr_Function_double Function
-%368 = OpVariable %_ptr_Function_double Function
-%369 = OpVariable %_ptr_Function_double Function
-%370 = OpVariable %_ptr_Function_double Function
-%371 = OpVariable %_ptr_Function_double Function
-%372 = OpVariable %_ptr_Function_double Function
-%373 = OpVariable %_ptr_Function_ulong Function
-%374 = OpVariable %_ptr_Function_double Function
-%375 = OpVariable %_ptr_Function_double Function
-%376 = OpVariable %_ptr_Function_double Function
-%377 = OpVariable %_ptr_Function_double Function
-%378 = OpVariable %_ptr_Function_double Function
-%379 = OpVariable %_ptr_Function_ulong Function
+%377 = OpVariable %_ptr_Function_ulong Function
+%378 = OpVariable %_ptr_Function_ulong Function
+%379 = OpVariable %_ptr_Function_double Function
 %380 = OpVariable %_ptr_Function_double Function
 %381 = OpVariable %_ptr_Function_double Function
 %382 = OpVariable %_ptr_Function_double Function
 %383 = OpVariable %_ptr_Function_double Function
-%384 = OpVariable %_ptr_Function_ulong Function
+%384 = OpVariable %_ptr_Function_double Function
 %385 = OpVariable %_ptr_Function_double Function
-%386 = OpVariable %_ptr_Function_double Function
+%386 = OpVariable %_ptr_Function_ulong Function
 %387 = OpVariable %_ptr_Function_double Function
-%388 = OpVariable %_ptr_Function_double Function
-%389 = OpVariable %_ptr_Function_ulong Function
-%390 = OpVariable %_ptr_Function_double Function
+%388 = OpVariable %_ptr_Function_ulong Function
+%389 = OpVariable %_ptr_Function_double Function
+%390 = OpVariable %_ptr_Function_ulong Function
 %391 = OpVariable %_ptr_Function_double Function
-%392 = OpVariable %_ptr_Function_double Function
+%392 = OpVariable %_ptr_Function_ulong Function
 %393 = OpVariable %_ptr_Function_double Function
-%394 = OpVariable %_ptr_Function_double Function
-%395 = OpVariable %_ptr_Function_ulong Function
-%396 = OpVariable %_ptr_Function_double Function
+%394 = OpVariable %_ptr_Function_ulong Function
+%395 = OpVariable %_ptr_Function_double Function
+%396 = OpVariable %_ptr_Function_ulong Function
 %397 = OpVariable %_ptr_Function_double Function
 %398 = OpVariable %_ptr_Function_double Function
 %399 = OpVariable %_ptr_Function_ulong Function
 %400 = OpVariable %_ptr_Function_double Function
 %401 = OpVariable %_ptr_Function_ulong Function
-%402 = OpVariable %_ptr_Function_ulong Function
+%402 = OpVariable %_ptr_Function_double Function
 %403 = OpVariable %_ptr_Function_double Function
-%404 = OpVariable %_ptr_Function_bool Function
+%404 = OpVariable %_ptr_Function_double Function
 %405 = OpVariable %_ptr_Function_ulong Function
-%406 = OpVariable %_ptr_Function_ulong Function
+%406 = OpVariable %_ptr_Function_double Function
 %407 = OpVariable %_ptr_Function_ulong Function
-%408 = OpVariable %_ptr_Function_ulong Function
-%409 = OpVariable %_ptr_Function_double Function
-%410 = OpVariable %_ptr_Function_bool Function
+%408 = OpVariable %_ptr_Function_double Function
+%409 = OpVariable %_ptr_Function_ulong Function
+%410 = OpVariable %_ptr_Function_double Function
 %411 = OpVariable %_ptr_Function_ulong Function
-%412 = OpVariable %_ptr_Function_ulong Function
-%413 = OpVariable %_ptr_Function_ulong Function
-%414 = OpVariable %_ptr_Function_bool Function
-%415 = OpVariable %_ptr_Function_ulong Function
+%412 = OpVariable %_ptr_Function_double Function
+%413 = OpVariable %_ptr_Function_double Function
+%414 = OpVariable %_ptr_Function_ulong Function
+%415 = OpVariable %_ptr_Function_double Function
 %416 = OpVariable %_ptr_Function_ulong Function
-%417 = OpVariable %_ptr_Function_ulong Function
-%418 = OpVariable %_ptr_Function_bool Function
+%417 = OpVariable %_ptr_Function_double Function
+%418 = OpVariable %_ptr_Function_double Function
 %419 = OpVariable %_ptr_Function_ulong Function
-%420 = OpVariable %_ptr_Function_ulong Function
+%420 = OpVariable %_ptr_Function_double Function
 %421 = OpVariable %_ptr_Function_ulong Function
-%422 = OpVariable %_ptr_Function_bool Function
+%422 = OpVariable %_ptr_Function_double Function
 %423 = OpVariable %_ptr_Function_ulong Function
-%424 = OpVariable %_ptr_Function_ulong Function
-%425 = OpVariable %_ptr_Function_ulong Function
-%426 = OpVariable %_ptr_Function_bool Function
-%427 = OpVariable %_ptr_Function_ulong Function
+%424 = OpVariable %_ptr_Function_double Function
+%425 = OpVariable %_ptr_Function_bool Function
+%426 = OpVariable %_ptr_Function_double Function
+%427 = OpVariable %_ptr_Function_double Function
 %428 = OpVariable %_ptr_Function_ulong Function
-%429 = OpVariable %_ptr_Function_ulong Function
-%430 = OpVariable %_ptr_Function_bool Function
-%431 = OpVariable %_ptr_Function_ulong Function
+%429 = OpVariable %_ptr_Function_double Function
+%430 = OpVariable %_ptr_Function_double Function
+%431 = OpVariable %_ptr_Function_double Function
 %432 = OpVariable %_ptr_Function_ulong Function
-%433 = OpVariable %_ptr_Function_ulong Function
-%434 = OpVariable %_ptr_Function_bool Function
-%435 = OpVariable %_ptr_Function_ulong Function
+%433 = OpVariable %_ptr_Function_double Function
+%434 = OpVariable %_ptr_Function_ulong Function
+%435 = OpVariable %_ptr_Function_double Function
 %436 = OpVariable %_ptr_Function_ulong Function
-%437 = OpVariable %_ptr_Function_ulong Function
-%438 = OpVariable %_ptr_Function_bool Function
-%439 = OpVariable %_ptr_Function_ulong Function
+%437 = OpVariable %_ptr_Function_double Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_double Function
 %440 = OpVariable %_ptr_Function_ulong Function
-%441 = OpVariable %_ptr_Function_ulong Function
-%442 = OpVariable %_ptr_Function_bool Function
-%443 = OpVariable %_ptr_Function_ulong Function
+%441 = OpVariable %_ptr_Function_double Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_double Function
 %444 = OpVariable %_ptr_Function_ulong Function
-%445 = OpVariable %_ptr_Function_ulong Function
-%446 = OpVariable %_ptr_Function_bool Function
-%447 = OpVariable %_ptr_Function_ulong Function
+%445 = OpVariable %_ptr_Function_double Function
+%446 = OpVariable %_ptr_Function_ulong Function
+%447 = OpVariable %_ptr_Function_double Function
 %448 = OpVariable %_ptr_Function_ulong Function
-%449 = OpVariable %_ptr_Function_ulong Function
-%450 = OpVariable %_ptr_Function_bool Function
-%451 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_double Function
+%450 = OpVariable %_ptr_Function_ulong Function
+%451 = OpVariable %_ptr_Function_double Function
 %452 = OpVariable %_ptr_Function_ulong Function
-%453 = OpVariable %_ptr_Function_ulong Function
-%454 = OpVariable %_ptr_Function_bool Function
-%455 = OpVariable %_ptr_Function_ulong Function
+%453 = OpVariable %_ptr_Function_double Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_double Function
 %456 = OpVariable %_ptr_Function_ulong Function
-%457 = OpVariable %_ptr_Function_ulong Function
-%458 = OpVariable %_ptr_Function_bool Function
-%459 = OpVariable %_ptr_Function_ulong Function
-%460 = OpVariable %_ptr_Function_ulong Function
-%461 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_double Function
+%458 = OpVariable %_ptr_Function_double Function
+%459 = OpVariable %_ptr_Function_bool Function
+%460 = OpVariable %_ptr_Function_double Function
+%461 = OpVariable %_ptr_Function_bool Function
 %462 = OpVariable %_ptr_Function_bool Function
-%463 = OpVariable %_ptr_Function_ulong Function
-%464 = OpVariable %_ptr_Function_ulong Function
-%465 = OpVariable %_ptr_Function_ulong Function
-%466 = OpVariable %_ptr_Function_bool Function
-%467 = OpVariable %_ptr_Function_ulong Function
-%468 = OpVariable %_ptr_Function_ulong Function
-%469 = OpVariable %_ptr_Function_ulong Function
-%470 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_bool Function
+%464 = OpVariable %_ptr_Function_bool Function
+%465 = OpVariable %_ptr_Function_double Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_double Function
+%468 = OpVariable %_ptr_Function_double Function
+%469 = OpVariable %_ptr_Function_double Function
+%470 = OpVariable %_ptr_Function_bool Function
 %471 = OpVariable %_ptr_Function_double Function
-%472 = OpVariable %_ptr_Function_bool Function
-%473 = OpVariable %_ptr_Function_ulong Function
-%474 = OpVariable %_ptr_Function_ulong Function
-%475 = OpVariable %_ptr_Function_ulong Function
-%476 = OpVariable %_ptr_Function_ulong Function
+%472 = OpVariable %_ptr_Function_double Function
+%473 = OpVariable %_ptr_Function_bool Function
+%474 = OpVariable %_ptr_Function_double Function
+%475 = OpVariable %_ptr_Function_double Function
+%476 = OpVariable %_ptr_Function_double Function
 %477 = OpVariable %_ptr_Function_double Function
 %478 = OpVariable %_ptr_Function_bool Function
-%479 = OpVariable %_ptr_Function_ulong Function
-%480 = OpVariable %_ptr_Function_ulong Function
-%481 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_double Function
+%480 = OpVariable %_ptr_Function_double Function
+%481 = OpVariable %_ptr_Function_double Function
 %482 = OpVariable %_ptr_Function_bool Function
-%483 = OpVariable %_ptr_Function_ulong Function
-%484 = OpVariable %_ptr_Function_ulong Function
-%485 = OpVariable %_ptr_Function_ulong Function
-%486 = OpVariable %_ptr_Function_bool Function
-%487 = OpVariable %_ptr_Function_ulong Function
-%488 = OpVariable %_ptr_Function_ulong Function
-%489 = OpVariable %_ptr_Function_ulong Function
-%490 = OpVariable %_ptr_Function_bool Function
-%491 = OpVariable %_ptr_Function_ulong Function
-%492 = OpVariable %_ptr_Function_ulong Function
-%493 = OpVariable %_ptr_Function_ulong Function
+%483 = OpVariable %_ptr_Function_bool Function
+%484 = OpVariable %_ptr_Function_double Function
+%485 = OpVariable %_ptr_Function_double Function
+%486 = OpVariable %_ptr_Function_double Function
+%487 = OpVariable %_ptr_Function_double Function
+%488 = OpVariable %_ptr_Function_double Function
+%489 = OpVariable %_ptr_Function_double Function
+%490 = OpVariable %_ptr_Function_double Function
+%491 = OpVariable %_ptr_Function_bool Function
+%492 = OpVariable %_ptr_Function_double Function
+%493 = OpVariable %_ptr_Function_bool Function
 %494 = OpVariable %_ptr_Function_bool Function
-%495 = OpVariable %_ptr_Function_ulong Function
-%496 = OpVariable %_ptr_Function_ulong Function
-%497 = OpVariable %_ptr_Function_ulong Function
-%498 = OpVariable %_ptr_Function_bool Function
-%499 = OpVariable %_ptr_Function_ulong Function
-%500 = OpVariable %_ptr_Function_ulong Function
-%501 = OpVariable %_ptr_Function_ulong Function
+%495 = OpVariable %_ptr_Function_bool Function
+%496 = OpVariable %_ptr_Function_bool Function
+%497 = OpVariable %_ptr_Function_double Function
+%498 = OpVariable %_ptr_Function_ulong Function
+%499 = OpVariable %_ptr_Function_double Function
+%500 = OpVariable %_ptr_Function_double Function
+%501 = OpVariable %_ptr_Function_double Function
 %502 = OpVariable %_ptr_Function_bool Function
-%503 = OpVariable %_ptr_Function_ulong Function
-%504 = OpVariable %_ptr_Function_ulong Function
-%505 = OpVariable %_ptr_Function_ulong Function
-%506 = OpVariable %_ptr_Function_bool Function
-%507 = OpVariable %_ptr_Function_ulong Function
-%508 = OpVariable %_ptr_Function_ulong Function
-%509 = OpVariable %_ptr_Function_ulong Function
+%503 = OpVariable %_ptr_Function_double Function
+%504 = OpVariable %_ptr_Function_double Function
+%505 = OpVariable %_ptr_Function_bool Function
+%506 = OpVariable %_ptr_Function_double Function
+%507 = OpVariable %_ptr_Function_double Function
+%508 = OpVariable %_ptr_Function_double Function
+%509 = OpVariable %_ptr_Function_double Function
 %510 = OpVariable %_ptr_Function_bool Function
-%511 = OpVariable %_ptr_Function_ulong Function
-%512 = OpVariable %_ptr_Function_ulong Function
-%513 = OpVariable %_ptr_Function_ulong Function
+%511 = OpVariable %_ptr_Function_double Function
+%512 = OpVariable %_ptr_Function_double Function
+%513 = OpVariable %_ptr_Function_double Function
 %514 = OpVariable %_ptr_Function_bool Function
-%515 = OpVariable %_ptr_Function_ulong Function
-%516 = OpVariable %_ptr_Function_ulong Function
-%517 = OpVariable %_ptr_Function_ulong Function
-%518 = OpVariable %_ptr_Function_bool Function
-%519 = OpVariable %_ptr_Function_ulong Function
-%520 = OpVariable %_ptr_Function_ulong Function
-%521 = OpVariable %_ptr_Function_ulong Function
-%522 = OpVariable %_ptr_Function_bool Function
-%523 = OpVariable %_ptr_Function_ulong Function
-%524 = OpVariable %_ptr_Function_ulong Function
-%525 = OpVariable %_ptr_Function_ulong Function
+%515 = OpVariable %_ptr_Function_bool Function
+%516 = OpVariable %_ptr_Function_double Function
+%517 = OpVariable %_ptr_Function_double Function
+%518 = OpVariable %_ptr_Function_double Function
+%519 = OpVariable %_ptr_Function_double Function
+%520 = OpVariable %_ptr_Function_double Function
+%521 = OpVariable %_ptr_Function_double Function
+%522 = OpVariable %_ptr_Function_double Function
+%523 = OpVariable %_ptr_Function_bool Function
+%524 = OpVariable %_ptr_Function_double Function
+%525 = OpVariable %_ptr_Function_bool Function
 %526 = OpVariable %_ptr_Function_bool Function
-%527 = OpVariable %_ptr_Function_ulong Function
-%528 = OpVariable %_ptr_Function_ulong Function
-%529 = OpVariable %_ptr_Function_ulong Function
-%530 = OpVariable %_ptr_Function_bool Function
-%531 = OpVariable %_ptr_Function_ulong Function
-%532 = OpVariable %_ptr_Function_ulong Function
-%533 = OpVariable %_ptr_Function_ulong Function
+%527 = OpVariable %_ptr_Function_bool Function
+%528 = OpVariable %_ptr_Function_bool Function
+%529 = OpVariable %_ptr_Function_double Function
+%530 = OpVariable %_ptr_Function_ulong Function
+%531 = OpVariable %_ptr_Function_double Function
+%532 = OpVariable %_ptr_Function_double Function
+%533 = OpVariable %_ptr_Function_double Function
 %534 = OpVariable %_ptr_Function_bool Function
-%535 = OpVariable %_ptr_Function_ulong Function
-%536 = OpVariable %_ptr_Function_ulong Function
-%537 = OpVariable %_ptr_Function_ulong Function
-%538 = OpVariable %_ptr_Function_bool Function
-%539 = OpVariable %_ptr_Function_ulong Function
-%540 = OpVariable %_ptr_Function_ulong Function
-%541 = OpVariable %_ptr_Function_ulong Function
+%535 = OpVariable %_ptr_Function_double Function
+%536 = OpVariable %_ptr_Function_double Function
+%537 = OpVariable %_ptr_Function_bool Function
+%538 = OpVariable %_ptr_Function_double Function
+%539 = OpVariable %_ptr_Function_double Function
+%540 = OpVariable %_ptr_Function_double Function
+%541 = OpVariable %_ptr_Function_double Function
 %542 = OpVariable %_ptr_Function_bool Function
-%543 = OpVariable %_ptr_Function_ulong Function
-%544 = OpVariable %_ptr_Function_ulong Function
-%545 = OpVariable %_ptr_Function_ulong Function
+%543 = OpVariable %_ptr_Function_double Function
+%544 = OpVariable %_ptr_Function_double Function
+%545 = OpVariable %_ptr_Function_double Function
 %546 = OpVariable %_ptr_Function_bool Function
-%547 = OpVariable %_ptr_Function_ulong Function
-%548 = OpVariable %_ptr_Function_ulong Function
-%549 = OpVariable %_ptr_Function_ulong Function
-%550 = OpVariable %_ptr_Function_bool Function
-%551 = OpVariable %_ptr_Function_ulong Function
-%552 = OpVariable %_ptr_Function_ulong Function
-%553 = OpVariable %_ptr_Function_ulong Function
-%554 = OpVariable %_ptr_Function_bool Function
-%555 = OpVariable %_ptr_Function_ulong Function
-%556 = OpVariable %_ptr_Function_ulong Function
-%557 = OpVariable %_ptr_Function_ulong Function
+%547 = OpVariable %_ptr_Function_bool Function
+%548 = OpVariable %_ptr_Function_double Function
+%549 = OpVariable %_ptr_Function_double Function
+%550 = OpVariable %_ptr_Function_double Function
+%551 = OpVariable %_ptr_Function_double Function
+%552 = OpVariable %_ptr_Function_double Function
+%553 = OpVariable %_ptr_Function_double Function
+%554 = OpVariable %_ptr_Function_double Function
+%555 = OpVariable %_ptr_Function_double Function
+%556 = OpVariable %_ptr_Function_bool Function
+%557 = OpVariable %_ptr_Function_double Function
 %558 = OpVariable %_ptr_Function_bool Function
-%559 = OpVariable %_ptr_Function_ulong Function
-%560 = OpVariable %_ptr_Function_ulong Function
-%561 = OpVariable %_ptr_Function_ulong Function
-%562 = OpVariable %_ptr_Function_bool Function
+%559 = OpVariable %_ptr_Function_bool Function
+%560 = OpVariable %_ptr_Function_bool Function
+%561 = OpVariable %_ptr_Function_bool Function
+%562 = OpVariable %_ptr_Function_double Function
 %563 = OpVariable %_ptr_Function_ulong Function
-%564 = OpVariable %_ptr_Function_ulong Function
-%565 = OpVariable %_ptr_Function_ulong Function
-%566 = OpVariable %_ptr_Function_bool Function
-%567 = OpVariable %_ptr_Function_ulong Function
-%568 = OpVariable %_ptr_Function_ulong Function
-%569 = OpVariable %_ptr_Function_ulong Function
+%564 = OpVariable %_ptr_Function_double Function
+%565 = OpVariable %_ptr_Function_double Function
+%566 = OpVariable %_ptr_Function_double Function
+%567 = OpVariable %_ptr_Function_bool Function
+%568 = OpVariable %_ptr_Function_double Function
+%569 = OpVariable %_ptr_Function_double Function
 %570 = OpVariable %_ptr_Function_bool Function
-%571 = OpVariable %_ptr_Function_ulong Function
-%572 = OpVariable %_ptr_Function_ulong Function
-%573 = OpVariable %_ptr_Function_ulong Function
-%574 = OpVariable %_ptr_Function_bool Function
-%575 = OpVariable %_ptr_Function_ulong Function
-%576 = OpVariable %_ptr_Function_ulong Function
-%577 = OpVariable %_ptr_Function_ulong Function
-%578 = OpVariable %_ptr_Function_bool Function
-%579 = OpVariable %_ptr_Function_ulong Function
-%580 = OpVariable %_ptr_Function_ulong Function
-%581 = OpVariable %_ptr_Function_ulong Function
-%582 = OpVariable %_ptr_Function_bool Function
-%583 = OpVariable %_ptr_Function_ulong Function
-%584 = OpVariable %_ptr_Function_ulong Function
-%585 = OpVariable %_ptr_Function_ulong Function
-%586 = OpVariable %_ptr_Function_bool Function
-%587 = OpVariable %_ptr_Function_ulong Function
-%588 = OpVariable %_ptr_Function_ulong Function
-%589 = OpVariable %_ptr_Function_ulong Function
+%571 = OpVariable %_ptr_Function_double Function
+%572 = OpVariable %_ptr_Function_double Function
+%573 = OpVariable %_ptr_Function_double Function
+%574 = OpVariable %_ptr_Function_double Function
+%575 = OpVariable %_ptr_Function_bool Function
+%576 = OpVariable %_ptr_Function_double Function
+%577 = OpVariable %_ptr_Function_double Function
+%578 = OpVariable %_ptr_Function_double Function
+%579 = OpVariable %_ptr_Function_bool Function
+%580 = OpVariable %_ptr_Function_bool Function
+%581 = OpVariable %_ptr_Function_double Function
+%582 = OpVariable %_ptr_Function_double Function
+%583 = OpVariable %_ptr_Function_double Function
+%584 = OpVariable %_ptr_Function_double Function
+%585 = OpVariable %_ptr_Function_double Function
+%586 = OpVariable %_ptr_Function_double Function
+%587 = OpVariable %_ptr_Function_double Function
+%588 = OpVariable %_ptr_Function_double Function
+%589 = OpVariable %_ptr_Function_bool Function
 %590 = OpVariable %_ptr_Function_bool Function
-%591 = OpVariable %_ptr_Function_ulong Function
-%592 = OpVariable %_ptr_Function_ulong Function
+%591 = OpVariable %_ptr_Function_bool Function
+%592 = OpVariable %_ptr_Function_double Function
 %593 = OpVariable %_ptr_Function_ulong Function
-OpStore %297 %53
-%594 = OpFunctionCall %ulong %4
-OpStore %298 %594
-OpBranch %58
-%58 = OpLabel
-%596 = OpLoad %ulong %297
-%597 = OpIAdd %ulong %ulong_4607182418800017408 %596
-OpStore %402 %597
-%598 = OpLoad %ulong %402
-%599 = OpBitcast %double %598
-OpStore %403 %599
-OpBranch %59
-%59 = OpLabel
-%601 = OpLoad %double %403
-%602 = OpFMul %double %double_1_5 %601
-OpStore %299 %602
-%604 = OpLoad %double %403
-%605 = OpFMul %double %double_0_25 %604
-OpStore %300 %605
-%606 = OpLoad %double %299
-%607 = OpLoad %double %300
-%608 = OpFAdd %double %606 %607
-OpStore %301 %608
-OpBranch %67
-%67 = OpLabel
-%609 = OpLoad %double %301
-%610 = OpLoad %double %301
-%611 = OpFUnordNotEqual %bool %609 %610
-OpStore %410 %611
-%612 = OpLoad %bool %410
-OpSelectionMerge %71 None
-OpBranchConditional %612 %68 %69
-%69 = OpLabel
-OpBranch %70
-%70 = OpLabel
-%613 = OpLoad %ulong %298
-%614 = OpLoad %double %301
-%615 = OpFunctionCall %ulong %6 %613 %614
-OpStore %412 %615
-%616 = OpLoad %ulong %412
-OpStore %413 %616
-OpBranch %71
-%68 = OpLabel
-%617 = OpLoad %ulong %298
-%618 = OpFunctionCall %ulong %5 %617 %ulong_18446744073709551615
-OpStore %411 %618
-%619 = OpLoad %ulong %411
-OpStore %413 %619
-OpBranch %71
-%71 = OpLabel
-%620 = OpLoad %double %299
-%621 = OpLoad %double %300
-%622 = OpFSub %double %620 %621
-OpStore %302 %622
-OpBranch %77
-%77 = OpLabel
-%623 = OpLoad %double %302
-%624 = OpLoad %double %302
-%625 = OpFUnordNotEqual %bool %623 %624
-OpStore %418 %625
-%626 = OpLoad %bool %418
-OpSelectionMerge %81 None
-OpBranchConditional %626 %78 %79
-%79 = OpLabel
-OpBranch %80
-%80 = OpLabel
-%627 = OpLoad %ulong %413
-%628 = OpLoad %double %302
-%629 = OpFunctionCall %ulong %6 %627 %628
-OpStore %420 %629
-%630 = OpLoad %ulong %420
-OpStore %421 %630
-OpBranch %81
-%78 = OpLabel
-%631 = OpLoad %ulong %413
-%632 = OpFunctionCall %ulong %5 %631 %ulong_18446744073709551615
-OpStore %419 %632
-%633 = OpLoad %ulong %419
-OpStore %421 %633
-OpBranch %81
-%81 = OpLabel
-%634 = OpLoad %double %300
-%635 = OpLoad %double %299
-%636 = OpFSub %double %634 %635
-OpStore %303 %636
-OpBranch %87
-%87 = OpLabel
-%637 = OpLoad %double %303
-%638 = OpLoad %double %303
-%639 = OpFUnordNotEqual %bool %637 %638
-OpStore %426 %639
-%640 = OpLoad %bool %426
-OpSelectionMerge %91 None
-OpBranchConditional %640 %88 %89
-%89 = OpLabel
-OpBranch %90
-%90 = OpLabel
-%641 = OpLoad %ulong %421
-%642 = OpLoad %double %303
-%643 = OpFunctionCall %ulong %6 %641 %642
-OpStore %428 %643
-%644 = OpLoad %ulong %428
-OpStore %429 %644
-OpBranch %91
-%88 = OpLabel
-%645 = OpLoad %ulong %421
-%646 = OpFunctionCall %ulong %5 %645 %ulong_18446744073709551615
-OpStore %427 %646
-%647 = OpLoad %ulong %427
-OpStore %429 %647
-OpBranch %91
-%91 = OpLabel
-%648 = OpLoad %double %299
-%649 = OpLoad %double %300
-%650 = OpFMul %double %648 %649
-OpStore %304 %650
-OpBranch %97
-%97 = OpLabel
-%651 = OpLoad %double %304
-%652 = OpLoad %double %304
-%653 = OpFUnordNotEqual %bool %651 %652
-OpStore %434 %653
-%654 = OpLoad %bool %434
-OpSelectionMerge %101 None
-OpBranchConditional %654 %98 %99
-%99 = OpLabel
-OpBranch %100
-%100 = OpLabel
-%655 = OpLoad %ulong %429
-%656 = OpLoad %double %304
-%657 = OpFunctionCall %ulong %6 %655 %656
-OpStore %436 %657
-%658 = OpLoad %ulong %436
-OpStore %437 %658
-OpBranch %101
-%98 = OpLabel
-%659 = OpLoad %ulong %429
-%660 = OpFunctionCall %ulong %5 %659 %ulong_18446744073709551615
-OpStore %435 %660
-%661 = OpLoad %ulong %435
-OpStore %437 %661
-OpBranch %101
-%101 = OpLabel
-%662 = OpLoad %double %299
-%663 = OpLoad %double %300
-%664 = OpFDiv %double %662 %663
-OpStore %305 %664
-OpBranch %107
-%107 = OpLabel
-%665 = OpLoad %double %305
-%666 = OpLoad %double %305
-%667 = OpFUnordNotEqual %bool %665 %666
-OpStore %442 %667
-%668 = OpLoad %bool %442
-OpSelectionMerge %111 None
-OpBranchConditional %668 %108 %109
-%109 = OpLabel
-OpBranch %110
-%110 = OpLabel
-%669 = OpLoad %ulong %437
-%670 = OpLoad %double %305
-%671 = OpFunctionCall %ulong %6 %669 %670
-OpStore %444 %671
-%672 = OpLoad %ulong %444
-OpStore %445 %672
-OpBranch %111
-%108 = OpLabel
-%673 = OpLoad %ulong %437
-%674 = OpFunctionCall %ulong %5 %673 %ulong_18446744073709551615
-OpStore %443 %674
-%675 = OpLoad %ulong %443
-OpStore %445 %675
-OpBranch %111
-%111 = OpLabel
-%676 = OpLoad %double %300
-%677 = OpLoad %double %299
-%678 = OpFDiv %double %676 %677
-OpStore %306 %678
-OpBranch %117
-%117 = OpLabel
-%679 = OpLoad %double %306
-%680 = OpLoad %double %306
-%681 = OpFUnordNotEqual %bool %679 %680
-OpStore %450 %681
-%682 = OpLoad %bool %450
-OpSelectionMerge %121 None
-OpBranchConditional %682 %118 %119
-%119 = OpLabel
-OpBranch %120
-%120 = OpLabel
-%683 = OpLoad %ulong %445
-%684 = OpLoad %double %306
-%685 = OpFunctionCall %ulong %6 %683 %684
-OpStore %452 %685
-%686 = OpLoad %ulong %452
-OpStore %453 %686
-OpBranch %121
-%118 = OpLabel
-%687 = OpLoad %ulong %445
-%688 = OpFunctionCall %ulong %5 %687 %ulong_18446744073709551615
-OpStore %451 %688
-%689 = OpLoad %ulong %451
-OpStore %453 %689
-OpBranch %121
-%121 = OpLabel
-%690 = OpLoad %double %299
-%691 = OpFNegate %double %690
-OpStore %307 %691
-OpBranch %127
-%127 = OpLabel
-%692 = OpLoad %double %307
-%693 = OpLoad %double %307
-%694 = OpFUnordNotEqual %bool %692 %693
-OpStore %458 %694
-%695 = OpLoad %bool %458
-OpSelectionMerge %131 None
-OpBranchConditional %695 %128 %129
-%129 = OpLabel
-OpBranch %130
-%130 = OpLabel
-%696 = OpLoad %ulong %453
-%697 = OpLoad %double %307
-%698 = OpFunctionCall %ulong %6 %696 %697
-OpStore %460 %698
-%699 = OpLoad %ulong %460
-OpStore %461 %699
-OpBranch %131
-%128 = OpLabel
-%700 = OpLoad %ulong %453
-%701 = OpFunctionCall %ulong %5 %700 %ulong_18446744073709551615
-OpStore %459 %701
-%702 = OpLoad %ulong %459
-OpStore %461 %702
-OpBranch %131
-%131 = OpLabel
-%704 = OpLoad %double %299
-%705 = OpFSub %double %double_0 %704
-OpStore %308 %705
-OpBranch %137
-%137 = OpLabel
-%706 = OpLoad %double %308
-%707 = OpLoad %double %308
-%708 = OpFUnordNotEqual %bool %706 %707
-OpStore %466 %708
-%709 = OpLoad %bool %466
-OpSelectionMerge %141 None
-OpBranchConditional %709 %138 %139
-%139 = OpLabel
-OpBranch %140
-%140 = OpLabel
-%710 = OpLoad %ulong %461
-%711 = OpLoad %double %308
-%712 = OpFunctionCall %ulong %6 %710 %711
-OpStore %468 %712
-%713 = OpLoad %ulong %468
-OpStore %469 %713
-OpBranch %141
-%138 = OpLabel
-%714 = OpLoad %ulong %461
-%715 = OpFunctionCall %ulong %5 %714 %ulong_18446744073709551615
-OpStore %467 %715
-%716 = OpLoad %ulong %467
-OpStore %469 %716
-OpBranch %141
-%141 = OpLabel
-%717 = OpLoad %double %299
-%718 = OpLoad %double %299
-%719 = OpFSub %double %717 %718
-OpStore %309 %719
-OpBranch %144
-%144 = OpLabel
-%720 = OpLoad %double %309
-%721 = OpLoad %double %309
-%722 = OpFUnordNotEqual %bool %720 %721
-OpStore %472 %722
-%723 = OpLoad %bool %472
-OpSelectionMerge %148 None
-OpBranchConditional %723 %145 %146
-%146 = OpLabel
-OpBranch %147
-%147 = OpLabel
-%724 = OpLoad %ulong %469
-%725 = OpLoad %double %309
-%726 = OpFunctionCall %ulong %6 %724 %725
-OpStore %474 %726
-%727 = OpLoad %ulong %474
-OpStore %475 %727
-OpBranch %148
-%145 = OpLabel
-%728 = OpLoad %ulong %469
-%729 = OpFunctionCall %ulong %5 %728 %ulong_18446744073709551615
-OpStore %473 %729
-%730 = OpLoad %ulong %473
-OpStore %475 %730
-OpBranch %148
-%148 = OpLabel
-%731 = OpLoad %double %299
-%732 = OpFSub %double %double_0 %731
-OpStore %310 %732
-%733 = OpLoad %double %310
-%734 = OpLoad %double %299
-%735 = OpFAdd %double %733 %734
-OpStore %311 %735
-OpBranch %151
-%151 = OpLabel
-%736 = OpLoad %double %311
-%737 = OpLoad %double %311
-%738 = OpFUnordNotEqual %bool %736 %737
-OpStore %478 %738
-%739 = OpLoad %bool %478
-OpSelectionMerge %155 None
-OpBranchConditional %739 %152 %153
-%153 = OpLabel
-OpBranch %154
-%154 = OpLabel
-%740 = OpLoad %ulong %475
-%741 = OpLoad %double %311
-%742 = OpFunctionCall %ulong %6 %740 %741
-OpStore %480 %742
-%743 = OpLoad %ulong %480
-OpStore %481 %743
-OpBranch %155
-%152 = OpLabel
-%744 = OpLoad %ulong %475
-%745 = OpFunctionCall %ulong %5 %744 %ulong_18446744073709551615
-OpStore %479 %745
-%746 = OpLoad %ulong %479
-OpStore %481 %746
-OpBranch %155
-%155 = OpLabel
-%748 = OpLoad %double %403
-%749 = OpFMul %double %double_3 %748
-OpStore %312 %749
-%750 = OpLoad %double %403
-%751 = OpLoad %double %312
-%752 = OpFDiv %double %750 %751
-OpStore %313 %752
-OpBranch %161
-%161 = OpLabel
-%753 = OpLoad %double %313
-%754 = OpLoad %double %313
-%755 = OpFUnordNotEqual %bool %753 %754
-OpStore %486 %755
-%756 = OpLoad %bool %486
-OpSelectionMerge %165 None
-OpBranchConditional %756 %162 %163
-%163 = OpLabel
-OpBranch %164
-%164 = OpLabel
-%757 = OpLoad %ulong %481
-%758 = OpLoad %double %313
-%759 = OpFunctionCall %ulong %6 %757 %758
-OpStore %488 %759
-%760 = OpLoad %ulong %488
-OpStore %489 %760
-OpBranch %165
-%162 = OpLabel
-%761 = OpLoad %ulong %481
-%762 = OpFunctionCall %ulong %5 %761 %ulong_18446744073709551615
-OpStore %487 %762
-%763 = OpLoad %ulong %487
-OpStore %489 %763
-OpBranch %165
-%165 = OpLabel
-%764 = OpLoad %double %313
-%765 = OpLoad %double %312
-%766 = OpFMul %double %764 %765
-OpStore %314 %766
-OpBranch %171
-%171 = OpLabel
-%767 = OpLoad %double %314
-%768 = OpLoad %double %314
-%769 = OpFUnordNotEqual %bool %767 %768
-OpStore %494 %769
-%770 = OpLoad %bool %494
-OpSelectionMerge %175 None
-OpBranchConditional %770 %172 %173
-%173 = OpLabel
-OpBranch %174
-%174 = OpLabel
-%771 = OpLoad %ulong %489
-%772 = OpLoad %double %314
-%773 = OpFunctionCall %ulong %6 %771 %772
-OpStore %496 %773
-%774 = OpLoad %ulong %496
-OpStore %497 %774
-OpBranch %175
-%172 = OpLabel
-%775 = OpLoad %ulong %489
-%776 = OpFunctionCall %ulong %5 %775 %ulong_18446744073709551615
-OpStore %495 %776
-%777 = OpLoad %ulong %495
-OpStore %497 %777
-OpBranch %175
-%175 = OpLabel
-%778 = OpLoad %double %403
-%779 = OpLoad %double %313
-%780 = OpFSub %double %778 %779
-OpStore %315 %780
-%781 = OpLoad %double %315
-%782 = OpLoad %double %313
-%783 = OpFSub %double %781 %782
-OpStore %316 %783
-%784 = OpLoad %double %316
-%785 = OpLoad %double %313
-%786 = OpFSub %double %784 %785
-OpStore %317 %786
-OpBranch %181
-%181 = OpLabel
-%787 = OpLoad %double %317
-%788 = OpLoad %double %317
-%789 = OpFUnordNotEqual %bool %787 %788
-OpStore %502 %789
-%790 = OpLoad %bool %502
-OpSelectionMerge %185 None
-OpBranchConditional %790 %182 %183
-%183 = OpLabel
-OpBranch %184
-%184 = OpLabel
-%791 = OpLoad %ulong %497
-%792 = OpLoad %double %317
-%793 = OpFunctionCall %ulong %6 %791 %792
-OpStore %504 %793
-%794 = OpLoad %ulong %504
-OpStore %505 %794
-OpBranch %185
-%182 = OpLabel
-%795 = OpLoad %ulong %497
-%796 = OpFunctionCall %ulong %5 %795 %ulong_18446744073709551615
-OpStore %503 %796
-%797 = OpLoad %ulong %503
-OpStore %505 %797
-OpBranch %185
-%185 = OpLabel
-%798 = OpLoad %double %403
-%800 = OpFDiv %double %798 %double_49
-OpStore %318 %800
-OpBranch %191
-%191 = OpLabel
-%801 = OpLoad %double %318
-%802 = OpLoad %double %318
-%803 = OpFUnordNotEqual %bool %801 %802
-OpStore %510 %803
-%804 = OpLoad %bool %510
-OpSelectionMerge %195 None
-OpBranchConditional %804 %192 %193
-%193 = OpLabel
-OpBranch %194
-%194 = OpLabel
-%805 = OpLoad %ulong %505
-%806 = OpLoad %double %318
-%807 = OpFunctionCall %ulong %6 %805 %806
-OpStore %512 %807
-%808 = OpLoad %ulong %512
-OpStore %513 %808
-OpBranch %195
-%192 = OpLabel
-%809 = OpLoad %ulong %505
-%810 = OpFunctionCall %ulong %5 %809 %ulong_18446744073709551615
-OpStore %511 %810
-%811 = OpLoad %ulong %511
-OpStore %513 %811
-OpBranch %195
-%195 = OpLabel
-%812 = OpLoad %double %403
-%814 = OpFDiv %double %812 %double_1048576_5
-OpStore %319 %814
-OpBranch %201
-%201 = OpLabel
-%815 = OpLoad %double %319
-%816 = OpLoad %double %319
-%817 = OpFUnordNotEqual %bool %815 %816
-OpStore %518 %817
-%818 = OpLoad %bool %518
-OpSelectionMerge %205 None
-OpBranchConditional %818 %202 %203
-%203 = OpLabel
-OpBranch %204
-%204 = OpLabel
-%819 = OpLoad %ulong %513
-%820 = OpLoad %double %319
-%821 = OpFunctionCall %ulong %6 %819 %820
-OpStore %520 %821
-%822 = OpLoad %ulong %520
-OpStore %521 %822
-OpBranch %205
-%202 = OpLabel
-%823 = OpLoad %ulong %513
-%824 = OpFunctionCall %ulong %5 %823 %ulong_18446744073709551615
-OpStore %519 %824
-%825 = OpLoad %ulong %519
-OpStore %521 %825
-OpBranch %205
-%205 = OpLabel
-%826 = OpLoad %double %312
-%827 = OpFDiv %double %double_1048576_5 %826
-OpStore %320 %827
-OpBranch %211
-%211 = OpLabel
-%828 = OpLoad %double %320
-%829 = OpLoad %double %320
-%830 = OpFUnordNotEqual %bool %828 %829
-OpStore %526 %830
-%831 = OpLoad %bool %526
-OpSelectionMerge %215 None
-OpBranchConditional %831 %212 %213
-%213 = OpLabel
-OpBranch %214
-%214 = OpLabel
-%832 = OpLoad %ulong %521
-%833 = OpLoad %double %320
-%834 = OpFunctionCall %ulong %6 %832 %833
-OpStore %528 %834
-%835 = OpLoad %ulong %528
-OpStore %529 %835
-OpBranch %215
-%212 = OpLabel
-%836 = OpLoad %ulong %521
-%837 = OpFunctionCall %ulong %5 %836 %ulong_18446744073709551615
-OpStore %527 %837
-%838 = OpLoad %ulong %527
-OpStore %529 %838
-OpBranch %215
-%215 = OpLabel
-%840 = OpLoad %double %403
-%841 = OpFMul %double %double_9007199254740992 %840
-OpStore %321 %841
-%842 = OpLoad %double %321
-%843 = OpLoad %double %403
-%844 = OpFAdd %double %842 %843
-OpStore %322 %844
-OpBranch %221
-%221 = OpLabel
-%845 = OpLoad %double %322
-%846 = OpLoad %double %322
-%847 = OpFUnordNotEqual %bool %845 %846
-OpStore %534 %847
-%848 = OpLoad %bool %534
-OpSelectionMerge %225 None
-OpBranchConditional %848 %222 %223
-%223 = OpLabel
-OpBranch %224
-%224 = OpLabel
-%849 = OpLoad %ulong %529
-%850 = OpLoad %double %322
-%851 = OpFunctionCall %ulong %6 %849 %850
-OpStore %536 %851
-%852 = OpLoad %ulong %536
-OpStore %537 %852
-OpBranch %225
-%222 = OpLabel
-%853 = OpLoad %ulong %529
-%854 = OpFunctionCall %ulong %5 %853 %ulong_18446744073709551615
-OpStore %535 %854
-%855 = OpLoad %ulong %535
-OpStore %537 %855
-OpBranch %225
-%225 = OpLabel
-%856 = OpLoad %double %321
-%857 = OpLoad %double %403
-%858 = OpFAdd %double %856 %857
-OpStore %323 %858
-%859 = OpLoad %double %323
-%860 = OpLoad %double %403
-%861 = OpFAdd %double %859 %860
-OpStore %324 %861
-OpBranch %231
-%231 = OpLabel
-%862 = OpLoad %double %324
-%863 = OpLoad %double %324
-%864 = OpFUnordNotEqual %bool %862 %863
-OpStore %542 %864
-%865 = OpLoad %bool %542
-OpSelectionMerge %235 None
-OpBranchConditional %865 %232 %233
-%233 = OpLabel
-OpBranch %234
-%234 = OpLabel
-%866 = OpLoad %ulong %537
-%867 = OpLoad %double %324
-%868 = OpFunctionCall %ulong %6 %866 %867
-OpStore %544 %868
-%869 = OpLoad %ulong %544
-OpStore %545 %869
-OpBranch %235
-%232 = OpLabel
-%870 = OpLoad %ulong %537
-%871 = OpFunctionCall %ulong %5 %870 %ulong_18446744073709551615
-OpStore %543 %871
-%872 = OpLoad %ulong %543
-OpStore %545 %872
-OpBranch %235
-%235 = OpLabel
-%873 = OpLoad %double %403
-%874 = OpLoad %double %403
-%875 = OpFAdd %double %873 %874
-OpStore %325 %875
-%876 = OpLoad %double %321
-%877 = OpLoad %double %325
-%878 = OpFAdd %double %876 %877
-OpStore %326 %878
-OpBranch %241
-%241 = OpLabel
-%879 = OpLoad %double %326
-%880 = OpLoad %double %326
-%881 = OpFUnordNotEqual %bool %879 %880
-OpStore %550 %881
-%882 = OpLoad %bool %550
-OpSelectionMerge %245 None
-OpBranchConditional %882 %242 %243
-%243 = OpLabel
-OpBranch %244
-%244 = OpLabel
-%883 = OpLoad %ulong %545
-%884 = OpLoad %double %326
-%885 = OpFunctionCall %ulong %6 %883 %884
-OpStore %552 %885
-%886 = OpLoad %ulong %552
-OpStore %553 %886
-OpBranch %245
-%242 = OpLabel
-%887 = OpLoad %ulong %545
-%888 = OpFunctionCall %ulong %5 %887 %ulong_18446744073709551615
-OpStore %551 %888
-%889 = OpLoad %ulong %551
-OpStore %553 %889
-OpBranch %245
-%245 = OpLabel
-%890 = OpLoad %double %321
-%891 = OpLoad %double %403
-%892 = OpFSub %double %890 %891
-OpStore %327 %892
-OpBranch %251
-%251 = OpLabel
-%893 = OpLoad %double %327
-%894 = OpLoad %double %327
-%895 = OpFUnordNotEqual %bool %893 %894
-OpStore %558 %895
-%896 = OpLoad %bool %558
-OpSelectionMerge %255 None
-OpBranchConditional %896 %252 %253
-%253 = OpLabel
-OpBranch %254
-%254 = OpLabel
-%897 = OpLoad %ulong %553
-%898 = OpLoad %double %327
-%899 = OpFunctionCall %ulong %6 %897 %898
-OpStore %560 %899
-%900 = OpLoad %ulong %560
-OpStore %561 %900
-OpBranch %255
-%252 = OpLabel
-%901 = OpLoad %ulong %553
-%902 = OpFunctionCall %ulong %5 %901 %ulong_18446744073709551615
-OpStore %559 %902
-%903 = OpLoad %ulong %559
-OpStore %561 %903
-OpBranch %255
-%255 = OpLabel
-%904 = OpLoad %double %321
-%905 = OpLoad %double %403
-%906 = OpFAdd %double %904 %905
-OpStore %328 %906
-%907 = OpLoad %double %328
-%908 = OpLoad %double %321
+%594 = OpVariable %_ptr_Function_double Function
+%595 = OpVariable %_ptr_Function_double Function
+%596 = OpVariable %_ptr_Function_double Function
+%597 = OpVariable %_ptr_Function_bool Function
+%598 = OpVariable %_ptr_Function_double Function
+%599 = OpVariable %_ptr_Function_double Function
+%600 = OpVariable %_ptr_Function_double Function
+%601 = OpVariable %_ptr_Function_double Function
+%602 = OpVariable %_ptr_Function_bool Function
+%603 = OpVariable %_ptr_Function_double Function
+%604 = OpVariable %_ptr_Function_double Function
+%605 = OpVariable %_ptr_Function_double Function
+%606 = OpVariable %_ptr_Function_bool Function
+%607 = OpVariable %_ptr_Function_bool Function
+%608 = OpVariable %_ptr_Function_double Function
+%609 = OpVariable %_ptr_Function_double Function
+%610 = OpVariable %_ptr_Function_double Function
+%611 = OpVariable %_ptr_Function_double Function
+%612 = OpVariable %_ptr_Function_double Function
+%613 = OpVariable %_ptr_Function_double Function
+%614 = OpVariable %_ptr_Function_bool Function
+%615 = OpVariable %_ptr_Function_double Function
+%616 = OpVariable %_ptr_Function_bool Function
+%617 = OpVariable %_ptr_Function_bool Function
+%618 = OpVariable %_ptr_Function_bool Function
+%619 = OpVariable %_ptr_Function_bool Function
+%620 = OpVariable %_ptr_Function_double Function
+%621 = OpVariable %_ptr_Function_ulong Function
+%622 = OpVariable %_ptr_Function_double Function
+%623 = OpVariable %_ptr_Function_double Function
+%624 = OpVariable %_ptr_Function_double Function
+%625 = OpVariable %_ptr_Function_bool Function
+%626 = OpVariable %_ptr_Function_double Function
+%627 = OpVariable %_ptr_Function_double Function
+%628 = OpVariable %_ptr_Function_bool Function
+%629 = OpVariable %_ptr_Function_double Function
+%630 = OpVariable %_ptr_Function_double Function
+%631 = OpVariable %_ptr_Function_double Function
+%632 = OpVariable %_ptr_Function_double Function
+%633 = OpVariable %_ptr_Function_bool Function
+%634 = OpVariable %_ptr_Function_double Function
+%635 = OpVariable %_ptr_Function_double Function
+%636 = OpVariable %_ptr_Function_double Function
+%637 = OpVariable %_ptr_Function_bool Function
+%638 = OpVariable %_ptr_Function_bool Function
+%639 = OpVariable %_ptr_Function_double Function
+%640 = OpVariable %_ptr_Function_double Function
+%641 = OpVariable %_ptr_Function_double Function
+%642 = OpVariable %_ptr_Function_double Function
+%643 = OpVariable %_ptr_Function_double Function
+%644 = OpVariable %_ptr_Function_double Function
+%645 = OpVariable %_ptr_Function_bool Function
+%646 = OpVariable %_ptr_Function_double Function
+%647 = OpVariable %_ptr_Function_bool Function
+%648 = OpVariable %_ptr_Function_bool Function
+%649 = OpVariable %_ptr_Function_bool Function
+%650 = OpVariable %_ptr_Function_bool Function
+%651 = OpVariable %_ptr_Function_double Function
+%652 = OpVariable %_ptr_Function_ulong Function
+%653 = OpVariable %_ptr_Function_double Function
+%654 = OpVariable %_ptr_Function_double Function
+%655 = OpVariable %_ptr_Function_double Function
+%656 = OpVariable %_ptr_Function_bool Function
+%657 = OpVariable %_ptr_Function_double Function
+%658 = OpVariable %_ptr_Function_double Function
+%659 = OpVariable %_ptr_Function_bool Function
+%660 = OpVariable %_ptr_Function_double Function
+%661 = OpVariable %_ptr_Function_double Function
+%662 = OpVariable %_ptr_Function_double Function
+%663 = OpVariable %_ptr_Function_double Function
+%664 = OpVariable %_ptr_Function_bool Function
+%665 = OpVariable %_ptr_Function_double Function
+%666 = OpVariable %_ptr_Function_double Function
+%667 = OpVariable %_ptr_Function_double Function
+%668 = OpVariable %_ptr_Function_bool Function
+%669 = OpVariable %_ptr_Function_bool Function
+%670 = OpVariable %_ptr_Function_double Function
+%671 = OpVariable %_ptr_Function_double Function
+%672 = OpVariable %_ptr_Function_double Function
+%673 = OpVariable %_ptr_Function_double Function
+%674 = OpVariable %_ptr_Function_double Function
+%675 = OpVariable %_ptr_Function_double Function
+%676 = OpVariable %_ptr_Function_double Function
+%677 = OpVariable %_ptr_Function_bool Function
+%678 = OpVariable %_ptr_Function_double Function
+%679 = OpVariable %_ptr_Function_bool Function
+%680 = OpVariable %_ptr_Function_bool Function
+%681 = OpVariable %_ptr_Function_bool Function
+%682 = OpVariable %_ptr_Function_bool Function
+%683 = OpVariable %_ptr_Function_double Function
+%684 = OpVariable %_ptr_Function_ulong Function
+%685 = OpVariable %_ptr_Function_double Function
+%686 = OpVariable %_ptr_Function_double Function
+%687 = OpVariable %_ptr_Function_double Function
+%688 = OpVariable %_ptr_Function_bool Function
+%689 = OpVariable %_ptr_Function_double Function
+%690 = OpVariable %_ptr_Function_double Function
+%691 = OpVariable %_ptr_Function_bool Function
+%692 = OpVariable %_ptr_Function_double Function
+%693 = OpVariable %_ptr_Function_double Function
+%694 = OpVariable %_ptr_Function_double Function
+%695 = OpVariable %_ptr_Function_double Function
+%696 = OpVariable %_ptr_Function_bool Function
+%697 = OpVariable %_ptr_Function_double Function
+%698 = OpVariable %_ptr_Function_double Function
+%699 = OpVariable %_ptr_Function_double Function
+%700 = OpVariable %_ptr_Function_bool Function
+%701 = OpVariable %_ptr_Function_bool Function
+%702 = OpVariable %_ptr_Function_double Function
+%703 = OpVariable %_ptr_Function_double Function
+%704 = OpVariable %_ptr_Function_double Function
+%705 = OpVariable %_ptr_Function_double Function
+%706 = OpVariable %_ptr_Function_double Function
+%707 = OpVariable %_ptr_Function_double Function
+%708 = OpVariable %_ptr_Function_ulong Function
+%709 = OpVariable %_ptr_Function_double Function
+%710 = OpVariable %_ptr_Function_ulong Function
+%711 = OpVariable %_ptr_Function_ulong Function
+%712 = OpVariable %_ptr_Function_double Function
+%713 = OpVariable %_ptr_Function_bool Function
+%714 = OpVariable %_ptr_Function_ulong Function
+%715 = OpVariable %_ptr_Function_ulong Function
+%716 = OpVariable %_ptr_Function_ulong Function
+%717 = OpVariable %_ptr_Function_ulong Function
+%718 = OpVariable %_ptr_Function_double Function
+%719 = OpVariable %_ptr_Function_bool Function
+%720 = OpVariable %_ptr_Function_ulong Function
+%721 = OpVariable %_ptr_Function_ulong Function
+%722 = OpVariable %_ptr_Function_ulong Function
+%723 = OpVariable %_ptr_Function_bool Function
+%724 = OpVariable %_ptr_Function_ulong Function
+%725 = OpVariable %_ptr_Function_ulong Function
+%726 = OpVariable %_ptr_Function_ulong Function
+%727 = OpVariable %_ptr_Function_bool Function
+%728 = OpVariable %_ptr_Function_ulong Function
+%729 = OpVariable %_ptr_Function_ulong Function
+%730 = OpVariable %_ptr_Function_ulong Function
+%731 = OpVariable %_ptr_Function_bool Function
+%732 = OpVariable %_ptr_Function_ulong Function
+%733 = OpVariable %_ptr_Function_ulong Function
+%734 = OpVariable %_ptr_Function_ulong Function
+%735 = OpVariable %_ptr_Function_bool Function
+%736 = OpVariable %_ptr_Function_ulong Function
+%737 = OpVariable %_ptr_Function_ulong Function
+%738 = OpVariable %_ptr_Function_ulong Function
+%739 = OpVariable %_ptr_Function_bool Function
+%740 = OpVariable %_ptr_Function_ulong Function
+%741 = OpVariable %_ptr_Function_ulong Function
+%742 = OpVariable %_ptr_Function_ulong Function
+%743 = OpVariable %_ptr_Function_bool Function
+%744 = OpVariable %_ptr_Function_ulong Function
+%745 = OpVariable %_ptr_Function_ulong Function
+%746 = OpVariable %_ptr_Function_ulong Function
+%747 = OpVariable %_ptr_Function_bool Function
+%748 = OpVariable %_ptr_Function_ulong Function
+%749 = OpVariable %_ptr_Function_ulong Function
+%750 = OpVariable %_ptr_Function_ulong Function
+%751 = OpVariable %_ptr_Function_bool Function
+%752 = OpVariable %_ptr_Function_ulong Function
+%753 = OpVariable %_ptr_Function_ulong Function
+%754 = OpVariable %_ptr_Function_ulong Function
+%755 = OpVariable %_ptr_Function_bool Function
+%756 = OpVariable %_ptr_Function_ulong Function
+%757 = OpVariable %_ptr_Function_ulong Function
+%758 = OpVariable %_ptr_Function_ulong Function
+%759 = OpVariable %_ptr_Function_bool Function
+%760 = OpVariable %_ptr_Function_ulong Function
+%761 = OpVariable %_ptr_Function_ulong Function
+%762 = OpVariable %_ptr_Function_ulong Function
+%763 = OpVariable %_ptr_Function_bool Function
+%764 = OpVariable %_ptr_Function_ulong Function
+%765 = OpVariable %_ptr_Function_ulong Function
+%766 = OpVariable %_ptr_Function_ulong Function
+%767 = OpVariable %_ptr_Function_bool Function
+%768 = OpVariable %_ptr_Function_ulong Function
+%769 = OpVariable %_ptr_Function_ulong Function
+%770 = OpVariable %_ptr_Function_ulong Function
+%771 = OpVariable %_ptr_Function_bool Function
+%772 = OpVariable %_ptr_Function_ulong Function
+%773 = OpVariable %_ptr_Function_ulong Function
+%774 = OpVariable %_ptr_Function_ulong Function
+%775 = OpVariable %_ptr_Function_bool Function
+%776 = OpVariable %_ptr_Function_ulong Function
+%777 = OpVariable %_ptr_Function_ulong Function
+%778 = OpVariable %_ptr_Function_ulong Function
+%779 = OpVariable %_ptr_Function_ulong Function
+%780 = OpVariable %_ptr_Function_double Function
+%781 = OpVariable %_ptr_Function_ulong Function
+%782 = OpVariable %_ptr_Function_double Function
+OpStore %377 %53
+%783 = OpFunctionCall %ulong %4
+OpStore %378 %783
+OpBranch %257
+%257 = OpLabel
+%785 = OpLoad %ulong %377
+%786 = OpIAdd %ulong %ulong_4607182418800017408 %785
+OpStore %711 %786
+%787 = OpLoad %ulong %711
+%788 = OpBitcast %double %787
+OpStore %712 %788
+OpBranch %258
+%258 = OpLabel
+%790 = OpLoad %double %712
+%791 = OpFMul %double %double_1_5 %790
+OpStore %379 %791
+%793 = OpLoad %double %712
+%794 = OpFMul %double %double_0_25 %793
+OpStore %380 %794
+%795 = OpLoad %double %379
+%796 = OpLoad %double %380
+%797 = OpFAdd %double %795 %796
+OpStore %381 %797
+OpBranch %306
+%306 = OpLabel
+%798 = OpLoad %double %381
+%799 = OpLoad %double %381
+%800 = OpFUnordNotEqual %bool %798 %799
+OpStore %751 %800
+%801 = OpLoad %bool %751
+OpSelectionMerge %310 None
+OpBranchConditional %801 %307 %308
+%308 = OpLabel
+OpBranch %309
+%309 = OpLabel
+%802 = OpLoad %ulong %378
+%803 = OpLoad %double %381
+%804 = OpFunctionCall %ulong %6 %802 %803
+OpStore %753 %804
+%805 = OpLoad %ulong %753
+OpStore %754 %805
+OpBranch %310
+%307 = OpLabel
+%806 = OpLoad %ulong %378
+%807 = OpFunctionCall %ulong %5 %806 %ulong_18446744073709551615
+OpStore %752 %807
+%808 = OpLoad %ulong %752
+OpStore %754 %808
+OpBranch %310
+%310 = OpLabel
+%809 = OpLoad %double %379
+%810 = OpLoad %double %380
+%811 = OpFSub %double %809 %810
+OpStore %382 %811
+OpBranch %316
+%316 = OpLabel
+%812 = OpLoad %double %382
+%813 = OpLoad %double %382
+%814 = OpFUnordNotEqual %bool %812 %813
+OpStore %759 %814
+%815 = OpLoad %bool %759
+OpSelectionMerge %320 None
+OpBranchConditional %815 %317 %318
+%318 = OpLabel
+OpBranch %319
+%319 = OpLabel
+%816 = OpLoad %ulong %754
+%817 = OpLoad %double %382
+%818 = OpFunctionCall %ulong %6 %816 %817
+OpStore %761 %818
+%819 = OpLoad %ulong %761
+OpStore %762 %819
+OpBranch %320
+%317 = OpLabel
+%820 = OpLoad %ulong %754
+%821 = OpFunctionCall %ulong %5 %820 %ulong_18446744073709551615
+OpStore %760 %821
+%822 = OpLoad %ulong %760
+OpStore %762 %822
+OpBranch %320
+%320 = OpLabel
+%823 = OpLoad %double %380
+%824 = OpLoad %double %379
+%825 = OpFSub %double %823 %824
+OpStore %383 %825
+OpBranch %326
+%326 = OpLabel
+%826 = OpLoad %double %383
+%827 = OpLoad %double %383
+%828 = OpFUnordNotEqual %bool %826 %827
+OpStore %767 %828
+%829 = OpLoad %bool %767
+OpSelectionMerge %330 None
+OpBranchConditional %829 %327 %328
+%328 = OpLabel
+OpBranch %329
+%329 = OpLabel
+%830 = OpLoad %ulong %762
+%831 = OpLoad %double %383
+%832 = OpFunctionCall %ulong %6 %830 %831
+OpStore %769 %832
+%833 = OpLoad %ulong %769
+OpStore %770 %833
+OpBranch %330
+%327 = OpLabel
+%834 = OpLoad %ulong %762
+%835 = OpFunctionCall %ulong %5 %834 %ulong_18446744073709551615
+OpStore %768 %835
+%836 = OpLoad %ulong %768
+OpStore %770 %836
+OpBranch %330
+%330 = OpLabel
+%837 = OpLoad %double %379
+%838 = OpLoad %double %380
+%839 = OpFMul %double %837 %838
+OpStore %384 %839
+OpBranch %336
+%336 = OpLabel
+%840 = OpLoad %double %384
+%841 = OpLoad %double %384
+%842 = OpFUnordNotEqual %bool %840 %841
+OpStore %775 %842
+%843 = OpLoad %bool %775
+OpSelectionMerge %340 None
+OpBranchConditional %843 %337 %338
+%338 = OpLabel
+OpBranch %339
+%339 = OpLabel
+%844 = OpLoad %ulong %770
+%845 = OpLoad %double %384
+%846 = OpFunctionCall %ulong %6 %844 %845
+OpStore %777 %846
+%847 = OpLoad %ulong %777
+OpStore %778 %847
+OpBranch %340
+%337 = OpLabel
+%848 = OpLoad %ulong %770
+%849 = OpFunctionCall %ulong %5 %848 %ulong_18446744073709551615
+OpStore %776 %849
+%850 = OpLoad %ulong %776
+OpStore %778 %850
+OpBranch %340
+%340 = OpLabel
+%851 = OpLoad %double %379
+%852 = OpLoad %double %380
+%853 = OpFDiv %double %851 %852
+OpStore %385 %853
+%854 = OpLoad %ulong %778
+%855 = OpLoad %double %385
+%856 = OpFunctionCall %ulong %2 %854 %855
+OpStore %386 %856
+%857 = OpLoad %double %380
+%858 = OpLoad %double %379
+%859 = OpFDiv %double %857 %858
+OpStore %387 %859
+%860 = OpLoad %ulong %386
+%861 = OpLoad %double %387
+%862 = OpFunctionCall %ulong %2 %860 %861
+OpStore %388 %862
+%863 = OpLoad %double %379
+%864 = OpFNegate %double %863
+OpStore %389 %864
+%865 = OpLoad %ulong %388
+%866 = OpLoad %double %389
+%867 = OpFunctionCall %ulong %2 %865 %866
+OpStore %390 %867
+%869 = OpLoad %double %379
+%870 = OpFSub %double %double_0 %869
+OpStore %391 %870
+%871 = OpLoad %ulong %390
+%872 = OpLoad %double %391
+%873 = OpFunctionCall %ulong %2 %871 %872
+OpStore %392 %873
+%874 = OpLoad %double %379
+%875 = OpLoad %double %379
+%876 = OpFSub %double %874 %875
+OpStore %393 %876
+%877 = OpLoad %ulong %392
+%878 = OpLoad %double %393
+%879 = OpFunctionCall %ulong %2 %877 %878
+OpStore %394 %879
+%880 = OpLoad %double %391
+%881 = OpLoad %double %379
+%882 = OpFAdd %double %880 %881
+OpStore %395 %882
+%883 = OpLoad %ulong %394
+%884 = OpLoad %double %395
+%885 = OpFunctionCall %ulong %2 %883 %884
+OpStore %396 %885
+%887 = OpLoad %double %712
+%888 = OpFMul %double %double_3 %887
+OpStore %397 %888
+%889 = OpLoad %double %712
+%890 = OpLoad %double %397
+%891 = OpFDiv %double %889 %890
+OpStore %398 %891
+%892 = OpLoad %ulong %396
+%893 = OpLoad %double %398
+%894 = OpFunctionCall %ulong %2 %892 %893
+OpStore %399 %894
+%895 = OpLoad %double %398
+%896 = OpLoad %double %397
+%897 = OpFMul %double %895 %896
+OpStore %400 %897
+%898 = OpLoad %ulong %399
+%899 = OpLoad %double %400
+%900 = OpFunctionCall %ulong %2 %898 %899
+OpStore %401 %900
+%901 = OpLoad %double %712
+%902 = OpLoad %double %398
+%903 = OpFSub %double %901 %902
+OpStore %402 %903
+%904 = OpLoad %double %402
+%905 = OpLoad %double %398
+%906 = OpFSub %double %904 %905
+OpStore %403 %906
+%907 = OpLoad %double %403
+%908 = OpLoad %double %398
 %909 = OpFSub %double %907 %908
-OpStore %329 %909
-OpBranch %261
-%261 = OpLabel
-%910 = OpLoad %double %329
-%911 = OpLoad %double %329
-%912 = OpFUnordNotEqual %bool %910 %911
-OpStore %566 %912
-%913 = OpLoad %bool %566
-OpSelectionMerge %265 None
-OpBranchConditional %913 %262 %263
-%263 = OpLabel
-OpBranch %264
-%264 = OpLabel
-%914 = OpLoad %ulong %561
-%915 = OpLoad %double %329
-%916 = OpFunctionCall %ulong %6 %914 %915
-OpStore %568 %916
-%917 = OpLoad %ulong %568
-OpStore %569 %917
-OpBranch %265
-%262 = OpLabel
-%918 = OpLoad %ulong %561
-%919 = OpFunctionCall %ulong %5 %918 %ulong_18446744073709551615
-OpStore %567 %919
-%920 = OpLoad %ulong %567
-OpStore %569 %920
-OpBranch %265
-%265 = OpLabel
-%921 = OpLoad %double %403
-%922 = OpFMul %double %double_0 %921
-OpStore %330 %922
-%923 = OpLoad %ulong %569
-OpStore %399 %923
-%924 = OpLoad %double %330
-OpStore %400 %924
-OpStore %401 %ulong_0
+OpStore %404 %909
+%910 = OpLoad %ulong %401
+%911 = OpLoad %double %404
+%912 = OpFunctionCall %ulong %2 %910 %911
+OpStore %405 %912
+%913 = OpLoad %double %712
+%915 = OpFDiv %double %913 %double_49
+OpStore %406 %915
+%916 = OpLoad %ulong %405
+%917 = OpLoad %double %406
+%918 = OpFunctionCall %ulong %2 %916 %917
+OpStore %407 %918
+%919 = OpLoad %double %712
+%921 = OpFDiv %double %919 %double_1048576_5
+OpStore %408 %921
+%922 = OpLoad %ulong %407
+%923 = OpLoad %double %408
+%924 = OpFunctionCall %ulong %2 %922 %923
+OpStore %409 %924
+%925 = OpLoad %double %397
+%926 = OpFDiv %double %double_1048576_5 %925
+OpStore %410 %926
+%927 = OpLoad %ulong %409
+%928 = OpLoad %double %410
+%929 = OpFunctionCall %ulong %2 %927 %928
+OpStore %411 %929
+%931 = OpLoad %double %712
+%932 = OpFMul %double %double_9007199254740992 %931
+OpStore %412 %932
+%933 = OpLoad %double %412
+%934 = OpLoad %double %712
+%935 = OpFAdd %double %933 %934
+OpStore %413 %935
+%936 = OpLoad %ulong %411
+%937 = OpLoad %double %413
+%938 = OpFunctionCall %ulong %2 %936 %937
+OpStore %414 %938
+%939 = OpLoad %double %413
+%940 = OpLoad %double %712
+%941 = OpFAdd %double %939 %940
+OpStore %415 %941
+%942 = OpLoad %ulong %414
+%943 = OpLoad %double %415
+%944 = OpFunctionCall %ulong %2 %942 %943
+OpStore %416 %944
+%945 = OpLoad %double %712
+%946 = OpLoad %double %712
+%947 = OpFAdd %double %945 %946
+OpStore %417 %947
+%948 = OpLoad %double %412
+%949 = OpLoad %double %417
+%950 = OpFAdd %double %948 %949
+OpStore %418 %950
+%951 = OpLoad %ulong %416
+%952 = OpLoad %double %418
+%953 = OpFunctionCall %ulong %2 %951 %952
+OpStore %419 %953
+%954 = OpLoad %double %412
+%955 = OpLoad %double %712
+%956 = OpFSub %double %954 %955
+OpStore %420 %956
+%957 = OpLoad %ulong %419
+%958 = OpLoad %double %420
+%959 = OpFunctionCall %ulong %2 %957 %958
+OpStore %421 %959
+%960 = OpLoad %double %413
+%961 = OpLoad %double %412
+%962 = OpFSub %double %960 %961
+OpStore %422 %962
+%963 = OpLoad %ulong %421
+%964 = OpLoad %double %422
+%965 = OpFunctionCall %ulong %2 %963 %964
+OpStore %423 %965
+%966 = OpLoad %double %712
+%967 = OpFMul %double %double_0 %966
+OpStore %424 %967
+%968 = OpLoad %ulong %423
+OpStore %708 %968
+%969 = OpLoad %double %424
+OpStore %709 %969
+OpStore %710 %ulong_0
 OpBranch %55
 %55 = OpLabel
-%926 = OpLoad %ulong %401
-%928 = OpULessThan %bool %926 %ulong_24
-OpStore %331 %928
-%929 = OpLoad %bool %331
-OpLoopMerge %57 %296 None
-OpBranchConditional %929 %56 %57
+%971 = OpLoad %ulong %710
+%973 = OpULessThan %bool %971 %ulong_24
+OpStore %425 %973
+%974 = OpLoad %bool %425
+OpLoopMerge %57 %376 None
+OpBranchConditional %974 %56 %57
 %57 = OpLabel
-OpBranch %65
-%65 = OpLabel
-%931 = OpLoad %ulong %297
-%932 = OpIAdd %ulong %ulong_9218868437227405311 %931
-OpStore %408 %932
-%933 = OpLoad %ulong %408
-%934 = OpBitcast %double %933
-OpStore %409 %934
-OpBranch %66
+OpBranch %264
+%264 = OpLabel
+%976 = OpLoad %ulong %377
+%977 = OpIAdd %ulong %ulong_9218868437227405311 %976
+OpStore %717 %977
+%978 = OpLoad %ulong %717
+%979 = OpBitcast %double %978
+OpStore %718 %979
+OpBranch %265
+%265 = OpLabel
+OpBranch %311
+%311 = OpLabel
+%980 = OpLoad %double %718
+%981 = OpLoad %double %718
+%982 = OpFUnordNotEqual %bool %980 %981
+OpStore %755 %982
+%983 = OpLoad %bool %755
+OpSelectionMerge %315 None
+OpBranchConditional %983 %312 %313
+%313 = OpLabel
+OpBranch %314
+%314 = OpLabel
+%984 = OpLoad %ulong %708
+%985 = OpLoad %double %718
+%986 = OpFunctionCall %ulong %6 %984 %985
+OpStore %757 %986
+%987 = OpLoad %ulong %757
+OpStore %758 %987
+OpBranch %315
+%312 = OpLabel
+%988 = OpLoad %ulong %708
+%989 = OpFunctionCall %ulong %5 %988 %ulong_18446744073709551615
+OpStore %756 %989
+%990 = OpLoad %ulong %756
+OpStore %758 %990
+OpBranch %315
+%315 = OpLabel
+%991 = OpLoad %double %718
+%993 = OpFDiv %double %991 %double_2
+OpStore %429 %993
+OpBranch %321
+%321 = OpLabel
+%994 = OpLoad %double %429
+%995 = OpLoad %double %429
+%996 = OpFUnordNotEqual %bool %994 %995
+OpStore %763 %996
+%997 = OpLoad %bool %763
+OpSelectionMerge %325 None
+OpBranchConditional %997 %322 %323
+%323 = OpLabel
+OpBranch %324
+%324 = OpLabel
+%998 = OpLoad %ulong %758
+%999 = OpLoad %double %429
+%1000 = OpFunctionCall %ulong %6 %998 %999
+OpStore %765 %1000
+%1001 = OpLoad %ulong %765
+OpStore %766 %1001
+OpBranch %325
+%322 = OpLabel
+%1002 = OpLoad %ulong %758
+%1003 = OpFunctionCall %ulong %5 %1002 %ulong_18446744073709551615
+OpStore %764 %1003
+%1004 = OpLoad %ulong %764
+OpStore %766 %1004
+OpBranch %325
+%325 = OpLabel
+%1005 = OpLoad %double %718
+%1006 = OpLoad %double %718
+%1007 = OpFAdd %double %1005 %1006
+OpStore %430 %1007
+OpBranch %331
+%331 = OpLabel
+%1008 = OpLoad %double %430
+%1009 = OpLoad %double %430
+%1010 = OpFUnordNotEqual %bool %1008 %1009
+OpStore %771 %1010
+%1011 = OpLoad %bool %771
+OpSelectionMerge %335 None
+OpBranchConditional %1011 %332 %333
+%333 = OpLabel
+OpBranch %334
+%334 = OpLabel
+%1012 = OpLoad %ulong %766
+%1013 = OpLoad %double %430
+%1014 = OpFunctionCall %ulong %6 %1012 %1013
+OpStore %773 %1014
+%1015 = OpLoad %ulong %773
+OpStore %774 %1015
+OpBranch %335
+%332 = OpLabel
+%1016 = OpLoad %ulong %766
+%1017 = OpFunctionCall %ulong %5 %1016 %ulong_18446744073709551615
+OpStore %772 %1017
+%1018 = OpLoad %ulong %772
+OpStore %774 %1018
+OpBranch %335
+%335 = OpLabel
+%1019 = OpLoad %double %718
+%1020 = OpFMul %double %1019 %double_2
+OpStore %431 %1020
+%1021 = OpLoad %ulong %774
+%1022 = OpLoad %double %431
+%1023 = OpFunctionCall %ulong %2 %1021 %1022
+OpStore %432 %1023
+%1024 = OpLoad %double %431
+%1025 = OpFSub %double %double_0 %1024
+OpStore %433 %1025
+%1026 = OpLoad %ulong %432
+%1027 = OpLoad %double %433
+%1028 = OpFunctionCall %ulong %2 %1026 %1027
+OpStore %434 %1028
+%1029 = OpLoad %double %718
+%1030 = OpLoad %double %718
+%1031 = OpFMul %double %1029 %1030
+OpStore %435 %1031
+%1032 = OpLoad %ulong %434
+%1033 = OpLoad %double %435
+%1034 = OpFunctionCall %ulong %2 %1032 %1033
+OpStore %436 %1034
+%1035 = OpLoad %double %718
+%1036 = OpLoad %double %718
+%1037 = OpFSub %double %1035 %1036
+OpStore %437 %1037
+%1038 = OpLoad %ulong %436
+%1039 = OpLoad %double %437
+%1040 = OpFunctionCall %ulong %2 %1038 %1039
+OpStore %438 %1040
+OpBranch %341
+%341 = OpLabel
+%1042 = OpLoad %ulong %377
+%1043 = OpIAdd %ulong %ulong_4503599627370496 %1042
+OpStore %779 %1043
+%1044 = OpLoad %ulong %779
+%1045 = OpBitcast %double %1044
+OpStore %780 %1045
+OpBranch %342
+%342 = OpLabel
+OpBranch %343
+%343 = OpLabel
+%1047 = OpLoad %ulong %377
+%1048 = OpIAdd %ulong %ulong_1 %1047
+OpStore %781 %1048
+%1049 = OpLoad %ulong %781
+%1050 = OpBitcast %double %1049
+OpStore %782 %1050
+OpBranch %344
+%344 = OpLabel
+%1051 = OpLoad %double %780
+%1053 = OpFMul %double %1051 %double_0_5
+OpStore %439 %1053
+%1054 = OpLoad %ulong %438
+%1055 = OpLoad %double %439
+%1056 = OpFunctionCall %ulong %2 %1054 %1055
+OpStore %440 %1056
+%1057 = OpLoad %double %780
+%1058 = OpFDiv %double %1057 %double_2
+OpStore %441 %1058
+%1059 = OpLoad %ulong %440
+%1060 = OpLoad %double %441
+%1061 = OpFunctionCall %ulong %2 %1059 %1060
+OpStore %442 %1061
+%1062 = OpLoad %double %780
+%1063 = OpLoad %double %782
+%1064 = OpFSub %double %1062 %1063
+OpStore %443 %1064
+%1065 = OpLoad %ulong %442
+%1066 = OpLoad %double %443
+%1067 = OpFunctionCall %ulong %2 %1065 %1066
+OpStore %444 %1067
+%1068 = OpLoad %double %780
+%1069 = OpLoad %double %712
+%1070 = OpFMul %double %1068 %1069
+OpStore %445 %1070
+%1071 = OpLoad %ulong %444
+%1072 = OpLoad %double %445
+%1073 = OpFunctionCall %ulong %2 %1071 %1072
+OpStore %446 %1073
+%1074 = OpLoad %double %782
+%1075 = OpLoad %double %782
+%1076 = OpFAdd %double %1074 %1075
+OpStore %447 %1076
+%1077 = OpLoad %ulong %446
+%1078 = OpLoad %double %447
+%1079 = OpFunctionCall %ulong %2 %1077 %1078
+OpStore %448 %1079
+%1080 = OpLoad %double %782
+%1081 = OpFMul %double %1080 %double_0_5
+OpStore %449 %1081
+%1082 = OpLoad %ulong %448
+%1083 = OpLoad %double %449
+%1084 = OpFunctionCall %ulong %2 %1082 %1083
+OpStore %450 %1084
+%1085 = OpLoad %double %782
+%1087 = OpFMul %double %1085 %double_0_75
+OpStore %451 %1087
+%1088 = OpLoad %ulong %450
+%1089 = OpLoad %double %451
+%1090 = OpFunctionCall %ulong %2 %1088 %1089
+OpStore %452 %1090
+%1091 = OpLoad %double %782
+%1092 = OpFMul %double %1091 %double_9007199254740992
+OpStore %453 %1092
+%1093 = OpLoad %ulong %452
+%1094 = OpLoad %double %453
+%1095 = OpFunctionCall %ulong %2 %1093 %1094
+OpStore %454 %1095
+%1096 = OpLoad %double %782
+%1097 = OpLoad %double %780
+%1098 = OpFDiv %double %1096 %1097
+OpStore %455 %1098
+%1099 = OpLoad %ulong %454
+%1100 = OpLoad %double %455
+%1101 = OpFunctionCall %ulong %2 %1099 %1100
+OpStore %456 %1101
+%1103 = OpLoad %double %712
+%1104 = OpFMul %double %double_5_5 %1103
+OpStore %457 %1104
+%1105 = OpLoad %double %712
+%1106 = OpFMul %double %double_3 %1105
+OpStore %458 %1106
+%1107 = OpLoad %double %458
+%1108 = OpFOrdEqual %bool %1107 %double_0
+OpStore %459 %1108
+%1109 = OpLoad %bool %459
+OpSelectionMerge %61 None
+OpBranchConditional %1109 %346 %58
+%58 = OpLabel
+%1110 = OpLoad %double %457
+%1111 = OpFMul %double %1110 %double_2
+OpStore %460 %1111
+%1112 = OpLoad %double %457
+%1113 = OpLoad %double %460
+%1114 = OpFOrdEqual %bool %1112 %1113
+OpStore %461 %1114
+%1115 = OpLoad %bool %461
+OpSelectionMerge %60 None
+OpBranchConditional %1115 %59 %345
+%345 = OpLabel
+%1116 = OpLoad %bool %461
+OpStore %463 %1116
+OpBranch %60
+%59 = OpLabel
+%1117 = OpLoad %double %457
+%1118 = OpFUnordNotEqual %bool %1117 %double_0
+OpStore %462 %1118
+%1119 = OpLoad %bool %462
+OpStore %463 %1119
+OpBranch %60
+%60 = OpLabel
+%1120 = OpLoad %bool %463
+OpStore %464 %1120
+OpBranch %61
+%346 = OpLabel
+%1121 = OpLoad %bool %459
+OpStore %464 %1121
+OpBranch %61
+%61 = OpLabel
+%1122 = OpLoad %bool %464
+OpSelectionMerge %64 None
+OpBranchConditional %1122 %62 %63
+%63 = OpLabel
+%1123 = OpLoad %double %457
+%1124 = OpFOrdLessThan %bool %1123 %double_0
+OpStore %470 %1124
+%1125 = OpLoad %bool %470
+OpSelectionMerge %67 None
+OpBranchConditional %1125 %65 %66
 %66 = OpLabel
-OpBranch %72
-%72 = OpLabel
-%935 = OpLoad %double %409
-%936 = OpLoad %double %409
-%937 = OpFUnordNotEqual %bool %935 %936
-OpStore %414 %937
-%938 = OpLoad %bool %414
-OpSelectionMerge %76 None
-OpBranchConditional %938 %73 %74
-%74 = OpLabel
-OpBranch %75
-%75 = OpLabel
-%939 = OpLoad %ulong %399
-%940 = OpLoad %double %409
-%941 = OpFunctionCall %ulong %6 %939 %940
-OpStore %416 %941
-%942 = OpLoad %ulong %416
-OpStore %417 %942
-OpBranch %76
+%1126 = OpLoad %double %457
+OpStore %472 %1126
+OpBranch %67
+%65 = OpLabel
+%1127 = OpLoad %double %457
+%1128 = OpFSub %double %double_0 %1127
+OpStore %471 %1128
+%1129 = OpLoad %double %471
+OpStore %472 %1129
+OpBranch %67
+%67 = OpLabel
+%1130 = OpLoad %double %458
+%1131 = OpFOrdLessThan %bool %1130 %double_0
+OpStore %473 %1131
+%1132 = OpLoad %bool %473
+OpSelectionMerge %70 None
+OpBranchConditional %1132 %68 %69
+%69 = OpLabel
+%1133 = OpLoad %double %458
+OpStore %475 %1133
+OpBranch %70
+%68 = OpLabel
+%1134 = OpLoad %double %458
+%1135 = OpFSub %double %double_0 %1134
+OpStore %474 %1135
+%1136 = OpLoad %double %474
+OpStore %475 %1136
+OpBranch %70
+%70 = OpLabel
+%1137 = OpLoad %double %472
+%1138 = OpFDiv %double %1137 %double_2
+OpStore %476 %1138
+%1139 = OpLoad %double %475
+OpStore %477 %1139
+OpBranch %71
+%71 = OpLabel
+%1140 = OpLoad %double %477
+%1141 = OpLoad %double %476
+%1142 = OpFOrdLessThanEqual %bool %1140 %1141
+OpStore %478 %1142
+%1143 = OpLoad %bool %478
+OpLoopMerge %73 %375 None
+OpBranchConditional %1143 %72 %73
 %73 = OpLabel
-%943 = OpLoad %ulong %399
-%944 = OpFunctionCall %ulong %5 %943 %ulong_18446744073709551615
-OpStore %415 %944
-%945 = OpLoad %ulong %415
-OpStore %417 %945
-OpBranch %76
-%76 = OpLabel
-%946 = OpLoad %double %409
-%948 = OpFDiv %double %946 %double_2
-OpStore %335 %948
+%1144 = OpLoad %double %472
+OpStore %480 %1144
+%1145 = OpLoad %double %477
+OpStore %481 %1145
+OpBranch %74
+%74 = OpLabel
+%1146 = OpLoad %double %475
+%1147 = OpLoad %double %481
+%1148 = OpFOrdLessThanEqual %bool %1146 %1147
+OpStore %482 %1148
+%1149 = OpLoad %bool %482
+OpLoopMerge %78 %374 None
+OpBranchConditional %1149 %79 %78
+%78 = OpLabel
+%1150 = OpLoad %bool %470
+OpSelectionMerge %82 None
+OpBranchConditional %1150 %80 %81
+%81 = OpLabel
+%1151 = OpLoad %double %480
+OpStore %488 %1151
+OpBranch %82
+%80 = OpLabel
+%1152 = OpLoad %double %480
+%1153 = OpFSub %double %double_0 %1152
+OpStore %487 %1153
+%1154 = OpLoad %double %487
+OpStore %488 %1154
 OpBranch %82
 %82 = OpLabel
-%949 = OpLoad %double %335
-%950 = OpLoad %double %335
-%951 = OpFUnordNotEqual %bool %949 %950
-OpStore %422 %951
-%952 = OpLoad %bool %422
-OpSelectionMerge %86 None
-OpBranchConditional %952 %83 %84
-%84 = OpLabel
-OpBranch %85
-%85 = OpLabel
-%953 = OpLoad %ulong %417
-%954 = OpLoad %double %335
-%955 = OpFunctionCall %ulong %6 %953 %954
-OpStore %424 %955
-%956 = OpLoad %ulong %424
-OpStore %425 %956
-OpBranch %86
-%83 = OpLabel
-%957 = OpLoad %ulong %417
-%958 = OpFunctionCall %ulong %5 %957 %ulong_18446744073709551615
-OpStore %423 %958
-%959 = OpLoad %ulong %423
-OpStore %425 %959
-OpBranch %86
-%86 = OpLabel
-%960 = OpLoad %double %409
-%961 = OpLoad %double %409
-%962 = OpFAdd %double %960 %961
-OpStore %336 %962
-OpBranch %92
-%92 = OpLabel
-%963 = OpLoad %double %336
-%964 = OpLoad %double %336
-%965 = OpFUnordNotEqual %bool %963 %964
-OpStore %430 %965
-%966 = OpLoad %bool %430
-OpSelectionMerge %96 None
-OpBranchConditional %966 %93 %94
-%94 = OpLabel
-OpBranch %95
-%95 = OpLabel
-%967 = OpLoad %ulong %425
-%968 = OpLoad %double %336
-%969 = OpFunctionCall %ulong %6 %967 %968
-OpStore %432 %969
-%970 = OpLoad %ulong %432
-OpStore %433 %970
-OpBranch %96
-%93 = OpLabel
-%971 = OpLoad %ulong %425
-%972 = OpFunctionCall %ulong %5 %971 %ulong_18446744073709551615
-OpStore %431 %972
-%973 = OpLoad %ulong %431
-OpStore %433 %973
-OpBranch %96
-%96 = OpLabel
-%974 = OpLoad %double %409
-%975 = OpFMul %double %974 %double_2
-OpStore %337 %975
-OpBranch %102
-%102 = OpLabel
-%976 = OpLoad %double %337
-%977 = OpLoad %double %337
-%978 = OpFUnordNotEqual %bool %976 %977
-OpStore %438 %978
-%979 = OpLoad %bool %438
-OpSelectionMerge %106 None
-OpBranchConditional %979 %103 %104
-%104 = OpLabel
-OpBranch %105
-%105 = OpLabel
-%980 = OpLoad %ulong %433
-%981 = OpLoad %double %337
-%982 = OpFunctionCall %ulong %6 %980 %981
-OpStore %440 %982
-%983 = OpLoad %ulong %440
-OpStore %441 %983
-OpBranch %106
-%103 = OpLabel
-%984 = OpLoad %ulong %433
-%985 = OpFunctionCall %ulong %5 %984 %ulong_18446744073709551615
-OpStore %439 %985
-%986 = OpLoad %ulong %439
-OpStore %441 %986
-OpBranch %106
-%106 = OpLabel
-%987 = OpLoad %double %409
-%988 = OpFMul %double %987 %double_2
-OpStore %338 %988
-%989 = OpLoad %double %338
-%990 = OpFSub %double %double_0 %989
-OpStore %339 %990
-OpBranch %112
-%112 = OpLabel
-%991 = OpLoad %double %339
-%992 = OpLoad %double %339
-%993 = OpFUnordNotEqual %bool %991 %992
-OpStore %446 %993
-%994 = OpLoad %bool %446
-OpSelectionMerge %116 None
-OpBranchConditional %994 %113 %114
-%114 = OpLabel
-OpBranch %115
-%115 = OpLabel
-%995 = OpLoad %ulong %441
-%996 = OpLoad %double %339
-%997 = OpFunctionCall %ulong %6 %995 %996
-OpStore %448 %997
-%998 = OpLoad %ulong %448
-OpStore %449 %998
-OpBranch %116
-%113 = OpLabel
-%999 = OpLoad %ulong %441
-%1000 = OpFunctionCall %ulong %5 %999 %ulong_18446744073709551615
-OpStore %447 %1000
-%1001 = OpLoad %ulong %447
-OpStore %449 %1001
-OpBranch %116
-%116 = OpLabel
-%1002 = OpLoad %double %409
-%1003 = OpLoad %double %409
-%1004 = OpFMul %double %1002 %1003
-OpStore %340 %1004
-OpBranch %122
-%122 = OpLabel
-%1005 = OpLoad %double %340
-%1006 = OpLoad %double %340
-%1007 = OpFUnordNotEqual %bool %1005 %1006
-OpStore %454 %1007
-%1008 = OpLoad %bool %454
-OpSelectionMerge %126 None
-OpBranchConditional %1008 %123 %124
-%124 = OpLabel
-OpBranch %125
-%125 = OpLabel
-%1009 = OpLoad %ulong %449
-%1010 = OpLoad %double %340
-%1011 = OpFunctionCall %ulong %6 %1009 %1010
-OpStore %456 %1011
-%1012 = OpLoad %ulong %456
-OpStore %457 %1012
-OpBranch %126
-%123 = OpLabel
-%1013 = OpLoad %ulong %449
-%1014 = OpFunctionCall %ulong %5 %1013 %ulong_18446744073709551615
-OpStore %455 %1014
-%1015 = OpLoad %ulong %455
-OpStore %457 %1015
-OpBranch %126
-%126 = OpLabel
-%1016 = OpLoad %double %409
-%1017 = OpLoad %double %409
-%1018 = OpFSub %double %1016 %1017
-OpStore %341 %1018
-OpBranch %132
-%132 = OpLabel
-%1019 = OpLoad %double %341
-%1020 = OpLoad %double %341
-%1021 = OpFUnordNotEqual %bool %1019 %1020
-OpStore %462 %1021
-%1022 = OpLoad %bool %462
-OpSelectionMerge %136 None
-OpBranchConditional %1022 %133 %134
-%134 = OpLabel
-OpBranch %135
-%135 = OpLabel
-%1023 = OpLoad %ulong %457
-%1024 = OpLoad %double %341
-%1025 = OpFunctionCall %ulong %6 %1023 %1024
-OpStore %464 %1025
-%1026 = OpLoad %ulong %464
-OpStore %465 %1026
-OpBranch %136
-%133 = OpLabel
-%1027 = OpLoad %ulong %457
-%1028 = OpFunctionCall %ulong %5 %1027 %ulong_18446744073709551615
-OpStore %463 %1028
-%1029 = OpLoad %ulong %463
-OpStore %465 %1029
-OpBranch %136
-%136 = OpLabel
-OpBranch %142
-%142 = OpLabel
-%1031 = OpLoad %ulong %297
-%1032 = OpIAdd %ulong %ulong_4503599627370496 %1031
-OpStore %470 %1032
-%1033 = OpLoad %ulong %470
-%1034 = OpBitcast %double %1033
-OpStore %471 %1034
-OpBranch %143
-%143 = OpLabel
-OpBranch %149
-%149 = OpLabel
-%1036 = OpLoad %ulong %297
-%1037 = OpIAdd %ulong %ulong_1 %1036
-OpStore %476 %1037
-%1038 = OpLoad %ulong %476
-%1039 = OpBitcast %double %1038
-OpStore %477 %1039
-OpBranch %150
-%150 = OpLabel
-%1040 = OpLoad %double %471
-%1042 = OpFMul %double %1040 %double_0_5
-OpStore %342 %1042
-OpBranch %156
-%156 = OpLabel
-%1043 = OpLoad %double %342
-%1044 = OpLoad %double %342
-%1045 = OpFUnordNotEqual %bool %1043 %1044
-OpStore %482 %1045
-%1046 = OpLoad %bool %482
-OpSelectionMerge %160 None
-OpBranchConditional %1046 %157 %158
-%158 = OpLabel
-OpBranch %159
-%159 = OpLabel
-%1047 = OpLoad %ulong %465
-%1048 = OpLoad %double %342
-%1049 = OpFunctionCall %ulong %6 %1047 %1048
-OpStore %484 %1049
-%1050 = OpLoad %ulong %484
-OpStore %485 %1050
-OpBranch %160
-%157 = OpLabel
-%1051 = OpLoad %ulong %465
-%1052 = OpFunctionCall %ulong %5 %1051 %ulong_18446744073709551615
-OpStore %483 %1052
-%1053 = OpLoad %ulong %483
-OpStore %485 %1053
-OpBranch %160
-%160 = OpLabel
-%1054 = OpLoad %double %471
-%1055 = OpFDiv %double %1054 %double_2
-OpStore %343 %1055
-OpBranch %166
-%166 = OpLabel
-%1056 = OpLoad %double %343
-%1057 = OpLoad %double %343
-%1058 = OpFUnordNotEqual %bool %1056 %1057
-OpStore %490 %1058
-%1059 = OpLoad %bool %490
-OpSelectionMerge %170 None
-OpBranchConditional %1059 %167 %168
-%168 = OpLabel
-OpBranch %169
-%169 = OpLabel
-%1060 = OpLoad %ulong %485
-%1061 = OpLoad %double %343
-%1062 = OpFunctionCall %ulong %6 %1060 %1061
-OpStore %492 %1062
-%1063 = OpLoad %ulong %492
-OpStore %493 %1063
-OpBranch %170
-%167 = OpLabel
-%1064 = OpLoad %ulong %485
-%1065 = OpFunctionCall %ulong %5 %1064 %ulong_18446744073709551615
-OpStore %491 %1065
-%1066 = OpLoad %ulong %491
-OpStore %493 %1066
-OpBranch %170
-%170 = OpLabel
-%1067 = OpLoad %double %471
-%1068 = OpLoad %double %477
-%1069 = OpFSub %double %1067 %1068
-OpStore %344 %1069
-OpBranch %176
-%176 = OpLabel
-%1070 = OpLoad %double %344
-%1071 = OpLoad %double %344
-%1072 = OpFUnordNotEqual %bool %1070 %1071
-OpStore %498 %1072
-%1073 = OpLoad %bool %498
-OpSelectionMerge %180 None
-OpBranchConditional %1073 %177 %178
-%178 = OpLabel
-OpBranch %179
-%179 = OpLabel
-%1074 = OpLoad %ulong %493
-%1075 = OpLoad %double %344
-%1076 = OpFunctionCall %ulong %6 %1074 %1075
-OpStore %500 %1076
-%1077 = OpLoad %ulong %500
-OpStore %501 %1077
-OpBranch %180
-%177 = OpLabel
-%1078 = OpLoad %ulong %493
-%1079 = OpFunctionCall %ulong %5 %1078 %ulong_18446744073709551615
-OpStore %499 %1079
-%1080 = OpLoad %ulong %499
-OpStore %501 %1080
-OpBranch %180
-%180 = OpLabel
-%1081 = OpLoad %double %471
-%1082 = OpLoad %double %403
-%1083 = OpFMul %double %1081 %1082
-OpStore %345 %1083
-OpBranch %186
-%186 = OpLabel
-%1084 = OpLoad %double %345
-%1085 = OpLoad %double %345
-%1086 = OpFUnordNotEqual %bool %1084 %1085
-OpStore %506 %1086
-%1087 = OpLoad %bool %506
-OpSelectionMerge %190 None
-OpBranchConditional %1087 %187 %188
-%188 = OpLabel
-OpBranch %189
-%189 = OpLabel
-%1088 = OpLoad %ulong %501
-%1089 = OpLoad %double %345
-%1090 = OpFunctionCall %ulong %6 %1088 %1089
-OpStore %508 %1090
-%1091 = OpLoad %ulong %508
-OpStore %509 %1091
-OpBranch %190
-%187 = OpLabel
-%1092 = OpLoad %ulong %501
-%1093 = OpFunctionCall %ulong %5 %1092 %ulong_18446744073709551615
-OpStore %507 %1093
-%1094 = OpLoad %ulong %507
-OpStore %509 %1094
-OpBranch %190
-%190 = OpLabel
-%1095 = OpLoad %double %477
-%1096 = OpLoad %double %477
-%1097 = OpFAdd %double %1095 %1096
-OpStore %346 %1097
-OpBranch %196
-%196 = OpLabel
-%1098 = OpLoad %double %346
-%1099 = OpLoad %double %346
-%1100 = OpFUnordNotEqual %bool %1098 %1099
-OpStore %514 %1100
-%1101 = OpLoad %bool %514
-OpSelectionMerge %200 None
-OpBranchConditional %1101 %197 %198
-%198 = OpLabel
-OpBranch %199
-%199 = OpLabel
-%1102 = OpLoad %ulong %509
-%1103 = OpLoad %double %346
-%1104 = OpFunctionCall %ulong %6 %1102 %1103
-OpStore %516 %1104
-%1105 = OpLoad %ulong %516
-OpStore %517 %1105
-OpBranch %200
-%197 = OpLabel
-%1106 = OpLoad %ulong %509
-%1107 = OpFunctionCall %ulong %5 %1106 %ulong_18446744073709551615
-OpStore %515 %1107
-%1108 = OpLoad %ulong %515
-OpStore %517 %1108
-OpBranch %200
-%200 = OpLabel
-%1109 = OpLoad %double %477
-%1110 = OpFMul %double %1109 %double_0_5
-OpStore %347 %1110
-OpBranch %206
-%206 = OpLabel
-%1111 = OpLoad %double %347
-%1112 = OpLoad %double %347
-%1113 = OpFUnordNotEqual %bool %1111 %1112
-OpStore %522 %1113
-%1114 = OpLoad %bool %522
-OpSelectionMerge %210 None
-OpBranchConditional %1114 %207 %208
-%208 = OpLabel
-OpBranch %209
-%209 = OpLabel
-%1115 = OpLoad %ulong %517
-%1116 = OpLoad %double %347
-%1117 = OpFunctionCall %ulong %6 %1115 %1116
-OpStore %524 %1117
-%1118 = OpLoad %ulong %524
-OpStore %525 %1118
-OpBranch %210
-%207 = OpLabel
-%1119 = OpLoad %ulong %517
-%1120 = OpFunctionCall %ulong %5 %1119 %ulong_18446744073709551615
-OpStore %523 %1120
-%1121 = OpLoad %ulong %523
-OpStore %525 %1121
-OpBranch %210
-%210 = OpLabel
-%1122 = OpLoad %double %477
-%1124 = OpFMul %double %1122 %double_0_75
-OpStore %348 %1124
-OpBranch %216
-%216 = OpLabel
-%1125 = OpLoad %double %348
-%1126 = OpLoad %double %348
-%1127 = OpFUnordNotEqual %bool %1125 %1126
-OpStore %530 %1127
-%1128 = OpLoad %bool %530
-OpSelectionMerge %220 None
-OpBranchConditional %1128 %217 %218
-%218 = OpLabel
-OpBranch %219
-%219 = OpLabel
-%1129 = OpLoad %ulong %525
-%1130 = OpLoad %double %348
-%1131 = OpFunctionCall %ulong %6 %1129 %1130
-OpStore %532 %1131
-%1132 = OpLoad %ulong %532
-OpStore %533 %1132
-OpBranch %220
-%217 = OpLabel
-%1133 = OpLoad %ulong %525
-%1134 = OpFunctionCall %ulong %5 %1133 %ulong_18446744073709551615
-OpStore %531 %1134
-%1135 = OpLoad %ulong %531
-OpStore %533 %1135
-OpBranch %220
-%220 = OpLabel
-%1136 = OpLoad %double %477
-%1137 = OpFMul %double %1136 %double_9007199254740992
-OpStore %349 %1137
-OpBranch %226
-%226 = OpLabel
-%1138 = OpLoad %double %349
-%1139 = OpLoad %double %349
-%1140 = OpFUnordNotEqual %bool %1138 %1139
-OpStore %538 %1140
-%1141 = OpLoad %bool %538
-OpSelectionMerge %230 None
-OpBranchConditional %1141 %227 %228
-%228 = OpLabel
-OpBranch %229
-%229 = OpLabel
-%1142 = OpLoad %ulong %533
-%1143 = OpLoad %double %349
-%1144 = OpFunctionCall %ulong %6 %1142 %1143
-OpStore %540 %1144
-%1145 = OpLoad %ulong %540
-OpStore %541 %1145
-OpBranch %230
-%227 = OpLabel
-%1146 = OpLoad %ulong %533
-%1147 = OpFunctionCall %ulong %5 %1146 %ulong_18446744073709551615
-OpStore %539 %1147
-%1148 = OpLoad %ulong %539
-OpStore %541 %1148
-OpBranch %230
-%230 = OpLabel
-%1149 = OpLoad %double %477
-%1150 = OpLoad %double %471
-%1151 = OpFDiv %double %1149 %1150
-OpStore %350 %1151
-OpBranch %236
-%236 = OpLabel
-%1152 = OpLoad %double %350
-%1153 = OpLoad %double %350
-%1154 = OpFUnordNotEqual %bool %1152 %1153
-OpStore %546 %1154
-%1155 = OpLoad %bool %546
-OpSelectionMerge %240 None
-OpBranchConditional %1155 %237 %238
-%238 = OpLabel
-OpBranch %239
-%239 = OpLabel
-%1156 = OpLoad %ulong %541
-%1157 = OpLoad %double %350
-%1158 = OpFunctionCall %ulong %6 %1156 %1157
-OpStore %548 %1158
-%1159 = OpLoad %ulong %548
-OpStore %549 %1159
-OpBranch %240
-%237 = OpLabel
-%1160 = OpLoad %ulong %541
-%1161 = OpFunctionCall %ulong %5 %1160 %ulong_18446744073709551615
-OpStore %547 %1161
-%1162 = OpLoad %ulong %547
-OpStore %549 %1162
-OpBranch %240
-%240 = OpLabel
-%1164 = OpLoad %double %403
-%1165 = OpFMul %double %double_5_5 %1164
-OpStore %351 %1165
-%1166 = OpLoad %double %403
-%1167 = OpFMul %double %double_3 %1166
-OpStore %352 %1167
-%1168 = OpLoad %double %351
-%1169 = OpLoad %double %352
-%1170 = OpFDiv %double %1168 %1169
-OpStore %353 %1170
-%1171 = OpLoad %double %353
-%1172 = OpConvertFToS %ulong %1171
-OpStore %354 %1172
-%1173 = OpLoad %ulong %354
-%1174 = OpConvertSToF %double %1173
-OpStore %355 %1174
-%1175 = OpLoad %double %355
-%1176 = OpLoad %double %352
-%1177 = OpFMul %double %1175 %1176
-OpStore %356 %1177
-%1178 = OpLoad %double %351
-%1179 = OpLoad %double %356
-%1180 = OpFSub %double %1178 %1179
-OpStore %357 %1180
-OpBranch %246
-%246 = OpLabel
-%1181 = OpLoad %double %357
-%1182 = OpLoad %double %357
-%1183 = OpFUnordNotEqual %bool %1181 %1182
-OpStore %554 %1183
-%1184 = OpLoad %bool %554
-OpSelectionMerge %250 None
-OpBranchConditional %1184 %247 %248
-%248 = OpLabel
-OpBranch %249
-%249 = OpLabel
-%1185 = OpLoad %ulong %549
-%1186 = OpLoad %double %357
-%1187 = OpFunctionCall %ulong %6 %1185 %1186
-OpStore %556 %1187
-%1188 = OpLoad %ulong %556
-OpStore %557 %1188
-OpBranch %250
-%247 = OpLabel
-%1189 = OpLoad %ulong %549
-%1190 = OpFunctionCall %ulong %5 %1189 %ulong_18446744073709551615
-OpStore %555 %1190
-%1191 = OpLoad %ulong %555
-OpStore %557 %1191
-OpBranch %250
-%250 = OpLabel
-%1192 = OpLoad %double %351
-%1193 = OpFSub %double %double_0 %1192
-OpStore %358 %1193
-%1194 = OpLoad %double %358
-%1195 = OpLoad %double %352
-%1196 = OpFDiv %double %1194 %1195
-OpStore %359 %1196
-%1197 = OpLoad %double %359
-%1198 = OpConvertFToS %ulong %1197
-OpStore %360 %1198
-%1199 = OpLoad %ulong %360
-%1200 = OpConvertSToF %double %1199
-OpStore %361 %1200
-%1201 = OpLoad %double %361
-%1202 = OpLoad %double %352
-%1203 = OpFMul %double %1201 %1202
-OpStore %362 %1203
-%1204 = OpLoad %double %358
-%1205 = OpLoad %double %362
-%1206 = OpFSub %double %1204 %1205
-OpStore %363 %1206
-OpBranch %256
-%256 = OpLabel
-%1207 = OpLoad %double %363
-%1208 = OpLoad %double %363
-%1209 = OpFUnordNotEqual %bool %1207 %1208
-OpStore %562 %1209
-%1210 = OpLoad %bool %562
-OpSelectionMerge %260 None
-OpBranchConditional %1210 %257 %258
-%258 = OpLabel
-OpBranch %259
-%259 = OpLabel
-%1211 = OpLoad %ulong %557
-%1212 = OpLoad %double %363
-%1213 = OpFunctionCall %ulong %6 %1211 %1212
-OpStore %564 %1213
-%1214 = OpLoad %ulong %564
-OpStore %565 %1214
-OpBranch %260
-%257 = OpLabel
-%1215 = OpLoad %ulong %557
-%1216 = OpFunctionCall %ulong %5 %1215 %ulong_18446744073709551615
-OpStore %563 %1216
-%1217 = OpLoad %ulong %563
-OpStore %565 %1217
-OpBranch %260
-%260 = OpLabel
-%1218 = OpLoad %double %352
-%1219 = OpFSub %double %double_0 %1218
-OpStore %364 %1219
-%1220 = OpLoad %double %351
-%1221 = OpLoad %double %364
-%1222 = OpFDiv %double %1220 %1221
-OpStore %365 %1222
-%1223 = OpLoad %double %365
-%1224 = OpConvertFToS %ulong %1223
-OpStore %366 %1224
-%1225 = OpLoad %ulong %366
-%1226 = OpConvertSToF %double %1225
-OpStore %367 %1226
-%1227 = OpLoad %double %367
-%1228 = OpLoad %double %364
-%1229 = OpFMul %double %1227 %1228
-OpStore %368 %1229
-%1230 = OpLoad %double %351
-%1231 = OpLoad %double %368
-%1232 = OpFSub %double %1230 %1231
-OpStore %369 %1232
+%1155 = OpLoad %double %488
+OpStore %489 %1155
+OpBranch %64
+%79 = OpLabel
+%1156 = OpLoad %double %481
+%1157 = OpLoad %double %480
+%1158 = OpFOrdLessThanEqual %bool %1156 %1157
+OpStore %483 %1158
+%1159 = OpLoad %bool %483
+OpSelectionMerge %77 None
+OpBranchConditional %1159 %75 %76
+%76 = OpLabel
+%1160 = OpLoad %double %480
+OpStore %485 %1160
+OpBranch %77
+%75 = OpLabel
+%1161 = OpLoad %double %480
+%1162 = OpLoad %double %481
+%1163 = OpFSub %double %1161 %1162
+OpStore %484 %1163
+%1164 = OpLoad %double %484
+OpStore %485 %1164
+OpBranch %77
+%77 = OpLabel
+%1165 = OpLoad %double %481
+%1166 = OpFDiv %double %1165 %double_2
+OpStore %486 %1166
+%1167 = OpLoad %double %485
+OpStore %480 %1167
+%1168 = OpLoad %double %486
+OpStore %481 %1168
+OpBranch %374
+%72 = OpLabel
+%1169 = OpLoad %double %477
+%1170 = OpFMul %double %1169 %double_2
+OpStore %479 %1170
+%1171 = OpLoad %double %479
+OpStore %477 %1171
+OpBranch %375
+%62 = OpLabel
+%1172 = OpLoad %double %457
+%1173 = OpLoad %double %458
+%1174 = OpFDiv %double %1172 %1173
+OpStore %465 %1174
+%1175 = OpLoad %double %465
+%1176 = OpConvertFToS %ulong %1175
+OpStore %466 %1176
+%1177 = OpLoad %ulong %466
+%1178 = OpConvertSToF %double %1177
+OpStore %467 %1178
+%1179 = OpLoad %double %467
+%1180 = OpLoad %double %458
+%1181 = OpFMul %double %1179 %1180
+OpStore %468 %1181
+%1182 = OpLoad %double %457
+%1183 = OpLoad %double %468
+%1184 = OpFSub %double %1182 %1183
+OpStore %469 %1184
+%1185 = OpLoad %double %469
+OpStore %489 %1185
+OpBranch %64
+%64 = OpLabel
 OpBranch %266
 %266 = OpLabel
-%1233 = OpLoad %double %369
-%1234 = OpLoad %double %369
-%1235 = OpFUnordNotEqual %bool %1233 %1234
-OpStore %570 %1235
-%1236 = OpLoad %bool %570
+%1186 = OpLoad %double %489
+%1187 = OpLoad %double %489
+%1188 = OpFUnordNotEqual %bool %1186 %1187
+OpStore %719 %1188
+%1189 = OpLoad %bool %719
 OpSelectionMerge %270 None
-OpBranchConditional %1236 %267 %268
+OpBranchConditional %1189 %267 %268
 %268 = OpLabel
 OpBranch %269
 %269 = OpLabel
-%1237 = OpLoad %ulong %565
-%1238 = OpLoad %double %369
-%1239 = OpFunctionCall %ulong %6 %1237 %1238
-OpStore %572 %1239
-%1240 = OpLoad %ulong %572
-OpStore %573 %1240
+%1190 = OpLoad %ulong %456
+%1191 = OpLoad %double %489
+%1192 = OpFunctionCall %ulong %6 %1190 %1191
+OpStore %721 %1192
+%1193 = OpLoad %ulong %721
+OpStore %722 %1193
 OpBranch %270
 %267 = OpLabel
-%1241 = OpLoad %ulong %565
-%1242 = OpFunctionCall %ulong %5 %1241 %ulong_18446744073709551615
-OpStore %571 %1242
-%1243 = OpLoad %ulong %571
-OpStore %573 %1243
+%1194 = OpLoad %ulong %456
+%1195 = OpFunctionCall %ulong %5 %1194 %ulong_18446744073709551615
+OpStore %720 %1195
+%1196 = OpLoad %ulong %720
+OpStore %722 %1196
 OpBranch %270
 %270 = OpLabel
-%1244 = OpLoad %double %351
+%1197 = OpLoad %double %457
+%1198 = OpFSub %double %double_0 %1197
+OpStore %490 %1198
+%1199 = OpLoad %double %458
+%1200 = OpFOrdEqual %bool %1199 %double_0
+OpStore %491 %1200
+%1201 = OpLoad %bool %491
+OpSelectionMerge %86 None
+OpBranchConditional %1201 %348 %83
+%83 = OpLabel
+%1202 = OpLoad %double %490
+%1203 = OpFMul %double %1202 %double_2
+OpStore %492 %1203
+%1204 = OpLoad %double %490
+%1205 = OpLoad %double %492
+%1206 = OpFOrdEqual %bool %1204 %1205
+OpStore %493 %1206
+%1207 = OpLoad %bool %493
+OpSelectionMerge %85 None
+OpBranchConditional %1207 %84 %347
+%347 = OpLabel
+%1208 = OpLoad %bool %493
+OpStore %495 %1208
+OpBranch %85
+%84 = OpLabel
+%1209 = OpLoad %double %490
+%1210 = OpFUnordNotEqual %bool %1209 %double_0
+OpStore %494 %1210
+%1211 = OpLoad %bool %494
+OpStore %495 %1211
+OpBranch %85
+%85 = OpLabel
+%1212 = OpLoad %bool %495
+OpStore %496 %1212
+OpBranch %86
+%348 = OpLabel
+%1213 = OpLoad %bool %491
+OpStore %496 %1213
+OpBranch %86
+%86 = OpLabel
+%1214 = OpLoad %bool %496
+OpSelectionMerge %89 None
+OpBranchConditional %1214 %87 %88
+%88 = OpLabel
+%1215 = OpLoad %double %490
+%1216 = OpFOrdLessThan %bool %1215 %double_0
+OpStore %502 %1216
+%1217 = OpLoad %bool %502
+OpSelectionMerge %92 None
+OpBranchConditional %1217 %90 %91
+%91 = OpLabel
+%1218 = OpLoad %double %490
+OpStore %504 %1218
+OpBranch %92
+%90 = OpLabel
+%1219 = OpLoad %double %490
+%1220 = OpFSub %double %double_0 %1219
+OpStore %503 %1220
+%1221 = OpLoad %double %503
+OpStore %504 %1221
+OpBranch %92
+%92 = OpLabel
+%1222 = OpLoad %double %458
+%1223 = OpFOrdLessThan %bool %1222 %double_0
+OpStore %505 %1223
+%1224 = OpLoad %bool %505
+OpSelectionMerge %95 None
+OpBranchConditional %1224 %93 %94
+%94 = OpLabel
+%1225 = OpLoad %double %458
+OpStore %507 %1225
+OpBranch %95
+%93 = OpLabel
+%1226 = OpLoad %double %458
+%1227 = OpFSub %double %double_0 %1226
+OpStore %506 %1227
+%1228 = OpLoad %double %506
+OpStore %507 %1228
+OpBranch %95
+%95 = OpLabel
+%1229 = OpLoad %double %504
+%1230 = OpFDiv %double %1229 %double_2
+OpStore %508 %1230
+%1231 = OpLoad %double %507
+OpStore %509 %1231
+OpBranch %96
+%96 = OpLabel
+%1232 = OpLoad %double %509
+%1233 = OpLoad %double %508
+%1234 = OpFOrdLessThanEqual %bool %1232 %1233
+OpStore %510 %1234
+%1235 = OpLoad %bool %510
+OpLoopMerge %98 %373 None
+OpBranchConditional %1235 %97 %98
+%98 = OpLabel
+%1236 = OpLoad %double %504
+OpStore %512 %1236
+%1237 = OpLoad %double %509
+OpStore %513 %1237
+OpBranch %99
+%99 = OpLabel
+%1238 = OpLoad %double %507
+%1239 = OpLoad %double %513
+%1240 = OpFOrdLessThanEqual %bool %1238 %1239
+OpStore %514 %1240
+%1241 = OpLoad %bool %514
+OpLoopMerge %103 %372 None
+OpBranchConditional %1241 %104 %103
+%103 = OpLabel
+%1242 = OpLoad %bool %502
+OpSelectionMerge %107 None
+OpBranchConditional %1242 %105 %106
+%106 = OpLabel
+%1243 = OpLoad %double %512
+OpStore %520 %1243
+OpBranch %107
+%105 = OpLabel
+%1244 = OpLoad %double %512
 %1245 = OpFSub %double %double_0 %1244
-OpStore %370 %1245
-%1246 = OpLoad %double %352
-%1247 = OpFSub %double %double_0 %1246
-OpStore %371 %1247
-%1248 = OpLoad %double %370
-%1249 = OpLoad %double %371
-%1250 = OpFDiv %double %1248 %1249
-OpStore %372 %1250
-%1251 = OpLoad %double %372
-%1252 = OpConvertFToS %ulong %1251
-OpStore %373 %1252
-%1253 = OpLoad %ulong %373
-%1254 = OpConvertSToF %double %1253
-OpStore %374 %1254
-%1255 = OpLoad %double %374
-%1256 = OpLoad %double %371
-%1257 = OpFMul %double %1255 %1256
-OpStore %375 %1257
-%1258 = OpLoad %double %370
-%1259 = OpLoad %double %375
-%1260 = OpFSub %double %1258 %1259
-OpStore %376 %1260
+OpStore %519 %1245
+%1246 = OpLoad %double %519
+OpStore %520 %1246
+OpBranch %107
+%107 = OpLabel
+%1247 = OpLoad %double %520
+OpStore %521 %1247
+OpBranch %89
+%104 = OpLabel
+%1248 = OpLoad %double %513
+%1249 = OpLoad %double %512
+%1250 = OpFOrdLessThanEqual %bool %1248 %1249
+OpStore %515 %1250
+%1251 = OpLoad %bool %515
+OpSelectionMerge %102 None
+OpBranchConditional %1251 %100 %101
+%101 = OpLabel
+%1252 = OpLoad %double %512
+OpStore %517 %1252
+OpBranch %102
+%100 = OpLabel
+%1253 = OpLoad %double %512
+%1254 = OpLoad %double %513
+%1255 = OpFSub %double %1253 %1254
+OpStore %516 %1255
+%1256 = OpLoad %double %516
+OpStore %517 %1256
+OpBranch %102
+%102 = OpLabel
+%1257 = OpLoad %double %513
+%1258 = OpFDiv %double %1257 %double_2
+OpStore %518 %1258
+%1259 = OpLoad %double %517
+OpStore %512 %1259
+%1260 = OpLoad %double %518
+OpStore %513 %1260
+OpBranch %372
+%97 = OpLabel
+%1261 = OpLoad %double %509
+%1262 = OpFMul %double %1261 %double_2
+OpStore %511 %1262
+%1263 = OpLoad %double %511
+OpStore %509 %1263
+OpBranch %373
+%87 = OpLabel
+%1264 = OpLoad %double %490
+%1265 = OpLoad %double %458
+%1266 = OpFDiv %double %1264 %1265
+OpStore %497 %1266
+%1267 = OpLoad %double %497
+%1268 = OpConvertFToS %ulong %1267
+OpStore %498 %1268
+%1269 = OpLoad %ulong %498
+%1270 = OpConvertSToF %double %1269
+OpStore %499 %1270
+%1271 = OpLoad %double %499
+%1272 = OpLoad %double %458
+%1273 = OpFMul %double %1271 %1272
+OpStore %500 %1273
+%1274 = OpLoad %double %490
+%1275 = OpLoad %double %500
+%1276 = OpFSub %double %1274 %1275
+OpStore %501 %1276
+%1277 = OpLoad %double %501
+OpStore %521 %1277
+OpBranch %89
+%89 = OpLabel
 OpBranch %271
 %271 = OpLabel
-%1261 = OpLoad %double %376
-%1262 = OpLoad %double %376
-%1263 = OpFUnordNotEqual %bool %1261 %1262
-OpStore %574 %1263
-%1264 = OpLoad %bool %574
+%1278 = OpLoad %double %521
+%1279 = OpLoad %double %521
+%1280 = OpFUnordNotEqual %bool %1278 %1279
+OpStore %723 %1280
+%1281 = OpLoad %bool %723
 OpSelectionMerge %275 None
-OpBranchConditional %1264 %272 %273
+OpBranchConditional %1281 %272 %273
 %273 = OpLabel
 OpBranch %274
 %274 = OpLabel
-%1265 = OpLoad %ulong %573
-%1266 = OpLoad %double %376
-%1267 = OpFunctionCall %ulong %6 %1265 %1266
-OpStore %576 %1267
-%1268 = OpLoad %ulong %576
-OpStore %577 %1268
+%1282 = OpLoad %ulong %722
+%1283 = OpLoad %double %521
+%1284 = OpFunctionCall %ulong %6 %1282 %1283
+OpStore %725 %1284
+%1285 = OpLoad %ulong %725
+OpStore %726 %1285
 OpBranch %275
 %272 = OpLabel
-%1269 = OpLoad %ulong %573
-%1270 = OpFunctionCall %ulong %5 %1269 %ulong_18446744073709551615
-OpStore %575 %1270
-%1271 = OpLoad %ulong %575
-OpStore %577 %1271
+%1286 = OpLoad %ulong %722
+%1287 = OpFunctionCall %ulong %5 %1286 %ulong_18446744073709551615
+OpStore %724 %1287
+%1288 = OpLoad %ulong %724
+OpStore %726 %1288
 OpBranch %275
 %275 = OpLabel
-%1273 = OpLoad %double %403
-%1274 = OpFMul %double %double_7 %1273
-OpStore %377 %1274
-%1275 = OpLoad %double %377
-%1276 = OpFDiv %double %1275 %double_0_5
-OpStore %378 %1276
-%1277 = OpLoad %double %378
-%1278 = OpConvertFToS %ulong %1277
-OpStore %379 %1278
-%1279 = OpLoad %ulong %379
-%1280 = OpConvertSToF %double %1279
-OpStore %380 %1280
-%1281 = OpLoad %double %380
-%1282 = OpFMul %double %1281 %double_0_5
-OpStore %381 %1282
-%1283 = OpLoad %double %377
-%1284 = OpLoad %double %381
-%1285 = OpFSub %double %1283 %1284
-OpStore %382 %1285
+%1289 = OpLoad %double %458
+%1290 = OpFSub %double %double_0 %1289
+OpStore %522 %1290
+%1291 = OpLoad %double %522
+%1292 = OpFOrdEqual %bool %1291 %double_0
+OpStore %523 %1292
+%1293 = OpLoad %bool %523
+OpSelectionMerge %111 None
+OpBranchConditional %1293 %350 %108
+%108 = OpLabel
+%1294 = OpLoad %double %457
+%1295 = OpFMul %double %1294 %double_2
+OpStore %524 %1295
+%1296 = OpLoad %double %457
+%1297 = OpLoad %double %524
+%1298 = OpFOrdEqual %bool %1296 %1297
+OpStore %525 %1298
+%1299 = OpLoad %bool %525
+OpSelectionMerge %110 None
+OpBranchConditional %1299 %109 %349
+%349 = OpLabel
+%1300 = OpLoad %bool %525
+OpStore %527 %1300
+OpBranch %110
+%109 = OpLabel
+%1301 = OpLoad %double %457
+%1302 = OpFUnordNotEqual %bool %1301 %double_0
+OpStore %526 %1302
+%1303 = OpLoad %bool %526
+OpStore %527 %1303
+OpBranch %110
+%110 = OpLabel
+%1304 = OpLoad %bool %527
+OpStore %528 %1304
+OpBranch %111
+%350 = OpLabel
+%1305 = OpLoad %bool %523
+OpStore %528 %1305
+OpBranch %111
+%111 = OpLabel
+%1306 = OpLoad %bool %528
+OpSelectionMerge %114 None
+OpBranchConditional %1306 %112 %113
+%113 = OpLabel
+%1307 = OpLoad %double %457
+%1308 = OpFOrdLessThan %bool %1307 %double_0
+OpStore %534 %1308
+%1309 = OpLoad %bool %534
+OpSelectionMerge %117 None
+OpBranchConditional %1309 %115 %116
+%116 = OpLabel
+%1310 = OpLoad %double %457
+OpStore %536 %1310
+OpBranch %117
+%115 = OpLabel
+%1311 = OpLoad %double %457
+%1312 = OpFSub %double %double_0 %1311
+OpStore %535 %1312
+%1313 = OpLoad %double %535
+OpStore %536 %1313
+OpBranch %117
+%117 = OpLabel
+%1314 = OpLoad %double %522
+%1315 = OpFOrdLessThan %bool %1314 %double_0
+OpStore %537 %1315
+%1316 = OpLoad %bool %537
+OpSelectionMerge %120 None
+OpBranchConditional %1316 %118 %119
+%119 = OpLabel
+%1317 = OpLoad %double %522
+OpStore %539 %1317
+OpBranch %120
+%118 = OpLabel
+%1318 = OpLoad %double %522
+%1319 = OpFSub %double %double_0 %1318
+OpStore %538 %1319
+%1320 = OpLoad %double %538
+OpStore %539 %1320
+OpBranch %120
+%120 = OpLabel
+%1321 = OpLoad %double %536
+%1322 = OpFDiv %double %1321 %double_2
+OpStore %540 %1322
+%1323 = OpLoad %double %539
+OpStore %541 %1323
+OpBranch %121
+%121 = OpLabel
+%1324 = OpLoad %double %541
+%1325 = OpLoad %double %540
+%1326 = OpFOrdLessThanEqual %bool %1324 %1325
+OpStore %542 %1326
+%1327 = OpLoad %bool %542
+OpLoopMerge %123 %371 None
+OpBranchConditional %1327 %122 %123
+%123 = OpLabel
+%1328 = OpLoad %double %536
+OpStore %544 %1328
+%1329 = OpLoad %double %541
+OpStore %545 %1329
+OpBranch %124
+%124 = OpLabel
+%1330 = OpLoad %double %539
+%1331 = OpLoad %double %545
+%1332 = OpFOrdLessThanEqual %bool %1330 %1331
+OpStore %546 %1332
+%1333 = OpLoad %bool %546
+OpLoopMerge %128 %370 None
+OpBranchConditional %1333 %129 %128
+%128 = OpLabel
+%1334 = OpLoad %bool %534
+OpSelectionMerge %132 None
+OpBranchConditional %1334 %130 %131
+%131 = OpLabel
+%1335 = OpLoad %double %544
+OpStore %552 %1335
+OpBranch %132
+%130 = OpLabel
+%1336 = OpLoad %double %544
+%1337 = OpFSub %double %double_0 %1336
+OpStore %551 %1337
+%1338 = OpLoad %double %551
+OpStore %552 %1338
+OpBranch %132
+%132 = OpLabel
+%1339 = OpLoad %double %552
+OpStore %553 %1339
+OpBranch %114
+%129 = OpLabel
+%1340 = OpLoad %double %545
+%1341 = OpLoad %double %544
+%1342 = OpFOrdLessThanEqual %bool %1340 %1341
+OpStore %547 %1342
+%1343 = OpLoad %bool %547
+OpSelectionMerge %127 None
+OpBranchConditional %1343 %125 %126
+%126 = OpLabel
+%1344 = OpLoad %double %544
+OpStore %549 %1344
+OpBranch %127
+%125 = OpLabel
+%1345 = OpLoad %double %544
+%1346 = OpLoad %double %545
+%1347 = OpFSub %double %1345 %1346
+OpStore %548 %1347
+%1348 = OpLoad %double %548
+OpStore %549 %1348
+OpBranch %127
+%127 = OpLabel
+%1349 = OpLoad %double %545
+%1350 = OpFDiv %double %1349 %double_2
+OpStore %550 %1350
+%1351 = OpLoad %double %549
+OpStore %544 %1351
+%1352 = OpLoad %double %550
+OpStore %545 %1352
+OpBranch %370
+%122 = OpLabel
+%1353 = OpLoad %double %541
+%1354 = OpFMul %double %1353 %double_2
+OpStore %543 %1354
+%1355 = OpLoad %double %543
+OpStore %541 %1355
+OpBranch %371
+%112 = OpLabel
+%1356 = OpLoad %double %457
+%1357 = OpLoad %double %522
+%1358 = OpFDiv %double %1356 %1357
+OpStore %529 %1358
+%1359 = OpLoad %double %529
+%1360 = OpConvertFToS %ulong %1359
+OpStore %530 %1360
+%1361 = OpLoad %ulong %530
+%1362 = OpConvertSToF %double %1361
+OpStore %531 %1362
+%1363 = OpLoad %double %531
+%1364 = OpLoad %double %522
+%1365 = OpFMul %double %1363 %1364
+OpStore %532 %1365
+%1366 = OpLoad %double %457
+%1367 = OpLoad %double %532
+%1368 = OpFSub %double %1366 %1367
+OpStore %533 %1368
+%1369 = OpLoad %double %533
+OpStore %553 %1369
+OpBranch %114
+%114 = OpLabel
 OpBranch %276
 %276 = OpLabel
-%1286 = OpLoad %double %382
-%1287 = OpLoad %double %382
-%1288 = OpFUnordNotEqual %bool %1286 %1287
-OpStore %578 %1288
-%1289 = OpLoad %bool %578
+%1370 = OpLoad %double %553
+%1371 = OpLoad %double %553
+%1372 = OpFUnordNotEqual %bool %1370 %1371
+OpStore %727 %1372
+%1373 = OpLoad %bool %727
 OpSelectionMerge %280 None
-OpBranchConditional %1289 %277 %278
+OpBranchConditional %1373 %277 %278
 %278 = OpLabel
 OpBranch %279
 %279 = OpLabel
-%1290 = OpLoad %ulong %577
-%1291 = OpLoad %double %382
-%1292 = OpFunctionCall %ulong %6 %1290 %1291
-OpStore %580 %1292
-%1293 = OpLoad %ulong %580
-OpStore %581 %1293
+%1374 = OpLoad %ulong %726
+%1375 = OpLoad %double %553
+%1376 = OpFunctionCall %ulong %6 %1374 %1375
+OpStore %729 %1376
+%1377 = OpLoad %ulong %729
+OpStore %730 %1377
 OpBranch %280
 %277 = OpLabel
-%1294 = OpLoad %ulong %577
-%1295 = OpFunctionCall %ulong %5 %1294 %ulong_18446744073709551615
-OpStore %579 %1295
-%1296 = OpLoad %ulong %579
-OpStore %581 %1296
+%1378 = OpLoad %ulong %726
+%1379 = OpFunctionCall %ulong %5 %1378 %ulong_18446744073709551615
+OpStore %728 %1379
+%1380 = OpLoad %ulong %728
+OpStore %730 %1380
 OpBranch %280
 %280 = OpLabel
-%1297 = OpLoad %double %403
-%1298 = OpLoad %double %352
-%1299 = OpFDiv %double %1297 %1298
-OpStore %383 %1299
-%1300 = OpLoad %double %383
-%1301 = OpConvertFToS %ulong %1300
-OpStore %384 %1301
-%1302 = OpLoad %ulong %384
-%1303 = OpConvertSToF %double %1302
-OpStore %385 %1303
-%1304 = OpLoad %double %385
-%1305 = OpLoad %double %352
-%1306 = OpFMul %double %1304 %1305
-OpStore %386 %1306
-%1307 = OpLoad %double %403
-%1308 = OpLoad %double %386
-%1309 = OpFSub %double %1307 %1308
-OpStore %387 %1309
+%1381 = OpLoad %double %457
+%1382 = OpFSub %double %double_0 %1381
+OpStore %554 %1382
+%1383 = OpLoad %double %458
+%1384 = OpFSub %double %double_0 %1383
+OpStore %555 %1384
+%1385 = OpLoad %double %555
+%1386 = OpFOrdEqual %bool %1385 %double_0
+OpStore %556 %1386
+%1387 = OpLoad %bool %556
+OpSelectionMerge %136 None
+OpBranchConditional %1387 %352 %133
+%133 = OpLabel
+%1388 = OpLoad %double %554
+%1389 = OpFMul %double %1388 %double_2
+OpStore %557 %1389
+%1390 = OpLoad %double %554
+%1391 = OpLoad %double %557
+%1392 = OpFOrdEqual %bool %1390 %1391
+OpStore %558 %1392
+%1393 = OpLoad %bool %558
+OpSelectionMerge %135 None
+OpBranchConditional %1393 %134 %351
+%351 = OpLabel
+%1394 = OpLoad %bool %558
+OpStore %560 %1394
+OpBranch %135
+%134 = OpLabel
+%1395 = OpLoad %double %554
+%1396 = OpFUnordNotEqual %bool %1395 %double_0
+OpStore %559 %1396
+%1397 = OpLoad %bool %559
+OpStore %560 %1397
+OpBranch %135
+%135 = OpLabel
+%1398 = OpLoad %bool %560
+OpStore %561 %1398
+OpBranch %136
+%352 = OpLabel
+%1399 = OpLoad %bool %556
+OpStore %561 %1399
+OpBranch %136
+%136 = OpLabel
+%1400 = OpLoad %bool %561
+OpSelectionMerge %139 None
+OpBranchConditional %1400 %137 %138
+%138 = OpLabel
+%1401 = OpLoad %double %554
+%1402 = OpFOrdLessThan %bool %1401 %double_0
+OpStore %567 %1402
+%1403 = OpLoad %bool %567
+OpSelectionMerge %142 None
+OpBranchConditional %1403 %140 %141
+%141 = OpLabel
+%1404 = OpLoad %double %554
+OpStore %569 %1404
+OpBranch %142
+%140 = OpLabel
+%1405 = OpLoad %double %554
+%1406 = OpFSub %double %double_0 %1405
+OpStore %568 %1406
+%1407 = OpLoad %double %568
+OpStore %569 %1407
+OpBranch %142
+%142 = OpLabel
+%1408 = OpLoad %double %555
+%1409 = OpFOrdLessThan %bool %1408 %double_0
+OpStore %570 %1409
+%1410 = OpLoad %bool %570
+OpSelectionMerge %145 None
+OpBranchConditional %1410 %143 %144
+%144 = OpLabel
+%1411 = OpLoad %double %555
+OpStore %572 %1411
+OpBranch %145
+%143 = OpLabel
+%1412 = OpLoad %double %555
+%1413 = OpFSub %double %double_0 %1412
+OpStore %571 %1413
+%1414 = OpLoad %double %571
+OpStore %572 %1414
+OpBranch %145
+%145 = OpLabel
+%1415 = OpLoad %double %569
+%1416 = OpFDiv %double %1415 %double_2
+OpStore %573 %1416
+%1417 = OpLoad %double %572
+OpStore %574 %1417
+OpBranch %146
+%146 = OpLabel
+%1418 = OpLoad %double %574
+%1419 = OpLoad %double %573
+%1420 = OpFOrdLessThanEqual %bool %1418 %1419
+OpStore %575 %1420
+%1421 = OpLoad %bool %575
+OpLoopMerge %148 %369 None
+OpBranchConditional %1421 %147 %148
+%148 = OpLabel
+%1422 = OpLoad %double %569
+OpStore %577 %1422
+%1423 = OpLoad %double %574
+OpStore %578 %1423
+OpBranch %149
+%149 = OpLabel
+%1424 = OpLoad %double %572
+%1425 = OpLoad %double %578
+%1426 = OpFOrdLessThanEqual %bool %1424 %1425
+OpStore %579 %1426
+%1427 = OpLoad %bool %579
+OpLoopMerge %153 %368 None
+OpBranchConditional %1427 %154 %153
+%153 = OpLabel
+%1428 = OpLoad %bool %567
+OpSelectionMerge %157 None
+OpBranchConditional %1428 %155 %156
+%156 = OpLabel
+%1429 = OpLoad %double %577
+OpStore %585 %1429
+OpBranch %157
+%155 = OpLabel
+%1430 = OpLoad %double %577
+%1431 = OpFSub %double %double_0 %1430
+OpStore %584 %1431
+%1432 = OpLoad %double %584
+OpStore %585 %1432
+OpBranch %157
+%157 = OpLabel
+%1433 = OpLoad %double %585
+OpStore %586 %1433
+OpBranch %139
+%154 = OpLabel
+%1434 = OpLoad %double %578
+%1435 = OpLoad %double %577
+%1436 = OpFOrdLessThanEqual %bool %1434 %1435
+OpStore %580 %1436
+%1437 = OpLoad %bool %580
+OpSelectionMerge %152 None
+OpBranchConditional %1437 %150 %151
+%151 = OpLabel
+%1438 = OpLoad %double %577
+OpStore %582 %1438
+OpBranch %152
+%150 = OpLabel
+%1439 = OpLoad %double %577
+%1440 = OpLoad %double %578
+%1441 = OpFSub %double %1439 %1440
+OpStore %581 %1441
+%1442 = OpLoad %double %581
+OpStore %582 %1442
+OpBranch %152
+%152 = OpLabel
+%1443 = OpLoad %double %578
+%1444 = OpFDiv %double %1443 %double_2
+OpStore %583 %1444
+%1445 = OpLoad %double %582
+OpStore %577 %1445
+%1446 = OpLoad %double %583
+OpStore %578 %1446
+OpBranch %368
+%147 = OpLabel
+%1447 = OpLoad %double %574
+%1448 = OpFMul %double %1447 %double_2
+OpStore %576 %1448
+%1449 = OpLoad %double %576
+OpStore %574 %1449
+OpBranch %369
+%137 = OpLabel
+%1450 = OpLoad %double %554
+%1451 = OpLoad %double %555
+%1452 = OpFDiv %double %1450 %1451
+OpStore %562 %1452
+%1453 = OpLoad %double %562
+%1454 = OpConvertFToS %ulong %1453
+OpStore %563 %1454
+%1455 = OpLoad %ulong %563
+%1456 = OpConvertSToF %double %1455
+OpStore %564 %1456
+%1457 = OpLoad %double %564
+%1458 = OpLoad %double %555
+%1459 = OpFMul %double %1457 %1458
+OpStore %565 %1459
+%1460 = OpLoad %double %554
+%1461 = OpLoad %double %565
+%1462 = OpFSub %double %1460 %1461
+OpStore %566 %1462
+%1463 = OpLoad %double %566
+OpStore %586 %1463
+OpBranch %139
+%139 = OpLabel
 OpBranch %281
 %281 = OpLabel
-%1310 = OpLoad %double %387
-%1311 = OpLoad %double %387
-%1312 = OpFUnordNotEqual %bool %1310 %1311
-OpStore %582 %1312
-%1313 = OpLoad %bool %582
+%1464 = OpLoad %double %586
+%1465 = OpLoad %double %586
+%1466 = OpFUnordNotEqual %bool %1464 %1465
+OpStore %731 %1466
+%1467 = OpLoad %bool %731
 OpSelectionMerge %285 None
-OpBranchConditional %1313 %282 %283
+OpBranchConditional %1467 %282 %283
 %283 = OpLabel
 OpBranch %284
 %284 = OpLabel
-%1314 = OpLoad %ulong %581
-%1315 = OpLoad %double %387
-%1316 = OpFunctionCall %ulong %6 %1314 %1315
-OpStore %584 %1316
-%1317 = OpLoad %ulong %584
-OpStore %585 %1317
+%1468 = OpLoad %ulong %730
+%1469 = OpLoad %double %586
+%1470 = OpFunctionCall %ulong %6 %1468 %1469
+OpStore %733 %1470
+%1471 = OpLoad %ulong %733
+OpStore %734 %1471
 OpBranch %285
 %282 = OpLabel
-%1318 = OpLoad %ulong %581
-%1319 = OpFunctionCall %ulong %5 %1318 %ulong_18446744073709551615
-OpStore %583 %1319
-%1320 = OpLoad %ulong %583
-OpStore %585 %1320
+%1472 = OpLoad %ulong %730
+%1473 = OpFunctionCall %ulong %5 %1472 %ulong_18446744073709551615
+OpStore %732 %1473
+%1474 = OpLoad %ulong %732
+OpStore %734 %1474
 OpBranch %285
 %285 = OpLabel
-%1321 = OpLoad %double %352
-%1322 = OpLoad %double %352
-%1323 = OpFDiv %double %1321 %1322
-OpStore %388 %1323
-%1324 = OpLoad %double %388
-%1325 = OpConvertFToS %ulong %1324
-OpStore %389 %1325
-%1326 = OpLoad %ulong %389
-%1327 = OpConvertSToF %double %1326
-OpStore %390 %1327
-%1328 = OpLoad %double %390
-%1329 = OpLoad %double %352
-%1330 = OpFMul %double %1328 %1329
-OpStore %391 %1330
-%1331 = OpLoad %double %352
-%1332 = OpLoad %double %391
-%1333 = OpFSub %double %1331 %1332
-OpStore %392 %1333
+%1476 = OpLoad %double %712
+%1477 = OpFMul %double %double_7 %1476
+OpStore %587 %1477
+OpBranch %158
+%158 = OpLabel
+%1478 = OpLoad %double %587
+%1479 = OpFMul %double %1478 %double_2
+OpStore %588 %1479
+%1480 = OpLoad %double %587
+%1481 = OpLoad %double %588
+%1482 = OpFOrdEqual %bool %1480 %1481
+OpStore %589 %1482
+%1483 = OpLoad %bool %589
+OpSelectionMerge %160 None
+OpBranchConditional %1483 %159 %353
+%353 = OpLabel
+%1484 = OpLoad %bool %589
+OpStore %591 %1484
+OpBranch %160
+%159 = OpLabel
+%1485 = OpLoad %double %587
+%1486 = OpFUnordNotEqual %bool %1485 %double_0
+OpStore %590 %1486
+%1487 = OpLoad %bool %590
+OpStore %591 %1487
+OpBranch %160
+%160 = OpLabel
+OpBranch %161
+%161 = OpLabel
+%1488 = OpLoad %bool %591
+OpSelectionMerge %164 None
+OpBranchConditional %1488 %162 %163
+%163 = OpLabel
+%1489 = OpLoad %double %587
+%1490 = OpFOrdLessThan %bool %1489 %double_0
+OpStore %597 %1490
+%1491 = OpLoad %bool %597
+OpSelectionMerge %167 None
+OpBranchConditional %1491 %165 %166
+%166 = OpLabel
+%1492 = OpLoad %double %587
+OpStore %599 %1492
+OpBranch %167
+%165 = OpLabel
+%1493 = OpLoad %double %587
+%1494 = OpFSub %double %double_0 %1493
+OpStore %598 %1494
+%1495 = OpLoad %double %598
+OpStore %599 %1495
+OpBranch %167
+%167 = OpLabel
+OpBranch %168
+%168 = OpLabel
+OpBranch %169
+%169 = OpLabel
+%1496 = OpLoad %double %599
+%1497 = OpFDiv %double %1496 %double_2
+OpStore %600 %1497
+OpStore %601 %double_0_5
+OpBranch %170
+%170 = OpLabel
+%1498 = OpLoad %double %601
+%1499 = OpLoad %double %600
+%1500 = OpFOrdLessThanEqual %bool %1498 %1499
+OpStore %602 %1500
+%1501 = OpLoad %bool %602
+OpLoopMerge %172 %367 None
+OpBranchConditional %1501 %171 %172
+%172 = OpLabel
+%1502 = OpLoad %double %599
+OpStore %604 %1502
+%1503 = OpLoad %double %601
+OpStore %605 %1503
+OpBranch %173
+%173 = OpLabel
+%1504 = OpLoad %double %605
+%1505 = OpFOrdLessThanEqual %bool %double_0_5 %1504
+OpStore %606 %1505
+%1506 = OpLoad %bool %606
+OpLoopMerge %177 %366 None
+OpBranchConditional %1506 %178 %177
+%177 = OpLabel
+%1507 = OpLoad %bool %597
+OpSelectionMerge %181 None
+OpBranchConditional %1507 %179 %180
+%180 = OpLabel
+%1508 = OpLoad %double %604
+OpStore %612 %1508
+OpBranch %181
+%179 = OpLabel
+%1509 = OpLoad %double %604
+%1510 = OpFSub %double %double_0 %1509
+OpStore %611 %1510
+%1511 = OpLoad %double %611
+OpStore %612 %1511
+OpBranch %181
+%181 = OpLabel
+%1512 = OpLoad %double %612
+OpStore %613 %1512
+OpBranch %164
+%178 = OpLabel
+%1513 = OpLoad %double %605
+%1514 = OpLoad %double %604
+%1515 = OpFOrdLessThanEqual %bool %1513 %1514
+OpStore %607 %1515
+%1516 = OpLoad %bool %607
+OpSelectionMerge %176 None
+OpBranchConditional %1516 %174 %175
+%175 = OpLabel
+%1517 = OpLoad %double %604
+OpStore %609 %1517
+OpBranch %176
+%174 = OpLabel
+%1518 = OpLoad %double %604
+%1519 = OpLoad %double %605
+%1520 = OpFSub %double %1518 %1519
+OpStore %608 %1520
+%1521 = OpLoad %double %608
+OpStore %609 %1521
+OpBranch %176
+%176 = OpLabel
+%1522 = OpLoad %double %605
+%1523 = OpFDiv %double %1522 %double_2
+OpStore %610 %1523
+%1524 = OpLoad %double %609
+OpStore %604 %1524
+%1525 = OpLoad %double %610
+OpStore %605 %1525
+OpBranch %366
+%171 = OpLabel
+%1526 = OpLoad %double %601
+%1527 = OpFMul %double %1526 %double_2
+OpStore %603 %1527
+%1528 = OpLoad %double %603
+OpStore %601 %1528
+OpBranch %367
+%162 = OpLabel
+%1529 = OpLoad %double %587
+%1530 = OpFDiv %double %1529 %double_0_5
+OpStore %592 %1530
+%1531 = OpLoad %double %592
+%1532 = OpConvertFToS %ulong %1531
+OpStore %593 %1532
+%1533 = OpLoad %ulong %593
+%1534 = OpConvertSToF %double %1533
+OpStore %594 %1534
+%1535 = OpLoad %double %594
+%1536 = OpFMul %double %1535 %double_0_5
+OpStore %595 %1536
+%1537 = OpLoad %double %587
+%1538 = OpLoad %double %595
+%1539 = OpFSub %double %1537 %1538
+OpStore %596 %1539
+%1540 = OpLoad %double %596
+OpStore %613 %1540
+OpBranch %164
+%164 = OpLabel
 OpBranch %286
 %286 = OpLabel
-%1334 = OpLoad %double %392
-%1335 = OpLoad %double %392
-%1336 = OpFUnordNotEqual %bool %1334 %1335
-OpStore %586 %1336
-%1337 = OpLoad %bool %586
+%1541 = OpLoad %double %613
+%1542 = OpLoad %double %613
+%1543 = OpFUnordNotEqual %bool %1541 %1542
+OpStore %735 %1543
+%1544 = OpLoad %bool %735
 OpSelectionMerge %290 None
-OpBranchConditional %1337 %287 %288
+OpBranchConditional %1544 %287 %288
 %288 = OpLabel
 OpBranch %289
 %289 = OpLabel
-%1338 = OpLoad %ulong %585
-%1339 = OpLoad %double %392
-%1340 = OpFunctionCall %ulong %6 %1338 %1339
-OpStore %588 %1340
-%1341 = OpLoad %ulong %588
-OpStore %589 %1341
+%1545 = OpLoad %ulong %734
+%1546 = OpLoad %double %613
+%1547 = OpFunctionCall %ulong %6 %1545 %1546
+OpStore %737 %1547
+%1548 = OpLoad %ulong %737
+OpStore %738 %1548
 OpBranch %290
 %287 = OpLabel
-%1342 = OpLoad %ulong %585
-%1343 = OpFunctionCall %ulong %5 %1342 %ulong_18446744073709551615
-OpStore %587 %1343
-%1344 = OpLoad %ulong %587
-OpStore %589 %1344
+%1549 = OpLoad %ulong %734
+%1550 = OpFunctionCall %ulong %5 %1549 %ulong_18446744073709551615
+OpStore %736 %1550
+%1551 = OpLoad %ulong %736
+OpStore %738 %1551
 OpBranch %290
 %290 = OpLabel
-%1346 = OpLoad %double %403
-%1347 = OpFMul %double %double_1048576 %1346
-OpStore %393 %1347
-%1348 = OpLoad %double %393
-%1349 = OpLoad %double %352
-%1350 = OpFDiv %double %1348 %1349
-OpStore %394 %1350
-%1351 = OpLoad %double %394
-%1352 = OpConvertFToS %ulong %1351
-OpStore %395 %1352
-%1353 = OpLoad %ulong %395
-%1354 = OpConvertSToF %double %1353
-OpStore %396 %1354
-%1355 = OpLoad %double %396
-%1356 = OpLoad %double %352
-%1357 = OpFMul %double %1355 %1356
-OpStore %397 %1357
-%1358 = OpLoad %double %393
-%1359 = OpLoad %double %397
-%1360 = OpFSub %double %1358 %1359
-OpStore %398 %1360
+%1552 = OpLoad %double %458
+%1553 = OpFOrdEqual %bool %1552 %double_0
+OpStore %614 %1553
+%1554 = OpLoad %bool %614
+OpSelectionMerge %185 None
+OpBranchConditional %1554 %355 %182
+%182 = OpLabel
+%1555 = OpLoad %double %712
+%1556 = OpFMul %double %1555 %double_2
+OpStore %615 %1556
+%1557 = OpLoad %double %712
+%1558 = OpLoad %double %615
+%1559 = OpFOrdEqual %bool %1557 %1558
+OpStore %616 %1559
+%1560 = OpLoad %bool %616
+OpSelectionMerge %184 None
+OpBranchConditional %1560 %183 %354
+%354 = OpLabel
+%1561 = OpLoad %bool %616
+OpStore %618 %1561
+OpBranch %184
+%183 = OpLabel
+%1562 = OpLoad %double %712
+%1563 = OpFUnordNotEqual %bool %1562 %double_0
+OpStore %617 %1563
+%1564 = OpLoad %bool %617
+OpStore %618 %1564
+OpBranch %184
+%184 = OpLabel
+%1565 = OpLoad %bool %618
+OpStore %619 %1565
+OpBranch %185
+%355 = OpLabel
+%1566 = OpLoad %bool %614
+OpStore %619 %1566
+OpBranch %185
+%185 = OpLabel
+%1567 = OpLoad %bool %619
+OpSelectionMerge %188 None
+OpBranchConditional %1567 %186 %187
+%187 = OpLabel
+%1568 = OpLoad %double %712
+%1569 = OpFOrdLessThan %bool %1568 %double_0
+OpStore %625 %1569
+%1570 = OpLoad %bool %625
+OpSelectionMerge %191 None
+OpBranchConditional %1570 %189 %190
+%190 = OpLabel
+%1571 = OpLoad %double %712
+OpStore %627 %1571
+OpBranch %191
+%189 = OpLabel
+%1572 = OpLoad %double %712
+%1573 = OpFSub %double %double_0 %1572
+OpStore %626 %1573
+%1574 = OpLoad %double %626
+OpStore %627 %1574
+OpBranch %191
+%191 = OpLabel
+%1575 = OpLoad %double %458
+%1576 = OpFOrdLessThan %bool %1575 %double_0
+OpStore %628 %1576
+%1577 = OpLoad %bool %628
+OpSelectionMerge %194 None
+OpBranchConditional %1577 %192 %193
+%193 = OpLabel
+%1578 = OpLoad %double %458
+OpStore %630 %1578
+OpBranch %194
+%192 = OpLabel
+%1579 = OpLoad %double %458
+%1580 = OpFSub %double %double_0 %1579
+OpStore %629 %1580
+%1581 = OpLoad %double %629
+OpStore %630 %1581
+OpBranch %194
+%194 = OpLabel
+%1582 = OpLoad %double %627
+%1583 = OpFDiv %double %1582 %double_2
+OpStore %631 %1583
+%1584 = OpLoad %double %630
+OpStore %632 %1584
+OpBranch %195
+%195 = OpLabel
+%1585 = OpLoad %double %632
+%1586 = OpLoad %double %631
+%1587 = OpFOrdLessThanEqual %bool %1585 %1586
+OpStore %633 %1587
+%1588 = OpLoad %bool %633
+OpLoopMerge %197 %365 None
+OpBranchConditional %1588 %196 %197
+%197 = OpLabel
+%1589 = OpLoad %double %627
+OpStore %635 %1589
+%1590 = OpLoad %double %632
+OpStore %636 %1590
+OpBranch %198
+%198 = OpLabel
+%1591 = OpLoad %double %630
+%1592 = OpLoad %double %636
+%1593 = OpFOrdLessThanEqual %bool %1591 %1592
+OpStore %637 %1593
+%1594 = OpLoad %bool %637
+OpLoopMerge %202 %364 None
+OpBranchConditional %1594 %203 %202
+%202 = OpLabel
+%1595 = OpLoad %bool %625
+OpSelectionMerge %206 None
+OpBranchConditional %1595 %204 %205
+%205 = OpLabel
+%1596 = OpLoad %double %635
+OpStore %643 %1596
+OpBranch %206
+%204 = OpLabel
+%1597 = OpLoad %double %635
+%1598 = OpFSub %double %double_0 %1597
+OpStore %642 %1598
+%1599 = OpLoad %double %642
+OpStore %643 %1599
+OpBranch %206
+%206 = OpLabel
+%1600 = OpLoad %double %643
+OpStore %644 %1600
+OpBranch %188
+%203 = OpLabel
+%1601 = OpLoad %double %636
+%1602 = OpLoad %double %635
+%1603 = OpFOrdLessThanEqual %bool %1601 %1602
+OpStore %638 %1603
+%1604 = OpLoad %bool %638
+OpSelectionMerge %201 None
+OpBranchConditional %1604 %199 %200
+%200 = OpLabel
+%1605 = OpLoad %double %635
+OpStore %640 %1605
+OpBranch %201
+%199 = OpLabel
+%1606 = OpLoad %double %635
+%1607 = OpLoad %double %636
+%1608 = OpFSub %double %1606 %1607
+OpStore %639 %1608
+%1609 = OpLoad %double %639
+OpStore %640 %1609
+OpBranch %201
+%201 = OpLabel
+%1610 = OpLoad %double %636
+%1611 = OpFDiv %double %1610 %double_2
+OpStore %641 %1611
+%1612 = OpLoad %double %640
+OpStore %635 %1612
+%1613 = OpLoad %double %641
+OpStore %636 %1613
+OpBranch %364
+%196 = OpLabel
+%1614 = OpLoad %double %632
+%1615 = OpFMul %double %1614 %double_2
+OpStore %634 %1615
+%1616 = OpLoad %double %634
+OpStore %632 %1616
+OpBranch %365
+%186 = OpLabel
+%1617 = OpLoad %double %712
+%1618 = OpLoad %double %458
+%1619 = OpFDiv %double %1617 %1618
+OpStore %620 %1619
+%1620 = OpLoad %double %620
+%1621 = OpConvertFToS %ulong %1620
+OpStore %621 %1621
+%1622 = OpLoad %ulong %621
+%1623 = OpConvertSToF %double %1622
+OpStore %622 %1623
+%1624 = OpLoad %double %622
+%1625 = OpLoad %double %458
+%1626 = OpFMul %double %1624 %1625
+OpStore %623 %1626
+%1627 = OpLoad %double %712
+%1628 = OpLoad %double %623
+%1629 = OpFSub %double %1627 %1628
+OpStore %624 %1629
+%1630 = OpLoad %double %624
+OpStore %644 %1630
+OpBranch %188
+%188 = OpLabel
 OpBranch %291
 %291 = OpLabel
-%1361 = OpLoad %double %398
-%1362 = OpLoad %double %398
-%1363 = OpFUnordNotEqual %bool %1361 %1362
-OpStore %590 %1363
-%1364 = OpLoad %bool %590
+%1631 = OpLoad %double %644
+%1632 = OpLoad %double %644
+%1633 = OpFUnordNotEqual %bool %1631 %1632
+OpStore %739 %1633
+%1634 = OpLoad %bool %739
 OpSelectionMerge %295 None
-OpBranchConditional %1364 %292 %293
+OpBranchConditional %1634 %292 %293
 %293 = OpLabel
 OpBranch %294
 %294 = OpLabel
-%1365 = OpLoad %ulong %589
-%1366 = OpLoad %double %398
-%1367 = OpFunctionCall %ulong %6 %1365 %1366
-OpStore %592 %1367
-%1368 = OpLoad %ulong %592
-OpStore %593 %1368
+%1635 = OpLoad %ulong %738
+%1636 = OpLoad %double %644
+%1637 = OpFunctionCall %ulong %6 %1635 %1636
+OpStore %741 %1637
+%1638 = OpLoad %ulong %741
+OpStore %742 %1638
 OpBranch %295
 %292 = OpLabel
-%1369 = OpLoad %ulong %589
-%1370 = OpFunctionCall %ulong %5 %1369 %ulong_18446744073709551615
-OpStore %591 %1370
-%1371 = OpLoad %ulong %591
-OpStore %593 %1371
+%1639 = OpLoad %ulong %738
+%1640 = OpFunctionCall %ulong %5 %1639 %ulong_18446744073709551615
+OpStore %740 %1640
+%1641 = OpLoad %ulong %740
+OpStore %742 %1641
 OpBranch %295
 %295 = OpLabel
-%1372 = OpLoad %ulong %593
-OpReturnValue %1372
-%56 = OpLabel
-%1373 = OpLoad %double %400
-%1374 = OpLoad %double %313
-%1375 = OpFAdd %double %1373 %1374
-OpStore %332 %1375
-%1376 = OpLoad %double %332
-%1377 = OpFMul %double %1376 %double_1_5
-OpStore %333 %1377
-OpBranch %60
-%60 = OpLabel
-%1378 = OpLoad %double %333
-%1379 = OpLoad %double %333
-%1380 = OpFUnordNotEqual %bool %1378 %1379
-OpStore %404 %1380
-%1381 = OpLoad %bool %404
-OpSelectionMerge %64 None
-OpBranchConditional %1381 %61 %62
-%62 = OpLabel
-OpBranch %63
-%63 = OpLabel
-%1382 = OpLoad %ulong %399
-%1383 = OpLoad %double %333
-%1384 = OpFunctionCall %ulong %6 %1382 %1383
-OpStore %406 %1384
-%1385 = OpLoad %ulong %406
-OpStore %407 %1385
-OpBranch %64
-%61 = OpLabel
-%1386 = OpLoad %ulong %399
-%1387 = OpFunctionCall %ulong %5 %1386 %ulong_18446744073709551615
-OpStore %405 %1387
-%1388 = OpLoad %ulong %405
-OpStore %407 %1388
-OpBranch %64
-%64 = OpLabel
-%1389 = OpLoad %ulong %401
-%1390 = OpIAdd %ulong %1389 %ulong_1
-OpStore %334 %1390
-%1391 = OpLoad %ulong %407
-OpStore %399 %1391
-%1392 = OpLoad %double %333
-OpStore %400 %1392
-%1393 = OpLoad %ulong %334
-OpStore %401 %1393
+%1642 = OpLoad %double %458
+%1643 = OpFOrdEqual %bool %1642 %double_0
+OpStore %645 %1643
+%1644 = OpLoad %bool %645
+OpSelectionMerge %210 None
+OpBranchConditional %1644 %357 %207
+%207 = OpLabel
+%1645 = OpLoad %double %458
+%1646 = OpFMul %double %1645 %double_2
+OpStore %646 %1646
+%1647 = OpLoad %double %458
+%1648 = OpLoad %double %646
+%1649 = OpFOrdEqual %bool %1647 %1648
+OpStore %647 %1649
+%1650 = OpLoad %bool %647
+OpSelectionMerge %209 None
+OpBranchConditional %1650 %208 %356
+%356 = OpLabel
+%1651 = OpLoad %bool %647
+OpStore %649 %1651
+OpBranch %209
+%208 = OpLabel
+%1652 = OpLoad %double %458
+%1653 = OpFUnordNotEqual %bool %1652 %double_0
+OpStore %648 %1653
+%1654 = OpLoad %bool %648
+OpStore %649 %1654
+OpBranch %209
+%209 = OpLabel
+%1655 = OpLoad %bool %649
+OpStore %650 %1655
+OpBranch %210
+%357 = OpLabel
+%1656 = OpLoad %bool %645
+OpStore %650 %1656
+OpBranch %210
+%210 = OpLabel
+%1657 = OpLoad %bool %650
+OpSelectionMerge %213 None
+OpBranchConditional %1657 %211 %212
+%212 = OpLabel
+%1658 = OpLoad %double %458
+%1659 = OpFOrdLessThan %bool %1658 %double_0
+OpStore %656 %1659
+%1660 = OpLoad %bool %656
+OpSelectionMerge %216 None
+OpBranchConditional %1660 %214 %215
+%215 = OpLabel
+%1661 = OpLoad %double %458
+OpStore %658 %1661
+OpBranch %216
+%214 = OpLabel
+%1662 = OpLoad %double %458
+%1663 = OpFSub %double %double_0 %1662
+OpStore %657 %1663
+%1664 = OpLoad %double %657
+OpStore %658 %1664
+OpBranch %216
+%216 = OpLabel
+%1665 = OpLoad %double %458
+%1666 = OpFOrdLessThan %bool %1665 %double_0
+OpStore %659 %1666
+%1667 = OpLoad %bool %659
+OpSelectionMerge %219 None
+OpBranchConditional %1667 %217 %218
+%218 = OpLabel
+%1668 = OpLoad %double %458
+OpStore %661 %1668
+OpBranch %219
+%217 = OpLabel
+%1669 = OpLoad %double %458
+%1670 = OpFSub %double %double_0 %1669
+OpStore %660 %1670
+%1671 = OpLoad %double %660
+OpStore %661 %1671
+OpBranch %219
+%219 = OpLabel
+%1672 = OpLoad %double %658
+%1673 = OpFDiv %double %1672 %double_2
+OpStore %662 %1673
+%1674 = OpLoad %double %661
+OpStore %663 %1674
+OpBranch %220
+%220 = OpLabel
+%1675 = OpLoad %double %663
+%1676 = OpLoad %double %662
+%1677 = OpFOrdLessThanEqual %bool %1675 %1676
+OpStore %664 %1677
+%1678 = OpLoad %bool %664
+OpLoopMerge %222 %363 None
+OpBranchConditional %1678 %221 %222
+%222 = OpLabel
+%1679 = OpLoad %double %658
+OpStore %666 %1679
+%1680 = OpLoad %double %663
+OpStore %667 %1680
+OpBranch %223
+%223 = OpLabel
+%1681 = OpLoad %double %661
+%1682 = OpLoad %double %667
+%1683 = OpFOrdLessThanEqual %bool %1681 %1682
+OpStore %668 %1683
+%1684 = OpLoad %bool %668
+OpLoopMerge %227 %362 None
+OpBranchConditional %1684 %228 %227
+%227 = OpLabel
+%1685 = OpLoad %bool %656
+OpSelectionMerge %231 None
+OpBranchConditional %1685 %229 %230
+%230 = OpLabel
+%1686 = OpLoad %double %666
+OpStore %674 %1686
+OpBranch %231
+%229 = OpLabel
+%1687 = OpLoad %double %666
+%1688 = OpFSub %double %double_0 %1687
+OpStore %673 %1688
+%1689 = OpLoad %double %673
+OpStore %674 %1689
+OpBranch %231
+%231 = OpLabel
+%1690 = OpLoad %double %674
+OpStore %675 %1690
+OpBranch %213
+%228 = OpLabel
+%1691 = OpLoad %double %667
+%1692 = OpLoad %double %666
+%1693 = OpFOrdLessThanEqual %bool %1691 %1692
+OpStore %669 %1693
+%1694 = OpLoad %bool %669
+OpSelectionMerge %226 None
+OpBranchConditional %1694 %224 %225
+%225 = OpLabel
+%1695 = OpLoad %double %666
+OpStore %671 %1695
+OpBranch %226
+%224 = OpLabel
+%1696 = OpLoad %double %666
+%1697 = OpLoad %double %667
+%1698 = OpFSub %double %1696 %1697
+OpStore %670 %1698
+%1699 = OpLoad %double %670
+OpStore %671 %1699
+OpBranch %226
+%226 = OpLabel
+%1700 = OpLoad %double %667
+%1701 = OpFDiv %double %1700 %double_2
+OpStore %672 %1701
+%1702 = OpLoad %double %671
+OpStore %666 %1702
+%1703 = OpLoad %double %672
+OpStore %667 %1703
+OpBranch %362
+%221 = OpLabel
+%1704 = OpLoad %double %663
+%1705 = OpFMul %double %1704 %double_2
+OpStore %665 %1705
+%1706 = OpLoad %double %665
+OpStore %663 %1706
+OpBranch %363
+%211 = OpLabel
+%1707 = OpLoad %double %458
+%1708 = OpLoad %double %458
+%1709 = OpFDiv %double %1707 %1708
+OpStore %651 %1709
+%1710 = OpLoad %double %651
+%1711 = OpConvertFToS %ulong %1710
+OpStore %652 %1711
+%1712 = OpLoad %ulong %652
+%1713 = OpConvertSToF %double %1712
+OpStore %653 %1713
+%1714 = OpLoad %double %653
+%1715 = OpLoad %double %458
+%1716 = OpFMul %double %1714 %1715
+OpStore %654 %1716
+%1717 = OpLoad %double %458
+%1718 = OpLoad %double %654
+%1719 = OpFSub %double %1717 %1718
+OpStore %655 %1719
+%1720 = OpLoad %double %655
+OpStore %675 %1720
+OpBranch %213
+%213 = OpLabel
 OpBranch %296
 %296 = OpLabel
+%1721 = OpLoad %double %675
+%1722 = OpLoad %double %675
+%1723 = OpFUnordNotEqual %bool %1721 %1722
+OpStore %743 %1723
+%1724 = OpLoad %bool %743
+OpSelectionMerge %300 None
+OpBranchConditional %1724 %297 %298
+%298 = OpLabel
+OpBranch %299
+%299 = OpLabel
+%1725 = OpLoad %ulong %742
+%1726 = OpLoad %double %675
+%1727 = OpFunctionCall %ulong %6 %1725 %1726
+OpStore %745 %1727
+%1728 = OpLoad %ulong %745
+OpStore %746 %1728
+OpBranch %300
+%297 = OpLabel
+%1729 = OpLoad %ulong %742
+%1730 = OpFunctionCall %ulong %5 %1729 %ulong_18446744073709551615
+OpStore %744 %1730
+%1731 = OpLoad %ulong %744
+OpStore %746 %1731
+OpBranch %300
+%300 = OpLabel
+%1733 = OpLoad %double %712
+%1734 = OpFMul %double %double_1048576 %1733
+OpStore %676 %1734
+%1735 = OpLoad %double %458
+%1736 = OpFOrdEqual %bool %1735 %double_0
+OpStore %677 %1736
+%1737 = OpLoad %bool %677
+OpSelectionMerge %235 None
+OpBranchConditional %1737 %359 %232
+%232 = OpLabel
+%1738 = OpLoad %double %676
+%1739 = OpFMul %double %1738 %double_2
+OpStore %678 %1739
+%1740 = OpLoad %double %676
+%1741 = OpLoad %double %678
+%1742 = OpFOrdEqual %bool %1740 %1741
+OpStore %679 %1742
+%1743 = OpLoad %bool %679
+OpSelectionMerge %234 None
+OpBranchConditional %1743 %233 %358
+%358 = OpLabel
+%1744 = OpLoad %bool %679
+OpStore %681 %1744
+OpBranch %234
+%233 = OpLabel
+%1745 = OpLoad %double %676
+%1746 = OpFUnordNotEqual %bool %1745 %double_0
+OpStore %680 %1746
+%1747 = OpLoad %bool %680
+OpStore %681 %1747
+OpBranch %234
+%234 = OpLabel
+%1748 = OpLoad %bool %681
+OpStore %682 %1748
+OpBranch %235
+%359 = OpLabel
+%1749 = OpLoad %bool %677
+OpStore %682 %1749
+OpBranch %235
+%235 = OpLabel
+%1750 = OpLoad %bool %682
+OpSelectionMerge %238 None
+OpBranchConditional %1750 %236 %237
+%237 = OpLabel
+%1751 = OpLoad %double %676
+%1752 = OpFOrdLessThan %bool %1751 %double_0
+OpStore %688 %1752
+%1753 = OpLoad %bool %688
+OpSelectionMerge %241 None
+OpBranchConditional %1753 %239 %240
+%240 = OpLabel
+%1754 = OpLoad %double %676
+OpStore %690 %1754
+OpBranch %241
+%239 = OpLabel
+%1755 = OpLoad %double %676
+%1756 = OpFSub %double %double_0 %1755
+OpStore %689 %1756
+%1757 = OpLoad %double %689
+OpStore %690 %1757
+OpBranch %241
+%241 = OpLabel
+%1758 = OpLoad %double %458
+%1759 = OpFOrdLessThan %bool %1758 %double_0
+OpStore %691 %1759
+%1760 = OpLoad %bool %691
+OpSelectionMerge %244 None
+OpBranchConditional %1760 %242 %243
+%243 = OpLabel
+%1761 = OpLoad %double %458
+OpStore %693 %1761
+OpBranch %244
+%242 = OpLabel
+%1762 = OpLoad %double %458
+%1763 = OpFSub %double %double_0 %1762
+OpStore %692 %1763
+%1764 = OpLoad %double %692
+OpStore %693 %1764
+OpBranch %244
+%244 = OpLabel
+%1765 = OpLoad %double %690
+%1766 = OpFDiv %double %1765 %double_2
+OpStore %694 %1766
+%1767 = OpLoad %double %693
+OpStore %695 %1767
+OpBranch %245
+%245 = OpLabel
+%1768 = OpLoad %double %695
+%1769 = OpLoad %double %694
+%1770 = OpFOrdLessThanEqual %bool %1768 %1769
+OpStore %696 %1770
+%1771 = OpLoad %bool %696
+OpLoopMerge %247 %361 None
+OpBranchConditional %1771 %246 %247
+%247 = OpLabel
+%1772 = OpLoad %double %690
+OpStore %698 %1772
+%1773 = OpLoad %double %695
+OpStore %699 %1773
+OpBranch %248
+%248 = OpLabel
+%1774 = OpLoad %double %693
+%1775 = OpLoad %double %699
+%1776 = OpFOrdLessThanEqual %bool %1774 %1775
+OpStore %700 %1776
+%1777 = OpLoad %bool %700
+OpLoopMerge %252 %360 None
+OpBranchConditional %1777 %253 %252
+%252 = OpLabel
+%1778 = OpLoad %bool %688
+OpSelectionMerge %256 None
+OpBranchConditional %1778 %254 %255
+%255 = OpLabel
+%1779 = OpLoad %double %698
+OpStore %706 %1779
+OpBranch %256
+%254 = OpLabel
+%1780 = OpLoad %double %698
+%1781 = OpFSub %double %double_0 %1780
+OpStore %705 %1781
+%1782 = OpLoad %double %705
+OpStore %706 %1782
+OpBranch %256
+%256 = OpLabel
+%1783 = OpLoad %double %706
+OpStore %707 %1783
+OpBranch %238
+%253 = OpLabel
+%1784 = OpLoad %double %699
+%1785 = OpLoad %double %698
+%1786 = OpFOrdLessThanEqual %bool %1784 %1785
+OpStore %701 %1786
+%1787 = OpLoad %bool %701
+OpSelectionMerge %251 None
+OpBranchConditional %1787 %249 %250
+%250 = OpLabel
+%1788 = OpLoad %double %698
+OpStore %703 %1788
+OpBranch %251
+%249 = OpLabel
+%1789 = OpLoad %double %698
+%1790 = OpLoad %double %699
+%1791 = OpFSub %double %1789 %1790
+OpStore %702 %1791
+%1792 = OpLoad %double %702
+OpStore %703 %1792
+OpBranch %251
+%251 = OpLabel
+%1793 = OpLoad %double %699
+%1794 = OpFDiv %double %1793 %double_2
+OpStore %704 %1794
+%1795 = OpLoad %double %703
+OpStore %698 %1795
+%1796 = OpLoad %double %704
+OpStore %699 %1796
+OpBranch %360
+%246 = OpLabel
+%1797 = OpLoad %double %695
+%1798 = OpFMul %double %1797 %double_2
+OpStore %697 %1798
+%1799 = OpLoad %double %697
+OpStore %695 %1799
+OpBranch %361
+%236 = OpLabel
+%1800 = OpLoad %double %676
+%1801 = OpLoad %double %458
+%1802 = OpFDiv %double %1800 %1801
+OpStore %683 %1802
+%1803 = OpLoad %double %683
+%1804 = OpConvertFToS %ulong %1803
+OpStore %684 %1804
+%1805 = OpLoad %ulong %684
+%1806 = OpConvertSToF %double %1805
+OpStore %685 %1806
+%1807 = OpLoad %double %685
+%1808 = OpLoad %double %458
+%1809 = OpFMul %double %1807 %1808
+OpStore %686 %1809
+%1810 = OpLoad %double %676
+%1811 = OpLoad %double %686
+%1812 = OpFSub %double %1810 %1811
+OpStore %687 %1812
+%1813 = OpLoad %double %687
+OpStore %707 %1813
+OpBranch %238
+%238 = OpLabel
+OpBranch %301
+%301 = OpLabel
+%1814 = OpLoad %double %707
+%1815 = OpLoad %double %707
+%1816 = OpFUnordNotEqual %bool %1814 %1815
+OpStore %747 %1816
+%1817 = OpLoad %bool %747
+OpSelectionMerge %305 None
+OpBranchConditional %1817 %302 %303
+%303 = OpLabel
+OpBranch %304
+%304 = OpLabel
+%1818 = OpLoad %ulong %746
+%1819 = OpLoad %double %707
+%1820 = OpFunctionCall %ulong %6 %1818 %1819
+OpStore %749 %1820
+%1821 = OpLoad %ulong %749
+OpStore %750 %1821
+OpBranch %305
+%302 = OpLabel
+%1822 = OpLoad %ulong %746
+%1823 = OpFunctionCall %ulong %5 %1822 %ulong_18446744073709551615
+OpStore %748 %1823
+%1824 = OpLoad %ulong %748
+OpStore %750 %1824
+OpBranch %305
+%305 = OpLabel
+%1825 = OpLoad %ulong %750
+OpReturnValue %1825
+%56 = OpLabel
+%1826 = OpLoad %double %709
+%1827 = OpLoad %double %398
+%1828 = OpFAdd %double %1826 %1827
+OpStore %426 %1828
+%1829 = OpLoad %double %426
+%1830 = OpFMul %double %1829 %double_1_5
+OpStore %427 %1830
+OpBranch %259
+%259 = OpLabel
+%1831 = OpLoad %double %427
+%1832 = OpLoad %double %427
+%1833 = OpFUnordNotEqual %bool %1831 %1832
+OpStore %713 %1833
+%1834 = OpLoad %bool %713
+OpSelectionMerge %263 None
+OpBranchConditional %1834 %260 %261
+%261 = OpLabel
+OpBranch %262
+%262 = OpLabel
+%1835 = OpLoad %ulong %708
+%1836 = OpLoad %double %427
+%1837 = OpFunctionCall %ulong %6 %1835 %1836
+OpStore %715 %1837
+%1838 = OpLoad %ulong %715
+OpStore %716 %1838
+OpBranch %263
+%260 = OpLabel
+%1839 = OpLoad %ulong %708
+%1840 = OpFunctionCall %ulong %5 %1839 %ulong_18446744073709551615
+OpStore %714 %1840
+%1841 = OpLoad %ulong %714
+OpStore %716 %1841
+OpBranch %263
+%263 = OpLabel
+%1842 = OpLoad %ulong %710
+%1843 = OpIAdd %ulong %1842 %ulong_1
+OpStore %428 %1843
+%1844 = OpLoad %ulong %716
+OpStore %708 %1844
+%1845 = OpLoad %double %427
+OpStore %709 %1845
+%1846 = OpLoad %ulong %428
+OpStore %710 %1846
+OpBranch %376
+%360 = OpLabel
+OpBranch %248
+%361 = OpLabel
+OpBranch %245
+%362 = OpLabel
+OpBranch %223
+%363 = OpLabel
+OpBranch %220
+%364 = OpLabel
+OpBranch %198
+%365 = OpLabel
+OpBranch %195
+%366 = OpLabel
+OpBranch %173
+%367 = OpLabel
+OpBranch %170
+%368 = OpLabel
+OpBranch %149
+%369 = OpLabel
+OpBranch %146
+%370 = OpLabel
+OpBranch %124
+%371 = OpLabel
+OpBranch %121
+%372 = OpLabel
+OpBranch %99
+%373 = OpLabel
+OpBranch %96
+%374 = OpLabel
+OpBranch %74
+%375 = OpLabel
+OpBranch %71
+%376 = OpLabel
 OpBranch %55
 OpFunctionEnd
-%4 = OpFunction %ulong None %1394
-%1395 = OpLabel
+%4 = OpFunction %ulong None %1847
+%1848 = OpLabel
 OpReturnValue %ulong_14695981039346656037
 OpFunctionEnd
-%5 = OpFunction %ulong None %1397
-%1398 = OpFunctionParameter %ulong
-%1399 = OpFunctionParameter %ulong
-%1400 = OpLabel
-%1405 = OpVariable %_ptr_Function_ulong Function
-%1406 = OpVariable %_ptr_Function_ulong Function
-%1407 = OpVariable %_ptr_Function_bool Function
-%1408 = OpVariable %_ptr_Function_ulong Function
-%1409 = OpVariable %_ptr_Function_ulong Function
-%1410 = OpVariable %_ptr_Function_ulong Function
-%1411 = OpVariable %_ptr_Function_ulong Function
-%1412 = OpVariable %_ptr_Function_ulong Function
-%1413 = OpVariable %_ptr_Function_ulong Function
-%1414 = OpVariable %_ptr_Function_ulong Function
-%1415 = OpVariable %_ptr_Function_ulong Function
-OpStore %1405 %1398
-OpStore %1406 %1399
-%1416 = OpLoad %ulong %1405
-OpStore %1414 %1416
-OpStore %1415 %ulong_0
-OpBranch %1401
-%1401 = OpLabel
-%1417 = OpLoad %ulong %1415
-%1419 = OpULessThan %bool %1417 %ulong_8
-OpStore %1407 %1419
-%1420 = OpLoad %bool %1407
-OpLoopMerge %1403 %1404 None
-OpBranchConditional %1420 %1402 %1403
-%1403 = OpLabel
-%1421 = OpLoad %ulong %1414
-OpReturnValue %1421
-%1402 = OpLabel
-%1422 = OpLoad %ulong %1415
-%1423 = OpIMul %ulong %1422 %ulong_8
-OpStore %1408 %1423
-%1424 = OpLoad %ulong %1406
-%1425 = OpLoad %ulong %1408
-%1426 = OpShiftRightLogical %ulong %1424 %1425
-OpStore %1409 %1426
-%1427 = OpLoad %ulong %1409
-%1429 = OpBitwiseAnd %ulong %1427 %ulong_255
-OpStore %1410 %1429
-%1430 = OpLoad %ulong %1414
-%1431 = OpLoad %ulong %1410
-%1432 = OpBitwiseXor %ulong %1430 %1431
-OpStore %1411 %1432
-%1433 = OpLoad %ulong %1411
-%1435 = OpIMul %ulong %1433 %ulong_1099511628211
-OpStore %1412 %1435
-%1436 = OpLoad %ulong %1415
-%1437 = OpIAdd %ulong %1436 %ulong_1
-OpStore %1413 %1437
-%1438 = OpLoad %ulong %1412
-OpStore %1414 %1438
-%1439 = OpLoad %ulong %1413
-OpStore %1415 %1439
-OpBranch %1404
-%1404 = OpLabel
-OpBranch %1401
+%5 = OpFunction %ulong None %1850
+%1851 = OpFunctionParameter %ulong
+%1852 = OpFunctionParameter %ulong
+%1853 = OpLabel
+%1858 = OpVariable %_ptr_Function_ulong Function
+%1859 = OpVariable %_ptr_Function_ulong Function
+%1860 = OpVariable %_ptr_Function_bool Function
+%1861 = OpVariable %_ptr_Function_ulong Function
+%1862 = OpVariable %_ptr_Function_ulong Function
+%1863 = OpVariable %_ptr_Function_ulong Function
+%1864 = OpVariable %_ptr_Function_ulong Function
+%1865 = OpVariable %_ptr_Function_ulong Function
+%1866 = OpVariable %_ptr_Function_ulong Function
+%1867 = OpVariable %_ptr_Function_ulong Function
+%1868 = OpVariable %_ptr_Function_ulong Function
+OpStore %1858 %1851
+OpStore %1859 %1852
+%1869 = OpLoad %ulong %1858
+OpStore %1867 %1869
+OpStore %1868 %ulong_0
+OpBranch %1854
+%1854 = OpLabel
+%1870 = OpLoad %ulong %1868
+%1872 = OpULessThan %bool %1870 %ulong_8
+OpStore %1860 %1872
+%1873 = OpLoad %bool %1860
+OpLoopMerge %1856 %1857 None
+OpBranchConditional %1873 %1855 %1856
+%1856 = OpLabel
+%1874 = OpLoad %ulong %1867
+OpReturnValue %1874
+%1855 = OpLabel
+%1875 = OpLoad %ulong %1868
+%1876 = OpIMul %ulong %1875 %ulong_8
+OpStore %1861 %1876
+%1877 = OpLoad %ulong %1859
+%1878 = OpLoad %ulong %1861
+%1879 = OpShiftRightLogical %ulong %1877 %1878
+OpStore %1862 %1879
+%1880 = OpLoad %ulong %1862
+%1882 = OpBitwiseAnd %ulong %1880 %ulong_255
+OpStore %1863 %1882
+%1883 = OpLoad %ulong %1867
+%1884 = OpLoad %ulong %1863
+%1885 = OpBitwiseXor %ulong %1883 %1884
+OpStore %1864 %1885
+%1886 = OpLoad %ulong %1864
+%1888 = OpIMul %ulong %1886 %ulong_1099511628211
+OpStore %1865 %1888
+%1889 = OpLoad %ulong %1868
+%1890 = OpIAdd %ulong %1889 %ulong_1
+OpStore %1866 %1890
+%1891 = OpLoad %ulong %1865
+OpStore %1867 %1891
+%1892 = OpLoad %ulong %1866
+OpStore %1868 %1892
+OpBranch %1857
+%1857 = OpLabel
+OpBranch %1854
 OpFunctionEnd
 %6 = OpFunction %ulong None %25
-%1440 = OpFunctionParameter %ulong
-%1441 = OpFunctionParameter %double
-%1442 = OpLabel
-%1449 = OpVariable %_ptr_Function_ulong Function
-%1450 = OpVariable %_ptr_Function_double Function
-%1451 = OpVariable %_ptr_Function_ulong Function
-%1452 = OpVariable %_ptr_Function_bool Function
-%1453 = OpVariable %_ptr_Function_ulong Function
-%1454 = OpVariable %_ptr_Function_ulong Function
-%1455 = OpVariable %_ptr_Function_ulong Function
-%1456 = OpVariable %_ptr_Function_ulong Function
-%1457 = OpVariable %_ptr_Function_ulong Function
-%1458 = OpVariable %_ptr_Function_ulong Function
-%1459 = OpVariable %_ptr_Function_ulong Function
-%1460 = OpVariable %_ptr_Function_ulong Function
-OpStore %1449 %1440
-OpStore %1450 %1441
-%1461 = OpLoad %double %1450
-%1462 = OpBitcast %ulong %1461
-OpStore %1451 %1462
-OpBranch %1443
-%1443 = OpLabel
-%1463 = OpLoad %ulong %1449
-OpStore %1459 %1463
-OpStore %1460 %ulong_0
-OpBranch %1444
-%1444 = OpLabel
-%1464 = OpLoad %ulong %1460
-%1465 = OpULessThan %bool %1464 %ulong_8
-OpStore %1452 %1465
-%1466 = OpLoad %bool %1452
-OpLoopMerge %1446 %1448 None
-OpBranchConditional %1466 %1445 %1446
-%1446 = OpLabel
-OpBranch %1447
-%1447 = OpLabel
-%1467 = OpLoad %ulong %1459
-OpReturnValue %1467
-%1445 = OpLabel
-%1468 = OpLoad %ulong %1460
-%1469 = OpIMul %ulong %1468 %ulong_8
-OpStore %1453 %1469
-%1470 = OpLoad %ulong %1451
-%1471 = OpLoad %ulong %1453
-%1472 = OpShiftRightLogical %ulong %1470 %1471
-OpStore %1454 %1472
-%1473 = OpLoad %ulong %1454
-%1474 = OpBitwiseAnd %ulong %1473 %ulong_255
-OpStore %1455 %1474
-%1475 = OpLoad %ulong %1459
-%1476 = OpLoad %ulong %1455
-%1477 = OpBitwiseXor %ulong %1475 %1476
-OpStore %1456 %1477
-%1478 = OpLoad %ulong %1456
-%1479 = OpIMul %ulong %1478 %ulong_1099511628211
-OpStore %1457 %1479
-%1480 = OpLoad %ulong %1460
-%1481 = OpIAdd %ulong %1480 %ulong_1
-OpStore %1458 %1481
-%1482 = OpLoad %ulong %1457
-OpStore %1459 %1482
-%1483 = OpLoad %ulong %1458
-OpStore %1460 %1483
-OpBranch %1448
-%1448 = OpLabel
-OpBranch %1444
+%1893 = OpFunctionParameter %ulong
+%1894 = OpFunctionParameter %double
+%1895 = OpLabel
+%1902 = OpVariable %_ptr_Function_ulong Function
+%1903 = OpVariable %_ptr_Function_double Function
+%1904 = OpVariable %_ptr_Function_ulong Function
+%1905 = OpVariable %_ptr_Function_bool Function
+%1906 = OpVariable %_ptr_Function_ulong Function
+%1907 = OpVariable %_ptr_Function_ulong Function
+%1908 = OpVariable %_ptr_Function_ulong Function
+%1909 = OpVariable %_ptr_Function_ulong Function
+%1910 = OpVariable %_ptr_Function_ulong Function
+%1911 = OpVariable %_ptr_Function_ulong Function
+%1912 = OpVariable %_ptr_Function_ulong Function
+%1913 = OpVariable %_ptr_Function_ulong Function
+OpStore %1902 %1893
+OpStore %1903 %1894
+%1914 = OpLoad %double %1903
+%1915 = OpBitcast %ulong %1914
+OpStore %1904 %1915
+OpBranch %1896
+%1896 = OpLabel
+%1916 = OpLoad %ulong %1902
+OpStore %1912 %1916
+OpStore %1913 %ulong_0
+OpBranch %1897
+%1897 = OpLabel
+%1917 = OpLoad %ulong %1913
+%1918 = OpULessThan %bool %1917 %ulong_8
+OpStore %1905 %1918
+%1919 = OpLoad %bool %1905
+OpLoopMerge %1899 %1901 None
+OpBranchConditional %1919 %1898 %1899
+%1899 = OpLabel
+OpBranch %1900
+%1900 = OpLabel
+%1920 = OpLoad %ulong %1912
+OpReturnValue %1920
+%1898 = OpLabel
+%1921 = OpLoad %ulong %1913
+%1922 = OpIMul %ulong %1921 %ulong_8
+OpStore %1906 %1922
+%1923 = OpLoad %ulong %1904
+%1924 = OpLoad %ulong %1906
+%1925 = OpShiftRightLogical %ulong %1923 %1924
+OpStore %1907 %1925
+%1926 = OpLoad %ulong %1907
+%1927 = OpBitwiseAnd %ulong %1926 %ulong_255
+OpStore %1908 %1927
+%1928 = OpLoad %ulong %1912
+%1929 = OpLoad %ulong %1908
+%1930 = OpBitwiseXor %ulong %1928 %1929
+OpStore %1909 %1930
+%1931 = OpLoad %ulong %1909
+%1932 = OpIMul %ulong %1931 %ulong_1099511628211
+OpStore %1910 %1932
+%1933 = OpLoad %ulong %1913
+%1934 = OpIAdd %ulong %1933 %ulong_1
+OpStore %1911 %1934
+%1935 = OpLoad %ulong %1910
+OpStore %1912 %1935
+%1936 = OpLoad %ulong %1911
+OpStore %1913 %1936
+OpBranch %1901
+%1901 = OpLabel
+OpBranch %1897
 OpFunctionEnd

--- a/test/golden/spirv/float/arith_f64.dis
+++ b/test/golden/spirv/float/arith_f64.dis
@@ -1156,7 +1156,7 @@ OpStore %488 %1151
 OpBranch %82
 %80 = OpLabel
 %1152 = OpLoad %double %480
-%1153 = OpFSub %double %double_0 %1152
+%1153 = OpFNegate %double %1152
 OpStore %487 %1153
 %1154 = OpLoad %double %487
 OpStore %488 %1154
@@ -1369,7 +1369,7 @@ OpStore %520 %1243
 OpBranch %107
 %105 = OpLabel
 %1244 = OpLoad %double %512
-%1245 = OpFSub %double %double_0 %1244
+%1245 = OpFNegate %double %1244
 OpStore %519 %1245
 %1246 = OpLoad %double %519
 OpStore %520 %1246
@@ -1582,7 +1582,7 @@ OpStore %552 %1335
 OpBranch %132
 %130 = OpLabel
 %1336 = OpLoad %double %544
-%1337 = OpFSub %double %double_0 %1336
+%1337 = OpFNegate %double %1336
 OpStore %551 %1337
 %1338 = OpLoad %double %551
 OpStore %552 %1338
@@ -1798,7 +1798,7 @@ OpStore %585 %1429
 OpBranch %157
 %155 = OpLabel
 %1430 = OpLoad %double %577
-%1431 = OpFSub %double %double_0 %1430
+%1431 = OpFNegate %double %1430
 OpStore %584 %1431
 %1432 = OpLoad %double %584
 OpStore %585 %1432
@@ -1984,7 +1984,7 @@ OpStore %612 %1508
 OpBranch %181
 %179 = OpLabel
 %1509 = OpLoad %double %604
-%1510 = OpFSub %double %double_0 %1509
+%1510 = OpFNegate %double %1509
 OpStore %611 %1510
 %1511 = OpLoad %double %611
 OpStore %612 %1511
@@ -2192,7 +2192,7 @@ OpStore %643 %1596
 OpBranch %206
 %204 = OpLabel
 %1597 = OpLoad %double %635
-%1598 = OpFSub %double %double_0 %1597
+%1598 = OpFNegate %double %1597
 OpStore %642 %1598
 %1599 = OpLoad %double %642
 OpStore %643 %1599
@@ -2402,7 +2402,7 @@ OpStore %674 %1686
 OpBranch %231
 %229 = OpLabel
 %1687 = OpLoad %double %666
-%1688 = OpFSub %double %double_0 %1687
+%1688 = OpFNegate %double %1687
 OpStore %673 %1688
 %1689 = OpLoad %double %673
 OpStore %674 %1689
@@ -2615,7 +2615,7 @@ OpStore %706 %1779
 OpBranch %256
 %254 = OpLabel
 %1780 = OpLoad %double %698
-%1781 = OpFSub %double %double_0 %1780
+%1781 = OpFNegate %double %1780
 OpStore %705 %1781
 %1782 = OpLoad %double %705
 OpStore %706 %1782

--- a/test/golden/x86_64-darwin/float/arith_f32.dis
+++ b/test/golden/x86_64-darwin/float/arith_f32.dis
@@ -516,8 +516,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
                	jmp	 <L76>
 <L75>:
-               	xorps	%xmm9, %xmm9
-               	subss	%xmm7, %xmm9
+               	movss	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1,2,3]
+               	xorps	, %xmm9 <L76>
 <L76>:
                	jmp	 <L82>
 <L77>:
@@ -532,11 +532,11 @@ Disassembly of section __TEXT,__text:
                	movss	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1,2,3]
                	subss	%xmm8, %xmm10
 <L79>:
-               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x7de>
+               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x7e2>
                	movsd	%xmm10, %xmm7           ## xmm7 = xmm10[0],xmm7[1]
                	jmp	 <L74>
 <L80>:
-               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x7f0>
+               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x7f4>
                	jmp	 <L73>
 <L81>:
                	movss	-0xf0(%rbp), %xmm0
@@ -582,7 +582,7 @@ Disassembly of section __TEXT,__text:
                	testb	%al, %al
                	jne	 <L89>
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x8ac>
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x8b0>
                	ucomiss	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -630,7 +630,7 @@ Disassembly of section __TEXT,__text:
                	subss	-0x100(%rbp), %xmm5
 <L94>:
                	movss	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x956>
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x95a>
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
 <L95>:
                	ucomiss	%xmm7, %xmm6
@@ -651,8 +651,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
                	jmp	 <L98>
 <L97>:
-               	xorps	%xmm10, %xmm10
-               	subss	%xmm8, %xmm10
+               	movss	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1,2,3]
+               	xorps	, %xmm10 <L98>
 <L98>:
                	jmp	 <L104>
 <L99>:
@@ -667,11 +667,11 @@ Disassembly of section __TEXT,__text:
                	movss	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
 <L101>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x9d9>
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x9e1>
                	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
                	jmp	 <L96>
 <L102>:
-               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x9eb>
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x9f3>
                	jmp	 <L95>
 <L103>:
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
@@ -716,7 +716,7 @@ Disassembly of section __TEXT,__text:
                	testb	%al, %al
                	jne	 <L111>
                	movss	-0xf0(%rbp), %xmm4
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xa9a>
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xaa2>
                	movss	-0xf0(%rbp), %xmm14
                	ucomiss	%xmm4, %xmm14
                	sete	%cl
@@ -766,7 +766,7 @@ Disassembly of section __TEXT,__text:
                	subss	%xmm0, %xmm5
 <L116>:
                	movss	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xb57>
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xb5f>
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
 <L117>:
                	ucomiss	%xmm7, %xmm6
@@ -787,8 +787,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
                	jmp	 <L120>
 <L119>:
-               	xorps	%xmm10, %xmm10
-               	subss	%xmm8, %xmm10
+               	movss	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1,2,3]
+               	xorps	, %xmm10 <L120>
 <L120>:
                	jmp	 <L126>
 <L121>:
@@ -803,11 +803,11 @@ Disassembly of section __TEXT,__text:
                	movss	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
 <L123>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xbda>
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xbe6>
                	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
                	jmp	 <L118>
 <L124>:
-               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xbec>
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xbf8>
                	jmp	 <L117>
 <L125>:
                	movss	-0xf0(%rbp), %xmm4
@@ -854,7 +854,7 @@ Disassembly of section __TEXT,__text:
                	testb	%al, %al
                	jne	 <L133>
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xca2>
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xcae>
                	ucomiss	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -902,7 +902,7 @@ Disassembly of section __TEXT,__text:
                	subss	%xmm2, %xmm5
 <L138>:
                	movss	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xd40>
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xd4c>
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
 <L139>:
                	ucomiss	%xmm7, %xmm6
@@ -923,8 +923,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
                	jmp	 <L142>
 <L141>:
-               	xorps	%xmm10, %xmm10
-               	subss	%xmm8, %xmm10
+               	movss	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1,2,3]
+               	xorps	, %xmm10 <L142>
 <L142>:
                	jmp	 <L148>
 <L143>:
@@ -939,11 +939,11 @@ Disassembly of section __TEXT,__text:
                	movss	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
 <L145>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xdc3>
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xdd3>
                	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
                	jmp	 <L140>
 <L146>:
-               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xdd5>
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xde5>
                	jmp	 <L139>
 <L147>:
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
@@ -977,9 +977,9 @@ Disassembly of section __TEXT,__text:
 <L151>:
                	movq	%rax, %rbx
 <L152>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xe4b>
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xe5b>
                	mulss	-0x30(%rbp), %xmm0
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xe59>
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xe69>
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
                	sete	%al
@@ -989,7 +989,7 @@ Disassembly of section __TEXT,__text:
                	testb	%al, %al
                	jne	 <L155>
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xe83>
+               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xe93>
                	ucomiss	%xmm2, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -1025,19 +1025,19 @@ Disassembly of section __TEXT,__text:
                	subss	%xmm0, %xmm2
 <L158>:
                	xorps	%xmm14, %xmm14
-               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xefa>
+               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xf0a>
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
                	jne	 <L159>
-               	movss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xf11>
+               	movss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xf21>
                	jmp	 <L160>
 <L159>:
                	xorps	%xmm4, %xmm4
                	subss	, %xmm4 <L160>
 <L160>:
                	movss	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1,2,3]
-               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xf2d>
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xf3d>
                	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
 <L161>:
                	ucomiss	%xmm6, %xmm5
@@ -1058,8 +1058,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
                	jmp	 <L164>
 <L163>:
-               	xorps	%xmm9, %xmm9
-               	subss	%xmm7, %xmm9
+               	movss	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1,2,3]
+               	xorps	, %xmm9 <L164>
 <L164>:
                	jmp	 <L170>
 <L165>:
@@ -1074,21 +1074,21 @@ Disassembly of section __TEXT,__text:
                	movss	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1,2,3]
                	subss	%xmm8, %xmm10
 <L167>:
-               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0xfaf>
+               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0xfc3>
                	movsd	%xmm10, %xmm7           ## xmm7 = xmm10[0],xmm7[1]
                	jmp	 <L162>
 <L168>:
-               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xfc1>
+               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xfd5>
                	jmp	 <L161>
 <L169>:
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xfd2>
+               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xfe6>
                	cvttss2si	%xmm2, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2ss	%r11, %xmm2
                	movss	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1,2,3]
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xfee>
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1002>
                	movss	%xmm0, %xmm9            ## xmm9 = xmm0[0],xmm9[1,2,3]
                	subss	%xmm4, %xmm9
 <L170>:
@@ -1122,7 +1122,7 @@ Disassembly of section __TEXT,__text:
                	testb	%al, %al
                	jne	 <L177>
                	movss	-0x30(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x106b>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x107f>
                	movss	-0x30(%rbp), %xmm14
                	ucomiss	%xmm0, %xmm14
                	sete	%cl
@@ -1172,7 +1172,7 @@ Disassembly of section __TEXT,__text:
                	subss	-0x100(%rbp), %xmm2
 <L182>:
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1125>
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1139>
                	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
 <L183>:
                	ucomiss	%xmm5, %xmm4
@@ -1193,8 +1193,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
                	jmp	 <L186>
 <L185>:
-               	xorps	%xmm8, %xmm8
-               	subss	%xmm6, %xmm8
+               	movss	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1,2,3]
+               	xorps	, %xmm8 <L186>
 <L186>:
                	jmp	 <L192>
 <L187>:
@@ -1209,11 +1209,11 @@ Disassembly of section __TEXT,__text:
                	movss	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1,2,3]
                	subss	%xmm7, %xmm9
 <L189>:
-               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x11a3>
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x11bb>
                	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
                	jmp	 <L184>
 <L190>:
-               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x11b5>
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x11cd>
                	jmp	 <L183>
 <L191>:
                	movss	-0x30(%rbp), %xmm0
@@ -1257,7 +1257,7 @@ Disassembly of section __TEXT,__text:
                	testb	%al, %al
                	jne	 <L199>
                	movss	-0x100(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1264>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x127c>
                	movss	-0x100(%rbp), %xmm14
                	ucomiss	%xmm0, %xmm14
                	sete	%cl
@@ -1307,7 +1307,7 @@ Disassembly of section __TEXT,__text:
                	subss	-0x100(%rbp), %xmm2
 <L204>:
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x132d>
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1345>
                	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
 <L205>:
                	ucomiss	%xmm5, %xmm4
@@ -1328,8 +1328,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
                	jmp	 <L208>
 <L207>:
-               	xorps	%xmm8, %xmm8
-               	subss	%xmm6, %xmm8
+               	movss	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1,2,3]
+               	xorps	, %xmm8 <L208>
 <L208>:
                	jmp	 <L214>
 <L209>:
@@ -1344,11 +1344,11 @@ Disassembly of section __TEXT,__text:
                	movss	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1,2,3]
                	subss	%xmm7, %xmm9
 <L211>:
-               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x13ab>
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x13c7>
                	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
                	jmp	 <L206>
 <L212>:
-               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x13bd>
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x13d9>
                	jmp	 <L205>
 <L213>:
                	movss	-0x100(%rbp), %xmm0
@@ -1382,7 +1382,7 @@ Disassembly of section __TEXT,__text:
 <L217>:
                	movq	%rax, %r12
 <L218>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1443>
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x145f>
                	mulss	-0x30(%rbp), %xmm0
                	movss	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
@@ -1394,7 +1394,7 @@ Disassembly of section __TEXT,__text:
                	testb	%al, %al
                	jne	 <L221>
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x147b>
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x1497>
                	ucomiss	%xmm1, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -1442,7 +1442,7 @@ Disassembly of section __TEXT,__text:
                	subss	-0x100(%rbp), %xmm2
 <L226>:
                	movss	%xmm1, %xmm4            ## xmm4 = xmm1[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1525>
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1541>
                	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
 <L227>:
                	ucomiss	%xmm5, %xmm4
@@ -1463,8 +1463,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
                	jmp	 <L230>
 <L229>:
-               	xorps	%xmm8, %xmm8
-               	subss	%xmm6, %xmm8
+               	movss	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1,2,3]
+               	xorps	, %xmm8 <L230>
 <L230>:
                	jmp	 <L236>
 <L231>:
@@ -1479,11 +1479,11 @@ Disassembly of section __TEXT,__text:
                	movss	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1,2,3]
                	subss	%xmm7, %xmm9
 <L233>:
-               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x15a3>
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x15c3>
                	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
                	jmp	 <L228>
 <L234>:
-               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x15b5>
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x15d5>
                	jmp	 <L227>
 <L235>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]

--- a/test/golden/x86_64-darwin/float/arith_f32.dis
+++ b/test/golden/x86_64-darwin/float/arith_f32.dis
@@ -40,11 +40,11 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.float.arith_f32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xf0, %rsp
-               	movq	%rbx, -0xd8(%rbp)
-               	movq	%r12, -0xe0(%rbp)
-               	movq	%r13, -0xe8(%rbp)
-               	movq	%r14, -0xf0(%rbp)
+               	subq	$0x120, %rsp            ## imm = 0x120
+               	movq	%rbx, -0x108(%rbp)
+               	movq	%r12, -0x110(%rbp)
+               	movq	%r13, -0x118(%rbp)
+               	movq	%r14, -0x120(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -145,430 +145,122 @@ Disassembly of section __TEXT,__text:
 <L16>:
                	movss	-0x10(%rbp), %xmm0
                	divss	-0x20(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L18>
                	movq	%r12, %rdi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rbx
-               	jmp	 <L20>
-<L18>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rbx
-<L20>:
                	movss	-0x20(%rbp), %xmm0
                	divss	-0x10(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L22>
-               	movq	%rbx, %rdi
+               	movq	%rax, %rdi
+               	callq	 <L18>
+<L18>:
+               	movss	-0x10(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1a6>
+               	movq	%rax, %rdi
+               	callq	 <L19>
+<L19>:
+               	xorps	%xmm14, %xmm14
+               	subss	-0x10(%rbp), %xmm14
+               	movss	%xmm14, -0x40(%rbp)
+               	movq	%rax, %rdi
+               	movss	-0x40(%rbp), %xmm0
+               	callq	 <L20>
+<L20>:
+               	movss	-0x10(%rbp), %xmm0
+               	subss	-0x10(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %r12
-               	jmp	 <L24>
+               	movss	-0x40(%rbp), %xmm0
+               	addss	-0x10(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L22>
 <L22>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x1f8>
+               	mulss	-0x30(%rbp), %xmm14
+               	movss	%xmm14, -0x50(%rbp)
+               	movss	-0x30(%rbp), %xmm14
+               	divss	-0x50(%rbp), %xmm14
+               	movss	%xmm14, -0x60(%rbp)
+               	movq	%rax, %rdi
+               	movss	-0x60(%rbp), %xmm0
                	callq	 <L23>
 <L23>:
-               	movq	%rax, %r12
+               	movss	-0x60(%rbp), %xmm0
+               	mulss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L24>
 <L24>:
-               	movss	-0x10(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x208>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L26>
-               	movq	%r12, %rdi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rbx
-               	jmp	 <L28>
-<L26>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rbx
-<L28>:
-               	xorps	%xmm0, %xmm0
-               	subss	-0x10(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L30>
-               	movq	%rbx, %rdi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %r12
-               	jmp	 <L32>
-<L30>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %r12
-<L32>:
-               	movss	-0x10(%rbp), %xmm0
-               	subss	-0x10(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L34>
-               	movq	%r12, %rdi
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rbx
-               	jmp	 <L36>
-<L34>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rbx
-<L36>:
-               	xorps	%xmm0, %xmm0
-               	subss	-0x10(%rbp), %xmm0
-               	movss	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1,2,3]
-               	addss	-0x10(%rbp), %xmm3
-               	ucomiss	%xmm3, %xmm3
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L38>
-               	movq	%rbx, %rdi
-               	movss	%xmm3, %xmm0            ## xmm0 = xmm3[0],xmm0[1,2,3]
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %r12
-               	jmp	 <L40>
-<L38>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %r12
-<L40>:
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x31c>
-               	mulss	-0x30(%rbp), %xmm14
-               	movss	%xmm14, -0x40(%rbp)
-               	movss	-0x30(%rbp), %xmm14
-               	divss	-0x40(%rbp), %xmm14
-               	movss	%xmm14, -0x50(%rbp)
-               	movss	-0x50(%rbp), %xmm14
-               	ucomiss	-0x50(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L42>
-               	movq	%r12, %rdi
-               	movss	-0x50(%rbp), %xmm0
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rbx
-               	jmp	 <L44>
-<L42>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rbx
-<L44>:
-               	movss	-0x50(%rbp), %xmm0
-               	mulss	-0x40(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L46>
-               	movq	%rbx, %rdi
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %r12
-               	jmp	 <L48>
-<L46>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %r12
-<L48>:
                	movss	-0x30(%rbp), %xmm0
-               	subss	-0x50(%rbp), %xmm0
-               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
-               	subss	-0x50(%rbp), %xmm4
-               	movss	%xmm4, %xmm0            ## xmm0 = xmm4[0],xmm0[1,2,3]
-               	subss	-0x50(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L50>
-               	movq	%r12, %rdi
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rbx
-               	jmp	 <L52>
-<L50>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rbx
-<L52>:
-               	movss	-0x30(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x425>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L54>
-               	movq	%rbx, %rdi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %r12
-               	jmp	 <L56>
-<L54>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %r12
-<L56>:
-               	movss	-0x30(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x46b>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L58>
-               	movq	%r12, %rdi
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rbx
-               	jmp	 <L60>
-<L58>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rbx
-<L60>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x4ac>
-               	divss	-0x40(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L62>
-               	movq	%rbx, %rdi
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %r12
-               	jmp	 <L64>
-<L62>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %r12
-<L64>:
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x4f3>
-               	mulss	-0x30(%rbp), %xmm14
-               	movss	%xmm14, -0x60(%rbp)
-               	movss	-0x60(%rbp), %xmm0
-               	addss	-0x30(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L66>
-               	movq	%r12, %rdi
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rbx
-               	jmp	 <L68>
-<L66>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rbx
-<L68>:
-               	movss	-0x60(%rbp), %xmm0
-               	addss	-0x30(%rbp), %xmm0
-               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
-               	addss	-0x30(%rbp), %xmm4
-               	ucomiss	%xmm4, %xmm4
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L70>
-               	movq	%rbx, %rdi
-               	movss	%xmm4, %xmm0            ## xmm0 = xmm4[0],xmm0[1,2,3]
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %r12
-               	jmp	 <L72>
-<L70>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %r12
-<L72>:
-               	movss	-0x30(%rbp), %xmm0
-               	addss	-0x30(%rbp), %xmm0
-               	movss	-0x60(%rbp), %xmm4
-               	addss	%xmm0, %xmm4
-               	ucomiss	%xmm4, %xmm4
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L74>
-               	movq	%r12, %rdi
-               	movss	%xmm4, %xmm0            ## xmm0 = xmm4[0],xmm0[1,2,3]
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rbx
-               	jmp	 <L76>
-<L74>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rbx
-<L76>:
-               	movss	-0x60(%rbp), %xmm0
-               	subss	-0x30(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L78>
-               	movq	%rbx, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %r12
-               	jmp	 <L80>
-<L78>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %r12
-<L80>:
-               	movss	-0x60(%rbp), %xmm0
-               	addss	-0x30(%rbp), %xmm0
+               	subss	-0x60(%rbp), %xmm0
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
                	subss	-0x60(%rbp), %xmm4
-               	ucomiss	%xmm4, %xmm4
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L82>
-               	movq	%r12, %rdi
                	movss	%xmm4, %xmm0            ## xmm0 = xmm4[0],xmm0[1,2,3]
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rbx
-               	jmp	 <L84>
-<L82>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rbx
-<L84>:
-               	xorps	%xmm0, %xmm0
-               	mulss	-0x30(%rbp), %xmm0
-               	movsd	%xmm0, -0x80(%rbp)
-               	movl	$0x0, %r12d
-               	cmpl	$0x18, %r12d
-               	jb	 <L85>
-               	jmp	 <L90>
-<L85>:
-               	movss	-0x80(%rbp), %xmm0
-               	addss	-0x50(%rbp), %xmm0
-               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
-               	mulss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x6af>
+               	subss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L25>
+<L25>:
+               	movss	-0x30(%rbp), %xmm0
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x266>
+               	movq	%rax, %rdi
+               	callq	 <L26>
+<L26>:
+               	movss	-0x30(%rbp), %xmm0
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x27b>
+               	movq	%rax, %rdi
+               	callq	 <L27>
+<L27>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x28b>
+               	divss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x2a1>
+               	mulss	-0x30(%rbp), %xmm14
                	movss	%xmm14, -0x70(%rbp)
                	movss	-0x70(%rbp), %xmm14
-               	ucomiss	-0x70(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L87>
-               	movq	%rbx, %rdi
+               	addss	-0x30(%rbp), %xmm14
+               	movss	%xmm14, -0x80(%rbp)
+               	movq	%rax, %rdi
+               	movss	-0x80(%rbp), %xmm0
+               	callq	 <L29>
+<L29>:
+               	movss	-0x80(%rbp), %xmm0
+               	addss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L30>
+<L30>:
+               	movss	-0x30(%rbp), %xmm0
+               	addss	-0x30(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm5
+               	addss	%xmm0, %xmm5
+               	movq	%rax, %rdi
+               	movss	%xmm5, %xmm0            ## xmm0 = xmm5[0],xmm0[1,2,3]
+               	callq	 <L31>
+<L31>:
                	movss	-0x70(%rbp), %xmm0
-               	callq	 <L86>
-<L86>:
-               	movq	%rax, %r14
-               	jmp	 <L89>
-<L87>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L88>
-<L88>:
-               	movq	%rax, %r14
-<L89>:
-               	addl	$0x1, %r12d
-               	movq	%r14, %rbx
-               	movq	-0x70(%rbp), %r11
-               	movq	%r11, -0x80(%rbp)
+               	subss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L32>
+<L32>:
+               	movss	-0x80(%rbp), %xmm0
+               	subss	-0x70(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L33>
+<L33>:
+               	xorps	%xmm0, %xmm0
+               	mulss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rbx
+               	movsd	%xmm0, -0xa0(%rbp)
+               	movl	$0x0, %r12d
                	cmpl	$0x18, %r12d
-               	jb	 <L85>
-<L90>:
-               	movl	$0x7f7fffff, %eax       ## imm = 0x7F7FFFFF
-               	addl	%r13d, %eax
-               	movl	%eax, -0x90(%rbp)
+               	jb	 <L34>
+               	jmp	 <L39>
+<L34>:
+               	movss	-0xa0(%rbp), %xmm0
+               	addss	-0x60(%rbp), %xmm0
+               	movss	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1,2,3]
+               	mulss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x364>
+               	movss	%xmm14, -0x90(%rbp)
                	movss	-0x90(%rbp), %xmm14
                	ucomiss	-0x90(%rbp), %xmm14
                	setne	%al
@@ -576,239 +268,72 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L92>
+               	jne	 <L36>
                	movq	%rbx, %rdi
                	movss	-0x90(%rbp), %xmm0
-               	callq	 <L91>
-<L91>:
-               	movq	%rax, %r12
-               	jmp	 <L94>
-<L92>:
+               	callq	 <L35>
+<L35>:
+               	movq	%rax, %r14
+               	jmp	 <L38>
+<L36>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L93>
-<L93>:
-               	movq	%rax, %r12
-<L94>:
-               	movss	-0x90(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x781>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L96>
-               	movq	%r12, %rdi
-               	callq	 <L95>
-<L95>:
-               	movq	%rax, %rbx
-               	jmp	 <L98>
-<L96>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L97>
-<L97>:
-               	movq	%rax, %rbx
-<L98>:
-               	movss	-0x90(%rbp), %xmm0
-               	addss	-0x90(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L100>
-               	movq	%rbx, %rdi
-               	callq	 <L99>
-<L99>:
-               	movq	%rax, %r12
-               	jmp	 <L102>
-<L100>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L101>
-<L101>:
-               	movq	%rax, %r12
-<L102>:
-               	movss	-0x90(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x813>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L104>
-               	movq	%r12, %rdi
-               	callq	 <L103>
-<L103>:
-               	movq	%rax, %rbx
-               	jmp	 <L106>
-<L104>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %rbx
-<L106>:
-               	movss	-0x90(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x85c>
-               	xorps	%xmm3, %xmm3
-               	subss	%xmm0, %xmm3
-               	ucomiss	%xmm3, %xmm3
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L108>
-               	movq	%rbx, %rdi
-               	movss	%xmm3, %xmm0            ## xmm0 = xmm3[0],xmm0[1,2,3]
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %r12
-               	jmp	 <L110>
-<L108>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L109>
-<L109>:
-               	movq	%rax, %r12
-<L110>:
-               	movss	-0x90(%rbp), %xmm0
-               	mulss	-0x90(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L112>
-               	movq	%r12, %rdi
-               	callq	 <L111>
-<L111>:
-               	movq	%rax, %rbx
-               	jmp	 <L114>
-<L112>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L113>
-<L113>:
-               	movq	%rax, %rbx
-<L114>:
-               	movss	-0x90(%rbp), %xmm0
-               	subss	-0x90(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L116>
-               	movq	%rbx, %rdi
-               	callq	 <L115>
-<L115>:
-               	movq	%rax, %r12
-               	jmp	 <L118>
-<L116>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L117>
-<L117>:
-               	movq	%rax, %r12
-<L118>:
-               	movl	$0x800000, %eax         ## imm = 0x800000
-               	addl	%r13d, %eax
-               	movl	%eax, -0xa0(%rbp)
-               	movl	$0x1, %eax
+               	callq	 <L37>
+<L37>:
+               	movq	%rax, %r14
+<L38>:
+               	addl	$0x1, %r12d
+               	movq	%r14, %rbx
+               	movq	-0x90(%rbp), %r11
+               	movq	%r11, -0xa0(%rbp)
+               	cmpl	$0x18, %r12d
+               	jb	 <L34>
+<L39>:
+               	movl	$0x7f7fffff, %eax       ## imm = 0x7F7FFFFF
                	addl	%r13d, %eax
                	movl	%eax, -0xb0(%rbp)
-               	movss	-0xa0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x95e>
+               	movss	-0xb0(%rbp), %xmm14
+               	ucomiss	-0xb0(%rbp), %xmm14
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L41>
+               	movq	%rbx, %rdi
+               	movss	-0xb0(%rbp), %xmm0
+               	callq	 <L40>
+<L40>:
+               	movq	%rax, %r12
+               	jmp	 <L43>
+<L41>:
+               	movq	%rbx, %rdi
+               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
+               	callq	 <L42>
+<L42>:
+               	movq	%rax, %r12
+<L43>:
+               	movss	-0xb0(%rbp), %xmm0
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x448>
                	ucomiss	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L120>
+               	jne	 <L45>
                	movq	%r12, %rdi
-               	callq	 <L119>
-<L119>:
+               	callq	 <L44>
+<L44>:
                	movq	%rax, %rbx
-               	jmp	 <L122>
-<L120>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L121>
-<L121>:
-               	movq	%rax, %rbx
-<L122>:
-               	movss	-0xa0(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x9a7>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L124>
-               	movq	%rbx, %rdi
-               	callq	 <L123>
-<L123>:
-               	movq	%rax, %r12
-               	jmp	 <L126>
-<L124>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L125>
-<L125>:
-               	movq	%rax, %r12
-<L126>:
-               	movss	-0xa0(%rbp), %xmm0
-               	subss	-0xb0(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L128>
-               	movq	%r12, %rdi
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %rbx
-               	jmp	 <L130>
-<L128>:
+               	jmp	 <L47>
+<L45>:
                	movq	%r12, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L129>
-<L129>:
+               	callq	 <L46>
+<L46>:
                	movq	%rax, %rbx
-<L130>:
-               	movss	-0xa0(%rbp), %xmm0
-               	mulss	-0x30(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L132>
-               	movq	%rbx, %rdi
-               	callq	 <L131>
-<L131>:
-               	movq	%rax, %r12
-               	jmp	 <L134>
-<L132>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L133>
-<L133>:
-               	movq	%rax, %r12
-<L134>:
+<L47>:
                	movss	-0xb0(%rbp), %xmm0
                	addss	-0xb0(%rbp), %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -817,173 +342,475 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L136>
-               	movq	%r12, %rdi
-               	callq	 <L135>
-<L135>:
-               	movq	%rax, %rbx
-               	jmp	 <L138>
-<L136>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L137>
-<L137>:
-               	movq	%rax, %rbx
-<L138>:
-               	movss	-0xb0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xac8>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L140>
+               	jne	 <L49>
                	movq	%rbx, %rdi
-               	callq	 <L139>
-<L139>:
+               	callq	 <L48>
+<L48>:
                	movq	%rax, %r12
-               	jmp	 <L142>
-<L140>:
+               	jmp	 <L51>
+<L49>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L141>
-<L141>:
+               	callq	 <L50>
+<L50>:
                	movq	%rax, %r12
-<L142>:
-               	movss	-0xb0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xb11>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L144>
-               	movq	%r12, %rdi
-               	callq	 <L143>
-<L143>:
-               	movq	%rax, %rbx
-               	jmp	 <L146>
-<L144>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L145>
-<L145>:
-               	movq	%rax, %rbx
-<L146>:
-               	movss	-0xb0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xb5a>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L148>
-               	movq	%rbx, %rdi
-               	callq	 <L147>
-<L147>:
-               	movq	%rax, %r12
-               	jmp	 <L150>
-<L148>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %r12
-<L150>:
-               	movss	-0xb0(%rbp), %xmm0
-               	divss	-0xa0(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L152>
-               	movq	%r12, %rdi
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-               	jmp	 <L154>
-<L152>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L153>
-<L153>:
-               	movq	%rax, %rbx
-<L154>:
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xbe5>
-               	mulss	-0x30(%rbp), %xmm14
+<L51>:
+               	movss	-0xb0(%rbp), %xmm14
+               	mulss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x4dc>
                	movss	%xmm14, -0xc0(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xbfd>
-               	mulss	-0x30(%rbp), %xmm14
-               	movss	%xmm14, -0xd0(%rbp)
+               	movq	%r12, %rdi
                	movss	-0xc0(%rbp), %xmm0
+               	callq	 <L52>
+<L52>:
+               	xorps	%xmm0, %xmm0
+               	subss	-0xc0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L53>
+<L53>:
+               	movss	-0xb0(%rbp), %xmm0
+               	mulss	-0xb0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L54>
+<L54>:
+               	movss	-0xb0(%rbp), %xmm0
+               	subss	-0xb0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L55>
+<L55>:
+               	movl	$0x800000, %ecx         ## imm = 0x800000
+               	addl	%r13d, %ecx
+               	movl	%ecx, -0xd0(%rbp)
+               	movl	$0x1, %ecx
+               	addl	%r13d, %ecx
+               	movl	%ecx, -0xe0(%rbp)
+               	movss	-0xd0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x564>
+               	movq	%rax, %rdi
+               	callq	 <L56>
+<L56>:
+               	movss	-0xd0(%rbp), %xmm0
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x57c>
+               	movq	%rax, %rdi
+               	callq	 <L57>
+<L57>:
+               	movss	-0xd0(%rbp), %xmm0
+               	subss	-0xe0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L58>
+<L58>:
+               	movss	-0xd0(%rbp), %xmm0
+               	mulss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L59>
+<L59>:
+               	movss	-0xe0(%rbp), %xmm0
+               	addss	-0xe0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L60>
+<L60>:
+               	movss	-0xe0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x5d9>
+               	movq	%rax, %rdi
+               	callq	 <L61>
+<L61>:
+               	movss	-0xe0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x5f1>
+               	movq	%rax, %rdi
+               	callq	 <L62>
+<L62>:
+               	movss	-0xe0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x609>
+               	movq	%rax, %rdi
+               	callq	 <L63>
+<L63>:
+               	movss	-0xe0(%rbp), %xmm0
                	divss	-0xd0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L64>
+<L64>:
+               	movq	%rax, %rbx
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x635>
+               	mulss	-0x30(%rbp), %xmm14
+               	movss	%xmm14, -0xf0(%rbp)
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x64d>
+               	mulss	-0x30(%rbp), %xmm14
+               	movss	%xmm14, -0x100(%rbp)
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L67>
+               	movss	-0xf0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x693>
+               	movss	-0xf0(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L65>
+               	jmp	 <L66>
+<L65>:
+               	movss	-0xf0(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L66>:
+               	jmp	 <L68>
+<L67>:
+               	movq	%rax, %rcx
+<L68>:
+               	testb	%cl, %cl
+               	jne	 <L81>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0xf0(%rbp), %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L69>
+               	movsd	-0xf0(%rbp), %xmm0
+               	jmp	 <L70>
+<L69>:
+               	xorps	%xmm0, %xmm0
+               	subss	-0xf0(%rbp), %xmm0
+<L70>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L71>
+               	movsd	-0x100(%rbp), %xmm4
+               	jmp	 <L72>
+<L71>:
+               	xorps	%xmm4, %xmm4
+               	subss	-0x100(%rbp), %xmm4
+<L72>:
+               	movss	%xmm0, %xmm5            ## xmm5 = xmm0[0],xmm5[1,2,3]
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x75c>
+               	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
+<L73>:
+               	ucomiss	%xmm6, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L80>
+               	movsd	%xmm0, %xmm7            ## xmm7 = xmm0[0],xmm7[1]
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+<L74>:
+               	ucomiss	%xmm4, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L77>
+               	testb	%al, %al
+               	jne	 <L75>
+               	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
+               	jmp	 <L76>
+<L75>:
+               	xorps	%xmm9, %xmm9
+               	subss	%xmm7, %xmm9
+<L76>:
+               	jmp	 <L82>
+<L77>:
+               	ucomiss	%xmm8, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L78>
+               	movsd	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1]
+               	jmp	 <L79>
+<L78>:
+               	movss	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1,2,3]
+               	subss	%xmm8, %xmm10
+<L79>:
+               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x7de>
+               	movsd	%xmm10, %xmm7           ## xmm7 = xmm10[0],xmm7[1]
+               	jmp	 <L74>
+<L80>:
+               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x7f0>
+               	jmp	 <L73>
+<L81>:
+               	movss	-0xf0(%rbp), %xmm0
+               	divss	-0x100(%rbp), %xmm0
                	cvttss2si	%xmm0, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2ss	%r11, %xmm0
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
-               	mulss	-0xd0(%rbp), %xmm4
-               	movss	-0xc0(%rbp), %xmm0
-               	subss	%xmm4, %xmm0
-               	ucomiss	%xmm0, %xmm0
+               	mulss	-0x100(%rbp), %xmm4
+               	movss	-0xf0(%rbp), %xmm9
+               	subss	%xmm4, %xmm9
+<L82>:
+               	ucomiss	%xmm9, %xmm9
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L156>
+               	jne	 <L84>
                	movq	%rbx, %rdi
-               	callq	 <L155>
-<L155>:
+               	movss	%xmm9, %xmm0            ## xmm0 = xmm9[0],xmm0[1,2,3]
+               	callq	 <L83>
+<L83>:
                	movq	%rax, %r12
-               	jmp	 <L158>
-<L156>:
+               	jmp	 <L86>
+<L84>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L157>
-<L157>:
+               	callq	 <L85>
+<L85>:
                	movq	%rax, %r12
-<L158>:
+<L86>:
                	xorps	%xmm0, %xmm0
-               	subss	-0xc0(%rbp), %xmm0
+               	subss	-0xf0(%rbp), %xmm0
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L89>
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
-               	divss	-0xd0(%rbp), %xmm4
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x8ac>
+               	ucomiss	%xmm4, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L87>
+               	jmp	 <L88>
+<L87>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L88>:
+               	jmp	 <L90>
+<L89>:
+               	movq	%rax, %rcx
+<L90>:
+               	testb	%cl, %cl
+               	jne	 <L103>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L91>
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L92>
+<L91>:
+               	xorps	%xmm4, %xmm4
+               	subss	%xmm0, %xmm4
+<L92>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L93>
+               	movsd	-0x100(%rbp), %xmm5
+               	jmp	 <L94>
+<L93>:
+               	xorps	%xmm5, %xmm5
+               	subss	-0x100(%rbp), %xmm5
+<L94>:
+               	movss	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1,2,3]
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x956>
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L95>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L102>
+               	movsd	%xmm4, %xmm8            ## xmm8 = xmm4[0],xmm8[1]
+               	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
+<L96>:
+               	ucomiss	%xmm5, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L99>
+               	testb	%al, %al
+               	jne	 <L97>
+               	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
+               	jmp	 <L98>
+<L97>:
+               	xorps	%xmm10, %xmm10
+               	subss	%xmm8, %xmm10
+<L98>:
+               	jmp	 <L104>
+<L99>:
+               	ucomiss	%xmm9, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L100>
+               	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
+               	jmp	 <L101>
+<L100>:
+               	movss	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1,2,3]
+               	subss	%xmm9, %xmm11
+<L101>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x9d9>
+               	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
+               	jmp	 <L96>
+<L102>:
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x9eb>
+               	jmp	 <L95>
+<L103>:
+               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
+               	divss	-0x100(%rbp), %xmm4
                	cvttss2si	%xmm4, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2ss	%r11, %xmm4
                	movss	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1,2,3]
-               	mulss	-0xd0(%rbp), %xmm5
-               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
-               	subss	%xmm5, %xmm4
-               	ucomiss	%xmm4, %xmm4
+               	mulss	-0x100(%rbp), %xmm5
+               	movss	%xmm0, %xmm10           ## xmm10 = xmm0[0],xmm10[1,2,3]
+               	subss	%xmm5, %xmm10
+<L104>:
+               	ucomiss	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L160>
+               	jne	 <L106>
                	movq	%r12, %rdi
-               	movss	%xmm4, %xmm0            ## xmm0 = xmm4[0],xmm0[1,2,3]
-               	callq	 <L159>
-<L159>:
+               	movss	%xmm10, %xmm0           ## xmm0 = xmm10[0],xmm0[1,2,3]
+               	callq	 <L105>
+<L105>:
                	movq	%rax, %rbx
-               	jmp	 <L162>
-<L160>:
+               	jmp	 <L108>
+<L106>:
                	movq	%r12, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L161>
-<L161>:
+               	callq	 <L107>
+<L107>:
                	movq	%rax, %rbx
-<L162>:
+<L108>:
                	xorps	%xmm0, %xmm0
-               	subss	-0xd0(%rbp), %xmm0
-               	movss	-0xc0(%rbp), %xmm4
+               	subss	-0x100(%rbp), %xmm0
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L111>
+               	movss	-0xf0(%rbp), %xmm4
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xa9a>
+               	movss	-0xf0(%rbp), %xmm14
+               	ucomiss	%xmm4, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L109>
+               	jmp	 <L110>
+<L109>:
+               	movss	-0xf0(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L110>:
+               	jmp	 <L112>
+<L111>:
+               	movq	%rax, %rcx
+<L112>:
+               	testb	%cl, %cl
+               	jne	 <L125>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0xf0(%rbp), %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L113>
+               	movsd	-0xf0(%rbp), %xmm4
+               	jmp	 <L114>
+<L113>:
+               	xorps	%xmm4, %xmm4
+               	subss	-0xf0(%rbp), %xmm4
+<L114>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L115>
+               	movsd	%xmm0, %xmm5            ## xmm5 = xmm0[0],xmm5[1]
+               	jmp	 <L116>
+<L115>:
+               	xorps	%xmm5, %xmm5
+               	subss	%xmm0, %xmm5
+<L116>:
+               	movss	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1,2,3]
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xb57>
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L117>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L124>
+               	movsd	%xmm4, %xmm8            ## xmm8 = xmm4[0],xmm8[1]
+               	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
+<L118>:
+               	ucomiss	%xmm5, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L121>
+               	testb	%al, %al
+               	jne	 <L119>
+               	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
+               	jmp	 <L120>
+<L119>:
+               	xorps	%xmm10, %xmm10
+               	subss	%xmm8, %xmm10
+<L120>:
+               	jmp	 <L126>
+<L121>:
+               	ucomiss	%xmm9, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L122>
+               	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
+               	jmp	 <L123>
+<L122>:
+               	movss	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1,2,3]
+               	subss	%xmm9, %xmm11
+<L123>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xbda>
+               	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
+               	jmp	 <L118>
+<L124>:
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xbec>
+               	jmp	 <L117>
+<L125>:
+               	movss	-0xf0(%rbp), %xmm4
                	divss	%xmm0, %xmm4
                	cvttss2si	%xmm4, %r11
                	movq	%r11, %rax
@@ -991,31 +818,134 @@ Disassembly of section __TEXT,__text:
                	cvtsi2ss	%r11, %xmm4
                	movss	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1,2,3]
                	mulss	%xmm0, %xmm5
-               	movss	-0xc0(%rbp), %xmm0
-               	subss	%xmm5, %xmm0
-               	ucomiss	%xmm0, %xmm0
+               	movss	-0xf0(%rbp), %xmm10
+               	subss	%xmm5, %xmm10
+<L126>:
+               	ucomiss	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L164>
+               	jne	 <L128>
                	movq	%rbx, %rdi
-               	callq	 <L163>
-<L163>:
+               	movss	%xmm10, %xmm0           ## xmm0 = xmm10[0],xmm0[1,2,3]
+               	callq	 <L127>
+<L127>:
                	movq	%rax, %r12
-               	jmp	 <L166>
-<L164>:
+               	jmp	 <L130>
+<L128>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L165>
-<L165>:
+               	callq	 <L129>
+<L129>:
                	movq	%rax, %r12
-<L166>:
+<L130>:
                	xorps	%xmm0, %xmm0
-               	subss	-0xc0(%rbp), %xmm0
+               	subss	-0xf0(%rbp), %xmm0
                	xorps	%xmm2, %xmm2
-               	subss	-0xd0(%rbp), %xmm2
+               	subss	-0x100(%rbp), %xmm2
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm2
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L133>
+               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xca2>
+               	ucomiss	%xmm4, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L131>
+               	jmp	 <L132>
+<L131>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L132>:
+               	jmp	 <L134>
+<L133>:
+               	movq	%rax, %rcx
+<L134>:
+               	testb	%cl, %cl
+               	jne	 <L147>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L135>
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L136>
+<L135>:
+               	xorps	%xmm4, %xmm4
+               	subss	%xmm0, %xmm4
+<L136>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm2, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L137>
+               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
+               	jmp	 <L138>
+<L137>:
+               	xorps	%xmm5, %xmm5
+               	subss	%xmm2, %xmm5
+<L138>:
+               	movss	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1,2,3]
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xd40>
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L139>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L146>
+               	movsd	%xmm4, %xmm8            ## xmm8 = xmm4[0],xmm8[1]
+               	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
+<L140>:
+               	ucomiss	%xmm5, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L143>
+               	testb	%al, %al
+               	jne	 <L141>
+               	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
+               	jmp	 <L142>
+<L141>:
+               	xorps	%xmm10, %xmm10
+               	subss	%xmm8, %xmm10
+<L142>:
+               	jmp	 <L148>
+<L143>:
+               	ucomiss	%xmm9, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L144>
+               	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
+               	jmp	 <L145>
+<L144>:
+               	movss	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1,2,3]
+               	subss	%xmm9, %xmm11
+<L145>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xdc3>
+               	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
+               	jmp	 <L140>
+<L146>:
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xdd5>
+               	jmp	 <L139>
+<L147>:
                	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
                	divss	%xmm2, %xmm4
                	cvttss2si	%xmm4, %r11
@@ -1024,41 +954,145 @@ Disassembly of section __TEXT,__text:
                	cvtsi2ss	%r11, %xmm4
                	movss	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1,2,3]
                	mulss	%xmm2, %xmm5
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm5, %xmm2
-               	ucomiss	%xmm2, %xmm2
+               	movss	%xmm0, %xmm10           ## xmm10 = xmm0[0],xmm10[1,2,3]
+               	subss	%xmm5, %xmm10
+<L148>:
+               	ucomiss	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L168>
+               	jne	 <L150>
                	movq	%r12, %rdi
-               	movss	%xmm2, %xmm0            ## xmm0 = xmm2[0],xmm0[1,2,3]
-               	callq	 <L167>
-<L167>:
+               	movss	%xmm10, %xmm0           ## xmm0 = xmm10[0],xmm0[1,2,3]
+               	callq	 <L149>
+<L149>:
                	movq	%rax, %rbx
-               	jmp	 <L170>
-<L168>:
+               	jmp	 <L152>
+<L150>:
                	movq	%r12, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L169>
-<L169>:
+               	callq	 <L151>
+<L151>:
                	movq	%rax, %rbx
-<L170>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xdec>
+<L152>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xe4b>
                	mulss	-0x30(%rbp), %xmm0
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xe59>
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L155>
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xdfd>
+               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xe83>
+               	ucomiss	%xmm2, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L153>
+               	jmp	 <L154>
+<L153>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L154>:
+               	jmp	 <L156>
+<L155>:
+               	movq	%rax, %rcx
+<L156>:
+               	testb	%cl, %cl
+               	jne	 <L169>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L157>
+               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
+               	jmp	 <L158>
+<L157>:
+               	xorps	%xmm2, %xmm2
+               	subss	%xmm0, %xmm2
+<L158>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xefa>
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L159>
+               	movss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xf11>
+               	jmp	 <L160>
+<L159>:
+               	xorps	%xmm4, %xmm4
+               	subss	, %xmm4 <L160>
+<L160>:
+               	movss	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1,2,3]
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xf2d>
+               	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
+<L161>:
+               	ucomiss	%xmm6, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L168>
+               	movsd	%xmm2, %xmm7            ## xmm7 = xmm2[0],xmm7[1]
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+<L162>:
+               	ucomiss	%xmm4, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L165>
+               	testb	%al, %al
+               	jne	 <L163>
+               	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
+               	jmp	 <L164>
+<L163>:
+               	xorps	%xmm9, %xmm9
+               	subss	%xmm7, %xmm9
+<L164>:
+               	jmp	 <L170>
+<L165>:
+               	ucomiss	%xmm8, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L166>
+               	movsd	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1]
+               	jmp	 <L167>
+<L166>:
+               	movss	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1,2,3]
+               	subss	%xmm8, %xmm10
+<L167>:
+               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0xfaf>
+               	movsd	%xmm10, %xmm7           ## xmm7 = xmm10[0],xmm7[1]
+               	jmp	 <L162>
+<L168>:
+               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xfc1>
+               	jmp	 <L161>
+<L169>:
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xfd2>
                	cvttss2si	%xmm2, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2ss	%r11, %xmm2
                	movss	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1,2,3]
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xe19>
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm4, %xmm2
-               	ucomiss	%xmm2, %xmm2
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xfee>
+               	movss	%xmm0, %xmm9            ## xmm9 = xmm0[0],xmm9[1,2,3]
+               	subss	%xmm4, %xmm9
+<L170>:
+               	ucomiss	%xmm9, %xmm9
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
@@ -1066,7 +1100,7 @@ Disassembly of section __TEXT,__text:
                	testb	%al, %al
                	jne	 <L172>
                	movq	%rbx, %rdi
-               	movss	%xmm2, %xmm0            ## xmm0 = xmm2[0],xmm0[1,2,3]
+               	movss	%xmm9, %xmm0            ## xmm0 = xmm9[0],xmm0[1,2,3]
                	callq	 <L171>
 <L171>:
                	movq	%rax, %r12
@@ -1078,101 +1112,416 @@ Disassembly of section __TEXT,__text:
 <L173>:
                	movq	%rax, %r12
 <L174>:
-               	movss	-0x30(%rbp), %xmm0
-               	divss	-0xd0(%rbp), %xmm0
-               	cvttss2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	-0xd0(%rbp), %xmm2
-               	movss	-0x30(%rbp), %xmm0
-               	subss	%xmm2, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L176>
-               	movq	%r12, %rdi
-               	callq	 <L175>
+               	jne	 <L177>
+               	movss	-0x30(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x106b>
+               	movss	-0x30(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L175>
+               	jmp	 <L176>
 <L175>:
-               	movq	%rax, %rbx
-               	jmp	 <L178>
+               	movss	-0x30(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
 <L176>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L177>
+               	jmp	 <L178>
 <L177>:
-               	movq	%rax, %rbx
+               	movq	%rax, %rcx
 <L178>:
-               	movss	-0xd0(%rbp), %xmm0
-               	divss	-0xd0(%rbp), %xmm0
+               	testb	%cl, %cl
+               	jne	 <L191>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x30(%rbp), %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L179>
+               	movsd	-0x30(%rbp), %xmm0
+               	jmp	 <L180>
+<L179>:
+               	xorps	%xmm0, %xmm0
+               	subss	-0x30(%rbp), %xmm0
+<L180>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L181>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L182>
+<L181>:
+               	xorps	%xmm2, %xmm2
+               	subss	-0x100(%rbp), %xmm2
+<L182>:
+               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1125>
+               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
+<L183>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L190>
+               	movsd	%xmm0, %xmm6            ## xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L184>:
+               	ucomiss	%xmm2, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L187>
+               	testb	%al, %al
+               	jne	 <L185>
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L186>
+<L185>:
+               	xorps	%xmm8, %xmm8
+               	subss	%xmm6, %xmm8
+<L186>:
+               	jmp	 <L192>
+<L187>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L188>
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L189>
+<L188>:
+               	movss	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1,2,3]
+               	subss	%xmm7, %xmm9
+<L189>:
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x11a3>
+               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L184>
+<L190>:
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x11b5>
+               	jmp	 <L183>
+<L191>:
+               	movss	-0x30(%rbp), %xmm0
+               	divss	-0x100(%rbp), %xmm0
                	cvttss2si	%xmm0, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2ss	%r11, %xmm0
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	-0xd0(%rbp), %xmm2
-               	movss	-0xd0(%rbp), %xmm0
-               	subss	%xmm2, %xmm0
-               	ucomiss	%xmm0, %xmm0
+               	mulss	-0x100(%rbp), %xmm2
+               	movss	-0x30(%rbp), %xmm8
+               	subss	%xmm2, %xmm8
+<L192>:
+               	ucomiss	%xmm8, %xmm8
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L180>
+               	jne	 <L194>
+               	movq	%r12, %rdi
+               	movss	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1,2,3]
+               	callq	 <L193>
+<L193>:
+               	movq	%rax, %rbx
+               	jmp	 <L196>
+<L194>:
+               	movq	%r12, %rdi
+               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
+               	callq	 <L195>
+<L195>:
+               	movq	%rax, %rbx
+<L196>:
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L199>
+               	movss	-0x100(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1264>
+               	movss	-0x100(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L197>
+               	jmp	 <L198>
+<L197>:
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L198>:
+               	jmp	 <L200>
+<L199>:
+               	movq	%rax, %rcx
+<L200>:
+               	testb	%cl, %cl
+               	jne	 <L213>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L201>
+               	movsd	-0x100(%rbp), %xmm0
+               	jmp	 <L202>
+<L201>:
+               	xorps	%xmm0, %xmm0
+               	subss	-0x100(%rbp), %xmm0
+<L202>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L203>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L204>
+<L203>:
+               	xorps	%xmm2, %xmm2
+               	subss	-0x100(%rbp), %xmm2
+<L204>:
+               	movss	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1,2,3]
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x132d>
+               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
+<L205>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L212>
+               	movsd	%xmm0, %xmm6            ## xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L206>:
+               	ucomiss	%xmm2, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L209>
+               	testb	%al, %al
+               	jne	 <L207>
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L208>
+<L207>:
+               	xorps	%xmm8, %xmm8
+               	subss	%xmm6, %xmm8
+<L208>:
+               	jmp	 <L214>
+<L209>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L210>
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L211>
+<L210>:
+               	movss	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1,2,3]
+               	subss	%xmm7, %xmm9
+<L211>:
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x13ab>
+               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L206>
+<L212>:
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x13bd>
+               	jmp	 <L205>
+<L213>:
+               	movss	-0x100(%rbp), %xmm0
+               	divss	-0x100(%rbp), %xmm0
+               	cvttss2si	%xmm0, %r11
+               	movq	%r11, %rax
+               	movq	%rax, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	-0x100(%rbp), %xmm2
+               	movss	-0x100(%rbp), %xmm8
+               	subss	%xmm2, %xmm8
+<L214>:
+               	ucomiss	%xmm8, %xmm8
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L216>
                	movq	%rbx, %rdi
-               	callq	 <L179>
-<L179>:
+               	movss	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1,2,3]
+               	callq	 <L215>
+<L215>:
                	movq	%rax, %r12
-               	jmp	 <L182>
-<L180>:
+               	jmp	 <L218>
+<L216>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L181>
-<L181>:
+               	callq	 <L217>
+<L217>:
                	movq	%rax, %r12
-<L182>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xf42>
+<L218>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1443>
                	mulss	-0x30(%rbp), %xmm0
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L221>
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	divss	-0xd0(%rbp), %xmm1
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x147b>
+               	ucomiss	%xmm1, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L219>
+               	jmp	 <L220>
+<L219>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L220>:
+               	jmp	 <L222>
+<L221>:
+               	movq	%rax, %rcx
+<L222>:
+               	testb	%cl, %cl
+               	jne	 <L235>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L223>
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L224>
+<L223>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm0, %xmm1
+<L224>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L225>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L226>
+<L225>:
+               	xorps	%xmm2, %xmm2
+               	subss	-0x100(%rbp), %xmm2
+<L226>:
+               	movss	%xmm1, %xmm4            ## xmm4 = xmm1[0],xmm4[1,2,3]
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1525>
+               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
+<L227>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L234>
+               	movsd	%xmm1, %xmm6            ## xmm6 = xmm1[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L228>:
+               	ucomiss	%xmm2, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L231>
+               	testb	%al, %al
+               	jne	 <L229>
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L230>
+<L229>:
+               	xorps	%xmm8, %xmm8
+               	subss	%xmm6, %xmm8
+<L230>:
+               	jmp	 <L236>
+<L231>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L232>
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L233>
+<L232>:
+               	movss	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1,2,3]
+               	subss	%xmm7, %xmm9
+<L233>:
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x15a3>
+               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L228>
+<L234>:
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x15b5>
+               	jmp	 <L227>
+<L235>:
+               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
+               	divss	-0x100(%rbp), %xmm1
                	cvttss2si	%xmm1, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2ss	%r11, %xmm1
                	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
-               	mulss	-0xd0(%rbp), %xmm2
-               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	%xmm2, %xmm1
-               	ucomiss	%xmm1, %xmm1
+               	mulss	-0x100(%rbp), %xmm2
+               	movss	%xmm0, %xmm8            ## xmm8 = xmm0[0],xmm8[1,2,3]
+               	subss	%xmm2, %xmm8
+<L236>:
+               	ucomiss	%xmm8, %xmm8
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L184>
+               	jne	 <L238>
                	movq	%r12, %rdi
-               	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	callq	 <L183>
-<L183>:
+               	movss	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1,2,3]
+               	callq	 <L237>
+<L237>:
                	movq	%rax, %rbx
-               	jmp	 <L186>
-<L184>:
+               	jmp	 <L240>
+<L238>:
                	movq	%r12, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L185>
-<L185>:
+               	callq	 <L239>
+<L239>:
                	movq	%rax, %rbx
-<L186>:
+<L240>:
                	movq	%rbx, %rax
-               	movq	-0xd8(%rbp), %rbx
-               	movq	-0xe0(%rbp), %r12
-               	movq	-0xe8(%rbp), %r13
-               	movq	-0xf0(%rbp), %r14
+               	movq	-0x108(%rbp), %rbx
+               	movq	-0x110(%rbp), %r12
+               	movq	-0x118(%rbp), %r13
+               	movq	-0x120(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/float/arith_f64.dis
+++ b/test/golden/x86_64-darwin/float/arith_f64.dis
@@ -40,11 +40,11 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.float.arith_f64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xf0, %rsp
-               	movq	%rbx, -0xd8(%rbp)
-               	movq	%r12, -0xe0(%rbp)
-               	movq	%r13, -0xe8(%rbp)
-               	movq	%r14, -0xf0(%rbp)
+               	subq	$0x120, %rsp            ## imm = 0x120
+               	movq	%rbx, -0x108(%rbp)
+               	movq	%r12, -0x110(%rbp)
+               	movq	%r13, -0x118(%rbp)
+               	movq	%r14, -0x120(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -144,430 +144,122 @@ Disassembly of section __TEXT,__text:
 <L16>:
                	movsd	-0x10(%rbp), %xmm0
                	divsd	-0x20(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L18>
                	movq	%r12, %rdi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %r13
-               	jmp	 <L20>
-<L18>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %r13
-<L20>:
                	movsd	-0x20(%rbp), %xmm0
                	divsd	-0x10(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L22>
-               	movq	%r13, %rdi
+               	movq	%rax, %rdi
+               	callq	 <L18>
+<L18>:
+               	movsd	-0x10(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1b5>
+               	movq	%rax, %rdi
+               	callq	 <L19>
+<L19>:
+               	xorps	%xmm14, %xmm14
+               	subsd	-0x10(%rbp), %xmm14
+               	movsd	%xmm14, -0x40(%rbp)
+               	movq	%rax, %rdi
+               	movsd	-0x40(%rbp), %xmm0
+               	callq	 <L20>
+<L20>:
+               	movsd	-0x10(%rbp), %xmm0
+               	subsd	-0x10(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %r12
-               	jmp	 <L24>
+               	movsd	-0x40(%rbp), %xmm0
+               	addsd	-0x10(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L22>
 <L22>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x207>
+               	mulsd	-0x30(%rbp), %xmm14
+               	movsd	%xmm14, -0x50(%rbp)
+               	movsd	-0x30(%rbp), %xmm14
+               	divsd	-0x50(%rbp), %xmm14
+               	movsd	%xmm14, -0x60(%rbp)
+               	movq	%rax, %rdi
+               	movsd	-0x60(%rbp), %xmm0
                	callq	 <L23>
 <L23>:
-               	movq	%rax, %r12
+               	movsd	-0x60(%rbp), %xmm0
+               	mulsd	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L24>
 <L24>:
-               	movsd	-0x10(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x21d>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L26>
-               	movq	%r12, %rdi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %r13
-               	jmp	 <L28>
-<L26>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %r13
-<L28>:
-               	xorps	%xmm0, %xmm0
-               	subsd	-0x10(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L30>
-               	movq	%r13, %rdi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %r12
-               	jmp	 <L32>
-<L30>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %r12
-<L32>:
-               	movsd	-0x10(%rbp), %xmm0
-               	subsd	-0x10(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L34>
-               	movq	%r12, %rdi
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %r13
-               	jmp	 <L36>
-<L34>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %r13
-<L36>:
-               	xorps	%xmm0, %xmm0
-               	subsd	-0x10(%rbp), %xmm0
-               	movsd	%xmm0, %xmm3            ## xmm3 = xmm0[0],xmm3[1]
-               	addsd	-0x10(%rbp), %xmm3
-               	ucomisd	%xmm3, %xmm3
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L38>
-               	movq	%r13, %rdi
-               	movsd	%xmm3, %xmm0            ## xmm0 = xmm3[0],xmm0[1]
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %r12
-               	jmp	 <L40>
-<L38>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %r12
-<L40>:
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x33d>
-               	mulsd	-0x30(%rbp), %xmm14
-               	movsd	%xmm14, -0x40(%rbp)
-               	movsd	-0x30(%rbp), %xmm14
-               	divsd	-0x40(%rbp), %xmm14
-               	movsd	%xmm14, -0x50(%rbp)
-               	movsd	-0x50(%rbp), %xmm14
-               	ucomisd	-0x50(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L42>
-               	movq	%r12, %rdi
-               	movsd	-0x50(%rbp), %xmm0
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %r13
-               	jmp	 <L44>
-<L42>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %r13
-<L44>:
-               	movsd	-0x50(%rbp), %xmm0
-               	mulsd	-0x40(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L46>
-               	movq	%r13, %rdi
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %r12
-               	jmp	 <L48>
-<L46>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %r12
-<L48>:
                	movsd	-0x30(%rbp), %xmm0
-               	subsd	-0x50(%rbp), %xmm0
-               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	subsd	-0x50(%rbp), %xmm4
-               	movsd	%xmm4, %xmm0            ## xmm0 = xmm4[0],xmm0[1]
-               	subsd	-0x50(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L50>
-               	movq	%r12, %rdi
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %r13
-               	jmp	 <L52>
-<L50>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %r13
-<L52>:
-               	movsd	-0x30(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x44f>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L54>
-               	movq	%r13, %rdi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %r12
-               	jmp	 <L56>
-<L54>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %r12
-<L56>:
-               	movsd	-0x30(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x498>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L58>
-               	movq	%r12, %rdi
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %r13
-               	jmp	 <L60>
-<L58>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %r13
-<L60>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x4dc>
-               	divsd	-0x40(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L62>
-               	movq	%r13, %rdi
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %r12
-               	jmp	 <L64>
-<L62>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %r12
-<L64>:
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x526>
-               	mulsd	-0x30(%rbp), %xmm14
-               	movsd	%xmm14, -0x60(%rbp)
-               	movsd	-0x60(%rbp), %xmm0
-               	addsd	-0x30(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L66>
-               	movq	%r12, %rdi
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %r13
-               	jmp	 <L68>
-<L66>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %r13
-<L68>:
-               	movsd	-0x60(%rbp), %xmm0
-               	addsd	-0x30(%rbp), %xmm0
-               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	addsd	-0x30(%rbp), %xmm4
-               	ucomisd	%xmm4, %xmm4
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L70>
-               	movq	%r13, %rdi
-               	movsd	%xmm4, %xmm0            ## xmm0 = xmm4[0],xmm0[1]
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %r12
-               	jmp	 <L72>
-<L70>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %r12
-<L72>:
-               	movsd	-0x30(%rbp), %xmm0
-               	addsd	-0x30(%rbp), %xmm0
-               	movsd	-0x60(%rbp), %xmm4
-               	addsd	%xmm0, %xmm4
-               	ucomisd	%xmm4, %xmm4
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L74>
-               	movq	%r12, %rdi
-               	movsd	%xmm4, %xmm0            ## xmm0 = xmm4[0],xmm0[1]
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %r13
-               	jmp	 <L76>
-<L74>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %r13
-<L76>:
-               	movsd	-0x60(%rbp), %xmm0
-               	subsd	-0x30(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L78>
-               	movq	%r13, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %r12
-               	jmp	 <L80>
-<L78>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %r12
-<L80>:
-               	movsd	-0x60(%rbp), %xmm0
-               	addsd	-0x30(%rbp), %xmm0
+               	subsd	-0x60(%rbp), %xmm0
                	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
                	subsd	-0x60(%rbp), %xmm4
-               	ucomisd	%xmm4, %xmm4
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L82>
-               	movq	%r12, %rdi
                	movsd	%xmm4, %xmm0            ## xmm0 = xmm4[0],xmm0[1]
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %r13
-               	jmp	 <L84>
-<L82>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %r13
-<L84>:
-               	xorps	%xmm0, %xmm0
-               	mulsd	-0x30(%rbp), %xmm0
-               	movsd	%xmm0, -0x80(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x18, %r12
-               	jb	 <L85>
-               	jmp	 <L90>
-<L85>:
-               	movsd	-0x80(%rbp), %xmm0
-               	addsd	-0x50(%rbp), %xmm0
-               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
-               	mulsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x6f2>
+               	subsd	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L25>
+<L25>:
+               	movsd	-0x30(%rbp), %xmm0
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x275>
+               	movq	%rax, %rdi
+               	callq	 <L26>
+<L26>:
+               	movsd	-0x30(%rbp), %xmm0
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x28a>
+               	movq	%rax, %rdi
+               	callq	 <L27>
+<L27>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x29a>
+               	divsd	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x2b0>
+               	mulsd	-0x30(%rbp), %xmm14
                	movsd	%xmm14, -0x70(%rbp)
                	movsd	-0x70(%rbp), %xmm14
-               	ucomisd	-0x70(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L87>
-               	movq	%r13, %rdi
+               	addsd	-0x30(%rbp), %xmm14
+               	movsd	%xmm14, -0x80(%rbp)
+               	movq	%rax, %rdi
+               	movsd	-0x80(%rbp), %xmm0
+               	callq	 <L29>
+<L29>:
+               	movsd	-0x80(%rbp), %xmm0
+               	addsd	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L30>
+<L30>:
+               	movsd	-0x30(%rbp), %xmm0
+               	addsd	-0x30(%rbp), %xmm0
+               	movsd	-0x70(%rbp), %xmm5
+               	addsd	%xmm0, %xmm5
+               	movq	%rax, %rdi
+               	movsd	%xmm5, %xmm0            ## xmm0 = xmm5[0],xmm0[1]
+               	callq	 <L31>
+<L31>:
                	movsd	-0x70(%rbp), %xmm0
-               	callq	 <L86>
-<L86>:
-               	movq	%rax, %r14
-               	jmp	 <L89>
-<L87>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L88>
-<L88>:
-               	movq	%rax, %r14
-<L89>:
-               	addq	$0x1, %r12
-               	movq	%r14, %r13
-               	movq	-0x70(%rbp), %r11
-               	movq	%r11, -0x80(%rbp)
-               	cmpq	$0x18, %r12
-               	jb	 <L85>
-<L90>:
-               	movabsq	$0x7fefffffffffffff, %rax ## imm = 0x7FEFFFFFFFFFFFFF
-               	addq	%rbx, %rax
-               	movq	%rax, -0x90(%rbp)
+               	subsd	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L32>
+<L32>:
+               	movsd	-0x80(%rbp), %xmm0
+               	subsd	-0x70(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L33>
+<L33>:
+               	xorps	%xmm0, %xmm0
+               	mulsd	-0x30(%rbp), %xmm0
+               	movq	%rax, %r12
+               	movsd	%xmm0, -0xa0(%rbp)
+               	movq	$0x0, %r13
+               	cmpq	$0x18, %r13
+               	jb	 <L34>
+               	jmp	 <L39>
+<L34>:
+               	movsd	-0xa0(%rbp), %xmm0
+               	addsd	-0x60(%rbp), %xmm0
+               	movsd	%xmm0, %xmm14           ## xmm14 = xmm0[0],xmm14[1]
+               	mulsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x374>
+               	movsd	%xmm14, -0x90(%rbp)
                	movsd	-0x90(%rbp), %xmm14
                	ucomisd	-0x90(%rbp), %xmm14
                	setne	%al
@@ -575,239 +267,72 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L92>
-               	movq	%r13, %rdi
-               	movsd	-0x90(%rbp), %xmm0
-               	callq	 <L91>
-<L91>:
-               	movq	%rax, %r12
-               	jmp	 <L94>
-<L92>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L93>
-<L93>:
-               	movq	%rax, %r12
-<L94>:
-               	movsd	-0x90(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x7d0>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L96>
+               	jne	 <L36>
                	movq	%r12, %rdi
-               	callq	 <L95>
-<L95>:
-               	movq	%rax, %r13
-               	jmp	 <L98>
-<L96>:
+               	movsd	-0x90(%rbp), %xmm0
+               	callq	 <L35>
+<L35>:
+               	movq	%rax, %r14
+               	jmp	 <L38>
+<L36>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L97>
-<L97>:
-               	movq	%rax, %r13
-<L98>:
-               	movsd	-0x90(%rbp), %xmm0
-               	addsd	-0x90(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L100>
-               	movq	%r13, %rdi
-               	callq	 <L99>
-<L99>:
-               	movq	%rax, %r12
-               	jmp	 <L102>
-<L100>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L101>
-<L101>:
-               	movq	%rax, %r12
-<L102>:
-               	movsd	-0x90(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x868>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L104>
-               	movq	%r12, %rdi
-               	callq	 <L103>
-<L103>:
-               	movq	%rax, %r13
-               	jmp	 <L106>
-<L104>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %r13
-<L106>:
-               	movsd	-0x90(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x8b4>
-               	xorps	%xmm3, %xmm3
-               	subsd	%xmm0, %xmm3
-               	ucomisd	%xmm3, %xmm3
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L108>
-               	movq	%r13, %rdi
-               	movsd	%xmm3, %xmm0            ## xmm0 = xmm3[0],xmm0[1]
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %r12
-               	jmp	 <L110>
-<L108>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L109>
-<L109>:
-               	movq	%rax, %r12
-<L110>:
-               	movsd	-0x90(%rbp), %xmm0
-               	mulsd	-0x90(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L112>
-               	movq	%r12, %rdi
-               	callq	 <L111>
-<L111>:
-               	movq	%rax, %r13
-               	jmp	 <L114>
-<L112>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L113>
-<L113>:
-               	movq	%rax, %r13
-<L114>:
-               	movsd	-0x90(%rbp), %xmm0
-               	subsd	-0x90(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L116>
-               	movq	%r13, %rdi
-               	callq	 <L115>
-<L115>:
-               	movq	%rax, %r12
-               	jmp	 <L118>
-<L116>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L117>
-<L117>:
-               	movq	%rax, %r12
-<L118>:
-               	movabsq	$0x10000000000000, %rax ## imm = 0x10000000000000
-               	addq	%rbx, %rax
-               	movq	%rax, -0xa0(%rbp)
-               	movq	$0x1, %rax
+               	callq	 <L37>
+<L37>:
+               	movq	%rax, %r14
+<L38>:
+               	addq	$0x1, %r13
+               	movq	%r14, %r12
+               	movq	-0x90(%rbp), %r11
+               	movq	%r11, -0xa0(%rbp)
+               	cmpq	$0x18, %r13
+               	jb	 <L34>
+<L39>:
+               	movabsq	$0x7fefffffffffffff, %rax ## imm = 0x7FEFFFFFFFFFFFFF
                	addq	%rbx, %rax
                	movq	%rax, -0xb0(%rbp)
-               	movsd	-0xa0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x9c8>
+               	movsd	-0xb0(%rbp), %xmm14
+               	ucomisd	-0xb0(%rbp), %xmm14
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L41>
+               	movq	%r12, %rdi
+               	movsd	-0xb0(%rbp), %xmm0
+               	callq	 <L40>
+<L40>:
+               	movq	%rax, %r13
+               	jmp	 <L43>
+<L41>:
+               	movq	%r12, %rdi
+               	movq	$-0x1, %rsi
+               	callq	 <L42>
+<L42>:
+               	movq	%rax, %r13
+<L43>:
+               	movsd	-0xb0(%rbp), %xmm0
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x464>
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L120>
-               	movq	%r12, %rdi
-               	callq	 <L119>
-<L119>:
-               	movq	%rax, %rbx
-               	jmp	 <L122>
-<L120>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L121>
-<L121>:
-               	movq	%rax, %rbx
-<L122>:
-               	movsd	-0xa0(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xa14>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L124>
-               	movq	%rbx, %rdi
-               	callq	 <L123>
-<L123>:
+               	jne	 <L45>
+               	movq	%r13, %rdi
+               	callq	 <L44>
+<L44>:
                	movq	%rax, %r12
-               	jmp	 <L126>
-<L124>:
-               	movq	%rbx, %rdi
+               	jmp	 <L47>
+<L45>:
+               	movq	%r13, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L125>
-<L125>:
+               	callq	 <L46>
+<L46>:
                	movq	%rax, %r12
-<L126>:
-               	movsd	-0xa0(%rbp), %xmm0
-               	subsd	-0xb0(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L128>
-               	movq	%r12, %rdi
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %rbx
-               	jmp	 <L130>
-<L128>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L129>
-<L129>:
-               	movq	%rax, %rbx
-<L130>:
-               	movsd	-0xa0(%rbp), %xmm0
-               	mulsd	-0x30(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L132>
-               	movq	%rbx, %rdi
-               	callq	 <L131>
-<L131>:
-               	movq	%rax, %r12
-               	jmp	 <L134>
-<L132>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L133>
-<L133>:
-               	movq	%rax, %r12
-<L134>:
+<L47>:
                	movsd	-0xb0(%rbp), %xmm0
                	addsd	-0xb0(%rbp), %xmm0
                	ucomisd	%xmm0, %xmm0
@@ -816,173 +341,475 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L136>
+               	jne	 <L49>
                	movq	%r12, %rdi
-               	callq	 <L135>
-<L135>:
-               	movq	%rax, %rbx
-               	jmp	 <L138>
-<L136>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L137>
-<L137>:
-               	movq	%rax, %rbx
-<L138>:
-               	movsd	-0xb0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xb41>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L140>
-               	movq	%rbx, %rdi
-               	callq	 <L139>
-<L139>:
-               	movq	%rax, %r12
-               	jmp	 <L142>
-<L140>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L141>
-<L141>:
-               	movq	%rax, %r12
-<L142>:
-               	movsd	-0xb0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xb8d>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L144>
-               	movq	%r12, %rdi
-               	callq	 <L143>
-<L143>:
-               	movq	%rax, %rbx
-               	jmp	 <L146>
-<L144>:
+               	callq	 <L48>
+<L48>:
+               	movq	%rax, %r13
+               	jmp	 <L51>
+<L49>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L145>
-<L145>:
-               	movq	%rax, %rbx
-<L146>:
-               	movsd	-0xb0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xbd9>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L148>
-               	movq	%rbx, %rdi
-               	callq	 <L147>
-<L147>:
-               	movq	%rax, %r12
-               	jmp	 <L150>
-<L148>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %r12
-<L150>:
-               	movsd	-0xb0(%rbp), %xmm0
-               	divsd	-0xa0(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L152>
-               	movq	%r12, %rdi
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-               	jmp	 <L154>
-<L152>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L153>
-<L153>:
-               	movq	%rax, %rbx
-<L154>:
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0xc6a>
-               	mulsd	-0x30(%rbp), %xmm14
+               	callq	 <L50>
+<L50>:
+               	movq	%rax, %r13
+<L51>:
+               	movsd	-0xb0(%rbp), %xmm14
+               	mulsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x4fe>
                	movsd	%xmm14, -0xc0(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0xc82>
-               	mulsd	-0x30(%rbp), %xmm14
-               	movsd	%xmm14, -0xd0(%rbp)
+               	movq	%r13, %rdi
                	movsd	-0xc0(%rbp), %xmm0
+               	callq	 <L52>
+<L52>:
+               	xorps	%xmm0, %xmm0
+               	subsd	-0xc0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L53>
+<L53>:
+               	movsd	-0xb0(%rbp), %xmm0
+               	mulsd	-0xb0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L54>
+<L54>:
+               	movsd	-0xb0(%rbp), %xmm0
+               	subsd	-0xb0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L55>
+<L55>:
+               	movabsq	$0x10000000000000, %rcx ## imm = 0x10000000000000
+               	addq	%rbx, %rcx
+               	movq	%rcx, -0xd0(%rbp)
+               	movq	$0x1, %rcx
+               	addq	%rbx, %rcx
+               	movq	%rcx, -0xe0(%rbp)
+               	movsd	-0xd0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x58f>
+               	movq	%rax, %rdi
+               	callq	 <L56>
+<L56>:
+               	movsd	-0xd0(%rbp), %xmm0
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x5a7>
+               	movq	%rax, %rdi
+               	callq	 <L57>
+<L57>:
+               	movsd	-0xd0(%rbp), %xmm0
+               	subsd	-0xe0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L58>
+<L58>:
+               	movsd	-0xd0(%rbp), %xmm0
+               	mulsd	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L59>
+<L59>:
+               	movsd	-0xe0(%rbp), %xmm0
+               	addsd	-0xe0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L60>
+<L60>:
+               	movsd	-0xe0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x604>
+               	movq	%rax, %rdi
+               	callq	 <L61>
+<L61>:
+               	movsd	-0xe0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x61c>
+               	movq	%rax, %rdi
+               	callq	 <L62>
+<L62>:
+               	movsd	-0xe0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x634>
+               	movq	%rax, %rdi
+               	callq	 <L63>
+<L63>:
+               	movsd	-0xe0(%rbp), %xmm0
                	divsd	-0xd0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L64>
+<L64>:
+               	movq	%rax, %rbx
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x660>
+               	mulsd	-0x30(%rbp), %xmm14
+               	movsd	%xmm14, -0xf0(%rbp)
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x678>
+               	mulsd	-0x30(%rbp), %xmm14
+               	movsd	%xmm14, -0x100(%rbp)
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L67>
+               	movsd	-0xf0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x6bf>
+               	movsd	-0xf0(%rbp), %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L65>
+               	jmp	 <L66>
+<L65>:
+               	movsd	-0xf0(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L66>:
+               	jmp	 <L68>
+<L67>:
+               	movq	%rax, %rcx
+<L68>:
+               	testb	%cl, %cl
+               	jne	 <L81>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0xf0(%rbp), %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L69>
+               	movsd	-0xf0(%rbp), %xmm0
+               	jmp	 <L70>
+<L69>:
+               	xorps	%xmm0, %xmm0
+               	subsd	-0xf0(%rbp), %xmm0
+<L70>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L71>
+               	movsd	-0x100(%rbp), %xmm4
+               	jmp	 <L72>
+<L71>:
+               	xorps	%xmm4, %xmm4
+               	subsd	-0x100(%rbp), %xmm4
+<L72>:
+               	movsd	%xmm0, %xmm5            ## xmm5 = xmm0[0],xmm5[1]
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x78c>
+               	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
+<L73>:
+               	ucomisd	%xmm6, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L80>
+               	movsd	%xmm0, %xmm7            ## xmm7 = xmm0[0],xmm7[1]
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+<L74>:
+               	ucomisd	%xmm4, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L77>
+               	testb	%al, %al
+               	jne	 <L75>
+               	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
+               	jmp	 <L76>
+<L75>:
+               	xorps	%xmm9, %xmm9
+               	subsd	%xmm7, %xmm9
+<L76>:
+               	jmp	 <L82>
+<L77>:
+               	ucomisd	%xmm8, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L78>
+               	movsd	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1]
+               	jmp	 <L79>
+<L78>:
+               	movsd	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1]
+               	subsd	%xmm8, %xmm10
+<L79>:
+               	divsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x811>
+               	movsd	%xmm10, %xmm7           ## xmm7 = xmm10[0],xmm7[1]
+               	jmp	 <L74>
+<L80>:
+               	mulsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x823>
+               	jmp	 <L73>
+<L81>:
+               	movsd	-0xf0(%rbp), %xmm0
+               	divsd	-0x100(%rbp), %xmm0
                	cvttsd2si	%xmm0, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2sd	%r11, %xmm0
                	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	mulsd	-0xd0(%rbp), %xmm4
-               	movsd	-0xc0(%rbp), %xmm0
-               	subsd	%xmm4, %xmm0
-               	ucomisd	%xmm0, %xmm0
+               	mulsd	-0x100(%rbp), %xmm4
+               	movsd	-0xf0(%rbp), %xmm9
+               	subsd	%xmm4, %xmm9
+<L82>:
+               	ucomisd	%xmm9, %xmm9
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L156>
+               	jne	 <L84>
                	movq	%rbx, %rdi
-               	callq	 <L155>
-<L155>:
+               	movsd	%xmm9, %xmm0            ## xmm0 = xmm9[0],xmm0[1]
+               	callq	 <L83>
+<L83>:
                	movq	%rax, %r12
-               	jmp	 <L158>
-<L156>:
+               	jmp	 <L86>
+<L84>:
                	movq	%rbx, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L157>
-<L157>:
+               	callq	 <L85>
+<L85>:
                	movq	%rax, %r12
-<L158>:
+<L86>:
                	xorps	%xmm0, %xmm0
-               	subsd	-0xc0(%rbp), %xmm0
+               	subsd	-0xf0(%rbp), %xmm0
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L89>
                	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	divsd	-0xd0(%rbp), %xmm4
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8e3>
+               	ucomisd	%xmm4, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L87>
+               	jmp	 <L88>
+<L87>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L88>:
+               	jmp	 <L90>
+<L89>:
+               	movq	%rax, %rcx
+<L90>:
+               	testb	%cl, %cl
+               	jne	 <L103>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L91>
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L92>
+<L91>:
+               	xorps	%xmm4, %xmm4
+               	subsd	%xmm0, %xmm4
+<L92>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L93>
+               	movsd	-0x100(%rbp), %xmm5
+               	jmp	 <L94>
+<L93>:
+               	xorps	%xmm5, %xmm5
+               	subsd	-0x100(%rbp), %xmm5
+<L94>:
+               	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x991>
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L95>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L102>
+               	movsd	%xmm4, %xmm8            ## xmm8 = xmm4[0],xmm8[1]
+               	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
+<L96>:
+               	ucomisd	%xmm5, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L99>
+               	testb	%al, %al
+               	jne	 <L97>
+               	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
+               	jmp	 <L98>
+<L97>:
+               	xorps	%xmm10, %xmm10
+               	subsd	%xmm8, %xmm10
+<L98>:
+               	jmp	 <L104>
+<L99>:
+               	ucomisd	%xmm9, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L100>
+               	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
+               	jmp	 <L101>
+<L100>:
+               	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
+               	subsd	%xmm9, %xmm11
+<L101>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xa17>
+               	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
+               	jmp	 <L96>
+<L102>:
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xa29>
+               	jmp	 <L95>
+<L103>:
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	divsd	-0x100(%rbp), %xmm4
                	cvttsd2si	%xmm4, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2sd	%r11, %xmm4
                	movsd	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1]
-               	mulsd	-0xd0(%rbp), %xmm5
-               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	subsd	%xmm5, %xmm4
-               	ucomisd	%xmm4, %xmm4
+               	mulsd	-0x100(%rbp), %xmm5
+               	movsd	%xmm0, %xmm10           ## xmm10 = xmm0[0],xmm10[1]
+               	subsd	%xmm5, %xmm10
+<L104>:
+               	ucomisd	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L160>
+               	jne	 <L106>
                	movq	%r12, %rdi
-               	movsd	%xmm4, %xmm0            ## xmm0 = xmm4[0],xmm0[1]
-               	callq	 <L159>
-<L159>:
+               	movsd	%xmm10, %xmm0           ## xmm0 = xmm10[0],xmm0[1]
+               	callq	 <L105>
+<L105>:
                	movq	%rax, %rbx
-               	jmp	 <L162>
-<L160>:
+               	jmp	 <L108>
+<L106>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L161>
-<L161>:
+               	callq	 <L107>
+<L107>:
                	movq	%rax, %rbx
-<L162>:
+<L108>:
                	xorps	%xmm0, %xmm0
-               	subsd	-0xd0(%rbp), %xmm0
-               	movsd	-0xc0(%rbp), %xmm4
+               	subsd	-0x100(%rbp), %xmm0
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L111>
+               	movsd	-0xf0(%rbp), %xmm4
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xadc>
+               	movsd	-0xf0(%rbp), %xmm14
+               	ucomisd	%xmm4, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L109>
+               	jmp	 <L110>
+<L109>:
+               	movsd	-0xf0(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L110>:
+               	jmp	 <L112>
+<L111>:
+               	movq	%rax, %rcx
+<L112>:
+               	testb	%cl, %cl
+               	jne	 <L125>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0xf0(%rbp), %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L113>
+               	movsd	-0xf0(%rbp), %xmm4
+               	jmp	 <L114>
+<L113>:
+               	xorps	%xmm4, %xmm4
+               	subsd	-0xf0(%rbp), %xmm4
+<L114>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L115>
+               	movsd	%xmm0, %xmm5            ## xmm5 = xmm0[0],xmm5[1]
+               	jmp	 <L116>
+<L115>:
+               	xorps	%xmm5, %xmm5
+               	subsd	%xmm0, %xmm5
+<L116>:
+               	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xb9d>
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L117>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L124>
+               	movsd	%xmm4, %xmm8            ## xmm8 = xmm4[0],xmm8[1]
+               	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
+<L118>:
+               	ucomisd	%xmm5, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L121>
+               	testb	%al, %al
+               	jne	 <L119>
+               	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
+               	jmp	 <L120>
+<L119>:
+               	xorps	%xmm10, %xmm10
+               	subsd	%xmm8, %xmm10
+<L120>:
+               	jmp	 <L126>
+<L121>:
+               	ucomisd	%xmm9, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L122>
+               	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
+               	jmp	 <L123>
+<L122>:
+               	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
+               	subsd	%xmm9, %xmm11
+<L123>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xc23>
+               	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
+               	jmp	 <L118>
+<L124>:
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xc35>
+               	jmp	 <L117>
+<L125>:
+               	movsd	-0xf0(%rbp), %xmm4
                	divsd	%xmm0, %xmm4
                	cvttsd2si	%xmm4, %r11
                	movq	%r11, %rax
@@ -990,31 +817,134 @@ Disassembly of section __TEXT,__text:
                	cvtsi2sd	%r11, %xmm4
                	movsd	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1]
                	mulsd	%xmm0, %xmm5
-               	movsd	-0xc0(%rbp), %xmm0
-               	subsd	%xmm5, %xmm0
-               	ucomisd	%xmm0, %xmm0
+               	movsd	-0xf0(%rbp), %xmm10
+               	subsd	%xmm5, %xmm10
+<L126>:
+               	ucomisd	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L164>
+               	jne	 <L128>
                	movq	%rbx, %rdi
-               	callq	 <L163>
-<L163>:
+               	movsd	%xmm10, %xmm0           ## xmm0 = xmm10[0],xmm0[1]
+               	callq	 <L127>
+<L127>:
                	movq	%rax, %r12
-               	jmp	 <L166>
-<L164>:
+               	jmp	 <L130>
+<L128>:
                	movq	%rbx, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L165>
-<L165>:
+               	callq	 <L129>
+<L129>:
                	movq	%rax, %r12
-<L166>:
+<L130>:
                	xorps	%xmm0, %xmm0
-               	subsd	-0xc0(%rbp), %xmm0
+               	subsd	-0xf0(%rbp), %xmm0
                	xorps	%xmm2, %xmm2
-               	subsd	-0xd0(%rbp), %xmm2
+               	subsd	-0x100(%rbp), %xmm2
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm2
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L133>
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xcef>
+               	ucomisd	%xmm4, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L131>
+               	jmp	 <L132>
+<L131>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L132>:
+               	jmp	 <L134>
+<L133>:
+               	movq	%rax, %rcx
+<L134>:
+               	testb	%cl, %cl
+               	jne	 <L147>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L135>
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L136>
+<L135>:
+               	xorps	%xmm4, %xmm4
+               	subsd	%xmm0, %xmm4
+<L136>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm2, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L137>
+               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
+               	jmp	 <L138>
+<L137>:
+               	xorps	%xmm5, %xmm5
+               	subsd	%xmm2, %xmm5
+<L138>:
+               	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xd91>
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L139>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L146>
+               	movsd	%xmm4, %xmm8            ## xmm8 = xmm4[0],xmm8[1]
+               	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
+<L140>:
+               	ucomisd	%xmm5, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L143>
+               	testb	%al, %al
+               	jne	 <L141>
+               	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
+               	jmp	 <L142>
+<L141>:
+               	xorps	%xmm10, %xmm10
+               	subsd	%xmm8, %xmm10
+<L142>:
+               	jmp	 <L148>
+<L143>:
+               	ucomisd	%xmm9, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L144>
+               	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
+               	jmp	 <L145>
+<L144>:
+               	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
+               	subsd	%xmm9, %xmm11
+<L145>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xe17>
+               	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
+               	jmp	 <L140>
+<L146>:
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xe29>
+               	jmp	 <L139>
+<L147>:
                	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
                	divsd	%xmm2, %xmm4
                	cvttsd2si	%xmm4, %r11
@@ -1023,155 +953,549 @@ Disassembly of section __TEXT,__text:
                	cvtsi2sd	%r11, %xmm4
                	movsd	%xmm4, %xmm5            ## xmm5 = xmm4[0],xmm5[1]
                	mulsd	%xmm2, %xmm5
+               	movsd	%xmm0, %xmm10           ## xmm10 = xmm0[0],xmm10[1]
+               	subsd	%xmm5, %xmm10
+<L148>:
+               	ucomisd	%xmm10, %xmm10
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L150>
+               	movq	%r12, %rdi
+               	movsd	%xmm10, %xmm0           ## xmm0 = xmm10[0],xmm0[1]
+               	callq	 <L149>
+<L149>:
+               	movq	%rax, %rbx
+               	jmp	 <L152>
+<L150>:
+               	movq	%r12, %rdi
+               	movq	$-0x1, %rsi
+               	callq	 <L151>
+<L151>:
+               	movq	%rax, %rbx
+<L152>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xea2>
+               	mulsd	-0x30(%rbp), %xmm0
                	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
-               	subsd	%xmm5, %xmm2
-               	ucomisd	%xmm2, %xmm2
+               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xeb3>
+               	ucomisd	%xmm2, %xmm0
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L153>
+               	jmp	 <L154>
+<L153>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+<L154>:
+               	testb	%al, %al
+               	jne	 <L165>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L155>
+               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
+               	jmp	 <L156>
+<L155>:
+               	xorps	%xmm2, %xmm2
+               	subsd	%xmm0, %xmm2
+<L156>:
+               	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xf25>
+               	movsd	, %xmm5 <L157>
+<L157>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L164>
+               	movsd	%xmm2, %xmm6            ## xmm6 = xmm2[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L158>:
+               	ucomisd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xf50>
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L161>
+               	testb	%al, %al
+               	jne	 <L159>
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L160>
+<L159>:
+               	xorps	%xmm8, %xmm8
+               	subsd	%xmm6, %xmm8
+<L160>:
+               	jmp	 <L166>
+<L161>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L162>
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L163>
+<L162>:
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	subsd	%xmm7, %xmm9
+<L163>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xfae>
+               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L158>
+<L164>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xfc0>
+               	jmp	 <L157>
+<L165>:
+               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xfd1>
+               	cvttsd2si	%xmm2, %r11
+               	movq	%r11, %rax
+               	movq	%rax, %r11
+               	cvtsi2sd	%r11, %xmm2
+               	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xfed>
+               	movsd	%xmm0, %xmm8            ## xmm8 = xmm0[0],xmm8[1]
+               	subsd	%xmm4, %xmm8
+<L166>:
+               	ucomisd	%xmm8, %xmm8
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
                	jne	 <L168>
-               	movq	%r12, %rdi
-               	movsd	%xmm2, %xmm0            ## xmm0 = xmm2[0],xmm0[1]
+               	movq	%rbx, %rdi
+               	movsd	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1]
                	callq	 <L167>
 <L167>:
-               	movq	%rax, %rbx
+               	movq	%rax, %r12
                	jmp	 <L170>
 <L168>:
-               	movq	%r12, %rdi
+               	movq	%rbx, %rdi
                	movq	$-0x1, %rsi
                	callq	 <L169>
 <L169>:
-               	movq	%rax, %rbx
+               	movq	%rax, %r12
 <L170>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xe7d>
-               	mulsd	-0x30(%rbp), %xmm0
-               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xe8e>
-               	cvttsd2si	%xmm2, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm2
-               	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xeaa>
-               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
-               	subsd	%xmm4, %xmm2
-               	ucomisd	%xmm2, %xmm2
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L172>
-               	movq	%rbx, %rdi
-               	movsd	%xmm2, %xmm0            ## xmm0 = xmm2[0],xmm0[1]
-               	callq	 <L171>
+               	jne	 <L173>
+               	movsd	-0x30(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x106e>
+               	movsd	-0x30(%rbp), %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L171>
+               	jmp	 <L172>
 <L171>:
-               	movq	%rax, %r12
-               	jmp	 <L174>
+               	movsd	-0x30(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
 <L172>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L173>
+               	jmp	 <L174>
 <L173>:
-               	movq	%rax, %r12
+               	movq	%rax, %rcx
 <L174>:
-               	movsd	-0x30(%rbp), %xmm0
-               	divsd	-0xd0(%rbp), %xmm0
-               	cvttsd2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
-               	mulsd	-0xd0(%rbp), %xmm2
-               	movsd	-0x30(%rbp), %xmm0
-               	subsd	%xmm2, %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
+               	testb	%cl, %cl
+               	jne	 <L187>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x30(%rbp), %xmm14
+               	seta	%al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L176>
-               	movq	%r12, %rdi
-               	callq	 <L175>
+               	jne	 <L175>
+               	movsd	-0x30(%rbp), %xmm0
+               	jmp	 <L176>
 <L175>:
-               	movq	%rax, %rbx
-               	jmp	 <L178>
+               	xorps	%xmm0, %xmm0
+               	subsd	-0x30(%rbp), %xmm0
 <L176>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L177>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L177>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L178>
 <L177>:
-               	movq	%rax, %rbx
+               	xorps	%xmm2, %xmm2
+               	subsd	-0x100(%rbp), %xmm2
 <L178>:
-               	movsd	-0xd0(%rbp), %xmm0
-               	divsd	-0xd0(%rbp), %xmm0
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x112c>
+               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
+<L179>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L186>
+               	movsd	%xmm0, %xmm6            ## xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L180>:
+               	ucomisd	%xmm2, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L183>
+               	testb	%al, %al
+               	jne	 <L181>
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L182>
+<L181>:
+               	xorps	%xmm8, %xmm8
+               	subsd	%xmm6, %xmm8
+<L182>:
+               	jmp	 <L188>
+<L183>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L184>
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L185>
+<L184>:
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	subsd	%xmm7, %xmm9
+<L185>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x11ad>
+               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L180>
+<L186>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x11bf>
+               	jmp	 <L179>
+<L187>:
+               	movsd	-0x30(%rbp), %xmm0
+               	divsd	-0x100(%rbp), %xmm0
                	cvttsd2si	%xmm0, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2sd	%r11, %xmm0
                	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
-               	mulsd	-0xd0(%rbp), %xmm2
-               	movsd	-0xd0(%rbp), %xmm0
-               	subsd	%xmm2, %xmm0
-               	ucomisd	%xmm0, %xmm0
+               	mulsd	-0x100(%rbp), %xmm2
+               	movsd	-0x30(%rbp), %xmm8
+               	subsd	%xmm2, %xmm8
+<L188>:
+               	ucomisd	%xmm8, %xmm8
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L180>
+               	jne	 <L190>
+               	movq	%r12, %rdi
+               	movsd	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1]
+               	callq	 <L189>
+<L189>:
+               	movq	%rax, %rbx
+               	jmp	 <L192>
+<L190>:
+               	movq	%r12, %rdi
+               	movq	$-0x1, %rsi
+               	callq	 <L191>
+<L191>:
+               	movq	%rax, %rbx
+<L192>:
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L195>
+               	movsd	-0x100(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1272>
+               	movsd	-0x100(%rbp), %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L193>
+               	jmp	 <L194>
+<L193>:
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L194>:
+               	jmp	 <L196>
+<L195>:
+               	movq	%rax, %rcx
+<L196>:
+               	testb	%cl, %cl
+               	jne	 <L209>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L197>
+               	movsd	-0x100(%rbp), %xmm0
+               	jmp	 <L198>
+<L197>:
+               	xorps	%xmm0, %xmm0
+               	subsd	-0x100(%rbp), %xmm0
+<L198>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L199>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L200>
+<L199>:
+               	xorps	%xmm2, %xmm2
+               	subsd	-0x100(%rbp), %xmm2
+<L200>:
+               	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x133f>
+               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
+<L201>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L208>
+               	movsd	%xmm0, %xmm6            ## xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L202>:
+               	ucomisd	%xmm2, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L205>
+               	testb	%al, %al
+               	jne	 <L203>
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L204>
+<L203>:
+               	xorps	%xmm8, %xmm8
+               	subsd	%xmm6, %xmm8
+<L204>:
+               	jmp	 <L210>
+<L205>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L206>
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L207>
+<L206>:
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	subsd	%xmm7, %xmm9
+<L207>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x13c0>
+               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L202>
+<L208>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x13d2>
+               	jmp	 <L201>
+<L209>:
+               	movsd	-0x100(%rbp), %xmm0
+               	divsd	-0x100(%rbp), %xmm0
+               	cvttsd2si	%xmm0, %r11
+               	movq	%r11, %rax
+               	movq	%rax, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
+               	mulsd	-0x100(%rbp), %xmm2
+               	movsd	-0x100(%rbp), %xmm8
+               	subsd	%xmm2, %xmm8
+<L210>:
+               	ucomisd	%xmm8, %xmm8
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L212>
                	movq	%rbx, %rdi
-               	callq	 <L179>
-<L179>:
+               	movsd	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1]
+               	callq	 <L211>
+<L211>:
                	movq	%rax, %r12
-               	jmp	 <L182>
-<L180>:
+               	jmp	 <L214>
+<L212>:
                	movq	%rbx, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L181>
-<L181>:
+               	callq	 <L213>
+<L213>:
                	movq	%rax, %r12
-<L182>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xfdc>
+<L214>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x145b>
                	mulsd	-0x30(%rbp), %xmm0
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L217>
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	divsd	-0xd0(%rbp), %xmm1
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x1494>
+               	ucomisd	%xmm1, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L215>
+               	jmp	 <L216>
+<L215>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L216>:
+               	jmp	 <L218>
+<L217>:
+               	movq	%rax, %rcx
+<L218>:
+               	testb	%cl, %cl
+               	jne	 <L231>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L219>
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L220>
+<L219>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm0, %xmm1
+<L220>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L221>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L222>
+<L221>:
+               	xorps	%xmm2, %xmm2
+               	subsd	-0x100(%rbp), %xmm2
+<L222>:
+               	movsd	%xmm1, %xmm4            ## xmm4 = xmm1[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1542>
+               	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
+<L223>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L230>
+               	movsd	%xmm1, %xmm6            ## xmm6 = xmm1[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
+<L224>:
+               	ucomisd	%xmm2, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L227>
+               	testb	%al, %al
+               	jne	 <L225>
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L226>
+<L225>:
+               	xorps	%xmm8, %xmm8
+               	subsd	%xmm6, %xmm8
+<L226>:
+               	jmp	 <L232>
+<L227>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L228>
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L229>
+<L228>:
+               	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
+               	subsd	%xmm7, %xmm9
+<L229>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x15c3>
+               	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L224>
+<L230>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x15d5>
+               	jmp	 <L223>
+<L231>:
+               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
+               	divsd	-0x100(%rbp), %xmm1
                	cvttsd2si	%xmm1, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2sd	%r11, %xmm1
                	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
-               	mulsd	-0xd0(%rbp), %xmm2
-               	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	subsd	%xmm2, %xmm1
-               	ucomisd	%xmm1, %xmm1
+               	mulsd	-0x100(%rbp), %xmm2
+               	movsd	%xmm0, %xmm8            ## xmm8 = xmm0[0],xmm8[1]
+               	subsd	%xmm2, %xmm8
+<L232>:
+               	ucomisd	%xmm8, %xmm8
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L184>
+               	jne	 <L234>
                	movq	%r12, %rdi
-               	movsd	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1]
-               	callq	 <L183>
-<L183>:
+               	movsd	%xmm8, %xmm0            ## xmm0 = xmm8[0],xmm0[1]
+               	callq	 <L233>
+<L233>:
                	movq	%rax, %rbx
-               	jmp	 <L186>
-<L184>:
+               	jmp	 <L236>
+<L234>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L185>
-<L185>:
+               	callq	 <L235>
+<L235>:
                	movq	%rax, %rbx
-<L186>:
+<L236>:
                	movq	%rbx, %rax
-               	movq	-0xd8(%rbp), %rbx
-               	movq	-0xe0(%rbp), %r12
-               	movq	-0xe8(%rbp), %r13
-               	movq	-0xf0(%rbp), %r14
+               	movq	-0x108(%rbp), %rbx
+               	movq	-0x110(%rbp), %r12
+               	movq	-0x118(%rbp), %r13
+               	movq	-0x120(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/float/arith_f64.dis
+++ b/test/golden/x86_64-darwin/float/arith_f64.dis
@@ -515,8 +515,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
                	jmp	 <L76>
 <L75>:
-               	xorps	%xmm9, %xmm9
-               	subsd	%xmm7, %xmm9
+               	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
+               	xorps	, %xmm9 <L76>
 <L76>:
                	jmp	 <L82>
 <L77>:
@@ -531,11 +531,11 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm7, %xmm10           ## xmm10 = xmm7[0],xmm10[1]
                	subsd	%xmm8, %xmm10
 <L79>:
-               	divsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x811>
+               	divsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x815>
                	movsd	%xmm10, %xmm7           ## xmm7 = xmm10[0],xmm7[1]
                	jmp	 <L74>
 <L80>:
-               	mulsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x823>
+               	mulsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x827>
                	jmp	 <L73>
 <L81>:
                	movsd	-0xf0(%rbp), %xmm0
@@ -581,7 +581,7 @@ Disassembly of section __TEXT,__text:
                	testb	%al, %al
                	jne	 <L89>
                	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8e3>
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8e7>
                	ucomisd	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -629,7 +629,7 @@ Disassembly of section __TEXT,__text:
                	subsd	-0x100(%rbp), %xmm5
 <L94>:
                	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x991>
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x995>
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
 <L95>:
                	ucomisd	%xmm7, %xmm6
@@ -650,8 +650,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
                	jmp	 <L98>
 <L97>:
-               	xorps	%xmm10, %xmm10
-               	subsd	%xmm8, %xmm10
+               	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
+               	xorps	, %xmm10 <L98>
 <L98>:
                	jmp	 <L104>
 <L99>:
@@ -666,11 +666,11 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
                	subsd	%xmm9, %xmm11
 <L101>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xa17>
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xa1f>
                	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
                	jmp	 <L96>
 <L102>:
-               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xa29>
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xa31>
                	jmp	 <L95>
 <L103>:
                	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
@@ -715,7 +715,7 @@ Disassembly of section __TEXT,__text:
                	testb	%al, %al
                	jne	 <L111>
                	movsd	-0xf0(%rbp), %xmm4
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xadc>
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xae4>
                	movsd	-0xf0(%rbp), %xmm14
                	ucomisd	%xmm4, %xmm14
                	sete	%cl
@@ -765,7 +765,7 @@ Disassembly of section __TEXT,__text:
                	subsd	%xmm0, %xmm5
 <L116>:
                	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xb9d>
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xba5>
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
 <L117>:
                	ucomisd	%xmm7, %xmm6
@@ -786,8 +786,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
                	jmp	 <L120>
 <L119>:
-               	xorps	%xmm10, %xmm10
-               	subsd	%xmm8, %xmm10
+               	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
+               	xorps	, %xmm10 <L120>
 <L120>:
                	jmp	 <L126>
 <L121>:
@@ -802,11 +802,11 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
                	subsd	%xmm9, %xmm11
 <L123>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xc23>
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xc2f>
                	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
                	jmp	 <L118>
 <L124>:
-               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xc35>
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xc41>
                	jmp	 <L117>
 <L125>:
                	movsd	-0xf0(%rbp), %xmm4
@@ -853,7 +853,7 @@ Disassembly of section __TEXT,__text:
                	testb	%al, %al
                	jne	 <L133>
                	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xcef>
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xcfb>
                	ucomisd	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -901,7 +901,7 @@ Disassembly of section __TEXT,__text:
                	subsd	%xmm2, %xmm5
 <L138>:
                	movsd	%xmm4, %xmm6            ## xmm6 = xmm4[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xd91>
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xd9d>
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
 <L139>:
                	ucomisd	%xmm7, %xmm6
@@ -922,8 +922,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
                	jmp	 <L142>
 <L141>:
-               	xorps	%xmm10, %xmm10
-               	subsd	%xmm8, %xmm10
+               	movsd	%xmm8, %xmm10           ## xmm10 = xmm8[0],xmm10[1]
+               	xorps	, %xmm10 <L142>
 <L142>:
                	jmp	 <L148>
 <L143>:
@@ -938,11 +938,11 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm8, %xmm11           ## xmm11 = xmm8[0],xmm11[1]
                	subsd	%xmm9, %xmm11
 <L145>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xe17>
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xe27>
                	movsd	%xmm11, %xmm8           ## xmm8 = xmm11[0],xmm8[1]
                	jmp	 <L140>
 <L146>:
-               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xe29>
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xe39>
                	jmp	 <L139>
 <L147>:
                	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
@@ -976,10 +976,10 @@ Disassembly of section __TEXT,__text:
 <L151>:
                	movq	%rax, %rbx
 <L152>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xea2>
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xeb2>
                	mulsd	-0x30(%rbp), %xmm0
                	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
-               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xeb3>
+               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xec3>
                	ucomisd	%xmm2, %xmm0
                	sete	%al
                	setnp	%r11b
@@ -1011,7 +1011,7 @@ Disassembly of section __TEXT,__text:
                	subsd	%xmm0, %xmm2
 <L156>:
                	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xf25>
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xf35>
                	movsd	, %xmm5 <L157>
 <L157>:
                	ucomisd	%xmm5, %xmm4
@@ -1022,7 +1022,7 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm2, %xmm6            ## xmm6 = xmm2[0],xmm6[1]
                	movsd	%xmm5, %xmm7            ## xmm7 = xmm5[0],xmm7[1]
 <L158>:
-               	ucomisd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xf50>
+               	ucomisd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xf60>
                	setae	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
@@ -1032,8 +1032,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
                	jmp	 <L160>
 <L159>:
-               	xorps	%xmm8, %xmm8
-               	subsd	%xmm6, %xmm8
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	xorps	, %xmm8 <L160>
 <L160>:
                	jmp	 <L166>
 <L161>:
@@ -1048,21 +1048,21 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
                	subsd	%xmm7, %xmm9
 <L163>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xfae>
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xfc2>
                	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
                	jmp	 <L158>
 <L164>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xfc0>
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xfd4>
                	jmp	 <L157>
 <L165>:
                	movsd	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xfd1>
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xfe5>
                	cvttsd2si	%xmm2, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2sd	%r11, %xmm2
                	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xfed>
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1001>
                	movsd	%xmm0, %xmm8            ## xmm8 = xmm0[0],xmm8[1]
                	subsd	%xmm4, %xmm8
 <L166>:
@@ -1096,7 +1096,7 @@ Disassembly of section __TEXT,__text:
                	testb	%al, %al
                	jne	 <L173>
                	movsd	-0x30(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x106e>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1082>
                	movsd	-0x30(%rbp), %xmm14
                	ucomisd	%xmm0, %xmm14
                	sete	%cl
@@ -1146,7 +1146,7 @@ Disassembly of section __TEXT,__text:
                	subsd	-0x100(%rbp), %xmm2
 <L178>:
                	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x112c>
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1140>
                	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
 <L179>:
                	ucomisd	%xmm5, %xmm4
@@ -1167,8 +1167,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
                	jmp	 <L182>
 <L181>:
-               	xorps	%xmm8, %xmm8
-               	subsd	%xmm6, %xmm8
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	xorps	, %xmm8 <L182>
 <L182>:
                	jmp	 <L188>
 <L183>:
@@ -1183,11 +1183,11 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
                	subsd	%xmm7, %xmm9
 <L185>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x11ad>
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x11c5>
                	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
                	jmp	 <L180>
 <L186>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x11bf>
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x11d7>
                	jmp	 <L179>
 <L187>:
                	movsd	-0x30(%rbp), %xmm0
@@ -1231,7 +1231,7 @@ Disassembly of section __TEXT,__text:
                	testb	%al, %al
                	jne	 <L195>
                	movsd	-0x100(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1272>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x128a>
                	movsd	-0x100(%rbp), %xmm14
                	ucomisd	%xmm0, %xmm14
                	sete	%cl
@@ -1281,7 +1281,7 @@ Disassembly of section __TEXT,__text:
                	subsd	-0x100(%rbp), %xmm2
 <L200>:
                	movsd	%xmm0, %xmm4            ## xmm4 = xmm0[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x133f>
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1357>
                	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
 <L201>:
                	ucomisd	%xmm5, %xmm4
@@ -1302,8 +1302,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
                	jmp	 <L204>
 <L203>:
-               	xorps	%xmm8, %xmm8
-               	subsd	%xmm6, %xmm8
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	xorps	, %xmm8 <L204>
 <L204>:
                	jmp	 <L210>
 <L205>:
@@ -1318,11 +1318,11 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
                	subsd	%xmm7, %xmm9
 <L207>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x13c0>
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x13dc>
                	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
                	jmp	 <L202>
 <L208>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x13d2>
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x13ee>
                	jmp	 <L201>
 <L209>:
                	movsd	-0x100(%rbp), %xmm0
@@ -1356,7 +1356,7 @@ Disassembly of section __TEXT,__text:
 <L213>:
                	movq	%rax, %r12
 <L214>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x145b>
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1477>
                	mulsd	-0x30(%rbp), %xmm0
                	movsd	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
@@ -1368,7 +1368,7 @@ Disassembly of section __TEXT,__text:
                	testb	%al, %al
                	jne	 <L217>
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x1494>
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x14b0>
                	ucomisd	%xmm1, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -1416,7 +1416,7 @@ Disassembly of section __TEXT,__text:
                	subsd	-0x100(%rbp), %xmm2
 <L222>:
                	movsd	%xmm1, %xmm4            ## xmm4 = xmm1[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1542>
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x155e>
                	movsd	%xmm2, %xmm5            ## xmm5 = xmm2[0],xmm5[1]
 <L223>:
                	ucomisd	%xmm5, %xmm4
@@ -1437,8 +1437,8 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
                	jmp	 <L226>
 <L225>:
-               	xorps	%xmm8, %xmm8
-               	subsd	%xmm6, %xmm8
+               	movsd	%xmm6, %xmm8            ## xmm8 = xmm6[0],xmm8[1]
+               	xorps	, %xmm8 <L226>
 <L226>:
                	jmp	 <L232>
 <L227>:
@@ -1453,11 +1453,11 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm6, %xmm9            ## xmm9 = xmm6[0],xmm9[1]
                	subsd	%xmm7, %xmm9
 <L229>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x15c3>
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x15e3>
                	movsd	%xmm9, %xmm6            ## xmm6 = xmm9[0],xmm6[1]
                	jmp	 <L224>
 <L230>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x15d5>
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x15f5>
                	jmp	 <L223>
 <L231>:
                	movsd	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1]

--- a/test/golden/x86_64-linux/float/arith_f32.dis
+++ b/test/golden/x86_64-linux/float/arith_f32.dis
@@ -516,8 +516,8 @@ Disassembly of section .text:
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
                	jmp	 <L76>
 <L75>:
-               	xorps	%xmm9, %xmm9
-               	subss	%xmm7, %xmm9
+               	movss	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1,2,3]
+               	xorps	, %xmm9 <L76>
 <L76>:
                	jmp	 <L82>
 <L77>:
@@ -532,11 +532,11 @@ Disassembly of section .text:
                	movss	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1,2,3]
                	subss	%xmm8, %xmm10
 <L79>:
-               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x7de>
+               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x7e2>
                	movsd	%xmm10, %xmm7           # xmm7 = xmm10[0],xmm7[1]
                	jmp	 <L74>
 <L80>:
-               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x7f0>
+               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x7f4>
                	jmp	 <L73>
 <L81>:
                	movss	-0xf0(%rbp), %xmm0
@@ -582,7 +582,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L89>
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x8ac>
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x8b0>
                	ucomiss	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -630,7 +630,7 @@ Disassembly of section .text:
                	subss	-0x100(%rbp), %xmm5
 <L94>:
                	movss	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x956>
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x95a>
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
 <L95>:
                	ucomiss	%xmm7, %xmm6
@@ -651,8 +651,8 @@ Disassembly of section .text:
                	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
                	jmp	 <L98>
 <L97>:
-               	xorps	%xmm10, %xmm10
-               	subss	%xmm8, %xmm10
+               	movss	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1,2,3]
+               	xorps	, %xmm10 <L98>
 <L98>:
                	jmp	 <L104>
 <L99>:
@@ -667,11 +667,11 @@ Disassembly of section .text:
                	movss	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
 <L101>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x9d9>
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x9e1>
                	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
                	jmp	 <L96>
 <L102>:
-               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x9eb>
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x9f3>
                	jmp	 <L95>
 <L103>:
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
@@ -716,7 +716,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L111>
                	movss	-0xf0(%rbp), %xmm4
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xa9a>
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xaa2>
                	movss	-0xf0(%rbp), %xmm14
                	ucomiss	%xmm4, %xmm14
                	sete	%cl
@@ -766,7 +766,7 @@ Disassembly of section .text:
                	subss	%xmm0, %xmm5
 <L116>:
                	movss	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xb57>
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xb5f>
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
 <L117>:
                	ucomiss	%xmm7, %xmm6
@@ -787,8 +787,8 @@ Disassembly of section .text:
                	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
                	jmp	 <L120>
 <L119>:
-               	xorps	%xmm10, %xmm10
-               	subss	%xmm8, %xmm10
+               	movss	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1,2,3]
+               	xorps	, %xmm10 <L120>
 <L120>:
                	jmp	 <L126>
 <L121>:
@@ -803,11 +803,11 @@ Disassembly of section .text:
                	movss	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
 <L123>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xbda>
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xbe6>
                	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
                	jmp	 <L118>
 <L124>:
-               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xbec>
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xbf8>
                	jmp	 <L117>
 <L125>:
                	movss	-0xf0(%rbp), %xmm4
@@ -854,7 +854,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L133>
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xca2>
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xcae>
                	ucomiss	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -902,7 +902,7 @@ Disassembly of section .text:
                	subss	%xmm2, %xmm5
 <L138>:
                	movss	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xd40>
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xd4c>
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
 <L139>:
                	ucomiss	%xmm7, %xmm6
@@ -923,8 +923,8 @@ Disassembly of section .text:
                	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
                	jmp	 <L142>
 <L141>:
-               	xorps	%xmm10, %xmm10
-               	subss	%xmm8, %xmm10
+               	movss	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1,2,3]
+               	xorps	, %xmm10 <L142>
 <L142>:
                	jmp	 <L148>
 <L143>:
@@ -939,11 +939,11 @@ Disassembly of section .text:
                	movss	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
 <L145>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xdc3>
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xdd3>
                	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
                	jmp	 <L140>
 <L146>:
-               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xdd5>
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xde5>
                	jmp	 <L139>
 <L147>:
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
@@ -977,9 +977,9 @@ Disassembly of section .text:
 <L151>:
                	movq	%rax, %rbx
 <L152>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xe4b>
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xe5b>
                	mulss	-0x30(%rbp), %xmm0
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xe59>
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xe69>
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
                	sete	%al
@@ -989,7 +989,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L155>
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xe83>
+               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xe93>
                	ucomiss	%xmm2, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -1025,19 +1025,19 @@ Disassembly of section .text:
                	subss	%xmm0, %xmm2
 <L158>:
                	xorps	%xmm14, %xmm14
-               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xefa>
+               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xf0a>
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
                	jne	 <L159>
-               	movss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xf11>
+               	movss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xf21>
                	jmp	 <L160>
 <L159>:
                	xorps	%xmm4, %xmm4
                	subss	, %xmm4 <L160>
 <L160>:
                	movss	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1,2,3]
-               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xf2d>
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xf3d>
                	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
 <L161>:
                	ucomiss	%xmm6, %xmm5
@@ -1058,8 +1058,8 @@ Disassembly of section .text:
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
                	jmp	 <L164>
 <L163>:
-               	xorps	%xmm9, %xmm9
-               	subss	%xmm7, %xmm9
+               	movss	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1,2,3]
+               	xorps	, %xmm9 <L164>
 <L164>:
                	jmp	 <L170>
 <L165>:
@@ -1074,21 +1074,21 @@ Disassembly of section .text:
                	movss	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1,2,3]
                	subss	%xmm8, %xmm10
 <L167>:
-               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0xfaf>
+               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0xfc3>
                	movsd	%xmm10, %xmm7           # xmm7 = xmm10[0],xmm7[1]
                	jmp	 <L162>
 <L168>:
-               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xfc1>
+               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xfd5>
                	jmp	 <L161>
 <L169>:
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xfd2>
+               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xfe6>
                	cvttss2si	%xmm2, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2ss	%r11, %xmm2
                	movss	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1,2,3]
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xfee>
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1002>
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
                	subss	%xmm4, %xmm9
 <L170>:
@@ -1122,7 +1122,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L177>
                	movss	-0x30(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x106b>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x107f>
                	movss	-0x30(%rbp), %xmm14
                	ucomiss	%xmm0, %xmm14
                	sete	%cl
@@ -1172,7 +1172,7 @@ Disassembly of section .text:
                	subss	-0x100(%rbp), %xmm2
 <L182>:
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1125>
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1139>
                	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
 <L183>:
                	ucomiss	%xmm5, %xmm4
@@ -1193,8 +1193,8 @@ Disassembly of section .text:
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
                	jmp	 <L186>
 <L185>:
-               	xorps	%xmm8, %xmm8
-               	subss	%xmm6, %xmm8
+               	movss	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1,2,3]
+               	xorps	, %xmm8 <L186>
 <L186>:
                	jmp	 <L192>
 <L187>:
@@ -1209,11 +1209,11 @@ Disassembly of section .text:
                	movss	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1,2,3]
                	subss	%xmm7, %xmm9
 <L189>:
-               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x11a3>
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x11bb>
                	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
                	jmp	 <L184>
 <L190>:
-               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x11b5>
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x11cd>
                	jmp	 <L183>
 <L191>:
                	movss	-0x30(%rbp), %xmm0
@@ -1257,7 +1257,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L199>
                	movss	-0x100(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1264>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x127c>
                	movss	-0x100(%rbp), %xmm14
                	ucomiss	%xmm0, %xmm14
                	sete	%cl
@@ -1307,7 +1307,7 @@ Disassembly of section .text:
                	subss	-0x100(%rbp), %xmm2
 <L204>:
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x132d>
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1345>
                	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
 <L205>:
                	ucomiss	%xmm5, %xmm4
@@ -1328,8 +1328,8 @@ Disassembly of section .text:
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
                	jmp	 <L208>
 <L207>:
-               	xorps	%xmm8, %xmm8
-               	subss	%xmm6, %xmm8
+               	movss	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1,2,3]
+               	xorps	, %xmm8 <L208>
 <L208>:
                	jmp	 <L214>
 <L209>:
@@ -1344,11 +1344,11 @@ Disassembly of section .text:
                	movss	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1,2,3]
                	subss	%xmm7, %xmm9
 <L211>:
-               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x13ab>
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x13c7>
                	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
                	jmp	 <L206>
 <L212>:
-               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x13bd>
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x13d9>
                	jmp	 <L205>
 <L213>:
                	movss	-0x100(%rbp), %xmm0
@@ -1382,7 +1382,7 @@ Disassembly of section .text:
 <L217>:
                	movq	%rax, %r12
 <L218>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1443>
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x145f>
                	mulss	-0x30(%rbp), %xmm0
                	movss	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
@@ -1394,7 +1394,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L221>
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x147b>
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x1497>
                	ucomiss	%xmm1, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -1442,7 +1442,7 @@ Disassembly of section .text:
                	subss	-0x100(%rbp), %xmm2
 <L226>:
                	movss	%xmm1, %xmm4            # xmm4 = xmm1[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1525>
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1541>
                	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
 <L227>:
                	ucomiss	%xmm5, %xmm4
@@ -1463,8 +1463,8 @@ Disassembly of section .text:
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
                	jmp	 <L230>
 <L229>:
-               	xorps	%xmm8, %xmm8
-               	subss	%xmm6, %xmm8
+               	movss	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1,2,3]
+               	xorps	, %xmm8 <L230>
 <L230>:
                	jmp	 <L236>
 <L231>:
@@ -1479,11 +1479,11 @@ Disassembly of section .text:
                	movss	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1,2,3]
                	subss	%xmm7, %xmm9
 <L233>:
-               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x15a3>
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x15c3>
                	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
                	jmp	 <L228>
 <L234>:
-               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x15b5>
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x15d5>
                	jmp	 <L227>
 <L235>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]

--- a/test/golden/x86_64-linux/float/arith_f32.dis
+++ b/test/golden/x86_64-linux/float/arith_f32.dis
@@ -40,11 +40,11 @@ Disassembly of section .text:
 <corpus.cases.float.arith_f32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xf0, %rsp
-               	movq	%rbx, -0xd8(%rbp)
-               	movq	%r12, -0xe0(%rbp)
-               	movq	%r13, -0xe8(%rbp)
-               	movq	%r14, -0xf0(%rbp)
+               	subq	$0x120, %rsp            # imm = 0x120
+               	movq	%rbx, -0x108(%rbp)
+               	movq	%r12, -0x110(%rbp)
+               	movq	%r13, -0x118(%rbp)
+               	movq	%r14, -0x120(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -145,430 +145,122 @@ Disassembly of section .text:
 <L16>:
                	movss	-0x10(%rbp), %xmm0
                	divss	-0x20(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L18>
                	movq	%r12, %rdi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rbx
-               	jmp	 <L20>
-<L18>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rbx
-<L20>:
                	movss	-0x20(%rbp), %xmm0
                	divss	-0x10(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L22>
-               	movq	%rbx, %rdi
+               	movq	%rax, %rdi
+               	callq	 <L18>
+<L18>:
+               	movss	-0x10(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1a6>
+               	movq	%rax, %rdi
+               	callq	 <L19>
+<L19>:
+               	xorps	%xmm14, %xmm14
+               	subss	-0x10(%rbp), %xmm14
+               	movss	%xmm14, -0x40(%rbp)
+               	movq	%rax, %rdi
+               	movss	-0x40(%rbp), %xmm0
+               	callq	 <L20>
+<L20>:
+               	movss	-0x10(%rbp), %xmm0
+               	subss	-0x10(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %r12
-               	jmp	 <L24>
+               	movss	-0x40(%rbp), %xmm0
+               	addss	-0x10(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L22>
 <L22>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x1f8>
+               	mulss	-0x30(%rbp), %xmm14
+               	movss	%xmm14, -0x50(%rbp)
+               	movss	-0x30(%rbp), %xmm14
+               	divss	-0x50(%rbp), %xmm14
+               	movss	%xmm14, -0x60(%rbp)
+               	movq	%rax, %rdi
+               	movss	-0x60(%rbp), %xmm0
                	callq	 <L23>
 <L23>:
-               	movq	%rax, %r12
+               	movss	-0x60(%rbp), %xmm0
+               	mulss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L24>
 <L24>:
-               	movss	-0x10(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x208>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L26>
-               	movq	%r12, %rdi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rbx
-               	jmp	 <L28>
-<L26>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rbx
-<L28>:
-               	xorps	%xmm0, %xmm0
-               	subss	-0x10(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L30>
-               	movq	%rbx, %rdi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %r12
-               	jmp	 <L32>
-<L30>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %r12
-<L32>:
-               	movss	-0x10(%rbp), %xmm0
-               	subss	-0x10(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L34>
-               	movq	%r12, %rdi
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rbx
-               	jmp	 <L36>
-<L34>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rbx
-<L36>:
-               	xorps	%xmm0, %xmm0
-               	subss	-0x10(%rbp), %xmm0
-               	movss	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1,2,3]
-               	addss	-0x10(%rbp), %xmm3
-               	ucomiss	%xmm3, %xmm3
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L38>
-               	movq	%rbx, %rdi
-               	movss	%xmm3, %xmm0            # xmm0 = xmm3[0],xmm0[1,2,3]
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %r12
-               	jmp	 <L40>
-<L38>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %r12
-<L40>:
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x31c>
-               	mulss	-0x30(%rbp), %xmm14
-               	movss	%xmm14, -0x40(%rbp)
-               	movss	-0x30(%rbp), %xmm14
-               	divss	-0x40(%rbp), %xmm14
-               	movss	%xmm14, -0x50(%rbp)
-               	movss	-0x50(%rbp), %xmm14
-               	ucomiss	-0x50(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L42>
-               	movq	%r12, %rdi
-               	movss	-0x50(%rbp), %xmm0
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rbx
-               	jmp	 <L44>
-<L42>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rbx
-<L44>:
-               	movss	-0x50(%rbp), %xmm0
-               	mulss	-0x40(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L46>
-               	movq	%rbx, %rdi
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %r12
-               	jmp	 <L48>
-<L46>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %r12
-<L48>:
                	movss	-0x30(%rbp), %xmm0
-               	subss	-0x50(%rbp), %xmm0
-               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	subss	-0x50(%rbp), %xmm4
-               	movss	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1,2,3]
-               	subss	-0x50(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L50>
-               	movq	%r12, %rdi
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rbx
-               	jmp	 <L52>
-<L50>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rbx
-<L52>:
-               	movss	-0x30(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x425>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L54>
-               	movq	%rbx, %rdi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %r12
-               	jmp	 <L56>
-<L54>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %r12
-<L56>:
-               	movss	-0x30(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x46b>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L58>
-               	movq	%r12, %rdi
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rbx
-               	jmp	 <L60>
-<L58>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rbx
-<L60>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x4ac>
-               	divss	-0x40(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L62>
-               	movq	%rbx, %rdi
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %r12
-               	jmp	 <L64>
-<L62>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %r12
-<L64>:
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x4f3>
-               	mulss	-0x30(%rbp), %xmm14
-               	movss	%xmm14, -0x60(%rbp)
-               	movss	-0x60(%rbp), %xmm0
-               	addss	-0x30(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L66>
-               	movq	%r12, %rdi
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rbx
-               	jmp	 <L68>
-<L66>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rbx
-<L68>:
-               	movss	-0x60(%rbp), %xmm0
-               	addss	-0x30(%rbp), %xmm0
-               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	addss	-0x30(%rbp), %xmm4
-               	ucomiss	%xmm4, %xmm4
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L70>
-               	movq	%rbx, %rdi
-               	movss	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1,2,3]
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %r12
-               	jmp	 <L72>
-<L70>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %r12
-<L72>:
-               	movss	-0x30(%rbp), %xmm0
-               	addss	-0x30(%rbp), %xmm0
-               	movss	-0x60(%rbp), %xmm4
-               	addss	%xmm0, %xmm4
-               	ucomiss	%xmm4, %xmm4
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L74>
-               	movq	%r12, %rdi
-               	movss	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1,2,3]
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rbx
-               	jmp	 <L76>
-<L74>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rbx
-<L76>:
-               	movss	-0x60(%rbp), %xmm0
-               	subss	-0x30(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L78>
-               	movq	%rbx, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %r12
-               	jmp	 <L80>
-<L78>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %r12
-<L80>:
-               	movss	-0x60(%rbp), %xmm0
-               	addss	-0x30(%rbp), %xmm0
+               	subss	-0x60(%rbp), %xmm0
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
                	subss	-0x60(%rbp), %xmm4
-               	ucomiss	%xmm4, %xmm4
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L82>
-               	movq	%r12, %rdi
                	movss	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1,2,3]
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rbx
-               	jmp	 <L84>
-<L82>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rbx
-<L84>:
-               	xorps	%xmm0, %xmm0
-               	mulss	-0x30(%rbp), %xmm0
-               	movsd	%xmm0, -0x80(%rbp)
-               	movl	$0x0, %r12d
-               	cmpl	$0x18, %r12d
-               	jb	 <L85>
-               	jmp	 <L90>
-<L85>:
-               	movss	-0x80(%rbp), %xmm0
-               	addss	-0x50(%rbp), %xmm0
-               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
-               	mulss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x6af>
+               	subss	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L25>
+<L25>:
+               	movss	-0x30(%rbp), %xmm0
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x266>
+               	movq	%rax, %rdi
+               	callq	 <L26>
+<L26>:
+               	movss	-0x30(%rbp), %xmm0
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x27b>
+               	movq	%rax, %rdi
+               	callq	 <L27>
+<L27>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x28b>
+               	divss	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x2a1>
+               	mulss	-0x30(%rbp), %xmm14
                	movss	%xmm14, -0x70(%rbp)
                	movss	-0x70(%rbp), %xmm14
-               	ucomiss	-0x70(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L87>
-               	movq	%rbx, %rdi
+               	addss	-0x30(%rbp), %xmm14
+               	movss	%xmm14, -0x80(%rbp)
+               	movq	%rax, %rdi
+               	movss	-0x80(%rbp), %xmm0
+               	callq	 <L29>
+<L29>:
+               	movss	-0x80(%rbp), %xmm0
+               	addss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L30>
+<L30>:
+               	movss	-0x30(%rbp), %xmm0
+               	addss	-0x30(%rbp), %xmm0
+               	movss	-0x70(%rbp), %xmm5
+               	addss	%xmm0, %xmm5
+               	movq	%rax, %rdi
+               	movss	%xmm5, %xmm0            # xmm0 = xmm5[0],xmm0[1,2,3]
+               	callq	 <L31>
+<L31>:
                	movss	-0x70(%rbp), %xmm0
-               	callq	 <L86>
-<L86>:
-               	movq	%rax, %r14
-               	jmp	 <L89>
-<L87>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L88>
-<L88>:
-               	movq	%rax, %r14
-<L89>:
-               	addl	$0x1, %r12d
-               	movq	%r14, %rbx
-               	movq	-0x70(%rbp), %r11
-               	movq	%r11, -0x80(%rbp)
+               	subss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L32>
+<L32>:
+               	movss	-0x80(%rbp), %xmm0
+               	subss	-0x70(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L33>
+<L33>:
+               	xorps	%xmm0, %xmm0
+               	mulss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rbx
+               	movsd	%xmm0, -0xa0(%rbp)
+               	movl	$0x0, %r12d
                	cmpl	$0x18, %r12d
-               	jb	 <L85>
-<L90>:
-               	movl	$0x7f7fffff, %eax       # imm = 0x7F7FFFFF
-               	addl	%r13d, %eax
-               	movl	%eax, -0x90(%rbp)
+               	jb	 <L34>
+               	jmp	 <L39>
+<L34>:
+               	movss	-0xa0(%rbp), %xmm0
+               	addss	-0x60(%rbp), %xmm0
+               	movss	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1,2,3]
+               	mulss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x364>
+               	movss	%xmm14, -0x90(%rbp)
                	movss	-0x90(%rbp), %xmm14
                	ucomiss	-0x90(%rbp), %xmm14
                	setne	%al
@@ -576,239 +268,72 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L92>
+               	jne	 <L36>
                	movq	%rbx, %rdi
                	movss	-0x90(%rbp), %xmm0
-               	callq	 <L91>
-<L91>:
-               	movq	%rax, %r12
-               	jmp	 <L94>
-<L92>:
+               	callq	 <L35>
+<L35>:
+               	movq	%rax, %r14
+               	jmp	 <L38>
+<L36>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L93>
-<L93>:
-               	movq	%rax, %r12
-<L94>:
-               	movss	-0x90(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x781>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L96>
-               	movq	%r12, %rdi
-               	callq	 <L95>
-<L95>:
-               	movq	%rax, %rbx
-               	jmp	 <L98>
-<L96>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L97>
-<L97>:
-               	movq	%rax, %rbx
-<L98>:
-               	movss	-0x90(%rbp), %xmm0
-               	addss	-0x90(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L100>
-               	movq	%rbx, %rdi
-               	callq	 <L99>
-<L99>:
-               	movq	%rax, %r12
-               	jmp	 <L102>
-<L100>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L101>
-<L101>:
-               	movq	%rax, %r12
-<L102>:
-               	movss	-0x90(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x813>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L104>
-               	movq	%r12, %rdi
-               	callq	 <L103>
-<L103>:
-               	movq	%rax, %rbx
-               	jmp	 <L106>
-<L104>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %rbx
-<L106>:
-               	movss	-0x90(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x85c>
-               	xorps	%xmm3, %xmm3
-               	subss	%xmm0, %xmm3
-               	ucomiss	%xmm3, %xmm3
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L108>
-               	movq	%rbx, %rdi
-               	movss	%xmm3, %xmm0            # xmm0 = xmm3[0],xmm0[1,2,3]
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %r12
-               	jmp	 <L110>
-<L108>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L109>
-<L109>:
-               	movq	%rax, %r12
-<L110>:
-               	movss	-0x90(%rbp), %xmm0
-               	mulss	-0x90(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L112>
-               	movq	%r12, %rdi
-               	callq	 <L111>
-<L111>:
-               	movq	%rax, %rbx
-               	jmp	 <L114>
-<L112>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L113>
-<L113>:
-               	movq	%rax, %rbx
-<L114>:
-               	movss	-0x90(%rbp), %xmm0
-               	subss	-0x90(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L116>
-               	movq	%rbx, %rdi
-               	callq	 <L115>
-<L115>:
-               	movq	%rax, %r12
-               	jmp	 <L118>
-<L116>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L117>
-<L117>:
-               	movq	%rax, %r12
-<L118>:
-               	movl	$0x800000, %eax         # imm = 0x800000
-               	addl	%r13d, %eax
-               	movl	%eax, -0xa0(%rbp)
-               	movl	$0x1, %eax
+               	callq	 <L37>
+<L37>:
+               	movq	%rax, %r14
+<L38>:
+               	addl	$0x1, %r12d
+               	movq	%r14, %rbx
+               	movq	-0x90(%rbp), %r11
+               	movq	%r11, -0xa0(%rbp)
+               	cmpl	$0x18, %r12d
+               	jb	 <L34>
+<L39>:
+               	movl	$0x7f7fffff, %eax       # imm = 0x7F7FFFFF
                	addl	%r13d, %eax
                	movl	%eax, -0xb0(%rbp)
-               	movss	-0xa0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x95e>
+               	movss	-0xb0(%rbp), %xmm14
+               	ucomiss	-0xb0(%rbp), %xmm14
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L41>
+               	movq	%rbx, %rdi
+               	movss	-0xb0(%rbp), %xmm0
+               	callq	 <L40>
+<L40>:
+               	movq	%rax, %r12
+               	jmp	 <L43>
+<L41>:
+               	movq	%rbx, %rdi
+               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
+               	callq	 <L42>
+<L42>:
+               	movq	%rax, %r12
+<L43>:
+               	movss	-0xb0(%rbp), %xmm0
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x448>
                	ucomiss	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L120>
+               	jne	 <L45>
                	movq	%r12, %rdi
-               	callq	 <L119>
-<L119>:
+               	callq	 <L44>
+<L44>:
                	movq	%rax, %rbx
-               	jmp	 <L122>
-<L120>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L121>
-<L121>:
-               	movq	%rax, %rbx
-<L122>:
-               	movss	-0xa0(%rbp), %xmm0
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x9a7>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L124>
-               	movq	%rbx, %rdi
-               	callq	 <L123>
-<L123>:
-               	movq	%rax, %r12
-               	jmp	 <L126>
-<L124>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L125>
-<L125>:
-               	movq	%rax, %r12
-<L126>:
-               	movss	-0xa0(%rbp), %xmm0
-               	subss	-0xb0(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L128>
-               	movq	%r12, %rdi
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %rbx
-               	jmp	 <L130>
-<L128>:
+               	jmp	 <L47>
+<L45>:
                	movq	%r12, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L129>
-<L129>:
+               	callq	 <L46>
+<L46>:
                	movq	%rax, %rbx
-<L130>:
-               	movss	-0xa0(%rbp), %xmm0
-               	mulss	-0x30(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L132>
-               	movq	%rbx, %rdi
-               	callq	 <L131>
-<L131>:
-               	movq	%rax, %r12
-               	jmp	 <L134>
-<L132>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L133>
-<L133>:
-               	movq	%rax, %r12
-<L134>:
+<L47>:
                	movss	-0xb0(%rbp), %xmm0
                	addss	-0xb0(%rbp), %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -817,173 +342,475 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L136>
-               	movq	%r12, %rdi
-               	callq	 <L135>
-<L135>:
-               	movq	%rax, %rbx
-               	jmp	 <L138>
-<L136>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L137>
-<L137>:
-               	movq	%rax, %rbx
-<L138>:
-               	movss	-0xb0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xac8>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L140>
+               	jne	 <L49>
                	movq	%rbx, %rdi
-               	callq	 <L139>
-<L139>:
+               	callq	 <L48>
+<L48>:
                	movq	%rax, %r12
-               	jmp	 <L142>
-<L140>:
+               	jmp	 <L51>
+<L49>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L141>
-<L141>:
+               	callq	 <L50>
+<L50>:
                	movq	%rax, %r12
-<L142>:
-               	movss	-0xb0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xb11>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L144>
-               	movq	%r12, %rdi
-               	callq	 <L143>
-<L143>:
-               	movq	%rax, %rbx
-               	jmp	 <L146>
-<L144>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L145>
-<L145>:
-               	movq	%rax, %rbx
-<L146>:
-               	movss	-0xb0(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xb5a>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L148>
-               	movq	%rbx, %rdi
-               	callq	 <L147>
-<L147>:
-               	movq	%rax, %r12
-               	jmp	 <L150>
-<L148>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %r12
-<L150>:
-               	movss	-0xb0(%rbp), %xmm0
-               	divss	-0xa0(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L152>
-               	movq	%r12, %rdi
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-               	jmp	 <L154>
-<L152>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L153>
-<L153>:
-               	movq	%rax, %rbx
-<L154>:
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xbe5>
-               	mulss	-0x30(%rbp), %xmm14
+<L51>:
+               	movss	-0xb0(%rbp), %xmm14
+               	mulss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x4dc>
                	movss	%xmm14, -0xc0(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xbfd>
-               	mulss	-0x30(%rbp), %xmm14
-               	movss	%xmm14, -0xd0(%rbp)
+               	movq	%r12, %rdi
                	movss	-0xc0(%rbp), %xmm0
+               	callq	 <L52>
+<L52>:
+               	xorps	%xmm0, %xmm0
+               	subss	-0xc0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L53>
+<L53>:
+               	movss	-0xb0(%rbp), %xmm0
+               	mulss	-0xb0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L54>
+<L54>:
+               	movss	-0xb0(%rbp), %xmm0
+               	subss	-0xb0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L55>
+<L55>:
+               	movl	$0x800000, %ecx         # imm = 0x800000
+               	addl	%r13d, %ecx
+               	movl	%ecx, -0xd0(%rbp)
+               	movl	$0x1, %ecx
+               	addl	%r13d, %ecx
+               	movl	%ecx, -0xe0(%rbp)
+               	movss	-0xd0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x564>
+               	movq	%rax, %rdi
+               	callq	 <L56>
+<L56>:
+               	movss	-0xd0(%rbp), %xmm0
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x57c>
+               	movq	%rax, %rdi
+               	callq	 <L57>
+<L57>:
+               	movss	-0xd0(%rbp), %xmm0
+               	subss	-0xe0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L58>
+<L58>:
+               	movss	-0xd0(%rbp), %xmm0
+               	mulss	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L59>
+<L59>:
+               	movss	-0xe0(%rbp), %xmm0
+               	addss	-0xe0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L60>
+<L60>:
+               	movss	-0xe0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x5d9>
+               	movq	%rax, %rdi
+               	callq	 <L61>
+<L61>:
+               	movss	-0xe0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x5f1>
+               	movq	%rax, %rdi
+               	callq	 <L62>
+<L62>:
+               	movss	-0xe0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x609>
+               	movq	%rax, %rdi
+               	callq	 <L63>
+<L63>:
+               	movss	-0xe0(%rbp), %xmm0
                	divss	-0xd0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L64>
+<L64>:
+               	movq	%rax, %rbx
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x635>
+               	mulss	-0x30(%rbp), %xmm14
+               	movss	%xmm14, -0xf0(%rbp)
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0x64d>
+               	mulss	-0x30(%rbp), %xmm14
+               	movss	%xmm14, -0x100(%rbp)
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L67>
+               	movss	-0xf0(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x693>
+               	movss	-0xf0(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L65>
+               	jmp	 <L66>
+<L65>:
+               	movss	-0xf0(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L66>:
+               	jmp	 <L68>
+<L67>:
+               	movq	%rax, %rcx
+<L68>:
+               	testb	%cl, %cl
+               	jne	 <L81>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0xf0(%rbp), %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L69>
+               	movsd	-0xf0(%rbp), %xmm0
+               	jmp	 <L70>
+<L69>:
+               	xorps	%xmm0, %xmm0
+               	subss	-0xf0(%rbp), %xmm0
+<L70>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L71>
+               	movsd	-0x100(%rbp), %xmm4
+               	jmp	 <L72>
+<L71>:
+               	xorps	%xmm4, %xmm4
+               	subss	-0x100(%rbp), %xmm4
+<L72>:
+               	movss	%xmm0, %xmm5            # xmm5 = xmm0[0],xmm5[1,2,3]
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x75c>
+               	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
+<L73>:
+               	ucomiss	%xmm6, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L80>
+               	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+<L74>:
+               	ucomiss	%xmm4, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L77>
+               	testb	%al, %al
+               	jne	 <L75>
+               	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
+               	jmp	 <L76>
+<L75>:
+               	xorps	%xmm9, %xmm9
+               	subss	%xmm7, %xmm9
+<L76>:
+               	jmp	 <L82>
+<L77>:
+               	ucomiss	%xmm8, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L78>
+               	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
+               	jmp	 <L79>
+<L78>:
+               	movss	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1,2,3]
+               	subss	%xmm8, %xmm10
+<L79>:
+               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x7de>
+               	movsd	%xmm10, %xmm7           # xmm7 = xmm10[0],xmm7[1]
+               	jmp	 <L74>
+<L80>:
+               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x7f0>
+               	jmp	 <L73>
+<L81>:
+               	movss	-0xf0(%rbp), %xmm0
+               	divss	-0x100(%rbp), %xmm0
                	cvttss2si	%xmm0, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2ss	%r11, %xmm0
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	mulss	-0xd0(%rbp), %xmm4
-               	movss	-0xc0(%rbp), %xmm0
-               	subss	%xmm4, %xmm0
-               	ucomiss	%xmm0, %xmm0
+               	mulss	-0x100(%rbp), %xmm4
+               	movss	-0xf0(%rbp), %xmm9
+               	subss	%xmm4, %xmm9
+<L82>:
+               	ucomiss	%xmm9, %xmm9
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L156>
+               	jne	 <L84>
                	movq	%rbx, %rdi
-               	callq	 <L155>
-<L155>:
+               	movss	%xmm9, %xmm0            # xmm0 = xmm9[0],xmm0[1,2,3]
+               	callq	 <L83>
+<L83>:
                	movq	%rax, %r12
-               	jmp	 <L158>
-<L156>:
+               	jmp	 <L86>
+<L84>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L157>
-<L157>:
+               	callq	 <L85>
+<L85>:
                	movq	%rax, %r12
-<L158>:
+<L86>:
                	xorps	%xmm0, %xmm0
-               	subss	-0xc0(%rbp), %xmm0
+               	subss	-0xf0(%rbp), %xmm0
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L89>
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	divss	-0xd0(%rbp), %xmm4
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x8ac>
+               	ucomiss	%xmm4, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L87>
+               	jmp	 <L88>
+<L87>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L88>:
+               	jmp	 <L90>
+<L89>:
+               	movq	%rax, %rcx
+<L90>:
+               	testb	%cl, %cl
+               	jne	 <L103>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L91>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L92>
+<L91>:
+               	xorps	%xmm4, %xmm4
+               	subss	%xmm0, %xmm4
+<L92>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L93>
+               	movsd	-0x100(%rbp), %xmm5
+               	jmp	 <L94>
+<L93>:
+               	xorps	%xmm5, %xmm5
+               	subss	-0x100(%rbp), %xmm5
+<L94>:
+               	movss	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1,2,3]
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x956>
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L95>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L102>
+               	movsd	%xmm4, %xmm8            # xmm8 = xmm4[0],xmm8[1]
+               	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
+<L96>:
+               	ucomiss	%xmm5, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L99>
+               	testb	%al, %al
+               	jne	 <L97>
+               	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
+               	jmp	 <L98>
+<L97>:
+               	xorps	%xmm10, %xmm10
+               	subss	%xmm8, %xmm10
+<L98>:
+               	jmp	 <L104>
+<L99>:
+               	ucomiss	%xmm9, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L100>
+               	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
+               	jmp	 <L101>
+<L100>:
+               	movss	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1,2,3]
+               	subss	%xmm9, %xmm11
+<L101>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x9d9>
+               	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
+               	jmp	 <L96>
+<L102>:
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x9eb>
+               	jmp	 <L95>
+<L103>:
+               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
+               	divss	-0x100(%rbp), %xmm4
                	cvttss2si	%xmm4, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2ss	%r11, %xmm4
                	movss	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1,2,3]
-               	mulss	-0xd0(%rbp), %xmm5
-               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
-               	subss	%xmm5, %xmm4
-               	ucomiss	%xmm4, %xmm4
+               	mulss	-0x100(%rbp), %xmm5
+               	movss	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1,2,3]
+               	subss	%xmm5, %xmm10
+<L104>:
+               	ucomiss	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L160>
+               	jne	 <L106>
                	movq	%r12, %rdi
-               	movss	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1,2,3]
-               	callq	 <L159>
-<L159>:
+               	movss	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1,2,3]
+               	callq	 <L105>
+<L105>:
                	movq	%rax, %rbx
-               	jmp	 <L162>
-<L160>:
+               	jmp	 <L108>
+<L106>:
                	movq	%r12, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L161>
-<L161>:
+               	callq	 <L107>
+<L107>:
                	movq	%rax, %rbx
-<L162>:
+<L108>:
                	xorps	%xmm0, %xmm0
-               	subss	-0xd0(%rbp), %xmm0
-               	movss	-0xc0(%rbp), %xmm4
+               	subss	-0x100(%rbp), %xmm0
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L111>
+               	movss	-0xf0(%rbp), %xmm4
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xa9a>
+               	movss	-0xf0(%rbp), %xmm14
+               	ucomiss	%xmm4, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L109>
+               	jmp	 <L110>
+<L109>:
+               	movss	-0xf0(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L110>:
+               	jmp	 <L112>
+<L111>:
+               	movq	%rax, %rcx
+<L112>:
+               	testb	%cl, %cl
+               	jne	 <L125>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0xf0(%rbp), %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L113>
+               	movsd	-0xf0(%rbp), %xmm4
+               	jmp	 <L114>
+<L113>:
+               	xorps	%xmm4, %xmm4
+               	subss	-0xf0(%rbp), %xmm4
+<L114>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L115>
+               	movsd	%xmm0, %xmm5            # xmm5 = xmm0[0],xmm5[1]
+               	jmp	 <L116>
+<L115>:
+               	xorps	%xmm5, %xmm5
+               	subss	%xmm0, %xmm5
+<L116>:
+               	movss	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1,2,3]
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xb57>
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L117>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L124>
+               	movsd	%xmm4, %xmm8            # xmm8 = xmm4[0],xmm8[1]
+               	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
+<L118>:
+               	ucomiss	%xmm5, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L121>
+               	testb	%al, %al
+               	jne	 <L119>
+               	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
+               	jmp	 <L120>
+<L119>:
+               	xorps	%xmm10, %xmm10
+               	subss	%xmm8, %xmm10
+<L120>:
+               	jmp	 <L126>
+<L121>:
+               	ucomiss	%xmm9, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L122>
+               	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
+               	jmp	 <L123>
+<L122>:
+               	movss	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1,2,3]
+               	subss	%xmm9, %xmm11
+<L123>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xbda>
+               	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
+               	jmp	 <L118>
+<L124>:
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xbec>
+               	jmp	 <L117>
+<L125>:
+               	movss	-0xf0(%rbp), %xmm4
                	divss	%xmm0, %xmm4
                	cvttss2si	%xmm4, %r11
                	movq	%r11, %rax
@@ -991,31 +818,134 @@ Disassembly of section .text:
                	cvtsi2ss	%r11, %xmm4
                	movss	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1,2,3]
                	mulss	%xmm0, %xmm5
-               	movss	-0xc0(%rbp), %xmm0
-               	subss	%xmm5, %xmm0
-               	ucomiss	%xmm0, %xmm0
+               	movss	-0xf0(%rbp), %xmm10
+               	subss	%xmm5, %xmm10
+<L126>:
+               	ucomiss	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L164>
+               	jne	 <L128>
                	movq	%rbx, %rdi
-               	callq	 <L163>
-<L163>:
+               	movss	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1,2,3]
+               	callq	 <L127>
+<L127>:
                	movq	%rax, %r12
-               	jmp	 <L166>
-<L164>:
+               	jmp	 <L130>
+<L128>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L165>
-<L165>:
+               	callq	 <L129>
+<L129>:
                	movq	%rax, %r12
-<L166>:
+<L130>:
                	xorps	%xmm0, %xmm0
-               	subss	-0xc0(%rbp), %xmm0
+               	subss	-0xf0(%rbp), %xmm0
                	xorps	%xmm2, %xmm2
-               	subss	-0xd0(%rbp), %xmm2
+               	subss	-0x100(%rbp), %xmm2
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm2
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L133>
+               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xca2>
+               	ucomiss	%xmm4, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L131>
+               	jmp	 <L132>
+<L131>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L132>:
+               	jmp	 <L134>
+<L133>:
+               	movq	%rax, %rcx
+<L134>:
+               	testb	%cl, %cl
+               	jne	 <L147>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L135>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L136>
+<L135>:
+               	xorps	%xmm4, %xmm4
+               	subss	%xmm0, %xmm4
+<L136>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm2, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L137>
+               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
+               	jmp	 <L138>
+<L137>:
+               	xorps	%xmm5, %xmm5
+               	subss	%xmm2, %xmm5
+<L138>:
+               	movss	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1,2,3]
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xd40>
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L139>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L146>
+               	movsd	%xmm4, %xmm8            # xmm8 = xmm4[0],xmm8[1]
+               	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
+<L140>:
+               	ucomiss	%xmm5, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L143>
+               	testb	%al, %al
+               	jne	 <L141>
+               	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
+               	jmp	 <L142>
+<L141>:
+               	xorps	%xmm10, %xmm10
+               	subss	%xmm8, %xmm10
+<L142>:
+               	jmp	 <L148>
+<L143>:
+               	ucomiss	%xmm9, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L144>
+               	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
+               	jmp	 <L145>
+<L144>:
+               	movss	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1,2,3]
+               	subss	%xmm9, %xmm11
+<L145>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xdc3>
+               	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
+               	jmp	 <L140>
+<L146>:
+               	mulss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xdd5>
+               	jmp	 <L139>
+<L147>:
                	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
                	divss	%xmm2, %xmm4
                	cvttss2si	%xmm4, %r11
@@ -1024,41 +954,145 @@ Disassembly of section .text:
                	cvtsi2ss	%r11, %xmm4
                	movss	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1,2,3]
                	mulss	%xmm2, %xmm5
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm5, %xmm2
-               	ucomiss	%xmm2, %xmm2
+               	movss	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1,2,3]
+               	subss	%xmm5, %xmm10
+<L148>:
+               	ucomiss	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L168>
+               	jne	 <L150>
                	movq	%r12, %rdi
-               	movss	%xmm2, %xmm0            # xmm0 = xmm2[0],xmm0[1,2,3]
-               	callq	 <L167>
-<L167>:
+               	movss	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1,2,3]
+               	callq	 <L149>
+<L149>:
                	movq	%rax, %rbx
-               	jmp	 <L170>
-<L168>:
+               	jmp	 <L152>
+<L150>:
                	movq	%r12, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L169>
-<L169>:
+               	callq	 <L151>
+<L151>:
                	movq	%rax, %rbx
-<L170>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xdec>
+<L152>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xe4b>
                	mulss	-0x30(%rbp), %xmm0
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xe59>
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L155>
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xdfd>
+               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xe83>
+               	ucomiss	%xmm2, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L153>
+               	jmp	 <L154>
+<L153>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L154>:
+               	jmp	 <L156>
+<L155>:
+               	movq	%rax, %rcx
+<L156>:
+               	testb	%cl, %cl
+               	jne	 <L169>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L157>
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	jmp	 <L158>
+<L157>:
+               	xorps	%xmm2, %xmm2
+               	subss	%xmm0, %xmm2
+<L158>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xefa>
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L159>
+               	movss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xf11>
+               	jmp	 <L160>
+<L159>:
+               	xorps	%xmm4, %xmm4
+               	subss	, %xmm4 <L160>
+<L160>:
+               	movss	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1,2,3]
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xf2d>
+               	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
+<L161>:
+               	ucomiss	%xmm6, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L168>
+               	movsd	%xmm2, %xmm7            # xmm7 = xmm2[0],xmm7[1]
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+<L162>:
+               	ucomiss	%xmm4, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L165>
+               	testb	%al, %al
+               	jne	 <L163>
+               	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
+               	jmp	 <L164>
+<L163>:
+               	xorps	%xmm9, %xmm9
+               	subss	%xmm7, %xmm9
+<L164>:
+               	jmp	 <L170>
+<L165>:
+               	ucomiss	%xmm8, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L166>
+               	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
+               	jmp	 <L167>
+<L166>:
+               	movss	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1,2,3]
+               	subss	%xmm8, %xmm10
+<L167>:
+               	divss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0xfaf>
+               	movsd	%xmm10, %xmm7           # xmm7 = xmm10[0],xmm7[1]
+               	jmp	 <L162>
+<L168>:
+               	mulss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0xfc1>
+               	jmp	 <L161>
+<L169>:
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xfd2>
                	cvttss2si	%xmm2, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2ss	%r11, %xmm2
                	movss	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1,2,3]
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xe19>
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	subss	%xmm4, %xmm2
-               	ucomiss	%xmm2, %xmm2
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xfee>
+               	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
+               	subss	%xmm4, %xmm9
+<L170>:
+               	ucomiss	%xmm9, %xmm9
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
@@ -1066,7 +1100,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L172>
                	movq	%rbx, %rdi
-               	movss	%xmm2, %xmm0            # xmm0 = xmm2[0],xmm0[1,2,3]
+               	movss	%xmm9, %xmm0            # xmm0 = xmm9[0],xmm0[1,2,3]
                	callq	 <L171>
 <L171>:
                	movq	%rax, %r12
@@ -1078,101 +1112,416 @@ Disassembly of section .text:
 <L173>:
                	movq	%rax, %r12
 <L174>:
-               	movss	-0x30(%rbp), %xmm0
-               	divss	-0xd0(%rbp), %xmm0
-               	cvttss2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	-0xd0(%rbp), %xmm2
-               	movss	-0x30(%rbp), %xmm0
-               	subss	%xmm2, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L176>
-               	movq	%r12, %rdi
-               	callq	 <L175>
+               	jne	 <L177>
+               	movss	-0x30(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x106b>
+               	movss	-0x30(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L175>
+               	jmp	 <L176>
 <L175>:
-               	movq	%rax, %rbx
-               	jmp	 <L178>
+               	movss	-0x30(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
 <L176>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L177>
+               	jmp	 <L178>
 <L177>:
-               	movq	%rax, %rbx
+               	movq	%rax, %rcx
 <L178>:
-               	movss	-0xd0(%rbp), %xmm0
-               	divss	-0xd0(%rbp), %xmm0
+               	testb	%cl, %cl
+               	jne	 <L191>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x30(%rbp), %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L179>
+               	movsd	-0x30(%rbp), %xmm0
+               	jmp	 <L180>
+<L179>:
+               	xorps	%xmm0, %xmm0
+               	subss	-0x30(%rbp), %xmm0
+<L180>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L181>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L182>
+<L181>:
+               	xorps	%xmm2, %xmm2
+               	subss	-0x100(%rbp), %xmm2
+<L182>:
+               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1125>
+               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
+<L183>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L190>
+               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L184>:
+               	ucomiss	%xmm2, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L187>
+               	testb	%al, %al
+               	jne	 <L185>
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L186>
+<L185>:
+               	xorps	%xmm8, %xmm8
+               	subss	%xmm6, %xmm8
+<L186>:
+               	jmp	 <L192>
+<L187>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L188>
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L189>
+<L188>:
+               	movss	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1,2,3]
+               	subss	%xmm7, %xmm9
+<L189>:
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x11a3>
+               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L184>
+<L190>:
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x11b5>
+               	jmp	 <L183>
+<L191>:
+               	movss	-0x30(%rbp), %xmm0
+               	divss	-0x100(%rbp), %xmm0
                	cvttss2si	%xmm0, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2ss	%r11, %xmm0
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	-0xd0(%rbp), %xmm2
-               	movss	-0xd0(%rbp), %xmm0
-               	subss	%xmm2, %xmm0
-               	ucomiss	%xmm0, %xmm0
+               	mulss	-0x100(%rbp), %xmm2
+               	movss	-0x30(%rbp), %xmm8
+               	subss	%xmm2, %xmm8
+<L192>:
+               	ucomiss	%xmm8, %xmm8
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L180>
+               	jne	 <L194>
+               	movq	%r12, %rdi
+               	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
+               	callq	 <L193>
+<L193>:
+               	movq	%rax, %rbx
+               	jmp	 <L196>
+<L194>:
+               	movq	%r12, %rdi
+               	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
+               	callq	 <L195>
+<L195>:
+               	movq	%rax, %rbx
+<L196>:
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L199>
+               	movss	-0x100(%rbp), %xmm0
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1264>
+               	movss	-0x100(%rbp), %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L197>
+               	jmp	 <L198>
+<L197>:
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L198>:
+               	jmp	 <L200>
+<L199>:
+               	movq	%rax, %rcx
+<L200>:
+               	testb	%cl, %cl
+               	jne	 <L213>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L201>
+               	movsd	-0x100(%rbp), %xmm0
+               	jmp	 <L202>
+<L201>:
+               	xorps	%xmm0, %xmm0
+               	subss	-0x100(%rbp), %xmm0
+<L202>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L203>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L204>
+<L203>:
+               	xorps	%xmm2, %xmm2
+               	subss	-0x100(%rbp), %xmm2
+<L204>:
+               	movss	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1,2,3]
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x132d>
+               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
+<L205>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L212>
+               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L206>:
+               	ucomiss	%xmm2, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L209>
+               	testb	%al, %al
+               	jne	 <L207>
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L208>
+<L207>:
+               	xorps	%xmm8, %xmm8
+               	subss	%xmm6, %xmm8
+<L208>:
+               	jmp	 <L214>
+<L209>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L210>
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L211>
+<L210>:
+               	movss	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1,2,3]
+               	subss	%xmm7, %xmm9
+<L211>:
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x13ab>
+               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L206>
+<L212>:
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x13bd>
+               	jmp	 <L205>
+<L213>:
+               	movss	-0x100(%rbp), %xmm0
+               	divss	-0x100(%rbp), %xmm0
+               	cvttss2si	%xmm0, %r11
+               	movq	%r11, %rax
+               	movq	%rax, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	-0x100(%rbp), %xmm2
+               	movss	-0x100(%rbp), %xmm8
+               	subss	%xmm2, %xmm8
+<L214>:
+               	ucomiss	%xmm8, %xmm8
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L216>
                	movq	%rbx, %rdi
-               	callq	 <L179>
-<L179>:
+               	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
+               	callq	 <L215>
+<L215>:
                	movq	%rax, %r12
-               	jmp	 <L182>
-<L180>:
+               	jmp	 <L218>
+<L216>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L181>
-<L181>:
+               	callq	 <L217>
+<L217>:
                	movq	%rax, %r12
-<L182>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xf42>
+<L218>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1443>
                	mulss	-0x30(%rbp), %xmm0
+               	movss	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L221>
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	divss	-0xd0(%rbp), %xmm1
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x147b>
+               	ucomiss	%xmm1, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L219>
+               	jmp	 <L220>
+<L219>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L220>:
+               	jmp	 <L222>
+<L221>:
+               	movq	%rax, %rcx
+<L222>:
+               	testb	%cl, %cl
+               	jne	 <L235>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L223>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L224>
+<L223>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm0, %xmm1
+<L224>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L225>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L226>
+<L225>:
+               	xorps	%xmm2, %xmm2
+               	subss	-0x100(%rbp), %xmm2
+<L226>:
+               	movss	%xmm1, %xmm4            # xmm4 = xmm1[0],xmm4[1,2,3]
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1525>
+               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
+<L227>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L234>
+               	movsd	%xmm1, %xmm6            # xmm6 = xmm1[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L228>:
+               	ucomiss	%xmm2, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L231>
+               	testb	%al, %al
+               	jne	 <L229>
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L230>
+<L229>:
+               	xorps	%xmm8, %xmm8
+               	subss	%xmm6, %xmm8
+<L230>:
+               	jmp	 <L236>
+<L231>:
+               	ucomiss	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L232>
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L233>
+<L232>:
+               	movss	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1,2,3]
+               	subss	%xmm7, %xmm9
+<L233>:
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x15a3>
+               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L228>
+<L234>:
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x15b5>
+               	jmp	 <L227>
+<L235>:
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	divss	-0x100(%rbp), %xmm1
                	cvttss2si	%xmm1, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2ss	%r11, %xmm1
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	mulss	-0xd0(%rbp), %xmm2
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	%xmm2, %xmm1
-               	ucomiss	%xmm1, %xmm1
+               	mulss	-0x100(%rbp), %xmm2
+               	movss	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1,2,3]
+               	subss	%xmm2, %xmm8
+<L236>:
+               	ucomiss	%xmm8, %xmm8
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L184>
+               	jne	 <L238>
                	movq	%r12, %rdi
-               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	callq	 <L183>
-<L183>:
+               	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
+               	callq	 <L237>
+<L237>:
                	movq	%rax, %rbx
-               	jmp	 <L186>
-<L184>:
+               	jmp	 <L240>
+<L238>:
                	movq	%r12, %rdi
                	movl	$0xffffffff, %esi       # imm = 0xFFFFFFFF
-               	callq	 <L185>
-<L185>:
+               	callq	 <L239>
+<L239>:
                	movq	%rax, %rbx
-<L186>:
+<L240>:
                	movq	%rbx, %rax
-               	movq	-0xd8(%rbp), %rbx
-               	movq	-0xe0(%rbp), %r12
-               	movq	-0xe8(%rbp), %r13
-               	movq	-0xf0(%rbp), %r14
+               	movq	-0x108(%rbp), %rbx
+               	movq	-0x110(%rbp), %r12
+               	movq	-0x118(%rbp), %r13
+               	movq	-0x120(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/float/arith_f64.dis
+++ b/test/golden/x86_64-linux/float/arith_f64.dis
@@ -40,11 +40,11 @@ Disassembly of section .text:
 <corpus.cases.float.arith_f64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xf0, %rsp
-               	movq	%rbx, -0xd8(%rbp)
-               	movq	%r12, -0xe0(%rbp)
-               	movq	%r13, -0xe8(%rbp)
-               	movq	%r14, -0xf0(%rbp)
+               	subq	$0x120, %rsp            # imm = 0x120
+               	movq	%rbx, -0x108(%rbp)
+               	movq	%r12, -0x110(%rbp)
+               	movq	%r13, -0x118(%rbp)
+               	movq	%r14, -0x120(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -144,430 +144,122 @@ Disassembly of section .text:
 <L16>:
                	movsd	-0x10(%rbp), %xmm0
                	divsd	-0x20(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L18>
                	movq	%r12, %rdi
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %r13
-               	jmp	 <L20>
-<L18>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %r13
-<L20>:
                	movsd	-0x20(%rbp), %xmm0
                	divsd	-0x10(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L22>
-               	movq	%r13, %rdi
+               	movq	%rax, %rdi
+               	callq	 <L18>
+<L18>:
+               	movsd	-0x10(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1b5>
+               	movq	%rax, %rdi
+               	callq	 <L19>
+<L19>:
+               	xorps	%xmm14, %xmm14
+               	subsd	-0x10(%rbp), %xmm14
+               	movsd	%xmm14, -0x40(%rbp)
+               	movq	%rax, %rdi
+               	movsd	-0x40(%rbp), %xmm0
+               	callq	 <L20>
+<L20>:
+               	movsd	-0x10(%rbp), %xmm0
+               	subsd	-0x10(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %r12
-               	jmp	 <L24>
+               	movsd	-0x40(%rbp), %xmm0
+               	addsd	-0x10(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L22>
 <L22>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x207>
+               	mulsd	-0x30(%rbp), %xmm14
+               	movsd	%xmm14, -0x50(%rbp)
+               	movsd	-0x30(%rbp), %xmm14
+               	divsd	-0x50(%rbp), %xmm14
+               	movsd	%xmm14, -0x60(%rbp)
+               	movq	%rax, %rdi
+               	movsd	-0x60(%rbp), %xmm0
                	callq	 <L23>
 <L23>:
-               	movq	%rax, %r12
+               	movsd	-0x60(%rbp), %xmm0
+               	mulsd	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L24>
 <L24>:
-               	movsd	-0x10(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x21d>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L26>
-               	movq	%r12, %rdi
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %r13
-               	jmp	 <L28>
-<L26>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %r13
-<L28>:
-               	xorps	%xmm0, %xmm0
-               	subsd	-0x10(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L30>
-               	movq	%r13, %rdi
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %r12
-               	jmp	 <L32>
-<L30>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %r12
-<L32>:
-               	movsd	-0x10(%rbp), %xmm0
-               	subsd	-0x10(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L34>
-               	movq	%r12, %rdi
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %r13
-               	jmp	 <L36>
-<L34>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %r13
-<L36>:
-               	xorps	%xmm0, %xmm0
-               	subsd	-0x10(%rbp), %xmm0
-               	movsd	%xmm0, %xmm3            # xmm3 = xmm0[0],xmm3[1]
-               	addsd	-0x10(%rbp), %xmm3
-               	ucomisd	%xmm3, %xmm3
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L38>
-               	movq	%r13, %rdi
-               	movsd	%xmm3, %xmm0            # xmm0 = xmm3[0],xmm0[1]
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %r12
-               	jmp	 <L40>
-<L38>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %r12
-<L40>:
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x33d>
-               	mulsd	-0x30(%rbp), %xmm14
-               	movsd	%xmm14, -0x40(%rbp)
-               	movsd	-0x30(%rbp), %xmm14
-               	divsd	-0x40(%rbp), %xmm14
-               	movsd	%xmm14, -0x50(%rbp)
-               	movsd	-0x50(%rbp), %xmm14
-               	ucomisd	-0x50(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L42>
-               	movq	%r12, %rdi
-               	movsd	-0x50(%rbp), %xmm0
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %r13
-               	jmp	 <L44>
-<L42>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %r13
-<L44>:
-               	movsd	-0x50(%rbp), %xmm0
-               	mulsd	-0x40(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L46>
-               	movq	%r13, %rdi
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %r12
-               	jmp	 <L48>
-<L46>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %r12
-<L48>:
                	movsd	-0x30(%rbp), %xmm0
-               	subsd	-0x50(%rbp), %xmm0
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	subsd	-0x50(%rbp), %xmm4
-               	movsd	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1]
-               	subsd	-0x50(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L50>
-               	movq	%r12, %rdi
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %r13
-               	jmp	 <L52>
-<L50>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %r13
-<L52>:
-               	movsd	-0x30(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x44f>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L54>
-               	movq	%r13, %rdi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %r12
-               	jmp	 <L56>
-<L54>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %r12
-<L56>:
-               	movsd	-0x30(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x498>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L58>
-               	movq	%r12, %rdi
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %r13
-               	jmp	 <L60>
-<L58>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %r13
-<L60>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x4dc>
-               	divsd	-0x40(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L62>
-               	movq	%r13, %rdi
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %r12
-               	jmp	 <L64>
-<L62>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %r12
-<L64>:
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x526>
-               	mulsd	-0x30(%rbp), %xmm14
-               	movsd	%xmm14, -0x60(%rbp)
-               	movsd	-0x60(%rbp), %xmm0
-               	addsd	-0x30(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L66>
-               	movq	%r12, %rdi
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %r13
-               	jmp	 <L68>
-<L66>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %r13
-<L68>:
-               	movsd	-0x60(%rbp), %xmm0
-               	addsd	-0x30(%rbp), %xmm0
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	addsd	-0x30(%rbp), %xmm4
-               	ucomisd	%xmm4, %xmm4
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L70>
-               	movq	%r13, %rdi
-               	movsd	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1]
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %r12
-               	jmp	 <L72>
-<L70>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %r12
-<L72>:
-               	movsd	-0x30(%rbp), %xmm0
-               	addsd	-0x30(%rbp), %xmm0
-               	movsd	-0x60(%rbp), %xmm4
-               	addsd	%xmm0, %xmm4
-               	ucomisd	%xmm4, %xmm4
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L74>
-               	movq	%r12, %rdi
-               	movsd	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1]
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %r13
-               	jmp	 <L76>
-<L74>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %r13
-<L76>:
-               	movsd	-0x60(%rbp), %xmm0
-               	subsd	-0x30(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L78>
-               	movq	%r13, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %r12
-               	jmp	 <L80>
-<L78>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %r12
-<L80>:
-               	movsd	-0x60(%rbp), %xmm0
-               	addsd	-0x30(%rbp), %xmm0
+               	subsd	-0x60(%rbp), %xmm0
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
                	subsd	-0x60(%rbp), %xmm4
-               	ucomisd	%xmm4, %xmm4
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L82>
-               	movq	%r12, %rdi
                	movsd	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1]
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %r13
-               	jmp	 <L84>
-<L82>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %r13
-<L84>:
-               	xorps	%xmm0, %xmm0
-               	mulsd	-0x30(%rbp), %xmm0
-               	movsd	%xmm0, -0x80(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x18, %r12
-               	jb	 <L85>
-               	jmp	 <L90>
-<L85>:
-               	movsd	-0x80(%rbp), %xmm0
-               	addsd	-0x50(%rbp), %xmm0
-               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
-               	mulsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x6f2>
+               	subsd	-0x60(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L25>
+<L25>:
+               	movsd	-0x30(%rbp), %xmm0
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x275>
+               	movq	%rax, %rdi
+               	callq	 <L26>
+<L26>:
+               	movsd	-0x30(%rbp), %xmm0
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x28a>
+               	movq	%rax, %rdi
+               	callq	 <L27>
+<L27>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x29a>
+               	divsd	-0x50(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x2b0>
+               	mulsd	-0x30(%rbp), %xmm14
                	movsd	%xmm14, -0x70(%rbp)
                	movsd	-0x70(%rbp), %xmm14
-               	ucomisd	-0x70(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L87>
-               	movq	%r13, %rdi
+               	addsd	-0x30(%rbp), %xmm14
+               	movsd	%xmm14, -0x80(%rbp)
+               	movq	%rax, %rdi
+               	movsd	-0x80(%rbp), %xmm0
+               	callq	 <L29>
+<L29>:
+               	movsd	-0x80(%rbp), %xmm0
+               	addsd	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L30>
+<L30>:
+               	movsd	-0x30(%rbp), %xmm0
+               	addsd	-0x30(%rbp), %xmm0
+               	movsd	-0x70(%rbp), %xmm5
+               	addsd	%xmm0, %xmm5
+               	movq	%rax, %rdi
+               	movsd	%xmm5, %xmm0            # xmm0 = xmm5[0],xmm0[1]
+               	callq	 <L31>
+<L31>:
                	movsd	-0x70(%rbp), %xmm0
-               	callq	 <L86>
-<L86>:
-               	movq	%rax, %r14
-               	jmp	 <L89>
-<L87>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L88>
-<L88>:
-               	movq	%rax, %r14
-<L89>:
-               	addq	$0x1, %r12
-               	movq	%r14, %r13
-               	movq	-0x70(%rbp), %r11
-               	movq	%r11, -0x80(%rbp)
-               	cmpq	$0x18, %r12
-               	jb	 <L85>
-<L90>:
-               	movabsq	$0x7fefffffffffffff, %rax # imm = 0x7FEFFFFFFFFFFFFF
-               	addq	%rbx, %rax
-               	movq	%rax, -0x90(%rbp)
+               	subsd	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L32>
+<L32>:
+               	movsd	-0x80(%rbp), %xmm0
+               	subsd	-0x70(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L33>
+<L33>:
+               	xorps	%xmm0, %xmm0
+               	mulsd	-0x30(%rbp), %xmm0
+               	movq	%rax, %r12
+               	movsd	%xmm0, -0xa0(%rbp)
+               	movq	$0x0, %r13
+               	cmpq	$0x18, %r13
+               	jb	 <L34>
+               	jmp	 <L39>
+<L34>:
+               	movsd	-0xa0(%rbp), %xmm0
+               	addsd	-0x60(%rbp), %xmm0
+               	movsd	%xmm0, %xmm14           # xmm14 = xmm0[0],xmm14[1]
+               	mulsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x374>
+               	movsd	%xmm14, -0x90(%rbp)
                	movsd	-0x90(%rbp), %xmm14
                	ucomisd	-0x90(%rbp), %xmm14
                	setne	%al
@@ -575,239 +267,72 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L92>
-               	movq	%r13, %rdi
-               	movsd	-0x90(%rbp), %xmm0
-               	callq	 <L91>
-<L91>:
-               	movq	%rax, %r12
-               	jmp	 <L94>
-<L92>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L93>
-<L93>:
-               	movq	%rax, %r12
-<L94>:
-               	movsd	-0x90(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x7d0>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L96>
+               	jne	 <L36>
                	movq	%r12, %rdi
-               	callq	 <L95>
-<L95>:
-               	movq	%rax, %r13
-               	jmp	 <L98>
-<L96>:
+               	movsd	-0x90(%rbp), %xmm0
+               	callq	 <L35>
+<L35>:
+               	movq	%rax, %r14
+               	jmp	 <L38>
+<L36>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L97>
-<L97>:
-               	movq	%rax, %r13
-<L98>:
-               	movsd	-0x90(%rbp), %xmm0
-               	addsd	-0x90(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L100>
-               	movq	%r13, %rdi
-               	callq	 <L99>
-<L99>:
-               	movq	%rax, %r12
-               	jmp	 <L102>
-<L100>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L101>
-<L101>:
-               	movq	%rax, %r12
-<L102>:
-               	movsd	-0x90(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x868>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L104>
-               	movq	%r12, %rdi
-               	callq	 <L103>
-<L103>:
-               	movq	%rax, %r13
-               	jmp	 <L106>
-<L104>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %r13
-<L106>:
-               	movsd	-0x90(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x8b4>
-               	xorps	%xmm3, %xmm3
-               	subsd	%xmm0, %xmm3
-               	ucomisd	%xmm3, %xmm3
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L108>
-               	movq	%r13, %rdi
-               	movsd	%xmm3, %xmm0            # xmm0 = xmm3[0],xmm0[1]
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %r12
-               	jmp	 <L110>
-<L108>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L109>
-<L109>:
-               	movq	%rax, %r12
-<L110>:
-               	movsd	-0x90(%rbp), %xmm0
-               	mulsd	-0x90(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L112>
-               	movq	%r12, %rdi
-               	callq	 <L111>
-<L111>:
-               	movq	%rax, %r13
-               	jmp	 <L114>
-<L112>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L113>
-<L113>:
-               	movq	%rax, %r13
-<L114>:
-               	movsd	-0x90(%rbp), %xmm0
-               	subsd	-0x90(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L116>
-               	movq	%r13, %rdi
-               	callq	 <L115>
-<L115>:
-               	movq	%rax, %r12
-               	jmp	 <L118>
-<L116>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L117>
-<L117>:
-               	movq	%rax, %r12
-<L118>:
-               	movabsq	$0x10000000000000, %rax # imm = 0x10000000000000
-               	addq	%rbx, %rax
-               	movq	%rax, -0xa0(%rbp)
-               	movq	$0x1, %rax
+               	callq	 <L37>
+<L37>:
+               	movq	%rax, %r14
+<L38>:
+               	addq	$0x1, %r13
+               	movq	%r14, %r12
+               	movq	-0x90(%rbp), %r11
+               	movq	%r11, -0xa0(%rbp)
+               	cmpq	$0x18, %r13
+               	jb	 <L34>
+<L39>:
+               	movabsq	$0x7fefffffffffffff, %rax # imm = 0x7FEFFFFFFFFFFFFF
                	addq	%rbx, %rax
                	movq	%rax, -0xb0(%rbp)
-               	movsd	-0xa0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x9c8>
+               	movsd	-0xb0(%rbp), %xmm14
+               	ucomisd	-0xb0(%rbp), %xmm14
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L41>
+               	movq	%r12, %rdi
+               	movsd	-0xb0(%rbp), %xmm0
+               	callq	 <L40>
+<L40>:
+               	movq	%rax, %r13
+               	jmp	 <L43>
+<L41>:
+               	movq	%r12, %rdi
+               	movq	$-0x1, %rsi
+               	callq	 <L42>
+<L42>:
+               	movq	%rax, %r13
+<L43>:
+               	movsd	-0xb0(%rbp), %xmm0
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x464>
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L120>
-               	movq	%r12, %rdi
-               	callq	 <L119>
-<L119>:
-               	movq	%rax, %rbx
-               	jmp	 <L122>
-<L120>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L121>
-<L121>:
-               	movq	%rax, %rbx
-<L122>:
-               	movsd	-0xa0(%rbp), %xmm0
-               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xa14>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L124>
-               	movq	%rbx, %rdi
-               	callq	 <L123>
-<L123>:
+               	jne	 <L45>
+               	movq	%r13, %rdi
+               	callq	 <L44>
+<L44>:
                	movq	%rax, %r12
-               	jmp	 <L126>
-<L124>:
-               	movq	%rbx, %rdi
+               	jmp	 <L47>
+<L45>:
+               	movq	%r13, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L125>
-<L125>:
+               	callq	 <L46>
+<L46>:
                	movq	%rax, %r12
-<L126>:
-               	movsd	-0xa0(%rbp), %xmm0
-               	subsd	-0xb0(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L128>
-               	movq	%r12, %rdi
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %rbx
-               	jmp	 <L130>
-<L128>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L129>
-<L129>:
-               	movq	%rax, %rbx
-<L130>:
-               	movsd	-0xa0(%rbp), %xmm0
-               	mulsd	-0x30(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L132>
-               	movq	%rbx, %rdi
-               	callq	 <L131>
-<L131>:
-               	movq	%rax, %r12
-               	jmp	 <L134>
-<L132>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L133>
-<L133>:
-               	movq	%rax, %r12
-<L134>:
+<L47>:
                	movsd	-0xb0(%rbp), %xmm0
                	addsd	-0xb0(%rbp), %xmm0
                	ucomisd	%xmm0, %xmm0
@@ -816,173 +341,475 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L136>
+               	jne	 <L49>
                	movq	%r12, %rdi
-               	callq	 <L135>
-<L135>:
-               	movq	%rax, %rbx
-               	jmp	 <L138>
-<L136>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L137>
-<L137>:
-               	movq	%rax, %rbx
-<L138>:
-               	movsd	-0xb0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xb41>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L140>
-               	movq	%rbx, %rdi
-               	callq	 <L139>
-<L139>:
-               	movq	%rax, %r12
-               	jmp	 <L142>
-<L140>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L141>
-<L141>:
-               	movq	%rax, %r12
-<L142>:
-               	movsd	-0xb0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xb8d>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L144>
-               	movq	%r12, %rdi
-               	callq	 <L143>
-<L143>:
-               	movq	%rax, %rbx
-               	jmp	 <L146>
-<L144>:
+               	callq	 <L48>
+<L48>:
+               	movq	%rax, %r13
+               	jmp	 <L51>
+<L49>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L145>
-<L145>:
-               	movq	%rax, %rbx
-<L146>:
-               	movsd	-0xb0(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xbd9>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L148>
-               	movq	%rbx, %rdi
-               	callq	 <L147>
-<L147>:
-               	movq	%rax, %r12
-               	jmp	 <L150>
-<L148>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %r12
-<L150>:
-               	movsd	-0xb0(%rbp), %xmm0
-               	divsd	-0xa0(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L152>
-               	movq	%r12, %rdi
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-               	jmp	 <L154>
-<L152>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L153>
-<L153>:
-               	movq	%rax, %rbx
-<L154>:
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0xc6a>
-               	mulsd	-0x30(%rbp), %xmm14
+               	callq	 <L50>
+<L50>:
+               	movq	%rax, %r13
+<L51>:
+               	movsd	-0xb0(%rbp), %xmm14
+               	mulsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x4fe>
                	movsd	%xmm14, -0xc0(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0xc82>
-               	mulsd	-0x30(%rbp), %xmm14
-               	movsd	%xmm14, -0xd0(%rbp)
+               	movq	%r13, %rdi
                	movsd	-0xc0(%rbp), %xmm0
+               	callq	 <L52>
+<L52>:
+               	xorps	%xmm0, %xmm0
+               	subsd	-0xc0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L53>
+<L53>:
+               	movsd	-0xb0(%rbp), %xmm0
+               	mulsd	-0xb0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L54>
+<L54>:
+               	movsd	-0xb0(%rbp), %xmm0
+               	subsd	-0xb0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L55>
+<L55>:
+               	movabsq	$0x10000000000000, %rcx # imm = 0x10000000000000
+               	addq	%rbx, %rcx
+               	movq	%rcx, -0xd0(%rbp)
+               	movq	$0x1, %rcx
+               	addq	%rbx, %rcx
+               	movq	%rcx, -0xe0(%rbp)
+               	movsd	-0xd0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x58f>
+               	movq	%rax, %rdi
+               	callq	 <L56>
+<L56>:
+               	movsd	-0xd0(%rbp), %xmm0
+               	divsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x5a7>
+               	movq	%rax, %rdi
+               	callq	 <L57>
+<L57>:
+               	movsd	-0xd0(%rbp), %xmm0
+               	subsd	-0xe0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L58>
+<L58>:
+               	movsd	-0xd0(%rbp), %xmm0
+               	mulsd	-0x30(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L59>
+<L59>:
+               	movsd	-0xe0(%rbp), %xmm0
+               	addsd	-0xe0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L60>
+<L60>:
+               	movsd	-0xe0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x604>
+               	movq	%rax, %rdi
+               	callq	 <L61>
+<L61>:
+               	movsd	-0xe0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x61c>
+               	movq	%rax, %rdi
+               	callq	 <L62>
+<L62>:
+               	movsd	-0xe0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x634>
+               	movq	%rax, %rdi
+               	callq	 <L63>
+<L63>:
+               	movsd	-0xe0(%rbp), %xmm0
                	divsd	-0xd0(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L64>
+<L64>:
+               	movq	%rax, %rbx
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x660>
+               	mulsd	-0x30(%rbp), %xmm14
+               	movsd	%xmm14, -0xf0(%rbp)
+               	movsd	, %xmm14 <corpus.cases.float.arith_f64.checksum+0x678>
+               	mulsd	-0x30(%rbp), %xmm14
+               	movsd	%xmm14, -0x100(%rbp)
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L67>
+               	movsd	-0xf0(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x6bf>
+               	movsd	-0xf0(%rbp), %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L65>
+               	jmp	 <L66>
+<L65>:
+               	movsd	-0xf0(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L66>:
+               	jmp	 <L68>
+<L67>:
+               	movq	%rax, %rcx
+<L68>:
+               	testb	%cl, %cl
+               	jne	 <L81>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0xf0(%rbp), %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L69>
+               	movsd	-0xf0(%rbp), %xmm0
+               	jmp	 <L70>
+<L69>:
+               	xorps	%xmm0, %xmm0
+               	subsd	-0xf0(%rbp), %xmm0
+<L70>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L71>
+               	movsd	-0x100(%rbp), %xmm4
+               	jmp	 <L72>
+<L71>:
+               	xorps	%xmm4, %xmm4
+               	subsd	-0x100(%rbp), %xmm4
+<L72>:
+               	movsd	%xmm0, %xmm5            # xmm5 = xmm0[0],xmm5[1]
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x78c>
+               	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
+<L73>:
+               	ucomisd	%xmm6, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L80>
+               	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+<L74>:
+               	ucomisd	%xmm4, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L77>
+               	testb	%al, %al
+               	jne	 <L75>
+               	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
+               	jmp	 <L76>
+<L75>:
+               	xorps	%xmm9, %xmm9
+               	subsd	%xmm7, %xmm9
+<L76>:
+               	jmp	 <L82>
+<L77>:
+               	ucomisd	%xmm8, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L78>
+               	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
+               	jmp	 <L79>
+<L78>:
+               	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
+               	subsd	%xmm8, %xmm10
+<L79>:
+               	divsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x811>
+               	movsd	%xmm10, %xmm7           # xmm7 = xmm10[0],xmm7[1]
+               	jmp	 <L74>
+<L80>:
+               	mulsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x823>
+               	jmp	 <L73>
+<L81>:
+               	movsd	-0xf0(%rbp), %xmm0
+               	divsd	-0x100(%rbp), %xmm0
                	cvttsd2si	%xmm0, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2sd	%r11, %xmm0
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	mulsd	-0xd0(%rbp), %xmm4
-               	movsd	-0xc0(%rbp), %xmm0
-               	subsd	%xmm4, %xmm0
-               	ucomisd	%xmm0, %xmm0
+               	mulsd	-0x100(%rbp), %xmm4
+               	movsd	-0xf0(%rbp), %xmm9
+               	subsd	%xmm4, %xmm9
+<L82>:
+               	ucomisd	%xmm9, %xmm9
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L156>
+               	jne	 <L84>
                	movq	%rbx, %rdi
-               	callq	 <L155>
-<L155>:
+               	movsd	%xmm9, %xmm0            # xmm0 = xmm9[0],xmm0[1]
+               	callq	 <L83>
+<L83>:
                	movq	%rax, %r12
-               	jmp	 <L158>
-<L156>:
+               	jmp	 <L86>
+<L84>:
                	movq	%rbx, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L157>
-<L157>:
+               	callq	 <L85>
+<L85>:
                	movq	%rax, %r12
-<L158>:
+<L86>:
                	xorps	%xmm0, %xmm0
-               	subsd	-0xc0(%rbp), %xmm0
+               	subsd	-0xf0(%rbp), %xmm0
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L89>
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	divsd	-0xd0(%rbp), %xmm4
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8e3>
+               	ucomisd	%xmm4, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L87>
+               	jmp	 <L88>
+<L87>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L88>:
+               	jmp	 <L90>
+<L89>:
+               	movq	%rax, %rcx
+<L90>:
+               	testb	%cl, %cl
+               	jne	 <L103>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L91>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L92>
+<L91>:
+               	xorps	%xmm4, %xmm4
+               	subsd	%xmm0, %xmm4
+<L92>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L93>
+               	movsd	-0x100(%rbp), %xmm5
+               	jmp	 <L94>
+<L93>:
+               	xorps	%xmm5, %xmm5
+               	subsd	-0x100(%rbp), %xmm5
+<L94>:
+               	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x991>
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L95>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L102>
+               	movsd	%xmm4, %xmm8            # xmm8 = xmm4[0],xmm8[1]
+               	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
+<L96>:
+               	ucomisd	%xmm5, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L99>
+               	testb	%al, %al
+               	jne	 <L97>
+               	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
+               	jmp	 <L98>
+<L97>:
+               	xorps	%xmm10, %xmm10
+               	subsd	%xmm8, %xmm10
+<L98>:
+               	jmp	 <L104>
+<L99>:
+               	ucomisd	%xmm9, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L100>
+               	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
+               	jmp	 <L101>
+<L100>:
+               	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
+               	subsd	%xmm9, %xmm11
+<L101>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xa17>
+               	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
+               	jmp	 <L96>
+<L102>:
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xa29>
+               	jmp	 <L95>
+<L103>:
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	divsd	-0x100(%rbp), %xmm4
                	cvttsd2si	%xmm4, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2sd	%r11, %xmm4
                	movsd	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1]
-               	mulsd	-0xd0(%rbp), %xmm5
-               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	subsd	%xmm5, %xmm4
-               	ucomisd	%xmm4, %xmm4
+               	mulsd	-0x100(%rbp), %xmm5
+               	movsd	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1]
+               	subsd	%xmm5, %xmm10
+<L104>:
+               	ucomisd	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L160>
+               	jne	 <L106>
                	movq	%r12, %rdi
-               	movsd	%xmm4, %xmm0            # xmm0 = xmm4[0],xmm0[1]
-               	callq	 <L159>
-<L159>:
+               	movsd	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1]
+               	callq	 <L105>
+<L105>:
                	movq	%rax, %rbx
-               	jmp	 <L162>
-<L160>:
+               	jmp	 <L108>
+<L106>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L161>
-<L161>:
+               	callq	 <L107>
+<L107>:
                	movq	%rax, %rbx
-<L162>:
+<L108>:
                	xorps	%xmm0, %xmm0
-               	subsd	-0xd0(%rbp), %xmm0
-               	movsd	-0xc0(%rbp), %xmm4
+               	subsd	-0x100(%rbp), %xmm0
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L111>
+               	movsd	-0xf0(%rbp), %xmm4
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xadc>
+               	movsd	-0xf0(%rbp), %xmm14
+               	ucomisd	%xmm4, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L109>
+               	jmp	 <L110>
+<L109>:
+               	movsd	-0xf0(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L110>:
+               	jmp	 <L112>
+<L111>:
+               	movq	%rax, %rcx
+<L112>:
+               	testb	%cl, %cl
+               	jne	 <L125>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0xf0(%rbp), %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L113>
+               	movsd	-0xf0(%rbp), %xmm4
+               	jmp	 <L114>
+<L113>:
+               	xorps	%xmm4, %xmm4
+               	subsd	-0xf0(%rbp), %xmm4
+<L114>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L115>
+               	movsd	%xmm0, %xmm5            # xmm5 = xmm0[0],xmm5[1]
+               	jmp	 <L116>
+<L115>:
+               	xorps	%xmm5, %xmm5
+               	subsd	%xmm0, %xmm5
+<L116>:
+               	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xb9d>
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L117>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L124>
+               	movsd	%xmm4, %xmm8            # xmm8 = xmm4[0],xmm8[1]
+               	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
+<L118>:
+               	ucomisd	%xmm5, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L121>
+               	testb	%al, %al
+               	jne	 <L119>
+               	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
+               	jmp	 <L120>
+<L119>:
+               	xorps	%xmm10, %xmm10
+               	subsd	%xmm8, %xmm10
+<L120>:
+               	jmp	 <L126>
+<L121>:
+               	ucomisd	%xmm9, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L122>
+               	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
+               	jmp	 <L123>
+<L122>:
+               	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
+               	subsd	%xmm9, %xmm11
+<L123>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xc23>
+               	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
+               	jmp	 <L118>
+<L124>:
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xc35>
+               	jmp	 <L117>
+<L125>:
+               	movsd	-0xf0(%rbp), %xmm4
                	divsd	%xmm0, %xmm4
                	cvttsd2si	%xmm4, %r11
                	movq	%r11, %rax
@@ -990,31 +817,134 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm4
                	movsd	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1]
                	mulsd	%xmm0, %xmm5
-               	movsd	-0xc0(%rbp), %xmm0
-               	subsd	%xmm5, %xmm0
-               	ucomisd	%xmm0, %xmm0
+               	movsd	-0xf0(%rbp), %xmm10
+               	subsd	%xmm5, %xmm10
+<L126>:
+               	ucomisd	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L164>
+               	jne	 <L128>
                	movq	%rbx, %rdi
-               	callq	 <L163>
-<L163>:
+               	movsd	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1]
+               	callq	 <L127>
+<L127>:
                	movq	%rax, %r12
-               	jmp	 <L166>
-<L164>:
+               	jmp	 <L130>
+<L128>:
                	movq	%rbx, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L165>
-<L165>:
+               	callq	 <L129>
+<L129>:
                	movq	%rax, %r12
-<L166>:
+<L130>:
                	xorps	%xmm0, %xmm0
-               	subsd	-0xc0(%rbp), %xmm0
+               	subsd	-0xf0(%rbp), %xmm0
                	xorps	%xmm2, %xmm2
-               	subsd	-0xd0(%rbp), %xmm2
+               	subsd	-0x100(%rbp), %xmm2
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm2
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L133>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xcef>
+               	ucomisd	%xmm4, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L131>
+               	jmp	 <L132>
+<L131>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L132>:
+               	jmp	 <L134>
+<L133>:
+               	movq	%rax, %rcx
+<L134>:
+               	testb	%cl, %cl
+               	jne	 <L147>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L135>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	jmp	 <L136>
+<L135>:
+               	xorps	%xmm4, %xmm4
+               	subsd	%xmm0, %xmm4
+<L136>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm2, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L137>
+               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
+               	jmp	 <L138>
+<L137>:
+               	xorps	%xmm5, %xmm5
+               	subsd	%xmm2, %xmm5
+<L138>:
+               	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xd91>
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L139>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L146>
+               	movsd	%xmm4, %xmm8            # xmm8 = xmm4[0],xmm8[1]
+               	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
+<L140>:
+               	ucomisd	%xmm5, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L143>
+               	testb	%al, %al
+               	jne	 <L141>
+               	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
+               	jmp	 <L142>
+<L141>:
+               	xorps	%xmm10, %xmm10
+               	subsd	%xmm8, %xmm10
+<L142>:
+               	jmp	 <L148>
+<L143>:
+               	ucomisd	%xmm9, %xmm8
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L144>
+               	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
+               	jmp	 <L145>
+<L144>:
+               	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
+               	subsd	%xmm9, %xmm11
+<L145>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xe17>
+               	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
+               	jmp	 <L140>
+<L146>:
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xe29>
+               	jmp	 <L139>
+<L147>:
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
                	divsd	%xmm2, %xmm4
                	cvttsd2si	%xmm4, %r11
@@ -1023,155 +953,549 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm4
                	movsd	%xmm4, %xmm5            # xmm5 = xmm4[0],xmm5[1]
                	mulsd	%xmm2, %xmm5
+               	movsd	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1]
+               	subsd	%xmm5, %xmm10
+<L148>:
+               	ucomisd	%xmm10, %xmm10
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L150>
+               	movq	%r12, %rdi
+               	movsd	%xmm10, %xmm0           # xmm0 = xmm10[0],xmm0[1]
+               	callq	 <L149>
+<L149>:
+               	movq	%rax, %rbx
+               	jmp	 <L152>
+<L150>:
+               	movq	%r12, %rdi
+               	movq	$-0x1, %rsi
+               	callq	 <L151>
+<L151>:
+               	movq	%rax, %rbx
+<L152>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xea2>
+               	mulsd	-0x30(%rbp), %xmm0
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	subsd	%xmm5, %xmm2
-               	ucomisd	%xmm2, %xmm2
+               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xeb3>
+               	ucomisd	%xmm2, %xmm0
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L153>
+               	jmp	 <L154>
+<L153>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+<L154>:
+               	testb	%al, %al
+               	jne	 <L165>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L155>
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	jmp	 <L156>
+<L155>:
+               	xorps	%xmm2, %xmm2
+               	subsd	%xmm0, %xmm2
+<L156>:
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xf25>
+               	movsd	, %xmm5 <L157>
+<L157>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L164>
+               	movsd	%xmm2, %xmm6            # xmm6 = xmm2[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L158>:
+               	ucomisd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xf50>
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L161>
+               	testb	%al, %al
+               	jne	 <L159>
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L160>
+<L159>:
+               	xorps	%xmm8, %xmm8
+               	subsd	%xmm6, %xmm8
+<L160>:
+               	jmp	 <L166>
+<L161>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L162>
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L163>
+<L162>:
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	subsd	%xmm7, %xmm9
+<L163>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xfae>
+               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L158>
+<L164>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xfc0>
+               	jmp	 <L157>
+<L165>:
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xfd1>
+               	cvttsd2si	%xmm2, %r11
+               	movq	%r11, %rax
+               	movq	%rax, %r11
+               	cvtsi2sd	%r11, %xmm2
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xfed>
+               	movsd	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1]
+               	subsd	%xmm4, %xmm8
+<L166>:
+               	ucomisd	%xmm8, %xmm8
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
                	jne	 <L168>
-               	movq	%r12, %rdi
-               	movsd	%xmm2, %xmm0            # xmm0 = xmm2[0],xmm0[1]
+               	movq	%rbx, %rdi
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
                	callq	 <L167>
 <L167>:
-               	movq	%rax, %rbx
+               	movq	%rax, %r12
                	jmp	 <L170>
 <L168>:
-               	movq	%r12, %rdi
+               	movq	%rbx, %rdi
                	movq	$-0x1, %rsi
                	callq	 <L169>
 <L169>:
-               	movq	%rax, %rbx
+               	movq	%rax, %r12
 <L170>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xe7d>
-               	mulsd	-0x30(%rbp), %xmm0
-               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xe8e>
-               	cvttsd2si	%xmm2, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm2
-               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xeaa>
-               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	subsd	%xmm4, %xmm2
-               	ucomisd	%xmm2, %xmm2
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L172>
-               	movq	%rbx, %rdi
-               	movsd	%xmm2, %xmm0            # xmm0 = xmm2[0],xmm0[1]
-               	callq	 <L171>
+               	jne	 <L173>
+               	movsd	-0x30(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x106e>
+               	movsd	-0x30(%rbp), %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L171>
+               	jmp	 <L172>
 <L171>:
-               	movq	%rax, %r12
-               	jmp	 <L174>
+               	movsd	-0x30(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
 <L172>:
-               	movq	%rbx, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L173>
+               	jmp	 <L174>
 <L173>:
-               	movq	%rax, %r12
+               	movq	%rax, %rcx
 <L174>:
-               	movsd	-0x30(%rbp), %xmm0
-               	divsd	-0xd0(%rbp), %xmm0
-               	cvttsd2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	mulsd	-0xd0(%rbp), %xmm2
-               	movsd	-0x30(%rbp), %xmm0
-               	subsd	%xmm2, %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
+               	testb	%cl, %cl
+               	jne	 <L187>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x30(%rbp), %xmm14
+               	seta	%al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L176>
-               	movq	%r12, %rdi
-               	callq	 <L175>
+               	jne	 <L175>
+               	movsd	-0x30(%rbp), %xmm0
+               	jmp	 <L176>
 <L175>:
-               	movq	%rax, %rbx
-               	jmp	 <L178>
+               	xorps	%xmm0, %xmm0
+               	subsd	-0x30(%rbp), %xmm0
 <L176>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L177>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L177>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L178>
 <L177>:
-               	movq	%rax, %rbx
+               	xorps	%xmm2, %xmm2
+               	subsd	-0x100(%rbp), %xmm2
 <L178>:
-               	movsd	-0xd0(%rbp), %xmm0
-               	divsd	-0xd0(%rbp), %xmm0
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x112c>
+               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
+<L179>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L186>
+               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L180>:
+               	ucomisd	%xmm2, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L183>
+               	testb	%al, %al
+               	jne	 <L181>
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L182>
+<L181>:
+               	xorps	%xmm8, %xmm8
+               	subsd	%xmm6, %xmm8
+<L182>:
+               	jmp	 <L188>
+<L183>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L184>
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L185>
+<L184>:
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	subsd	%xmm7, %xmm9
+<L185>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x11ad>
+               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L180>
+<L186>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x11bf>
+               	jmp	 <L179>
+<L187>:
+               	movsd	-0x30(%rbp), %xmm0
+               	divsd	-0x100(%rbp), %xmm0
                	cvttsd2si	%xmm0, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2sd	%r11, %xmm0
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	mulsd	-0xd0(%rbp), %xmm2
-               	movsd	-0xd0(%rbp), %xmm0
-               	subsd	%xmm2, %xmm0
-               	ucomisd	%xmm0, %xmm0
+               	mulsd	-0x100(%rbp), %xmm2
+               	movsd	-0x30(%rbp), %xmm8
+               	subsd	%xmm2, %xmm8
+<L188>:
+               	ucomisd	%xmm8, %xmm8
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L180>
+               	jne	 <L190>
+               	movq	%r12, %rdi
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	callq	 <L189>
+<L189>:
+               	movq	%rax, %rbx
+               	jmp	 <L192>
+<L190>:
+               	movq	%r12, %rdi
+               	movq	$-0x1, %rsi
+               	callq	 <L191>
+<L191>:
+               	movq	%rax, %rbx
+<L192>:
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L195>
+               	movsd	-0x100(%rbp), %xmm0
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1272>
+               	movsd	-0x100(%rbp), %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L193>
+               	jmp	 <L194>
+<L193>:
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L194>:
+               	jmp	 <L196>
+<L195>:
+               	movq	%rax, %rcx
+<L196>:
+               	testb	%cl, %cl
+               	jne	 <L209>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L197>
+               	movsd	-0x100(%rbp), %xmm0
+               	jmp	 <L198>
+<L197>:
+               	xorps	%xmm0, %xmm0
+               	subsd	-0x100(%rbp), %xmm0
+<L198>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L199>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L200>
+<L199>:
+               	xorps	%xmm2, %xmm2
+               	subsd	-0x100(%rbp), %xmm2
+<L200>:
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x133f>
+               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
+<L201>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L208>
+               	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L202>:
+               	ucomisd	%xmm2, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L205>
+               	testb	%al, %al
+               	jne	 <L203>
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L204>
+<L203>:
+               	xorps	%xmm8, %xmm8
+               	subsd	%xmm6, %xmm8
+<L204>:
+               	jmp	 <L210>
+<L205>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L206>
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L207>
+<L206>:
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	subsd	%xmm7, %xmm9
+<L207>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x13c0>
+               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L202>
+<L208>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x13d2>
+               	jmp	 <L201>
+<L209>:
+               	movsd	-0x100(%rbp), %xmm0
+               	divsd	-0x100(%rbp), %xmm0
+               	cvttsd2si	%xmm0, %r11
+               	movq	%r11, %rax
+               	movq	%rax, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	mulsd	-0x100(%rbp), %xmm2
+               	movsd	-0x100(%rbp), %xmm8
+               	subsd	%xmm2, %xmm8
+<L210>:
+               	ucomisd	%xmm8, %xmm8
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L212>
                	movq	%rbx, %rdi
-               	callq	 <L179>
-<L179>:
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	callq	 <L211>
+<L211>:
                	movq	%rax, %r12
-               	jmp	 <L182>
-<L180>:
+               	jmp	 <L214>
+<L212>:
                	movq	%rbx, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L181>
-<L181>:
+               	callq	 <L213>
+<L213>:
                	movq	%rax, %r12
-<L182>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xfdc>
+<L214>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x145b>
                	mulsd	-0x30(%rbp), %xmm0
+               	movsd	-0x100(%rbp), %xmm14
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L217>
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	-0xd0(%rbp), %xmm1
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x1494>
+               	ucomisd	%xmm1, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L215>
+               	jmp	 <L216>
+<L215>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L216>:
+               	jmp	 <L218>
+<L217>:
+               	movq	%rax, %rcx
+<L218>:
+               	testb	%cl, %cl
+               	jne	 <L231>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L219>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L220>
+<L219>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm0, %xmm1
+<L220>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	-0x100(%rbp), %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L221>
+               	movsd	-0x100(%rbp), %xmm2
+               	jmp	 <L222>
+<L221>:
+               	xorps	%xmm2, %xmm2
+               	subsd	-0x100(%rbp), %xmm2
+<L222>:
+               	movsd	%xmm1, %xmm4            # xmm4 = xmm1[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1542>
+               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
+<L223>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L230>
+               	movsd	%xmm1, %xmm6            # xmm6 = xmm1[0],xmm6[1]
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+<L224>:
+               	ucomisd	%xmm2, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L227>
+               	testb	%al, %al
+               	jne	 <L225>
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	jmp	 <L226>
+<L225>:
+               	xorps	%xmm8, %xmm8
+               	subsd	%xmm6, %xmm8
+<L226>:
+               	jmp	 <L232>
+<L227>:
+               	ucomisd	%xmm7, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L228>
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	jmp	 <L229>
+<L228>:
+               	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
+               	subsd	%xmm7, %xmm9
+<L229>:
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x15c3>
+               	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
+               	jmp	 <L224>
+<L230>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x15d5>
+               	jmp	 <L223>
+<L231>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	-0x100(%rbp), %xmm1
                	cvttsd2si	%xmm1, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2sd	%r11, %xmm1
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	mulsd	-0xd0(%rbp), %xmm2
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	%xmm2, %xmm1
-               	ucomisd	%xmm1, %xmm1
+               	mulsd	-0x100(%rbp), %xmm2
+               	movsd	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1]
+               	subsd	%xmm2, %xmm8
+<L232>:
+               	ucomisd	%xmm8, %xmm8
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L184>
+               	jne	 <L234>
                	movq	%r12, %rdi
-               	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
-               	callq	 <L183>
-<L183>:
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	callq	 <L233>
+<L233>:
                	movq	%rax, %rbx
-               	jmp	 <L186>
-<L184>:
+               	jmp	 <L236>
+<L234>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L185>
-<L185>:
+               	callq	 <L235>
+<L235>:
                	movq	%rax, %rbx
-<L186>:
+<L236>:
                	movq	%rbx, %rax
-               	movq	-0xd8(%rbp), %rbx
-               	movq	-0xe0(%rbp), %r12
-               	movq	-0xe8(%rbp), %r13
-               	movq	-0xf0(%rbp), %r14
+               	movq	-0x108(%rbp), %rbx
+               	movq	-0x110(%rbp), %r12
+               	movq	-0x118(%rbp), %r13
+               	movq	-0x120(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-linux/float/arith_f64.dis
+++ b/test/golden/x86_64-linux/float/arith_f64.dis
@@ -515,8 +515,8 @@ Disassembly of section .text:
                	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
                	jmp	 <L76>
 <L75>:
-               	xorps	%xmm9, %xmm9
-               	subsd	%xmm7, %xmm9
+               	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
+               	xorps	, %xmm9 <L76>
 <L76>:
                	jmp	 <L82>
 <L77>:
@@ -531,11 +531,11 @@ Disassembly of section .text:
                	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
                	subsd	%xmm8, %xmm10
 <L79>:
-               	divsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x811>
+               	divsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x815>
                	movsd	%xmm10, %xmm7           # xmm7 = xmm10[0],xmm7[1]
                	jmp	 <L74>
 <L80>:
-               	mulsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x823>
+               	mulsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x827>
                	jmp	 <L73>
 <L81>:
                	movsd	-0xf0(%rbp), %xmm0
@@ -581,7 +581,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L89>
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8e3>
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8e7>
                	ucomisd	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -629,7 +629,7 @@ Disassembly of section .text:
                	subsd	-0x100(%rbp), %xmm5
 <L94>:
                	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x991>
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x995>
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
 <L95>:
                	ucomisd	%xmm7, %xmm6
@@ -650,8 +650,8 @@ Disassembly of section .text:
                	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
                	jmp	 <L98>
 <L97>:
-               	xorps	%xmm10, %xmm10
-               	subsd	%xmm8, %xmm10
+               	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
+               	xorps	, %xmm10 <L98>
 <L98>:
                	jmp	 <L104>
 <L99>:
@@ -666,11 +666,11 @@ Disassembly of section .text:
                	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
                	subsd	%xmm9, %xmm11
 <L101>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xa17>
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xa1f>
                	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
                	jmp	 <L96>
 <L102>:
-               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xa29>
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xa31>
                	jmp	 <L95>
 <L103>:
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
@@ -715,7 +715,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L111>
                	movsd	-0xf0(%rbp), %xmm4
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xadc>
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xae4>
                	movsd	-0xf0(%rbp), %xmm14
                	ucomisd	%xmm4, %xmm14
                	sete	%cl
@@ -765,7 +765,7 @@ Disassembly of section .text:
                	subsd	%xmm0, %xmm5
 <L116>:
                	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xb9d>
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xba5>
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
 <L117>:
                	ucomisd	%xmm7, %xmm6
@@ -786,8 +786,8 @@ Disassembly of section .text:
                	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
                	jmp	 <L120>
 <L119>:
-               	xorps	%xmm10, %xmm10
-               	subsd	%xmm8, %xmm10
+               	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
+               	xorps	, %xmm10 <L120>
 <L120>:
                	jmp	 <L126>
 <L121>:
@@ -802,11 +802,11 @@ Disassembly of section .text:
                	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
                	subsd	%xmm9, %xmm11
 <L123>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xc23>
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xc2f>
                	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
                	jmp	 <L118>
 <L124>:
-               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xc35>
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xc41>
                	jmp	 <L117>
 <L125>:
                	movsd	-0xf0(%rbp), %xmm4
@@ -853,7 +853,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L133>
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xcef>
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xcfb>
                	ucomisd	%xmm4, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -901,7 +901,7 @@ Disassembly of section .text:
                	subsd	%xmm2, %xmm5
 <L138>:
                	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xd91>
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0xd9d>
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
 <L139>:
                	ucomisd	%xmm7, %xmm6
@@ -922,8 +922,8 @@ Disassembly of section .text:
                	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
                	jmp	 <L142>
 <L141>:
-               	xorps	%xmm10, %xmm10
-               	subsd	%xmm8, %xmm10
+               	movsd	%xmm8, %xmm10           # xmm10 = xmm8[0],xmm10[1]
+               	xorps	, %xmm10 <L142>
 <L142>:
                	jmp	 <L148>
 <L143>:
@@ -938,11 +938,11 @@ Disassembly of section .text:
                	movsd	%xmm8, %xmm11           # xmm11 = xmm8[0],xmm11[1]
                	subsd	%xmm9, %xmm11
 <L145>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xe17>
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xe27>
                	movsd	%xmm11, %xmm8           # xmm8 = xmm11[0],xmm8[1]
                	jmp	 <L140>
 <L146>:
-               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xe29>
+               	mulsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xe39>
                	jmp	 <L139>
 <L147>:
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
@@ -976,10 +976,10 @@ Disassembly of section .text:
 <L151>:
                	movq	%rax, %rbx
 <L152>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xea2>
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xeb2>
                	mulsd	-0x30(%rbp), %xmm0
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xeb3>
+               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xec3>
                	ucomisd	%xmm2, %xmm0
                	sete	%al
                	setnp	%r11b
@@ -1011,7 +1011,7 @@ Disassembly of section .text:
                	subsd	%xmm0, %xmm2
 <L156>:
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xf25>
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xf35>
                	movsd	, %xmm5 <L157>
 <L157>:
                	ucomisd	%xmm5, %xmm4
@@ -1022,7 +1022,7 @@ Disassembly of section .text:
                	movsd	%xmm2, %xmm6            # xmm6 = xmm2[0],xmm6[1]
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
 <L158>:
-               	ucomisd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xf50>
+               	ucomisd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xf60>
                	setae	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
@@ -1032,8 +1032,8 @@ Disassembly of section .text:
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
                	jmp	 <L160>
 <L159>:
-               	xorps	%xmm8, %xmm8
-               	subsd	%xmm6, %xmm8
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	xorps	, %xmm8 <L160>
 <L160>:
                	jmp	 <L166>
 <L161>:
@@ -1048,21 +1048,21 @@ Disassembly of section .text:
                	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
                	subsd	%xmm7, %xmm9
 <L163>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xfae>
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xfc2>
                	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
                	jmp	 <L158>
 <L164>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xfc0>
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xfd4>
                	jmp	 <L157>
 <L165>:
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xfd1>
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xfe5>
                	cvttsd2si	%xmm2, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2sd	%r11, %xmm2
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xfed>
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1001>
                	movsd	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1]
                	subsd	%xmm4, %xmm8
 <L166>:
@@ -1096,7 +1096,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L173>
                	movsd	-0x30(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x106e>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1082>
                	movsd	-0x30(%rbp), %xmm14
                	ucomisd	%xmm0, %xmm14
                	sete	%cl
@@ -1146,7 +1146,7 @@ Disassembly of section .text:
                	subsd	-0x100(%rbp), %xmm2
 <L178>:
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x112c>
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1140>
                	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
 <L179>:
                	ucomisd	%xmm5, %xmm4
@@ -1167,8 +1167,8 @@ Disassembly of section .text:
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
                	jmp	 <L182>
 <L181>:
-               	xorps	%xmm8, %xmm8
-               	subsd	%xmm6, %xmm8
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	xorps	, %xmm8 <L182>
 <L182>:
                	jmp	 <L188>
 <L183>:
@@ -1183,11 +1183,11 @@ Disassembly of section .text:
                	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
                	subsd	%xmm7, %xmm9
 <L185>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x11ad>
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x11c5>
                	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
                	jmp	 <L180>
 <L186>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x11bf>
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x11d7>
                	jmp	 <L179>
 <L187>:
                	movsd	-0x30(%rbp), %xmm0
@@ -1231,7 +1231,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L195>
                	movsd	-0x100(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1272>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x128a>
                	movsd	-0x100(%rbp), %xmm14
                	ucomisd	%xmm0, %xmm14
                	sete	%cl
@@ -1281,7 +1281,7 @@ Disassembly of section .text:
                	subsd	-0x100(%rbp), %xmm2
 <L200>:
                	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x133f>
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1357>
                	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
 <L201>:
                	ucomisd	%xmm5, %xmm4
@@ -1302,8 +1302,8 @@ Disassembly of section .text:
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
                	jmp	 <L204>
 <L203>:
-               	xorps	%xmm8, %xmm8
-               	subsd	%xmm6, %xmm8
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	xorps	, %xmm8 <L204>
 <L204>:
                	jmp	 <L210>
 <L205>:
@@ -1318,11 +1318,11 @@ Disassembly of section .text:
                	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
                	subsd	%xmm7, %xmm9
 <L207>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x13c0>
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x13dc>
                	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
                	jmp	 <L202>
 <L208>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x13d2>
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x13ee>
                	jmp	 <L201>
 <L209>:
                	movsd	-0x100(%rbp), %xmm0
@@ -1356,7 +1356,7 @@ Disassembly of section .text:
 <L213>:
                	movq	%rax, %r12
 <L214>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x145b>
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x1477>
                	mulsd	-0x30(%rbp), %xmm0
                	movsd	-0x100(%rbp), %xmm14
                	xorps	%xmm15, %xmm15
@@ -1368,7 +1368,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L217>
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x1494>
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x14b0>
                	ucomisd	%xmm1, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -1416,7 +1416,7 @@ Disassembly of section .text:
                	subsd	-0x100(%rbp), %xmm2
 <L222>:
                	movsd	%xmm1, %xmm4            # xmm4 = xmm1[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x1542>
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x155e>
                	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
 <L223>:
                	ucomisd	%xmm5, %xmm4
@@ -1437,8 +1437,8 @@ Disassembly of section .text:
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
                	jmp	 <L226>
 <L225>:
-               	xorps	%xmm8, %xmm8
-               	subsd	%xmm6, %xmm8
+               	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
+               	xorps	, %xmm8 <L226>
 <L226>:
                	jmp	 <L232>
 <L227>:
@@ -1453,11 +1453,11 @@ Disassembly of section .text:
                	movsd	%xmm6, %xmm9            # xmm9 = xmm6[0],xmm9[1]
                	subsd	%xmm7, %xmm9
 <L229>:
-               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x15c3>
+               	divsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x15e3>
                	movsd	%xmm9, %xmm6            # xmm6 = xmm9[0],xmm6[1]
                	jmp	 <L224>
 <L230>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x15d5>
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x15f5>
                	jmp	 <L223>
 <L231>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]

--- a/test/golden/x86_64-windows/float/arith_f32.dis
+++ b/test/golden/x86_64-windows/float/arith_f32.dis
@@ -46,7 +46,7 @@ Disassembly of section .text:
 <corpus.cases.float.arith_f32.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xa0, %rsp
+               	subq	$0xc0, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
@@ -55,8 +55,10 @@ Disassembly of section .text:
                	movaps	%xmm7, -0x40(%rbp)
                	movaps	%xmm8, -0x50(%rbp)
                	movaps	%xmm9, -0x60(%rbp)
-               	movaps	%xmm14, -0x70(%rbp)
-               	movaps	%xmm15, -0x80(%rbp)
+               	movaps	%xmm10, -0x70(%rbp)
+               	movaps	%xmm11, -0x80(%rbp)
+               	movaps	%xmm14, -0x90(%rbp)
+               	movaps	%xmm15, -0xa0(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -65,9 +67,9 @@ Disassembly of section .text:
                	movl	$0x3f800000, %eax       # imm = 0x3F800000
                	addl	%edi, %eax
                	movd	%eax, %xmm6
-               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x58>
+               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x68>
                	mulss	%xmm6, %xmm7
-               	movss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x65>
+               	movss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x75>
                	mulss	%xmm6, %xmm8
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	addss	%xmm8, %xmm0
@@ -159,428 +161,154 @@ Disassembly of section .text:
 <L16>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	divss	%xmm8, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L18>
                	movq	%rsi, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rbx
-               	jmp	 <L20>
-<L18>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rbx
-<L20>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
                	divss	%xmm7, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L22>
-               	movq	%rbx, %rcx
+               	movq	%rax, %rcx
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	callq	 <L18>
+<L18>:
+               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
+               	xorps	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1c7>
+               	movq	%rax, %rcx
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	callq	 <L19>
+<L19>:
+               	xorps	%xmm8, %xmm8
+               	subss	%xmm7, %xmm8
+               	movq	%rax, %rcx
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	callq	 <L20>
+<L20>:
+               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
+               	subss	%xmm7, %xmm0
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %rsi
-               	jmp	 <L24>
+               	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
+               	addss	%xmm7, %xmm0
+               	movq	%rax, %rcx
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	callq	 <L22>
 <L22>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rsi
-<L24>:
-               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	xorps	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x219>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L26>
-               	movq	%rsi, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rbx
-               	jmp	 <L28>
-<L26>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rbx
-<L28>:
-               	xorps	%xmm0, %xmm0
-               	subss	%xmm7, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L30>
-               	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rsi
-               	jmp	 <L32>
-<L30>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rsi
-<L32>:
-               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	subss	%xmm7, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L34>
-               	movq	%rsi, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rbx
-               	jmp	 <L36>
-<L34>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rbx
-<L36>:
-               	xorps	%xmm0, %xmm0
-               	subss	%xmm7, %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	addss	%xmm7, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L38>
-               	movq	%rbx, %rcx
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rsi
-               	jmp	 <L40>
-<L38>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rsi
-<L40>:
-               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x32f>
+               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x21a>
                	mulss	%xmm6, %xmm7
                	movss	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1,2,3]
                	divss	%xmm7, %xmm8
-               	ucomiss	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L42>
-               	movq	%rsi, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rbx
-               	jmp	 <L44>
-<L42>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rbx
-<L44>:
+               	callq	 <L23>
+<L23>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
                	mulss	%xmm7, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L46>
-               	movq	%rbx, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rsi
-               	jmp	 <L48>
-<L46>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %rsi
-<L48>:
+               	callq	 <L24>
+<L24>:
                	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
                	subss	%xmm8, %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	subss	%xmm8, %xmm1
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
                	subss	%xmm8, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L50>
-               	movq	%rsi, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rbx
-               	jmp	 <L52>
-<L50>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rbx
-<L52>:
+               	callq	 <L25>
+<L25>:
                	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x426>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L54>
-               	movq	%rbx, %rcx
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x27d>
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rsi
-               	jmp	 <L56>
-<L54>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rsi
-<L56>:
+               	callq	 <L26>
+<L26>:
                	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x46f>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L58>
-               	movq	%rsi, %rcx
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x295>
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rbx
-               	jmp	 <L60>
-<L58>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rbx
-<L60>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x4b4>
+               	callq	 <L27>
+<L27>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x2a9>
                	divss	%xmm7, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L62>
-               	movq	%rbx, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rsi
-               	jmp	 <L64>
-<L62>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rsi
-<L64>:
-               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x4fd>
+               	callq	 <L28>
+<L28>:
+               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x2c1>
                	mulss	%xmm6, %xmm7
-               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
+               	movss	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1,2,3]
+               	addss	%xmm6, %xmm9
+               	movq	%rax, %rcx
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	callq	 <L29>
+<L29>:
+               	movss	%xmm9, %xmm0            # xmm0 = xmm9[0],xmm0[1,2,3]
                	addss	%xmm6, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L66>
-               	movq	%rsi, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rbx
-               	jmp	 <L68>
-<L66>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rbx
-<L68>:
-               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	addss	%xmm6, %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	addss	%xmm6, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L70>
-               	movq	%rbx, %rcx
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rsi
-               	jmp	 <L72>
-<L70>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rsi
-<L72>:
+               	callq	 <L30>
+<L30>:
                	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
                	addss	%xmm6, %xmm0
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
                	addss	%xmm0, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L74>
-               	movq	%rsi, %rcx
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rbx
-               	jmp	 <L76>
-<L74>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rbx
-<L76>:
+               	movq	%rax, %rcx
+               	callq	 <L31>
+<L31>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	subss	%xmm6, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L78>
-               	movq	%rbx, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %rsi
-               	jmp	 <L80>
-<L78>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rsi
-<L80>:
-               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	addss	%xmm6, %xmm0
+               	callq	 <L32>
+<L32>:
+               	movss	%xmm9, %xmm0            # xmm0 = xmm9[0],xmm0[1,2,3]
+               	subss	%xmm7, %xmm0
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	%xmm7, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L82>
-               	movq	%rsi, %rcx
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rbx
-               	jmp	 <L84>
-<L82>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rbx
-<L84>:
+               	callq	 <L33>
+<L33>:
                	xorps	%xmm0, %xmm0
                	mulss	%xmm6, %xmm0
+               	movq	%rax, %rbx
                	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
                	movl	$0x0, %esi
                	cmpl	$0x18, %esi
-               	jb	 <L85>
-               	jmp	 <L90>
-<L85>:
+               	jb	 <L34>
+               	jmp	 <L39>
+<L34>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	addss	%xmm8, %xmm0
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
-               	mulss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x69b>
+               	mulss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x36a>
                	ucomiss	%xmm9, %xmm9
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L87>
+               	jne	 <L36>
                	movq	%rbx, %rcx
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L86>
-<L86>:
+               	callq	 <L35>
+<L35>:
                	movq	%rax, %r12
-               	jmp	 <L89>
-<L87>:
+               	jmp	 <L38>
+<L36>:
                	movq	%rbx, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L88>
-<L88>:
+               	callq	 <L37>
+<L37>:
                	movq	%rax, %r12
-<L89>:
+<L38>:
                	addl	$0x1, %esi
                	movq	%r12, %rbx
                	movsd	%xmm9, %xmm7            # xmm7 = xmm9[0],xmm7[1]
                	cmpl	$0x18, %esi
-               	jb	 <L85>
-<L90>:
+               	jb	 <L34>
+<L39>:
                	movl	$0x7f7fffff, %eax       # imm = 0x7F7FFFFF
                	addl	%edi, %eax
                	movd	%eax, %xmm7
@@ -590,42 +318,42 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L92>
+               	jne	 <L41>
                	movq	%rbx, %rcx
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L91>
-<L91>:
+               	callq	 <L40>
+<L40>:
                	movq	%rax, %rsi
-               	jmp	 <L94>
-<L92>:
+               	jmp	 <L43>
+<L41>:
                	movq	%rbx, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L93>
-<L93>:
+               	callq	 <L42>
+<L42>:
                	movq	%rax, %rsi
-<L94>:
+<L43>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x743>
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x412>
                	ucomiss	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L96>
+               	jne	 <L45>
                	movq	%rsi, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L95>
-<L95>:
+               	callq	 <L44>
+<L44>:
                	movq	%rax, %rbx
-               	jmp	 <L98>
-<L96>:
+               	jmp	 <L47>
+<L45>:
                	movq	%rsi, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L97>
-<L97>:
+               	callq	 <L46>
+<L46>:
                	movq	%rax, %rbx
-<L98>:
+<L47>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	addss	%xmm7, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -634,317 +362,210 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L100>
+               	jne	 <L49>
                	movq	%rbx, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L99>
-<L99>:
+               	callq	 <L48>
+<L48>:
                	movq	%rax, %rsi
-               	jmp	 <L102>
-<L100>:
+               	jmp	 <L51>
+<L49>:
                	movq	%rbx, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L101>
-<L101>:
+               	callq	 <L50>
+<L50>:
                	movq	%rax, %rsi
-<L102>:
-               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x7d1>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L104>
+<L51>:
+               	movss	%xmm7, %xmm8            # xmm8 = xmm7[0],xmm8[1,2,3]
+               	mulss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x4a2>
                	movq	%rsi, %rcx
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	callq	 <L52>
+<L52>:
+               	xorps	%xmm0, %xmm0
+               	subss	%xmm8, %xmm0
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L103>
-<L103>:
-               	movq	%rax, %rbx
-               	jmp	 <L106>
-<L104>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L105>
-<L105>:
-               	movq	%rax, %rbx
-<L106>:
-               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x81a>
-               	xorps	%xmm1, %xmm1
-               	subss	%xmm0, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L108>
-               	movq	%rbx, %rcx
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %rsi
-               	jmp	 <L110>
-<L108>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L109>
-<L109>:
-               	movq	%rax, %rsi
-<L110>:
+               	callq	 <L53>
+<L53>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	mulss	%xmm7, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L112>
-               	movq	%rsi, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L111>
-<L111>:
-               	movq	%rax, %rbx
-               	jmp	 <L114>
-<L112>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L113>
-<L113>:
-               	movq	%rax, %rbx
-<L114>:
+               	callq	 <L54>
+<L54>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	subss	%xmm7, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L116>
-               	movq	%rbx, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L115>
-<L115>:
-               	movq	%rax, %rsi
-               	jmp	 <L118>
-<L116>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L117>
-<L117>:
-               	movq	%rax, %rsi
-<L118>:
-               	movl	$0x800000, %eax         # imm = 0x800000
-               	addl	%edi, %eax
-               	movd	%eax, %xmm7
-               	movl	$0x1, %eax
-               	addl	%edi, %eax
-               	movd	%eax, %xmm8
+               	callq	 <L55>
+<L55>:
+               	movl	$0x800000, %ecx         # imm = 0x800000
+               	addl	%edi, %ecx
+               	movd	%ecx, %xmm7
+               	movl	$0x1, %ecx
+               	addl	%edi, %ecx
+               	movd	%ecx, %xmm8
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x908>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L120>
-               	movq	%rsi, %rcx
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x50f>
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L119>
-<L119>:
-               	movq	%rax, %rbx
-               	jmp	 <L122>
-<L120>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L121>
-<L121>:
-               	movq	%rax, %rbx
-<L122>:
+               	callq	 <L56>
+<L56>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x951>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L124>
-               	movq	%rbx, %rcx
+               	divss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x527>
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L123>
-<L123>:
-               	movq	%rax, %rsi
-               	jmp	 <L126>
-<L124>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L125>
-<L125>:
-               	movq	%rax, %rsi
-<L126>:
+               	callq	 <L57>
+<L57>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	subss	%xmm8, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L128>
-               	movq	%rsi, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %rbx
-               	jmp	 <L130>
-<L128>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L129>
-<L129>:
-               	movq	%rax, %rbx
-<L130>:
+               	callq	 <L58>
+<L58>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	mulss	%xmm6, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L132>
-               	movq	%rbx, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L131>
-<L131>:
-               	movq	%rax, %rsi
-               	jmp	 <L134>
-<L132>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L133>
-<L133>:
-               	movq	%rax, %rsi
-<L134>:
+               	callq	 <L59>
+<L59>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
                	addss	%xmm8, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L136>
-               	movq	%rsi, %rcx
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L135>
-<L135>:
-               	movq	%rax, %rbx
-               	jmp	 <L138>
-<L136>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L137>
-<L137>:
-               	movq	%rax, %rbx
-<L138>:
+               	callq	 <L60>
+<L60>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xa6d>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L140>
-               	movq	%rbx, %rcx
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x57f>
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L139>
-<L139>:
-               	movq	%rax, %rsi
-               	jmp	 <L142>
-<L140>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L141>
-<L141>:
-               	movq	%rax, %rsi
-<L142>:
+               	callq	 <L61>
+<L61>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xab7>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L144>
-               	movq	%rsi, %rcx
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x598>
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L143>
-<L143>:
-               	movq	%rax, %rbx
-               	jmp	 <L146>
-<L144>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L145>
-<L145>:
-               	movq	%rax, %rbx
-<L146>:
+               	callq	 <L62>
+<L62>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xb01>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L148>
-               	movq	%rbx, %rcx
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x5b1>
+               	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L147>
-<L147>:
-               	movq	%rax, %rsi
-               	jmp	 <L150>
-<L148>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %rsi
-<L150>:
+               	callq	 <L63>
+<L63>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
                	divss	%xmm7, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
+               	movq	%rax, %rcx
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	callq	 <L64>
+<L64>:
+               	movq	%rax, %rbx
+               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0x5dd>
+               	mulss	%xmm6, %xmm7
+               	movss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0x5ea>
+               	mulss	%xmm6, %xmm8
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm8
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L152>
-               	movq	%rsi, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-               	jmp	 <L154>
-<L152>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L153>
-<L153>:
-               	movq	%rax, %rbx
-<L154>:
-               	movss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xb8c>
-               	mulss	%xmm6, %xmm7
-               	movss	, %xmm8 <corpus.cases.float.arith_f32.checksum+0xb99>
-               	mulss	%xmm6, %xmm8
+               	jne	 <L67>
+               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x619>
+               	ucomiss	%xmm0, %xmm7
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L65>
+               	jmp	 <L66>
+<L65>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm7
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L66>:
+               	jmp	 <L68>
+<L67>:
+               	movq	%rax, %rcx
+<L68>:
+               	testb	%cl, %cl
+               	jne	 <L81>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm7, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L69>
+               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
+               	jmp	 <L70>
+<L69>:
+               	xorps	%xmm0, %xmm0
+               	subss	%xmm7, %xmm0
+<L70>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm8, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L71>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	jmp	 <L72>
+<L71>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm8, %xmm1
+<L72>:
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0x6b9>
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+<L73>:
+               	ucomiss	%xmm3, %xmm2
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L80>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+<L74>:
+               	ucomiss	%xmm1, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L77>
+               	testb	%al, %al
+               	jne	 <L75>
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	jmp	 <L76>
+<L75>:
+               	xorps	%xmm9, %xmm9
+               	subss	%xmm4, %xmm9
+<L76>:
+               	jmp	 <L82>
+<L77>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L78>
+               	movsd	%xmm4, %xmm10           # xmm10 = xmm4[0],xmm10[1]
+               	jmp	 <L79>
+<L78>:
+               	movss	%xmm4, %xmm10           # xmm10 = xmm4[0],xmm10[1,2,3]
+               	subss	%xmm5, %xmm10
+<L79>:
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x737>
+               	movsd	%xmm10, %xmm4           # xmm4 = xmm10[0],xmm4[1]
+               	jmp	 <L74>
+<L80>:
+               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x749>
+               	jmp	 <L73>
+<L81>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
                	divss	%xmm8, %xmm0
                	cvttss2si	%xmm0, %r11
@@ -953,30 +574,132 @@ Disassembly of section .text:
                	cvtsi2ss	%r11, %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	mulss	%xmm8, %xmm1
-               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	subss	%xmm1, %xmm0
-               	ucomiss	%xmm0, %xmm0
+               	movss	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1,2,3]
+               	subss	%xmm1, %xmm9
+<L82>:
+               	ucomiss	%xmm9, %xmm9
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L156>
+               	jne	 <L84>
                	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L155>
-<L155>:
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	callq	 <L83>
+<L83>:
                	movq	%rax, %rsi
-               	jmp	 <L158>
-<L156>:
+               	jmp	 <L86>
+<L84>:
                	movq	%rbx, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L157>
-<L157>:
+               	callq	 <L85>
+<L85>:
                	movq	%rax, %rsi
-<L158>:
+<L86>:
                	xorps	%xmm0, %xmm0
                	subss	%xmm7, %xmm0
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm8
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L89>
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x7ea>
+               	ucomiss	%xmm1, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L87>
+               	jmp	 <L88>
+<L87>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L88>:
+               	jmp	 <L90>
+<L89>:
+               	movq	%rax, %rcx
+<L90>:
+               	testb	%cl, %cl
+               	jne	 <L103>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L91>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L92>
+<L91>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm0, %xmm1
+<L92>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm8, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L93>
+               	movsd	%xmm8, %xmm2            # xmm2 = xmm8[0],xmm2[1]
+               	jmp	 <L94>
+<L93>:
+               	xorps	%xmm2, %xmm2
+               	subss	%xmm8, %xmm2
+<L94>:
+               	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
+               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x88a>
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+<L95>:
+               	ucomiss	%xmm4, %xmm3
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L102>
+               	movsd	%xmm1, %xmm5            # xmm5 = xmm1[0],xmm5[1]
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+<L96>:
+               	ucomiss	%xmm2, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L99>
+               	testb	%al, %al
+               	jne	 <L97>
+               	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
+               	jmp	 <L98>
+<L97>:
+               	xorps	%xmm10, %xmm10
+               	subss	%xmm5, %xmm10
+<L98>:
+               	jmp	 <L104>
+<L99>:
+               	ucomiss	%xmm9, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L100>
+               	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
+               	jmp	 <L101>
+<L100>:
+               	movss	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1,2,3]
+               	subss	%xmm9, %xmm11
+<L101>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x90c>
+               	movsd	%xmm11, %xmm5           # xmm5 = xmm11[0],xmm5[1]
+               	jmp	 <L96>
+<L102>:
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x91e>
+               	jmp	 <L95>
+<L103>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	divss	%xmm8, %xmm1
                	cvttss2si	%xmm1, %r11
@@ -985,29 +708,132 @@ Disassembly of section .text:
                	cvtsi2ss	%r11, %xmm1
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
                	mulss	%xmm8, %xmm2
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	%xmm2, %xmm1
-               	ucomiss	%xmm1, %xmm1
+               	movss	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1,2,3]
+               	subss	%xmm2, %xmm10
+<L104>:
+               	ucomiss	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L160>
+               	jne	 <L106>
                	movq	%rsi, %rcx
-               	callq	 <L159>
-<L159>:
+               	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
+               	callq	 <L105>
+<L105>:
                	movq	%rax, %rbx
-               	jmp	 <L162>
-<L160>:
+               	jmp	 <L108>
+<L106>:
                	movq	%rsi, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L161>
-<L161>:
+               	callq	 <L107>
+<L107>:
                	movq	%rax, %rbx
-<L162>:
+<L108>:
                	xorps	%xmm0, %xmm0
                	subss	%xmm8, %xmm0
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L111>
+               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x9c0>
+               	ucomiss	%xmm1, %xmm7
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L109>
+               	jmp	 <L110>
+<L109>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm7
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L110>:
+               	jmp	 <L112>
+<L111>:
+               	movq	%rax, %rcx
+<L112>:
+               	testb	%cl, %cl
+               	jne	 <L125>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm7, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L113>
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	jmp	 <L114>
+<L113>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm7, %xmm1
+<L114>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L115>
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	jmp	 <L116>
+<L115>:
+               	xorps	%xmm2, %xmm2
+               	subss	%xmm0, %xmm2
+<L116>:
+               	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
+               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0xa5e>
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+<L117>:
+               	ucomiss	%xmm4, %xmm3
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L124>
+               	movsd	%xmm1, %xmm5            # xmm5 = xmm1[0],xmm5[1]
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+<L118>:
+               	ucomiss	%xmm2, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L121>
+               	testb	%al, %al
+               	jne	 <L119>
+               	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
+               	jmp	 <L120>
+<L119>:
+               	xorps	%xmm10, %xmm10
+               	subss	%xmm5, %xmm10
+<L120>:
+               	jmp	 <L126>
+<L121>:
+               	ucomiss	%xmm9, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L122>
+               	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
+               	jmp	 <L123>
+<L122>:
+               	movss	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1,2,3]
+               	subss	%xmm9, %xmm11
+<L123>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xae0>
+               	movsd	%xmm11, %xmm5           # xmm5 = xmm11[0],xmm5[1]
+               	jmp	 <L118>
+<L124>:
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xaf2>
+               	jmp	 <L117>
+<L125>:
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
                	divss	%xmm0, %xmm1
                	cvttss2si	%xmm1, %r11
@@ -1016,32 +842,134 @@ Disassembly of section .text:
                	cvtsi2ss	%r11, %xmm1
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
                	mulss	%xmm0, %xmm2
-               	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
-               	subss	%xmm2, %xmm0
-               	ucomiss	%xmm0, %xmm0
+               	movss	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1,2,3]
+               	subss	%xmm2, %xmm10
+<L126>:
+               	ucomiss	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L164>
+               	jne	 <L128>
                	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L163>
-<L163>:
+               	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
+               	callq	 <L127>
+<L127>:
                	movq	%rax, %rsi
-               	jmp	 <L166>
-<L164>:
+               	jmp	 <L130>
+<L128>:
                	movq	%rbx, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L165>
-<L165>:
+               	callq	 <L129>
+<L129>:
                	movq	%rax, %rsi
-<L166>:
+<L130>:
                	xorps	%xmm0, %xmm0
                	subss	%xmm7, %xmm0
                	xorps	%xmm1, %xmm1
                	subss	%xmm8, %xmm1
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm1
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L133>
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xb99>
+               	ucomiss	%xmm2, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L131>
+               	jmp	 <L132>
+<L131>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L132>:
+               	jmp	 <L134>
+<L133>:
+               	movq	%rax, %rcx
+<L134>:
+               	testb	%cl, %cl
+               	jne	 <L147>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L135>
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	jmp	 <L136>
+<L135>:
+               	xorps	%xmm2, %xmm2
+               	subss	%xmm0, %xmm2
+<L136>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm1, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L137>
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+               	jmp	 <L138>
+<L137>:
+               	xorps	%xmm3, %xmm3
+               	subss	%xmm1, %xmm3
+<L138>:
+               	movss	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1,2,3]
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xc37>
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+<L139>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L146>
+               	movsd	%xmm2, %xmm7            # xmm7 = xmm2[0],xmm7[1]
+               	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
+<L140>:
+               	ucomiss	%xmm3, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L143>
+               	testb	%al, %al
+               	jne	 <L141>
+               	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
+               	jmp	 <L142>
+<L141>:
+               	xorps	%xmm10, %xmm10
+               	subss	%xmm7, %xmm10
+<L142>:
+               	jmp	 <L148>
+<L143>:
+               	ucomiss	%xmm9, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L144>
+               	movsd	%xmm7, %xmm11           # xmm11 = xmm7[0],xmm11[1]
+               	jmp	 <L145>
+<L144>:
+               	movss	%xmm7, %xmm11           # xmm11 = xmm7[0],xmm11[1,2,3]
+               	subss	%xmm9, %xmm11
+<L145>:
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xcb9>
+               	movsd	%xmm11, %xmm7           # xmm7 = xmm11[0],xmm7[1]
+               	jmp	 <L140>
+<L146>:
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xccb>
+               	jmp	 <L139>
+<L147>:
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	divss	%xmm1, %xmm2
                	cvttss2si	%xmm2, %r11
@@ -1050,40 +978,145 @@ Disassembly of section .text:
                	cvtsi2ss	%r11, %xmm2
                	movss	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1,2,3]
                	mulss	%xmm1, %xmm3
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	%xmm3, %xmm1
-               	ucomiss	%xmm1, %xmm1
+               	movss	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1,2,3]
+               	subss	%xmm3, %xmm10
+<L148>:
+               	ucomiss	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L168>
+               	jne	 <L150>
                	movq	%rsi, %rcx
-               	callq	 <L167>
-<L167>:
+               	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
+               	callq	 <L149>
+<L149>:
                	movq	%rax, %rbx
-               	jmp	 <L170>
-<L168>:
+               	jmp	 <L152>
+<L150>:
                	movq	%rsi, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L169>
-<L169>:
+               	callq	 <L151>
+<L151>:
                	movq	%rax, %rbx
-<L170>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xd54>
+<L152>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xd41>
                	mulss	%xmm6, %xmm0
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xd4e>
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm14
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L155>
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	divss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0xd64>
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0xd78>
+               	ucomiss	%xmm1, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L153>
+               	jmp	 <L154>
+<L153>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L154>:
+               	jmp	 <L156>
+<L155>:
+               	movq	%rax, %rcx
+<L156>:
+               	testb	%cl, %cl
+               	jne	 <L169>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L157>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L158>
+<L157>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm0, %xmm1
+<L158>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xdef>
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L159>
+               	movss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xe06>
+               	jmp	 <L160>
+<L159>:
+               	xorps	%xmm2, %xmm2
+               	subss	, %xmm2 <L160>
+<L160>:
+               	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
+               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0xe22>
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+<L161>:
+               	ucomiss	%xmm4, %xmm3
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L168>
+               	movsd	%xmm1, %xmm5            # xmm5 = xmm1[0],xmm5[1]
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+<L162>:
+               	ucomiss	%xmm2, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L165>
+               	testb	%al, %al
+               	jne	 <L163>
+               	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
+               	jmp	 <L164>
+<L163>:
+               	xorps	%xmm9, %xmm9
+               	subss	%xmm5, %xmm9
+<L164>:
+               	jmp	 <L170>
+<L165>:
+               	ucomiss	%xmm7, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L166>
+               	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
+               	jmp	 <L167>
+<L166>:
+               	movss	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1,2,3]
+               	subss	%xmm7, %xmm10
+<L167>:
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xea0>
+               	movsd	%xmm10, %xmm5           # xmm5 = xmm10[0],xmm5[1]
+               	jmp	 <L162>
+<L168>:
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xeb2>
+               	jmp	 <L161>
+<L169>:
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	divss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0xec3>
                	cvttss2si	%xmm1, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2ss	%r11, %xmm1
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xd80>
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	%xmm2, %xmm1
-               	ucomiss	%xmm1, %xmm1
+               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xedf>
+               	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
+               	subss	%xmm2, %xmm9
+<L170>:
+               	ucomiss	%xmm9, %xmm9
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
@@ -1091,6 +1124,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L172>
                	movq	%rbx, %rcx
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
                	callq	 <L171>
 <L171>:
                	movq	%rax, %rsi
@@ -1102,36 +1136,239 @@ Disassembly of section .text:
 <L173>:
                	movq	%rax, %rsi
 <L174>:
-               	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
-               	divss	%xmm8, %xmm0
-               	cvttss2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	%xmm8, %xmm1
-               	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
-               	subss	%xmm1, %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm8
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L176>
-               	movq	%rsi, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L175>
+               	jne	 <L177>
+               	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xf52>
+               	ucomiss	%xmm0, %xmm6
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L175>
+               	jmp	 <L176>
 <L175>:
-               	movq	%rax, %rbx
-               	jmp	 <L178>
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm6
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
 <L176>:
+               	jmp	 <L178>
+<L177>:
+               	movq	%rax, %rcx
+<L178>:
+               	testb	%cl, %cl
+               	jne	 <L191>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm6, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L179>
+               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
+               	jmp	 <L180>
+<L179>:
+               	xorps	%xmm0, %xmm0
+               	subss	%xmm6, %xmm0
+<L180>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm8, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L181>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	jmp	 <L182>
+<L181>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm8, %xmm1
+<L182>:
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xff2>
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+<L183>:
+               	ucomiss	%xmm3, %xmm2
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L190>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+<L184>:
+               	ucomiss	%xmm1, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L187>
+               	testb	%al, %al
+               	jne	 <L185>
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	jmp	 <L186>
+<L185>:
+               	xorps	%xmm7, %xmm7
+               	subss	%xmm4, %xmm7
+<L186>:
+               	jmp	 <L192>
+<L187>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L188>
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	jmp	 <L189>
+<L188>:
+               	movss	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1,2,3]
+               	subss	%xmm5, %xmm9
+<L189>:
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x106d>
+               	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
+               	jmp	 <L184>
+<L190>:
+               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x107f>
+               	jmp	 <L183>
+<L191>:
+               	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
+               	divss	%xmm8, %xmm0
+               	cvttss2si	%xmm0, %r11
+               	movq	%r11, %rax
+               	movq	%rax, %r11
+               	cvtsi2ss	%r11, %xmm0
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	%xmm8, %xmm1
+               	movss	%xmm6, %xmm7            # xmm7 = xmm6[0],xmm7[1,2,3]
+               	subss	%xmm1, %xmm7
+<L192>:
+               	ucomiss	%xmm7, %xmm7
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L194>
+               	movq	%rsi, %rcx
+               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
+               	callq	 <L193>
+<L193>:
+               	movq	%rax, %rbx
+               	jmp	 <L196>
+<L194>:
                	movq	%rsi, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L177>
-<L177>:
+               	callq	 <L195>
+<L195>:
                	movq	%rax, %rbx
-<L178>:
+<L196>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm8
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L199>
+               	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1116>
+               	ucomiss	%xmm0, %xmm8
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L197>
+               	jmp	 <L198>
+<L197>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm8
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L198>:
+               	jmp	 <L200>
+<L199>:
+               	movq	%rax, %rcx
+<L200>:
+               	testb	%cl, %cl
+               	jne	 <L213>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm8, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L201>
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	jmp	 <L202>
+<L201>:
+               	xorps	%xmm0, %xmm0
+               	subss	%xmm8, %xmm0
+<L202>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm8, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L203>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	jmp	 <L204>
+<L203>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm8, %xmm1
+<L204>:
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0x11b9>
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+<L205>:
+               	ucomiss	%xmm3, %xmm2
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L212>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+<L206>:
+               	ucomiss	%xmm1, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L209>
+               	testb	%al, %al
+               	jne	 <L207>
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	jmp	 <L208>
+<L207>:
+               	xorps	%xmm7, %xmm7
+               	subss	%xmm4, %xmm7
+<L208>:
+               	jmp	 <L214>
+<L209>:
+               	ucomiss	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L210>
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	jmp	 <L211>
+<L210>:
+               	movss	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1,2,3]
+               	subss	%xmm5, %xmm9
+<L211>:
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x1234>
+               	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
+               	jmp	 <L206>
+<L212>:
+               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x1246>
+               	jmp	 <L205>
+<L213>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
                	divss	%xmm8, %xmm0
                	cvttss2si	%xmm0, %r11
@@ -1140,30 +1377,132 @@ Disassembly of section .text:
                	cvtsi2ss	%r11, %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	mulss	%xmm8, %xmm1
-               	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
-               	subss	%xmm1, %xmm0
-               	ucomiss	%xmm0, %xmm0
+               	movss	%xmm8, %xmm7            # xmm7 = xmm8[0],xmm7[1,2,3]
+               	subss	%xmm1, %xmm7
+<L214>:
+               	ucomiss	%xmm7, %xmm7
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L180>
+               	jne	 <L216>
                	movq	%rbx, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L179>
-<L179>:
+               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
+               	callq	 <L215>
+<L215>:
                	movq	%rax, %rsi
-               	jmp	 <L182>
-<L180>:
+               	jmp	 <L218>
+<L216>:
                	movq	%rbx, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L181>
-<L181>:
+               	callq	 <L217>
+<L217>:
                	movq	%rax, %rsi
-<L182>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xe99>
+<L218>:
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x12bc>
                	mulss	%xmm6, %xmm0
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm8
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L221>
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x12ea>
+               	ucomiss	%xmm1, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L219>
+               	jmp	 <L220>
+<L219>:
+               	xorps	%xmm15, %xmm15
+               	ucomiss	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L220>:
+               	jmp	 <L222>
+<L221>:
+               	movq	%rax, %rcx
+<L222>:
+               	testb	%cl, %cl
+               	jne	 <L235>
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L223>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L224>
+<L223>:
+               	xorps	%xmm1, %xmm1
+               	subss	%xmm0, %xmm1
+<L224>:
+               	xorps	%xmm14, %xmm14
+               	ucomiss	%xmm8, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L225>
+               	movsd	%xmm8, %xmm2            # xmm2 = xmm8[0],xmm2[1]
+               	jmp	 <L226>
+<L225>:
+               	xorps	%xmm2, %xmm2
+               	subss	%xmm8, %xmm2
+<L226>:
+               	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
+               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x138a>
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+<L227>:
+               	ucomiss	%xmm4, %xmm3
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L234>
+               	movsd	%xmm1, %xmm5            # xmm5 = xmm1[0],xmm5[1]
+               	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
+<L228>:
+               	ucomiss	%xmm2, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L231>
+               	testb	%al, %al
+               	jne	 <L229>
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+               	jmp	 <L230>
+<L229>:
+               	xorps	%xmm7, %xmm7
+               	subss	%xmm5, %xmm7
+<L230>:
+               	jmp	 <L236>
+<L231>:
+               	ucomiss	%xmm6, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L232>
+               	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
+               	jmp	 <L233>
+<L232>:
+               	movss	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1,2,3]
+               	subss	%xmm6, %xmm9
+<L233>:
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x1405>
+               	movsd	%xmm9, %xmm5            # xmm5 = xmm9[0],xmm5[1]
+               	jmp	 <L228>
+<L234>:
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1417>
+               	jmp	 <L227>
+<L235>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	divss	%xmm8, %xmm1
                	cvttss2si	%xmm1, %r11
@@ -1172,34 +1511,38 @@ Disassembly of section .text:
                	cvtsi2ss	%r11, %xmm1
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
                	mulss	%xmm8, %xmm2
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	%xmm2, %xmm1
-               	ucomiss	%xmm1, %xmm1
+               	movss	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1,2,3]
+               	subss	%xmm2, %xmm7
+<L236>:
+               	ucomiss	%xmm7, %xmm7
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L184>
+               	jne	 <L238>
                	movq	%rsi, %rcx
-               	callq	 <L183>
-<L183>:
+               	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
+               	callq	 <L237>
+<L237>:
                	movq	%rax, %rbx
-               	jmp	 <L186>
-<L184>:
+               	jmp	 <L240>
+<L238>:
                	movq	%rsi, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L185>
-<L185>:
+               	callq	 <L239>
+<L239>:
                	movq	%rax, %rbx
-<L186>:
+<L240>:
                	movq	%rbx, %rax
                	movaps	-0x30(%rbp), %xmm6
                	movaps	-0x40(%rbp), %xmm7
                	movaps	-0x50(%rbp), %xmm8
                	movaps	-0x60(%rbp), %xmm9
-               	movaps	-0x70(%rbp), %xmm14
-               	movaps	-0x80(%rbp), %xmm15
+               	movaps	-0x70(%rbp), %xmm10
+               	movaps	-0x80(%rbp), %xmm11
+               	movaps	-0x90(%rbp), %xmm14
+               	movaps	-0xa0(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi

--- a/test/golden/x86_64-windows/float/arith_f32.dis
+++ b/test/golden/x86_64-windows/float/arith_f32.dis
@@ -543,8 +543,8 @@ Disassembly of section .text:
                	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
                	jmp	 <L76>
 <L75>:
-               	xorps	%xmm9, %xmm9
-               	subss	%xmm4, %xmm9
+               	movss	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1,2,3]
+               	xorps	, %xmm9 <L76>
 <L76>:
                	jmp	 <L82>
 <L77>:
@@ -559,11 +559,11 @@ Disassembly of section .text:
                	movss	%xmm4, %xmm10           # xmm10 = xmm4[0],xmm10[1,2,3]
                	subss	%xmm5, %xmm10
 <L79>:
-               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x737>
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x73b>
                	movsd	%xmm10, %xmm4           # xmm4 = xmm10[0],xmm4[1]
                	jmp	 <L74>
 <L80>:
-               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x749>
+               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x74d>
                	jmp	 <L73>
 <L81>:
                	movss	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1,2,3]
@@ -608,7 +608,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L89>
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x7ea>
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x7ee>
                	ucomiss	%xmm1, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -656,7 +656,7 @@ Disassembly of section .text:
                	subss	%xmm8, %xmm2
 <L94>:
                	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
-               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x88a>
+               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x88e>
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
 <L95>:
                	ucomiss	%xmm4, %xmm3
@@ -677,8 +677,8 @@ Disassembly of section .text:
                	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
                	jmp	 <L98>
 <L97>:
-               	xorps	%xmm10, %xmm10
-               	subss	%xmm5, %xmm10
+               	movss	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1,2,3]
+               	xorps	, %xmm10 <L98>
 <L98>:
                	jmp	 <L104>
 <L99>:
@@ -693,11 +693,11 @@ Disassembly of section .text:
                	movss	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
 <L101>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x90c>
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0x914>
                	movsd	%xmm11, %xmm5           # xmm5 = xmm11[0],xmm5[1]
                	jmp	 <L96>
 <L102>:
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x91e>
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x926>
                	jmp	 <L95>
 <L103>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
@@ -742,7 +742,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L111>
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x9c0>
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x9c8>
                	ucomiss	%xmm1, %xmm7
                	sete	%cl
                	setnp	%r11b
@@ -790,7 +790,7 @@ Disassembly of section .text:
                	subss	%xmm0, %xmm2
 <L116>:
                	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
-               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0xa5e>
+               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0xa66>
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
 <L117>:
                	ucomiss	%xmm4, %xmm3
@@ -811,8 +811,8 @@ Disassembly of section .text:
                	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
                	jmp	 <L120>
 <L119>:
-               	xorps	%xmm10, %xmm10
-               	subss	%xmm5, %xmm10
+               	movss	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1,2,3]
+               	xorps	, %xmm10 <L120>
 <L120>:
                	jmp	 <L126>
 <L121>:
@@ -827,11 +827,11 @@ Disassembly of section .text:
                	movss	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
 <L123>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xae0>
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xaec>
                	movsd	%xmm11, %xmm5           # xmm5 = xmm11[0],xmm5[1]
                	jmp	 <L118>
 <L124>:
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xaf2>
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xafe>
                	jmp	 <L117>
 <L125>:
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
@@ -878,7 +878,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L133>
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xb99>
+               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xba5>
                	ucomiss	%xmm2, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -926,7 +926,7 @@ Disassembly of section .text:
                	subss	%xmm1, %xmm3
 <L138>:
                	movss	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xc37>
+               	divss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xc43>
                	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
 <L139>:
                	ucomiss	%xmm5, %xmm4
@@ -947,8 +947,8 @@ Disassembly of section .text:
                	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
                	jmp	 <L142>
 <L141>:
-               	xorps	%xmm10, %xmm10
-               	subss	%xmm7, %xmm10
+               	movss	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1,2,3]
+               	xorps	, %xmm10 <L142>
 <L142>:
                	jmp	 <L148>
 <L143>:
@@ -963,11 +963,11 @@ Disassembly of section .text:
                	movss	%xmm7, %xmm11           # xmm11 = xmm7[0],xmm11[1,2,3]
                	subss	%xmm9, %xmm11
 <L145>:
-               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xcb9>
+               	divss	, %xmm9 <corpus.cases.float.arith_f32.checksum+0xcc9>
                	movsd	%xmm11, %xmm7           # xmm7 = xmm11[0],xmm7[1]
                	jmp	 <L140>
 <L146>:
-               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xccb>
+               	mulss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0xcdb>
                	jmp	 <L139>
 <L147>:
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
@@ -1001,9 +1001,9 @@ Disassembly of section .text:
 <L151>:
                	movq	%rax, %rbx
 <L152>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xd41>
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xd51>
                	mulss	%xmm6, %xmm0
-               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xd4e>
+               	movss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xd5e>
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm14
                	sete	%al
@@ -1013,7 +1013,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L155>
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0xd78>
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0xd88>
                	ucomiss	%xmm1, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -1049,19 +1049,19 @@ Disassembly of section .text:
                	subss	%xmm0, %xmm1
 <L158>:
                	xorps	%xmm14, %xmm14
-               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xdef>
+               	ucomiss	, %xmm14 <corpus.cases.float.arith_f32.checksum+0xdff>
                	seta	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
                	jne	 <L159>
-               	movss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xe06>
+               	movss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xe16>
                	jmp	 <L160>
 <L159>:
                	xorps	%xmm2, %xmm2
                	subss	, %xmm2 <L160>
 <L160>:
                	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
-               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0xe22>
+               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0xe32>
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
 <L161>:
                	ucomiss	%xmm4, %xmm3
@@ -1082,8 +1082,8 @@ Disassembly of section .text:
                	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
                	jmp	 <L164>
 <L163>:
-               	xorps	%xmm9, %xmm9
-               	subss	%xmm5, %xmm9
+               	movss	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1,2,3]
+               	xorps	, %xmm9 <L164>
 <L164>:
                	jmp	 <L170>
 <L165>:
@@ -1098,21 +1098,21 @@ Disassembly of section .text:
                	movss	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1,2,3]
                	subss	%xmm7, %xmm10
 <L167>:
-               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xea0>
+               	divss	, %xmm7 <corpus.cases.float.arith_f32.checksum+0xeb4>
                	movsd	%xmm10, %xmm5           # xmm5 = xmm10[0],xmm5[1]
                	jmp	 <L162>
 <L168>:
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xeb2>
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0xec6>
                	jmp	 <L161>
 <L169>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	divss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0xec3>
+               	divss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0xed7>
                	cvttss2si	%xmm1, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2ss	%r11, %xmm1
                	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xedf>
+               	mulss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xef3>
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
                	subss	%xmm2, %xmm9
 <L170>:
@@ -1145,7 +1145,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L177>
                	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xf52>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0xf66>
                	ucomiss	%xmm0, %xmm6
                	sete	%cl
                	setnp	%r11b
@@ -1193,7 +1193,7 @@ Disassembly of section .text:
                	subss	%xmm8, %xmm1
 <L182>:
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0xff2>
+               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0x1006>
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
 <L183>:
                	ucomiss	%xmm3, %xmm2
@@ -1214,8 +1214,8 @@ Disassembly of section .text:
                	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
                	jmp	 <L186>
 <L185>:
-               	xorps	%xmm7, %xmm7
-               	subss	%xmm4, %xmm7
+               	movss	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1,2,3]
+               	xorps	, %xmm7 <L186>
 <L186>:
                	jmp	 <L192>
 <L187>:
@@ -1230,11 +1230,11 @@ Disassembly of section .text:
                	movss	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1,2,3]
                	subss	%xmm5, %xmm9
 <L189>:
-               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x106d>
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x1085>
                	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
                	jmp	 <L184>
 <L190>:
-               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x107f>
+               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x1097>
                	jmp	 <L183>
 <L191>:
                	movss	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1,2,3]
@@ -1277,7 +1277,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L199>
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
-               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x1116>
+               	mulss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x112e>
                	ucomiss	%xmm0, %xmm8
                	sete	%cl
                	setnp	%r11b
@@ -1325,7 +1325,7 @@ Disassembly of section .text:
                	subss	%xmm8, %xmm1
 <L204>:
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
-               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0x11b9>
+               	divss	, %xmm2 <corpus.cases.float.arith_f32.checksum+0x11d1>
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
 <L205>:
                	ucomiss	%xmm3, %xmm2
@@ -1346,8 +1346,8 @@ Disassembly of section .text:
                	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
                	jmp	 <L208>
 <L207>:
-               	xorps	%xmm7, %xmm7
-               	subss	%xmm4, %xmm7
+               	movss	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1,2,3]
+               	xorps	, %xmm7 <L208>
 <L208>:
                	jmp	 <L214>
 <L209>:
@@ -1362,11 +1362,11 @@ Disassembly of section .text:
                	movss	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1,2,3]
                	subss	%xmm5, %xmm9
 <L211>:
-               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x1234>
+               	divss	, %xmm5 <corpus.cases.float.arith_f32.checksum+0x1250>
                	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
                	jmp	 <L206>
 <L212>:
-               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x1246>
+               	mulss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x1262>
                	jmp	 <L205>
 <L213>:
                	movss	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1,2,3]
@@ -1400,7 +1400,7 @@ Disassembly of section .text:
 <L217>:
                	movq	%rax, %rsi
 <L218>:
-               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x12bc>
+               	movss	, %xmm0 <corpus.cases.float.arith_f32.checksum+0x12d8>
                	mulss	%xmm6, %xmm0
                	xorps	%xmm15, %xmm15
                	ucomiss	%xmm15, %xmm8
@@ -1411,7 +1411,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L221>
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x12ea>
+               	mulss	, %xmm1 <corpus.cases.float.arith_f32.checksum+0x1306>
                	ucomiss	%xmm1, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -1459,7 +1459,7 @@ Disassembly of section .text:
                	subss	%xmm8, %xmm2
 <L226>:
                	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
-               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x138a>
+               	divss	, %xmm3 <corpus.cases.float.arith_f32.checksum+0x13a6>
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
 <L227>:
                	ucomiss	%xmm4, %xmm3
@@ -1480,8 +1480,8 @@ Disassembly of section .text:
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
                	jmp	 <L230>
 <L229>:
-               	xorps	%xmm7, %xmm7
-               	subss	%xmm5, %xmm7
+               	movss	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1,2,3]
+               	xorps	, %xmm7 <L230>
 <L230>:
                	jmp	 <L236>
 <L231>:
@@ -1496,11 +1496,11 @@ Disassembly of section .text:
                	movss	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1,2,3]
                	subss	%xmm6, %xmm9
 <L233>:
-               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x1405>
+               	divss	, %xmm6 <corpus.cases.float.arith_f32.checksum+0x1425>
                	movsd	%xmm9, %xmm5            # xmm5 = xmm9[0],xmm5[1]
                	jmp	 <L228>
 <L234>:
-               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1417>
+               	mulss	, %xmm4 <corpus.cases.float.arith_f32.checksum+0x1437>
                	jmp	 <L227>
 <L235>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]

--- a/test/golden/x86_64-windows/float/arith_f64.dis
+++ b/test/golden/x86_64-windows/float/arith_f64.dis
@@ -46,7 +46,7 @@ Disassembly of section .text:
 <corpus.cases.float.arith_f64.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xa0, %rsp
+               	subq	$0xc0, %rsp
                	movq	%rbx, -0x8(%rbp)
                	movq	%rdi, -0x10(%rbp)
                	movq	%rsi, -0x18(%rbp)
@@ -55,8 +55,10 @@ Disassembly of section .text:
                	movaps	%xmm7, -0x40(%rbp)
                	movaps	%xmm8, -0x50(%rbp)
                	movaps	%xmm9, -0x60(%rbp)
-               	movaps	%xmm14, -0x70(%rbp)
-               	movaps	%xmm15, -0x80(%rbp)
+               	movaps	%xmm10, -0x70(%rbp)
+               	movaps	%xmm11, -0x80(%rbp)
+               	movaps	%xmm14, -0x90(%rbp)
+               	movaps	%xmm15, -0xa0(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -64,9 +66,9 @@ Disassembly of section .text:
                	movabsq	$0x3ff0000000000000, %rax # imm = 0x3FF0000000000000
                	addq	%rbx, %rax
                	movq	%rax, %xmm6
-               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x5c>
+               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x6c>
                	mulsd	%xmm6, %xmm7
-               	movsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x69>
+               	movsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x79>
                	mulsd	%xmm6, %xmm8
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	addsd	%xmm8, %xmm1
@@ -154,417 +156,142 @@ Disassembly of section .text:
 <L16>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	divsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L18>
                	movq	%rsi, %rcx
                	callq	 <L17>
 <L17>:
-               	movq	%rax, %rdi
-               	jmp	 <L20>
-<L18>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L19>
-<L19>:
-               	movq	%rax, %rdi
-<L20>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	divsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L22>
-               	movq	%rdi, %rcx
+               	movq	%rax, %rcx
+               	callq	 <L18>
+<L18>:
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	xorps	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x1bf>
+               	movq	%rax, %rcx
+               	callq	 <L19>
+<L19>:
+               	xorps	%xmm8, %xmm8
+               	subsd	%xmm7, %xmm8
+               	movq	%rax, %rcx
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	callq	 <L20>
+<L20>:
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	subsd	%xmm7, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %rsi
-               	jmp	 <L24>
-<L22>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L23>
-<L23>:
-               	movq	%rax, %rsi
-<L24>:
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	xorps	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x217>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L26>
-               	movq	%rsi, %rcx
-               	callq	 <L25>
-<L25>:
-               	movq	%rax, %rdi
-               	jmp	 <L28>
-<L26>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L27>
-<L27>:
-               	movq	%rax, %rdi
-<L28>:
-               	xorps	%xmm1, %xmm1
-               	subsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L30>
-               	movq	%rdi, %rcx
-               	callq	 <L29>
-<L29>:
-               	movq	%rax, %rsi
-               	jmp	 <L32>
-<L30>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L31>
-<L31>:
-               	movq	%rax, %rsi
-<L32>:
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	subsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L34>
-               	movq	%rsi, %rcx
-               	callq	 <L33>
-<L33>:
-               	movq	%rax, %rdi
-               	jmp	 <L36>
-<L34>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rdi
-<L36>:
-               	xorps	%xmm0, %xmm0
-               	subsd	%xmm7, %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	addsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L38>
-               	movq	%rdi, %rcx
-               	callq	 <L37>
-<L37>:
-               	movq	%rax, %rsi
-               	jmp	 <L40>
-<L38>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rsi
-<L40>:
-               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x32d>
+               	movq	%rax, %rcx
+               	callq	 <L22>
+<L22>:
+               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x206>
                	mulsd	%xmm6, %xmm7
                	movsd	%xmm6, %xmm8            # xmm8 = xmm6[0],xmm8[1]
                	divsd	%xmm7, %xmm8
-               	ucomisd	%xmm8, %xmm8
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L42>
-               	movq	%rsi, %rcx
+               	movq	%rax, %rcx
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rdi
-               	jmp	 <L44>
-<L42>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-<L44>:
+               	callq	 <L23>
+<L23>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	mulsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L46>
-               	movq	%rdi, %rcx
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rsi
-               	jmp	 <L48>
-<L46>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %rsi
-<L48>:
+               	movq	%rax, %rcx
+               	callq	 <L24>
+<L24>:
                	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
                	subsd	%xmm8, %xmm0
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	subsd	%xmm8, %xmm1
                	movsd	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1]
                	subsd	%xmm8, %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L50>
-               	movq	%rsi, %rcx
+               	movq	%rax, %rcx
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rdi
-               	jmp	 <L52>
-<L50>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rdi
-<L52>:
+               	callq	 <L25>
+<L25>:
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x429>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L54>
-               	movq	%rdi, %rcx
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rsi
-               	jmp	 <L56>
-<L54>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rsi
-<L56>:
+               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x265>
+               	movq	%rax, %rcx
+               	callq	 <L26>
+<L26>:
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x471>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L58>
-               	movq	%rsi, %rcx
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rdi
-               	jmp	 <L60>
-<L58>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rdi
-<L60>:
-               	movsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x4b5>
+               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x279>
+               	movq	%rax, %rcx
+               	callq	 <L27>
+<L27>:
+               	movsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x289>
                	divsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L62>
-               	movq	%rdi, %rcx
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rsi
-               	jmp	 <L64>
-<L62>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rsi
-<L64>:
-               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x4fd>
+               	movq	%rax, %rcx
+               	callq	 <L28>
+<L28>:
+               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x29d>
                	mulsd	%xmm6, %xmm7
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
+               	addsd	%xmm6, %xmm9
+               	movq	%rax, %rcx
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	callq	 <L29>
+<L29>:
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
                	addsd	%xmm6, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L66>
-               	movq	%rsi, %rcx
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rdi
-               	jmp	 <L68>
-<L66>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rdi
-<L68>:
-               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
-               	addsd	%xmm6, %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	addsd	%xmm6, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L70>
-               	movq	%rdi, %rcx
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rsi
-               	jmp	 <L72>
-<L70>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rsi
-<L72>:
+               	movq	%rax, %rcx
+               	callq	 <L30>
+<L30>:
                	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
                	addsd	%xmm6, %xmm0
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	addsd	%xmm0, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L74>
-               	movq	%rsi, %rcx
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rdi
-               	jmp	 <L76>
-<L74>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rdi
-<L76>:
+               	movq	%rax, %rcx
+               	callq	 <L31>
+<L31>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	subsd	%xmm6, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L78>
-               	movq	%rdi, %rcx
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %rsi
-               	jmp	 <L80>
-<L78>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rsi
-<L80>:
-               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
-               	addsd	%xmm6, %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	movq	%rax, %rcx
+               	callq	 <L32>
+<L32>:
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
                	subsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L82>
-               	movq	%rsi, %rcx
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rdi
-               	jmp	 <L84>
-<L82>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rdi
-<L84>:
+               	movq	%rax, %rcx
+               	callq	 <L33>
+<L33>:
                	xorps	%xmm0, %xmm0
                	mulsd	%xmm6, %xmm0
+               	movq	%rax, %rsi
                	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
-               	movq	$0x0, %rsi
-               	cmpq	$0x18, %rsi
-               	jb	 <L85>
-               	jmp	 <L90>
-<L85>:
+               	movq	$0x0, %rdi
+               	cmpq	$0x18, %rdi
+               	jb	 <L34>
+               	jmp	 <L39>
+<L34>:
                	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
                	addsd	%xmm8, %xmm0
                	movsd	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1]
-               	mulsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0x6a5>
+               	mulsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0x33d>
                	ucomisd	%xmm9, %xmm9
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L87>
-               	movq	%rdi, %rcx
+               	jne	 <L36>
+               	movq	%rsi, %rcx
                	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	callq	 <L86>
-<L86>:
+               	callq	 <L35>
+<L35>:
                	movq	%rax, %r12
-               	jmp	 <L89>
-<L87>:
-               	movq	%rdi, %rcx
+               	jmp	 <L38>
+<L36>:
+               	movq	%rsi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L88>
-<L88>:
+               	callq	 <L37>
+<L37>:
                	movq	%rax, %r12
-<L89>:
-               	addq	$0x1, %rsi
-               	movq	%r12, %rdi
+<L38>:
+               	addq	$0x1, %rdi
+               	movq	%r12, %rsi
                	movsd	%xmm9, %xmm7            # xmm7 = xmm9[0],xmm7[1]
-               	cmpq	$0x18, %rsi
-               	jb	 <L85>
-<L90>:
+               	cmpq	$0x18, %rdi
+               	jb	 <L34>
+<L39>:
                	movabsq	$0x7fefffffffffffff, %rax # imm = 0x7FEFFFFFFFFFFFFF
                	addq	%rbx, %rax
                	movq	%rax, %xmm7
@@ -574,41 +301,41 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L92>
-               	movq	%rdi, %rcx
+               	jne	 <L41>
+               	movq	%rsi, %rcx
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	callq	 <L91>
-<L91>:
-               	movq	%rax, %rsi
-               	jmp	 <L94>
-<L92>:
-               	movq	%rdi, %rcx
+               	callq	 <L40>
+<L40>:
+               	movq	%rax, %rdi
+               	jmp	 <L43>
+<L41>:
+               	movq	%rsi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L93>
-<L93>:
-               	movq	%rax, %rsi
-<L94>:
+               	callq	 <L42>
+<L42>:
+               	movq	%rax, %rdi
+<L43>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x75b>
+               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x3f3>
                	ucomisd	%xmm1, %xmm1
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L96>
-               	movq	%rsi, %rcx
-               	callq	 <L95>
-<L95>:
-               	movq	%rax, %rdi
-               	jmp	 <L98>
-<L96>:
-               	movq	%rsi, %rcx
+               	jne	 <L45>
+               	movq	%rdi, %rcx
+               	callq	 <L44>
+<L44>:
+               	movq	%rax, %rsi
+               	jmp	 <L47>
+<L45>:
+               	movq	%rdi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L97>
-<L97>:
-               	movq	%rax, %rdi
-<L98>:
+               	callq	 <L46>
+<L46>:
+               	movq	%rax, %rsi
+<L47>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	addsd	%xmm7, %xmm1
                	ucomisd	%xmm1, %xmm1
@@ -617,304 +344,197 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L100>
-               	movq	%rdi, %rcx
-               	callq	 <L99>
-<L99>:
-               	movq	%rax, %rsi
-               	jmp	 <L102>
-<L100>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L101>
-<L101>:
-               	movq	%rax, %rsi
-<L102>:
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x7e7>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L104>
+               	jne	 <L49>
                	movq	%rsi, %rcx
-               	callq	 <L103>
-<L103>:
+               	callq	 <L48>
+<L48>:
                	movq	%rax, %rdi
-               	jmp	 <L106>
-<L104>:
+               	jmp	 <L51>
+<L49>:
                	movq	%rsi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L105>
-<L105>:
+               	callq	 <L50>
+<L50>:
                	movq	%rax, %rdi
-<L106>:
-               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x82f>
+<L51>:
+               	movsd	%xmm7, %xmm8            # xmm8 = xmm7[0],xmm8[1]
+               	mulsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x481>
+               	movq	%rdi, %rcx
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	callq	 <L52>
+<L52>:
                	xorps	%xmm1, %xmm1
-               	subsd	%xmm0, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L108>
-               	movq	%rdi, %rcx
-               	callq	 <L107>
-<L107>:
-               	movq	%rax, %rsi
-               	jmp	 <L110>
-<L108>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L109>
-<L109>:
-               	movq	%rax, %rsi
-<L110>:
+               	subsd	%xmm8, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L53>
+<L53>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	mulsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L112>
-               	movq	%rsi, %rcx
-               	callq	 <L111>
-<L111>:
-               	movq	%rax, %rdi
-               	jmp	 <L114>
-<L112>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L113>
-<L113>:
-               	movq	%rax, %rdi
-<L114>:
+               	movq	%rax, %rcx
+               	callq	 <L54>
+<L54>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	subsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L116>
-               	movq	%rdi, %rcx
-               	callq	 <L115>
-<L115>:
-               	movq	%rax, %rsi
-               	jmp	 <L118>
-<L116>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L117>
-<L117>:
-               	movq	%rax, %rsi
-<L118>:
-               	movabsq	$0x10000000000000, %rax # imm = 0x10000000000000
-               	addq	%rbx, %rax
-               	movq	%rax, %xmm7
-               	movq	$0x1, %rax
-               	addq	%rbx, %rax
-               	movq	%rax, %xmm8
+               	movq	%rax, %rcx
+               	callq	 <L55>
+<L55>:
+               	movabsq	$0x10000000000000, %rcx # imm = 0x10000000000000
+               	addq	%rbx, %rcx
+               	movq	%rcx, %xmm7
+               	movq	$0x1, %rcx
+               	addq	%rbx, %rcx
+               	movq	%rcx, %xmm8
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x927>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L120>
-               	movq	%rsi, %rcx
-               	callq	 <L119>
-<L119>:
-               	movq	%rax, %rbx
-               	jmp	 <L122>
-<L120>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L121>
-<L121>:
-               	movq	%rax, %rbx
-<L122>:
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x4eb>
+               	movq	%rax, %rcx
+               	callq	 <L56>
+<L56>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x96f>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L124>
-               	movq	%rbx, %rcx
-               	callq	 <L123>
-<L123>:
-               	movq	%rax, %rsi
-               	jmp	 <L126>
-<L124>:
-               	movq	%rbx, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L125>
-<L125>:
-               	movq	%rax, %rsi
-<L126>:
+               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x4ff>
+               	movq	%rax, %rcx
+               	callq	 <L57>
+<L57>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	subsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L128>
-               	movq	%rsi, %rcx
-               	callq	 <L127>
-<L127>:
-               	movq	%rax, %rbx
-               	jmp	 <L130>
-<L128>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L129>
-<L129>:
-               	movq	%rax, %rbx
-<L130>:
+               	movq	%rax, %rcx
+               	callq	 <L58>
+<L58>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	mulsd	%xmm6, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L132>
-               	movq	%rbx, %rcx
-               	callq	 <L131>
-<L131>:
-               	movq	%rax, %rsi
-               	jmp	 <L134>
-<L132>:
-               	movq	%rbx, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L133>
-<L133>:
-               	movq	%rax, %rsi
-<L134>:
+               	movq	%rax, %rcx
+               	callq	 <L59>
+<L59>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	addsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L136>
-               	movq	%rsi, %rcx
-               	callq	 <L135>
-<L135>:
-               	movq	%rax, %rbx
-               	jmp	 <L138>
-<L136>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L137>
-<L137>:
-               	movq	%rax, %rbx
-<L138>:
+               	movq	%rax, %rcx
+               	callq	 <L60>
+<L60>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xa87>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L140>
-               	movq	%rbx, %rcx
-               	callq	 <L139>
-<L139>:
-               	movq	%rax, %rsi
-               	jmp	 <L142>
-<L140>:
-               	movq	%rbx, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L141>
-<L141>:
-               	movq	%rax, %rsi
-<L142>:
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x547>
+               	movq	%rax, %rcx
+               	callq	 <L61>
+<L61>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xad0>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L144>
-               	movq	%rsi, %rcx
-               	callq	 <L143>
-<L143>:
-               	movq	%rax, %rbx
-               	jmp	 <L146>
-<L144>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L145>
-<L145>:
-               	movq	%rax, %rbx
-<L146>:
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x55c>
+               	movq	%rax, %rcx
+               	callq	 <L62>
+<L62>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xb19>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L148>
-               	movq	%rbx, %rcx
-               	callq	 <L147>
-<L147>:
-               	movq	%rax, %rsi
-               	jmp	 <L150>
-<L148>:
-               	movq	%rbx, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L149>
-<L149>:
-               	movq	%rax, %rsi
-<L150>:
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x571>
+               	movq	%rax, %rcx
+               	callq	 <L63>
+<L63>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	divsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
+               	movq	%rax, %rcx
+               	callq	 <L64>
+<L64>:
+               	movq	%rax, %rbx
+               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0x595>
+               	mulsd	%xmm6, %xmm7
+               	movsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0x5a2>
+               	mulsd	%xmm6, %xmm8
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm8
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L152>
-               	movq	%rsi, %rcx
-               	callq	 <L151>
-<L151>:
-               	movq	%rax, %rbx
-               	jmp	 <L154>
-<L152>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L153>
-<L153>:
-               	movq	%rax, %rbx
-<L154>:
-               	movsd	, %xmm7 <corpus.cases.float.arith_f64.checksum+0xba2>
-               	mulsd	%xmm6, %xmm7
-               	movsd	, %xmm8 <corpus.cases.float.arith_f64.checksum+0xbaf>
-               	mulsd	%xmm6, %xmm8
+               	jne	 <L67>
+               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x5d2>
+               	ucomisd	%xmm0, %xmm7
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L65>
+               	jmp	 <L66>
+<L65>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm7
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L66>:
+               	jmp	 <L68>
+<L67>:
+               	movq	%rax, %rcx
+<L68>:
+               	testb	%cl, %cl
+               	jne	 <L81>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm7, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L69>
+               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
+               	jmp	 <L70>
+<L69>:
+               	xorps	%xmm0, %xmm0
+               	subsd	%xmm7, %xmm0
+<L70>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm8, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L71>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	jmp	 <L72>
+<L71>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm8, %xmm1
+<L72>:
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0x676>
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+<L73>:
+               	ucomisd	%xmm3, %xmm2
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L80>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+<L74>:
+               	ucomisd	%xmm1, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L77>
+               	testb	%al, %al
+               	jne	 <L75>
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	jmp	 <L76>
+<L75>:
+               	xorps	%xmm9, %xmm9
+               	subsd	%xmm4, %xmm9
+<L76>:
+               	jmp	 <L82>
+<L77>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L78>
+               	movsd	%xmm4, %xmm10           # xmm10 = xmm4[0],xmm10[1]
+               	jmp	 <L79>
+<L78>:
+               	movsd	%xmm4, %xmm10           # xmm10 = xmm4[0],xmm10[1]
+               	subsd	%xmm5, %xmm10
+<L79>:
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x6f7>
+               	movsd	%xmm10, %xmm4           # xmm4 = xmm10[0],xmm4[1]
+               	jmp	 <L74>
+<L80>:
+               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x709>
+               	jmp	 <L73>
+<L81>:
                	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
                	divsd	%xmm8, %xmm0
                	cvttsd2si	%xmm0, %r11
@@ -923,30 +543,132 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm0
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	mulsd	%xmm8, %xmm1
-               	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
-               	subsd	%xmm1, %xmm0
-               	ucomisd	%xmm0, %xmm0
+               	movsd	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1]
+               	subsd	%xmm1, %xmm9
+<L82>:
+               	ucomisd	%xmm9, %xmm9
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L156>
+               	jne	 <L84>
                	movq	%rbx, %rcx
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	callq	 <L155>
-<L155>:
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	callq	 <L83>
+<L83>:
                	movq	%rax, %rsi
-               	jmp	 <L158>
-<L156>:
+               	jmp	 <L86>
+<L84>:
                	movq	%rbx, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L157>
-<L157>:
+               	callq	 <L85>
+<L85>:
                	movq	%rax, %rsi
-<L158>:
+<L86>:
                	xorps	%xmm0, %xmm0
                	subsd	%xmm7, %xmm0
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm8
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L89>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x7ae>
+               	ucomisd	%xmm1, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L87>
+               	jmp	 <L88>
+<L87>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L88>:
+               	jmp	 <L90>
+<L89>:
+               	movq	%rax, %rcx
+<L90>:
+               	testb	%cl, %cl
+               	jne	 <L103>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L91>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L92>
+<L91>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm0, %xmm1
+<L92>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm8, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L93>
+               	movsd	%xmm8, %xmm2            # xmm2 = xmm8[0],xmm2[1]
+               	jmp	 <L94>
+<L93>:
+               	xorps	%xmm2, %xmm2
+               	subsd	%xmm8, %xmm2
+<L94>:
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x852>
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+<L95>:
+               	ucomisd	%xmm4, %xmm3
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L102>
+               	movsd	%xmm1, %xmm5            # xmm5 = xmm1[0],xmm5[1]
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+<L96>:
+               	ucomisd	%xmm2, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L99>
+               	testb	%al, %al
+               	jne	 <L97>
+               	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
+               	jmp	 <L98>
+<L97>:
+               	xorps	%xmm10, %xmm10
+               	subsd	%xmm5, %xmm10
+<L98>:
+               	jmp	 <L104>
+<L99>:
+               	ucomisd	%xmm9, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L100>
+               	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
+               	jmp	 <L101>
+<L100>:
+               	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
+               	subsd	%xmm9, %xmm11
+<L101>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0x8d7>
+               	movsd	%xmm11, %xmm5           # xmm5 = xmm11[0],xmm5[1]
+               	jmp	 <L96>
+<L102>:
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8e9>
+               	jmp	 <L95>
+<L103>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	divsd	%xmm8, %xmm1
                	cvttsd2si	%xmm1, %r11
@@ -955,29 +677,132 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm1
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
                	mulsd	%xmm8, %xmm2
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	%xmm2, %xmm1
-               	ucomisd	%xmm1, %xmm1
+               	movsd	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1]
+               	subsd	%xmm2, %xmm10
+<L104>:
+               	ucomisd	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L160>
+               	jne	 <L106>
                	movq	%rsi, %rcx
-               	callq	 <L159>
-<L159>:
+               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
+               	callq	 <L105>
+<L105>:
                	movq	%rax, %rbx
-               	jmp	 <L162>
-<L160>:
+               	jmp	 <L108>
+<L106>:
                	movq	%rsi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L161>
-<L161>:
+               	callq	 <L107>
+<L107>:
                	movq	%rax, %rbx
-<L162>:
+<L108>:
                	xorps	%xmm0, %xmm0
                	subsd	%xmm8, %xmm0
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L111>
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x98f>
+               	ucomisd	%xmm1, %xmm7
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L109>
+               	jmp	 <L110>
+<L109>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm7
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L110>:
+               	jmp	 <L112>
+<L111>:
+               	movq	%rax, %rcx
+<L112>:
+               	testb	%cl, %cl
+               	jne	 <L125>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm7, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L113>
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	jmp	 <L114>
+<L113>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm7, %xmm1
+<L114>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L115>
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	jmp	 <L116>
+<L115>:
+               	xorps	%xmm2, %xmm2
+               	subsd	%xmm0, %xmm2
+<L116>:
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0xa31>
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+<L117>:
+               	ucomisd	%xmm4, %xmm3
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L124>
+               	movsd	%xmm1, %xmm5            # xmm5 = xmm1[0],xmm5[1]
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+<L118>:
+               	ucomisd	%xmm2, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L121>
+               	testb	%al, %al
+               	jne	 <L119>
+               	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
+               	jmp	 <L120>
+<L119>:
+               	xorps	%xmm10, %xmm10
+               	subsd	%xmm5, %xmm10
+<L120>:
+               	jmp	 <L126>
+<L121>:
+               	ucomisd	%xmm9, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L122>
+               	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
+               	jmp	 <L123>
+<L122>:
+               	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
+               	subsd	%xmm9, %xmm11
+<L123>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xab6>
+               	movsd	%xmm11, %xmm5           # xmm5 = xmm11[0],xmm5[1]
+               	jmp	 <L118>
+<L124>:
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xac8>
+               	jmp	 <L117>
+<L125>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	divsd	%xmm0, %xmm1
                	cvttsd2si	%xmm1, %r11
@@ -986,31 +811,134 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm1
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
                	mulsd	%xmm0, %xmm2
-               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	subsd	%xmm2, %xmm1
-               	ucomisd	%xmm1, %xmm1
+               	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
+               	subsd	%xmm2, %xmm10
+<L126>:
+               	ucomisd	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L164>
+               	jne	 <L128>
                	movq	%rbx, %rcx
-               	callq	 <L163>
-<L163>:
+               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
+               	callq	 <L127>
+<L127>:
                	movq	%rax, %rsi
-               	jmp	 <L166>
-<L164>:
+               	jmp	 <L130>
+<L128>:
                	movq	%rbx, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L165>
-<L165>:
+               	callq	 <L129>
+<L129>:
                	movq	%rax, %rsi
-<L166>:
+<L130>:
                	xorps	%xmm0, %xmm0
                	subsd	%xmm7, %xmm0
                	xorps	%xmm1, %xmm1
                	subsd	%xmm8, %xmm1
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm1
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L133>
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xb73>
+               	ucomisd	%xmm2, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L131>
+               	jmp	 <L132>
+<L131>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L132>:
+               	jmp	 <L134>
+<L133>:
+               	movq	%rax, %rcx
+<L134>:
+               	testb	%cl, %cl
+               	jne	 <L147>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L135>
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	jmp	 <L136>
+<L135>:
+               	xorps	%xmm2, %xmm2
+               	subsd	%xmm0, %xmm2
+<L136>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm1, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L137>
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+               	jmp	 <L138>
+<L137>:
+               	xorps	%xmm3, %xmm3
+               	subsd	%xmm1, %xmm3
+<L138>:
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xc15>
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+<L139>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L146>
+               	movsd	%xmm2, %xmm7            # xmm7 = xmm2[0],xmm7[1]
+               	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
+<L140>:
+               	ucomisd	%xmm3, %xmm9
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L143>
+               	testb	%al, %al
+               	jne	 <L141>
+               	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
+               	jmp	 <L142>
+<L141>:
+               	xorps	%xmm10, %xmm10
+               	subsd	%xmm7, %xmm10
+<L142>:
+               	jmp	 <L148>
+<L143>:
+               	ucomisd	%xmm9, %xmm7
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L144>
+               	movsd	%xmm7, %xmm11           # xmm11 = xmm7[0],xmm11[1]
+               	jmp	 <L145>
+<L144>:
+               	movsd	%xmm7, %xmm11           # xmm11 = xmm7[0],xmm11[1]
+               	subsd	%xmm9, %xmm11
+<L145>:
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xc9a>
+               	movsd	%xmm11, %xmm7           # xmm7 = xmm11[0],xmm7[1]
+               	jmp	 <L140>
+<L146>:
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xcac>
+               	jmp	 <L139>
+<L147>:
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
                	divsd	%xmm1, %xmm2
                	cvttsd2si	%xmm2, %r11
@@ -1019,88 +947,372 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm2
                	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
                	mulsd	%xmm1, %xmm3
+               	movsd	%xmm0, %xmm10           # xmm10 = xmm0[0],xmm10[1]
+               	subsd	%xmm3, %xmm10
+<L148>:
+               	ucomisd	%xmm10, %xmm10
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L150>
+               	movq	%rsi, %rcx
+               	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
+               	callq	 <L149>
+<L149>:
+               	movq	%rax, %rbx
+               	jmp	 <L152>
+<L150>:
+               	movq	%rsi, %rcx
+               	movq	$-0x1, %rdx
+               	callq	 <L151>
+<L151>:
+               	movq	%rax, %rbx
+<L152>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xd25>
+               	mulsd	%xmm6, %xmm0
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	%xmm3, %xmm1
-               	ucomisd	%xmm1, %xmm1
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xd35>
+               	ucomisd	%xmm1, %xmm0
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L153>
+               	jmp	 <L154>
+<L153>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+<L154>:
+               	testb	%al, %al
+               	jne	 <L165>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L155>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L156>
+<L155>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm0, %xmm1
+<L156>:
+               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xda7>
+               	movsd	, %xmm3 <L157>
+<L157>:
+               	ucomisd	%xmm3, %xmm2
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L164>
+               	movsd	%xmm1, %xmm4            # xmm4 = xmm1[0],xmm4[1]
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+<L158>:
+               	ucomisd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xdd2>
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L161>
+               	testb	%al, %al
+               	jne	 <L159>
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	jmp	 <L160>
+<L159>:
+               	xorps	%xmm7, %xmm7
+               	subsd	%xmm4, %xmm7
+<L160>:
+               	jmp	 <L166>
+<L161>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L162>
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	jmp	 <L163>
+<L162>:
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	subsd	%xmm5, %xmm9
+<L163>:
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xe2d>
+               	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
+               	jmp	 <L158>
+<L164>:
+               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0xe3f>
+               	jmp	 <L157>
+<L165>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xe50>
+               	cvttsd2si	%xmm1, %r11
+               	movq	%r11, %rax
+               	movq	%rax, %r11
+               	cvtsi2sd	%r11, %xmm1
+               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
+               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xe6c>
+               	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
+               	subsd	%xmm2, %xmm7
+<L166>:
+               	ucomisd	%xmm7, %xmm7
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
                	jne	 <L168>
-               	movq	%rsi, %rcx
+               	movq	%rbx, %rcx
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	callq	 <L167>
 <L167>:
-               	movq	%rax, %rbx
+               	movq	%rax, %rsi
                	jmp	 <L170>
 <L168>:
-               	movq	%rsi, %rcx
+               	movq	%rbx, %rcx
                	movq	$-0x1, %rdx
                	callq	 <L169>
 <L169>:
-               	movq	%rax, %rbx
+               	movq	%rax, %rsi
 <L170>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xd72>
-               	mulsd	%xmm6, %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xd82>
-               	cvttsd2si	%xmm1, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xd9e>
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	%xmm2, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm8
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L172>
-               	movq	%rbx, %rcx
-               	callq	 <L171>
+               	jne	 <L173>
+               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xedf>
+               	ucomisd	%xmm0, %xmm6
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L171>
+               	jmp	 <L172>
 <L171>:
-               	movq	%rax, %rsi
-               	jmp	 <L174>
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm6
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
 <L172>:
-               	movq	%rbx, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L173>
+               	jmp	 <L174>
 <L173>:
-               	movq	%rax, %rsi
+               	movq	%rax, %rcx
 <L174>:
-               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
-               	divsd	%xmm8, %xmm0
-               	cvttsd2si	%xmm0, %r11
-               	movq	%r11, %rax
-               	movq	%rax, %r11
-               	cvtsi2sd	%r11, %xmm0
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	%xmm8, %xmm1
-               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
-               	subsd	%xmm1, %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
+               	testb	%cl, %cl
+               	jne	 <L187>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm6, %xmm14
+               	seta	%al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L176>
-               	movq	%rsi, %rcx
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	callq	 <L175>
+               	jne	 <L175>
+               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
+               	jmp	 <L176>
 <L175>:
-               	movq	%rax, %rbx
-               	jmp	 <L178>
+               	xorps	%xmm0, %xmm0
+               	subsd	%xmm6, %xmm0
 <L176>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm8, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L177>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	jmp	 <L178>
+<L177>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm8, %xmm1
+<L178>:
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xf83>
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+<L179>:
+               	ucomisd	%xmm3, %xmm2
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L186>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+<L180>:
+               	ucomisd	%xmm1, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L183>
+               	testb	%al, %al
+               	jne	 <L181>
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	jmp	 <L182>
+<L181>:
+               	xorps	%xmm7, %xmm7
+               	subsd	%xmm4, %xmm7
+<L182>:
+               	jmp	 <L188>
+<L183>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L184>
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	jmp	 <L185>
+<L184>:
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	subsd	%xmm5, %xmm9
+<L185>:
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x1001>
+               	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
+               	jmp	 <L180>
+<L186>:
+               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x1013>
+               	jmp	 <L179>
+<L187>:
+               	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
+               	divsd	%xmm8, %xmm0
+               	cvttsd2si	%xmm0, %r11
+               	movq	%r11, %rax
+               	movq	%rax, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	mulsd	%xmm8, %xmm1
+               	movsd	%xmm6, %xmm7            # xmm7 = xmm6[0],xmm7[1]
+               	subsd	%xmm1, %xmm7
+<L188>:
+               	ucomisd	%xmm7, %xmm7
+               	setne	%al
+               	setp	%r11b
+               	orb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L190>
+               	movq	%rsi, %rcx
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	callq	 <L189>
+<L189>:
+               	movq	%rax, %rbx
+               	jmp	 <L192>
+<L190>:
                	movq	%rsi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L177>
-<L177>:
+               	callq	 <L191>
+<L191>:
                	movq	%rax, %rbx
-<L178>:
+<L192>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm8
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L195>
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x10ae>
+               	ucomisd	%xmm0, %xmm8
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L193>
+               	jmp	 <L194>
+<L193>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm8
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L194>:
+               	jmp	 <L196>
+<L195>:
+               	movq	%rax, %rcx
+<L196>:
+               	testb	%cl, %cl
+               	jne	 <L209>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm8, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L197>
+               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
+               	jmp	 <L198>
+<L197>:
+               	xorps	%xmm0, %xmm0
+               	subsd	%xmm8, %xmm0
+<L198>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm8, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L199>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	jmp	 <L200>
+<L199>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm8, %xmm1
+<L200>:
+               	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0x1155>
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+<L201>:
+               	ucomisd	%xmm3, %xmm2
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L208>
+               	movsd	%xmm0, %xmm4            # xmm4 = xmm0[0],xmm4[1]
+               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
+<L202>:
+               	ucomisd	%xmm1, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L205>
+               	testb	%al, %al
+               	jne	 <L203>
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	jmp	 <L204>
+<L203>:
+               	xorps	%xmm7, %xmm7
+               	subsd	%xmm4, %xmm7
+<L204>:
+               	jmp	 <L210>
+<L205>:
+               	ucomisd	%xmm5, %xmm4
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L206>
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	jmp	 <L207>
+<L206>:
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	subsd	%xmm5, %xmm9
+<L207>:
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x11d3>
+               	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
+               	jmp	 <L202>
+<L208>:
+               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x11e5>
+               	jmp	 <L201>
+<L209>:
                	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
                	divsd	%xmm8, %xmm0
                	cvttsd2si	%xmm0, %r11
@@ -1109,30 +1321,132 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm0
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	mulsd	%xmm8, %xmm1
-               	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
-               	subsd	%xmm1, %xmm0
-               	ucomisd	%xmm0, %xmm0
+               	movsd	%xmm8, %xmm7            # xmm7 = xmm8[0],xmm7[1]
+               	subsd	%xmm1, %xmm7
+<L210>:
+               	ucomisd	%xmm7, %xmm7
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L180>
+               	jne	 <L212>
                	movq	%rbx, %rcx
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	callq	 <L179>
-<L179>:
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	callq	 <L211>
+<L211>:
                	movq	%rax, %rsi
-               	jmp	 <L182>
-<L180>:
+               	jmp	 <L214>
+<L212>:
                	movq	%rbx, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L181>
-<L181>:
+               	callq	 <L213>
+<L213>:
                	movq	%rax, %rsi
-<L182>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xec0>
+<L214>:
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x125e>
                	mulsd	%xmm6, %xmm0
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm8
+               	sete	%al
+               	setnp	%r11b
+               	andb	%r11b, %al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L217>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x128d>
+               	ucomisd	%xmm1, %xmm0
+               	sete	%cl
+               	setnp	%r11b
+               	andb	%r11b, %cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L215>
+               	jmp	 <L216>
+<L215>:
+               	xorps	%xmm15, %xmm15
+               	ucomisd	%xmm15, %xmm0
+               	setne	%cl
+               	setp	%r11b
+               	orb	%r11b, %cl
+               	movzbq	%cl, %rcx
+<L216>:
+               	jmp	 <L218>
+<L217>:
+               	movq	%rax, %rcx
+<L218>:
+               	testb	%cl, %cl
+               	jne	 <L231>
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm0, %xmm14
+               	seta	%al
+               	movzbq	%al, %rax
+               	testb	%al, %al
+               	jne	 <L219>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	jmp	 <L220>
+<L219>:
+               	xorps	%xmm1, %xmm1
+               	subsd	%xmm0, %xmm1
+<L220>:
+               	xorps	%xmm14, %xmm14
+               	ucomisd	%xmm8, %xmm14
+               	seta	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L221>
+               	movsd	%xmm8, %xmm2            # xmm2 = xmm8[0],xmm2[1]
+               	jmp	 <L222>
+<L221>:
+               	xorps	%xmm2, %xmm2
+               	subsd	%xmm8, %xmm2
+<L222>:
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x1331>
+               	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
+<L223>:
+               	ucomisd	%xmm4, %xmm3
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L230>
+               	movsd	%xmm1, %xmm5            # xmm5 = xmm1[0],xmm5[1]
+               	movsd	%xmm4, %xmm6            # xmm6 = xmm4[0],xmm6[1]
+<L224>:
+               	ucomisd	%xmm2, %xmm6
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L227>
+               	testb	%al, %al
+               	jne	 <L225>
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+               	jmp	 <L226>
+<L225>:
+               	xorps	%xmm7, %xmm7
+               	subsd	%xmm5, %xmm7
+<L226>:
+               	jmp	 <L232>
+<L227>:
+               	ucomisd	%xmm6, %xmm5
+               	setae	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L228>
+               	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
+               	jmp	 <L229>
+<L228>:
+               	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
+               	subsd	%xmm6, %xmm9
+<L229>:
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x13af>
+               	movsd	%xmm9, %xmm5            # xmm5 = xmm9[0],xmm5[1]
+               	jmp	 <L224>
+<L230>:
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x13c1>
+               	jmp	 <L223>
+<L231>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	divsd	%xmm8, %xmm1
                	cvttsd2si	%xmm1, %r11
@@ -1141,34 +1455,38 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm1
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
                	mulsd	%xmm8, %xmm2
-               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	%xmm2, %xmm1
-               	ucomisd	%xmm1, %xmm1
+               	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
+               	subsd	%xmm2, %xmm7
+<L232>:
+               	ucomisd	%xmm7, %xmm7
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L184>
+               	jne	 <L234>
                	movq	%rsi, %rcx
-               	callq	 <L183>
-<L183>:
+               	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
+               	callq	 <L233>
+<L233>:
                	movq	%rax, %rbx
-               	jmp	 <L186>
-<L184>:
+               	jmp	 <L236>
+<L234>:
                	movq	%rsi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L185>
-<L185>:
+               	callq	 <L235>
+<L235>:
                	movq	%rax, %rbx
-<L186>:
+<L236>:
                	movq	%rbx, %rax
                	movaps	-0x30(%rbp), %xmm6
                	movaps	-0x40(%rbp), %xmm7
                	movaps	-0x50(%rbp), %xmm8
                	movaps	-0x60(%rbp), %xmm9
-               	movaps	-0x70(%rbp), %xmm14
-               	movaps	-0x80(%rbp), %xmm15
+               	movaps	-0x70(%rbp), %xmm10
+               	movaps	-0x80(%rbp), %xmm11
+               	movaps	-0x90(%rbp), %xmm14
+               	movaps	-0xa0(%rbp), %xmm15
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi
                	movq	-0x18(%rbp), %rsi

--- a/test/golden/x86_64-windows/float/arith_f64.dis
+++ b/test/golden/x86_64-windows/float/arith_f64.dis
@@ -512,8 +512,8 @@ Disassembly of section .text:
                	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
                	jmp	 <L76>
 <L75>:
-               	xorps	%xmm9, %xmm9
-               	subsd	%xmm4, %xmm9
+               	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
+               	xorps	, %xmm9 <L76>
 <L76>:
                	jmp	 <L82>
 <L77>:
@@ -528,11 +528,11 @@ Disassembly of section .text:
                	movsd	%xmm4, %xmm10           # xmm10 = xmm4[0],xmm10[1]
                	subsd	%xmm5, %xmm10
 <L79>:
-               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x6f7>
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x6fb>
                	movsd	%xmm10, %xmm4           # xmm4 = xmm10[0],xmm4[1]
                	jmp	 <L74>
 <L80>:
-               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x709>
+               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x70d>
                	jmp	 <L73>
 <L81>:
                	movsd	%xmm7, %xmm0            # xmm0 = xmm7[0],xmm0[1]
@@ -577,7 +577,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L89>
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x7ae>
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x7b2>
                	ucomisd	%xmm1, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -625,7 +625,7 @@ Disassembly of section .text:
                	subsd	%xmm8, %xmm2
 <L94>:
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x852>
+               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x856>
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
 <L95>:
                	ucomisd	%xmm4, %xmm3
@@ -646,8 +646,8 @@ Disassembly of section .text:
                	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
                	jmp	 <L98>
 <L97>:
-               	xorps	%xmm10, %xmm10
-               	subsd	%xmm5, %xmm10
+               	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
+               	xorps	, %xmm10 <L98>
 <L98>:
                	jmp	 <L104>
 <L99>:
@@ -662,11 +662,11 @@ Disassembly of section .text:
                	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
                	subsd	%xmm9, %xmm11
 <L101>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0x8d7>
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0x8df>
                	movsd	%xmm11, %xmm5           # xmm5 = xmm11[0],xmm5[1]
                	jmp	 <L96>
 <L102>:
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8e9>
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x8f1>
                	jmp	 <L95>
 <L103>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
@@ -711,7 +711,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L111>
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x98f>
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x997>
                	ucomisd	%xmm1, %xmm7
                	sete	%cl
                	setnp	%r11b
@@ -759,7 +759,7 @@ Disassembly of section .text:
                	subsd	%xmm0, %xmm2
 <L116>:
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0xa31>
+               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0xa39>
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
 <L117>:
                	ucomisd	%xmm4, %xmm3
@@ -780,8 +780,8 @@ Disassembly of section .text:
                	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
                	jmp	 <L120>
 <L119>:
-               	xorps	%xmm10, %xmm10
-               	subsd	%xmm5, %xmm10
+               	movsd	%xmm5, %xmm10           # xmm10 = xmm5[0],xmm10[1]
+               	xorps	, %xmm10 <L120>
 <L120>:
                	jmp	 <L126>
 <L121>:
@@ -796,11 +796,11 @@ Disassembly of section .text:
                	movsd	%xmm5, %xmm11           # xmm11 = xmm5[0],xmm11[1]
                	subsd	%xmm9, %xmm11
 <L123>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xab6>
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xac2>
                	movsd	%xmm11, %xmm5           # xmm5 = xmm11[0],xmm5[1]
                	jmp	 <L118>
 <L124>:
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xac8>
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xad4>
                	jmp	 <L117>
 <L125>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
@@ -847,7 +847,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L133>
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xb73>
+               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xb7f>
                	ucomisd	%xmm2, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -895,7 +895,7 @@ Disassembly of section .text:
                	subsd	%xmm1, %xmm3
 <L138>:
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
-               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xc15>
+               	divsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0xc21>
                	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
 <L139>:
                	ucomisd	%xmm5, %xmm4
@@ -916,8 +916,8 @@ Disassembly of section .text:
                	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
                	jmp	 <L142>
 <L141>:
-               	xorps	%xmm10, %xmm10
-               	subsd	%xmm7, %xmm10
+               	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
+               	xorps	, %xmm10 <L142>
 <L142>:
                	jmp	 <L148>
 <L143>:
@@ -932,11 +932,11 @@ Disassembly of section .text:
                	movsd	%xmm7, %xmm11           # xmm11 = xmm7[0],xmm11[1]
                	subsd	%xmm9, %xmm11
 <L145>:
-               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xc9a>
+               	divsd	, %xmm9 <corpus.cases.float.arith_f64.checksum+0xcaa>
                	movsd	%xmm11, %xmm7           # xmm7 = xmm11[0],xmm7[1]
                	jmp	 <L140>
 <L146>:
-               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xcac>
+               	mulsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xcbc>
                	jmp	 <L139>
 <L147>:
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
@@ -970,10 +970,10 @@ Disassembly of section .text:
 <L151>:
                	movq	%rax, %rbx
 <L152>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xd25>
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xd35>
                	mulsd	%xmm6, %xmm0
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xd35>
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xd45>
                	ucomisd	%xmm1, %xmm0
                	sete	%al
                	setnp	%r11b
@@ -1005,7 +1005,7 @@ Disassembly of section .text:
                	subsd	%xmm0, %xmm1
 <L156>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xda7>
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xdb7>
                	movsd	, %xmm3 <L157>
 <L157>:
                	ucomisd	%xmm3, %xmm2
@@ -1016,7 +1016,7 @@ Disassembly of section .text:
                	movsd	%xmm1, %xmm4            # xmm4 = xmm1[0],xmm4[1]
                	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
 <L158>:
-               	ucomisd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xdd2>
+               	ucomisd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xde2>
                	setae	%cl
                	movzbq	%cl, %rcx
                	testb	%cl, %cl
@@ -1026,8 +1026,8 @@ Disassembly of section .text:
                	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
                	jmp	 <L160>
 <L159>:
-               	xorps	%xmm7, %xmm7
-               	subsd	%xmm4, %xmm7
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	xorps	, %xmm7 <L160>
 <L160>:
                	jmp	 <L166>
 <L161>:
@@ -1042,21 +1042,21 @@ Disassembly of section .text:
                	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
                	subsd	%xmm5, %xmm9
 <L163>:
-               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xe2d>
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0xe41>
                	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
                	jmp	 <L158>
 <L164>:
-               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0xe3f>
+               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0xe53>
                	jmp	 <L157>
 <L165>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xe50>
+               	divsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0xe64>
                	cvttsd2si	%xmm1, %r11
                	movq	%r11, %rax
                	movq	%rax, %r11
                	cvtsi2sd	%r11, %xmm1
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xe6c>
+               	mulsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xe80>
                	movsd	%xmm0, %xmm7            # xmm7 = xmm0[0],xmm7[1]
                	subsd	%xmm2, %xmm7
 <L166>:
@@ -1089,7 +1089,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L173>
                	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xedf>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0xef3>
                	ucomisd	%xmm0, %xmm6
                	sete	%cl
                	setnp	%r11b
@@ -1137,7 +1137,7 @@ Disassembly of section .text:
                	subsd	%xmm8, %xmm1
 <L178>:
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xf83>
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0xf97>
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
 <L179>:
                	ucomisd	%xmm3, %xmm2
@@ -1158,8 +1158,8 @@ Disassembly of section .text:
                	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
                	jmp	 <L182>
 <L181>:
-               	xorps	%xmm7, %xmm7
-               	subsd	%xmm4, %xmm7
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	xorps	, %xmm7 <L182>
 <L182>:
                	jmp	 <L188>
 <L183>:
@@ -1174,11 +1174,11 @@ Disassembly of section .text:
                	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
                	subsd	%xmm5, %xmm9
 <L185>:
-               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x1001>
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x1019>
                	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
                	jmp	 <L180>
 <L186>:
-               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x1013>
+               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x102b>
                	jmp	 <L179>
 <L187>:
                	movsd	%xmm6, %xmm0            # xmm0 = xmm6[0],xmm0[1]
@@ -1221,7 +1221,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L195>
                	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
-               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x10ae>
+               	mulsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x10c6>
                	ucomisd	%xmm0, %xmm8
                	sete	%cl
                	setnp	%r11b
@@ -1269,7 +1269,7 @@ Disassembly of section .text:
                	subsd	%xmm8, %xmm1
 <L200>:
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0x1155>
+               	divsd	, %xmm2 <corpus.cases.float.arith_f64.checksum+0x116d>
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
 <L201>:
                	ucomisd	%xmm3, %xmm2
@@ -1290,8 +1290,8 @@ Disassembly of section .text:
                	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
                	jmp	 <L204>
 <L203>:
-               	xorps	%xmm7, %xmm7
-               	subsd	%xmm4, %xmm7
+               	movsd	%xmm4, %xmm7            # xmm7 = xmm4[0],xmm7[1]
+               	xorps	, %xmm7 <L204>
 <L204>:
                	jmp	 <L210>
 <L205>:
@@ -1306,11 +1306,11 @@ Disassembly of section .text:
                	movsd	%xmm4, %xmm9            # xmm9 = xmm4[0],xmm9[1]
                	subsd	%xmm5, %xmm9
 <L207>:
-               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x11d3>
+               	divsd	, %xmm5 <corpus.cases.float.arith_f64.checksum+0x11ef>
                	movsd	%xmm9, %xmm4            # xmm4 = xmm9[0],xmm4[1]
                	jmp	 <L202>
 <L208>:
-               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x11e5>
+               	mulsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x1201>
                	jmp	 <L201>
 <L209>:
                	movsd	%xmm8, %xmm0            # xmm0 = xmm8[0],xmm0[1]
@@ -1344,7 +1344,7 @@ Disassembly of section .text:
 <L213>:
                	movq	%rax, %rsi
 <L214>:
-               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x125e>
+               	movsd	, %xmm0 <corpus.cases.float.arith_f64.checksum+0x127a>
                	mulsd	%xmm6, %xmm0
                	xorps	%xmm15, %xmm15
                	ucomisd	%xmm15, %xmm8
@@ -1355,7 +1355,7 @@ Disassembly of section .text:
                	testb	%al, %al
                	jne	 <L217>
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x128d>
+               	mulsd	, %xmm1 <corpus.cases.float.arith_f64.checksum+0x12a9>
                	ucomisd	%xmm1, %xmm0
                	sete	%cl
                	setnp	%r11b
@@ -1403,7 +1403,7 @@ Disassembly of section .text:
                	subsd	%xmm8, %xmm2
 <L222>:
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
-               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x1331>
+               	divsd	, %xmm3 <corpus.cases.float.arith_f64.checksum+0x134d>
                	movsd	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1]
 <L223>:
                	ucomisd	%xmm4, %xmm3
@@ -1424,8 +1424,8 @@ Disassembly of section .text:
                	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
                	jmp	 <L226>
 <L225>:
-               	xorps	%xmm7, %xmm7
-               	subsd	%xmm5, %xmm7
+               	movsd	%xmm5, %xmm7            # xmm7 = xmm5[0],xmm7[1]
+               	xorps	, %xmm7 <L226>
 <L226>:
                	jmp	 <L232>
 <L227>:
@@ -1440,11 +1440,11 @@ Disassembly of section .text:
                	movsd	%xmm5, %xmm9            # xmm9 = xmm5[0],xmm9[1]
                	subsd	%xmm6, %xmm9
 <L229>:
-               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x13af>
+               	divsd	, %xmm6 <corpus.cases.float.arith_f64.checksum+0x13cf>
                	movsd	%xmm9, %xmm5            # xmm5 = xmm9[0],xmm5[1]
                	jmp	 <L224>
 <L230>:
-               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x13c1>
+               	mulsd	, %xmm4 <corpus.cases.float.arith_f64.checksum+0x13e1>
                	jmp	 <L223>
 <L231>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]

--- a/test/link/cases/2543-bsd-ar-extended-name/mach.toml
+++ b/test/link/cases/2543-bsd-ar-extended-name/mach.toml
@@ -37,7 +37,6 @@ need = []
 
 [step.shim]
 argv = ["bash", "build-archive.sh", "{project.out}/obj/bsd-ar/libshim.a"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["build-archive.sh", "shim.s"]
 out = ["{project.out}/obj/bsd-ar/libshim.a", "{project.out}/obj/bsd-ar/foreign-object-with-long-name.o"]
 need = []

--- a/test/link/cases/2558-dep-step-home/provider/mach.toml
+++ b/test/link/cases/2558-dep-step-home/provider/mach.toml
@@ -14,7 +14,6 @@ export = true
 
 [step.provider]
 argv = ["sh", "build.sh", "{project.out}/vendor/provider/provider.o"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["build.sh", "provider.c"]
 out = ["{project.out}/vendor/provider/provider.o"]
 need = []

--- a/test/link/cases/2800-cascade-library-attribution/provider/mach.toml
+++ b/test/link/cases/2800-cascade-library-attribution/provider/mach.toml
@@ -6,7 +6,6 @@ out = "out/{target.name}/{profile.name}"
 
 [step.libdemo]
 argv = ["sh", "build.sh", "{project.out}/lib/libdemo.so.1"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["build.sh", "demo.c"]
 out = ["{project.out}/lib/libdemo.so.1"]
 need = []

--- a/test/link/cases/2800-pin-to-absent-library/provider/mach.toml
+++ b/test/link/cases/2800-pin-to-absent-library/provider/mach.toml
@@ -17,7 +17,6 @@ export = true
 
 [step.provider]
 argv = ["sh", "build.sh", "{project.out}/vendor/provider/provider.o"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["build.sh", "provider.c"]
 out = ["{project.out}/vendor/provider/provider.o"]
 need = []

--- a/test/link/cases/2800-pin-to-static-entry-with-dynlib/provider/mach.toml
+++ b/test/link/cases/2800-pin-to-static-entry-with-dynlib/provider/mach.toml
@@ -31,14 +31,12 @@ export = true
 
 [step.provider]
 argv = ["sh", "build.sh", "{project.out}/vendor/provider/provider.o"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["build.sh", "provider.c"]
 out = ["{project.out}/vendor/provider/provider.o"]
 need = []
 
 [step.libdemo]
 argv = ["sh", "libdemo-build.sh", "{project.out}/lib/libdemo.so.1"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["libdemo-build.sh", "demo.c"]
 out = ["{project.out}/lib/libdemo.so.1"]
 need = []

--- a/test/link/cases/2800-pin-to-static-entry/provider/mach.toml
+++ b/test/link/cases/2800-pin-to-static-entry/provider/mach.toml
@@ -17,7 +17,6 @@ export = true
 
 [step.provider]
 argv = ["sh", "build.sh", "{project.out}/vendor/provider/provider.o"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["build.sh", "provider.c"]
 out = ["{project.out}/vendor/provider/provider.o"]
 need = []

--- a/test/link/cases/c-variadic/mach.toml
+++ b/test/link/cases/c-variadic/mach.toml
@@ -46,7 +46,7 @@ simd = "scalarize"
 
 [step.probe]
 argv = ["sh", "../../lib/cc.sh", "-c", "-O1", "-fno-stack-protector", "probe.c", "-o", "{project.out}/obj/probe.o"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin", MACH_TARGET_ISA = "{target.isa}", MACH_TARGET_OS = "{target.os}", MACH_TARGET_ABI = "{target.abi}" }
+env = { MACH_TARGET_ISA = "{target.isa}", MACH_TARGET_OS = "{target.os}", MACH_TARGET_ABI = "{target.abi}" }
 in = ["probe.c"]
 out = ["{project.out}/obj/probe.o"]
 need = []

--- a/test/link/cases/elf-gotpcrelx/mach.toml
+++ b/test/link/cases/elf-gotpcrelx/mach.toml
@@ -21,7 +21,6 @@ simd = "scalarize"
 
 [step.probe]
 argv = ["sh", "-c", "cc -c -O1 -fPIC -fno-plt probe.c -o {project.out}/obj/probe.o && cc -c -O1 defs.c -o {project.out}/obj/defs.o && readelf -r --wide {project.out}/obj/probe.o | grep -q 'R_X86_64_REX_GOTPCRELX' && readelf -r --wide {project.out}/obj/probe.o | grep -q 'R_X86_64_GOTPCRELX '"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["probe.c", "defs.c"]
 out = ["{project.out}/obj/probe.o", "{project.out}/obj/defs.o"]
 need = []

--- a/test/link/cases/ext-byval-aggregate/mach.toml
+++ b/test/link/cases/ext-byval-aggregate/mach.toml
@@ -46,7 +46,7 @@ simd = "scalarize"
 
 [step.probe]
 argv = ["sh", "../../lib/cc.sh", "-c", "-O0", "-fno-stack-protector", "probe.c", "-o", "{project.out}/obj/probe.o"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin", MACH_TARGET_ISA = "{target.isa}", MACH_TARGET_OS = "{target.os}", MACH_TARGET_ABI = "{target.abi}" }
+env = { MACH_TARGET_ISA = "{target.isa}", MACH_TARGET_OS = "{target.os}", MACH_TARGET_ABI = "{target.abi}" }
 in = ["probe.c"]
 out = ["{project.out}/obj/probe.o"]
 need = []

--- a/test/link/cases/link-include-referenced/provider/mach.toml
+++ b/test/link/cases/link-include-referenced/provider/mach.toml
@@ -6,7 +6,6 @@ out = "out/{target.name}/{profile.name}"
 
 [step.libdemo]
 argv = ["sh", "build.sh", "{project.out}/lib/libdemo.so.1"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["build.sh", "demo.c"]
 out = ["{project.out}/lib/libdemo.so.1"]
 need = []

--- a/test/link/cases/link-include-unreferenced/provider/mach.toml
+++ b/test/link/cases/link-include-unreferenced/provider/mach.toml
@@ -6,7 +6,6 @@ out = "out/{target.name}/{profile.name}"
 
 [step.libdemo]
 argv = ["sh", "build.sh", "{project.out}/lib/libdemo.so.1"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["build.sh", "demo.c"]
 out = ["{project.out}/lib/libdemo.so.1"]
 need = []

--- a/test/link/cases/narrow-stack-args/mach.toml
+++ b/test/link/cases/narrow-stack-args/mach.toml
@@ -46,7 +46,7 @@ simd = "scalarize"
 
 [step.probe]
 argv = ["sh", "../../lib/cc.sh", "-c", "-O1", "-fno-stack-protector", "probe.c", "-o", "{project.out}/obj/probe.o"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin", MACH_TARGET_ISA = "{target.isa}", MACH_TARGET_OS = "{target.os}", MACH_TARGET_ABI = "{target.abi}" }
+env = { MACH_TARGET_ISA = "{target.isa}", MACH_TARGET_OS = "{target.os}", MACH_TARGET_ABI = "{target.abi}" }
 in = ["probe.c"]
 out = ["{project.out}/obj/probe.o"]
 need = []

--- a/test/link/cases/pe-dllimport-indirection/mach.toml
+++ b/test/link/cases/pe-dllimport-indirection/mach.toml
@@ -46,7 +46,6 @@ export = false
 
 [step.foreign]
 argv = ["sh", "decode-fixture.sh", "{project.out}/obj/foreign/qz.o"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["decode-fixture.sh", "qz.c", "qz.o.b64"]
 out = ["{project.out}/obj/foreign/qz.o"]
 need = []

--- a/test/link/cases/pe-foreign-codeview/mach.toml
+++ b/test/link/cases/pe-foreign-codeview/mach.toml
@@ -37,7 +37,6 @@ export = false
 
 [step.foreign]
 argv = ["sh", "decode-fixture.sh", "{project.out}/obj/foreign/codeview.o"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["decode-fixture.sh", "codeview.c", "codeview.o.b64"]
 out = ["{project.out}/obj/foreign/codeview.o"]
 need = []

--- a/test/link/cases/pe-foreign-unwind/mach.toml
+++ b/test/link/cases/pe-foreign-unwind/mach.toml
@@ -37,7 +37,6 @@ export = false
 
 [step.foreign]
 argv = ["sh", "decode-fixture.sh", "{project.out}/obj/foreign/qz.o"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["decode-fixture.sh", "qz.c", "qz.o.b64"]
 out = ["{project.out}/obj/foreign/qz.o"]
 need = []

--- a/test/link/cases/pe-imp-alias-liveness/mach.toml
+++ b/test/link/cases/pe-imp-alias-liveness/mach.toml
@@ -45,14 +45,12 @@ export = false
 
 [step.foreign]
 argv = ["sh", "decode-fixture.sh", "{project.out}/obj/foreign/qz.o"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["decode-fixture.sh", "qz.c", "qz.o.b64"]
 out = ["{project.out}/obj/foreign/qz.o"]
 need = []
 
 [step.implib]
 argv = ["sh", "mkimplib.sh", "{project.out}/lib/libaliasprobe.a"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["mkimplib.sh"]
 out = ["{project.out}/lib/libaliasprobe.a"]
 need = []

--- a/test/link/cases/pe-import-library/mach.toml
+++ b/test/link/cases/pe-import-library/mach.toml
@@ -37,7 +37,6 @@ export = false
 
 [step.implib]
 argv = ["sh", "mkimplib.sh", "{project.out}/lib/libwin.a"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["mkimplib.sh"]
 out = ["{project.out}/lib/libwin.a"]
 need = []

--- a/test/link/cases/pe-local-import-pointer/mach.toml
+++ b/test/link/cases/pe-local-import-pointer/mach.toml
@@ -77,14 +77,12 @@ export = false
 
 [step.foreign]
 argv = ["sh", "decode-fixture.sh", "{project.out}/obj/foreign"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["decode-fixture.sh", "alias.c", "alias-two.c", "comdat-winner.cpp", "comdat-loser.cpp", "provider.c", "alias.o.b64", "alias-two.o.b64", "comdat-winner.o.b64", "comdat-loser.o.b64", "provider.o.b64"]
 out = ["{project.out}/obj/foreign/alias.o", "{project.out}/obj/foreign/alias-two.o", "{project.out}/obj/foreign/comdat-winner.o", "{project.out}/obj/foreign/comdat-loser.o", "{project.out}/obj/foreign/provider.o"]
 need = []
 
 [step.implib]
 argv = ["sh", "mkimplib.sh", "{project.out}/lib/liblocal.a"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["mkimplib.sh"]
 out = ["{project.out}/lib/liblocal.a"]
 need = []

--- a/test/link/cases/pe-mingw-static-crt/mach.toml
+++ b/test/link/cases/pe-mingw-static-crt/mach.toml
@@ -37,7 +37,6 @@ export = false
 
 [step.crt]
 argv = ["sh", "decode-fixture.sh", "{project.out}/lib/mingw-crt.lib"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["decode-fixture.sh", "caller.c", "caller.o.b64", "vsnprintf.c", "vsnprintf.o.b64", "options.c", "options.o.b64", "startup.c", "startup.o.b64"]
 out = ["{project.out}/lib/mingw-crt.lib"]
 need = []

--- a/test/link/cases/pe-resources/mach.toml
+++ b/test/link/cases/pe-resources/mach.toml
@@ -31,7 +31,6 @@ manifest = "assets/app.manifest"
 
 [step.icon]
 argv = ["sh", "decode-icon.sh", "out/resource/app.ico"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin" }
 in = ["decode-icon.sh", "assets/app.ico.b64"]
 out = ["out/resource/app.ico"]
 need = []

--- a/test/link/cases/riscv-pcrel-pair/mach.toml
+++ b/test/link/cases/riscv-pcrel-pair/mach.toml
@@ -29,7 +29,7 @@ simd = "scalarize"
 
 [step.probe]
 argv = ["sh", "../../lib/cc.sh", "-c", "-O1", "-fno-stack-protector", "probe.c", "-o", "{project.out}/obj/probe.o"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin", MACH_TARGET_ISA = "{target.isa}", MACH_TARGET_OS = "{target.os}", MACH_TARGET_ABI = "{target.abi}" }
+env = { MACH_TARGET_ISA = "{target.isa}", MACH_TARGET_OS = "{target.os}", MACH_TARGET_ABI = "{target.abi}" }
 in = ["probe.c"]
 out = ["{project.out}/obj/probe.o"]
 need = []

--- a/test/link/cases/va-list/mach.toml
+++ b/test/link/cases/va-list/mach.toml
@@ -46,7 +46,7 @@ simd = "scalarize"
 
 [step.probe]
 argv = ["sh", "../../lib/cc.sh", "-c", "-O0", "-fno-stack-protector", "probe.c", "-o", "{project.out}/obj/probe.o"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin", MACH_TARGET_ISA = "{target.isa}", MACH_TARGET_OS = "{target.os}", MACH_TARGET_ABI = "{target.abi}" }
+env = { MACH_TARGET_ISA = "{target.isa}", MACH_TARGET_OS = "{target.os}", MACH_TARGET_ABI = "{target.abi}" }
 in = ["probe.c"]
 out = ["{project.out}/obj/probe.o"]
 need = []

--- a/test/link/cases/win64-vector-call/mach.toml
+++ b/test/link/cases/win64-vector-call/mach.toml
@@ -21,7 +21,7 @@ simd = "scalarize"
 
 [step.probe]
 argv = ["sh", "../../lib/cc.sh", "-c", "-O1", "-fno-stack-protector", "probe.c", "-o", "{project.out}/obj/probe.o"]
-env = { PATH = "/usr/local/bin:/usr/bin:/bin", MACH_TARGET_ISA = "{target.isa}", MACH_TARGET_OS = "{target.os}", MACH_TARGET_ABI = "{target.abi}" }
+env = { MACH_TARGET_ISA = "{target.isa}", MACH_TARGET_OS = "{target.os}", MACH_TARGET_ABI = "{target.abi}" }
 in = ["probe.c"]
 out = ["{project.out}/obj/probe.o"]
 need = []

--- a/test/version-vendor.sh
+++ b/test/version-vendor.sh
@@ -23,7 +23,12 @@ if [ "$("$cc" info --version)" != "$compiler_ver" ]; then
 fi
 work=$(mktemp -d)
 trap 'rm -rf "$work"' EXIT
-mkdir -p "$work/src"
+git init -q "$work"
+mkdir -p "$work/project/src" "$work/mach" "$work/std"
+cp "$root/mach.toml" "$work/mach/"
+cp -R "$root/src" "$work/mach/"
+cp "$root/dep/std/mach.toml" "$work/std/"
+cp -R "$root/dep/std/src" "$work/std/"
 
 case "$(uname -m)" in
     x86_64)  isa=x86_64; abi=sysv64 ;;
@@ -31,7 +36,7 @@ case "$(uname -m)" in
     *) echo "version-vendor.sh: unsupported host architecture" >&2; exit 2 ;;
 esac
 
-cat > "$work/mach.toml" <<EOF
+cat > "$work/project/mach.toml" <<EOF
 [project]
 id = "mach-version-vendor-test"
 version = "mach-version-vendor-test"
@@ -57,14 +62,13 @@ link = []
 need = []
 
 [dep.mach]
-path = "$root"
+path = "../mach"
 
 [dep.std]
-git = "https://github.com/briar-systems/mach-std"
-ref = "branch/main"
+path = "../std"
 EOF
 
-cat > "$work/src/main.mach" <<EOF
+cat > "$work/project/src/main.mach" <<EOF
 use std.runtime;
 use std.types.string.str_equals;
 use std.types.size.usize;
@@ -84,10 +88,10 @@ test "mach.lang.version:vendored_context" {
 fun main(argc: usize, argv: *str) i64 { ret dispatch(argc, argv); }
 EOF
 
-cd "$work"
+cd "$work/project"
 "$cc" dep pull
-vendored_cli="$work/vendored-mach"
-"$cc" build . -o "$vendored_cli"
+vendored_cli=./vendored-mach
+"$cc" build . -o vendored-mach
 if [ "$("$vendored_cli" info --version)" != "$compiler_ver" ]; then
     echo "version-vendor.sh: built vendored CLI reports the embedding project version" >&2
     exit 1


### PR DESCRIPTION
The optimization-flag CLI fixture selected native Windows debug information implicitly, so its successful `-O0` and `-O2` cases failed for an unrelated capability refusal. Give the fixture a complete profile with debug information disabled and SIMD scalarization explicit. Keep every optimization and side-effect assertion.

Validation on detached source `2168f439` with std `17bf1f7`: published seed to A to B on Linux and Windows, focused baseline 1 passed / 0 failed on each. Restoring the implicit profile fails the Windows test at runtime with exit 1 and both expected unsupported-debug diagnostics. Every compiler invocation had an empty process census and the exact source and pin were restored. Evidence: run 33998109792.

This PR is stacked on the audit integration and awaits the combined compiler validation bar.

Closes #3175
