### PR TITLE
fix(ci): install the pinned Homebrew LLVM major

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,8 @@ The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 ### Fixed
 
+- Darwin CI installs the Homebrew LLVM formula selected by the committed oracle major, so a newer Homebrew stable release cannot break the pinned disassembly lane (#3181).
+
 #### Language and frontend
 
 - `?` on a temporary (a call result, literal, cast, operator result, array, record or vector literal, or a field or element of one) is refused, naming the operand kind. It used to compile to a pointer into dead stack.

--- a/test/ci-tools.sh
+++ b/test/ci-tools.sh
@@ -66,18 +66,15 @@ install_llvm() {
     fi
 
     if [ "$host_os" = darwin ]; then
-        # homebrew's `llvm` is the current stable and carries no version in its name,
-        # so it is checked against the pin rather than trusted: when brew's stable
-        # moves past the pinned major this fails and names the versioned formula,
-        # instead of installing a decoder no golden was blessed against. llvm is
-        # keg-only, so its tools reach PATH only through the prefix.
-        brew install llvm
+        # select the pinned major independently of homebrew's moving stable formula
+        local formula="llvm@$major"
+        brew install "$formula"
         local prefix
-        prefix=$(brew --prefix llvm)
+        prefix=$(brew --prefix "$formula")
         local got
         got=$("$prefix/bin/llvm-objdump" --version | grep -o 'LLVM version [0-9]*' | grep -o '[0-9]*$')
         if [ "$got" != "$major" ]; then
-            echo "ci-tools.sh: brew's llvm is major $got and tools.lock pins $major; install llvm@$major instead, or move the pin and re-bless" >&2
+            echo "ci-tools.sh: $formula installed major $got but tools.lock pins $major" >&2
             exit 1
         fi
         echo "$prefix/bin" >> "${GITHUB_PATH:-/dev/null}"


### PR DESCRIPTION
Darwin corpus setup selected Homebrew’s moving `llvm` formula and now installs LLVM 23 against the committed 22.1.8 oracle pin. Select `llvm@<major>` from the existing pin and use that keg on PATH. Keep the installer major check and corpus exact-version checks.

Validation: shell syntax and whitespace checks pass. Native Intel and Apple Silicon jobs in [run 33998811705](https://github.com/briar-systems/mach/actions/runs/33998811705) install the pinned tools and complete both compiler provenance passes. Each source passes 273 structural and 182 native runtime cells per architecture. Disassembly mismatches remain explicitly tracked by #3179. The original Apple Silicon installer failure at run 33998669742 is retained as reproduction.

Closes #3181
