### PR TITLE
test(corpus): reconcile audited Windows and Darwin disassemblies

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,8 @@ The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 ### Fixed
 
+- Windows and Darwin corpus disassemblies now reflect the audited aggregate and vector ABI, scratch-register preservation, canonical boolean, trapping remainder, inline, vector-loop and Darwin x18 fixes. All 77 updates were independently decoded and reviewed against native C-reference results (#3179).
+
 - Darwin CI installs the Homebrew LLVM formula selected by the committed oracle major, so a newer Homebrew stable release cannot break the pinned disassembly lane (#3181).
 
 #### Language and frontend

--- a/test/golden/aarch64-darwin/call/call_chain.dis
+++ b/test/golden/aarch64-darwin/call/call_chain.dis
@@ -78,7 +78,7 @@ Disassembly of section __TEXT,__text:
                	eor	x13, x0, x16
                	mov	x16, #0xd               ; =13
                	mul	x15, x0, x16
-               	add	x18, x15, #0xc
+               	add	x19, x15, #0xc
                	eor	x15, x2, x0
                	mov	x16, #0x3ff             ; =1023
                	and	x2, x0, x16
@@ -87,26 +87,26 @@ Disassembly of section __TEXT,__text:
                	fdiv	d1, d0, d30
                	lsr	x2, x0, #5
                	mov	x16, #0x3ff             ; =1023
-               	and	x19, x2, x16
-               	ucvtf	d0, x19
+               	and	x20, x2, x16
+               	ucvtf	d0, x20
                	fmov	d30, #8.00000000
                	fdiv	d2, d0, d30
                	lsr	x2, x0, #11
                	mov	x16, #0x3ff             ; =1023
-               	and	x19, x2, x16
-               	ucvtf	d0, x19
+               	and	x20, x2, x16
+               	ucvtf	d0, x20
                	fmov	d30, #8.00000000
                	fdiv	d3, d0, d30
                	lsr	x2, x0, #17
                	mov	x16, #0xff              ; =255
-               	and	x19, x2, x16
-               	ucvtf	s0, x19
+               	and	x20, x2, x16
+               	ucvtf	s0, x20
                	fmov	s30, #4.00000000
                	fdiv	s4, s0, s30
                	lsr	x2, x0, #23
                	mov	x16, #0xff              ; =255
-               	and	x19, x2, x16
-               	ucvtf	s0, x19
+               	and	x20, x2, x16
+               	ucvtf	s0, x20
                	fmov	s30, #4.00000000
                	fdiv	s5, s0, s30
                	lsr	x2, x0, #29
@@ -115,17 +115,16 @@ Disassembly of section __TEXT,__text:
                	ucvtf	s0, x0
                	fmov	s30, #4.00000000
                	fdiv	s6, s0, s30
-               	mov	x19, x1
-               	mov	x20, x3
-               	mov	x21, x4
-               	mov	x22, x6
-               	mov	x23, x5
-               	mov	x24, x8
-               	mov	x25, x7
-               	mov	x26, x12
-               	mov	x27, x14
-               	mov	x28, x13
-               	mov	x9, x18
+               	mov	x20, x1
+               	mov	x21, x3
+               	mov	x22, x4
+               	mov	x23, x6
+               	mov	x24, x5
+               	mov	x25, x8
+               	mov	x26, x7
+               	mov	x27, x12
+               	mov	x28, x14
+               	mov	x9, x13
                	stur	x9, [x29, #-0x8]
                	mov	x9, x15
                	stur	x9, [x29, #-0x10]
@@ -140,22 +139,22 @@ Disassembly of section __TEXT,__text:
                	b.lo	 <L0>
                	b	 <L1>
 <L0>:
-               	add	x19, x19, x20
-               	eor	x20, x20, x21
-               	add	x21, x21, x22
-               	eor	x22, x22, x23
-               	add	x23, x23, x24
-               	eor	x24, x24, x25
-               	add	x25, x25, x26
-               	eor	x26, x26, x27
-               	add	x27, x27, x28
+               	add	x20, x20, x21
+               	eor	x21, x21, x22
+               	add	x22, x22, x23
+               	eor	x23, x23, x24
+               	add	x24, x24, x25
+               	eor	x25, x25, x26
+               	add	x26, x26, x27
+               	eor	x27, x27, x28
                	ldur	x9, [x29, #-0x8]
-               	eor	x28, x28, x9
+               	add	x28, x28, x9
                	ldur	x9, [x29, #-0x8]
-               	ldur	x10, [x29, #-0x10]
-               	add	x2, x9, x10
+               	eor	x2, x9, x19
                	ldur	x9, [x29, #-0x10]
-               	eor	x3, x9, x19
+               	add	x19, x19, x9
+               	ldur	x9, [x29, #-0x10]
+               	eor	x3, x9, x20
                	fadd	d8, d8, d9
                	fsub	d9, d9, d10
                	fadd	d10, d10, d8
@@ -171,20 +170,20 @@ Disassembly of section __TEXT,__text:
                	b.lo	 <L0>
 <L1>:
                	bl	 <L1>
-               	eor	x1, x19, x20
-               	eor	x4, x1, x21
-               	eor	x1, x4, x22
-               	eor	x4, x1, x23
-               	eor	x1, x4, x24
+               	eor	x1, x20, x21
+               	eor	x4, x1, x22
+               	eor	x1, x4, x23
+               	eor	x4, x1, x24
+               	eor	x1, x4, x25
 <L2>:
                	bl	 <L2>
-               	eor	x1, x25, x26
-               	eor	x4, x1, x27
-               	eor	x1, x4, x28
+               	eor	x1, x26, x27
+               	eor	x4, x1, x28
                	ldur	x9, [x29, #-0x8]
-               	eor	x4, x1, x9
-               	ldur	x9, [x29, #-0x10]
                	eor	x1, x4, x9
+               	eor	x2, x1, x19
+               	ldur	x9, [x29, #-0x10]
+               	eor	x1, x2, x9
 <L3>:
                	bl	 <L3>
                	fadd	d0, d8, d9
@@ -881,26 +880,26 @@ Disassembly of section __TEXT,__text:
                	mov	x16, #0xd               ; =13
                	mul	x1, x0, x16
                	add	x9, x1, #0x3
-               	stur	x9, [x29, #-0x30]
+               	stur	x9, [x29, #-0x38]
                	mov	x16, #0x5555            ; =21845
                	movk	x16, #0x5555, lsl #16
                	eor	x9, x0, x16
-               	stur	x9, [x29, #-0x38]
+               	stur	x9, [x29, #-0x40]
                	mvn	x1, x0
                	mov	x16, #0x3               ; =3
                	mul	x9, x1, x16
-               	stur	x9, [x29, #-0x40]
-               	add	x9, x0, #0x11
                	stur	x9, [x29, #-0x48]
+               	add	x9, x0, #0x11
+               	stur	x9, [x29, #-0x50]
                	mov	x16, #0x13              ; =19
                	mul	x9, x0, x16
-               	stur	x9, [x29, #-0x50]
+               	stur	x9, [x29, #-0x58]
                	mov	x16, #0x5678            ; =22136
                	movk	x16, #0x1234, lsl #16
                	eor	x9, x0, x16
-               	stur	x9, [x29, #-0x58]
-               	add	x9, x0, #0x17
                	stur	x9, [x29, #-0x60]
+               	add	x9, x0, #0x17
+               	stur	x9, [x29, #-0x68]
                	lsr	x1, x0, #6
                	mov	x16, #0x3ff             ; =1023
                	and	x12, x1, x16
@@ -931,32 +930,32 @@ Disassembly of section __TEXT,__text:
                	ucvtf	s0, x12
                	fmov	s30, #4.00000000
                	fdiv	s31, s0, s30
-               	stur	s31, [x29, #-0x70]
+               	stur	s31, [x29, #-0x78]
                	add	x9, x0, #0x1d
-               	stur	x9, [x29, #-0x8]
-               	ldur	x10, [x29, #-0x8]
+               	stur	x9, [x29, #-0x10]
+               	ldur	x10, [x29, #-0x10]
                	mov	x16, #0xb               ; =11
                	eor	x9, x10, x16
-               	stur	x9, [x29, #-0x78]
-               	ldur	x9, [x29, #-0x8]
+               	stur	x9, [x29, #-0x80]
+               	ldur	x9, [x29, #-0x10]
                	mov	x16, #0x5               ; =5
                	mul	x0, x9, x16
                	add	x9, x0, #0x2
-               	stur	x9, [x29, #-0x80]
-               	ldur	x9, [x29, #-0x8]
+               	stur	x9, [x29, #-0x88]
+               	ldur	x9, [x29, #-0x10]
                	mvn	x0, x9
                	add	x9, x0, #0x7
-               	stur	x9, [x29, #-0x88]
-               	ldur	x10, [x29, #-0x8]
+               	stur	x9, [x29, #-0x90]
+               	ldur	x10, [x29, #-0x10]
                	mov	x16, #0xaaaa            ; =43690
                	movk	x16, #0xaaaa, lsl #16
                	add	x9, x10, x16
-               	stur	x9, [x29, #-0x90]
-               	ldur	x10, [x29, #-0x8]
+               	stur	x9, [x29, #-0x98]
+               	ldur	x10, [x29, #-0x10]
                	mov	x16, #0x9               ; =9
                	mul	x9, x10, x16
-               	stur	x9, [x29, #-0x98]
-               	ldur	x9, [x29, #-0x8]
+               	stur	x9, [x29, #-0x8]
+               	ldur	x9, [x29, #-0x10]
                	lsr	x0, x9, #4
                	mov	x16, #0x3ff             ; =1023
                	and	x1, x0, x16
@@ -964,7 +963,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d30, #8.00000000
                	fdiv	d31, d0, d30
                	stur	d31, [x29, #-0xa8]
-               	ldur	x9, [x29, #-0x8]
+               	ldur	x9, [x29, #-0x10]
                	lsr	x0, x9, #14
                	mov	x16, #0x3ff             ; =1023
                	and	x1, x0, x16
@@ -972,7 +971,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d30, #8.00000000
                	fdiv	d31, d0, d30
                	stur	d31, [x29, #-0xb8]
-               	ldur	x9, [x29, #-0x8]
+               	ldur	x9, [x29, #-0x10]
                	lsr	x0, x9, #21
                	mov	x16, #0xff              ; =255
                	and	x1, x0, x16
@@ -980,22 +979,22 @@ Disassembly of section __TEXT,__text:
                	fmov	s30, #4.00000000
                	fdiv	s31, s0, s30
                	stur	s31, [x29, #-0xc8]
-               	ldur	x9, [x29, #-0x8]
+               	ldur	x9, [x29, #-0x10]
                	mov	x16, #0x7               ; =7
                	mul	x0, x9, x16
                	add	x9, x0, #0x1
-               	stur	x9, [x29, #-0x28]
-               	ldur	x10, [x29, #-0x28]
+               	stur	x9, [x29, #-0x30]
+               	ldur	x10, [x29, #-0x30]
                	add	x9, x10, #0x1
-               	stur	x9, [x29, #-0x10]
-               	ldur	x10, [x29, #-0x28]
+               	stur	x9, [x29, #-0x18]
+               	ldur	x10, [x29, #-0x30]
                	mov	x16, #0x3               ; =3
                	mul	x9, x10, x16
-               	stur	x9, [x29, #-0x18]
-               	ldur	x10, [x29, #-0x28]
-               	mvn	x9, x10
                	stur	x9, [x29, #-0x20]
-               	ldur	x9, [x29, #-0x28]
+               	ldur	x10, [x29, #-0x30]
+               	mvn	x9, x10
+               	stur	x9, [x29, #-0x28]
+               	ldur	x9, [x29, #-0x30]
                	lsr	x0, x9, #2
                	mov	x16, #0x3ff             ; =1023
                	and	x1, x0, x16
@@ -1003,7 +1002,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d30, #8.00000000
                	fdiv	d31, d0, d30
                	stur	d31, [x29, #-0xd8]
-               	ldur	x9, [x29, #-0x28]
+               	ldur	x9, [x29, #-0x30]
                	lsr	x0, x9, #7
                	mov	x16, #0xff              ; =255
                	and	x1, x0, x16
@@ -1011,7 +1010,7 @@ Disassembly of section __TEXT,__text:
                	fmov	s30, #4.00000000
                	fdiv	s31, s0, s30
                	stur	s31, [x29, #-0xe8]
-               	ldur	x9, [x29, #-0x28]
+               	ldur	x9, [x29, #-0x30]
                	mov	x16, #0x3039            ; =12345
                	eor	x0, x9, x16
 <L0>:
@@ -1020,15 +1019,15 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x19
 <L1>:
                	bl	 <L1>
-               	ldur	x9, [x29, #-0x10]
+               	ldur	x9, [x29, #-0x18]
                	mov	x1, x9
 <L2>:
                	bl	 <L2>
-               	ldur	x9, [x29, #-0x18]
+               	ldur	x9, [x29, #-0x20]
                	mov	x1, x9
 <L3>:
                	bl	 <L3>
-               	ldur	x9, [x29, #-0x20]
+               	ldur	x9, [x29, #-0x28]
                	mov	x1, x9
 <L4>:
                	bl	 <L4>
@@ -1038,23 +1037,23 @@ Disassembly of section __TEXT,__text:
                	ldur	s0, [x29, #-0xe8]
 <L6>:
                	bl	 <L6>
-               	ldur	x9, [x29, #-0x78]
+               	ldur	x9, [x29, #-0x80]
                	mov	x1, x9
 <L7>:
                	bl	 <L7>
-               	ldur	x9, [x29, #-0x80]
+               	ldur	x9, [x29, #-0x88]
                	mov	x1, x9
 <L8>:
                	bl	 <L8>
-               	ldur	x9, [x29, #-0x88]
+               	ldur	x9, [x29, #-0x90]
                	mov	x1, x9
 <L9>:
                	bl	 <L9>
-               	ldur	x9, [x29, #-0x90]
+               	ldur	x9, [x29, #-0x98]
                	mov	x1, x9
 <L10>:
                	bl	 <L10>
-               	ldur	x9, [x29, #-0x98]
+               	ldur	x9, [x29, #-0x8]
                	mov	x1, x9
 <L11>:
                	bl	 <L11>
@@ -1067,36 +1066,36 @@ Disassembly of section __TEXT,__text:
                	ldur	s0, [x29, #-0xc8]
 <L14>:
                	bl	 <L14>
-               	ldur	x9, [x29, #-0x78]
-               	ldur	x10, [x29, #-0x98]
+               	ldur	x9, [x29, #-0x80]
+               	ldur	x10, [x29, #-0x8]
                	eor	x1, x9, x10
 <L15>:
                	bl	 <L15>
-               	ldur	x9, [x29, #-0x30]
+               	ldur	x9, [x29, #-0x38]
                	mov	x1, x9
 <L16>:
                	bl	 <L16>
-               	ldur	x9, [x29, #-0x38]
+               	ldur	x9, [x29, #-0x40]
                	mov	x1, x9
 <L17>:
                	bl	 <L17>
-               	ldur	x9, [x29, #-0x40]
+               	ldur	x9, [x29, #-0x48]
                	mov	x1, x9
 <L18>:
                	bl	 <L18>
-               	ldur	x9, [x29, #-0x48]
+               	ldur	x9, [x29, #-0x50]
                	mov	x1, x9
 <L19>:
                	bl	 <L19>
-               	ldur	x9, [x29, #-0x50]
+               	ldur	x9, [x29, #-0x58]
                	mov	x1, x9
 <L20>:
                	bl	 <L20>
-               	ldur	x9, [x29, #-0x58]
+               	ldur	x9, [x29, #-0x60]
                	mov	x1, x9
 <L21>:
                	bl	 <L21>
-               	ldur	x9, [x29, #-0x60]
+               	ldur	x9, [x29, #-0x68]
                	mov	x1, x9
 <L22>:
                	bl	 <L22>
@@ -1112,13 +1111,13 @@ Disassembly of section __TEXT,__text:
                	fmov	s0, s15
 <L26>:
                	bl	 <L26>
-               	ldur	s0, [x29, #-0x70]
+               	ldur	s0, [x29, #-0x78]
 <L27>:
                	bl	 <L27>
-               	ldur	x9, [x29, #-0x30]
-               	ldur	x10, [x29, #-0x48]
+               	ldur	x9, [x29, #-0x38]
+               	ldur	x10, [x29, #-0x50]
                	add	x1, x9, x10
-               	ldur	x9, [x29, #-0x60]
+               	ldur	x9, [x29, #-0x68]
                	add	x2, x1, x9
                	mov	x1, x2
 <L28>:
@@ -1265,13 +1264,13 @@ Disassembly of section __TEXT,__text:
                	eor	x28, x0, x16
                	mov	x16, #0x35              ; =53
                	mul	x9, x0, x16
-               	stur	x9, [x29, #-0x78]
-               	add	x9, x1, #0x3b
                	stur	x9, [x29, #-0x80]
+               	add	x9, x1, #0x3b
+               	stur	x9, [x29, #-0x88]
                	mov	x16, #0x3d              ; =61
                	mul	x1, x0, x16
                	add	x9, x1, #0x4
-               	stur	x9, [x29, #-0x88]
+               	stur	x9, [x29, #-0x90]
                	lsr	x1, x0, #8
                	mov	x16, #0x3ff             ; =1023
                	and	x5, x1, x16
@@ -1302,26 +1301,26 @@ Disassembly of section __TEXT,__text:
                	mov	x16, #0xd               ; =13
                	mul	x1, x0, x16
                	add	x9, x1, #0x3
-               	stur	x9, [x29, #-0x90]
+               	stur	x9, [x29, #-0x98]
                	mov	x16, #0x5555            ; =21845
                	movk	x16, #0x5555, lsl #16
                	eor	x9, x0, x16
-               	stur	x9, [x29, #-0x98]
+               	stur	x9, [x29, #-0xa0]
                	mvn	x1, x0
                	mov	x16, #0x3               ; =3
                	mul	x9, x1, x16
-               	stur	x9, [x29, #-0xa0]
-               	add	x9, x0, #0x11
                	stur	x9, [x29, #-0xa8]
+               	add	x9, x0, #0x11
+               	stur	x9, [x29, #-0xb0]
                	mov	x16, #0x13              ; =19
                	mul	x9, x0, x16
-               	stur	x9, [x29, #-0xb0]
+               	stur	x9, [x29, #-0xb8]
                	mov	x16, #0x5678            ; =22136
                	movk	x16, #0x1234, lsl #16
                	eor	x9, x0, x16
-               	stur	x9, [x29, #-0xb8]
-               	add	x9, x0, #0x17
                	stur	x9, [x29, #-0xc0]
+               	add	x9, x0, #0x17
+               	stur	x9, [x29, #-0xc8]
                	lsr	x1, x0, #6
                	mov	x16, #0x3ff             ; =1023
                	and	x15, x1, x16
@@ -1352,32 +1351,32 @@ Disassembly of section __TEXT,__text:
                	ucvtf	s0, x15
                	fmov	s30, #4.00000000
                	fdiv	s31, s0, s30
-               	stur	s31, [x29, #-0xd0]
+               	stur	s31, [x29, #-0xd8]
                	add	x9, x0, #0x1d
-               	stur	x9, [x29, #-0x50]
-               	ldur	x10, [x29, #-0x50]
+               	stur	x9, [x29, #-0x58]
+               	ldur	x10, [x29, #-0x58]
                	mov	x16, #0xb               ; =11
                	eor	x9, x10, x16
-               	stur	x9, [x29, #-0xd8]
-               	ldur	x9, [x29, #-0x50]
+               	stur	x9, [x29, #-0xe0]
+               	ldur	x9, [x29, #-0x58]
                	mov	x16, #0x5               ; =5
                	mul	x0, x9, x16
                	add	x9, x0, #0x2
-               	stur	x9, [x29, #-0xe0]
-               	ldur	x9, [x29, #-0x50]
+               	stur	x9, [x29, #-0x38]
+               	ldur	x9, [x29, #-0x58]
                	mvn	x0, x9
                	add	x9, x0, #0x7
-               	stur	x9, [x29, #-0x38]
-               	ldur	x10, [x29, #-0x50]
+               	stur	x9, [x29, #-0x40]
+               	ldur	x10, [x29, #-0x58]
                	mov	x16, #0xaaaa            ; =43690
                	movk	x16, #0xaaaa, lsl #16
                	add	x9, x10, x16
-               	stur	x9, [x29, #-0x40]
-               	ldur	x10, [x29, #-0x50]
+               	stur	x9, [x29, #-0x48]
+               	ldur	x10, [x29, #-0x58]
                	mov	x16, #0x9               ; =9
                	mul	x9, x10, x16
-               	stur	x9, [x29, #-0x48]
-               	ldur	x9, [x29, #-0x50]
+               	stur	x9, [x29, #-0x50]
+               	ldur	x9, [x29, #-0x58]
                	lsr	x0, x9, #4
                	mov	x16, #0x3ff             ; =1023
                	and	x1, x0, x16
@@ -1385,7 +1384,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d30, #8.00000000
                	fdiv	d31, d0, d30
                	stur	d31, [x29, #-0xf0]
-               	ldur	x9, [x29, #-0x50]
+               	ldur	x9, [x29, #-0x58]
                	lsr	x0, x9, #14
                	mov	x16, #0x3ff             ; =1023
                	and	x1, x0, x16
@@ -1393,7 +1392,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d30, #8.00000000
                	fdiv	d31, d0, d30
                	stur	d31, [x29, #-0x100]
-               	ldur	x9, [x29, #-0x50]
+               	ldur	x9, [x29, #-0x58]
                	lsr	x0, x9, #21
                	mov	x16, #0xff              ; =255
                	and	x1, x0, x16
@@ -1405,22 +1404,22 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	s31, [x29, x16]
-               	ldur	x9, [x29, #-0x50]
+               	ldur	x9, [x29, #-0x58]
                	mov	x16, #0x7               ; =7
                	mul	x0, x9, x16
                	add	x9, x0, #0x1
-               	stur	x9, [x29, #-0x70]
-               	ldur	x10, [x29, #-0x70]
+               	stur	x9, [x29, #-0x78]
+               	ldur	x10, [x29, #-0x78]
                	add	x9, x10, #0x1
-               	stur	x9, [x29, #-0x58]
-               	ldur	x10, [x29, #-0x70]
+               	stur	x9, [x29, #-0x60]
+               	ldur	x10, [x29, #-0x78]
                	mov	x16, #0x3               ; =3
                	mul	x9, x10, x16
-               	stur	x9, [x29, #-0x60]
-               	ldur	x10, [x29, #-0x70]
-               	mvn	x9, x10
                	stur	x9, [x29, #-0x68]
-               	ldur	x9, [x29, #-0x70]
+               	ldur	x10, [x29, #-0x78]
+               	mvn	x9, x10
+               	stur	x9, [x29, #-0x70]
+               	ldur	x9, [x29, #-0x78]
                	lsr	x0, x9, #2
                	mov	x16, #0x3ff             ; =1023
                	and	x1, x0, x16
@@ -1432,7 +1431,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	d31, [x29, x16]
-               	ldur	x9, [x29, #-0x70]
+               	ldur	x9, [x29, #-0x78]
                	lsr	x0, x9, #7
                	mov	x16, #0xff              ; =255
                	and	x1, x0, x16
@@ -1444,7 +1443,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	s31, [x29, x16]
-               	ldur	x9, [x29, #-0x70]
+               	ldur	x9, [x29, #-0x78]
                	mov	x16, #0x3039            ; =12345
                	eor	x0, x9, x16
 <L6>:
@@ -1453,15 +1452,15 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x21
 <L7>:
                	bl	 <L7>
-               	ldur	x9, [x29, #-0x58]
+               	ldur	x9, [x29, #-0x60]
                	mov	x1, x9
 <L8>:
                	bl	 <L8>
-               	ldur	x9, [x29, #-0x60]
+               	ldur	x9, [x29, #-0x68]
                	mov	x1, x9
 <L9>:
                	bl	 <L9>
-               	ldur	x9, [x29, #-0x68]
+               	ldur	x9, [x29, #-0x70]
                	mov	x1, x9
 <L10>:
                	bl	 <L10>
@@ -1479,23 +1478,23 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x29, x16]
 <L12>:
                	bl	 <L12>
-               	ldur	x9, [x29, #-0xd8]
+               	ldur	x9, [x29, #-0xe0]
                	mov	x1, x9
 <L13>:
                	bl	 <L13>
-               	ldur	x9, [x29, #-0xe0]
+               	ldur	x9, [x29, #-0x38]
                	mov	x1, x9
 <L14>:
                	bl	 <L14>
-               	ldur	x9, [x29, #-0x38]
+               	ldur	x9, [x29, #-0x40]
                	mov	x1, x9
 <L15>:
                	bl	 <L15>
-               	ldur	x9, [x29, #-0x40]
+               	ldur	x9, [x29, #-0x48]
                	mov	x1, x9
 <L16>:
                	bl	 <L16>
-               	ldur	x9, [x29, #-0x48]
+               	ldur	x9, [x29, #-0x50]
                	mov	x1, x9
 <L17>:
                	bl	 <L17>
@@ -1512,36 +1511,36 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x29, x16]
 <L20>:
                	bl	 <L20>
-               	ldur	x9, [x29, #-0xd8]
-               	ldur	x10, [x29, #-0x48]
+               	ldur	x9, [x29, #-0xe0]
+               	ldur	x10, [x29, #-0x50]
                	eor	x1, x9, x10
 <L21>:
                	bl	 <L21>
-               	ldur	x9, [x29, #-0x90]
+               	ldur	x9, [x29, #-0x98]
                	mov	x1, x9
 <L22>:
                	bl	 <L22>
-               	ldur	x9, [x29, #-0x98]
+               	ldur	x9, [x29, #-0xa0]
                	mov	x1, x9
 <L23>:
                	bl	 <L23>
-               	ldur	x9, [x29, #-0xa0]
+               	ldur	x9, [x29, #-0xa8]
                	mov	x1, x9
 <L24>:
                	bl	 <L24>
-               	ldur	x9, [x29, #-0xa8]
+               	ldur	x9, [x29, #-0xb0]
                	mov	x1, x9
 <L25>:
                	bl	 <L25>
-               	ldur	x9, [x29, #-0xb0]
+               	ldur	x9, [x29, #-0xb8]
                	mov	x1, x9
 <L26>:
                	bl	 <L26>
-               	ldur	x9, [x29, #-0xb8]
+               	ldur	x9, [x29, #-0xc0]
                	mov	x1, x9
 <L27>:
                	bl	 <L27>
-               	ldur	x9, [x29, #-0xc0]
+               	ldur	x9, [x29, #-0xc8]
                	mov	x1, x9
 <L28>:
                	bl	 <L28>
@@ -1557,13 +1556,13 @@ Disassembly of section __TEXT,__text:
                	fmov	s0, s15
 <L32>:
                	bl	 <L32>
-               	ldur	s0, [x29, #-0xd0]
+               	ldur	s0, [x29, #-0xd8]
 <L33>:
                	bl	 <L33>
-               	ldur	x9, [x29, #-0x90]
-               	ldur	x10, [x29, #-0xa8]
+               	ldur	x9, [x29, #-0x98]
+               	ldur	x10, [x29, #-0xb0]
                	add	x1, x9, x10
-               	ldur	x9, [x29, #-0xc0]
+               	ldur	x9, [x29, #-0xc8]
                	add	x5, x1, x9
                	mov	x1, x5
 <L34>:
@@ -1586,15 +1585,15 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x28
 <L40>:
                	bl	 <L40>
-               	ldur	x9, [x29, #-0x78]
+               	ldur	x9, [x29, #-0x80]
                	mov	x1, x9
 <L41>:
                	bl	 <L41>
-               	ldur	x9, [x29, #-0x80]
+               	ldur	x9, [x29, #-0x88]
                	mov	x1, x9
 <L42>:
                	bl	 <L42>
-               	ldur	x9, [x29, #-0x88]
+               	ldur	x9, [x29, #-0x90]
                	mov	x1, x9
 <L43>:
                	bl	 <L43>
@@ -1611,7 +1610,7 @@ Disassembly of section __TEXT,__text:
 <L47>:
                	bl	 <L47>
                	eor	x1, x23, x27
-               	ldur	x9, [x29, #-0x88]
+               	ldur	x9, [x29, #-0x90]
                	eor	x2, x1, x9
                	mov	x1, x2
 <L48>:

--- a/test/golden/aarch64-darwin/call/call_indirect.dis
+++ b/test/golden/aarch64-darwin/call/call_indirect.dis
@@ -331,14 +331,15 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_indirect.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1e0
-               	stp	x19, x20, [x29, #-0x180]
-               	stp	x21, x22, [x29, #-0x190]
-               	stp	x23, x24, [x29, #-0x1a0]
-               	stp	x25, x26, [x29, #-0x1b0]
-               	stp	x27, x28, [x29, #-0x1c0]
-               	stp	d8, d9, [x29, #-0x1d0]
-               	stp	d10, d11, [x29, #-0x1e0]
+               	sub	sp, sp, #0x210
+               	stp	x19, x20, [x29, #-0x1b0]
+               	stp	x21, x22, [x29, #-0x1c0]
+               	stp	x23, x24, [x29, #-0x1d0]
+               	stp	x25, x26, [x29, #-0x1e0]
+               	stp	x27, x28, [x29, #-0x1f0]
+               	sub	x16, x29, #0x200
+               	stp	d8, d9, [x16]
+               	stp	d10, d11, [x16, #-0x10]
                	mov	x19, x0
 <L0>:
                	bl	 <L0>
@@ -448,25 +449,33 @@ Disassembly of section __TEXT,__text:
                	udiv	x16, x1, x0
                	msub	x28, x16, x0, x1
                	add	x9, x21, x28, lsl #3
-               	stur	x9, [x29, #-0x100]
-               	ldur	x9, [x29, #-0x100]
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	ldr	x3, [x9]
                	ldr	x1, [x27]
                	mov	x0, x25
                	blr	x3
                	mov	x9, x0
-               	mov	x16, #0xfef8            ; =65272
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfef8            ; =65272
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x24
-               	mov	x16, #0xfef8            ; =65272
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -475,20 +484,24 @@ Disassembly of section __TEXT,__text:
 <L5>:
                	bl	 <L5>
                	mov	x9, x0
-               	mov	x16, #0xfef0            ; =65264
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfef0            ; =65264
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldur	x9, [x29, #-0x100]
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	ldr	x5, [x9]
                	ldr	x1, [x27]
-               	mov	x16, #0xfef8            ; =65272
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -496,7 +509,7 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x9
                	blr	x5
                	mov	x1, x0
-               	mov	x16, #0xfef0            ; =65264
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -516,25 +529,25 @@ Disassembly of section __TEXT,__text:
                	ldr	x28, [x0]
                	add	x0, x20, x26, lsl #3
                	ldr	x9, [x0]
-               	mov	x16, #0xfee8            ; =65256
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfef8            ; =65272
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x9
-               	mov	x16, #0xfee8            ; =65256
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x1, x9
                	blr	x28
-               	mov	x16, #0xfee8            ; =65256
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -590,7 +603,7 @@ Disassembly of section __TEXT,__text:
 <L15>:
                	add	x0, x20, x26, lsl #3
                	ldr	x1, [x0]
-               	mov	x16, #0xfef8            ; =65272
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -603,7 +616,7 @@ Disassembly of section __TEXT,__text:
                	bl	 <L16>
                	add	x26, x26, #0x1
                	mov	x24, x0
-               	mov	x16, #0xfef8            ; =65272
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -687,38 +700,38 @@ Disassembly of section __TEXT,__text:
                	ldr	x1, [x0]
                	add	x0, x1, x25
                	sub	x9, x29, #0xe0
-               	mov	x16, #0xfee0            ; =65248
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x8, x9
                	blr	x2
-               	mov	x16, #0xfee0            ; =65248
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x16, #0xfee0            ; =65248
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x0, [x9]
                	str	x0, [x28]
-               	mov	x16, #0xfee0            ; =65248
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x0, [x9, #0x8]
                	str	x0, [x28, #0x8]
-               	mov	x16, #0xfee0            ; =65248
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -729,14 +742,14 @@ Disassembly of section __TEXT,__text:
                	ldr	x1, [x0]
                	add	x0, x28, #0x8
                	ldr	x9, [x0]
-               	mov	x16, #0xfed8            ; =65240
+               	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	add	x0, x28, #0x10
                	ldr	x9, [x0]
-               	mov	x16, #0xfed0            ; =65232
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -744,7 +757,7 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x24
 <L26>:
                	bl	 <L26>
-               	mov	x16, #0xfed8            ; =65240
+               	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -752,7 +765,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L27>:
                	bl	 <L27>
-               	mov	x16, #0xfed0            ; =65232
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -761,32 +774,38 @@ Disassembly of section __TEXT,__text:
 <L28>:
                	bl	 <L28>
                	mov	x9, x0
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x9, x22, x27, lsl #3
-               	mov	x16, #0xfec8            ; =65224
+               	mov	x16, #0xfe98            ; =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfec8            ; =65224
+               	mov	x16, #0xfe98            ; =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	ldr	x27, [x9]
-               	mov	x0, x28
+               	ldr	x0, [x28]
+               	stur	x0, [x29, #-0xf8]
+               	ldr	x0, [x28, #0x8]
+               	stur	x0, [x29, #-0xf0]
+               	ldr	x0, [x28, #0x10]
+               	stur	x0, [x29, #-0xe8]
+               	sub	x0, x29, #0xf8
                	blr	x27
                	mov	x3, x0
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -796,7 +815,7 @@ Disassembly of section __TEXT,__text:
 <L29>:
                	bl	 <L29>
                	mov	x27, x0
-               	mov	x16, #0xfec8            ; =65224
+               	mov	x16, #0xfe98            ; =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -806,13 +825,13 @@ Disassembly of section __TEXT,__text:
                	ldr	x26, [x0]
                	add	x0, x20, x21, lsl #3
                	ldr	x1, [x0]
-               	sub	x9, x29, #0xf8
-               	mov	x16, #0xfeb8            ; =65208
+               	sub	x9, x29, #0x110
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfeb8            ; =65208
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -820,17 +839,45 @@ Disassembly of section __TEXT,__text:
                	mov	x8, x9
                	mov	x0, x1
                	blr	x26
-               	mov	x16, #0xfeb8            ; =65208
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x16, #0xfeb8            ; =65208
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x0, x9
+               	ldr	x0, [x9]
+               	mov	x16, #0xfed8            ; =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	mov	x16, #0xfe88            ; =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9, #0x8]
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	mov	x16, #0xfe88            ; =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x0, [x9, #0x10]
+               	mov	x16, #0xfee8            ; =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	sub	x0, x29, #0x128
                	blr	x28
                	mov	x1, x0
                	mov	x0, x27
@@ -869,7 +916,7 @@ Disassembly of section __TEXT,__text:
                	fdiv	d10, d0, d30
                	mov	w28, w22
                	mvn	x9, x22
-               	mov	x16, #0xfeb0            ; =65200
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -881,7 +928,7 @@ Disassembly of section __TEXT,__text:
                	fmov	s30, w16
                	fsub	s11, s0, s30
                	eor	x9, x22, x25
-               	mov	x16, #0xfea8            ; =65192
+               	mov	x16, #0xfe78            ; =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -915,7 +962,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x28
 <L42>:
                	bl	 <L42>
-               	mov	x16, #0xfeb0            ; =65200
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -926,7 +973,7 @@ Disassembly of section __TEXT,__text:
                	fmov	s0, s11
 <L44>:
                	bl	 <L44>
-               	mov	x16, #0xfea8            ; =65192
+               	mov	x16, #0xfe78            ; =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -958,13 +1005,13 @@ Disassembly of section __TEXT,__text:
                	fmov	d30, x16
                	fdiv	d10, d0, d30
                	mov	w9, w22
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	mvn	x9, x22
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfe68            ; =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -976,7 +1023,7 @@ Disassembly of section __TEXT,__text:
                	fmov	s30, w16
                	fsub	s11, s0, s30
                	eor	x9, x22, x25
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1007,7 +1054,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d0, d10
 <L55>:
                	bl	 <L55>
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1015,7 +1062,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L56>:
                	bl	 <L56>
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfe68            ; =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1026,7 +1073,7 @@ Disassembly of section __TEXT,__text:
                	fmov	s0, s11
 <L58>:
                	bl	 <L58>
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1044,13 +1091,14 @@ Disassembly of section __TEXT,__text:
                	b.lo	 <L32>
 <L61>:
                	mov	x0, x24
-               	ldp	d8, d9, [x29, #-0x1d0]
-               	ldp	d10, d11, [x29, #-0x1e0]
-               	ldp	x19, x20, [x29, #-0x180]
-               	ldp	x21, x22, [x29, #-0x190]
-               	ldp	x23, x24, [x29, #-0x1a0]
-               	ldp	x25, x26, [x29, #-0x1b0]
-               	ldp	x27, x28, [x29, #-0x1c0]
+               	sub	x16, x29, #0x200
+               	ldp	d8, d9, [x16]
+               	ldp	d10, d11, [x16, #-0x10]
+               	ldp	x19, x20, [x29, #-0x1b0]
+               	ldp	x21, x22, [x29, #-0x1c0]
+               	ldp	x23, x24, [x29, #-0x1d0]
+               	ldp	x25, x26, [x29, #-0x1e0]
+               	ldp	x27, x28, [x29, #-0x1f0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/call/call_int_regs.dis
+++ b/test/golden/aarch64-darwin/call/call_int_regs.dis
@@ -354,35 +354,23 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	ldr	x1, [x0]
                	mov	w9, w1
-               	stur	x9, [x29, #-0xc8]
+               	stur	x9, [x29, #-0xe0]
                	add	x0, x20, #0x28
                	ldr	x1, [x0]
                	mov	w9, w1
-               	stur	x9, [x29, #-0xd0]
+               	stur	x9, [x29, #-0xe8]
                	add	x0, x20, #0x30
                	ldr	x1, [x0]
                	add	x9, x1, x24
-               	stur	x9, [x29, #-0xd8]
+               	stur	x9, [x29, #-0xf0]
                	add	x0, x20, #0x38
                	ldr	x9, [x0]
-               	stur	x9, [x29, #-0xe0]
+               	stur	x9, [x29, #-0xf8]
                	add	x0, x20, #0x40
                	ldr	x1, [x0]
                	mov	w9, w1
-               	stur	x9, [x29, #-0xe8]
-               	add	x0, x20, #0x48
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0xf0]
-               	add	x0, x20, #0x50
-               	ldr	x1, [x0]
-               	mov	w9, w1
-               	stur	x9, [x29, #-0xf8]
-               	add	x0, x20, #0x58
-               	ldr	x1, [x0]
-               	mov	w9, w1
                	stur	x9, [x29, #-0x100]
-               	add	x0, x20, #0x60
+               	add	x0, x20, #0x48
                	ldr	x1, [x0]
                	mov	w9, w1
                	mov	x16, #0xfef8            ; =65272
@@ -390,7 +378,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	add	x0, x20, #0x68
+               	add	x0, x20, #0x50
                	ldr	x1, [x0]
                	mov	w9, w1
                	mov	x16, #0xfef0            ; =65264
@@ -398,21 +386,41 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
+               	add	x0, x20, #0x58
+               	ldr	x1, [x0]
+               	mov	w9, w1
+               	mov	x16, #0xfee8            ; =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x20, #0x60
+               	ldr	x1, [x0]
+               	mov	w9, w1
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x20, #0x68
+               	ldr	x1, [x0]
+               	mov	w9, w1
+               	mov	x16, #0xfed8            ; =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	add	x0, x20, #0x70
                	ldr	x1, [x0]
                	add	x9, x1, x24
-               	mov	x16, #0xfee8            ; =65256
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	add	x0, x20, #0x78
                	ldr	x9, [x0]
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	stur	x9, [x29, #-0xa8]
 <L4>:
                	bl	 <L4>
                	mov	x1, x25
@@ -427,39 +435,51 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x28
 <L8>:
                	bl	 <L8>
-               	ldur	x9, [x29, #-0xc8]
+               	ldur	x9, [x29, #-0xe0]
                	mov	w1, w9
 <L9>:
                	bl	 <L9>
-               	ldur	x9, [x29, #-0xd0]
+               	ldur	x9, [x29, #-0xe8]
                	mov	w1, w9
 <L10>:
                	bl	 <L10>
-               	ldur	x9, [x29, #-0xd8]
+               	ldur	x9, [x29, #-0xf0]
                	mov	x1, x9
 <L11>:
                	bl	 <L11>
-               	ldur	x9, [x29, #-0xe0]
+               	ldur	x9, [x29, #-0xf8]
                	mov	x1, x9
 <L12>:
                	bl	 <L12>
-               	ldur	x9, [x29, #-0xe8]
+               	ldur	x9, [x29, #-0x100]
                	mov	x1, x9
 <L13>:
                	bl	 <L13>
-               	ldur	x9, [x29, #-0xf0]
+               	mov	x16, #0xfef8            ; =65272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L14>:
                	bl	 <L14>
-               	ldur	x9, [x29, #-0xf8]
+               	mov	x16, #0xfef0            ; =65264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L15>:
                	bl	 <L15>
-               	ldur	x9, [x29, #-0x100]
+               	mov	x16, #0xfee8            ; =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x1, x9
 <L16>:
                	bl	 <L16>
-               	mov	x16, #0xfef8            ; =65272
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -467,7 +487,7 @@ Disassembly of section __TEXT,__text:
                	mov	w1, w9
 <L17>:
                	bl	 <L17>
-               	mov	x16, #0xfef0            ; =65264
+               	mov	x16, #0xfed8            ; =65240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -475,7 +495,7 @@ Disassembly of section __TEXT,__text:
                	mov	w1, w9
 <L18>:
                	bl	 <L18>
-               	mov	x16, #0xfee8            ; =65256
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -483,11 +503,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L19>:
                	bl	 <L19>
-               	mov	x16, #0xfee0            ; =65248
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
+               	ldur	x9, [x29, #-0xa8]
                	mov	x1, x9
 <L20>:
                	bl	 <L20>
@@ -508,7 +524,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x18
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfed8            ; =65240
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -516,7 +532,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfed0            ; =65232
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -524,7 +540,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x28
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfec8            ; =65224
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -532,7 +548,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x30
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -540,7 +556,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x38
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfeb8            ; =65208
+               	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -549,7 +565,7 @@ Disassembly of section __TEXT,__text:
                	ldr	x1, [x0]
                	add	x0, x1, x24
                	mov	w9, w0
-               	mov	x16, #0xfeb0            ; =65200
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -557,7 +573,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x48
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfea8            ; =65192
+               	mov	x16, #0xfe98            ; =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -565,7 +581,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x50
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -573,7 +589,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x58
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -581,7 +597,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x60
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -589,7 +605,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x68
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfe88            ; =65160
+               	mov	x16, #0xfe78            ; =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -597,11 +613,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x70
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	stur	x9, [x29, #-0xb0]
                	add	x0, x20, #0x78
                	ldr	x1, [x0]
                	add	x0, x1, x24
@@ -617,7 +629,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x28
 <L25>:
                	bl	 <L25>
-               	mov	x16, #0xfed8            ; =65240
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -625,7 +637,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L26>:
                	bl	 <L26>
-               	mov	x16, #0xfed0            ; =65232
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -633,7 +645,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L27>:
                	bl	 <L27>
-               	mov	x16, #0xfec8            ; =65224
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -641,7 +653,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L28>:
                	bl	 <L28>
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -649,7 +661,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L29>:
                	bl	 <L29>
-               	mov	x16, #0xfeb8            ; =65208
+               	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -657,7 +669,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L30>:
                	bl	 <L30>
-               	mov	x16, #0xfeb0            ; =65200
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -665,7 +677,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L31>:
                	bl	 <L31>
-               	mov	x16, #0xfea8            ; =65192
+               	mov	x16, #0xfe98            ; =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -673,7 +685,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L32>:
                	bl	 <L32>
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -681,7 +693,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L33>:
                	bl	 <L33>
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -689,7 +701,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L34>:
                	bl	 <L34>
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -697,7 +709,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L35>:
                	bl	 <L35>
-               	mov	x16, #0xfe88            ; =65160
+               	mov	x16, #0xfe78            ; =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -705,11 +717,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L36>:
                	bl	 <L36>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
+               	ldur	x9, [x29, #-0xb0]
                	mov	x1, x9
 <L37>:
                	bl	 <L37>
@@ -749,7 +757,7 @@ Disassembly of section __TEXT,__text:
                	ldr	x28, [x0]
                	add	x0, x20, #0x38
                	ldr	x9, [x0]
-               	mov	x16, #0xfe78            ; =65144
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -757,7 +765,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x40
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe68            ; =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -765,7 +773,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x48
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfe68            ; =65128
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -773,7 +781,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x50
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe58            ; =65112
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -781,7 +789,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x58
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfe58            ; =65112
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -789,7 +797,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x60
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe48            ; =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -797,21 +805,21 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x68
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfe48            ; =65096
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	add	x0, x20, #0x70
                	ldr	x9, [x0]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe38            ; =65080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	add	x0, x20, #0x78
                	ldr	x9, [x0]
-               	mov	x16, #0xfe38            ; =65080
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -839,7 +847,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x28
 <L48>:
                	bl	 <L48>
-               	mov	x16, #0xfe78            ; =65144
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -847,7 +855,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L49>:
                	bl	 <L49>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe68            ; =65128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -855,7 +863,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L50>:
                	bl	 <L50>
-               	mov	x16, #0xfe68            ; =65128
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -863,7 +871,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L51>:
                	bl	 <L51>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe58            ; =65112
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -871,7 +879,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L52>:
                	bl	 <L52>
-               	mov	x16, #0xfe58            ; =65112
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -879,7 +887,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L53>:
                	bl	 <L53>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe48            ; =65096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -887,7 +895,7 @@ Disassembly of section __TEXT,__text:
                	mov	w1, w9
 <L54>:
                	bl	 <L54>
-               	mov	x16, #0xfe48            ; =65096
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -895,7 +903,7 @@ Disassembly of section __TEXT,__text:
                	mov	w1, w9
 <L55>:
                	bl	 <L55>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe38            ; =65080
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -903,7 +911,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L56>:
                	bl	 <L56>
-               	mov	x16, #0xfe38            ; =65080
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -932,7 +940,7 @@ Disassembly of section __TEXT,__text:
                	add	x3, x20, #0x80
                	ldr	x4, [x3]
                	mov	w9, w4
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfe28            ; =65064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -940,7 +948,7 @@ Disassembly of section __TEXT,__text:
                	add	x4, x20, #0x88
                	ldr	x5, [x4]
                	mov	w9, w5
-               	mov	x16, #0xfe28            ; =65064
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -948,7 +956,7 @@ Disassembly of section __TEXT,__text:
                	add	x5, x20, #0x90
                	ldr	x6, [x5]
                	mov	w9, w6
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe18            ; =65048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -956,7 +964,7 @@ Disassembly of section __TEXT,__text:
                	add	x6, x20, #0x98
                	ldr	x7, [x6]
                	mov	w9, w7
-               	mov	x16, #0xfe18            ; =65048
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -964,28 +972,28 @@ Disassembly of section __TEXT,__text:
                	add	x7, x20, #0x20
                	ldr	x8, [x7]
                	mov	w9, w8
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe08            ; =65032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	ldr	x8, [x0]
                	mov	w9, w8
-               	mov	x16, #0xfe08            ; =65032
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	ldr	x0, [x1]
                	mov	w9, w0
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfdf8            ; =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	ldr	x0, [x2]
                	mov	w9, w0
-               	mov	x16, #0xfdf8            ; =65016
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -993,7 +1001,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x40
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfdf0            ; =65008
+               	mov	x16, #0xfde8            ; =65000
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1001,7 +1009,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x48
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfde8            ; =65000
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1009,7 +1017,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x50
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfdd8            ; =64984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1017,30 +1025,26 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x58
                	ldr	x1, [x0]
                	mov	w9, w1
-               	mov	x16, #0xfdd8            ; =64984
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	stur	x9, [x29, #-0xb8]
                	add	x0, x20, #0x60
                	ldr	x1, [x0]
                	mov	w9, w1
-               	stur	x9, [x29, #-0xa8]
+               	stur	x9, [x29, #-0xc0]
                	add	x0, x20, #0x68
                	ldr	x1, [x0]
                	mov	w9, w1
-               	stur	x9, [x29, #-0xb0]
+               	stur	x9, [x29, #-0xc8]
                	add	x0, x20, #0x70
                	ldr	x1, [x0]
                	mov	w9, w1
-               	stur	x9, [x29, #-0xb8]
+               	stur	x9, [x29, #-0xd0]
                	add	x0, x20, #0x78
                	ldr	x1, [x0]
                	mov	w9, w1
-               	stur	x9, [x29, #-0xc0]
+               	stur	x9, [x29, #-0xd8]
 <L58>:
                	bl	 <L58>
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfe28            ; =65064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1048,7 +1052,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L59>:
                	bl	 <L59>
-               	mov	x16, #0xfe28            ; =65064
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1056,7 +1060,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L60>:
                	bl	 <L60>
-               	mov	x16, #0xfe20            ; =65056
+               	mov	x16, #0xfe18            ; =65048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1064,7 +1068,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L61>:
                	bl	 <L61>
-               	mov	x16, #0xfe18            ; =65048
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1072,7 +1076,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L62>:
                	bl	 <L62>
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe08            ; =65032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1080,7 +1084,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L63>:
                	bl	 <L63>
-               	mov	x16, #0xfe08            ; =65032
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1088,7 +1092,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L64>:
                	bl	 <L64>
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfdf8            ; =65016
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1096,7 +1100,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L65>:
                	bl	 <L65>
-               	mov	x16, #0xfdf8            ; =65016
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1104,7 +1108,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L66>:
                	bl	 <L66>
-               	mov	x16, #0xfdf0            ; =65008
+               	mov	x16, #0xfde8            ; =65000
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1112,7 +1116,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L67>:
                	bl	 <L67>
-               	mov	x16, #0xfde8            ; =65000
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1120,7 +1124,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L68>:
                	bl	 <L68>
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfdd8            ; =64984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1128,27 +1132,23 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L69>:
                	bl	 <L69>
-               	mov	x16, #0xfdd8            ; =64984
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
+               	ldur	x9, [x29, #-0xb8]
                	mov	x1, x9
 <L70>:
                	bl	 <L70>
-               	ldur	x9, [x29, #-0xa8]
+               	ldur	x9, [x29, #-0xc0]
                	mov	x1, x9
 <L71>:
                	bl	 <L71>
-               	ldur	x9, [x29, #-0xb0]
+               	ldur	x9, [x29, #-0xc8]
                	mov	x1, x9
 <L72>:
                	bl	 <L72>
-               	ldur	x9, [x29, #-0xb8]
+               	ldur	x9, [x29, #-0xd0]
                	mov	x1, x9
 <L73>:
                	bl	 <L73>
-               	ldur	x9, [x29, #-0xc0]
+               	ldur	x9, [x29, #-0xd8]
                	mov	x1, x9
 <L74>:
                	bl	 <L74>

--- a/test/golden/aarch64-darwin/call/call_mixed.dis
+++ b/test/golden/aarch64-darwin/call/call_mixed.dis
@@ -308,14 +308,17 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_mixed.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x1b0
-               	stp	x19, x20, [x29, #-0x170]
-               	stp	x21, x22, [x29, #-0x180]
-               	mov	x16, #0xfe78            ; =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x23, [x29, x16]
+               	sub	sp, sp, #0x280
+               	sub	x16, x29, #0x1f0
+               	stp	x19, x20, [x16]
+               	stp	x21, x22, [x16, #-0x10]
+               	stp	x23, x24, [x16, #-0x20]
+               	stp	x25, x26, [x16, #-0x30]
+               	stp	x27, x28, [x16, #-0x40]
+               	sub	x16, x29, #0x240
+               	stp	d11, d12, [x16]
+               	stp	d13, d14, [x16, #-0x10]
+               	stur	d15, [x16, #-0x18]
                	mov	x19, x0
 <L0>:
                	bl	 <L0>
@@ -371,264 +374,320 @@ Disassembly of section __TEXT,__text:
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x3
                	b.lo	 <L3>
-               	b	 <L6>
+               	b	 <L11>
 <L3>:
                	mov	x16, #0xb               ; =11
                	mul	x0, x23, x16
-               	add	x1, x0, x19
+               	add	x24, x0, x19
                	sub	x0, x29, #0xcc
-               	add	x2, x20, #0x80
-               	ldr	x3, [x2]
+               	add	x1, x20, #0x80
+               	ldr	x2, [x1]
                	mov	x16, #0xfff             ; =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x1, x2, x16
+               	ucvtf	s0, x1
                	mov	w16, #0x45000000        ; =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0x0
-               	str	s0, [x2]
-               	add	x2, x20, #0x88
-               	ldr	x3, [x2]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	add	x1, x20, #0x88
+               	ldr	x2, [x1]
                	mov	x16, #0xfff             ; =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x1, x2, x16
+               	ucvtf	s0, x1
                	mov	w16, #0x45000000        ; =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0x4
-               	str	s0, [x2]
-               	add	x2, x20, #0x90
-               	ldr	x3, [x2]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	add	x1, x20, #0x90
+               	ldr	x2, [x1]
                	mov	x16, #0xfff             ; =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x1, x2, x16
+               	ucvtf	s0, x1
                	mov	w16, #0x45000000        ; =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0x8
-               	str	s0, [x2]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
                	stur	xzr, [x29, #-0xe8]
                	stur	xzr, [x29, #-0xe0]
-               	ldr	x2, [x0]
-               	stur	x2, [x29, #-0xe8]
-               	ldr	w2, [x0, #0x8]
-               	stur	w2, [x29, #-0xe0]
-               	ldur	q2, [x29, #-0xe8]
+               	ldr	x1, [x0]
+               	stur	x1, [x29, #-0xe8]
+               	ldr	w1, [x0, #0x8]
+               	stur	w1, [x29, #-0xe0]
+               	ldur	q31, [x29, #-0xe8]
+               	mov	x16, #0xfec0            ; =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
                	sub	x0, x29, #0x100
-               	add	x2, x20, #0x98
-               	ldr	x3, [x2]
+               	add	x1, x20, #0x98
+               	ldr	x2, [x1]
                	mov	x16, #0xfff             ; =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x1, x2, x16
+               	ucvtf	s0, x1
                	mov	w16, #0x45000000        ; =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0x0
-               	str	s0, [x2]
-               	add	x2, x20, #0xa0
-               	ldr	x3, [x2]
+               	add	x1, x0, #0x0
+               	str	s0, [x1]
+               	add	x1, x20, #0xa0
+               	ldr	x2, [x1]
                	mov	x16, #0xfff             ; =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x1, x2, x16
+               	ucvtf	s0, x1
                	mov	w16, #0x45000000        ; =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0x4
-               	str	s0, [x2]
-               	add	x2, x20, #0xa8
-               	ldr	x3, [x2]
+               	add	x1, x0, #0x4
+               	str	s0, [x1]
+               	add	x1, x20, #0xa8
+               	ldr	x2, [x1]
                	mov	x16, #0xfff             ; =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x1, x2, x16
+               	ucvtf	s0, x1
                	mov	w16, #0x45000000        ; =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0x8
-               	str	s0, [x2]
-               	add	x2, x20, #0xb0
-               	ldr	x3, [x2]
+               	add	x1, x0, #0x8
+               	str	s0, [x1]
+               	add	x1, x20, #0xb0
+               	ldr	x2, [x1]
                	mov	x16, #0xfff             ; =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x1, x2, x16
+               	ucvtf	s0, x1
                	mov	w16, #0x45000000        ; =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0xc
-               	str	s0, [x2]
-               	ldr	q4, [x0]
-               	sub	x0, x29, #0x128
-               	add	x2, x20, #0xb8
-               	ldr	x3, [x2]
+               	add	x1, x0, #0xc
+               	str	s0, [x1]
+               	ldr	q31, [x0]
+               	mov	x16, #0xfeb0            ; =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	sub	x25, x29, #0x128
+               	add	x0, x20, #0xb8
+               	ldr	x1, [x0]
                	mov	x16, #0xfff             ; =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
+               	and	x0, x1, x16
+               	ucvtf	s0, x0
                	mov	w16, #0x45000000        ; =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x2, x0, #0x0
-               	str	s0, [x2]
-               	add	x2, x20, #0x0
-               	ldr	x3, [x2]
-               	add	x2, x3, x1
-               	mov	x16, #0xfff             ; =4095
-               	and	x3, x2, x16
-               	ucvtf	s0, x3
-               	mov	w16, #0x45000000        ; =1157627904
-               	fmov	s30, w16
-               	fsub	s1, s0, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s0, s1, s30
-               	add	x2, x0, #0x4
-               	str	s0, [x2]
-               	ldr	d16, [x0]
-               	add	x0, x20, #0x0
-               	ldr	x2, [x0]
-               	add	x0, x2, x1
-               	add	x2, x20, #0x8
-               	ldr	x3, [x2]
-               	mov	x16, #0xfff             ; =4095
-               	and	x2, x3, x16
-               	ucvtf	s0, x2
-               	mov	w16, #0x45000000        ; =1157627904
-               	fmov	s30, w16
-               	fsub	s1, s0, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s0, s1, s30
-               	add	x2, x20, #0x10
-               	ldr	x3, [x2]
-               	mov	w2, w3
-               	add	x3, x20, #0x18
-               	ldr	x4, [x3]
-               	mov	x16, #0xffff            ; =65535
-               	movk	x16, #0xf, lsl #16
-               	and	x3, x4, x16
-               	ucvtf	d1, x3
-               	mov	x16, #0x4120000000000000 ; =4692750811720056832
-               	fmov	d30, x16
-               	fsub	d3, d1, d30
-               	mov	x16, #0x4050000000000000 ; =4634204016564240384
-               	fmov	d30, x16
-               	fdiv	d1, d3, d30
-               	add	x3, x20, #0x20
-               	ldr	x4, [x3]
-               	add	x3, x20, #0x28
-               	ldr	x5, [x3]
-               	mov	x16, #0xfff             ; =4095
-               	and	x3, x5, x16
-               	ucvtf	s3, x3
-               	mov	w16, #0x45000000        ; =1157627904
-               	fmov	s30, w16
-               	fsub	s5, s3, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s3, s5, s30
-               	add	x3, x20, #0x30
-               	ldr	x5, [x3]
-               	mov	w3, w5
-               	add	x5, x20, #0x38
-               	ldr	x6, [x5]
-               	mov	x16, #0xffff            ; =65535
-               	movk	x16, #0xf, lsl #16
-               	and	x5, x6, x16
-               	ucvtf	d5, x5
-               	mov	x16, #0x4120000000000000 ; =4692750811720056832
-               	fmov	d30, x16
-               	fsub	d6, d5, d30
-               	mov	x16, #0x4050000000000000 ; =4634204016564240384
-               	fmov	d30, x16
-               	fdiv	d5, d6, d30
-               	add	x5, x20, #0x40
-               	ldr	x6, [x5]
-               	add	x5, x20, #0x48
-               	ldr	x7, [x5]
-               	mov	x16, #0xfff             ; =4095
-               	and	x5, x7, x16
-               	ucvtf	s6, x5
-               	mov	w16, #0x45000000        ; =1157627904
-               	fmov	s30, w16
-               	fsub	s7, s6, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s6, s7, s30
-               	add	x5, x20, #0x50
-               	ldr	x7, [x5]
-               	mov	w5, w7
-               	add	x7, x20, #0x58
-               	ldr	x8, [x7]
-               	mov	x16, #0xffff            ; =65535
-               	movk	x16, #0xf, lsl #16
-               	and	x7, x8, x16
-               	ucvtf	d7, x7
-               	mov	x16, #0x4120000000000000 ; =4692750811720056832
-               	fmov	d30, x16
-               	fsub	d17, d7, d30
-               	mov	x16, #0x4050000000000000 ; =4634204016564240384
-               	fmov	d30, x16
-               	fdiv	d7, d17, d30
-               	add	x7, x20, #0x60
-               	ldr	x8, [x7]
-               	add	x7, x20, #0x68
-               	ldr	x12, [x7]
-               	mov	x16, #0xfff             ; =4095
-               	and	x7, x12, x16
-               	ucvtf	s17, x7
-               	mov	w16, #0x45000000        ; =1157627904
-               	fmov	s30, w16
-               	fsub	s18, s17, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s17, s18, s30
-               	add	x7, x20, #0x70
-               	ldr	x12, [x7]
-               	mov	w7, w12
-               	add	x12, x20, #0x78
-               	ldr	x13, [x12]
-               	mov	x16, #0xffff            ; =65535
-               	movk	x16, #0xf, lsl #16
-               	and	x12, x13, x16
-               	ucvtf	d18, x12
-               	mov	x16, #0x4120000000000000 ; =4692750811720056832
-               	fmov	d30, x16
-               	fsub	d19, d18, d30
-               	mov	x16, #0x4050000000000000 ; =4634204016564240384
-               	fmov	d30, x16
-               	fdiv	d18, d19, d30
-               	add	x12, x20, #0x8
-               	ldr	x13, [x12]
-               	add	x12, x13, x1
-               	mov	w1, w2
-               	mov	x2, x4
-               	mov	x4, x6
-               	str	d16, [sp]
-               	mov	x6, x8
-               	str	s17, [sp, #0x8]
-               	str	d18, [sp, #0x10]
-               	str	x12, [sp, #0x18]
+               	add	x0, x25, #0x0
+               	str	s0, [x0]
+               	add	x26, x20, #0x0
+               	ldr	x0, [x26]
+               	add	x1, x0, x24
+               	mov	x0, x1
 <L4>:
                	bl	 <L4>
+               	add	x0, x25, #0x4
+               	str	s0, [x0]
+               	ldr	d31, [x25]
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
+               	ldr	x0, [x26]
+               	add	x25, x0, x24
+               	add	x0, x20, #0x8
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L5>:
+               	bl	 <L5>
+               	fmov	s11, s0
+               	add	x0, x20, #0x10
+               	ldr	x1, [x0]
+               	mov	w26, w1
+               	add	x0, x20, #0x18
+               	ldr	x1, [x0]
+               	mov	x16, #0xffff            ; =65535
+               	movk	x16, #0xf, lsl #16
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
+               	mov	x16, #0x4120000000000000 ; =4692750811720056832
+               	fmov	d30, x16
+               	fsub	d1, d0, d30
+               	mov	x16, #0x4050000000000000 ; =4634204016564240384
+               	fmov	d30, x16
+               	fdiv	d12, d1, d30
+               	add	x0, x20, #0x20
+               	ldr	x27, [x0]
+               	add	x0, x20, #0x28
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L6>:
+               	bl	 <L6>
+               	fmov	s13, s0
+               	add	x0, x20, #0x30
+               	ldr	x1, [x0]
+               	mov	w28, w1
+               	add	x0, x20, #0x38
+               	ldr	x1, [x0]
+               	mov	x16, #0xffff            ; =65535
+               	movk	x16, #0xf, lsl #16
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
+               	mov	x16, #0x4120000000000000 ; =4692750811720056832
+               	fmov	d30, x16
+               	fsub	d1, d0, d30
+               	mov	x16, #0x4050000000000000 ; =4634204016564240384
+               	fmov	d30, x16
+               	fdiv	d14, d1, d30
+               	add	x0, x20, #0x40
+               	ldr	x9, [x0]
+               	mov	x16, #0xfe98            ; =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x20, #0x48
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L7>:
+               	bl	 <L7>
+               	fmov	s15, s0
+               	add	x0, x20, #0x50
+               	ldr	x1, [x0]
+               	mov	w9, w1
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x20, #0x58
+               	ldr	x1, [x0]
+               	mov	x16, #0xffff            ; =65535
+               	movk	x16, #0xf, lsl #16
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
+               	mov	x16, #0x4120000000000000 ; =4692750811720056832
+               	fmov	d30, x16
+               	fsub	d1, d0, d30
+               	mov	x16, #0x4050000000000000 ; =4634204016564240384
+               	fmov	d30, x16
+               	fdiv	d31, d1, d30
+               	mov	x16, #0xfe78            ; =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
+               	add	x0, x20, #0x60
+               	ldr	x9, [x0]
+               	mov	x16, #0xfe88            ; =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	add	x0, x20, #0x68
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L8>:
+               	bl	 <L8>
+               	fmov	s16, s0
+               	add	x0, x20, #0x70
+               	ldr	x1, [x0]
+               	mov	w7, w1
+               	add	x0, x20, #0x78
+               	ldr	x1, [x0]
+               	mov	x16, #0xffff            ; =65535
+               	movk	x16, #0xf, lsl #16
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
+               	mov	x16, #0x4120000000000000 ; =4692750811720056832
+               	fmov	d30, x16
+               	fsub	d1, d0, d30
+               	mov	x16, #0x4050000000000000 ; =4634204016564240384
+               	fmov	d30, x16
+               	fdiv	d17, d1, d30
+               	add	x0, x20, #0x8
+               	ldr	x1, [x0]
+               	add	x8, x1, x24
+               	mov	x0, x25
+               	fmov	s0, s11
+               	mov	w1, w26
+               	fmov	d1, d12
+               	mov	x16, #0xfec0            ; =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q2, [x29, x16]
+               	mov	x2, x27
+               	fmov	s3, s13
+               	mov	x3, x28
+               	mov	x16, #0xfeb0            ; =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q4, [x29, x16]
+               	fmov	d5, d14
+               	mov	x16, #0xfe98            ; =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x4, x9
+               	fmov	s6, s15
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x5, x9
+               	mov	x16, #0xfe78            ; =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d7, [x29, x16]
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d31, [x29, x16]
+               	str	d31, [sp]
+               	mov	x16, #0xfe88            ; =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	mov	x6, x9
+               	str	s16, [sp, #0x8]
+               	str	d17, [sp, #0x10]
+               	str	x8, [sp, #0x18]
+<L9>:
+               	bl	 <L9>
                	mov	x22, x0
                	mov	x0, x21
                	mov	x1, x22
-<L5>:
-               	bl	 <L5>
+<L10>:
+               	bl	 <L10>
                	add	x23, x23, #0x1
                	mov	x21, x0
                	cmp	x23, #0x3
                	b.lo	 <L3>
-<L6>:
+<L11>:
                	sub	x0, x29, #0xd8
                	mov	x16, #0xfff             ; =4095
                	and	x1, x22, x16
@@ -691,7 +750,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -746,322 +805,322 @@ Disassembly of section __TEXT,__text:
                	add	x1, x0, #0xc
                	str	s0, [x1]
                	ldr	q31, [x0]
-               	mov	x16, #0xfeb0            ; =65200
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	sub	x0, x29, #0x130
-               	add	x1, x20, #0x40
-               	ldr	x2, [x1]
-               	mov	x16, #0xfff             ; =4095
-               	and	x1, x2, x16
-               	ucvtf	s0, x1
-               	mov	w16, #0x45000000        ; =1157627904
-               	fmov	s30, w16
-               	fsub	s1, s0, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s0, s1, s30
-               	add	x1, x0, #0x0
-               	str	s0, [x1]
-               	add	x1, x20, #0x48
-               	ldr	x2, [x1]
-               	mov	x16, #0xfff             ; =4095
-               	and	x1, x2, x16
-               	ucvtf	s0, x1
-               	mov	w16, #0x45000000        ; =1157627904
-               	fmov	s30, w16
-               	fsub	s1, s0, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s0, s1, s30
-               	add	x1, x0, #0x4
-               	str	s0, [x1]
-               	ldr	d31, [x0]
-               	mov	x16, #0xfea0            ; =65184
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	d31, [x29, x16]
-               	add	x0, x20, #0x0
+               	sub	x19, x29, #0x130
+               	add	x0, x20, #0x40
                	ldr	x1, [x0]
-               	add	x0, x20, #0x8
-               	ldr	x2, [x0]
                	mov	x16, #0xfff             ; =4095
-               	and	x0, x2, x16
+               	and	x0, x1, x16
                	ucvtf	s0, x0
                	mov	w16, #0x45000000        ; =1157627904
                	fmov	s30, w16
                	fsub	s1, s0, s30
                	fmov	s30, #8.00000000
                	fdiv	s0, s1, s30
-               	add	x0, x20, #0x10
-               	ldr	x2, [x0]
-               	mov	w3, w2
-               	add	x0, x20, #0x18
-               	ldr	x2, [x0]
-               	mov	x16, #0xffff            ; =65535
-               	movk	x16, #0xf, lsl #16
-               	and	x0, x2, x16
-               	ucvtf	d1, x0
-               	mov	x16, #0x4120000000000000 ; =4692750811720056832
-               	fmov	d30, x16
-               	fsub	d2, d1, d30
-               	mov	x16, #0x4050000000000000 ; =4634204016564240384
-               	fmov	d30, x16
-               	fdiv	d1, d2, d30
-               	add	x0, x20, #0x20
-               	ldr	x2, [x0]
-               	add	x0, x20, #0x28
-               	ldr	x4, [x0]
-               	mov	x16, #0xfff             ; =4095
-               	and	x0, x4, x16
-               	ucvtf	s2, x0
-               	mov	w16, #0x45000000        ; =1157627904
-               	fmov	s30, w16
-               	fsub	s3, s2, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s4, s3, s30
-               	add	x0, x20, #0x30
-               	ldr	x4, [x0]
-               	mov	w5, w4
-               	add	x0, x20, #0x38
-               	ldr	x4, [x0]
-               	mov	x16, #0xffff            ; =65535
-               	movk	x16, #0xf, lsl #16
-               	and	x0, x4, x16
-               	ucvtf	d2, x0
-               	mov	x16, #0x4120000000000000 ; =4692750811720056832
-               	fmov	d30, x16
-               	fsub	d3, d2, d30
-               	mov	x16, #0x4050000000000000 ; =4634204016564240384
-               	fmov	d30, x16
-               	fdiv	d5, d3, d30
-               	add	x0, x20, #0x40
-               	ldr	x4, [x0]
+               	add	x0, x19, #0x0
+               	str	s0, [x0]
                	add	x0, x20, #0x48
-               	ldr	x6, [x0]
-               	mov	x16, #0xfff             ; =4095
-               	and	x0, x6, x16
-               	ucvtf	s2, x0
-               	mov	w16, #0x45000000        ; =1157627904
-               	fmov	s30, w16
-               	fsub	s3, s2, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s6, s3, s30
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L12>:
+               	bl	 <L12>
+               	add	x0, x19, #0x4
+               	str	s0, [x0]
+               	ldr	d31, [x19]
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
+               	add	x0, x20, #0x0
+               	ldr	x19, [x0]
+               	add	x0, x20, #0x8
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L13>:
+               	bl	 <L13>
+               	fmov	s11, s0
+               	add	x0, x20, #0x10
+               	ldr	x1, [x0]
+               	mov	w23, w1
+               	add	x0, x20, #0x18
+               	ldr	x1, [x0]
+               	mov	x16, #0xffff            ; =65535
+               	movk	x16, #0xf, lsl #16
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
+               	mov	x16, #0x4120000000000000 ; =4692750811720056832
+               	fmov	d30, x16
+               	fsub	d1, d0, d30
+               	mov	x16, #0x4050000000000000 ; =4634204016564240384
+               	fmov	d30, x16
+               	fdiv	d12, d1, d30
+               	add	x0, x20, #0x20
+               	ldr	x24, [x0]
+               	add	x0, x20, #0x28
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L14>:
+               	bl	 <L14>
+               	fmov	s13, s0
+               	add	x0, x20, #0x30
+               	ldr	x1, [x0]
+               	mov	w25, w1
+               	add	x0, x20, #0x38
+               	ldr	x1, [x0]
+               	mov	x16, #0xffff            ; =65535
+               	movk	x16, #0xf, lsl #16
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
+               	mov	x16, #0x4120000000000000 ; =4692750811720056832
+               	fmov	d30, x16
+               	fsub	d1, d0, d30
+               	mov	x16, #0x4050000000000000 ; =4634204016564240384
+               	fmov	d30, x16
+               	fdiv	d14, d1, d30
+               	add	x0, x20, #0x40
+               	ldr	x26, [x0]
+               	add	x0, x20, #0x48
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L15>:
+               	bl	 <L15>
+               	fmov	s15, s0
                	add	x0, x20, #0x50
-               	ldr	x6, [x0]
-               	mov	w7, w6
+               	ldr	x1, [x0]
+               	mov	w27, w1
                	add	x0, x20, #0x58
-               	ldr	x6, [x0]
+               	ldr	x1, [x0]
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xf, lsl #16
-               	and	x0, x6, x16
-               	ucvtf	d2, x0
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
                	mov	x16, #0x4120000000000000 ; =4692750811720056832
                	fmov	d30, x16
-               	fsub	d3, d2, d30
+               	fsub	d1, d0, d30
                	mov	x16, #0x4050000000000000 ; =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d7, d3, d30
+               	fdiv	d31, d1, d30
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
                	add	x0, x20, #0x60
-               	ldr	x6, [x0]
+               	ldr	x28, [x0]
                	add	x0, x20, #0x68
-               	ldr	x8, [x0]
-               	mov	x16, #0xfff             ; =4095
-               	and	x0, x8, x16
-               	ucvtf	s2, x0
-               	mov	w16, #0x45000000        ; =1157627904
-               	fmov	s30, w16
-               	fsub	s3, s2, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s16, s3, s30
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L16>:
+               	bl	 <L16>
+               	fmov	s16, s0
                	add	x0, x20, #0x70
-               	ldr	x8, [x0]
-               	mov	w12, w8
+               	ldr	x1, [x0]
+               	mov	w7, w1
                	add	x0, x20, #0x78
-               	ldr	x8, [x0]
+               	ldr	x1, [x0]
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xf, lsl #16
-               	and	x0, x8, x16
-               	ucvtf	d2, x0
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
                	mov	x16, #0x4120000000000000 ; =4692750811720056832
                	fmov	d30, x16
-               	fsub	d3, d2, d30
+               	fsub	d1, d0, d30
                	mov	x16, #0x4050000000000000 ; =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d17, d3, d30
+               	fdiv	d17, d1, d30
                	add	x0, x20, #0x8
                	ldr	x8, [x0]
-               	mov	x0, x1
-               	mov	w1, w3
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x0, x19
+               	fmov	s0, s11
+               	mov	w1, w23
+               	fmov	d1, d12
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q2, [x29, x16]
-               	fmov	s3, s4
-               	mov	x3, x5
-               	mov	x16, #0xfeb0            ; =65200
+               	mov	x2, x24
+               	fmov	s3, s13
+               	mov	x3, x25
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q4, [x29, x16]
-               	mov	x5, x7
-               	mov	x16, #0xfea0            ; =65184
+               	fmov	d5, d14
+               	mov	x4, x26
+               	fmov	s6, s15
+               	mov	x5, x27
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d7, [x29, x16]
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d31, [x29, x16]
                	str	d31, [sp]
+               	mov	x6, x28
                	str	s16, [sp, #0x8]
-               	mov	w7, w12
                	str	d17, [sp, #0x10]
                	str	x8, [sp, #0x18]
-<L7>:
-               	bl	 <L7>
-               	add	x1, x20, #0x18
-               	ldr	x2, [x1]
-               	mov	x16, #0xfff             ; =4095
-               	and	x1, x2, x16
-               	ucvtf	s0, x1
-               	mov	w16, #0x45000000        ; =1157627904
-               	fmov	s30, w16
-               	fsub	s1, s0, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s0, s1, s30
-               	add	x1, x20, #0x28
-               	ldr	x2, [x1]
-               	mov	w1, w2
-               	add	x2, x20, #0x38
-               	ldr	x3, [x2]
+<L17>:
+               	bl	 <L17>
+               	mov	x19, x0
+               	add	x0, x20, #0x18
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L18>:
+               	bl	 <L18>
+               	fmov	s11, s0
+               	add	x0, x20, #0x28
+               	ldr	x1, [x0]
+               	mov	w23, w1
+               	add	x0, x20, #0x38
+               	ldr	x1, [x0]
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xf, lsl #16
-               	and	x2, x3, x16
-               	ucvtf	d1, x2
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
                	mov	x16, #0x4120000000000000 ; =4692750811720056832
                	fmov	d30, x16
-               	fsub	d2, d1, d30
+               	fsub	d1, d0, d30
                	mov	x16, #0x4050000000000000 ; =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d1, d2, d30
-               	add	x2, x20, #0x48
-               	ldr	x3, [x2]
-               	add	x2, x20, #0x58
-               	ldr	x4, [x2]
-               	mov	x16, #0xfff             ; =4095
-               	and	x2, x4, x16
-               	ucvtf	s2, x2
-               	mov	w16, #0x45000000        ; =1157627904
-               	fmov	s30, w16
-               	fsub	s3, s2, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s4, s3, s30
-               	add	x2, x20, #0x68
-               	ldr	x4, [x2]
-               	mov	w5, w4
-               	add	x2, x20, #0x78
-               	ldr	x4, [x2]
+               	fdiv	d12, d1, d30
+               	add	x0, x20, #0x48
+               	ldr	x24, [x0]
+               	add	x0, x20, #0x58
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L19>:
+               	bl	 <L19>
+               	fmov	s13, s0
+               	add	x0, x20, #0x68
+               	ldr	x1, [x0]
+               	mov	w25, w1
+               	add	x0, x20, #0x78
+               	ldr	x1, [x0]
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xf, lsl #16
-               	and	x2, x4, x16
-               	ucvtf	d2, x2
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
                	mov	x16, #0x4120000000000000 ; =4692750811720056832
                	fmov	d30, x16
-               	fsub	d3, d2, d30
+               	fsub	d1, d0, d30
                	mov	x16, #0x4050000000000000 ; =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d5, d3, d30
-               	add	x2, x20, #0x88
-               	ldr	x4, [x2]
-               	add	x2, x20, #0x98
-               	ldr	x6, [x2]
-               	mov	x16, #0xfff             ; =4095
-               	and	x2, x6, x16
-               	ucvtf	s2, x2
-               	mov	w16, #0x45000000        ; =1157627904
-               	fmov	s30, w16
-               	fsub	s3, s2, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s6, s3, s30
-               	add	x2, x20, #0xa8
-               	ldr	x6, [x2]
-               	mov	w7, w6
-               	add	x2, x20, #0xb8
-               	ldr	x6, [x2]
+               	fdiv	d14, d1, d30
+               	add	x0, x20, #0x88
+               	ldr	x26, [x0]
+               	add	x0, x20, #0x98
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L20>:
+               	bl	 <L20>
+               	fmov	s15, s0
+               	add	x0, x20, #0xa8
+               	ldr	x1, [x0]
+               	mov	w27, w1
+               	add	x0, x20, #0xb8
+               	ldr	x1, [x0]
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xf, lsl #16
-               	and	x2, x6, x16
-               	ucvtf	d2, x2
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
                	mov	x16, #0x4120000000000000 ; =4692750811720056832
                	fmov	d30, x16
-               	fsub	d3, d2, d30
+               	fsub	d1, d0, d30
                	mov	x16, #0x4050000000000000 ; =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d7, d3, d30
-               	add	x2, x20, #0x10
-               	ldr	x6, [x2]
-               	add	x2, x20, #0x20
-               	ldr	x8, [x2]
-               	mov	x16, #0xfff             ; =4095
-               	and	x2, x8, x16
-               	ucvtf	s2, x2
-               	mov	w16, #0x45000000        ; =1157627904
-               	fmov	s30, w16
-               	fsub	s3, s2, s30
-               	fmov	s30, #8.00000000
-               	fdiv	s16, s3, s30
-               	add	x2, x20, #0x30
-               	ldr	x8, [x2]
-               	mov	w12, w8
-               	add	x2, x20, #0x40
-               	ldr	x8, [x2]
+               	fdiv	d31, d1, d30
+               	mov	x16, #0xfe20            ; =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	d31, [x29, x16]
+               	add	x0, x20, #0x10
+               	ldr	x28, [x0]
+               	add	x0, x20, #0x20
+               	ldr	x1, [x0]
+               	mov	x0, x1
+<L21>:
+               	bl	 <L21>
+               	fmov	s16, s0
+               	add	x0, x20, #0x30
+               	ldr	x1, [x0]
+               	mov	w7, w1
+               	add	x0, x20, #0x40
+               	ldr	x1, [x0]
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xf, lsl #16
-               	and	x2, x8, x16
-               	ucvtf	d2, x2
+               	and	x0, x1, x16
+               	ucvtf	d0, x0
                	mov	x16, #0x4120000000000000 ; =4692750811720056832
                	fmov	d30, x16
-               	fsub	d3, d2, d30
+               	fsub	d1, d0, d30
                	mov	x16, #0x4050000000000000 ; =4634204016564240384
                	fmov	d30, x16
-               	fdiv	d17, d3, d30
-               	mov	x16, #0xfec0            ; =65216
+               	fdiv	d17, d1, d30
+               	mov	x0, x19
+               	fmov	s0, s11
+               	mov	w1, w23
+               	fmov	d1, d12
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q2, [x29, x16]
-               	mov	x2, x3
-               	fmov	s3, s4
-               	mov	x3, x5
-               	mov	x16, #0xfeb0            ; =65200
+               	mov	x2, x24
+               	fmov	s3, s13
+               	mov	x3, x25
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q4, [x29, x16]
-               	mov	x5, x7
-               	mov	x16, #0xfea0            ; =65184
+               	fmov	d5, d14
+               	mov	x4, x26
+               	fmov	s6, s15
+               	mov	x5, x27
+               	mov	x16, #0xfe20            ; =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	d7, [x29, x16]
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d31, [x29, x16]
                	str	d31, [sp]
+               	mov	x6, x28
                	str	s16, [sp, #0x8]
-               	mov	w7, w12
                	str	d17, [sp, #0x10]
                	str	x22, [sp, #0x18]
-<L8>:
-               	bl	 <L8>
+<L22>:
+               	bl	 <L22>
                	mov	x1, x0
                	mov	x0, x21
-<L9>:
-               	bl	 <L9>
-               	ldp	x19, x20, [x29, #-0x170]
-               	ldp	x21, x22, [x29, #-0x180]
-               	mov	x16, #0xfe78            ; =65144
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x23, [x29, x16]
+<L23>:
+               	bl	 <L23>
+               	sub	x16, x29, #0x240
+               	ldp	d11, d12, [x16]
+               	ldp	d13, d14, [x16, #-0x10]
+               	ldur	d15, [x16, #-0x18]
+               	sub	x16, x29, #0x1f0
+               	ldp	x19, x20, [x16]
+               	ldp	x21, x22, [x16, #-0x10]
+               	ldp	x23, x24, [x16, #-0x20]
+               	ldp	x25, x26, [x16, #-0x30]
+               	ldp	x27, x28, [x16, #-0x40]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/call/call_rec_edge.dis
+++ b/test/golden/aarch64-darwin/call/call_rec_edge.dis
@@ -359,20 +359,24 @@ Disassembly of section __TEXT,__text:
                	ldr	w28, [x7]
                	sub	x7, x29, #0x1c
                	ldr	w9, [x7]
-               	stur	x9, [x29, #-0xf8]
+               	stur	x9, [x29, #-0x100]
                	sub	x7, x29, #0x18
                	ldr	w9, [x7]
-               	stur	x9, [x29, #-0x100]
+               	mov	x16, #0xfef8            ; =65272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	sub	x7, x29, #0x30
                	ldr	x9, [x7]
-               	mov	x16, #0xfef8            ; =65272
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x7, x29, #0x28
                	ldr	x9, [x7]
-               	mov	x16, #0xfef0            ; =65264
+               	mov	x16, #0xfee8            ; =65256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -383,7 +387,7 @@ Disassembly of section __TEXT,__text:
                	ldr	d11, [x7]
                	add	x7, x1, #0x0
                	ldr	x9, [x7]
-               	mov	x16, #0xfee8            ; =65256
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -391,19 +395,19 @@ Disassembly of section __TEXT,__text:
                	add	x7, x1, #0x8
                	ldr	d12, [x7]
                	sub	x9, x29, #0x71
-               	stur	x9, [x29, #-0xf0]
+               	stur	x9, [x29, #-0xf8]
                	ldr	x1, [x2]
-               	ldur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xf8]
                	str	x1, [x9]
                	ldr	x1, [x2, #0x8]
-               	ldur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xf8]
                	str	x1, [x9, #0x8]
                	ldrb	w1, [x2, #0x10]
-               	ldur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xf8]
                	strb	w1, [x9, #0x10]
                	add	x1, x3, #0x0
                	ldrb	w9, [x1]
-               	mov	x16, #0xfee0            ; =65248
+               	mov	x16, #0xfed8            ; =65240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -413,18 +417,14 @@ Disassembly of section __TEXT,__text:
                	str	x3, [x24]
                	add	x1, x4, #0x0
                	ldr	w9, [x1]
-               	mov	x16, #0xfed8            ; =65240
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	add	x1, x4, #0x4
                	ldr	w9, [x1]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
+               	stur	x9, [x29, #-0xe0]
                	add	x1, x4, #0x8
                	ldr	w9, [x1]
                	mov	x16, #0xfec8            ; =65224
@@ -434,7 +434,7 @@ Disassembly of section __TEXT,__text:
                	str	x9, [x29, x16]
                	add	x1, x5, #0x0
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xe0]
+               	stur	x9, [x29, #-0xe8]
                	add	x1, x5, #0x8
                	ldr	x9, [x1]
                	mov	x16, #0xfec0            ; =65216
@@ -443,15 +443,15 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x82
-               	stur	x9, [x29, #-0xe8]
+               	stur	x9, [x29, #-0xf0]
                	ldr	x1, [x6]
-               	ldur	x9, [x29, #-0xe8]
+               	ldur	x9, [x29, #-0xf0]
                	str	x1, [x9]
                	ldr	x1, [x6, #0x8]
-               	ldur	x9, [x29, #-0xe8]
+               	ldur	x9, [x29, #-0xf0]
                	str	x1, [x9, #0x8]
                	ldrb	w1, [x6, #0x10]
-               	ldur	x9, [x29, #-0xe8]
+               	ldur	x9, [x29, #-0xf0]
                	strb	w1, [x9, #0x10]
 <L0>:
                	bl	 <L0>
@@ -488,18 +488,22 @@ Disassembly of section __TEXT,__text:
                	mov	w1, w28
 <L7>:
                	bl	 <L7>
-               	ldur	x9, [x29, #-0xf8]
+               	ldur	x9, [x29, #-0x100]
                	mov	w1, w9
 <L8>:
                	bl	 <L8>
-               	ldur	x9, [x29, #-0x100]
+               	mov	x16, #0xfef8            ; =65272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	w1, w9
 <L9>:
                	bl	 <L9>
                	fmov	d0, d8
 <L10>:
                	bl	 <L10>
-               	mov	x16, #0xfef8            ; =65272
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -507,7 +511,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L11>:
                	bl	 <L11>
-               	mov	x16, #0xfef0            ; =65264
+               	mov	x16, #0xfee8            ; =65256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -521,7 +525,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d0, d11
 <L14>:
                	bl	 <L14>
-               	mov	x16, #0xfee8            ; =65256
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -536,13 +540,13 @@ Disassembly of section __TEXT,__text:
 <L17>:
                	bl	 <L17>
                	sub	x19, x29, #0xb5
-               	ldur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xf8]
                	ldr	x1, [x9]
                	str	x1, [x19]
-               	ldur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xf8]
                	ldr	x1, [x9, #0x8]
                	str	x1, [x19, #0x8]
-               	ldur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xf8]
                	ldrb	w1, [x9, #0x10]
                	strb	w1, [x19, #0x10]
                	add	x1, x19, #0x0
@@ -571,7 +575,7 @@ Disassembly of section __TEXT,__text:
                	ldr	x0, [x24]
                	str	x0, [x26]
                	mov	x0, x20
-               	mov	x16, #0xfee0            ; =65248
+               	mov	x16, #0xfed8            ; =65240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -596,7 +600,7 @@ Disassembly of section __TEXT,__text:
                	b.lo	 <L23>
 <L25>:
                	mov	x0, x19
-               	mov	x16, #0xfed8            ; =65240
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -604,11 +608,7 @@ Disassembly of section __TEXT,__text:
                	mov	w1, w9
 <L26>:
                	bl	 <L26>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
+               	ldur	x9, [x29, #-0xe0]
                	mov	w1, w9
 <L27>:
                	bl	 <L27>
@@ -620,7 +620,7 @@ Disassembly of section __TEXT,__text:
                	mov	w1, w9
 <L28>:
                	bl	 <L28>
-               	ldur	x9, [x29, #-0xe0]
+               	ldur	x9, [x29, #-0xe8]
                	mov	x1, x9
 <L29>:
                	bl	 <L29>
@@ -633,13 +633,13 @@ Disassembly of section __TEXT,__text:
 <L30>:
                	bl	 <L30>
                	sub	x19, x29, #0xc6
-               	ldur	x9, [x29, #-0xe8]
+               	ldur	x9, [x29, #-0xf0]
                	ldr	x1, [x9]
                	str	x1, [x19]
-               	ldur	x9, [x29, #-0xe8]
+               	ldur	x9, [x29, #-0xf0]
                	ldr	x1, [x9, #0x8]
                	str	x1, [x19, #0x8]
-               	ldur	x9, [x29, #-0xe8]
+               	ldur	x9, [x29, #-0xf0]
                	ldrb	w1, [x9, #0x10]
                	strb	w1, [x19, #0x10]
                	add	x1, x19, #0x0
@@ -673,13 +673,13 @@ Disassembly of section __TEXT,__text:
 <L36>:
                	bl	 <L36>
                	sub	x1, x29, #0xd7
-               	ldur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xf8]
                	ldr	x2, [x9]
                	str	x2, [x1]
-               	ldur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xf8]
                	ldr	x2, [x9, #0x8]
                	str	x2, [x1, #0x8]
-               	ldur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xf8]
                	ldrb	w2, [x9, #0x10]
                	strb	w2, [x1, #0x10]
                	add	x2, x1, #0x0
@@ -733,13 +733,13 @@ Disassembly of section __TEXT,__text:
                	b.lo	 <L40>
 <L42>:
                	sub	x19, x29, #0xa4
-               	ldur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xf8]
                	ldr	x0, [x9]
                	str	x0, [x19]
-               	ldur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xf8]
                	ldr	x0, [x9, #0x8]
                	str	x0, [x19, #0x8]
-               	ldur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xf8]
                	ldrb	w0, [x9, #0x10]
                	strb	w0, [x19, #0x10]
                	add	x0, x19, #0x0
@@ -950,16 +950,13 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_edge.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x240
-               	stp	x19, x20, [x29, #-0x1a0]
-               	stp	x21, x22, [x29, #-0x1b0]
-               	stp	x23, x24, [x29, #-0x1c0]
-               	stp	x25, x26, [x29, #-0x1d0]
-               	mov	x16, #0xfe28            ; =65064
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x27, [x29, x16]
+               	sub	sp, sp, #0x2a0
+               	sub	x16, x29, #0x200
+               	stp	x19, x20, [x16]
+               	stp	x21, x22, [x16, #-0x10]
+               	stp	x23, x24, [x16, #-0x20]
+               	stp	x25, x26, [x16, #-0x30]
+               	stp	x27, x28, [x16, #-0x40]
                	mov	x19, x0
 <L0>:
                	bl	 <L0>
@@ -1181,10 +1178,10 @@ Disassembly of section __TEXT,__text:
                	lsr	x15, x4, x5
                	mov	w5, w15
                	mov	w15, w1
-               	eor	w18, w5, w15
+               	eor	w24, w5, w15
                	add	x5, x14, #0x1
                	add	x15, x5, x1
-               	strb	w18, [x15]
+               	strb	w24, [x15]
                	add	x1, x1, #0x1
                	cmp	x1, #0x10
                	b.lo	 <L24>
@@ -1204,50 +1201,50 @@ Disassembly of section __TEXT,__text:
 <L26>:
                	mov	x16, #0x8               ; =8
                	mul	x5, x1, x16
-               	lsr	x18, x4, x5
-               	mov	w5, w18
-               	mov	w18, w1
-               	add	w24, w5, w18
+               	lsr	x24, x4, x5
+               	mov	w5, w24
+               	mov	w24, w1
+               	add	w25, w5, w24
                	add	x5, x15, #0x1
-               	add	x18, x5, x1
-               	strb	w24, [x18]
+               	add	x24, x5, x1
+               	strb	w25, [x24]
                	add	x1, x1, #0x1
                	cmp	x1, #0x8
                	b.lo	 <L26>
 <L27>:
                	add	x1, x20, #0x58
                	ldr	x4, [x1]
-               	sub	x18, x29, #0x130
+               	sub	x24, x29, #0x130
                	mov	w1, w4
-               	add	x5, x18, #0x0
+               	add	x5, x24, #0x0
                	str	w1, [x5]
                	lsr	x1, x4, #16
                	mov	w5, w1
-               	add	x1, x18, #0x4
+               	add	x1, x24, #0x4
                	str	w5, [x1]
                	lsr	x1, x4, #32
                	mov	w4, w1
-               	add	x1, x18, #0x8
+               	add	x1, x24, #0x8
                	str	w4, [x1]
                	add	x1, x20, #0x0
                	ldr	x4, [x1]
-               	sub	x24, x29, #0x150
-               	add	x1, x24, #0x0
+               	sub	x25, x29, #0x150
+               	add	x1, x25, #0x0
                	str	x4, [x1]
                	mov	x16, #0x3               ; =3
                	mul	x1, x4, x16
                	add	x4, x1, #0x7
-               	add	x1, x24, #0x8
+               	add	x1, x25, #0x8
                	str	x4, [x1]
                	add	x1, x20, #0x8
                	ldr	x4, [x1]
-               	sub	x25, x29, #0x171
-               	str	xzr, [x25]
-               	str	xzr, [x25, #0x8]
-               	strb	wzr, [x25, #0x10]
+               	sub	x26, x29, #0x171
+               	str	xzr, [x26]
+               	str	xzr, [x26, #0x8]
+               	strb	wzr, [x26, #0x10]
                	lsr	x1, x4, #7
                	mov	w5, w1
-               	add	x1, x25, #0x0
+               	add	x1, x26, #0x0
                	strb	w5, [x1]
                	mov	x1, #0x0                ; =0
                	cmp	x1, #0x10
@@ -1256,13 +1253,13 @@ Disassembly of section __TEXT,__text:
 <L28>:
                	mov	x16, #0x4               ; =4
                	mul	x5, x1, x16
-               	lsr	x26, x4, x5
-               	mov	w5, w26
-               	mov	w26, w1
-               	eor	w27, w5, w26
-               	add	x5, x25, #0x1
-               	add	x26, x5, x1
-               	strb	w27, [x26]
+               	lsr	x27, x4, x5
+               	mov	w5, w27
+               	mov	w27, w1
+               	eor	w28, w5, w27
+               	add	x5, x26, #0x1
+               	add	x27, x5, x1
+               	strb	w28, [x27]
                	add	x1, x1, #0x1
                	cmp	x1, #0x10
                	b.lo	 <L28>
@@ -1273,7 +1270,7 @@ Disassembly of section __TEXT,__text:
                	and	x1, x4, x16
                	ucvtf	s3, x1
                	add	x1, x20, #0x18
-               	ldr	x26, [x1]
+               	ldr	x27, [x1]
                	ldr	x1, [x2]
                	ldr	x2, [x2, #0x8]
                	ldr	x4, [x6]
@@ -1287,21 +1284,59 @@ Disassembly of section __TEXT,__text:
                	ldr	x8, [x12, #0x8]
                	str	x8, [sp, #0x8]
                	str	x13, [sp, #0x10]
-               	str	x14, [sp, #0x18]
+               	ldr	x8, [x14]
+               	mov	x16, #0xfe77            ; =65143
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x14, #0x8]
+               	mov	x16, #0xfe7f            ; =65151
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldrb	w8, [x14, #0x10]
+               	mov	x16, #0xfe87            ; =65159
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w8, [x29, x16]
+               	sub	x8, x29, #0x189
+               	str	x8, [sp, #0x18]
                	ldr	x8, [x15]
                	str	x8, [sp, #0x20]
                	ldrb	w8, [x15, #0x8]
                	strb	w8, [sp, #0x28]
-               	ldr	x8, [x18]
-               	stur	x8, [sp, #0x2c]
-               	ldr	w8, [x18, #0x8]
-               	str	w8, [sp, #0x34]
                	ldr	x8, [x24]
+               	stur	x8, [sp, #0x2c]
+               	ldr	w8, [x24, #0x8]
+               	str	w8, [sp, #0x34]
+               	ldr	x8, [x25]
                	str	x8, [sp, #0x38]
-               	ldr	x8, [x24, #0x8]
+               	ldr	x8, [x25, #0x8]
                	str	x8, [sp, #0x40]
-               	str	x25, [sp, #0x48]
-               	str	x26, [sp, #0x50]
+               	ldr	x8, [x26]
+               	mov	x16, #0xfe5f            ; =65119
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x26, #0x8]
+               	mov	x16, #0xfe67            ; =65127
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldrb	w8, [x26, #0x10]
+               	mov	x16, #0xfe6f            ; =65135
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w8, [x29, x16]
+               	sub	x8, x29, #0x1a1
+               	str	x8, [sp, #0x48]
+               	str	x27, [sp, #0x50]
 <L30>:
                	bl	 <L30>
                	mov	x22, x0
@@ -1439,47 +1474,47 @@ Disassembly of section __TEXT,__text:
                	lsr	x6, x1, x4
                	mov	w4, w6
                	mov	w6, w0
-               	add	w18, w4, w6
+               	add	w19, w4, w6
                	add	x4, x15, #0x1
                	add	x6, x4, x0
-               	strb	w18, [x6]
+               	strb	w19, [x6]
                	add	x0, x0, #0x1
                	cmp	x0, #0x8
                	b.lo	 <L37>
 <L38>:
                	add	x0, x20, #0x58
                	ldr	x1, [x0]
-               	sub	x18, x29, #0x13c
+               	sub	x19, x29, #0x13c
                	mov	w0, w1
-               	add	x4, x18, #0x0
+               	add	x4, x19, #0x0
                	str	w0, [x4]
                	lsr	x0, x1, #16
                	mov	w4, w0
-               	add	x0, x18, #0x4
+               	add	x0, x19, #0x4
                	str	w4, [x0]
                	lsr	x0, x1, #32
                	mov	w1, w0
-               	add	x0, x18, #0x8
+               	add	x0, x19, #0x8
                	str	w1, [x0]
                	add	x0, x20, #0x0
                	ldr	x1, [x0]
-               	sub	x19, x29, #0x160
-               	add	x0, x19, #0x0
+               	sub	x23, x29, #0x160
+               	add	x0, x23, #0x0
                	str	x1, [x0]
                	mov	x16, #0x3               ; =3
                	mul	x0, x1, x16
                	add	x1, x0, #0x7
-               	add	x0, x19, #0x8
+               	add	x0, x23, #0x8
                	str	x1, [x0]
                	add	x0, x20, #0x8
                	ldr	x1, [x0]
-               	sub	x23, x29, #0x182
-               	str	xzr, [x23]
-               	str	xzr, [x23, #0x8]
-               	strb	wzr, [x23, #0x10]
+               	sub	x24, x29, #0x1b2
+               	str	xzr, [x24]
+               	str	xzr, [x24, #0x8]
+               	strb	wzr, [x24, #0x10]
                	lsr	x0, x1, #7
                	mov	w4, w0
-               	add	x0, x23, #0x0
+               	add	x0, x24, #0x0
                	strb	w4, [x0]
                	mov	x0, #0x0                ; =0
                	cmp	x0, #0x10
@@ -1491,10 +1526,10 @@ Disassembly of section __TEXT,__text:
                	lsr	x6, x1, x4
                	mov	w4, w6
                	mov	w6, w0
-               	eor	w24, w4, w6
-               	add	x4, x23, #0x1
+               	eor	w25, w4, w6
+               	add	x4, x24, #0x1
                	add	x6, x4, x0
-               	strb	w24, [x6]
+               	strb	w25, [x6]
                	add	x0, x0, #0x1
                	cmp	x0, #0x10
                	b.lo	 <L39>
@@ -1520,20 +1555,58 @@ Disassembly of section __TEXT,__text:
                	ldr	x8, [x12, #0x8]
                	str	x8, [sp, #0x8]
                	str	x13, [sp, #0x10]
-               	str	x14, [sp, #0x18]
+               	ldr	x8, [x14]
+               	mov	x16, #0xfe36            ; =65078
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x14, #0x8]
+               	mov	x16, #0xfe3e            ; =65086
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldrb	w8, [x14, #0x10]
+               	mov	x16, #0xfe46            ; =65094
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w8, [x29, x16]
+               	sub	x8, x29, #0x1ca
+               	str	x8, [sp, #0x18]
                	ldr	x8, [x15]
                	str	x8, [sp, #0x20]
                	ldrb	w8, [x15, #0x8]
                	strb	w8, [sp, #0x28]
-               	ldr	x8, [x18]
-               	stur	x8, [sp, #0x2c]
-               	ldr	w8, [x18, #0x8]
-               	str	w8, [sp, #0x34]
                	ldr	x8, [x19]
+               	stur	x8, [sp, #0x2c]
+               	ldr	w8, [x19, #0x8]
+               	str	w8, [sp, #0x34]
+               	ldr	x8, [x23]
                	str	x8, [sp, #0x38]
-               	ldr	x8, [x19, #0x8]
+               	ldr	x8, [x23, #0x8]
                	str	x8, [sp, #0x40]
-               	str	x23, [sp, #0x48]
+               	ldr	x8, [x24]
+               	mov	x16, #0xfe1e            ; =65054
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x24, #0x8]
+               	mov	x16, #0xfe26            ; =65062
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldrb	w8, [x24, #0x10]
+               	mov	x16, #0xfe2e            ; =65070
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	strb	w8, [x29, x16]
+               	sub	x8, x29, #0x1e2
+               	str	x8, [sp, #0x48]
                	str	x20, [sp, #0x50]
 <L41>:
                	bl	 <L41>
@@ -1541,15 +1614,12 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x21
 <L42>:
                	bl	 <L42>
-               	ldp	x19, x20, [x29, #-0x1a0]
-               	ldp	x21, x22, [x29, #-0x1b0]
-               	ldp	x23, x24, [x29, #-0x1c0]
-               	ldp	x25, x26, [x29, #-0x1d0]
-               	mov	x16, #0xfe28            ; =65064
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x27, [x29, x16]
+               	sub	x16, x29, #0x200
+               	ldp	x19, x20, [x16]
+               	ldp	x21, x22, [x16, #-0x10]
+               	ldp	x23, x24, [x16, #-0x20]
+               	ldp	x25, x26, [x16, #-0x30]
+               	ldp	x27, x28, [x16, #-0x40]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/call/call_rec_large.dis
+++ b/test/golden/aarch64-darwin/call/call_rec_large.dis
@@ -461,24 +461,24 @@ Disassembly of section __TEXT,__text:
                	ldr	x28, [x1]
                	add	x1, x4, #0x8
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xb8]
+               	stur	x9, [x29, #-0xc0]
                	add	x1, x4, #0x10
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xc0]
+               	stur	x9, [x29, #-0xc8]
                	add	x1, x4, #0x18
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xc8]
+               	stur	x9, [x29, #-0xd0]
                	add	x1, x5, #0x0
                	add	x14, x1, #0x0
-               	ldr	x9, [x14]
-               	stur	x9, [x29, #-0x100]
-               	add	x14, x1, #0x8
                	ldr	x9, [x14]
                	mov	x16, #0xfef8            ; =65272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
+               	add	x14, x1, #0x8
+               	ldr	x9, [x14]
+               	stur	x9, [x29, #-0x20]
                	add	x1, x5, #0x10
                	add	x5, x1, #0x0
                	ldr	x9, [x5]
@@ -489,83 +489,83 @@ Disassembly of section __TEXT,__text:
                	str	x9, [x29, x16]
                	add	x5, x1, #0x8
                	ldr	x9, [x5]
-               	stur	x9, [x29, #-0x20]
+               	stur	x9, [x29, #-0x28]
                	add	x1, x6, #0x0
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xd0]
+               	stur	x9, [x29, #-0xd8]
                	add	x1, x6, #0x8
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x28]
+               	stur	x9, [x29, #-0x30]
                	add	x1, x6, #0x10
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x30]
+               	stur	x9, [x29, #-0x38]
                	add	x1, x6, #0x18
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x38]
+               	stur	x9, [x29, #-0x40]
                	add	x1, x6, #0x20
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x40]
+               	stur	x9, [x29, #-0x48]
                	add	x1, x6, #0x28
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xd8]
+               	stur	x9, [x29, #-0xe0]
                	add	x1, x7, #0x0
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x48]
+               	stur	x9, [x29, #-0x50]
                	add	x1, x7, #0x8
                	ldr	d14, [x1]
                	add	x1, x7, #0x10
                	ldr	w9, [x1]
-               	stur	x9, [x29, #-0x50]
+               	stur	x9, [x29, #-0x58]
                	add	x1, x7, #0x14
                	ldr	w9, [x1]
-               	stur	x9, [x29, #-0x58]
+               	stur	x9, [x29, #-0x60]
                	add	x1, x7, #0x18
                	ldr	d15, [x1]
                	add	x1, x7, #0x20
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x60]
+               	stur	x9, [x29, #-0x68]
                	add	x1, x7, #0x28
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xe0]
+               	stur	x9, [x29, #-0xe8]
                	add	x1, x3, #0x0
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x68]
+               	stur	x9, [x29, #-0x70]
                	add	x1, x3, #0x8
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x70]
+               	stur	x9, [x29, #-0x78]
                	add	x1, x3, #0x10
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xe8]
+               	stur	x9, [x29, #-0xf0]
                	add	x1, x8, #0x0
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x78]
+               	stur	x9, [x29, #-0x80]
                	add	x1, x8, #0x8
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x80]
+               	stur	x9, [x29, #-0x88]
                	add	x1, x8, #0x10
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x88]
+               	stur	x9, [x29, #-0x90]
                	add	x1, x8, #0x18
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xf0]
+               	stur	x9, [x29, #-0xf8]
                	add	x1, x12, #0x0
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x90]
+               	stur	x9, [x29, #-0x98]
                	add	x1, x12, #0x8
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0x98]
+               	stur	x9, [x29, #-0xa0]
                	add	x1, x12, #0x10
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xa0]
+               	stur	x9, [x29, #-0xa8]
                	add	x1, x12, #0x18
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xa8]
+               	stur	x9, [x29, #-0xb0]
                	add	x1, x12, #0x20
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xb0]
+               	stur	x9, [x29, #-0xb8]
                	add	x1, x12, #0x28
                	ldr	x9, [x1]
-               	stur	x9, [x29, #-0xf8]
+               	stur	x9, [x29, #-0x100]
 <L0>:
                	bl	 <L0>
                	mov	x1, x0
@@ -609,27 +609,27 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x28
 <L13>:
                	bl	 <L13>
-               	ldur	x9, [x29, #-0xb8]
+               	ldur	x9, [x29, #-0xc0]
                	mov	x1, x9
 <L14>:
                	bl	 <L14>
-               	ldur	x9, [x29, #-0xc0]
+               	ldur	x9, [x29, #-0xc8]
                	mov	x1, x9
 <L15>:
                	bl	 <L15>
-               	ldur	x9, [x29, #-0xc8]
+               	ldur	x9, [x29, #-0xd0]
                	mov	x1, x9
 <L16>:
                	bl	 <L16>
-               	ldur	x9, [x29, #-0x100]
-               	mov	x1, x9
-<L17>:
-               	bl	 <L17>
                	mov	x16, #0xfef8            ; =65272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
+               	mov	x1, x9
+<L17>:
+               	bl	 <L17>
+               	ldur	x9, [x29, #-0x20]
                	mov	x1, x9
 <L18>:
                	bl	 <L18>
@@ -641,112 +641,112 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L19>:
                	bl	 <L19>
-               	ldur	x9, [x29, #-0x20]
+               	ldur	x9, [x29, #-0x28]
                	mov	x1, x9
 <L20>:
                	bl	 <L20>
                	fmov	d0, d8
 <L21>:
                	bl	 <L21>
-               	ldur	x9, [x29, #-0xd0]
+               	ldur	x9, [x29, #-0xd8]
                	mov	x1, x9
 <L22>:
                	bl	 <L22>
-               	ldur	x9, [x29, #-0x28]
+               	ldur	x9, [x29, #-0x30]
                	mov	x1, x9
 <L23>:
                	bl	 <L23>
-               	ldur	x9, [x29, #-0x30]
+               	ldur	x9, [x29, #-0x38]
                	mov	x1, x9
 <L24>:
                	bl	 <L24>
-               	ldur	x9, [x29, #-0x38]
+               	ldur	x9, [x29, #-0x40]
                	mov	x1, x9
 <L25>:
                	bl	 <L25>
-               	ldur	x9, [x29, #-0x40]
+               	ldur	x9, [x29, #-0x48]
                	mov	x1, x9
 <L26>:
                	bl	 <L26>
-               	ldur	x9, [x29, #-0xd8]
+               	ldur	x9, [x29, #-0xe0]
                	mov	x1, x9
 <L27>:
                	bl	 <L27>
-               	ldur	x9, [x29, #-0x48]
+               	ldur	x9, [x29, #-0x50]
                	mov	x1, x9
 <L28>:
                	bl	 <L28>
                	fmov	d0, d14
 <L29>:
                	bl	 <L29>
-               	ldur	x9, [x29, #-0x50]
+               	ldur	x9, [x29, #-0x58]
                	mov	w1, w9
 <L30>:
                	bl	 <L30>
-               	ldur	x9, [x29, #-0x58]
+               	ldur	x9, [x29, #-0x60]
                	mov	w1, w9
 <L31>:
                	bl	 <L31>
                	fmov	d0, d15
 <L32>:
                	bl	 <L32>
-               	ldur	x9, [x29, #-0x60]
+               	ldur	x9, [x29, #-0x68]
                	mov	x1, x9
 <L33>:
                	bl	 <L33>
-               	ldur	x9, [x29, #-0xe0]
+               	ldur	x9, [x29, #-0xe8]
                	mov	x1, x9
 <L34>:
                	bl	 <L34>
-               	ldur	x9, [x29, #-0x68]
+               	ldur	x9, [x29, #-0x70]
                	mov	x1, x9
 <L35>:
                	bl	 <L35>
-               	ldur	x9, [x29, #-0x70]
+               	ldur	x9, [x29, #-0x78]
                	mov	x1, x9
 <L36>:
                	bl	 <L36>
-               	ldur	x9, [x29, #-0xe8]
+               	ldur	x9, [x29, #-0xf0]
                	mov	x1, x9
 <L37>:
                	bl	 <L37>
-               	ldur	x9, [x29, #-0x78]
+               	ldur	x9, [x29, #-0x80]
                	mov	x1, x9
 <L38>:
                	bl	 <L38>
-               	ldur	x9, [x29, #-0x80]
+               	ldur	x9, [x29, #-0x88]
                	mov	x1, x9
 <L39>:
                	bl	 <L39>
-               	ldur	x9, [x29, #-0x88]
+               	ldur	x9, [x29, #-0x90]
                	mov	x1, x9
 <L40>:
                	bl	 <L40>
-               	ldur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xf8]
                	mov	x1, x9
 <L41>:
                	bl	 <L41>
-               	ldur	x9, [x29, #-0x90]
+               	ldur	x9, [x29, #-0x98]
                	mov	x1, x9
 <L42>:
                	bl	 <L42>
-               	ldur	x9, [x29, #-0x98]
+               	ldur	x9, [x29, #-0xa0]
                	mov	x1, x9
 <L43>:
                	bl	 <L43>
-               	ldur	x9, [x29, #-0xa0]
+               	ldur	x9, [x29, #-0xa8]
                	mov	x1, x9
 <L44>:
                	bl	 <L44>
-               	ldur	x9, [x29, #-0xa8]
+               	ldur	x9, [x29, #-0xb0]
                	mov	x1, x9
 <L45>:
                	bl	 <L45>
-               	ldur	x9, [x29, #-0xb0]
+               	ldur	x9, [x29, #-0xb8]
                	mov	x1, x9
 <L46>:
                	bl	 <L46>
-               	ldur	x9, [x29, #-0xf8]
+               	ldur	x9, [x29, #-0x100]
                	mov	x1, x9
 <L47>:
                	bl	 <L47>
@@ -756,54 +756,54 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x21
 <L49>:
                	bl	 <L49>
-               	ldur	x9, [x29, #-0xd0]
-               	add	x1, x9, #0x1
                	ldur	x9, [x29, #-0xd8]
+               	add	x1, x9, #0x1
+               	ldur	x9, [x29, #-0xe0]
                	mov	x16, #0xffff            ; =65535
                	movk	x16, #0xffff, lsl #16
                	eor	x19, x9, x16
 <L50>:
                	bl	 <L50>
-               	ldur	x9, [x29, #-0x28]
+               	ldur	x9, [x29, #-0x30]
                	mov	x1, x9
 <L51>:
                	bl	 <L51>
-               	ldur	x9, [x29, #-0x30]
+               	ldur	x9, [x29, #-0x38]
                	mov	x1, x9
 <L52>:
                	bl	 <L52>
-               	ldur	x9, [x29, #-0x38]
+               	ldur	x9, [x29, #-0x40]
                	mov	x1, x9
 <L53>:
                	bl	 <L53>
-               	ldur	x9, [x29, #-0x40]
+               	ldur	x9, [x29, #-0x48]
                	mov	x1, x9
 <L54>:
                	bl	 <L54>
                	mov	x1, x19
 <L55>:
                	bl	 <L55>
-               	ldur	x9, [x29, #-0xd0]
+               	ldur	x9, [x29, #-0xd8]
                	mov	x1, x9
 <L56>:
                	bl	 <L56>
-               	ldur	x9, [x29, #-0x28]
+               	ldur	x9, [x29, #-0x30]
                	mov	x1, x9
 <L57>:
                	bl	 <L57>
-               	ldur	x9, [x29, #-0x30]
+               	ldur	x9, [x29, #-0x38]
                	mov	x1, x9
 <L58>:
                	bl	 <L58>
-               	ldur	x9, [x29, #-0x38]
+               	ldur	x9, [x29, #-0x40]
                	mov	x1, x9
 <L59>:
                	bl	 <L59>
-               	ldur	x9, [x29, #-0x40]
+               	ldur	x9, [x29, #-0x48]
                	mov	x1, x9
 <L60>:
                	bl	 <L60>
-               	ldur	x9, [x29, #-0xd8]
+               	ldur	x9, [x29, #-0xe0]
                	mov	x1, x9
 <L61>:
                	bl	 <L61>
@@ -1081,14 +1081,14 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_rec_large.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x3f0
-               	sub	x16, x29, #0x380
+               	sub	sp, sp, #0x660
+               	sub	x16, x29, #0x5f0
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	sub	x16, x29, #0x3d0
+               	sub	x16, x29, #0x640
                	str	d8, [x16, #0x8]
                	mov	x19, x0
 <L0>:
@@ -1260,12 +1260,12 @@ Disassembly of section __TEXT,__text:
                	ldr	x2, [x0]
                	add	x0, x2, x1
                	sub	x9, x29, #0x110
-               	mov	x16, #0xfcb0            ; =64688
+               	mov	x16, #0xfa40            ; =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfcb0            ; =64688
+               	mov	x16, #0xfa40            ; =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1273,7 +1273,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x0
                	str	x0, [x1]
                	mvn	x1, x0
-               	mov	x16, #0xfcb0            ; =64688
+               	mov	x16, #0xfa40            ; =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1282,7 +1282,7 @@ Disassembly of section __TEXT,__text:
                	str	x1, [x2]
                	mov	x16, #0x5               ; =5
                	mul	x1, x0, x16
-               	mov	x16, #0xfcb0            ; =64688
+               	mov	x16, #0xfa40            ; =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1290,7 +1290,7 @@ Disassembly of section __TEXT,__text:
                	add	x2, x9, #0x10
                	str	x1, [x2]
                	lsr	x1, x0, #3
-               	mov	x16, #0xfcb0            ; =64688
+               	mov	x16, #0xfa40            ; =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1300,7 +1300,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x30
                	ldr	x1, [x0]
                	sub	x9, x29, #0x150
-               	mov	x16, #0xfca8            ; =64680
+               	mov	x16, #0xfa38            ; =64056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1311,7 +1311,7 @@ Disassembly of section __TEXT,__text:
                	add	x2, x1, #0xb
                	add	x3, x0, #0x8
                	str	x2, [x3]
-               	mov	x16, #0xfca8            ; =64680
+               	mov	x16, #0xfa38            ; =64056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1329,7 +1329,7 @@ Disassembly of section __TEXT,__text:
                	mvn	x2, x1
                	add	x1, x0, #0x8
                	str	x2, [x1]
-               	mov	x16, #0xfca8            ; =64680
+               	mov	x16, #0xfa38            ; =64056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1347,12 +1347,12 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x40
                	ldr	x1, [x0]
                	sub	x9, x29, #0x1e0
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfa30            ; =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfa30            ; =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1360,7 +1360,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x9, #0x0
                	str	x1, [x0]
                	add	x0, x1, #0x1
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfa30            ; =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1368,7 +1368,7 @@ Disassembly of section __TEXT,__text:
                	add	x2, x9, #0x8
                	str	x0, [x2]
                	add	x0, x1, #0x2
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfa30            ; =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1377,7 +1377,7 @@ Disassembly of section __TEXT,__text:
                	str	x0, [x2]
                	mov	x16, #0x9               ; =9
                	mul	x0, x1, x16
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfa30            ; =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1385,7 +1385,7 @@ Disassembly of section __TEXT,__text:
                	add	x2, x9, #0x18
                	str	x0, [x2]
                	mvn	x0, x1
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfa30            ; =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1395,7 +1395,7 @@ Disassembly of section __TEXT,__text:
                	mov	x16, #0xaaaa            ; =43690
                	movk	x16, #0xaaaa, lsl #16
                	eor	x0, x1, x16
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfa30            ; =64048
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1405,12 +1405,12 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x48
                	ldr	x1, [x0]
                	sub	x9, x29, #0x210
-               	mov	x16, #0xfcb8            ; =64696
+               	mov	x16, #0xfa48            ; =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfcb8            ; =64696
+               	mov	x16, #0xfa48            ; =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1419,7 +1419,7 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x1
 <L21>:
                	bl	 <L21>
-               	mov	x16, #0xfcb8            ; =64696
+               	mov	x16, #0xfa48            ; =64072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1485,40 +1485,357 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x10
                	ldr	x14, [x0]
                	mov	x0, x24
-               	mov	x1, x25
+               	ldr	x1, [x25]
+               	mov	x16, #0xfcd8            ; =64728
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x25, #0x8]
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x25, #0x10]
+               	mov	x16, #0xfce8            ; =64744
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x1, x29, #0x328
                	ldr	d0, [x26]
                	ldr	d1, [x26, #0x8]
                	ldr	d2, [x26, #0x10]
-               	mov	x2, x27
+               	ldr	x2, [x27]
+               	mov	x16, #0xfcc0            ; =64704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x27, #0x8]
+               	mov	x16, #0xfcc8            ; =64712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x27, #0x10]
+               	mov	x16, #0xfcd0            ; =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	sub	x2, x29, #0x340
                	mov	w3, w28
-               	mov	x16, #0xfcb0            ; =64688
+               	mov	x16, #0xfa40            ; =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x4, x9
-               	mov	x16, #0xfca8            ; =64680
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x5, x9
-               	fmov	d3, d8
+               	ldr	x15, [x9]
                	mov	x16, #0xfca0            ; =64672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x6, x9
-               	mov	x16, #0xfcb8            ; =64696
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa40            ; =64064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x7, x9
+               	ldr	x15, [x9, #0x8]
+               	mov	x16, #0xfca8            ; =64680
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa40            ; =64064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x10]
+               	mov	x16, #0xfcb0            ; =64688
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa40            ; =64064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x18]
+               	mov	x16, #0xfcb8            ; =64696
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	sub	x4, x29, #0x360
+               	mov	x16, #0xfa38            ; =64056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9]
+               	mov	x16, #0xfc80            ; =64640
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa38            ; =64056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x8]
+               	mov	x16, #0xfc88            ; =64648
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa38            ; =64056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x10]
+               	mov	x16, #0xfc90            ; =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa38            ; =64056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x18]
+               	mov	x16, #0xfc98            ; =64664
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	sub	x5, x29, #0x380
+               	fmov	d3, d8
+               	mov	x16, #0xfa30            ; =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9]
+               	mov	x16, #0xfc50            ; =64592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa30            ; =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x8]
+               	mov	x16, #0xfc58            ; =64600
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa30            ; =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x10]
+               	mov	x16, #0xfc60            ; =64608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa30            ; =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x18]
+               	mov	x16, #0xfc68            ; =64616
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa30            ; =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x20]
+               	mov	x16, #0xfc70            ; =64624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa30            ; =64048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x28]
+               	mov	x16, #0xfc78            ; =64632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	sub	x6, x29, #0x3b0
+               	mov	x16, #0xfa48            ; =64072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9]
+               	mov	x16, #0xfc20            ; =64544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa48            ; =64072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x8]
+               	mov	x16, #0xfc28            ; =64552
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa48            ; =64072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x10]
+               	mov	x16, #0xfc30            ; =64560
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa48            ; =64072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x18]
+               	mov	x16, #0xfc38            ; =64568
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa48            ; =64072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x20]
+               	mov	x16, #0xfc40            ; =64576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa48            ; =64072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x28]
+               	mov	x16, #0xfc48            ; =64584
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	sub	x7, x29, #0x3e0
+               	ldr	x15, [x8]
+               	mov	x16, #0xfc08            ; =64520
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	ldr	x15, [x8, #0x8]
+               	mov	x16, #0xfc10            ; =64528
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	ldr	x15, [x8, #0x10]
+               	mov	x16, #0xfc18            ; =64536
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	sub	x8, x29, #0x3f8
                	str	x8, [sp]
-               	str	x12, [sp, #0x8]
-               	str	x13, [sp, #0x10]
+               	ldr	x8, [x12]
+               	mov	x16, #0xfbe8            ; =64488
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x12, #0x8]
+               	mov	x16, #0xfbf0            ; =64496
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x12, #0x10]
+               	mov	x16, #0xfbf8            ; =64504
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x12, #0x18]
+               	mov	x16, #0xfc00            ; =64512
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	sub	x8, x29, #0x418
+               	str	x8, [sp, #0x8]
+               	ldr	x8, [x13]
+               	mov	x16, #0xfbb8            ; =64440
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x8]
+               	mov	x16, #0xfbc0            ; =64448
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x10]
+               	mov	x16, #0xfbc8            ; =64456
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x18]
+               	mov	x16, #0xfbd0            ; =64464
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x20]
+               	mov	x16, #0xfbd8            ; =64472
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x28]
+               	mov	x16, #0xfbe0            ; =64480
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	sub	x8, x29, #0x448
+               	str	x8, [sp, #0x10]
                	str	x14, [sp, #0x18]
 <L22>:
                	bl	 <L22>
@@ -1651,12 +1968,12 @@ Disassembly of section __TEXT,__text:
                	add	x1, x28, #0x28
                	str	x0, [x1]
                	sub	x9, x29, #0x270
-               	mov	x16, #0xfc98            ; =64664
+               	mov	x16, #0xfa28            ; =64040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xfc98            ; =64664
+               	mov	x16, #0xfa28            ; =64040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1665,7 +1982,7 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x22
 <L25>:
                	bl	 <L25>
-               	mov	x16, #0xfc98            ; =64664
+               	mov	x16, #0xfa28            ; =64040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1702,7 +2019,7 @@ Disassembly of section __TEXT,__text:
                	str	x0, [x1]
                	add	x0, x20, #0x0
                	ldr	x1, [x0]
-               	sub	x13, x29, #0x340
+               	sub	x13, x29, #0x478
                	add	x0, x13, #0x0
                	str	x1, [x0]
                	add	x0, x1, #0x1
@@ -1731,25 +2048,287 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x18
                	ldr	x14, [x0]
                	mov	x0, x22
-               	mov	x1, x19
+               	ldr	x1, [x19]
+               	mov	x16, #0xfb70            ; =64368
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x19, #0x8]
+               	mov	x16, #0xfb78            ; =64376
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x19, #0x10]
+               	mov	x16, #0xfb80            ; =64384
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x1, x29, #0x490
                	ldr	d0, [x23]
                	ldr	d1, [x23, #0x8]
                	ldr	d2, [x23, #0x10]
-               	mov	x2, x24
+               	ldr	x2, [x24]
+               	mov	x16, #0xfb58            ; =64344
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x24, #0x8]
+               	mov	x16, #0xfb60            ; =64352
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x24, #0x10]
+               	mov	x16, #0xfb68            ; =64360
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	sub	x2, x29, #0x4a8
                	mov	w3, w25
-               	mov	x4, x26
-               	mov	x5, x27
+               	ldr	x4, [x26]
+               	mov	x16, #0xfb38            ; =64312
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	ldr	x4, [x26, #0x8]
+               	mov	x16, #0xfb40            ; =64320
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	ldr	x4, [x26, #0x10]
+               	mov	x16, #0xfb48            ; =64328
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	ldr	x4, [x26, #0x18]
+               	mov	x16, #0xfb50            ; =64336
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x4, [x29, x16]
+               	sub	x4, x29, #0x4c8
+               	ldr	x5, [x27]
+               	mov	x16, #0xfb18            ; =64280
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x5, [x29, x16]
+               	ldr	x5, [x27, #0x8]
+               	mov	x16, #0xfb20            ; =64288
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x5, [x29, x16]
+               	ldr	x5, [x27, #0x10]
+               	mov	x16, #0xfb28            ; =64296
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x5, [x29, x16]
+               	ldr	x5, [x27, #0x18]
+               	mov	x16, #0xfb30            ; =64304
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x5, [x29, x16]
+               	sub	x5, x29, #0x4e8
                	fmov	d3, d8
-               	mov	x6, x28
-               	mov	x16, #0xfc98            ; =64664
+               	ldr	x6, [x28]
+               	mov	x16, #0xfae8            ; =64232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x6, [x29, x16]
+               	ldr	x6, [x28, #0x8]
+               	mov	x16, #0xfaf0            ; =64240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x6, [x29, x16]
+               	ldr	x6, [x28, #0x10]
+               	mov	x16, #0xfaf8            ; =64248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x6, [x29, x16]
+               	ldr	x6, [x28, #0x18]
+               	mov	x16, #0xfb00            ; =64256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x6, [x29, x16]
+               	ldr	x6, [x28, #0x20]
+               	mov	x16, #0xfb08            ; =64264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x6, [x29, x16]
+               	ldr	x6, [x28, #0x28]
+               	mov	x16, #0xfb10            ; =64272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x6, [x29, x16]
+               	sub	x6, x29, #0x518
+               	mov	x16, #0xfa28            ; =64040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	mov	x7, x9
+               	ldr	x15, [x9]
+               	mov	x16, #0xfab8            ; =64184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa28            ; =64040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x8]
+               	mov	x16, #0xfac0            ; =64192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa28            ; =64040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x10]
+               	mov	x16, #0xfac8            ; =64200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa28            ; =64040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x18]
+               	mov	x16, #0xfad0            ; =64208
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa28            ; =64040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x20]
+               	mov	x16, #0xfad8            ; =64216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	mov	x16, #0xfa28            ; =64040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ldr	x15, [x9, #0x28]
+               	mov	x16, #0xfae0            ; =64224
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	sub	x7, x29, #0x548
+               	ldr	x15, [x8]
+               	mov	x16, #0xfaa0            ; =64160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	ldr	x15, [x8, #0x8]
+               	mov	x16, #0xfaa8            ; =64168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	ldr	x15, [x8, #0x10]
+               	mov	x16, #0xfab0            ; =64176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x15, [x29, x16]
+               	sub	x8, x29, #0x560
                	str	x8, [sp]
-               	str	x12, [sp, #0x8]
-               	str	x13, [sp, #0x10]
+               	ldr	x8, [x12]
+               	mov	x16, #0xfa80            ; =64128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x12, #0x8]
+               	mov	x16, #0xfa88            ; =64136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x12, #0x10]
+               	mov	x16, #0xfa90            ; =64144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x12, #0x18]
+               	mov	x16, #0xfa98            ; =64152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	sub	x8, x29, #0x580
+               	str	x8, [sp, #0x8]
+               	ldr	x8, [x13]
+               	mov	x16, #0xfa50            ; =64080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x8]
+               	mov	x16, #0xfa58            ; =64088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x10]
+               	mov	x16, #0xfa60            ; =64096
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x18]
+               	mov	x16, #0xfa68            ; =64104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x20]
+               	mov	x16, #0xfa70            ; =64112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	ldr	x8, [x13, #0x28]
+               	mov	x16, #0xfa78            ; =64120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x8, [x29, x16]
+               	sub	x8, x29, #0x5b0
+               	str	x8, [sp, #0x10]
                	str	x14, [sp, #0x18]
 <L26>:
                	bl	 <L26>
@@ -1757,9 +2336,9 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x21
 <L27>:
                	bl	 <L27>
-               	sub	x16, x29, #0x3d0
+               	sub	x16, x29, #0x640
                	ldr	d8, [x16, #0x8]
-               	sub	x16, x29, #0x380
+               	sub	x16, x29, #0x5f0
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-darwin/call/call_rec_small.dis
+++ b/test/golden/aarch64-darwin/call/call_rec_small.dis
@@ -231,37 +231,37 @@ Disassembly of section __TEXT,__text:
                	ldrh	w28, [x4]
                	sub	x4, x29, #0x20
                	ldr	w9, [x4]
-               	stur	x9, [x29, #-0x30]
+               	stur	x9, [x29, #-0x38]
                	sub	x4, x29, #0x1c
                	ldrh	w9, [x4]
-               	stur	x9, [x29, #-0x38]
+               	stur	x9, [x29, #-0x40]
                	sub	x4, x29, #0x1a
                	ldrb	w9, [x4]
-               	stur	x9, [x29, #-0x40]
+               	stur	x9, [x29, #-0x48]
                	sub	x4, x29, #0x28
                	ldrb	w9, [x4]
-               	stur	x9, [x29, #-0x48]
+               	stur	x9, [x29, #-0x50]
                	add	x4, x1, #0x0
                	ldrb	w9, [x4]
-               	stur	x9, [x29, #-0x50]
+               	stur	x9, [x29, #-0x58]
                	add	x4, x1, #0x1
                	ldrb	w9, [x4]
-               	stur	x9, [x29, #-0x58]
+               	stur	x9, [x29, #-0x60]
                	add	x1, x2, #0x0
                	ldrb	w9, [x1]
-               	stur	x9, [x29, #-0x60]
+               	stur	x9, [x29, #-0x68]
                	add	x1, x2, #0x1
                	ldrb	w9, [x1]
-               	stur	x9, [x29, #-0x68]
+               	stur	x9, [x29, #-0x70]
                	add	x1, x2, #0x2
                	ldrh	w9, [x1]
-               	stur	x9, [x29, #-0x70]
+               	stur	x9, [x29, #-0x78]
                	add	x1, x3, #0x0
                	ldr	w9, [x1]
-               	stur	x9, [x29, #-0x78]
+               	stur	x9, [x29, #-0x80]
                	add	x1, x3, #0x4
                	ldrh	w9, [x1]
-               	stur	x9, [x29, #-0x80]
+               	stur	x9, [x29, #-0x30]
                	add	x1, x3, #0x6
                	ldrb	w9, [x1]
                	stur	x9, [x29, #-0x88]
@@ -299,47 +299,47 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x21
 <L10>:
                	bl	 <L10>
-               	ldur	x9, [x29, #-0x30]
+               	ldur	x9, [x29, #-0x38]
                	mov	w1, w9
 <L11>:
                	bl	 <L11>
-               	ldur	x9, [x29, #-0x38]
+               	ldur	x9, [x29, #-0x40]
                	mov	x1, x9
 <L12>:
                	bl	 <L12>
-               	ldur	x9, [x29, #-0x40]
+               	ldur	x9, [x29, #-0x48]
                	mov	x1, x9
 <L13>:
                	bl	 <L13>
-               	ldur	x9, [x29, #-0x48]
+               	ldur	x9, [x29, #-0x50]
                	mov	x1, x9
 <L14>:
                	bl	 <L14>
-               	ldur	x9, [x29, #-0x50]
+               	ldur	x9, [x29, #-0x58]
                	mov	x1, x9
 <L15>:
                	bl	 <L15>
-               	ldur	x9, [x29, #-0x58]
+               	ldur	x9, [x29, #-0x60]
                	mov	x1, x9
 <L16>:
                	bl	 <L16>
-               	ldur	x9, [x29, #-0x60]
+               	ldur	x9, [x29, #-0x68]
                	mov	x1, x9
 <L17>:
                	bl	 <L17>
-               	ldur	x9, [x29, #-0x68]
+               	ldur	x9, [x29, #-0x70]
                	mov	x1, x9
 <L18>:
                	bl	 <L18>
-               	ldur	x9, [x29, #-0x70]
+               	ldur	x9, [x29, #-0x78]
                	mov	x1, x9
 <L19>:
                	bl	 <L19>
-               	ldur	x9, [x29, #-0x78]
+               	ldur	x9, [x29, #-0x80]
                	mov	w1, w9
 <L20>:
                	bl	 <L20>
-               	ldur	x9, [x29, #-0x80]
+               	ldur	x9, [x29, #-0x30]
                	mov	x1, x9
 <L21>:
                	bl	 <L21>
@@ -353,11 +353,11 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x22
 <L24>:
                	bl	 <L24>
-               	ldur	x9, [x29, #-0x30]
-               	add	w1, w9, #0x1
                	ldur	x9, [x29, #-0x38]
-               	add	w19, w9, #0x2
+               	add	w1, w9, #0x1
                	ldur	x9, [x29, #-0x40]
+               	add	w19, w9, #0x2
+               	ldur	x9, [x29, #-0x48]
                	add	w20, w9, #0x3
 <L25>:
                	bl	 <L25>
@@ -367,15 +367,15 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x20
 <L27>:
                	bl	 <L27>
-               	ldur	x9, [x29, #-0x30]
+               	ldur	x9, [x29, #-0x38]
                	mov	w1, w9
 <L28>:
                	bl	 <L28>
-               	ldur	x9, [x29, #-0x38]
+               	ldur	x9, [x29, #-0x40]
                	mov	x1, x9
 <L29>:
                	bl	 <L29>
-               	ldur	x9, [x29, #-0x40]
+               	ldur	x9, [x29, #-0x48]
                	mov	x1, x9
 <L30>:
                	bl	 <L30>
@@ -467,7 +467,7 @@ Disassembly of section __TEXT,__text:
                	sub	sp, sp, #0xf0
                	stp	x19, x20, [x29, #-0xb0]
                	stp	x21, x22, [x29, #-0xc0]
-               	stur	x23, [x29, #-0xc8]
+               	stp	x23, x24, [x29, #-0xd0]
                	mov	x19, x0
 <L0>:
                	bl	 <L0>
@@ -647,12 +647,12 @@ Disassembly of section __TEXT,__text:
                	ldr	x6, [x1]
                	sub	x15, x29, #0x98
                	mov	w1, w6
-               	add	x18, x15, #0x0
-               	str	w1, [x18]
+               	add	x24, x15, #0x0
+               	str	w1, [x24]
                	lsr	x1, x6, #32
-               	mov	w18, w1
+               	mov	w24, w1
                	add	x1, x15, #0x4
-               	strh	w18, [x1]
+               	strh	w24, [x1]
                	lsr	x1, x6, #48
                	mov	w6, w1
                	add	x1, x15, #0x6
@@ -663,7 +663,7 @@ Disassembly of section __TEXT,__text:
                	and	x1, x6, x16
                	ucvtf	s1, x1
                	add	x1, x20, #0x8
-               	ldr	x18, [x1]
+               	ldr	x24, [x1]
                	ldr	x1, [x2]
                	mov	w2, w3
                	ldr	x3, [x4]
@@ -677,7 +677,7 @@ Disassembly of section __TEXT,__text:
                	stur	w8, [sp, #0x2]
                	ldr	x8, [x15]
                	str	x8, [sp, #0x8]
-               	str	x18, [sp, #0x10]
+               	str	x24, [sp, #0x10]
 <L17>:
                	bl	 <L17>
                	mov	x22, x0
@@ -804,7 +804,7 @@ Disassembly of section __TEXT,__text:
                	bl	 <L21>
                	ldp	x19, x20, [x29, #-0xb0]
                	ldp	x21, x22, [x29, #-0xc0]
-               	ldur	x23, [x29, #-0xc8]
+               	ldp	x23, x24, [x29, #-0xd0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/call/call_ret_large.dis
+++ b/test/golden/aarch64-darwin/call/call_ret_large.dis
@@ -879,14 +879,14 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_ret_large.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x4d0
-               	sub	x16, x29, #0x480
+               	sub	sp, sp, #0x690
+               	sub	x16, x29, #0x640
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
                	stp	x23, x24, [x16, #-0x20]
                	stp	x25, x26, [x16, #-0x30]
                	stp	x27, x28, [x16, #-0x40]
-               	sub	x16, x29, #0x4d0
+               	sub	x16, x29, #0x690
                	stp	d8, d9, [x16]
                	mov	x19, x0
 <L0>:
@@ -918,7 +918,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, #0x20               ; =32
 <L9>:
                	bl	 <L9>
-               	sub	x20, x29, #0x190
+               	sub	x20, x29, #0x1c0
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
@@ -1099,11 +1099,11 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x28
 <L39>:
                	bl	 <L39>
-               	sub	x1, x29, #0x418
+               	sub	x1, x29, #0x5b0
                	mov	w2, w23
                	add	x3, x1, #0x0
                	str	w2, [x3]
-               	sub	x2, x29, #0x430
+               	sub	x2, x29, #0x5c8
                	add	x3, x2, #0x0
                	str	x23, [x3]
                	mvn	x3, x23
@@ -1121,7 +1121,7 @@ Disassembly of section __TEXT,__text:
                	str	x4, [x3, #0x8]
                	ldr	x4, [x2, #0x10]
                	str	x4, [x3, #0x10]
-               	sub	x2, x29, #0x440
+               	sub	x2, x29, #0x5d8
                	mov	x16, #0xb               ; =11
                	mul	x3, x23, x16
                	add	x4, x2, #0x0
@@ -1134,6 +1134,43 @@ Disassembly of section __TEXT,__text:
                	str	x4, [x3]
                	ldr	x4, [x2, #0x8]
                	str	x4, [x3, #0x8]
+               	ldr	x2, [x1]
+               	mov	x16, #0xf9f8            ; =63992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x8]
+               	mov	x16, #0xfa00            ; =64000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x10]
+               	mov	x16, #0xfa08            ; =64008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x18]
+               	mov	x16, #0xfa10            ; =64016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x20]
+               	mov	x16, #0xfa18            ; =64024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x28]
+               	mov	x16, #0xfa20            ; =64032
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	sub	x1, x29, #0x608
 <L40>:
                	bl	 <L40>
                	add	x22, x22, #0x1
@@ -1179,7 +1216,7 @@ Disassembly of section __TEXT,__text:
 <L46>:
                	sub	x22, x29, #0x30
                	add	x0, x19, #0x2
-               	sub	x1, x29, #0x1c0
+               	sub	x1, x29, #0x1f0
                	add	x2, x1, #0x0
                	str	x0, [x2]
                	add	x2, x0, #0x1
@@ -1221,7 +1258,19 @@ Disassembly of section __TEXT,__text:
                	ldr	x1, [x0]
                	sub	x24, x29, #0x60
                	mov	x8, x24
-               	mov	x0, x22
+               	ldr	x0, [x22]
+               	stur	x0, [x29, #-0x90]
+               	ldr	x0, [x22, #0x8]
+               	stur	x0, [x29, #-0x88]
+               	ldr	x0, [x22, #0x10]
+               	stur	x0, [x29, #-0x80]
+               	ldr	x0, [x22, #0x18]
+               	stur	x0, [x29, #-0x78]
+               	ldr	x0, [x22, #0x20]
+               	stur	x0, [x29, #-0x70]
+               	ldr	x0, [x22, #0x28]
+               	stur	x0, [x29, #-0x68]
+               	sub	x0, x29, #0x90
 <L48>:
                	bl	 <L48>
                	ldr	x0, [x24]
@@ -1271,7 +1320,7 @@ Disassembly of section __TEXT,__text:
                	cmp	x23, #0x8
                	b.lo	 <L47>
 <L55>:
-               	sub	x22, x29, #0x120
+               	sub	x22, x29, #0x150
                	str	xzr, [x22]
                	str	xzr, [x22, #0x8]
                	str	xzr, [x22, #0x10]
@@ -1304,7 +1353,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x20, x0, lsl #3
                	ldr	x2, [x1]
                	add	x1, x2, x19
-               	sub	x2, x29, #0x1e0
+               	sub	x2, x29, #0x210
                	add	x3, x2, #0x0
                	str	x1, [x3]
                	add	x3, x1, #0x1
@@ -1366,7 +1415,7 @@ Disassembly of section __TEXT,__text:
                	cmp	x23, #0x6
                	b.lo	 <L58>
 <L63>:
-               	sub	x1, x29, #0x150
+               	sub	x1, x29, #0x180
                	str	xzr, [x1]
                	str	xzr, [x1, #0x8]
                	str	xzr, [x1, #0x10]
@@ -1384,7 +1433,7 @@ Disassembly of section __TEXT,__text:
                	add	x4, x3, #0x1
                	add	x3, x20, #0x0
                	ldr	x5, [x3]
-               	sub	x3, x29, #0x240
+               	sub	x3, x29, #0x288
                	add	x6, x0, x5
                	add	x7, x3, #0x0
                	str	x6, [x7]
@@ -1401,7 +1450,7 @@ Disassembly of section __TEXT,__text:
                	str	x2, [x0, #0x8]
                	ldr	x2, [x3, #0x10]
                	str	x2, [x0, #0x10]
-               	sub	x0, x29, #0x250
+               	sub	x0, x29, #0x298
                	add	x2, x20, #0x8
                	ldr	x3, [x2]
                	add	x2, x0, #0x0
@@ -1416,6 +1465,43 @@ Disassembly of section __TEXT,__text:
                	ldr	x3, [x0, #0x8]
                	str	x3, [x2, #0x8]
                	mov	x0, x21
+               	ldr	x2, [x1]
+               	mov	x16, #0xfd38            ; =64824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x8]
+               	mov	x16, #0xfd40            ; =64832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x10]
+               	mov	x16, #0xfd48            ; =64840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x18]
+               	mov	x16, #0xfd50            ; =64848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x20]
+               	mov	x16, #0xfd58            ; =64856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	ldr	x2, [x1, #0x28]
+               	mov	x16, #0xfd60            ; =64864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x2, [x29, x16]
+               	sub	x1, x29, #0x2c8
 <L64>:
                	bl	 <L64>
                	mov	x21, x0
@@ -1427,7 +1513,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, x22, lsl #3
                	ldr	x1, [x0]
                	add	x23, x1, x19
-               	sub	x0, x29, #0x1f8
+               	sub	x0, x29, #0x228
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	mvn	x1, x23
@@ -1438,11 +1524,30 @@ Disassembly of section __TEXT,__text:
                	add	x2, x1, #0x1
                	add	x1, x0, #0x10
                	str	x2, [x1]
-               	sub	x24, x29, #0x228
+               	sub	x24, x29, #0x258
                	mov	x8, x24
+               	ldr	x1, [x0]
+               	mov	x16, #0xfd90            ; =64912
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x8]
+               	mov	x16, #0xfd98            ; =64920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x10]
+               	mov	x16, #0xfda0            ; =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x0, x29, #0x270
 <L66>:
                	bl	 <L66>
-               	sub	x0, x29, #0x280
+               	sub	x0, x29, #0x2f8
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	add	x1, x23, #0x1
@@ -1463,8 +1568,45 @@ Disassembly of section __TEXT,__text:
                	eor	x1, x23, x16
                	add	x2, x0, #0x28
                	str	x1, [x2]
-               	sub	x25, x29, #0x298
+               	sub	x25, x29, #0x310
                	mov	x8, x25
+               	ldr	x1, [x0]
+               	mov	x16, #0xfcc0            ; =64704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x8]
+               	mov	x16, #0xfcc8            ; =64712
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x10]
+               	mov	x16, #0xfcd0            ; =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x18]
+               	mov	x16, #0xfcd8            ; =64728
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x20]
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x28]
+               	mov	x16, #0xfce8            ; =64744
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x0, x29, #0x340
 <L67>:
                	bl	 <L67>
                	add	x0, x24, #0x0
@@ -1475,14 +1617,14 @@ Disassembly of section __TEXT,__text:
                	ldr	x28, [x0]
                	add	x0, x24, #0x18
                	ldr	x9, [x0]
-               	mov	x16, #0xfbb8            ; =64440
+               	mov	x16, #0xf9f0            ; =63984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	add	x0, x24, #0x20
                	ldr	x9, [x0]
-               	mov	x16, #0xfbb0            ; =64432
+               	mov	x16, #0xf9e8            ; =63976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1491,14 +1633,14 @@ Disassembly of section __TEXT,__text:
                	ldr	x24, [x0]
                	add	x0, x25, #0x0
                	ldr	x9, [x0]
-               	mov	x16, #0xfba8            ; =64424
+               	mov	x16, #0xf9e0            ; =63968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	add	x0, x25, #0x8
                	ldr	x9, [x0]
-               	mov	x16, #0xfba0            ; =64416
+               	mov	x16, #0xf9d8            ; =63960
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1516,7 +1658,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x28
 <L71>:
                	bl	 <L71>
-               	mov	x16, #0xfbb8            ; =64440
+               	mov	x16, #0xf9f0            ; =63984
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1524,7 +1666,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L72>:
                	bl	 <L72>
-               	mov	x16, #0xfbb0            ; =64432
+               	mov	x16, #0xf9e8            ; =63976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1535,7 +1677,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x24
 <L74>:
                	bl	 <L74>
-               	mov	x16, #0xfba8            ; =64424
+               	mov	x16, #0xf9e0            ; =63968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1543,7 +1685,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L75>:
                	bl	 <L75>
-               	mov	x16, #0xfba0            ; =64416
+               	mov	x16, #0xf9d8            ; =63960
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1562,7 +1704,7 @@ Disassembly of section __TEXT,__text:
 <L79>:
                	bl	 <L79>
                	mov	x24, x0
-               	sub	x0, x29, #0x2c8
+               	sub	x0, x29, #0x370
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	add	x1, x23, #0x1
@@ -1583,13 +1725,68 @@ Disassembly of section __TEXT,__text:
                	eor	x1, x23, x16
                	add	x2, x0, #0x28
                	str	x1, [x2]
-               	sub	x25, x29, #0x2e0
+               	sub	x25, x29, #0x388
                	mov	x8, x25
+               	ldr	x1, [x0]
+               	mov	x16, #0xfc48            ; =64584
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x8]
+               	mov	x16, #0xfc50            ; =64592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x10]
+               	mov	x16, #0xfc58            ; =64600
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x18]
+               	mov	x16, #0xfc60            ; =64608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x20]
+               	mov	x16, #0xfc68            ; =64616
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x28]
+               	mov	x16, #0xfc70            ; =64624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x0, x29, #0x3b8
 <L80>:
                	bl	 <L80>
-               	sub	x26, x29, #0x310
+               	sub	x26, x29, #0x3e8
                	mov	x8, x26
-               	mov	x0, x25
+               	ldr	x0, [x25]
+               	mov	x16, #0xfc00            ; =64512
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x8]
+               	mov	x16, #0xfc08            ; =64520
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x10]
+               	mov	x16, #0xfc10            ; =64528
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	sub	x0, x29, #0x400
 <L81>:
                	bl	 <L81>
                	add	x0, x26, #0x0
@@ -1602,7 +1799,7 @@ Disassembly of section __TEXT,__text:
                	ldr	x28, [x0]
                	add	x0, x26, #0x20
                	ldr	x9, [x0]
-               	mov	x16, #0xfb98            ; =64408
+               	mov	x16, #0xf9d0            ; =63952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1621,7 +1818,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x28
 <L85>:
                	bl	 <L85>
-               	mov	x16, #0xfb98            ; =64408
+               	mov	x16, #0xf9d0            ; =63952
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1633,7 +1830,7 @@ Disassembly of section __TEXT,__text:
 <L87>:
                	bl	 <L87>
                	mov	x24, x0
-               	sub	x0, x29, #0x328
+               	sub	x0, x29, #0x418
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	mvn	x1, x23
@@ -1644,13 +1841,68 @@ Disassembly of section __TEXT,__text:
                	add	x2, x1, #0x1
                	add	x1, x0, #0x10
                	str	x2, [x1]
-               	sub	x25, x29, #0x358
+               	sub	x25, x29, #0x448
                	mov	x8, x25
+               	ldr	x1, [x0]
+               	mov	x16, #0xfba0            ; =64416
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x8]
+               	mov	x16, #0xfba8            ; =64424
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x10]
+               	mov	x16, #0xfbb0            ; =64432
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x0, x29, #0x460
 <L88>:
                	bl	 <L88>
-               	sub	x26, x29, #0x370
+               	sub	x26, x29, #0x478
                	mov	x8, x26
-               	mov	x0, x25
+               	ldr	x0, [x25]
+               	mov	x16, #0xfb58            ; =64344
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x8]
+               	mov	x16, #0xfb60            ; =64352
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x10]
+               	mov	x16, #0xfb68            ; =64360
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x18]
+               	mov	x16, #0xfb70            ; =64368
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x20]
+               	mov	x16, #0xfb78            ; =64376
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x28]
+               	mov	x16, #0xfb80            ; =64384
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	sub	x0, x29, #0x4a8
 <L89>:
                	bl	 <L89>
                	add	x0, x26, #0x0
@@ -1669,7 +1921,7 @@ Disassembly of section __TEXT,__text:
 <L92>:
                	bl	 <L92>
                	mov	x24, x0
-               	sub	x0, x29, #0x3a0
+               	sub	x0, x29, #0x4d8
                	add	x1, x0, #0x0
                	str	x23, [x1]
                	add	x1, x23, #0x1
@@ -1690,14 +1942,87 @@ Disassembly of section __TEXT,__text:
                	eor	x1, x23, x16
                	add	x2, x0, #0x28
                	str	x1, [x2]
-               	sub	x25, x29, #0x3d0
+               	sub	x25, x29, #0x508
                	mov	x8, x25
+               	ldr	x1, [x0]
+               	mov	x16, #0xfac8            ; =64200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x8]
+               	mov	x16, #0xfad0            ; =64208
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x10]
+               	mov	x16, #0xfad8            ; =64216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x18]
+               	mov	x16, #0xfae0            ; =64224
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x20]
+               	mov	x16, #0xfae8            ; =64232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x0, #0x28]
+               	mov	x16, #0xfaf0            ; =64240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x0, x29, #0x538
                	mov	x1, x23
 <L93>:
                	bl	 <L93>
-               	sub	x26, x29, #0x3e8
+               	sub	x26, x29, #0x550
                	mov	x8, x26
-               	mov	x0, x25
+               	ldr	x0, [x25]
+               	mov	x16, #0xfa80            ; =64128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x8]
+               	mov	x16, #0xfa88            ; =64136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x10]
+               	mov	x16, #0xfa90            ; =64144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x18]
+               	mov	x16, #0xfa98            ; =64152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x20]
+               	mov	x16, #0xfaa0            ; =64160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	ldr	x0, [x25, #0x28]
+               	mov	x16, #0xfaa8            ; =64168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x0, [x29, x16]
+               	sub	x0, x29, #0x580
 <L94>:
                	bl	 <L94>
                	add	x0, x26, #0x0
@@ -1725,9 +2050,9 @@ Disassembly of section __TEXT,__text:
                	b.lo	 <L65>
 <L98>:
                	mov	x0, x21
-               	sub	x16, x29, #0x4d0
+               	sub	x16, x29, #0x690
                	ldp	d8, d9, [x16]
-               	sub	x16, x29, #0x480
+               	sub	x16, x29, #0x640
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	ldp	x23, x24, [x16, #-0x20]

--- a/test/golden/aarch64-darwin/cmp/short_circuit.dis
+++ b/test/golden/aarch64-darwin/cmp/short_circuit.dis
@@ -203,22 +203,25 @@ Disassembly of section __TEXT,__text:
                	add	x1, x1, #0x0
                	str	x0, [x1]
                	mov	w17, #0x1               ; =1
-               	eor	w1, w17, w20
+               	eor	w0, w17, w20
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x2, x0, #0x1
+               	ldr	x1, [x16]
+               	add	x2, x1, #0x1
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	x2, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x2, [x0]
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	ldr	x2, [x1]
                	add	x3, x2, #0x1
-               	str	x3, [x0]
+               	str	x3, [x1]
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
+               	ldr	x1, [x16]
                	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x2, x2, #0x0
-               	str	x0, [x2]
+               	str	x1, [x2]
+               	uxtb	w17, w0
+               	cmp	w17, #0x1
+               	cset	w1, eq
                	mov	x0, x22
 <L11>:
                	bl	 <L11>
@@ -337,163 +340,46 @@ Disassembly of section __TEXT,__text:
                	cmp	x2, #0x4
                	b.lo	 <L25>
 <L26>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	mov	w17, #0x1               ; =1
-               	eor	w1, w17, w20
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x2, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x2, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x2, [x0]
-               	add	x3, x2, #0x1
-               	str	x3, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x2, x2, #0x0
-               	str	x0, [x2]
-               	mov	x0, x22
+               	mov	x0, #0x0                ; =0
+               	mov	x1, #0x0                ; =0
 <L27>:
                	bl	 <L27>
+               	uxtb	w17, w0
+               	cmp	w17, #0x1
+               	cset	w1, eq
+               	cbnz	w1,  <L28>
+               	mov	w17, #0x1               ; =1
+               	eor	w0, w17, w20
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x1, [x16]
+               	ldr	x2, [x16]
+               	add	x3, x2, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x3, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	ldr	x3, [x2]
+               	add	x4, x3, #0x1
+               	str	x4, [x2]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x2, [x16]
+               	adrp	x3, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x3, x3, #0x0
+               	str	x2, [x3]
+               	uxtb	w17, w0
+               	cmp	w17, #0x1
+               	cset	w2, eq
+               	b	 <L29>
 <L28>:
-               	bl	 <L28>
-               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x19, x19, #0x0
-               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x21, x21, #0x0
-               	mov	x22, x0
-               	mov	x23, #0x0               ; =0
-               	cmp	x23, #0x4
-               	b.lo	 <L29>
-               	b	 <L32>
+               	mov	x2, x1
 <L29>:
-               	add	x0, x19, x23, lsl #3
-               	ldr	x1, [x0]
                	mov	x0, x22
+               	mov	x1, x2
 <L30>:
                	bl	 <L30>
-               	add	x1, x21, x23, lsl #3
-               	ldr	x2, [x1]
-               	mov	x1, x2
-<L31>:
-               	bl	 <L31>
-               	add	x23, x23, #0x1
-               	mov	x22, x0
-               	cmp	x23, #0x4
-               	b.lo	 <L29>
-<L32>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	xzr, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	mov	x2, #0x0                ; =0
-               	cmp	x2, #0x4
-               	b.lo	 <L33>
-               	b	 <L34>
-<L33>:
-               	add	x3, x0, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x3, x1, x2, lsl #3
-               	str	xzr, [x3]
-               	add	x2, x2, #0x1
-               	cmp	x2, #0x4
-               	b.lo	 <L33>
-<L34>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	cbnz	w20,  <L35>
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	mov	x0, #0x1                ; =1
-               	b	 <L36>
-<L35>:
-               	mov	x0, x20
-<L36>:
-               	mov	x1, x0
-               	mov	x0, x22
-<L37>:
-               	bl	 <L37>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x1, [x16]
-<L38>:
-               	bl	 <L38>
+<L31>:
+               	bl	 <L31>
                	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x19, x19, #0x0
                	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
@@ -501,24 +387,24 @@ Disassembly of section __TEXT,__text:
                	mov	x22, x0
                	mov	x23, #0x0               ; =0
                	cmp	x23, #0x4
-               	b.lo	 <L39>
-               	b	 <L42>
-<L39>:
+               	b.lo	 <L32>
+               	b	 <L35>
+<L32>:
                	add	x0, x19, x23, lsl #3
                	ldr	x1, [x0]
                	mov	x0, x22
-<L40>:
-               	bl	 <L40>
+<L33>:
+               	bl	 <L33>
                	add	x1, x21, x23, lsl #3
                	ldr	x2, [x1]
                	mov	x1, x2
-<L41>:
-               	bl	 <L41>
+<L34>:
+               	bl	 <L34>
                	add	x23, x23, #0x1
                	mov	x22, x0
                	cmp	x23, #0x4
-               	b.lo	 <L39>
-<L42>:
+               	b.lo	 <L32>
+<L35>:
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	str	xzr, [x16]
                	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
@@ -527,49 +413,25 @@ Disassembly of section __TEXT,__text:
                	add	x1, x1, #0x0
                	mov	x2, #0x0                ; =0
                	cmp	x2, #0x4
-               	b.lo	 <L43>
-               	b	 <L44>
-<L43>:
+               	b.lo	 <L36>
+               	b	 <L37>
+<L36>:
                	add	x3, x0, x2, lsl #3
                	str	xzr, [x3]
                	add	x3, x1, x2, lsl #3
                	str	xzr, [x3]
                	add	x2, x2, #0x1
                	cmp	x2, #0x4
-               	b.lo	 <L43>
-<L44>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	mov	w17, #0x1               ; =1
-               	eor	w1, w17, w20
+               	b.lo	 <L36>
+<L37>:
+               	mov	x0, #0x0                ; =0
+               	mov	x1, #0x0                ; =0
+<L38>:
+               	bl	 <L38>
+               	uxtb	w17, w0
+               	cmp	w17, #0x1
+               	cset	w1, eq
+               	cbnz	w1,  <L39>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x0, [x16]
                	add	x2, x0, #0x1
@@ -585,6 +447,56 @@ Disassembly of section __TEXT,__text:
                	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x2, x2, #0x0
                	str	x0, [x2]
+               	mov	x0, #0x1                ; =1
+               	b	 <L40>
+<L39>:
+               	mov	x0, x1
+<L40>:
+               	cbnz	w0,  <L41>
+               	mov	x1, x0
+               	b	 <L44>
+<L41>:
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	add	x2, x0, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x2, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	ldr	x2, [x0]
+               	add	x3, x2, #0x1
+               	str	x3, [x0]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	str	x0, [x2]
+               	uxtb	w17, w20
+               	cmp	w17, #0x1
+               	cset	w0, eq
+               	cbnz	w0,  <L42>
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x2, [x16]
+               	add	x3, x2, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x3, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	ldr	x3, [x2]
+               	add	x4, x3, #0x1
+               	str	x4, [x2]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x2, [x16]
+               	adrp	x3, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x3, x3, #0x0
+               	str	x2, [x3]
+               	mov	x2, #0x1                ; =1
+               	b	 <L43>
+<L42>:
+               	mov	x2, x0
+<L43>:
+               	mov	x1, x2
+<L44>:
                	mov	x0, x22
 <L45>:
                	bl	 <L45>
@@ -636,64 +548,184 @@ Disassembly of section __TEXT,__text:
                	cmp	x2, #0x4
                	b.lo	 <L51>
 <L52>:
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	add	x1, x0, #0x1
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
-               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
-               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	cbnz	w20,  <L53>
-               	b	 <L54>
+               	mov	x0, #0x0                ; =0
+               	mov	x1, #0x1                ; =1
 <L53>:
+               	bl	 <L53>
+               	uxtb	w17, w0
+               	cmp	w17, #0x1
+               	cset	w1, eq
+               	cbnz	w1,  <L54>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x0, [x16]
-               	add	x1, x0, #0x1
+               	add	x2, x0, #0x1
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	str	x1, [x16]
+               	str	x2, [x16]
                	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x0, x0, #0x0
-               	ldr	x1, [x0]
-               	add	x2, x1, #0x1
-               	str	x2, [x0]
+               	ldr	x2, [x0]
+               	add	x3, x2, #0x1
+               	str	x3, [x0]
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x0, [x16]
-               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
-               	add	x1, x1, #0x0
-               	str	x0, [x1]
-               	mov	x20, #0x1               ; =1
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	str	x0, [x2]
+               	mov	x0, #0x1                ; =1
+               	b	 <L55>
 <L54>:
-               	mov	x0, x22
-               	mov	x1, x20
+               	mov	x0, x1
 <L55>:
-               	bl	 <L55>
+               	cbnz	w0,  <L56>
+               	mov	x1, x0
+               	b	 <L57>
+<L56>:
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	add	x2, x0, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x2, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	ldr	x2, [x0]
+               	add	x3, x2, #0x1
+               	str	x3, [x0]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	str	x0, [x2]
+               	mov	w17, #0x1               ; =1
+               	eor	w0, w17, w20
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x2, [x16]
+               	add	x3, x2, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x3, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	ldr	x3, [x2]
+               	add	x4, x3, #0x1
+               	str	x4, [x2]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x2, [x16]
+               	adrp	x3, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x3, x3, #0x0
+               	str	x2, [x3]
+               	uxtb	w17, w0
+               	cmp	w17, #0x1
+               	cset	w2, eq
+               	mov	x1, x2
+<L57>:
+               	mov	x0, x22
+<L58>:
+               	bl	 <L58>
                	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	ldr	x1, [x16]
-<L56>:
-               	bl	 <L56>
+<L59>:
+               	bl	 <L59>
+               	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x19, x19, #0x0
+               	adrp	x21, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x21, x21, #0x0
+               	mov	x22, x0
+               	mov	x23, #0x0               ; =0
+               	cmp	x23, #0x4
+               	b.lo	 <L60>
+               	b	 <L63>
+<L60>:
+               	add	x0, x19, x23, lsl #3
+               	ldr	x1, [x0]
+               	mov	x0, x22
+<L61>:
+               	bl	 <L61>
+               	add	x1, x21, x23, lsl #3
+               	ldr	x2, [x1]
+               	mov	x1, x2
+<L62>:
+               	bl	 <L62>
+               	add	x23, x23, #0x1
+               	mov	x22, x0
+               	cmp	x23, #0x4
+               	b.lo	 <L60>
+<L63>:
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	xzr, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	adrp	x1, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x1, x1, #0x0
+               	mov	x2, #0x0                ; =0
+               	cmp	x2, #0x4
+               	b.lo	 <L64>
+               	b	 <L65>
+<L64>:
+               	add	x3, x0, x2, lsl #3
+               	str	xzr, [x3]
+               	add	x3, x1, x2, lsl #3
+               	str	xzr, [x3]
+               	add	x2, x2, #0x1
+               	cmp	x2, #0x4
+               	b.lo	 <L64>
+<L65>:
+               	mov	x0, #0x0                ; =0
+               	mov	x1, #0x0                ; =0
+<L66>:
+               	bl	 <L66>
+               	uxtb	w17, w0
+               	cmp	w17, #0x1
+               	cset	w1, eq
+               	cbnz	w1,  <L67>
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	add	x2, x0, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x2, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	ldr	x2, [x0]
+               	add	x3, x2, #0x1
+               	str	x3, [x0]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	str	x0, [x2]
+               	uxtb	w17, w20
+               	cmp	w17, #0x1
+               	cset	w0, eq
+               	b	 <L68>
+<L67>:
+               	mov	x0, x1
+<L68>:
+               	cbnz	w0,  <L69>
+               	mov	x1, x0
+               	b	 <L70>
+<L69>:
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	add	x2, x0, #0x1
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	str	x2, [x16]
+               	adrp	x0, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x0, x0, #0x0
+               	ldr	x2, [x0]
+               	add	x3, x2, #0x1
+               	str	x3, [x0]
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x0, [x16]
+               	adrp	x2, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	add	x2, x2, #0x0
+               	str	x0, [x2]
+               	mov	x1, #0x1                ; =1
+<L70>:
+               	mov	x0, x22
+<L71>:
+               	bl	 <L71>
+               	adrp	x16, 0x0 <corpus.cases.cmp.short_circuit.probe>
+               	ldr	x1, [x16]
+<L72>:
+               	bl	 <L72>
                	adrp	x19, 0x0 <corpus.cases.cmp.short_circuit.probe>
                	add	x19, x19, #0x0
                	adrp	x20, 0x0 <corpus.cases.cmp.short_circuit.probe>
@@ -701,24 +733,24 @@ Disassembly of section __TEXT,__text:
                	mov	x21, x0
                	mov	x22, #0x0               ; =0
                	cmp	x22, #0x4
-               	b.lo	 <L57>
-               	b	 <L60>
-<L57>:
+               	b.lo	 <L73>
+               	b	 <L76>
+<L73>:
                	add	x0, x19, x22, lsl #3
                	ldr	x1, [x0]
                	mov	x0, x21
-<L58>:
-               	bl	 <L58>
+<L74>:
+               	bl	 <L74>
                	add	x1, x20, x22, lsl #3
                	ldr	x2, [x1]
                	mov	x1, x2
-<L59>:
-               	bl	 <L59>
+<L75>:
+               	bl	 <L75>
                	add	x22, x22, #0x1
                	mov	x21, x0
                	cmp	x22, #0x4
-               	b.lo	 <L57>
-<L60>:
+               	b.lo	 <L73>
+<L76>:
                	mov	x0, x21
                	ldp	x19, x20, [x29, #-0x10]
                	ldp	x21, x22, [x29, #-0x20]

--- a/test/golden/aarch64-darwin/float/cmp_f32.dis
+++ b/test/golden/aarch64-darwin/float/cmp_f32.dis
@@ -227,8 +227,8 @@ Disassembly of section __TEXT,__text:
                	fcmp	s8, s9
                	cset	w1, mi
                	uxtb	w17, w1
-               	cmp	w17, #0x0
-               	cset	w2, eq
+               	cmp	w17, #0x1
+               	cset	w2, ne
                	mov	x1, x2
 <L27>:
                	bl	 <L27>

--- a/test/golden/aarch64-darwin/float/cmp_f64.dis
+++ b/test/golden/aarch64-darwin/float/cmp_f64.dis
@@ -235,8 +235,8 @@ Disassembly of section __TEXT,__text:
                	fcmp	d8, d9
                	cset	w1, mi
                	uxtb	w17, w1
-               	cmp	w17, #0x0
-               	cset	w2, eq
+               	cmp	w17, #0x1
+               	cset	w2, ne
                	mov	x1, x2
 <L27>:
                	bl	 <L27>

--- a/test/golden/aarch64-darwin/float/special_f32.dis
+++ b/test/golden/aarch64-darwin/float/special_f32.dis
@@ -221,1084 +221,288 @@ Disassembly of section __TEXT,__text:
                	mov	x20, x0
 <L32>:
                	fsub	s0, s11, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L34>
                	mov	x0, x20
 <L33>:
                	bl	 <L33>
-               	mov	x19, x0
-               	b	 <L36>
+               	fsub	s0, s11, s11
 <L34>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L34>
+               	fmul	s0, s10, s8
 <L35>:
                	bl	 <L35>
-               	mov	x19, x0
+               	fmul	s0, s10, s9
 <L36>:
-               	fsub	s0, s11, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L38>
-               	mov	x0, x19
+               	bl	 <L36>
+               	fmul	s0, s11, s8
 <L37>:
                	bl	 <L37>
-               	mov	x20, x0
-               	b	 <L40>
+               	fmul	s0, s11, s9
 <L38>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L38>
+               	fmul	s0, s11, s11
 <L39>:
                	bl	 <L39>
-               	mov	x20, x0
+               	fmul	s0, s10, s11
 <L40>:
-               	fmul	s0, s10, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L42>
-               	mov	x0, x20
+               	bl	 <L40>
+               	fneg	s0, s10
 <L41>:
                	bl	 <L41>
-               	mov	x19, x0
-               	b	 <L44>
+               	fneg	s0, s11
 <L42>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
+               	bl	 <L42>
+               	fdiv	s0, s10, s8
 <L43>:
                	bl	 <L43>
-               	mov	x19, x0
+               	fdiv	s0, s10, s9
 <L44>:
-               	fmul	s0, s10, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L46>
-               	mov	x0, x19
+               	bl	 <L44>
+               	fdiv	s0, s11, s8
 <L45>:
                	bl	 <L45>
-               	mov	x20, x0
-               	b	 <L48>
-<L46>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L47>:
-               	bl	 <L47>
-               	mov	x20, x0
-<L48>:
-               	fmul	s0, s11, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L50>
-               	mov	x0, x20
-<L49>:
-               	bl	 <L49>
-               	mov	x19, x0
-               	b	 <L52>
-<L50>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L51>:
-               	bl	 <L51>
-               	mov	x19, x0
-<L52>:
-               	fmul	s0, s11, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L54>
-               	mov	x0, x19
-<L53>:
-               	bl	 <L53>
-               	mov	x20, x0
-               	b	 <L56>
-<L54>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L55>:
-               	bl	 <L55>
-               	mov	x20, x0
-<L56>:
-               	fmul	s0, s11, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L58>
-               	mov	x0, x20
-<L57>:
-               	bl	 <L57>
-               	mov	x19, x0
-               	b	 <L60>
-<L58>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L59>:
-               	bl	 <L59>
-               	mov	x19, x0
-<L60>:
-               	fmul	s0, s10, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L62>
-               	mov	x0, x19
-<L61>:
-               	bl	 <L61>
-               	mov	x20, x0
-               	b	 <L64>
-<L62>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L63>:
-               	bl	 <L63>
-               	mov	x20, x0
-<L64>:
-               	fneg	s0, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L66>
-               	mov	x0, x20
-<L65>:
-               	bl	 <L65>
-               	mov	x19, x0
-               	b	 <L68>
-<L66>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L67>:
-               	bl	 <L67>
-               	mov	x19, x0
-<L68>:
-               	fneg	s0, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L70>
-               	mov	x0, x19
-<L69>:
-               	bl	 <L69>
-               	mov	x20, x0
-               	b	 <L72>
-<L70>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L71>:
-               	bl	 <L71>
-               	mov	x20, x0
-<L72>:
-               	fdiv	s0, s10, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L74>
-               	mov	x0, x20
-<L73>:
-               	bl	 <L73>
-               	mov	x19, x0
-               	b	 <L76>
-<L74>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L75>:
-               	bl	 <L75>
-               	mov	x19, x0
-<L76>:
-               	fdiv	s0, s10, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L78>
-               	mov	x0, x19
-<L77>:
-               	bl	 <L77>
-               	mov	x20, x0
-               	b	 <L80>
-<L78>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L79>:
-               	bl	 <L79>
-               	mov	x20, x0
-<L80>:
-               	fdiv	s0, s11, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L82>
-               	mov	x0, x20
-<L81>:
-               	bl	 <L81>
-               	mov	x19, x0
-               	b	 <L84>
-<L82>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L83>:
-               	bl	 <L83>
-               	mov	x19, x0
-<L84>:
                	fdiv	s0, s11, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L86>
-               	mov	x0, x19
-<L85>:
-               	bl	 <L85>
-               	mov	x20, x0
-               	b	 <L88>
-<L86>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L87>:
-               	bl	 <L87>
-               	mov	x20, x0
-<L88>:
+<L46>:
+               	bl	 <L46>
                	fcmp	s10, s11
                	cset	w1, eq
-               	mov	x0, x20
-<L89>:
-               	bl	 <L89>
+<L47>:
+               	bl	 <L47>
                	fcmp	s10, s11
                	cset	w1, mi
-<L90>:
-               	bl	 <L90>
+<L48>:
+               	bl	 <L48>
                	fcmp	s11, s10
                	cset	w1, mi
-<L91>:
-               	bl	 <L91>
-               	mov	x19, x0
-               	fcmp	s12, s12
-               	cset	w0, ne
-               	cbnz	w0,  <L93>
-               	mov	x0, x19
+<L49>:
+               	bl	 <L49>
                	fmov	s0, s12
-<L92>:
-               	bl	 <L92>
-               	mov	x20, x0
-               	b	 <L95>
-<L93>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L94>:
-               	bl	 <L94>
-               	mov	x20, x0
-<L95>:
-               	fcmp	s13, s13
-               	cset	w0, ne
-               	cbnz	w0,  <L97>
-               	mov	x0, x20
+<L50>:
+               	bl	 <L50>
                	fmov	s0, s13
-<L96>:
-               	bl	 <L96>
-               	mov	x19, x0
-               	b	 <L99>
-<L97>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L98>:
-               	bl	 <L98>
-               	mov	x19, x0
-<L99>:
+<L51>:
+               	bl	 <L51>
                	fneg	s0, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L101>
-               	mov	x0, x19
-<L100>:
-               	bl	 <L100>
-               	mov	x20, x0
-               	b	 <L103>
-<L101>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L102>:
-               	bl	 <L102>
-               	mov	x20, x0
-<L103>:
+<L52>:
+               	bl	 <L52>
                	fdiv	s0, s8, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L105>
-               	mov	x0, x20
-<L104>:
-               	bl	 <L104>
-               	mov	x19, x0
-               	b	 <L107>
-<L105>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L106>:
-               	bl	 <L106>
-               	mov	x19, x0
-<L107>:
+<L53>:
+               	bl	 <L53>
                	fdiv	s0, s8, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L109>
-               	mov	x0, x19
-<L108>:
-               	bl	 <L108>
-               	mov	x20, x0
-               	b	 <L111>
-<L109>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L110>:
-               	bl	 <L110>
-               	mov	x20, x0
-<L111>:
+<L54>:
+               	bl	 <L54>
                	fdiv	s0, s9, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L113>
-               	mov	x0, x20
-<L112>:
-               	bl	 <L112>
-               	mov	x19, x0
-               	b	 <L115>
-<L113>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L114>:
-               	bl	 <L114>
-               	mov	x19, x0
-<L115>:
+<L55>:
+               	bl	 <L55>
                	fdiv	s0, s9, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L117>
-               	mov	x0, x19
-<L116>:
-               	bl	 <L116>
-               	mov	x20, x0
-               	b	 <L119>
-<L117>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L118>:
-               	bl	 <L118>
-               	mov	x20, x0
-<L119>:
+<L56>:
+               	bl	 <L56>
                	fadd	s0, s12, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L121>
-               	mov	x0, x20
-<L120>:
-               	bl	 <L120>
-               	mov	x19, x0
-               	b	 <L123>
-<L121>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L122>:
-               	bl	 <L122>
-               	mov	x19, x0
-<L123>:
+<L57>:
+               	bl	 <L57>
                	fadd	s0, s12, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L125>
-               	mov	x0, x19
-<L124>:
-               	bl	 <L124>
-               	mov	x20, x0
-               	b	 <L127>
-<L125>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L126>:
-               	bl	 <L126>
-               	mov	x20, x0
-<L127>:
+<L58>:
+               	bl	 <L58>
                	fsub	s0, s12, s13
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L129>
-               	mov	x0, x20
-<L128>:
-               	bl	 <L128>
-               	mov	x19, x0
-               	b	 <L131>
-<L129>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L130>:
-               	bl	 <L130>
-               	mov	x19, x0
-<L131>:
+<L59>:
+               	bl	 <L59>
                	fmul	s0, s12, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L133>
-               	mov	x0, x19
-<L132>:
-               	bl	 <L132>
-               	mov	x20, x0
-               	b	 <L135>
-<L133>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L134>:
-               	bl	 <L134>
-               	mov	x20, x0
-<L135>:
+<L60>:
+               	bl	 <L60>
                	fmul	s0, s12, s13
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L137>
-               	mov	x0, x20
-<L136>:
-               	bl	 <L136>
-               	mov	x19, x0
-               	b	 <L139>
-<L137>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L138>:
-               	bl	 <L138>
-               	mov	x19, x0
-<L139>:
+<L61>:
+               	bl	 <L61>
                	fmul	s0, s12, s9
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L141>
-               	mov	x0, x19
-<L140>:
-               	bl	 <L140>
-               	mov	x20, x0
-               	b	 <L143>
-<L141>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L142>:
-               	bl	 <L142>
-               	mov	x20, x0
-<L143>:
+<L62>:
+               	bl	 <L62>
                	fdiv	s0, s8, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L145>
-               	mov	x0, x20
-<L144>:
-               	bl	 <L144>
-               	mov	x19, x0
-               	b	 <L147>
-<L145>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L146>:
-               	bl	 <L146>
-               	mov	x19, x0
-<L147>:
+<L63>:
+               	bl	 <L63>
                	fdiv	s0, s9, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L149>
-               	mov	x0, x19
-<L148>:
-               	bl	 <L148>
-               	mov	x20, x0
-               	b	 <L151>
-<L149>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L150>:
-               	bl	 <L150>
-               	mov	x20, x0
-<L151>:
+<L64>:
+               	bl	 <L64>
                	fdiv	s0, s8, s13
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L153>
-               	mov	x0, x20
-<L152>:
-               	bl	 <L152>
-               	mov	x19, x0
-               	b	 <L155>
-<L153>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L154>:
-               	bl	 <L154>
-               	mov	x19, x0
-<L155>:
+<L65>:
+               	bl	 <L65>
                	fdiv	s0, s12, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L157>
-               	mov	x0, x19
-<L156>:
-               	bl	 <L156>
-               	mov	x20, x0
-               	b	 <L159>
-<L157>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L158>:
-               	bl	 <L158>
-               	mov	x20, x0
-<L159>:
+<L66>:
+               	bl	 <L66>
                	fadd	s0, s15, s15
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L161>
-               	mov	x0, x20
-<L160>:
-               	bl	 <L160>
-               	mov	x19, x0
-               	b	 <L163>
-<L161>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L162>:
-               	bl	 <L162>
-               	mov	x19, x0
-<L163>:
+<L67>:
+               	bl	 <L67>
                	fcmp	s15, s12
                	cset	w1, mi
-               	mov	x0, x19
-<L164>:
-               	bl	 <L164>
+<L68>:
+               	bl	 <L68>
                	fmov	s31, wzr
                	fsub	s0, s31, s15
                	fcmp	s13, s0
                	cset	w1, mi
-<L165>:
-               	bl	 <L165>
-               	mov	x19, x0
+<L69>:
+               	bl	 <L69>
                	fsub	s0, s12, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L167>
-               	mov	x0, x19
-<L166>:
-               	bl	 <L166>
-               	mov	x20, x0
-               	b	 <L169>
-<L167>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L168>:
-               	bl	 <L168>
-               	mov	x20, x0
-<L169>:
+<L70>:
+               	bl	 <L70>
                	fadd	s0, s13, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L171>
-               	mov	x0, x20
-<L170>:
-               	bl	 <L170>
-               	mov	x19, x0
-               	b	 <L173>
-<L171>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L172>:
-               	bl	 <L172>
-               	mov	x19, x0
-<L173>:
+<L71>:
+               	bl	 <L71>
                	fmul	s0, s12, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L175>
-               	mov	x0, x19
-<L174>:
-               	bl	 <L174>
-               	mov	x20, x0
-               	b	 <L177>
-<L175>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L176>:
-               	bl	 <L176>
-               	mov	x20, x0
-<L177>:
+<L72>:
+               	bl	 <L72>
                	fmul	s0, s13, s11
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L179>
-               	mov	x0, x20
-<L178>:
-               	bl	 <L178>
-               	mov	x19, x0
-               	b	 <L181>
-<L179>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L180>:
-               	bl	 <L180>
-               	mov	x19, x0
-<L181>:
+<L73>:
+               	bl	 <L73>
                	fdiv	s0, s12, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L183>
-               	mov	x0, x19
-<L182>:
-               	bl	 <L182>
-               	mov	x20, x0
-               	b	 <L185>
-<L183>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L184>:
-               	bl	 <L184>
-               	mov	x20, x0
-<L185>:
+<L74>:
+               	bl	 <L74>
                	fdiv	s0, s10, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L187>
-               	mov	x0, x20
-<L186>:
-               	bl	 <L186>
-               	mov	x19, x0
-               	b	 <L189>
-<L187>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L188>:
-               	bl	 <L188>
-               	mov	x19, x0
-<L189>:
+<L75>:
+               	bl	 <L75>
                	fdiv	s0, s11, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L191>
-               	mov	x0, x19
-<L190>:
-               	bl	 <L190>
-               	mov	x20, x0
-               	b	 <L193>
-<L191>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L192>:
-               	bl	 <L192>
-               	mov	x20, x0
-<L193>:
+<L76>:
+               	bl	 <L76>
                	fmov	w1, s14
-               	mov	x0, x20
-<L194>:
-               	bl	 <L194>
+<L77>:
+               	bl	 <L77>
                	fcmp	s14, s14
                	cset	w1, ne
-<L195>:
-               	bl	 <L195>
+<L78>:
+               	bl	 <L78>
                	fcmp	s14, s14
                	cset	w1, eq
-<L196>:
-               	bl	 <L196>
+<L79>:
+               	bl	 <L79>
                	fcmp	s14, s14
                	cset	w1, mi
-<L197>:
-               	bl	 <L197>
+<L80>:
+               	bl	 <L80>
                	fcmp	s14, s14
                	cset	w1, ls
-<L198>:
-               	bl	 <L198>
+<L81>:
+               	bl	 <L81>
                	fneg	s9, s14
                	fmov	w1, s9
-<L199>:
-               	bl	 <L199>
+<L82>:
+               	bl	 <L82>
                	fneg	s0, s9
                	fmov	w1, s0
-<L200>:
-               	bl	 <L200>
-               	mov	x19, x0
+<L83>:
+               	bl	 <L83>
                	fadd	s0, s14, s8
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L202>
-               	mov	x0, x19
-<L201>:
-               	bl	 <L201>
-               	mov	x20, x0
-               	b	 <L204>
-<L202>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L203>:
-               	bl	 <L203>
-               	mov	x20, x0
-<L204>:
+<L84>:
+               	bl	 <L84>
                	fadd	s0, s8, s14
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L206>
-               	mov	x0, x20
-<L205>:
-               	bl	 <L205>
-               	mov	x19, x0
-               	b	 <L208>
-<L206>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L207>:
-               	bl	 <L207>
-               	mov	x19, x0
-<L208>:
+<L85>:
+               	bl	 <L85>
                	fmul	s0, s14, s10
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L210>
-               	mov	x0, x19
-<L209>:
-               	bl	 <L209>
-               	mov	x20, x0
-               	b	 <L212>
-<L210>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L211>:
-               	bl	 <L211>
-               	mov	x20, x0
-<L212>:
+<L86>:
+               	bl	 <L86>
                	fsub	s0, s14, s14
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L214>
-               	mov	x0, x20
-<L213>:
-               	bl	 <L213>
-               	mov	x19, x0
-               	b	 <L216>
-<L214>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L215>:
-               	bl	 <L215>
-               	mov	x19, x0
-<L216>:
+<L87>:
+               	bl	 <L87>
                	fdiv	s0, s14, s14
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L218>
-               	mov	x0, x19
-<L217>:
-               	bl	 <L217>
-               	mov	x20, x0
-               	b	 <L220>
-<L218>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L219>:
-               	bl	 <L219>
-               	mov	x20, x0
-<L220>:
+<L88>:
+               	bl	 <L88>
                	fdiv	s0, s14, s12
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L222>
-               	mov	x0, x20
-<L221>:
-               	bl	 <L221>
-               	mov	x19, x0
-               	b	 <L224>
-<L222>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L223>:
-               	bl	 <L223>
-               	mov	x19, x0
-<L224>:
-               	ldur	s31, [x29, #-0x50]
-               	ldur	s30, [x29, #-0x50]
-               	fcmp	s31, s30
-               	cset	w0, ne
-               	cbnz	w0,  <L226>
-               	mov	x0, x19
+<L89>:
+               	bl	 <L89>
                	ldur	s0, [x29, #-0x50]
-<L225>:
-               	bl	 <L225>
-               	mov	x20, x0
-               	b	 <L228>
-<L226>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L227>:
-               	bl	 <L227>
-               	mov	x20, x0
-<L228>:
-               	ldur	s31, [x29, #-0x40]
-               	ldur	s30, [x29, #-0x40]
-               	fcmp	s31, s30
-               	cset	w0, ne
-               	cbnz	w0,  <L230>
-               	mov	x0, x20
+<L90>:
+               	bl	 <L90>
                	ldur	s0, [x29, #-0x40]
-<L229>:
-               	bl	 <L229>
-               	mov	x19, x0
-               	b	 <L232>
-<L230>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L231>:
-               	bl	 <L231>
-               	mov	x19, x0
-<L232>:
-               	ldur	s31, [x29, #-0x30]
-               	ldur	s30, [x29, #-0x30]
-               	fcmp	s31, s30
-               	cset	w0, ne
-               	cbnz	w0,  <L234>
-               	mov	x0, x19
+<L91>:
+               	bl	 <L91>
                	ldur	s0, [x29, #-0x30]
-<L233>:
-               	bl	 <L233>
-               	mov	x20, x0
-               	b	 <L236>
-<L234>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L235>:
-               	bl	 <L235>
-               	mov	x20, x0
-<L236>:
+<L92>:
+               	bl	 <L92>
                	ldur	s31, [x29, #-0x40]
                	ldur	s30, [x29, #-0x50]
                	fadd	s0, s31, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L238>
-               	mov	x0, x20
-<L237>:
-               	bl	 <L237>
-               	mov	x19, x0
-               	b	 <L240>
-<L238>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L239>:
-               	bl	 <L239>
-               	mov	x19, x0
-<L240>:
+<L93>:
+               	bl	 <L93>
                	ldur	s31, [x29, #-0x30]
                	ldur	s30, [x29, #-0x50]
                	fsub	s0, s31, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L242>
-               	mov	x0, x19
-<L241>:
-               	bl	 <L241>
-               	mov	x20, x0
-               	b	 <L244>
-<L242>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L243>:
-               	bl	 <L243>
-               	mov	x20, x0
-<L244>:
+<L94>:
+               	bl	 <L94>
                	ldur	s31, [x29, #-0x50]
                	ldur	s30, [x29, #-0x50]
                	fadd	s0, s31, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L246>
-               	mov	x0, x20
-<L245>:
-               	bl	 <L245>
-               	mov	x19, x0
-               	b	 <L248>
-<L246>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L247>:
-               	bl	 <L247>
-               	mov	x19, x0
-<L248>:
+<L95>:
+               	bl	 <L95>
                	ldur	s31, [x29, #-0x50]
                	fmov	s30, #1.50000000
                	fmul	s0, s31, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L250>
-               	mov	x0, x19
-<L249>:
-               	bl	 <L249>
-               	mov	x20, x0
-               	b	 <L252>
-<L250>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L251>:
-               	bl	 <L251>
-               	mov	x20, x0
-<L252>:
+<L96>:
+               	bl	 <L96>
                	ldur	s31, [x29, #-0x50]
                	fmov	s30, #0.50000000
                	fmul	s0, s31, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L254>
-               	mov	x0, x20
-<L253>:
-               	bl	 <L253>
-               	mov	x19, x0
-               	b	 <L256>
-<L254>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L255>:
-               	bl	 <L255>
-               	mov	x19, x0
-<L256>:
+<L97>:
+               	bl	 <L97>
                	ldur	s31, [x29, #-0x50]
                	fneg	s0, s31
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L258>
-               	mov	x0, x19
-<L257>:
-               	bl	 <L257>
-               	mov	x20, x0
-               	b	 <L260>
-<L258>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L259>:
-               	bl	 <L259>
-               	mov	x20, x0
-<L260>:
+<L98>:
+               	bl	 <L98>
                	ldur	s31, [x29, #-0x50]
                	mov	w16, #0x4b000000        ; =1258291200
                	fmov	s30, w16
                	fmul	s0, s31, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L262>
-               	mov	x0, x20
-<L261>:
-               	bl	 <L261>
-               	mov	x19, x0
-               	b	 <L264>
-<L262>:
-               	mov	x0, x20
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L263>:
-               	bl	 <L263>
-               	mov	x19, x0
-<L264>:
+<L99>:
+               	bl	 <L99>
                	ldur	s31, [x29, #-0x40]
                	ldur	s30, [x29, #-0x30]
                	fdiv	s0, s31, s30
-               	fcmp	s0, s0
-               	cset	w0, ne
-               	cbnz	w0,  <L266>
-               	mov	x0, x19
-<L265>:
-               	bl	 <L265>
-               	mov	x20, x0
-               	b	 <L268>
-<L266>:
-               	mov	x0, x19
-               	mov	w1, #0xffff             ; =65535
-               	movk	w1, #0xffff, lsl #16
-<L267>:
-               	bl	 <L267>
-               	mov	x20, x0
-<L268>:
+<L100>:
+               	bl	 <L100>
                	ldur	s30, [x29, #-0x50]
                	fcmp	s10, s30
                	cset	w1, mi
-               	mov	x0, x20
-<L269>:
-               	bl	 <L269>
+<L101>:
+               	bl	 <L101>
                	ldur	s31, [x29, #-0x50]
                	fcmp	s31, s10
                	cset	w1, eq
-<L270>:
-               	bl	 <L270>
+<L102>:
+               	bl	 <L102>
                	fmov	s31, wzr
                	ldur	s30, [x29, #-0x50]
                	fsub	s0, s31, s30
                	fcmp	s0, s11
                	cset	w1, mi
-<L271>:
-               	bl	 <L271>
+<L103>:
+               	bl	 <L103>
                	mov	x19, x0
                	ldur	d9, [x29, #-0x30]
                	mov	w20, #0x0               ; =0
                	cmp	w20, #0x1e
-               	b.lo	 <L272>
-               	b	 <L277>
-<L272>:
+               	b.lo	 <L104>
+               	b	 <L109>
+<L104>:
                	fmov	s30, #0.50000000
                	fmul	s11, s9, s30
                	fcmp	s11, s11
                	cset	w0, ne
-               	cbnz	w0,  <L274>
+               	cbnz	w0,  <L106>
                	mov	x0, x19
                	fmov	s0, s11
-<L273>:
-               	bl	 <L273>
+<L105>:
+               	bl	 <L105>
                	mov	x22, x0
-               	b	 <L276>
-<L274>:
+               	b	 <L108>
+<L106>:
                	mov	x0, x19
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L275>:
-               	bl	 <L275>
+<L107>:
+               	bl	 <L107>
                	mov	x22, x0
-<L276>:
+<L108>:
                	add	w20, w20, #0x1
                	mov	x19, x22
                	fmov	d9, d11
                	cmp	w20, #0x1e
-               	b.lo	 <L272>
-<L277>:
+               	b.lo	 <L104>
+<L109>:
                	sub	x20, x29, #0x20
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -1312,7 +516,6 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x8
                	mov	w17, #0x1               ; =1
                	str	w17, [x0]
-<L278>:
                	add	x0, x20, #0xc
                	mov	w17, #0x7f800000        ; =2139095040
                	str	w17, [x0]
@@ -1332,9 +535,9 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x0]
                	mov	w22, #0x0               ; =0
                	cmp	w22, #0x8
-               	b.lo	 <L279>
-               	b	 <L281>
-<L279>:
+               	b.lo	 <L110>
+               	b	 <L112>
+<L110>:
                	mov	w0, w22
                	add	x1, x20, x0, lsl #2
                	ldr	w0, [x1]
@@ -1342,13 +545,13 @@ Disassembly of section __TEXT,__text:
                	fmov	s0, w1
                	fmov	w1, s0
                	mov	x0, x19
-<L280>:
-               	bl	 <L280>
+<L111>:
+               	bl	 <L111>
                	add	w22, w22, #0x1
                	mov	x19, x0
                	cmp	w22, #0x8
-               	b.lo	 <L279>
-<L281>:
+               	b.lo	 <L110>
+<L112>:
                	mov	w17, #0x1000000         ; =16777216
                	add	w0, w17, w21
                	mov	w17, #0x1               ; =1
@@ -1368,128 +571,128 @@ Disassembly of section __TEXT,__text:
                	ucvtf	s0, w0
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L283>
+               	cbnz	w0,  <L114>
                	mov	x0, x19
-<L282>:
-               	bl	 <L282>
+<L113>:
+               	bl	 <L113>
                	mov	x26, x0
-               	b	 <L285>
-<L283>:
+               	b	 <L116>
+<L114>:
                	mov	x0, x19
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L284>:
-               	bl	 <L284>
+<L115>:
+               	bl	 <L115>
                	mov	x26, x0
-<L285>:
+<L116>:
                	ucvtf	s0, w20
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L287>
+               	cbnz	w0,  <L118>
                	mov	x0, x26
-<L286>:
-               	bl	 <L286>
+<L117>:
+               	bl	 <L117>
                	mov	x19, x0
-               	b	 <L289>
-<L287>:
+               	b	 <L120>
+<L118>:
                	mov	x0, x26
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L288>:
-               	bl	 <L288>
+<L119>:
+               	bl	 <L119>
                	mov	x19, x0
-<L289>:
+<L120>:
                	ucvtf	s0, w22
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L291>
+               	cbnz	w0,  <L122>
                	mov	x0, x19
-<L290>:
-               	bl	 <L290>
+<L121>:
+               	bl	 <L121>
                	mov	x20, x0
-               	b	 <L293>
-<L291>:
+               	b	 <L124>
+<L122>:
                	mov	x0, x19
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L292>:
-               	bl	 <L292>
+<L123>:
+               	bl	 <L123>
                	mov	x20, x0
-<L293>:
+<L124>:
                	ucvtf	s0, w23
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L295>
+               	cbnz	w0,  <L126>
                	mov	x0, x20
-<L294>:
-               	bl	 <L294>
+<L125>:
+               	bl	 <L125>
                	mov	x19, x0
-               	b	 <L297>
-<L295>:
+               	b	 <L128>
+<L126>:
                	mov	x0, x20
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L296>:
-               	bl	 <L296>
+<L127>:
+               	bl	 <L127>
                	mov	x19, x0
-<L297>:
+<L128>:
                	ucvtf	s0, w21
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L299>
+               	cbnz	w0,  <L130>
                	mov	x0, x19
-<L298>:
-               	bl	 <L298>
+<L129>:
+               	bl	 <L129>
                	mov	x20, x0
-               	b	 <L301>
-<L299>:
+               	b	 <L132>
+<L130>:
                	mov	x0, x19
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L300>:
-               	bl	 <L300>
+<L131>:
+               	bl	 <L131>
                	mov	x20, x0
-<L301>:
+<L132>:
                	scvtf	s0, w24
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L303>
+               	cbnz	w0,  <L134>
                	mov	x0, x20
-<L302>:
-               	bl	 <L302>
+<L133>:
+               	bl	 <L133>
                	mov	x19, x0
-               	b	 <L305>
-<L303>:
+               	b	 <L136>
+<L134>:
                	mov	x0, x20
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L304>:
-               	bl	 <L304>
+<L135>:
+               	bl	 <L135>
                	mov	x19, x0
-<L305>:
+<L136>:
                	scvtf	s0, w25
                	fcmp	s0, s0
                	cset	w0, ne
-               	cbnz	w0,  <L307>
+               	cbnz	w0,  <L138>
                	mov	x0, x19
-<L306>:
-               	bl	 <L306>
+<L137>:
+               	bl	 <L137>
                	mov	x20, x0
-               	b	 <L309>
-<L307>:
+               	b	 <L140>
+<L138>:
                	mov	x0, x19
                	mov	w1, #0xffff             ; =65535
                	movk	w1, #0xffff, lsl #16
-<L308>:
-               	bl	 <L308>
+<L139>:
+               	bl	 <L139>
                	mov	x20, x0
-<L309>:
+<L140>:
                	fmov	s31, #1.50000000
                	fmul	s0, s31, s8
                	mov	w16, #0x4b800000        ; =1266679808
                	fmov	s31, w16
                	fmul	s9, s31, s8
-               	adrp	x16, 0x1000 <L278>
+               	adrp	x16, 0x0 <corpus.cases.float.special_f32.opaque_f32>
                	ldr	s31, [x16]
                	fmul	s11, s31, s8
                	fmov	s31, wzr
@@ -1498,39 +701,39 @@ Disassembly of section __TEXT,__text:
                	fmul	s13, s31, s8
                	fcvtzu	w1, s0
                	mov	x0, x20
-<L310>:
-               	bl	 <L310>
+<L141>:
+               	bl	 <L141>
                	fcvtzu	w1, s9
-<L311>:
-               	bl	 <L311>
+<L142>:
+               	bl	 <L142>
                	fcvtzu	w1, s11
-<L312>:
-               	bl	 <L312>
+<L143>:
+               	bl	 <L143>
                	fcvtzu	w1, s13
-<L313>:
-               	bl	 <L313>
+<L144>:
+               	bl	 <L144>
                	fcvtzu	w1, s10
-<L314>:
-               	bl	 <L314>
+<L145>:
+               	bl	 <L145>
                	fcvtzs	w1, s12
-<L315>:
-               	bl	 <L315>
+<L146>:
+               	bl	 <L146>
                	fcvtzs	w1, s11
-<L316>:
-               	bl	 <L316>
+<L147>:
+               	bl	 <L147>
                	fmov	s31, wzr
                	fsub	s0, s31, s13
                	fcvtzs	w1, s0
-<L317>:
-               	bl	 <L317>
+<L148>:
+               	bl	 <L148>
                	fcvtzs	x1, s12
-<L318>:
-               	bl	 <L318>
+<L149>:
+               	bl	 <L149>
                	fmov	s31, wzr
                	fsub	s0, s31, s9
                	fcvtzs	x1, s0
-<L319>:
-               	bl	 <L319>
+<L150>:
+               	bl	 <L150>
                	ldp	d8, d9, [x29, #-0xa0]
                	ldp	d10, d11, [x29, #-0xb0]
                	ldp	d12, d13, [x29, #-0xc0]

--- a/test/golden/aarch64-darwin/float/special_f64.dis
+++ b/test/golden/aarch64-darwin/float/special_f64.dis
@@ -185,1255 +185,299 @@ Disassembly of section __TEXT,__text:
                	mov	x21, x0
 <L20>:
                	fadd	d0, d11, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L22>
                	mov	x0, x21
 <L21>:
                	bl	 <L21>
-               	mov	x20, x0
-               	b	 <L24>
+               	fsub	d0, d10, d10
 <L22>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L22>
+               	fsub	d0, d10, d11
 <L23>:
                	bl	 <L23>
-               	mov	x20, x0
+               	fsub	d0, d11, d10
 <L24>:
-               	fsub	d0, d10, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L26>
-               	mov	x0, x20
+               	bl	 <L24>
+               	fsub	d0, d11, d11
 <L25>:
                	bl	 <L25>
-               	mov	x21, x0
-               	b	 <L28>
+               	fmul	d0, d10, d8
 <L26>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L26>
+               	fmul	d0, d10, d9
 <L27>:
                	bl	 <L27>
-               	mov	x21, x0
+               	fmul	d0, d11, d8
 <L28>:
-               	fsub	d0, d10, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L30>
-               	mov	x0, x21
+               	bl	 <L28>
+               	fmul	d0, d11, d9
 <L29>:
                	bl	 <L29>
-               	mov	x20, x0
-               	b	 <L32>
+               	fmul	d0, d11, d11
 <L30>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L30>
+               	fmul	d0, d10, d11
 <L31>:
                	bl	 <L31>
-               	mov	x20, x0
+               	fneg	d0, d10
 <L32>:
-               	fsub	d0, d11, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L34>
-               	mov	x0, x20
+               	bl	 <L32>
+               	fneg	d0, d11
 <L33>:
                	bl	 <L33>
-               	mov	x21, x0
-               	b	 <L36>
+               	fdiv	d0, d10, d8
 <L34>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L34>
+               	fdiv	d0, d10, d9
 <L35>:
                	bl	 <L35>
-               	mov	x21, x0
+               	fdiv	d0, d11, d8
 <L36>:
-               	fsub	d0, d11, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L38>
-               	mov	x0, x21
+               	bl	 <L36>
+               	fdiv	d0, d11, d9
 <L37>:
                	bl	 <L37>
-               	mov	x20, x0
-               	b	 <L40>
-<L38>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L39>:
-               	bl	 <L39>
-               	mov	x20, x0
-<L40>:
-               	fmul	d0, d10, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L42>
-               	mov	x0, x20
-<L41>:
-               	bl	 <L41>
-               	mov	x21, x0
-               	b	 <L44>
-<L42>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L43>:
-               	bl	 <L43>
-               	mov	x21, x0
-<L44>:
-               	fmul	d0, d10, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L46>
-               	mov	x0, x21
-<L45>:
-               	bl	 <L45>
-               	mov	x20, x0
-               	b	 <L48>
-<L46>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L47>:
-               	bl	 <L47>
-               	mov	x20, x0
-<L48>:
-               	fmul	d0, d11, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L50>
-               	mov	x0, x20
-<L49>:
-               	bl	 <L49>
-               	mov	x21, x0
-               	b	 <L52>
-<L50>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L51>:
-               	bl	 <L51>
-               	mov	x21, x0
-<L52>:
-               	fmul	d0, d11, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L54>
-               	mov	x0, x21
-<L53>:
-               	bl	 <L53>
-               	mov	x20, x0
-               	b	 <L56>
-<L54>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L55>:
-               	bl	 <L55>
-               	mov	x20, x0
-<L56>:
-               	fmul	d0, d11, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L58>
-               	mov	x0, x20
-<L57>:
-               	bl	 <L57>
-               	mov	x21, x0
-               	b	 <L60>
-<L58>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L59>:
-               	bl	 <L59>
-               	mov	x21, x0
-<L60>:
-               	fmul	d0, d10, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L62>
-               	mov	x0, x21
-<L61>:
-               	bl	 <L61>
-               	mov	x20, x0
-               	b	 <L64>
-<L62>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L63>:
-               	bl	 <L63>
-               	mov	x20, x0
-<L64>:
-               	fneg	d0, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L66>
-               	mov	x0, x20
-<L65>:
-               	bl	 <L65>
-               	mov	x21, x0
-               	b	 <L68>
-<L66>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L67>:
-               	bl	 <L67>
-               	mov	x21, x0
-<L68>:
-               	fneg	d0, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L70>
-               	mov	x0, x21
-<L69>:
-               	bl	 <L69>
-               	mov	x20, x0
-               	b	 <L72>
-<L70>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L71>:
-               	bl	 <L71>
-               	mov	x20, x0
-<L72>:
-               	fdiv	d0, d10, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L74>
-               	mov	x0, x20
-<L73>:
-               	bl	 <L73>
-               	mov	x21, x0
-               	b	 <L76>
-<L74>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L75>:
-               	bl	 <L75>
-               	mov	x21, x0
-<L76>:
-               	fdiv	d0, d10, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L78>
-               	mov	x0, x21
-<L77>:
-               	bl	 <L77>
-               	mov	x20, x0
-               	b	 <L80>
-<L78>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L79>:
-               	bl	 <L79>
-               	mov	x20, x0
-<L80>:
-               	fdiv	d0, d11, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L82>
-               	mov	x0, x20
-<L81>:
-               	bl	 <L81>
-               	mov	x21, x0
-               	b	 <L84>
-<L82>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L83>:
-               	bl	 <L83>
-               	mov	x21, x0
-<L84>:
-               	fdiv	d0, d11, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L86>
-               	mov	x0, x21
-<L85>:
-               	bl	 <L85>
-               	mov	x20, x0
-               	b	 <L88>
-<L86>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L87>:
-               	bl	 <L87>
-               	mov	x20, x0
-<L88>:
                	fcmp	d10, d11
                	cset	w1, eq
-               	mov	x0, x20
-<L89>:
-               	bl	 <L89>
+<L38>:
+               	bl	 <L38>
                	fcmp	d10, d11
                	cset	w1, mi
-<L90>:
-               	bl	 <L90>
+<L39>:
+               	bl	 <L39>
                	fcmp	d11, d10
                	cset	w1, mi
+<L40>:
+               	bl	 <L40>
+               	fmov	d0, d12
+<L41>:
+               	bl	 <L41>
+               	fmov	d0, d13
+<L42>:
+               	bl	 <L42>
+               	fneg	d0, d12
+<L43>:
+               	bl	 <L43>
+               	fdiv	d0, d8, d10
+<L44>:
+               	bl	 <L44>
+               	fdiv	d0, d8, d11
+<L45>:
+               	bl	 <L45>
+               	fdiv	d0, d9, d10
+<L46>:
+               	bl	 <L46>
+               	fdiv	d0, d9, d11
+<L47>:
+               	bl	 <L47>
+               	fadd	d0, d12, d8
+<L48>:
+               	bl	 <L48>
+               	fadd	d0, d12, d12
+<L49>:
+               	bl	 <L49>
+               	fsub	d0, d12, d13
+<L50>:
+               	bl	 <L50>
+               	fmul	d0, d12, d12
+<L51>:
+               	bl	 <L51>
+               	fmul	d0, d12, d13
+<L52>:
+               	bl	 <L52>
+               	fmul	d0, d12, d9
+<L53>:
+               	bl	 <L53>
+               	fdiv	d0, d8, d12
+<L54>:
+               	bl	 <L54>
+               	fdiv	d0, d9, d12
+<L55>:
+               	bl	 <L55>
+               	fdiv	d0, d8, d13
+<L56>:
+               	bl	 <L56>
+               	fdiv	d0, d12, d8
+<L57>:
+               	bl	 <L57>
+               	fadd	d0, d15, d15
+<L58>:
+               	bl	 <L58>
+               	fcmp	d15, d12
+               	cset	w1, mi
+<L59>:
+               	bl	 <L59>
+               	fmov	d31, xzr
+               	fsub	d0, d31, d15
+               	fcmp	d13, d0
+               	cset	w1, mi
+<L60>:
+               	bl	 <L60>
+               	fsub	d0, d12, d12
+<L61>:
+               	bl	 <L61>
+               	fadd	d0, d13, d12
+<L62>:
+               	bl	 <L62>
+               	fmul	d0, d12, d10
+<L63>:
+               	bl	 <L63>
+               	fmul	d0, d13, d11
+<L64>:
+               	bl	 <L64>
+               	fdiv	d0, d12, d12
+<L65>:
+               	bl	 <L65>
+               	fdiv	d0, d10, d10
+<L66>:
+               	bl	 <L66>
+               	fdiv	d0, d11, d10
+<L67>:
+               	bl	 <L67>
+               	fmov	x1, d14
+<L68>:
+               	bl	 <L68>
+               	fcmp	d14, d14
+               	cset	w1, ne
+<L69>:
+               	bl	 <L69>
+               	fcmp	d14, d14
+               	cset	w1, eq
+<L70>:
+               	bl	 <L70>
+               	fcmp	d14, d14
+               	cset	w1, mi
+<L71>:
+               	bl	 <L71>
+               	fcmp	d14, d14
+               	cset	w1, ls
+<L72>:
+               	bl	 <L72>
+               	fneg	d9, d14
+               	fmov	x1, d9
+<L73>:
+               	bl	 <L73>
+               	fneg	d0, d9
+               	fmov	x1, d0
+<L74>:
+               	bl	 <L74>
+               	fadd	d0, d14, d8
+<L75>:
+               	bl	 <L75>
+               	fadd	d0, d8, d14
+<L76>:
+               	bl	 <L76>
+               	fmul	d0, d14, d10
+<L77>:
+               	bl	 <L77>
+               	fsub	d0, d14, d14
+<L78>:
+               	bl	 <L78>
+               	fdiv	d0, d14, d14
+<L79>:
+               	bl	 <L79>
+               	fdiv	d0, d14, d12
+<L80>:
+               	bl	 <L80>
+               	ldur	d0, [x29, #-0x70]
+<L81>:
+               	bl	 <L81>
+               	ldur	d0, [x29, #-0x60]
+<L82>:
+               	bl	 <L82>
+               	ldur	d0, [x29, #-0x50]
+<L83>:
+               	bl	 <L83>
+               	ldur	d31, [x29, #-0x60]
+               	ldur	d30, [x29, #-0x70]
+               	fadd	d0, d31, d30
+<L84>:
+               	bl	 <L84>
+               	ldur	d31, [x29, #-0x50]
+               	ldur	d30, [x29, #-0x70]
+               	fsub	d0, d31, d30
+<L85>:
+               	bl	 <L85>
+               	ldur	d31, [x29, #-0x70]
+               	ldur	d30, [x29, #-0x70]
+               	fadd	d0, d31, d30
+<L86>:
+               	bl	 <L86>
+               	ldur	d31, [x29, #-0x70]
+               	fmov	d30, #1.50000000
+               	fmul	d0, d31, d30
+<L87>:
+               	bl	 <L87>
+               	ldur	d31, [x29, #-0x70]
+               	fmov	d30, #0.50000000
+               	fmul	d0, d31, d30
+<L88>:
+               	bl	 <L88>
+               	ldur	d31, [x29, #-0x70]
+               	fneg	d0, d31
+<L89>:
+               	bl	 <L89>
+               	ldur	d31, [x29, #-0x70]
+               	mov	x16, #0x4330000000000000 ; =4841369599423283200
+               	fmov	d30, x16
+               	fmul	d0, d31, d30
+<L90>:
+               	bl	 <L90>
+               	ldur	d31, [x29, #-0x60]
+               	ldur	d30, [x29, #-0x50]
+               	fdiv	d0, d31, d30
 <L91>:
                	bl	 <L91>
-               	mov	x20, x0
-               	fcmp	d12, d12
-               	cset	w0, ne
-               	cbnz	w0,  <L93>
-               	mov	x0, x20
-               	fmov	d0, d12
+               	ldur	d30, [x29, #-0x70]
+               	fcmp	d10, d30
+               	cset	w1, mi
 <L92>:
                	bl	 <L92>
-               	mov	x21, x0
-               	b	 <L95>
+               	ldur	d31, [x29, #-0x70]
+               	fcmp	d31, d10
+               	cset	w1, eq
 <L93>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
+               	bl	 <L93>
+               	fmov	d31, xzr
+               	ldur	d30, [x29, #-0x70]
+               	fsub	d0, d31, d30
+               	fcmp	d0, d11
+               	cset	w1, mi
 <L94>:
                	bl	 <L94>
-               	mov	x21, x0
+               	mov	x20, x0
+               	ldur	d9, [x29, #-0x50]
+               	mov	x21, #0x0               ; =0
+               	cmp	x21, #0x3c
+               	b.lo	 <L95>
+               	b	 <L100>
 <L95>:
-               	fcmp	d13, d13
+               	fmov	d30, #0.50000000
+               	fmul	d12, d9, d30
+               	fcmp	d12, d12
                	cset	w0, ne
                	cbnz	w0,  <L97>
-               	mov	x0, x21
-               	fmov	d0, d13
+               	mov	x0, x20
+               	fmov	d0, d12
 <L96>:
                	bl	 <L96>
-               	mov	x20, x0
+               	mov	x22, x0
                	b	 <L99>
 <L97>:
-               	mov	x0, x21
+               	mov	x0, x20
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
 <L98>:
                	bl	 <L98>
-               	mov	x20, x0
+               	mov	x22, x0
 <L99>:
-               	fneg	d0, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L101>
-               	mov	x0, x20
-<L100>:
-               	bl	 <L100>
-               	mov	x21, x0
-               	b	 <L103>
-<L101>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L102>:
-               	bl	 <L102>
-               	mov	x21, x0
-<L103>:
-               	fdiv	d0, d8, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L105>
-               	mov	x0, x21
-<L104>:
-               	bl	 <L104>
-               	mov	x20, x0
-               	b	 <L107>
-<L105>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L106>:
-               	bl	 <L106>
-               	mov	x20, x0
-<L107>:
-               	fdiv	d0, d8, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L109>
-               	mov	x0, x20
-<L108>:
-               	bl	 <L108>
-               	mov	x21, x0
-               	b	 <L111>
-<L109>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L110>:
-               	bl	 <L110>
-               	mov	x21, x0
-<L111>:
-               	fdiv	d0, d9, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L113>
-               	mov	x0, x21
-<L112>:
-               	bl	 <L112>
-               	mov	x20, x0
-               	b	 <L115>
-<L113>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L114>:
-               	bl	 <L114>
-               	mov	x20, x0
-<L115>:
-               	fdiv	d0, d9, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L117>
-               	mov	x0, x20
-<L116>:
-               	bl	 <L116>
-               	mov	x21, x0
-               	b	 <L119>
-<L117>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L118>:
-               	bl	 <L118>
-               	mov	x21, x0
-<L119>:
-               	fadd	d0, d12, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L121>
-               	mov	x0, x21
-<L120>:
-               	bl	 <L120>
-               	mov	x20, x0
-               	b	 <L123>
-<L121>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L122>:
-               	bl	 <L122>
-               	mov	x20, x0
-<L123>:
-               	fadd	d0, d12, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L125>
-               	mov	x0, x20
-<L124>:
-               	bl	 <L124>
-               	mov	x21, x0
-               	b	 <L127>
-<L125>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L126>:
-               	bl	 <L126>
-               	mov	x21, x0
-<L127>:
-               	fsub	d0, d12, d13
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L129>
-               	mov	x0, x21
-<L128>:
-               	bl	 <L128>
-               	mov	x20, x0
-               	b	 <L131>
-<L129>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L130>:
-               	bl	 <L130>
-               	mov	x20, x0
-<L131>:
-               	fmul	d0, d12, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L133>
-               	mov	x0, x20
-<L132>:
-               	bl	 <L132>
-               	mov	x21, x0
-               	b	 <L135>
-<L133>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L134>:
-               	bl	 <L134>
-               	mov	x21, x0
-<L135>:
-               	fmul	d0, d12, d13
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L137>
-               	mov	x0, x21
-<L136>:
-               	bl	 <L136>
-               	mov	x20, x0
-               	b	 <L139>
-<L137>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L138>:
-               	bl	 <L138>
-               	mov	x20, x0
-<L139>:
-               	fmul	d0, d12, d9
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L141>
-               	mov	x0, x20
-<L140>:
-               	bl	 <L140>
-               	mov	x21, x0
-               	b	 <L143>
-<L141>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L142>:
-               	bl	 <L142>
-               	mov	x21, x0
-<L143>:
-               	fdiv	d0, d8, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L145>
-               	mov	x0, x21
-<L144>:
-               	bl	 <L144>
-               	mov	x20, x0
-               	b	 <L147>
-<L145>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L146>:
-               	bl	 <L146>
-               	mov	x20, x0
-<L147>:
-               	fdiv	d0, d9, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L149>
-               	mov	x0, x20
-<L148>:
-               	bl	 <L148>
-               	mov	x21, x0
-               	b	 <L151>
-<L149>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L150>:
-               	bl	 <L150>
-               	mov	x21, x0
-<L151>:
-               	fdiv	d0, d8, d13
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L153>
-               	mov	x0, x21
-<L152>:
-               	bl	 <L152>
-               	mov	x20, x0
-               	b	 <L155>
-<L153>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L154>:
-               	bl	 <L154>
-               	mov	x20, x0
-<L155>:
-               	fdiv	d0, d12, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L157>
-               	mov	x0, x20
-<L156>:
-               	bl	 <L156>
-               	mov	x21, x0
-               	b	 <L159>
-<L157>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L158>:
-               	bl	 <L158>
-               	mov	x21, x0
-<L159>:
-               	fadd	d0, d15, d15
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L161>
-               	mov	x0, x21
-<L160>:
-               	bl	 <L160>
-               	mov	x20, x0
-               	b	 <L163>
-<L161>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L162>:
-               	bl	 <L162>
-               	mov	x20, x0
-<L163>:
-               	fcmp	d15, d12
-               	cset	w1, mi
-               	mov	x0, x20
-<L164>:
-               	bl	 <L164>
-               	fmov	d31, xzr
-               	fsub	d0, d31, d15
-               	fcmp	d13, d0
-               	cset	w1, mi
-<L165>:
-               	bl	 <L165>
-               	mov	x20, x0
-               	fsub	d0, d12, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L167>
-               	mov	x0, x20
-<L166>:
-               	bl	 <L166>
-               	mov	x21, x0
-               	b	 <L169>
-<L167>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L168>:
-               	bl	 <L168>
-               	mov	x21, x0
-<L169>:
-               	fadd	d0, d13, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L171>
-               	mov	x0, x21
-<L170>:
-               	bl	 <L170>
-               	mov	x20, x0
-               	b	 <L173>
-<L171>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L172>:
-               	bl	 <L172>
-               	mov	x20, x0
-<L173>:
-               	fmul	d0, d12, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L175>
-               	mov	x0, x20
-<L174>:
-               	bl	 <L174>
-               	mov	x21, x0
-               	b	 <L177>
-<L175>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L176>:
-               	bl	 <L176>
-               	mov	x21, x0
-<L177>:
-               	fmul	d0, d13, d11
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L179>
-               	mov	x0, x21
-<L178>:
-               	bl	 <L178>
-               	mov	x20, x0
-               	b	 <L181>
-<L179>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L180>:
-               	bl	 <L180>
-               	mov	x20, x0
-<L181>:
-               	fdiv	d0, d12, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L183>
-               	mov	x0, x20
-<L182>:
-               	bl	 <L182>
-               	mov	x21, x0
-               	b	 <L185>
-<L183>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L184>:
-               	bl	 <L184>
-               	mov	x21, x0
-<L185>:
-               	fdiv	d0, d10, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L187>
-               	mov	x0, x21
-<L186>:
-               	bl	 <L186>
-               	mov	x20, x0
-               	b	 <L189>
-<L187>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L188>:
-               	bl	 <L188>
-               	mov	x20, x0
-<L189>:
-               	fdiv	d0, d11, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L191>
-               	mov	x0, x20
-<L190>:
-               	bl	 <L190>
-               	mov	x21, x0
-               	b	 <L193>
-<L191>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L192>:
-               	bl	 <L192>
-               	mov	x21, x0
-<L193>:
-               	fmov	x1, d14
-               	mov	x0, x21
-<L194>:
-               	bl	 <L194>
-               	fcmp	d14, d14
-               	cset	w1, ne
-<L195>:
-               	bl	 <L195>
-               	fcmp	d14, d14
-               	cset	w1, eq
-<L196>:
-               	bl	 <L196>
-               	fcmp	d14, d14
-               	cset	w1, mi
-<L197>:
-               	bl	 <L197>
-               	fcmp	d14, d14
-               	cset	w1, ls
-<L198>:
-               	bl	 <L198>
-               	fneg	d9, d14
-               	fmov	x1, d9
-<L199>:
-               	bl	 <L199>
-               	fneg	d0, d9
-               	fmov	x1, d0
-<L200>:
-               	bl	 <L200>
-               	mov	x20, x0
-               	fadd	d0, d14, d8
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L202>
-               	mov	x0, x20
-<L201>:
-               	bl	 <L201>
-               	mov	x21, x0
-               	b	 <L204>
-<L202>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L203>:
-               	bl	 <L203>
-               	mov	x21, x0
-<L204>:
-               	fadd	d0, d8, d14
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L206>
-               	mov	x0, x21
-<L205>:
-               	bl	 <L205>
-               	mov	x20, x0
-               	b	 <L208>
-<L206>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L207>:
-               	bl	 <L207>
-               	mov	x20, x0
-<L208>:
-               	fmul	d0, d14, d10
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L210>
-               	mov	x0, x20
-<L209>:
-               	bl	 <L209>
-               	mov	x21, x0
-               	b	 <L212>
-<L210>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L211>:
-               	bl	 <L211>
-               	mov	x21, x0
-<L212>:
-               	fsub	d0, d14, d14
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L214>
-               	mov	x0, x21
-<L213>:
-               	bl	 <L213>
-               	mov	x20, x0
-               	b	 <L216>
-<L214>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L215>:
-               	bl	 <L215>
-               	mov	x20, x0
-<L216>:
-               	fdiv	d0, d14, d14
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L218>
-               	mov	x0, x20
-<L217>:
-               	bl	 <L217>
-               	mov	x21, x0
-               	b	 <L220>
-<L218>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L219>:
-               	bl	 <L219>
-               	mov	x21, x0
-<L220>:
-               	fdiv	d0, d14, d12
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L222>
-               	mov	x0, x21
-<L221>:
-               	bl	 <L221>
-               	mov	x20, x0
-               	b	 <L224>
-<L222>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L223>:
-               	bl	 <L223>
-               	mov	x20, x0
-<L224>:
-               	ldur	d31, [x29, #-0x70]
-               	ldur	d30, [x29, #-0x70]
-               	fcmp	d31, d30
-               	cset	w0, ne
-               	cbnz	w0,  <L226>
-               	mov	x0, x20
-               	ldur	d0, [x29, #-0x70]
-<L225>:
-               	bl	 <L225>
-               	mov	x21, x0
-               	b	 <L228>
-<L226>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L227>:
-               	bl	 <L227>
-               	mov	x21, x0
-<L228>:
-               	ldur	d31, [x29, #-0x60]
-               	ldur	d30, [x29, #-0x60]
-               	fcmp	d31, d30
-               	cset	w0, ne
-               	cbnz	w0,  <L230>
-               	mov	x0, x21
-               	ldur	d0, [x29, #-0x60]
-<L229>:
-               	bl	 <L229>
-               	mov	x20, x0
-               	b	 <L232>
-<L230>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L231>:
-               	bl	 <L231>
-               	mov	x20, x0
-<L232>:
-               	ldur	d31, [x29, #-0x50]
-               	ldur	d30, [x29, #-0x50]
-               	fcmp	d31, d30
-               	cset	w0, ne
-               	cbnz	w0,  <L234>
-               	mov	x0, x20
-               	ldur	d0, [x29, #-0x50]
-<L233>:
-               	bl	 <L233>
-               	mov	x21, x0
-               	b	 <L236>
-<L234>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L235>:
-               	bl	 <L235>
-               	mov	x21, x0
-<L236>:
-               	ldur	d31, [x29, #-0x60]
-               	ldur	d30, [x29, #-0x70]
-               	fadd	d0, d31, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L238>
-               	mov	x0, x21
-<L237>:
-               	bl	 <L237>
-               	mov	x20, x0
-               	b	 <L240>
-<L238>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L239>:
-               	bl	 <L239>
-               	mov	x20, x0
-<L240>:
-               	ldur	d31, [x29, #-0x50]
-               	ldur	d30, [x29, #-0x70]
-               	fsub	d0, d31, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L242>
-               	mov	x0, x20
-<L241>:
-               	bl	 <L241>
-               	mov	x21, x0
-               	b	 <L244>
-<L242>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L243>:
-               	bl	 <L243>
-               	mov	x21, x0
-<L244>:
-               	ldur	d31, [x29, #-0x70]
-               	ldur	d30, [x29, #-0x70]
-               	fadd	d0, d31, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L246>
-               	mov	x0, x21
-<L245>:
-               	bl	 <L245>
-               	mov	x20, x0
-               	b	 <L248>
-<L246>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L247>:
-               	bl	 <L247>
-               	mov	x20, x0
-<L248>:
-               	ldur	d31, [x29, #-0x70]
-               	fmov	d30, #1.50000000
-               	fmul	d0, d31, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L250>
-               	mov	x0, x20
-<L249>:
-               	bl	 <L249>
-               	mov	x21, x0
-               	b	 <L252>
-<L250>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L251>:
-               	bl	 <L251>
-               	mov	x21, x0
-<L252>:
-               	ldur	d31, [x29, #-0x70]
-               	fmov	d30, #0.50000000
-               	fmul	d0, d31, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L254>
-               	mov	x0, x21
-<L253>:
-               	bl	 <L253>
-               	mov	x20, x0
-               	b	 <L256>
-<L254>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L255>:
-               	bl	 <L255>
-               	mov	x20, x0
-<L256>:
-               	ldur	d31, [x29, #-0x70]
-               	fneg	d0, d31
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L258>
-               	mov	x0, x20
-<L257>:
-               	bl	 <L257>
-               	mov	x21, x0
-               	b	 <L260>
-<L258>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L259>:
-               	bl	 <L259>
-               	mov	x21, x0
-<L260>:
-               	ldur	d31, [x29, #-0x70]
-               	mov	x16, #0x4330000000000000 ; =4841369599423283200
-               	fmov	d30, x16
-               	fmul	d0, d31, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L262>
-               	mov	x0, x21
-<L261>:
-               	bl	 <L261>
-               	mov	x20, x0
-               	b	 <L264>
-<L262>:
-               	mov	x0, x21
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L263>:
-               	bl	 <L263>
-               	mov	x20, x0
-<L264>:
-               	ldur	d31, [x29, #-0x60]
-               	ldur	d30, [x29, #-0x50]
-               	fdiv	d0, d31, d30
-               	fcmp	d0, d0
-               	cset	w0, ne
-               	cbnz	w0,  <L266>
-               	mov	x0, x20
-<L265>:
-               	bl	 <L265>
-               	mov	x21, x0
-               	b	 <L268>
-<L266>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L267>:
-               	bl	 <L267>
-               	mov	x21, x0
-<L268>:
-               	ldur	d30, [x29, #-0x70]
-               	fcmp	d10, d30
-               	cset	w1, mi
-               	mov	x0, x21
-<L269>:
-               	bl	 <L269>
-               	ldur	d31, [x29, #-0x70]
-               	fcmp	d31, d10
-               	cset	w1, eq
-<L270>:
-               	bl	 <L270>
-               	fmov	d31, xzr
-               	ldur	d30, [x29, #-0x70]
-               	fsub	d0, d31, d30
-               	fcmp	d0, d11
-               	cset	w1, mi
-<L271>:
-               	bl	 <L271>
-               	mov	x20, x0
-               	ldur	d9, [x29, #-0x50]
-               	mov	x21, #0x0               ; =0
-               	cmp	x21, #0x3c
-               	b.lo	 <L272>
-               	b	 <L277>
-<L272>:
-               	fmov	d30, #0.50000000
-               	fmul	d12, d9, d30
-               	fcmp	d12, d12
-               	cset	w0, ne
-               	cbnz	w0,  <L274>
-               	mov	x0, x20
-               	fmov	d0, d12
-<L273>:
-               	bl	 <L273>
-               	mov	x22, x0
-               	b	 <L276>
-<L274>:
-               	mov	x0, x20
-               	mov	x1, #0xffff             ; =65535
-               	movk	x1, #0xffff, lsl #16
-               	movk	x1, #0xffff, lsl #32
-               	movk	x1, #0xffff, lsl #48
-<L275>:
-               	bl	 <L275>
-               	mov	x22, x0
-<L276>:
                	add	x21, x21, #0x1
                	mov	x20, x22
                	fmov	d9, d12
                	cmp	x21, #0x3c
-               	b.lo	 <L272>
-<L277>:
+               	b.lo	 <L95>
+<L100>:
                	sub	x21, x29, #0x40
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -1471,22 +515,22 @@ Disassembly of section __TEXT,__text:
                	str	x17, [x0]
                	mov	x22, #0x0               ; =0
                	cmp	x22, #0x8
-               	b.lo	 <L278>
-               	b	 <L280>
-<L278>:
+               	b.lo	 <L101>
+               	b	 <L103>
+<L101>:
                	add	x0, x21, x22, lsl #3
                	ldr	x1, [x0]
                	add	x0, x1, x19
                	fmov	d0, x0
                	fmov	x1, d0
                	mov	x0, x20
-<L279>:
-               	bl	 <L279>
+<L102>:
+               	bl	 <L102>
                	add	x22, x22, #0x1
                	mov	x20, x0
                	cmp	x22, #0x8
-               	b.lo	 <L278>
-<L280>:
+               	b.lo	 <L101>
+<L103>:
                	fcvt	s0, d15
                	ldur	d31, [x29, #-0x70]
                	fcvt	s9, d31
@@ -1508,85 +552,85 @@ Disassembly of section __TEXT,__text:
                	stur	s31, [x29, #-0x80]
                	fcvt	s11, d13
                	mov	x0, x20
-<L281>:
-               	bl	 <L281>
+<L104>:
+               	bl	 <L104>
                	fmov	s0, s9
-<L282>:
-               	bl	 <L282>
+<L105>:
+               	bl	 <L105>
                	fmov	s0, s12
-<L283>:
-               	bl	 <L283>
+<L106>:
+               	bl	 <L106>
                	fmov	s0, s14
-<L284>:
-               	bl	 <L284>
+<L107>:
+               	bl	 <L107>
                	fmov	s0, s15
-<L285>:
-               	bl	 <L285>
+<L108>:
+               	bl	 <L108>
                	ldur	s0, [x29, #-0x80]
-<L286>:
-               	bl	 <L286>
+<L109>:
+               	bl	 <L109>
                	fmov	s0, s11
-<L287>:
-               	bl	 <L287>
+<L110>:
+               	bl	 <L110>
                	mov	x20, x0
                	fcvt	d0, s12
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L289>
+               	cbnz	w0,  <L112>
                	mov	x0, x20
-<L288>:
-               	bl	 <L288>
+<L111>:
+               	bl	 <L111>
                	mov	x21, x0
-               	b	 <L291>
-<L289>:
+               	b	 <L114>
+<L112>:
                	mov	x0, x20
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L290>:
-               	bl	 <L290>
+<L113>:
+               	bl	 <L113>
                	mov	x21, x0
-<L291>:
+<L114>:
                	ldur	s31, [x29, #-0x80]
                	fcvt	d0, s31
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L293>
+               	cbnz	w0,  <L116>
                	mov	x0, x21
-<L292>:
-               	bl	 <L292>
+<L115>:
+               	bl	 <L115>
                	mov	x20, x0
-               	b	 <L295>
-<L293>:
+               	b	 <L118>
+<L116>:
                	mov	x0, x21
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L294>:
-               	bl	 <L294>
+<L117>:
+               	bl	 <L117>
                	mov	x20, x0
-<L295>:
+<L118>:
                	fcvt	d0, s11
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L297>
+               	cbnz	w0,  <L120>
                	mov	x0, x20
-<L296>:
-               	bl	 <L296>
+<L119>:
+               	bl	 <L119>
                	mov	x21, x0
-               	b	 <L299>
-<L297>:
+               	b	 <L122>
+<L120>:
                	mov	x0, x20
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L298>:
-               	bl	 <L298>
+<L121>:
+               	bl	 <L121>
                	mov	x21, x0
-<L299>:
+<L122>:
                	mov	x17, #0x20000000000000  ; =9007199254740992
                	add	x0, x17, x19
                	mov	x17, #0x1               ; =1
@@ -1610,136 +654,136 @@ Disassembly of section __TEXT,__text:
                	ucvtf	d0, x0
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L301>
+               	cbnz	w0,  <L124>
                	mov	x0, x21
-<L300>:
-               	bl	 <L300>
+<L123>:
+               	bl	 <L123>
                	mov	x26, x0
-               	b	 <L303>
-<L301>:
+               	b	 <L126>
+<L124>:
                	mov	x0, x21
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L302>:
-               	bl	 <L302>
+<L125>:
+               	bl	 <L125>
                	mov	x26, x0
-<L303>:
+<L126>:
                	ucvtf	d0, x20
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L305>
+               	cbnz	w0,  <L128>
                	mov	x0, x26
-<L304>:
-               	bl	 <L304>
+<L127>:
+               	bl	 <L127>
                	mov	x20, x0
-               	b	 <L307>
-<L305>:
+               	b	 <L130>
+<L128>:
                	mov	x0, x26
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L306>:
-               	bl	 <L306>
+<L129>:
+               	bl	 <L129>
                	mov	x20, x0
-<L307>:
+<L130>:
                	ucvtf	d0, x22
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L309>
+               	cbnz	w0,  <L132>
                	mov	x0, x20
-<L308>:
-               	bl	 <L308>
+<L131>:
+               	bl	 <L131>
                	mov	x21, x0
-               	b	 <L311>
-<L309>:
+               	b	 <L134>
+<L132>:
                	mov	x0, x20
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L310>:
-               	bl	 <L310>
+<L133>:
+               	bl	 <L133>
                	mov	x21, x0
-<L311>:
+<L134>:
                	ucvtf	d0, x23
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L313>
+               	cbnz	w0,  <L136>
                	mov	x0, x21
-<L312>:
-               	bl	 <L312>
+<L135>:
+               	bl	 <L135>
                	mov	x20, x0
-               	b	 <L315>
-<L313>:
+               	b	 <L138>
+<L136>:
                	mov	x0, x21
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L314>:
-               	bl	 <L314>
+<L137>:
+               	bl	 <L137>
                	mov	x20, x0
-<L315>:
+<L138>:
                	ucvtf	d0, x19
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L317>
+               	cbnz	w0,  <L140>
                	mov	x0, x20
-<L316>:
-               	bl	 <L316>
+<L139>:
+               	bl	 <L139>
                	mov	x19, x0
-               	b	 <L319>
-<L317>:
+               	b	 <L142>
+<L140>:
                	mov	x0, x20
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L318>:
-               	bl	 <L318>
+<L141>:
+               	bl	 <L141>
                	mov	x19, x0
-<L319>:
+<L142>:
                	scvtf	d0, x24
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L321>
+               	cbnz	w0,  <L144>
                	mov	x0, x19
-<L320>:
-               	bl	 <L320>
+<L143>:
+               	bl	 <L143>
                	mov	x20, x0
-               	b	 <L323>
-<L321>:
+               	b	 <L146>
+<L144>:
                	mov	x0, x19
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L322>:
-               	bl	 <L322>
+<L145>:
+               	bl	 <L145>
                	mov	x20, x0
-<L323>:
+<L146>:
                	scvtf	d0, x25
                	fcmp	d0, d0
                	cset	w0, ne
-               	cbnz	w0,  <L325>
+               	cbnz	w0,  <L148>
                	mov	x0, x20
-<L324>:
-               	bl	 <L324>
+<L147>:
+               	bl	 <L147>
                	mov	x19, x0
-               	b	 <L327>
-<L325>:
+               	b	 <L150>
+<L148>:
                	mov	x0, x20
                	mov	x1, #0xffff             ; =65535
                	movk	x1, #0xffff, lsl #16
                	movk	x1, #0xffff, lsl #32
                	movk	x1, #0xffff, lsl #48
-<L326>:
-               	bl	 <L326>
+<L149>:
+               	bl	 <L149>
                	mov	x19, x0
-<L327>:
+<L150>:
                	fmov	d31, #1.50000000
                	fmul	d9, d31, d8
                	mov	x16, #0x4340000000000000 ; =4845873199050653696
@@ -1754,37 +798,37 @@ Disassembly of section __TEXT,__text:
                	fmul	d14, d31, d8
                	fcvtzu	x1, d9
                	mov	x0, x19
-<L328>:
-               	bl	 <L328>
+<L151>:
+               	bl	 <L151>
                	fcvtzu	x1, d11
-<L329>:
-               	bl	 <L329>
+<L152>:
+               	bl	 <L152>
                	fcvtzu	x1, d12
-<L330>:
-               	bl	 <L330>
+<L153>:
+               	bl	 <L153>
                	fcvtzu	x1, d14
-<L331>:
-               	bl	 <L331>
+<L154>:
+               	bl	 <L154>
                	fcvtzu	x1, d10
-<L332>:
-               	bl	 <L332>
+<L155>:
+               	bl	 <L155>
                	fcvtzs	x1, d13
-<L333>:
-               	bl	 <L333>
+<L156>:
+               	bl	 <L156>
                	fcvtzs	x1, d12
-<L334>:
-               	bl	 <L334>
+<L157>:
+               	bl	 <L157>
                	fmov	d31, xzr
                	fsub	d0, d31, d14
                	fcvtzs	x1, d0
-<L335>:
-               	bl	 <L335>
+<L158>:
+               	bl	 <L158>
                	fcvtzs	w1, d13
-<L336>:
-               	bl	 <L336>
+<L159>:
+               	bl	 <L159>
                	fcvtzu	w1, d9
-<L337>:
-               	bl	 <L337>
+<L160>:
+               	bl	 <L160>
                	ldp	d8, d9, [x29, #-0xd0]
                	ldp	d10, d11, [x29, #-0xe0]
                	ldp	d12, d13, [x29, #-0xf0]

--- a/test/golden/aarch64-darwin/frame/frame_spill.dis
+++ b/test/golden/aarch64-darwin/frame/frame_spill.dis
@@ -91,37 +91,37 @@ Disassembly of section __TEXT,__text:
                	movk	x17, #0xaaaa, lsl #16
                	movk	x17, #0xaaaa, lsl #32
                	movk	x17, #0xaaaa, lsl #48
-               	add	x18, x17, x19
+               	add	x20, x17, x19
                	mov	x17, #0x5bdb            ; =23515
                	movk	x17, #0x94b9, lsl #16
                	movk	x17, #0x39cb, lsl #32
                	movk	x17, #0xda3e, lsl #48
-               	eor	x20, x17, x19
+               	eor	x21, x17, x19
                	mov	x17, #0x2ad1            ; =10961
                	movk	x17, #0x5ac2, lsl #16
                	movk	x17, #0x512d, lsl #32
                	movk	x17, #0x1f2e, lsl #48
-               	add	x21, x17, x19
+               	add	x22, x17, x19
                	mov	x17, #0x977f            ; =38783
                	movk	x17, #0x111a, lsl #16
                	movk	x17, #0xe746, lsl #32
                	movk	x17, #0x2d54, lsl #48
-               	eor	x22, x17, x19
+               	eor	x23, x17, x19
                	mov	x17, #0x79b1            ; =31153
                	movk	x17, #0x9e37, lsl #16
-               	add	x23, x17, x19
-               	mov	w24, w23
+               	add	x24, x17, x19
+               	mov	w25, w24
                	mov	x17, #0x9e37            ; =40503
-               	eor	x23, x17, x19
-               	mov	w25, w23
+               	eor	x24, x17, x19
+               	mov	w26, w24
                	mov	x17, #0xca77            ; =51831
                	movk	x17, #0x85eb, lsl #16
-               	add	x23, x17, x19
-               	mov	w26, w23
+               	add	x24, x17, x19
+               	mov	w27, w24
                	mov	x17, #0xae3d            ; =44605
                	movk	x17, #0xc2b2, lsl #16
-               	eor	x23, x17, x19
-               	mov	w27, w23
+               	eor	x24, x17, x19
+               	mov	w28, w24
                	ucvtf	d0, x19
                	fmov	d31, #1.50000000
                	fadd	d1, d31, d0
@@ -141,82 +141,77 @@ Disassembly of section __TEXT,__text:
                	fmov	d31, #-4.50000000
                	fadd	d16, d31, d0
                	mov	x19, x0
-               	mov	x23, x1
-               	mov	x28, x2
+               	mov	x24, x1
+               	mov	x9, x2
+               	stur	x9, [x29, #-0x8]
                	mov	x9, x3
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x9, x4
                	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x9, x5
+               	mov	x9, x4
                	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x9, x6
+               	mov	x9, x5
                	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x9, x7
+               	mov	x9, x6
                	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x9, x8
+               	mov	x9, x7
                	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x9, x12
+               	mov	x9, x8
                	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x9, x13
+               	mov	x9, x12
                	mov	x16, #0xfe98            ; =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x9, x14
+               	mov	x9, x13
                	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x9, x15
+               	mov	x9, x14
                	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x9, x18
+               	mov	x9, x15
                	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x9, x24
-               	stur	x9, [x29, #-0x50]
                	mov	x9, x25
-               	stur	x9, [x29, #-0x20]
+               	stur	x9, [x29, #-0x58]
                	mov	x9, x26
-               	stur	x9, [x29, #-0x30]
+               	stur	x9, [x29, #-0x28]
                	mov	x9, x27
-               	stur	x9, [x29, #-0x40]
+               	stur	x9, [x29, #-0x38]
+               	mov	x9, x28
+               	stur	x9, [x29, #-0x48]
                	fmov	d8, d1
                	fmov	d9, d2
                	fmov	d10, d3
@@ -240,312 +235,304 @@ Disassembly of section __TEXT,__text:
                	b.lo	 <L1>
                	b	 <L5>
 <L1>:
-               	lsl	x0, x22, #29
-               	lsr	x1, x22, #35
+               	lsl	x0, x23, #29
+               	lsr	x1, x23, #35
                	orr	x9, x0, x1
-               	stur	x9, [x29, #-0x8]
-               	ldur	x10, [x29, #-0x8]
-               	eor	x9, x23, x10
                	stur	x9, [x29, #-0x10]
-               	lsl	x1, x23, #7
-               	lsr	x0, x23, #57
-               	orr	x9, x1, x0
+               	ldur	x10, [x29, #-0x10]
+               	eor	x9, x24, x10
                	stur	x9, [x29, #-0x18]
-               	ldur	x9, [x29, #-0x18]
-               	add	x25, x28, x9
-               	lsl	x0, x28, #11
-               	lsr	x1, x28, #53
+               	lsl	x1, x24, #7
+               	lsr	x0, x24, #57
+               	orr	x9, x1, x0
+               	stur	x9, [x29, #-0x20]
+               	ldur	x9, [x29, #-0x8]
+               	ldur	x10, [x29, #-0x20]
+               	add	x26, x9, x10
+               	ldur	x9, [x29, #-0x8]
+               	lsl	x0, x9, #11
+               	ldur	x9, [x29, #-0x8]
+               	lsr	x1, x9, #53
                	orr	x9, x0, x1
-               	stur	x9, [x29, #-0x28]
-               	mov	x16, #0xfed0            ; =65232
+               	stur	x9, [x29, #-0x30]
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x28]
-               	eor	x26, x9, x10
-               	mov	x16, #0xfed0            ; =65232
+               	ldur	x10, [x29, #-0x30]
+               	eor	x27, x9, x10
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #13
-               	mov	x16, #0xfed0            ; =65232
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsr	x1, x9, #51
                	orr	x9, x0, x1
-               	stur	x9, [x29, #-0x38]
-               	mov	x16, #0xfec8            ; =65224
+               	stur	x9, [x29, #-0x40]
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x38]
-               	add	x27, x9, x10
-               	mov	x16, #0xfec8            ; =65224
+               	ldur	x10, [x29, #-0x40]
+               	add	x28, x9, x10
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #17
-               	mov	x16, #0xfec8            ; =65224
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsr	x1, x9, #47
                	orr	x9, x0, x1
-               	stur	x9, [x29, #-0x48]
-               	mov	x16, #0xfec0            ; =65216
+               	stur	x9, [x29, #-0x50]
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x48]
-               	eor	x24, x9, x10
-               	mov	x16, #0xfec0            ; =65216
+               	ldur	x10, [x29, #-0x50]
+               	eor	x25, x9, x10
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #19
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsr	x1, x9, #45
                	orr	x9, x0, x1
-               	stur	x9, [x29, #-0x58]
-               	mov	x16, #0xfeb8            ; =65208
+               	stur	x9, [x29, #-0x60]
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0x58]
+               	ldur	x11, [x29, #-0x60]
                	add	x9, x10, x11
-               	stur	x9, [x29, #-0x60]
-               	mov	x16, #0xfeb8            ; =65208
+               	stur	x9, [x29, #-0x68]
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #23
-               	mov	x16, #0xfeb8            ; =65208
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsr	x1, x9, #41
                	orr	x9, x0, x1
-               	stur	x9, [x29, #-0x68]
-               	mov	x16, #0xfeb0            ; =65200
+               	stur	x9, [x29, #-0x70]
+               	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0x68]
+               	ldur	x11, [x29, #-0x70]
                	eor	x9, x10, x11
-               	stur	x9, [x29, #-0x70]
-               	mov	x16, #0xfeb0            ; =65200
+               	stur	x9, [x29, #-0x78]
+               	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #31
-               	mov	x16, #0xfeb0            ; =65200
+               	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsr	x1, x9, #33
                	orr	x9, x0, x1
-               	stur	x9, [x29, #-0x78]
-               	mov	x16, #0xfea8            ; =65192
+               	stur	x9, [x29, #-0x80]
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0x78]
+               	ldur	x11, [x29, #-0x80]
                	add	x9, x10, x11
-               	stur	x9, [x29, #-0x80]
-               	mov	x16, #0xfea8            ; =65192
+               	stur	x9, [x29, #-0x88]
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #37
-               	mov	x16, #0xfea8            ; =65192
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsr	x1, x9, #27
                	orr	x9, x0, x1
-               	stur	x9, [x29, #-0x88]
-               	mov	x16, #0xfea0            ; =65184
+               	stur	x9, [x29, #-0x90]
+               	mov	x16, #0xfe98            ; =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0x88]
+               	ldur	x11, [x29, #-0x90]
                	eor	x9, x10, x11
-               	stur	x9, [x29, #-0x90]
-               	mov	x16, #0xfea0            ; =65184
+               	stur	x9, [x29, #-0x98]
+               	mov	x16, #0xfe98            ; =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #41
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfe98            ; =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsr	x1, x9, #23
                	orr	x9, x0, x1
-               	stur	x9, [x29, #-0x98]
-               	mov	x16, #0xfe98            ; =65176
+               	stur	x9, [x29, #-0xa0]
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0x98]
+               	ldur	x11, [x29, #-0xa0]
                	add	x9, x10, x11
-               	stur	x9, [x29, #-0xa0]
-               	mov	x16, #0xfe98            ; =65176
+               	stur	x9, [x29, #-0xa8]
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #43
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsr	x1, x9, #21
                	orr	x9, x0, x1
-               	stur	x9, [x29, #-0xa8]
-               	mov	x16, #0xfe90            ; =65168
+               	stur	x9, [x29, #-0xb0]
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0xa8]
+               	ldur	x11, [x29, #-0xb0]
                	eor	x9, x10, x11
-               	stur	x9, [x29, #-0xb0]
-               	mov	x16, #0xfe90            ; =65168
+               	stur	x9, [x29, #-0xb8]
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #47
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsr	x1, x9, #17
                	orr	x9, x0, x1
-               	stur	x9, [x29, #-0xb8]
-               	mov	x16, #0xfe88            ; =65160
+               	stur	x9, [x29, #-0xc0]
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0xb8]
+               	ldur	x11, [x29, #-0xc0]
                	add	x9, x10, x11
-               	stur	x9, [x29, #-0xc0]
-               	mov	x16, #0xfe88            ; =65160
+               	stur	x9, [x29, #-0xc8]
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsl	x0, x9, #53
-               	mov	x16, #0xfe88            ; =65160
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	lsr	x1, x9, #11
                	orr	x9, x0, x1
-               	stur	x9, [x29, #-0xc8]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	ldur	x11, [x29, #-0xc8]
-               	eor	x9, x10, x11
                	stur	x9, [x29, #-0xd0]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	lsl	x0, x9, #59
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	lsr	x1, x9, #5
-               	orr	x9, x0, x1
+               	ldur	x10, [x29, #-0xd0]
+               	eor	x9, x20, x10
                	stur	x9, [x29, #-0xd8]
-               	ldur	x10, [x29, #-0xd8]
-               	add	x9, x20, x10
+               	lsl	x0, x20, #59
+               	lsr	x1, x20, #5
+               	orr	x9, x0, x1
                	stur	x9, [x29, #-0xe0]
-               	lsl	x0, x20, #61
-               	lsr	x1, x20, #3
-               	orr	x9, x0, x1
+               	ldur	x10, [x29, #-0xe0]
+               	add	x9, x21, x10
                	stur	x9, [x29, #-0xe8]
-               	ldur	x10, [x29, #-0xe8]
-               	eor	x9, x21, x10
-               	stur	x9, [x29, #-0xf0]
-               	lsl	x0, x21, #3
-               	lsr	x1, x21, #61
+               	lsl	x0, x21, #61
+               	lsr	x1, x21, #3
                	orr	x9, x0, x1
+               	stur	x9, [x29, #-0xf0]
+               	ldur	x10, [x29, #-0xf0]
+               	eor	x9, x22, x10
                	stur	x9, [x29, #-0xf8]
-               	ldur	x9, [x29, #-0xf8]
-               	add	x21, x22, x9
-               	ldur	x9, [x29, #-0x10]
+               	lsl	x0, x22, #3
+               	lsr	x1, x22, #61
+               	orr	x9, x0, x1
+               	stur	x9, [x29, #-0x100]
+               	ldur	x9, [x29, #-0x100]
+               	add	x22, x23, x9
+               	ldur	x9, [x29, #-0x18]
                	mov	x16, #0xfe78            ; =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
-               	add	x22, x9, x10
-               	ldur	x9, [x29, #-0xe0]
+               	add	x23, x9, x10
+               	ldur	x9, [x29, #-0xe8]
                	mov	w0, w9
-               	ldur	x10, [x29, #-0x50]
+               	ldur	x10, [x29, #-0x58]
                	eor	w9, w10, w0
-               	stur	x9, [x29, #-0x100]
-               	mov	w0, w25
-               	ldur	x10, [x29, #-0x20]
-               	add	w9, w10, w0
                	mov	x16, #0xfef8            ; =65272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x9, [x29, #-0x60]
-               	mov	w0, w9
-               	ldur	x10, [x29, #-0x30]
-               	eor	w9, w10, w0
+               	mov	w0, w26
+               	ldur	x10, [x29, #-0x28]
+               	add	w9, w10, w0
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x9, [x29, #-0xa0]
+               	ldur	x9, [x29, #-0x68]
                	mov	w0, w9
-               	ldur	x10, [x29, #-0x40]
-               	add	w9, w10, w0
+               	ldur	x10, [x29, #-0x38]
+               	eor	w9, w10, w0
                	mov	x16, #0xfee8            ; =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	ldur	x9, [x29, #-0xa8]
+               	mov	w0, w9
+               	ldur	x10, [x29, #-0x48]
+               	add	w9, w10, w0
+               	mov	x16, #0xfee0            ; =65248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -553,7 +540,7 @@ Disassembly of section __TEXT,__text:
                	fmov	d30, #1.50000000
                	fmul	d0, d8, d30
                	fadd	d31, d0, d9
-               	mov	x16, #0xfed8            ; =65240
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -579,12 +566,12 @@ Disassembly of section __TEXT,__text:
                	fmov	d30, #0.87500000
                	fmul	d0, d15, d30
                	fadd	d15, d0, d8
-               	ldur	x9, [x29, #-0xa0]
-               	eor	x1, x25, x9
+               	ldur	x9, [x29, #-0xa8]
+               	eor	x1, x26, x9
                	mov	x0, x19
 <L2>:
                	bl	 <L2>
-               	mov	x16, #0xfef8            ; =65272
+               	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -592,7 +579,7 @@ Disassembly of section __TEXT,__text:
                	mov	w1, w9
 <L3>:
                	bl	 <L3>
-               	mov	x16, #0xfed8            ; =65240
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -605,117 +592,117 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x1
+               	add	x15, x9, #0x1
                	mov	x19, x0
-               	mov	x23, x25
-               	mov	x28, x26
+               	mov	x24, x26
                	mov	x9, x27
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	mov	x9, x24
+               	stur	x9, [x29, #-0x8]
+               	mov	x9, x28
                	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x60]
-               	mov	x9, x10
+               	mov	x9, x25
                	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x70]
+               	ldur	x10, [x29, #-0x68]
                	mov	x9, x10
                	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x80]
+               	ldur	x10, [x29, #-0x78]
                	mov	x9, x10
                	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0x90]
+               	ldur	x10, [x29, #-0x88]
                	mov	x9, x10
                	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0xa0]
+               	ldur	x10, [x29, #-0x98]
                	mov	x9, x10
                	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0xb0]
+               	ldur	x10, [x29, #-0xa8]
                	mov	x9, x10
                	mov	x16, #0xfe98            ; =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0xc0]
+               	ldur	x10, [x29, #-0xb8]
                	mov	x9, x10
                	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0xd0]
+               	ldur	x10, [x29, #-0xc8]
                	mov	x9, x10
                	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x10, [x29, #-0xe0]
+               	ldur	x10, [x29, #-0xd8]
                	mov	x9, x10
                	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	ldur	x9, [x29, #-0xf0]
+               	ldur	x9, [x29, #-0xe8]
                	mov	x20, x9
-               	mov	x16, #0xfef8            ; =65272
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x10, [x29, x16]
-               	mov	x9, x10
-               	stur	x9, [x29, #-0x50]
+               	ldur	x9, [x29, #-0xf8]
+               	mov	x21, x9
                	mov	x16, #0xfef0            ; =65264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	mov	x9, x10
-               	stur	x9, [x29, #-0x20]
+               	stur	x9, [x29, #-0x58]
                	mov	x16, #0xfee8            ; =65256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	mov	x9, x10
-               	stur	x9, [x29, #-0x30]
-               	ldur	x10, [x29, #-0x100]
+               	stur	x9, [x29, #-0x28]
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
                	mov	x9, x10
-               	stur	x9, [x29, #-0x40]
-               	mov	x16, #0xfed8            ; =65240
+               	stur	x9, [x29, #-0x38]
+               	mov	x16, #0xfef8            ; =65272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x10, [x29, x16]
+               	mov	x9, x10
+               	stur	x9, [x29, #-0x48]
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d8, [x29, x16]
-               	mov	x9, x18
+               	mov	x9, x15
                	mov	x16, #0xfe78            ; =65144
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -730,13 +717,14 @@ Disassembly of section __TEXT,__text:
                	b.lo	 <L1>
 <L5>:
                	mov	x0, x19
-               	mov	x1, x23
+               	mov	x1, x24
 <L6>:
                	bl	 <L6>
-               	mov	x1, x28
+               	ldur	x9, [x29, #-0x8]
+               	mov	x1, x9
 <L7>:
                	bl	 <L7>
-               	mov	x16, #0xfed0            ; =65232
+               	mov	x16, #0xfec8            ; =65224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -744,7 +732,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L8>:
                	bl	 <L8>
-               	mov	x16, #0xfec8            ; =65224
+               	mov	x16, #0xfec0            ; =65216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -752,7 +740,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L9>:
                	bl	 <L9>
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x16, #0xfeb8            ; =65208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -760,7 +748,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L10>:
                	bl	 <L10>
-               	mov	x16, #0xfeb8            ; =65208
+               	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -768,7 +756,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L11>:
                	bl	 <L11>
-               	mov	x16, #0xfeb0            ; =65200
+               	mov	x16, #0xfea8            ; =65192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -776,7 +764,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L12>:
                	bl	 <L12>
-               	mov	x16, #0xfea8            ; =65192
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -784,7 +772,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L13>:
                	bl	 <L13>
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfe98            ; =65176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -792,7 +780,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L14>:
                	bl	 <L14>
-               	mov	x16, #0xfe98            ; =65176
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -800,7 +788,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L15>:
                	bl	 <L15>
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe88            ; =65160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -808,7 +796,7 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L16>:
                	bl	 <L16>
-               	mov	x16, #0xfe88            ; =65160
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -816,36 +804,31 @@ Disassembly of section __TEXT,__text:
                	mov	x1, x9
 <L17>:
                	bl	 <L17>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	mov	x1, x9
+               	mov	x1, x20
 <L18>:
                	bl	 <L18>
-               	mov	x1, x20
+               	mov	x1, x21
 <L19>:
                	bl	 <L19>
-               	mov	x1, x21
+               	mov	x1, x22
 <L20>:
                	bl	 <L20>
-               	mov	x1, x22
+               	mov	x1, x23
 <L21>:
                	bl	 <L21>
-               	ldur	x9, [x29, #-0x50]
+               	ldur	x9, [x29, #-0x58]
                	mov	w1, w9
 <L22>:
                	bl	 <L22>
-               	ldur	x9, [x29, #-0x20]
+               	ldur	x9, [x29, #-0x28]
                	mov	w1, w9
 <L23>:
                	bl	 <L23>
-               	ldur	x9, [x29, #-0x30]
+               	ldur	x9, [x29, #-0x38]
                	mov	w1, w9
 <L24>:
                	bl	 <L24>
-               	ldur	x9, [x29, #-0x40]
+               	ldur	x9, [x29, #-0x48]
                	mov	w1, w9
 <L25>:
                	bl	 <L25>

--- a/test/golden/aarch64-darwin/mem/global_data.dis
+++ b/test/golden/aarch64-darwin/mem/global_data.dis
@@ -310,9 +310,16 @@ Disassembly of section __TEXT,__text:
                	udiv	x16, x0, x2
                	msub	x3, x16, x2, x0
                	add	x2, x1, x3, lsl #1
-               	ldrh	w1, [x2]
-               	add	w3, w1, #0x64
-               	strh	w3, [x2]
+               	ldrh	w3, [x2]
+               	add	w2, w3, #0x64
+               	mov	x3, #0x3                ; =3
+               	cbnz	x3,  <L3>
+               	brk	#0
+<L3>:
+               	udiv	x16, x0, x3
+               	msub	x4, x16, x3, x0
+               	add	x3, x1, x4, lsl #1
+               	strh	w2, [x3]
                	adrp	x1, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	add	x1, x1, #0x0
                	ldr	w2, [x1]
@@ -376,7 +383,7 @@ Disassembly of section __TEXT,__text:
                	mov	x28, #0x0               ; =0
                	cmp	x28, #0x5
                	b.lo	 <L5>
-               	b	 <L10>
+               	b	 <L11>
 <L5>:
                	add	x0, x28, #0x1
                	add	x1, x0, x19
@@ -485,20 +492,27 @@ Disassembly of section __TEXT,__text:
                	msub	x2, x16, x0, x1
                	add	x0, x25, x2, lsl #1
                	ldrh	w2, [x0]
-               	add	w3, w2, #0x64
-               	strh	w3, [x0]
+               	add	w0, w2, #0x64
+               	mov	x2, #0x3                ; =3
+               	cbnz	x2,  <L9>
+               	brk	#0
+<L9>:
+               	udiv	x16, x1, x2
+               	msub	x3, x16, x2, x1
+               	add	x2, x25, x3, lsl #1
+               	strh	w0, [x2]
                	ldr	w0, [x26]
                	mov	w2, w1
                	sub	w1, w0, w2
                	str	w1, [x26]
                	mov	x0, x27
-<L9>:
-               	bl	 <L9>
+<L10>:
+               	bl	 <L10>
                	add	x28, x28, #0x1
                	mov	x27, x0
                	cmp	x28, #0x5
                	b.lo	 <L5>
-<L10>:
+<L11>:
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	ldr	x0, [x16]
                	mov	x16, #0x7c15            ; =31765
@@ -511,8 +525,8 @@ Disassembly of section __TEXT,__text:
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	ldr	x1, [x16]
                	mov	x0, x27
-<L11>:
-               	bl	 <L11>
+<L12>:
+               	bl	 <L12>
                	sub	x1, x29, #0x10
                	adrp	x16, 0x0 <corpus.cases.mem.global_data.fold_cell>
                	ldr	x2, [x16]
@@ -540,16 +554,16 @@ Disassembly of section __TEXT,__text:
                	add	x1, x1, #0x0
                	ldr	x20, [x1]
                	mov	x1, x2
-<L12>:
-               	bl	 <L12>
-               	mov	x1, x19
 <L13>:
                	bl	 <L13>
-               	mov	x1, x20
+               	mov	x1, x19
 <L14>:
                	bl	 <L14>
+               	mov	x1, x20
 <L15>:
                	bl	 <L15>
+<L16>:
+               	bl	 <L16>
                	ldp	x19, x20, [x29, #-0x20]
                	ldp	x21, x22, [x29, #-0x30]
                	ldp	x23, x24, [x29, #-0x40]

--- a/test/golden/aarch64-darwin/mem/loadstore.dis
+++ b/test/golden/aarch64-darwin/mem/loadstore.dis
@@ -77,11 +77,11 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.loadstore.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x70
-               	stp	x19, x20, [x29, #-0x40]
-               	stp	x21, x22, [x29, #-0x50]
-               	stp	x23, x24, [x29, #-0x60]
-               	stp	x25, x26, [x29, #-0x70]
+               	sub	sp, sp, #0xb0
+               	stp	x19, x20, [x29, #-0x80]
+               	stp	x21, x22, [x29, #-0x90]
+               	stp	x23, x24, [x29, #-0xa0]
+               	stp	x25, x26, [x29, #-0xb0]
                	mov	x19, x0
 <L0>:
                	bl	 <L0>
@@ -91,7 +91,13 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x8]
                	str	xzr, [x20, #0x10]
                	mov	x0, x1
-               	mov	x1, x20
+               	ldr	x1, [x20]
+               	stur	x1, [x29, #-0x30]
+               	ldr	x1, [x20, #0x8]
+               	stur	x1, [x29, #-0x28]
+               	ldr	x1, [x20, #0x10]
+               	stur	x1, [x29, #-0x20]
+               	sub	x1, x29, #0x30
 <L1>:
                	bl	 <L1>
                	mov	x1, x0
@@ -128,7 +134,13 @@ Disassembly of section __TEXT,__text:
                	add	x2, x20, #0x10
                	str	x21, [x2]
                	mov	x0, x1
-               	mov	x1, x20
+               	ldr	x1, [x20]
+               	stur	x1, [x29, #-0x48]
+               	ldr	x1, [x20, #0x8]
+               	stur	x1, [x29, #-0x40]
+               	ldr	x1, [x20, #0x10]
+               	stur	x1, [x29, #-0x38]
+               	sub	x1, x29, #0x48
 <L2>:
                	bl	 <L2>
                	mov	x22, x0
@@ -152,7 +164,13 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x8
                	str	w1, [x0]
                	mov	x0, x22
-               	mov	x1, x20
+               	ldr	x1, [x20]
+               	stur	x1, [x29, #-0x60]
+               	ldr	x1, [x20, #0x8]
+               	stur	x1, [x29, #-0x58]
+               	ldr	x1, [x20, #0x10]
+               	stur	x1, [x29, #-0x50]
+               	sub	x1, x29, #0x60
 <L4>:
                	bl	 <L4>
                	mov	x22, x0
@@ -211,7 +229,7 @@ Disassembly of section __TEXT,__text:
                	cmp	x20, #0x6
                	b.lo	 <L6>
 <L17>:
-               	sub	x19, x29, #0x28
+               	sub	x19, x29, #0x70
                	str	xzr, [x19]
                	str	xzr, [x19, #0x8]
                	mov	x0, #0x0                ; =0
@@ -260,10 +278,10 @@ Disassembly of section __TEXT,__text:
                	add	x1, x19, #0x1
 <L24>:
                	bl	 <L24>
-               	ldp	x19, x20, [x29, #-0x40]
-               	ldp	x21, x22, [x29, #-0x50]
-               	ldp	x23, x24, [x29, #-0x60]
-               	ldp	x25, x26, [x29, #-0x70]
+               	ldp	x19, x20, [x29, #-0x80]
+               	ldp	x21, x22, [x29, #-0x90]
+               	ldp	x23, x24, [x29, #-0xa0]
+               	ldp	x25, x26, [x29, #-0xb0]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/mem/rec_layout.dis
+++ b/test/golden/aarch64-darwin/mem/rec_layout.dis
@@ -327,10 +327,11 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.rec_layout.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0xa0
-               	stp	x19, x20, [x29, #-0x80]
-               	stp	x21, x22, [x29, #-0x90]
-               	stp	x23, x24, [x29, #-0xa0]
+               	sub	sp, sp, #0x310
+               	sub	x16, x29, #0x2f0
+               	stp	x19, x20, [x16]
+               	stp	x21, x22, [x16, #-0x10]
+               	stp	x23, x24, [x16, #-0x20]
                	mov	x19, x0
 <L0>:
                	bl	 <L0>
@@ -434,7 +435,29 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x21, #0x48]
                	str	xzr, [x21, #0x50]
                	mov	x0, x1
-               	mov	x1, x21
+               	ldr	x1, [x21]
+               	stur	x1, [x29, #-0xb0]
+               	ldr	x1, [x21, #0x8]
+               	stur	x1, [x29, #-0xa8]
+               	ldr	x1, [x21, #0x10]
+               	stur	x1, [x29, #-0xa0]
+               	ldr	x1, [x21, #0x18]
+               	stur	x1, [x29, #-0x98]
+               	ldr	x1, [x21, #0x20]
+               	stur	x1, [x29, #-0x90]
+               	ldr	x1, [x21, #0x28]
+               	stur	x1, [x29, #-0x88]
+               	ldr	x1, [x21, #0x30]
+               	stur	x1, [x29, #-0x80]
+               	ldr	x1, [x21, #0x38]
+               	stur	x1, [x29, #-0x78]
+               	ldr	x1, [x21, #0x40]
+               	stur	x1, [x29, #-0x70]
+               	ldr	x1, [x21, #0x48]
+               	stur	x1, [x29, #-0x68]
+               	ldr	x1, [x21, #0x50]
+               	stur	x1, [x29, #-0x60]
+               	sub	x1, x29, #0xb0
 <L18>:
                	bl	 <L18>
                	add	x1, x21, #0x0
@@ -539,7 +562,33 @@ Disassembly of section __TEXT,__text:
                	add	w1, w17, w20
                	add	x19, x21, #0x50
                	str	w1, [x19]
-               	mov	x1, x21
+               	ldr	x1, [x21]
+               	mov	x16, #0xfef8            ; =65272
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x8]
+               	stur	x1, [x29, #-0x100]
+               	ldr	x1, [x21, #0x10]
+               	stur	x1, [x29, #-0xf8]
+               	ldr	x1, [x21, #0x18]
+               	stur	x1, [x29, #-0xf0]
+               	ldr	x1, [x21, #0x20]
+               	stur	x1, [x29, #-0xe8]
+               	ldr	x1, [x21, #0x28]
+               	stur	x1, [x29, #-0xe0]
+               	ldr	x1, [x21, #0x30]
+               	stur	x1, [x29, #-0xd8]
+               	ldr	x1, [x21, #0x38]
+               	stur	x1, [x29, #-0xd0]
+               	ldr	x1, [x21, #0x40]
+               	stur	x1, [x29, #-0xc8]
+               	ldr	x1, [x21, #0x48]
+               	stur	x1, [x29, #-0xc0]
+               	ldr	x1, [x21, #0x50]
+               	stur	x1, [x29, #-0xb8]
+               	sub	x1, x29, #0x108
 <L19>:
                	bl	 <L19>
                	add	x20, x21, #0x0
@@ -551,7 +600,73 @@ Disassembly of section __TEXT,__text:
                	movk	w16, #0xf0f0, lsl #16
                	eor	w3, w2, w16
                	str	w3, [x1]
-               	mov	x1, x21
+               	ldr	x1, [x21]
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x8]
+               	mov	x16, #0xfea8            ; =65192
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x10]
+               	mov	x16, #0xfeb0            ; =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x18]
+               	mov	x16, #0xfeb8            ; =65208
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x20]
+               	mov	x16, #0xfec0            ; =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x28]
+               	mov	x16, #0xfec8            ; =65224
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x30]
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x38]
+               	mov	x16, #0xfed8            ; =65240
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x40]
+               	mov	x16, #0xfee0            ; =65248
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x48]
+               	mov	x16, #0xfee8            ; =65256
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x50]
+               	mov	x16, #0xfef0            ; =65264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x1, x29, #0x160
 <L20>:
                	bl	 <L20>
                	add	x22, x21, #0x28
@@ -561,24 +676,222 @@ Disassembly of section __TEXT,__text:
                	ldrb	w2, [x1]
                	add	w3, w2, #0x7
                	strb	w3, [x1]
-               	mov	x1, x21
+               	ldr	x1, [x21]
+               	mov	x16, #0xfe48            ; =65096
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x8]
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x10]
+               	mov	x16, #0xfe58            ; =65112
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x18]
+               	mov	x16, #0xfe60            ; =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x20]
+               	mov	x16, #0xfe68            ; =65128
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x28]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x30]
+               	mov	x16, #0xfe78            ; =65144
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x38]
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x40]
+               	mov	x16, #0xfe88            ; =65160
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x48]
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x50]
+               	mov	x16, #0xfe98            ; =65176
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x1, x29, #0x1b8
 <L21>:
                	bl	 <L21>
                	add	x1, x20, #0x18
                	ldr	x2, [x1]
                	lsr	x3, x2, #3
                	str	x3, [x1]
-               	mov	x1, x21
+               	ldr	x1, [x21]
+               	mov	x16, #0xfdf0            ; =65008
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x8]
+               	mov	x16, #0xfdf8            ; =65016
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x10]
+               	mov	x16, #0xfe00            ; =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x18]
+               	mov	x16, #0xfe08            ; =65032
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x20]
+               	mov	x16, #0xfe10            ; =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x28]
+               	mov	x16, #0xfe18            ; =65048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x30]
+               	mov	x16, #0xfe20            ; =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x38]
+               	mov	x16, #0xfe28            ; =65064
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x40]
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x48]
+               	mov	x16, #0xfe38            ; =65080
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x50]
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x1, x29, #0x210
 <L22>:
                	bl	 <L22>
                	ldr	w1, [x19]
                	mov	w16, #0x3               ; =3
                	mul	w2, w1, w16
                	str	w2, [x19]
-               	mov	x1, x21
+               	ldr	x1, [x21]
+               	mov	x16, #0xfd98            ; =64920
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x8]
+               	mov	x16, #0xfda0            ; =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x10]
+               	mov	x16, #0xfda8            ; =64936
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x18]
+               	mov	x16, #0xfdb0            ; =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x20]
+               	mov	x16, #0xfdb8            ; =64952
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x28]
+               	mov	x16, #0xfdc0            ; =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x30]
+               	mov	x16, #0xfdc8            ; =64968
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x38]
+               	mov	x16, #0xfdd0            ; =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x40]
+               	mov	x16, #0xfdd8            ; =64984
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x48]
+               	mov	x16, #0xfde0            ; =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x50]
+               	mov	x16, #0xfde8            ; =65000
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x1, x29, #0x268
 <L23>:
                	bl	 <L23>
-               	sub	x19, x29, #0x6c
+               	sub	x19, x29, #0x27c
                	add	x1, x22, #0x0
                	ldr	x2, [x1]
                	str	x2, [x19]
@@ -653,12 +966,79 @@ Disassembly of section __TEXT,__text:
                	str	x1, [x2, #0x8]
                	ldr	w1, [x19, #0x10]
                	str	w1, [x2, #0x10]
-               	mov	x1, x21
+               	ldr	x1, [x21]
+               	mov	x16, #0xfd28            ; =64808
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x8]
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x10]
+               	mov	x16, #0xfd38            ; =64824
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x18]
+               	mov	x16, #0xfd40            ; =64832
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x20]
+               	mov	x16, #0xfd48            ; =64840
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x28]
+               	mov	x16, #0xfd50            ; =64848
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x30]
+               	mov	x16, #0xfd58            ; =64856
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x38]
+               	mov	x16, #0xfd60            ; =64864
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x40]
+               	mov	x16, #0xfd68            ; =64872
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x48]
+               	mov	x16, #0xfd70            ; =64880
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	ldr	x1, [x21, #0x50]
+               	mov	x16, #0xfd78            ; =64888
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x1, [x29, x16]
+               	sub	x1, x29, #0x2d8
 <L34>:
                	bl	 <L34>
-               	ldp	x19, x20, [x29, #-0x80]
-               	ldp	x21, x22, [x29, #-0x90]
-               	ldp	x23, x24, [x29, #-0xa0]
+               	sub	x16, x29, #0x2f0
+               	ldp	x19, x20, [x16]
+               	ldp	x21, x22, [x16, #-0x10]
+               	ldp	x23, x24, [x16, #-0x20]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/vec/autovec_loop.dis
+++ b/test/golden/aarch64-darwin/vec/autovec_loop.dis
@@ -161,24 +161,39 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x23, #0xf8]
                	str	xzr, [x23, #0x100]
                	str	wzr, [x23, #0x108]
-               	add	x1, x19, #0x0
-               	add	x2, x19, x20, lsl #2
-               	add	x3, x22, #0x0
-               	add	x4, x22, x20, lsl #2
-               	add	x5, x23, #0x0
-               	add	x6, x23, x20, lsl #2
-               	cmp	x6, x1
-               	cset	w7, ls
-               	cmp	x2, x5
+               	mov	x16, #0xffff            ; =65535
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xfffe, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	cmp	x20, x16
                	cset	w1, ls
-               	orr	w2, w7, w1
-               	cmp	x6, x3
-               	cset	w1, ls
-               	cmp	x4, x5
-               	cset	w3, ls
-               	orr	w4, w1, w3
-               	and	w1, w2, w4
-               	cbnz	w1,  <L4>
+               	mov	w16, #0x1               ; =1
+               	and	w2, w1, w16
+               	mov	w16, #0x1               ; =1
+               	and	w1, w2, w16
+               	mov	w16, #0x1               ; =1
+               	and	w2, w1, w16
+               	mov	w16, #0x1               ; =1
+               	and	w1, w2, w16
+               	add	x2, x19, #0x0
+               	add	x3, x19, x20, lsl #2
+               	add	x4, x22, #0x0
+               	add	x5, x22, x20, lsl #2
+               	add	x6, x23, #0x0
+               	add	x7, x23, x20, lsl #2
+               	cmp	x7, x2
+               	cset	w8, ls
+               	cmp	x3, x6
+               	cset	w2, ls
+               	orr	w3, w8, w2
+               	cmp	x7, x4
+               	cset	w2, ls
+               	cmp	x5, x6
+               	cset	w4, ls
+               	orr	w5, w2, w4
+               	and	w2, w3, w5
+               	and	w3, w1, w2
+               	cbnz	w3,  <L4>
                	mov	x1, #0x0                ; =0
                	cmp	x1, x20
                	b.lo	 <L3>
@@ -198,53 +213,54 @@ Disassembly of section __TEXT,__text:
                	b.lo	 <L3>
                	b	 <L8>
 <L4>:
-               	sub	x1, x20, #0x4
-               	sub	x2, x29, #0x8a8
-               	add	x3, x2, #0x0
+               	sub	x1, x29, #0x8a8
+               	add	x2, x1, #0x0
                	mov	w17, #0x3               ; =3
-               	str	w17, [x3]
-               	add	x3, x2, #0x4
+               	str	w17, [x2]
+               	add	x2, x1, #0x4
                	mov	w17, #0x3               ; =3
-               	str	w17, [x3]
-               	add	x3, x2, #0x8
+               	str	w17, [x2]
+               	add	x2, x1, #0x8
                	mov	w17, #0x3               ; =3
-               	str	w17, [x3]
-               	add	x3, x2, #0xc
+               	str	w17, [x2]
+               	add	x2, x1, #0xc
                	mov	w17, #0x3               ; =3
-               	str	w17, [x3]
-               	ldr	q0, [x2]
-               	mov	x2, #0x0                ; =0
-               	cmp	x2, x1
-               	b.le	 <L5>
+               	str	w17, [x2]
+               	ldr	q0, [x1]
+               	mov	x1, #0x0                ; =0
+               	add	x2, x1, #0x4
+               	cmp	x2, x20
+               	b.ls	 <L5>
                	b	 <L6>
 <L5>:
-               	add	x3, x19, x2, lsl #2
-               	ldr	q1, [x3]
+               	add	x2, x19, x1, lsl #2
+               	ldr	q1, [x2]
                	mul.4s	v2, v1, v0
-               	add	x3, x22, x2, lsl #2
-               	ldr	q1, [x3]
+               	add	x2, x22, x1, lsl #2
+               	ldr	q1, [x2]
                	add.4s	v3, v2, v1
-               	add	x3, x23, x2, lsl #2
-               	str	q3, [x3]
-               	add	x2, x2, #0x4
-               	cmp	x2, x1
-               	b.le	 <L5>
-<L6>:
+               	add	x2, x23, x1, lsl #2
+               	str	q3, [x2]
+               	add	x1, x1, #0x4
+               	add	x2, x1, #0x4
                	cmp	x2, x20
+               	b.ls	 <L5>
+<L6>:
+               	cmp	x1, x20
                	b.lo	 <L7>
                	b	 <L8>
 <L7>:
-               	add	x1, x19, x2, lsl #2
-               	ldr	w3, [x1]
+               	add	x2, x19, x1, lsl #2
+               	ldr	w3, [x2]
                	mov	w16, #0x3               ; =3
-               	mul	w1, w3, w16
-               	add	x3, x22, x2, lsl #2
+               	mul	w2, w3, w16
+               	add	x3, x22, x1, lsl #2
                	ldr	w4, [x3]
-               	add	w3, w1, w4
-               	add	x1, x23, x2, lsl #2
-               	str	w3, [x1]
-               	add	x2, x2, #0x1
-               	cmp	x2, x20
+               	add	w3, w2, w4
+               	add	x2, x23, x1, lsl #2
+               	str	w3, [x2]
+               	add	x1, x1, #0x1
+               	cmp	x1, x20
                	b.lo	 <L7>
 <L8>:
                	mov	x24, x0
@@ -597,24 +613,39 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x23, #0x80]
                	str	xzr, [x23, #0x88]
                	str	wzr, [x23, #0x90]
-               	add	x0, x19, #0x0
-               	add	x1, x19, x21, lsl #2
-               	add	x2, x20, #0x0
-               	add	x3, x20, x21, lsl #2
-               	add	x4, x23, #0x0
-               	add	x5, x23, x21, lsl #2
-               	cmp	x5, x0
-               	cset	w6, ls
-               	cmp	x1, x4
+               	mov	x16, #0xffff            ; =65535
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xfffe, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	cmp	x21, x16
                	cset	w0, ls
-               	orr	w1, w6, w0
-               	cmp	x5, x2
-               	cset	w0, ls
-               	cmp	x3, x4
-               	cset	w2, ls
-               	orr	w3, w0, w2
-               	and	w0, w1, w3
-               	cbnz	w0,  <L38>
+               	mov	w16, #0x1               ; =1
+               	and	w1, w0, w16
+               	mov	w16, #0x1               ; =1
+               	and	w0, w1, w16
+               	mov	w16, #0x1               ; =1
+               	and	w1, w0, w16
+               	mov	w16, #0x1               ; =1
+               	and	w0, w1, w16
+               	add	x1, x19, #0x0
+               	add	x2, x19, x21, lsl #2
+               	add	x3, x20, #0x0
+               	add	x4, x20, x21, lsl #2
+               	add	x5, x23, #0x0
+               	add	x6, x23, x21, lsl #2
+               	cmp	x6, x1
+               	cset	w7, ls
+               	cmp	x2, x5
+               	cset	w1, ls
+               	orr	w2, w7, w1
+               	cmp	x6, x3
+               	cset	w1, ls
+               	cmp	x4, x5
+               	cset	w3, ls
+               	orr	w4, w1, w3
+               	and	w1, w2, w4
+               	and	w2, w0, w1
+               	cbnz	w2,  <L38>
                	mov	x0, #0x0                ; =0
                	cmp	x0, x21
                	b.lo	 <L37>
@@ -632,36 +663,37 @@ Disassembly of section __TEXT,__text:
                	b.lo	 <L37>
                	b	 <L42>
 <L38>:
-               	sub	x0, x21, #0x4
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, x0
-               	b.le	 <L39>
+               	mov	x0, #0x0                ; =0
+               	add	x1, x0, #0x4
+               	cmp	x1, x21
+               	b.ls	 <L39>
                	b	 <L40>
 <L39>:
-               	add	x2, x19, x1, lsl #2
-               	ldr	q0, [x2]
-               	add	x2, x20, x1, lsl #2
-               	ldr	q1, [x2]
+               	add	x1, x19, x0, lsl #2
+               	ldr	q0, [x1]
+               	add	x1, x20, x0, lsl #2
+               	ldr	q1, [x1]
                	fmul.4s	v2, v0, v1
-               	add	x2, x23, x1, lsl #2
-               	str	q2, [x2]
-               	add	x1, x1, #0x4
-               	cmp	x1, x0
-               	b.le	 <L39>
-<L40>:
+               	add	x1, x23, x0, lsl #2
+               	str	q2, [x1]
+               	add	x0, x0, #0x4
+               	add	x1, x0, #0x4
                	cmp	x1, x21
+               	b.ls	 <L39>
+<L40>:
+               	cmp	x0, x21
                	b.lo	 <L41>
                	b	 <L42>
 <L41>:
-               	add	x0, x19, x1, lsl #2
-               	ldr	s0, [x0]
-               	add	x0, x20, x1, lsl #2
-               	ldr	s1, [x0]
+               	add	x1, x19, x0, lsl #2
+               	ldr	s0, [x1]
+               	add	x1, x20, x0, lsl #2
+               	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	add	x0, x23, x1, lsl #2
-               	str	s2, [x0]
-               	add	x1, x1, #0x1
-               	cmp	x1, x21
+               	add	x1, x23, x0, lsl #2
+               	str	s2, [x1]
+               	add	x0, x0, #0x1
+               	cmp	x0, x21
                	b.lo	 <L41>
 <L42>:
                	mov	x24, #0x0               ; =0
@@ -699,24 +731,39 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x23, #0x80]
                	str	xzr, [x23, #0x88]
                	str	wzr, [x23, #0x90]
-               	add	x0, x19, #0x0
-               	add	x1, x19, x21, lsl #2
-               	add	x2, x20, #0x0
-               	add	x3, x20, x21, lsl #2
-               	add	x4, x23, #0x0
-               	add	x5, x23, x21, lsl #2
-               	cmp	x5, x0
-               	cset	w6, ls
-               	cmp	x1, x4
+               	mov	x16, #0xffff            ; =65535
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xfffe, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	cmp	x21, x16
                	cset	w0, ls
-               	orr	w1, w6, w0
-               	cmp	x5, x2
-               	cset	w0, ls
-               	cmp	x3, x4
-               	cset	w2, ls
-               	orr	w3, w0, w2
-               	and	w0, w1, w3
-               	cbnz	w0,  <L47>
+               	mov	w16, #0x1               ; =1
+               	and	w1, w0, w16
+               	mov	w16, #0x1               ; =1
+               	and	w0, w1, w16
+               	mov	w16, #0x1               ; =1
+               	and	w1, w0, w16
+               	mov	w16, #0x1               ; =1
+               	and	w0, w1, w16
+               	add	x1, x19, #0x0
+               	add	x2, x19, x21, lsl #2
+               	add	x3, x20, #0x0
+               	add	x4, x20, x21, lsl #2
+               	add	x5, x23, #0x0
+               	add	x6, x23, x21, lsl #2
+               	cmp	x6, x1
+               	cset	w7, ls
+               	cmp	x2, x5
+               	cset	w1, ls
+               	orr	w2, w7, w1
+               	cmp	x6, x3
+               	cset	w1, ls
+               	cmp	x4, x5
+               	cset	w3, ls
+               	orr	w4, w1, w3
+               	and	w1, w2, w4
+               	and	w2, w0, w1
+               	cbnz	w2,  <L47>
                	mov	x0, #0x0                ; =0
                	cmp	x0, x21
                	b.lo	 <L46>
@@ -734,36 +781,37 @@ Disassembly of section __TEXT,__text:
                	b.lo	 <L46>
                	b	 <L51>
 <L47>:
-               	sub	x0, x21, #0x4
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, x0
-               	b.le	 <L48>
+               	mov	x0, #0x0                ; =0
+               	add	x1, x0, #0x4
+               	cmp	x1, x21
+               	b.ls	 <L48>
                	b	 <L49>
 <L48>:
-               	add	x2, x19, x1, lsl #2
-               	ldr	q0, [x2]
-               	add	x2, x20, x1, lsl #2
-               	ldr	q1, [x2]
+               	add	x1, x19, x0, lsl #2
+               	ldr	q0, [x1]
+               	add	x1, x20, x0, lsl #2
+               	ldr	q1, [x1]
                	fdiv.4s	v2, v0, v1
-               	add	x2, x23, x1, lsl #2
-               	str	q2, [x2]
-               	add	x1, x1, #0x4
-               	cmp	x1, x0
-               	b.le	 <L48>
-<L49>:
+               	add	x1, x23, x0, lsl #2
+               	str	q2, [x1]
+               	add	x0, x0, #0x4
+               	add	x1, x0, #0x4
                	cmp	x1, x21
+               	b.ls	 <L48>
+<L49>:
+               	cmp	x0, x21
                	b.lo	 <L50>
                	b	 <L51>
 <L50>:
-               	add	x0, x19, x1, lsl #2
-               	ldr	s0, [x0]
-               	add	x0, x20, x1, lsl #2
-               	ldr	s1, [x0]
+               	add	x1, x19, x0, lsl #2
+               	ldr	s0, [x1]
+               	add	x1, x20, x0, lsl #2
+               	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	add	x0, x23, x1, lsl #2
-               	str	s2, [x0]
-               	add	x1, x1, #0x1
-               	cmp	x1, x21
+               	add	x1, x23, x0, lsl #2
+               	str	s2, [x1]
+               	add	x0, x0, #0x1
+               	cmp	x0, x21
                	b.lo	 <L50>
 <L51>:
                	mov	x19, #0x0               ; =0

--- a/test/golden/aarch64-darwin/vec/vec_cmp_select.dis
+++ b/test/golden/aarch64-darwin/vec/vec_cmp_select.dis
@@ -284,11 +284,11 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_cmp_select.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x3e0
-               	sub	x16, x29, #0x3c0
+               	sub	sp, sp, #0x390
+               	sub	x16, x29, #0x370
                	stp	x19, x20, [x16]
                	stp	x21, x22, [x16, #-0x10]
-               	sub	x16, x29, #0x3e0
+               	sub	x16, x29, #0x390
                	str	d8, [x16, #0x8]
                	mov	x19, x0
 <L0>:
@@ -1211,34 +1211,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
+               	ldr	q0, [x29, x16]
 <L73>:
                	bl	 <L73>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L76>:
-               	bl	 <L76>
                	mov	x16, #0xfdd0            ; =64976
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1249,8 +1224,110 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	fcmgt.4s	v31, v31, v30
+               	fcmgt.4s	v0, v31, v30
+<L74>:
+               	bl	 <L74>
+               	mov	x16, #0xfdd0            ; =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfde0            ; =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	fcmeq.4s	v0, v31, v30
+<L75>:
+               	bl	 <L75>
+               	mov	x16, #0xfdd0            ; =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfde0            ; =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	fcmeq.4s	v0, v31, v30
+               	mvn.16b	v0, v0
+<L76>:
+               	bl	 <L76>
+               	mov	x16, #0xfde0            ; =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfdd0            ; =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	fcmge.4s	v0, v31, v30
+<L77>:
+               	bl	 <L77>
+               	mov	x16, #0xfdd0            ; =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfde0            ; =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	fcmge.4s	v0, v31, v30
+<L78>:
+               	bl	 <L78>
+               	mov	x16, #0xfdc0            ; =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfdd0            ; =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v0, v31, v30
+               	mov	x16, #0xfdc0            ; =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mvn.16b	v1, v31
+               	mov	x16, #0xfde0            ; =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v2, v1, v30
+               	orr.16b	v31, v0, v2
                	mov	x16, #0xfdb0            ; =64944
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfdc0            ; =64960
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfde0            ; =64992
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v0, v31, v30
+               	mov	x16, #0xfdd0            ; =64976
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v2, v1, v30
+               	orr.16b	v31, v0, v2
+               	mov	x16, #0xfda0            ; =64928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1260,23 +1337,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov	s0, v31[0]
 <L79>:
                	bl	 <L79>
                	mov	x16, #0xfdb0            ; =64944
@@ -1284,39 +1345,23 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
+               	mov	s0, v31[1]
 <L80>:
                	bl	 <L80>
-               	mov	x16, #0xfdd0            ; =64976
+               	mov	x16, #0xfdb0            ; =64944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	fcmeq.4s	v31, v31, v30
-               	mov	x16, #0xfda0            ; =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfda0            ; =64928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
+               	mov	s0, v31[2]
 <L81>:
                	bl	 <L81>
-               	mov	x16, #0xfda0            ; =64928
+               	mov	x16, #0xfdb0            ; =64944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov	s0, v31[3]
 <L82>:
                	bl	 <L82>
                	mov	x16, #0xfda0            ; =64928
@@ -1324,7 +1369,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov	s0, v31[0]
 <L83>:
                	bl	 <L83>
                	mov	x16, #0xfda0            ; =64928
@@ -1332,21 +1377,36 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
+               	mov	s0, v31[1]
 <L84>:
                	bl	 <L84>
-               	mov	x16, #0xfdd0            ; =64976
+               	mov	x16, #0xfda0            ; =64928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
+               	mov	s0, v31[2]
+<L85>:
+               	bl	 <L85>
+               	mov	x16, #0xfda0            ; =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	s0, v31[3]
+<L86>:
+               	bl	 <L86>
+               	mov	x16, #0xfda0            ; =64928
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfdb0            ; =64944
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
-               	fcmeq.4s	v31, v31, v30
-               	mvn.16b	v31, v31
+               	fsub.4s	v31, v31, v30
                	mov	x16, #0xfd90            ; =64912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1357,23 +1417,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L85>:
-               	bl	 <L85>
-               	mov	x16, #0xfd90            ; =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L86>:
-               	bl	 <L86>
-               	mov	x16, #0xfd90            ; =64912
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
+               	mov	s0, v31[0]
 <L87>:
                	bl	 <L87>
                	mov	x16, #0xfd90            ; =64912
@@ -1381,265 +1425,25 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
+               	mov	s0, v31[1]
 <L88>:
                	bl	 <L88>
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfd90            ; =64912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	fcmge.4s	v31, v31, v30
-               	mov	x16, #0xfd80            ; =64896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfd80            ; =64896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
+               	mov	s0, v31[2]
 <L89>:
                	bl	 <L89>
-               	mov	x16, #0xfd80            ; =64896
+               	mov	x16, #0xfd90            ; =64912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
+               	mov	s0, v31[3]
 <L90>:
                	bl	 <L90>
-               	mov	x16, #0xfd80            ; =64896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L91>:
-               	bl	 <L91>
-               	mov	x16, #0xfd80            ; =64896
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L92>:
-               	bl	 <L92>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	fcmge.4s	v31, v31, v30
-               	mov	x16, #0xfd70            ; =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfd70            ; =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L93>:
-               	bl	 <L93>
-               	mov	x16, #0xfd70            ; =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xfd70            ; =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xfd70            ; =64880
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	fcmgt.4s	v0, v31, v30
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and.16b	v1, v0, v30
-               	mvn.16b	v2, v0
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and.16b	v3, v2, v30
-               	orr.16b	v31, v1, v3
-               	mov	x16, #0xfd60            ; =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and.16b	v1, v0, v30
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and.16b	v0, v2, v30
-               	orr.16b	v31, v1, v0
-               	mov	x16, #0xfd50            ; =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfd60            ; =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L97>:
-               	bl	 <L97>
-               	mov	x16, #0xfd60            ; =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L98>:
-               	bl	 <L98>
-               	mov	x16, #0xfd60            ; =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L99>:
-               	bl	 <L99>
-               	mov	x16, #0xfd60            ; =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L100>:
-               	bl	 <L100>
-               	mov	x16, #0xfd50            ; =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L101>:
-               	bl	 <L101>
-               	mov	x16, #0xfd50            ; =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L102>:
-               	bl	 <L102>
-               	mov	x16, #0xfd50            ; =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L103>:
-               	bl	 <L103>
-               	mov	x16, #0xfd50            ; =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L104>:
-               	bl	 <L104>
-               	mov	x16, #0xfd50            ; =64848
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd60            ; =64864
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	fsub.4s	v31, v31, v30
-               	mov	x16, #0xfd40            ; =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfd40            ; =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[0]
-<L105>:
-               	bl	 <L105>
-               	mov	x16, #0xfd40            ; =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[1]
-<L106>:
-               	bl	 <L106>
-               	mov	x16, #0xfd40            ; =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[2]
-<L107>:
-               	bl	 <L107>
-               	mov	x16, #0xfd40            ; =64832
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	s0, v31[3]
-<L108>:
-               	bl	 <L108>
                	sub	x1, x29, #0x70
                	add	x2, x1, #0x0
                	mov	x17, #0x3ff8000000000000 ; =4609434218613702656
@@ -1655,7 +1459,7 @@ Disassembly of section __TEXT,__text:
                	add	x2, x1, #0x8
                	str	xzr, [x2]
                	ldr	q31, [x1]
-               	mov	x16, #0xfd30            ; =64816
+               	mov	x16, #0xfd80            ; =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1665,140 +1469,140 @@ Disassembly of section __TEXT,__text:
                	fadd	d3, d1, d2
                	mov.16b	v30, v0
                	mov.d	v30[0], v3[0]
-               	mov	x16, #0xfd20            ; =64800
+               	mov	x16, #0xfd70            ; =64880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfd30            ; =64816
+               	mov	x16, #0xfd80            ; =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd20            ; =64800
+               	mov	x16, #0xfd70            ; =64880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmgt.2d	v31, v31, v30
-               	mov	x16, #0xfd10            ; =64784
+               	mov	x16, #0xfd60            ; =64864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd10            ; =64784
+               	mov	x16, #0xfd60            ; =64864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
-<L109>:
-               	bl	 <L109>
-               	mov	x16, #0xfd10            ; =64784
+<L91>:
+               	bl	 <L91>
+               	mov	x16, #0xfd60            ; =64864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L110>:
-               	bl	 <L110>
-               	mov	x16, #0xfd20            ; =64800
+<L92>:
+               	bl	 <L92>
+               	mov	x16, #0xfd70            ; =64880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd30            ; =64816
+               	mov	x16, #0xfd80            ; =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmeq.2d	v31, v31, v30
-               	mov	x16, #0xfd00            ; =64768
+               	mov	x16, #0xfd50            ; =64848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd00            ; =64768
+               	mov	x16, #0xfd50            ; =64848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
-<L111>:
-               	bl	 <L111>
-               	mov	x16, #0xfd00            ; =64768
+<L93>:
+               	bl	 <L93>
+               	mov	x16, #0xfd50            ; =64848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L112>:
-               	bl	 <L112>
-               	mov	x16, #0xfd20            ; =64800
+<L94>:
+               	bl	 <L94>
+               	mov	x16, #0xfd70            ; =64880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd30            ; =64816
+               	mov	x16, #0xfd80            ; =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmeq.2d	v31, v31, v30
                	mvn.16b	v31, v31
-               	mov	x16, #0xfcf0            ; =64752
+               	mov	x16, #0xfd40            ; =64832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfcf0            ; =64752
+               	mov	x16, #0xfd40            ; =64832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
-<L113>:
-               	bl	 <L113>
-               	mov	x16, #0xfcf0            ; =64752
+<L95>:
+               	bl	 <L95>
+               	mov	x16, #0xfd40            ; =64832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L114>:
-               	bl	 <L114>
-               	mov	x16, #0xfd20            ; =64800
+<L96>:
+               	bl	 <L96>
+               	mov	x16, #0xfd70            ; =64880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfd30            ; =64816
+               	mov	x16, #0xfd80            ; =64896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	fcmge.2d	v31, v31, v30
-               	mov	x16, #0xfce0            ; =64736
+               	mov	x16, #0xfd30            ; =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfce0            ; =64736
+               	mov	x16, #0xfd30            ; =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
-<L115>:
-               	bl	 <L115>
-               	mov	x16, #0xfce0            ; =64736
+<L97>:
+               	bl	 <L97>
+               	mov	x16, #0xfd30            ; =64816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L116>:
-               	bl	 <L116>
+<L98>:
+               	bl	 <L98>
                	sub	x1, x29, #0x90
                	add	x2, x1, #0x0
                	mov	w17, #0x1               ; =1
@@ -1854,7 +1658,7 @@ Disassembly of section __TEXT,__text:
                	add	w2, w1, w21
                	mov.16b	v30, v0
                	mov.h	v30[0], w2
-               	mov	x16, #0xfcd0            ; =64720
+               	mov	x16, #0xfd20            ; =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1863,89 +1667,295 @@ Disassembly of section __TEXT,__text:
                	add	w2, w1, w21
                	mov.16b	v30, v1
                	mov.h	v30[7], w2
-               	mov	x16, #0xfcc0            ; =64704
+               	mov	x16, #0xfd10            ; =64784
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfcc0            ; =64704
+               	mov	x16, #0xfd10            ; =64784
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcd0            ; =64720
+               	mov	x16, #0xfd20            ; =64800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhi.8h	v31, v31, v30
-               	mov	x16, #0xfcb0            ; =64688
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfcb0            ; =64688
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[0]
-<L117>:
-               	bl	 <L117>
-               	mov	x16, #0xfcb0            ; =64688
+<L99>:
+               	bl	 <L99>
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[1]
-<L118>:
-               	bl	 <L118>
-               	mov	x16, #0xfcb0            ; =64688
+<L100>:
+               	bl	 <L100>
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[2]
-<L119>:
-               	bl	 <L119>
-               	mov	x16, #0xfcb0            ; =64688
+<L101>:
+               	bl	 <L101>
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[3]
-<L120>:
-               	bl	 <L120>
-               	mov	x16, #0xfcb0            ; =64688
+<L102>:
+               	bl	 <L102>
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[4]
-<L121>:
-               	bl	 <L121>
-               	mov	x16, #0xfcb0            ; =64688
+<L103>:
+               	bl	 <L103>
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[5]
-<L122>:
-               	bl	 <L122>
-               	mov	x16, #0xfcb0            ; =64688
+<L104>:
+               	bl	 <L104>
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[6]
-<L123>:
-               	bl	 <L123>
-               	mov	x16, #0xfcb0            ; =64688
+<L105>:
+               	bl	 <L105>
+               	mov	x16, #0xfd00            ; =64768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[7]
+<L106>:
+               	bl	 <L106>
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd10            ; =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq.8h	v31, v31, v30
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[0]
+<L107>:
+               	bl	 <L107>
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[1]
+<L108>:
+               	bl	 <L108>
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[2]
+<L109>:
+               	bl	 <L109>
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[3]
+<L110>:
+               	bl	 <L110>
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[4]
+<L111>:
+               	bl	 <L111>
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[5]
+<L112>:
+               	bl	 <L112>
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[6]
+<L113>:
+               	bl	 <L113>
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[7]
+<L114>:
+               	bl	 <L114>
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd10            ; =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhi.8h	v31, v31, v30
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[0]
+<L115>:
+               	bl	 <L115>
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[1]
+<L116>:
+               	bl	 <L116>
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[2]
+<L117>:
+               	bl	 <L117>
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[3]
+<L118>:
+               	bl	 <L118>
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[4]
+<L119>:
+               	bl	 <L119>
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[5]
+<L120>:
+               	bl	 <L120>
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[6]
+<L121>:
+               	bl	 <L121>
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[7]
+<L122>:
+               	bl	 <L122>
+               	mov	x16, #0xfd10            ; =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhi.8h	v0, v31, v30
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v1, v0, v30
+               	mvn.16b	v2, v0
+               	mov	x16, #0xfd10            ; =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v0, v2, v30
+               	orr.16b	v31, v1, v0
+               	mov	x16, #0xfcd0            ; =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfcd0            ; =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[0]
+<L123>:
+               	bl	 <L123>
+               	mov	x16, #0xfcd0            ; =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	umov.h	w1, v31[1]
 <L124>:
                	bl	 <L124>
                	mov	x16, #0xfcd0            ; =64720
@@ -1953,255 +1963,49 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcc0            ; =64704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmeq.8h	v31, v31, v30
-               	mov	x16, #0xfca0            ; =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfca0            ; =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
+               	umov.h	w1, v31[2]
 <L125>:
                	bl	 <L125>
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfcd0            ; =64720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
+               	umov.h	w1, v31[3]
 <L126>:
                	bl	 <L126>
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfcd0            ; =64720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
+               	umov.h	w1, v31[4]
 <L127>:
                	bl	 <L127>
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfcd0            ; =64720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
+               	umov.h	w1, v31[5]
 <L128>:
                	bl	 <L128>
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfcd0            ; =64720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
+               	umov.h	w1, v31[6]
 <L129>:
                	bl	 <L129>
-               	mov	x16, #0xfca0            ; =64672
+               	mov	x16, #0xfcd0            ; =64720
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
+               	umov.h	w1, v31[7]
 <L130>:
                	bl	 <L130>
-               	mov	x16, #0xfca0            ; =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L131>:
-               	bl	 <L131>
-               	mov	x16, #0xfca0            ; =64672
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L132>:
-               	bl	 <L132>
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcc0            ; =64704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmhi.8h	v31, v31, v30
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L133>:
-               	bl	 <L133>
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L134>:
-               	bl	 <L134>
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L135>:
-               	bl	 <L135>
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L136>:
-               	bl	 <L136>
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L137>:
-               	bl	 <L137>
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L138>:
-               	bl	 <L138>
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L139>:
-               	bl	 <L139>
-               	mov	x16, #0xfc90            ; =64656
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L140>:
-               	bl	 <L140>
-               	mov	x16, #0xfcc0            ; =64704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	cmhi.8h	v0, v31, v30
-               	mov	x16, #0xfcd0            ; =64720
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and.16b	v1, v0, v30
-               	mvn.16b	v2, v0
-               	mov	x16, #0xfcc0            ; =64704
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	and.16b	v0, v2, v30
-               	orr.16b	v31, v1, v0
-               	mov	x16, #0xfc80            ; =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfc80            ; =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L141>:
-               	bl	 <L141>
-               	mov	x16, #0xfc80            ; =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L142>:
-               	bl	 <L142>
-               	mov	x16, #0xfc80            ; =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L143>:
-               	bl	 <L143>
-               	mov	x16, #0xfc80            ; =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L144>:
-               	bl	 <L144>
-               	mov	x16, #0xfc80            ; =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L145>:
-               	bl	 <L145>
-               	mov	x16, #0xfc80            ; =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L146>:
-               	bl	 <L146>
-               	mov	x16, #0xfc80            ; =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L147>:
-               	bl	 <L147>
-               	mov	x16, #0xfc80            ; =64640
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L148>:
-               	bl	 <L148>
                	sub	x1, x29, #0xb0
                	add	x2, x1, #0x0
                	mov	w17, #0x1               ; =1
@@ -2305,7 +2109,7 @@ Disassembly of section __TEXT,__text:
                	add	w2, w1, w22
                	mov.16b	v30, v0
                	mov.b	v30[0], w2
-               	mov	x16, #0xfc70            ; =64624
+               	mov	x16, #0xfcc0            ; =64704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2314,78 +2118,78 @@ Disassembly of section __TEXT,__text:
                	add	w2, w1, w22
                	mov.16b	v30, v1
                	mov.b	v30[15], w2
-               	mov	x16, #0xfc60            ; =64608
+               	mov	x16, #0xfcb0            ; =64688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfc60            ; =64608
+               	mov	x16, #0xfcb0            ; =64688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc70            ; =64624
+               	mov	x16, #0xfcc0            ; =64704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhi.16b	v31, v31, v30
-               	mov	x16, #0xfc50            ; =64592
+               	mov	x16, #0xfca0            ; =64672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfc50            ; =64592
+               	mov	x16, #0xfca0            ; =64672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-<L149>:
-               	bl	 <L149>
-               	mov	x16, #0xfc70            ; =64624
+<L131>:
+               	bl	 <L131>
+               	mov	x16, #0xfcc0            ; =64704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc60            ; =64608
+               	mov	x16, #0xfcb0            ; =64688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmeq.16b	v0, v31, v30
-<L150>:
-               	bl	 <L150>
-               	mov	x16, #0xfc70            ; =64624
+<L132>:
+               	bl	 <L132>
+               	mov	x16, #0xfcc0            ; =64704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc60            ; =64608
+               	mov	x16, #0xfcb0            ; =64688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	cmhs.16b	v0, v31, v30
-<L151>:
-               	bl	 <L151>
-               	mov	x16, #0xfc50            ; =64592
+<L133>:
+               	bl	 <L133>
+               	mov	x16, #0xfca0            ; =64672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfc70            ; =64624
+               	mov	x16, #0xfcc0            ; =64704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	and.16b	v0, v31, v30
-               	mov	x16, #0xfc50            ; =64592
+               	mov	x16, #0xfca0            ; =64672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mvn.16b	v1, v31
-               	mov	x16, #0xfc60            ; =64608
+               	mov	x16, #0xfcb0            ; =64688
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2393,11 +2197,11 @@ Disassembly of section __TEXT,__text:
                	and.16b	v2, v1, v30
                	orr.16b	v1, v0, v2
                	mov.16b	v0, v1
-<L152>:
-               	bl	 <L152>
-               	sub	x16, x29, #0x3e0
+<L134>:
+               	bl	 <L134>
+               	sub	x16, x29, #0x390
                	ldr	d8, [x16, #0x8]
-               	sub	x16, x29, #0x3c0
+               	sub	x16, x29, #0x370
                	ldp	x19, x20, [x16]
                	ldp	x21, x22, [x16, #-0x10]
                	mov	sp, x29

--- a/test/golden/aarch64-darwin/vec/vec_f32x5.dis
+++ b/test/golden/aarch64-darwin/vec/vec_f32x5.dis
@@ -85,7 +85,7 @@ Disassembly of section __TEXT,__text:
                	sub	x1, x29, #0x1e0
                	sub	x1, x29, #0x1f4
                	sub	x9, x29, #0x208
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf328            ; =62248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -93,7 +93,7 @@ Disassembly of section __TEXT,__text:
                	sub	x2, x29, #0x21c
                	sub	x2, x29, #0x230
                	sub	x9, x29, #0x244
-               	mov	x16, #0xf328            ; =62248
+               	mov	x16, #0xf320            ; =62240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -101,7 +101,7 @@ Disassembly of section __TEXT,__text:
                	sub	x3, x29, #0x258
                	sub	x3, x29, #0x26c
                	sub	x9, x29, #0x280
-               	mov	x16, #0xf320            ; =62240
+               	mov	x16, #0xf318            ; =62232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -109,7 +109,7 @@ Disassembly of section __TEXT,__text:
                	sub	x4, x29, #0x294
                	sub	x4, x29, #0x2a8
                	sub	x9, x29, #0x2bc
-               	mov	x16, #0xf318            ; =62232
+               	mov	x16, #0xf310            ; =62224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -117,7 +117,7 @@ Disassembly of section __TEXT,__text:
                	sub	x5, x29, #0x2d0
                	sub	x5, x29, #0x2e4
                	sub	x9, x29, #0x2f8
-               	mov	x16, #0xf310            ; =62224
+               	mov	x16, #0xf308            ; =62216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -125,7 +125,7 @@ Disassembly of section __TEXT,__text:
                	sub	x6, x29, #0x30c
                	sub	x6, x29, #0x320
                	sub	x9, x29, #0x334
-               	mov	x16, #0xf308            ; =62216
+               	mov	x16, #0xf300            ; =62208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -139,7 +139,7 @@ Disassembly of section __TEXT,__text:
                	sub	x8, x29, #0x35c
                	sub	x8, x29, #0x370
                	sub	x9, x29, #0x384
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -148,7 +148,7 @@ Disassembly of section __TEXT,__text:
                	sub	x12, x29, #0x3ac
                	sub	x12, x29, #0x3c0
                	sub	x9, x29, #0x3d4
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf2f0            ; =62192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -157,7 +157,7 @@ Disassembly of section __TEXT,__text:
                	sub	x13, x29, #0x3fc
                	sub	x13, x29, #0x410
                	sub	x9, x29, #0x424
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf2e8            ; =62184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -167,7 +167,7 @@ Disassembly of section __TEXT,__text:
                	sub	x14, x29, #0x460
                	sub	x14, x29, #0x474
                	sub	x9, x29, #0x488
-               	mov	x16, #0xf2e8            ; =62184
+               	mov	x16, #0xf2e0            ; =62176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -175,21 +175,21 @@ Disassembly of section __TEXT,__text:
                	sub	x15, x29, #0x49c
                	sub	x15, x29, #0x4b0
                	sub	x9, x29, #0x4c4
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf348            ; =62280
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x18, x29, #0x4d8
-               	sub	x18, x29, #0x4ec
-               	sub	x18, x29, #0x500
+               	sub	x7, x29, #0x4d8
+               	sub	x7, x29, #0x4ec
+               	sub	x7, x29, #0x500
                	sub	x9, x29, #0x514
-               	mov	x16, #0xf2e0            ; =62176
+               	mov	x16, #0xf330            ; =62256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x7, x29, #0x528
+               	sub	x15, x29, #0x528
                	sub	x9, x29, #0x53c
                	mov	x16, #0xf2d8            ; =62168
                	movk	x16, #0xffff, lsl #16
@@ -197,595 +197,595 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x550
-               	mov	x16, #0xf348            ; =62280
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x9, x29, #0x564
                	mov	x16, #0xf340            ; =62272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x15, x29, #0x578
-               	sub	x15, x29, #0x58c
-               	sub	x15, x29, #0x5a0
-               	sub	x15, x29, #0x5b4
-               	sub	x15, x29, #0x5c8
-               	sub	x15, x29, #0x5dc
-               	sub	x15, x29, #0x5f0
-               	sub	x15, x29, #0x604
-               	sub	x15, x29, #0x618
-               	sub	x15, x29, #0x62c
-               	sub	x15, x29, #0x640
-               	sub	x15, x29, #0x654
-               	sub	x15, x29, #0x668
-               	sub	x15, x29, #0x67c
-               	sub	x15, x29, #0x690
-               	sub	x15, x29, #0x6a4
-               	sub	x15, x29, #0x6b8
-               	sub	x15, x29, #0x6cc
-               	sub	x15, x29, #0x6e0
-               	sub	x15, x29, #0x6f4
-               	sub	x15, x29, #0x708
-               	sub	x15, x29, #0x71c
-               	sub	x15, x29, #0x730
-               	sub	x15, x29, #0x744
-               	sub	x15, x29, #0x758
-               	sub	x15, x29, #0x76c
-               	sub	x15, x29, #0x780
-               	sub	x15, x29, #0x794
-               	sub	x15, x29, #0x7a8
-               	sub	x15, x29, #0x7bc
-               	sub	x15, x29, #0x7d0
-               	sub	x15, x29, #0x7e4
-               	sub	x15, x29, #0x7f8
-               	sub	x15, x29, #0x80c
-               	sub	x15, x29, #0x820
-               	sub	x15, x29, #0x834
-               	sub	x15, x29, #0x848
-               	sub	x15, x29, #0x85c
-               	sub	x15, x29, #0x870
-               	sub	x15, x29, #0x884
-               	sub	x15, x29, #0x898
-               	sub	x15, x29, #0x8ac
-               	sub	x15, x29, #0x8c0
-               	sub	x15, x29, #0x8d4
-               	sub	x15, x29, #0x8e8
-               	sub	x15, x29, #0x8fc
-               	sub	x15, x29, #0x910
-               	sub	x15, x29, #0x924
-               	sub	x15, x29, #0x938
-               	sub	x15, x29, #0x94c
-               	sub	x15, x29, #0x960
-               	sub	x15, x29, #0x974
-               	sub	x15, x29, #0x988
-               	sub	x15, x29, #0x99c
-               	sub	x15, x29, #0x9b0
-               	sub	x15, x29, #0x9c4
-               	sub	x15, x29, #0x9d8
-               	sub	x15, x29, #0x9ec
-               	sub	x15, x29, #0xa00
-               	sub	x15, x29, #0xa14
-               	sub	x15, x29, #0xa28
-               	sub	x15, x29, #0xa3c
-               	sub	x15, x29, #0xa50
-               	sub	x15, x29, #0xa64
-               	sub	x15, x29, #0xa78
-               	sub	x15, x29, #0xa8c
-               	sub	x15, x29, #0xaa0
-               	sub	x15, x29, #0xab4
-               	sub	x15, x29, #0xac8
-               	sub	x15, x29, #0xadc
-               	sub	x15, x29, #0xaf0
-               	sub	x15, x29, #0xb04
-               	sub	x15, x29, #0xb18
-               	sub	x15, x29, #0xb2c
-               	sub	x15, x29, #0xb40
-               	sub	x15, x29, #0xb54
-               	sub	x15, x29, #0xb68
-               	sub	x15, x29, #0xb7c
-               	sub	x15, x29, #0xb90
-               	sub	x15, x29, #0xba4
+               	sub	x9, x29, #0x564
+               	mov	x16, #0xf338            ; =62264
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	sub	x7, x29, #0x578
+               	sub	x7, x29, #0x58c
+               	sub	x7, x29, #0x5a0
+               	sub	x7, x29, #0x5b4
+               	sub	x7, x29, #0x5c8
+               	sub	x7, x29, #0x5dc
+               	sub	x7, x29, #0x5f0
+               	sub	x7, x29, #0x604
+               	sub	x7, x29, #0x618
+               	sub	x7, x29, #0x62c
+               	sub	x7, x29, #0x640
+               	sub	x7, x29, #0x654
+               	sub	x7, x29, #0x668
+               	sub	x7, x29, #0x67c
+               	sub	x7, x29, #0x690
+               	sub	x7, x29, #0x6a4
+               	sub	x7, x29, #0x6b8
+               	sub	x7, x29, #0x6cc
+               	sub	x7, x29, #0x6e0
+               	sub	x7, x29, #0x6f4
+               	sub	x7, x29, #0x708
+               	sub	x7, x29, #0x71c
+               	sub	x7, x29, #0x730
+               	sub	x7, x29, #0x744
+               	sub	x7, x29, #0x758
+               	sub	x7, x29, #0x76c
+               	sub	x7, x29, #0x780
+               	sub	x7, x29, #0x794
+               	sub	x7, x29, #0x7a8
+               	sub	x7, x29, #0x7bc
+               	sub	x7, x29, #0x7d0
+               	sub	x7, x29, #0x7e4
+               	sub	x7, x29, #0x7f8
+               	sub	x7, x29, #0x80c
+               	sub	x7, x29, #0x820
+               	sub	x7, x29, #0x834
+               	sub	x7, x29, #0x848
+               	sub	x7, x29, #0x85c
+               	sub	x7, x29, #0x870
+               	sub	x7, x29, #0x884
+               	sub	x7, x29, #0x898
+               	sub	x7, x29, #0x8ac
+               	sub	x7, x29, #0x8c0
+               	sub	x7, x29, #0x8d4
+               	sub	x7, x29, #0x8e8
+               	sub	x7, x29, #0x8fc
+               	sub	x7, x29, #0x910
+               	sub	x7, x29, #0x924
+               	sub	x7, x29, #0x938
+               	sub	x7, x29, #0x94c
+               	sub	x7, x29, #0x960
+               	sub	x7, x29, #0x974
+               	sub	x7, x29, #0x988
+               	sub	x7, x29, #0x99c
+               	sub	x7, x29, #0x9b0
+               	sub	x7, x29, #0x9c4
+               	sub	x7, x29, #0x9d8
+               	sub	x7, x29, #0x9ec
+               	sub	x7, x29, #0xa00
+               	sub	x7, x29, #0xa14
+               	sub	x7, x29, #0xa28
+               	sub	x7, x29, #0xa3c
+               	sub	x7, x29, #0xa50
+               	sub	x7, x29, #0xa64
+               	sub	x7, x29, #0xa78
+               	sub	x7, x29, #0xa8c
+               	sub	x7, x29, #0xaa0
+               	sub	x7, x29, #0xab4
+               	sub	x7, x29, #0xac8
+               	sub	x7, x29, #0xadc
+               	sub	x7, x29, #0xaf0
+               	sub	x7, x29, #0xb04
+               	sub	x7, x29, #0xb18
+               	sub	x7, x29, #0xb2c
+               	sub	x7, x29, #0xb40
+               	sub	x7, x29, #0xb54
+               	sub	x7, x29, #0xb68
+               	sub	x7, x29, #0xb7c
+               	sub	x7, x29, #0xb90
+               	sub	x7, x29, #0xba4
 <L0>:
                	bl	 <L0>
                	ucvtf	s0, x19
-               	sub	x15, x29, #0xbb8
-               	add	x19, x15, #0x0
+               	sub	x7, x29, #0xbb8
+               	add	x19, x7, #0x0
                	mov	w17, #0x3fc00000        ; =1069547520
                	str	w17, [x19]
                	fmov	s31, #2.25000000
                	fneg	s1, s31
-               	add	x19, x15, #0x4
+               	add	x19, x7, #0x4
                	str	s1, [x19]
-               	add	x19, x15, #0x8
+               	add	x19, x7, #0x8
                	mov	w17, #0x40700000        ; =1081081856
                	str	w17, [x19]
                	fmov	s31, #0.50000000
                	fneg	s1, s31
-               	add	x19, x15, #0xc
+               	add	x19, x7, #0xc
                	str	s1, [x19]
-               	add	x19, x15, #0x10
+               	add	x19, x7, #0x10
                	mov	w17, #0x40c80000        ; =1086849024
                	str	w17, [x19]
-               	add	x19, x15, #0x0
+               	add	x19, x7, #0x0
                	ldr	s1, [x19]
                	add	x19, x20, #0x0
                	str	s1, [x19]
-               	add	x19, x15, #0x4
+               	add	x19, x7, #0x4
                	ldr	s1, [x19]
                	add	x19, x20, #0x4
                	str	s1, [x19]
-               	add	x19, x15, #0x8
+               	add	x19, x7, #0x8
                	ldr	s1, [x19]
                	add	x19, x20, #0x8
                	str	s1, [x19]
-               	add	x19, x15, #0xc
+               	add	x19, x7, #0xc
                	ldr	s1, [x19]
                	add	x19, x20, #0xc
                	str	s1, [x19]
-               	add	x19, x15, #0x10
+               	add	x19, x7, #0x10
                	ldr	s1, [x19]
-               	add	x15, x20, #0x10
-               	str	s1, [x15]
-               	sub	x15, x29, #0xbcc
-               	add	x19, x15, #0x0
+               	add	x7, x20, #0x10
+               	str	s1, [x7]
+               	sub	x7, x29, #0xbcc
+               	add	x19, x7, #0x0
                	mov	w17, #0x3f000000        ; =1056964608
                	str	w17, [x19]
-               	add	x19, x15, #0x4
+               	add	x19, x7, #0x4
                	mov	w17, #0x40800000        ; =1082130432
                	str	w17, [x19]
                	fmov	s31, #0.12500000
                	fneg	s1, s31
-               	add	x19, x15, #0x8
+               	add	x19, x7, #0x8
                	str	s1, [x19]
-               	add	x19, x15, #0xc
+               	add	x19, x7, #0xc
                	mov	w17, #0x41000000        ; =1090519040
                	str	w17, [x19]
                	fmov	s31, #2.00000000
                	fneg	s1, s31
-               	add	x19, x15, #0x10
+               	add	x19, x7, #0x10
                	str	s1, [x19]
-               	add	x19, x15, #0x0
+               	add	x19, x7, #0x0
                	ldr	s1, [x19]
                	add	x19, x21, #0x0
                	str	s1, [x19]
-               	add	x19, x15, #0x4
+               	add	x19, x7, #0x4
                	ldr	s1, [x19]
                	add	x19, x21, #0x4
                	str	s1, [x19]
-               	add	x19, x15, #0x8
+               	add	x19, x7, #0x8
                	ldr	s1, [x19]
                	add	x19, x21, #0x8
                	str	s1, [x19]
-               	add	x19, x15, #0xc
+               	add	x19, x7, #0xc
                	ldr	s1, [x19]
                	add	x19, x21, #0xc
                	str	s1, [x19]
-               	add	x19, x15, #0x10
+               	add	x19, x7, #0x10
                	ldr	s1, [x19]
-               	add	x15, x21, #0x10
-               	str	s1, [x15]
-               	sub	x15, x29, #0xbe0
-               	add	x19, x15, #0x0
+               	add	x7, x21, #0x10
+               	str	s1, [x7]
+               	sub	x7, x29, #0xbe0
+               	add	x19, x7, #0x0
                	mov	w17, #0x3f800000        ; =1065353216
                	str	w17, [x19]
-               	add	x19, x15, #0x4
+               	add	x19, x7, #0x4
                	mov	w17, #0x40400000        ; =1077936128
                	str	w17, [x19]
-               	add	x19, x15, #0x8
+               	add	x19, x7, #0x8
                	mov	w17, #0x41100000        ; =1091567616
                	str	w17, [x19]
-               	add	x19, x15, #0xc
+               	add	x19, x7, #0xc
                	mov	w17, #0x41d80000        ; =1104674816
                	str	w17, [x19]
-               	add	x19, x15, #0x10
+               	add	x19, x7, #0x10
                	mov	w17, #0x42a20000        ; =1117913088
                	str	w17, [x19]
-               	add	x19, x15, #0x0
+               	add	x19, x7, #0x0
                	ldr	s1, [x19]
                	add	x19, x22, #0x0
                	str	s1, [x19]
-               	add	x19, x15, #0x4
+               	add	x19, x7, #0x4
                	ldr	s1, [x19]
                	add	x19, x22, #0x4
                	str	s1, [x19]
-               	add	x19, x15, #0x8
+               	add	x19, x7, #0x8
                	ldr	s1, [x19]
                	add	x19, x22, #0x8
                	str	s1, [x19]
-               	add	x19, x15, #0xc
+               	add	x19, x7, #0xc
                	ldr	s1, [x19]
                	add	x19, x22, #0xc
                	str	s1, [x19]
-               	add	x19, x15, #0x10
+               	add	x19, x7, #0x10
                	ldr	s1, [x19]
-               	add	x15, x22, #0x10
-               	str	s1, [x15]
-               	add	x15, x20, #0x0
-               	ldr	s1, [x15]
+               	add	x7, x22, #0x10
+               	str	s1, [x7]
+               	add	x7, x20, #0x0
+               	ldr	s1, [x7]
                	fadd	s2, s1, s0
-               	add	x15, x20, #0x0
-               	ldr	s1, [x15]
-               	add	x15, x23, #0x0
-               	str	s1, [x15]
-               	add	x15, x20, #0x4
-               	ldr	s1, [x15]
-               	add	x15, x23, #0x4
-               	str	s1, [x15]
-               	add	x15, x20, #0x8
-               	ldr	s1, [x15]
-               	add	x15, x23, #0x8
-               	str	s1, [x15]
-               	add	x15, x20, #0xc
-               	ldr	s1, [x15]
-               	add	x15, x23, #0xc
-               	str	s1, [x15]
-               	add	x15, x20, #0x10
-               	ldr	s1, [x15]
-               	add	x15, x23, #0x10
-               	str	s1, [x15]
-               	add	x15, x23, #0x0
-               	str	s2, [x15]
-               	add	x15, x23, #0x10
-               	ldr	s1, [x15]
+               	add	x7, x20, #0x0
+               	ldr	s1, [x7]
+               	add	x7, x23, #0x0
+               	str	s1, [x7]
+               	add	x7, x20, #0x4
+               	ldr	s1, [x7]
+               	add	x7, x23, #0x4
+               	str	s1, [x7]
+               	add	x7, x20, #0x8
+               	ldr	s1, [x7]
+               	add	x7, x23, #0x8
+               	str	s1, [x7]
+               	add	x7, x20, #0xc
+               	ldr	s1, [x7]
+               	add	x7, x23, #0xc
+               	str	s1, [x7]
+               	add	x7, x20, #0x10
+               	ldr	s1, [x7]
+               	add	x7, x23, #0x10
+               	str	s1, [x7]
+               	add	x7, x23, #0x0
+               	str	s2, [x7]
+               	add	x7, x23, #0x10
+               	ldr	s1, [x7]
                	fadd	s2, s1, s0
-               	add	x15, x23, #0x0
-               	ldr	s1, [x15]
-               	add	x15, x24, #0x0
-               	str	s1, [x15]
-               	add	x15, x23, #0x4
-               	ldr	s1, [x15]
-               	add	x15, x24, #0x4
-               	str	s1, [x15]
-               	add	x15, x23, #0x8
-               	ldr	s1, [x15]
-               	add	x15, x24, #0x8
-               	str	s1, [x15]
-               	add	x15, x23, #0xc
-               	ldr	s1, [x15]
-               	add	x15, x24, #0xc
-               	str	s1, [x15]
-               	add	x15, x23, #0x10
-               	ldr	s1, [x15]
-               	add	x15, x24, #0x10
-               	str	s1, [x15]
-               	add	x15, x24, #0x10
-               	str	s2, [x15]
-               	add	x15, x21, #0x8
-               	ldr	s1, [x15]
+               	add	x7, x23, #0x0
+               	ldr	s1, [x7]
+               	add	x7, x24, #0x0
+               	str	s1, [x7]
+               	add	x7, x23, #0x4
+               	ldr	s1, [x7]
+               	add	x7, x24, #0x4
+               	str	s1, [x7]
+               	add	x7, x23, #0x8
+               	ldr	s1, [x7]
+               	add	x7, x24, #0x8
+               	str	s1, [x7]
+               	add	x7, x23, #0xc
+               	ldr	s1, [x7]
+               	add	x7, x24, #0xc
+               	str	s1, [x7]
+               	add	x7, x23, #0x10
+               	ldr	s1, [x7]
+               	add	x7, x24, #0x10
+               	str	s1, [x7]
+               	add	x7, x24, #0x10
+               	str	s2, [x7]
+               	add	x7, x21, #0x8
+               	ldr	s1, [x7]
                	fadd	s2, s1, s0
-               	add	x15, x21, #0x0
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x0
-               	str	s0, [x15]
-               	add	x15, x21, #0x4
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x4
-               	str	s0, [x15]
-               	add	x15, x21, #0x8
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x8
-               	str	s0, [x15]
-               	add	x15, x21, #0xc
-               	ldr	s0, [x15]
-               	add	x15, x25, #0xc
-               	str	s0, [x15]
-               	add	x15, x21, #0x10
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x10
-               	str	s0, [x15]
-               	add	x15, x25, #0x8
-               	str	s2, [x15]
-               	add	x15, x24, #0x0
-               	ldr	s0, [x15]
+               	add	x7, x21, #0x0
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x0
+               	str	s0, [x7]
+               	add	x7, x21, #0x4
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x4
+               	str	s0, [x7]
+               	add	x7, x21, #0x8
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x8
+               	str	s0, [x7]
+               	add	x7, x21, #0xc
+               	ldr	s0, [x7]
+               	add	x7, x25, #0xc
+               	str	s0, [x7]
+               	add	x7, x21, #0x10
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x10
+               	str	s0, [x7]
+               	add	x7, x25, #0x8
+               	str	s2, [x7]
+               	add	x7, x24, #0x0
+               	ldr	s0, [x7]
 <L1>:
                	bl	 <L1>
-               	add	x15, x24, #0x4
-               	ldr	s0, [x15]
+               	add	x7, x24, #0x4
+               	ldr	s0, [x7]
 <L2>:
                	bl	 <L2>
-               	add	x15, x24, #0x8
-               	ldr	s0, [x15]
+               	add	x7, x24, #0x8
+               	ldr	s0, [x7]
 <L3>:
                	bl	 <L3>
-               	add	x15, x24, #0xc
-               	ldr	s0, [x15]
+               	add	x7, x24, #0xc
+               	ldr	s0, [x7]
 <L4>:
                	bl	 <L4>
-               	add	x15, x24, #0x10
-               	ldr	s0, [x15]
+               	add	x7, x24, #0x10
+               	ldr	s0, [x7]
 <L5>:
                	bl	 <L5>
-               	add	x15, x25, #0x0
-               	ldr	s0, [x15]
+               	add	x7, x25, #0x0
+               	ldr	s0, [x7]
 <L6>:
                	bl	 <L6>
-               	add	x15, x25, #0x4
-               	ldr	s0, [x15]
+               	add	x7, x25, #0x4
+               	ldr	s0, [x7]
 <L7>:
                	bl	 <L7>
-               	add	x15, x25, #0x8
-               	ldr	s0, [x15]
+               	add	x7, x25, #0x8
+               	ldr	s0, [x7]
 <L8>:
                	bl	 <L8>
-               	add	x15, x25, #0xc
-               	ldr	s0, [x15]
+               	add	x7, x25, #0xc
+               	ldr	s0, [x7]
 <L9>:
                	bl	 <L9>
-               	add	x15, x25, #0x10
-               	ldr	s0, [x15]
+               	add	x7, x25, #0x10
+               	ldr	s0, [x7]
 <L10>:
                	bl	 <L10>
-               	add	x15, x24, #0x0
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x0
-               	ldr	s1, [x15]
+               	add	x7, x24, #0x0
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x0
+               	ldr	s1, [x7]
                	fadd	s2, s0, s1
-               	add	x15, x26, #0x0
-               	str	s2, [x15]
-               	add	x15, x24, #0x4
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x4
-               	ldr	s1, [x15]
+               	add	x7, x26, #0x0
+               	str	s2, [x7]
+               	add	x7, x24, #0x4
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x4
+               	ldr	s1, [x7]
                	fadd	s2, s0, s1
-               	add	x15, x26, #0x4
-               	str	s2, [x15]
-               	add	x15, x24, #0x8
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x8
-               	ldr	s1, [x15]
+               	add	x7, x26, #0x4
+               	str	s2, [x7]
+               	add	x7, x24, #0x8
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x8
+               	ldr	s1, [x7]
                	fadd	s2, s0, s1
-               	add	x15, x26, #0x8
-               	str	s2, [x15]
-               	add	x15, x24, #0xc
-               	ldr	s0, [x15]
-               	add	x15, x25, #0xc
-               	ldr	s1, [x15]
+               	add	x7, x26, #0x8
+               	str	s2, [x7]
+               	add	x7, x24, #0xc
+               	ldr	s0, [x7]
+               	add	x7, x25, #0xc
+               	ldr	s1, [x7]
                	fadd	s2, s0, s1
-               	add	x15, x26, #0xc
-               	str	s2, [x15]
-               	add	x15, x24, #0x10
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x10
-               	ldr	s1, [x15]
+               	add	x7, x26, #0xc
+               	str	s2, [x7]
+               	add	x7, x24, #0x10
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x10
+               	ldr	s1, [x7]
                	fadd	s2, s0, s1
-               	add	x15, x26, #0x10
-               	str	s2, [x15]
-               	add	x15, x26, #0x0
-               	ldr	s0, [x15]
+               	add	x7, x26, #0x10
+               	str	s2, [x7]
+               	add	x7, x26, #0x0
+               	ldr	s0, [x7]
 <L11>:
                	bl	 <L11>
-               	add	x15, x26, #0x4
-               	ldr	s0, [x15]
+               	add	x7, x26, #0x4
+               	ldr	s0, [x7]
 <L12>:
                	bl	 <L12>
-               	add	x15, x26, #0x8
-               	ldr	s0, [x15]
+               	add	x7, x26, #0x8
+               	ldr	s0, [x7]
 <L13>:
                	bl	 <L13>
-               	add	x15, x26, #0xc
-               	ldr	s0, [x15]
+               	add	x7, x26, #0xc
+               	ldr	s0, [x7]
 <L14>:
                	bl	 <L14>
-               	add	x15, x26, #0x10
-               	ldr	s0, [x15]
+               	add	x7, x26, #0x10
+               	ldr	s0, [x7]
 <L15>:
                	bl	 <L15>
-               	add	x15, x24, #0x0
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x0
-               	ldr	s1, [x15]
+               	add	x7, x24, #0x0
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x0
+               	ldr	s1, [x7]
                	fsub	s2, s0, s1
-               	add	x15, x27, #0x0
-               	str	s2, [x15]
-               	add	x15, x24, #0x4
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x4
-               	ldr	s1, [x15]
+               	add	x7, x27, #0x0
+               	str	s2, [x7]
+               	add	x7, x24, #0x4
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x4
+               	ldr	s1, [x7]
                	fsub	s2, s0, s1
-               	add	x15, x27, #0x4
-               	str	s2, [x15]
-               	add	x15, x24, #0x8
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x8
-               	ldr	s1, [x15]
+               	add	x7, x27, #0x4
+               	str	s2, [x7]
+               	add	x7, x24, #0x8
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x8
+               	ldr	s1, [x7]
                	fsub	s2, s0, s1
-               	add	x15, x27, #0x8
-               	str	s2, [x15]
-               	add	x15, x24, #0xc
-               	ldr	s0, [x15]
-               	add	x15, x25, #0xc
-               	ldr	s1, [x15]
+               	add	x7, x27, #0x8
+               	str	s2, [x7]
+               	add	x7, x24, #0xc
+               	ldr	s0, [x7]
+               	add	x7, x25, #0xc
+               	ldr	s1, [x7]
                	fsub	s2, s0, s1
-               	add	x15, x27, #0xc
-               	str	s2, [x15]
-               	add	x15, x24, #0x10
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x10
-               	ldr	s1, [x15]
+               	add	x7, x27, #0xc
+               	str	s2, [x7]
+               	add	x7, x24, #0x10
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x10
+               	ldr	s1, [x7]
                	fsub	s2, s0, s1
-               	add	x15, x27, #0x10
-               	str	s2, [x15]
-               	add	x15, x27, #0x0
-               	ldr	s0, [x15]
+               	add	x7, x27, #0x10
+               	str	s2, [x7]
+               	add	x7, x27, #0x0
+               	ldr	s0, [x7]
 <L16>:
                	bl	 <L16>
-               	add	x15, x27, #0x4
-               	ldr	s0, [x15]
+               	add	x7, x27, #0x4
+               	ldr	s0, [x7]
 <L17>:
                	bl	 <L17>
-               	add	x15, x27, #0x8
-               	ldr	s0, [x15]
+               	add	x7, x27, #0x8
+               	ldr	s0, [x7]
 <L18>:
                	bl	 <L18>
-               	add	x15, x27, #0xc
-               	ldr	s0, [x15]
+               	add	x7, x27, #0xc
+               	ldr	s0, [x7]
 <L19>:
                	bl	 <L19>
-               	add	x15, x27, #0x10
-               	ldr	s0, [x15]
+               	add	x7, x27, #0x10
+               	ldr	s0, [x7]
 <L20>:
                	bl	 <L20>
-               	add	x15, x25, #0x0
-               	ldr	s0, [x15]
-               	add	x15, x24, #0x0
-               	ldr	s1, [x15]
+               	add	x7, x25, #0x0
+               	ldr	s0, [x7]
+               	add	x7, x24, #0x0
+               	ldr	s1, [x7]
                	fsub	s2, s0, s1
-               	add	x15, x28, #0x0
-               	str	s2, [x15]
-               	add	x15, x25, #0x4
-               	ldr	s0, [x15]
-               	add	x15, x24, #0x4
-               	ldr	s1, [x15]
+               	add	x7, x28, #0x0
+               	str	s2, [x7]
+               	add	x7, x25, #0x4
+               	ldr	s0, [x7]
+               	add	x7, x24, #0x4
+               	ldr	s1, [x7]
                	fsub	s2, s0, s1
-               	add	x15, x28, #0x4
-               	str	s2, [x15]
-               	add	x15, x25, #0x8
-               	ldr	s0, [x15]
-               	add	x15, x24, #0x8
-               	ldr	s1, [x15]
+               	add	x7, x28, #0x4
+               	str	s2, [x7]
+               	add	x7, x25, #0x8
+               	ldr	s0, [x7]
+               	add	x7, x24, #0x8
+               	ldr	s1, [x7]
                	fsub	s2, s0, s1
-               	add	x15, x28, #0x8
-               	str	s2, [x15]
-               	add	x15, x25, #0xc
-               	ldr	s0, [x15]
-               	add	x15, x24, #0xc
-               	ldr	s1, [x15]
+               	add	x7, x28, #0x8
+               	str	s2, [x7]
+               	add	x7, x25, #0xc
+               	ldr	s0, [x7]
+               	add	x7, x24, #0xc
+               	ldr	s1, [x7]
                	fsub	s2, s0, s1
-               	add	x15, x28, #0xc
-               	str	s2, [x15]
-               	add	x15, x25, #0x10
-               	ldr	s0, [x15]
-               	add	x15, x24, #0x10
-               	ldr	s1, [x15]
+               	add	x7, x28, #0xc
+               	str	s2, [x7]
+               	add	x7, x25, #0x10
+               	ldr	s0, [x7]
+               	add	x7, x24, #0x10
+               	ldr	s1, [x7]
                	fsub	s2, s0, s1
-               	add	x15, x28, #0x10
-               	str	s2, [x15]
-               	add	x15, x28, #0x0
-               	ldr	s0, [x15]
+               	add	x7, x28, #0x10
+               	str	s2, [x7]
+               	add	x7, x28, #0x0
+               	ldr	s0, [x7]
 <L21>:
                	bl	 <L21>
-               	add	x15, x28, #0x4
-               	ldr	s0, [x15]
+               	add	x7, x28, #0x4
+               	ldr	s0, [x7]
 <L22>:
                	bl	 <L22>
-               	add	x15, x28, #0x8
-               	ldr	s0, [x15]
+               	add	x7, x28, #0x8
+               	ldr	s0, [x7]
 <L23>:
                	bl	 <L23>
-               	add	x15, x28, #0xc
-               	ldr	s0, [x15]
+               	add	x7, x28, #0xc
+               	ldr	s0, [x7]
 <L24>:
                	bl	 <L24>
-               	add	x15, x28, #0x10
-               	ldr	s0, [x15]
+               	add	x7, x28, #0x10
+               	ldr	s0, [x7]
 <L25>:
                	bl	 <L25>
-               	add	x15, x24, #0x0
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x0
-               	ldr	s1, [x15]
+               	add	x7, x24, #0x0
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x0
+               	ldr	s1, [x7]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf328            ; =62248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x0
-               	str	s2, [x15]
-               	add	x15, x24, #0x4
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x4
-               	ldr	s1, [x15]
+               	add	x7, x9, #0x0
+               	str	s2, [x7]
+               	add	x7, x24, #0x4
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x4
+               	ldr	s1, [x7]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf328            ; =62248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x4
-               	str	s2, [x15]
-               	add	x15, x24, #0x8
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x8
-               	ldr	s1, [x15]
+               	add	x7, x9, #0x4
+               	str	s2, [x7]
+               	add	x7, x24, #0x8
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x8
+               	ldr	s1, [x7]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf328            ; =62248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x8
-               	str	s2, [x15]
-               	add	x15, x24, #0xc
-               	ldr	s0, [x15]
-               	add	x15, x25, #0xc
-               	ldr	s1, [x15]
+               	add	x7, x9, #0x8
+               	str	s2, [x7]
+               	add	x7, x24, #0xc
+               	ldr	s0, [x7]
+               	add	x7, x25, #0xc
+               	ldr	s1, [x7]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf328            ; =62248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x15, x9, #0xc
-               	str	s2, [x15]
-               	add	x15, x24, #0x10
-               	ldr	s0, [x15]
-               	add	x15, x25, #0x10
-               	ldr	s1, [x15]
+               	add	x7, x9, #0xc
+               	str	s2, [x7]
+               	add	x7, x24, #0x10
+               	ldr	s0, [x7]
+               	add	x7, x25, #0x10
+               	ldr	s1, [x7]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf328            ; =62248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x10
-               	str	s2, [x15]
-               	mov	x16, #0xf330            ; =62256
+               	add	x7, x9, #0x10
+               	str	s2, [x7]
+               	mov	x16, #0xf328            ; =62248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x0
-               	ldr	s0, [x15]
+               	add	x7, x9, #0x0
+               	ldr	s0, [x7]
 <L26>:
                	bl	 <L26>
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf328            ; =62248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x4
-               	ldr	s0, [x15]
+               	add	x7, x9, #0x4
+               	ldr	s0, [x7]
 <L27>:
                	bl	 <L27>
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf328            ; =62248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x8
-               	ldr	s0, [x15]
+               	add	x7, x9, #0x8
+               	ldr	s0, [x7]
 <L28>:
                	bl	 <L28>
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf328            ; =62248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x15, x9, #0xc
-               	ldr	s0, [x15]
+               	add	x7, x9, #0xc
+               	ldr	s0, [x7]
 <L29>:
                	bl	 <L29>
-               	mov	x16, #0xf330            ; =62256
+               	mov	x16, #0xf328            ; =62248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x15, x9, #0x10
-               	ldr	s0, [x15]
+               	add	x7, x9, #0x10
+               	ldr	s0, [x7]
 <L30>:
                	bl	 <L30>
                	add	x1, x24, #0x0
@@ -793,7 +793,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0x0
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf328            ; =62248
+               	mov	x16, #0xf320            ; =62240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -805,7 +805,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0x4
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf328            ; =62248
+               	mov	x16, #0xf320            ; =62240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -817,7 +817,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0x8
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf328            ; =62248
+               	mov	x16, #0xf320            ; =62240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -829,7 +829,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0xc
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf328            ; =62248
+               	mov	x16, #0xf320            ; =62240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -841,14 +841,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0x10
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf328            ; =62248
+               	mov	x16, #0xf320            ; =62240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s2, [x1]
-               	mov	x16, #0xf328            ; =62248
+               	mov	x16, #0xf320            ; =62240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -857,7 +857,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L31>:
                	bl	 <L31>
-               	mov	x16, #0xf328            ; =62248
+               	mov	x16, #0xf320            ; =62240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -866,7 +866,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L32>:
                	bl	 <L32>
-               	mov	x16, #0xf328            ; =62248
+               	mov	x16, #0xf320            ; =62240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -875,7 +875,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L33>:
                	bl	 <L33>
-               	mov	x16, #0xf328            ; =62248
+               	mov	x16, #0xf320            ; =62240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -884,7 +884,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L34>:
                	bl	 <L34>
-               	mov	x16, #0xf328            ; =62248
+               	mov	x16, #0xf320            ; =62240
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -898,7 +898,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x0
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            ; =62240
+               	mov	x16, #0xf318            ; =62232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -910,7 +910,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x4
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            ; =62240
+               	mov	x16, #0xf318            ; =62232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -922,7 +922,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x8
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            ; =62240
+               	mov	x16, #0xf318            ; =62232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -934,7 +934,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0xc
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            ; =62240
+               	mov	x16, #0xf318            ; =62232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -946,14 +946,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x10
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf320            ; =62240
+               	mov	x16, #0xf318            ; =62232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s2, [x1]
-               	mov	x16, #0xf320            ; =62240
+               	mov	x16, #0xf318            ; =62232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -962,7 +962,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L36>:
                	bl	 <L36>
-               	mov	x16, #0xf320            ; =62240
+               	mov	x16, #0xf318            ; =62232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -971,7 +971,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L37>:
                	bl	 <L37>
-               	mov	x16, #0xf320            ; =62240
+               	mov	x16, #0xf318            ; =62232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -980,7 +980,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L38>:
                	bl	 <L38>
-               	mov	x16, #0xf320            ; =62240
+               	mov	x16, #0xf318            ; =62232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -989,7 +989,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L39>:
                	bl	 <L39>
-               	mov	x16, #0xf320            ; =62240
+               	mov	x16, #0xf318            ; =62232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1003,7 +1003,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x22, #0x0
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf318            ; =62232
+               	mov	x16, #0xf310            ; =62224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1015,7 +1015,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x22, #0x4
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf318            ; =62232
+               	mov	x16, #0xf310            ; =62224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1027,7 +1027,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x22, #0x8
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf318            ; =62232
+               	mov	x16, #0xf310            ; =62224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1039,7 +1039,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x22, #0xc
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf318            ; =62232
+               	mov	x16, #0xf310            ; =62224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1051,14 +1051,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x22, #0x10
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf318            ; =62232
+               	mov	x16, #0xf310            ; =62224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s2, [x1]
-               	mov	x16, #0xf318            ; =62232
+               	mov	x16, #0xf310            ; =62224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1067,7 +1067,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L41>:
                	bl	 <L41>
-               	mov	x16, #0xf318            ; =62232
+               	mov	x16, #0xf310            ; =62224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1076,7 +1076,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L42>:
                	bl	 <L42>
-               	mov	x16, #0xf318            ; =62232
+               	mov	x16, #0xf310            ; =62224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1085,7 +1085,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L43>:
                	bl	 <L43>
-               	mov	x16, #0xf318            ; =62232
+               	mov	x16, #0xf310            ; =62224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1094,7 +1094,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L44>:
                	bl	 <L44>
-               	mov	x16, #0xf318            ; =62232
+               	mov	x16, #0xf310            ; =62224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1108,7 +1108,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0x0
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf310            ; =62224
+               	mov	x16, #0xf308            ; =62216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1120,7 +1120,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0x4
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf310            ; =62224
+               	mov	x16, #0xf308            ; =62216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1132,7 +1132,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0x8
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf310            ; =62224
+               	mov	x16, #0xf308            ; =62216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1144,7 +1144,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0xc
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf310            ; =62224
+               	mov	x16, #0xf308            ; =62216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1156,14 +1156,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0x10
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf310            ; =62224
+               	mov	x16, #0xf308            ; =62216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s2, [x1]
-               	mov	x16, #0xf310            ; =62224
+               	mov	x16, #0xf308            ; =62216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1172,7 +1172,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L46>:
                	bl	 <L46>
-               	mov	x16, #0xf310            ; =62224
+               	mov	x16, #0xf308            ; =62216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1181,7 +1181,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L47>:
                	bl	 <L47>
-               	mov	x16, #0xf310            ; =62224
+               	mov	x16, #0xf308            ; =62216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1190,7 +1190,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L48>:
                	bl	 <L48>
-               	mov	x16, #0xf310            ; =62224
+               	mov	x16, #0xf308            ; =62216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1199,7 +1199,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L49>:
                	bl	 <L49>
-               	mov	x16, #0xf310            ; =62224
+               	mov	x16, #0xf308            ; =62216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1213,7 +1213,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x0
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf308            ; =62216
+               	mov	x16, #0xf300            ; =62208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1225,7 +1225,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x4
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf308            ; =62216
+               	mov	x16, #0xf300            ; =62208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1237,7 +1237,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x8
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf308            ; =62216
+               	mov	x16, #0xf300            ; =62208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1249,7 +1249,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0xc
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf308            ; =62216
+               	mov	x16, #0xf300            ; =62208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1261,14 +1261,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x10
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xf308            ; =62216
+               	mov	x16, #0xf300            ; =62208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s2, [x1]
-               	mov	x16, #0xf308            ; =62216
+               	mov	x16, #0xf300            ; =62208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1277,7 +1277,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L51>:
                	bl	 <L51>
-               	mov	x16, #0xf308            ; =62216
+               	mov	x16, #0xf300            ; =62208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1286,7 +1286,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L52>:
                	bl	 <L52>
-               	mov	x16, #0xf308            ; =62216
+               	mov	x16, #0xf300            ; =62208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1295,7 +1295,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L53>:
                	bl	 <L53>
-               	mov	x16, #0xf308            ; =62216
+               	mov	x16, #0xf300            ; =62208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1304,7 +1304,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L54>:
                	bl	 <L54>
-               	mov	x16, #0xf308            ; =62216
+               	mov	x16, #0xf300            ; =62208
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1386,7 +1386,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x0
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1398,7 +1398,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x4
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1410,7 +1410,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x8
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1422,7 +1422,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0xc
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1434,14 +1434,14 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x10
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x10
                	str	s2, [x0]
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1451,7 +1451,7 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x19
 <L57>:
                	bl	 <L57>
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1460,7 +1460,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L58>:
                	bl	 <L58>
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1469,7 +1469,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L59>:
                	bl	 <L59>
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1478,7 +1478,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L60>:
                	bl	 <L60>
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1489,7 +1489,7 @@ Disassembly of section __TEXT,__text:
                	bl	 <L61>
                	add	x1, x20, #0x0
                	ldr	s0, [x1]
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1497,7 +1497,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x0
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf2f0            ; =62192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1506,7 +1506,7 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1514,7 +1514,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x4
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf2f0            ; =62192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1523,7 +1523,7 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1531,7 +1531,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x8
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf2f0            ; =62192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1540,7 +1540,7 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1548,7 +1548,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0xc
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf2f0            ; =62192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1557,7 +1557,7 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xf300            ; =62208
+               	mov	x16, #0xf2f8            ; =62200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1565,14 +1565,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x10
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf2f0            ; =62192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s2, [x1]
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf2f0            ; =62192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1581,7 +1581,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L62>:
                	bl	 <L62>
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf2f0            ; =62192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1590,7 +1590,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L63>:
                	bl	 <L63>
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf2f0            ; =62192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1599,7 +1599,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L64>:
                	bl	 <L64>
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf2f0            ; =62192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1608,7 +1608,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L65>:
                	bl	 <L65>
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf2f0            ; =62192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1622,7 +1622,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0x0
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf2e8            ; =62184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1634,7 +1634,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0x4
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf2e8            ; =62184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1646,7 +1646,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0x8
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf2e8            ; =62184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1658,7 +1658,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0xc
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf2e8            ; =62184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1670,14 +1670,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x25, #0x10
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf2e8            ; =62184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s2, [x1]
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf2e8            ; =62184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1686,7 +1686,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L67>:
                	bl	 <L67>
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf2e8            ; =62184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1695,7 +1695,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L68>:
                	bl	 <L68>
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf2e8            ; =62184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1704,7 +1704,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L69>:
                	bl	 <L69>
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf2e8            ; =62184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1713,7 +1713,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L70>:
                	bl	 <L70>
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf2e8            ; =62184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1724,13 +1724,13 @@ Disassembly of section __TEXT,__text:
                	bl	 <L71>
                	add	x21, x21, #0x1
                	mov	x19, x0
-               	mov	x16, #0xf2f0            ; =62192
+               	mov	x16, #0xf2e8            ; =62184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x24, x9
-               	mov	x16, #0xf2f8            ; =62200
+               	mov	x16, #0xf2f0            ; =62192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1781,7 +1781,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x25, #0x0
                	ldr	s1, [x0]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf2e8            ; =62184
+               	mov	x16, #0xf2e0            ; =62176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1793,7 +1793,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x25, #0x4
                	ldr	s1, [x0]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf2e8            ; =62184
+               	mov	x16, #0xf2e0            ; =62176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1805,7 +1805,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x25, #0x8
                	ldr	s1, [x0]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf2e8            ; =62184
+               	mov	x16, #0xf2e0            ; =62176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1817,7 +1817,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x25, #0xc
                	ldr	s1, [x0]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf2e8            ; =62184
+               	mov	x16, #0xf2e0            ; =62176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1829,7 +1829,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x25, #0x10
                	ldr	s1, [x0]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf2e8            ; =62184
+               	mov	x16, #0xf2e0            ; =62176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1837,7 +1837,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x9, #0x10
                	str	s2, [x0]
                	add	x0, x21, #0x14
-               	mov	x16, #0xf2e8            ; =62184
+               	mov	x16, #0xf2e0            ; =62176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1846,7 +1846,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x0
                	str	s0, [x1]
-               	mov	x16, #0xf2e8            ; =62184
+               	mov	x16, #0xf2e0            ; =62176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1855,7 +1855,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x4
                	str	s0, [x1]
-               	mov	x16, #0xf2e8            ; =62184
+               	mov	x16, #0xf2e0            ; =62176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1864,7 +1864,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x8
                	str	s0, [x1]
-               	mov	x16, #0xf2e8            ; =62184
+               	mov	x16, #0xf2e0            ; =62176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1873,7 +1873,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0xc
                	str	s0, [x1]
-               	mov	x16, #0xf2e8            ; =62184
+               	mov	x16, #0xf2e0            ; =62176
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1887,7 +1887,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x0
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf348            ; =62280
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1899,7 +1899,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x4
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf348            ; =62280
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1911,7 +1911,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x8
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf348            ; =62280
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1923,7 +1923,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0xc
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf348            ; =62280
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1935,7 +1935,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x10
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf348            ; =62280
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1943,7 +1943,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x9, #0x10
                	str	s2, [x0]
                	add	x0, x21, #0x28
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf348            ; =62280
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1952,7 +1952,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x0
                	str	s0, [x1]
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf348            ; =62280
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1961,7 +1961,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x4
                	str	s0, [x1]
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf348            ; =62280
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1970,7 +1970,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x8
                	str	s0, [x1]
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf348            ; =62280
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1979,7 +1979,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0xc
                	str	s0, [x1]
-               	mov	x16, #0xf338            ; =62264
+               	mov	x16, #0xf348            ; =62280
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2014,7 +2014,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x24, #0x0
                	ldr	s1, [x0]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf2e0            ; =62176
+               	mov	x16, #0xf330            ; =62256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2026,7 +2026,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x24, #0x4
                	ldr	s1, [x0]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf2e0            ; =62176
+               	mov	x16, #0xf330            ; =62256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2038,7 +2038,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x24, #0x8
                	ldr	s1, [x0]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf2e0            ; =62176
+               	mov	x16, #0xf330            ; =62256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2050,7 +2050,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x24, #0xc
                	ldr	s1, [x0]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf2e0            ; =62176
+               	mov	x16, #0xf330            ; =62256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2062,7 +2062,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x24, #0x10
                	ldr	s1, [x0]
                	fsub	s2, s0, s1
-               	mov	x16, #0xf2e0            ; =62176
+               	mov	x16, #0xf330            ; =62256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2070,7 +2070,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x9, #0x10
                	str	s2, [x0]
                	add	x0, x21, #0x50
-               	mov	x16, #0xf2e0            ; =62176
+               	mov	x16, #0xf330            ; =62256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2079,7 +2079,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x0
                	str	s0, [x1]
-               	mov	x16, #0xf2e0            ; =62176
+               	mov	x16, #0xf330            ; =62256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2088,7 +2088,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x4
                	str	s0, [x1]
-               	mov	x16, #0xf2e0            ; =62176
+               	mov	x16, #0xf330            ; =62256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2097,7 +2097,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x8
                	str	s0, [x1]
-               	mov	x16, #0xf2e0            ; =62176
+               	mov	x16, #0xf330            ; =62256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2106,7 +2106,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0xc
                	str	s0, [x1]
-               	mov	x16, #0xf2e0            ; =62176
+               	mov	x16, #0xf330            ; =62256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2254,7 +2254,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x21, #0x28
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf348            ; =62280
+               	mov	x16, #0xf340            ; =62272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2263,7 +2263,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf348            ; =62280
+               	mov	x16, #0xf340            ; =62272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2272,7 +2272,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf348            ; =62280
+               	mov	x16, #0xf340            ; =62272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2281,7 +2281,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf348            ; =62280
+               	mov	x16, #0xf340            ; =62272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2290,7 +2290,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf348            ; =62280
+               	mov	x16, #0xf340            ; =62272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2298,7 +2298,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x10
                	str	s0, [x1]
                	add	x21, x20, #0x10
-               	mov	x16, #0xf348            ; =62280
+               	mov	x16, #0xf340            ; =62272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2307,7 +2307,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x21, #0x0
                	str	s0, [x1]
-               	mov	x16, #0xf348            ; =62280
+               	mov	x16, #0xf340            ; =62272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2316,7 +2316,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x21, #0x4
                	str	s0, [x1]
-               	mov	x16, #0xf348            ; =62280
+               	mov	x16, #0xf340            ; =62272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2325,7 +2325,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x21, #0x8
                	str	s0, [x1]
-               	mov	x16, #0xf348            ; =62280
+               	mov	x16, #0xf340            ; =62272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2334,7 +2334,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x21, #0xc
                	str	s0, [x1]
-               	mov	x16, #0xf348            ; =62280
+               	mov	x16, #0xf340            ; =62272
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2353,7 +2353,7 @@ Disassembly of section __TEXT,__text:
                	bl	 <L80>
                	add	x1, x21, #0x0
                	ldr	s0, [x1]
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf338            ; =62264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2362,7 +2362,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x21, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf338            ; =62264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2371,7 +2371,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x21, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf338            ; =62264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2380,7 +2380,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x21, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf338            ; =62264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2389,14 +2389,14 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x21, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf338            ; =62264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf338            ; =62264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2405,7 +2405,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L81>:
                	bl	 <L81>
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf338            ; =62264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2414,7 +2414,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L82>:
                	bl	 <L82>
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf338            ; =62264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2423,7 +2423,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L83>:
                	bl	 <L83>
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf338            ; =62264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2432,7 +2432,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L84>:
                	bl	 <L84>
-               	mov	x16, #0xf340            ; =62272
+               	mov	x16, #0xf338            ; =62264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48

--- a/test/golden/aarch64-darwin/vec/vec_f32x8.dis
+++ b/test/golden/aarch64-darwin/vec/vec_f32x8.dis
@@ -119,7 +119,7 @@ Disassembly of section __TEXT,__text:
                	sub	x1, x29, #0x300
                	sub	x1, x29, #0x320
                	sub	x9, x29, #0x340
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -127,7 +127,7 @@ Disassembly of section __TEXT,__text:
                	sub	x2, x29, #0x360
                	sub	x2, x29, #0x380
                	sub	x9, x29, #0x3a0
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -135,7 +135,7 @@ Disassembly of section __TEXT,__text:
                	sub	x3, x29, #0x3c0
                	sub	x3, x29, #0x3e0
                	sub	x9, x29, #0x400
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -143,7 +143,7 @@ Disassembly of section __TEXT,__text:
                	sub	x4, x29, #0x420
                	sub	x4, x29, #0x440
                	sub	x9, x29, #0x460
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -151,7 +151,7 @@ Disassembly of section __TEXT,__text:
                	sub	x5, x29, #0x480
                	sub	x5, x29, #0x4a0
                	sub	x9, x29, #0x4c0
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -159,7 +159,7 @@ Disassembly of section __TEXT,__text:
                	sub	x6, x29, #0x4e0
                	sub	x6, x29, #0x500
                	sub	x9, x29, #0x520
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -167,7 +167,7 @@ Disassembly of section __TEXT,__text:
                	sub	x7, x29, #0x540
                	sub	x7, x29, #0x560
                	sub	x9, x29, #0x580
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -181,7 +181,7 @@ Disassembly of section __TEXT,__text:
                	sub	x12, x29, #0x5c0
                	sub	x12, x29, #0x5e0
                	sub	x9, x29, #0x600
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -190,7 +190,7 @@ Disassembly of section __TEXT,__text:
                	sub	x13, x29, #0x640
                	sub	x13, x29, #0x660
                	sub	x9, x29, #0x680
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -199,7 +199,7 @@ Disassembly of section __TEXT,__text:
                	sub	x14, x29, #0x6c0
                	sub	x14, x29, #0x6e0
                	sub	x9, x29, #0x700
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -209,438 +209,438 @@ Disassembly of section __TEXT,__text:
                	sub	x15, x29, #0x760
                	sub	x15, x29, #0x780
                	sub	x9, x29, #0x7a0
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x18, x29, #0x7c0
-               	sub	x18, x29, #0x7e0
+               	sub	x8, x29, #0x7c0
+               	sub	x8, x29, #0x7e0
                	sub	x9, x29, #0x800
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x8, x29, #0x820
                	sub	x9, x29, #0x840
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x860
-               	mov	x16, #0xe630            ; =58928
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x9, x29, #0x880
                	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x18, x29, #0x8a0
-               	sub	x18, x29, #0x8c0
-               	sub	x18, x29, #0x8e0
-               	sub	x18, x29, #0x900
-               	sub	x18, x29, #0x920
-               	sub	x18, x29, #0x940
-               	sub	x18, x29, #0x960
-               	sub	x18, x29, #0x980
-               	sub	x18, x29, #0x9a0
-               	sub	x18, x29, #0x9c0
-               	sub	x18, x29, #0x9e0
-               	sub	x18, x29, #0xa00
-               	sub	x18, x29, #0xa20
-               	sub	x18, x29, #0xa40
-               	sub	x18, x29, #0xa60
-               	sub	x18, x29, #0xa80
-               	sub	x18, x29, #0xaa0
-               	sub	x18, x29, #0xac0
-               	sub	x18, x29, #0xae0
-               	sub	x18, x29, #0xb00
-               	sub	x18, x29, #0xb20
-               	sub	x18, x29, #0xb40
-               	sub	x18, x29, #0xb60
-               	sub	x18, x29, #0xb80
-               	sub	x18, x29, #0xba0
-               	sub	x18, x29, #0xbc0
-               	sub	x18, x29, #0xbe0
-               	sub	x18, x29, #0xc00
-               	sub	x18, x29, #0xc20
-               	sub	x18, x29, #0xc40
-               	sub	x18, x29, #0xc60
-               	sub	x18, x29, #0xc80
-               	sub	x18, x29, #0xca0
-               	sub	x18, x29, #0xcc0
-               	sub	x18, x29, #0xce0
-               	sub	x18, x29, #0xd00
-               	sub	x18, x29, #0xd20
-               	sub	x18, x29, #0xd40
-               	sub	x18, x29, #0xd60
-               	sub	x18, x29, #0xd80
-               	sub	x18, x29, #0xda0
-               	sub	x18, x29, #0xdc0
-               	sub	x18, x29, #0xde0
-               	sub	x18, x29, #0xe00
-               	sub	x18, x29, #0xe20
-               	sub	x18, x29, #0xe40
-               	sub	x18, x29, #0xe60
-               	sub	x18, x29, #0xe80
-               	sub	x18, x29, #0xea0
-               	sub	x18, x29, #0xec0
-               	sub	x18, x29, #0xee0
-               	sub	x18, x29, #0xf00
-               	sub	x18, x29, #0xf20
-               	sub	x18, x29, #0xf40
-               	sub	x18, x29, #0xf60
-               	sub	x18, x29, #0xf80
-               	sub	x18, x29, #0xfa0
-               	sub	x18, x29, #0xfc0
-               	sub	x18, x29, #0xfe0
-               	sub	x18, x29, #0x1, lsl #12 ; =0x1000
+               	sub	x9, x29, #0x880
+               	mov	x16, #0xe620            ; =58912
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	sub	x8, x29, #0x8a0
+               	sub	x8, x29, #0x8c0
+               	sub	x8, x29, #0x8e0
+               	sub	x8, x29, #0x900
+               	sub	x8, x29, #0x920
+               	sub	x8, x29, #0x940
+               	sub	x8, x29, #0x960
+               	sub	x8, x29, #0x980
+               	sub	x8, x29, #0x9a0
+               	sub	x8, x29, #0x9c0
+               	sub	x8, x29, #0x9e0
+               	sub	x8, x29, #0xa00
+               	sub	x8, x29, #0xa20
+               	sub	x8, x29, #0xa40
+               	sub	x8, x29, #0xa60
+               	sub	x8, x29, #0xa80
+               	sub	x8, x29, #0xaa0
+               	sub	x8, x29, #0xac0
+               	sub	x8, x29, #0xae0
+               	sub	x8, x29, #0xb00
+               	sub	x8, x29, #0xb20
+               	sub	x8, x29, #0xb40
+               	sub	x8, x29, #0xb60
+               	sub	x8, x29, #0xb80
+               	sub	x8, x29, #0xba0
+               	sub	x8, x29, #0xbc0
+               	sub	x8, x29, #0xbe0
+               	sub	x8, x29, #0xc00
+               	sub	x8, x29, #0xc20
+               	sub	x8, x29, #0xc40
+               	sub	x8, x29, #0xc60
+               	sub	x8, x29, #0xc80
+               	sub	x8, x29, #0xca0
+               	sub	x8, x29, #0xcc0
+               	sub	x8, x29, #0xce0
+               	sub	x8, x29, #0xd00
+               	sub	x8, x29, #0xd20
+               	sub	x8, x29, #0xd40
+               	sub	x8, x29, #0xd60
+               	sub	x8, x29, #0xd80
+               	sub	x8, x29, #0xda0
+               	sub	x8, x29, #0xdc0
+               	sub	x8, x29, #0xde0
+               	sub	x8, x29, #0xe00
+               	sub	x8, x29, #0xe20
+               	sub	x8, x29, #0xe40
+               	sub	x8, x29, #0xe60
+               	sub	x8, x29, #0xe80
+               	sub	x8, x29, #0xea0
+               	sub	x8, x29, #0xec0
+               	sub	x8, x29, #0xee0
+               	sub	x8, x29, #0xf00
+               	sub	x8, x29, #0xf20
+               	sub	x8, x29, #0xf40
+               	sub	x8, x29, #0xf60
+               	sub	x8, x29, #0xf80
+               	sub	x8, x29, #0xfa0
+               	sub	x8, x29, #0xfc0
+               	sub	x8, x29, #0xfe0
+               	sub	x8, x29, #0x1, lsl #12  ; =0x1000
                	mov	x16, #0xefe0            ; =61408
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xefc0            ; =61376
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xefa0            ; =61344
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xef80            ; =61312
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xef60            ; =61280
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xef40            ; =61248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xef20            ; =61216
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xef00            ; =61184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xeee0            ; =61152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xeec0            ; =61120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xeea0            ; =61088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xee80            ; =61056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xee60            ; =61024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xee40            ; =60992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xee20            ; =60960
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xee00            ; =60928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xede0            ; =60896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xedc0            ; =60864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xeda0            ; =60832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xed80            ; =60800
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xed60            ; =60768
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xed40            ; =60736
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xed20            ; =60704
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xed00            ; =60672
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xece0            ; =60640
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xecc0            ; =60608
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xeca0            ; =60576
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xec80            ; =60544
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xec60            ; =60512
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xec40            ; =60480
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xec20            ; =60448
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xec00            ; =60416
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xebe0            ; =60384
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xebc0            ; =60352
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xeba0            ; =60320
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xeb80            ; =60288
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xeb60            ; =60256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xeb40            ; =60224
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xeb20            ; =60192
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xeb00            ; =60160
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xeae0            ; =60128
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xeac0            ; =60096
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xeaa0            ; =60064
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xea80            ; =60032
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xea60            ; =60000
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xea40            ; =59968
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xea20            ; =59936
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xea00            ; =59904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe9e0            ; =59872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe9c0            ; =59840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe9a0            ; =59808
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe980            ; =59776
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe960            ; =59744
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe940            ; =59712
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe920            ; =59680
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe900            ; =59648
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe8e0            ; =59616
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe8c0            ; =59584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe8a0            ; =59552
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe880            ; =59520
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe860            ; =59488
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe840            ; =59456
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe820            ; =59424
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe800            ; =59392
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe7e0            ; =59360
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe7c0            ; =59328
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe7a0            ; =59296
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
                	mov	x16, #0xe780            ; =59264
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
+               	add	x8, x29, x16
 <L0>:
                	bl	 <L0>
                	ucvtf	s0, x19
@@ -648,750 +648,750 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	add	x19, x18, #0x0
+               	add	x8, x29, x16
+               	add	x19, x8, #0x0
                	mov	w17, #0x3fc00000        ; =1069547520
                	str	w17, [x19]
                	fmov	s31, #2.25000000
                	fneg	s1, s31
-               	add	x19, x18, #0x4
+               	add	x19, x8, #0x4
                	str	s1, [x19]
-               	add	x19, x18, #0x8
+               	add	x19, x8, #0x8
                	mov	w17, #0x40700000        ; =1081081856
                	str	w17, [x19]
                	fmov	s31, #0.50000000
                	fneg	s1, s31
-               	add	x19, x18, #0xc
+               	add	x19, x8, #0xc
                	str	s1, [x19]
-               	add	x19, x18, #0x10
+               	add	x19, x8, #0x10
                	mov	w17, #0x40c80000        ; =1086849024
                	str	w17, [x19]
                	mov	w16, #0x41020000        ; =1090650112
                	fmov	s31, w16
                	fneg	s1, s31
-               	add	x19, x18, #0x14
+               	add	x19, x8, #0x14
                	str	s1, [x19]
-               	add	x19, x18, #0x18
+               	add	x19, x8, #0x18
                	mov	w17, #0x3f400000        ; =1061158912
                	str	w17, [x19]
                	fmov	s31, #16.00000000
                	fneg	s1, s31
-               	add	x19, x18, #0x1c
+               	add	x19, x8, #0x1c
                	str	s1, [x19]
-               	add	x19, x18, #0x0
+               	add	x19, x8, #0x0
                	ldr	s1, [x19]
                	add	x19, x20, #0x0
                	str	s1, [x19]
-               	add	x19, x18, #0x4
+               	add	x19, x8, #0x4
                	ldr	s1, [x19]
                	add	x19, x20, #0x4
                	str	s1, [x19]
-               	add	x19, x18, #0x8
+               	add	x19, x8, #0x8
                	ldr	s1, [x19]
                	add	x19, x20, #0x8
                	str	s1, [x19]
-               	add	x19, x18, #0xc
+               	add	x19, x8, #0xc
                	ldr	s1, [x19]
                	add	x19, x20, #0xc
                	str	s1, [x19]
-               	add	x19, x18, #0x10
+               	add	x19, x8, #0x10
                	ldr	s1, [x19]
                	add	x19, x20, #0x10
                	str	s1, [x19]
-               	add	x19, x18, #0x14
+               	add	x19, x8, #0x14
                	ldr	s1, [x19]
                	add	x19, x20, #0x14
                	str	s1, [x19]
-               	add	x19, x18, #0x18
+               	add	x19, x8, #0x18
                	ldr	s1, [x19]
                	add	x19, x20, #0x18
                	str	s1, [x19]
-               	add	x19, x18, #0x1c
+               	add	x19, x8, #0x1c
                	ldr	s1, [x19]
-               	add	x18, x20, #0x1c
-               	str	s1, [x18]
+               	add	x8, x20, #0x1c
+               	str	s1, [x8]
                	mov	x16, #0xe740            ; =59200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	add	x19, x18, #0x0
+               	add	x8, x29, x16
+               	add	x19, x8, #0x0
                	mov	w17, #0x3f000000        ; =1056964608
                	str	w17, [x19]
-               	add	x19, x18, #0x4
+               	add	x19, x8, #0x4
                	mov	w17, #0x40800000        ; =1082130432
                	str	w17, [x19]
                	fmov	s31, #0.12500000
                	fneg	s1, s31
-               	add	x19, x18, #0x8
+               	add	x19, x8, #0x8
                	str	s1, [x19]
-               	add	x19, x18, #0xc
+               	add	x19, x8, #0xc
                	mov	w17, #0x41000000        ; =1090519040
                	str	w17, [x19]
                	fmov	s31, #2.00000000
                	fneg	s1, s31
-               	add	x19, x18, #0x10
+               	add	x19, x8, #0x10
                	str	s1, [x19]
-               	add	x19, x18, #0x14
+               	add	x19, x8, #0x14
                	mov	w17, #0x3fa00000        ; =1067450368
                	str	w17, [x19]
                	mov	w16, #0x42000000        ; =1107296256
                	fmov	s31, w16
                	fneg	s1, s31
-               	add	x19, x18, #0x18
+               	add	x19, x8, #0x18
                	str	s1, [x19]
-               	add	x19, x18, #0x1c
+               	add	x19, x8, #0x1c
                	mov	w17, #0x3d800000        ; =1031798784
                	str	w17, [x19]
-               	add	x19, x18, #0x0
+               	add	x19, x8, #0x0
                	ldr	s1, [x19]
                	add	x19, x21, #0x0
                	str	s1, [x19]
-               	add	x19, x18, #0x4
+               	add	x19, x8, #0x4
                	ldr	s1, [x19]
                	add	x19, x21, #0x4
                	str	s1, [x19]
-               	add	x19, x18, #0x8
+               	add	x19, x8, #0x8
                	ldr	s1, [x19]
                	add	x19, x21, #0x8
                	str	s1, [x19]
-               	add	x19, x18, #0xc
+               	add	x19, x8, #0xc
                	ldr	s1, [x19]
                	add	x19, x21, #0xc
                	str	s1, [x19]
-               	add	x19, x18, #0x10
+               	add	x19, x8, #0x10
                	ldr	s1, [x19]
                	add	x19, x21, #0x10
                	str	s1, [x19]
-               	add	x19, x18, #0x14
+               	add	x19, x8, #0x14
                	ldr	s1, [x19]
                	add	x19, x21, #0x14
                	str	s1, [x19]
-               	add	x19, x18, #0x18
+               	add	x19, x8, #0x18
                	ldr	s1, [x19]
                	add	x19, x21, #0x18
                	str	s1, [x19]
-               	add	x19, x18, #0x1c
+               	add	x19, x8, #0x1c
                	ldr	s1, [x19]
-               	add	x18, x21, #0x1c
-               	str	s1, [x18]
+               	add	x8, x21, #0x1c
+               	str	s1, [x8]
                	mov	x16, #0xe720            ; =59168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	add	x18, x29, x16
-               	add	x19, x18, #0x0
+               	add	x8, x29, x16
+               	add	x19, x8, #0x0
                	mov	w17, #0x3f800000        ; =1065353216
                	str	w17, [x19]
-               	add	x19, x18, #0x4
+               	add	x19, x8, #0x4
                	mov	w17, #0x40400000        ; =1077936128
                	str	w17, [x19]
-               	add	x19, x18, #0x8
+               	add	x19, x8, #0x8
                	mov	w17, #0x41100000        ; =1091567616
                	str	w17, [x19]
-               	add	x19, x18, #0xc
+               	add	x19, x8, #0xc
                	mov	w17, #0x41d80000        ; =1104674816
                	str	w17, [x19]
-               	add	x19, x18, #0x10
+               	add	x19, x8, #0x10
                	mov	w17, #0x42a20000        ; =1117913088
                	str	w17, [x19]
-               	add	x19, x18, #0x14
+               	add	x19, x8, #0x14
                	mov	w17, #0x43730000        ; =1131610112
                	str	w17, [x19]
-               	add	x19, x18, #0x18
+               	add	x19, x8, #0x18
                	mov	w17, #0x4000            ; =16384
                	movk	w17, #0x4436, lsl #16
                	str	w17, [x19]
-               	add	x19, x18, #0x1c
+               	add	x19, x8, #0x1c
                	mov	w17, #0xb000            ; =45056
                	movk	w17, #0x4508, lsl #16
                	str	w17, [x19]
-               	add	x19, x18, #0x0
+               	add	x19, x8, #0x0
                	ldr	s1, [x19]
                	add	x19, x22, #0x0
                	str	s1, [x19]
-               	add	x19, x18, #0x4
+               	add	x19, x8, #0x4
                	ldr	s1, [x19]
                	add	x19, x22, #0x4
                	str	s1, [x19]
-               	add	x19, x18, #0x8
+               	add	x19, x8, #0x8
                	ldr	s1, [x19]
                	add	x19, x22, #0x8
                	str	s1, [x19]
-               	add	x19, x18, #0xc
+               	add	x19, x8, #0xc
                	ldr	s1, [x19]
                	add	x19, x22, #0xc
                	str	s1, [x19]
-               	add	x19, x18, #0x10
+               	add	x19, x8, #0x10
                	ldr	s1, [x19]
                	add	x19, x22, #0x10
                	str	s1, [x19]
-               	add	x19, x18, #0x14
+               	add	x19, x8, #0x14
                	ldr	s1, [x19]
                	add	x19, x22, #0x14
                	str	s1, [x19]
-               	add	x19, x18, #0x18
+               	add	x19, x8, #0x18
                	ldr	s1, [x19]
                	add	x19, x22, #0x18
                	str	s1, [x19]
-               	add	x19, x18, #0x1c
+               	add	x19, x8, #0x1c
                	ldr	s1, [x19]
-               	add	x18, x22, #0x1c
-               	str	s1, [x18]
-               	add	x18, x20, #0x0
-               	ldr	s1, [x18]
+               	add	x8, x22, #0x1c
+               	str	s1, [x8]
+               	add	x8, x20, #0x0
+               	ldr	s1, [x8]
                	fadd	s2, s1, s0
-               	add	x18, x20, #0x0
-               	ldr	s1, [x18]
-               	add	x18, x23, #0x0
-               	str	s1, [x18]
-               	add	x18, x20, #0x4
-               	ldr	s1, [x18]
-               	add	x18, x23, #0x4
-               	str	s1, [x18]
-               	add	x18, x20, #0x8
-               	ldr	s1, [x18]
-               	add	x18, x23, #0x8
-               	str	s1, [x18]
-               	add	x18, x20, #0xc
-               	ldr	s1, [x18]
-               	add	x18, x23, #0xc
-               	str	s1, [x18]
-               	add	x18, x20, #0x10
-               	ldr	s1, [x18]
-               	add	x18, x23, #0x10
-               	str	s1, [x18]
-               	add	x18, x20, #0x14
-               	ldr	s1, [x18]
-               	add	x18, x23, #0x14
-               	str	s1, [x18]
-               	add	x18, x20, #0x18
-               	ldr	s1, [x18]
-               	add	x18, x23, #0x18
-               	str	s1, [x18]
-               	add	x18, x20, #0x1c
-               	ldr	s1, [x18]
-               	add	x18, x23, #0x1c
-               	str	s1, [x18]
-               	add	x18, x23, #0x0
-               	str	s2, [x18]
-               	add	x18, x23, #0x1c
-               	ldr	s1, [x18]
+               	add	x8, x20, #0x0
+               	ldr	s1, [x8]
+               	add	x8, x23, #0x0
+               	str	s1, [x8]
+               	add	x8, x20, #0x4
+               	ldr	s1, [x8]
+               	add	x8, x23, #0x4
+               	str	s1, [x8]
+               	add	x8, x20, #0x8
+               	ldr	s1, [x8]
+               	add	x8, x23, #0x8
+               	str	s1, [x8]
+               	add	x8, x20, #0xc
+               	ldr	s1, [x8]
+               	add	x8, x23, #0xc
+               	str	s1, [x8]
+               	add	x8, x20, #0x10
+               	ldr	s1, [x8]
+               	add	x8, x23, #0x10
+               	str	s1, [x8]
+               	add	x8, x20, #0x14
+               	ldr	s1, [x8]
+               	add	x8, x23, #0x14
+               	str	s1, [x8]
+               	add	x8, x20, #0x18
+               	ldr	s1, [x8]
+               	add	x8, x23, #0x18
+               	str	s1, [x8]
+               	add	x8, x20, #0x1c
+               	ldr	s1, [x8]
+               	add	x8, x23, #0x1c
+               	str	s1, [x8]
+               	add	x8, x23, #0x0
+               	str	s2, [x8]
+               	add	x8, x23, #0x1c
+               	ldr	s1, [x8]
                	fadd	s2, s1, s0
-               	add	x18, x23, #0x0
-               	ldr	s1, [x18]
-               	add	x18, x24, #0x0
-               	str	s1, [x18]
-               	add	x18, x23, #0x4
-               	ldr	s1, [x18]
-               	add	x18, x24, #0x4
-               	str	s1, [x18]
-               	add	x18, x23, #0x8
-               	ldr	s1, [x18]
-               	add	x18, x24, #0x8
-               	str	s1, [x18]
-               	add	x18, x23, #0xc
-               	ldr	s1, [x18]
-               	add	x18, x24, #0xc
-               	str	s1, [x18]
-               	add	x18, x23, #0x10
-               	ldr	s1, [x18]
-               	add	x18, x24, #0x10
-               	str	s1, [x18]
-               	add	x18, x23, #0x14
-               	ldr	s1, [x18]
-               	add	x18, x24, #0x14
-               	str	s1, [x18]
-               	add	x18, x23, #0x18
-               	ldr	s1, [x18]
-               	add	x18, x24, #0x18
-               	str	s1, [x18]
-               	add	x18, x23, #0x1c
-               	ldr	s1, [x18]
-               	add	x18, x24, #0x1c
-               	str	s1, [x18]
-               	add	x18, x24, #0x1c
-               	str	s2, [x18]
-               	add	x18, x21, #0xc
-               	ldr	s1, [x18]
+               	add	x8, x23, #0x0
+               	ldr	s1, [x8]
+               	add	x8, x24, #0x0
+               	str	s1, [x8]
+               	add	x8, x23, #0x4
+               	ldr	s1, [x8]
+               	add	x8, x24, #0x4
+               	str	s1, [x8]
+               	add	x8, x23, #0x8
+               	ldr	s1, [x8]
+               	add	x8, x24, #0x8
+               	str	s1, [x8]
+               	add	x8, x23, #0xc
+               	ldr	s1, [x8]
+               	add	x8, x24, #0xc
+               	str	s1, [x8]
+               	add	x8, x23, #0x10
+               	ldr	s1, [x8]
+               	add	x8, x24, #0x10
+               	str	s1, [x8]
+               	add	x8, x23, #0x14
+               	ldr	s1, [x8]
+               	add	x8, x24, #0x14
+               	str	s1, [x8]
+               	add	x8, x23, #0x18
+               	ldr	s1, [x8]
+               	add	x8, x24, #0x18
+               	str	s1, [x8]
+               	add	x8, x23, #0x1c
+               	ldr	s1, [x8]
+               	add	x8, x24, #0x1c
+               	str	s1, [x8]
+               	add	x8, x24, #0x1c
+               	str	s2, [x8]
+               	add	x8, x21, #0xc
+               	ldr	s1, [x8]
                	fadd	s2, s1, s0
-               	add	x18, x21, #0x0
-               	ldr	s1, [x18]
-               	add	x18, x25, #0x0
-               	str	s1, [x18]
-               	add	x18, x21, #0x4
-               	ldr	s1, [x18]
-               	add	x18, x25, #0x4
-               	str	s1, [x18]
-               	add	x18, x21, #0x8
-               	ldr	s1, [x18]
-               	add	x18, x25, #0x8
-               	str	s1, [x18]
-               	add	x18, x21, #0xc
-               	ldr	s1, [x18]
-               	add	x18, x25, #0xc
-               	str	s1, [x18]
-               	add	x18, x21, #0x10
-               	ldr	s1, [x18]
-               	add	x18, x25, #0x10
-               	str	s1, [x18]
-               	add	x18, x21, #0x14
-               	ldr	s1, [x18]
-               	add	x18, x25, #0x14
-               	str	s1, [x18]
-               	add	x18, x21, #0x18
-               	ldr	s1, [x18]
-               	add	x18, x25, #0x18
-               	str	s1, [x18]
-               	add	x18, x21, #0x1c
-               	ldr	s1, [x18]
-               	add	x18, x25, #0x1c
-               	str	s1, [x18]
-               	add	x18, x25, #0xc
-               	str	s2, [x18]
-               	add	x18, x25, #0x10
-               	ldr	s1, [x18]
+               	add	x8, x21, #0x0
+               	ldr	s1, [x8]
+               	add	x8, x25, #0x0
+               	str	s1, [x8]
+               	add	x8, x21, #0x4
+               	ldr	s1, [x8]
+               	add	x8, x25, #0x4
+               	str	s1, [x8]
+               	add	x8, x21, #0x8
+               	ldr	s1, [x8]
+               	add	x8, x25, #0x8
+               	str	s1, [x8]
+               	add	x8, x21, #0xc
+               	ldr	s1, [x8]
+               	add	x8, x25, #0xc
+               	str	s1, [x8]
+               	add	x8, x21, #0x10
+               	ldr	s1, [x8]
+               	add	x8, x25, #0x10
+               	str	s1, [x8]
+               	add	x8, x21, #0x14
+               	ldr	s1, [x8]
+               	add	x8, x25, #0x14
+               	str	s1, [x8]
+               	add	x8, x21, #0x18
+               	ldr	s1, [x8]
+               	add	x8, x25, #0x18
+               	str	s1, [x8]
+               	add	x8, x21, #0x1c
+               	ldr	s1, [x8]
+               	add	x8, x25, #0x1c
+               	str	s1, [x8]
+               	add	x8, x25, #0xc
+               	str	s2, [x8]
+               	add	x8, x25, #0x10
+               	ldr	s1, [x8]
                	fadd	s2, s1, s0
-               	add	x18, x25, #0x0
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x0
-               	str	s0, [x18]
-               	add	x18, x25, #0x4
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x4
-               	str	s0, [x18]
-               	add	x18, x25, #0x8
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x8
-               	str	s0, [x18]
-               	add	x18, x25, #0xc
-               	ldr	s0, [x18]
-               	add	x18, x26, #0xc
-               	str	s0, [x18]
-               	add	x18, x25, #0x10
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x10
-               	str	s0, [x18]
-               	add	x18, x25, #0x14
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x14
-               	str	s0, [x18]
-               	add	x18, x25, #0x18
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x18
-               	str	s0, [x18]
-               	add	x18, x25, #0x1c
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x1c
-               	str	s0, [x18]
-               	add	x18, x26, #0x10
-               	str	s2, [x18]
-               	add	x18, x24, #0x0
-               	ldr	s0, [x18]
+               	add	x8, x25, #0x0
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x0
+               	str	s0, [x8]
+               	add	x8, x25, #0x4
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x4
+               	str	s0, [x8]
+               	add	x8, x25, #0x8
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x8
+               	str	s0, [x8]
+               	add	x8, x25, #0xc
+               	ldr	s0, [x8]
+               	add	x8, x26, #0xc
+               	str	s0, [x8]
+               	add	x8, x25, #0x10
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x10
+               	str	s0, [x8]
+               	add	x8, x25, #0x14
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x14
+               	str	s0, [x8]
+               	add	x8, x25, #0x18
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x18
+               	str	s0, [x8]
+               	add	x8, x25, #0x1c
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x1c
+               	str	s0, [x8]
+               	add	x8, x26, #0x10
+               	str	s2, [x8]
+               	add	x8, x24, #0x0
+               	ldr	s0, [x8]
 <L1>:
                	bl	 <L1>
-               	add	x18, x24, #0x4
-               	ldr	s0, [x18]
+               	add	x8, x24, #0x4
+               	ldr	s0, [x8]
 <L2>:
                	bl	 <L2>
-               	add	x18, x24, #0x8
-               	ldr	s0, [x18]
+               	add	x8, x24, #0x8
+               	ldr	s0, [x8]
 <L3>:
                	bl	 <L3>
-               	add	x18, x24, #0xc
-               	ldr	s0, [x18]
+               	add	x8, x24, #0xc
+               	ldr	s0, [x8]
 <L4>:
                	bl	 <L4>
-               	add	x18, x24, #0x10
-               	ldr	s0, [x18]
+               	add	x8, x24, #0x10
+               	ldr	s0, [x8]
 <L5>:
                	bl	 <L5>
-               	add	x18, x24, #0x14
-               	ldr	s0, [x18]
+               	add	x8, x24, #0x14
+               	ldr	s0, [x8]
 <L6>:
                	bl	 <L6>
-               	add	x18, x24, #0x18
-               	ldr	s0, [x18]
+               	add	x8, x24, #0x18
+               	ldr	s0, [x8]
 <L7>:
                	bl	 <L7>
-               	add	x18, x24, #0x1c
-               	ldr	s0, [x18]
+               	add	x8, x24, #0x1c
+               	ldr	s0, [x8]
 <L8>:
                	bl	 <L8>
-               	add	x18, x26, #0x0
-               	ldr	s0, [x18]
+               	add	x8, x26, #0x0
+               	ldr	s0, [x8]
 <L9>:
                	bl	 <L9>
-               	add	x18, x26, #0x4
-               	ldr	s0, [x18]
+               	add	x8, x26, #0x4
+               	ldr	s0, [x8]
 <L10>:
                	bl	 <L10>
-               	add	x18, x26, #0x8
-               	ldr	s0, [x18]
+               	add	x8, x26, #0x8
+               	ldr	s0, [x8]
 <L11>:
                	bl	 <L11>
-               	add	x18, x26, #0xc
-               	ldr	s0, [x18]
+               	add	x8, x26, #0xc
+               	ldr	s0, [x8]
 <L12>:
                	bl	 <L12>
-               	add	x18, x26, #0x10
-               	ldr	s0, [x18]
+               	add	x8, x26, #0x10
+               	ldr	s0, [x8]
 <L13>:
                	bl	 <L13>
-               	add	x18, x26, #0x14
-               	ldr	s0, [x18]
+               	add	x8, x26, #0x14
+               	ldr	s0, [x8]
 <L14>:
                	bl	 <L14>
-               	add	x18, x26, #0x18
-               	ldr	s0, [x18]
+               	add	x8, x26, #0x18
+               	ldr	s0, [x8]
 <L15>:
                	bl	 <L15>
-               	add	x18, x26, #0x1c
-               	ldr	s0, [x18]
+               	add	x8, x26, #0x1c
+               	ldr	s0, [x8]
 <L16>:
                	bl	 <L16>
-               	add	x18, x24, #0x0
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x0
-               	ldr	s1, [x18]
+               	add	x8, x24, #0x0
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x0
+               	ldr	s1, [x8]
                	fadd	s2, s0, s1
-               	add	x18, x27, #0x0
-               	str	s2, [x18]
-               	add	x18, x24, #0x4
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x4
-               	ldr	s1, [x18]
+               	add	x8, x27, #0x0
+               	str	s2, [x8]
+               	add	x8, x24, #0x4
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x4
+               	ldr	s1, [x8]
                	fadd	s2, s0, s1
-               	add	x18, x27, #0x4
-               	str	s2, [x18]
-               	add	x18, x24, #0x8
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x8
-               	ldr	s1, [x18]
+               	add	x8, x27, #0x4
+               	str	s2, [x8]
+               	add	x8, x24, #0x8
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x8
+               	ldr	s1, [x8]
                	fadd	s2, s0, s1
-               	add	x18, x27, #0x8
-               	str	s2, [x18]
-               	add	x18, x24, #0xc
-               	ldr	s0, [x18]
-               	add	x18, x26, #0xc
-               	ldr	s1, [x18]
+               	add	x8, x27, #0x8
+               	str	s2, [x8]
+               	add	x8, x24, #0xc
+               	ldr	s0, [x8]
+               	add	x8, x26, #0xc
+               	ldr	s1, [x8]
                	fadd	s2, s0, s1
-               	add	x18, x27, #0xc
-               	str	s2, [x18]
-               	add	x18, x24, #0x10
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x10
-               	ldr	s1, [x18]
+               	add	x8, x27, #0xc
+               	str	s2, [x8]
+               	add	x8, x24, #0x10
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x10
+               	ldr	s1, [x8]
                	fadd	s2, s0, s1
-               	add	x18, x27, #0x10
-               	str	s2, [x18]
-               	add	x18, x24, #0x14
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x14
-               	ldr	s1, [x18]
+               	add	x8, x27, #0x10
+               	str	s2, [x8]
+               	add	x8, x24, #0x14
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x14
+               	ldr	s1, [x8]
                	fadd	s2, s0, s1
-               	add	x18, x27, #0x14
-               	str	s2, [x18]
-               	add	x18, x24, #0x18
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x18
-               	ldr	s1, [x18]
+               	add	x8, x27, #0x14
+               	str	s2, [x8]
+               	add	x8, x24, #0x18
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x18
+               	ldr	s1, [x8]
                	fadd	s2, s0, s1
-               	add	x18, x27, #0x18
-               	str	s2, [x18]
-               	add	x18, x24, #0x1c
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x1c
-               	ldr	s1, [x18]
+               	add	x8, x27, #0x18
+               	str	s2, [x8]
+               	add	x8, x24, #0x1c
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x1c
+               	ldr	s1, [x8]
                	fadd	s2, s0, s1
-               	add	x18, x27, #0x1c
-               	str	s2, [x18]
-               	add	x18, x27, #0x0
-               	ldr	s0, [x18]
+               	add	x8, x27, #0x1c
+               	str	s2, [x8]
+               	add	x8, x27, #0x0
+               	ldr	s0, [x8]
 <L17>:
                	bl	 <L17>
-               	add	x18, x27, #0x4
-               	ldr	s0, [x18]
+               	add	x8, x27, #0x4
+               	ldr	s0, [x8]
 <L18>:
                	bl	 <L18>
-               	add	x18, x27, #0x8
-               	ldr	s0, [x18]
+               	add	x8, x27, #0x8
+               	ldr	s0, [x8]
 <L19>:
                	bl	 <L19>
-               	add	x18, x27, #0xc
-               	ldr	s0, [x18]
+               	add	x8, x27, #0xc
+               	ldr	s0, [x8]
 <L20>:
                	bl	 <L20>
-               	add	x18, x27, #0x10
-               	ldr	s0, [x18]
+               	add	x8, x27, #0x10
+               	ldr	s0, [x8]
 <L21>:
                	bl	 <L21>
-               	add	x18, x27, #0x14
-               	ldr	s0, [x18]
+               	add	x8, x27, #0x14
+               	ldr	s0, [x8]
 <L22>:
                	bl	 <L22>
-               	add	x18, x27, #0x18
-               	ldr	s0, [x18]
+               	add	x8, x27, #0x18
+               	ldr	s0, [x8]
 <L23>:
                	bl	 <L23>
-               	add	x18, x27, #0x1c
-               	ldr	s0, [x18]
+               	add	x8, x27, #0x1c
+               	ldr	s0, [x8]
 <L24>:
                	bl	 <L24>
-               	add	x18, x24, #0x0
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x0
-               	ldr	s1, [x18]
+               	add	x8, x24, #0x0
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x0
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	add	x18, x28, #0x0
-               	str	s2, [x18]
-               	add	x18, x24, #0x4
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x4
-               	ldr	s1, [x18]
+               	add	x8, x28, #0x0
+               	str	s2, [x8]
+               	add	x8, x24, #0x4
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x4
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	add	x18, x28, #0x4
-               	str	s2, [x18]
-               	add	x18, x24, #0x8
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x8
-               	ldr	s1, [x18]
+               	add	x8, x28, #0x4
+               	str	s2, [x8]
+               	add	x8, x24, #0x8
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x8
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	add	x18, x28, #0x8
-               	str	s2, [x18]
-               	add	x18, x24, #0xc
-               	ldr	s0, [x18]
-               	add	x18, x26, #0xc
-               	ldr	s1, [x18]
+               	add	x8, x28, #0x8
+               	str	s2, [x8]
+               	add	x8, x24, #0xc
+               	ldr	s0, [x8]
+               	add	x8, x26, #0xc
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	add	x18, x28, #0xc
-               	str	s2, [x18]
-               	add	x18, x24, #0x10
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x10
-               	ldr	s1, [x18]
+               	add	x8, x28, #0xc
+               	str	s2, [x8]
+               	add	x8, x24, #0x10
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x10
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	add	x18, x28, #0x10
-               	str	s2, [x18]
-               	add	x18, x24, #0x14
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x14
-               	ldr	s1, [x18]
+               	add	x8, x28, #0x10
+               	str	s2, [x8]
+               	add	x8, x24, #0x14
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x14
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	add	x18, x28, #0x14
-               	str	s2, [x18]
-               	add	x18, x24, #0x18
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x18
-               	ldr	s1, [x18]
+               	add	x8, x28, #0x14
+               	str	s2, [x8]
+               	add	x8, x24, #0x18
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x18
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	add	x18, x28, #0x18
-               	str	s2, [x18]
-               	add	x18, x24, #0x1c
-               	ldr	s0, [x18]
-               	add	x18, x26, #0x1c
-               	ldr	s1, [x18]
+               	add	x8, x28, #0x18
+               	str	s2, [x8]
+               	add	x8, x24, #0x1c
+               	ldr	s0, [x8]
+               	add	x8, x26, #0x1c
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	add	x18, x28, #0x1c
-               	str	s2, [x18]
-               	add	x18, x28, #0x0
-               	ldr	s0, [x18]
+               	add	x8, x28, #0x1c
+               	str	s2, [x8]
+               	add	x8, x28, #0x0
+               	ldr	s0, [x8]
 <L25>:
                	bl	 <L25>
-               	add	x18, x28, #0x4
-               	ldr	s0, [x18]
+               	add	x8, x28, #0x4
+               	ldr	s0, [x8]
 <L26>:
                	bl	 <L26>
-               	add	x18, x28, #0x8
-               	ldr	s0, [x18]
+               	add	x8, x28, #0x8
+               	ldr	s0, [x8]
 <L27>:
                	bl	 <L27>
-               	add	x18, x28, #0xc
-               	ldr	s0, [x18]
+               	add	x8, x28, #0xc
+               	ldr	s0, [x8]
 <L28>:
                	bl	 <L28>
-               	add	x18, x28, #0x10
-               	ldr	s0, [x18]
+               	add	x8, x28, #0x10
+               	ldr	s0, [x8]
 <L29>:
                	bl	 <L29>
-               	add	x18, x28, #0x14
-               	ldr	s0, [x18]
+               	add	x8, x28, #0x14
+               	ldr	s0, [x8]
 <L30>:
                	bl	 <L30>
-               	add	x18, x28, #0x18
-               	ldr	s0, [x18]
+               	add	x8, x28, #0x18
+               	ldr	s0, [x8]
 <L31>:
                	bl	 <L31>
-               	add	x18, x28, #0x1c
-               	ldr	s0, [x18]
+               	add	x8, x28, #0x1c
+               	ldr	s0, [x8]
 <L32>:
                	bl	 <L32>
-               	add	x18, x26, #0x0
-               	ldr	s0, [x18]
-               	add	x18, x24, #0x0
-               	ldr	s1, [x18]
+               	add	x8, x26, #0x0
+               	ldr	s0, [x8]
+               	add	x8, x24, #0x0
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x0
-               	str	s2, [x18]
-               	add	x18, x26, #0x4
-               	ldr	s0, [x18]
-               	add	x18, x24, #0x4
-               	ldr	s1, [x18]
+               	add	x8, x9, #0x0
+               	str	s2, [x8]
+               	add	x8, x26, #0x4
+               	ldr	s0, [x8]
+               	add	x8, x24, #0x4
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x4
-               	str	s2, [x18]
-               	add	x18, x26, #0x8
-               	ldr	s0, [x18]
-               	add	x18, x24, #0x8
-               	ldr	s1, [x18]
+               	add	x8, x9, #0x4
+               	str	s2, [x8]
+               	add	x8, x26, #0x8
+               	ldr	s0, [x8]
+               	add	x8, x24, #0x8
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x8
-               	str	s2, [x18]
-               	add	x18, x26, #0xc
-               	ldr	s0, [x18]
-               	add	x18, x24, #0xc
-               	ldr	s1, [x18]
+               	add	x8, x9, #0x8
+               	str	s2, [x8]
+               	add	x8, x26, #0xc
+               	ldr	s0, [x8]
+               	add	x8, x24, #0xc
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0xc
-               	str	s2, [x18]
-               	add	x18, x26, #0x10
-               	ldr	s0, [x18]
-               	add	x18, x24, #0x10
-               	ldr	s1, [x18]
+               	add	x8, x9, #0xc
+               	str	s2, [x8]
+               	add	x8, x26, #0x10
+               	ldr	s0, [x8]
+               	add	x8, x24, #0x10
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x10
-               	str	s2, [x18]
-               	add	x18, x26, #0x14
-               	ldr	s0, [x18]
-               	add	x18, x24, #0x14
-               	ldr	s1, [x18]
+               	add	x8, x9, #0x10
+               	str	s2, [x8]
+               	add	x8, x26, #0x14
+               	ldr	s0, [x8]
+               	add	x8, x24, #0x14
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x14
-               	str	s2, [x18]
-               	add	x18, x26, #0x18
-               	ldr	s0, [x18]
-               	add	x18, x24, #0x18
-               	ldr	s1, [x18]
+               	add	x8, x9, #0x14
+               	str	s2, [x8]
+               	add	x8, x26, #0x18
+               	ldr	s0, [x8]
+               	add	x8, x24, #0x18
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x18
-               	str	s2, [x18]
-               	add	x18, x26, #0x1c
-               	ldr	s0, [x18]
-               	add	x18, x24, #0x1c
-               	ldr	s1, [x18]
+               	add	x8, x9, #0x18
+               	str	s2, [x8]
+               	add	x8, x26, #0x1c
+               	ldr	s0, [x8]
+               	add	x8, x24, #0x1c
+               	ldr	s1, [x8]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x1c
-               	str	s2, [x18]
-               	mov	x16, #0xe618            ; =58904
+               	add	x8, x9, #0x1c
+               	str	s2, [x8]
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x0
-               	ldr	s0, [x18]
+               	add	x8, x9, #0x0
+               	ldr	s0, [x8]
 <L33>:
                	bl	 <L33>
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x4
-               	ldr	s0, [x18]
+               	add	x8, x9, #0x4
+               	ldr	s0, [x8]
 <L34>:
                	bl	 <L34>
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x8
-               	ldr	s0, [x18]
+               	add	x8, x9, #0x8
+               	ldr	s0, [x8]
 <L35>:
                	bl	 <L35>
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0xc
-               	ldr	s0, [x18]
+               	add	x8, x9, #0xc
+               	ldr	s0, [x8]
 <L36>:
                	bl	 <L36>
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x10
-               	ldr	s0, [x18]
+               	add	x8, x9, #0x10
+               	ldr	s0, [x8]
 <L37>:
                	bl	 <L37>
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x14
-               	ldr	s0, [x18]
+               	add	x8, x9, #0x14
+               	ldr	s0, [x8]
 <L38>:
                	bl	 <L38>
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x18
-               	ldr	s0, [x18]
+               	add	x8, x9, #0x18
+               	ldr	s0, [x8]
 <L39>:
                	bl	 <L39>
-               	mov	x16, #0xe618            ; =58904
+               	mov	x16, #0xe610            ; =58896
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x18, x9, #0x1c
-               	ldr	s0, [x18]
+               	add	x8, x9, #0x1c
+               	ldr	s0, [x8]
 <L40>:
                	bl	 <L40>
                	add	x1, x24, #0x0
@@ -1399,7 +1399,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x0
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1411,7 +1411,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x4
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1423,7 +1423,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x8
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1435,7 +1435,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0xc
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1447,7 +1447,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x10
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1459,7 +1459,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x14
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1471,7 +1471,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x18
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1483,14 +1483,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x1c
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s2, [x1]
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1499,7 +1499,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L41>:
                	bl	 <L41>
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1508,7 +1508,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L42>:
                	bl	 <L42>
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1517,7 +1517,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L43>:
                	bl	 <L43>
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1526,7 +1526,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L44>:
                	bl	 <L44>
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1535,7 +1535,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L45>:
                	bl	 <L45>
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1544,7 +1544,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L46>:
                	bl	 <L46>
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1553,7 +1553,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L47>:
                	bl	 <L47>
-               	mov	x16, #0xe610            ; =58896
+               	mov	x16, #0xe608            ; =58888
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1567,7 +1567,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x0
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1579,7 +1579,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x4
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1591,7 +1591,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x8
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1603,7 +1603,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0xc
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1615,7 +1615,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x10
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1627,7 +1627,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x14
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1639,7 +1639,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x18
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1651,14 +1651,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x1c
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s2, [x1]
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1667,7 +1667,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L49>:
                	bl	 <L49>
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1676,7 +1676,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L50>:
                	bl	 <L50>
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1685,7 +1685,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L51>:
                	bl	 <L51>
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1694,7 +1694,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L52>:
                	bl	 <L52>
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1703,7 +1703,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L53>:
                	bl	 <L53>
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1712,7 +1712,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L54>:
                	bl	 <L54>
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1721,7 +1721,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L55>:
                	bl	 <L55>
-               	mov	x16, #0xe608            ; =58888
+               	mov	x16, #0xe600            ; =58880
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1735,7 +1735,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x0
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1747,7 +1747,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x4
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1759,7 +1759,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x8
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1771,7 +1771,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0xc
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1783,7 +1783,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x10
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1795,7 +1795,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x14
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1807,7 +1807,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x18
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1819,14 +1819,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x1c
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s2, [x1]
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1835,7 +1835,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L57>:
                	bl	 <L57>
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1844,7 +1844,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L58>:
                	bl	 <L58>
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1853,7 +1853,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L59>:
                	bl	 <L59>
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1862,7 +1862,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L60>:
                	bl	 <L60>
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1871,7 +1871,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L61>:
                	bl	 <L61>
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1880,7 +1880,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L62>:
                	bl	 <L62>
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1889,7 +1889,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L63>:
                	bl	 <L63>
-               	mov	x16, #0xe600            ; =58880
+               	mov	x16, #0xe5f8            ; =58872
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1903,7 +1903,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x22, #0x0
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1915,7 +1915,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x22, #0x4
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1927,7 +1927,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x22, #0x8
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1939,7 +1939,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x22, #0xc
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1951,7 +1951,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x22, #0x10
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1963,7 +1963,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x22, #0x14
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1975,7 +1975,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x22, #0x18
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1987,14 +1987,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x22, #0x1c
                	ldr	s1, [x1]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s2, [x1]
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2003,7 +2003,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L65>:
                	bl	 <L65>
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2012,7 +2012,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L66>:
                	bl	 <L66>
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2021,7 +2021,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L67>:
                	bl	 <L67>
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2030,7 +2030,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L68>:
                	bl	 <L68>
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2039,7 +2039,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L69>:
                	bl	 <L69>
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2048,7 +2048,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L70>:
                	bl	 <L70>
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2057,7 +2057,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L71>:
                	bl	 <L71>
-               	mov	x16, #0xe5f8            ; =58872
+               	mov	x16, #0xe5f0            ; =58864
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2071,7 +2071,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x0
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2083,7 +2083,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x4
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2095,7 +2095,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x8
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2107,7 +2107,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0xc
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2119,7 +2119,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x10
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2131,7 +2131,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x14
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2143,7 +2143,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x18
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2155,14 +2155,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x1c
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s2, [x1]
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2171,7 +2171,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L73>:
                	bl	 <L73>
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2180,7 +2180,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L74>:
                	bl	 <L74>
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2189,7 +2189,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L75>:
                	bl	 <L75>
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2198,7 +2198,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L76>:
                	bl	 <L76>
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2207,7 +2207,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L77>:
                	bl	 <L77>
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2216,7 +2216,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L78>:
                	bl	 <L78>
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2225,7 +2225,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L79>:
                	bl	 <L79>
-               	mov	x16, #0xe5f0            ; =58864
+               	mov	x16, #0xe5e8            ; =58856
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2239,7 +2239,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x0
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2251,7 +2251,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x4
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2263,7 +2263,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x8
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2275,7 +2275,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0xc
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2287,7 +2287,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x10
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2299,7 +2299,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x14
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2311,7 +2311,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x18
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2323,14 +2323,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x24, #0x1c
                	ldr	s1, [x1]
                	fdiv	s2, s0, s1
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s2, [x1]
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2339,7 +2339,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L81>:
                	bl	 <L81>
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2348,7 +2348,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L82>:
                	bl	 <L82>
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2357,7 +2357,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L83>:
                	bl	 <L83>
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2366,7 +2366,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L84>:
                	bl	 <L84>
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2375,7 +2375,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L85>:
                	bl	 <L85>
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2384,7 +2384,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L86>:
                	bl	 <L86>
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2393,7 +2393,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L87>:
                	bl	 <L87>
-               	mov	x16, #0xe5e8            ; =58856
+               	mov	x16, #0xe5e0            ; =58848
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2512,7 +2512,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x0
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2524,7 +2524,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x4
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2536,7 +2536,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x8
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2548,7 +2548,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0xc
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2560,7 +2560,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x10
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2572,7 +2572,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x14
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2584,7 +2584,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x18
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2596,14 +2596,14 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x1c
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x1c
                	str	s2, [x0]
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2613,7 +2613,7 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x19
 <L90>:
                	bl	 <L90>
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2622,7 +2622,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L91>:
                	bl	 <L91>
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2631,7 +2631,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L92>:
                	bl	 <L92>
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2640,7 +2640,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L93>:
                	bl	 <L93>
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2649,7 +2649,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L94>:
                	bl	 <L94>
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2658,7 +2658,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L95>:
                	bl	 <L95>
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2667,7 +2667,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L96>:
                	bl	 <L96>
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2678,7 +2678,7 @@ Disassembly of section __TEXT,__text:
                	bl	 <L97>
                	add	x1, x20, #0x0
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2686,7 +2686,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x0
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2695,7 +2695,7 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2703,7 +2703,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x4
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2712,7 +2712,7 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2720,7 +2720,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x8
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2729,7 +2729,7 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2737,7 +2737,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0xc
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2746,7 +2746,7 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2754,7 +2754,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x10
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2763,7 +2763,7 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x14
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2771,7 +2771,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x14
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2780,7 +2780,7 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x18
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2788,7 +2788,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x18
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2797,7 +2797,7 @@ Disassembly of section __TEXT,__text:
                	str	s2, [x1]
                	add	x1, x20, #0x1c
                	ldr	s0, [x1]
-               	mov	x16, #0xe5e0            ; =58848
+               	mov	x16, #0xe5d8            ; =58840
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2805,14 +2805,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x1c
                	ldr	s1, [x1]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s2, [x1]
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2821,7 +2821,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L98>:
                	bl	 <L98>
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2830,7 +2830,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L99>:
                	bl	 <L99>
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2839,7 +2839,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L100>:
                	bl	 <L100>
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2848,7 +2848,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L101>:
                	bl	 <L101>
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2857,7 +2857,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L102>:
                	bl	 <L102>
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2866,7 +2866,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L103>:
                	bl	 <L103>
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2875,7 +2875,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L104>:
                	bl	 <L104>
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2889,7 +2889,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x0
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2901,7 +2901,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x4
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2913,7 +2913,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x8
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2925,7 +2925,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0xc
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2937,7 +2937,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x10
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2949,7 +2949,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x14
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2961,7 +2961,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x18
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2973,14 +2973,14 @@ Disassembly of section __TEXT,__text:
                	add	x1, x26, #0x1c
                	ldr	s1, [x1]
                	fsub	s2, s0, s1
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s2, [x1]
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2989,7 +2989,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L106>:
                	bl	 <L106>
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2998,7 +2998,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L107>:
                	bl	 <L107>
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3007,7 +3007,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L108>:
                	bl	 <L108>
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3016,7 +3016,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L109>:
                	bl	 <L109>
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3025,7 +3025,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L110>:
                	bl	 <L110>
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3034,7 +3034,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L111>:
                	bl	 <L111>
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3043,7 +3043,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L112>:
                	bl	 <L112>
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3054,13 +3054,13 @@ Disassembly of section __TEXT,__text:
                	bl	 <L113>
                	add	x21, x21, #0x1
                	mov	x19, x0
-               	mov	x16, #0xe5d0            ; =58832
+               	mov	x16, #0xe5c8            ; =58824
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x24, x9
-               	mov	x16, #0xe5d8            ; =58840
+               	mov	x16, #0xe5d0            ; =58832
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3128,7 +3128,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x26, #0x0
                	ldr	s1, [x0]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3140,7 +3140,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x26, #0x4
                	ldr	s1, [x0]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3152,7 +3152,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x26, #0x8
                	ldr	s1, [x0]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3164,7 +3164,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x26, #0xc
                	ldr	s1, [x0]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3176,7 +3176,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x26, #0x10
                	ldr	s1, [x0]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3188,7 +3188,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x26, #0x14
                	ldr	s1, [x0]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3200,7 +3200,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x26, #0x18
                	ldr	s1, [x0]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3212,7 +3212,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x26, #0x1c
                	ldr	s1, [x0]
                	fadd	s2, s0, s1
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3220,7 +3220,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x9, #0x1c
                	str	s2, [x0]
                	add	x0, x21, #0x20
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3229,7 +3229,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x0
                	str	s0, [x1]
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3238,7 +3238,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x4
                	str	s0, [x1]
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3247,7 +3247,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x8
                	str	s0, [x1]
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3256,7 +3256,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0xc
                	str	s0, [x1]
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3265,7 +3265,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x10
                	str	s0, [x1]
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3274,7 +3274,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x14
                	str	s0, [x1]
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3283,7 +3283,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x18
                	str	s0, [x1]
-               	mov	x16, #0xe5c8            ; =58824
+               	mov	x16, #0xe5c0            ; =58816
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3297,7 +3297,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x0
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3309,7 +3309,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x4
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3321,7 +3321,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x8
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3333,7 +3333,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0xc
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3345,7 +3345,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x10
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3357,7 +3357,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x14
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3369,7 +3369,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x18
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3381,7 +3381,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x22, #0x1c
                	ldr	s1, [x0]
                	fmul	s2, s0, s1
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3389,7 +3389,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x9, #0x1c
                	str	s2, [x0]
                	add	x0, x21, #0x40
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3398,7 +3398,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x0
                	str	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3407,7 +3407,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x4
                	str	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3416,7 +3416,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x8
                	str	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3425,7 +3425,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0xc
                	str	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3434,7 +3434,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x10
                	str	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3443,7 +3443,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x14
                	str	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3452,7 +3452,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x0, #0x18
                	str	s0, [x1]
-               	mov	x16, #0xe620            ; =58912
+               	mov	x16, #0xe630            ; =58928
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3504,7 +3504,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x21, x0
                	add	x0, x1, #0x0
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3513,7 +3513,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x4
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3522,7 +3522,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x8
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3531,7 +3531,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0xc
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3540,7 +3540,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x10
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3549,7 +3549,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x14
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3558,7 +3558,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x18
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3567,14 +3567,14 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x1c
                	ldr	s0, [x0]
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x1c
                	str	s0, [x0]
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3584,7 +3584,7 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x19
 <L116>:
                	bl	 <L116>
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3593,7 +3593,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L117>:
                	bl	 <L117>
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3602,7 +3602,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L118>:
                	bl	 <L118>
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3611,7 +3611,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L119>:
                	bl	 <L119>
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3620,7 +3620,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L120>:
                	bl	 <L120>
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3629,7 +3629,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L121>:
                	bl	 <L121>
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3638,7 +3638,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L122>:
                	bl	 <L122>
-               	mov	x16, #0xe5c0            ; =58816
+               	mov	x16, #0xe618            ; =58904
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3672,7 +3672,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x21, #0x40
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3681,7 +3681,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3690,7 +3690,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3699,7 +3699,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3708,7 +3708,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3717,7 +3717,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x14
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3726,7 +3726,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x18
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3735,7 +3735,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x1c
                	ldr	s0, [x2]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3743,7 +3743,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x1c
                	str	s0, [x1]
                	add	x21, x20, #0x10
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3752,7 +3752,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x21, #0x0
                	str	s0, [x1]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3761,7 +3761,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x21, #0x4
                	str	s0, [x1]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3770,7 +3770,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x21, #0x8
                	str	s0, [x1]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3779,7 +3779,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x21, #0xc
                	str	s0, [x1]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3788,7 +3788,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x21, #0x10
                	str	s0, [x1]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3797,7 +3797,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x21, #0x14
                	str	s0, [x1]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3806,7 +3806,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x21, #0x18
                	str	s0, [x1]
-               	mov	x16, #0xe630            ; =58928
+               	mov	x16, #0xe628            ; =58920
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3825,7 +3825,7 @@ Disassembly of section __TEXT,__text:
                	bl	 <L125>
                	add	x1, x21, #0x0
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3834,7 +3834,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x21, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3843,7 +3843,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x21, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3852,7 +3852,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x21, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3861,7 +3861,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x21, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3870,7 +3870,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x21, #0x14
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3879,7 +3879,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x21, #0x18
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3888,14 +3888,14 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x21, #0x1c
                	ldr	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x1c
                	str	s0, [x1]
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3904,7 +3904,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L126>:
                	bl	 <L126>
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3913,7 +3913,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L127>:
                	bl	 <L127>
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3922,7 +3922,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L128>:
                	bl	 <L128>
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3931,7 +3931,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L129>:
                	bl	 <L129>
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3940,7 +3940,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L130>:
                	bl	 <L130>
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3949,7 +3949,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L131>:
                	bl	 <L131>
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3958,7 +3958,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L132>:
                	bl	 <L132>
-               	mov	x16, #0xe628            ; =58920
+               	mov	x16, #0xe620            ; =58912
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48

--- a/test/golden/aarch64-darwin/vec/vec_i16x4.dis
+++ b/test/golden/aarch64-darwin/vec/vec_i16x4.dis
@@ -42,10 +42,13 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_i16x4.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x240
-               	sub	x16, x29, #0x230
-               	stp	x19, x20, [x16]
-               	stur	x21, [x16, #-0x8]
+               	sub	sp, sp, #0x1f0
+               	stp	x19, x20, [x29, #-0x1e0]
+               	mov	x16, #0xfe18            ; =65048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x21, [x29, x16]
                	mov	x19, x0
 <L0>:
                	bl	 <L0>
@@ -358,87 +361,96 @@ Disassembly of section __TEXT,__text:
                	bl	 <L40>
                	ldur	q31, [x29, #-0x80]
                	ldur	q30, [x29, #-0xa0]
-               	sub.8h	v31, v31, v30
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
+               	sub.8h	v0, v31, v30
 <L41>:
                	bl	 <L41>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfed0            ; =65232
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L44>:
-               	bl	 <L44>
                	ldur	q31, [x29, #-0x90]
                	ldur	q30, [x29, #-0xa0]
                	and.16b	v31, v31, v30
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfec0            ; =65216
+               	mov	x16, #0xfed0            ; =65232
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfec0            ; =65216
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L48>:
-               	bl	 <L48>
+               	ldr	q0, [x29, x16]
+<L42>:
+               	bl	 <L42>
                	ldur	q31, [x29, #-0x90]
                	ldur	q30, [x29, #-0xa0]
                	orr.16b	v31, v31, v30
+               	mov	x16, #0xfec0            ; =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfec0            ; =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L43>:
+               	bl	 <L43>
+               	ldur	q31, [x29, #-0x90]
+               	ldur	q30, [x29, #-0xa0]
+               	eor.16b	v0, v31, v30
+<L44>:
+               	bl	 <L44>
+               	ldur	q31, [x29, #-0x90]
+               	mvn.16b	v0, v31
+<L45>:
+               	bl	 <L45>
+               	ldur	q31, [x29, #-0xa0]
+               	mvn.16b	v0, v31
+<L46>:
+               	bl	 <L46>
+               	mov	x16, #0xfed0            ; =65232
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfec0            ; =65216
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	eor.16b	v0, v31, v30
+<L47>:
+               	bl	 <L47>
+               	mov	x19, x0
+               	ldur	q31, [x29, #-0x90]
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x80]
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0x80]
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x20, #0x0               ; =0
+               	cmp	x20, #0x6
+               	b.lo	 <L48>
+               	b	 <L65>
+<L48>:
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0x70]
+               	mul.8h	v31, v31, v30
                	mov	x16, #0xfeb0            ; =65200
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -450,6 +462,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[0]
+               	mov	x0, x19
 <L49>:
                	bl	 <L49>
                	mov	x16, #0xfeb0            ; =65200
@@ -476,15 +489,23 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[3]
 <L52>:
                	bl	 <L52>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfeb0            ; =65200
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
                	eor.16b	v31, v31, v30
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -492,7 +513,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[0]
 <L53>:
                	bl	 <L53>
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -500,7 +521,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[1]
 <L54>:
                	bl	 <L54>
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -508,7 +529,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[2]
 <L55>:
                	bl	 <L55>
-               	mov	x16, #0xfea0            ; =65184
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -516,14 +537,23 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[3]
 <L56>:
                	bl	 <L56>
-               	ldur	q31, [x29, #-0x90]
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	add.8h	v31, v31, v30
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -531,7 +561,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[0]
 <L57>:
                	bl	 <L57>
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -539,7 +569,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[1]
 <L58>:
                	bl	 <L58>
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -547,7 +577,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[2]
 <L59>:
                	bl	 <L59>
-               	mov	x16, #0xfe90            ; =65168
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -555,14 +585,19 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[3]
 <L60>:
                	bl	 <L60>
-               	ldur	q31, [x29, #-0xa0]
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfea0            ; =65184
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xa0]
+               	add.8h	v31, v31, v30
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -570,7 +605,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[0]
 <L61>:
                	bl	 <L61>
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -578,7 +613,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[1]
 <L62>:
                	bl	 <L62>
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -586,7 +621,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[2]
 <L63>:
                	bl	 <L63>
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -594,294 +629,41 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[3]
 <L64>:
                	bl	 <L64>
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
-               	and.16b	v0, v31, v30
-               	ldur	q31, [x29, #-0x90]
-               	ldur	q30, [x29, #-0xa0]
-               	orr.16b	v1, v31, v30
-               	eor.16b	v31, v0, v1
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L68>:
-               	bl	 <L68>
-               	mov	x19, x0
-               	ldur	q31, [x29, #-0x90]
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0x80]
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0x80]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x20, #0x0               ; =0
-               	cmp	x20, #0x6
-               	b.lo	 <L69>
-               	b	 <L86>
-<L69>:
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0x70]
-               	mul.8h	v31, v31, v30
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-               	mov	x0, x19
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L72>:
-               	bl	 <L72>
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	eor.16b	v31, v31, v30
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	add.8h	v31, v31, v30
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L80>:
-               	bl	 <L80>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xa0]
-               	add.8h	v31, v31, v30
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L82>:
-               	bl	 <L82>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L83>:
-               	bl	 <L83>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L85>:
-               	bl	 <L85>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfe90            ; =65168
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe60            ; =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L69>
-<L86>:
+               	b.lo	 <L48>
+<L65>:
                	sub	x20, x29, #0x50
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -890,13 +672,13 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x20]
                	str	xzr, [x20, #0x28]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d31, [x29, x16]
                	str	d31, [x0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -905,7 +687,7 @@ Disassembly of section __TEXT,__text:
                	add.8h	v0, v31, v30
                	add	x0, x20, #0x8
                	str	d0, [x0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -915,20 +697,20 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x10
                	str	d0, [x0]
                	add	x0, x20, #0x18
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe90            ; =65168
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d31, [x29, x16]
                	str	d31, [x0]
                	add	x0, x20, #0x20
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	d31, [x29, x16]
                	str	d31, [x0]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfea0            ; =65184
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -939,54 +721,54 @@ Disassembly of section __TEXT,__text:
                	str	d0, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x6
-               	b.lo	 <L87>
-               	b	 <L92>
-<L87>:
+               	b.lo	 <L66>
+               	b	 <L71>
+<L66>:
                	add	x0, x20, x21, lsl #3
                	ldr	d31, [x0]
-               	mov	x16, #0xfdf0            ; =65008
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	d31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[0]
                	mov	x0, x19
-<L88>:
-               	bl	 <L88>
-               	mov	x16, #0xfdf0            ; =65008
+<L67>:
+               	bl	 <L67>
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[1]
-<L89>:
-               	bl	 <L89>
-               	mov	x16, #0xfdf0            ; =65008
+<L68>:
+               	bl	 <L68>
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[2]
-<L90>:
-               	bl	 <L90>
-               	mov	x16, #0xfdf0            ; =65008
+<L69>:
+               	bl	 <L69>
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[3]
-<L91>:
-               	bl	 <L91>
+<L70>:
+               	bl	 <L70>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x6
-               	b.lo	 <L87>
-<L92>:
+               	b.lo	 <L66>
+<L71>:
                	sub	x21, x29, #0x5c
                	str	xzr, [x21]
                	str	wzr, [x21, #0x8]
@@ -1002,54 +784,57 @@ Disassembly of section __TEXT,__text:
                	strb	w17, [x1]
                	ldrb	w1, [x0]
                	mov	x0, x19
-<L93>:
-               	bl	 <L93>
+<L72>:
+               	bl	 <L72>
                	ldr	d31, [x20]
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	d31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[0]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xfde0            ; =64992
+<L73>:
+               	bl	 <L73>
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[1]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xfde0            ; =64992
+<L74>:
+               	bl	 <L74>
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[2]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xfde0            ; =64992
+<L75>:
+               	bl	 <L75>
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[3]
-<L97>:
-               	bl	 <L97>
+<L76>:
+               	bl	 <L76>
                	add	x1, x21, #0xa
                	ldrb	w2, [x1]
                	mov	x1, x2
-<L98>:
-               	bl	 <L98>
-               	sub	x16, x29, #0x230
-               	ldp	x19, x20, [x16]
-               	ldur	x21, [x16, #-0x8]
+<L77>:
+               	bl	 <L77>
+               	ldp	x19, x20, [x29, #-0x1e0]
+               	mov	x16, #0xfe18            ; =65048
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x21, [x29, x16]
                	mov	sp, x29
                	ldp	x29, x30, [sp], #0x10
                	ret

--- a/test/golden/aarch64-darwin/vec/vec_i16x8.dis
+++ b/test/golden/aarch64-darwin/vec/vec_i16x8.dis
@@ -70,8 +70,8 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_i16x8.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x290
-               	sub	x16, x29, #0x280
+               	sub	sp, sp, #0x240
+               	sub	x16, x29, #0x230
                	stp	x19, x20, [x16]
                	stur	x21, [x16, #-0x8]
                	mov	x19, x0
@@ -802,7 +802,12 @@ Disassembly of section __TEXT,__text:
                	bl	 <L80>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
-               	sub.8h	v31, v31, v30
+               	sub.8h	v0, v31, v30
+<L81>:
+               	bl	 <L81>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	and.16b	v31, v31, v30
                	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -812,48 +817,35 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
+               	ldr	q0, [x29, x16]
 <L82>:
                	bl	 <L82>
-               	mov	x16, #0xfe80            ; =65152
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	orr.16b	v31, v31, v30
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
 <L83>:
                	bl	 <L83>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor.16b	v0, v31, v30
 <L84>:
                	bl	 <L84>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
+               	ldur	q31, [x29, #-0xe0]
+               	mvn.16b	v0, v31
 <L85>:
                	bl	 <L85>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
+               	ldur	q31, [x29, #-0xf0]
+               	mvn.16b	v0, v31
 <L86>:
                	bl	 <L86>
                	mov	x16, #0xfe80            ; =65152
@@ -861,34 +853,60 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L87>:
-               	bl	 <L87>
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L88>:
-               	bl	 <L88>
+               	ldr	q30, [x29, x16]
+               	eor.16b	v0, v31, v30
+<L87>:
+               	bl	 <L87>
+               	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and.16b	v31, v31, v30
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	ldur	q31, [x29, #-0xd0]
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x20, #0x0               ; =0
+               	cmp	x20, #0x6
+               	b.lo	 <L88>
+               	b	 <L121>
+<L88>:
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xc0]
+               	mul.8h	v31, v31, v30
+               	mov	x16, #0xfe60            ; =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[0]
+               	mov	x0, x19
 <L89>:
                	bl	 <L89>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -896,7 +914,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[1]
 <L90>:
                	bl	 <L90>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -904,7 +922,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[2]
 <L91>:
                	bl	 <L91>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -912,7 +930,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[3]
 <L92>:
                	bl	 <L92>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -920,7 +938,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[4]
 <L93>:
                	bl	 <L93>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -928,7 +946,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[5]
 <L94>:
                	bl	 <L94>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -936,7 +954,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[6]
 <L95>:
                	bl	 <L95>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -944,15 +962,23 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[7]
 <L96>:
                	bl	 <L96>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr.16b	v31, v31, v30
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	eor.16b	v31, v31, v30
+               	mov	x16, #0xfe20            ; =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -960,7 +986,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[0]
 <L97>:
                	bl	 <L97>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -968,7 +994,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[1]
 <L98>:
                	bl	 <L98>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -976,7 +1002,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[2]
 <L99>:
                	bl	 <L99>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -984,7 +1010,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[3]
 <L100>:
                	bl	 <L100>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -992,7 +1018,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[4]
 <L101>:
                	bl	 <L101>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1000,7 +1026,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[5]
 <L102>:
                	bl	 <L102>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1008,7 +1034,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[6]
 <L103>:
                	bl	 <L103>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1016,15 +1042,23 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[7]
 <L104>:
                	bl	 <L104>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	eor.16b	v31, v31, v30
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	add.8h	v31, v31, v30
+               	mov	x16, #0xfe10            ; =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1032,7 +1066,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[0]
 <L105>:
                	bl	 <L105>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1040,7 +1074,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[1]
 <L106>:
                	bl	 <L106>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1048,7 +1082,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[2]
 <L107>:
                	bl	 <L107>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1056,7 +1090,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[3]
 <L108>:
                	bl	 <L108>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1064,7 +1098,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[4]
 <L109>:
                	bl	 <L109>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1072,7 +1106,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[5]
 <L110>:
                	bl	 <L110>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1080,7 +1114,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[6]
 <L111>:
                	bl	 <L111>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1088,14 +1122,19 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[7]
 <L112>:
                	bl	 <L112>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
+               	add.8h	v31, v31, v30
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1103,7 +1142,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[0]
 <L113>:
                	bl	 <L113>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1111,7 +1150,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[1]
 <L114>:
                	bl	 <L114>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1119,7 +1158,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[2]
 <L115>:
                	bl	 <L115>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1127,7 +1166,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[3]
 <L116>:
                	bl	 <L116>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1135,7 +1174,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[4]
 <L117>:
                	bl	 <L117>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1143,7 +1182,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[5]
 <L118>:
                	bl	 <L118>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1151,7 +1190,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[6]
 <L119>:
                	bl	 <L119>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1159,525 +1198,41 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[7]
 <L120>:
                	bl	 <L120>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L121>:
-               	bl	 <L121>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L122>:
-               	bl	 <L122>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L123>:
-               	bl	 <L123>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L124>:
-               	bl	 <L124>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L125>:
-               	bl	 <L125>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L126>:
-               	bl	 <L126>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L127>:
-               	bl	 <L127>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L128>:
-               	bl	 <L128>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and.16b	v0, v31, v30
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr.16b	v1, v31, v30
-               	eor.16b	v31, v0, v1
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L129>:
-               	bl	 <L129>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L130>:
-               	bl	 <L130>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L131>:
-               	bl	 <L131>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L132>:
-               	bl	 <L132>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L133>:
-               	bl	 <L133>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L134>:
-               	bl	 <L134>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L135>:
-               	bl	 <L135>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L136>:
-               	bl	 <L136>
-               	mov	x19, x0
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x20, #0x0               ; =0
-               	cmp	x20, #0x6
-               	b.lo	 <L137>
-               	b	 <L170>
-<L137>:
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xc0]
-               	mul.8h	v31, v31, v30
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-               	mov	x0, x19
-<L138>:
-               	bl	 <L138>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L139>:
-               	bl	 <L139>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L140>:
-               	bl	 <L140>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L141>:
-               	bl	 <L141>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L142>:
-               	bl	 <L142>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L143>:
-               	bl	 <L143>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L144>:
-               	bl	 <L144>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L145>:
-               	bl	 <L145>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	eor.16b	v31, v31, v30
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L146>:
-               	bl	 <L146>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L147>:
-               	bl	 <L147>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L148>:
-               	bl	 <L148>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L149>:
-               	bl	 <L149>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L150>:
-               	bl	 <L150>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L151>:
-               	bl	 <L151>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L152>:
-               	bl	 <L152>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L153>:
-               	bl	 <L153>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	add.8h	v31, v31, v30
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L154>:
-               	bl	 <L154>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L155>:
-               	bl	 <L155>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L156>:
-               	bl	 <L156>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L157>:
-               	bl	 <L157>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L158>:
-               	bl	 <L158>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L159>:
-               	bl	 <L159>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L160>:
-               	bl	 <L160>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L161>:
-               	bl	 <L161>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xf0]
-               	add.8h	v31, v31, v30
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L162>:
-               	bl	 <L162>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L163>:
-               	bl	 <L163>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L164>:
-               	bl	 <L164>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L165>:
-               	bl	 <L165>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L166>:
-               	bl	 <L166>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L167>:
-               	bl	 <L167>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L168>:
-               	bl	 <L168>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L169>:
-               	bl	 <L169>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            ; =64960
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe10            ; =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L137>
-<L170>:
+               	b.lo	 <L88>
+<L121>:
                	sub	x20, x29, #0x80
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -1688,13 +1243,13 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1703,7 +1258,7 @@ Disassembly of section __TEXT,__text:
                	add.8h	v0, v31, v30
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1713,7 +1268,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfdf0            ; =65008
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1721,88 +1276,88 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L171>
-               	b	 <L180>
-<L171>:
+               	b.lo	 <L122>
+               	b	 <L131>
+<L122>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q31, [x1]
-               	mov	x16, #0xfda0            ; =64928
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfda0            ; =64928
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[0]
                	mov	x0, x19
-<L172>:
-               	bl	 <L172>
-               	mov	x16, #0xfda0            ; =64928
+<L123>:
+               	bl	 <L123>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[1]
-<L173>:
-               	bl	 <L173>
-               	mov	x16, #0xfda0            ; =64928
+<L124>:
+               	bl	 <L124>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[2]
-<L174>:
-               	bl	 <L174>
-               	mov	x16, #0xfda0            ; =64928
+<L125>:
+               	bl	 <L125>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[3]
-<L175>:
-               	bl	 <L175>
-               	mov	x16, #0xfda0            ; =64928
+<L126>:
+               	bl	 <L126>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[4]
-<L176>:
-               	bl	 <L176>
-               	mov	x16, #0xfda0            ; =64928
+<L127>:
+               	bl	 <L127>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[5]
-<L177>:
-               	bl	 <L177>
-               	mov	x16, #0xfda0            ; =64928
+<L128>:
+               	bl	 <L128>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[6]
-<L178>:
-               	bl	 <L178>
-               	mov	x16, #0xfda0            ; =64928
+<L129>:
+               	bl	 <L129>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[7]
-<L179>:
-               	bl	 <L179>
+<L130>:
+               	bl	 <L130>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L171>
-<L180>:
+               	b.lo	 <L122>
+<L131>:
                	sub	x21, x29, #0xb0
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -1824,84 +1379,84 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x1]
                	ldr	w1, [x0]
                	mov	x0, x19
-<L181>:
-               	bl	 <L181>
+<L132>:
+               	bl	 <L132>
                	ldr	q31, [x20]
-               	mov	x16, #0xfd90            ; =64912
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd90            ; =64912
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[0]
-<L182>:
-               	bl	 <L182>
-               	mov	x16, #0xfd90            ; =64912
+<L133>:
+               	bl	 <L133>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[1]
-<L183>:
-               	bl	 <L183>
-               	mov	x16, #0xfd90            ; =64912
+<L134>:
+               	bl	 <L134>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[2]
-<L184>:
-               	bl	 <L184>
-               	mov	x16, #0xfd90            ; =64912
+<L135>:
+               	bl	 <L135>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[3]
-<L185>:
-               	bl	 <L185>
-               	mov	x16, #0xfd90            ; =64912
+<L136>:
+               	bl	 <L136>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[4]
-<L186>:
-               	bl	 <L186>
-               	mov	x16, #0xfd90            ; =64912
+<L137>:
+               	bl	 <L137>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[5]
-<L187>:
-               	bl	 <L187>
-               	mov	x16, #0xfd90            ; =64912
+<L138>:
+               	bl	 <L138>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[6]
-<L188>:
-               	bl	 <L188>
-               	mov	x16, #0xfd90            ; =64912
+<L139>:
+               	bl	 <L139>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[7]
-<L189>:
-               	bl	 <L189>
+<L140>:
+               	bl	 <L140>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L190>:
-               	bl	 <L190>
-               	sub	x16, x29, #0x280
+<L141>:
+               	bl	 <L141>
+               	sub	x16, x29, #0x230
                	ldp	x19, x20, [x16]
                	ldur	x21, [x16, #-0x8]
                	mov	sp, x29

--- a/test/golden/aarch64-darwin/vec/vec_i32x4.dis
+++ b/test/golden/aarch64-darwin/vec/vec_i32x4.dis
@@ -42,8 +42,8 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_i32x4.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x280
-               	sub	x16, x29, #0x270
+               	sub	sp, sp, #0x230
+               	sub	x16, x29, #0x220
                	stp	x19, x20, [x16]
                	stur	x21, [x16, #-0x8]
                	mov	x19, x0
@@ -462,87 +462,90 @@ Disassembly of section __TEXT,__text:
                	bl	 <L40>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
-               	sub.4s	v31, v31, v30
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
+               	sub.4s	v0, v31, v30
 <L41>:
                	bl	 <L41>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L44>:
-               	bl	 <L44>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and.16b	v31, v31, v30
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L48>:
-               	bl	 <L48>
+               	ldr	q0, [x29, x16]
+<L42>:
+               	bl	 <L42>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr.16b	v31, v31, v30
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L43>:
+               	bl	 <L43>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor.16b	v0, v31, v30
+<L44>:
+               	bl	 <L44>
+               	ldur	q31, [x29, #-0xe0]
+               	mvn.16b	v0, v31
+<L45>:
+               	bl	 <L45>
+               	ldur	q31, [x29, #-0xf0]
+               	mvn.16b	v0, v31
+<L46>:
+               	bl	 <L46>
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	eor.16b	v0, v31, v30
+<L47>:
+               	bl	 <L47>
+               	mov	x19, x0
+               	ldur	q31, [x29, #-0xe0]
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x20, #0x0               ; =0
+               	cmp	x20, #0x6
+               	b.lo	 <L48>
+               	b	 <L65>
+<L48>:
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xc0]
+               	mul.4s	v31, v31, v30
                	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -554,6 +557,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	x0, x19
 <L49>:
                	bl	 <L49>
                	mov	x16, #0xfe60            ; =65120
@@ -580,15 +584,23 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[3]
 <L52>:
                	bl	 <L52>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	eor.16b	v31, v31, v30
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe60            ; =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	add.4s	v31, v31, v30
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -596,7 +608,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[0]
 <L53>:
                	bl	 <L53>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -604,7 +616,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[1]
 <L54>:
                	bl	 <L54>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -612,7 +624,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[2]
 <L55>:
                	bl	 <L55>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -620,14 +632,19 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[3]
 <L56>:
                	bl	 <L56>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
+               	eor.16b	v31, v31, v30
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -635,7 +652,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[0]
 <L57>:
                	bl	 <L57>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -643,7 +660,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[1]
 <L58>:
                	bl	 <L58>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -651,7 +668,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[2]
 <L59>:
                	bl	 <L59>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -659,14 +676,19 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[3]
 <L60>:
                	bl	 <L60>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
+               	add.4s	v31, v31, v30
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -674,7 +696,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[0]
 <L61>:
                	bl	 <L61>
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -682,7 +704,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[1]
 <L62>:
                	bl	 <L62>
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -690,7 +712,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[2]
 <L63>:
                	bl	 <L63>
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -698,274 +720,31 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[3]
 <L64>:
                	bl	 <L64>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and.16b	v0, v31, v30
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr.16b	v1, v31, v30
-               	eor.16b	v31, v0, v1
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L68>:
-               	bl	 <L68>
-               	mov	x19, x0
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x20, #0x0               ; =0
-               	cmp	x20, #0x6
-               	b.lo	 <L69>
-               	b	 <L86>
-<L69>:
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xc0]
-               	mul.4s	v31, v31, v30
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-               	mov	x0, x19
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L72>:
-               	bl	 <L72>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	add.4s	v31, v31, v30
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xf0]
-               	eor.16b	v31, v31, v30
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L80>:
-               	bl	 <L80>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xf0]
-               	add.4s	v31, v31, v30
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L82>:
-               	bl	 <L82>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L83>:
-               	bl	 <L83>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L85>:
-               	bl	 <L85>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfdc0            ; =64960
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L69>
-<L86>:
+               	b.lo	 <L48>
+<L65>:
                	sub	x20, x29, #0x80
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -976,13 +755,13 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -991,7 +770,7 @@ Disassembly of section __TEXT,__text:
                	add.4s	v0, v31, v30
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1001,7 +780,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfdf0            ; =65008
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1009,56 +788,56 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L87>
-               	b	 <L92>
-<L87>:
+               	b.lo	 <L66>
+               	b	 <L71>
+<L66>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q31, [x1]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdb0            ; =64944
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
                	mov	x0, x19
-<L88>:
-               	bl	 <L88>
-               	mov	x16, #0xfdb0            ; =64944
+<L67>:
+               	bl	 <L67>
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[1]
-<L89>:
-               	bl	 <L89>
-               	mov	x16, #0xfdb0            ; =64944
+<L68>:
+               	bl	 <L68>
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[2]
-<L90>:
-               	bl	 <L90>
-               	mov	x16, #0xfdb0            ; =64944
+<L69>:
+               	bl	 <L69>
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[3]
-<L91>:
-               	bl	 <L91>
+<L70>:
+               	bl	 <L70>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L87>
-<L92>:
+               	b.lo	 <L66>
+<L71>:
                	sub	x21, x29, #0xb0
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -1080,52 +859,52 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x1]
                	ldr	w1, [x0]
                	mov	x0, x19
-<L93>:
-               	bl	 <L93>
+<L72>:
+               	bl	 <L72>
                	ldr	q31, [x20]
-               	mov	x16, #0xfda0            ; =64928
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfda0            ; =64928
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xfda0            ; =64928
+<L73>:
+               	bl	 <L73>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[1]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xfda0            ; =64928
+<L74>:
+               	bl	 <L74>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[2]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xfda0            ; =64928
+<L75>:
+               	bl	 <L75>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[3]
-<L97>:
-               	bl	 <L97>
+<L76>:
+               	bl	 <L76>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L98>:
-               	bl	 <L98>
-               	sub	x16, x29, #0x270
+<L77>:
+               	bl	 <L77>
+               	sub	x16, x29, #0x220
                	ldp	x19, x20, [x16]
                	ldur	x21, [x16, #-0x8]
                	mov	sp, x29

--- a/test/golden/aarch64-darwin/vec/vec_i64x2.dis
+++ b/test/golden/aarch64-darwin/vec/vec_i64x2.dis
@@ -28,8 +28,8 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_i64x2.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x290
-               	sub	x16, x29, #0x280
+               	sub	sp, sp, #0x240
+               	sub	x16, x29, #0x230
                	stp	x19, x20, [x16]
                	stur	x21, [x16, #-0x8]
                	mov	x19, x0
@@ -331,7 +331,12 @@ Disassembly of section __TEXT,__text:
                	bl	 <L20>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
-               	sub.2d	v31, v31, v30
+               	sub.2d	v0, v31, v30
+<L21>:
+               	bl	 <L21>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	and.16b	v31, v31, v30
                	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -341,21 +346,12 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
+               	ldr	q0, [x29, x16]
 <L22>:
                	bl	 <L22>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	and.16b	v31, v31, v30
+               	orr.16b	v31, v31, v30
                	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -365,165 +361,60 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
+               	ldr	q0, [x29, x16]
 <L23>:
                	bl	 <L23>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor.16b	v0, v31, v30
 <L24>:
                	bl	 <L24>
                	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr.16b	v31, v31, v30
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
+               	mvn.16b	v0, v31
 <L25>:
                	bl	 <L25>
+               	ldur	q31, [x29, #-0xf0]
+               	mvn.16b	v0, v31
+<L26>:
+               	bl	 <L26>
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	eor.16b	v0, v31, v30
+<L27>:
+               	bl	 <L27>
+               	mov	x19, x0
+               	ldur	q31, [x29, #-0xe0]
                	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L26>:
-               	bl	 <L26>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	eor.16b	v31, v31, v30
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
                	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L28>:
-               	bl	 <L28>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L30>:
-               	bl	 <L30>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L32>:
-               	bl	 <L32>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and.16b	v0, v31, v30
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr.16b	v1, v31, v30
-               	eor.16b	v31, v0, v1
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x19, x0
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfdf0            ; =65008
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x6
-               	b.lo	 <L35>
-               	b	 <L44>
-<L35>:
-               	mov	x16, #0xfe10            ; =65040
+               	b.lo	 <L28>
+               	b	 <L37>
+<L28>:
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -532,7 +423,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -541,7 +432,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -550,155 +441,155 @@ Disassembly of section __TEXT,__text:
                	mov.d	v0[0], x2
                	mov.16b	v30, v0
                	mov.d	v30[1], x3
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
                	mov	x0, x19
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfde0            ; =64992
+<L29>:
+               	bl	 <L29>
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfe00            ; =65024
+<L30>:
+               	bl	 <L30>
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v31, v31, v30
-               	mov	x16, #0xfdd0            ; =64976
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfdd0            ; =64976
+<L31>:
+               	bl	 <L31>
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfdf0            ; =65008
+<L32>:
+               	bl	 <L32>
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add.2d	v31, v31, v30
-               	mov	x16, #0xfdc0            ; =64960
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            ; =64960
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
-<L40>:
-               	bl	 <L40>
-               	mov	x16, #0xfdc0            ; =64960
+<L33>:
+               	bl	 <L33>
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfe10            ; =65040
+<L34>:
+               	bl	 <L34>
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add.2d	v31, v31, v30
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L43>:
-               	bl	 <L43>
-               	add	x20, x20, #0x1
-               	mov	x19, x0
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            ; =64960
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
+               	mov.d	x1, v31[0]
+<L35>:
+               	bl	 <L35>
+               	mov	x16, #0xfe00            ; =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L36>:
+               	bl	 <L36>
+               	add	x20, x20, #0x1
+               	mov	x19, x0
+               	mov	x16, #0xfe00            ; =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe60            ; =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe20            ; =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe10            ; =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L35>
-<L44>:
+               	b.lo	 <L28>
+<L37>:
                	sub	x20, x29, #0x80
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -709,13 +600,13 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -724,7 +615,7 @@ Disassembly of section __TEXT,__text:
                	add.2d	v0, v31, v30
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -733,7 +624,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -742,7 +633,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -754,7 +645,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	str	q1, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -762,40 +653,40 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L45>
-               	b	 <L48>
-<L45>:
+               	b.lo	 <L38>
+               	b	 <L41>
+<L38>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q31, [x1]
-               	mov	x16, #0xfda0            ; =64928
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfda0            ; =64928
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
                	mov	x0, x19
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfda0            ; =64928
+<L39>:
+               	bl	 <L39>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L47>:
-               	bl	 <L47>
+<L40>:
+               	bl	 <L40>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L45>
-<L48>:
+               	b.lo	 <L38>
+<L41>:
                	sub	x21, x29, #0xb0
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -817,36 +708,36 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x1]
                	ldr	w1, [x0]
                	mov	x0, x19
-<L49>:
-               	bl	 <L49>
+<L42>:
+               	bl	 <L42>
                	ldr	q31, [x20]
-               	mov	x16, #0xfd90            ; =64912
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd90            ; =64912
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfd90            ; =64912
+<L43>:
+               	bl	 <L43>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L51>:
-               	bl	 <L51>
+<L44>:
+               	bl	 <L44>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L52>:
-               	bl	 <L52>
-               	sub	x16, x29, #0x280
+<L45>:
+               	bl	 <L45>
+               	sub	x16, x29, #0x230
                	ldp	x19, x20, [x16]
                	ldur	x21, [x16, #-0x8]
                	mov	sp, x29

--- a/test/golden/aarch64-darwin/vec/vec_mem.dis
+++ b/test/golden/aarch64-darwin/vec/vec_mem.dis
@@ -98,67 +98,67 @@ Disassembly of section __TEXT,__text:
                	sub	x27, x29, #0xa0
                	sub	x28, x29, #0xb4
                	sub	x9, x29, #0xc8
-               	mov	x16, #0xf840            ; =63552
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x9, x29, #0xdc
-               	mov	x16, #0xf838            ; =63544
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	x9, [x29, x16]
-               	sub	x9, x29, #0xf0
                	mov	x16, #0xf830            ; =63536
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x9, x29, #0x104
+               	sub	x9, x29, #0xdc
                	mov	x16, #0xf828            ; =63528
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x9, x29, #0x118
+               	sub	x9, x29, #0xf0
                	mov	x16, #0xf820            ; =63520
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x9, x29, #0x12c
+               	sub	x9, x29, #0x104
                	mov	x16, #0xf818            ; =63512
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x9, x29, #0x140
+               	sub	x9, x29, #0x118
                	mov	x16, #0xf810            ; =63504
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	sub	x9, x29, #0x154
+               	sub	x9, x29, #0x12c
                	mov	x16, #0xf808            ; =63496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
+               	sub	x9, x29, #0x140
+               	mov	x16, #0xf800            ; =63488
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	sub	x9, x29, #0x154
+               	mov	x16, #0xf7f8            ; =63480
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
                	sub	x9, x29, #0x168
-               	mov	x16, #0xf890            ; =63632
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x17c
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xf880            ; =63616
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
                	sub	x9, x29, #0x190
-               	mov	x16, #0xf800            ; =63488
+               	mov	x16, #0xf860            ; =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -214,15 +214,30 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x19, #0x40]
                	str	xzr, [x19, #0x48]
                	str	wzr, [x19, #0x50]
-               	mov	x1, #0x0                ; =0
-               	cmp	x1, #0x7
+               	mov	x9, #0x0                ; =0
+               	mov	x16, #0xf890            ; =63632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf890            ; =63632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	cmp	x9, #0x7
                	b.lo	 <L1>
                	b	 <L2>
 <L1>:
-               	ucvtf	s0, x1
-               	sub	x18, x29, #0x3e4
-               	str	xzr, [x18]
-               	str	wzr, [x18, #0x8]
+               	mov	x16, #0xf890            ; =63632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	ucvtf	s0, x9
+               	sub	x0, x29, #0x3e4
+               	str	xzr, [x0]
+               	str	wzr, [x0, #0x8]
                	fadd	s1, s0, s8
                	mov	x16, #0xfc0c            ; =64524
                	movk	x16, #0xffff, lsl #16
@@ -234,18 +249,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x0, [x18]
+               	ldr	x1, [x0]
                	mov	x16, #0xfc0c            ; =64524
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x0, [x29, x16]
-               	ldr	w0, [x18, #0x8]
+               	str	x1, [x29, x16]
+               	ldr	w1, [x0, #0x8]
                	mov	x16, #0xfc14            ; =64532
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w0, [x29, x16]
+               	str	w1, [x29, x16]
                	mov	x16, #0xfc0c            ; =64524
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -262,14 +277,14 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x0, [x29, x16]
-               	str	x0, [x18]
+               	ldr	x1, [x29, x16]
+               	str	x1, [x0]
                	mov	x16, #0xfc04            ; =64516
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	w0, [x29, x16]
-               	str	w0, [x18, #0x8]
+               	ldr	w1, [x29, x16]
+               	str	w1, [x0, #0x8]
                	fmov	s30, #1.25000000
                	fsub	s1, s0, s30
                	mov	x16, #0xfbec            ; =64492
@@ -282,18 +297,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x0, [x18]
+               	ldr	x1, [x0]
                	mov	x16, #0xfbec            ; =64492
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x0, [x29, x16]
-               	ldr	w0, [x18, #0x8]
+               	str	x1, [x29, x16]
+               	ldr	w1, [x0, #0x8]
                	mov	x16, #0xfbf4            ; =64500
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w0, [x29, x16]
+               	str	w1, [x29, x16]
                	mov	x16, #0xfbec            ; =64492
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -310,14 +325,14 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x0, [x29, x16]
-               	str	x0, [x18]
+               	ldr	x1, [x29, x16]
+               	str	x1, [x0]
                	mov	x16, #0xfbe4            ; =64484
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	w0, [x29, x16]
-               	str	w0, [x18, #0x8]
+               	ldr	w1, [x29, x16]
+               	str	w1, [x0, #0x8]
                	mov	w16, #0x42c80000        ; =1120403456
                	fmov	s31, w16
                	fsub	s1, s31, s0
@@ -331,18 +346,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x0, [x18]
+               	ldr	x1, [x0]
                	mov	x16, #0xfbcc            ; =64460
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x0, [x29, x16]
-               	ldr	w0, [x18, #0x8]
+               	str	x1, [x29, x16]
+               	ldr	w1, [x0, #0x8]
                	mov	x16, #0xfbd4            ; =64468
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w0, [x29, x16]
+               	str	w1, [x29, x16]
                	mov	x16, #0xfbcc            ; =64460
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -359,14 +374,14 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x0, [x29, x16]
-               	str	x0, [x18]
+               	ldr	x1, [x29, x16]
+               	str	x1, [x0]
                	mov	x16, #0xfbc4            ; =64452
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	w0, [x29, x16]
-               	str	w0, [x18, #0x8]
+               	ldr	w1, [x29, x16]
+               	str	w1, [x0, #0x8]
                	mov	x16, #0xfbac            ; =64428
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -377,26 +392,31 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x0, [x18]
+               	ldr	x1, [x0]
                	mov	x16, #0xfbac            ; =64428
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x0, [x29, x16]
-               	ldr	w0, [x18, #0x8]
+               	str	x1, [x29, x16]
+               	ldr	w1, [x0, #0x8]
                	mov	x16, #0xfbb4            ; =64436
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w0, [x29, x16]
+               	str	w1, [x29, x16]
                	mov	x16, #0xfbac            ; =64428
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
+               	mov	x16, #0xf890            ; =63632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
                	mov	x16, #0xc               ; =12
-               	mul	x0, x1, x16
-               	add	x18, x19, x0
+               	mul	x0, x9, x16
+               	add	x1, x19, x0
                	mov	x16, #0xfb9c            ; =64412
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -407,15 +427,31 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x0, [x29, x16]
-               	str	x0, [x18]
+               	str	x0, [x1]
                	mov	x16, #0xfba4            ; =64420
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	w0, [x29, x16]
-               	str	w0, [x18, #0x8]
-               	add	x1, x1, #0x1
-               	cmp	x1, #0x7
+               	str	w0, [x1, #0x8]
+               	mov	x16, #0xf890            ; =63632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x0, x9, #0x1
+               	mov	x9, x0
+               	mov	x16, #0xf890            ; =63632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	x9, [x29, x16]
+               	mov	x16, #0xf890            ; =63632
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	cmp	x9, #0x7
                	b.lo	 <L1>
 <L2>:
                	mov	x16, #0xf898            ; =63640
@@ -451,12 +487,12 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	sub	x9, x10, #0x1
-               	mov	x16, #0xf7f8            ; =63480
+               	mov	x16, #0xf7f0            ; =63472
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf7f8            ; =63480
+               	mov	x16, #0xf7f0            ; =63472
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -464,7 +500,7 @@ Disassembly of section __TEXT,__text:
                	mov	x16, #0xc               ; =12
                	mul	x0, x9, x16
                	add	x9, x19, x0
-               	mov	x16, #0xf888            ; =63624
+               	mov	x16, #0xf878            ; =63608
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -479,7 +515,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xf888            ; =63624
+               	mov	x16, #0xf878            ; =63608
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -490,7 +526,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
-               	mov	x16, #0xf888            ; =63624
+               	mov	x16, #0xf878            ; =63608
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -547,7 +583,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf7f8            ; =63480
+               	mov	x16, #0xf7f0            ; =63472
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -622,12 +658,12 @@ Disassembly of section __TEXT,__text:
                	ldr	x9, [x29, x16]
                	str	xzr, [x9, #0x38]
                	mov	x9, #0x0                ; =0
-               	mov	x16, #0xf880            ; =63616
+               	mov	x16, #0xf870            ; =63600
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf880            ; =63616
+               	mov	x16, #0xf870            ; =63600
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -636,14 +672,14 @@ Disassembly of section __TEXT,__text:
                	b.lo	 <L8>
                	b	 <L9>
 <L8>:
-               	mov	x16, #0xf880            ; =63616
+               	mov	x16, #0xf870            ; =63600
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x16, #0xc               ; =12
-               	mul	x18, x9, x16
-               	add	x0, x19, x18
+               	mul	x14, x9, x16
+               	add	x0, x19, x14
                	mov	x16, #0xfb3c            ; =64316
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -654,24 +690,24 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x18, [x0]
+               	ldr	x14, [x0]
                	mov	x16, #0xfb3c            ; =64316
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x18, [x29, x16]
-               	ldr	w18, [x0, #0x8]
+               	str	x14, [x29, x16]
+               	ldr	w14, [x0, #0x8]
                	mov	x16, #0xfb44            ; =64324
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w18, [x29, x16]
+               	str	w14, [x29, x16]
                	mov	x16, #0xfb3c            ; =64316
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q0, [x29, x16]
-               	mov	x16, #0xf880            ; =63616
+               	mov	x16, #0xf870            ; =63600
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -684,12 +720,12 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	x10, [x29, x16]
                	add	x9, x10, x0
-               	mov	x16, #0xf878            ; =63608
+               	mov	x16, #0xf868            ; =63592
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf878            ; =63608
+               	mov	x16, #0xf868            ; =63592
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -704,15 +740,15 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x18, [x29, x16]
-               	str	x18, [x0]
+               	ldr	x14, [x29, x16]
+               	str	x14, [x0]
                	mov	x16, #0xfb34            ; =64308
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	w18, [x29, x16]
-               	str	w18, [x0, #0x8]
-               	mov	x16, #0xf880            ; =63616
+               	ldr	w14, [x29, x16]
+               	str	w14, [x0, #0x8]
+               	mov	x16, #0xf870            ; =63600
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -720,27 +756,27 @@ Disassembly of section __TEXT,__text:
                	mov	w0, w9
                	mov	w17, #0xaaaa            ; =43690
                	movk	w17, #0xaaaa, lsl #16
-               	sub	w18, w17, w0
-               	mov	x16, #0xf878            ; =63608
+               	sub	w14, w17, w0
+               	mov	x16, #0xf868            ; =63592
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0xc
-               	str	w18, [x0]
-               	mov	x16, #0xf880            ; =63616
+               	str	w14, [x0]
+               	mov	x16, #0xf870            ; =63600
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x1
                	mov	x9, x0
-               	mov	x16, #0xf880            ; =63616
+               	mov	x16, #0xf870            ; =63600
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf880            ; =63616
+               	mov	x16, #0xf870            ; =63600
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -851,12 +887,12 @@ Disassembly of section __TEXT,__text:
 <L13>:
                	bl	 <L13>
                	mov	x9, x0
-               	mov	x16, #0xf868            ; =63592
+               	mov	x16, #0xf858            ; =63576
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf868            ; =63592
+               	mov	x16, #0xf858            ; =63576
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -876,18 +912,18 @@ Disassembly of section __TEXT,__text:
                	add	x0, x9, x1
                	add	x1, x0, #0xc
                	ldr	w9, [x1]
-               	mov	x16, #0xf860            ; =63584
+               	mov	x16, #0xf850            ; =63568
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf868            ; =63592
+               	mov	x16, #0xf858            ; =63576
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x0, x9
-               	mov	x16, #0xf860            ; =63584
+               	mov	x16, #0xf850            ; =63568
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -900,14 +936,14 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
-               	add	x14, x9, #0x1
+               	add	x15, x9, #0x1
                	mov	x9, x0
                	mov	x16, #0xf7a8            ; =63400
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x9, x14
+               	mov	x9, x15
                	mov	x16, #0xf7a0            ; =63392
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -964,18 +1000,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x14, [x1]
+               	ldr	x15, [x1]
                	mov	x16, #0xfaf8            ; =64248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x14, [x29, x16]
-               	ldr	w14, [x1, #0x8]
+               	str	x15, [x29, x16]
+               	ldr	w15, [x1, #0x8]
                	mov	x16, #0xfb00            ; =64256
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w14, [x29, x16]
+               	str	w15, [x29, x16]
                	mov	x16, #0xfaf8            ; =64248
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1113,12 +1149,12 @@ Disassembly of section __TEXT,__text:
 <L20>:
                	bl	 <L20>
                	mov	x9, x0
-               	mov	x16, #0xf858            ; =63576
+               	mov	x16, #0xf848            ; =63560
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf858            ; =63576
+               	mov	x16, #0xf848            ; =63560
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1276,7 +1312,7 @@ Disassembly of section __TEXT,__text:
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x0
                	ldrb	w1, [x0]
-               	mov	x16, #0xf858            ; =63576
+               	mov	x16, #0xf848            ; =63560
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1443,12 +1479,12 @@ Disassembly of section __TEXT,__text:
 <L30>:
                	bl	 <L30>
                	mov	x9, x0
-               	mov	x16, #0xf850            ; =63568
+               	mov	x16, #0xf840            ; =63552
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x9, [x29, x16]
-               	mov	x16, #0xf850            ; =63568
+               	mov	x16, #0xf840            ; =63552
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1515,18 +1551,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x18, [x14]
+               	ldr	x15, [x14]
                	mov	x16, #0xf974            ; =63860
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x18, [x29, x16]
-               	ldr	w18, [x14, #0x8]
+               	str	x15, [x29, x16]
+               	ldr	w15, [x14, #0x8]
                	mov	x16, #0xf97c            ; =63868
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w18, [x29, x16]
+               	str	w15, [x29, x16]
                	mov	x16, #0xf974            ; =63860
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1538,7 +1574,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x14, x9, #0x4
-               	add	x18, x14, #0x0
+               	add	x15, x14, #0x0
                	mov	x16, #0xf964            ; =63844
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1549,13 +1585,13 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x0, [x29, x16]
-               	str	x0, [x18]
+               	str	x0, [x15]
                	mov	x16, #0xf96c            ; =63852
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	w0, [x29, x16]
-               	str	w0, [x18, #0x8]
+               	str	w0, [x15, #0x8]
                	add	x0, x19, #0x24
                	mov	x16, #0xf954            ; =63828
                	movk	x16, #0xffff, lsl #16
@@ -1567,18 +1603,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x18, [x0]
+               	ldr	x15, [x0]
                	mov	x16, #0xf954            ; =63828
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x18, [x29, x16]
-               	ldr	w18, [x0, #0x8]
+               	str	x15, [x29, x16]
+               	ldr	w15, [x0, #0x8]
                	mov	x16, #0xf95c            ; =63836
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w18, [x29, x16]
+               	str	w15, [x29, x16]
                	mov	x16, #0xf954            ; =63828
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1594,14 +1630,14 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	x18, [x29, x16]
-               	str	x18, [x0]
+               	ldr	x15, [x29, x16]
+               	str	x15, [x0]
                	mov	x16, #0xf94c            ; =63820
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	w18, [x29, x16]
-               	str	w18, [x0, #0x8]
+               	ldr	w15, [x29, x16]
+               	str	w15, [x0, #0x8]
                	add	x0, x19, #0x48
                	mov	x16, #0xf934            ; =63796
                	movk	x16, #0xffff, lsl #16
@@ -1613,18 +1649,18 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	ldr	x18, [x0]
+               	ldr	x15, [x0]
                	mov	x16, #0xf934            ; =63796
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	x18, [x29, x16]
-               	ldr	w18, [x0, #0x8]
+               	str	x15, [x29, x16]
+               	ldr	w15, [x0, #0x8]
                	mov	x16, #0xf93c            ; =63804
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	w18, [x29, x16]
+               	str	w15, [x29, x16]
                	mov	x16, #0xf934            ; =63796
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -1658,7 +1694,7 @@ Disassembly of section __TEXT,__text:
                	movk	w17, #0x1234, lsl #16
                	str	w17, [x0]
                	ldr	w14, [x1]
-               	mov	x16, #0xf850            ; =63568
+               	mov	x16, #0xf840            ; =63552
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1700,9 +1736,9 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	mov	x16, #0xc               ; =12
-               	mul	x18, x9, x16
-               	add	x9, x0, x18
-               	mov	x16, #0xf848            ; =63560
+               	mul	x15, x9, x16
+               	add	x9, x0, x15
+               	mov	x16, #0xf838            ; =63544
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1717,7 +1753,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	xzr, [x29, x16]
-               	mov	x16, #0xf848            ; =63560
+               	mov	x16, #0xf838            ; =63544
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1728,7 +1764,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	x0, [x29, x16]
-               	mov	x16, #0xf848            ; =63560
+               	mov	x16, #0xf838            ; =63544
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2489,7 +2525,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x14]
                	add	x14, x28, #0x0
                	ldr	s0, [x14]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf830            ; =63536
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2498,7 +2534,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x14]
                	add	x14, x28, #0x4
                	ldr	s0, [x14]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf830            ; =63536
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2507,7 +2543,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x14]
                	add	x14, x28, #0x8
                	ldr	s0, [x14]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf830            ; =63536
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2516,7 +2552,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x14]
                	add	x14, x28, #0xc
                	ldr	s0, [x14]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf830            ; =63536
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2525,21 +2561,21 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x14]
                	add	x14, x28, #0x10
                	ldr	s0, [x14]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf830            ; =63536
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x14, x9, #0x10
                	str	s0, [x14]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf830            ; =63536
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x14, x9, #0x10
                	str	s1, [x14]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf830            ; =63536
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2548,7 +2584,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x14]
                	add	x14, x13, #0x0
                	str	s0, [x14]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf830            ; =63536
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2557,7 +2593,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x14]
                	add	x14, x13, #0x4
                	str	s0, [x14]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf830            ; =63536
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2566,7 +2602,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x14]
                	add	x14, x13, #0x8
                	str	s0, [x14]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf830            ; =63536
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2575,7 +2611,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x14]
                	add	x14, x13, #0xc
                	str	s0, [x14]
-               	mov	x16, #0xf840            ; =63552
+               	mov	x16, #0xf830            ; =63536
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2586,7 +2622,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x14]
                	add	x14, x13, #0x0
                	ldr	s0, [x14]
-               	mov	x16, #0xf838            ; =63544
+               	mov	x16, #0xf828            ; =63528
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2595,7 +2631,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x14]
                	add	x14, x13, #0x4
                	ldr	s0, [x14]
-               	mov	x16, #0xf838            ; =63544
+               	mov	x16, #0xf828            ; =63528
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2604,7 +2640,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x14]
                	add	x14, x13, #0x8
                	ldr	s0, [x14]
-               	mov	x16, #0xf838            ; =63544
+               	mov	x16, #0xf828            ; =63528
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2613,7 +2649,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x14]
                	add	x14, x13, #0xc
                	ldr	s0, [x14]
-               	mov	x16, #0xf838            ; =63544
+               	mov	x16, #0xf828            ; =63528
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2622,7 +2658,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x14]
                	add	x14, x13, #0x10
                	ldr	s0, [x14]
-               	mov	x16, #0xf838            ; =63544
+               	mov	x16, #0xf828            ; =63528
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2632,7 +2668,7 @@ Disassembly of section __TEXT,__text:
                	mov	x16, #0x14              ; =20
                	mul	x13, x1, x16
                	add	x14, x19, x13
-               	mov	x16, #0xf838            ; =63544
+               	mov	x16, #0xf828            ; =63528
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2641,7 +2677,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x13]
                	add	x13, x14, #0x0
                	str	s0, [x13]
-               	mov	x16, #0xf838            ; =63544
+               	mov	x16, #0xf828            ; =63528
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2650,7 +2686,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x13]
                	add	x13, x14, #0x4
                	str	s0, [x13]
-               	mov	x16, #0xf838            ; =63544
+               	mov	x16, #0xf828            ; =63528
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2659,7 +2695,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x13]
                	add	x13, x14, #0x8
                	str	s0, [x13]
-               	mov	x16, #0xf838            ; =63544
+               	mov	x16, #0xf828            ; =63528
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2668,7 +2704,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x13]
                	add	x13, x14, #0xc
                	str	s0, [x13]
-               	mov	x16, #0xf838            ; =63544
+               	mov	x16, #0xf828            ; =63528
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2694,7 +2730,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x19, x0
                	add	x0, x1, #0x0
                	ldr	s0, [x0]
-               	mov	x16, #0xf830            ; =63536
+               	mov	x16, #0xf820            ; =63520
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2703,7 +2739,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x4
                	ldr	s0, [x0]
-               	mov	x16, #0xf830            ; =63536
+               	mov	x16, #0xf820            ; =63520
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2712,7 +2748,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x8
                	ldr	s0, [x0]
-               	mov	x16, #0xf830            ; =63536
+               	mov	x16, #0xf820            ; =63520
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2721,7 +2757,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0xc
                	ldr	s0, [x0]
-               	mov	x16, #0xf830            ; =63536
+               	mov	x16, #0xf820            ; =63520
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2730,14 +2766,14 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x0]
                	add	x0, x1, #0x10
                	ldr	s0, [x0]
-               	mov	x16, #0xf830            ; =63536
+               	mov	x16, #0xf820            ; =63520
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x0, x9, #0x10
                	str	s0, [x0]
-               	mov	x16, #0xf830            ; =63536
+               	mov	x16, #0xf820            ; =63520
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2747,7 +2783,7 @@ Disassembly of section __TEXT,__text:
                	mov	x0, x20
 <L56>:
                	bl	 <L56>
-               	mov	x16, #0xf830            ; =63536
+               	mov	x16, #0xf820            ; =63520
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2756,7 +2792,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L57>:
                	bl	 <L57>
-               	mov	x16, #0xf830            ; =63536
+               	mov	x16, #0xf820            ; =63520
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2765,7 +2801,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L58>:
                	bl	 <L58>
-               	mov	x16, #0xf830            ; =63536
+               	mov	x16, #0xf820            ; =63520
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2774,7 +2810,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L59>:
                	bl	 <L59>
-               	mov	x16, #0xf830            ; =63536
+               	mov	x16, #0xf820            ; =63520
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2803,7 +2839,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x19, #0x3c
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf828            ; =63528
+               	mov	x16, #0xf818            ; =63512
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2812,7 +2848,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf828            ; =63528
+               	mov	x16, #0xf818            ; =63512
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2821,7 +2857,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf828            ; =63528
+               	mov	x16, #0xf818            ; =63512
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2830,7 +2866,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf828            ; =63528
+               	mov	x16, #0xf818            ; =63512
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2839,7 +2875,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf828            ; =63528
+               	mov	x16, #0xf818            ; =63512
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2847,7 +2883,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x9, #0x10
                	str	s0, [x1]
                	add	x22, x21, #0x10
-               	mov	x16, #0xf828            ; =63528
+               	mov	x16, #0xf818            ; =63512
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2856,7 +2892,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x22, #0x0
                	str	s0, [x1]
-               	mov	x16, #0xf828            ; =63528
+               	mov	x16, #0xf818            ; =63512
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2865,7 +2901,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x22, #0x4
                	str	s0, [x1]
-               	mov	x16, #0xf828            ; =63528
+               	mov	x16, #0xf818            ; =63512
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2874,7 +2910,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x22, #0x8
                	str	s0, [x1]
-               	mov	x16, #0xf828            ; =63528
+               	mov	x16, #0xf818            ; =63512
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2883,7 +2919,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
                	add	x1, x22, #0xc
                	str	s0, [x1]
-               	mov	x16, #0xf828            ; =63528
+               	mov	x16, #0xf818            ; =63512
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2902,7 +2938,7 @@ Disassembly of section __TEXT,__text:
                	bl	 <L62>
                	add	x1, x22, #0x0
                	ldr	s0, [x1]
-               	mov	x16, #0xf820            ; =63520
+               	mov	x16, #0xf810            ; =63504
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2911,7 +2947,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x22, #0x4
                	ldr	s0, [x1]
-               	mov	x16, #0xf820            ; =63520
+               	mov	x16, #0xf810            ; =63504
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2920,7 +2956,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x22, #0x8
                	ldr	s0, [x1]
-               	mov	x16, #0xf820            ; =63520
+               	mov	x16, #0xf810            ; =63504
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2929,7 +2965,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x22, #0xc
                	ldr	s0, [x1]
-               	mov	x16, #0xf820            ; =63520
+               	mov	x16, #0xf810            ; =63504
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2938,14 +2974,14 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x1]
                	add	x1, x22, #0x10
                	ldr	s0, [x1]
-               	mov	x16, #0xf820            ; =63520
+               	mov	x16, #0xf810            ; =63504
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	mov	x16, #0xf820            ; =63520
+               	mov	x16, #0xf810            ; =63504
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2954,7 +2990,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L63>:
                	bl	 <L63>
-               	mov	x16, #0xf820            ; =63520
+               	mov	x16, #0xf810            ; =63504
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2963,7 +2999,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L64>:
                	bl	 <L64>
-               	mov	x16, #0xf820            ; =63520
+               	mov	x16, #0xf810            ; =63504
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2972,7 +3008,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L65>:
                	bl	 <L65>
-               	mov	x16, #0xf820            ; =63520
+               	mov	x16, #0xf810            ; =63504
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2981,7 +3017,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L66>:
                	bl	 <L66>
-               	mov	x16, #0xf820            ; =63520
+               	mov	x16, #0xf810            ; =63504
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -2998,7 +3034,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x19, #0x14
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf818            ; =63512
+               	mov	x16, #0xf808            ; =63496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3007,7 +3043,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf818            ; =63512
+               	mov	x16, #0xf808            ; =63496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3016,7 +3052,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf818            ; =63512
+               	mov	x16, #0xf808            ; =63496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3025,7 +3061,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf818            ; =63512
+               	mov	x16, #0xf808            ; =63496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3034,7 +3070,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf818            ; =63512
+               	mov	x16, #0xf808            ; =63496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3044,7 +3080,7 @@ Disassembly of section __TEXT,__text:
                	add	x2, x19, #0x50
                	add	x3, x2, #0x0
                	ldr	s0, [x3]
-               	mov	x16, #0xf810            ; =63504
+               	mov	x16, #0xf800            ; =63488
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3053,7 +3089,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x3]
                	add	x3, x2, #0x4
                	ldr	s0, [x3]
-               	mov	x16, #0xf810            ; =63504
+               	mov	x16, #0xf800            ; =63488
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3062,7 +3098,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x3]
                	add	x3, x2, #0x8
                	ldr	s0, [x3]
-               	mov	x16, #0xf810            ; =63504
+               	mov	x16, #0xf800            ; =63488
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3071,7 +3107,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x3]
                	add	x3, x2, #0xc
                	ldr	s0, [x3]
-               	mov	x16, #0xf810            ; =63504
+               	mov	x16, #0xf800            ; =63488
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3080,43 +3116,43 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x3]
                	add	x3, x2, #0x10
                	ldr	s0, [x3]
-               	mov	x16, #0xf810            ; =63504
+               	mov	x16, #0xf800            ; =63488
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x2, x9, #0x10
                	str	s0, [x2]
-               	mov	x16, #0xf818            ; =63512
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x0
-               	ldr	s0, [x2]
-               	mov	x16, #0xf810            ; =63504
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	x9, [x29, x16]
-               	add	x2, x9, #0x0
-               	ldr	s1, [x2]
-               	fadd	s2, s0, s1
                	mov	x16, #0xf808            ; =63496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x2, x9, #0x0
+               	ldr	s0, [x2]
+               	mov	x16, #0xf800            ; =63488
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x2, x9, #0x0
+               	ldr	s1, [x2]
+               	fadd	s2, s0, s1
+               	mov	x16, #0xf7f8            ; =63480
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	x9, [x29, x16]
+               	add	x2, x9, #0x0
                	str	s2, [x2]
-               	mov	x16, #0xf818            ; =63512
+               	mov	x16, #0xf808            ; =63496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x2, x9, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf810            ; =63504
+               	mov	x16, #0xf800            ; =63488
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3124,21 +3160,21 @@ Disassembly of section __TEXT,__text:
                	add	x2, x9, #0x4
                	ldr	s1, [x2]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf808            ; =63496
+               	mov	x16, #0xf7f8            ; =63480
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x2, x9, #0x4
                	str	s2, [x2]
-               	mov	x16, #0xf818            ; =63512
+               	mov	x16, #0xf808            ; =63496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x2, x9, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf810            ; =63504
+               	mov	x16, #0xf800            ; =63488
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3146,21 +3182,21 @@ Disassembly of section __TEXT,__text:
                	add	x2, x9, #0x8
                	ldr	s1, [x2]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf808            ; =63496
+               	mov	x16, #0xf7f8            ; =63480
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x2, x9, #0x8
                	str	s2, [x2]
-               	mov	x16, #0xf818            ; =63512
+               	mov	x16, #0xf808            ; =63496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x2, x9, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf810            ; =63504
+               	mov	x16, #0xf800            ; =63488
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3168,21 +3204,21 @@ Disassembly of section __TEXT,__text:
                	add	x2, x9, #0xc
                	ldr	s1, [x2]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf808            ; =63496
+               	mov	x16, #0xf7f8            ; =63480
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x2, x9, #0xc
                	str	s2, [x2]
-               	mov	x16, #0xf818            ; =63512
+               	mov	x16, #0xf808            ; =63496
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x2, x9, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf810            ; =63504
+               	mov	x16, #0xf800            ; =63488
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3190,14 +3226,14 @@ Disassembly of section __TEXT,__text:
                	add	x2, x9, #0x10
                	ldr	s1, [x2]
                	fadd	s2, s0, s1
-               	mov	x16, #0xf808            ; =63496
+               	mov	x16, #0xf7f8            ; =63480
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x2, x9, #0x10
                	str	s2, [x2]
-               	mov	x16, #0xf808            ; =63496
+               	mov	x16, #0xf7f8            ; =63480
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3206,7 +3242,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x2]
                	add	x2, x1, #0x0
                	str	s0, [x2]
-               	mov	x16, #0xf808            ; =63496
+               	mov	x16, #0xf7f8            ; =63480
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3215,7 +3251,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x2]
                	add	x2, x1, #0x4
                	str	s0, [x2]
-               	mov	x16, #0xf808            ; =63496
+               	mov	x16, #0xf7f8            ; =63480
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3224,7 +3260,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x2]
                	add	x2, x1, #0x8
                	str	s0, [x2]
-               	mov	x16, #0xf808            ; =63496
+               	mov	x16, #0xf7f8            ; =63480
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3233,7 +3269,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x2]
                	add	x2, x1, #0xc
                	str	s0, [x2]
-               	mov	x16, #0xf808            ; =63496
+               	mov	x16, #0xf7f8            ; =63480
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3245,7 +3281,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x19, #0x0
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf890            ; =63632
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3254,7 +3290,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf890            ; =63632
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3263,7 +3299,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf890            ; =63632
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3272,7 +3308,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf890            ; =63632
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3281,14 +3317,14 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf890            ; =63632
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	mov	x16, #0xf890            ; =63632
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3297,7 +3333,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L69>:
                	bl	 <L69>
-               	mov	x16, #0xf890            ; =63632
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3306,7 +3342,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L70>:
                	bl	 <L70>
-               	mov	x16, #0xf890            ; =63632
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3315,7 +3351,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L71>:
                	bl	 <L71>
-               	mov	x16, #0xf890            ; =63632
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3324,7 +3360,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L72>:
                	bl	 <L72>
-               	mov	x16, #0xf890            ; =63632
+               	mov	x16, #0xf888            ; =63624
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3336,7 +3372,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x19, #0x14
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xf880            ; =63616
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3345,7 +3381,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xf880            ; =63616
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3354,7 +3390,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xf880            ; =63616
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3363,7 +3399,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xf880            ; =63616
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3372,14 +3408,14 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xf880            ; =63616
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xf880            ; =63616
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3388,7 +3424,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L74>:
                	bl	 <L74>
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xf880            ; =63616
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3397,7 +3433,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L75>:
                	bl	 <L75>
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xf880            ; =63616
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3406,7 +3442,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L76>:
                	bl	 <L76>
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xf880            ; =63616
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3415,7 +3451,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L77>:
                	bl	 <L77>
-               	mov	x16, #0xf870            ; =63600
+               	mov	x16, #0xf880            ; =63616
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3427,7 +3463,7 @@ Disassembly of section __TEXT,__text:
                	add	x1, x19, #0x28
                	add	x2, x1, #0x0
                	ldr	s0, [x2]
-               	mov	x16, #0xf800            ; =63488
+               	mov	x16, #0xf860            ; =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3436,7 +3472,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x4
                	ldr	s0, [x2]
-               	mov	x16, #0xf800            ; =63488
+               	mov	x16, #0xf860            ; =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3445,7 +3481,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x8
                	ldr	s0, [x2]
-               	mov	x16, #0xf800            ; =63488
+               	mov	x16, #0xf860            ; =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3454,7 +3490,7 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0xc
                	ldr	s0, [x2]
-               	mov	x16, #0xf800            ; =63488
+               	mov	x16, #0xf860            ; =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3463,14 +3499,14 @@ Disassembly of section __TEXT,__text:
                	str	s0, [x2]
                	add	x2, x1, #0x10
                	ldr	s0, [x2]
-               	mov	x16, #0xf800            ; =63488
+               	mov	x16, #0xf860            ; =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	x9, [x29, x16]
                	add	x1, x9, #0x10
                	str	s0, [x1]
-               	mov	x16, #0xf800            ; =63488
+               	mov	x16, #0xf860            ; =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3479,7 +3515,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L79>:
                	bl	 <L79>
-               	mov	x16, #0xf800            ; =63488
+               	mov	x16, #0xf860            ; =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3488,7 +3524,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L80>:
                	bl	 <L80>
-               	mov	x16, #0xf800            ; =63488
+               	mov	x16, #0xf860            ; =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3497,7 +3533,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L81>:
                	bl	 <L81>
-               	mov	x16, #0xf800            ; =63488
+               	mov	x16, #0xf860            ; =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -3506,7 +3542,7 @@ Disassembly of section __TEXT,__text:
                	ldr	s0, [x1]
 <L82>:
                	bl	 <L82>
-               	mov	x16, #0xf800            ; =63488
+               	mov	x16, #0xf860            ; =63584
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48

--- a/test/golden/aarch64-darwin/vec/vec_u16x8.dis
+++ b/test/golden/aarch64-darwin/vec/vec_u16x8.dis
@@ -70,8 +70,8 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_u16x8.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x290
-               	sub	x16, x29, #0x280
+               	sub	sp, sp, #0x240
+               	sub	x16, x29, #0x230
                	stp	x19, x20, [x16]
                	stur	x21, [x16, #-0x8]
                	mov	x19, x0
@@ -802,7 +802,12 @@ Disassembly of section __TEXT,__text:
                	bl	 <L80>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
-               	sub.8h	v31, v31, v30
+               	sub.8h	v0, v31, v30
+<L81>:
+               	bl	 <L81>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	and.16b	v31, v31, v30
                	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -812,48 +817,35 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
+               	ldr	q0, [x29, x16]
 <L82>:
                	bl	 <L82>
-               	mov	x16, #0xfe80            ; =65152
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	orr.16b	v31, v31, v30
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
 <L83>:
                	bl	 <L83>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor.16b	v0, v31, v30
 <L84>:
                	bl	 <L84>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
+               	ldur	q31, [x29, #-0xe0]
+               	mvn.16b	v0, v31
 <L85>:
                	bl	 <L85>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
+               	ldur	q31, [x29, #-0xf0]
+               	mvn.16b	v0, v31
 <L86>:
                	bl	 <L86>
                	mov	x16, #0xfe80            ; =65152
@@ -861,34 +853,60 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L87>:
-               	bl	 <L87>
-               	mov	x16, #0xfe80            ; =65152
+               	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L88>:
-               	bl	 <L88>
+               	ldr	q30, [x29, x16]
+               	eor.16b	v0, v31, v30
+<L87>:
+               	bl	 <L87>
+               	mov	x19, x0
                	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and.16b	v31, v31, v30
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	ldur	q31, [x29, #-0xd0]
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x20, #0x0               ; =0
+               	cmp	x20, #0x6
+               	b.lo	 <L88>
+               	b	 <L121>
+<L88>:
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xc0]
+               	mul.8h	v31, v31, v30
+               	mov	x16, #0xfe60            ; =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[0]
+               	mov	x0, x19
 <L89>:
                	bl	 <L89>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -896,7 +914,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[1]
 <L90>:
                	bl	 <L90>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -904,7 +922,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[2]
 <L91>:
                	bl	 <L91>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -912,7 +930,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[3]
 <L92>:
                	bl	 <L92>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -920,7 +938,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[4]
 <L93>:
                	bl	 <L93>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -928,7 +946,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[5]
 <L94>:
                	bl	 <L94>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -936,7 +954,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[6]
 <L95>:
                	bl	 <L95>
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -944,15 +962,23 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[7]
 <L96>:
                	bl	 <L96>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr.16b	v31, v31, v30
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	eor.16b	v31, v31, v30
+               	mov	x16, #0xfe20            ; =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -960,7 +986,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[0]
 <L97>:
                	bl	 <L97>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -968,7 +994,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[1]
 <L98>:
                	bl	 <L98>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -976,7 +1002,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[2]
 <L99>:
                	bl	 <L99>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -984,7 +1010,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[3]
 <L100>:
                	bl	 <L100>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -992,7 +1018,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[4]
 <L101>:
                	bl	 <L101>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1000,7 +1026,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[5]
 <L102>:
                	bl	 <L102>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1008,7 +1034,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[6]
 <L103>:
                	bl	 <L103>
-               	mov	x16, #0xfe60            ; =65120
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1016,15 +1042,23 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[7]
 <L104>:
                	bl	 <L104>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	eor.16b	v31, v31, v30
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	add.8h	v31, v31, v30
+               	mov	x16, #0xfe10            ; =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1032,7 +1066,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[0]
 <L105>:
                	bl	 <L105>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1040,7 +1074,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[1]
 <L106>:
                	bl	 <L106>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1048,7 +1082,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[2]
 <L107>:
                	bl	 <L107>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1056,7 +1090,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[3]
 <L108>:
                	bl	 <L108>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1064,7 +1098,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[4]
 <L109>:
                	bl	 <L109>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1072,7 +1106,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[5]
 <L110>:
                	bl	 <L110>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1080,7 +1114,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[6]
 <L111>:
                	bl	 <L111>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1088,14 +1122,19 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[7]
 <L112>:
                	bl	 <L112>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
+               	add.8h	v31, v31, v30
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1103,7 +1142,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[0]
 <L113>:
                	bl	 <L113>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1111,7 +1150,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[1]
 <L114>:
                	bl	 <L114>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1119,7 +1158,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[2]
 <L115>:
                	bl	 <L115>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1127,7 +1166,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[3]
 <L116>:
                	bl	 <L116>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1135,7 +1174,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[4]
 <L117>:
                	bl	 <L117>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1143,7 +1182,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[5]
 <L118>:
                	bl	 <L118>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1151,7 +1190,7 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[6]
 <L119>:
                	bl	 <L119>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1159,525 +1198,41 @@ Disassembly of section __TEXT,__text:
                	umov.h	w1, v31[7]
 <L120>:
                	bl	 <L120>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L121>:
-               	bl	 <L121>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L122>:
-               	bl	 <L122>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L123>:
-               	bl	 <L123>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L124>:
-               	bl	 <L124>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L125>:
-               	bl	 <L125>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L126>:
-               	bl	 <L126>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L127>:
-               	bl	 <L127>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L128>:
-               	bl	 <L128>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and.16b	v0, v31, v30
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr.16b	v1, v31, v30
-               	eor.16b	v31, v0, v1
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L129>:
-               	bl	 <L129>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L130>:
-               	bl	 <L130>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L131>:
-               	bl	 <L131>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L132>:
-               	bl	 <L132>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L133>:
-               	bl	 <L133>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L134>:
-               	bl	 <L134>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L135>:
-               	bl	 <L135>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L136>:
-               	bl	 <L136>
-               	mov	x19, x0
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x20, #0x0               ; =0
-               	cmp	x20, #0x6
-               	b.lo	 <L137>
-               	b	 <L170>
-<L137>:
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xc0]
-               	mul.8h	v31, v31, v30
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-               	mov	x0, x19
-<L138>:
-               	bl	 <L138>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L139>:
-               	bl	 <L139>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L140>:
-               	bl	 <L140>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L141>:
-               	bl	 <L141>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L142>:
-               	bl	 <L142>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L143>:
-               	bl	 <L143>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L144>:
-               	bl	 <L144>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L145>:
-               	bl	 <L145>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	eor.16b	v31, v31, v30
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L146>:
-               	bl	 <L146>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L147>:
-               	bl	 <L147>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L148>:
-               	bl	 <L148>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L149>:
-               	bl	 <L149>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L150>:
-               	bl	 <L150>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L151>:
-               	bl	 <L151>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L152>:
-               	bl	 <L152>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L153>:
-               	bl	 <L153>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	add.8h	v31, v31, v30
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L154>:
-               	bl	 <L154>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L155>:
-               	bl	 <L155>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L156>:
-               	bl	 <L156>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L157>:
-               	bl	 <L157>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L158>:
-               	bl	 <L158>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L159>:
-               	bl	 <L159>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L160>:
-               	bl	 <L160>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L161>:
-               	bl	 <L161>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xf0]
-               	add.8h	v31, v31, v30
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[0]
-<L162>:
-               	bl	 <L162>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[1]
-<L163>:
-               	bl	 <L163>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[2]
-<L164>:
-               	bl	 <L164>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[3]
-<L165>:
-               	bl	 <L165>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[4]
-<L166>:
-               	bl	 <L166>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[5]
-<L167>:
-               	bl	 <L167>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[6]
-<L168>:
-               	bl	 <L168>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	umov.h	w1, v31[7]
-<L169>:
-               	bl	 <L169>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            ; =64960
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe10            ; =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L137>
-<L170>:
+               	b.lo	 <L88>
+<L121>:
                	sub	x20, x29, #0x80
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -1688,13 +1243,13 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1703,7 +1258,7 @@ Disassembly of section __TEXT,__text:
                	add.8h	v0, v31, v30
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1713,7 +1268,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfdf0            ; =65008
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1721,88 +1276,88 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L171>
-               	b	 <L180>
-<L171>:
+               	b.lo	 <L122>
+               	b	 <L131>
+<L122>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q31, [x1]
-               	mov	x16, #0xfda0            ; =64928
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfda0            ; =64928
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[0]
                	mov	x0, x19
-<L172>:
-               	bl	 <L172>
-               	mov	x16, #0xfda0            ; =64928
+<L123>:
+               	bl	 <L123>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[1]
-<L173>:
-               	bl	 <L173>
-               	mov	x16, #0xfda0            ; =64928
+<L124>:
+               	bl	 <L124>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[2]
-<L174>:
-               	bl	 <L174>
-               	mov	x16, #0xfda0            ; =64928
+<L125>:
+               	bl	 <L125>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[3]
-<L175>:
-               	bl	 <L175>
-               	mov	x16, #0xfda0            ; =64928
+<L126>:
+               	bl	 <L126>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[4]
-<L176>:
-               	bl	 <L176>
-               	mov	x16, #0xfda0            ; =64928
+<L127>:
+               	bl	 <L127>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[5]
-<L177>:
-               	bl	 <L177>
-               	mov	x16, #0xfda0            ; =64928
+<L128>:
+               	bl	 <L128>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[6]
-<L178>:
-               	bl	 <L178>
-               	mov	x16, #0xfda0            ; =64928
+<L129>:
+               	bl	 <L129>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[7]
-<L179>:
-               	bl	 <L179>
+<L130>:
+               	bl	 <L130>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L171>
-<L180>:
+               	b.lo	 <L122>
+<L131>:
                	sub	x21, x29, #0xb0
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -1824,84 +1379,84 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x1]
                	ldr	w1, [x0]
                	mov	x0, x19
-<L181>:
-               	bl	 <L181>
+<L132>:
+               	bl	 <L132>
                	ldr	q31, [x20]
-               	mov	x16, #0xfd90            ; =64912
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd90            ; =64912
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[0]
-<L182>:
-               	bl	 <L182>
-               	mov	x16, #0xfd90            ; =64912
+<L133>:
+               	bl	 <L133>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[1]
-<L183>:
-               	bl	 <L183>
-               	mov	x16, #0xfd90            ; =64912
+<L134>:
+               	bl	 <L134>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[2]
-<L184>:
-               	bl	 <L184>
-               	mov	x16, #0xfd90            ; =64912
+<L135>:
+               	bl	 <L135>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[3]
-<L185>:
-               	bl	 <L185>
-               	mov	x16, #0xfd90            ; =64912
+<L136>:
+               	bl	 <L136>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[4]
-<L186>:
-               	bl	 <L186>
-               	mov	x16, #0xfd90            ; =64912
+<L137>:
+               	bl	 <L137>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[5]
-<L187>:
-               	bl	 <L187>
-               	mov	x16, #0xfd90            ; =64912
+<L138>:
+               	bl	 <L138>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[6]
-<L188>:
-               	bl	 <L188>
-               	mov	x16, #0xfd90            ; =64912
+<L139>:
+               	bl	 <L139>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	umov.h	w1, v31[7]
-<L189>:
-               	bl	 <L189>
+<L140>:
+               	bl	 <L140>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L190>:
-               	bl	 <L190>
-               	sub	x16, x29, #0x280
+<L141>:
+               	bl	 <L141>
+               	sub	x16, x29, #0x230
                	ldp	x19, x20, [x16]
                	ldur	x21, [x16, #-0x8]
                	mov	sp, x29

--- a/test/golden/aarch64-darwin/vec/vec_u32x4.dis
+++ b/test/golden/aarch64-darwin/vec/vec_u32x4.dis
@@ -42,8 +42,8 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_u32x4.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x290
-               	sub	x16, x29, #0x280
+               	sub	sp, sp, #0x240
+               	sub	x16, x29, #0x230
                	stp	x19, x20, [x16]
                	stur	x21, [x16, #-0x8]
                	mov	x19, x0
@@ -462,87 +462,96 @@ Disassembly of section __TEXT,__text:
                	bl	 <L40>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
-               	sub.4s	v31, v31, v30
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
+               	sub.4s	v0, v31, v30
 <L41>:
                	bl	 <L41>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L43>:
-               	bl	 <L43>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L44>:
-               	bl	 <L44>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	and.16b	v31, v31, v30
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe70            ; =65136
+               	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L45>:
-               	bl	 <L45>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L47>:
-               	bl	 <L47>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L48>:
-               	bl	 <L48>
+               	ldr	q0, [x29, x16]
+<L42>:
+               	bl	 <L42>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
                	orr.16b	v31, v31, v30
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q0, [x29, x16]
+<L43>:
+               	bl	 <L43>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor.16b	v0, v31, v30
+<L44>:
+               	bl	 <L44>
+               	ldur	q31, [x29, #-0xe0]
+               	mvn.16b	v0, v31
+<L45>:
+               	bl	 <L45>
+               	ldur	q31, [x29, #-0xf0]
+               	mvn.16b	v0, v31
+<L46>:
+               	bl	 <L46>
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	eor.16b	v0, v31, v30
+<L47>:
+               	bl	 <L47>
+               	mov	x19, x0
+               	ldur	q31, [x29, #-0xe0]
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x20, #0x0               ; =0
+               	cmp	x20, #0x6
+               	b.lo	 <L48>
+               	b	 <L65>
+<L48>:
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xc0]
+               	mul.4s	v31, v31, v30
                	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -554,6 +563,7 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
+               	mov	x0, x19
 <L49>:
                	bl	 <L49>
                	mov	x16, #0xfe60            ; =65120
@@ -580,15 +590,23 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[3]
 <L52>:
                	bl	 <L52>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe60            ; =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
                	eor.16b	v31, v31, v30
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -596,7 +614,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[0]
 <L53>:
                	bl	 <L53>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -604,7 +622,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[1]
 <L54>:
                	bl	 <L54>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -612,7 +630,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[2]
 <L55>:
                	bl	 <L55>
-               	mov	x16, #0xfe50            ; =65104
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -620,14 +638,23 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[3]
 <L56>:
                	bl	 <L56>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe30            ; =65072
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	add.4s	v31, v31, v30
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -635,7 +662,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[0]
 <L57>:
                	bl	 <L57>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -643,7 +670,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[1]
 <L58>:
                	bl	 <L58>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -651,7 +678,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[2]
 <L59>:
                	bl	 <L59>
-               	mov	x16, #0xfe40            ; =65088
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -659,14 +686,19 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[3]
 <L60>:
                	bl	 <L60>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	ldur	q30, [x29, #-0xf0]
+               	add.4s	v31, v31, v30
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -674,7 +706,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[0]
 <L61>:
                	bl	 <L61>
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -682,7 +714,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[1]
 <L62>:
                	bl	 <L62>
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -690,7 +722,7 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[2]
 <L63>:
                	bl	 <L63>
-               	mov	x16, #0xfe30            ; =65072
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -698,294 +730,41 @@ Disassembly of section __TEXT,__text:
                	mov.s	w1, v31[3]
 <L64>:
                	bl	 <L64>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and.16b	v0, v31, v30
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr.16b	v1, v31, v30
-               	eor.16b	v31, v0, v1
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L65>:
-               	bl	 <L65>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L66>:
-               	bl	 <L66>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L67>:
-               	bl	 <L67>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L68>:
-               	bl	 <L68>
-               	mov	x19, x0
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x20, #0x0               ; =0
-               	cmp	x20, #0x6
-               	b.lo	 <L69>
-               	b	 <L86>
-<L69>:
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xc0]
-               	mul.4s	v31, v31, v30
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-               	mov	x0, x19
-<L70>:
-               	bl	 <L70>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L71>:
-               	bl	 <L71>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L72>:
-               	bl	 <L72>
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L73>:
-               	bl	 <L73>
-               	mov	x16, #0xfdf0            ; =65008
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	eor.16b	v31, v31, v30
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L74>:
-               	bl	 <L74>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L75>:
-               	bl	 <L75>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L76>:
-               	bl	 <L76>
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L77>:
-               	bl	 <L77>
-               	mov	x16, #0xfde0            ; =64992
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q30, [x29, x16]
-               	add.4s	v31, v31, v30
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L78>:
-               	bl	 <L78>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L79>:
-               	bl	 <L79>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L80>:
-               	bl	 <L80>
-               	mov	x16, #0xfdc0            ; =64960
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L81>:
-               	bl	 <L81>
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	ldur	q30, [x29, #-0xf0]
-               	add.4s	v31, v31, v30
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[0]
-<L82>:
-               	bl	 <L82>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[1]
-<L83>:
-               	bl	 <L83>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[2]
-<L84>:
-               	bl	 <L84>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.s	w1, v31[3]
-<L85>:
-               	bl	 <L85>
                	add	x20, x20, #0x1
                	mov	x19, x0
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            ; =64960
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfe40            ; =65088
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe10            ; =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L69>
-<L86>:
+               	b.lo	 <L48>
+<L65>:
                	sub	x20, x29, #0x80
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -996,13 +775,13 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1011,7 +790,7 @@ Disassembly of section __TEXT,__text:
                	add.4s	v0, v31, v30
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1021,7 +800,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	str	q0, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfdf0            ; =65008
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -1029,56 +808,56 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L87>
-               	b	 <L92>
-<L87>:
+               	b.lo	 <L66>
+               	b	 <L71>
+<L66>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q31, [x1]
-               	mov	x16, #0xfda0            ; =64928
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfda0            ; =64928
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
                	mov	x0, x19
-<L88>:
-               	bl	 <L88>
-               	mov	x16, #0xfda0            ; =64928
+<L67>:
+               	bl	 <L67>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[1]
-<L89>:
-               	bl	 <L89>
-               	mov	x16, #0xfda0            ; =64928
+<L68>:
+               	bl	 <L68>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[2]
-<L90>:
-               	bl	 <L90>
-               	mov	x16, #0xfda0            ; =64928
+<L69>:
+               	bl	 <L69>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[3]
-<L91>:
-               	bl	 <L91>
+<L70>:
+               	bl	 <L70>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L87>
-<L92>:
+               	b.lo	 <L66>
+<L71>:
                	sub	x21, x29, #0xb0
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -1100,52 +879,52 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x1]
                	ldr	w1, [x0]
                	mov	x0, x19
-<L93>:
-               	bl	 <L93>
+<L72>:
+               	bl	 <L72>
                	ldr	q31, [x20]
-               	mov	x16, #0xfd90            ; =64912
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd90            ; =64912
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[0]
-<L94>:
-               	bl	 <L94>
-               	mov	x16, #0xfd90            ; =64912
+<L73>:
+               	bl	 <L73>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[1]
-<L95>:
-               	bl	 <L95>
-               	mov	x16, #0xfd90            ; =64912
+<L74>:
+               	bl	 <L74>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[2]
-<L96>:
-               	bl	 <L96>
-               	mov	x16, #0xfd90            ; =64912
+<L75>:
+               	bl	 <L75>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.s	w1, v31[3]
-<L97>:
-               	bl	 <L97>
+<L76>:
+               	bl	 <L76>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L98>:
-               	bl	 <L98>
-               	sub	x16, x29, #0x280
+<L77>:
+               	bl	 <L77>
+               	sub	x16, x29, #0x230
                	ldp	x19, x20, [x16]
                	ldur	x21, [x16, #-0x8]
                	mov	sp, x29

--- a/test/golden/aarch64-darwin/vec/vec_u64x2.dis
+++ b/test/golden/aarch64-darwin/vec/vec_u64x2.dis
@@ -28,8 +28,8 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_u64x2.checksum>:
                	stp	x29, x30, [sp, #-0x10]!
                	mov	x29, sp
-               	sub	sp, sp, #0x290
-               	sub	x16, x29, #0x280
+               	sub	sp, sp, #0x240
+               	sub	x16, x29, #0x230
                	stp	x19, x20, [x16]
                	stur	x21, [x16, #-0x8]
                	mov	x19, x0
@@ -330,7 +330,12 @@ Disassembly of section __TEXT,__text:
                	bl	 <L20>
                	ldur	q31, [x29, #-0xd0]
                	ldur	q30, [x29, #-0xf0]
-               	sub.2d	v31, v31, v30
+               	sub.2d	v0, v31, v30
+<L21>:
+               	bl	 <L21>
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	and.16b	v31, v31, v30
                	mov	x16, #0xfe80            ; =65152
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -340,21 +345,12 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L21>:
-               	bl	 <L21>
-               	mov	x16, #0xfe80            ; =65152
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
+               	ldr	q0, [x29, x16]
 <L22>:
                	bl	 <L22>
                	ldur	q31, [x29, #-0xe0]
                	ldur	q30, [x29, #-0xf0]
-               	and.16b	v31, v31, v30
+               	orr.16b	v31, v31, v30
                	mov	x16, #0xfe70            ; =65136
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
@@ -364,165 +360,60 @@ Disassembly of section __TEXT,__text:
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
+               	ldr	q0, [x29, x16]
 <L23>:
                	bl	 <L23>
-               	mov	x16, #0xfe70            ; =65136
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
+               	ldur	q31, [x29, #-0xe0]
+               	ldur	q30, [x29, #-0xf0]
+               	eor.16b	v0, v31, v30
 <L24>:
                	bl	 <L24>
                	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr.16b	v31, v31, v30
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe60            ; =65120
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
+               	mvn.16b	v0, v31
 <L25>:
                	bl	 <L25>
+               	ldur	q31, [x29, #-0xf0]
+               	mvn.16b	v0, v31
+<L26>:
+               	bl	 <L26>
+               	mov	x16, #0xfe80            ; =65152
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe70            ; =65136
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	eor.16b	v0, v31, v30
+<L27>:
+               	bl	 <L27>
+               	mov	x19, x0
+               	ldur	q31, [x29, #-0xe0]
                	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L26>:
-               	bl	 <L26>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	eor.16b	v31, v31, v30
+               	str	q31, [x29, x16]
+               	ldur	q31, [x29, #-0xd0]
                	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L27>:
-               	bl	 <L27>
-               	mov	x16, #0xfe50            ; =65104
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L28>:
-               	bl	 <L28>
-               	ldur	q31, [x29, #-0xe0]
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L29>:
-               	bl	 <L29>
-               	mov	x16, #0xfe40            ; =65088
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L30>:
-               	bl	 <L30>
-               	ldur	q31, [x29, #-0xf0]
-               	mvn.16b	v31, v31
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L31>:
-               	bl	 <L31>
-               	mov	x16, #0xfe30            ; =65072
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L32>:
-               	bl	 <L32>
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	and.16b	v0, v31, v30
-               	ldur	q31, [x29, #-0xe0]
-               	ldur	q30, [x29, #-0xf0]
-               	orr.16b	v1, v31, v30
-               	eor.16b	v31, v0, v1
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L33>:
-               	bl	 <L33>
-               	mov	x16, #0xfe20            ; =65056
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L34>:
-               	bl	 <L34>
-               	mov	x19, x0
-               	ldur	q31, [x29, #-0xe0]
-               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfe00            ; =65024
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	ldur	q31, [x29, #-0xd0]
-               	mov	x16, #0xfdf0            ; =65008
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	mov	x20, #0x0               ; =0
                	cmp	x20, #0x6
-               	b.lo	 <L35>
-               	b	 <L44>
-<L35>:
-               	mov	x16, #0xfe10            ; =65040
+               	b.lo	 <L28>
+               	b	 <L37>
+<L28>:
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -531,7 +422,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -540,7 +431,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -549,155 +440,155 @@ Disassembly of section __TEXT,__text:
                	mov.d	v0[0], x2
                	mov.16b	v30, v0
                	mov.d	v30[1], x3
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q30, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
                	mov	x0, x19
-<L36>:
-               	bl	 <L36>
-               	mov	x16, #0xfde0            ; =64992
+<L29>:
+               	bl	 <L29>
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L37>:
-               	bl	 <L37>
-               	mov	x16, #0xfe00            ; =65024
+<L30>:
+               	bl	 <L30>
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfde0            ; =64992
+               	mov	x16, #0xfe30            ; =65072
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	eor.16b	v31, v31, v30
-               	mov	x16, #0xfdd0            ; =64976
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
-<L38>:
-               	bl	 <L38>
-               	mov	x16, #0xfdd0            ; =64976
+<L31>:
+               	bl	 <L31>
+               	mov	x16, #0xfe20            ; =65056
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L39>:
-               	bl	 <L39>
-               	mov	x16, #0xfdf0            ; =65008
+<L32>:
+               	bl	 <L32>
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q30, [x29, x16]
                	add.2d	v31, v31, v30
-               	mov	x16, #0xfdc0            ; =64960
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            ; =64960
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
-<L40>:
-               	bl	 <L40>
-               	mov	x16, #0xfdc0            ; =64960
+<L33>:
+               	bl	 <L33>
+               	mov	x16, #0xfe10            ; =65040
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L41>:
-               	bl	 <L41>
-               	mov	x16, #0xfe10            ; =65040
+<L34>:
+               	bl	 <L34>
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	ldur	q30, [x29, #-0xf0]
                	add.2d	v31, v31, v30
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[0]
-<L42>:
-               	bl	 <L42>
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov.d	x1, v31[1]
-<L43>:
-               	bl	 <L43>
-               	add	x20, x20, #0x1
-               	mov	x19, x0
-               	mov	x16, #0xfdb0            ; =64944
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
-               	mov	x16, #0xfe10            ; =65040
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	str	q31, [x29, x16]
-               	mov	x16, #0xfdd0            ; =64976
-               	movk	x16, #0xffff, lsl #16
-               	movk	x16, #0xffff, lsl #32
-               	movk	x16, #0xffff, lsl #48
-               	ldr	q31, [x29, x16]
                	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfdc0            ; =64960
+               	mov	x16, #0xfe00            ; =65024
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
-               	mov	x16, #0xfdf0            ; =65008
+               	mov.d	x1, v31[0]
+<L35>:
+               	bl	 <L35>
+               	mov	x16, #0xfe00            ; =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L36>:
+               	bl	 <L36>
+               	add	x20, x20, #0x1
+               	mov	x19, x0
+               	mov	x16, #0xfe00            ; =65024
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe60            ; =65120
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe20            ; =65056
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe50            ; =65104
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfe10            ; =65040
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfe40            ; =65088
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
                	cmp	x20, #0x6
-               	b.lo	 <L35>
-<L44>:
+               	b.lo	 <L28>
+<L37>:
                	sub	x20, x29, #0x80
                	str	xzr, [x20]
                	str	xzr, [x20, #0x8]
@@ -708,13 +599,13 @@ Disassembly of section __TEXT,__text:
                	str	xzr, [x20, #0x30]
                	str	xzr, [x20, #0x38]
                	add	x0, x20, #0x0
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	str	q31, [x0]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -723,7 +614,7 @@ Disassembly of section __TEXT,__text:
                	add.2d	v0, v31, v30
                	add	x0, x20, #0x10
                	str	q0, [x0]
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -732,7 +623,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[0]
                	mul	x2, x0, x1
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -741,7 +632,7 @@ Disassembly of section __TEXT,__text:
                	ldur	q31, [x29, #-0xc0]
                	mov.d	x1, v31[1]
                	mul	x3, x0, x1
-               	mov	x16, #0xfe10            ; =65040
+               	mov	x16, #0xfe60            ; =65120
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -753,7 +644,7 @@ Disassembly of section __TEXT,__text:
                	add	x0, x20, #0x20
                	str	q1, [x0]
                	add	x0, x20, #0x30
-               	mov	x16, #0xfe00            ; =65024
+               	mov	x16, #0xfe50            ; =65104
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
@@ -761,40 +652,40 @@ Disassembly of section __TEXT,__text:
                	str	q31, [x0]
                	mov	x21, #0x0               ; =0
                	cmp	x21, #0x4
-               	b.lo	 <L45>
-               	b	 <L48>
-<L45>:
+               	b.lo	 <L38>
+               	b	 <L41>
+<L38>:
                	mov	x16, #0x10              ; =16
                	mul	x0, x21, x16
                	add	x1, x20, x0
                	ldr	q31, [x1]
-               	mov	x16, #0xfda0            ; =64928
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfda0            ; =64928
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
                	mov	x0, x19
-<L46>:
-               	bl	 <L46>
-               	mov	x16, #0xfda0            ; =64928
+<L39>:
+               	bl	 <L39>
+               	mov	x16, #0xfdf0            ; =65008
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L47>:
-               	bl	 <L47>
+<L40>:
+               	bl	 <L40>
                	add	x21, x21, #0x1
                	mov	x19, x0
                	cmp	x21, #0x4
-               	b.lo	 <L45>
-<L48>:
+               	b.lo	 <L38>
+<L41>:
                	sub	x21, x29, #0xb0
                	str	xzr, [x21]
                	str	xzr, [x21, #0x8]
@@ -816,36 +707,36 @@ Disassembly of section __TEXT,__text:
                	str	w17, [x1]
                	ldr	w1, [x0]
                	mov	x0, x19
-<L49>:
-               	bl	 <L49>
+<L42>:
+               	bl	 <L42>
                	ldr	q31, [x20]
-               	mov	x16, #0xfd90            ; =64912
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	str	q31, [x29, x16]
-               	mov	x16, #0xfd90            ; =64912
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[0]
-<L50>:
-               	bl	 <L50>
-               	mov	x16, #0xfd90            ; =64912
+<L43>:
+               	bl	 <L43>
+               	mov	x16, #0xfde0            ; =64992
                	movk	x16, #0xffff, lsl #16
                	movk	x16, #0xffff, lsl #32
                	movk	x16, #0xffff, lsl #48
                	ldr	q31, [x29, x16]
                	mov.d	x1, v31[1]
-<L51>:
-               	bl	 <L51>
+<L44>:
+               	bl	 <L44>
                	add	x1, x21, #0x20
                	ldr	w2, [x1]
                	mov	w1, w2
-<L52>:
-               	bl	 <L52>
-               	sub	x16, x29, #0x280
+<L45>:
+               	bl	 <L45>
+               	sub	x16, x29, #0x230
                	ldp	x19, x20, [x16]
                	ldur	x21, [x16, #-0x8]
                	mov	sp, x29

--- a/test/golden/x86_64-darwin/call/call_mixed.dis
+++ b/test/golden/x86_64-darwin/call/call_mixed.dis
@@ -317,12 +317,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.call.call_mixed.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x240, %rsp            ## imm = 0x240
-               	movq	%rbx, -0x1e8(%rbp)
-               	movq	%r12, -0x1f0(%rbp)
-               	movq	%r13, -0x1f8(%rbp)
-               	movq	%r14, -0x200(%rbp)
-               	movq	%r15, -0x208(%rbp)
+               	subq	$0x3e0, %rsp            ## imm = 0x3E0
+               	movq	%rbx, -0x388(%rbp)
+               	movq	%r12, -0x390(%rbp)
+               	movq	%r13, -0x398(%rbp)
+               	movq	%r14, -0x3a0(%rbp)
+               	movq	%r15, -0x3a8(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -373,12 +373,14 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, %r15
                	cmpq	$0x3, %r15
                	jb	 <L3>
-               	jmp	 <L40>
+               	jmp	 <L35>
 <L3>:
                	movq	%r15, %rax
                	imulq	$0xb, %rax, %rax
-               	addq	%rbx, %rax
-               	leaq	-0xcc(%rbp), %rcx
+               	movq	%rax, %r8
+               	addq	%rbx, %r8
+               	movq	%r8, -0x1b8(%rbp)
+               	leaq	-0xcc(%rbp), %rax
                	leaq	0x80(%r12), %rdx
                	movq	(%rdx), %rsi
                	andq	$0xfff, %rsi            ## imm = 0xFFF
@@ -396,10 +398,10 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L5>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x1f3>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x1fd>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x1ff>
-               	leaq	(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x209>
+               	leaq	(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0x88(%r12), %rdx
                	movq	(%rdx), %rsi
@@ -418,10 +420,10 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L7>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x250>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x25a>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x25c>
-               	leaq	0x4(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x266>
+               	leaq	0x4(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0x90(%r12), %rdx
                	movq	(%rdx), %rsi
@@ -440,19 +442,20 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L9>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x2ae>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x2b8>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x2ba>
-               	leaq	0x8(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x2c4>
+               	leaq	0x8(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	movq	$0x0, -0xe8(%rbp)
                	movq	$0x0, -0xe0(%rbp)
-               	movq	(%rcx), %rdx
+               	movq	(%rax), %rdx
                	movq	%rdx, -0xe8(%rbp)
-               	movl	0x8(%rcx), %edx
+               	movl	0x8(%rax), %edx
                	movl	%edx, -0xe0(%rbp)
-               	movups	-0xe8(%rbp), %xmm2
-               	leaq	-0x100(%rbp), %rcx
+               	movups	-0xe8(%rbp), %xmm14
+               	movups	%xmm14, -0x1d0(%rbp)
+               	leaq	-0x100(%rbp), %rax
                	leaq	0x98(%r12), %rdx
                	movq	(%rdx), %rsi
                	andq	$0xfff, %rsi            ## imm = 0xFFF
@@ -470,10 +473,10 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L11>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x343>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x356>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x34f>
-               	leaq	(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x362>
+               	leaq	(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0xa0(%r12), %rdx
                	movq	(%rdx), %rsi
@@ -492,10 +495,10 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L13>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x3a0>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x3b3>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x3ac>
-               	leaq	0x4(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x3bf>
+               	leaq	0x4(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0xa8(%r12), %rdx
                	movq	(%rdx), %rsi
@@ -514,10 +517,10 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L15>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x3fe>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x411>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x40a>
-               	leaq	0x8(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x41d>
+               	leaq	0x8(%rax), %rdx
                	movss	%xmm0, (%rdx)
                	leaq	0xb0(%r12), %rdx
                	movq	(%rdx), %rsi
@@ -536,13 +539,15 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L17>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x45c>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x46f>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x468>
-               	leaq	0xc(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x47b>
+               	leaq	0xc(%rax), %rdx
                	movss	%xmm0, (%rdx)
-               	movups	(%rcx), %xmm4
-               	leaq	-0x128(%rbp), %rcx
+               	movups	(%rax), %xmm14
+               	movups	%xmm14, -0x1e0(%rbp)
+               	leaq	-0x128(%rbp), %r8
+               	movq	%r8, -0x1e8(%rbp)
                	leaq	0xb8(%r12), %rdx
                	movq	(%rdx), %rsi
                	andq	$0xfff, %rsi            ## imm = 0xFFF
@@ -560,104 +565,71 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm0, %xmm0
 <L19>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x4c4>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x4e7>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x4d0>
-               	leaq	(%rcx), %rdx
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x4f3>
+               	movq	-0x1e8(%rbp), %r8
+               	leaq	(%r8), %rdx
                	movss	%xmm0, (%rdx)
-               	leaq	(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	addq	%rax, %rsi
-               	andq	$0xfff, %rsi            ## imm = 0xFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L20>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L21>
+               	leaq	(%r12), %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	movq	(%r8), %rsi
+               	movq	-0x1b8(%rbp), %r8
+               	addq	%r8, %rsi
+               	movq	%rsi, %rdi
+               	callq	 <L20>
 <L20>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
+               	movq	-0x1e8(%rbp), %r8
+               	leaq	0x4(%r8), %rsi
+               	movss	%xmm0, (%rsi)
+               	movq	-0x1e8(%rbp), %r8
+               	movq	(%r8), %r11
+               	movq	%r11, -0x200(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	-0x1b8(%rbp), %r9
+               	movq	%rax, %r8
+               	addq	%r9, %r8
+               	movq	%r8, -0x208(%rbp)
+               	leaq	0x8(%r12), %rax
+               	movq	(%rax), %rdi
+               	callq	 <L21>
 <L21>:
-               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x520>
-               	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x52c>
-               	leaq	0x4(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	movsd	(%rcx), %xmm8
-               	leaq	(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	addq	%rax, %rdx
-               	leaq	0x8(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	andq	$0xfff, %rsi            ## imm = 0xFFF
-               	movq	%rsi, %r11
+               	movss	%xmm0, -0x218(%rbp)
+               	leaq	0x10(%r12), %rax
+               	movq	(%rax), %rsi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x220(%rbp)
+               	leaq	0x18(%r12), %rsi
+               	movq	(%rsi), %rdi
+               	andq	$0xfffff, %rdi          ## imm = 0xFFFFF
+               	movq	%rdi, %r11
                	testq	%r11, %r11
                	jl	 <L22>
-               	cvtsi2ss	%r11, %xmm0
+               	cvtsi2sd	%r11, %xmm1
                	jmp	 <L23>
 <L22>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L23>:
-               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x58a>
-               	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x596>
-               	leaq	0x10(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	movl	%esi, %ecx
-               	leaq	0x18(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	andq	$0xfffff, %rdi          ## imm = 0xFFFFF
-               	movq	%rdi, %r11
-               	testq	%r11, %r11
-               	jl	 <L24>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L25>
-<L24>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L25>:
+<L23>:
                	movsd	%xmm1, %xmm3            ## xmm3 = xmm1[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x5e7>
-               	movsd	%xmm3, %xmm1            ## xmm1 = xmm3[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x5f3>
+               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x5d4>
+               	movsd	%xmm3, %xmm14           ## xmm14 = xmm3[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x5e2>
+               	movsd	%xmm14, -0x230(%rbp)
                	leaq	0x20(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x138(%rbp)
                	leaq	0x28(%r12), %rsi
                	movq	(%rsi), %rdi
-               	andq	$0xfff, %rdi            ## imm = 0xFFF
-               	movq	%rdi, %r11
-               	testq	%r11, %r11
-               	jl	 <L26>
-               	cvtsi2ss	%r11, %xmm3
-               	jmp	 <L27>
-<L26>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm3
-               	addss	%xmm3, %xmm3
-<L27>:
-               	movss	%xmm3, %xmm5            ## xmm5 = xmm3[0],xmm5[1,2,3]
-               	subss	, %xmm5 <corpus.cases.call.call_mixed.checksum+0x649>
-               	movss	%xmm5, %xmm3            ## xmm3 = xmm5[0],xmm3[1,2,3]
-               	divss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x655>
+               	callq	 <L24>
+<L24>:
+               	movss	%xmm0, -0x240(%rbp)
                	leaq	0x30(%r12), %rsi
                	movq	(%rsi), %rdi
                	movw	%di, %r8w
@@ -667,44 +639,30 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %rdi          ## imm = 0xFFFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L28>
+               	jl	 <L25>
                	cvtsi2sd	%r11, %xmm5
-               	jmp	 <L29>
-<L28>:
+               	jmp	 <L26>
+<L25>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm5
                	addsd	%xmm5, %xmm5
-<L29>:
+<L26>:
                	movsd	%xmm5, %xmm6            ## xmm6 = xmm5[0],xmm6[1]
-               	subsd	, %xmm6 <corpus.cases.call.call_mixed.checksum+0x6af>
-               	movsd	%xmm6, %xmm5            ## xmm5 = xmm6[0],xmm5[1]
-               	divsd	, %xmm5 <corpus.cases.call.call_mixed.checksum+0x6bb>
+               	subsd	, %xmm6 <corpus.cases.call.call_mixed.checksum+0x669>
+               	movsd	%xmm6, %xmm14           ## xmm14 = xmm6[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x677>
+               	movsd	%xmm14, -0x250(%rbp)
                	leaq	0x40(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x148(%rbp)
                	leaq	0x48(%r12), %rsi
                	movq	(%rsi), %rdi
-               	andq	$0xfff, %rdi            ## imm = 0xFFF
-               	movq	%rdi, %r11
-               	testq	%r11, %r11
-               	jl	 <L30>
-               	cvtsi2ss	%r11, %xmm6
-               	jmp	 <L31>
-<L30>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm6
-               	addss	%xmm6, %xmm6
-<L31>:
-               	movss	%xmm6, %xmm7            ## xmm7 = xmm6[0],xmm7[1,2,3]
-               	subss	, %xmm7 <corpus.cases.call.call_mixed.checksum+0x711>
-               	movss	%xmm7, %xmm6            ## xmm6 = xmm7[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.call.call_mixed.checksum+0x71d>
+               	callq	 <L27>
+<L27>:
+               	movss	%xmm0, -0x260(%rbp)
                	leaq	0x50(%r12), %rsi
                	movq	(%rsi), %rdi
                	movb	%dil, %r8b
@@ -714,44 +672,30 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %rdi          ## imm = 0xFFFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L32>
+               	jl	 <L28>
                	cvtsi2sd	%r11, %xmm7
-               	jmp	 <L33>
-<L32>:
+               	jmp	 <L29>
+<L28>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm7
                	addsd	%xmm7, %xmm7
-<L33>:
+<L29>:
                	movsd	%xmm7, %xmm9            ## xmm9 = xmm7[0],xmm9[1]
-               	subsd	, %xmm9 <corpus.cases.call.call_mixed.checksum+0x778>
-               	movsd	%xmm9, %xmm7            ## xmm7 = xmm9[0],xmm7[1]
-               	divsd	, %xmm7 <corpus.cases.call.call_mixed.checksum+0x785>
+               	subsd	, %xmm9 <corpus.cases.call.call_mixed.checksum+0x6ff>
+               	movsd	%xmm9, %xmm14           ## xmm14 = xmm9[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x70d>
+               	movsd	%xmm14, -0x270(%rbp)
                	leaq	0x60(%r12), %rsi
                	movq	(%rsi), %r8
                	movq	%r8, -0x158(%rbp)
                	leaq	0x68(%r12), %rsi
                	movq	(%rsi), %rdi
-               	andq	$0xfff, %rdi            ## imm = 0xFFF
-               	movq	%rdi, %r11
-               	testq	%r11, %r11
-               	jl	 <L34>
-               	cvtsi2ss	%r11, %xmm9
-               	jmp	 <L35>
-<L34>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm9
-               	addss	%xmm9, %xmm9
-<L35>:
-               	movss	%xmm9, %xmm10           ## xmm10 = xmm9[0],xmm10[1,2,3]
-               	subss	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x7de>
-               	movss	%xmm10, %xmm9           ## xmm9 = xmm10[0],xmm9[1,2,3]
-               	divss	, %xmm9 <corpus.cases.call.call_mixed.checksum+0x7ec>
+               	callq	 <L30>
+<L30>:
+               	movss	%xmm0, %xmm9            ## xmm9 = xmm0[0],xmm9[1,2,3]
                	leaq	0x70(%r12), %rsi
                	movq	(%rsi), %rdi
                	movl	%edi, %r8d
@@ -761,35 +705,47 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfffff, %rdi          ## imm = 0xFFFFF
                	movq	%rdi, %r11
                	testq	%r11, %r11
-               	jl	 <L36>
+               	jl	 <L31>
                	cvtsi2sd	%r11, %xmm10
-               	jmp	 <L37>
-<L36>:
+               	jmp	 <L32>
+<L31>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm10
                	addsd	%xmm10, %xmm10
-<L37>:
+<L32>:
                	movsd	%xmm10, %xmm11          ## xmm11 = xmm10[0],xmm11[1]
-               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x848>
+               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x793>
                	movsd	%xmm11, %xmm10          ## xmm10 = xmm11[0],xmm10[1]
-               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x856>
+               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x7a1>
                	leaq	0x8(%r12), %rsi
                	movq	(%rsi), %rdi
+               	movq	-0x1b8(%rbp), %r9
                	movq	%rdi, %r8
-               	addq	%rax, %r8
+               	addq	%r9, %r8
                	movq	%r8, -0x168(%rbp)
-               	movq	%rdx, %rdi
-               	movl	%ecx, %esi
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %rdi
+               	movss	-0x218(%rbp), %xmm0
+               	movq	-0x220(%rbp), %r8
+               	movl	%r8d, %esi
+               	movsd	-0x230(%rbp), %xmm1
+               	movups	-0x1d0(%rbp), %xmm2
                	movq	-0x138(%rbp), %r8
                	movq	%r8, %rdx
+               	movss	-0x240(%rbp), %xmm3
                	movq	-0x140(%rbp), %r8
                	movq	%r8, %rcx
+               	movups	-0x1e0(%rbp), %xmm4
+               	movsd	-0x250(%rbp), %xmm5
                	movq	-0x148(%rbp), %r8
+               	movss	-0x260(%rbp), %xmm6
                	movq	-0x150(%rbp), %r9
-               	movsd	%xmm8, (%rsp)
+               	movsd	-0x270(%rbp), %xmm7
+               	movq	-0x200(%rbp), %r11
+               	movq	%r11, (%rsp)
                	movq	-0x158(%rbp), %r10
                	movq	%r10, 0x8(%rsp)
                	movsd	%xmm9, 0x10(%rsp)
@@ -798,38 +754,38 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm10, 0x20(%rsp)
                	movq	-0x168(%rbp), %r10
                	movq	%r10, 0x28(%rsp)
-               	callq	 <L38>
-<L38>:
+               	callq	 <L33>
+<L33>:
                	movq	%rax, %r14
                	movq	%r13, %rdi
                	movq	%r14, %rsi
-               	callq	 <L39>
-<L39>:
+               	callq	 <L34>
+<L34>:
                	addq	$0x1, %r15
                	movq	%rax, %r13
                	cmpq	$0x3, %r15
                	jb	 <L3>
-<L40>:
+<L35>:
                	leaq	-0xd8(%rbp), %rax
                	movq	%r14, %rcx
                	andq	$0xfff, %rcx            ## imm = 0xFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L41>
+               	jl	 <L36>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L42>
-<L41>:
+               	jmp	 <L37>
+<L36>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L42>:
+<L37>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x937>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x8db>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x943>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x8e7>
                	leaq	(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x10(%r12), %rcx
@@ -837,21 +793,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rdx            ## imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L43>
+               	jl	 <L38>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L44>
-<L43>:
+               	jmp	 <L39>
+<L38>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L44>:
+<L39>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x991>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x935>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x99d>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x941>
                	leaq	0x4(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x18(%r12), %rcx
@@ -859,21 +815,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rdx            ## imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L45>
+               	jl	 <L40>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L46>
-<L45>:
+               	jmp	 <L41>
+<L40>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L46>:
+<L41>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x9ec>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x990>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x9f8>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x99c>
                	leaq	0x8(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	movq	$0x0, -0x110(%rbp)
@@ -883,28 +839,28 @@ Disassembly of section __TEXT,__text:
                	movl	0x8(%rax), %ecx
                	movl	%ecx, -0x108(%rbp)
                	movups	-0x110(%rbp), %xmm14
-               	movups	%xmm14, -0x1c0(%rbp)
+               	movups	%xmm14, -0x280(%rbp)
                	leaq	-0x120(%rbp), %rax
                	leaq	0x20(%r12), %rcx
                	movq	(%rcx), %rdx
                	andq	$0xfff, %rdx            ## imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L47>
+               	jl	 <L42>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L48>
-<L47>:
+               	jmp	 <L43>
+<L42>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L48>:
+<L43>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa87>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa2b>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa93>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa37>
                	leaq	(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x28(%r12), %rcx
@@ -912,21 +868,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rdx            ## imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L49>
+               	jl	 <L44>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L50>
-<L49>:
+               	jmp	 <L45>
+<L44>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L50>:
+<L45>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xae1>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa85>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xaed>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa91>
                	leaq	0x4(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x30(%r12), %rcx
@@ -934,21 +890,21 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rdx            ## imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L51>
+               	jl	 <L46>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L52>
-<L51>:
+               	jmp	 <L47>
+<L46>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L52>:
+<L47>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xb3c>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xae0>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xb48>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xaec>
                	leaq	0x8(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x38(%r12), %rcx
@@ -956,239 +912,295 @@ Disassembly of section __TEXT,__text:
                	andq	$0xfff, %rdx            ## imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L53>
+               	jl	 <L48>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L54>
-<L53>:
+               	jmp	 <L49>
+<L48>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L54>:
+<L49>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xb97>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xb3b>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xba3>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xb47>
                	leaq	0xc(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	movups	(%rax), %xmm14
-               	movups	%xmm14, -0x1d0(%rbp)
-               	leaq	-0x130(%rbp), %rax
-               	leaq	0x40(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0xfff, %rdx            ## imm = 0xFFF
-               	movq	%rdx, %r11
-               	testq	%r11, %r11
-               	jl	 <L55>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L56>
-<L55>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L56>:
-               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xc05>
-               	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xc11>
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x48(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0xfff, %rdx            ## imm = 0xFFF
-               	movq	%rdx, %r11
-               	testq	%r11, %r11
-               	jl	 <L57>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L58>
-<L57>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L58>:
-               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xc5f>
-               	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xc6b>
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movq	(%rax), %r11
-               	movq	%r11, -0x1e0(%rbp)
-               	leaq	(%r12), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x178(%rbp)
-               	leaq	0x8(%r12), %rax
+               	movups	%xmm14, -0x290(%rbp)
+               	leaq	-0x130(%rbp), %rbx
+               	leaq	0x40(%r12), %rax
                	movq	(%rax), %rcx
                	andq	$0xfff, %rcx            ## imm = 0xFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L59>
+               	jl	 <L50>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L60>
-<L59>:
+               	jmp	 <L51>
+<L50>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L60>:
+<L51>:
                	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xcd2>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xba9>
                	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xcde>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xbb5>
+               	leaq	(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x48(%r12), %rax
+               	movq	(%rax), %rdi
+               	callq	 <L52>
+<L52>:
+               	leaq	0x4(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movq	(%rbx), %r11
+               	movq	%r11, -0x2a0(%rbp)
+               	leaq	(%r12), %rax
+               	movq	(%rax), %rbx
+               	leaq	0x8(%r12), %rax
+               	movq	(%rax), %rdi
+               	callq	 <L53>
+<L53>:
+               	movss	%xmm0, -0x2b0(%rbp)
                	leaq	0x10(%r12), %rax
                	movq	(%rax), %rcx
-               	movl	%ecx, %eax
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0xfffff, %rdx          ## imm = 0xFFFFF
-               	movq	%rdx, %r11
+               	movl	%ecx, %r15d
+               	leaq	0x18(%r12), %rax
+               	movq	(%rax), %rcx
+               	andq	$0xfffff, %rcx          ## imm = 0xFFFFF
+               	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L61>
+               	jl	 <L54>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L62>
-<L61>:
+               	jmp	 <L55>
+<L54>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L62>:
+<L55>:
                	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xd2f>
-               	movsd	%xmm2, %xmm1            ## xmm1 = xmm2[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xd3b>
-               	leaq	0x20(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	0x28(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	andq	$0xfff, %rsi            ## imm = 0xFFF
+               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xc49>
+               	movsd	%xmm2, %xmm14           ## xmm14 = xmm2[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xc57>
+               	movsd	%xmm14, -0x2c8(%rbp)
+               	leaq	0x20(%r12), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x2b8(%rbp)
+               	leaq	0x28(%r12), %rax
+               	movq	(%rax), %rdi
+               	callq	 <L56>
+<L56>:
+               	movss	%xmm0, -0x2d8(%rbp)
+               	leaq	0x30(%r12), %rax
+               	movq	(%rax), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x2e0(%rbp)
+               	leaq	0x38(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L57>
+               	cvtsi2sd	%r11, %xmm2
+               	jmp	 <L58>
+<L57>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm2
+               	addsd	%xmm2, %xmm2
+<L58>:
+               	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xcde>
+               	movsd	%xmm4, %xmm14           ## xmm14 = xmm4[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xcec>
+               	movsd	%xmm14, -0x2f0(%rbp)
+               	leaq	0x40(%r12), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x170(%rbp)
+               	leaq	0x48(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	callq	 <L59>
+<L59>:
+               	movss	%xmm0, -0x300(%rbp)
+               	leaq	0x50(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, -0x178(%rbp)
+               	leaq	0x58(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L60>
+               	cvtsi2sd	%r11, %xmm2
+               	jmp	 <L61>
+<L60>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm2
+               	addsd	%xmm2, %xmm2
+<L61>:
+               	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xd72>
+               	movsd	%xmm4, %xmm14           ## xmm14 = xmm4[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xd80>
+               	movsd	%xmm14, -0x310(%rbp)
+               	leaq	0x60(%r12), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x180(%rbp)
+               	leaq	0x68(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	callq	 <L62>
+<L62>:
+               	movss	%xmm0, %xmm11           ## xmm11 = xmm0[0],xmm11[1,2,3]
+               	leaq	0x70(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x188(%rbp)
+               	leaq	0x78(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
                	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L63>
-               	cvtsi2ss	%r11, %xmm2
+               	cvtsi2sd	%r11, %xmm2
                	jmp	 <L64>
 <L63>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm2
-               	addss	%xmm2, %xmm2
-<L64>:
-               	movss	%xmm2, %xmm3            ## xmm3 = xmm2[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xd8a>
-               	movss	%xmm3, %xmm4            ## xmm4 = xmm3[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xd96>
-               	leaq	0x30(%r12), %rcx
-               	movq	(%rcx), %rsi
-               	movw	%si, %cx
-               	leaq	0x38(%r12), %rsi
-               	movq	(%rsi), %rbx
-               	andq	$0xfffff, %rbx          ## imm = 0xFFFFF
-               	movq	%rbx, %r11
-               	testq	%r11, %r11
-               	jl	 <L65>
-               	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L66>
-<L65>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
+<L64>:
+               	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xe03>
+               	movsd	%xmm4, %xmm12           ## xmm12 = xmm4[0],xmm12[1]
+               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0xe11>
+               	leaq	0x8(%r12), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x190(%rbp)
+               	movq	%rbx, %rdi
+               	movss	-0x2b0(%rbp), %xmm0
+               	movl	%r15d, %esi
+               	movsd	-0x2c8(%rbp), %xmm1
+               	movups	-0x280(%rbp), %xmm2
+               	movq	-0x2b8(%rbp), %r8
+               	movq	%r8, %rdx
+               	movss	-0x2d8(%rbp), %xmm3
+               	movq	-0x2e0(%rbp), %r8
+               	movq	%r8, %rcx
+               	movups	-0x290(%rbp), %xmm4
+               	movsd	-0x2f0(%rbp), %xmm5
+               	movq	-0x170(%rbp), %r8
+               	movss	-0x300(%rbp), %xmm6
+               	movq	-0x178(%rbp), %r9
+               	movsd	-0x310(%rbp), %xmm7
+               	movq	-0x2a0(%rbp), %r11
+               	movq	%r11, (%rsp)
+               	movq	-0x180(%rbp), %r10
+               	movq	%r10, 0x8(%rsp)
+               	movsd	%xmm11, 0x10(%rsp)
+               	movq	-0x188(%rbp), %r10
+               	movq	%r10, 0x18(%rsp)
+               	movsd	%xmm12, 0x20(%rsp)
+               	movq	-0x190(%rbp), %r10
+               	movq	%r10, 0x28(%rsp)
+               	callq	 <L65>
+<L65>:
+               	movq	%rax, %rbx
+               	leaq	0x18(%r12), %rax
+               	movq	(%rax), %rdi
+               	callq	 <L66>
 <L66>:
-               	movsd	%xmm2, %xmm3            ## xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xde8>
-               	movsd	%xmm3, %xmm5            ## xmm5 = xmm3[0],xmm5[1]
-               	divsd	, %xmm5 <corpus.cases.call.call_mixed.checksum+0xdf4>
-               	leaq	0x40(%r12), %rsi
-               	movq	(%rsi), %rbx
-               	leaq	0x48(%r12), %rsi
-               	movq	(%rsi), %r15
-               	andq	$0xfff, %r15            ## imm = 0xFFF
-               	movq	%r15, %r11
+               	movss	%xmm0, -0x320(%rbp)
+               	leaq	0x28(%r12), %rax
+               	movq	(%rax), %rcx
+               	movl	%ecx, %r15d
+               	leaq	0x38(%r12), %rax
+               	movq	(%rax), %rcx
+               	andq	$0xfffff, %rcx          ## imm = 0xFFFFF
+               	movq	%rcx, %r11
                	testq	%r11, %r11
                	jl	 <L67>
-               	cvtsi2ss	%r11, %xmm2
+               	cvtsi2sd	%r11, %xmm1
                	jmp	 <L68>
 <L67>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm2
-               	addss	%xmm2, %xmm2
+               	cvtsi2sd	%r11, %xmm1
+               	addsd	%xmm1, %xmm1
 <L68>:
-               	movss	%xmm2, %xmm3            ## xmm3 = xmm2[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xe43>
-               	movss	%xmm3, %xmm6            ## xmm6 = xmm3[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.call.call_mixed.checksum+0xe4f>
-               	leaq	0x50(%r12), %rsi
-               	movq	(%rsi), %r15
-               	movb	%r15b, %r8b
-               	movq	%r8, -0x170(%rbp)
-               	leaq	0x58(%r12), %rsi
-               	movq	(%rsi), %r15
-               	andq	$0xfffff, %r15          ## imm = 0xFFFFF
-               	movq	%r15, %r11
-               	testq	%r11, %r11
-               	jl	 <L69>
-               	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L70>
+               	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
+               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xf32>
+               	movsd	%xmm2, %xmm14           ## xmm14 = xmm2[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xf40>
+               	movsd	%xmm14, -0x338(%rbp)
+               	leaq	0x48(%r12), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x328(%rbp)
+               	leaq	0x58(%r12), %rax
+               	movq	(%rax), %rdi
+               	callq	 <L69>
 <L69>:
+               	movss	%xmm0, -0x348(%rbp)
+               	leaq	0x68(%r12), %rax
+               	movq	(%rax), %rdx
+               	movw	%dx, %r8w
+               	movq	%r8, -0x350(%rbp)
+               	leaq	0x78(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
+               	movq	%rsi, %r11
+               	testq	%r11, %r11
+               	jl	 <L70>
+               	cvtsi2sd	%r11, %xmm2
+               	jmp	 <L71>
+<L70>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L70>:
-               	movsd	%xmm2, %xmm3            ## xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xea8>
-               	movsd	%xmm3, %xmm7            ## xmm7 = xmm3[0],xmm7[1]
-               	divsd	, %xmm7 <corpus.cases.call.call_mixed.checksum+0xeb4>
-               	leaq	0x60(%r12), %rsi
-               	movq	(%rsi), %r15
-               	leaq	0x68(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	andq	$0xfff, %rdi            ## imm = 0xFFF
-               	movq	%rdi, %r11
-               	testq	%r11, %r11
-               	jl	 <L71>
-               	cvtsi2ss	%r11, %xmm2
-               	jmp	 <L72>
 <L71>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm2
-               	addss	%xmm2, %xmm2
+               	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xfc7>
+               	movsd	%xmm4, %xmm14           ## xmm14 = xmm4[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xfd5>
+               	movsd	%xmm14, -0x360(%rbp)
+               	leaq	0x88(%r12), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x198(%rbp)
+               	leaq	0x98(%r12), %rdx
+               	movq	(%rdx), %rdi
+               	callq	 <L72>
 <L72>:
-               	movss	%xmm2, %xmm3            ## xmm3 = xmm2[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xf03>
-               	movss	%xmm3, %xmm11           ## xmm11 = xmm3[0],xmm11[1,2,3]
-               	divss	, %xmm11 <corpus.cases.call.call_mixed.checksum+0xf11>
-               	leaq	0x70(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	movl	%edi, %r8d
-               	movq	%r8, -0x180(%rbp)
-               	leaq	0x78(%r12), %rsi
-               	movq	(%rsi), %rdi
-               	andq	$0xfffff, %rdi          ## imm = 0xFFFFF
-               	movq	%rdi, %r11
+               	movss	%xmm0, -0x370(%rbp)
+               	leaq	0xa8(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	movb	%sil, %r8b
+               	movq	%r8, -0x1a0(%rbp)
+               	leaq	0xb8(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L73>
                	cvtsi2sd	%r11, %xmm2
@@ -1201,243 +1213,79 @@ Disassembly of section __TEXT,__text:
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
 <L74>:
-               	movsd	%xmm2, %xmm3            ## xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xf6a>
-               	movsd	%xmm3, %xmm12           ## xmm12 = xmm3[0],xmm12[1]
-               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0xf78>
-               	leaq	0x8(%r12), %rsi
-               	movq	(%rsi), %r8
-               	movq	%r8, -0x188(%rbp)
-               	movq	-0x178(%rbp), %r8
-               	movq	%r8, %rdi
-               	movl	%eax, %esi
-               	movups	-0x1c0(%rbp), %xmm2
-               	movss	%xmm4, %xmm3            ## xmm3 = xmm4[0],xmm3[1,2,3]
-               	movups	-0x1d0(%rbp), %xmm4
-               	movq	%rbx, %r8
-               	movq	-0x170(%rbp), %r9
-               	movq	-0x1e0(%rbp), %r11
-               	movq	%r11, (%rsp)
-               	movq	%r15, 0x8(%rsp)
-               	movsd	%xmm11, 0x10(%rsp)
-               	movq	-0x180(%rbp), %r10
-               	movq	%r10, 0x18(%rsp)
-               	movsd	%xmm12, 0x20(%rsp)
-               	movq	-0x188(%rbp), %r10
-               	movq	%r10, 0x28(%rsp)
+               	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0x1067>
+               	movsd	%xmm4, %xmm14           ## xmm14 = xmm4[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x1075>
+               	movsd	%xmm14, -0x380(%rbp)
+               	leaq	0x10(%r12), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x1a8(%rbp)
+               	leaq	0x20(%r12), %rdx
+               	movq	(%rdx), %rdi
                	callq	 <L75>
 <L75>:
-               	leaq	0x18(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0xfff, %rdx            ## imm = 0xFFF
-               	movq	%rdx, %r11
+               	movss	%xmm0, %xmm11           ## xmm11 = xmm0[0],xmm11[1,2,3]
+               	leaq	0x30(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	movl	%esi, %r8d
+               	movq	%r8, -0x1b0(%rbp)
+               	leaq	0x40(%r12), %rdx
+               	movq	(%rdx), %rsi
+               	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L76>
-               	cvtsi2ss	%r11, %xmm0
+               	cvtsi2sd	%r11, %xmm2
                	jmp	 <L77>
 <L76>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
+               	cvtsi2sd	%r11, %xmm2
+               	addsd	%xmm2, %xmm2
 <L77>:
-               	movss	%xmm0, %xmm1            ## xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x1031>
-               	movss	%xmm1, %xmm0            ## xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x103d>
-               	leaq	0x28(%r12), %rcx
-               	movq	(%rcx), %rdx
-               	movl	%edx, %ecx
-               	leaq	0x38(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L78>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L79>
-<L78>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L79>:
-               	movsd	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x108e>
-               	movsd	%xmm2, %xmm1            ## xmm1 = xmm2[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x109a>
-               	leaq	0x48(%r12), %rdx
-               	movq	(%rdx), %rbx
-               	leaq	0x58(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	andq	$0xfff, %rsi            ## imm = 0xFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L80>
-               	cvtsi2ss	%r11, %xmm2
-               	jmp	 <L81>
-<L80>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm2
-               	addss	%xmm2, %xmm2
-<L81>:
-               	movss	%xmm2, %xmm3            ## xmm3 = xmm2[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x10e9>
-               	movss	%xmm3, %xmm4            ## xmm4 = xmm3[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.call.call_mixed.checksum+0x10f5>
-               	leaq	0x68(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movw	%si, %r15w
-               	leaq	0x78(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L82>
-               	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L83>
-<L82>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm2
-               	addsd	%xmm2, %xmm2
-<L83>:
-               	movsd	%xmm2, %xmm3            ## xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x1148>
-               	movsd	%xmm3, %xmm5            ## xmm5 = xmm3[0],xmm5[1]
-               	divsd	, %xmm5 <corpus.cases.call.call_mixed.checksum+0x1154>
-               	leaq	0x88(%r12), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x190(%rbp)
-               	leaq	0x98(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	andq	$0xfff, %rsi            ## imm = 0xFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L84>
-               	cvtsi2ss	%r11, %xmm2
-               	jmp	 <L85>
-<L84>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm2
-               	addss	%xmm2, %xmm2
-<L85>:
-               	movss	%xmm2, %xmm3            ## xmm3 = xmm2[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x11b0>
-               	movss	%xmm3, %xmm6            ## xmm6 = xmm3[0],xmm6[1,2,3]
-               	divss	, %xmm6 <corpus.cases.call.call_mixed.checksum+0x11bc>
-               	leaq	0xa8(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movb	%sil, %r8b
-               	movq	%r8, -0x198(%rbp)
-               	leaq	0xb8(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L86>
-               	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L87>
-<L86>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm2
-               	addsd	%xmm2, %xmm2
-<L87>:
-               	movsd	%xmm2, %xmm3            ## xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x121b>
-               	movsd	%xmm3, %xmm7            ## xmm7 = xmm3[0],xmm7[1]
-               	divsd	, %xmm7 <corpus.cases.call.call_mixed.checksum+0x1227>
-               	leaq	0x10(%r12), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x1a0(%rbp)
-               	leaq	0x20(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	andq	$0xfff, %rsi            ## imm = 0xFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L88>
-               	cvtsi2ss	%r11, %xmm2
-               	jmp	 <L89>
-<L88>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm2
-               	addss	%xmm2, %xmm2
-<L89>:
-               	movss	%xmm2, %xmm3            ## xmm3 = xmm2[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x127d>
-               	movss	%xmm3, %xmm11           ## xmm11 = xmm3[0],xmm11[1,2,3]
-               	divss	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x128b>
-               	leaq	0x30(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	movl	%esi, %r8d
-               	movq	%r8, -0x1a8(%rbp)
-               	leaq	0x40(%r12), %rdx
-               	movq	(%rdx), %rsi
-               	andq	$0xfffff, %rsi          ## imm = 0xFFFFF
-               	movq	%rsi, %r11
-               	testq	%r11, %r11
-               	jl	 <L90>
-               	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L91>
-<L90>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm2
-               	addsd	%xmm2, %xmm2
-<L91>:
-               	movsd	%xmm2, %xmm3            ## xmm3 = xmm2[0],xmm3[1]
-               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x12e4>
-               	movsd	%xmm3, %xmm12           ## xmm12 = xmm3[0],xmm12[1]
-               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0x12f2>
-               	movq	%rax, %rdi
-               	movl	%ecx, %esi
-               	movups	-0x1c0(%rbp), %xmm2
-               	movq	%rbx, %rdx
-               	movss	%xmm4, %xmm3            ## xmm3 = xmm4[0],xmm3[1,2,3]
-               	movq	%r15, %rcx
-               	movups	-0x1d0(%rbp), %xmm4
-               	movq	-0x190(%rbp), %r8
-               	movq	-0x198(%rbp), %r9
-               	movq	-0x1e0(%rbp), %r11
+               	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
+               	subsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0x10f8>
+               	movsd	%xmm4, %xmm12           ## xmm12 = xmm4[0],xmm12[1]
+               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0x1106>
+               	movq	%rbx, %rdi
+               	movss	-0x320(%rbp), %xmm0
+               	movl	%r15d, %esi
+               	movsd	-0x338(%rbp), %xmm1
+               	movups	-0x280(%rbp), %xmm2
+               	movq	-0x328(%rbp), %r8
+               	movq	%r8, %rdx
+               	movss	-0x348(%rbp), %xmm3
+               	movq	-0x350(%rbp), %r8
+               	movq	%r8, %rcx
+               	movups	-0x290(%rbp), %xmm4
+               	movsd	-0x360(%rbp), %xmm5
+               	movq	-0x198(%rbp), %r8
+               	movss	-0x370(%rbp), %xmm6
+               	movq	-0x1a0(%rbp), %r9
+               	movsd	-0x380(%rbp), %xmm7
+               	movq	-0x2a0(%rbp), %r11
                	movq	%r11, (%rsp)
-               	movq	-0x1a0(%rbp), %r10
+               	movq	-0x1a8(%rbp), %r10
                	movq	%r10, 0x8(%rsp)
                	movsd	%xmm11, 0x10(%rsp)
-               	movq	-0x1a8(%rbp), %r10
+               	movq	-0x1b0(%rbp), %r10
                	movq	%r10, 0x18(%rsp)
                	movsd	%xmm12, 0x20(%rsp)
                	movq	%r14, 0x28(%rsp)
-               	callq	 <L92>
-<L92>:
+               	callq	 <L78>
+<L78>:
                	movq	%r13, %rdi
                	movq	%rax, %rsi
-               	callq	 <L93>
-<L93>:
-               	movq	-0x1e8(%rbp), %rbx
-               	movq	-0x1f0(%rbp), %r12
-               	movq	-0x1f8(%rbp), %r13
-               	movq	-0x200(%rbp), %r14
-               	movq	-0x208(%rbp), %r15
+               	callq	 <L79>
+<L79>:
+               	movq	-0x388(%rbp), %rbx
+               	movq	-0x390(%rbp), %r12
+               	movq	-0x398(%rbp), %r13
+               	movq	-0x3a0(%rbp), %r14
+               	movq	-0x3a8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/cmp/short_circuit.dis
+++ b/test/golden/x86_64-darwin/cmp/short_circuit.dis
@@ -176,27 +176,30 @@ Disassembly of section __TEXT,__text:
                	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x1a0>
                	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1a7>
                	movq	%rax, (%rcx)
-               	movl	$0x1, %esi
-               	xorl	%r12d, %esi
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x1b9>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x1c4>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x1d3>
-               	movq	(%rax), %rcx
+               	movl	$0x1, %eax
+               	xorl	%r12d, %eax
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1b9>
                	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x1dc>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1eb>
-               	movq	%rax, (%rcx)
+               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x1c4>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1d3>
+               	movq	(%rcx), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rcx)
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1dc>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x1eb>
+               	movq	%rcx, (%rdx)
+               	cmpb	$0x1, %al
+               	sete	%sil
+               	movzbq	%sil, %rsi
                	movq	%r14, %rdi
                	callq	 <L11>
 <L11>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x1f5>
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x200>
                	movq	%rax, %rdi
                	callq	 <L12>
 <L12>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x204>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x20b>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x20f>
+               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x216>
                	movq	%rax, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
@@ -218,9 +221,9 @@ Disassembly of section __TEXT,__text:
                	cmpq	$0x4, %r15
                	jb	 <L13>
 <L16>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x25b>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x266>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x26d>
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x266>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x271>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x278>
                	movq	$0x0, %rdx
                	cmpq	$0x4, %rdx
                	jb	 <L17>
@@ -234,26 +237,26 @@ Disassembly of section __TEXT,__text:
                	cmpq	$0x4, %rdx
                	jb	 <L17>
 <L18>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2ae>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2b9>
                	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x2b9>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2c0>
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x2c4>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2cb>
                	movq	(%rax), %rcx
                	addq	$0x1, %rcx
                	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2d1>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x2d8>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2dc>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x2e3>
                	movq	%rax, (%rcx)
                	movq	%r14, %rdi
                	movq	$0x1, %rsi
                	callq	 <L19>
 <L19>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x2f1>
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x2fc>
                	movq	%rax, %rdi
                	callq	 <L20>
 <L20>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x300>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x307>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x30b>
+               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x312>
                	movq	%rax, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
@@ -275,9 +278,9 @@ Disassembly of section __TEXT,__text:
                	cmpq	$0x4, %r15
                	jb	 <L21>
 <L24>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x357>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x362>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x369>
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x362>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x36d>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x374>
                	movq	$0x0, %rdx
                	cmpq	$0x4, %rdx
                	jb	 <L25>
@@ -291,209 +294,151 @@ Disassembly of section __TEXT,__text:
                	cmpq	$0x4, %rdx
                	jb	 <L25>
 <L26>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x3aa>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x3b5>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x3bc>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x3cd>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x3d4>
-               	movq	%rax, (%rcx)
-               	movl	$0x1, %esi
-               	xorl	%r12d, %esi
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x3e6>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x3f1>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x400>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x409>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x418>
-               	movq	%rax, (%rcx)
-               	movq	%r14, %rdi
+               	movq	$0x0, %rdi
+               	movq	$0x0, %rsi
                	callq	 <L27>
 <L27>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x422>
-               	movq	%rax, %rdi
-               	callq	 <L28>
+               	cmpb	$0x1, %al
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L28>
+               	movl	$0x1, %eax
+               	xorl	%r12d, %eax
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x3e2>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x3ed>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x3fc>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x405>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x414>
+               	movq	%rdx, (%rsi)
+               	cmpb	$0x1, %al
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	jmp	 <L29>
 <L28>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x431>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x438>
-               	movq	%rax, %r14
-               	movq	$0x0, %r15
-               	cmpq	$0x4, %r15
-               	jb	 <L29>
-               	jmp	 <L32>
+               	movq	%rcx, %rdx
 <L29>:
-               	leaq	(%rbx,%r15,8), %rax
-               	movq	(%rax), %rsi
                	movq	%r14, %rdi
+               	movq	%rdx, %rsi
                	callq	 <L30>
 <L30>:
-               	leaq	(%r13,%r15,8), %rcx
-               	movq	(%rcx), %rsi
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x433>
                	movq	%rax, %rdi
                	callq	 <L31>
 <L31>:
-               	addq	$0x1, %r15
-               	movq	%rax, %r14
-               	cmpq	$0x4, %r15
-               	jb	 <L29>
-<L32>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x488>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x493>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x49a>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L33>
-               	jmp	 <L34>
-<L33>:
-               	leaq	(%rax,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	leaq	(%rcx,%rdx,8), %rsi
-               	movq	$0x0, (%rsi)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L33>
-<L34>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4db>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x4e6>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4ed>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4fe>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x505>
-               	movq	%rax, (%rcx)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x50f>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x51a>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x529>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x532>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x541>
-               	movq	%rax, (%rcx)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x543>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x54e>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x565>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x566>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x57d>
-               	movq	%rax, (%rcx)
-               	testb	%r12b, %r12b
-               	jne	 <L35>
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x580>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x58b>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x5aa>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x5a3>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x5c2>
-               	movq	%rax, (%rcx)
-               	movq	$0x1, %rax
-               	jmp	 <L36>
-<L35>:
-               	movq	%r12, %rax
-<L36>:
-               	movq	%r14, %rdi
-               	movq	%rax, %rsi
-               	callq	 <L37>
-<L37>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x5ce>
-               	movq	%rax, %rdi
-               	callq	 <L38>
-<L38>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x5dd>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x5e4>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x442>
+               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x449>
                	movq	%rax, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L39>
-               	jmp	 <L42>
-<L39>:
+               	jb	 <L32>
+               	jmp	 <L35>
+<L32>:
                	leaq	(%rbx,%r15,8), %rax
                	movq	(%rax), %rsi
                	movq	%r14, %rdi
-               	callq	 <L40>
-<L40>:
+               	callq	 <L33>
+<L33>:
                	leaq	(%r13,%r15,8), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
+               	callq	 <L34>
+<L34>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x4, %r15
-               	jb	 <L39>
-<L42>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x634>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x63f>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x646>
+               	jb	 <L32>
+<L35>:
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x499>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4a4>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x4ab>
                	movq	$0x0, %rdx
                	cmpq	$0x4, %rdx
-               	jb	 <L43>
-               	jmp	 <L44>
-<L43>:
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
                	leaq	(%rax,%rdx,8), %rsi
                	movq	$0x0, (%rsi)
                	leaq	(%rcx,%rdx,8), %rsi
                	movq	$0x0, (%rsi)
                	addq	$0x1, %rdx
                	cmpq	$0x4, %rdx
-               	jb	 <L43>
+               	jb	 <L36>
+<L37>:
+               	movq	$0x0, %rdi
+               	movq	$0x0, %rsi
+               	callq	 <L38>
+<L38>:
+               	cmpb	$0x1, %al
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L39>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x511>
+               	addq	$0x1, %rax
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x51c>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x52b>
+               	movq	(%rax), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x534>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x543>
+               	movq	%rax, (%rdx)
+               	movq	$0x1, %rax
+               	jmp	 <L40>
+<L39>:
+               	movq	%rcx, %rax
+<L40>:
+               	testb	%al, %al
+               	jne	 <L41>
+               	jmp	 <L44>
+<L41>:
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x561>
+               	addq	$0x1, %rcx
+               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x56c>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x583>
+               	movq	(%rcx), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rcx)
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x584>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x59b>
+               	movq	%rcx, (%rdx)
+               	cmpb	$0x1, %r12b
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L42>
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5a8>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x5b3>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5d2>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5cb>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x5ea>
+               	movq	%rdx, (%rsi)
+               	movq	$0x1, %rdx
+               	jmp	 <L43>
+<L42>:
+               	movq	%rcx, %rdx
+<L43>:
+               	movq	%rdx, %rax
 <L44>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x687>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x692>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x699>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6aa>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x6b1>
-               	movq	%rax, (%rcx)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6bb>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x6c6>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6dd>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6de>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x6f5>
-               	movq	%rax, (%rcx)
-               	movl	$0x1, %esi
-               	xorl	%r12d, %esi
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6f7>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x702>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x721>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x71a>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x739>
-               	movq	%rax, (%rcx)
                	movq	%r14, %rdi
+               	movq	%rax, %rsi
                	callq	 <L45>
 <L45>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x733>
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x5f9>
                	movq	%rax, %rdi
                	callq	 <L46>
 <L46>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x742>
-               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x749>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x608>
+               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x60f>
                	movq	%rax, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
@@ -515,9 +460,9 @@ Disassembly of section __TEXT,__text:
                	cmpq	$0x4, %r15
                	jb	 <L47>
 <L50>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x799>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x7a4>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x7ab>
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x65f>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x66a>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x671>
                	movq	$0x0, %rdx
                	cmpq	$0x4, %rdx
                	jb	 <L51>
@@ -531,73 +476,181 @@ Disassembly of section __TEXT,__text:
                	cmpq	$0x4, %rdx
                	jb	 <L51>
 <L52>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x7ec>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x7f7>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x7fe>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x80f>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x816>
-               	movq	%rax, (%rcx)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x820>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x82b>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x83a>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x843>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x852>
-               	movq	%rax, (%rcx)
-               	testb	%r12b, %r12b
-               	jne	 <L53>
-               	jmp	 <L54>
+               	movq	$0x0, %rdi
+               	movq	$0x1, %rsi
+               	callq	 <L53>
 <L53>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x862>
+               	cmpb	$0x1, %al
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L54>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6d7>
                	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x86d>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x884>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x885>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x89c>
-               	movq	%rax, (%rcx)
-               	movq	$0x1, %r12
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x6e2>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6f1>
+               	movq	(%rax), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6fa>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x709>
+               	movq	%rax, (%rdx)
+               	movq	$0x1, %rax
+               	jmp	 <L55>
 <L54>:
-               	movq	%r14, %rdi
-               	movq	%r12, %rsi
-               	callq	 <L55>
+               	movq	%rcx, %rax
 <L55>:
-               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x8a8>
-               	movq	%rax, %rdi
-               	callq	 <L56>
+               	testb	%al, %al
+               	jne	 <L56>
+               	jmp	 <L57>
 <L56>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x8b7>
-               	leaq	, %r12 <corpus.cases.cmp.short_circuit.checksum+0x8be>
-               	movq	%rax, %r13
-               	movq	$0x0, %r14
-               	cmpq	$0x4, %r14
-               	jb	 <L57>
-               	jmp	 <L60>
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x727>
+               	addq	$0x1, %rcx
+               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x732>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x749>
+               	movq	(%rcx), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rcx)
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x74a>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x761>
+               	movq	%rcx, (%rdx)
+               	movl	$0x1, %ecx
+               	xorl	%r12d, %ecx
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x763>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x76e>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x78d>
+               	movq	(%rdx), %rsi
+               	addq	$0x1, %rsi
+               	movq	%rsi, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x786>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x7a5>
+               	movq	%rdx, (%rsi)
+               	cmpb	$0x1, %cl
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	movq	%rdx, %rax
 <L57>:
-               	leaq	(%rbx,%r14,8), %rax
-               	movq	(%rax), %rsi
-               	movq	%r13, %rdi
+               	movq	%r14, %rdi
+               	movq	%rax, %rsi
                	callq	 <L58>
 <L58>:
-               	leaq	(%r12,%r14,8), %rcx
-               	movq	(%rcx), %rsi
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x7af>
                	movq	%rax, %rdi
                	callq	 <L59>
 <L59>:
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x7be>
+               	leaq	, %r13 <corpus.cases.cmp.short_circuit.checksum+0x7c5>
+               	movq	%rax, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x4, %r15
+               	jb	 <L60>
+               	jmp	 <L63>
+<L60>:
+               	leaq	(%rbx,%r15,8), %rax
+               	movq	(%rax), %rsi
+               	movq	%r14, %rdi
+               	callq	 <L61>
+<L61>:
+               	leaq	(%r13,%r15,8), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L62>
+<L62>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r14
+               	cmpq	$0x4, %r15
+               	jb	 <L60>
+<L63>:
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x815>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x820>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x827>
+               	movq	$0x0, %rdx
+               	cmpq	$0x4, %rdx
+               	jb	 <L64>
+               	jmp	 <L65>
+<L64>:
+               	leaq	(%rax,%rdx,8), %rsi
+               	movq	$0x0, (%rsi)
+               	leaq	(%rcx,%rdx,8), %rsi
+               	movq	$0x0, (%rsi)
+               	addq	$0x1, %rdx
+               	cmpq	$0x4, %rdx
+               	jb	 <L64>
+<L65>:
+               	movq	$0x0, %rdi
+               	movq	$0x0, %rsi
+               	callq	 <L66>
+<L66>:
+               	cmpb	$0x1, %al
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L67>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x88d>
+               	addq	$0x1, %rax
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x898>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x8a7>
+               	movq	(%rax), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x8b0>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x8bf>
+               	movq	%rax, (%rdx)
+               	cmpb	$0x1, %r12b
+               	sete	%al
+               	movzbq	%al, %rax
+               	jmp	 <L68>
+<L67>:
+               	movq	%rcx, %rax
+<L68>:
+               	testb	%al, %al
+               	jne	 <L69>
+               	jmp	 <L70>
+<L69>:
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x8e1>
+               	addq	$0x1, %rcx
+               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x8ec>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x903>
+               	movq	(%rcx), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rcx)
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x904>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x91b>
+               	movq	%rcx, (%rdx)
+               	movq	$0x1, %rax
+<L70>:
+               	movq	%r14, %rdi
+               	movq	%rax, %rsi
+               	callq	 <L71>
+<L71>:
+               	movq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x927>
+               	movq	%rax, %rdi
+               	callq	 <L72>
+<L72>:
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x936>
+               	leaq	, %r12 <corpus.cases.cmp.short_circuit.checksum+0x93d>
+               	movq	%rax, %r13
+               	movq	$0x0, %r14
+               	cmpq	$0x4, %r14
+               	jb	 <L73>
+               	jmp	 <L76>
+<L73>:
+               	leaq	(%rbx,%r14,8), %rax
+               	movq	(%rax), %rsi
+               	movq	%r13, %rdi
+               	callq	 <L74>
+<L74>:
+               	leaq	(%r12,%r14,8), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L75>
+<L75>:
                	addq	$0x1, %r14
                	movq	%rax, %r13
                	cmpq	$0x4, %r14
-               	jb	 <L57>
-<L60>:
+               	jb	 <L73>
+<L76>:
                	movq	%r13, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %r12

--- a/test/golden/x86_64-darwin/float/cmp_f32.dis
+++ b/test/golden/x86_64-darwin/float/cmp_f32.dis
@@ -297,8 +297,8 @@ Disassembly of section __TEXT,__text:
                	ucomiss	-0x48(%rbp), %xmm14
                	seta	%cl
                	movzbq	%cl, %rcx
-               	cmpb	$0x0, %cl
-               	sete	%sil
+               	cmpb	$0x1, %cl
+               	setne	%sil
                	movzbq	%sil, %rsi
                	callq	 <L28>
 <L28>:

--- a/test/golden/x86_64-darwin/float/cmp_f64.dis
+++ b/test/golden/x86_64-darwin/float/cmp_f64.dis
@@ -302,8 +302,8 @@ Disassembly of section __TEXT,__text:
                	ucomisd	-0x98(%rbp), %xmm14
                	seta	%dl
                	movzbq	%dl, %rdx
-               	cmpb	$0x0, %dl
-               	sete	%sil
+               	cmpb	$0x1, %dl
+               	setne	%sil
                	movzbq	%sil, %rsi
                	callq	 <L28>
 <L28>:

--- a/test/golden/x86_64-darwin/float/special_f32.dis
+++ b/test/golden/x86_64-darwin/float/special_f32.dis
@@ -252,868 +252,240 @@ Disassembly of section __TEXT,__text:
 <L32>:
                	movss	-0x68(%rbp), %xmm0
                	subss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L34>
                	movq	%r12, %rdi
                	callq	 <L33>
 <L33>:
-               	movq	%rax, %rbx
-               	jmp	 <L36>
-<L34>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rbx
-<L36>:
                	movss	-0x68(%rbp), %xmm0
                	subss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L38>
-               	movq	%rbx, %rdi
+               	movq	%rax, %rdi
+               	callq	 <L34>
+<L34>:
+               	movss	-0x58(%rbp), %xmm0
+               	mulss	-0x38(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L35>
+<L35>:
+               	movss	-0x58(%rbp), %xmm0
+               	mulss	-0x48(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L36>
+<L36>:
+               	movss	-0x68(%rbp), %xmm0
+               	mulss	-0x38(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L37>
 <L37>:
-               	movq	%rax, %r12
-               	jmp	 <L40>
+               	movss	-0x68(%rbp), %xmm0
+               	mulss	-0x48(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L38>
 <L38>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
+               	movss	-0x68(%rbp), %xmm0
+               	mulss	-0x68(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L39>
 <L39>:
-               	movq	%rax, %r12
+               	movss	-0x58(%rbp), %xmm0
+               	mulss	-0x68(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L40>
 <L40>:
                	movss	-0x58(%rbp), %xmm0
-               	mulss	-0x38(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L42>
-               	movq	%r12, %rdi
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x37a>
+               	movq	%rax, %rdi
                	callq	 <L41>
 <L41>:
-               	movq	%rax, %rbx
-               	jmp	 <L44>
+               	movss	-0x68(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x38e>
+               	movq	%rax, %rdi
+               	callq	 <L42>
 <L42>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
+               	movss	-0x58(%rbp), %xmm0
+               	divss	-0x38(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L43>
 <L43>:
-               	movq	%rax, %rbx
-<L44>:
                	movss	-0x58(%rbp), %xmm0
-               	mulss	-0x48(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L46>
-               	movq	%rbx, %rdi
+               	divss	-0x48(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L44>
+<L44>:
+               	movss	-0x68(%rbp), %xmm0
+               	divss	-0x38(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L45>
 <L45>:
-               	movq	%rax, %r12
-               	jmp	 <L48>
+               	movss	-0x68(%rbp), %xmm0
+               	divss	-0x48(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L46>
 <L46>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %r12
-<L48>:
-               	movss	-0x68(%rbp), %xmm0
-               	mulss	-0x38(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L50>
-               	movq	%r12, %rdi
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rbx
-               	jmp	 <L52>
-<L50>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rbx
-<L52>:
-               	movss	-0x68(%rbp), %xmm0
-               	mulss	-0x48(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L54>
-               	movq	%rbx, %rdi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %r12
-               	jmp	 <L56>
-<L54>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %r12
-<L56>:
-               	movss	-0x68(%rbp), %xmm0
-               	mulss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L58>
-               	movq	%r12, %rdi
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rbx
-               	jmp	 <L60>
-<L58>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rbx
-<L60>:
-               	movss	-0x58(%rbp), %xmm0
-               	mulss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L62>
-               	movq	%rbx, %rdi
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %r12
-               	jmp	 <L64>
-<L62>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %r12
-<L64>:
-               	movss	-0x58(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x502>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L66>
-               	movq	%r12, %rdi
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rbx
-               	jmp	 <L68>
-<L66>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rbx
-<L68>:
-               	movss	-0x68(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x547>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L70>
-               	movq	%rbx, %rdi
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %r12
-               	jmp	 <L72>
-<L70>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %r12
-<L72>:
-               	movss	-0x58(%rbp), %xmm0
-               	divss	-0x38(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L74>
-               	movq	%r12, %rdi
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rbx
-               	jmp	 <L76>
-<L74>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rbx
-<L76>:
-               	movss	-0x58(%rbp), %xmm0
-               	divss	-0x48(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L78>
-               	movq	%rbx, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %r12
-               	jmp	 <L80>
-<L78>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %r12
-<L80>:
-               	movss	-0x68(%rbp), %xmm0
-               	divss	-0x38(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L82>
-               	movq	%r12, %rdi
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rbx
-               	jmp	 <L84>
-<L82>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rbx
-<L84>:
-               	movss	-0x68(%rbp), %xmm0
-               	divss	-0x48(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L86>
-               	movq	%rbx, %rdi
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %r12
-               	jmp	 <L88>
-<L86>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L87>
-<L87>:
-               	movq	%rax, %r12
-<L88>:
                	movss	-0x58(%rbp), %xmm14
                	ucomiss	-0x68(%rbp), %xmm14
                	sete	%sil
                	setnp	%r11b
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	movq	%r12, %rdi
-               	callq	 <L89>
-<L89>:
+               	movq	%rax, %rdi
+               	callq	 <L47>
+<L47>:
                	movss	-0x68(%rbp), %xmm14
                	ucomiss	-0x58(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
+               	callq	 <L48>
+<L48>:
                	movss	-0x58(%rbp), %xmm14
                	ucomiss	-0x68(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
-               	movq	%rax, %rbx
-               	movss	-0x78(%rbp), %xmm14
-               	ucomiss	-0x78(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L93>
-               	movq	%rbx, %rdi
+               	callq	 <L49>
+<L49>:
+               	movq	%rax, %rdi
                	movss	-0x78(%rbp), %xmm0
-               	callq	 <L92>
-<L92>:
-               	movq	%rax, %r12
-               	jmp	 <L95>
-<L93>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L94>
-<L94>:
-               	movq	%rax, %r12
-<L95>:
-               	movss	-0x88(%rbp), %xmm14
-               	ucomiss	-0x88(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L97>
-               	movq	%r12, %rdi
+               	callq	 <L50>
+<L50>:
+               	movq	%rax, %rdi
                	movss	-0x88(%rbp), %xmm0
-               	callq	 <L96>
-<L96>:
-               	movq	%rax, %rbx
-               	jmp	 <L99>
-<L97>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L98>
-<L98>:
-               	movq	%rax, %rbx
-<L99>:
+               	callq	 <L51>
+<L51>:
                	movss	-0x78(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x788>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L101>
-               	movq	%rbx, %rdi
-               	callq	 <L100>
-<L100>:
-               	movq	%rax, %r12
-               	jmp	 <L103>
-<L101>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L102>
-<L102>:
-               	movq	%rax, %r12
-<L103>:
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x45f>
+               	movq	%rax, %rdi
+               	callq	 <L52>
+<L52>:
                	movss	-0x38(%rbp), %xmm0
                	divss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L105>
-               	movq	%r12, %rdi
-               	callq	 <L104>
-<L104>:
-               	movq	%rax, %rbx
-               	jmp	 <L107>
-<L105>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L106>
-<L106>:
-               	movq	%rax, %rbx
-<L107>:
+               	movq	%rax, %rdi
+               	callq	 <L53>
+<L53>:
                	movss	-0x38(%rbp), %xmm0
                	divss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L109>
-               	movq	%rbx, %rdi
-               	callq	 <L108>
-<L108>:
-               	movq	%rax, %r12
-               	jmp	 <L111>
-<L109>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L110>
-<L110>:
-               	movq	%rax, %r12
-<L111>:
+               	movq	%rax, %rdi
+               	callq	 <L54>
+<L54>:
                	movss	-0x48(%rbp), %xmm0
                	divss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L113>
-               	movq	%r12, %rdi
-               	callq	 <L112>
-<L112>:
-               	movq	%rax, %rbx
-               	jmp	 <L115>
-<L113>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L114>
-<L114>:
-               	movq	%rax, %rbx
-<L115>:
+               	movq	%rax, %rdi
+               	callq	 <L55>
+<L55>:
                	movss	-0x48(%rbp), %xmm0
                	divss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L117>
-               	movq	%rbx, %rdi
-               	callq	 <L116>
-<L116>:
-               	movq	%rax, %r12
-               	jmp	 <L119>
-<L117>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L118>
-<L118>:
-               	movq	%rax, %r12
-<L119>:
+               	movq	%rax, %rdi
+               	callq	 <L56>
+<L56>:
                	movss	-0x78(%rbp), %xmm0
                	addss	-0x38(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L121>
-               	movq	%r12, %rdi
-               	callq	 <L120>
-<L120>:
-               	movq	%rax, %rbx
-               	jmp	 <L123>
-<L121>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L122>
-<L122>:
-               	movq	%rax, %rbx
-<L123>:
+               	movq	%rax, %rdi
+               	callq	 <L57>
+<L57>:
                	movss	-0x78(%rbp), %xmm0
                	addss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L125>
-               	movq	%rbx, %rdi
-               	callq	 <L124>
-<L124>:
-               	movq	%rax, %r12
-               	jmp	 <L127>
-<L125>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L126>
-<L126>:
-               	movq	%rax, %r12
-<L127>:
+               	movq	%rax, %rdi
+               	callq	 <L58>
+<L58>:
                	movss	-0x78(%rbp), %xmm0
                	subss	-0x88(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L129>
-               	movq	%r12, %rdi
-               	callq	 <L128>
-<L128>:
-               	movq	%rax, %rbx
-               	jmp	 <L131>
-<L129>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L130>
-<L130>:
-               	movq	%rax, %rbx
-<L131>:
+               	movq	%rax, %rdi
+               	callq	 <L59>
+<L59>:
                	movss	-0x78(%rbp), %xmm0
                	mulss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L133>
-               	movq	%rbx, %rdi
-               	callq	 <L132>
-<L132>:
-               	movq	%rax, %r12
-               	jmp	 <L135>
-<L133>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L134>
-<L134>:
-               	movq	%rax, %r12
-<L135>:
+               	movq	%rax, %rdi
+               	callq	 <L60>
+<L60>:
                	movss	-0x78(%rbp), %xmm0
                	mulss	-0x88(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L137>
-               	movq	%r12, %rdi
-               	callq	 <L136>
-<L136>:
-               	movq	%rax, %rbx
-               	jmp	 <L139>
-<L137>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L138>
-<L138>:
-               	movq	%rax, %rbx
-<L139>:
+               	movq	%rax, %rdi
+               	callq	 <L61>
+<L61>:
                	movss	-0x78(%rbp), %xmm0
                	mulss	-0x48(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L141>
-               	movq	%rbx, %rdi
-               	callq	 <L140>
-<L140>:
-               	movq	%rax, %r12
-               	jmp	 <L143>
-<L141>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L142>
-<L142>:
-               	movq	%rax, %r12
-<L143>:
+               	movq	%rax, %rdi
+               	callq	 <L62>
+<L62>:
                	movss	-0x38(%rbp), %xmm0
                	divss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L145>
-               	movq	%r12, %rdi
-               	callq	 <L144>
-<L144>:
-               	movq	%rax, %rbx
-               	jmp	 <L147>
-<L145>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L146>
-<L146>:
-               	movq	%rax, %rbx
-<L147>:
+               	movq	%rax, %rdi
+               	callq	 <L63>
+<L63>:
                	movss	-0x48(%rbp), %xmm0
                	divss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L149>
-               	movq	%rbx, %rdi
-               	callq	 <L148>
-<L148>:
-               	movq	%rax, %r12
-               	jmp	 <L151>
-<L149>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L150>
-<L150>:
-               	movq	%rax, %r12
-<L151>:
+               	movq	%rax, %rdi
+               	callq	 <L64>
+<L64>:
                	movss	-0x38(%rbp), %xmm0
                	divss	-0x88(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L153>
-               	movq	%r12, %rdi
-               	callq	 <L152>
-<L152>:
-               	movq	%rax, %rbx
-               	jmp	 <L155>
-<L153>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L154>
-<L154>:
-               	movq	%rax, %rbx
-<L155>:
+               	movq	%rax, %rdi
+               	callq	 <L65>
+<L65>:
                	movss	-0x78(%rbp), %xmm0
                	divss	-0x38(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L157>
-               	movq	%rbx, %rdi
-               	callq	 <L156>
-<L156>:
-               	movq	%rax, %r12
-               	jmp	 <L159>
-<L157>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L158>
-<L158>:
-               	movq	%rax, %r12
-<L159>:
+               	movq	%rax, %rdi
+               	callq	 <L66>
+<L66>:
                	movss	-0xa8(%rbp), %xmm0
                	addss	-0xa8(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L161>
-               	movq	%r12, %rdi
-               	callq	 <L160>
-<L160>:
-               	movq	%rax, %rbx
-               	jmp	 <L163>
-<L161>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L162>
-<L162>:
-               	movq	%rax, %rbx
-<L163>:
+               	movq	%rax, %rdi
+               	callq	 <L67>
+<L67>:
                	movss	-0x78(%rbp), %xmm14
                	ucomiss	-0xa8(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
-               	movq	%rbx, %rdi
-               	callq	 <L164>
-<L164>:
+               	movq	%rax, %rdi
+               	callq	 <L68>
+<L68>:
                	xorps	%xmm0, %xmm0
                	subss	-0xa8(%rbp), %xmm0
                	ucomiss	-0x88(%rbp), %xmm0
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L165>
-<L165>:
-               	movq	%rax, %rbx
+               	callq	 <L69>
+<L69>:
                	movss	-0x78(%rbp), %xmm0
                	subss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L167>
-               	movq	%rbx, %rdi
-               	callq	 <L166>
-<L166>:
-               	movq	%rax, %r12
-               	jmp	 <L169>
-<L167>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L168>
-<L168>:
-               	movq	%rax, %r12
-<L169>:
+               	movq	%rax, %rdi
+               	callq	 <L70>
+<L70>:
                	movss	-0x88(%rbp), %xmm0
                	addss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L171>
-               	movq	%r12, %rdi
-               	callq	 <L170>
-<L170>:
-               	movq	%rax, %rbx
-               	jmp	 <L173>
-<L171>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L172>
-<L172>:
-               	movq	%rax, %rbx
-<L173>:
+               	movq	%rax, %rdi
+               	callq	 <L71>
+<L71>:
                	movss	-0x78(%rbp), %xmm0
                	mulss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L175>
-               	movq	%rbx, %rdi
-               	callq	 <L174>
-<L174>:
-               	movq	%rax, %r12
-               	jmp	 <L177>
-<L175>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L176>
-<L176>:
-               	movq	%rax, %r12
-<L177>:
+               	movq	%rax, %rdi
+               	callq	 <L72>
+<L72>:
                	movss	-0x88(%rbp), %xmm0
                	mulss	-0x68(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L179>
-               	movq	%r12, %rdi
-               	callq	 <L178>
-<L178>:
-               	movq	%rax, %rbx
-               	jmp	 <L181>
-<L179>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L180>
-<L180>:
-               	movq	%rax, %rbx
-<L181>:
+               	movq	%rax, %rdi
+               	callq	 <L73>
+<L73>:
                	movss	-0x78(%rbp), %xmm0
                	divss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L183>
-               	movq	%rbx, %rdi
-               	callq	 <L182>
-<L182>:
-               	movq	%rax, %r12
-               	jmp	 <L185>
-<L183>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L184>
-<L184>:
-               	movq	%rax, %r12
-<L185>:
+               	movq	%rax, %rdi
+               	callq	 <L74>
+<L74>:
                	movss	-0x58(%rbp), %xmm0
                	divss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L187>
-               	movq	%r12, %rdi
-               	callq	 <L186>
-<L186>:
-               	movq	%rax, %rbx
-               	jmp	 <L189>
-<L187>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L188>
-<L188>:
-               	movq	%rax, %rbx
-<L189>:
+               	movq	%rax, %rdi
+               	callq	 <L75>
+<L75>:
                	movss	-0x68(%rbp), %xmm0
                	divss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L191>
-               	movq	%rbx, %rdi
-               	callq	 <L190>
-<L190>:
-               	movq	%rax, %r12
-               	jmp	 <L193>
-<L191>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L192>
-<L192>:
-               	movq	%rax, %r12
-<L193>:
-               	movl	-0x98(%rbp), %eax
-               	movq	%r12, %rdi
-               	movl	%eax, %esi
-               	callq	 <L194>
-<L194>:
+               	movq	%rax, %rdi
+               	callq	 <L76>
+<L76>:
+               	movl	-0x98(%rbp), %ecx
+               	movq	%rax, %rdi
+               	movl	%ecx, %esi
+               	callq	 <L77>
+<L77>:
                	movss	-0x98(%rbp), %xmm14
                	ucomiss	-0x98(%rbp), %xmm14
                	setne	%sil
@@ -1121,8 +493,8 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L195>
-<L195>:
+               	callq	 <L78>
+<L78>:
                	movss	-0x98(%rbp), %xmm14
                	ucomiss	-0x98(%rbp), %xmm14
                	sete	%sil
@@ -1130,402 +502,126 @@ Disassembly of section __TEXT,__text:
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L196>
-<L196>:
+               	callq	 <L79>
+<L79>:
                	movss	-0x98(%rbp), %xmm14
                	ucomiss	-0x98(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L197>
-<L197>:
+               	callq	 <L80>
+<L80>:
                	movss	-0x98(%rbp), %xmm14
                	ucomiss	-0x98(%rbp), %xmm14
                	setae	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L198>
-<L198>:
+               	callq	 <L81>
+<L81>:
                	movss	-0x98(%rbp), %xmm14
-               	xorps	, %xmm14 <corpus.cases.float.special_f32.checksum+0xe8e>
+               	xorps	, %xmm14 <corpus.cases.float.special_f32.checksum+0x6fb>
                	movss	%xmm14, -0xe8(%rbp)
                	movl	-0xe8(%rbp), %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L199>
-<L199>:
+               	callq	 <L82>
+<L82>:
                	movss	-0xe8(%rbp), %xmm2
-               	xorps	, %xmm2 <corpus.cases.float.special_f32.checksum+0xeb6>
+               	xorps	, %xmm2 <corpus.cases.float.special_f32.checksum+0x723>
                	movd	%xmm2, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L200>
-<L200>:
-               	movq	%rax, %rbx
+               	callq	 <L83>
+<L83>:
                	movss	-0x98(%rbp), %xmm0
                	addss	-0x38(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L202>
-               	movq	%rbx, %rdi
-               	callq	 <L201>
-<L201>:
-               	movq	%rax, %r12
-               	jmp	 <L204>
-<L202>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L203>
-<L203>:
-               	movq	%rax, %r12
-<L204>:
+               	movq	%rax, %rdi
+               	callq	 <L84>
+<L84>:
                	movss	-0x38(%rbp), %xmm0
                	addss	-0x98(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L206>
-               	movq	%r12, %rdi
-               	callq	 <L205>
-<L205>:
-               	movq	%rax, %rbx
-               	jmp	 <L208>
-<L206>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L207>
-<L207>:
-               	movq	%rax, %rbx
-<L208>:
+               	movq	%rax, %rdi
+               	callq	 <L85>
+<L85>:
                	movss	-0x98(%rbp), %xmm0
                	mulss	-0x58(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L210>
-               	movq	%rbx, %rdi
-               	callq	 <L209>
-<L209>:
-               	movq	%rax, %r12
-               	jmp	 <L212>
-<L210>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L211>
-<L211>:
-               	movq	%rax, %r12
-<L212>:
+               	movq	%rax, %rdi
+               	callq	 <L86>
+<L86>:
                	movss	-0x98(%rbp), %xmm0
                	subss	-0x98(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L214>
-               	movq	%r12, %rdi
-               	callq	 <L213>
-<L213>:
-               	movq	%rax, %rbx
-               	jmp	 <L216>
-<L214>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L215>
-<L215>:
-               	movq	%rax, %rbx
-<L216>:
+               	movq	%rax, %rdi
+               	callq	 <L87>
+<L87>:
                	movss	-0x98(%rbp), %xmm0
                	divss	-0x98(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L218>
-               	movq	%rbx, %rdi
-               	callq	 <L217>
-<L217>:
-               	movq	%rax, %r12
-               	jmp	 <L220>
-<L218>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L219>
-<L219>:
-               	movq	%rax, %r12
-<L220>:
+               	movq	%rax, %rdi
+               	callq	 <L88>
+<L88>:
                	movss	-0x98(%rbp), %xmm0
                	divss	-0x78(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L222>
-               	movq	%r12, %rdi
-               	callq	 <L221>
-<L221>:
-               	movq	%rax, %rbx
-               	jmp	 <L224>
-<L222>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L223>
-<L223>:
-               	movq	%rax, %rbx
-<L224>:
-               	movss	-0xd8(%rbp), %xmm14
-               	ucomiss	-0xd8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L226>
-               	movq	%rbx, %rdi
+               	movq	%rax, %rdi
+               	callq	 <L89>
+<L89>:
+               	movq	%rax, %rdi
                	movss	-0xd8(%rbp), %xmm0
-               	callq	 <L225>
-<L225>:
-               	movq	%rax, %r12
-               	jmp	 <L228>
-<L226>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L227>
-<L227>:
-               	movq	%rax, %r12
-<L228>:
-               	movss	-0xc8(%rbp), %xmm14
-               	ucomiss	-0xc8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L230>
-               	movq	%r12, %rdi
+               	callq	 <L90>
+<L90>:
+               	movq	%rax, %rdi
                	movss	-0xc8(%rbp), %xmm0
-               	callq	 <L229>
-<L229>:
-               	movq	%rax, %rbx
-               	jmp	 <L232>
-<L230>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L231>
-<L231>:
-               	movq	%rax, %rbx
-<L232>:
-               	movss	-0xb8(%rbp), %xmm14
-               	ucomiss	-0xb8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L234>
-               	movq	%rbx, %rdi
+               	callq	 <L91>
+<L91>:
+               	movq	%rax, %rdi
                	movss	-0xb8(%rbp), %xmm0
-               	callq	 <L233>
-<L233>:
-               	movq	%rax, %r12
-               	jmp	 <L236>
-<L234>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L235>
-<L235>:
-               	movq	%rax, %r12
-<L236>:
+               	callq	 <L92>
+<L92>:
                	movss	-0xc8(%rbp), %xmm0
                	addss	-0xd8(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L238>
-               	movq	%r12, %rdi
-               	callq	 <L237>
-<L237>:
-               	movq	%rax, %rbx
-               	jmp	 <L240>
-<L238>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L239>
-<L239>:
-               	movq	%rax, %rbx
-<L240>:
+               	movq	%rax, %rdi
+               	callq	 <L93>
+<L93>:
                	movss	-0xb8(%rbp), %xmm0
                	subss	-0xd8(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L242>
-               	movq	%rbx, %rdi
-               	callq	 <L241>
-<L241>:
-               	movq	%rax, %r12
-               	jmp	 <L244>
-<L242>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L243>
-<L243>:
-               	movq	%rax, %r12
-<L244>:
+               	movq	%rax, %rdi
+               	callq	 <L94>
+<L94>:
                	movss	-0xd8(%rbp), %xmm0
                	addss	-0xd8(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L246>
-               	movq	%r12, %rdi
-               	callq	 <L245>
-<L245>:
-               	movq	%rax, %rbx
-               	jmp	 <L248>
-<L246>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L247>
-<L247>:
-               	movq	%rax, %rbx
-<L248>:
+               	movq	%rax, %rdi
+               	callq	 <L95>
+<L95>:
                	movss	-0xd8(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x124a>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L250>
-               	movq	%rbx, %rdi
-               	callq	 <L249>
-<L249>:
-               	movq	%rax, %r12
-               	jmp	 <L252>
-<L250>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L251>
-<L251>:
-               	movq	%rax, %r12
-<L252>:
+               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x83e>
+               	movq	%rax, %rdi
+               	callq	 <L96>
+<L96>:
                	movss	-0xd8(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x1293>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L254>
-               	movq	%r12, %rdi
-               	callq	 <L253>
-<L253>:
-               	movq	%rax, %rbx
-               	jmp	 <L256>
-<L254>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L255>
-<L255>:
-               	movq	%rax, %rbx
-<L256>:
+               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x856>
+               	movq	%rax, %rdi
+               	callq	 <L97>
+<L97>:
                	movss	-0xd8(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x12db>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L258>
-               	movq	%rbx, %rdi
-               	callq	 <L257>
-<L257>:
-               	movq	%rax, %r12
-               	jmp	 <L260>
-<L258>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L259>
-<L259>:
-               	movq	%rax, %r12
-<L260>:
+               	xorps	, %xmm0 <corpus.cases.float.special_f32.checksum+0x86d>
+               	movq	%rax, %rdi
+               	callq	 <L98>
+<L98>:
                	movss	-0xd8(%rbp), %xmm0
-               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x1324>
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L262>
-               	movq	%r12, %rdi
-               	callq	 <L261>
-<L261>:
-               	movq	%rax, %rbx
-               	jmp	 <L264>
-<L262>:
-               	movq	%r12, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L263>
-<L263>:
-               	movq	%rax, %rbx
-<L264>:
+               	mulss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x885>
+               	movq	%rax, %rdi
+               	callq	 <L99>
+<L99>:
                	movss	-0xc8(%rbp), %xmm0
                	divss	-0xb8(%rbp), %xmm0
-               	ucomiss	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L266>
-               	movq	%rbx, %rdi
-               	callq	 <L265>
-<L265>:
-               	movq	%rax, %r12
-               	jmp	 <L268>
-<L266>:
-               	movq	%rbx, %rdi
-               	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L267>
-<L267>:
-               	movq	%rax, %r12
-<L268>:
+               	movq	%rax, %rdi
+               	callq	 <L100>
+<L100>:
                	movss	-0xd8(%rbp), %xmm14
                	ucomiss	-0x58(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
-               	movq	%r12, %rdi
-               	callq	 <L269>
-<L269>:
+               	movq	%rax, %rdi
+               	callq	 <L101>
+<L101>:
                	movss	-0xd8(%rbp), %xmm14
                	ucomiss	-0x58(%rbp), %xmm14
                	sete	%sil
@@ -1533,8 +629,8 @@ Disassembly of section __TEXT,__text:
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L270>
-<L270>:
+               	callq	 <L102>
+<L102>:
                	xorps	%xmm0, %xmm0
                	subss	-0xd8(%rbp), %xmm0
                	movss	-0x68(%rbp), %xmm14
@@ -1542,18 +638,18 @@ Disassembly of section __TEXT,__text:
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L271>
-<L271>:
+               	callq	 <L103>
+<L103>:
                	movq	%rax, %rbx
                	movq	-0xb8(%rbp), %r11
                	movq	%r11, -0x108(%rbp)
                	movl	$0x0, %r12d
                	cmpl	$0x1e, %r12d
-               	jb	 <L272>
-               	jmp	 <L277>
-<L272>:
+               	jb	 <L104>
+               	jmp	 <L109>
+<L104>:
                	movss	-0x108(%rbp), %xmm14
-               	mulss	, %xmm14 <corpus.cases.float.special_f32.checksum+0x1446>
+               	mulss	, %xmm14 <corpus.cases.float.special_f32.checksum+0x945>
                	movss	%xmm14, -0xf8(%rbp)
                	movss	-0xf8(%rbp), %xmm14
                	ucomiss	-0xf8(%rbp), %xmm14
@@ -1562,27 +658,27 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L274>
+               	jne	 <L106>
                	movq	%rbx, %rdi
                	movss	-0xf8(%rbp), %xmm0
-               	callq	 <L273>
-<L273>:
+               	callq	 <L105>
+<L105>:
                	movq	%rax, %r14
-               	jmp	 <L276>
-<L274>:
+               	jmp	 <L108>
+<L106>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L275>
-<L275>:
+               	callq	 <L107>
+<L107>:
                	movq	%rax, %r14
-<L276>:
+<L108>:
                	addl	$0x1, %r12d
                	movq	%r14, %rbx
                	movq	-0xf8(%rbp), %r11
                	movq	%r11, -0x108(%rbp)
                	cmpl	$0x1e, %r12d
-               	jb	 <L272>
-<L277>:
+               	jb	 <L104>
+<L109>:
                	leaq	-0x20(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
@@ -1606,9 +702,9 @@ Disassembly of section __TEXT,__text:
                	movl	$0x7f800001, (%rax)     ## imm = 0x7F800001
                	movl	$0x0, %r14d
                	cmpl	$0x8, %r14d
-               	jb	 <L278>
-               	jmp	 <L280>
-<L278>:
+               	jb	 <L110>
+               	jmp	 <L112>
+<L110>:
                	movl	%r14d, %eax
                	leaq	(%r12,%rax,4), %rcx
                	movl	(%rcx), %eax
@@ -1617,13 +713,13 @@ Disassembly of section __TEXT,__text:
                	movd	%xmm0, %eax
                	movq	%rbx, %rdi
                	movl	%eax, %esi
-               	callq	 <L279>
-<L279>:
+               	callq	 <L111>
+<L111>:
                	addl	$0x1, %r14d
                	movq	%rax, %rbx
                	cmpl	$0x8, %r14d
-               	jb	 <L278>
-<L280>:
+               	jb	 <L110>
+<L112>:
                	movl	$0x1000000, %eax        ## imm = 0x1000000
                	addl	%r13d, %eax
                	movl	$0x1000001, %r12d       ## imm = 0x1000001
@@ -1646,21 +742,21 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L282>
+               	jne	 <L114>
                	movq	%rbx, %rdi
-               	callq	 <L281>
-<L281>:
+               	callq	 <L113>
+<L113>:
                	movq	%rax, %r8
                	movq	%r8, -0x28(%rbp)
-               	jmp	 <L284>
-<L282>:
+               	jmp	 <L116>
+<L114>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L283>
-<L283>:
+               	callq	 <L115>
+<L115>:
                	movq	%rax, %r8
                	movq	%r8, -0x28(%rbp)
-<L284>:
+<L116>:
                	movl	%r12d, %r11d
                	cvtsi2ss	%r11, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -1669,21 +765,21 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L286>
+               	jne	 <L118>
                	movq	-0x28(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L285>
-<L285>:
+               	callq	 <L117>
+<L117>:
                	movq	%rax, %rbx
-               	jmp	 <L288>
-<L286>:
+               	jmp	 <L120>
+<L118>:
                	movq	-0x28(%rbp), %r8
                	movq	%r8, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L287>
-<L287>:
+               	callq	 <L119>
+<L119>:
                	movq	%rax, %rbx
-<L288>:
+<L120>:
                	movl	%r14d, %r11d
                	cvtsi2ss	%r11, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -1692,19 +788,19 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L290>
+               	jne	 <L122>
                	movq	%rbx, %rdi
-               	callq	 <L289>
-<L289>:
+               	callq	 <L121>
+<L121>:
                	movq	%rax, %r12
-               	jmp	 <L292>
-<L290>:
+               	jmp	 <L124>
+<L122>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L291>
-<L291>:
+               	callq	 <L123>
+<L123>:
                	movq	%rax, %r12
-<L292>:
+<L124>:
                	movl	%r15d, %r11d
                	cvtsi2ss	%r11, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -1713,19 +809,19 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L294>
+               	jne	 <L126>
                	movq	%r12, %rdi
-               	callq	 <L293>
-<L293>:
+               	callq	 <L125>
+<L125>:
                	movq	%rax, %rbx
-               	jmp	 <L296>
-<L294>:
+               	jmp	 <L128>
+<L126>:
                	movq	%r12, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L295>
-<L295>:
+               	callq	 <L127>
+<L127>:
                	movq	%rax, %rbx
-<L296>:
+<L128>:
                	movl	%r13d, %r11d
                	cvtsi2ss	%r11, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -1734,19 +830,19 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L298>
+               	jne	 <L130>
                	movq	%rbx, %rdi
-               	callq	 <L297>
-<L297>:
+               	callq	 <L129>
+<L129>:
                	movq	%rax, %r12
-               	jmp	 <L300>
-<L298>:
+               	jmp	 <L132>
+<L130>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L299>
-<L299>:
+               	callq	 <L131>
+<L131>:
                	movq	%rax, %r12
-<L300>:
+<L132>:
                	movq	-0x110(%rbp), %r8
                	movslq	%r8d, %r11
                	cvtsi2ss	%r11, %xmm0
@@ -1756,19 +852,19 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L302>
+               	jne	 <L134>
                	movq	%r12, %rdi
-               	callq	 <L301>
-<L301>:
+               	callq	 <L133>
+<L133>:
                	movq	%rax, %rbx
-               	jmp	 <L304>
-<L302>:
+               	jmp	 <L136>
+<L134>:
                	movq	%r12, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L303>
-<L303>:
+               	callq	 <L135>
+<L135>:
                	movq	%rax, %rbx
-<L304>:
+<L136>:
                	movq	-0x118(%rbp), %r8
                	movslq	%r8d, %r11
                	cvtsi2ss	%r11, %xmm0
@@ -1778,102 +874,102 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L306>
+               	jne	 <L138>
                	movq	%rbx, %rdi
-               	callq	 <L305>
-<L305>:
+               	callq	 <L137>
+<L137>:
                	movq	%rax, %r12
-               	jmp	 <L308>
-<L306>:
+               	jmp	 <L140>
+<L138>:
                	movq	%rbx, %rdi
                	movl	$0xffffffff, %esi       ## imm = 0xFFFFFFFF
-               	callq	 <L307>
-<L307>:
+               	callq	 <L139>
+<L139>:
                	movq	%rax, %r12
-<L308>:
-               	movss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x17b1>
+<L140>:
+               	movss	, %xmm0 <corpus.cases.float.special_f32.checksum+0xcb0>
                	mulss	-0x38(%rbp), %xmm0
-               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0x17bf>
+               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0xcbe>
                	mulss	-0x38(%rbp), %xmm14
                	movss	%xmm14, -0x128(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0x17d7>
+               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0xcd6>
                	mulss	-0x38(%rbp), %xmm14
                	movss	%xmm14, -0x138(%rbp)
                	xorps	%xmm14, %xmm14
                	subss	%xmm0, %xmm14
                	movss	%xmm14, -0x148(%rbp)
-               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0x1801>
+               	movss	, %xmm14 <corpus.cases.float.special_f32.checksum+0xd00>
                	mulss	-0x38(%rbp), %xmm14
                	movss	%xmm14, -0x158(%rbp)
                	cvttss2si	%xmm0, %r11
                	movl	%r11d, %eax
                	movq	%r12, %rdi
                	movl	%eax, %esi
-               	callq	 <L309>
-<L309>:
+               	callq	 <L141>
+<L141>:
                	movss	-0x128(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L310>
-<L310>:
+               	callq	 <L142>
+<L142>:
                	movss	-0x138(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L311>
-<L311>:
+               	callq	 <L143>
+<L143>:
                	movss	-0x158(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L312>
-<L312>:
+               	callq	 <L144>
+<L144>:
                	movss	-0x58(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L313>
-<L313>:
+               	callq	 <L145>
+<L145>:
                	movss	-0x148(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L314>
-<L314>:
+               	callq	 <L146>
+<L146>:
                	movss	-0x138(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11d
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L315>
-<L315>:
+               	callq	 <L147>
+<L147>:
                	xorps	%xmm0, %xmm0
                	subss	-0x158(%rbp), %xmm0
                	cvttss2si	%xmm0, %r11d
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L316>
-<L316>:
+               	callq	 <L148>
+<L148>:
                	movss	-0x148(%rbp), %xmm14
                	cvttss2si	%xmm14, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L317>
-<L317>:
+               	callq	 <L149>
+<L149>:
                	xorps	%xmm0, %xmm0
                	subss	-0x128(%rbp), %xmm0
                	cvttss2si	%xmm0, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L318>
-<L318>:
+               	callq	 <L150>
+<L150>:
                	movq	-0x168(%rbp), %rbx
                	movq	-0x170(%rbp), %r12
                	movq	-0x178(%rbp), %r13

--- a/test/golden/x86_64-darwin/float/special_f64.dis
+++ b/test/golden/x86_64-darwin/float/special_f64.dis
@@ -188,930 +188,254 @@ Disassembly of section __TEXT,__text:
 <L20>:
                	movsd	-0x88(%rbp), %xmm0
                	addsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L22>
                	movq	%r13, %rdi
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %r12
-               	jmp	 <L24>
+               	movsd	-0x78(%rbp), %xmm0
+               	subsd	-0x78(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L22>
 <L22>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x78(%rbp), %xmm0
+               	subsd	-0x88(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L23>
 <L23>:
-               	movq	%rax, %r12
-<L24>:
-               	movsd	-0x78(%rbp), %xmm0
+               	movsd	-0x88(%rbp), %xmm0
                	subsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L26>
-               	movq	%r12, %rdi
+               	movq	%rax, %rdi
+               	callq	 <L24>
+<L24>:
+               	movsd	-0x88(%rbp), %xmm0
+               	subsd	-0x88(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L25>
 <L25>:
-               	movq	%rax, %r13
-               	jmp	 <L28>
+               	movsd	-0x78(%rbp), %xmm0
+               	mulsd	-0x58(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L26>
 <L26>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x78(%rbp), %xmm0
+               	mulsd	-0x68(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L27>
 <L27>:
-               	movq	%rax, %r13
+               	movsd	-0x88(%rbp), %xmm0
+               	mulsd	-0x58(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L28>
 <L28>:
-               	movsd	-0x78(%rbp), %xmm0
-               	subsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L30>
-               	movq	%r13, %rdi
+               	movsd	-0x88(%rbp), %xmm0
+               	mulsd	-0x68(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L29>
 <L29>:
-               	movq	%rax, %r12
-               	jmp	 <L32>
+               	movsd	-0x88(%rbp), %xmm0
+               	mulsd	-0x88(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L30>
 <L30>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x78(%rbp), %xmm0
+               	mulsd	-0x88(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L31>
 <L31>:
-               	movq	%rax, %r12
+               	movsd	-0x78(%rbp), %xmm0
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x362>
+               	movq	%rax, %rdi
+               	callq	 <L32>
 <L32>:
                	movsd	-0x88(%rbp), %xmm0
-               	subsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L34>
-               	movq	%r12, %rdi
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x379>
+               	movq	%rax, %rdi
                	callq	 <L33>
 <L33>:
-               	movq	%rax, %r13
-               	jmp	 <L36>
+               	movsd	-0x78(%rbp), %xmm0
+               	divsd	-0x58(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L34>
 <L34>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
+               	movsd	-0x78(%rbp), %xmm0
+               	divsd	-0x68(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L35>
 <L35>:
-               	movq	%rax, %r13
+               	movsd	-0x88(%rbp), %xmm0
+               	divsd	-0x58(%rbp), %xmm0
+               	movq	%rax, %rdi
+               	callq	 <L36>
 <L36>:
                	movsd	-0x88(%rbp), %xmm0
-               	subsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L38>
-               	movq	%r13, %rdi
+               	divsd	-0x68(%rbp), %xmm0
+               	movq	%rax, %rdi
                	callq	 <L37>
 <L37>:
-               	movq	%rax, %r12
-               	jmp	 <L40>
-<L38>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %r12
-<L40>:
-               	movsd	-0x78(%rbp), %xmm0
-               	mulsd	-0x58(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L42>
-               	movq	%r12, %rdi
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %r13
-               	jmp	 <L44>
-<L42>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %r13
-<L44>:
-               	movsd	-0x78(%rbp), %xmm0
-               	mulsd	-0x68(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L46>
-               	movq	%r13, %rdi
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %r12
-               	jmp	 <L48>
-<L46>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %r12
-<L48>:
-               	movsd	-0x88(%rbp), %xmm0
-               	mulsd	-0x58(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L50>
-               	movq	%r12, %rdi
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %r13
-               	jmp	 <L52>
-<L50>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %r13
-<L52>:
-               	movsd	-0x88(%rbp), %xmm0
-               	mulsd	-0x68(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L54>
-               	movq	%r13, %rdi
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %r12
-               	jmp	 <L56>
-<L54>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %r12
-<L56>:
-               	movsd	-0x88(%rbp), %xmm0
-               	mulsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L58>
-               	movq	%r12, %rdi
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %r13
-               	jmp	 <L60>
-<L58>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %r13
-<L60>:
-               	movsd	-0x78(%rbp), %xmm0
-               	mulsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L62>
-               	movq	%r13, %rdi
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %r12
-               	jmp	 <L64>
-<L62>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %r12
-<L64>:
-               	movsd	-0x78(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x59e>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L66>
-               	movq	%r12, %rdi
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %r13
-               	jmp	 <L68>
-<L66>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %r13
-<L68>:
-               	movsd	-0x88(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x5e9>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L70>
-               	movq	%r13, %rdi
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %r12
-               	jmp	 <L72>
-<L70>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %r12
-<L72>:
-               	movsd	-0x78(%rbp), %xmm0
-               	divsd	-0x58(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L74>
-               	movq	%r12, %rdi
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %r13
-               	jmp	 <L76>
-<L74>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %r13
-<L76>:
-               	movsd	-0x78(%rbp), %xmm0
-               	divsd	-0x68(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L78>
-               	movq	%r13, %rdi
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %r12
-               	jmp	 <L80>
-<L78>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %r12
-<L80>:
-               	movsd	-0x88(%rbp), %xmm0
-               	divsd	-0x58(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L82>
-               	movq	%r12, %rdi
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %r13
-               	jmp	 <L84>
-<L82>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %r13
-<L84>:
-               	movsd	-0x88(%rbp), %xmm0
-               	divsd	-0x68(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L86>
-               	movq	%r13, %rdi
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %r12
-               	jmp	 <L88>
-<L86>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L87>
-<L87>:
-               	movq	%rax, %r12
-<L88>:
                	movsd	-0x78(%rbp), %xmm14
                	ucomisd	-0x88(%rbp), %xmm14
                	sete	%sil
                	setnp	%r11b
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
-               	movq	%r12, %rdi
-               	callq	 <L89>
-<L89>:
+               	movq	%rax, %rdi
+               	callq	 <L38>
+<L38>:
                	movsd	-0x88(%rbp), %xmm14
                	ucomisd	-0x78(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
+               	callq	 <L39>
+<L39>:
                	movsd	-0x78(%rbp), %xmm14
                	ucomisd	-0x88(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
-               	movq	%rax, %r12
-               	movsd	-0x98(%rbp), %xmm14
-               	ucomisd	-0x98(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L93>
-               	movq	%r12, %rdi
+               	callq	 <L40>
+<L40>:
+               	movq	%rax, %rdi
                	movsd	-0x98(%rbp), %xmm0
-               	callq	 <L92>
-<L92>:
-               	movq	%rax, %r13
-               	jmp	 <L95>
-<L93>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L94>
-<L94>:
-               	movq	%rax, %r13
-<L95>:
-               	movsd	-0xa8(%rbp), %xmm14
-               	ucomisd	-0xa8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L97>
-               	movq	%r13, %rdi
+               	callq	 <L41>
+<L41>:
+               	movq	%rax, %rdi
                	movsd	-0xa8(%rbp), %xmm0
-               	callq	 <L96>
-<L96>:
-               	movq	%rax, %r12
-               	jmp	 <L99>
-<L97>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L98>
-<L98>:
-               	movq	%rax, %r12
-<L99>:
+               	callq	 <L42>
+<L42>:
                	movsd	-0x98(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x85d>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L101>
-               	movq	%r12, %rdi
-               	callq	 <L100>
-<L100>:
-               	movq	%rax, %r13
-               	jmp	 <L103>
-<L101>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L102>
-<L102>:
-               	movq	%rax, %r13
-<L103>:
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x462>
+               	movq	%rax, %rdi
+               	callq	 <L43>
+<L43>:
                	movsd	-0x58(%rbp), %xmm0
                	divsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L105>
-               	movq	%r13, %rdi
-               	callq	 <L104>
-<L104>:
-               	movq	%rax, %r12
-               	jmp	 <L107>
-<L105>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L106>
-<L106>:
-               	movq	%rax, %r12
-<L107>:
+               	movq	%rax, %rdi
+               	callq	 <L44>
+<L44>:
                	movsd	-0x58(%rbp), %xmm0
                	divsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L109>
-               	movq	%r12, %rdi
-               	callq	 <L108>
-<L108>:
-               	movq	%rax, %r13
-               	jmp	 <L111>
-<L109>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L110>
-<L110>:
-               	movq	%rax, %r13
-<L111>:
+               	movq	%rax, %rdi
+               	callq	 <L45>
+<L45>:
                	movsd	-0x68(%rbp), %xmm0
                	divsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L113>
-               	movq	%r13, %rdi
-               	callq	 <L112>
-<L112>:
-               	movq	%rax, %r12
-               	jmp	 <L115>
-<L113>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L114>
-<L114>:
-               	movq	%rax, %r12
-<L115>:
+               	movq	%rax, %rdi
+               	callq	 <L46>
+<L46>:
                	movsd	-0x68(%rbp), %xmm0
                	divsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L117>
-               	movq	%r12, %rdi
-               	callq	 <L116>
-<L116>:
-               	movq	%rax, %r13
-               	jmp	 <L119>
-<L117>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L118>
-<L118>:
-               	movq	%rax, %r13
-<L119>:
+               	movq	%rax, %rdi
+               	callq	 <L47>
+<L47>:
                	movsd	-0x98(%rbp), %xmm0
                	addsd	-0x58(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L121>
-               	movq	%r13, %rdi
-               	callq	 <L120>
-<L120>:
-               	movq	%rax, %r12
-               	jmp	 <L123>
-<L121>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L122>
-<L122>:
-               	movq	%rax, %r12
-<L123>:
+               	movq	%rax, %rdi
+               	callq	 <L48>
+<L48>:
                	movsd	-0x98(%rbp), %xmm0
                	addsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L125>
-               	movq	%r12, %rdi
-               	callq	 <L124>
-<L124>:
-               	movq	%rax, %r13
-               	jmp	 <L127>
-<L125>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L126>
-<L126>:
-               	movq	%rax, %r13
-<L127>:
+               	movq	%rax, %rdi
+               	callq	 <L49>
+<L49>:
                	movsd	-0x98(%rbp), %xmm0
                	subsd	-0xa8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L129>
-               	movq	%r13, %rdi
-               	callq	 <L128>
-<L128>:
-               	movq	%rax, %r12
-               	jmp	 <L131>
-<L129>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L130>
-<L130>:
-               	movq	%rax, %r12
-<L131>:
+               	movq	%rax, %rdi
+               	callq	 <L50>
+<L50>:
                	movsd	-0x98(%rbp), %xmm0
                	mulsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L133>
-               	movq	%r12, %rdi
-               	callq	 <L132>
-<L132>:
-               	movq	%rax, %r13
-               	jmp	 <L135>
-<L133>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L134>
-<L134>:
-               	movq	%rax, %r13
-<L135>:
+               	movq	%rax, %rdi
+               	callq	 <L51>
+<L51>:
                	movsd	-0x98(%rbp), %xmm0
                	mulsd	-0xa8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L137>
-               	movq	%r13, %rdi
-               	callq	 <L136>
-<L136>:
-               	movq	%rax, %r12
-               	jmp	 <L139>
-<L137>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L138>
-<L138>:
-               	movq	%rax, %r12
-<L139>:
+               	movq	%rax, %rdi
+               	callq	 <L52>
+<L52>:
                	movsd	-0x98(%rbp), %xmm0
                	mulsd	-0x68(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L141>
-               	movq	%r12, %rdi
-               	callq	 <L140>
-<L140>:
-               	movq	%rax, %r13
-               	jmp	 <L143>
-<L141>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L142>
-<L142>:
-               	movq	%rax, %r13
-<L143>:
+               	movq	%rax, %rdi
+               	callq	 <L53>
+<L53>:
                	movsd	-0x58(%rbp), %xmm0
                	divsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L145>
-               	movq	%r13, %rdi
-               	callq	 <L144>
-<L144>:
-               	movq	%rax, %r12
-               	jmp	 <L147>
-<L145>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L146>
-<L146>:
-               	movq	%rax, %r12
-<L147>:
+               	movq	%rax, %rdi
+               	callq	 <L54>
+<L54>:
                	movsd	-0x68(%rbp), %xmm0
                	divsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L149>
-               	movq	%r12, %rdi
-               	callq	 <L148>
-<L148>:
-               	movq	%rax, %r13
-               	jmp	 <L151>
-<L149>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L150>
-<L150>:
-               	movq	%rax, %r13
-<L151>:
+               	movq	%rax, %rdi
+               	callq	 <L55>
+<L55>:
                	movsd	-0x58(%rbp), %xmm0
                	divsd	-0xa8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L153>
-               	movq	%r13, %rdi
-               	callq	 <L152>
-<L152>:
-               	movq	%rax, %r12
-               	jmp	 <L155>
-<L153>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L154>
-<L154>:
-               	movq	%rax, %r12
-<L155>:
+               	movq	%rax, %rdi
+               	callq	 <L56>
+<L56>:
                	movsd	-0x98(%rbp), %xmm0
                	divsd	-0x58(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L157>
-               	movq	%r12, %rdi
-               	callq	 <L156>
-<L156>:
-               	movq	%rax, %r13
-               	jmp	 <L159>
-<L157>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L158>
-<L158>:
-               	movq	%rax, %r13
-<L159>:
+               	movq	%rax, %rdi
+               	callq	 <L57>
+<L57>:
                	movsd	-0xc8(%rbp), %xmm0
                	addsd	-0xc8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L161>
-               	movq	%r13, %rdi
-               	callq	 <L160>
-<L160>:
-               	movq	%rax, %r12
-               	jmp	 <L163>
-<L161>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L162>
-<L162>:
-               	movq	%rax, %r12
-<L163>:
+               	movq	%rax, %rdi
+               	callq	 <L58>
+<L58>:
                	movsd	-0x98(%rbp), %xmm14
                	ucomisd	-0xc8(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
-               	movq	%r12, %rdi
-               	callq	 <L164>
-<L164>:
+               	movq	%rax, %rdi
+               	callq	 <L59>
+<L59>:
                	xorps	%xmm0, %xmm0
                	subsd	-0xc8(%rbp), %xmm0
                	ucomisd	-0xa8(%rbp), %xmm0
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L165>
-<L165>:
-               	movq	%rax, %r12
+               	callq	 <L60>
+<L60>:
                	movsd	-0x98(%rbp), %xmm0
                	subsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L167>
-               	movq	%r12, %rdi
-               	callq	 <L166>
-<L166>:
-               	movq	%rax, %r13
-               	jmp	 <L169>
-<L167>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L168>
-<L168>:
-               	movq	%rax, %r13
-<L169>:
+               	movq	%rax, %rdi
+               	callq	 <L61>
+<L61>:
                	movsd	-0xa8(%rbp), %xmm0
                	addsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L171>
-               	movq	%r13, %rdi
-               	callq	 <L170>
-<L170>:
-               	movq	%rax, %r12
-               	jmp	 <L173>
-<L171>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L172>
-<L172>:
-               	movq	%rax, %r12
-<L173>:
+               	movq	%rax, %rdi
+               	callq	 <L62>
+<L62>:
                	movsd	-0x98(%rbp), %xmm0
                	mulsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L175>
-               	movq	%r12, %rdi
-               	callq	 <L174>
-<L174>:
-               	movq	%rax, %r13
-               	jmp	 <L177>
-<L175>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L176>
-<L176>:
-               	movq	%rax, %r13
-<L177>:
+               	movq	%rax, %rdi
+               	callq	 <L63>
+<L63>:
                	movsd	-0xa8(%rbp), %xmm0
                	mulsd	-0x88(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L179>
-               	movq	%r13, %rdi
-               	callq	 <L178>
-<L178>:
-               	movq	%rax, %r12
-               	jmp	 <L181>
-<L179>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L180>
-<L180>:
-               	movq	%rax, %r12
-<L181>:
+               	movq	%rax, %rdi
+               	callq	 <L64>
+<L64>:
                	movsd	-0x98(%rbp), %xmm0
                	divsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L183>
-               	movq	%r12, %rdi
-               	callq	 <L182>
-<L182>:
-               	movq	%rax, %r13
-               	jmp	 <L185>
-<L183>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L184>
-<L184>:
-               	movq	%rax, %r13
-<L185>:
+               	movq	%rax, %rdi
+               	callq	 <L65>
+<L65>:
                	movsd	-0x78(%rbp), %xmm0
                	divsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L187>
-               	movq	%r13, %rdi
-               	callq	 <L186>
-<L186>:
-               	movq	%rax, %r12
-               	jmp	 <L189>
-<L187>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L188>
-<L188>:
-               	movq	%rax, %r12
-<L189>:
+               	movq	%rax, %rdi
+               	callq	 <L66>
+<L66>:
                	movsd	-0x88(%rbp), %xmm0
                	divsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L191>
-               	movq	%r12, %rdi
-               	callq	 <L190>
-<L190>:
-               	movq	%rax, %r13
-               	jmp	 <L193>
-<L191>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L192>
-<L192>:
-               	movq	%rax, %r13
-<L193>:
+               	movq	%rax, %rdi
+               	callq	 <L67>
+<L67>:
                	movq	-0xb8(%rbp), %rsi
-               	movq	%r13, %rdi
-               	callq	 <L194>
-<L194>:
+               	movq	%rax, %rdi
+               	callq	 <L68>
+<L68>:
                	movsd	-0xb8(%rbp), %xmm14
                	ucomisd	-0xb8(%rbp), %xmm14
                	setne	%sil
@@ -1119,8 +443,8 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L195>
-<L195>:
+               	callq	 <L69>
+<L69>:
                	movsd	-0xb8(%rbp), %xmm14
                	ucomisd	-0xb8(%rbp), %xmm14
                	sete	%sil
@@ -1128,400 +452,124 @@ Disassembly of section __TEXT,__text:
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L196>
-<L196>:
+               	callq	 <L70>
+<L70>:
                	movsd	-0xb8(%rbp), %xmm14
                	ucomisd	-0xb8(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L197>
-<L197>:
+               	callq	 <L71>
+<L71>:
                	movsd	-0xb8(%rbp), %xmm14
                	ucomisd	-0xb8(%rbp), %xmm14
                	setae	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L198>
-<L198>:
+               	callq	 <L72>
+<L72>:
                	movsd	-0xb8(%rbp), %xmm14
-               	xorps	, %xmm14 <corpus.cases.float.special_f64.checksum+0xfef>
+               	xorps	, %xmm14 <corpus.cases.float.special_f64.checksum+0x745>
                	movsd	%xmm14, -0x108(%rbp)
                	movq	-0x108(%rbp), %rsi
                	movq	%rax, %rdi
-               	callq	 <L199>
-<L199>:
+               	callq	 <L73>
+<L73>:
                	movsd	-0x108(%rbp), %xmm2
-               	xorps	, %xmm2 <corpus.cases.float.special_f64.checksum+0x1016>
+               	xorps	, %xmm2 <corpus.cases.float.special_f64.checksum+0x76c>
                	movq	%xmm2, %rsi
                	movq	%rax, %rdi
-               	callq	 <L200>
-<L200>:
-               	movq	%rax, %r12
+               	callq	 <L74>
+<L74>:
                	movsd	-0xb8(%rbp), %xmm0
                	addsd	-0x58(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L202>
-               	movq	%r12, %rdi
-               	callq	 <L201>
-<L201>:
-               	movq	%rax, %r13
-               	jmp	 <L204>
-<L202>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L203>
-<L203>:
-               	movq	%rax, %r13
-<L204>:
+               	movq	%rax, %rdi
+               	callq	 <L75>
+<L75>:
                	movsd	-0x58(%rbp), %xmm0
                	addsd	-0xb8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L206>
-               	movq	%r13, %rdi
-               	callq	 <L205>
-<L205>:
-               	movq	%rax, %r12
-               	jmp	 <L208>
-<L206>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L207>
-<L207>:
-               	movq	%rax, %r12
-<L208>:
+               	movq	%rax, %rdi
+               	callq	 <L76>
+<L76>:
                	movsd	-0xb8(%rbp), %xmm0
                	mulsd	-0x78(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L210>
-               	movq	%r12, %rdi
-               	callq	 <L209>
-<L209>:
-               	movq	%rax, %r13
-               	jmp	 <L212>
-<L210>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L211>
-<L211>:
-               	movq	%rax, %r13
-<L212>:
+               	movq	%rax, %rdi
+               	callq	 <L77>
+<L77>:
                	movsd	-0xb8(%rbp), %xmm0
                	subsd	-0xb8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L214>
-               	movq	%r13, %rdi
-               	callq	 <L213>
-<L213>:
-               	movq	%rax, %r12
-               	jmp	 <L216>
-<L214>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L215>
-<L215>:
-               	movq	%rax, %r12
-<L216>:
+               	movq	%rax, %rdi
+               	callq	 <L78>
+<L78>:
                	movsd	-0xb8(%rbp), %xmm0
                	divsd	-0xb8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L218>
-               	movq	%r12, %rdi
-               	callq	 <L217>
-<L217>:
-               	movq	%rax, %r13
-               	jmp	 <L220>
-<L218>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L219>
-<L219>:
-               	movq	%rax, %r13
-<L220>:
+               	movq	%rax, %rdi
+               	callq	 <L79>
+<L79>:
                	movsd	-0xb8(%rbp), %xmm0
                	divsd	-0x98(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L222>
-               	movq	%r13, %rdi
-               	callq	 <L221>
-<L221>:
-               	movq	%rax, %r12
-               	jmp	 <L224>
-<L222>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L223>
-<L223>:
-               	movq	%rax, %r12
-<L224>:
-               	movsd	-0xf8(%rbp), %xmm14
-               	ucomisd	-0xf8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L226>
-               	movq	%r12, %rdi
+               	movq	%rax, %rdi
+               	callq	 <L80>
+<L80>:
+               	movq	%rax, %rdi
                	movsd	-0xf8(%rbp), %xmm0
-               	callq	 <L225>
-<L225>:
-               	movq	%rax, %r13
-               	jmp	 <L228>
-<L226>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L227>
-<L227>:
-               	movq	%rax, %r13
-<L228>:
-               	movsd	-0xe8(%rbp), %xmm14
-               	ucomisd	-0xe8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L230>
-               	movq	%r13, %rdi
+               	callq	 <L81>
+<L81>:
+               	movq	%rax, %rdi
                	movsd	-0xe8(%rbp), %xmm0
-               	callq	 <L229>
-<L229>:
-               	movq	%rax, %r12
-               	jmp	 <L232>
-<L230>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L231>
-<L231>:
-               	movq	%rax, %r12
-<L232>:
-               	movsd	-0xd8(%rbp), %xmm14
-               	ucomisd	-0xd8(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L234>
-               	movq	%r12, %rdi
+               	callq	 <L82>
+<L82>:
+               	movq	%rax, %rdi
                	movsd	-0xd8(%rbp), %xmm0
-               	callq	 <L233>
-<L233>:
-               	movq	%rax, %r13
-               	jmp	 <L236>
-<L234>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L235>
-<L235>:
-               	movq	%rax, %r13
-<L236>:
+               	callq	 <L83>
+<L83>:
                	movsd	-0xe8(%rbp), %xmm0
                	addsd	-0xf8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L238>
-               	movq	%r13, %rdi
-               	callq	 <L237>
-<L237>:
-               	movq	%rax, %r12
-               	jmp	 <L240>
-<L238>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L239>
-<L239>:
-               	movq	%rax, %r12
-<L240>:
+               	movq	%rax, %rdi
+               	callq	 <L84>
+<L84>:
                	movsd	-0xd8(%rbp), %xmm0
                	subsd	-0xf8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L242>
-               	movq	%r12, %rdi
-               	callq	 <L241>
-<L241>:
-               	movq	%rax, %r13
-               	jmp	 <L244>
-<L242>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L243>
-<L243>:
-               	movq	%rax, %r13
-<L244>:
+               	movq	%rax, %rdi
+               	callq	 <L85>
+<L85>:
                	movsd	-0xf8(%rbp), %xmm0
                	addsd	-0xf8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L246>
-               	movq	%r13, %rdi
-               	callq	 <L245>
-<L245>:
-               	movq	%rax, %r12
-               	jmp	 <L248>
-<L246>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L247>
-<L247>:
-               	movq	%rax, %r12
-<L248>:
+               	movq	%rax, %rdi
+               	callq	 <L86>
+<L86>:
                	movsd	-0xf8(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x13cf>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L250>
-               	movq	%r12, %rdi
-               	callq	 <L249>
-<L249>:
-               	movq	%rax, %r13
-               	jmp	 <L252>
-<L250>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L251>
-<L251>:
-               	movq	%rax, %r13
-<L252>:
+               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x888>
+               	movq	%rax, %rdi
+               	callq	 <L87>
+<L87>:
                	movsd	-0xf8(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x141b>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L254>
-               	movq	%r13, %rdi
-               	callq	 <L253>
-<L253>:
-               	movq	%rax, %r12
-               	jmp	 <L256>
-<L254>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L255>
-<L255>:
-               	movq	%rax, %r12
-<L256>:
+               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x8a0>
+               	movq	%rax, %rdi
+               	callq	 <L88>
+<L88>:
                	movsd	-0xf8(%rbp), %xmm0
-               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x1466>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L258>
-               	movq	%r12, %rdi
-               	callq	 <L257>
-<L257>:
-               	movq	%rax, %r13
-               	jmp	 <L260>
-<L258>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L259>
-<L259>:
-               	movq	%rax, %r13
-<L260>:
+               	xorps	, %xmm0 <corpus.cases.float.special_f64.checksum+0x8b7>
+               	movq	%rax, %rdi
+               	callq	 <L89>
+<L89>:
                	movsd	-0xf8(%rbp), %xmm0
-               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x14b2>
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L262>
-               	movq	%r13, %rdi
-               	callq	 <L261>
-<L261>:
-               	movq	%rax, %r12
-               	jmp	 <L264>
-<L262>:
-               	movq	%r13, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L263>
-<L263>:
-               	movq	%rax, %r12
-<L264>:
+               	mulsd	, %xmm0 <corpus.cases.float.special_f64.checksum+0x8cf>
+               	movq	%rax, %rdi
+               	callq	 <L90>
+<L90>:
                	movsd	-0xe8(%rbp), %xmm0
                	divsd	-0xd8(%rbp), %xmm0
-               	ucomisd	%xmm0, %xmm0
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L266>
-               	movq	%r12, %rdi
-               	callq	 <L265>
-<L265>:
-               	movq	%rax, %r13
-               	jmp	 <L268>
-<L266>:
-               	movq	%r12, %rdi
-               	movq	$-0x1, %rsi
-               	callq	 <L267>
-<L267>:
-               	movq	%rax, %r13
-<L268>:
+               	movq	%rax, %rdi
+               	callq	 <L91>
+<L91>:
                	movsd	-0xf8(%rbp), %xmm14
                	ucomisd	-0x78(%rbp), %xmm14
                	seta	%sil
                	movzbq	%sil, %rsi
-               	movq	%r13, %rdi
-               	callq	 <L269>
-<L269>:
+               	movq	%rax, %rdi
+               	callq	 <L92>
+<L92>:
                	movsd	-0xf8(%rbp), %xmm14
                	ucomisd	-0x78(%rbp), %xmm14
                	sete	%sil
@@ -1529,8 +577,8 @@ Disassembly of section __TEXT,__text:
                	andb	%r11b, %sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L270>
-<L270>:
+               	callq	 <L93>
+<L93>:
                	xorps	%xmm0, %xmm0
                	subsd	-0xf8(%rbp), %xmm0
                	movsd	-0x88(%rbp), %xmm14
@@ -1538,18 +586,18 @@ Disassembly of section __TEXT,__text:
                	seta	%sil
                	movzbq	%sil, %rsi
                	movq	%rax, %rdi
-               	callq	 <L271>
-<L271>:
+               	callq	 <L94>
+<L94>:
                	movq	%rax, %r12
                	movq	-0xd8(%rbp), %r11
                	movq	%r11, -0x128(%rbp)
                	movq	$0x0, %r13
                	cmpq	$0x3c, %r13
-               	jb	 <L272>
-               	jmp	 <L277>
-<L272>:
+               	jb	 <L95>
+               	jmp	 <L100>
+<L95>:
                	movsd	-0x128(%rbp), %xmm14
-               	mulsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x15e1>
+               	mulsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x996>
                	movsd	%xmm14, -0x118(%rbp)
                	movsd	-0x118(%rbp), %xmm14
                	ucomisd	-0x118(%rbp), %xmm14
@@ -1558,27 +606,27 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L274>
+               	jne	 <L97>
                	movq	%r12, %rdi
                	movsd	-0x118(%rbp), %xmm0
-               	callq	 <L273>
-<L273>:
+               	callq	 <L96>
+<L96>:
                	movq	%rax, %r14
-               	jmp	 <L276>
-<L274>:
+               	jmp	 <L99>
+<L97>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L275>
-<L275>:
+               	callq	 <L98>
+<L98>:
                	movq	%rax, %r14
-<L276>:
+<L99>:
                	addq	$0x1, %r13
                	movq	%r14, %r12
                	movq	-0x118(%rbp), %r11
                	movq	%r11, -0x128(%rbp)
                	cmpq	$0x3c, %r13
-               	jb	 <L272>
-<L277>:
+               	jb	 <L95>
+<L100>:
                	leaq	-0x40(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
@@ -1612,22 +660,22 @@ Disassembly of section __TEXT,__text:
                	movq	%r11, (%rax)
                	movq	$0x0, %r14
                	cmpq	$0x8, %r14
-               	jb	 <L278>
-               	jmp	 <L280>
-<L278>:
+               	jb	 <L101>
+               	jmp	 <L103>
+<L101>:
                	leaq	(%r13,%r14,8), %rax
                	movq	(%rax), %rcx
                	addq	%rbx, %rcx
                	movq	%rcx, %xmm0
                	movq	%xmm0, %rsi
                	movq	%r12, %rdi
-               	callq	 <L279>
-<L279>:
+               	callq	 <L102>
+<L102>:
                	addq	$0x1, %r14
                	movq	%rax, %r12
                	cmpq	$0x8, %r14
-               	jb	 <L278>
-<L280>:
+               	jb	 <L101>
+<L103>:
                	movsd	-0xc8(%rbp), %xmm15
                	cvtsd2ss	%xmm15, %xmm0
                	movsd	-0xf8(%rbp), %xmm15
@@ -1655,32 +703,32 @@ Disassembly of section __TEXT,__text:
                	cvtsd2ss	%xmm15, %xmm14
                	movss	%xmm14, -0x188(%rbp)
                	movq	%r12, %rdi
-               	callq	 <L281>
-<L281>:
+               	callq	 <L104>
+<L104>:
                	movq	%rax, %rdi
                	movss	-0x138(%rbp), %xmm0
-               	callq	 <L282>
-<L282>:
+               	callq	 <L105>
+<L105>:
                	movq	%rax, %rdi
                	movss	-0x148(%rbp), %xmm0
-               	callq	 <L283>
-<L283>:
+               	callq	 <L106>
+<L106>:
                	movq	%rax, %rdi
                	movss	-0x158(%rbp), %xmm0
-               	callq	 <L284>
-<L284>:
+               	callq	 <L107>
+<L107>:
                	movq	%rax, %rdi
                	movss	-0x168(%rbp), %xmm0
-               	callq	 <L285>
-<L285>:
+               	callq	 <L108>
+<L108>:
                	movq	%rax, %rdi
                	movss	-0x178(%rbp), %xmm0
-               	callq	 <L286>
-<L286>:
+               	callq	 <L109>
+<L109>:
                	movq	%rax, %rdi
                	movss	-0x188(%rbp), %xmm0
-               	callq	 <L287>
-<L287>:
+               	callq	 <L110>
+<L110>:
                	movq	%rax, %r12
                	movss	-0x148(%rbp), %xmm15
                	cvtss2sd	%xmm15, %xmm0
@@ -1690,19 +738,19 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L289>
+               	jne	 <L112>
                	movq	%r12, %rdi
-               	callq	 <L288>
-<L288>:
+               	callq	 <L111>
+<L111>:
                	movq	%rax, %r13
-               	jmp	 <L291>
-<L289>:
+               	jmp	 <L114>
+<L112>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L290>
-<L290>:
+               	callq	 <L113>
+<L113>:
                	movq	%rax, %r13
-<L291>:
+<L114>:
                	movss	-0x178(%rbp), %xmm15
                	cvtss2sd	%xmm15, %xmm0
                	ucomisd	%xmm0, %xmm0
@@ -1711,19 +759,19 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L293>
+               	jne	 <L116>
                	movq	%r13, %rdi
-               	callq	 <L292>
-<L292>:
+               	callq	 <L115>
+<L115>:
                	movq	%rax, %r12
-               	jmp	 <L295>
-<L293>:
+               	jmp	 <L118>
+<L116>:
                	movq	%r13, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L294>
-<L294>:
+               	callq	 <L117>
+<L117>:
                	movq	%rax, %r12
-<L295>:
+<L118>:
                	movss	-0x188(%rbp), %xmm15
                	cvtss2sd	%xmm15, %xmm0
                	ucomisd	%xmm0, %xmm0
@@ -1732,19 +780,19 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L297>
+               	jne	 <L120>
                	movq	%r12, %rdi
-               	callq	 <L296>
-<L296>:
+               	callq	 <L119>
+<L119>:
                	movq	%rax, %r13
-               	jmp	 <L299>
-<L297>:
+               	jmp	 <L122>
+<L120>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L298>
-<L298>:
+               	callq	 <L121>
+<L121>:
                	movq	%rax, %r13
-<L299>:
+<L122>:
                	movabsq	$0x20000000000000, %rax ## imm = 0x20000000000000
                	addq	%rbx, %rax
                	movabsq	$0x20000000000001, %r12 ## imm = 0x20000000000001
@@ -1761,168 +809,168 @@ Disassembly of section __TEXT,__text:
                	movq	%r8, -0x198(%rbp)
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L300>
+               	jl	 <L123>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L301>
-<L300>:
+               	jmp	 <L124>
+<L123>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L301>:
+<L124>:
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L303>
+               	jne	 <L126>
                	movq	%r13, %rdi
-               	callq	 <L302>
-<L302>:
+               	callq	 <L125>
+<L125>:
                	movq	%rax, %r8
                	movq	%r8, -0x48(%rbp)
-               	jmp	 <L305>
-<L303>:
+               	jmp	 <L128>
+<L126>:
                	movq	%r13, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L304>
-<L304>:
+               	callq	 <L127>
+<L127>:
                	movq	%rax, %r8
                	movq	%r8, -0x48(%rbp)
-<L305>:
+<L128>:
                	movq	%r12, %r11
                	testq	%r11, %r11
-               	jl	 <L306>
+               	jl	 <L129>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L307>
-<L306>:
+               	jmp	 <L130>
+<L129>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L307>:
+<L130>:
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L309>
+               	jne	 <L132>
                	movq	-0x48(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L308>
-<L308>:
+               	callq	 <L131>
+<L131>:
                	movq	%rax, %r12
-               	jmp	 <L311>
-<L309>:
+               	jmp	 <L134>
+<L132>:
                	movq	-0x48(%rbp), %r8
                	movq	%r8, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L310>
-<L310>:
+               	callq	 <L133>
+<L133>:
                	movq	%rax, %r12
-<L311>:
+<L134>:
                	movq	%r14, %r11
                	testq	%r11, %r11
-               	jl	 <L312>
+               	jl	 <L135>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L313>
-<L312>:
+               	jmp	 <L136>
+<L135>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L313>:
+<L136>:
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L315>
+               	jne	 <L138>
                	movq	%r12, %rdi
-               	callq	 <L314>
-<L314>:
+               	callq	 <L137>
+<L137>:
                	movq	%rax, %r13
-               	jmp	 <L317>
-<L315>:
+               	jmp	 <L140>
+<L138>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L316>
-<L316>:
+               	callq	 <L139>
+<L139>:
                	movq	%rax, %r13
-<L317>:
+<L140>:
                	movq	%r15, %r11
                	testq	%r11, %r11
-               	jl	 <L318>
+               	jl	 <L141>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L319>
-<L318>:
+               	jmp	 <L142>
+<L141>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L319>:
+<L142>:
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L321>
+               	jne	 <L144>
                	movq	%r13, %rdi
-               	callq	 <L320>
-<L320>:
+               	callq	 <L143>
+<L143>:
                	movq	%rax, %r12
-               	jmp	 <L323>
-<L321>:
+               	jmp	 <L146>
+<L144>:
                	movq	%r13, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L322>
-<L322>:
+               	callq	 <L145>
+<L145>:
                	movq	%rax, %r12
-<L323>:
+<L146>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L324>
+               	jl	 <L147>
                	cvtsi2sd	%r11, %xmm0
-               	jmp	 <L325>
-<L324>:
+               	jmp	 <L148>
+<L147>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm0
                	addsd	%xmm0, %xmm0
-<L325>:
+<L148>:
                	ucomisd	%xmm0, %xmm0
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L327>
+               	jne	 <L150>
                	movq	%r12, %rdi
-               	callq	 <L326>
-<L326>:
+               	callq	 <L149>
+<L149>:
                	movq	%rax, %rbx
-               	jmp	 <L329>
-<L327>:
+               	jmp	 <L152>
+<L150>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L328>
-<L328>:
+               	callq	 <L151>
+<L151>:
                	movq	%rax, %rbx
-<L329>:
+<L152>:
                	movq	-0x190(%rbp), %r8
                	movq	%r8, %r11
                	cvtsi2sd	%r11, %xmm0
@@ -1932,19 +980,19 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L331>
+               	jne	 <L154>
                	movq	%rbx, %rdi
-               	callq	 <L330>
-<L330>:
+               	callq	 <L153>
+<L153>:
                	movq	%rax, %r12
-               	jmp	 <L333>
-<L331>:
+               	jmp	 <L156>
+<L154>:
                	movq	%rbx, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L332>
-<L332>:
+               	callq	 <L155>
+<L155>:
                	movq	%rax, %r12
-<L333>:
+<L156>:
                	movq	-0x198(%rbp), %r8
                	movq	%r8, %r11
                	cvtsi2sd	%r11, %xmm0
@@ -1954,147 +1002,147 @@ Disassembly of section __TEXT,__text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L335>
+               	jne	 <L158>
                	movq	%r12, %rdi
-               	callq	 <L334>
-<L334>:
+               	callq	 <L157>
+<L157>:
                	movq	%rax, %rbx
-               	jmp	 <L337>
-<L335>:
+               	jmp	 <L160>
+<L158>:
                	movq	%r12, %rdi
                	movq	$-0x1, %rsi
-               	callq	 <L336>
-<L336>:
+               	callq	 <L159>
+<L159>:
                	movq	%rax, %rbx
-<L337>:
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1c6b>
+<L160>:
+               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1020>
                	mulsd	-0x58(%rbp), %xmm14
                	movsd	%xmm14, -0x1a8(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1c83>
+               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1038>
                	mulsd	-0x58(%rbp), %xmm14
                	movsd	%xmm14, -0x1b8(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1c9b>
+               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1050>
                	mulsd	-0x58(%rbp), %xmm14
                	movsd	%xmm14, -0x1c8(%rbp)
                	xorps	%xmm14, %xmm14
                	subsd	-0x1a8(%rbp), %xmm14
                	movsd	%xmm14, -0x1d8(%rbp)
-               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1cc9>
+               	movsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x107e>
                	mulsd	-0x58(%rbp), %xmm14
                	movsd	%xmm14, -0x1e8(%rbp)
                	movsd	-0x1a8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1cea>
-               	jb	 <L338>
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x109f>
+               	jb	 <L161>
                	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1cfd>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10b2>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L339>
-<L338>:
+               	jmp	 <L162>
+<L161>:
                	cvttsd2si	%xmm14, %r11
-<L339>:
+<L162>:
                	movq	%r11, %rsi
                	movq	%rbx, %rdi
-               	callq	 <L340>
-<L340>:
+               	callq	 <L163>
+<L163>:
                	movsd	-0x1b8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1d36>
-               	jb	 <L341>
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10eb>
+               	jb	 <L164>
                	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1d49>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x10fe>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L342>
-<L341>:
+               	jmp	 <L165>
+<L164>:
                	cvttsd2si	%xmm14, %r11
-<L342>:
+<L165>:
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L343>
-<L343>:
+               	callq	 <L166>
+<L166>:
                	movsd	-0x1c8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1d82>
-               	jb	 <L344>
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1137>
+               	jb	 <L167>
                	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1d95>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x114a>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L345>
-<L344>:
+               	jmp	 <L168>
+<L167>:
                	cvttsd2si	%xmm14, %r11
-<L345>:
+<L168>:
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L346>
-<L346>:
+               	callq	 <L169>
+<L169>:
                	movsd	-0x1e8(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1dce>
-               	jb	 <L347>
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1183>
+               	jb	 <L170>
                	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1de1>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1196>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L348>
-<L347>:
+               	jmp	 <L171>
+<L170>:
                	cvttsd2si	%xmm14, %r11
-<L348>:
+<L171>:
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L349>
-<L349>:
+               	callq	 <L172>
+<L172>:
                	movsd	-0x78(%rbp), %xmm14
-               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1e17>
-               	jb	 <L350>
+               	ucomisd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x11cc>
+               	jb	 <L173>
                	movaps	%xmm14, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1e2a>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x11df>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 ## imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L351>
-<L350>:
+               	jmp	 <L174>
+<L173>:
                	cvttsd2si	%xmm14, %r11
-<L351>:
+<L174>:
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L352>
-<L352>:
+               	callq	 <L175>
+<L175>:
                	movsd	-0x1d8(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L353>
-<L353>:
+               	callq	 <L176>
+<L176>:
                	movsd	-0x1c8(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L354>
-<L354>:
+               	callq	 <L177>
+<L177>:
                	xorps	%xmm1, %xmm1
                	subsd	-0x1e8(%rbp), %xmm1
                	cvttsd2si	%xmm1, %r11
                	movq	%r11, %rsi
                	movq	%rax, %rdi
-               	callq	 <L355>
-<L355>:
+               	callq	 <L178>
+<L178>:
                	movsd	-0x1d8(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11d
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L356>
-<L356>:
+               	callq	 <L179>
+<L179>:
                	movsd	-0x1a8(%rbp), %xmm14
                	cvttsd2si	%xmm14, %r11
                	movl	%r11d, %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L357>
-<L357>:
+               	callq	 <L180>
+<L180>:
                	movq	-0x1f8(%rbp), %rbx
                	movq	-0x200(%rbp), %r12
                	movq	-0x208(%rbp), %r13

--- a/test/golden/x86_64-darwin/mem/global_data.dis
+++ b/test/golden/x86_64-darwin/mem/global_data.dis
@@ -260,10 +260,16 @@ Disassembly of section __TEXT,__text:
                	divq	%rsi
                	movq	%rdx, %rsi
                	leaq	(%rcx,%rsi,2), %rbx
-               	movzwl	(%rbx), %ecx
-               	addl	$0x64, %ecx
-               	movw	%cx, (%rbx)
-               	leaq	, %rcx <corpus.cases.mem.global_data.advance+0x1d6>
+               	movzwl	(%rbx), %esi
+               	addl	$0x64, %esi
+               	movq	%rdi, %rax
+               	movq	$0x3, %rbx
+               	xorl	%edx, %edx
+               	divq	%rbx
+               	movq	%rdx, %rbx
+               	leaq	(%rcx,%rbx,2), %r12
+               	movw	%si, (%r12)
+               	leaq	, %rcx <corpus.cases.mem.global_data.advance+0x1ee>
                	movl	(%rcx), %esi
                	movl	%edi, %ebx
                	subl	%ebx, %esi
@@ -280,12 +286,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.mem.global_data.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xf0, %rsp
-               	movq	%rbx, -0xc8(%rbp)
-               	movq	%r12, -0xd0(%rbp)
-               	movq	%r13, -0xd8(%rbp)
-               	movq	%r14, -0xe0(%rbp)
-               	movq	%r15, -0xe8(%rbp)
+               	subq	$0x100, %rsp            ## imm = 0x100
+               	movq	%rbx, -0xd8(%rbp)
+               	movq	%r12, -0xe0(%rbp)
+               	movq	%r13, -0xe8(%rbp)
+               	movq	%r14, -0xf0(%rbp)
+               	movq	%r15, -0xf8(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -311,7 +317,7 @@ Disassembly of section __TEXT,__text:
                	leaq	, %r14 <corpus.cases.mem.global_data.checksum+0x8a>
                	leaq	, %r15 <corpus.cases.mem.global_data.checksum+0x97>
                	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0x96>
-               	movq	%r8, -0xb8(%rbp)
+               	movq	%r8, -0xc8(%rbp)
                	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xb4>
                	movq	%r8, -0x18(%rbp)
                	leaq	, %r8 <corpus.cases.mem.global_data.checksum+0xc7>
@@ -319,13 +325,13 @@ Disassembly of section __TEXT,__text:
                	movq	%rcx, %r8
                	movq	%r8, -0x28(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0xb0(%rbp)
-               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	-0xc0(%rbp), %r8
                	cmpq	$0x5, %r8
                	jb	 <L5>
                	jmp	 <L9>
 <L5>:
-               	movq	-0xb0(%rbp), %r8
+               	movq	-0xc0(%rbp), %r8
                	movq	%r8, %rdi
                	addq	$0x1, %rdi
                	movq	%rdi, %r8
@@ -450,10 +456,10 @@ Disassembly of section __TEXT,__text:
                	addq	%r8, %rdi
                	movq	%rdi, (%r15)
                	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x30a>
-               	movq	-0xb8(%rbp), %r8
+               	movq	-0xc8(%rbp), %r8
                	movq	%rdi, (%r8)
                	movq	, %rdi <corpus.cases.mem.global_data.checksum+0x323>
-               	movq	-0xb8(%rbp), %r8
+               	movq	-0xc8(%rbp), %r8
                	movq	%rdi, 0x8(%r8)
                	movq	-0x30(%rbp), %r8
                	movq	%r8, %rax
@@ -466,63 +472,75 @@ Disassembly of section __TEXT,__text:
                	movq	%r8, -0x98(%rbp)
                	movq	-0x98(%rbp), %r8
                	movzwl	(%r8), %edi
-               	addl	$0x64, %edi
-               	movq	-0x98(%rbp), %r8
-               	movw	%di, (%r8)
-               	movq	-0x20(%rbp), %r9
-               	movl	(%r9), %r8d
+               	movl	%edi, %r8d
+               	addl	$0x64, %r8d
                	movq	%r8, -0xa0(%rbp)
                	movq	-0x30(%rbp), %r8
-               	movl	%r8d, %edi
+               	movq	%r8, %rax
+               	movq	$0x3, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	movq	-0x18(%rbp), %r9
+               	leaq	(%r9,%rdi,2), %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	-0xa8(%rbp), %r8
                	movq	-0xa0(%rbp), %r9
+               	movw	%r9w, (%r8)
+               	movq	-0x20(%rbp), %r9
+               	movl	(%r9), %r8d
+               	movq	%r8, -0xb0(%rbp)
+               	movq	-0x30(%rbp), %r8
+               	movl	%r8d, %edi
+               	movq	-0xb0(%rbp), %r9
                	movl	%r9d, %r8d
                	subl	%edi, %r8d
-               	movq	%r8, -0xa8(%rbp)
+               	movq	%r8, -0xb8(%rbp)
                	movq	-0x20(%rbp), %r8
-               	movq	-0xa8(%rbp), %r9
+               	movq	-0xb8(%rbp), %r9
                	movl	%r9d, (%r8)
                	movq	-0x28(%rbp), %r8
                	movq	%r8, %rdi
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rdi
-               	movq	-0xb0(%rbp), %r8
+               	movq	-0xc0(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rdi, %r8
                	movq	%r8, -0x28(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0xb0(%rbp)
-               	movq	-0xb0(%rbp), %r8
+               	movq	%r8, -0xc0(%rbp)
+               	movq	-0xc0(%rbp), %r8
                	cmpq	$0x5, %r8
                	jb	 <L5>
 <L9>:
-               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x3e1>
+               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x418>
                	movabsq	$-0x61c8864680b583eb, %r11 ## imm = 0x9E3779B97F4A7C15
                	xorq	%r11, %rcx
-               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x3f5>
-               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x3fc>
+               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x42c>
+               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x433>
                	movq	-0x28(%rbp), %r8
                	movq	%r8, %rdi
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rdi
                	leaq	-0x10(%rbp), %rcx
-               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x416>
+               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x44d>
                	movq	%rsi, (%rcx)
-               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x428>
+               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x45f>
                	movq	%rsi, 0x8(%rcx)
                	leaq	0x8(%rcx), %rsi
                	movq	(%rsi), %rbx
                	addq	$0x1, %rbx
                	movq	%rbx, (%rsi)
                	movq	(%rcx), %rsi
-               	movq	%rsi,  <corpus.cases.mem.global_data.checksum+0x43c>
+               	movq	%rsi,  <corpus.cases.mem.global_data.checksum+0x473>
                	movq	0x8(%rcx), %rsi
-               	movq	%rsi,  <corpus.cases.mem.global_data.checksum+0x44f>
-               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x44e>
+               	movq	%rsi,  <corpus.cases.mem.global_data.checksum+0x486>
+               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x485>
                	movzwl	(%rcx), %esi
-               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x45a>
+               	leaq	, %rcx <corpus.cases.mem.global_data.checksum+0x491>
                	movzbl	(%rcx), %ebx
                	leaq	, %rcx <L11>
                	movq	(%rcx), %r12
@@ -541,11 +559,11 @@ Disassembly of section __TEXT,__text:
 <L14>:
                	movq	%rax, %rcx
                	movq	%rcx, %rax
-               	movq	-0xc8(%rbp), %rbx
-               	movq	-0xd0(%rbp), %r12
-               	movq	-0xd8(%rbp), %r13
-               	movq	-0xe0(%rbp), %r14
-               	movq	-0xe8(%rbp), %r15
+               	movq	-0xd8(%rbp), %rbx
+               	movq	-0xe0(%rbp), %r12
+               	movq	-0xe8(%rbp), %r13
+               	movq	-0xf0(%rbp), %r14
+               	movq	-0xf8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/autovec_loop.dis
+++ b/test/golden/x86_64-darwin/vec/autovec_loop.dis
@@ -5,12 +5,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.autovec_loop.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x970, %rsp            ## imm = 0x970
-               	movq	%rbx, -0x948(%rbp)
-               	movq	%r12, -0x950(%rbp)
-               	movq	%r13, -0x958(%rbp)
-               	movq	%r14, -0x960(%rbp)
-               	movq	%r15, -0x968(%rbp)
+               	subq	$0x980, %rsp            ## imm = 0x980
+               	movq	%rbx, -0x958(%rbp)
+               	movq	%r12, -0x960(%rbp)
+               	movq	%r13, -0x968(%rbp)
+               	movq	%r14, -0x970(%rbp)
+               	movq	%r15, -0x978(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -39,7 +39,7 @@ Disassembly of section __TEXT,__text:
                	cvtsi2ss	%r11, %xmm14
                	addss	%xmm14, %xmm14
 <L2>:
-               	movss	%xmm14, -0x930(%rbp)
+               	movss	%xmm14, -0x940(%rbp)
                	leaq	-0x10c(%rbp), %rbx
                	movq	$0x0, (%rbx)
                	movq	$0x0, 0x8(%rbx)
@@ -204,7 +204,7 @@ Disassembly of section __TEXT,__text:
 <L6>:
                	movq	-0x8a0(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x938(%rbp)
+               	movq	%r8, -0x948(%rbp)
                	movq	$0x0, %r13
                	cmpq	%r12, %r13
                	jb	 <L7>
@@ -213,7 +213,7 @@ Disassembly of section __TEXT,__text:
                	leaq	(%r15,%r13,4), %rsi
                	movl	(%rsi), %r8d
                	movq	%r8, -0x8c0(%rbp)
-               	movq	-0x938(%rbp), %r8
+               	movq	-0x948(%rbp), %r8
                	movq	%r8, %rdi
                	movq	-0x8c0(%rbp), %r8
                	movl	%r8d, %esi
@@ -222,7 +222,7 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rcx
                	addq	$0x1, %r13
                	movq	%rcx, %r8
-               	movq	%r8, -0x938(%rbp)
+               	movq	%r8, -0x948(%rbp)
                	cmpq	%r12, %r13
                	jb	 <L7>
 <L9>:
@@ -255,7 +255,7 @@ Disassembly of section __TEXT,__text:
                	cmpq	%r12, %rsi
                	jb	 <L10>
 <L11>:
-               	movq	-0x938(%rbp), %r8
+               	movq	-0x948(%rbp), %r8
                	movq	%r8, %rdi
                	movq	-0x8d0(%rbp), %r8
                	movl	%r8d, %esi
@@ -354,13 +354,13 @@ Disassembly of section __TEXT,__text:
                	movq	-0x8e0(%rbp), %r8
                	movq	%r8, %r14
                	movq	$0x0, %r8
-               	movq	%r8, -0x940(%rbp)
-               	movq	-0x940(%rbp), %r8
+               	movq	%r8, -0x950(%rbp)
+               	movq	-0x950(%rbp), %r8
                	cmpq	%r12, %r8
                	jb	 <L18>
                	jmp	 <L20>
 <L18>:
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x950(%rbp), %r8
                	leaq	(%r13,%r8,4), %rsi
                	movl	(%rsi), %r8d
                	movq	%r8, -0x8f0(%rbp)
@@ -370,12 +370,12 @@ Disassembly of section __TEXT,__text:
                	callq	 <L19>
 <L19>:
                	movq	%rax, %r14
-               	movq	-0x940(%rbp), %r8
+               	movq	-0x950(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rcx, %r8
-               	movq	%r8, -0x940(%rbp)
-               	movq	-0x940(%rbp), %r8
+               	movq	%r8, -0x950(%rbp)
+               	movq	-0x950(%rbp), %r8
                	cmpq	%r12, %r8
                	jb	 <L18>
 <L20>:
@@ -587,7 +587,7 @@ Disassembly of section __TEXT,__text:
                	addss	%xmm1, %xmm1
 <L35>:
                	movss	%xmm1, %xmm2            ## xmm2 = xmm1[0],xmm2[1,2,3]
-               	addss	-0x930(%rbp), %xmm2
+               	addss	-0x940(%rbp), %xmm2
                	leaq	(%rbx,%rcx,4), %rsi
                	movss	%xmm2, (%rsi)
                	movss	, %xmm2 <corpus.cases.vec.autovec_loop.checksum+0xea6>
@@ -619,38 +619,52 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x80(%r13)
                	movq	$0x0, 0x88(%r13)
                	movl	$0x0, 0x90(%r13)
-               	leaq	(%rbx), %rcx
                	movq	-0x8b8(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rsi
+               	movabsq	$-0x100000001, %r11     ## imm = 0xFFFFFFFEFFFFFFFF
+               	cmpq	%r11, %r8
+               	setbe	%cl
+               	movzbq	%cl, %rcx
+               	andl	$0x1, %ecx
+               	andl	$0x1, %ecx
+               	andl	$0x1, %ecx
+               	movl	%ecx, %r8d
+               	andl	$0x1, %r8d
+               	movq	%r8, -0x8f8(%rbp)
+               	leaq	(%rbx), %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	leaq	(%rbx,%r8,4), %rdi
                	leaq	(%r12), %r8
-               	movq	%r8, -0x900(%rbp)
+               	movq	%r8, -0x908(%rbp)
                	movq	-0x8b8(%rbp), %r9
                	leaq	(%r12,%r9,4), %r8
-               	movq	%r8, -0x908(%rbp)
+               	movq	%r8, -0x910(%rbp)
                	leaq	(%r13), %r8
-               	movq	%r8, -0x8f8(%rbp)
+               	movq	%r8, -0x900(%rbp)
                	movq	-0x8b8(%rbp), %r8
-               	leaq	(%r13,%r8,4), %rdi
-               	cmpq	%rcx, %rdi
-               	setbe	%r15b
-               	movzbq	%r15b, %r15
-               	movq	-0x8f8(%rbp), %r8
-               	cmpq	%r8, %rsi
+               	leaq	(%r13,%r8,4), %r15
+               	cmpq	%rsi, %r15
                	setbe	%cl
                	movzbq	%cl, %rcx
-               	orl	%ecx, %r15d
                	movq	-0x900(%rbp), %r8
                	cmpq	%r8, %rdi
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	movq	-0x908(%rbp), %r8
-               	movq	-0x8f8(%rbp), %r9
-               	cmpq	%r9, %r8
                	setbe	%sil
                	movzbq	%sil, %rsi
                	orl	%esi, %ecx
-               	andl	%ecx, %r15d
-               	testb	%r15b, %r15b
+               	movq	-0x908(%rbp), %r8
+               	cmpq	%r8, %r15
+               	setbe	%sil
+               	movzbq	%sil, %rsi
+               	movq	-0x910(%rbp), %r8
+               	movq	-0x900(%rbp), %r9
+               	cmpq	%r9, %r8
+               	setbe	%dil
+               	movzbq	%dil, %rdi
+               	orl	%edi, %esi
+               	andl	%esi, %ecx
+               	movq	-0x8f8(%rbp), %r8
+               	movl	%r8d, %esi
+               	andl	%ecx, %esi
+               	testb	%sil, %sil
                	jne	 <L38>
                	movq	$0x0, %rcx
                	movq	-0x8b8(%rbp), %r8
@@ -672,43 +686,46 @@ Disassembly of section __TEXT,__text:
                	jb	 <L37>
                	jmp	 <L42>
 <L38>:
+               	movq	$0x0, %rcx
+               	movq	%rcx, %rsi
+               	addq	$0x4, %rsi
                	movq	-0x8b8(%rbp), %r8
-               	movq	%r8, %rcx
-               	subq	$0x4, %rcx
-               	movq	$0x0, %rsi
-               	cmpq	%rcx, %rsi
-               	jle	 <L39>
+               	cmpq	%r8, %rsi
+               	jbe	 <L39>
                	jmp	 <L40>
 <L39>:
-               	leaq	(%rbx,%rsi,4), %rdi
-               	movups	(%rdi), %xmm0
-               	leaq	(%r12,%rsi,4), %rdi
-               	movups	(%rdi), %xmm1
+               	leaq	(%rbx,%rcx,4), %rsi
+               	movups	(%rsi), %xmm0
+               	leaq	(%r12,%rcx,4), %rsi
+               	movups	(%rsi), %xmm1
                	movaps	%xmm0, %xmm14
                	mulps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	(%r13,%rsi,4), %rdi
-               	movups	%xmm0, (%rdi)
+               	leaq	(%r13,%rcx,4), %rsi
+               	movups	%xmm0, (%rsi)
+               	addq	$0x4, %rcx
+               	movq	%rcx, %rsi
                	addq	$0x4, %rsi
-               	cmpq	%rcx, %rsi
-               	jle	 <L39>
-<L40>:
                	movq	-0x8b8(%rbp), %r8
                	cmpq	%r8, %rsi
+               	jbe	 <L39>
+<L40>:
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rcx
                	jb	 <L41>
                	jmp	 <L42>
 <L41>:
-               	leaq	(%rbx,%rsi,4), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r12,%rsi,4), %rcx
-               	movss	(%rcx), %xmm1
+               	leaq	(%rbx,%rcx,4), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%r12,%rcx,4), %rsi
+               	movss	(%rsi), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	leaq	(%r13,%rsi,4), %rcx
-               	movss	%xmm2, (%rcx)
-               	addq	$0x1, %rsi
+               	leaq	(%r13,%rcx,4), %rsi
+               	movss	%xmm2, (%rsi)
+               	addq	$0x1, %rcx
                	movq	-0x8b8(%rbp), %r8
-               	cmpq	%r8, %rsi
+               	cmpq	%r8, %rcx
                	jb	 <L41>
 <L42>:
                	movq	$0x0, %r15
@@ -748,38 +765,52 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x80(%r13)
                	movq	$0x0, 0x88(%r13)
                	movl	$0x0, 0x90(%r13)
-               	leaq	(%rbx), %rcx
                	movq	-0x8b8(%rbp), %r8
-               	leaq	(%rbx,%r8,4), %rsi
-               	leaq	(%r12), %r8
-               	movq	%r8, -0x918(%rbp)
-               	movq	-0x8b8(%rbp), %r9
-               	leaq	(%r12,%r9,4), %r8
-               	movq	%r8, -0x920(%rbp)
-               	leaq	(%r13), %r8
-               	movq	%r8, -0x910(%rbp)
-               	movq	-0x8b8(%rbp), %r8
-               	leaq	(%r13,%r8,4), %rdi
-               	cmpq	%rcx, %rdi
-               	setbe	%r15b
-               	movzbq	%r15b, %r15
-               	movq	-0x910(%rbp), %r8
-               	cmpq	%r8, %rsi
+               	movabsq	$-0x100000001, %r11     ## imm = 0xFFFFFFFEFFFFFFFF
+               	cmpq	%r11, %r8
                	setbe	%cl
                	movzbq	%cl, %rcx
-               	orl	%ecx, %r15d
-               	movq	-0x918(%rbp), %r8
-               	cmpq	%r8, %rdi
+               	andl	$0x1, %ecx
+               	andl	$0x1, %ecx
+               	andl	$0x1, %ecx
+               	movl	%ecx, %r8d
+               	andl	$0x1, %r8d
+               	movq	%r8, -0x918(%rbp)
+               	leaq	(%rbx), %rsi
+               	movq	-0x8b8(%rbp), %r8
+               	leaq	(%rbx,%r8,4), %rdi
+               	leaq	(%r12), %r8
+               	movq	%r8, -0x928(%rbp)
+               	movq	-0x8b8(%rbp), %r9
+               	leaq	(%r12,%r9,4), %r8
+               	movq	%r8, -0x930(%rbp)
+               	leaq	(%r13), %r8
+               	movq	%r8, -0x920(%rbp)
+               	movq	-0x8b8(%rbp), %r8
+               	leaq	(%r13,%r8,4), %r15
+               	cmpq	%rsi, %r15
                	setbe	%cl
                	movzbq	%cl, %rcx
                	movq	-0x920(%rbp), %r8
-               	movq	-0x910(%rbp), %r9
-               	cmpq	%r9, %r8
+               	cmpq	%r8, %rdi
                	setbe	%sil
                	movzbq	%sil, %rsi
                	orl	%esi, %ecx
-               	andl	%ecx, %r15d
-               	testb	%r15b, %r15b
+               	movq	-0x928(%rbp), %r8
+               	cmpq	%r8, %r15
+               	setbe	%sil
+               	movzbq	%sil, %rsi
+               	movq	-0x930(%rbp), %r8
+               	movq	-0x920(%rbp), %r9
+               	cmpq	%r9, %r8
+               	setbe	%dil
+               	movzbq	%dil, %rdi
+               	orl	%edi, %esi
+               	andl	%esi, %ecx
+               	movq	-0x918(%rbp), %r8
+               	movl	%r8d, %esi
+               	andl	%ecx, %esi
+               	testb	%sil, %sil
                	jne	 <L47>
                	movq	$0x0, %rcx
                	movq	-0x8b8(%rbp), %r8
@@ -801,43 +832,46 @@ Disassembly of section __TEXT,__text:
                	jb	 <L46>
                	jmp	 <L51>
 <L47>:
+               	movq	$0x0, %rcx
+               	movq	%rcx, %rsi
+               	addq	$0x4, %rsi
                	movq	-0x8b8(%rbp), %r8
-               	movq	%r8, %rcx
-               	subq	$0x4, %rcx
-               	movq	$0x0, %rsi
-               	cmpq	%rcx, %rsi
-               	jle	 <L48>
+               	cmpq	%r8, %rsi
+               	jbe	 <L48>
                	jmp	 <L49>
 <L48>:
-               	leaq	(%rbx,%rsi,4), %rdi
-               	movups	(%rdi), %xmm0
-               	leaq	(%r12,%rsi,4), %rdi
-               	movups	(%rdi), %xmm1
+               	leaq	(%rbx,%rcx,4), %rsi
+               	movups	(%rsi), %xmm0
+               	leaq	(%r12,%rcx,4), %rsi
+               	movups	(%rsi), %xmm1
                	movaps	%xmm0, %xmm14
                	divps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	(%r13,%rsi,4), %rdi
-               	movups	%xmm2, (%rdi)
+               	leaq	(%r13,%rcx,4), %rsi
+               	movups	%xmm2, (%rsi)
+               	addq	$0x4, %rcx
+               	movq	%rcx, %rsi
                	addq	$0x4, %rsi
-               	cmpq	%rcx, %rsi
-               	jle	 <L48>
-<L49>:
                	movq	-0x8b8(%rbp), %r8
                	cmpq	%r8, %rsi
+               	jbe	 <L48>
+<L49>:
+               	movq	-0x8b8(%rbp), %r8
+               	cmpq	%r8, %rcx
                	jb	 <L50>
                	jmp	 <L51>
 <L50>:
-               	leaq	(%rbx,%rsi,4), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%r12,%rsi,4), %rcx
-               	movss	(%rcx), %xmm1
+               	leaq	(%rbx,%rcx,4), %rsi
+               	movss	(%rsi), %xmm0
+               	leaq	(%r12,%rcx,4), %rsi
+               	movss	(%rsi), %xmm1
                	movss	%xmm0, %xmm2            ## xmm2 = xmm0[0],xmm2[1,2,3]
                	divss	%xmm1, %xmm2
-               	leaq	(%r13,%rsi,4), %rcx
-               	movss	%xmm2, (%rcx)
-               	addq	$0x1, %rsi
+               	leaq	(%r13,%rcx,4), %rsi
+               	movss	%xmm2, (%rsi)
+               	addq	$0x1, %rcx
                	movq	-0x8b8(%rbp), %r8
-               	cmpq	%r8, %rsi
+               	cmpq	%r8, %rcx
                	jb	 <L50>
 <L51>:
                	movq	$0x0, %rbx
@@ -877,11 +911,11 @@ Disassembly of section __TEXT,__text:
 <L57>:
                	movq	%rax, %rcx
                	movq	%rcx, %rax
-               	movq	-0x948(%rbp), %rbx
-               	movq	-0x950(%rbp), %r12
-               	movq	-0x958(%rbp), %r13
-               	movq	-0x960(%rbp), %r14
-               	movq	-0x968(%rbp), %r15
+               	movq	-0x958(%rbp), %rbx
+               	movq	-0x960(%rbp), %r12
+               	movq	-0x968(%rbp), %r13
+               	movq	-0x970(%rbp), %r14
+               	movq	-0x978(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_cmp_select.dis
+++ b/test/golden/x86_64-darwin/vec/vec_cmp_select.dis
@@ -234,12 +234,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_cmp_select.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x560, %rsp            ## imm = 0x560
-               	movq	%rbx, -0x538(%rbp)
-               	movq	%r12, -0x540(%rbp)
-               	movq	%r13, -0x548(%rbp)
-               	movq	%r14, -0x550(%rbp)
-               	movq	%r15, -0x558(%rbp)
+               	subq	$0x510, %rsp            ## imm = 0x510
+               	movq	%rbx, -0x4e8(%rbp)
+               	movq	%r12, -0x4f0(%rbp)
+               	movq	%r13, -0x4f8(%rbp)
+               	movq	%r14, -0x500(%rbp)
+               	movq	%r15, -0x508(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -257,7 +257,7 @@ Disassembly of section __TEXT,__text:
                	cvtsi2ss	%r11, %xmm14
                	addss	%xmm14, %xmm14
 <L2>:
-               	movss	%xmm14, -0x430(%rbp)
+               	movss	%xmm14, -0x3d0(%rbp)
                	movw	%bx, %r13w
                	movb	%bl, %r14b
                	leaq	-0x10(%rbp), %rcx
@@ -292,7 +292,7 @@ Disassembly of section __TEXT,__text:
                	leaq	(%rsi), %rdi
                	movl	%ecx, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x440(%rbp)
+               	movups	%xmm14, -0x3e0(%rbp)
                	leaq	0xc(%rdx), %rcx
                	movl	(%rcx), %edx
                	addl	%r12d, %edx
@@ -301,12 +301,12 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rcx), %rsi
                	movl	%edx, (%rsi)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x450(%rbp)
+               	movups	%xmm14, -0x3f0(%rbp)
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x450(%rbp), %xmm15
+               	pxor	-0x3f0(%rbp), %xmm15
                	pcmpgtd	%xmm14, %xmm15
                	movaps	%xmm15, %xmm3
                	leaq	-0x70(%rbp), %r15
@@ -337,9 +337,9 @@ Disassembly of section __TEXT,__text:
 <L6>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x450(%rbp), %xmm14
+               	movaps	-0x3f0(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x440(%rbp), %xmm15
+               	pxor	-0x3e0(%rbp), %xmm15
                	pcmpgtd	%xmm14, %xmm15
                	movaps	%xmm15, %xmm3
                	leaq	-0x80(%rbp), %r15
@@ -368,8 +368,8 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L10>
 <L10>:
-               	movaps	-0x440(%rbp), %xmm14
-               	pcmpeqd	-0x450(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
+               	pcmpeqd	-0x3f0(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x90(%rbp), %r15
                	movups	%xmm3, (%r15)
@@ -397,8 +397,8 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L14>
 <L14>:
-               	movaps	-0x440(%rbp), %xmm14
-               	pcmpeqd	-0x450(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
+               	pcmpeqd	-0x3f0(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -430,9 +430,9 @@ Disassembly of section __TEXT,__text:
 <L18>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x450(%rbp), %xmm15
+               	pxor	-0x3f0(%rbp), %xmm15
                	pcmpgtd	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
@@ -465,9 +465,9 @@ Disassembly of section __TEXT,__text:
 <L22>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x450(%rbp), %xmm14
+               	movaps	-0x3f0(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x440(%rbp), %xmm15
+               	pxor	-0x3e0(%rbp), %xmm15
                	pcmpgtd	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
@@ -500,20 +500,20 @@ Disassembly of section __TEXT,__text:
 <L26>:
                	pcmpeqd	%xmm15, %xmm15
                	pslld	$0x1f, %xmm15
-               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
                	pxor	%xmm15, %xmm14
-               	pxor	-0x450(%rbp), %xmm15
+               	pxor	-0x3f0(%rbp), %xmm15
                	pcmpgtd	%xmm14, %xmm15
-               	movaps	%xmm15, -0x460(%rbp)
-               	movaps	-0x460(%rbp), %xmm14
-               	pand	-0x440(%rbp), %xmm14
+               	movaps	%xmm15, -0x400(%rbp)
+               	movaps	-0x400(%rbp), %xmm14
+               	pand	-0x3e0(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x460(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm5, %xmm14
-               	pand	-0x450(%rbp), %xmm14
+               	pand	-0x3f0(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm4, %xmm14
                	por	%xmm5, %xmm14
@@ -544,15 +544,15 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L30>
 <L30>:
-               	movaps	-0x460(%rbp), %xmm14
-               	pand	-0x450(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm14
+               	pand	-0x3f0(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x460(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm5, %xmm14
-               	pand	-0x440(%rbp), %xmm14
+               	pand	-0x3e0(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
                	movaps	%xmm4, %xmm14
                	por	%xmm5, %xmm14
@@ -583,10 +583,10 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L34>
 <L34>:
-               	movaps	-0x440(%rbp), %xmm14
-               	paddd	-0x450(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
+               	paddd	-0x3f0(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x460(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm14
                	pand	%xmm4, %xmm14
                	movaps	%xmm14, %xmm5
                	leaq	-0xf0(%rbp), %r15
@@ -615,12 +615,12 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L38>
 <L38>:
-               	movaps	-0x460(%rbp), %xmm14
+               	movaps	-0x400(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	-0x440(%rbp), %xmm14
-               	psubd	-0x450(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
+               	psubd	-0x3f0(%rbp), %xmm14
                	movaps	%xmm14, %xmm1
                	movaps	%xmm4, %xmm14
                	por	%xmm1, %xmm14
@@ -683,7 +683,7 @@ Disassembly of section __TEXT,__text:
                	leaq	(%rsi), %rdi
                	movl	%ecx, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x470(%rbp)
+               	movups	%xmm14, -0x410(%rbp)
                	leaq	0xc(%rdx), %rcx
                	movl	(%rcx), %edx
                	addl	%r12d, %edx
@@ -692,9 +692,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rcx), %rsi
                	movl	%edx, (%rsi)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x480(%rbp)
-               	movaps	-0x480(%rbp), %xmm14
-               	pcmpgtd	-0x470(%rbp), %xmm14
+               	movups	%xmm14, -0x420(%rbp)
+               	movaps	-0x420(%rbp), %xmm14
+               	pcmpgtd	-0x410(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x170(%rbp), %r12
                	movups	%xmm3, (%r12)
@@ -722,8 +722,8 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L46>
 <L46>:
-               	movaps	-0x470(%rbp), %xmm14
-               	pcmpgtd	-0x480(%rbp), %xmm14
+               	movaps	-0x410(%rbp), %xmm14
+               	pcmpgtd	-0x420(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x180(%rbp), %r12
                	movups	%xmm3, (%r12)
@@ -751,8 +751,8 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L50>
 <L50>:
-               	movaps	-0x470(%rbp), %xmm14
-               	pcmpeqd	-0x480(%rbp), %xmm14
+               	movaps	-0x410(%rbp), %xmm14
+               	pcmpeqd	-0x420(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	-0x190(%rbp), %r12
                	movups	%xmm3, (%r12)
@@ -780,8 +780,8 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L54>
 <L54>:
-               	movaps	-0x470(%rbp), %xmm14
-               	pcmpeqd	-0x480(%rbp), %xmm14
+               	movaps	-0x410(%rbp), %xmm14
+               	pcmpeqd	-0x420(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -811,8 +811,8 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L58>
 <L58>:
-               	movaps	-0x470(%rbp), %xmm14
-               	pcmpgtd	-0x480(%rbp), %xmm14
+               	movaps	-0x410(%rbp), %xmm14
+               	pcmpgtd	-0x420(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -842,8 +842,8 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L62>
 <L62>:
-               	movaps	-0x480(%rbp), %xmm14
-               	pcmpgtd	-0x470(%rbp), %xmm14
+               	movaps	-0x420(%rbp), %xmm14
+               	pcmpgtd	-0x410(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm3
@@ -901,20 +901,20 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rdx), %rsi
                	movss	%xmm2, (%rsi)
                	movups	(%rdx), %xmm14
-               	movups	%xmm14, -0x490(%rbp)
+               	movups	%xmm14, -0x430(%rbp)
                	leaq	-0x200(%rbp), %r12
-               	movups	-0x490(%rbp), %xmm14
+               	movups	-0x430(%rbp), %xmm14
                	movups	%xmm14, (%r12)
                	leaq	(%rcx), %rdx
                	movss	(%rdx), %xmm3
                	movss	%xmm3, %xmm4            ## xmm4 = xmm3[0],xmm4[1,2,3]
-               	addss	-0x430(%rbp), %xmm4
+               	addss	-0x3d0(%rbp), %xmm4
                	leaq	-0x210(%rbp), %r15
                	movups	%xmm1, (%r15)
                	leaq	(%r15), %rcx
                	movss	%xmm4, (%rcx)
                	movups	(%r15), %xmm14
-               	movups	%xmm14, -0x4a0(%rbp)
+               	movups	%xmm14, -0x440(%rbp)
                	leaq	(%r15), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
@@ -955,284 +955,143 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L74>
 <L74>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	movaps	-0x490(%rbp), %xmm15
+               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x430(%rbp), %xmm15
                	cmpltps	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x220(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm14, -0x450(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x450(%rbp), %xmm0
                	callq	 <L75>
 <L75>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x430(%rbp), %xmm14
+               	movaps	-0x440(%rbp), %xmm15
+               	cmpltps	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L76>
 <L76>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L77>
-<L77>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L78>
-<L78>:
-               	movaps	-0x490(%rbp), %xmm14
-               	movaps	-0x4a0(%rbp), %xmm15
-               	cmpltps	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x230(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L79>
-<L79>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L80>
-<L80>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L81>
-<L81>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L82>
-<L82>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	movaps	-0x490(%rbp), %xmm15
+               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x430(%rbp), %xmm15
                	cmpeqps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x240(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L83>
-<L83>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L84>
-<L84>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L85>
-<L85>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L86>
-<L86>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	movaps	-0x490(%rbp), %xmm15
+               	callq	 <L77>
+<L77>:
+               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x430(%rbp), %xmm15
                	cmpneqps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x250(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L87>
-<L87>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L88>
-<L88>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L89>
-<L89>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L90>
-<L90>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	movaps	-0x490(%rbp), %xmm15
+               	callq	 <L78>
+<L78>:
+               	movaps	-0x440(%rbp), %xmm14
+               	movaps	-0x430(%rbp), %xmm15
                	cmpleps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x260(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L91>
-<L91>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L92>
-<L92>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L93>
-<L93>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L94>
-<L94>:
-               	movaps	-0x490(%rbp), %xmm14
-               	movaps	-0x4a0(%rbp), %xmm15
+               	callq	 <L79>
+<L79>:
+               	movaps	-0x430(%rbp), %xmm14
+               	movaps	-0x440(%rbp), %xmm15
                	cmpleps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x270(%rbp), %r12
-               	movups	%xmm0, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L95>
-<L95>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L96>
-<L96>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L97>
-<L97>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L98>
-<L98>:
-               	movaps	-0x4a0(%rbp), %xmm14
-               	movaps	-0x490(%rbp), %xmm15
-               	cmpltps	%xmm15, %xmm14
+               	callq	 <L80>
+<L80>:
+               	movaps	-0x450(%rbp), %xmm14
+               	pand	-0x440(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
-               	pand	-0x4a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	%xmm0, %xmm14
+               	movaps	-0x450(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm4
                	movaps	%xmm4, %xmm14
-               	pand	-0x490(%rbp), %xmm14
+               	pand	-0x430(%rbp), %xmm14
                	movaps	%xmm14, %xmm5
-               	movaps	%xmm3, %xmm14
+               	movaps	%xmm0, %xmm14
                	por	%xmm5, %xmm14
-               	movaps	%xmm14, -0x4b0(%rbp)
-               	leaq	-0x280(%rbp), %r12
-               	movups	-0x4b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x460(%rbp)
+               	leaq	-0x220(%rbp), %r12
+               	movups	-0x460(%rbp), %xmm14
                	movups	%xmm14, (%r12)
-               	movaps	%xmm0, %xmm14
-               	pand	-0x490(%rbp), %xmm14
-               	movaps	%xmm14, %xmm0
+               	movaps	-0x450(%rbp), %xmm14
+               	pand	-0x430(%rbp), %xmm14
+               	movaps	%xmm14, %xmm3
                	movaps	%xmm4, %xmm14
-               	pand	-0x4a0(%rbp), %xmm14
+               	pand	-0x440(%rbp), %xmm14
                	movaps	%xmm14, %xmm4
-               	movaps	%xmm0, %xmm14
+               	movaps	%xmm3, %xmm14
                	por	%xmm4, %xmm14
-               	movaps	%xmm14, -0x4c0(%rbp)
-               	leaq	-0x290(%rbp), %r15
-               	movups	-0x4c0(%rbp), %xmm14
+               	movaps	%xmm14, -0x470(%rbp)
+               	leaq	-0x230(%rbp), %r15
+               	movups	-0x470(%rbp), %xmm14
                	movups	%xmm14, (%r15)
                	leaq	(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L99>
-<L99>:
+               	callq	 <L81>
+<L81>:
                	leaq	0x4(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L100>
-<L100>:
+               	callq	 <L82>
+<L82>:
                	leaq	0x8(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L101>
-<L101>:
+               	callq	 <L83>
+<L83>:
                	leaq	0xc(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L102>
-<L102>:
+               	callq	 <L84>
+<L84>:
                	leaq	(%r15), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L103>
-<L103>:
+               	callq	 <L85>
+<L85>:
                	leaq	0x4(%r15), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L104>
-<L104>:
+               	callq	 <L86>
+<L86>:
                	leaq	0x8(%r15), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L105>
-<L105>:
+               	callq	 <L87>
+<L87>:
                	leaq	0xc(%r15), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L106>
-<L106>:
-               	movaps	-0x4c0(%rbp), %xmm14
-               	subps	-0x4b0(%rbp), %xmm14
+               	callq	 <L88>
+<L88>:
+               	movaps	-0x470(%rbp), %xmm14
+               	subps	-0x460(%rbp), %xmm14
                	movaps	%xmm14, %xmm1
-               	leaq	-0x2a0(%rbp), %r12
+               	leaq	-0x240(%rbp), %r12
                	movups	%xmm1, (%r12)
                	leaq	(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L107>
-<L107>:
+               	callq	 <L89>
+<L89>:
                	leaq	0x4(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L108>
-<L108>:
+               	callq	 <L90>
+<L90>:
                	leaq	0x8(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L109>
-<L109>:
+               	callq	 <L91>
+<L91>:
                	leaq	0xc(%r12), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rdi
-               	callq	 <L110>
-<L110>:
-               	leaq	-0x2b0(%rbp), %rcx
+               	callq	 <L92>
+<L92>:
+               	leaq	-0x250(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movabsq	$0x3ff8000000000000, %r11 ## imm = 0x3FF8000000000000
                	movq	%r11, (%rdx)
@@ -1240,104 +1099,104 @@ Disassembly of section __TEXT,__text:
                	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
                	movq	%r11, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x2c0(%rbp), %rcx
+               	leaq	-0x260(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x2d0(%rbp), %rdx
+               	leaq	-0x270(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movabsq	$0x4004000000000000, %r11 ## imm = 0x4004000000000000
                	movq	%r11, (%rsi)
                	leaq	0x8(%rdx), %rsi
                	movq	$0x0, (%rsi)
                	movups	(%rdx), %xmm14
-               	movups	%xmm14, -0x4d0(%rbp)
+               	movups	%xmm14, -0x480(%rbp)
                	leaq	(%rcx), %rdx
                	movsd	(%rdx), %xmm2
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L111>
+               	jl	 <L93>
                	cvtsi2sd	%r11, %xmm3
-               	jmp	 <L112>
-<L111>:
+               	jmp	 <L94>
+<L93>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm3
                	addsd	%xmm3, %xmm3
-<L112>:
+<L94>:
                	movsd	%xmm2, %xmm4            ## xmm4 = xmm2[0],xmm4[1]
                	addsd	%xmm3, %xmm4
-               	leaq	-0x2e0(%rbp), %rcx
+               	leaq	-0x280(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movsd	%xmm4, (%rdx)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x4e0(%rbp)
-               	movaps	-0x4e0(%rbp), %xmm14
-               	movaps	-0x4d0(%rbp), %xmm15
+               	movups	%xmm14, -0x490(%rbp)
+               	movaps	-0x490(%rbp), %xmm14
+               	movaps	-0x480(%rbp), %xmm15
                	cmpltpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x2f0(%rbp), %rbx
+               	leaq	-0x290(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L113>
-<L113>:
+               	callq	 <L95>
+<L95>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L114>
-<L114>:
-               	movaps	-0x4e0(%rbp), %xmm14
-               	movaps	-0x4d0(%rbp), %xmm15
+               	callq	 <L96>
+<L96>:
+               	movaps	-0x490(%rbp), %xmm14
+               	movaps	-0x480(%rbp), %xmm15
                	cmpeqpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x300(%rbp), %rbx
+               	leaq	-0x2a0(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L115>
-<L115>:
+               	callq	 <L97>
+<L97>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L116>
-<L116>:
-               	movaps	-0x4e0(%rbp), %xmm14
-               	movaps	-0x4d0(%rbp), %xmm15
+               	callq	 <L98>
+<L98>:
+               	movaps	-0x490(%rbp), %xmm14
+               	movaps	-0x480(%rbp), %xmm15
                	cmpneqpd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x310(%rbp), %rbx
+               	leaq	-0x2b0(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L117>
-<L117>:
+               	callq	 <L99>
+<L99>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L118>
-<L118>:
-               	movaps	-0x4d0(%rbp), %xmm14
-               	movaps	-0x4e0(%rbp), %xmm15
+               	callq	 <L100>
+<L100>:
+               	movaps	-0x480(%rbp), %xmm14
+               	movaps	-0x490(%rbp), %xmm15
                	cmplepd	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x320(%rbp), %rbx
+               	leaq	-0x2c0(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L119>
-<L119>:
+               	callq	 <L101>
+<L101>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L120>
-<L120>:
-               	leaq	-0x330(%rbp), %rcx
+               	callq	 <L102>
+<L102>:
+               	leaq	-0x2d0(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movw	$0x1, (%rdx)
                	leaq	0x2(%rcx), %rdx
@@ -1355,9 +1214,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rcx), %rdx
                	movw	$0xfffe, (%rdx)         ## imm = 0xFFFE
                	movups	(%rcx), %xmm0
-               	leaq	-0x340(%rbp), %rcx
+               	leaq	-0x2e0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x350(%rbp), %rdx
+               	leaq	-0x2f0(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movw	$0x2, (%rsi)
                	leaq	0x2(%rdx), %rsi
@@ -1375,232 +1234,232 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rdx), %rsi
                	movw	$0xffff, (%rsi)         ## imm = 0xFFFF
                	movups	(%rdx), %xmm1
-               	leaq	-0x360(%rbp), %rdx
+               	leaq	-0x300(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	(%rcx), %rsi
                	movzwl	(%rsi), %ecx
                	addl	%r13d, %ecx
-               	leaq	-0x370(%rbp), %rsi
+               	leaq	-0x310(%rbp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
                	movw	%cx, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x4f0(%rbp)
+               	movups	%xmm14, -0x4a0(%rbp)
                	leaq	0xe(%rdx), %rcx
                	movzwl	(%rcx), %edx
                	addl	%r13d, %edx
-               	leaq	-0x380(%rbp), %rcx
+               	leaq	-0x320(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0xe(%rcx), %rsi
                	movw	%dx, (%rsi)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x500(%rbp)
-               	movaps	-0x500(%rbp), %xmm14
-               	psubusw	-0x4f0(%rbp), %xmm14
+               	movups	%xmm14, -0x4b0(%rbp)
+               	movaps	-0x4b0(%rbp), %xmm14
+               	psubusw	-0x4a0(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqw	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	-0x390(%rbp), %rbx
+               	leaq	-0x330(%rbp), %rbx
                	movups	%xmm2, (%rbx)
                	leaq	(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L103>
+<L103>:
+               	leaq	0x2(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L104>
+<L104>:
+               	leaq	0x4(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L105>
+<L105>:
+               	leaq	0x6(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L106>
+<L106>:
+               	leaq	0x8(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L107>
+<L107>:
+               	leaq	0xa(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L108>
+<L108>:
+               	leaq	0xc(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L109>
+<L109>:
+               	leaq	0xe(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L110>
+<L110>:
+               	movaps	-0x4a0(%rbp), %xmm14
+               	pcmpeqw	-0x4b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x340(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L111>
+<L111>:
+               	leaq	0x2(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L112>
+<L112>:
+               	leaq	0x4(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L113>
+<L113>:
+               	leaq	0x6(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L114>
+<L114>:
+               	leaq	0x8(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L115>
+<L115>:
+               	leaq	0xa(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L116>
+<L116>:
+               	leaq	0xc(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L117>
+<L117>:
+               	leaq	0xe(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L118>
+<L118>:
+               	movaps	-0x4a0(%rbp), %xmm14
+               	psubusw	-0x4b0(%rbp), %xmm14
+               	pxor	%xmm15, %xmm15
+               	pcmpeqw	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x350(%rbp), %rbx
+               	movups	%xmm2, (%rbx)
+               	leaq	(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L119>
+<L119>:
+               	leaq	0x2(%rbx), %rcx
+               	movzwl	(%rcx), %esi
+               	movq	%rax, %rdi
+               	callq	 <L120>
+<L120>:
+               	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L121>
 <L121>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L122>
 <L122>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x8(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L123>
 <L123>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0xa(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L124>
 <L124>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0xc(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L125>
 <L125>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xe(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L126>
 <L126>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L127>
-<L127>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L128>
-<L128>:
-               	movaps	-0x4f0(%rbp), %xmm14
-               	pcmpeqw	-0x500(%rbp), %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3a0(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L129>
-<L129>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L130>
-<L130>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L131>
-<L131>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L132>
-<L132>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L133>
-<L133>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L134>
-<L134>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L135>
-<L135>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L136>
-<L136>:
-               	movaps	-0x4f0(%rbp), %xmm14
-               	psubusw	-0x500(%rbp), %xmm14
-               	pxor	%xmm15, %xmm15
-               	pcmpeqw	%xmm15, %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	leaq	-0x3b0(%rbp), %rbx
-               	movups	%xmm2, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L137>
-<L137>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L138>
-<L138>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L139>
-<L139>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L140>
-<L140>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L141>
-<L141>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L142>
-<L142>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L143>
-<L143>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L144>
-<L144>:
-               	movaps	-0x500(%rbp), %xmm14
-               	psubusw	-0x4f0(%rbp), %xmm14
+               	movaps	-0x4b0(%rbp), %xmm14
+               	psubusw	-0x4a0(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqw	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
                	movaps	%xmm2, %xmm14
-               	pand	-0x4f0(%rbp), %xmm14
+               	pand	-0x4a0(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	movaps	%xmm2, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movaps	%xmm0, %xmm14
-               	pand	-0x500(%rbp), %xmm14
+               	pand	-0x4b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movaps	%xmm3, %xmm14
                	por	%xmm0, %xmm14
                	movaps	%xmm14, %xmm3
-               	leaq	-0x3c0(%rbp), %rbx
+               	leaq	-0x360(%rbp), %rbx
                	movups	%xmm3, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L145>
-<L145>:
+               	callq	 <L127>
+<L127>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L146>
-<L146>:
+               	callq	 <L128>
+<L128>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L147>
-<L147>:
+               	callq	 <L129>
+<L129>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L148>
-<L148>:
+               	callq	 <L130>
+<L130>:
                	leaq	0x8(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L149>
-<L149>:
+               	callq	 <L131>
+<L131>:
                	leaq	0xa(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L150>
-<L150>:
+               	callq	 <L132>
+<L132>:
                	leaq	0xc(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L151>
-<L151>:
+               	callq	 <L133>
+<L133>:
                	leaq	0xe(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L152>
-<L152>:
-               	leaq	-0x3d0(%rbp), %rcx
+               	callq	 <L134>
+<L134>:
+               	leaq	-0x370(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movb	$0x1, (%rdx)
                	leaq	0x1(%rcx), %rdx
@@ -1634,9 +1493,9 @@ Disassembly of section __TEXT,__text:
                	leaq	0xf(%rcx), %rdx
                	movb	$0x1d, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x3e0(%rbp), %rcx
+               	leaq	-0x380(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	-0x3f0(%rbp), %rdx
+               	leaq	-0x390(%rbp), %rdx
                	leaq	(%rdx), %rsi
                	movb	$0x2, (%rsi)
                	leaq	0x1(%rdx), %rsi
@@ -1670,72 +1529,72 @@ Disassembly of section __TEXT,__text:
                	leaq	0xf(%rdx), %rsi
                	movb	$0x1e, (%rsi)
                	movups	(%rdx), %xmm1
-               	leaq	-0x400(%rbp), %rdx
+               	leaq	-0x3a0(%rbp), %rdx
                	movups	%xmm1, (%rdx)
                	leaq	(%rcx), %rsi
                	movzbl	(%rsi), %ecx
                	addl	%r14d, %ecx
-               	leaq	-0x410(%rbp), %rsi
+               	leaq	-0x3b0(%rbp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
                	movb	%cl, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x520(%rbp)
+               	movups	%xmm14, -0x4d0(%rbp)
                	leaq	0xf(%rdx), %rcx
                	movzbl	(%rcx), %edx
                	addl	%r14d, %edx
-               	leaq	-0x420(%rbp), %rcx
+               	leaq	-0x3c0(%rbp), %rcx
                	movups	%xmm1, (%rcx)
                	leaq	0xf(%rcx), %rsi
                	movb	%dl, (%rsi)
                	movups	(%rcx), %xmm14
-               	movups	%xmm14, -0x530(%rbp)
-               	movaps	-0x530(%rbp), %xmm14
-               	psubusb	-0x520(%rbp), %xmm14
+               	movups	%xmm14, -0x4e0(%rbp)
+               	movaps	-0x4e0(%rbp), %xmm14
+               	psubusb	-0x4d0(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqb	%xmm15, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, -0x510(%rbp)
+               	movaps	%xmm14, -0x4c0(%rbp)
                	movq	%rax, %rdi
-               	movups	-0x510(%rbp), %xmm0
-               	callq	 <L153>
-<L153>:
-               	movaps	-0x520(%rbp), %xmm14
-               	pcmpeqb	-0x530(%rbp), %xmm14
+               	movups	-0x4c0(%rbp), %xmm0
+               	callq	 <L135>
+<L135>:
+               	movaps	-0x4d0(%rbp), %xmm14
+               	pcmpeqb	-0x4e0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L154>
-<L154>:
-               	movaps	-0x530(%rbp), %xmm14
-               	psubusb	-0x520(%rbp), %xmm14
+               	callq	 <L136>
+<L136>:
+               	movaps	-0x4e0(%rbp), %xmm14
+               	psubusb	-0x4d0(%rbp), %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqb	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L155>
-<L155>:
-               	movaps	-0x510(%rbp), %xmm14
-               	pand	-0x520(%rbp), %xmm14
+               	callq	 <L137>
+<L137>:
+               	movaps	-0x4c0(%rbp), %xmm14
+               	pand	-0x4d0(%rbp), %xmm14
                	movaps	%xmm14, %xmm0
-               	movaps	-0x510(%rbp), %xmm14
+               	movaps	-0x4c0(%rbp), %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm2
                	movaps	%xmm2, %xmm14
-               	pand	-0x530(%rbp), %xmm14
+               	pand	-0x4e0(%rbp), %xmm14
                	movaps	%xmm14, %xmm2
                	movaps	%xmm0, %xmm14
                	por	%xmm2, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	callq	 <L156>
-<L156>:
-               	movq	-0x538(%rbp), %rbx
-               	movq	-0x540(%rbp), %r12
-               	movq	-0x548(%rbp), %r13
-               	movq	-0x550(%rbp), %r14
-               	movq	-0x558(%rbp), %r15
+               	callq	 <L138>
+<L138>:
+               	movq	-0x4e8(%rbp), %rbx
+               	movq	-0x4f0(%rbp), %r12
+               	movq	-0x4f8(%rbp), %r13
+               	movq	-0x500(%rbp), %r14
+               	movq	-0x508(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_i16x4.dis
+++ b/test/golden/x86_64-darwin/vec/vec_i16x4.dis
@@ -36,11 +36,11 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_i16x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x210, %rsp            ## imm = 0x210
-               	movq	%rbx, -0x1f8(%rbp)
-               	movq	%r12, -0x200(%rbp)
-               	movq	%r13, -0x208(%rbp)
-               	movq	%r14, -0x210(%rbp)
+               	subq	$0x1f0, %rsp            ## imm = 0x1F0
+               	movq	%rbx, -0x1d8(%rbp)
+               	movq	%r12, -0x1e0(%rbp)
+               	movq	%r13, -0x1e8(%rbp)
+               	movq	%r14, -0x1f0(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -79,7 +79,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x6(%rdi), %rbx
                	movw	$0x4, (%rbx)
                	movq	(%rdi), %r11
-               	movq	%r11, -0x150(%rbp)
+               	movq	%r11, -0x110(%rbp)
                	leaq	-0x30(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x0, (%rbx)
@@ -90,7 +90,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x6(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	movq	(%rdi), %r11
-               	movq	%r11, -0x160(%rbp)
+               	movq	%r11, -0x120(%rbp)
                	leaq	(%rdx), %rdi
                	movzwl	(%rdi), %edx
                	addl	%ecx, %edx
@@ -107,7 +107,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x6(%rbx), %rdx
                	movw	%di, (%rdx)
                	movq	(%rbx), %r11
-               	movq	%r11, -0x170(%rbp)
+               	movq	%r11, -0x130(%rbp)
                	leaq	0x2(%rsi), %rdx
                	movzwl	(%rdx), %esi
                	addl	%ecx, %esi
@@ -115,16 +115,16 @@ Disassembly of section __TEXT,__text:
                	movsd	%xmm1, (%rdx)
                	leaq	0x2(%rdx), %rdi
                	movw	%si, (%rdi)
-               	movsd	(%rdx), %xmm1
+               	movsd	(%rdx), %xmm0
                	leaq	0x4(%rdx), %rsi
                	movzwl	(%rsi), %edx
                	addl	%ecx, %edx
                	leaq	-0x50(%rbp), %r12
-               	movsd	%xmm1, (%r12)
+               	movsd	%xmm0, (%r12)
                	leaq	0x4(%r12), %rcx
                	movw	%dx, (%rcx)
                	movq	(%r12), %r11
-               	movq	%r11, -0x180(%rbp)
+               	movq	%r11, -0x140(%rbp)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -165,11 +165,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L8>
 <L8>:
-               	movaps	-0x170(%rbp), %xmm14
-               	paddw	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x130(%rbp), %xmm14
+               	paddw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xb4(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -190,11 +190,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L12>
 <L12>:
-               	movaps	-0x170(%rbp), %xmm14
-               	psubw	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x130(%rbp), %xmm14
+               	psubw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xc4(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -215,11 +215,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L16>
 <L16>:
-               	movaps	-0x180(%rbp), %xmm14
-               	psubw	-0x170(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x140(%rbp), %xmm14
+               	psubw	-0x130(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xd4(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -240,11 +240,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L20>
 <L20>:
-               	movaps	-0x170(%rbp), %xmm14
-               	pmullw	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x130(%rbp), %xmm14
+               	pmullw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xdc(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -265,11 +265,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L24>
 <L24>:
-               	movaps	-0x170(%rbp), %xmm14
-               	pmullw	-0x150(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x130(%rbp), %xmm14
+               	pmullw	-0x110(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xe4(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -290,11 +290,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L28>
 <L28>:
-               	movaps	-0x180(%rbp), %xmm14
-               	pmullw	-0x150(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x140(%rbp), %xmm14
+               	pmullw	-0x110(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xec(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -315,14 +315,14 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L32>
 <L32>:
-               	movaps	-0x170(%rbp), %xmm14
-               	paddw	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm4, %xmm14
-               	pmullw	-0x150(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x130(%rbp), %xmm14
+               	paddw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm0, %xmm14
+               	pmullw	-0x110(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xf4(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -343,11 +343,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L36>
 <L36>:
-               	movaps	-0x160(%rbp), %xmm14
-               	psubw	-0x170(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x120(%rbp), %xmm14
+               	psubw	-0x130(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0xfc(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -368,316 +368,180 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L40>
 <L40>:
-               	movaps	-0x160(%rbp), %xmm14
-               	psubw	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x104(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x120(%rbp), %xmm14
+               	psubw	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L41>
 <L41>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x130(%rbp), %xmm14
+               	pand	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, -0x150(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x150(%rbp), %xmm0
                	callq	 <L42>
 <L42>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x130(%rbp), %xmm14
+               	por	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, -0x160(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x160(%rbp), %xmm0
                	callq	 <L43>
 <L43>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x130(%rbp), %xmm14
+               	pxor	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L44>
 <L44>:
-               	movaps	-0x170(%rbp), %xmm14
-               	pand	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x10c(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x130(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L45>
 <L45>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x140(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L46>
 <L46>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x150(%rbp), %xmm14
+               	pxor	-0x160(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
                	movq	%rax, %rdi
+               	movaps	%xmm5, %xmm0
                	callq	 <L47>
 <L47>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L48>
+               	movq	%rax, %rbx
+               	movups	-0x130(%rbp), %xmm14
+               	movups	%xmm14, -0x180(%rbp)
+               	movups	-0x120(%rbp), %xmm14
+               	movups	%xmm14, -0x190(%rbp)
+               	movups	-0x120(%rbp), %xmm14
+               	movups	%xmm14, -0x1a0(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x6, %r12
+               	jb	 <L48>
+               	jmp	 <L65>
 <L48>:
-               	movaps	-0x170(%rbp), %xmm14
-               	por	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x114(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
+               	movaps	-0x180(%rbp), %xmm14
+               	pmullw	-0x110(%rbp), %xmm14
+               	movaps	%xmm14, -0x170(%rbp)
+               	leaq	-0x58(%rbp), %r13
+               	movq	-0x170(%rbp), %r11
+               	movq	%r11, (%r13)
+               	leaq	(%r13), %rax
+               	movzwl	(%rax), %esi
+               	movq	%rbx, %rdi
                	callq	 <L49>
 <L49>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L50>
 <L50>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L51>
 <L51>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L52>
 <L52>:
-               	movaps	-0x170(%rbp), %xmm14
-               	pxor	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x11c(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	movaps	-0x190(%rbp), %xmm14
+               	pxor	-0x170(%rbp), %xmm14
+               	movaps	%xmm14, -0x1b0(%rbp)
+               	leaq	-0xac(%rbp), %r13
+               	movq	-0x1b0(%rbp), %r11
+               	movq	%r11, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L53>
 <L53>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L54>
 <L54>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L55>
 <L55>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L56>
 <L56>:
-               	movaps	-0x170(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x124(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	movaps	-0x1a0(%rbp), %xmm14
+               	paddw	-0x180(%rbp), %xmm14
+               	movaps	%xmm14, -0x1c0(%rbp)
+               	leaq	-0xbc(%rbp), %r13
+               	movq	-0x1c0(%rbp), %r11
+               	movq	%r11, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L57>
 <L57>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L58>
 <L58>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L59>
 <L59>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L60>
 <L60>:
                	movaps	-0x180(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x12c(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L61>
-<L61>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L63>
-<L63>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L64>
-<L64>:
-               	movaps	-0x170(%rbp), %xmm14
-               	pand	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	-0x170(%rbp), %xmm14
-               	por	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm5
-               	movaps	%xmm4, %xmm14
-               	pxor	%xmm5, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x134(%rbp), %rbx
-               	movsd	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L65>
-<L65>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L67>
-<L67>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L68>
-<L68>:
-               	movq	%rax, %rbx
-               	movups	-0x170(%rbp), %xmm14
-               	movups	%xmm14, -0x1a0(%rbp)
-               	movups	-0x160(%rbp), %xmm14
-               	movups	%xmm14, -0x1b0(%rbp)
-               	movups	-0x160(%rbp), %xmm14
-               	movups	%xmm14, -0x1c0(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L69>
-               	jmp	 <L86>
-<L69>:
-               	movaps	-0x1a0(%rbp), %xmm14
-               	pmullw	-0x150(%rbp), %xmm14
-               	movaps	%xmm14, -0x190(%rbp)
-               	leaq	-0x58(%rbp), %r13
-               	movq	-0x190(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rax
-               	movzwl	(%rax), %esi
-               	movq	%rbx, %rdi
-               	callq	 <L70>
-<L70>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L71>
-<L71>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L72>
-<L72>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L73>
-<L73>:
-               	movaps	-0x1b0(%rbp), %xmm14
-               	pxor	-0x190(%rbp), %xmm14
+               	paddw	-0x140(%rbp), %xmm14
                	movaps	%xmm14, -0x1d0(%rbp)
-               	leaq	-0xac(%rbp), %r13
+               	leaq	-0xcc(%rbp), %r13
                	movq	-0x1d0(%rbp), %r11
                	movq	%r11, (%r13)
                	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L74>
-<L74>:
+               	callq	 <L61>
+<L61>:
                	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L75>
-<L75>:
+               	callq	 <L62>
+<L62>:
                	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L76>
-<L76>:
+               	callq	 <L63>
+<L63>:
                	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
-               	movaps	-0x1c0(%rbp), %xmm14
-               	paddw	-0x1a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x1e0(%rbp)
-               	leaq	-0xbc(%rbp), %r13
-               	movq	-0x1e0(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L81>
-<L81>:
-               	movaps	-0x1a0(%rbp), %xmm14
-               	paddw	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, -0x1f0(%rbp)
-               	leaq	-0xcc(%rbp), %r13
-               	movq	-0x1f0(%rbp), %r11
-               	movq	%r11, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L82>
-<L82>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L83>
-<L83>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L84>
-<L84>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L85>
-<L85>:
+               	callq	 <L64>
+<L64>:
                	addq	$0x1, %r12
                	movq	%rax, %rbx
-               	movups	-0x1f0(%rbp), %xmm14
-               	movups	%xmm14, -0x1a0(%rbp)
                	movups	-0x1d0(%rbp), %xmm14
-               	movups	%xmm14, -0x1b0(%rbp)
-               	movups	-0x1e0(%rbp), %xmm14
-               	movups	%xmm14, -0x1c0(%rbp)
+               	movups	%xmm14, -0x180(%rbp)
+               	movups	-0x1b0(%rbp), %xmm14
+               	movups	%xmm14, -0x190(%rbp)
+               	movups	-0x1c0(%rbp), %xmm14
+               	movups	%xmm14, -0x1a0(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L69>
-<L86>:
+               	jb	 <L48>
+<L65>:
                	leaq	-0x88(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
@@ -686,34 +550,34 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x20(%r12)
                	movq	$0x0, 0x28(%r12)
                	leaq	(%r12), %rax
-               	movq	-0x1a0(%rbp), %r11
+               	movq	-0x180(%rbp), %r11
                	movq	%r11, (%rax)
-               	movaps	-0x1a0(%rbp), %xmm14
-               	paddw	-0x180(%rbp), %xmm14
+               	movaps	-0x180(%rbp), %xmm14
+               	paddw	-0x140(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	0x8(%r12), %rax
                	movsd	%xmm3, (%rax)
-               	movaps	-0x1a0(%rbp), %xmm14
-               	pmullw	-0x150(%rbp), %xmm14
+               	movaps	-0x180(%rbp), %xmm14
+               	pmullw	-0x110(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	0x10(%r12), %rax
                	movsd	%xmm3, (%rax)
                	leaq	0x18(%r12), %rax
-               	movq	-0x1b0(%rbp), %r11
+               	movq	-0x190(%rbp), %r11
                	movq	%r11, (%rax)
                	leaq	0x20(%r12), %rax
-               	movq	-0x1c0(%rbp), %r11
+               	movq	-0x1a0(%rbp), %r11
                	movq	%r11, (%rax)
-               	movaps	-0x1a0(%rbp), %xmm14
-               	pxor	-0x180(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x180(%rbp), %xmm14
+               	pxor	-0x140(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x28(%r12), %rax
-               	movsd	%xmm4, (%rax)
+               	movsd	%xmm0, (%rax)
                	movq	$0x0, %r13
                	cmpq	$0x6, %r13
-               	jb	 <L87>
-               	jmp	 <L92>
-<L87>:
+               	jb	 <L66>
+               	jmp	 <L71>
+<L66>:
                	leaq	(%r12,%r13,8), %rax
                	movsd	(%rax), %xmm0
                	leaq	-0x90(%rbp), %r14
@@ -721,28 +585,28 @@ Disassembly of section __TEXT,__text:
                	leaq	(%r14), %rax
                	movzwl	(%rax), %esi
                	movq	%rbx, %rdi
-               	callq	 <L88>
-<L88>:
+               	callq	 <L67>
+<L67>:
                	leaq	0x2(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L89>
-<L89>:
+               	callq	 <L68>
+<L68>:
                	leaq	0x4(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L90>
-<L90>:
+               	callq	 <L69>
+<L69>:
                	leaq	0x6(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L91>
-<L91>:
+               	callq	 <L70>
+<L70>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
                	cmpq	$0x6, %r13
-               	jb	 <L87>
-<L92>:
+               	jb	 <L66>
+<L71>:
                	leaq	-0x9c(%rbp), %r13
                	movq	$0x0, (%r13)
                	movl	$0x0, 0x8(%r13)
@@ -756,40 +620,40 @@ Disassembly of section __TEXT,__text:
                	movb	$-0x53, (%rcx)
                	movzbl	(%rax), %esi
                	movq	%rbx, %rdi
-               	callq	 <L93>
-<L93>:
+               	callq	 <L72>
+<L72>:
                	movsd	(%r12), %xmm0
                	leaq	-0xa4(%rbp), %rbx
                	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L94>
-<L94>:
+               	callq	 <L73>
+<L73>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L95>
-<L95>:
+               	callq	 <L74>
+<L74>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L96>
-<L96>:
+               	callq	 <L75>
+<L75>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L97>
-<L97>:
+               	callq	 <L76>
+<L76>:
                	leaq	0xa(%r13), %rcx
                	movzbl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L98>
-<L98>:
-               	movq	-0x1f8(%rbp), %rbx
-               	movq	-0x200(%rbp), %r12
-               	movq	-0x208(%rbp), %r13
-               	movq	-0x210(%rbp), %r14
+               	callq	 <L77>
+<L77>:
+               	movq	-0x1d8(%rbp), %rbx
+               	movq	-0x1e0(%rbp), %r12
+               	movq	-0x1e8(%rbp), %r13
+               	movq	-0x1f0(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_i16x8.dis
+++ b/test/golden/x86_64-darwin/vec/vec_i16x8.dis
@@ -56,11 +56,11 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_i16x8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x330, %rsp            ## imm = 0x330
-               	movq	%rbx, -0x318(%rbp)
-               	movq	%r12, -0x320(%rbp)
-               	movq	%r13, -0x328(%rbp)
-               	movq	%r14, -0x330(%rbp)
+               	subq	$0x2e0, %rsp            ## imm = 0x2E0
+               	movq	%rbx, -0x2c8(%rbp)
+               	movq	%r12, -0x2d0(%rbp)
+               	movq	%r13, -0x2d8(%rbp)
+               	movq	%r14, -0x2e0(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -123,7 +123,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x8, (%rbx)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x270(%rbp)
+               	movups	%xmm14, -0x200(%rbp)
                	leaq	-0x60(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x0, (%rbx)
@@ -142,7 +142,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x280(%rbp)
+               	movups	%xmm14, -0x210(%rbp)
                	leaq	(%rdx), %rdi
                	movzwl	(%rdi), %edx
                	addl	%ecx, %edx
@@ -159,7 +159,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rbx), %rdx
                	movw	%di, (%rdx)
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
+               	movups	%xmm14, -0x220(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movzwl	(%rdx), %esi
                	addl	%ecx, %esi
@@ -167,16 +167,16 @@ Disassembly of section __TEXT,__text:
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movw	%si, (%rdi)
-               	movups	(%rdx), %xmm1
+               	movups	(%rdx), %xmm0
                	leaq	0xe(%rdx), %rsi
                	movzwl	(%rsi), %edx
                	addl	%ecx, %edx
                	leaq	-0xa0(%rbp), %r12
-               	movups	%xmm1, (%r12)
+               	movups	%xmm0, (%r12)
                	leaq	0xe(%r12), %rcx
                	movw	%dx, (%rcx)
                	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x2a0(%rbp)
+               	movups	%xmm14, -0x230(%rbp)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -257,11 +257,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L16>
 <L16>:
-               	movaps	-0x290(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -302,11 +302,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L24>
 <L24>:
-               	movaps	-0x290(%rbp), %xmm14
-               	psubw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	psubw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -347,11 +347,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L32>
 <L32>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	psubw	-0x290(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x230(%rbp), %xmm14
+               	psubw	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -392,11 +392,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L40>
 <L40>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pmullw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	pmullw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -437,11 +437,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L48>
 <L48>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -482,11 +482,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L56>
 <L56>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x230(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -527,14 +527,14 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L64>
 <L64>:
-               	movaps	-0x290(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm4, %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm0, %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1e0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -575,11 +575,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L72>
 <L72>:
-               	movaps	-0x280(%rbp), %xmm14
-               	psubw	-0x290(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x210(%rbp), %xmm14
+               	psubw	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1f0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -620,536 +620,260 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L80>
 <L80>:
-               	movaps	-0x280(%rbp), %xmm14
-               	psubw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x200(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x210(%rbp), %xmm14
+               	psubw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L81>
 <L81>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	pand	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, -0x240(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x240(%rbp), %xmm0
                	callq	 <L82>
 <L82>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	por	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, -0x250(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x250(%rbp), %xmm0
                	callq	 <L83>
 <L83>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	pxor	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L84>
 <L84>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L85>
 <L85>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x230(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L86>
 <L86>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x240(%rbp), %xmm14
+               	pxor	-0x250(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
                	movq	%rax, %rdi
+               	movaps	%xmm5, %xmm0
                	callq	 <L87>
 <L87>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L88>
+               	movq	%rax, %rbx
+               	movups	-0x220(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x6, %r12
+               	jb	 <L88>
+               	jmp	 <L121>
 <L88>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pand	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x210(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
+               	movaps	-0x270(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, -0x260(%rbp)
+               	leaq	-0xb0(%rbp), %r13
+               	movups	-0x260(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rax
+               	movzwl	(%rax), %esi
+               	movq	%rbx, %rdi
                	callq	 <L89>
 <L89>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L90>
 <L90>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L91>
 <L91>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L92>
 <L92>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L93>
 <L93>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L94>
 <L94>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L95>
 <L95>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L96>
 <L96>:
-               	movaps	-0x290(%rbp), %xmm14
-               	por	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x220(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	movaps	-0x280(%rbp), %xmm14
+               	pxor	-0x260(%rbp), %xmm14
+               	movaps	%xmm14, -0x2a0(%rbp)
+               	leaq	-0x150(%rbp), %r13
+               	movups	-0x2a0(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L97>
 <L97>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L98>
 <L98>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L99>
 <L99>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L100>
 <L100>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L101>
 <L101>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L102>
 <L102>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L103>
 <L103>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L104>
 <L104>:
                	movaps	-0x290(%rbp), %xmm14
-               	pxor	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x230(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	paddw	-0x270(%rbp), %xmm14
+               	movaps	%xmm14, -0x2b0(%rbp)
+               	leaq	-0x170(%rbp), %r13
+               	movups	-0x2b0(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L105>
 <L105>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L106>
 <L106>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L107>
 <L107>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L108>
 <L108>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L109>
 <L109>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L110>
 <L110>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L111>
 <L111>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L112>
 <L112>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x240(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	movaps	-0x270(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, -0x2c0(%rbp)
+               	leaq	-0x190(%rbp), %r13
+               	movups	-0x2c0(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L113>
 <L113>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L114>
 <L114>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L115>
 <L115>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L116>
 <L116>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L117>
 <L117>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L118>
 <L118>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L119>
 <L119>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L120>
 <L120>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x250(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L121>
-<L121>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L122>
-<L122>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L123>
-<L123>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L124>
-<L124>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L125>
-<L125>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L126>
-<L126>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L127>
-<L127>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L128>
-<L128>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pand	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	-0x290(%rbp), %xmm14
-               	por	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm5
-               	movaps	%xmm4, %xmm14
-               	pxor	%xmm5, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L129>
-<L129>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L130>
-<L130>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L131>
-<L131>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L132>
-<L132>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L133>
-<L133>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L134>
-<L134>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L135>
-<L135>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L136>
-<L136>:
-               	movq	%rax, %rbx
-               	movups	-0x290(%rbp), %xmm14
-               	movups	%xmm14, -0x2c0(%rbp)
-               	movups	-0x280(%rbp), %xmm14
-               	movups	%xmm14, -0x2d0(%rbp)
-               	movups	-0x280(%rbp), %xmm14
-               	movups	%xmm14, -0x2e0(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L137>
-               	jmp	 <L170>
-<L137>:
-               	movaps	-0x2c0(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, -0x2b0(%rbp)
-               	leaq	-0xb0(%rbp), %r13
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rax
-               	movzwl	(%rax), %esi
-               	movq	%rbx, %rdi
-               	callq	 <L138>
-<L138>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L139>
-<L139>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L140>
-<L140>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L141>
-<L141>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L142>
-<L142>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L143>
-<L143>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L144>
-<L144>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L145>
-<L145>:
-               	movaps	-0x2d0(%rbp), %xmm14
-               	pxor	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x2f0(%rbp)
-               	leaq	-0x150(%rbp), %r13
-               	movups	-0x2f0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L146>
-<L146>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L147>
-<L147>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L148>
-<L148>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L149>
-<L149>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L150>
-<L150>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L151>
-<L151>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L152>
-<L152>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L153>
-<L153>:
-               	movaps	-0x2e0(%rbp), %xmm14
-               	paddw	-0x2c0(%rbp), %xmm14
-               	movaps	%xmm14, -0x300(%rbp)
-               	leaq	-0x170(%rbp), %r13
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L154>
-<L154>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L155>
-<L155>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L156>
-<L156>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L157>
-<L157>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L158>
-<L158>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L159>
-<L159>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L160>
-<L160>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L161>
-<L161>:
-               	movaps	-0x2c0(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x310(%rbp)
-               	leaq	-0x190(%rbp), %r13
-               	movups	-0x310(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L162>
-<L162>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L163>
-<L163>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L164>
-<L164>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L165>
-<L165>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L166>
-<L166>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L167>
-<L167>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L168>
-<L168>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L169>
-<L169>:
                	addq	$0x1, %r12
                	movq	%rax, %rbx
-               	movups	-0x310(%rbp), %xmm14
-               	movups	%xmm14, -0x2c0(%rbp)
-               	movups	-0x2f0(%rbp), %xmm14
-               	movups	%xmm14, -0x2d0(%rbp)
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, -0x2e0(%rbp)
+               	movups	-0x2c0(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x2a0(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x2b0(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L137>
-<L170>:
+               	jb	 <L88>
+<L121>:
                	leaq	-0xf0(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
@@ -1160,26 +884,26 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
                	leaq	(%r12), %rax
-               	movups	-0x2c0(%rbp), %xmm14
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x2c0(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
+               	movaps	-0x270(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	0x10(%r12), %rax
                	movups	%xmm3, (%rax)
-               	movaps	-0x2c0(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x270(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x20(%r12), %rax
-               	movups	%xmm4, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	0x30(%r12), %rax
-               	movups	-0x2d0(%rbp), %xmm14
+               	movups	-0x280(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L171>
-               	jmp	 <L180>
-<L171>:
+               	jb	 <L122>
+               	jmp	 <L131>
+<L122>:
                	movq	%r13, %rax
                	imulq	$0x10, %rax, %rax
                	leaq	(%r12,%rax), %rcx
@@ -1189,48 +913,48 @@ Disassembly of section __TEXT,__text:
                	leaq	(%r14), %rax
                	movzwl	(%rax), %esi
                	movq	%rbx, %rdi
-               	callq	 <L172>
-<L172>:
+               	callq	 <L123>
+<L123>:
                	leaq	0x2(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L173>
-<L173>:
+               	callq	 <L124>
+<L124>:
                	leaq	0x4(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L174>
-<L174>:
+               	callq	 <L125>
+<L125>:
                	leaq	0x6(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L175>
-<L175>:
+               	callq	 <L126>
+<L126>:
                	leaq	0x8(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L176>
-<L176>:
+               	callq	 <L127>
+<L127>:
                	leaq	0xa(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L177>
-<L177>:
+               	callq	 <L128>
+<L128>:
                	leaq	0xc(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L178>
-<L178>:
+               	callq	 <L129>
+<L129>:
                	leaq	0xe(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L179>
-<L179>:
+               	callq	 <L130>
+<L130>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
                	cmpq	$0x4, %r13
-               	jb	 <L171>
-<L180>:
+               	jb	 <L122>
+<L131>:
                	leaq	-0x130(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
@@ -1249,61 +973,61 @@ Disassembly of section __TEXT,__text:
                	movl	(%rax), %ecx
                	movq	%rbx, %rdi
                	movl	%ecx, %esi
-               	callq	 <L181>
-<L181>:
+               	callq	 <L132>
+<L132>:
                	movups	(%r12), %xmm0
                	leaq	-0x140(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L182>
-<L182>:
+               	callq	 <L133>
+<L133>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L183>
-<L183>:
+               	callq	 <L134>
+<L134>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L184>
-<L184>:
+               	callq	 <L135>
+<L135>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L185>
-<L185>:
+               	callq	 <L136>
+<L136>:
                	leaq	0x8(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L186>
-<L186>:
+               	callq	 <L137>
+<L137>:
                	leaq	0xa(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L187>
-<L187>:
+               	callq	 <L138>
+<L138>:
                	leaq	0xc(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L188>
-<L188>:
+               	callq	 <L139>
+<L139>:
                	leaq	0xe(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L189>
-<L189>:
+               	callq	 <L140>
+<L140>:
                	leaq	0x20(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L190>
-<L190>:
-               	movq	-0x318(%rbp), %rbx
-               	movq	-0x320(%rbp), %r12
-               	movq	-0x328(%rbp), %r13
-               	movq	-0x330(%rbp), %r14
+               	callq	 <L141>
+<L141>:
+               	movq	-0x2c8(%rbp), %rbx
+               	movq	-0x2d0(%rbp), %r12
+               	movq	-0x2d8(%rbp), %r13
+               	movq	-0x2e0(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_i32x4.dis
+++ b/test/golden/x86_64-darwin/vec/vec_i32x4.dis
@@ -40,12 +40,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_i32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x4d0, %rsp            ## imm = 0x4D0
-               	movq	%rbx, -0x4a8(%rbp)
-               	movq	%r12, -0x4b0(%rbp)
-               	movq	%r13, -0x4b8(%rbp)
-               	movq	%r14, -0x4c0(%rbp)
-               	movq	%r15, -0x4c8(%rbp)
+               	subq	$0x480, %rsp            ## imm = 0x480
+               	movq	%rbx, -0x458(%rbp)
+               	movq	%r12, -0x460(%rbp)
+               	movq	%r13, -0x468(%rbp)
+               	movq	%r14, -0x470(%rbp)
+               	movq	%r15, -0x478(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -96,7 +96,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rdi), %r12
                	movl	$0x0, (%r12)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x3f0(%rbp)
+               	movups	%xmm14, -0x380(%rbp)
                	leaq	(%rdx), %rdi
                	movl	(%rdi), %edx
                	addl	%ecx, %edx
@@ -113,7 +113,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x8(%r12), %rdx
                	movl	%edi, (%rdx)
                	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x400(%rbp)
+               	movups	%xmm14, -0x390(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movl	(%rdx), %esi
                	addl	%ecx, %esi
@@ -121,16 +121,16 @@ Disassembly of section __TEXT,__text:
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movl	%esi, (%rdi)
-               	movups	(%rdx), %xmm1
+               	movups	(%rdx), %xmm0
                	leaq	0xc(%rdx), %rsi
                	movl	(%rsi), %edx
                	addl	%ecx, %edx
                	leaq	-0xb0(%rbp), %r13
-               	movups	%xmm1, (%r13)
+               	movups	%xmm0, (%r13)
                	leaq	0xc(%r13), %rcx
                	movl	%edx, (%rcx)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x410(%rbp)
+               	movups	%xmm14, -0x3a0(%rbp)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -179,11 +179,11 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L8>
 <L8>:
-               	movaps	-0x400(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x390(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -208,11 +208,11 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L12>
 <L12>:
-               	movaps	-0x400(%rbp), %xmm14
-               	psubd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x390(%rbp), %xmm14
+               	psubd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x210(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -237,11 +237,11 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L16>
 <L16>:
-               	movaps	-0x410(%rbp), %xmm14
-               	psubd	-0x400(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x3a0(%rbp), %xmm14
+               	psubd	-0x390(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x230(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -287,26 +287,26 @@ Disassembly of section __TEXT,__text:
                	movl	(%rcx), %r15d
                	imull	%r15d, %r14d
                	leaq	-0x240(%rbp), %rcx
-               	movups	-0x400(%rbp), %xmm14
+               	movups	-0x390(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r15
                	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x270(%rbp), %r15
-               	movups	%xmm3, (%r15)
+               	movups	%xmm0, (%r15)
                	leaq	0xc(%r15), %rcx
                	movl	%r14d, (%rcx)
-               	movups	(%r15), %xmm3
+               	movups	(%r15), %xmm0
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -352,26 +352,26 @@ Disassembly of section __TEXT,__text:
                	movl	(%rcx), %r14d
                	imull	%r14d, %r12d
                	leaq	-0x280(%rbp), %rcx
-               	movups	-0x400(%rbp), %xmm14
+               	movups	-0x390(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r14
                	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2b0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	0xc(%r14), %rcx
                	movl	%r12d, (%rcx)
-               	movups	(%r14), %xmm3
+               	movups	(%r14), %xmm0
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -417,26 +417,26 @@ Disassembly of section __TEXT,__text:
                	movl	(%rcx), %r13d
                	imull	%r13d, %r12d
                	leaq	-0x2c0(%rbp), %rcx
-               	movups	-0x410(%rbp), %xmm14
+               	movups	-0x3a0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r13
                	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2d0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2f0(%rbp), %r13
-               	movups	%xmm3, (%r13)
+               	movups	%xmm0, (%r13)
                	leaq	0xc(%r13), %rcx
                	movl	%r12d, (%rcx)
-               	movups	(%r13), %xmm3
+               	movups	(%r13), %xmm0
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -461,11 +461,11 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L32>
 <L32>:
-               	movaps	-0x400(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x390(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movl	(%rdx), %esi
                	leaq	(%rbx), %rdx
@@ -487,25 +487,25 @@ Disassembly of section __TEXT,__text:
                	movl	(%rdx), %r13d
                	imull	%r13d, %ecx
                	leaq	-0x310(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	(%rdx), %r13
                	movl	%esi, (%r13)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x320(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	0x4(%rdx), %rsi
                	movl	%edi, (%rsi)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x330(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	0x8(%rdx), %rsi
                	movl	%r12d, (%rsi)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x340(%rbp), %r12
-               	movups	%xmm3, (%r12)
+               	movups	%xmm0, (%r12)
                	leaq	0xc(%r12), %rdx
                	movl	%ecx, (%rdx)
-               	movups	(%r12), %xmm3
+               	movups	(%r12), %xmm0
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -530,11 +530,11 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L36>
 <L36>:
-               	movaps	-0x3f0(%rbp), %xmm14
-               	psubd	-0x400(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x380(%rbp), %xmm14
+               	psubd	-0x390(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x350(%rbp), %r12
-               	movups	%xmm3, (%r12)
+               	movups	%xmm0, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -559,229 +559,65 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L40>
 <L40>:
-               	movaps	-0x3f0(%rbp), %xmm14
-               	psubd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x360(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x380(%rbp), %xmm14
+               	psubd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L41>
 <L41>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	pand	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x3b0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x3b0(%rbp), %xmm0
                	callq	 <L42>
 <L42>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	por	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x3c0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x3c0(%rbp), %xmm0
                	callq	 <L43>
 <L43>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	pxor	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L44>
 <L44>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pand	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x370(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L45>
 <L45>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x3a0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L46>
 <L46>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x3b0(%rbp), %xmm14
+               	pxor	-0x3c0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movaps	%xmm4, %xmm0
                	callq	 <L47>
 <L47>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L48>
-<L48>:
-               	movaps	-0x400(%rbp), %xmm14
-               	por	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x380(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L51>
-<L51>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L52>
-<L52>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pxor	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x390(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L53>
-<L53>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L54>
-<L54>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L55>
-<L55>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L56>
-<L56>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x3a0(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L58>
-<L58>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L59>
-<L59>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L60>
-<L60>:
-               	movaps	-0x410(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x3b0(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L61>
-<L61>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L63>
-<L63>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L64>
-<L64>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pand	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	-0x400(%rbp), %xmm14
-               	por	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm3, %xmm14
-               	pxor	%xmm4, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x3c0(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L65>
-<L65>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L67>
-<L67>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L68>
-<L68>:
                	movq	%rax, %r12
-               	movups	-0x400(%rbp), %xmm14
-               	movups	%xmm14, -0x430(%rbp)
-               	movups	-0x3f0(%rbp), %xmm14
-               	movups	%xmm14, -0x440(%rbp)
+               	movups	-0x390(%rbp), %xmm14
+               	movups	%xmm14, -0x3e0(%rbp)
+               	movups	-0x380(%rbp), %xmm14
+               	movups	%xmm14, -0x3f0(%rbp)
                	movq	$0x0, %r13
-<L69>:
+<L48>:
                	leaq	-0xc0(%rbp), %r14
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L82>
+               	jb	 <L61>
                	leaq	-0x140(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
@@ -792,10 +628,10 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x430(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
                	movaps	%xmm14, %xmm2
                	leaq	0x10(%r15), %rax
                	movups	%xmm2, (%rax)
@@ -805,7 +641,7 @@ Disassembly of section __TEXT,__text:
                	movl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x3c8(%rbp)
+               	movq	%r8, -0x358(%rbp)
                	leaq	0x4(%r14), %rax
                	movl	(%rax), %edx
                	leaq	0x4(%rbx), %rax
@@ -822,10 +658,10 @@ Disassembly of section __TEXT,__text:
                	movl	(%rax), %ecx
                	imull	%ecx, %edi
                	leaq	-0x150(%rbp), %rax
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	leaq	(%rax), %rcx
-               	movq	-0x3c8(%rbp), %r8
+               	movq	-0x358(%rbp), %r8
                	movl	%r8d, (%rcx)
                	movups	(%rax), %xmm2
                	leaq	-0x160(%rbp), %rax
@@ -846,142 +682,142 @@ Disassembly of section __TEXT,__text:
                	leaq	0x20(%r15), %rax
                	movups	%xmm2, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x440(%rbp), %xmm14
+               	movups	-0x3f0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%r12, %r8
-               	movq	%r8, -0x418(%rbp)
+               	movq	%r8, -0x3c8(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x448(%rbp)
-               	movq	-0x448(%rbp), %r8
+               	movq	%r8, -0x3f8(%rbp)
+               	movq	-0x3f8(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L70>
-               	jmp	 <L75>
-<L70>:
-               	movq	-0x448(%rbp), %r8
+               	jb	 <L49>
+               	jmp	 <L54>
+<L49>:
+               	movq	-0x3f8(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r15,%rdx), %rsi
                	movups	(%rsi), %xmm2
                	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x450(%rbp)
-               	movq	-0x450(%rbp), %r8
+               	movq	%r8, -0x400(%rbp)
+               	movq	-0x400(%rbp), %r8
                	movups	%xmm2, (%r8)
-               	movq	-0x450(%rbp), %r8
+               	movq	-0x400(%rbp), %r8
                	leaq	(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0x3d0(%rbp)
-               	movq	-0x418(%rbp), %r8
+               	movq	%r8, -0x360(%rbp)
+               	movq	-0x3c8(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	-0x3d0(%rbp), %r8
+               	movq	-0x360(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L71>
-<L71>:
+               	callq	 <L50>
+<L50>:
                	movq	%rax, %rdi
-               	movq	-0x450(%rbp), %r8
+               	movq	-0x400(%rbp), %r8
                	leaq	0x4(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0x3d8(%rbp)
-               	movq	-0x3d8(%rbp), %r8
+               	movq	%r8, -0x368(%rbp)
+               	movq	-0x368(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L72>
-<L72>:
+               	callq	 <L51>
+<L51>:
                	movq	%rax, %rdi
-               	movq	-0x450(%rbp), %r8
+               	movq	-0x400(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0x3e0(%rbp)
-               	movq	-0x3e0(%rbp), %r8
+               	movq	%r8, -0x370(%rbp)
+               	movq	-0x370(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L73>
-<L73>:
+               	callq	 <L52>
+<L52>:
                	movq	%rax, %rdi
-               	movq	-0x450(%rbp), %r8
+               	movq	-0x400(%rbp), %r8
                	leaq	0xc(%r8), %rsi
                	movl	(%rsi), %edx
                	movl	%edx, %esi
-               	callq	 <L74>
-<L74>:
+               	callq	 <L53>
+<L53>:
                	movq	%rax, %rdx
-               	movq	-0x448(%rbp), %r8
+               	movq	-0x3f8(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rdx, %r8
-               	movq	%r8, -0x418(%rbp)
+               	movq	%r8, -0x3c8(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x448(%rbp)
-               	movq	-0x448(%rbp), %r8
+               	movq	%r8, -0x3f8(%rbp)
+               	movq	-0x3f8(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L70>
-<L75>:
+               	jb	 <L49>
+<L54>:
                	leaq	-0x1c0(%rbp), %r8
-               	movq	%r8, -0x458(%rbp)
-               	movq	-0x458(%rbp), %r8
+               	movq	%r8, -0x408(%rbp)
+               	movq	-0x408(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	movq	$0x0, 0x10(%r8)
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	movq	$0x0, 0x18(%r8)
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	movq	$0x0, 0x20(%r8)
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	movq	$0x0, 0x28(%r8)
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	leaq	(%r8), %rdx
                	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
                	leaq	0x20(%r15), %rsi
                	movups	(%rsi), %xmm2
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	leaq	0x10(%r8), %r15
                	movups	%xmm2, (%r15)
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	leaq	0x20(%r8), %rsi
                	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
                	movl	(%rdx), %esi
-               	movq	-0x418(%rbp), %r8
+               	movq	-0x3c8(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L76>
-<L76>:
+               	callq	 <L55>
+<L55>:
                	movups	(%r15), %xmm2
                	leaq	-0x1d0(%rbp), %r15
                	movups	%xmm2, (%r15)
                	leaq	(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
+               	callq	 <L56>
+<L56>:
                	leaq	0x4(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
+               	callq	 <L57>
+<L57>:
                	leaq	0x8(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
+               	callq	 <L58>
+<L58>:
                	leaq	0xc(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movq	-0x458(%rbp), %r8
+               	callq	 <L59>
+<L59>:
+               	movq	-0x408(%rbp), %r8
                	leaq	0x20(%r8), %rdx
                	movl	(%rdx), %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L81>
-<L81>:
-               	movq	-0x4a8(%rbp), %rbx
-               	movq	-0x4b0(%rbp), %r12
-               	movq	-0x4b8(%rbp), %r13
-               	movq	-0x4c0(%rbp), %r14
-               	movq	-0x4c8(%rbp), %r15
+               	callq	 <L60>
+<L60>:
+               	movq	-0x458(%rbp), %rbx
+               	movq	-0x460(%rbp), %r12
+               	movq	-0x468(%rbp), %r13
+               	movq	-0x470(%rbp), %r14
+               	movq	-0x478(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L82>:
+<L61>:
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	leaq	(%rbx), %rcx
@@ -1003,7 +839,7 @@ Disassembly of section __TEXT,__text:
                	movl	(%rcx), %r15d
                	imull	%r15d, %r14d
                	leaq	-0xd0(%rbp), %rcx
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r15
                	movl	%edx, (%r15)
@@ -1023,125 +859,125 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%r15), %rcx
                	movl	%r14d, (%rcx)
                	movups	(%r15), %xmm14
-               	movups	%xmm14, -0x470(%rbp)
+               	movups	%xmm14, -0x420(%rbp)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%r12, %rdi
                	movl	%edx, %esi
-               	callq	 <L83>
-<L83>:
+               	callq	 <L62>
+<L62>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L84>
-<L84>:
+               	callq	 <L63>
+<L63>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L85>
-<L85>:
+               	callq	 <L64>
+<L64>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L86>
-<L86>:
-               	movaps	-0x440(%rbp), %xmm14
-               	paddd	-0x470(%rbp), %xmm14
-               	movaps	%xmm14, -0x480(%rbp)
+               	callq	 <L65>
+<L65>:
+               	movaps	-0x3f0(%rbp), %xmm14
+               	paddd	-0x420(%rbp), %xmm14
+               	movaps	%xmm14, -0x430(%rbp)
                	leaq	-0x1e0(%rbp), %r14
-               	movups	-0x480(%rbp), %xmm14
+               	movups	-0x430(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L87>
-<L87>:
+               	callq	 <L66>
+<L66>:
                	leaq	0x4(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L88>
-<L88>:
+               	callq	 <L67>
+<L67>:
                	leaq	0x8(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L89>
-<L89>:
+               	callq	 <L68>
+<L68>:
                	leaq	0xc(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L90>
-<L90>:
-               	movaps	-0x480(%rbp), %xmm14
-               	pxor	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, -0x490(%rbp)
-               	leaq	-0x200(%rbp), %r14
-               	movups	-0x490(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L91>
-<L91>:
-               	leaq	0x4(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L92>
-<L92>:
-               	leaq	0x8(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L93>
-<L93>:
-               	leaq	0xc(%r14), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L94>
-<L94>:
+               	callq	 <L69>
+<L69>:
                	movaps	-0x430(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, -0x4a0(%rbp)
-               	leaq	-0x220(%rbp), %r14
-               	movups	-0x4a0(%rbp), %xmm14
+               	pxor	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x440(%rbp)
+               	leaq	-0x200(%rbp), %r14
+               	movups	-0x440(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L95>
-<L95>:
+               	callq	 <L70>
+<L70>:
                	leaq	0x4(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L96>
-<L96>:
+               	callq	 <L71>
+<L71>:
                	leaq	0x8(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L97>
-<L97>:
+               	callq	 <L72>
+<L72>:
                	leaq	0xc(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L98>
-<L98>:
+               	callq	 <L73>
+<L73>:
+               	movaps	-0x3e0(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x450(%rbp)
+               	leaq	-0x220(%rbp), %r14
+               	movups	-0x450(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	(%r14), %rcx
+               	movl	(%rcx), %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L74>
+<L74>:
+               	leaq	0x4(%r14), %rcx
+               	movl	(%rcx), %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L75>
+<L75>:
+               	leaq	0x8(%r14), %rcx
+               	movl	(%rcx), %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L76>
+<L76>:
+               	leaq	0xc(%r14), %rcx
+               	movl	(%rcx), %edx
+               	movq	%rax, %rdi
+               	movl	%edx, %esi
+               	callq	 <L77>
+<L77>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
-               	movups	-0x4a0(%rbp), %xmm14
-               	movups	%xmm14, -0x430(%rbp)
-               	movups	-0x490(%rbp), %xmm14
-               	movups	%xmm14, -0x440(%rbp)
-               	jmp	 <L69>
+               	movups	-0x450(%rbp), %xmm14
+               	movups	%xmm14, -0x3e0(%rbp)
+               	movups	-0x440(%rbp), %xmm14
+               	movups	%xmm14, -0x3f0(%rbp)
+               	jmp	 <L48>

--- a/test/golden/x86_64-darwin/vec/vec_i64x2.dis
+++ b/test/golden/x86_64-darwin/vec/vec_i64x2.dis
@@ -26,12 +26,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_i64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x3f0, %rsp            ## imm = 0x3F0
-               	movq	%rbx, -0x3c8(%rbp)
-               	movq	%r12, -0x3d0(%rbp)
-               	movq	%r13, -0x3d8(%rbp)
-               	movq	%r14, -0x3e0(%rbp)
-               	movq	%r15, -0x3e8(%rbp)
+               	subq	$0x3a0, %rsp            ## imm = 0x3A0
+               	movq	%rbx, -0x378(%rbp)
+               	movq	%r12, -0x380(%rbp)
+               	movq	%r13, -0x388(%rbp)
+               	movq	%r14, -0x390(%rbp)
+               	movq	%r15, -0x398(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -67,7 +67,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x8(%rsi), %rdi
                	movq	$0x0, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x300(%rbp)
+               	movups	%xmm14, -0x290(%rbp)
                	leaq	(%rcx), %rsi
                	movq	(%rsi), %rcx
                	addq	%rbx, %rcx
@@ -76,7 +76,7 @@ Disassembly of section __TEXT,__text:
                	leaq	(%r13), %rsi
                	movq	%rcx, (%rsi)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x310(%rbp)
+               	movups	%xmm14, -0x2a0(%rbp)
                	leaq	0x8(%rdx), %rcx
                	movq	(%rcx), %rdx
                	addq	%rbx, %rdx
@@ -85,7 +85,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x8(%rbx), %rcx
                	movq	%rdx, (%rcx)
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x320(%rbp)
+               	movups	%xmm14, -0x2b0(%rbp)
                	leaq	(%r13), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -106,11 +106,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movaps	-0x310(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2a0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x190(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -121,11 +121,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	movaps	-0x310(%rbp), %xmm14
-               	psubq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2a0(%rbp), %xmm14
+               	psubq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1b0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -136,11 +136,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L8>
 <L8>:
-               	movaps	-0x320(%rbp), %xmm14
-               	psubq	-0x310(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2b0(%rbp), %xmm14
+               	psubq	-0x2a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1d0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -162,16 +162,16 @@ Disassembly of section __TEXT,__text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0x1e0(%rbp), %rcx
-               	movups	-0x310(%rbp), %xmm14
+               	movups	-0x2a0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	0x8(%r14), %rcx
                	movq	%rsi, (%rcx)
-               	movups	(%r14), %xmm3
+               	movups	(%r14), %xmm0
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -193,16 +193,16 @@ Disassembly of section __TEXT,__text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0x200(%rbp), %rcx
-               	movups	-0x310(%rbp), %xmm14
+               	movups	-0x2a0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x210(%rbp), %r13
-               	movups	%xmm3, (%r13)
+               	movups	%xmm0, (%r13)
                	leaq	0x8(%r13), %rcx
                	movq	%rsi, (%rcx)
-               	movups	(%r13), %xmm3
+               	movups	(%r13), %xmm0
                	leaq	(%r13), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -224,16 +224,16 @@ Disassembly of section __TEXT,__text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0x220(%rbp), %rcx
-               	movups	-0x320(%rbp), %xmm14
+               	movups	-0x2b0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x230(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	0x8(%rbx), %rcx
                	movq	%rsi, (%rcx)
-               	movups	(%rbx), %xmm3
+               	movups	(%rbx), %xmm0
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -244,11 +244,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L16>
 <L16>:
-               	movaps	-0x310(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2a0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movq	(%rdx), %rsi
                	leaq	(%r12), %rdx
@@ -260,15 +260,15 @@ Disassembly of section __TEXT,__text:
                	movq	(%rdx), %rdi
                	imulq	%rdi, %rcx
                	leaq	-0x250(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	(%rdx), %rdi
                	movq	%rsi, (%rdi)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	0x8(%rbx), %rdx
                	movq	%rcx, (%rdx)
-               	movups	(%rbx), %xmm3
+               	movups	(%rbx), %xmm0
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -279,11 +279,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L18>
 <L18>:
-               	movaps	-0x300(%rbp), %xmm14
-               	psubq	-0x310(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x290(%rbp), %xmm14
+               	psubq	-0x2a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x270(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -294,133 +294,67 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L20>
 <L20>:
-               	movaps	-0x300(%rbp), %xmm14
-               	psubq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x280(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x290(%rbp), %xmm14
+               	psubq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L21>
 <L21>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	pand	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x2c0(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x2c0(%rbp), %xmm0
                	callq	 <L22>
 <L22>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pand	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x290(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	por	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x2d0(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x2d0(%rbp), %xmm0
                	callq	 <L23>
 <L23>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	pxor	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L24>
 <L24>:
-               	movaps	-0x310(%rbp), %xmm14
-               	por	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2a0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L25>
 <L25>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2b0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L26>
 <L26>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pxor	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2b0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2c0(%rbp), %xmm14
+               	pxor	-0x2d0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
+               	movaps	%xmm4, %xmm0
                	callq	 <L27>
 <L27>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2c0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	movaps	-0x320(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2d0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pand	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	-0x310(%rbp), %xmm14
-               	por	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm3, %xmm14
-               	pxor	%xmm4, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2e0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
                	movq	%rax, %rbx
-               	movups	-0x310(%rbp), %xmm14
-               	movups	%xmm14, -0x340(%rbp)
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, -0x350(%rbp)
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, -0x360(%rbp)
+               	movups	-0x2a0(%rbp), %xmm14
+               	movups	%xmm14, -0x2f0(%rbp)
+               	movups	-0x290(%rbp), %xmm14
+               	movups	%xmm14, -0x300(%rbp)
+               	movups	-0x290(%rbp), %xmm14
+               	movups	%xmm14, -0x310(%rbp)
                	movq	$0x0, %r13
-<L35>:
+<L28>:
                	leaq	-0xa0(%rbp), %r14
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L44>
+               	jb	 <L37>
                	leaq	-0x100(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
@@ -431,10 +365,10 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x340(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
+               	movaps	-0x2f0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm2
                	leaq	0x10(%r15), %rax
                	movups	%xmm2, (%rax)
@@ -449,7 +383,7 @@ Disassembly of section __TEXT,__text:
                	movq	(%rax), %rsi
                	imulq	%rsi, %rdx
                	leaq	-0x110(%rbp), %rax
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	leaq	(%rax), %rsi
                	movq	%rcx, (%rsi)
@@ -462,114 +396,114 @@ Disassembly of section __TEXT,__text:
                	leaq	0x20(%r15), %rax
                	movups	%xmm2, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x350(%rbp), %xmm14
+               	movups	-0x300(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%rbx, %r8
-               	movq	%r8, -0x328(%rbp)
+               	movq	%r8, -0x2d8(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x368(%rbp)
-               	movq	-0x368(%rbp), %r8
+               	movq	%r8, -0x318(%rbp)
+               	movq	-0x318(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L36>
-               	jmp	 <L39>
-<L36>:
-               	movq	-0x368(%rbp), %r8
+               	jb	 <L29>
+               	jmp	 <L32>
+<L29>:
+               	movq	-0x318(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r15,%rdx), %rsi
                	movups	(%rsi), %xmm2
                	leaq	-0x130(%rbp), %r8
-               	movq	%r8, -0x370(%rbp)
-               	movq	-0x370(%rbp), %r8
+               	movq	%r8, -0x320(%rbp)
+               	movq	-0x320(%rbp), %r8
                	movups	%xmm2, (%r8)
-               	movq	-0x370(%rbp), %r8
+               	movq	-0x320(%rbp), %r8
                	leaq	(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0x2e8(%rbp)
-               	movq	-0x328(%rbp), %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	-0x2d8(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	-0x2e8(%rbp), %r8
+               	movq	-0x278(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L37>
-<L37>:
+               	callq	 <L30>
+<L30>:
                	movq	%rax, %rdi
-               	movq	-0x370(%rbp), %r8
+               	movq	-0x320(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movq	(%rsi), %rdx
                	movq	%rdx, %rsi
-               	callq	 <L38>
-<L38>:
+               	callq	 <L31>
+<L31>:
                	movq	%rax, %rdx
-               	movq	-0x368(%rbp), %r8
+               	movq	-0x318(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rdx, %r8
-               	movq	%r8, -0x328(%rbp)
+               	movq	%r8, -0x2d8(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x368(%rbp)
-               	movq	-0x368(%rbp), %r8
+               	movq	%r8, -0x318(%rbp)
+               	movq	-0x318(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L36>
-<L39>:
+               	jb	 <L29>
+<L32>:
                	leaq	-0x160(%rbp), %r8
-               	movq	%r8, -0x378(%rbp)
-               	movq	-0x378(%rbp), %r8
+               	movq	%r8, -0x328(%rbp)
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x10(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x18(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x20(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x28(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	leaq	(%r8), %rdx
                	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
                	leaq	0x20(%r15), %rsi
                	movups	(%rsi), %xmm2
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	leaq	0x10(%r8), %r15
                	movups	%xmm2, (%r15)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	leaq	0x20(%r8), %rsi
                	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
                	movl	(%rdx), %esi
-               	movq	-0x328(%rbp), %r8
+               	movq	-0x2d8(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L40>
-<L40>:
+               	callq	 <L33>
+<L33>:
                	movups	(%r15), %xmm2
                	leaq	-0x170(%rbp), %r15
                	movups	%xmm2, (%r15)
                	leaq	(%r15), %rdx
                	movq	(%rdx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
+               	callq	 <L34>
+<L34>:
                	leaq	0x8(%r15), %rdx
                	movq	(%rdx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	movq	-0x378(%rbp), %r8
+               	callq	 <L35>
+<L35>:
+               	movq	-0x328(%rbp), %r8
                	leaq	0x20(%r8), %rdx
                	movl	(%rdx), %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L43>
-<L43>:
-               	movq	-0x3c8(%rbp), %rbx
-               	movq	-0x3d0(%rbp), %r12
-               	movq	-0x3d8(%rbp), %r13
-               	movq	-0x3e0(%rbp), %r14
-               	movq	-0x3e8(%rbp), %r15
+               	callq	 <L36>
+<L36>:
+               	movq	-0x378(%rbp), %rbx
+               	movq	-0x380(%rbp), %r12
+               	movq	-0x388(%rbp), %r13
+               	movq	-0x390(%rbp), %r14
+               	movq	-0x398(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L44>:
+<L37>:
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rdx
                	leaq	(%r12), %rcx
@@ -581,7 +515,7 @@ Disassembly of section __TEXT,__text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0xb0(%rbp), %rcx
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
@@ -591,71 +525,71 @@ Disassembly of section __TEXT,__text:
                	leaq	0x8(%r14), %rcx
                	movq	%rsi, (%rcx)
                	movups	(%r14), %xmm14
-               	movups	%xmm14, -0x390(%rbp)
+               	movups	%xmm14, -0x340(%rbp)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rbx, %rdi
+               	callq	 <L38>
+<L38>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L39>
+<L39>:
+               	movaps	-0x300(%rbp), %xmm14
+               	pxor	-0x340(%rbp), %xmm14
+               	movaps	%xmm14, -0x350(%rbp)
+               	leaq	-0x180(%rbp), %r14
+               	movups	-0x350(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L40>
+<L40>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L41>
+<L41>:
+               	movaps	-0x310(%rbp), %xmm14
+               	paddq	-0x2f0(%rbp), %xmm14
+               	movaps	%xmm14, -0x360(%rbp)
+               	leaq	-0x1a0(%rbp), %r14
+               	movups	-0x360(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L42>
+<L42>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L43>
+<L43>:
+               	movaps	-0x2f0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x370(%rbp)
+               	leaq	-0x1c0(%rbp), %r14
+               	movups	-0x370(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L44>
+<L44>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
                	callq	 <L45>
 <L45>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movaps	-0x350(%rbp), %xmm14
-               	pxor	-0x390(%rbp), %xmm14
-               	movaps	%xmm14, -0x3a0(%rbp)
-               	leaq	-0x180(%rbp), %r14
-               	movups	-0x3a0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L48>
-<L48>:
-               	movaps	-0x360(%rbp), %xmm14
-               	paddq	-0x340(%rbp), %xmm14
-               	movaps	%xmm14, -0x3b0(%rbp)
-               	leaq	-0x1a0(%rbp), %r14
-               	movups	-0x3b0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	movaps	-0x340(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, -0x3c0(%rbp)
-               	leaq	-0x1c0(%rbp), %r14
-               	movups	-0x3c0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
-               	movups	-0x3c0(%rbp), %xmm14
-               	movups	%xmm14, -0x340(%rbp)
-               	movups	-0x3a0(%rbp), %xmm14
-               	movups	%xmm14, -0x350(%rbp)
-               	movups	-0x3b0(%rbp), %xmm14
-               	movups	%xmm14, -0x360(%rbp)
-               	jmp	 <L35>
+               	movups	-0x370(%rbp), %xmm14
+               	movups	%xmm14, -0x2f0(%rbp)
+               	movups	-0x350(%rbp), %xmm14
+               	movups	%xmm14, -0x300(%rbp)
+               	movups	-0x360(%rbp), %xmm14
+               	movups	%xmm14, -0x310(%rbp)
+               	jmp	 <L28>

--- a/test/golden/x86_64-darwin/vec/vec_u16x8.dis
+++ b/test/golden/x86_64-darwin/vec/vec_u16x8.dis
@@ -56,11 +56,11 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_u16x8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x330, %rsp            ## imm = 0x330
-               	movq	%rbx, -0x318(%rbp)
-               	movq	%r12, -0x320(%rbp)
-               	movq	%r13, -0x328(%rbp)
-               	movq	%r14, -0x330(%rbp)
+               	subq	$0x2e0, %rsp            ## imm = 0x2E0
+               	movq	%rbx, -0x2c8(%rbp)
+               	movq	%r12, -0x2d0(%rbp)
+               	movq	%r13, -0x2d8(%rbp)
+               	movq	%r14, -0x2e0(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -123,7 +123,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x88b, (%rbx)          ## imm = 0x88B
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x270(%rbp)
+               	movups	%xmm14, -0x200(%rbp)
                	leaq	-0x60(%rbp), %rdi
                	leaq	(%rdi), %rbx
                	movw	$0x0, (%rbx)
@@ -142,7 +142,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0xe(%rdi), %rbx
                	movw	$0x0, (%rbx)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x280(%rbp)
+               	movups	%xmm14, -0x210(%rbp)
                	leaq	(%rdx), %rdi
                	movzwl	(%rdi), %edx
                	addl	%ecx, %edx
@@ -159,7 +159,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rbx), %rdx
                	movw	%di, (%rdx)
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x290(%rbp)
+               	movups	%xmm14, -0x220(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movzwl	(%rdx), %esi
                	addl	%ecx, %esi
@@ -167,16 +167,16 @@ Disassembly of section __TEXT,__text:
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movw	%si, (%rdi)
-               	movups	(%rdx), %xmm1
+               	movups	(%rdx), %xmm0
                	leaq	0xe(%rdx), %rsi
                	movzwl	(%rsi), %edx
                	addl	%ecx, %edx
                	leaq	-0xa0(%rbp), %r12
-               	movups	%xmm1, (%r12)
+               	movups	%xmm0, (%r12)
                	leaq	0xe(%r12), %rcx
                	movw	%dx, (%rcx)
                	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x2a0(%rbp)
+               	movups	%xmm14, -0x230(%rbp)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -257,11 +257,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L16>
 <L16>:
-               	movaps	-0x290(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x160(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -302,11 +302,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L24>
 <L24>:
-               	movaps	-0x290(%rbp), %xmm14
-               	psubw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	psubw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x180(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -347,11 +347,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L32>
 <L32>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	psubw	-0x290(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x230(%rbp), %xmm14
+               	psubw	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1a0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -392,11 +392,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L40>
 <L40>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pmullw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	pmullw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1b0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -437,11 +437,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L48>
 <L48>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1c0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -482,11 +482,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L56>
 <L56>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x230(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1d0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -527,14 +527,14 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L64>
 <L64>:
-               	movaps	-0x290(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm4, %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x220(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm0, %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1e0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -575,11 +575,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L72>
 <L72>:
-               	movaps	-0x280(%rbp), %xmm14
-               	psubw	-0x290(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x210(%rbp), %xmm14
+               	psubw	-0x220(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1f0(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
@@ -620,536 +620,260 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L80>
 <L80>:
-               	movaps	-0x280(%rbp), %xmm14
-               	psubw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x200(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x210(%rbp), %xmm14
+               	psubw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L81>
 <L81>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	pand	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, -0x240(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x240(%rbp), %xmm0
                	callq	 <L82>
 <L82>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	por	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, -0x250(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x250(%rbp), %xmm0
                	callq	 <L83>
 <L83>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	pxor	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L84>
 <L84>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x220(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L85>
 <L85>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x230(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L86>
 <L86>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
+               	movaps	-0x240(%rbp), %xmm14
+               	pxor	-0x250(%rbp), %xmm14
+               	movaps	%xmm14, %xmm5
                	movq	%rax, %rdi
+               	movaps	%xmm5, %xmm0
                	callq	 <L87>
 <L87>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L88>
+               	movq	%rax, %rbx
+               	movups	-0x220(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x210(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
+               	movq	$0x0, %r12
+               	cmpq	$0x6, %r12
+               	jb	 <L88>
+               	jmp	 <L121>
 <L88>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pand	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x210(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
+               	movaps	-0x270(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, -0x260(%rbp)
+               	leaq	-0xb0(%rbp), %r13
+               	movups	-0x260(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rax
+               	movzwl	(%rax), %esi
+               	movq	%rbx, %rdi
                	callq	 <L89>
 <L89>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L90>
 <L90>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L91>
 <L91>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L92>
 <L92>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L93>
 <L93>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L94>
 <L94>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L95>
 <L95>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L96>
 <L96>:
-               	movaps	-0x290(%rbp), %xmm14
-               	por	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x220(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	movaps	-0x280(%rbp), %xmm14
+               	pxor	-0x260(%rbp), %xmm14
+               	movaps	%xmm14, -0x2a0(%rbp)
+               	leaq	-0x150(%rbp), %r13
+               	movups	-0x2a0(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L97>
 <L97>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L98>
 <L98>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L99>
 <L99>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L100>
 <L100>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L101>
 <L101>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L102>
 <L102>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L103>
 <L103>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L104>
 <L104>:
                	movaps	-0x290(%rbp), %xmm14
-               	pxor	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x230(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	paddw	-0x270(%rbp), %xmm14
+               	movaps	%xmm14, -0x2b0(%rbp)
+               	leaq	-0x170(%rbp), %r13
+               	movups	-0x2b0(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L105>
 <L105>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L106>
 <L106>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L107>
 <L107>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L108>
 <L108>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L109>
 <L109>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L110>
 <L110>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L111>
 <L111>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L112>
 <L112>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x240(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
+               	movaps	-0x270(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
+               	movaps	%xmm14, -0x2c0(%rbp)
+               	leaq	-0x190(%rbp), %r13
+               	movups	-0x2c0(%rbp), %xmm14
+               	movups	%xmm14, (%r13)
+               	leaq	(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L113>
 <L113>:
-               	leaq	0x2(%rbx), %rcx
+               	leaq	0x2(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L114>
 <L114>:
-               	leaq	0x4(%rbx), %rcx
+               	leaq	0x4(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L115>
 <L115>:
-               	leaq	0x6(%rbx), %rcx
+               	leaq	0x6(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L116>
 <L116>:
-               	leaq	0x8(%rbx), %rcx
+               	leaq	0x8(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L117>
 <L117>:
-               	leaq	0xa(%rbx), %rcx
+               	leaq	0xa(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L118>
 <L118>:
-               	leaq	0xc(%rbx), %rcx
+               	leaq	0xc(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L119>
 <L119>:
-               	leaq	0xe(%rbx), %rcx
+               	leaq	0xe(%r13), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
                	callq	 <L120>
 <L120>:
-               	movaps	-0x2a0(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x250(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L121>
-<L121>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L122>
-<L122>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L123>
-<L123>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L124>
-<L124>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L125>
-<L125>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L126>
-<L126>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L127>
-<L127>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L128>
-<L128>:
-               	movaps	-0x290(%rbp), %xmm14
-               	pand	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	-0x290(%rbp), %xmm14
-               	por	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, %xmm5
-               	movaps	%xmm4, %xmm14
-               	pxor	%xmm5, %xmm14
-               	movaps	%xmm14, %xmm4
-               	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm4, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L129>
-<L129>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L130>
-<L130>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L131>
-<L131>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L132>
-<L132>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L133>
-<L133>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L134>
-<L134>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L135>
-<L135>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L136>
-<L136>:
-               	movq	%rax, %rbx
-               	movups	-0x290(%rbp), %xmm14
-               	movups	%xmm14, -0x2c0(%rbp)
-               	movups	-0x280(%rbp), %xmm14
-               	movups	%xmm14, -0x2d0(%rbp)
-               	movups	-0x280(%rbp), %xmm14
-               	movups	%xmm14, -0x2e0(%rbp)
-               	movq	$0x0, %r12
-               	cmpq	$0x6, %r12
-               	jb	 <L137>
-               	jmp	 <L170>
-<L137>:
-               	movaps	-0x2c0(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, -0x2b0(%rbp)
-               	leaq	-0xb0(%rbp), %r13
-               	movups	-0x2b0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rax
-               	movzwl	(%rax), %esi
-               	movq	%rbx, %rdi
-               	callq	 <L138>
-<L138>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L139>
-<L139>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L140>
-<L140>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L141>
-<L141>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L142>
-<L142>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L143>
-<L143>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L144>
-<L144>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L145>
-<L145>:
-               	movaps	-0x2d0(%rbp), %xmm14
-               	pxor	-0x2b0(%rbp), %xmm14
-               	movaps	%xmm14, -0x2f0(%rbp)
-               	leaq	-0x150(%rbp), %r13
-               	movups	-0x2f0(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L146>
-<L146>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L147>
-<L147>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L148>
-<L148>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L149>
-<L149>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L150>
-<L150>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L151>
-<L151>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L152>
-<L152>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L153>
-<L153>:
-               	movaps	-0x2e0(%rbp), %xmm14
-               	paddw	-0x2c0(%rbp), %xmm14
-               	movaps	%xmm14, -0x300(%rbp)
-               	leaq	-0x170(%rbp), %r13
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L154>
-<L154>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L155>
-<L155>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L156>
-<L156>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L157>
-<L157>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L158>
-<L158>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L159>
-<L159>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L160>
-<L160>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L161>
-<L161>:
-               	movaps	-0x2c0(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
-               	movaps	%xmm14, -0x310(%rbp)
-               	leaq	-0x190(%rbp), %r13
-               	movups	-0x310(%rbp), %xmm14
-               	movups	%xmm14, (%r13)
-               	leaq	(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L162>
-<L162>:
-               	leaq	0x2(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L163>
-<L163>:
-               	leaq	0x4(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L164>
-<L164>:
-               	leaq	0x6(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L165>
-<L165>:
-               	leaq	0x8(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L166>
-<L166>:
-               	leaq	0xa(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L167>
-<L167>:
-               	leaq	0xc(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L168>
-<L168>:
-               	leaq	0xe(%r13), %rcx
-               	movzwl	(%rcx), %esi
-               	movq	%rax, %rdi
-               	callq	 <L169>
-<L169>:
                	addq	$0x1, %r12
                	movq	%rax, %rbx
-               	movups	-0x310(%rbp), %xmm14
-               	movups	%xmm14, -0x2c0(%rbp)
-               	movups	-0x2f0(%rbp), %xmm14
-               	movups	%xmm14, -0x2d0(%rbp)
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, -0x2e0(%rbp)
+               	movups	-0x2c0(%rbp), %xmm14
+               	movups	%xmm14, -0x270(%rbp)
+               	movups	-0x2a0(%rbp), %xmm14
+               	movups	%xmm14, -0x280(%rbp)
+               	movups	-0x2b0(%rbp), %xmm14
+               	movups	%xmm14, -0x290(%rbp)
                	cmpq	$0x6, %r12
-               	jb	 <L137>
-<L170>:
+               	jb	 <L88>
+<L121>:
                	leaq	-0xf0(%rbp), %r12
                	movq	$0x0, (%r12)
                	movq	$0x0, 0x8(%r12)
@@ -1160,26 +884,26 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x30(%r12)
                	movq	$0x0, 0x38(%r12)
                	leaq	(%r12), %rax
-               	movups	-0x2c0(%rbp), %xmm14
+               	movups	-0x270(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x2c0(%rbp), %xmm14
-               	paddw	-0x2a0(%rbp), %xmm14
+               	movaps	-0x270(%rbp), %xmm14
+               	paddw	-0x230(%rbp), %xmm14
                	movaps	%xmm14, %xmm3
                	leaq	0x10(%r12), %rax
                	movups	%xmm3, (%rax)
-               	movaps	-0x2c0(%rbp), %xmm14
-               	pmullw	-0x270(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
+               	movaps	-0x270(%rbp), %xmm14
+               	pmullw	-0x200(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	0x20(%r12), %rax
-               	movups	%xmm4, (%rax)
+               	movups	%xmm0, (%rax)
                	leaq	0x30(%r12), %rax
-               	movups	-0x2d0(%rbp), %xmm14
+               	movups	-0x280(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L171>
-               	jmp	 <L180>
-<L171>:
+               	jb	 <L122>
+               	jmp	 <L131>
+<L122>:
                	movq	%r13, %rax
                	imulq	$0x10, %rax, %rax
                	leaq	(%r12,%rax), %rcx
@@ -1189,48 +913,48 @@ Disassembly of section __TEXT,__text:
                	leaq	(%r14), %rax
                	movzwl	(%rax), %esi
                	movq	%rbx, %rdi
-               	callq	 <L172>
-<L172>:
+               	callq	 <L123>
+<L123>:
                	leaq	0x2(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L173>
-<L173>:
+               	callq	 <L124>
+<L124>:
                	leaq	0x4(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L174>
-<L174>:
+               	callq	 <L125>
+<L125>:
                	leaq	0x6(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L175>
-<L175>:
+               	callq	 <L126>
+<L126>:
                	leaq	0x8(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L176>
-<L176>:
+               	callq	 <L127>
+<L127>:
                	leaq	0xa(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L177>
-<L177>:
+               	callq	 <L128>
+<L128>:
                	leaq	0xc(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L178>
-<L178>:
+               	callq	 <L129>
+<L129>:
                	leaq	0xe(%r14), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L179>
-<L179>:
+               	callq	 <L130>
+<L130>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
                	cmpq	$0x4, %r13
-               	jb	 <L171>
-<L180>:
+               	jb	 <L122>
+<L131>:
                	leaq	-0x130(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
@@ -1249,61 +973,61 @@ Disassembly of section __TEXT,__text:
                	movl	(%rax), %ecx
                	movq	%rbx, %rdi
                	movl	%ecx, %esi
-               	callq	 <L181>
-<L181>:
+               	callq	 <L132>
+<L132>:
                	movups	(%r12), %xmm0
                	leaq	-0x140(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L182>
-<L182>:
+               	callq	 <L133>
+<L133>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L183>
-<L183>:
+               	callq	 <L134>
+<L134>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L184>
-<L184>:
+               	callq	 <L135>
+<L135>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L185>
-<L185>:
+               	callq	 <L136>
+<L136>:
                	leaq	0x8(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L186>
-<L186>:
+               	callq	 <L137>
+<L137>:
                	leaq	0xa(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L187>
-<L187>:
+               	callq	 <L138>
+<L138>:
                	leaq	0xc(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L188>
-<L188>:
+               	callq	 <L139>
+<L139>:
                	leaq	0xe(%rbx), %rcx
                	movzwl	(%rcx), %esi
                	movq	%rax, %rdi
-               	callq	 <L189>
-<L189>:
+               	callq	 <L140>
+<L140>:
                	leaq	0x20(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L190>
-<L190>:
-               	movq	-0x318(%rbp), %rbx
-               	movq	-0x320(%rbp), %r12
-               	movq	-0x328(%rbp), %r13
-               	movq	-0x330(%rbp), %r14
+               	callq	 <L141>
+<L141>:
+               	movq	-0x2c8(%rbp), %rbx
+               	movq	-0x2d0(%rbp), %r12
+               	movq	-0x2d8(%rbp), %r13
+               	movq	-0x2e0(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-darwin/vec/vec_u32x4.dis
+++ b/test/golden/x86_64-darwin/vec/vec_u32x4.dis
@@ -40,12 +40,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_u32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x4e0, %rsp            ## imm = 0x4E0
-               	movq	%rbx, -0x4b8(%rbp)
-               	movq	%r12, -0x4c0(%rbp)
-               	movq	%r13, -0x4c8(%rbp)
-               	movq	%r14, -0x4d0(%rbp)
-               	movq	%r15, -0x4d8(%rbp)
+               	subq	$0x490, %rsp            ## imm = 0x490
+               	movq	%rbx, -0x468(%rbp)
+               	movq	%r12, -0x470(%rbp)
+               	movq	%r13, -0x478(%rbp)
+               	movq	%r14, -0x480(%rbp)
+               	movq	%r15, -0x488(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -96,7 +96,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%rdi), %r12
                	movl	$0x0, (%r12)
                	movups	(%rdi), %xmm14
-               	movups	%xmm14, -0x3f0(%rbp)
+               	movups	%xmm14, -0x380(%rbp)
                	leaq	(%rdx), %rdi
                	movl	(%rdi), %edx
                	addl	%ecx, %edx
@@ -113,7 +113,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x8(%r12), %rdx
                	movl	%edi, (%rdx)
                	movups	(%r12), %xmm14
-               	movups	%xmm14, -0x400(%rbp)
+               	movups	%xmm14, -0x390(%rbp)
                	leaq	0x4(%rsi), %rdx
                	movl	(%rdx), %esi
                	addl	%ecx, %esi
@@ -121,16 +121,16 @@ Disassembly of section __TEXT,__text:
                	movups	%xmm1, (%rdx)
                	leaq	0x4(%rdx), %rdi
                	movl	%esi, (%rdi)
-               	movups	(%rdx), %xmm1
+               	movups	(%rdx), %xmm0
                	leaq	0xc(%rdx), %rsi
                	movl	(%rsi), %edx
                	addl	%ecx, %edx
                	leaq	-0xb0(%rbp), %r13
-               	movups	%xmm1, (%r13)
+               	movups	%xmm0, (%r13)
                	leaq	0xc(%r13), %rcx
                	movl	%edx, (%rcx)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x410(%rbp)
+               	movups	%xmm14, -0x3a0(%rbp)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -179,11 +179,11 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L8>
 <L8>:
-               	movaps	-0x400(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x390(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -208,11 +208,11 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L12>
 <L12>:
-               	movaps	-0x400(%rbp), %xmm14
-               	psubd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x390(%rbp), %xmm14
+               	psubd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x210(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -237,11 +237,11 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L16>
 <L16>:
-               	movaps	-0x410(%rbp), %xmm14
-               	psubd	-0x400(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x3a0(%rbp), %xmm14
+               	psubd	-0x390(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x230(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -287,26 +287,26 @@ Disassembly of section __TEXT,__text:
                	movl	(%rcx), %r15d
                	imull	%r15d, %r14d
                	leaq	-0x240(%rbp), %rcx
-               	movups	-0x400(%rbp), %xmm14
+               	movups	-0x390(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r15
                	movl	%edx, (%r15)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x250(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x260(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x270(%rbp), %r15
-               	movups	%xmm3, (%r15)
+               	movups	%xmm0, (%r15)
                	leaq	0xc(%r15), %rcx
                	movl	%r14d, (%rcx)
-               	movups	(%r15), %xmm3
+               	movups	(%r15), %xmm0
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -352,26 +352,26 @@ Disassembly of section __TEXT,__text:
                	movl	(%rcx), %r14d
                	imull	%r14d, %r12d
                	leaq	-0x280(%rbp), %rcx
-               	movups	-0x400(%rbp), %xmm14
+               	movups	-0x390(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r14
                	movl	%edx, (%r14)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x290(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2a0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2b0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	0xc(%r14), %rcx
                	movl	%r12d, (%rcx)
-               	movups	(%r14), %xmm3
+               	movups	(%r14), %xmm0
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -417,26 +417,26 @@ Disassembly of section __TEXT,__text:
                	movl	(%rcx), %r13d
                	imull	%r13d, %r12d
                	leaq	-0x2c0(%rbp), %rcx
-               	movups	-0x410(%rbp), %xmm14
+               	movups	-0x3a0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r13
                	movl	%edx, (%r13)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2d0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdx
                	movl	%esi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdx
                	movl	%edi, (%rdx)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x2f0(%rbp), %r13
-               	movups	%xmm3, (%r13)
+               	movups	%xmm0, (%r13)
                	leaq	0xc(%r13), %rcx
                	movl	%r12d, (%rcx)
-               	movups	(%r13), %xmm3
+               	movups	(%r13), %xmm0
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -461,11 +461,11 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L32>
 <L32>:
-               	movaps	-0x400(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x390(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movl	(%rdx), %esi
                	leaq	(%rbx), %rdx
@@ -487,25 +487,25 @@ Disassembly of section __TEXT,__text:
                	movl	(%rdx), %r13d
                	imull	%r13d, %ecx
                	leaq	-0x310(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	(%rdx), %r13
                	movl	%esi, (%r13)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x320(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	0x4(%rdx), %rsi
                	movl	%edi, (%rsi)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x330(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	0x8(%rdx), %rsi
                	movl	%r12d, (%rsi)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x340(%rbp), %r12
-               	movups	%xmm3, (%r12)
+               	movups	%xmm0, (%r12)
                	leaq	0xc(%r12), %rdx
                	movl	%ecx, (%rdx)
-               	movups	(%r12), %xmm3
+               	movups	(%r12), %xmm0
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -530,11 +530,11 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L36>
 <L36>:
-               	movaps	-0x3f0(%rbp), %xmm14
-               	psubd	-0x400(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x380(%rbp), %xmm14
+               	psubd	-0x390(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x350(%rbp), %r12
-               	movups	%xmm3, (%r12)
+               	movups	%xmm0, (%r12)
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
@@ -559,231 +559,67 @@ Disassembly of section __TEXT,__text:
                	movl	%edx, %esi
                	callq	 <L40>
 <L40>:
-               	movaps	-0x3f0(%rbp), %xmm14
-               	psubd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x360(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x380(%rbp), %xmm14
+               	psubd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L41>
 <L41>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	pand	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x3b0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x3b0(%rbp), %xmm0
                	callq	 <L42>
 <L42>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	por	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x3c0(%rbp)
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movups	-0x3c0(%rbp), %xmm0
                	callq	 <L43>
 <L43>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	pxor	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L44>
 <L44>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pand	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x370(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x390(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L45>
 <L45>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x3a0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
-               	movl	%edx, %esi
                	callq	 <L46>
 <L46>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
+               	movaps	-0x3b0(%rbp), %xmm14
+               	pxor	-0x3c0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
-               	movl	%edx, %esi
+               	movaps	%xmm4, %xmm0
                	callq	 <L47>
 <L47>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L48>
-<L48>:
-               	movaps	-0x400(%rbp), %xmm14
-               	por	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x380(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L51>
-<L51>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L52>
-<L52>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pxor	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x390(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L53>
-<L53>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L54>
-<L54>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L55>
-<L55>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L56>
-<L56>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x3a0(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L57>
-<L57>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L58>
-<L58>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L59>
-<L59>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L60>
-<L60>:
-               	movaps	-0x410(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x3b0(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L61>
-<L61>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L62>
-<L62>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L63>
-<L63>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L64>
-<L64>:
-               	movaps	-0x400(%rbp), %xmm14
-               	pand	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	-0x400(%rbp), %xmm14
-               	por	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm3, %xmm14
-               	pxor	%xmm4, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x3c0(%rbp), %r12
-               	movups	%xmm3, (%r12)
-               	leaq	(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L65>
-<L65>:
-               	leaq	0x4(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L66>
-<L66>:
-               	leaq	0x8(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L67>
-<L67>:
-               	leaq	0xc(%r12), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rdi
-               	movl	%edx, %esi
-               	callq	 <L68>
-<L68>:
                	movq	%rax, %r12
-               	movups	-0x400(%rbp), %xmm14
-               	movups	%xmm14, -0x430(%rbp)
-               	movups	-0x3f0(%rbp), %xmm14
-               	movups	%xmm14, -0x440(%rbp)
-               	movups	-0x3f0(%rbp), %xmm14
-               	movups	%xmm14, -0x450(%rbp)
+               	movups	-0x390(%rbp), %xmm14
+               	movups	%xmm14, -0x3e0(%rbp)
+               	movups	-0x380(%rbp), %xmm14
+               	movups	%xmm14, -0x3f0(%rbp)
+               	movups	-0x380(%rbp), %xmm14
+               	movups	%xmm14, -0x400(%rbp)
                	movq	$0x0, %r13
-<L69>:
+<L48>:
                	leaq	-0xc0(%rbp), %r14
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L82>
+               	jb	 <L61>
                	leaq	-0x140(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
@@ -794,10 +630,10 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x430(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
+               	movaps	-0x3e0(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
                	movaps	%xmm14, %xmm2
                	leaq	0x10(%r15), %rax
                	movups	%xmm2, (%rax)
@@ -807,7 +643,7 @@ Disassembly of section __TEXT,__text:
                	movl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x3c8(%rbp)
+               	movq	%r8, -0x358(%rbp)
                	leaq	0x4(%r14), %rax
                	movl	(%rax), %edx
                	leaq	0x4(%rbx), %rax
@@ -824,10 +660,10 @@ Disassembly of section __TEXT,__text:
                	movl	(%rax), %ecx
                	imull	%ecx, %edi
                	leaq	-0x150(%rbp), %rax
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	leaq	(%rax), %rcx
-               	movq	-0x3c8(%rbp), %r8
+               	movq	-0x358(%rbp), %r8
                	movl	%r8d, (%rcx)
                	movups	(%rax), %xmm2
                	leaq	-0x160(%rbp), %rax
@@ -848,142 +684,142 @@ Disassembly of section __TEXT,__text:
                	leaq	0x20(%r15), %rax
                	movups	%xmm2, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x440(%rbp), %xmm14
+               	movups	-0x3f0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%r12, %r8
-               	movq	%r8, -0x418(%rbp)
+               	movq	%r8, -0x3c8(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x458(%rbp)
-               	movq	-0x458(%rbp), %r8
+               	movq	%r8, -0x408(%rbp)
+               	movq	-0x408(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L70>
-               	jmp	 <L75>
-<L70>:
-               	movq	-0x458(%rbp), %r8
+               	jb	 <L49>
+               	jmp	 <L54>
+<L49>:
+               	movq	-0x408(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r15,%rdx), %rsi
                	movups	(%rsi), %xmm2
                	leaq	-0x190(%rbp), %r8
-               	movq	%r8, -0x460(%rbp)
-               	movq	-0x460(%rbp), %r8
+               	movq	%r8, -0x410(%rbp)
+               	movq	-0x410(%rbp), %r8
                	movups	%xmm2, (%r8)
-               	movq	-0x460(%rbp), %r8
+               	movq	-0x410(%rbp), %r8
                	leaq	(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0x3d0(%rbp)
-               	movq	-0x418(%rbp), %r8
+               	movq	%r8, -0x360(%rbp)
+               	movq	-0x3c8(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	-0x3d0(%rbp), %r8
+               	movq	-0x360(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L71>
-<L71>:
+               	callq	 <L50>
+<L50>:
                	movq	%rax, %rdi
-               	movq	-0x460(%rbp), %r8
+               	movq	-0x410(%rbp), %r8
                	leaq	0x4(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0x3d8(%rbp)
-               	movq	-0x3d8(%rbp), %r8
+               	movq	%r8, -0x368(%rbp)
+               	movq	-0x368(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L72>
-<L72>:
+               	callq	 <L51>
+<L51>:
                	movq	%rax, %rdi
-               	movq	-0x460(%rbp), %r8
+               	movq	-0x410(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movl	(%rsi), %r8d
-               	movq	%r8, -0x3e0(%rbp)
-               	movq	-0x3e0(%rbp), %r8
+               	movq	%r8, -0x370(%rbp)
+               	movq	-0x370(%rbp), %r8
                	movl	%r8d, %esi
-               	callq	 <L73>
-<L73>:
+               	callq	 <L52>
+<L52>:
                	movq	%rax, %rdi
-               	movq	-0x460(%rbp), %r8
+               	movq	-0x410(%rbp), %r8
                	leaq	0xc(%r8), %rsi
                	movl	(%rsi), %edx
                	movl	%edx, %esi
-               	callq	 <L74>
-<L74>:
+               	callq	 <L53>
+<L53>:
                	movq	%rax, %rdx
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x408(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rdx, %r8
-               	movq	%r8, -0x418(%rbp)
+               	movq	%r8, -0x3c8(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x458(%rbp)
-               	movq	-0x458(%rbp), %r8
+               	movq	%r8, -0x408(%rbp)
+               	movq	-0x408(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L70>
-<L75>:
+               	jb	 <L49>
+<L54>:
                	leaq	-0x1c0(%rbp), %r8
-               	movq	%r8, -0x468(%rbp)
-               	movq	-0x468(%rbp), %r8
+               	movq	%r8, -0x418(%rbp)
+               	movq	-0x418(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	movq	$0x0, 0x10(%r8)
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	movq	$0x0, 0x18(%r8)
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	movq	$0x0, 0x20(%r8)
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	movq	$0x0, 0x28(%r8)
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	leaq	(%r8), %rdx
                	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
                	leaq	0x20(%r15), %rsi
                	movups	(%rsi), %xmm2
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	leaq	0x10(%r8), %r15
                	movups	%xmm2, (%r15)
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x418(%rbp), %r8
                	leaq	0x20(%r8), %rsi
                	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
                	movl	(%rdx), %esi
-               	movq	-0x418(%rbp), %r8
+               	movq	-0x3c8(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L76>
-<L76>:
+               	callq	 <L55>
+<L55>:
                	movups	(%r15), %xmm2
                	leaq	-0x1d0(%rbp), %r15
                	movups	%xmm2, (%r15)
                	leaq	(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L77>
-<L77>:
+               	callq	 <L56>
+<L56>:
                	leaq	0x4(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L78>
-<L78>:
+               	callq	 <L57>
+<L57>:
                	leaq	0x8(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L79>
-<L79>:
+               	callq	 <L58>
+<L58>:
                	leaq	0xc(%r15), %rdx
                	movl	(%rdx), %esi
                	movq	%rax, %rdi
-               	callq	 <L80>
-<L80>:
-               	movq	-0x468(%rbp), %r8
+               	callq	 <L59>
+<L59>:
+               	movq	-0x418(%rbp), %r8
                	leaq	0x20(%r8), %rdx
                	movl	(%rdx), %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L81>
-<L81>:
-               	movq	-0x4b8(%rbp), %rbx
-               	movq	-0x4c0(%rbp), %r12
-               	movq	-0x4c8(%rbp), %r13
-               	movq	-0x4d0(%rbp), %r14
-               	movq	-0x4d8(%rbp), %r15
+               	callq	 <L60>
+<L60>:
+               	movq	-0x468(%rbp), %rbx
+               	movq	-0x470(%rbp), %r12
+               	movq	-0x478(%rbp), %r13
+               	movq	-0x480(%rbp), %r14
+               	movq	-0x488(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L82>:
+<L61>:
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	leaq	(%rbx), %rcx
@@ -1005,7 +841,7 @@ Disassembly of section __TEXT,__text:
                	movl	(%rcx), %r15d
                	imull	%r15d, %r14d
                	leaq	-0xd0(%rbp), %rcx
-               	movups	-0x430(%rbp), %xmm14
+               	movups	-0x3e0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %r15
                	movl	%edx, (%r15)
@@ -1025,127 +861,127 @@ Disassembly of section __TEXT,__text:
                	leaq	0xc(%r15), %rcx
                	movl	%r14d, (%rcx)
                	movups	(%r15), %xmm14
-               	movups	%xmm14, -0x480(%rbp)
+               	movups	%xmm14, -0x430(%rbp)
                	leaq	(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%r12, %rdi
                	movl	%edx, %esi
-               	callq	 <L83>
-<L83>:
+               	callq	 <L62>
+<L62>:
                	leaq	0x4(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L84>
-<L84>:
+               	callq	 <L63>
+<L63>:
                	leaq	0x8(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L85>
-<L85>:
+               	callq	 <L64>
+<L64>:
                	leaq	0xc(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L86>
-<L86>:
-               	movaps	-0x440(%rbp), %xmm14
-               	pxor	-0x480(%rbp), %xmm14
-               	movaps	%xmm14, -0x490(%rbp)
+               	callq	 <L65>
+<L65>:
+               	movaps	-0x3f0(%rbp), %xmm14
+               	pxor	-0x430(%rbp), %xmm14
+               	movaps	%xmm14, -0x440(%rbp)
                	leaq	-0x1e0(%rbp), %r14
-               	movups	-0x490(%rbp), %xmm14
+               	movups	-0x440(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L87>
-<L87>:
+               	callq	 <L66>
+<L66>:
                	leaq	0x4(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L88>
-<L88>:
+               	callq	 <L67>
+<L67>:
                	leaq	0x8(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L89>
-<L89>:
+               	callq	 <L68>
+<L68>:
                	leaq	0xc(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L90>
-<L90>:
-               	movaps	-0x450(%rbp), %xmm14
-               	paddd	-0x430(%rbp), %xmm14
-               	movaps	%xmm14, -0x4a0(%rbp)
+               	callq	 <L69>
+<L69>:
+               	movaps	-0x400(%rbp), %xmm14
+               	paddd	-0x3e0(%rbp), %xmm14
+               	movaps	%xmm14, -0x450(%rbp)
                	leaq	-0x200(%rbp), %r14
-               	movups	-0x4a0(%rbp), %xmm14
+               	movups	-0x450(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L91>
-<L91>:
+               	callq	 <L70>
+<L70>:
                	leaq	0x4(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L92>
-<L92>:
+               	callq	 <L71>
+<L71>:
                	leaq	0x8(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L93>
-<L93>:
+               	callq	 <L72>
+<L72>:
                	leaq	0xc(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L94>
-<L94>:
-               	movaps	-0x430(%rbp), %xmm14
-               	paddd	-0x410(%rbp), %xmm14
-               	movaps	%xmm14, -0x4b0(%rbp)
+               	callq	 <L73>
+<L73>:
+               	movaps	-0x3e0(%rbp), %xmm14
+               	paddd	-0x3a0(%rbp), %xmm14
+               	movaps	%xmm14, -0x460(%rbp)
                	leaq	-0x220(%rbp), %r14
-               	movups	-0x4b0(%rbp), %xmm14
+               	movups	-0x460(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	leaq	(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L95>
-<L95>:
+               	callq	 <L74>
+<L74>:
                	leaq	0x4(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L96>
-<L96>:
+               	callq	 <L75>
+<L75>:
                	leaq	0x8(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L97>
-<L97>:
+               	callq	 <L76>
+<L76>:
                	leaq	0xc(%r14), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rdi
                	movl	%edx, %esi
-               	callq	 <L98>
-<L98>:
+               	callq	 <L77>
+<L77>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
-               	movups	-0x4b0(%rbp), %xmm14
-               	movups	%xmm14, -0x430(%rbp)
-               	movups	-0x490(%rbp), %xmm14
-               	movups	%xmm14, -0x440(%rbp)
-               	movups	-0x4a0(%rbp), %xmm14
-               	movups	%xmm14, -0x450(%rbp)
-               	jmp	 <L69>
+               	movups	-0x460(%rbp), %xmm14
+               	movups	%xmm14, -0x3e0(%rbp)
+               	movups	-0x440(%rbp), %xmm14
+               	movups	%xmm14, -0x3f0(%rbp)
+               	movups	-0x450(%rbp), %xmm14
+               	movups	%xmm14, -0x400(%rbp)
+               	jmp	 <L48>

--- a/test/golden/x86_64-darwin/vec/vec_u64x2.dis
+++ b/test/golden/x86_64-darwin/vec/vec_u64x2.dis
@@ -26,12 +26,12 @@ Disassembly of section __TEXT,__text:
 <corpus.cases.vec.vec_u64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x3f0, %rsp            ## imm = 0x3F0
-               	movq	%rbx, -0x3c8(%rbp)
-               	movq	%r12, -0x3d0(%rbp)
-               	movq	%r13, -0x3d8(%rbp)
-               	movq	%r14, -0x3e0(%rbp)
-               	movq	%r15, -0x3e8(%rbp)
+               	subq	$0x3a0, %rsp            ## imm = 0x3A0
+               	movq	%rbx, -0x378(%rbp)
+               	movq	%r12, -0x380(%rbp)
+               	movq	%r13, -0x388(%rbp)
+               	movq	%r14, -0x390(%rbp)
+               	movq	%r15, -0x398(%rbp)
                	movq	%rdi, %rbx
                	callq	 <L0>
 <L0>:
@@ -65,7 +65,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x8(%rsi), %rdi
                	movq	$0x0, (%rdi)
                	movups	(%rsi), %xmm14
-               	movups	%xmm14, -0x300(%rbp)
+               	movups	%xmm14, -0x290(%rbp)
                	leaq	(%rcx), %rsi
                	movq	(%rsi), %rcx
                	addq	%rbx, %rcx
@@ -74,7 +74,7 @@ Disassembly of section __TEXT,__text:
                	leaq	(%r13), %rsi
                	movq	%rcx, (%rsi)
                	movups	(%r13), %xmm14
-               	movups	%xmm14, -0x310(%rbp)
+               	movups	%xmm14, -0x2a0(%rbp)
                	leaq	0x8(%rdx), %rcx
                	movq	(%rcx), %rdx
                	addq	%rbx, %rdx
@@ -83,7 +83,7 @@ Disassembly of section __TEXT,__text:
                	leaq	0x8(%rbx), %rcx
                	movq	%rdx, (%rcx)
                	movups	(%rbx), %xmm14
-               	movups	%xmm14, -0x320(%rbp)
+               	movups	%xmm14, -0x2b0(%rbp)
                	leaq	(%r13), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -104,11 +104,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L4>
 <L4>:
-               	movaps	-0x310(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2a0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x190(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -119,11 +119,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L6>
 <L6>:
-               	movaps	-0x310(%rbp), %xmm14
-               	psubq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2a0(%rbp), %xmm14
+               	psubq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1b0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -134,11 +134,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L8>
 <L8>:
-               	movaps	-0x320(%rbp), %xmm14
-               	psubq	-0x310(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2b0(%rbp), %xmm14
+               	psubq	-0x2a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x1d0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -160,16 +160,16 @@ Disassembly of section __TEXT,__text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0x1e0(%rbp), %rcx
-               	movups	-0x310(%rbp), %xmm14
+               	movups	-0x2a0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x1f0(%rbp), %r14
-               	movups	%xmm3, (%r14)
+               	movups	%xmm0, (%r14)
                	leaq	0x8(%r14), %rcx
                	movq	%rsi, (%rcx)
-               	movups	(%r14), %xmm3
+               	movups	(%r14), %xmm0
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -191,16 +191,16 @@ Disassembly of section __TEXT,__text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0x200(%rbp), %rcx
-               	movups	-0x310(%rbp), %xmm14
+               	movups	-0x2a0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x210(%rbp), %r13
-               	movups	%xmm3, (%r13)
+               	movups	%xmm0, (%r13)
                	leaq	0x8(%r13), %rcx
                	movq	%rsi, (%rcx)
-               	movups	(%r13), %xmm3
+               	movups	(%r13), %xmm0
                	leaq	(%r13), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -222,16 +222,16 @@ Disassembly of section __TEXT,__text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0x220(%rbp), %rcx
-               	movups	-0x320(%rbp), %xmm14
+               	movups	-0x2b0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
-               	movups	(%rcx), %xmm3
+               	movups	(%rcx), %xmm0
                	leaq	-0x230(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	0x8(%rbx), %rcx
                	movq	%rsi, (%rcx)
-               	movups	(%rbx), %xmm3
+               	movups	(%rbx), %xmm0
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -242,11 +242,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L16>
 <L16>:
-               	movaps	-0x310(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x2a0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x240(%rbp), %rcx
-               	movups	%xmm3, (%rcx)
+               	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdx
                	movq	(%rdx), %rsi
                	leaq	(%r12), %rdx
@@ -258,15 +258,15 @@ Disassembly of section __TEXT,__text:
                	movq	(%rdx), %rdi
                	imulq	%rdi, %rcx
                	leaq	-0x250(%rbp), %rdx
-               	movups	%xmm3, (%rdx)
+               	movups	%xmm0, (%rdx)
                	leaq	(%rdx), %rdi
                	movq	%rsi, (%rdi)
-               	movups	(%rdx), %xmm3
+               	movups	(%rdx), %xmm0
                	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	0x8(%rbx), %rdx
                	movq	%rcx, (%rdx)
-               	movups	(%rbx), %xmm3
+               	movups	(%rbx), %xmm0
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -277,11 +277,11 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L18>
 <L18>:
-               	movaps	-0x300(%rbp), %xmm14
-               	psubq	-0x310(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	-0x290(%rbp), %xmm14
+               	psubq	-0x2a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	leaq	-0x270(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rsi
                	movq	%rax, %rdi
@@ -292,133 +292,67 @@ Disassembly of section __TEXT,__text:
                	movq	%rax, %rdi
                	callq	 <L20>
 <L20>:
-               	movaps	-0x300(%rbp), %xmm14
-               	psubq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x280(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x290(%rbp), %xmm14
+               	psubq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L21>
 <L21>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	pand	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x2c0(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x2c0(%rbp), %xmm0
                	callq	 <L22>
 <L22>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pand	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x290(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	por	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x2d0(%rbp)
                	movq	%rax, %rdi
+               	movups	-0x2d0(%rbp), %xmm0
                	callq	 <L23>
 <L23>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	pxor	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L24>
 <L24>:
-               	movaps	-0x310(%rbp), %xmm14
-               	por	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2a0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2a0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L25>
 <L25>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2b0(%rbp), %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rdi
                	callq	 <L26>
 <L26>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pxor	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2b0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
+               	movaps	-0x2c0(%rbp), %xmm14
+               	pxor	-0x2d0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm4
                	movq	%rax, %rdi
+               	movaps	%xmm4, %xmm0
                	callq	 <L27>
 <L27>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L28>
-<L28>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2c0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L29>
-<L29>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L30>
-<L30>:
-               	movaps	-0x320(%rbp), %xmm14
-               	pcmpeqd	%xmm15, %xmm15
-               	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2d0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L31>
-<L31>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L32>
-<L32>:
-               	movaps	-0x310(%rbp), %xmm14
-               	pand	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm3
-               	movaps	-0x310(%rbp), %xmm14
-               	por	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, %xmm4
-               	movaps	%xmm3, %xmm14
-               	pxor	%xmm4, %xmm14
-               	movaps	%xmm14, %xmm3
-               	leaq	-0x2e0(%rbp), %rbx
-               	movups	%xmm3, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L33>
-<L33>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L34>
-<L34>:
                	movq	%rax, %rbx
-               	movups	-0x310(%rbp), %xmm14
-               	movups	%xmm14, -0x340(%rbp)
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, -0x350(%rbp)
-               	movups	-0x300(%rbp), %xmm14
-               	movups	%xmm14, -0x360(%rbp)
+               	movups	-0x2a0(%rbp), %xmm14
+               	movups	%xmm14, -0x2f0(%rbp)
+               	movups	-0x290(%rbp), %xmm14
+               	movups	%xmm14, -0x300(%rbp)
+               	movups	-0x290(%rbp), %xmm14
+               	movups	%xmm14, -0x310(%rbp)
                	movq	$0x0, %r13
-<L35>:
+<L28>:
                	leaq	-0xa0(%rbp), %r14
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%r14)
                	cmpq	$0x6, %r13
-               	jb	 <L44>
+               	jb	 <L37>
                	leaq	-0x100(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
@@ -429,10 +363,10 @@ Disassembly of section __TEXT,__text:
                	movq	$0x0, 0x30(%r15)
                	movq	$0x0, 0x38(%r15)
                	leaq	(%r15), %rax
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
-               	movaps	-0x340(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
+               	movaps	-0x2f0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
                	movaps	%xmm14, %xmm2
                	leaq	0x10(%r15), %rax
                	movups	%xmm2, (%rax)
@@ -447,7 +381,7 @@ Disassembly of section __TEXT,__text:
                	movq	(%rax), %rsi
                	imulq	%rsi, %rdx
                	leaq	-0x110(%rbp), %rax
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	leaq	(%rax), %rsi
                	movq	%rcx, (%rsi)
@@ -460,114 +394,114 @@ Disassembly of section __TEXT,__text:
                	leaq	0x20(%r15), %rax
                	movups	%xmm2, (%rax)
                	leaq	0x30(%r15), %rax
-               	movups	-0x350(%rbp), %xmm14
+               	movups	-0x300(%rbp), %xmm14
                	movups	%xmm14, (%rax)
                	movq	%rbx, %r8
-               	movq	%r8, -0x328(%rbp)
+               	movq	%r8, -0x2d8(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x368(%rbp)
-               	movq	-0x368(%rbp), %r8
+               	movq	%r8, -0x318(%rbp)
+               	movq	-0x318(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L36>
-               	jmp	 <L39>
-<L36>:
-               	movq	-0x368(%rbp), %r8
+               	jb	 <L29>
+               	jmp	 <L32>
+<L29>:
+               	movq	-0x318(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0x10, %rdx, %rdx
                	leaq	(%r15,%rdx), %rsi
                	movups	(%rsi), %xmm2
                	leaq	-0x130(%rbp), %r8
-               	movq	%r8, -0x370(%rbp)
-               	movq	-0x370(%rbp), %r8
+               	movq	%r8, -0x320(%rbp)
+               	movq	-0x320(%rbp), %r8
                	movups	%xmm2, (%r8)
-               	movq	-0x370(%rbp), %r8
+               	movq	-0x320(%rbp), %r8
                	leaq	(%r8), %rsi
                	movq	(%rsi), %r8
-               	movq	%r8, -0x2e8(%rbp)
-               	movq	-0x328(%rbp), %r8
+               	movq	%r8, -0x278(%rbp)
+               	movq	-0x2d8(%rbp), %r8
                	movq	%r8, %rdi
-               	movq	-0x2e8(%rbp), %r8
+               	movq	-0x278(%rbp), %r8
                	movq	%r8, %rsi
-               	callq	 <L37>
-<L37>:
+               	callq	 <L30>
+<L30>:
                	movq	%rax, %rdi
-               	movq	-0x370(%rbp), %r8
+               	movq	-0x320(%rbp), %r8
                	leaq	0x8(%r8), %rsi
                	movq	(%rsi), %rdx
                	movq	%rdx, %rsi
-               	callq	 <L38>
-<L38>:
+               	callq	 <L31>
+<L31>:
                	movq	%rax, %rdx
-               	movq	-0x368(%rbp), %r8
+               	movq	-0x318(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
                	movq	%rdx, %r8
-               	movq	%r8, -0x328(%rbp)
+               	movq	%r8, -0x2d8(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x368(%rbp)
-               	movq	-0x368(%rbp), %r8
+               	movq	%r8, -0x318(%rbp)
+               	movq	-0x318(%rbp), %r8
                	cmpq	$0x4, %r8
-               	jb	 <L36>
-<L39>:
+               	jb	 <L29>
+<L32>:
                	leaq	-0x160(%rbp), %r8
-               	movq	%r8, -0x378(%rbp)
-               	movq	-0x378(%rbp), %r8
+               	movq	%r8, -0x328(%rbp)
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x10(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x18(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x20(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	movq	$0x0, 0x28(%r8)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	leaq	(%r8), %rdx
                	movl	$0xffffffff, (%rdx)     ## imm = 0xFFFFFFFF
                	leaq	0x20(%r15), %rsi
                	movups	(%rsi), %xmm2
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	leaq	0x10(%r8), %r15
                	movups	%xmm2, (%r15)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	leaq	0x20(%r8), %rsi
                	movl	$0x12345678, (%rsi)     ## imm = 0x12345678
                	movl	(%rdx), %esi
-               	movq	-0x328(%rbp), %r8
+               	movq	-0x2d8(%rbp), %r8
                	movq	%r8, %rdi
-               	callq	 <L40>
-<L40>:
+               	callq	 <L33>
+<L33>:
                	movups	(%r15), %xmm2
                	leaq	-0x170(%rbp), %r15
                	movups	%xmm2, (%r15)
                	leaq	(%r15), %rdx
                	movq	(%rdx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L41>
-<L41>:
+               	callq	 <L34>
+<L34>:
                	leaq	0x8(%r15), %rdx
                	movq	(%rdx), %rsi
                	movq	%rax, %rdi
-               	callq	 <L42>
-<L42>:
-               	movq	-0x378(%rbp), %r8
+               	callq	 <L35>
+<L35>:
+               	movq	-0x328(%rbp), %r8
                	leaq	0x20(%r8), %rdx
                	movl	(%rdx), %ecx
                	movq	%rax, %rdi
                	movl	%ecx, %esi
-               	callq	 <L43>
-<L43>:
-               	movq	-0x3c8(%rbp), %rbx
-               	movq	-0x3d0(%rbp), %r12
-               	movq	-0x3d8(%rbp), %r13
-               	movq	-0x3e0(%rbp), %r14
-               	movq	-0x3e8(%rbp), %r15
+               	callq	 <L36>
+<L36>:
+               	movq	-0x378(%rbp), %rbx
+               	movq	-0x380(%rbp), %r12
+               	movq	-0x388(%rbp), %r13
+               	movq	-0x390(%rbp), %r14
+               	movq	-0x398(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L44>:
+<L37>:
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rdx
                	leaq	(%r12), %rcx
@@ -579,7 +513,7 @@ Disassembly of section __TEXT,__text:
                	movq	(%rcx), %rdi
                	imulq	%rdi, %rsi
                	leaq	-0xb0(%rbp), %rcx
-               	movups	-0x340(%rbp), %xmm14
+               	movups	-0x2f0(%rbp), %xmm14
                	movups	%xmm14, (%rcx)
                	leaq	(%rcx), %rdi
                	movq	%rdx, (%rdi)
@@ -589,71 +523,71 @@ Disassembly of section __TEXT,__text:
                	leaq	0x8(%r14), %rcx
                	movq	%rsi, (%rcx)
                	movups	(%r14), %xmm14
-               	movups	%xmm14, -0x390(%rbp)
+               	movups	%xmm14, -0x340(%rbp)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %rsi
                	movq	%rbx, %rdi
+               	callq	 <L38>
+<L38>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L39>
+<L39>:
+               	movaps	-0x300(%rbp), %xmm14
+               	pxor	-0x340(%rbp), %xmm14
+               	movaps	%xmm14, -0x350(%rbp)
+               	leaq	-0x180(%rbp), %r14
+               	movups	-0x350(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L40>
+<L40>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L41>
+<L41>:
+               	movaps	-0x310(%rbp), %xmm14
+               	paddq	-0x2f0(%rbp), %xmm14
+               	movaps	%xmm14, -0x360(%rbp)
+               	leaq	-0x1a0(%rbp), %r14
+               	movups	-0x360(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L42>
+<L42>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L43>
+<L43>:
+               	movaps	-0x2f0(%rbp), %xmm14
+               	paddq	-0x2b0(%rbp), %xmm14
+               	movaps	%xmm14, -0x370(%rbp)
+               	leaq	-0x1c0(%rbp), %r14
+               	movups	-0x370(%rbp), %xmm14
+               	movups	%xmm14, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L44>
+<L44>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%rax, %rdi
                	callq	 <L45>
 <L45>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L46>
-<L46>:
-               	movaps	-0x350(%rbp), %xmm14
-               	pxor	-0x390(%rbp), %xmm14
-               	movaps	%xmm14, -0x3a0(%rbp)
-               	leaq	-0x180(%rbp), %r14
-               	movups	-0x3a0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L47>
-<L47>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L48>
-<L48>:
-               	movaps	-0x360(%rbp), %xmm14
-               	paddq	-0x340(%rbp), %xmm14
-               	movaps	%xmm14, -0x3b0(%rbp)
-               	leaq	-0x1a0(%rbp), %r14
-               	movups	-0x3b0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L49>
-<L49>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L50>
-<L50>:
-               	movaps	-0x340(%rbp), %xmm14
-               	paddq	-0x320(%rbp), %xmm14
-               	movaps	%xmm14, -0x3c0(%rbp)
-               	leaq	-0x1c0(%rbp), %r14
-               	movups	-0x3c0(%rbp), %xmm14
-               	movups	%xmm14, (%r14)
-               	leaq	(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L51>
-<L51>:
-               	leaq	0x8(%r14), %rcx
-               	movq	(%rcx), %rsi
-               	movq	%rax, %rdi
-               	callq	 <L52>
-<L52>:
                	addq	$0x1, %r13
                	movq	%rax, %rbx
-               	movups	-0x3c0(%rbp), %xmm14
-               	movups	%xmm14, -0x340(%rbp)
-               	movups	-0x3a0(%rbp), %xmm14
-               	movups	%xmm14, -0x350(%rbp)
-               	movups	-0x3b0(%rbp), %xmm14
-               	movups	%xmm14, -0x360(%rbp)
-               	jmp	 <L35>
+               	movups	-0x370(%rbp), %xmm14
+               	movups	%xmm14, -0x2f0(%rbp)
+               	movups	-0x350(%rbp), %xmm14
+               	movups	%xmm14, -0x300(%rbp)
+               	movups	-0x360(%rbp), %xmm14
+               	movups	%xmm14, -0x310(%rbp)
+               	jmp	 <L28>

--- a/test/golden/x86_64-windows/call/call_indirect.dis
+++ b/test/golden/x86_64-windows/call/call_indirect.dis
@@ -361,50 +361,50 @@ Disassembly of section .text:
 <corpus.cases.call.call_indirect.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x230, %rsp            # imm = 0x230
-               	movq	%rbx, -0x178(%rbp)
-               	movq	%rdi, -0x180(%rbp)
-               	movq	%rsi, -0x188(%rbp)
-               	movq	%r12, -0x190(%rbp)
-               	movq	%r13, -0x198(%rbp)
-               	movq	%r14, -0x1a0(%rbp)
-               	movq	%r15, -0x1a8(%rbp)
-               	movaps	%xmm6, -0x1c0(%rbp)
-               	movaps	%xmm7, -0x1d0(%rbp)
-               	movaps	%xmm8, -0x1e0(%rbp)
-               	movaps	%xmm9, -0x1f0(%rbp)
-               	movaps	%xmm14, -0x200(%rbp)
-               	movaps	%xmm15, -0x210(%rbp)
+               	subq	$0x260, %rsp            # imm = 0x260
+               	movq	%rbx, -0x1a8(%rbp)
+               	movq	%rdi, -0x1b0(%rbp)
+               	movq	%rsi, -0x1b8(%rbp)
+               	movq	%r12, -0x1c0(%rbp)
+               	movq	%r13, -0x1c8(%rbp)
+               	movq	%r14, -0x1d0(%rbp)
+               	movq	%r15, -0x1d8(%rbp)
+               	movaps	%xmm6, -0x1f0(%rbp)
+               	movaps	%xmm7, -0x200(%rbp)
+               	movaps	%xmm8, -0x210(%rbp)
+               	movaps	%xmm9, -0x220(%rbp)
+               	movaps	%xmm14, -0x230(%rbp)
+               	movaps	%xmm15, -0x240(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x100(%rbp)
+               	movq	%r8, -0x130(%rbp)
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rcx
                	leaq	-0x60(%rbp), %r8
-               	movq	%r8, -0x128(%rbp)
-               	movq	-0x128(%rbp), %r8
+               	movq	%r8, -0x158(%rbp)
+               	movq	-0x158(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	movq	$0x0, 0x10(%r8)
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	movq	$0x0, 0x18(%r8)
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	movq	$0x0, 0x20(%r8)
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	movq	$0x0, 0x28(%r8)
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	movq	$0x0, 0x30(%r8)
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	movq	$0x0, 0x38(%r8)
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	movq	$0x0, 0x40(%r8)
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	movq	$0x0, 0x48(%r8)
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	movq	$0x0, 0x50(%r8)
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	movq	$0x0, 0x58(%r8)
                	movq	$0x0, %rdi
                	cmpq	$0xc, %rdi
@@ -416,9 +416,9 @@ Disassembly of section .text:
                	imulq	%r11, %r12
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
                	addq	%r11, %r12
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x130(%rbp), %r8
                	addq	%r8, %r12
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	leaq	(%r8,%rdi,8), %r13
                	movq	%r12, (%r13)
                	addq	$0x1, %rdi
@@ -451,49 +451,49 @@ Disassembly of section .text:
                	leaq	, %r13 <corpus.cases.call.call_indirect.checksum+0x220>
                	movq	%r13, (%r12)
                	leaq	-0xa0(%rbp), %r8
-               	movq	%r8, -0x108(%rbp)
-               	movq	-0x108(%rbp), %r8
+               	movq	%r8, -0x138(%rbp)
+               	movq	-0x138(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x108(%rbp), %r8
+               	movq	-0x138(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x108(%rbp), %r8
+               	movq	-0x138(%rbp), %r8
                	leaq	(%r8), %r13
                	leaq	, %r14 <corpus.cases.call.call_indirect.checksum+0x260>
                	movq	%r14, (%r13)
-               	movq	-0x108(%rbp), %r8
+               	movq	-0x138(%rbp), %r8
                	leaq	0x8(%r8), %r13
                	leaq	, %r14 <corpus.cases.call.call_indirect.checksum+0x276>
                	movq	%r14, (%r13)
                	leaq	-0xb0(%rbp), %r8
-               	movq	%r8, -0x110(%rbp)
-               	movq	-0x110(%rbp), %r8
+               	movq	%r8, -0x140(%rbp)
+               	movq	-0x140(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x140(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x140(%rbp), %r8
                	leaq	(%r8), %r14
                	leaq	, %r15 <corpus.cases.call.call_indirect.checksum+0x2b6>
                	movq	%r15, (%r14)
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x140(%rbp), %r8
                	leaq	0x8(%r8), %r14
                	leaq	, %r15 <corpus.cases.call.call_indirect.checksum+0x2cb>
                	movq	%r15, (%r14)
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x130(%rbp), %r8
                	movq	%r8, %r14
                	addq	$0x1, %r14
                	movq	%rcx, %r8
-               	movq	%r8, -0x118(%rbp)
+               	movq	%r8, -0x148(%rbp)
                	movq	%r14, %r8
-               	movq	%r8, -0x120(%rbp)
+               	movq	%r8, -0x150(%rbp)
                	movq	$0x0, %rbx
                	cmpq	$0xc, %rbx
                	jb	 <L3>
                	jmp	 <L14>
 <L3>:
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	leaq	(%r8,%rbx,8), %r12
                	movq	(%r12), %rcx
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x130(%rbp), %r8
                	addq	%r8, %rcx
                	movq	%rcx, %rax
                	movq	$0x6, %rcx
@@ -503,23 +503,23 @@ Disassembly of section .text:
                	leaq	(%rdi,%r13,8), %r15
                	movq	(%r15), %r14
                	movq	(%r12), %rsi
-               	movq	-0x120(%rbp), %r8
+               	movq	-0x150(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%rsi, %rdx
                	callq	*%r14
                	movq	%rax, %r8
-               	movq	%r8, -0x130(%rbp)
-               	movq	-0x130(%rbp), %r8
-               	movq	-0x118(%rbp), %r8
+               	movq	%r8, -0x160(%rbp)
+               	movq	-0x160(%rbp), %r8
+               	movq	-0x148(%rbp), %r8
                	movq	%r8, %rcx
-               	movq	-0x130(%rbp), %r8
+               	movq	-0x160(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L4>
 <L4>:
                	movq	%rax, %r14
                	movq	(%r15), %rsi
                	movq	(%r12), %r15
-               	movq	-0x130(%rbp), %r8
+               	movq	-0x160(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%r15, %rdx
                	callq	*%rsi
@@ -537,10 +537,10 @@ Disassembly of section .text:
                	movq	%rdx, %rcx
                	leaq	(%rdi,%rcx,8), %r12
                	movq	(%r12), %r13
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	leaq	(%r8,%rbx,8), %rcx
                	movq	(%rcx), %r12
-               	movq	-0x130(%rbp), %r8
+               	movq	-0x160(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%r12, %rdx
                	callq	*%r13
@@ -553,10 +553,10 @@ Disassembly of section .text:
                	callq	 <L6>
 <L6>:
                	movq	%rax, %rsi
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	leaq	(%r8,%rbx,8), %rcx
                	movq	(%rcx), %r12
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x130(%rbp), %r8
                	addq	%r8, %r12
                	movq	%r12, %rax
                	movq	$0x6, %rcx
@@ -590,10 +590,10 @@ Disassembly of section .text:
 <L11>:
                	leaq	, %r12 <L12>
 <L12>:
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	leaq	(%r8,%rbx,8), %rcx
                	movq	(%rcx), %r13
-               	movq	-0x130(%rbp), %r8
+               	movq	-0x160(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%r13, %rdx
                	callq	*%r12
@@ -605,17 +605,17 @@ Disassembly of section .text:
                	movq	%rax, %rcx
                	addq	$0x1, %rbx
                	movq	%rcx, %r8
-               	movq	%r8, -0x118(%rbp)
-               	movq	-0x130(%rbp), %r9
+               	movq	%r8, -0x148(%rbp)
+               	movq	-0x160(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x120(%rbp)
+               	movq	%r8, -0x150(%rbp)
                	cmpq	$0xc, %rbx
                	jb	 <L3>
 <L14>:
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	leaq	(%r8), %rcx
                	movq	(%rcx), %rbx
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x130(%rbp), %r8
                	addq	%r8, %rbx
                	movq	%rbx, %rax
                	movq	$0x6, %rcx
@@ -624,21 +624,21 @@ Disassembly of section .text:
                	movq	%rdx, %rcx
                	leaq	(%rdi,%rcx,8), %rbx
                	movq	(%rbx), %rcx
-               	movq	-0x118(%rbp), %r8
+               	movq	-0x148(%rbp), %r8
                	movq	%r8, %rbx
-               	movq	-0x120(%rbp), %r9
+               	movq	-0x150(%rbp), %r9
                	movq	%r9, %r8
-               	movq	%r8, -0x158(%rbp)
+               	movq	%r8, -0x188(%rbp)
                	movq	$0x0, %r12
                	movq	%rcx, %r13
                	cmpq	$0x8, %r12
                	jb	 <L15>
                	jmp	 <L17>
 <L15>:
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	leaq	(%r8,%r12,8), %rcx
                	movq	(%rcx), %r14
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x130(%rbp), %r8
                	addq	%r8, %r14
                	addq	%r12, %r14
                	movq	%r14, %rax
@@ -649,12 +649,12 @@ Disassembly of section .text:
                	leaq	(%rdi,%r14,8), %r15
                	movq	(%r15), %r14
                	movq	(%rcx), %r15
-               	movq	-0x158(%rbp), %r8
+               	movq	-0x188(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%r15, %rdx
                	callq	*%r14
                	movq	%rax, %r15
-               	movq	-0x158(%rbp), %r8
+               	movq	-0x188(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%r15, %rdx
                	callq	*%r13
@@ -666,7 +666,7 @@ Disassembly of section .text:
                	movq	%rax, %rbx
                	addq	$0x1, %r12
                	movq	%rsi, %r8
-               	movq	%r8, -0x158(%rbp)
+               	movq	%r8, -0x188(%rbp)
                	movq	%r14, %r13
                	cmpq	$0x8, %r12
                	jb	 <L15>
@@ -676,10 +676,10 @@ Disassembly of section .text:
                	jb	 <L18>
                	jmp	 <L24>
 <L18>:
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	leaq	(%r8,%rdi,8), %rcx
                	movq	(%rcx), %r12
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x130(%rbp), %r8
                	addq	%r8, %r12
                	movq	%r12, %rax
                	movq	$0x2, %r12
@@ -687,7 +687,7 @@ Disassembly of section .text:
                	divq	%r12
                	movq	%rdx, %r12
                	movq	(%rcx), %r13
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x130(%rbp), %r8
                	addq	%r8, %r13
                	addq	$0x1, %r13
                	movq	%r13, %rax
@@ -696,57 +696,63 @@ Disassembly of section .text:
                	divq	%r13
                	movq	%rdx, %r13
                	leaq	-0xc8(%rbp), %r14
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x140(%rbp), %r8
                	leaq	(%r8,%r12,8), %r15
                	movq	(%r15), %r8
-               	movq	%r8, -0x138(%rbp)
+               	movq	%r8, -0x168(%rbp)
                	movq	(%rcx), %r15
-               	movq	-0x158(%rbp), %r8
+               	movq	-0x188(%rbp), %r8
                	addq	%r8, %r15
                	leaq	-0xe0(%rbp), %r8
-               	movq	%r8, -0x140(%rbp)
-               	movq	-0x140(%rbp), %r8
+               	movq	%r8, -0x170(%rbp)
+               	movq	-0x170(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%r15, %rdx
-               	movq	-0x138(%rbp), %r8
+               	movq	-0x168(%rbp), %r8
                	callq	*%r8
-               	movq	-0x140(%rbp), %r8
-               	movq	-0x140(%rbp), %r8
+               	movq	-0x170(%rbp), %r8
+               	movq	-0x170(%rbp), %r8
                	movq	(%r8), %rcx
                	movq	%rcx, (%r14)
-               	movq	-0x140(%rbp), %r8
+               	movq	-0x170(%rbp), %r8
                	movq	0x8(%r8), %rcx
                	movq	%rcx, 0x8(%r14)
-               	movq	-0x140(%rbp), %r8
+               	movq	-0x170(%rbp), %r8
                	movq	0x10(%r8), %rcx
                	movq	%rcx, 0x10(%r14)
                	leaq	(%r14), %rcx
                	movq	(%rcx), %r15
                	leaq	0x8(%r14), %rcx
                	movq	(%rcx), %r8
-               	movq	%r8, -0x148(%rbp)
+               	movq	%r8, -0x178(%rbp)
                	leaq	0x10(%r14), %rcx
                	movq	(%rcx), %r8
-               	movq	%r8, -0x150(%rbp)
+               	movq	%r8, -0x180(%rbp)
                	movq	%rbx, %rcx
                	movq	%r15, %rdx
                	callq	 <L19>
 <L19>:
                	movq	%rax, %rcx
-               	movq	-0x148(%rbp), %r8
+               	movq	-0x178(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L20>
 <L20>:
                	movq	%rax, %rcx
-               	movq	-0x150(%rbp), %r8
+               	movq	-0x180(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L21>
 <L21>:
                	movq	%rax, %r15
-               	movq	-0x108(%rbp), %r8
+               	movq	-0x138(%rbp), %r8
                	leaq	(%r8,%r13,8), %rsi
                	movq	(%rsi), %r13
-               	movq	%r14, %rcx
+               	movq	(%r14), %rcx
+               	movq	%rcx, -0xf8(%rbp)
+               	movq	0x8(%r14), %rcx
+               	movq	%rcx, -0xf0(%rbp)
+               	movq	0x10(%r14), %rcx
+               	movq	%rcx, -0xe8(%rbp)
+               	leaq	-0xf8(%rbp), %rcx
                	callq	*%r13
                	movq	%rax, %r13
                	movq	%r15, %rcx
@@ -755,17 +761,23 @@ Disassembly of section .text:
 <L22>:
                	movq	%rax, %r13
                	movq	(%rsi), %r14
-               	movq	-0x110(%rbp), %r8
+               	movq	-0x140(%rbp), %r8
                	leaq	(%r8,%r12,8), %rcx
                	movq	(%rcx), %rsi
-               	movq	-0x128(%rbp), %r8
+               	movq	-0x158(%rbp), %r8
                	leaq	(%r8,%rdi,8), %rcx
                	movq	(%rcx), %r12
-               	leaq	-0xf8(%rbp), %r15
+               	leaq	-0x110(%rbp), %r15
                	movq	%r15, %rcx
                	movq	%r12, %rdx
                	callq	*%rsi
-               	movq	%r15, %rcx
+               	movq	(%r15), %rcx
+               	movq	%rcx, -0x128(%rbp)
+               	movq	0x8(%r15), %rcx
+               	movq	%rcx, -0x120(%rbp)
+               	movq	0x10(%r15), %rcx
+               	movq	%rcx, -0x118(%rbp)
+               	leaq	-0x128(%rbp), %rcx
                	callq	*%r14
                	movq	%rax, %rsi
                	movq	%r13, %rcx
@@ -778,19 +790,19 @@ Disassembly of section .text:
                	jb	 <L18>
 <L24>:
                	movq	%rbx, %r8
-               	movq	%r8, -0x160(%rbp)
+               	movq	%r8, -0x190(%rbp)
                	movq	$0x0, %r8
-               	movq	%r8, -0x168(%rbp)
-               	movq	-0x168(%rbp), %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x198(%rbp), %r8
                	cmpq	$0x4, %r8
                	jb	 <L25>
                	jmp	 <L70>
 <L25>:
-               	movq	-0x128(%rbp), %r8
-               	movq	-0x168(%rbp), %r9
+               	movq	-0x158(%rbp), %r8
+               	movq	-0x198(%rbp), %r9
                	leaq	(%r8,%r9,8), %rcx
                	movq	(%rcx), %rdi
-               	movq	-0x100(%rbp), %r8
+               	movq	-0x130(%rbp), %r8
                	addq	%r8, %rdi
                	movl	%edi, %r12d
                	movq	%rdi, %rcx
@@ -809,7 +821,7 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L27>:
                	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.call.call_indirect.checksum+0x818>
+               	divsd	, %xmm6 <corpus.cases.call.call_indirect.checksum+0x860>
                	movb	%dil, %r13b
                	movq	%rdi, %rcx
                	andq	$0xff, %rcx
@@ -844,7 +856,7 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L31>:
                	movsd	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1]
-               	divsd	, %xmm8 <corpus.cases.call.call_indirect.checksum+0x89c>
+               	divsd	, %xmm8 <corpus.cases.call.call_indirect.checksum+0x8e4>
                	movw	%di, %r15w
                	movq	%rdi, %rbx
                	xorq	$-0x1, %rbx
@@ -864,8 +876,8 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L33>:
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
-               	subss	, %xmm9 <corpus.cases.call.call_indirect.checksum+0x8eb>
-               	movq	-0x158(%rbp), %r8
+               	subss	, %xmm9 <corpus.cases.call.call_indirect.checksum+0x933>
+               	movq	-0x188(%rbp), %r8
                	movq	%rdi, %rsi
                	xorq	%r8, %rsi
                	callq	 <L34>
@@ -919,14 +931,14 @@ Disassembly of section .text:
                	callq	 <L46>
 <L46>:
                	movq	%rax, %rbx
-               	movq	-0x160(%rbp), %r8
+               	movq	-0x190(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%rbx, %rdx
                	callq	 <L47>
 <L47>:
                	movq	%rax, %r8
-               	movq	%r8, -0x170(%rbp)
-               	movq	-0x170(%rbp), %r8
+               	movq	%r8, -0x1a0(%rbp)
+               	movq	-0x1a0(%rbp), %r8
                	movl	%edi, %esi
                	movq	%rdi, %rcx
                	andq	$0xfff, %rcx            # imm = 0xFFF
@@ -944,7 +956,7 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L49>:
                	movsd	%xmm0, %xmm6            # xmm6 = xmm0[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.call.call_indirect.checksum+0x9f1>
+               	divsd	, %xmm6 <corpus.cases.call.call_indirect.checksum+0xa39>
                	movb	%dil, %r12b
                	movq	%rdi, %rcx
                	andq	$0xff, %rcx
@@ -979,7 +991,7 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L53>:
                	movsd	%xmm0, %xmm8            # xmm8 = xmm0[0],xmm8[1]
-               	divsd	, %xmm8 <corpus.cases.call.call_indirect.checksum+0xa75>
+               	divsd	, %xmm8 <corpus.cases.call.call_indirect.checksum+0xabd>
                	movw	%di, %r14w
                	movq	%rdi, %r15
                	xorq	$-0x1, %r15
@@ -999,8 +1011,8 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L55>:
                	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
-               	subss	, %xmm9 <corpus.cases.call.call_indirect.checksum+0xac4>
-               	movq	-0x158(%rbp), %r8
+               	subss	, %xmm9 <corpus.cases.call.call_indirect.checksum+0xb0c>
+               	movq	-0x188(%rbp), %r8
                	movq	%rdi, %rbx
                	xorq	%r8, %rbx
                	callq	 <L56>
@@ -1054,38 +1066,38 @@ Disassembly of section .text:
                	callq	 <L68>
 <L68>:
                	movq	%rax, %rbx
-               	movq	-0x170(%rbp), %r8
+               	movq	-0x1a0(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%rbx, %rdx
                	callq	 <L69>
 <L69>:
                	movq	%rax, %rcx
-               	movq	-0x168(%rbp), %r8
+               	movq	-0x198(%rbp), %r8
                	movq	%r8, %rbx
                	addq	$0x1, %rbx
                	movq	%rcx, %r8
-               	movq	%r8, -0x160(%rbp)
+               	movq	%r8, -0x190(%rbp)
                	movq	%rbx, %r8
-               	movq	%r8, -0x168(%rbp)
-               	movq	-0x168(%rbp), %r8
+               	movq	%r8, -0x198(%rbp)
+               	movq	-0x198(%rbp), %r8
                	cmpq	$0x4, %r8
                	jb	 <L25>
 <L70>:
-               	movq	-0x160(%rbp), %r8
+               	movq	-0x190(%rbp), %r8
                	movq	%r8, %rax
-               	movaps	-0x1c0(%rbp), %xmm6
-               	movaps	-0x1d0(%rbp), %xmm7
-               	movaps	-0x1e0(%rbp), %xmm8
-               	movaps	-0x1f0(%rbp), %xmm9
-               	movaps	-0x200(%rbp), %xmm14
-               	movaps	-0x210(%rbp), %xmm15
-               	movq	-0x178(%rbp), %rbx
-               	movq	-0x180(%rbp), %rdi
-               	movq	-0x188(%rbp), %rsi
-               	movq	-0x190(%rbp), %r12
-               	movq	-0x198(%rbp), %r13
-               	movq	-0x1a0(%rbp), %r14
-               	movq	-0x1a8(%rbp), %r15
+               	movaps	-0x1f0(%rbp), %xmm6
+               	movaps	-0x200(%rbp), %xmm7
+               	movaps	-0x210(%rbp), %xmm8
+               	movaps	-0x220(%rbp), %xmm9
+               	movaps	-0x230(%rbp), %xmm14
+               	movaps	-0x240(%rbp), %xmm15
+               	movq	-0x1a8(%rbp), %rbx
+               	movq	-0x1b0(%rbp), %rdi
+               	movq	-0x1b8(%rbp), %rsi
+               	movq	-0x1c0(%rbp), %r12
+               	movq	-0x1c8(%rbp), %r13
+               	movq	-0x1d0(%rbp), %r14
+               	movq	-0x1d8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/call/call_mixed.dis
+++ b/test/golden/x86_64-windows/call/call_mixed.dis
@@ -97,32 +97,35 @@ Disassembly of section .text:
                	movss	%xmm1, %xmm6            # xmm6 = xmm1[0],xmm6[1,2,3]
                	movl	%r8d, %esi
                	movsd	%xmm3, %xmm7            # xmm7 = xmm3[0],xmm7[1]
+               	movq	0x30(%rbp), %rcx
                	movq	$0x0, -0x10(%rbp)
                	movq	$0x0, -0x8(%rbp)
-               	movq	0x30(%rbp), %rcx
-               	movq	%rcx, -0x10(%rbp)
-               	movl	0x38(%rbp), %ecx
-               	movl	%ecx, -0x8(%rbp)
+               	movq	(%rcx), %rdx
+               	movq	%rdx, -0x10(%rbp)
+               	movl	0x8(%rcx), %edx
+               	movl	%edx, -0x8(%rbp)
                	movups	-0x10(%rbp), %xmm8
-               	movq	0x40(%rbp), %rdi
-               	movsd	0x48(%rbp), %xmm9
-               	movq	0x50(%rbp), %r12
-               	movups	0x60(%rbp), %xmm0
-               	movsd	0x70(%rbp), %xmm10
-               	movq	0x78(%rbp), %r8
+               	movq	0x38(%rbp), %rdi
+               	movsd	0x40(%rbp), %xmm9
+               	movq	0x48(%rbp), %r12
+               	movq	0x50(%rbp), %rcx
+               	movups	(%rcx), %xmm0
+               	movsd	0x58(%rbp), %xmm10
+               	movq	0x60(%rbp), %r8
                	movq	%r8, -0xa8(%rbp)
-               	movsd	0x80(%rbp), %xmm11
-               	movq	0x88(%rbp), %r8
+               	movsd	0x68(%rbp), %xmm11
+               	movq	0x70(%rbp), %r8
                	movq	%r8, -0xa0(%rbp)
-               	movsd	0x90(%rbp), %xmm12
-               	movsd	0x98(%rbp), %xmm1
-               	movq	0xa0(%rbp), %r15
-               	movsd	0xa8(%rbp), %xmm13
-               	movq	0xb0(%rbp), %r8
+               	movsd	0x78(%rbp), %xmm12
+               	movq	0x80(%rbp), %rcx
+               	movsd	(%rcx), %xmm1
+               	movq	0x88(%rbp), %r15
+               	movsd	0x90(%rbp), %xmm13
+               	movq	0x98(%rbp), %r8
                	movq	%r8, -0x98(%rbp)
-               	movq	0xb8(%rbp), %r11
+               	movq	0xa0(%rbp), %r11
                	movq	%r11, -0xb8(%rbp)
-               	movq	0xc0(%rbp), %r8
+               	movq	0xa8(%rbp), %r8
                	movq	%r8, -0x90(%rbp)
                	leaq	-0x1c(%rbp), %rbx
                	leaq	-0x30(%rbp), %r14
@@ -361,24 +364,26 @@ Disassembly of section .text:
 <corpus.cases.call.call_mixed.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x360, %rsp            # imm = 0x360
-               	movq	%rbx, -0x1d8(%rbp)
-               	movq	%rdi, -0x1e0(%rbp)
-               	movq	%rsi, -0x1e8(%rbp)
-               	movq	%r12, -0x1f0(%rbp)
-               	movq	%r13, -0x1f8(%rbp)
-               	movq	%r14, -0x200(%rbp)
-               	movq	%r15, -0x208(%rbp)
-               	movaps	%xmm6, -0x220(%rbp)
-               	movaps	%xmm7, -0x230(%rbp)
-               	movaps	%xmm8, -0x240(%rbp)
-               	movaps	%xmm9, -0x250(%rbp)
-               	movaps	%xmm10, -0x260(%rbp)
-               	movaps	%xmm11, -0x270(%rbp)
-               	movaps	%xmm12, -0x280(%rbp)
-               	movaps	%xmm14, -0x290(%rbp)
-               	movaps	%xmm15, -0x2a0(%rbp)
-               	movq	%rcx, %rbx
+               	subq	$0x420, %rsp            # imm = 0x420
+               	movq	%rbx, -0x2a8(%rbp)
+               	movq	%rdi, -0x2b0(%rbp)
+               	movq	%rsi, -0x2b8(%rbp)
+               	movq	%r12, -0x2c0(%rbp)
+               	movq	%r13, -0x2c8(%rbp)
+               	movq	%r14, -0x2d0(%rbp)
+               	movq	%r15, -0x2d8(%rbp)
+               	movaps	%xmm6, -0x2f0(%rbp)
+               	movaps	%xmm7, -0x300(%rbp)
+               	movaps	%xmm8, -0x310(%rbp)
+               	movaps	%xmm9, -0x320(%rbp)
+               	movaps	%xmm10, -0x330(%rbp)
+               	movaps	%xmm11, -0x340(%rbp)
+               	movaps	%xmm12, -0x350(%rbp)
+               	movaps	%xmm13, -0x360(%rbp)
+               	movaps	%xmm14, -0x370(%rbp)
+               	movaps	%xmm15, -0x380(%rbp)
+               	movq	%rcx, %r8
+               	movq	%r8, -0x228(%rbp)
                	callq	 <L0>
 <L0>:
                	leaq	-0xc0(%rbp), %rsi
@@ -416,30 +421,33 @@ Disassembly of section .text:
                	imulq	%r11, %rdx
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
                	addq	%r11, %rdx
-               	addq	%rbx, %rdx
+               	movq	-0x228(%rbp), %r8
+               	addq	%r8, %rdx
                	leaq	(%rsi,%rcx,8), %rdi
                	movq	%rdx, (%rdi)
                	addq	$0x1, %rcx
                	cmpq	$0x18, %rcx
                	jb	 <L1>
 <L2>:
-               	movq	%rax, %rdi
-               	movq	$0x0, %r12
+               	movq	%rax, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	$0x0, %r8
+               	movq	%r8, -0x200(%rbp)
                	movq	$0x0, %r13
                	cmpq	$0x3, %r13
                	jb	 <L3>
-               	jmp	 <L40>
+               	jmp	 <L35>
 <L3>:
                	movq	%r13, %rax
                	imulq	$0xb, %rax, %rax
-               	movq	%rax, %r8
-               	addq	%rbx, %r8
-               	movq	%r8, -0x168(%rbp)
-               	leaq	-0xcc(%rbp), %rcx
-               	leaq	0x80(%rsi), %rdx
-               	movq	(%rdx), %r14
-               	andq	$0xfff, %r14            # imm = 0xFFF
-               	movq	%r14, %r11
+               	movq	-0x228(%rbp), %r8
+               	movq	%rax, %r14
+               	addq	%r8, %r14
+               	leaq	-0xcc(%rbp), %rax
+               	leaq	0x80(%rsi), %rcx
+               	movq	(%rcx), %rdx
+               	andq	$0xfff, %rdx            # imm = 0xFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L4>
                	cvtsi2ss	%r11, %xmm0
@@ -453,15 +461,15 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L5>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x238>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x25c>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x244>
-               	leaq	(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x88(%rsi), %rdx
-               	movq	(%rdx), %r14
-               	andq	$0xfff, %r14            # imm = 0xFFF
-               	movq	%r14, %r11
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x268>
+               	leaq	(%rax), %rcx
+               	movss	%xmm0, (%rcx)
+               	leaq	0x88(%rsi), %rcx
+               	movq	(%rcx), %rdx
+               	andq	$0xfff, %rdx            # imm = 0xFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L6>
                	cvtsi2ss	%r11, %xmm0
@@ -475,15 +483,15 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L7>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x294>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x2b8>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x2a0>
-               	leaq	0x4(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
-               	leaq	0x90(%rsi), %rdx
-               	movq	(%rdx), %r14
-               	andq	$0xfff, %r14            # imm = 0xFFF
-               	movq	%r14, %r11
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x2c4>
+               	leaq	0x4(%rax), %rcx
+               	movss	%xmm0, (%rcx)
+               	leaq	0x90(%rsi), %rcx
+               	movq	(%rcx), %rdx
+               	andq	$0xfff, %rdx            # imm = 0xFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L8>
                	cvtsi2ss	%r11, %xmm0
@@ -497,408 +505,361 @@ Disassembly of section .text:
                	addss	%xmm0, %xmm0
 <L9>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x2f1>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x315>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x2fd>
-               	leaq	0x8(%rcx), %rdx
-               	movss	%xmm0, (%rdx)
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x321>
+               	leaq	0x8(%rax), %rcx
+               	movss	%xmm0, (%rcx)
                	movq	$0x0, -0xe8(%rbp)
                	movq	$0x0, -0xe0(%rbp)
+               	movq	(%rax), %rcx
+               	movq	%rcx, -0xe8(%rbp)
+               	movl	0x8(%rax), %ecx
+               	movl	%ecx, -0xe0(%rbp)
+               	movups	-0xe8(%rbp), %xmm6
+               	leaq	-0x100(%rbp), %rax
+               	leaq	0x98(%rsi), %rcx
                	movq	(%rcx), %rdx
-               	movq	%rdx, -0xe8(%rbp)
-               	movl	0x8(%rcx), %edx
-               	movl	%edx, -0xe0(%rbp)
-               	movups	-0xe8(%rbp), %xmm0
-               	leaq	-0x100(%rbp), %rcx
-               	leaq	0x98(%rsi), %rdx
-               	movq	(%rdx), %r14
-               	andq	$0xfff, %r14            # imm = 0xFFF
-               	movq	%r14, %r11
+               	andq	$0xfff, %rdx            # imm = 0xFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L10>
-               	cvtsi2ss	%r11, %xmm1
+               	cvtsi2ss	%r11, %xmm0
                	jmp	 <L11>
 <L10>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm1
-               	addss	%xmm1, %xmm1
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
 <L11>:
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	subss	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x385>
-               	movss	%xmm2, %xmm1            # xmm1 = xmm2[0],xmm1[1,2,3]
-               	divss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x391>
-               	leaq	(%rcx), %rdx
-               	movss	%xmm1, (%rdx)
-               	leaq	0xa0(%rsi), %rdx
-               	movq	(%rdx), %r14
-               	andq	$0xfff, %r14            # imm = 0xFFF
-               	movq	%r14, %r11
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x3a9>
+               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x3b5>
+               	leaq	(%rax), %rcx
+               	movss	%xmm0, (%rcx)
+               	leaq	0xa0(%rsi), %rcx
+               	movq	(%rcx), %rdx
+               	andq	$0xfff, %rdx            # imm = 0xFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L12>
-               	cvtsi2ss	%r11, %xmm1
+               	cvtsi2ss	%r11, %xmm0
                	jmp	 <L13>
 <L12>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm1
-               	addss	%xmm1, %xmm1
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
 <L13>:
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	subss	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x3e1>
-               	movss	%xmm2, %xmm1            # xmm1 = xmm2[0],xmm1[1,2,3]
-               	divss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x3ed>
-               	leaq	0x4(%rcx), %rdx
-               	movss	%xmm1, (%rdx)
-               	leaq	0xa8(%rsi), %rdx
-               	movq	(%rdx), %r14
-               	andq	$0xfff, %r14            # imm = 0xFFF
-               	movq	%r14, %r11
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x405>
+               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x411>
+               	leaq	0x4(%rax), %rcx
+               	movss	%xmm0, (%rcx)
+               	leaq	0xa8(%rsi), %rcx
+               	movq	(%rcx), %rdx
+               	andq	$0xfff, %rdx            # imm = 0xFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L14>
-               	cvtsi2ss	%r11, %xmm1
+               	cvtsi2ss	%r11, %xmm0
                	jmp	 <L15>
 <L14>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm1
-               	addss	%xmm1, %xmm1
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
 <L15>:
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	subss	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x43e>
-               	movss	%xmm2, %xmm1            # xmm1 = xmm2[0],xmm1[1,2,3]
-               	divss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x44a>
-               	leaq	0x8(%rcx), %rdx
-               	movss	%xmm1, (%rdx)
-               	leaq	0xb0(%rsi), %rdx
-               	movq	(%rdx), %r14
-               	andq	$0xfff, %r14            # imm = 0xFFF
-               	movq	%r14, %r11
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x462>
+               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x46e>
+               	leaq	0x8(%rax), %rcx
+               	movss	%xmm0, (%rcx)
+               	leaq	0xb0(%rsi), %rcx
+               	movq	(%rcx), %rdx
+               	andq	$0xfff, %rdx            # imm = 0xFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L16>
-               	cvtsi2ss	%r11, %xmm1
+               	cvtsi2ss	%r11, %xmm0
                	jmp	 <L17>
 <L16>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm1
-               	addss	%xmm1, %xmm1
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
 <L17>:
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	subss	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x49b>
-               	movss	%xmm2, %xmm1            # xmm1 = xmm2[0],xmm1[1,2,3]
-               	divss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x4a7>
-               	leaq	0xc(%rcx), %rdx
-               	movss	%xmm1, (%rdx)
-               	movups	(%rcx), %xmm2
-               	leaq	-0x128(%rbp), %rcx
-               	leaq	0xb8(%rsi), %rdx
-               	movq	(%rdx), %r14
-               	andq	$0xfff, %r14            # imm = 0xFFF
-               	movq	%r14, %r11
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x4bf>
+               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x4cb>
+               	leaq	0xc(%rax), %rcx
+               	movss	%xmm0, (%rcx)
+               	movups	(%rax), %xmm7
+               	leaq	-0x128(%rbp), %r15
+               	leaq	0xb8(%rsi), %rax
+               	movq	(%rax), %rcx
+               	andq	$0xfff, %rcx            # imm = 0xFFF
+               	movq	%rcx, %r11
                	testq	%r11, %r11
                	jl	 <L18>
-               	cvtsi2ss	%r11, %xmm1
+               	cvtsi2ss	%r11, %xmm0
                	jmp	 <L19>
 <L18>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm1
-               	addss	%xmm1, %xmm1
+               	cvtsi2ss	%r11, %xmm0
+               	addss	%xmm0, %xmm0
 <L19>:
-               	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x502>
-               	movss	%xmm3, %xmm1            # xmm1 = xmm3[0],xmm1[1,2,3]
-               	divss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x50e>
-               	leaq	(%rcx), %rdx
-               	movss	%xmm1, (%rdx)
-               	leaq	(%rsi), %rdx
-               	movq	(%rdx), %r14
-               	movq	-0x168(%rbp), %r8
-               	addq	%r8, %r14
-               	andq	$0xfff, %r14            # imm = 0xFFF
-               	movq	%r14, %r11
-               	testq	%r11, %r11
-               	jl	 <L20>
-               	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L21>
+               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x526>
+               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x532>
+               	leaq	(%r15), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	(%rsi), %r8
+               	movq	%r8, -0x248(%rbp)
+               	movq	-0x248(%rbp), %r8
+               	movq	(%r8), %rcx
+               	addq	%r14, %rcx
+               	callq	 <L20>
 <L20>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm1
-               	addss	%xmm1, %xmm1
+               	leaq	0x4(%r15), %rcx
+               	movss	%xmm0, (%rcx)
+               	movsd	(%r15), %xmm8
+               	movq	-0x248(%rbp), %r8
+               	movq	(%r8), %rcx
+               	movq	%rcx, %r15
+               	addq	%r14, %r15
+               	leaq	0x8(%rsi), %rax
+               	movq	(%rax), %rcx
+               	callq	 <L21>
 <L21>:
-               	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x564>
-               	movss	%xmm3, %xmm1            # xmm1 = xmm3[0],xmm1[1,2,3]
-               	divss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x570>
-               	leaq	0x4(%rcx), %rdx
-               	movss	%xmm1, (%rdx)
-               	movsd	(%rcx), %xmm4
-               	leaq	(%rsi), %rcx
+               	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
+               	leaq	0x10(%rsi), %rax
+               	movq	(%rax), %rcx
+               	movl	%ecx, %r8d
+               	movq	%r8, -0x250(%rbp)
+               	leaq	0x18(%rsi), %rcx
                	movq	(%rcx), %rdx
-               	movq	-0x168(%rbp), %r9
-               	movq	%rdx, %r8
-               	addq	%r9, %r8
-               	movq	%r8, -0x170(%rbp)
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %r14
-               	andq	$0xfff, %r14            # imm = 0xFFF
-               	movq	%r14, %r11
+               	andq	$0xfffff, %rdx          # imm = 0xFFFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L22>
-               	cvtsi2ss	%r11, %xmm1
+               	cvtsi2sd	%r11, %xmm0
                	jmp	 <L23>
 <L22>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm1
-               	addss	%xmm1, %xmm1
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
 <L23>:
-               	movss	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1,2,3]
-               	subss	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x5dc>
-               	movss	%xmm3, %xmm1            # xmm1 = xmm3[0],xmm1[1,2,3]
-               	divss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x5e8>
-               	leaq	0x10(%rsi), %rcx
-               	movq	(%rcx), %r14
-               	movl	%r14d, %r8d
-               	movq	%r8, -0x178(%rbp)
-               	leaq	0x18(%rsi), %rcx
-               	movq	(%rcx), %r14
-               	andq	$0xfffff, %r14          # imm = 0xFFFFF
-               	movq	%r14, %r11
-               	testq	%r11, %r11
-               	jl	 <L24>
-               	cvtsi2sd	%r11, %xmm3
-               	jmp	 <L25>
-<L24>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm3
-               	addsd	%xmm3, %xmm3
-<L25>:
-               	movsd	%xmm3, %xmm5            # xmm5 = xmm3[0],xmm5[1]
-               	subsd	, %xmm5 <corpus.cases.call.call_mixed.checksum+0x63f>
-               	movsd	%xmm5, %xmm3            # xmm3 = xmm5[0],xmm3[1]
-               	divsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x64b>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x5da>
+               	movsd	%xmm1, %xmm10           # xmm10 = xmm1[0],xmm10[1]
+               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x5e8>
                	leaq	0x20(%rsi), %rcx
                	movq	(%rcx), %r8
-               	movq	%r8, -0x188(%rbp)
+               	movq	%r8, -0x258(%rbp)
                	leaq	0x28(%rsi), %rcx
-               	movq	(%rcx), %rax
-               	andq	$0xfff, %rax            # imm = 0xFFF
-               	movq	%rax, %r11
+               	movq	(%rcx), %r8
+               	movq	%r8, -0x1c8(%rbp)
+               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L24>
+<L24>:
+               	movss	%xmm0, %xmm11           # xmm11 = xmm0[0],xmm11[1,2,3]
+               	leaq	0x30(%rsi), %rcx
+               	movq	(%rcx), %r8
+               	movq	%r8, -0x1d0(%rbp)
+               	movq	-0x1d0(%rbp), %r8
+               	movw	%r8w, %di
+               	leaq	0x38(%rsi), %rcx
+               	movq	(%rcx), %r8
+               	movq	%r8, -0x1e0(%rbp)
+               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, %rcx
+               	andq	$0xfffff, %rcx          # imm = 0xFFFFF
+               	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L26>
-               	cvtsi2ss	%r11, %xmm5
-               	jmp	 <L27>
-<L26>:
+               	jl	 <L25>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L26>
+<L25>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm5
-               	addss	%xmm5, %xmm5
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L26>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x688>
+               	movsd	%xmm1, %xmm12           # xmm12 = xmm1[0],xmm12[1]
+               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0x696>
+               	leaq	0x40(%rsi), %rcx
+               	movq	(%rcx), %r8
+               	movq	%r8, -0x1e8(%rbp)
+               	leaq	0x48(%rsi), %rcx
+               	movq	(%rcx), %r8
+               	movq	%r8, -0x1f0(%rbp)
+               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L27>
 <L27>:
-               	movss	%xmm5, %xmm6            # xmm6 = xmm5[0],xmm6[1,2,3]
-               	subss	, %xmm6 <corpus.cases.call.call_mixed.checksum+0x69f>
-               	movss	%xmm6, %xmm5            # xmm5 = xmm6[0],xmm5[1,2,3]
-               	divss	, %xmm5 <corpus.cases.call.call_mixed.checksum+0x6ab>
-               	leaq	0x30(%rsi), %rax
-               	movq	(%rax), %rcx
-               	movw	%cx, %r8w
-               	movq	%r8, -0x198(%rbp)
-               	leaq	0x38(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0xfffff, %rdx          # imm = 0xFFFFF
-               	movq	%rdx, %r11
+               	movss	%xmm0, %xmm13           # xmm13 = xmm0[0],xmm13[1,2,3]
+               	leaq	0x50(%rsi), %rcx
+               	movq	(%rcx), %r8
+               	movq	%r8, -0x1f8(%rbp)
+               	movq	-0x1f8(%rbp), %r8
+               	movb	%r8b, %r12b
+               	leaq	0x58(%rsi), %rcx
+               	movq	(%rcx), %r8
+               	movq	%r8, -0x208(%rbp)
+               	movq	-0x208(%rbp), %r8
+               	movq	%r8, %rcx
+               	andq	$0xfffff, %rcx          # imm = 0xFFFFF
+               	movq	%rcx, %r11
                	testq	%r11, %r11
                	jl	 <L28>
-               	cvtsi2sd	%r11, %xmm6
+               	cvtsi2sd	%r11, %xmm0
                	jmp	 <L29>
 <L28>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm6
-               	addsd	%xmm6, %xmm6
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
 <L29>:
-               	movsd	%xmm6, %xmm7            # xmm7 = xmm6[0],xmm7[1]
-               	subsd	, %xmm7 <corpus.cases.call.call_mixed.checksum+0x703>
-               	movsd	%xmm7, %xmm6            # xmm6 = xmm7[0],xmm6[1]
-               	divsd	, %xmm6 <corpus.cases.call.call_mixed.checksum+0x70f>
-               	leaq	0x40(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	0x48(%rsi), %rcx
-               	movq	(%rcx), %r15
-               	andq	$0xfff, %r15            # imm = 0xFFF
-               	movq	%r15, %r11
-               	testq	%r11, %r11
-               	jl	 <L30>
-               	cvtsi2ss	%r11, %xmm7
-               	jmp	 <L31>
-<L30>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm7
-               	addss	%xmm7, %xmm7
-<L31>:
-               	movss	%xmm7, %xmm8            # xmm8 = xmm7[0],xmm8[1,2,3]
-               	subss	, %xmm8 <corpus.cases.call.call_mixed.checksum+0x75e>
-               	movss	%xmm8, %xmm7            # xmm7 = xmm8[0],xmm7[1,2,3]
-               	divss	, %xmm7 <corpus.cases.call.call_mixed.checksum+0x76b>
-               	leaq	0x50(%rsi), %rcx
-               	movq	(%rcx), %r15
-               	movb	%r15b, %r8b
-               	movq	%r8, -0x180(%rbp)
-               	leaq	0x58(%rsi), %rcx
-               	movq	(%rcx), %r15
-               	andq	$0xfffff, %r15          # imm = 0xFFFFF
-               	movq	%r15, %r11
-               	testq	%r11, %r11
-               	jl	 <L32>
-               	cvtsi2sd	%r11, %xmm8
-               	jmp	 <L33>
-<L32>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm8
-               	addsd	%xmm8, %xmm8
-<L33>:
-               	movsd	%xmm8, %xmm9            # xmm9 = xmm8[0],xmm9[1]
-               	subsd	, %xmm9 <corpus.cases.call.call_mixed.checksum+0x7c5>
-               	movsd	%xmm9, %xmm8            # xmm8 = xmm9[0],xmm8[1]
-               	divsd	, %xmm8 <corpus.cases.call.call_mixed.checksum+0x7d3>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x735>
+               	movsd	%xmm1, %xmm14           # xmm14 = xmm1[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x743>
+               	movsd	%xmm14, -0x268(%rbp)
                	leaq	0x60(%rsi), %rcx
-               	movq	(%rcx), %r15
+               	movq	(%rcx), %r8
+               	movq	%r8, -0x210(%rbp)
                	leaq	0x68(%rsi), %rcx
-               	movq	(%rcx), %r14
-               	andq	$0xfff, %r14            # imm = 0xFFF
-               	movq	%r14, %r11
+               	movq	(%rcx), %r8
+               	movq	%r8, -0x218(%rbp)
+               	movq	-0x218(%rbp), %r8
+               	movq	%r8, %rcx
+               	callq	 <L30>
+<L30>:
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	leaq	0x70(%rsi), %rcx
+               	movq	(%rcx), %r8
+               	movq	%r8, -0x220(%rbp)
+               	movq	-0x220(%rbp), %r9
+               	movl	%r9d, %r8d
+               	movq	%r8, -0x230(%rbp)
+               	leaq	0x78(%rsi), %rcx
+               	movq	(%rcx), %rbx
+               	andq	$0xfffff, %rbx          # imm = 0xFFFFF
+               	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L34>
-               	cvtsi2ss	%r11, %xmm9
-               	jmp	 <L35>
-<L34>:
+               	jl	 <L31>
+               	cvtsi2sd	%r11, %xmm1
+               	jmp	 <L32>
+<L31>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm9
-               	addss	%xmm9, %xmm9
+               	cvtsi2sd	%r11, %xmm1
+               	addsd	%xmm1, %xmm1
+<L32>:
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x7e0>
+               	movsd	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0x7ec>
+               	leaq	0x8(%rsi), %rcx
+               	movq	(%rcx), %rbx
+               	addq	%r14, %rbx
+               	movq	%r15, %rcx
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	movq	-0x250(%rbp), %r8
+               	movsd	%xmm10, %xmm3           # xmm3 = xmm10[0],xmm3[1]
+               	movups	%xmm6, -0x140(%rbp)
+               	leaq	-0x140(%rbp), %rax
+               	movq	%rax, 0x20(%rsp)
+               	movq	-0x258(%rbp), %r9
+               	movq	%r9, 0x28(%rsp)
+               	movsd	%xmm11, 0x30(%rsp)
+               	movq	%rdi, 0x38(%rsp)
+               	movups	%xmm7, -0x150(%rbp)
+               	leaq	-0x150(%rbp), %rax
+               	movq	%rax, 0x40(%rsp)
+               	movsd	%xmm12, 0x48(%rsp)
+               	movq	-0x1e8(%rbp), %r9
+               	movq	%r9, 0x50(%rsp)
+               	movsd	%xmm13, 0x58(%rsp)
+               	movq	%r12, 0x60(%rsp)
+               	movq	-0x268(%rbp), %r11
+               	movq	%r11, 0x68(%rsp)
+               	movups	%xmm8, -0x160(%rbp)
+               	leaq	-0x160(%rbp), %rax
+               	movq	%rax, 0x70(%rsp)
+               	movq	-0x210(%rbp), %r9
+               	movq	%r9, 0x78(%rsp)
+               	movsd	%xmm2, 0x80(%rsp)
+               	movq	-0x230(%rbp), %r9
+               	movq	%r9, 0x88(%rsp)
+               	movsd	%xmm4, 0x90(%rsp)
+               	movq	%rbx, 0x98(%rsp)
+               	callq	 <L33>
+<L33>:
+               	movq	%rax, %rbx
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, %rcx
+               	movq	%rbx, %rdx
+               	callq	 <L34>
+<L34>:
+               	addq	$0x1, %r13
+               	movq	%rax, %r8
+               	movq	%r8, -0x1d8(%rbp)
+               	movq	%rbx, %r8
+               	movq	%r8, -0x200(%rbp)
+               	cmpq	$0x3, %r13
+               	jb	 <L3>
 <L35>:
-               	movss	%xmm9, %xmm10           # xmm10 = xmm9[0],xmm10[1,2,3]
-               	subss	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x823>
-               	movss	%xmm10, %xmm9           # xmm9 = xmm10[0],xmm9[1,2,3]
-               	divss	, %xmm9 <corpus.cases.call.call_mixed.checksum+0x831>
-               	leaq	0x70(%rsi), %rcx
-               	movq	(%rcx), %r14
-               	movl	%r14d, %r8d
-               	movq	%r8, -0x190(%rbp)
-               	leaq	0x78(%rsi), %rcx
-               	movq	(%rcx), %r14
-               	andq	$0xfffff, %r14          # imm = 0xFFFFF
-               	movq	%r14, %r11
+               	leaq	-0xd8(%rbp), %rax
+               	movq	-0x200(%rbp), %r8
+               	movq	%r8, %rcx
+               	andq	$0xfff, %rcx            # imm = 0xFFF
+               	movq	%rcx, %r11
                	testq	%r11, %r11
                	jl	 <L36>
-               	cvtsi2sd	%r11, %xmm10
+               	cvtsi2ss	%r11, %xmm0
                	jmp	 <L37>
 <L36>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm10
-               	addsd	%xmm10, %xmm10
-<L37>:
-               	movsd	%xmm10, %xmm11          # xmm11 = xmm10[0],xmm11[1]
-               	subsd	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x88b>
-               	movsd	%xmm11, %xmm10          # xmm10 = xmm11[0],xmm10[1]
-               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x899>
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %r14
-               	movq	-0x168(%rbp), %r8
-               	addq	%r8, %r14
-               	movq	-0x170(%rbp), %r8
-               	movq	%r8, %rcx
-               	movq	-0x178(%rbp), %r8
-               	movups	%xmm0, -0x140(%rbp)
-               	movq	-0x140(%rbp), %rax
-               	movq	%rax, 0x20(%rsp)
-               	movl	-0x138(%rbp), %eax
-               	movl	%eax, 0x28(%rsp)
-               	movq	-0x188(%rbp), %r9
-               	movq	%r9, 0x30(%rsp)
-               	movsd	%xmm5, 0x38(%rsp)
-               	movq	-0x198(%rbp), %r9
-               	movq	%r9, 0x40(%rsp)
-               	movups	%xmm2, 0x50(%rsp)
-               	movsd	%xmm6, 0x60(%rsp)
-               	movq	%rdx, 0x68(%rsp)
-               	movsd	%xmm7, 0x70(%rsp)
-               	movq	-0x180(%rbp), %r9
-               	movq	%r9, 0x78(%rsp)
-               	movsd	%xmm8, 0x80(%rsp)
-               	movsd	%xmm4, 0x88(%rsp)
-               	movq	%r15, 0x90(%rsp)
-               	movsd	%xmm9, 0x98(%rsp)
-               	movq	-0x190(%rbp), %r9
-               	movq	%r9, 0xa0(%rsp)
-               	movsd	%xmm10, 0xa8(%rsp)
-               	movq	%r14, 0xb0(%rsp)
-               	callq	 <L38>
-<L38>:
-               	movq	%rax, %r12
-               	movq	%rdi, %rcx
-               	movq	%r12, %rdx
-               	callq	 <L39>
-<L39>:
-               	addq	$0x1, %r13
-               	movq	%rax, %rdi
-               	cmpq	$0x3, %r13
-               	jb	 <L3>
-<L40>:
-               	leaq	-0xd8(%rbp), %rax
-               	movq	%r12, %rcx
-               	andq	$0xfff, %rcx            # imm = 0xFFF
-               	movq	%rcx, %r11
-               	testq	%r11, %r11
-               	jl	 <L41>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L42>
-<L41>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L42>:
+<L37>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x9cb>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x948>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x9d7>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x954>
                	leaq	(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x10(%rsi), %rcx
@@ -906,21 +867,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L43>
+               	jl	 <L38>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L44>
-<L43>:
+               	jmp	 <L39>
+<L38>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L44>:
+<L39>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa24>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x9a1>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa30>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x9ad>
                	leaq	0x4(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x18(%rsi), %rcx
@@ -928,21 +889,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L45>
+               	jl	 <L40>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L46>
-<L45>:
+               	jmp	 <L41>
+<L40>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L46>:
+<L41>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa7e>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x9fb>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa8a>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa07>
                	leaq	0x8(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	movq	$0x0, -0x110(%rbp)
@@ -958,21 +919,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L47>
+               	jl	 <L42>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L48>
-<L47>:
+               	jmp	 <L43>
+<L42>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L48>:
+<L43>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xb0f>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xa8c>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xb1b>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xa98>
                	leaq	(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x28(%rsi), %rcx
@@ -980,21 +941,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L49>
+               	jl	 <L44>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L50>
-<L49>:
+               	jmp	 <L45>
+<L44>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L50>:
+<L45>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xb68>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xae5>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xb74>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xaf1>
                	leaq	0x4(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x30(%rsi), %rcx
@@ -1002,21 +963,21 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L51>
+               	jl	 <L46>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L52>
-<L51>:
+               	jmp	 <L47>
+<L46>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L52>:
+<L47>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xbc2>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xb3f>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xbce>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xb4b>
                	leaq	0x8(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	leaq	0x38(%rsi), %rcx
@@ -1024,512 +985,386 @@ Disassembly of section .text:
                	andq	$0xfff, %rdx            # imm = 0xFFF
                	movq	%rdx, %r11
                	testq	%r11, %r11
-               	jl	 <L53>
+               	jl	 <L48>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L54>
-<L53>:
+               	jmp	 <L49>
+<L48>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L54>:
+<L49>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xc1c>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xb99>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xc28>
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xba5>
                	leaq	0xc(%rax), %rcx
                	movss	%xmm0, (%rcx)
                	movups	(%rax), %xmm7
-               	leaq	-0x130(%rbp), %rax
-               	leaq	0x40(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0xfff, %rdx            # imm = 0xFFF
-               	movq	%rdx, %r11
+               	leaq	-0x130(%rbp), %rbx
+               	leaq	0x40(%rsi), %rax
+               	movq	(%rax), %rcx
+               	andq	$0xfff, %rcx            # imm = 0xFFF
+               	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L55>
+               	jl	 <L50>
                	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L56>
-<L55>:
+               	jmp	 <L51>
+<L50>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2ss	%r11, %xmm0
                	addss	%xmm0, %xmm0
-<L56>:
+<L51>:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xc80>
+               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xbfd>
                	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xc8c>
-               	leaq	(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	leaq	0x48(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0xfff, %rdx            # imm = 0xFFF
-               	movq	%rdx, %r11
+               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xc09>
+               	leaq	(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	leaq	0x48(%rsi), %rax
+               	movq	(%rax), %rcx
+               	callq	 <L52>
+<L52>:
+               	leaq	0x4(%rbx), %rax
+               	movss	%xmm0, (%rax)
+               	movsd	(%rbx), %xmm8
+               	leaq	(%rsi), %rax
+               	movq	(%rax), %rbx
+               	leaq	0x8(%rsi), %rax
+               	movq	(%rax), %rcx
+               	callq	 <L53>
+<L53>:
+               	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
+               	leaq	0x10(%rsi), %rax
+               	movq	(%rax), %rcx
+               	movl	%ecx, %edi
+               	leaq	0x18(%rsi), %rax
+               	movq	(%rax), %rcx
+               	andq	$0xfffff, %rcx          # imm = 0xFFFFF
+               	movq	%rcx, %r11
+               	testq	%r11, %r11
+               	jl	 <L54>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L55>
+<L54>:
+               	movq	%r11, %r10
+               	shrq	%r10
+               	andq	$0x1, %r11
+               	orq	%r10, %r11
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L55>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xc8f>
+               	movsd	%xmm1, %xmm10           # xmm10 = xmm1[0],xmm10[1]
+               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0xc9d>
+               	leaq	0x20(%rsi), %rax
+               	movq	(%rax), %r12
+               	leaq	0x28(%rsi), %rax
+               	movq	(%rax), %rcx
+               	callq	 <L56>
+<L56>:
+               	movss	%xmm0, %xmm11           # xmm11 = xmm0[0],xmm11[1,2,3]
+               	leaq	0x30(%rsi), %rax
+               	movq	(%rax), %rcx
+               	movw	%cx, %r13w
+               	leaq	0x38(%rsi), %rax
+               	movq	(%rax), %rcx
+               	andq	$0xfffff, %rcx          # imm = 0xFFFFF
+               	movq	%rcx, %r11
                	testq	%r11, %r11
                	jl	 <L57>
-               	cvtsi2ss	%r11, %xmm0
+               	cvtsi2sd	%r11, %xmm0
                	jmp	 <L58>
 <L57>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
 <L58>:
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xcd9>
-               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xce5>
-               	leaq	0x4(%rax), %rcx
-               	movss	%xmm0, (%rcx)
-               	movsd	(%rax), %xmm8
-               	leaq	(%rsi), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x1a0(%rbp)
-               	leaq	0x8(%rsi), %rax
-               	movq	(%rax), %rdx
-               	andq	$0xfff, %rdx            # imm = 0xFFF
-               	movq	%rdx, %r11
-               	testq	%r11, %r11
-               	jl	 <L59>
-               	cvtsi2ss	%r11, %xmm0
-               	jmp	 <L60>
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xd06>
+               	movsd	%xmm1, %xmm12           # xmm12 = xmm1[0],xmm12[1]
+               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0xd14>
+               	leaq	0x40(%rsi), %rax
+               	movq	(%rax), %r14
+               	leaq	0x48(%rsi), %rax
+               	movq	(%rax), %rcx
+               	callq	 <L59>
 <L59>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
-<L60>:
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xd45>
-               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0xd51>
-               	leaq	0x10(%rsi), %rax
-               	movq	(%rax), %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x1a8(%rbp)
-               	leaq	0x18(%rsi), %rdx
-               	movq	(%rdx), %rbx
-               	andq	$0xfffff, %rbx          # imm = 0xFFFFF
-               	movq	%rbx, %r11
+               	movss	%xmm0, %xmm13           # xmm13 = xmm0[0],xmm13[1,2,3]
+               	leaq	0x50(%rsi), %rax
+               	movq	(%rax), %rcx
+               	movb	%cl, %r15b
+               	leaq	0x58(%rsi), %rax
+               	movq	(%rax), %rcx
+               	andq	$0xfffff, %rcx          # imm = 0xFFFFF
+               	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L61>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L62>
-<L61>:
+               	jl	 <L60>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L61>
+<L60>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L61>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xd7c>
+               	movsd	%xmm1, %xmm14           # xmm14 = xmm1[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0xd8a>
+               	movsd	%xmm14, -0x280(%rbp)
+               	leaq	0x60(%rsi), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x270(%rbp)
+               	leaq	0x68(%rsi), %rax
+               	movq	(%rax), %rcx
+               	callq	 <L62>
 <L62>:
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xda8>
-               	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
-               	divsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xdb4>
-               	leaq	0x20(%rsi), %rdx
-               	movq	(%rdx), %r8
-               	movq	%r8, -0x1b0(%rbp)
-               	leaq	0x28(%rsi), %rdx
-               	movq	(%rdx), %r13
-               	andq	$0xfff, %r13            # imm = 0xFFF
-               	movq	%r13, %r11
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	leaq	0x70(%rsi), %rax
+               	movq	(%rax), %rcx
+               	movl	%ecx, %r8d
+               	movq	%r8, -0x238(%rbp)
+               	leaq	0x78(%rsi), %rcx
+               	movq	(%rcx), %rax
+               	andq	$0xfffff, %rax          # imm = 0xFFFFF
+               	movq	%rax, %r11
                	testq	%r11, %r11
                	jl	 <L63>
-               	cvtsi2ss	%r11, %xmm1
+               	cvtsi2sd	%r11, %xmm1
                	jmp	 <L64>
 <L63>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm1
-               	addss	%xmm1, %xmm1
-<L64>:
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	subss	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xe08>
-               	movss	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xe14>
-               	leaq	0x30(%rsi), %rdx
-               	movq	(%rdx), %r13
-               	movw	%r13w, %r8w
-               	movq	%r8, -0x1b8(%rbp)
-               	leaq	0x38(%rsi), %r13
-               	movq	(%r13), %r14
-               	andq	$0xfffff, %r14          # imm = 0xFFFFF
-               	movq	%r14, %r11
-               	testq	%r11, %r11
-               	jl	 <L65>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L66>
-<L65>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
+<L64>:
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0xe08>
+               	movsd	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0xe14>
+               	leaq	0x8(%rsi), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x240(%rbp)
+               	movq	%rbx, %rcx
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	movl	%edi, %r8d
+               	movsd	%xmm10, %xmm3           # xmm3 = xmm10[0],xmm3[1]
+               	movups	%xmm6, -0x170(%rbp)
+               	leaq	-0x170(%rbp), %rax
+               	movq	%rax, 0x20(%rsp)
+               	movq	%r12, 0x28(%rsp)
+               	movsd	%xmm11, 0x30(%rsp)
+               	movq	%r13, 0x38(%rsp)
+               	movups	%xmm7, -0x180(%rbp)
+               	leaq	-0x180(%rbp), %rax
+               	movq	%rax, 0x40(%rsp)
+               	movsd	%xmm12, 0x48(%rsp)
+               	movq	%r14, 0x50(%rsp)
+               	movsd	%xmm13, 0x58(%rsp)
+               	movq	%r15, 0x60(%rsp)
+               	movq	-0x280(%rbp), %r11
+               	movq	%r11, 0x68(%rsp)
+               	movups	%xmm8, -0x190(%rbp)
+               	leaq	-0x190(%rbp), %rax
+               	movq	%rax, 0x70(%rsp)
+               	movq	-0x270(%rbp), %r9
+               	movq	%r9, 0x78(%rsp)
+               	movsd	%xmm2, 0x80(%rsp)
+               	movq	-0x238(%rbp), %r9
+               	movq	%r9, 0x88(%rsp)
+               	movsd	%xmm4, 0x90(%rsp)
+               	movq	-0x240(%rbp), %r9
+               	movq	%r9, 0x98(%rsp)
+               	callq	 <L65>
+<L65>:
+               	movq	%rax, %rbx
+               	leaq	0x18(%rsi), %rax
+               	movq	(%rax), %rcx
+               	callq	 <L66>
 <L66>:
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xe6d>
-               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
-               	divsd	, %xmm5 <corpus.cases.call.call_mixed.checksum+0xe79>
-               	leaq	0x40(%rsi), %r13
-               	movq	(%r13), %r14
-               	leaq	0x48(%rsi), %r13
-               	movq	(%r13), %r15
-               	andq	$0xfff, %r15            # imm = 0xFFF
-               	movq	%r15, %r11
+               	movss	%xmm0, %xmm9            # xmm9 = xmm0[0],xmm9[1,2,3]
+               	leaq	0x28(%rsi), %rax
+               	movq	(%rax), %rcx
+               	movl	%ecx, %edi
+               	leaq	0x38(%rsi), %rax
+               	movq	(%rax), %rcx
+               	andq	$0xfffff, %rcx          # imm = 0xFFFFF
+               	movq	%rcx, %r11
                	testq	%r11, %r11
                	jl	 <L67>
-               	cvtsi2ss	%r11, %xmm1
+               	cvtsi2sd	%r11, %xmm0
                	jmp	 <L68>
 <L67>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm1
-               	addss	%xmm1, %xmm1
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
 <L68>:
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	subss	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xec8>
-               	movss	%xmm2, %xmm9            # xmm9 = xmm2[0],xmm9[1,2,3]
-               	divss	, %xmm9 <corpus.cases.call.call_mixed.checksum+0xed6>
-               	leaq	0x50(%rsi), %r13
-               	movq	(%r13), %r15
-               	movb	%r15b, %r13b
-               	leaq	0x58(%rsi), %r15
-               	movq	(%r15), %rcx
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xf45>
+               	movsd	%xmm1, %xmm10           # xmm10 = xmm1[0],xmm10[1]
+               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0xf53>
+               	leaq	0x48(%rsi), %rax
+               	movq	(%rax), %r12
+               	leaq	0x58(%rsi), %rax
+               	movq	(%rax), %rcx
+               	callq	 <L69>
+<L69>:
+               	movss	%xmm0, %xmm11           # xmm11 = xmm0[0],xmm11[1,2,3]
+               	leaq	0x68(%rsi), %rax
+               	movq	(%rax), %rcx
+               	movw	%cx, %r13w
+               	leaq	0x78(%rsi), %rax
+               	movq	(%rax), %rcx
                	andq	$0xfffff, %rcx          # imm = 0xFFFFF
                	movq	%rcx, %r11
                	testq	%r11, %r11
-               	jl	 <L69>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L70>
-<L69>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
+               	jl	 <L70>
+               	cvtsi2sd	%r11, %xmm0
+               	jmp	 <L71>
 <L70>:
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xf27>
-               	movsd	%xmm2, %xmm10           # xmm10 = xmm2[0],xmm10[1]
-               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0xf35>
-               	leaq	0x60(%rsi), %rcx
-               	movq	(%rcx), %r15
-               	leaq	0x68(%rsi), %rcx
-               	movq	(%rcx), %rax
-               	andq	$0xfff, %rax            # imm = 0xFFF
-               	movq	%rax, %r11
-               	testq	%r11, %r11
-               	jl	 <L71>
-               	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L72>
-<L71>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm1
-               	addss	%xmm1, %xmm1
-<L72>:
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	subss	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xf82>
-               	movss	%xmm2, %xmm11           # xmm11 = xmm2[0],xmm11[1,2,3]
-               	divss	, %xmm11 <corpus.cases.call.call_mixed.checksum+0xf90>
-               	leaq	0x70(%rsi), %rax
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
+<L71>:
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0xfbc>
+               	movsd	%xmm1, %xmm12           # xmm12 = xmm1[0],xmm12[1]
+               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0xfca>
+               	leaq	0x88(%rsi), %rax
+               	movq	(%rax), %r14
+               	leaq	0x98(%rsi), %rax
                	movq	(%rax), %rcx
-               	movl	%ecx, %eax
-               	leaq	0x78(%rsi), %rcx
-               	movq	(%rcx), %rbx
-               	andq	$0xfffff, %rbx          # imm = 0xFFFFF
-               	movq	%rbx, %r11
+               	callq	 <L72>
+<L72>:
+               	movss	%xmm0, %xmm13           # xmm13 = xmm0[0],xmm13[1,2,3]
+               	leaq	0xa8(%rsi), %rax
+               	movq	(%rax), %rcx
+               	movb	%cl, %r15b
+               	leaq	0xb8(%rsi), %rax
+               	movq	(%rax), %rcx
+               	andq	$0xfffff, %rcx          # imm = 0xFFFFF
+               	movq	%rcx, %r11
                	testq	%r11, %r11
                	jl	 <L73>
-               	cvtsi2sd	%r11, %xmm1
+               	cvtsi2sd	%r11, %xmm0
                	jmp	 <L74>
 <L73>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
+               	cvtsi2sd	%r11, %xmm0
+               	addsd	%xmm0, %xmm0
 <L74>:
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0xfdf>
-               	movsd	%xmm2, %xmm12           # xmm12 = xmm2[0],xmm12[1]
-               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0xfed>
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %rbx
-               	movq	-0x1a0(%rbp), %r8
-               	movq	%r8, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	movq	-0x1a8(%rbp), %r8
-               	movups	%xmm6, -0x150(%rbp)
-               	movq	-0x150(%rbp), %rdx
-               	movq	%rdx, 0x20(%rsp)
-               	movl	-0x148(%rbp), %edx
-               	movl	%edx, 0x28(%rsp)
-               	movq	-0x1b0(%rbp), %r9
-               	movq	%r9, 0x30(%rsp)
-               	movsd	%xmm4, 0x38(%rsp)
-               	movq	-0x1b8(%rbp), %r9
-               	movq	%r9, 0x40(%rsp)
-               	movups	%xmm7, 0x50(%rsp)
-               	movsd	%xmm5, 0x60(%rsp)
-               	movq	%r14, 0x68(%rsp)
-               	movsd	%xmm9, 0x70(%rsp)
-               	movq	%r13, 0x78(%rsp)
-               	movsd	%xmm10, 0x80(%rsp)
-               	movsd	%xmm8, 0x88(%rsp)
-               	movq	%r15, 0x90(%rsp)
-               	movsd	%xmm11, 0x98(%rsp)
-               	movq	%rax, 0xa0(%rsp)
-               	movsd	%xmm12, 0xa8(%rsp)
-               	movq	%rbx, 0xb0(%rsp)
+               	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
+               	subsd	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x103e>
+               	movsd	%xmm1, %xmm14           # xmm14 = xmm1[0],xmm14[1]
+               	divsd	, %xmm14 <corpus.cases.call.call_mixed.checksum+0x104c>
+               	movsd	%xmm14, -0x298(%rbp)
+               	leaq	0x10(%rsi), %rax
+               	movq	(%rax), %r8
+               	movq	%r8, -0x288(%rbp)
+               	leaq	0x20(%rsi), %rax
+               	movq	(%rax), %rcx
                	callq	 <L75>
 <L75>:
-               	leaq	0x18(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0xfff, %rdx            # imm = 0xFFF
-               	movq	%rdx, %r11
+               	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
+               	leaq	0x30(%rsi), %rax
+               	movq	(%rax), %rcx
+               	movl	%ecx, %eax
+               	leaq	0x40(%rsi), %rcx
+               	movq	(%rcx), %rsi
+               	andq	$0xfffff, %rsi          # imm = 0xFFFFF
+               	movq	%rsi, %r11
                	testq	%r11, %r11
                	jl	 <L76>
-               	cvtsi2ss	%r11, %xmm0
+               	cvtsi2sd	%r11, %xmm1
                	jmp	 <L77>
 <L76>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm0
-               	addss	%xmm0, %xmm0
+               	cvtsi2sd	%r11, %xmm1
+               	addsd	%xmm1, %xmm1
 <L77>:
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	subss	, %xmm1 <corpus.cases.call.call_mixed.checksum+0x10eb>
-               	movss	%xmm1, %xmm0            # xmm0 = xmm1[0],xmm0[1,2,3]
-               	divss	, %xmm0 <corpus.cases.call.call_mixed.checksum+0x10f7>
-               	leaq	0x28(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	movl	%edx, %r8d
-               	movq	%r8, -0x1c8(%rbp)
-               	leaq	0x38(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	andq	$0xfffff, %rdx          # imm = 0xFFFFF
-               	movq	%rdx, %r11
-               	testq	%r11, %r11
-               	jl	 <L78>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L79>
-<L78>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L79>:
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x114e>
-               	movsd	%xmm2, %xmm3            # xmm3 = xmm2[0],xmm3[1]
-               	divsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x115a>
-               	leaq	0x48(%rsi), %rcx
-               	movq	(%rcx), %rdx
-               	leaq	0x58(%rsi), %rcx
-               	movq	(%rcx), %r13
-               	andq	$0xfff, %r13            # imm = 0xFFF
-               	movq	%r13, %r11
-               	testq	%r11, %r11
-               	jl	 <L80>
-               	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L81>
-<L80>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm1
-               	addss	%xmm1, %xmm1
-<L81>:
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	subss	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x11a7>
-               	movss	%xmm2, %xmm4            # xmm4 = xmm2[0],xmm4[1,2,3]
-               	divss	, %xmm4 <corpus.cases.call.call_mixed.checksum+0x11b3>
-               	leaq	0x68(%rsi), %rcx
-               	movq	(%rcx), %r13
-               	movw	%r13w, %r14w
-               	leaq	0x78(%rsi), %rcx
-               	movq	(%rcx), %r13
-               	andq	$0xfffff, %r13          # imm = 0xFFFFF
-               	movq	%r13, %r11
-               	testq	%r11, %r11
-               	jl	 <L82>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L83>
-<L82>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L83>:
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x1204>
-               	movsd	%xmm2, %xmm5            # xmm5 = xmm2[0],xmm5[1]
-               	divsd	, %xmm5 <corpus.cases.call.call_mixed.checksum+0x1210>
-               	leaq	0x88(%rsi), %rcx
-               	movq	(%rcx), %r13
-               	leaq	0x98(%rsi), %rcx
-               	movq	(%rcx), %r15
-               	andq	$0xfff, %r15            # imm = 0xFFF
-               	movq	%r15, %r11
-               	testq	%r11, %r11
-               	jl	 <L84>
-               	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L85>
-<L84>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm1
-               	addss	%xmm1, %xmm1
-<L85>:
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	subss	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x1263>
-               	movss	%xmm2, %xmm9            # xmm9 = xmm2[0],xmm9[1,2,3]
-               	divss	, %xmm9 <corpus.cases.call.call_mixed.checksum+0x1271>
-               	leaq	0xa8(%rsi), %rcx
-               	movq	(%rcx), %r15
-               	movb	%r15b, %r8b
-               	movq	%r8, -0x1c0(%rbp)
-               	leaq	0xb8(%rsi), %rcx
-               	movq	(%rcx), %r15
-               	andq	$0xfffff, %r15          # imm = 0xFFFFF
-               	movq	%r15, %r11
-               	testq	%r11, %r11
-               	jl	 <L86>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L87>
-<L86>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L87>:
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x12ce>
-               	movsd	%xmm2, %xmm10           # xmm10 = xmm2[0],xmm10[1]
-               	divsd	, %xmm10 <corpus.cases.call.call_mixed.checksum+0x12dc>
-               	leaq	0x10(%rsi), %rcx
-               	movq	(%rcx), %r15
-               	leaq	0x20(%rsi), %rcx
-               	movq	(%rcx), %rbx
-               	andq	$0xfff, %rbx            # imm = 0xFFF
-               	movq	%rbx, %r11
-               	testq	%r11, %r11
-               	jl	 <L88>
-               	cvtsi2ss	%r11, %xmm1
-               	jmp	 <L89>
-<L88>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2ss	%r11, %xmm1
-               	addss	%xmm1, %xmm1
-<L89>:
-               	movss	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1,2,3]
-               	subss	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x1329>
-               	movss	%xmm2, %xmm11           # xmm11 = xmm2[0],xmm11[1,2,3]
-               	divss	, %xmm11 <corpus.cases.call.call_mixed.checksum+0x1337>
-               	leaq	0x30(%rsi), %rcx
-               	movq	(%rcx), %rbx
-               	movl	%ebx, %r8d
-               	movq	%r8, -0x1d0(%rbp)
-               	leaq	0x40(%rsi), %rcx
-               	movq	(%rcx), %rbx
-               	andq	$0xfffff, %rbx          # imm = 0xFFFFF
-               	movq	%rbx, %r11
-               	testq	%r11, %r11
-               	jl	 <L90>
-               	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L91>
-<L90>:
-               	movq	%r11, %r10
-               	shrq	%r10
-               	andq	$0x1, %r11
-               	orq	%r10, %r11
-               	cvtsi2sd	%r11, %xmm1
-               	addsd	%xmm1, %xmm1
-<L91>:
-               	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_mixed.checksum+0x138e>
-               	movsd	%xmm2, %xmm12           # xmm12 = xmm2[0],xmm12[1]
-               	divsd	, %xmm12 <corpus.cases.call.call_mixed.checksum+0x139c>
-               	movq	%rax, %rcx
-               	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	movq	-0x1c8(%rbp), %r8
-               	movups	%xmm6, -0x160(%rbp)
-               	movq	-0x160(%rbp), %rax
-               	movq	%rax, 0x20(%rsp)
-               	movl	-0x158(%rbp), %eax
-               	movl	%eax, 0x28(%rsp)
-               	movq	%rdx, 0x30(%rsp)
-               	movsd	%xmm4, 0x38(%rsp)
-               	movq	%r14, 0x40(%rsp)
-               	movups	%xmm7, 0x50(%rsp)
-               	movsd	%xmm5, 0x60(%rsp)
-               	movq	%r13, 0x68(%rsp)
-               	movsd	%xmm9, 0x70(%rsp)
-               	movq	-0x1c0(%rbp), %r9
+               	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
+               	subsd	, %xmm3 <corpus.cases.call.call_mixed.checksum+0x10c2>
+               	movsd	%xmm3, %xmm4            # xmm4 = xmm3[0],xmm4[1]
+               	divsd	, %xmm4 <corpus.cases.call.call_mixed.checksum+0x10ce>
+               	movq	%rbx, %rcx
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	movl	%edi, %r8d
+               	movsd	%xmm10, %xmm3           # xmm3 = xmm10[0],xmm3[1]
+               	movups	%xmm6, -0x1a0(%rbp)
+               	leaq	-0x1a0(%rbp), %rbx
+               	movq	%rbx, 0x20(%rsp)
+               	movq	%r12, 0x28(%rsp)
+               	movsd	%xmm11, 0x30(%rsp)
+               	movq	%r13, 0x38(%rsp)
+               	movups	%xmm7, -0x1b0(%rbp)
+               	leaq	-0x1b0(%rbp), %rbx
+               	movq	%rbx, 0x40(%rsp)
+               	movsd	%xmm12, 0x48(%rsp)
+               	movq	%r14, 0x50(%rsp)
+               	movsd	%xmm13, 0x58(%rsp)
+               	movq	%r15, 0x60(%rsp)
+               	movq	-0x298(%rbp), %r11
+               	movq	%r11, 0x68(%rsp)
+               	movups	%xmm8, -0x1c0(%rbp)
+               	leaq	-0x1c0(%rbp), %rbx
+               	movq	%rbx, 0x70(%rsp)
+               	movq	-0x288(%rbp), %r9
                	movq	%r9, 0x78(%rsp)
-               	movsd	%xmm10, 0x80(%rsp)
-               	movsd	%xmm8, 0x88(%rsp)
-               	movq	%r15, 0x90(%rsp)
-               	movsd	%xmm11, 0x98(%rsp)
-               	movq	-0x1d0(%rbp), %r9
-               	movq	%r9, 0xa0(%rsp)
-               	movsd	%xmm12, 0xa8(%rsp)
-               	movq	%r12, 0xb0(%rsp)
-               	callq	 <L92>
-<L92>:
-               	movq	%rdi, %rcx
+               	movsd	%xmm2, 0x80(%rsp)
+               	movq	%rax, 0x88(%rsp)
+               	movsd	%xmm4, 0x90(%rsp)
+               	movq	-0x200(%rbp), %r9
+               	movq	%r9, 0x98(%rsp)
+               	callq	 <L78>
+<L78>:
+               	movq	-0x1d8(%rbp), %r8
+               	movq	%r8, %rcx
                	movq	%rax, %rdx
-               	callq	 <L93>
-<L93>:
-               	movaps	-0x220(%rbp), %xmm6
-               	movaps	-0x230(%rbp), %xmm7
-               	movaps	-0x240(%rbp), %xmm8
-               	movaps	-0x250(%rbp), %xmm9
-               	movaps	-0x260(%rbp), %xmm10
-               	movaps	-0x270(%rbp), %xmm11
-               	movaps	-0x280(%rbp), %xmm12
-               	movaps	-0x290(%rbp), %xmm14
-               	movaps	-0x2a0(%rbp), %xmm15
-               	movq	-0x1d8(%rbp), %rbx
-               	movq	-0x1e0(%rbp), %rdi
-               	movq	-0x1e8(%rbp), %rsi
-               	movq	-0x1f0(%rbp), %r12
-               	movq	-0x1f8(%rbp), %r13
-               	movq	-0x200(%rbp), %r14
-               	movq	-0x208(%rbp), %r15
+               	callq	 <L79>
+<L79>:
+               	movaps	-0x2f0(%rbp), %xmm6
+               	movaps	-0x300(%rbp), %xmm7
+               	movaps	-0x310(%rbp), %xmm8
+               	movaps	-0x320(%rbp), %xmm9
+               	movaps	-0x330(%rbp), %xmm10
+               	movaps	-0x340(%rbp), %xmm11
+               	movaps	-0x350(%rbp), %xmm12
+               	movaps	-0x360(%rbp), %xmm13
+               	movaps	-0x370(%rbp), %xmm14
+               	movaps	-0x380(%rbp), %xmm15
+               	movq	-0x2a8(%rbp), %rbx
+               	movq	-0x2b0(%rbp), %rdi
+               	movq	-0x2b8(%rbp), %rsi
+               	movq	-0x2c0(%rbp), %r12
+               	movq	-0x2c8(%rbp), %r13
+               	movq	-0x2d0(%rbp), %r14
+               	movq	-0x2d8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/call/call_rec_edge.dis
+++ b/test/golden/x86_64-windows/call/call_rec_edge.dis
@@ -988,16 +988,16 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_edge.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x350, %rsp            # imm = 0x350
-               	movq	%rbx, -0x278(%rbp)
-               	movq	%rdi, -0x280(%rbp)
-               	movq	%rsi, -0x288(%rbp)
-               	movq	%r12, -0x290(%rbp)
-               	movq	%r13, -0x298(%rbp)
-               	movq	%r14, -0x2a0(%rbp)
-               	movq	%r15, -0x2a8(%rbp)
-               	movaps	%xmm14, -0x2c0(%rbp)
-               	movaps	%xmm15, -0x2d0(%rbp)
+               	subq	$0x4c0, %rsp            # imm = 0x4C0
+               	movq	%rbx, -0x3e8(%rbp)
+               	movq	%rdi, -0x3f0(%rbp)
+               	movq	%rsi, -0x3f8(%rbp)
+               	movq	%r12, -0x400(%rbp)
+               	movq	%r13, -0x408(%rbp)
+               	movq	%r14, -0x410(%rbp)
+               	movq	%r15, -0x418(%rbp)
+               	movaps	%xmm14, -0x430(%rbp)
+               	movaps	%xmm15, -0x440(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -1114,25 +1114,25 @@ Disassembly of section .text:
                	imulq	$0x11, %rax, %rax
                	movq	%rax, %r8
                	addq	%rbx, %r8
-               	movq	%r8, -0x1a0(%rbp)
+               	movq	%r8, -0x308(%rbp)
                	leaq	(%rsi), %rdx
                	movq	(%rdx), %r14
-               	movq	-0x1a0(%rbp), %r9
+               	movq	-0x308(%rbp), %r9
                	movq	%r14, %r8
                	addq	%r9, %r8
-               	movq	%r8, -0x190(%rbp)
+               	movq	%r8, -0x2f8(%rbp)
                	leaq	0x8(%rsi), %rdx
                	movq	(%rdx), %r8
-               	movq	%r8, -0x1a8(%rbp)
+               	movq	%r8, -0x310(%rbp)
                	leaq	-0x69(%rbp), %r8
-               	movq	%r8, -0x198(%rbp)
-               	movq	-0x198(%rbp), %r8
+               	movq	%r8, -0x300(%rbp)
+               	movq	-0x300(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x198(%rbp), %r8
+               	movq	-0x300(%rbp), %r8
                	movb	$0x0, 0x8(%r8)
-               	movq	-0x1a8(%rbp), %r8
+               	movq	-0x310(%rbp), %r8
                	movb	%r8b, %r14b
-               	movq	-0x198(%rbp), %r8
+               	movq	-0x300(%rbp), %r8
                	leaq	(%r8), %rdx
                	movb	%r14b, (%rdx)
                	movq	$0x0, %rdx
@@ -1143,13 +1143,13 @@ Disassembly of section .text:
                	movq	%rdx, %r14
                	imulq	$0x8, %r14, %r14
                	movq	%r14, %rcx
-               	movq	-0x1a8(%rbp), %r8
+               	movq	-0x310(%rbp), %r8
                	movq	%r8, %r14
                	shrq	%cl, %r14
                	movb	%r14b, %al
                	movb	%dl, %r14b
                	addl	%r14d, %eax
-               	movq	-0x198(%rbp), %r8
+               	movq	-0x300(%rbp), %r8
                	leaq	0x1(%r8), %r14
                	leaq	(%r14,%rdx), %r15
                	movb	%al, (%r15)
@@ -1160,24 +1160,24 @@ Disassembly of section .text:
                	leaq	0x10(%rsi), %rax
                	movq	(%rax), %rdx
                	movl	%edx, %r8d
-               	movq	%r8, -0x1b0(%rbp)
+               	movq	%r8, -0x318(%rbp)
                	leaq	0x18(%rsi), %rdx
                	movq	(%rdx), %r14
                	leaq	-0x80(%rbp), %r8
-               	movq	%r8, -0x1d8(%rbp)
+               	movq	%r8, -0x340(%rbp)
                	movl	%r14d, %edx
-               	movq	-0x1d8(%rbp), %r8
+               	movq	-0x340(%rbp), %r8
                	leaq	(%r8), %rax
                	movl	%edx, (%rax)
                	movq	%r14, %rax
                	shrq	$0x10, %rax
                	movl	%eax, %edx
-               	movq	-0x1d8(%rbp), %r8
+               	movq	-0x340(%rbp), %r8
                	leaq	0x4(%r8), %rax
                	movl	%edx, (%rax)
                	shrq	$0x20, %r14
                	movl	%r14d, %eax
-               	movq	-0x1d8(%rbp), %r8
+               	movq	-0x340(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movl	%eax, (%rdx)
                	leaq	0x20(%rsi), %rax
@@ -1198,22 +1198,22 @@ Disassembly of section .text:
 <L25>:
                	leaq	0x28(%rsi), %rax
                	movq	(%rax), %rdx
-               	movq	-0x1a0(%rbp), %r8
+               	movq	-0x308(%rbp), %r8
                	addq	%r8, %rdx
                	leaq	-0xa0(%rbp), %r8
-               	movq	%r8, -0x1c8(%rbp)
-               	movq	-0x1c8(%rbp), %r8
+               	movq	%r8, -0x330(%rbp)
+               	movq	-0x330(%rbp), %r8
                	leaq	(%r8), %r14
                	movq	%rdx, (%r14)
                	imulq	$0x3, %rdx, %rdx
                	addq	$0x7, %rdx
-               	movq	-0x1c8(%rbp), %r8
+               	movq	-0x330(%rbp), %r8
                	leaq	0x8(%r8), %r14
                	movq	%rdx, (%r14)
                	leaq	0x30(%rsi), %rdx
                	movq	(%rdx), %r14
                	leaq	-0xc0(%rbp), %r8
-               	movq	%r8, -0x1b8(%rbp)
+               	movq	%r8, -0x320(%rbp)
                	movq	%r14, %rdx
                	andq	$0xffff, %rdx           # imm = 0xFFFF
                	movq	%rdx, %r11
@@ -1231,7 +1231,7 @@ Disassembly of section .text:
 <L27>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
                	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x42f>
-               	movq	-0x1b8(%rbp), %r8
+               	movq	-0x320(%rbp), %r8
                	leaq	(%r8), %rdx
                	movsd	%xmm2, (%rdx)
                	andq	$0xfff, %r14            # imm = 0xFFF
@@ -1250,16 +1250,16 @@ Disassembly of section .text:
 <L29>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
                	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x47c>
-               	movq	-0x1b8(%rbp), %r8
+               	movq	-0x320(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movsd	%xmm2, (%rdx)
                	leaq	0x38(%rsi), %rdx
                	movq	(%rdx), %r14
                	leaq	-0xe0(%rbp), %r8
-               	movq	%r8, -0x1c0(%rbp)
+               	movq	%r8, -0x328(%rbp)
                	movq	%r14, %rdx
                	xorq	$0x12345678, %rdx       # imm = 0x12345678
-               	movq	-0x1c0(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	leaq	(%r8), %rax
                	movq	%rdx, (%rax)
                	andq	$0x3ffff, %r14          # imm = 0x3FFFF
@@ -1278,28 +1278,28 @@ Disassembly of section .text:
 <L31>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
                	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0x4f6>
-               	movq	-0x1c0(%rbp), %r8
+               	movq	-0x328(%rbp), %r8
                	leaq	0x8(%r8), %rax
                	movsd	%xmm2, (%rax)
                	leaq	0x40(%rsi), %rax
                	movq	(%rax), %r8
-               	movq	%r8, -0x1d0(%rbp)
+               	movq	%r8, -0x338(%rbp)
                	leaq	0x48(%rsi), %rax
                	movq	(%rax), %r8
-               	movq	%r8, -0x1e8(%rbp)
+               	movq	%r8, -0x350(%rbp)
                	leaq	-0x101(%rbp), %r8
-               	movq	%r8, -0x1e0(%rbp)
-               	movq	-0x1e0(%rbp), %r8
+               	movq	%r8, -0x348(%rbp)
+               	movq	-0x348(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x1e0(%rbp), %r8
+               	movq	-0x348(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x1e0(%rbp), %r8
+               	movq	-0x348(%rbp), %r8
                	movb	$0x0, 0x10(%r8)
-               	movq	-0x1e8(%rbp), %r8
+               	movq	-0x350(%rbp), %r8
                	movq	%r8, %r14
                	shrq	$0x7, %r14
                	movb	%r14b, %r15b
-               	movq	-0x1e0(%rbp), %r8
+               	movq	-0x348(%rbp), %r8
                	leaq	(%r8), %r14
                	movb	%r15b, (%r14)
                	movq	$0x0, %r14
@@ -1310,13 +1310,13 @@ Disassembly of section .text:
                	movq	%r14, %r15
                	imulq	$0x4, %r15, %r15
                	movq	%r15, %rcx
-               	movq	-0x1e8(%rbp), %r8
+               	movq	-0x350(%rbp), %r8
                	movq	%r8, %r15
                	shrq	%cl, %r15
                	movb	%r15b, %al
                	movb	%r14b, %r15b
                	xorl	%r15d, %eax
-               	movq	-0x1e0(%rbp), %r8
+               	movq	-0x348(%rbp), %r8
                	leaq	0x1(%r8), %r15
                	leaq	(%r15,%r14), %rdx
                	movb	%al, (%rdx)
@@ -1326,16 +1326,16 @@ Disassembly of section .text:
 <L33>:
                	leaq	0x50(%rsi), %rax
                	movq	(%rax), %r8
-               	movq	%r8, -0x1f8(%rbp)
+               	movq	%r8, -0x360(%rbp)
                	leaq	-0x11b(%rbp), %r8
-               	movq	%r8, -0x1f0(%rbp)
-               	movq	-0x1f0(%rbp), %r8
+               	movq	%r8, -0x358(%rbp)
+               	movq	-0x358(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x1f0(%rbp), %r8
+               	movq	-0x358(%rbp), %r8
                	movb	$0x0, 0x8(%r8)
-               	movq	-0x1f8(%rbp), %r8
+               	movq	-0x360(%rbp), %r8
                	movb	%r8b, %r14b
-               	movq	-0x1f0(%rbp), %r8
+               	movq	-0x358(%rbp), %r8
                	leaq	(%r8), %r15
                	movb	%r14b, (%r15)
                	movq	$0x0, %r14
@@ -1346,13 +1346,13 @@ Disassembly of section .text:
                	movq	%r14, %r15
                	imulq	$0x8, %r15, %r15
                	movq	%r15, %rcx
-               	movq	-0x1f8(%rbp), %r8
+               	movq	-0x360(%rbp), %r8
                	movq	%r8, %r15
                	shrq	%cl, %r15
                	movb	%r15b, %al
                	movb	%r14b, %r15b
                	addl	%r15d, %eax
-               	movq	-0x1f0(%rbp), %r8
+               	movq	-0x358(%rbp), %r8
                	leaq	0x1(%r8), %r15
                	leaq	(%r15,%r14), %rdx
                	movb	%al, (%rdx)
@@ -1363,72 +1363,72 @@ Disassembly of section .text:
                	leaq	0x58(%rsi), %rax
                	movq	(%rax), %rdx
                	leaq	-0x130(%rbp), %r8
-               	movq	%r8, -0x208(%rbp)
+               	movq	%r8, -0x378(%rbp)
                	movl	%edx, %r14d
-               	movq	-0x208(%rbp), %r8
+               	movq	-0x378(%rbp), %r8
                	leaq	(%r8), %r15
                	movl	%r14d, (%r15)
                	movq	%rdx, %r14
                	shrq	$0x10, %r14
                	movl	%r14d, %r15d
-               	movq	-0x208(%rbp), %r8
+               	movq	-0x378(%rbp), %r8
                	leaq	0x4(%r8), %r14
                	movl	%r15d, (%r14)
                	shrq	$0x20, %rdx
                	movl	%edx, %r14d
-               	movq	-0x208(%rbp), %r8
+               	movq	-0x378(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movl	%r14d, (%rdx)
                	leaq	(%rsi), %rdx
                	movq	(%rdx), %r14
                	leaq	-0x150(%rbp), %r8
-               	movq	%r8, -0x210(%rbp)
-               	movq	-0x210(%rbp), %r8
+               	movq	%r8, -0x370(%rbp)
+               	movq	-0x370(%rbp), %r8
                	leaq	(%r8), %rdx
                	movq	%r14, (%rdx)
                	imulq	$0x3, %r14, %r14
                	addq	$0x7, %r14
-               	movq	-0x210(%rbp), %r8
+               	movq	-0x370(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	%r14, (%rdx)
                	leaq	0x8(%rsi), %rdx
                	movq	(%rdx), %r8
-               	movq	%r8, -0x218(%rbp)
+               	movq	%r8, -0x380(%rbp)
                	leaq	-0x171(%rbp), %r8
-               	movq	%r8, -0x200(%rbp)
-               	movq	-0x200(%rbp), %r8
+               	movq	%r8, -0x368(%rbp)
+               	movq	-0x368(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x200(%rbp), %r8
+               	movq	-0x368(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x200(%rbp), %r8
+               	movq	-0x368(%rbp), %r8
                	movb	$0x0, 0x10(%r8)
-               	movq	-0x218(%rbp), %r8
+               	movq	-0x380(%rbp), %r8
                	movq	%r8, %rdx
                	shrq	$0x7, %rdx
-               	movb	%dl, %al
-               	movq	-0x200(%rbp), %r8
+               	movb	%dl, %r15b
+               	movq	-0x368(%rbp), %r8
                	leaq	(%r8), %rdx
-               	movb	%al, (%rdx)
-               	movq	$0x0, %rax
-               	cmpq	$0x10, %rax
+               	movb	%r15b, (%rdx)
+               	movq	$0x0, %rdx
+               	cmpq	$0x10, %rdx
                	jb	 <L36>
                	jmp	 <L37>
 <L36>:
-               	movq	%rax, %rdx
-               	imulq	$0x4, %rdx, %rdx
-               	movq	%rdx, %rcx
-               	movq	-0x218(%rbp), %r8
-               	movq	%r8, %rdx
-               	shrq	%cl, %rdx
+               	movq	%rdx, %r15
+               	imulq	$0x4, %r15, %r15
+               	movq	%r15, %rcx
+               	movq	-0x380(%rbp), %r8
+               	movq	%r8, %r15
+               	shrq	%cl, %r15
+               	movb	%r15b, %al
                	movb	%dl, %r15b
-               	movb	%al, %dl
-               	xorl	%edx, %r15d
-               	movq	-0x200(%rbp), %r8
-               	leaq	0x1(%r8), %rdx
-               	leaq	(%rdx,%rax), %r14
-               	movb	%r15b, (%r14)
-               	addq	$0x1, %rax
-               	cmpq	$0x10, %rax
+               	xorl	%r15d, %eax
+               	movq	-0x368(%rbp), %r8
+               	leaq	0x1(%r8), %r15
+               	leaq	(%r15,%rdx), %r14
+               	movb	%al, (%r14)
+               	addq	$0x1, %rdx
+               	cmpq	$0x10, %rdx
                	jb	 <L36>
 <L37>:
                	leaq	0x10(%rsi), %rax
@@ -1449,31 +1449,97 @@ Disassembly of section .text:
 <L39>:
                	leaq	0x18(%rsi), %rax
                	movq	(%rax), %r14
-               	movq	-0x190(%rbp), %r8
+               	movq	-0x2f8(%rbp), %r8
                	movq	%r8, %rcx
-               	movq	-0x198(%rbp), %r8
-               	movq	%r8, %rdx
-               	movq	-0x1b0(%rbp), %r8
-               	movq	-0x1d8(%rbp), %r9
+               	movq	-0x300(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	%rax, -0x181(%rbp)
+               	movq	-0x300(%rbp), %r8
+               	movb	0x8(%r8), %al
+               	movb	%al, -0x179(%rbp)
+               	leaq	-0x181(%rbp), %rdx
+               	movq	-0x318(%rbp), %r8
+               	movq	-0x340(%rbp), %r9
+               	movq	(%r9), %rax
+               	movq	%rax, -0x194(%rbp)
+               	movq	-0x340(%rbp), %r9
+               	movl	0x8(%r9), %eax
+               	movl	%eax, -0x18c(%rbp)
+               	leaq	-0x194(%rbp), %rax
+               	movq	%rax, %r9
                	movsd	%xmm0, 0x20(%rsp)
-               	movq	-0x1c8(%rbp), %r10
-               	movq	%r10, 0x28(%rsp)
-               	movq	-0x1b8(%rbp), %r10
-               	movq	%r10, 0x30(%rsp)
-               	movq	-0x1c0(%rbp), %r10
-               	movq	%r10, 0x38(%rsp)
-               	movq	-0x1d0(%rbp), %r10
+               	movq	-0x330(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x1a8(%rbp)
+               	movq	-0x330(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x1a0(%rbp)
+               	leaq	-0x1a8(%rbp), %rax
+               	movq	%rax, 0x28(%rsp)
+               	movq	-0x320(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x1b8(%rbp)
+               	movq	-0x320(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x1b0(%rbp)
+               	leaq	-0x1b8(%rbp), %rax
+               	movq	%rax, 0x30(%rsp)
+               	movq	-0x328(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x1c8(%rbp)
+               	movq	-0x328(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x1c0(%rbp)
+               	leaq	-0x1c8(%rbp), %rax
+               	movq	%rax, 0x38(%rsp)
+               	movq	-0x338(%rbp), %r10
                	movq	%r10, 0x40(%rsp)
-               	movq	-0x1e0(%rbp), %r10
-               	movq	%r10, 0x48(%rsp)
-               	movq	-0x1f0(%rbp), %r10
-               	movq	%r10, 0x50(%rsp)
-               	movq	-0x208(%rbp), %r10
-               	movq	%r10, 0x58(%rsp)
-               	movq	-0x210(%rbp), %r10
-               	movq	%r10, 0x60(%rsp)
-               	movq	-0x200(%rbp), %r10
-               	movq	%r10, 0x68(%rsp)
+               	movq	-0x348(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x1e0(%rbp)
+               	movq	-0x348(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x1d8(%rbp)
+               	movq	-0x348(%rbp), %r10
+               	movb	0x10(%r10), %al
+               	movb	%al, -0x1d0(%rbp)
+               	leaq	-0x1e0(%rbp), %rax
+               	movq	%rax, 0x48(%rsp)
+               	movq	-0x358(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x1f0(%rbp)
+               	movq	-0x358(%rbp), %r10
+               	movb	0x8(%r10), %al
+               	movb	%al, -0x1e8(%rbp)
+               	leaq	-0x1f0(%rbp), %rax
+               	movq	%rax, 0x50(%rsp)
+               	movq	-0x378(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x200(%rbp)
+               	movq	-0x378(%rbp), %r10
+               	movl	0x8(%r10), %eax
+               	movl	%eax, -0x1f8(%rbp)
+               	leaq	-0x200(%rbp), %rax
+               	movq	%rax, 0x58(%rsp)
+               	movq	-0x370(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x210(%rbp)
+               	movq	-0x370(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x208(%rbp)
+               	leaq	-0x210(%rbp), %rax
+               	movq	%rax, 0x60(%rsp)
+               	movq	-0x368(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x228(%rbp)
+               	movq	-0x368(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x220(%rbp)
+               	movq	-0x368(%rbp), %r10
+               	movb	0x10(%r10), %al
+               	movb	%al, -0x218(%rbp)
+               	leaq	-0x228(%rbp), %rax
+               	movq	%rax, 0x68(%rsp)
                	movsd	%xmm1, 0x70(%rsp)
                	movq	%r14, 0x78(%rsp)
                	callq	 <L40>
@@ -1489,59 +1555,59 @@ Disassembly of section .text:
                	jb	 <L21>
 <L42>:
                	leaq	-0x72(%rbp), %r8
-               	movq	%r8, -0x250(%rbp)
-               	movq	-0x250(%rbp), %r8
+               	movq	%r8, -0x3c0(%rbp)
+               	movq	-0x3c0(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x250(%rbp), %r8
+               	movq	-0x3c0(%rbp), %r8
                	movb	$0x0, 0x8(%r8)
-               	movb	%r12b, %al
-               	movq	-0x250(%rbp), %r8
+               	movb	%r12b, %dl
+               	movq	-0x3c0(%rbp), %r8
                	leaq	(%r8), %rbx
-               	movb	%al, (%rbx)
-               	movq	$0x0, %rax
-               	cmpq	$0x8, %rax
+               	movb	%dl, (%rbx)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L43>
                	jmp	 <L44>
 <L43>:
-               	movq	%rax, %rbx
+               	movq	%rdx, %rbx
                	imulq	$0x8, %rbx, %rbx
                	movq	%rbx, %rcx
                	movq	%r12, %rbx
                	shrq	%cl, %rbx
                	movb	%bl, %r13b
-               	movb	%al, %bl
+               	movb	%dl, %bl
                	addl	%ebx, %r13d
-               	movq	-0x250(%rbp), %r8
+               	movq	-0x3c0(%rbp), %r8
                	leaq	0x1(%r8), %rbx
-               	leaq	(%rbx,%rax), %r14
+               	leaq	(%rbx,%rdx), %r14
                	movb	%r13b, (%r14)
-               	addq	$0x1, %rax
-               	cmpq	$0x8, %rax
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L43>
 <L44>:
                	movl	%r12d, %r8d
-               	movq	%r8, -0x220(%rbp)
+               	movq	%r8, -0x390(%rbp)
                	leaq	-0x8c(%rbp), %r8
-               	movq	%r8, -0x240(%rbp)
-               	movl	%r12d, %r13d
-               	movq	-0x240(%rbp), %r8
+               	movq	%r8, -0x3b8(%rbp)
+               	movl	%r12d, %edx
+               	movq	-0x3b8(%rbp), %r8
                	leaq	(%r8), %r14
-               	movl	%r13d, (%r14)
-               	movq	%r12, %r13
-               	shrq	$0x10, %r13
-               	movl	%r13d, %r14d
-               	movq	-0x240(%rbp), %r8
-               	leaq	0x4(%r8), %r13
-               	movl	%r14d, (%r13)
-               	movq	%r12, %r13
-               	shrq	$0x20, %r13
-               	movl	%r13d, %r14d
-               	movq	-0x240(%rbp), %r8
-               	leaq	0x8(%r8), %r13
-               	movl	%r14d, (%r13)
-               	movq	%r12, %r13
-               	andq	$0x3ff, %r13            # imm = 0x3FF
-               	movq	%r13, %r11
+               	movl	%edx, (%r14)
+               	movq	%r12, %rdx
+               	shrq	$0x10, %rdx
+               	movl	%edx, %r14d
+               	movq	-0x3b8(%rbp), %r8
+               	leaq	0x4(%r8), %rdx
+               	movl	%r14d, (%rdx)
+               	movq	%r12, %rdx
+               	shrq	$0x20, %rdx
+               	movl	%edx, %r14d
+               	movq	-0x3b8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movl	%r14d, (%rdx)
+               	movq	%r12, %rdx
+               	andq	$0x3ff, %rdx            # imm = 0x3FF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L45>
                	cvtsi2sd	%r11, %xmm0
@@ -1555,21 +1621,21 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L46>:
                	leaq	-0xb0(%rbp), %r8
-               	movq	%r8, -0x228(%rbp)
-               	movq	-0x228(%rbp), %r8
-               	leaq	(%r8), %r14
-               	movq	%r12, (%r14)
-               	movq	%r12, %r14
-               	imulq	$0x3, %r14, %r14
-               	addq	$0x7, %r14
-               	movq	-0x228(%rbp), %r8
+               	movq	%r8, -0x3a8(%rbp)
+               	movq	-0x3a8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	%r12, (%rdx)
+               	movq	%r12, %rdx
+               	imulq	$0x3, %rdx, %rdx
+               	addq	$0x7, %rdx
+               	movq	-0x3a8(%rbp), %r8
                	leaq	0x8(%r8), %r15
-               	movq	%r14, (%r15)
+               	movq	%rdx, (%r15)
                	leaq	-0xd0(%rbp), %r8
-               	movq	%r8, -0x238(%rbp)
-               	movq	%r12, %r15
-               	andq	$0xffff, %r15           # imm = 0xFFFF
-               	movq	%r15, %r11
+               	movq	%r8, -0x3b0(%rbp)
+               	movq	%r12, %rdx
+               	andq	$0xffff, %rdx           # imm = 0xFFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L47>
                	cvtsi2sd	%r11, %xmm1
@@ -1583,13 +1649,13 @@ Disassembly of section .text:
                	addsd	%xmm1, %xmm1
 <L48>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xa46>
-               	movq	-0x238(%rbp), %r8
-               	leaq	(%r8), %r15
-               	movsd	%xmm2, (%r15)
-               	movq	%r12, %r15
-               	andq	$0xfff, %r15            # imm = 0xFFF
-               	movq	%r15, %r11
+               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xbc3>
+               	movq	-0x3b0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movsd	%xmm2, (%rdx)
+               	movq	%r12, %rdx
+               	andq	$0xfff, %rdx            # imm = 0xFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L49>
                	cvtsi2sd	%r11, %xmm1
@@ -1603,20 +1669,20 @@ Disassembly of section .text:
                	addsd	%xmm1, %xmm1
 <L50>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xa97>
-               	movq	-0x238(%rbp), %r8
-               	leaq	0x8(%r8), %r15
-               	movsd	%xmm2, (%r15)
+               	subsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xc13>
+               	movq	-0x3b0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movsd	%xmm2, (%rdx)
                	leaq	-0xf0(%rbp), %r8
-               	movq	%r8, -0x248(%rbp)
-               	movq	%r12, %rax
-               	xorq	$0x12345678, %rax       # imm = 0x12345678
-               	movq	-0x248(%rbp), %r8
-               	leaq	(%r8), %r13
-               	movq	%rax, (%r13)
-               	movq	%r12, %rax
-               	andq	$0x3ffff, %rax          # imm = 0x3FFFF
-               	movq	%rax, %r11
+               	movq	%r8, -0x388(%rbp)
+               	movq	%r12, %rdx
+               	xorq	$0x12345678, %rdx       # imm = 0x12345678
+               	movq	-0x388(%rbp), %r8
+               	leaq	(%r8), %rbx
+               	movq	%rdx, (%rbx)
+               	movq	%r12, %rdx
+               	andq	$0x3ffff, %rdx          # imm = 0x3FFFF
+               	movq	%rdx, %r11
                	testq	%r11, %r11
                	jl	 <L51>
                	cvtsi2sd	%r11, %xmm1
@@ -1630,139 +1696,139 @@ Disassembly of section .text:
                	addsd	%xmm1, %xmm1
 <L52>:
                	movsd	%xmm1, %xmm2            # xmm2 = xmm1[0],xmm2[1]
-               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xb0f>
-               	movq	-0x248(%rbp), %r8
-               	leaq	0x8(%r8), %rax
-               	movsd	%xmm2, (%rax)
-               	leaq	0x40(%rsi), %rax
-               	movq	(%rax), %r8
-               	movq	%r8, -0x230(%rbp)
+               	divsd	, %xmm2 <corpus.cases.call.call_rec_edge.checksum+0xc89>
+               	movq	-0x388(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movsd	%xmm2, (%rdx)
+               	leaq	0x40(%rsi), %rdx
+               	movq	(%rdx), %r8
+               	movq	%r8, -0x3a0(%rbp)
                	leaq	-0x112(%rbp), %r8
-               	movq	%r8, -0x258(%rbp)
-               	movq	-0x258(%rbp), %r8
+               	movq	%r8, -0x398(%rbp)
+               	movq	-0x398(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x258(%rbp), %r8
+               	movq	-0x398(%rbp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	-0x258(%rbp), %r8
+               	movq	-0x398(%rbp), %r8
                	movb	$0x0, 0x10(%r8)
-               	movq	%r12, %r13
-               	shrq	$0x7, %r13
-               	movb	%r13b, %r14b
-               	movq	-0x258(%rbp), %r8
-               	leaq	(%r8), %r13
-               	movb	%r14b, (%r13)
-               	movq	$0x0, %r13
-               	cmpq	$0x10, %r13
+               	movq	%r12, %rdx
+               	shrq	$0x7, %rdx
+               	movb	%dl, %bl
+               	movq	-0x398(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movb	%bl, (%rdx)
+               	movq	$0x0, %rdx
+               	cmpq	$0x10, %rdx
                	jb	 <L53>
                	jmp	 <L54>
 <L53>:
-               	movq	%r13, %r14
-               	imulq	$0x4, %r14, %r14
-               	movq	%r14, %rcx
-               	movq	%r12, %r14
-               	shrq	%cl, %r14
-               	movb	%r14b, %bl
-               	movb	%r13b, %r14b
-               	xorl	%r14d, %ebx
-               	movq	-0x258(%rbp), %r8
-               	leaq	0x1(%r8), %r14
-               	leaq	(%r14,%r13), %r15
-               	movb	%bl, (%r15)
-               	addq	$0x1, %r13
-               	cmpq	$0x10, %r13
+               	movq	%rdx, %rbx
+               	imulq	$0x4, %rbx, %rbx
+               	movq	%rbx, %rcx
+               	movq	%r12, %rbx
+               	shrq	%cl, %rbx
+               	movb	%bl, %r14b
+               	movb	%dl, %bl
+               	xorl	%ebx, %r14d
+               	movq	-0x398(%rbp), %r8
+               	leaq	0x1(%r8), %rbx
+               	leaq	(%rbx,%rdx), %r15
+               	movb	%r14b, (%r15)
+               	addq	$0x1, %rdx
+               	cmpq	$0x10, %rdx
                	jb	 <L53>
 <L54>:
-               	leaq	0x50(%rsi), %rbx
-               	movq	(%rbx), %r13
+               	leaq	0x50(%rsi), %rdx
+               	movq	(%rdx), %rbx
                	leaq	-0x124(%rbp), %r8
-               	movq	%r8, -0x260(%rbp)
-               	movq	-0x260(%rbp), %r8
+               	movq	%r8, -0x3d0(%rbp)
+               	movq	-0x3d0(%rbp), %r8
                	movq	$0x0, (%r8)
-               	movq	-0x260(%rbp), %r8
+               	movq	-0x3d0(%rbp), %r8
                	movb	$0x0, 0x8(%r8)
-               	movb	%r13b, %r14b
-               	movq	-0x260(%rbp), %r8
+               	movb	%bl, %dl
+               	movq	-0x3d0(%rbp), %r8
                	leaq	(%r8), %r15
-               	movb	%r14b, (%r15)
-               	movq	$0x0, %r14
-               	cmpq	$0x8, %r14
+               	movb	%dl, (%r15)
+               	movq	$0x0, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L55>
                	jmp	 <L56>
 <L55>:
-               	movq	%r14, %r15
+               	movq	%rdx, %r15
                	imulq	$0x8, %r15, %r15
                	movq	%r15, %rcx
-               	movq	%r13, %r15
+               	movq	%rbx, %r15
                	shrq	%cl, %r15
-               	movb	%r15b, %dl
-               	movb	%r14b, %r15b
-               	addl	%r15d, %edx
-               	movq	-0x260(%rbp), %r8
+               	movb	%r15b, %r13b
+               	movb	%dl, %r15b
+               	addl	%r15d, %r13d
+               	movq	-0x3d0(%rbp), %r8
                	leaq	0x1(%r8), %r15
-               	leaq	(%r15,%r14), %rax
-               	movb	%dl, (%rax)
-               	addq	$0x1, %r14
-               	cmpq	$0x8, %r14
+               	leaq	(%r15,%rdx), %rax
+               	movb	%r13b, (%rax)
+               	addq	$0x1, %rdx
+               	cmpq	$0x8, %rdx
                	jb	 <L55>
 <L56>:
                	leaq	0x58(%rsi), %rax
                	movq	(%rax), %rdx
                	leaq	-0x13c(%rbp), %r8
-               	movq	%r8, -0x268(%rbp)
-               	movl	%edx, %r13d
-               	movq	-0x268(%rbp), %r8
-               	leaq	(%r8), %r14
-               	movl	%r13d, (%r14)
-               	movq	%rdx, %r13
-               	shrq	$0x10, %r13
-               	movl	%r13d, %r14d
-               	movq	-0x268(%rbp), %r8
-               	leaq	0x4(%r8), %r13
-               	movl	%r14d, (%r13)
+               	movq	%r8, -0x3d8(%rbp)
+               	movl	%edx, %ebx
+               	movq	-0x3d8(%rbp), %r8
+               	leaq	(%r8), %r13
+               	movl	%ebx, (%r13)
+               	movq	%rdx, %rbx
+               	shrq	$0x10, %rbx
+               	movl	%ebx, %r13d
+               	movq	-0x3d8(%rbp), %r8
+               	leaq	0x4(%r8), %rbx
+               	movl	%r13d, (%rbx)
                	shrq	$0x20, %rdx
-               	movl	%edx, %r13d
-               	movq	-0x268(%rbp), %r8
+               	movl	%edx, %ebx
+               	movq	-0x3d8(%rbp), %r8
                	leaq	0x8(%r8), %rdx
-               	movl	%r13d, (%rdx)
+               	movl	%ebx, (%rdx)
                	leaq	(%rsi), %rdx
-               	movq	(%rdx), %r13
+               	movq	(%rdx), %rbx
                	leaq	-0x160(%rbp), %r8
-               	movq	%r8, -0x270(%rbp)
-               	movq	-0x270(%rbp), %r8
+               	movq	%r8, -0x3c8(%rbp)
+               	movq	-0x3c8(%rbp), %r8
                	leaq	(%r8), %rdx
-               	movq	%r13, (%rdx)
-               	imulq	$0x3, %r13, %r13
-               	addq	$0x7, %r13
-               	movq	-0x270(%rbp), %r8
+               	movq	%rbx, (%rdx)
+               	imulq	$0x3, %rbx, %rbx
+               	addq	$0x7, %rbx
+               	movq	-0x3c8(%rbp), %r8
                	leaq	0x8(%r8), %rdx
-               	movq	%r13, (%rdx)
+               	movq	%rbx, (%rdx)
                	leaq	0x8(%rsi), %rdx
-               	movq	(%rdx), %r13
-               	leaq	-0x182(%rbp), %r15
+               	movq	(%rdx), %rbx
+               	leaq	-0x239(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movb	$0x0, 0x10(%r15)
-               	movq	%r13, %rdx
+               	movq	%rbx, %rdx
                	shrq	$0x7, %rdx
-               	movb	%dl, %bl
+               	movb	%dl, %r13b
                	leaq	(%r15), %rdx
-               	movb	%bl, (%rdx)
+               	movb	%r13b, (%rdx)
                	movq	$0x0, %rdx
                	cmpq	$0x10, %rdx
                	jb	 <L57>
                	jmp	 <L58>
 <L57>:
-               	movq	%rdx, %rbx
-               	imulq	$0x4, %rbx, %rbx
-               	movq	%rbx, %rcx
-               	movq	%r13, %rbx
-               	shrq	%cl, %rbx
-               	movb	%bl, %al
-               	movb	%dl, %bl
-               	xorl	%ebx, %eax
-               	leaq	0x1(%r15), %rbx
-               	leaq	(%rbx,%rdx), %r14
-               	movb	%al, (%r14)
+               	movq	%rdx, %r13
+               	imulq	$0x4, %r13, %r13
+               	movq	%r13, %rcx
+               	movq	%rbx, %r13
+               	shrq	%cl, %r13
+               	movb	%r13b, %r14b
+               	movb	%dl, %r13b
+               	xorl	%r13d, %r14d
+               	leaq	0x1(%r15), %r13
+               	leaq	(%r13,%rdx), %rax
+               	movb	%r14b, (%rax)
                	addq	$0x1, %rdx
                	cmpq	$0x10, %rdx
                	jb	 <L57>
@@ -1786,28 +1852,92 @@ Disassembly of section .text:
                	leaq	0x20(%rsi), %rax
                	movq	(%rax), %rbx
                	movq	%r12, %rcx
-               	movq	-0x250(%rbp), %r8
-               	movq	%r8, %rdx
-               	movq	-0x220(%rbp), %r8
-               	movq	-0x240(%rbp), %r9
+               	movq	-0x3c0(%rbp), %r8
+               	movq	(%r8), %rax
+               	movq	%rax, -0x249(%rbp)
+               	movq	-0x3c0(%rbp), %r8
+               	movb	0x8(%r8), %al
+               	movb	%al, -0x241(%rbp)
+               	leaq	-0x249(%rbp), %rdx
+               	movq	-0x390(%rbp), %r8
+               	movq	-0x3b8(%rbp), %r9
+               	movq	(%r9), %rax
+               	movq	%rax, -0x25c(%rbp)
+               	movq	-0x3b8(%rbp), %r9
+               	movl	0x8(%r9), %eax
+               	movl	%eax, -0x254(%rbp)
+               	leaq	-0x25c(%rbp), %rax
+               	movq	%rax, %r9
                	movsd	%xmm0, 0x20(%rsp)
-               	movq	-0x228(%rbp), %r10
-               	movq	%r10, 0x28(%rsp)
-               	movq	-0x238(%rbp), %r10
-               	movq	%r10, 0x30(%rsp)
-               	movq	-0x248(%rbp), %r10
-               	movq	%r10, 0x38(%rsp)
-               	movq	-0x230(%rbp), %r10
+               	movq	-0x3a8(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x270(%rbp)
+               	movq	-0x3a8(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x268(%rbp)
+               	leaq	-0x270(%rbp), %rax
+               	movq	%rax, 0x28(%rsp)
+               	movq	-0x3b0(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x280(%rbp)
+               	movq	-0x3b0(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x278(%rbp)
+               	leaq	-0x280(%rbp), %rax
+               	movq	%rax, 0x30(%rsp)
+               	movq	-0x388(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x290(%rbp)
+               	movq	-0x388(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x288(%rbp)
+               	leaq	-0x290(%rbp), %rax
+               	movq	%rax, 0x38(%rsp)
+               	movq	-0x3a0(%rbp), %r10
                	movq	%r10, 0x40(%rsp)
-               	movq	-0x258(%rbp), %r10
-               	movq	%r10, 0x48(%rsp)
-               	movq	-0x260(%rbp), %r10
-               	movq	%r10, 0x50(%rsp)
-               	movq	-0x268(%rbp), %r10
-               	movq	%r10, 0x58(%rsp)
-               	movq	-0x270(%rbp), %r10
-               	movq	%r10, 0x60(%rsp)
-               	movq	%r15, 0x68(%rsp)
+               	movq	-0x398(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x2a8(%rbp)
+               	movq	-0x398(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x2a0(%rbp)
+               	movq	-0x398(%rbp), %r10
+               	movb	0x10(%r10), %al
+               	movb	%al, -0x298(%rbp)
+               	leaq	-0x2a8(%rbp), %rax
+               	movq	%rax, 0x48(%rsp)
+               	movq	-0x3d0(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x2b8(%rbp)
+               	movq	-0x3d0(%rbp), %r10
+               	movb	0x8(%r10), %al
+               	movb	%al, -0x2b0(%rbp)
+               	leaq	-0x2b8(%rbp), %rax
+               	movq	%rax, 0x50(%rsp)
+               	movq	-0x3d8(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x2c8(%rbp)
+               	movq	-0x3d8(%rbp), %r10
+               	movl	0x8(%r10), %eax
+               	movl	%eax, -0x2c0(%rbp)
+               	leaq	-0x2c8(%rbp), %rax
+               	movq	%rax, 0x58(%rsp)
+               	movq	-0x3c8(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x2d8(%rbp)
+               	movq	-0x3c8(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x2d0(%rbp)
+               	leaq	-0x2d8(%rbp), %rax
+               	movq	%rax, 0x60(%rsp)
+               	movq	(%r15), %rax
+               	movq	%rax, -0x2f0(%rbp)
+               	movq	0x8(%r15), %rax
+               	movq	%rax, -0x2e8(%rbp)
+               	movb	0x10(%r15), %al
+               	movb	%al, -0x2e0(%rbp)
+               	leaq	-0x2f0(%rbp), %rax
+               	movq	%rax, 0x68(%rsp)
                	movsd	%xmm1, 0x70(%rsp)
                	movq	%rbx, 0x78(%rsp)
                	callq	 <L61>
@@ -1816,15 +1946,15 @@ Disassembly of section .text:
                	movq	%rax, %rdx
                	callq	 <L62>
 <L62>:
-               	movaps	-0x2c0(%rbp), %xmm14
-               	movaps	-0x2d0(%rbp), %xmm15
-               	movq	-0x278(%rbp), %rbx
-               	movq	-0x280(%rbp), %rdi
-               	movq	-0x288(%rbp), %rsi
-               	movq	-0x290(%rbp), %r12
-               	movq	-0x298(%rbp), %r13
-               	movq	-0x2a0(%rbp), %r14
-               	movq	-0x2a8(%rbp), %r15
+               	movaps	-0x430(%rbp), %xmm14
+               	movaps	-0x440(%rbp), %xmm15
+               	movq	-0x3e8(%rbp), %rbx
+               	movq	-0x3f0(%rbp), %rdi
+               	movq	-0x3f8(%rbp), %rsi
+               	movq	-0x400(%rbp), %r12
+               	movq	-0x408(%rbp), %r13
+               	movq	-0x410(%rbp), %r14
+               	movq	-0x418(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/call/call_rec_large.dis
+++ b/test/golden/x86_64-windows/call/call_rec_large.dis
@@ -1263,17 +1263,17 @@ Disassembly of section .text:
 <corpus.cases.call.call_rec_large.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x540, %rsp            # imm = 0x540
-               	movq	%rbx, -0x458(%rbp)
-               	movq	%rdi, -0x460(%rbp)
-               	movq	%rsi, -0x468(%rbp)
-               	movq	%r12, -0x470(%rbp)
-               	movq	%r13, -0x478(%rbp)
-               	movq	%r14, -0x480(%rbp)
-               	movq	%r15, -0x488(%rbp)
-               	movaps	%xmm6, -0x4a0(%rbp)
-               	movaps	%xmm14, -0x4b0(%rbp)
-               	movaps	%xmm15, -0x4c0(%rbp)
+               	subq	$0x7e0, %rsp            # imm = 0x7E0
+               	movq	%rbx, -0x6f8(%rbp)
+               	movq	%rdi, -0x700(%rbp)
+               	movq	%rsi, -0x708(%rbp)
+               	movq	%r12, -0x710(%rbp)
+               	movq	%r13, -0x718(%rbp)
+               	movq	%r14, -0x720(%rbp)
+               	movq	%r15, -0x728(%rbp)
+               	movaps	%xmm6, -0x740(%rbp)
+               	movaps	%xmm14, -0x750(%rbp)
+               	movaps	%xmm15, -0x760(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -1376,7 +1376,7 @@ Disassembly of section .text:
                	jb	 <L18>
 <L19>:
                	movq	%rax, %r8
-               	movq	%r8, -0x3e8(%rbp)
+               	movq	%r8, -0x688(%rbp)
                	movq	$0x0, %r12
                	movq	$0x0, %r13
                	cmpq	$0x3, %r13
@@ -1387,10 +1387,10 @@ Disassembly of section .text:
                	imulq	$0x13, %rax, %rax
                	movq	%rax, %r8
                	addq	%rbx, %r8
-               	movq	%r8, -0x348(%rbp)
+               	movq	%r8, -0x5e8(%rbp)
                	leaq	(%rsi), %rcx
                	movq	(%rcx), %rdx
-               	movq	-0x348(%rbp), %r8
+               	movq	-0x5e8(%rbp), %r8
                	movq	%rdx, %r14
                	addq	%r8, %r14
                	leaq	0x8(%rsi), %rcx
@@ -1409,7 +1409,7 @@ Disassembly of section .text:
                	leaq	0x10(%rsi), %rax
                	movq	(%rax), %rcx
                	leaq	-0xa8(%rbp), %r8
-               	movq	%r8, -0x440(%rbp)
+               	movq	%r8, -0x6e0(%rbp)
                	movq	%rcx, %rdx
                	andq	$0xffff, %rdx           # imm = 0xFFFF
                	movq	%rdx, %r11
@@ -1427,7 +1427,7 @@ Disassembly of section .text:
 <L22>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x2df>
-               	movq	-0x440(%rbp), %r8
+               	movq	-0x6e0(%rbp), %r8
                	leaq	(%r8), %rdx
                	movsd	%xmm1, (%rdx)
                	movq	%rcx, %rdx
@@ -1447,7 +1447,7 @@ Disassembly of section .text:
 <L24>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x32f>
-               	movq	-0x440(%rbp), %r8
+               	movq	-0x6e0(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movsd	%xmm1, (%rdx)
                	andq	$0x3ffff, %rcx          # imm = 0x3FFFF
@@ -1466,19 +1466,19 @@ Disassembly of section .text:
 <L26>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x37d>
-               	movq	-0x440(%rbp), %r8
+               	movq	-0x6e0(%rbp), %r8
                	leaq	0x10(%r8), %rcx
                	movsd	%xmm1, (%rcx)
                	leaq	0x18(%rsi), %rcx
                	movq	(%rcx), %r8
-               	movq	%r8, -0x358(%rbp)
+               	movq	%r8, -0x5f8(%rbp)
                	leaq	-0xd8(%rbp), %r8
-               	movq	%r8, -0x350(%rbp)
-               	movq	-0x350(%rbp), %r8
+               	movq	%r8, -0x5f0(%rbp)
+               	movq	-0x5f0(%rbp), %r8
                	leaq	(%r8), %rcx
-               	movq	-0x358(%rbp), %r8
+               	movq	-0x5f8(%rbp), %r8
                	movq	%r8, (%rcx)
-               	movq	-0x358(%rbp), %r8
+               	movq	-0x5f8(%rbp), %r8
                	movq	%r8, %rcx
                	andq	$0x7fff, %rcx           # imm = 0x7FFF
                	movq	%rcx, %r11
@@ -1496,100 +1496,100 @@ Disassembly of section .text:
 <L28>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
                	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0x405>
-               	movq	-0x350(%rbp), %r8
+               	movq	-0x5f0(%rbp), %r8
                	leaq	0x8(%r8), %rcx
                	movsd	%xmm1, (%rcx)
-               	movq	-0x358(%rbp), %r8
+               	movq	-0x5f8(%rbp), %r8
                	movl	%r8d, %ecx
-               	movq	-0x350(%rbp), %r8
+               	movq	-0x5f0(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movl	%ecx, (%rdx)
-               	movq	-0x358(%rbp), %r8
+               	movq	-0x5f8(%rbp), %r8
                	movq	%r8, %rcx
                	shrq	$0x20, %rcx
                	movl	%ecx, %edx
-               	movq	-0x350(%rbp), %r8
+               	movq	-0x5f0(%rbp), %r8
                	leaq	0x14(%r8), %rcx
                	movl	%edx, (%rcx)
                	leaq	0x20(%rsi), %rcx
                	movq	(%rcx), %rdx
                	movl	%edx, %r8d
-               	movq	%r8, -0x360(%rbp)
+               	movq	%r8, -0x600(%rbp)
                	leaq	0x28(%rsi), %rcx
                	movq	(%rcx), %rdx
-               	movq	-0x348(%rbp), %r9
+               	movq	-0x5e8(%rbp), %r9
                	movq	%rdx, %r8
                	addq	%r9, %r8
-               	movq	%r8, -0x370(%rbp)
+               	movq	%r8, -0x610(%rbp)
                	leaq	-0x110(%rbp), %r8
-               	movq	%r8, -0x368(%rbp)
-               	movq	-0x368(%rbp), %r8
+               	movq	%r8, -0x608(%rbp)
+               	movq	-0x608(%rbp), %r8
                	leaq	(%r8), %rcx
-               	movq	-0x370(%rbp), %r8
+               	movq	-0x610(%rbp), %r8
                	movq	%r8, (%rcx)
-               	movq	-0x370(%rbp), %r8
+               	movq	-0x610(%rbp), %r8
                	movq	%r8, %rcx
                	xorq	$-0x1, %rcx
-               	movq	-0x368(%rbp), %r8
+               	movq	-0x608(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x370(%rbp), %r8
+               	movq	-0x610(%rbp), %r8
                	movq	%r8, %rcx
                	imulq	$0x5, %rcx, %rcx
-               	movq	-0x368(%rbp), %r8
+               	movq	-0x608(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x370(%rbp), %r8
+               	movq	-0x610(%rbp), %r8
                	movq	%r8, %rcx
                	shrq	$0x3, %rcx
-               	movq	-0x368(%rbp), %r8
+               	movq	-0x608(%rbp), %r8
                	leaq	0x18(%r8), %rdx
                	movq	%rcx, (%rdx)
                	leaq	0x30(%rsi), %rcx
                	movq	(%rcx), %r8
-               	movq	%r8, -0x380(%rbp)
+               	movq	%r8, -0x620(%rbp)
                	leaq	-0x150(%rbp), %r8
-               	movq	%r8, -0x378(%rbp)
+               	movq	%r8, -0x618(%rbp)
                	leaq	-0x160(%rbp), %r8
-               	movq	%r8, -0x388(%rbp)
-               	movq	-0x388(%rbp), %r8
+               	movq	%r8, -0x628(%rbp)
+               	movq	-0x628(%rbp), %r8
                	leaq	(%r8), %rdx
-               	movq	-0x380(%rbp), %r8
+               	movq	-0x620(%rbp), %r8
                	movq	%r8, (%rdx)
-               	movq	-0x380(%rbp), %r8
+               	movq	-0x620(%rbp), %r8
                	movq	%r8, %rdx
                	addq	$0xb, %rdx
-               	movq	-0x388(%rbp), %r8
+               	movq	-0x628(%rbp), %r8
                	leaq	0x8(%r8), %rcx
                	movq	%rdx, (%rcx)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x618(%rbp), %r8
                	leaq	(%r8), %rcx
-               	movq	-0x388(%rbp), %r8
+               	movq	-0x628(%rbp), %r8
                	movq	(%r8), %rdx
                	movq	%rdx, (%rcx)
-               	movq	-0x388(%rbp), %r8
+               	movq	-0x628(%rbp), %r8
                	movq	0x8(%r8), %rdx
                	movq	%rdx, 0x8(%rcx)
                	leaq	-0x170(%rbp), %r8
-               	movq	%r8, -0x390(%rbp)
-               	movq	-0x380(%rbp), %r8
+               	movq	%r8, -0x630(%rbp)
+               	movq	-0x620(%rbp), %r8
                	movq	%r8, %rdx
                	imulq	$0x7, %rdx, %rdx
-               	movq	-0x390(%rbp), %r8
+               	movq	-0x630(%rbp), %r8
                	leaq	(%r8), %rcx
                	movq	%rdx, (%rcx)
-               	movq	-0x380(%rbp), %r8
+               	movq	-0x620(%rbp), %r8
                	movq	%r8, %rcx
                	xorq	$-0x1, %rcx
-               	movq	-0x390(%rbp), %r8
+               	movq	-0x630(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x378(%rbp), %r8
+               	movq	-0x618(%rbp), %r8
                	leaq	0x10(%r8), %rcx
-               	movq	-0x390(%rbp), %r8
+               	movq	-0x630(%rbp), %r8
                	movq	(%r8), %rdx
                	movq	%rdx, (%rcx)
-               	movq	-0x390(%rbp), %r8
+               	movq	-0x630(%rbp), %r8
                	movq	0x8(%r8), %rdx
                	movq	%rdx, 0x8(%rcx)
                	leaq	0x38(%rsi), %rcx
@@ -1610,140 +1610,140 @@ Disassembly of section .text:
 <L30>:
                	leaq	0x40(%rsi), %rcx
                	movq	(%rcx), %r8
-               	movq	%r8, -0x3a0(%rbp)
+               	movq	%r8, -0x640(%rbp)
                	leaq	-0x1e0(%rbp), %r8
-               	movq	%r8, -0x398(%rbp)
-               	movq	-0x398(%rbp), %r8
+               	movq	%r8, -0x638(%rbp)
+               	movq	-0x638(%rbp), %r8
                	leaq	(%r8), %rcx
-               	movq	-0x3a0(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	movq	%r8, (%rcx)
-               	movq	-0x3a0(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
-               	movq	-0x398(%rbp), %r8
+               	movq	-0x638(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x3a0(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x2, %rcx
-               	movq	-0x398(%rbp), %r8
+               	movq	-0x638(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x3a0(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	movq	%r8, %rcx
                	imulq	$0x9, %rcx, %rcx
-               	movq	-0x398(%rbp), %r8
+               	movq	-0x638(%rbp), %r8
                	leaq	0x18(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x3a0(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	movq	%r8, %rcx
                	xorq	$-0x1, %rcx
-               	movq	-0x398(%rbp), %r8
+               	movq	-0x638(%rbp), %r8
                	leaq	0x20(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x3a0(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	movq	%r8, %rcx
                	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
                	xorq	%r11, %rcx
-               	movq	-0x398(%rbp), %r8
+               	movq	-0x638(%rbp), %r8
                	leaq	0x28(%r8), %rdx
                	movq	%rcx, (%rdx)
                	leaq	0x48(%rsi), %rcx
                	movq	(%rcx), %rdx
                	leaq	-0x210(%rbp), %r8
-               	movq	%r8, -0x3a8(%rbp)
-               	movq	-0x3a8(%rbp), %r8
+               	movq	%r8, -0x648(%rbp)
+               	movq	-0x648(%rbp), %r8
                	movq	%r8, %rcx
                	callq	 <L31>
 <L31>:
-               	movq	-0x3a8(%rbp), %r8
+               	movq	-0x648(%rbp), %r8
                	leaq	0x50(%rsi), %rcx
                	movq	(%rcx), %r8
-               	movq	%r8, -0x3b8(%rbp)
+               	movq	%r8, -0x658(%rbp)
                	leaq	-0x288(%rbp), %r8
-               	movq	%r8, -0x3b0(%rbp)
-               	movq	-0x3b0(%rbp), %r8
+               	movq	%r8, -0x650(%rbp)
+               	movq	-0x650(%rbp), %r8
                	leaq	(%r8), %rcx
-               	movq	-0x3b8(%rbp), %r8
+               	movq	-0x658(%rbp), %r8
                	movq	%r8, (%rcx)
-               	movq	-0x3b8(%rbp), %r8
+               	movq	-0x658(%rbp), %r8
                	movq	%r8, %rcx
                	imulq	$0x3, %rcx, %rcx
                	addq	$0x1, %rcx
-               	movq	-0x3b0(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x3b8(%rbp), %r8
+               	movq	-0x658(%rbp), %r8
                	movq	%r8, %rcx
                	xorq	$0x12345678, %rcx       # imm = 0x12345678
-               	movq	-0x3b0(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movq	%rcx, (%rdx)
                	leaq	0x58(%rsi), %rcx
                	movq	(%rcx), %r8
-               	movq	%r8, -0x3c8(%rbp)
+               	movq	%r8, -0x668(%rbp)
                	leaq	-0x2c0(%rbp), %r8
-               	movq	%r8, -0x3c0(%rbp)
-               	movq	-0x3c0(%rbp), %r8
+               	movq	%r8, -0x660(%rbp)
+               	movq	-0x660(%rbp), %r8
                	leaq	(%r8), %rcx
-               	movq	-0x3c8(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	movq	%r8, (%rcx)
-               	movq	-0x3c8(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	movq	%r8, %rcx
                	xorq	$-0x1, %rcx
-               	movq	-0x3c0(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x3c8(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	movq	%r8, %rcx
                	imulq	$0x5, %rcx, %rcx
-               	movq	-0x3c0(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x3c8(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	movq	%r8, %rcx
                	shrq	$0x3, %rcx
-               	movq	-0x3c0(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	leaq	0x18(%r8), %rdx
                	movq	%rcx, (%rdx)
                	leaq	(%rsi), %rcx
                	movq	(%rcx), %r8
-               	movq	%r8, -0x3d8(%rbp)
+               	movq	%r8, -0x678(%rbp)
                	leaq	-0x310(%rbp), %r8
-               	movq	%r8, -0x3d0(%rbp)
-               	movq	-0x3d0(%rbp), %r8
+               	movq	%r8, -0x670(%rbp)
+               	movq	-0x670(%rbp), %r8
                	leaq	(%r8), %rcx
-               	movq	-0x3d8(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	movq	%r8, (%rcx)
-               	movq	-0x3d8(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
-               	movq	-0x3d0(%rbp), %r8
+               	movq	-0x670(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x3d8(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x2, %rcx
-               	movq	-0x3d0(%rbp), %r8
+               	movq	-0x670(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x3d8(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	movq	%r8, %rcx
                	imulq	$0x9, %rcx, %rcx
-               	movq	-0x3d0(%rbp), %r8
+               	movq	-0x670(%rbp), %r8
                	leaq	0x18(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x3d8(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	movq	%r8, %rcx
                	xorq	$-0x1, %rcx
-               	movq	-0x3d0(%rbp), %r8
+               	movq	-0x670(%rbp), %r8
                	leaq	0x20(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x3d8(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	movq	%r8, %rcx
                	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
                	xorq	%r11, %rcx
-               	movq	-0x3d0(%rbp), %r8
+               	movq	-0x670(%rbp), %r8
                	leaq	0x28(%r8), %rdx
                	movq	%rcx, (%rdx)
                	leaq	0x8(%rsi), %rcx
@@ -1764,42 +1764,167 @@ Disassembly of section .text:
 <L33>:
                	leaq	0x10(%rsi), %rcx
                	movq	(%rcx), %r8
-               	movq	%r8, -0x3e0(%rbp)
+               	movq	%r8, -0x680(%rbp)
                	movq	%r14, %rcx
-               	movq	%r15, %rdx
-               	movq	-0x440(%rbp), %r8
-               	movq	-0x350(%rbp), %r9
-               	movq	-0x360(%rbp), %r10
+               	movq	(%r15), %rdx
+               	movq	%rdx, -0x328(%rbp)
+               	movq	0x8(%r15), %rdx
+               	movq	%rdx, -0x320(%rbp)
+               	movq	0x10(%r15), %rdx
+               	movq	%rdx, -0x318(%rbp)
+               	leaq	-0x328(%rbp), %rdx
+               	movq	-0x6e0(%rbp), %r8
+               	movq	(%r8), %r14
+               	movq	%r14, -0x340(%rbp)
+               	movq	-0x6e0(%rbp), %r8
+               	movq	0x8(%r8), %r14
+               	movq	%r14, -0x338(%rbp)
+               	movq	-0x6e0(%rbp), %r8
+               	movq	0x10(%r8), %r14
+               	movq	%r14, -0x330(%rbp)
+               	leaq	-0x340(%rbp), %rax
+               	movq	%rax, %r8
+               	movq	-0x5f0(%rbp), %r9
+               	movq	(%r9), %rax
+               	movq	%rax, -0x358(%rbp)
+               	movq	-0x5f0(%rbp), %r9
+               	movq	0x8(%r9), %rax
+               	movq	%rax, -0x350(%rbp)
+               	movq	-0x5f0(%rbp), %r9
+               	movq	0x10(%r9), %rax
+               	movq	%rax, -0x348(%rbp)
+               	leaq	-0x358(%rbp), %rax
+               	movq	%rax, %r9
+               	movq	-0x600(%rbp), %r10
                	movq	%r10, 0x20(%rsp)
-               	movq	-0x368(%rbp), %r10
-               	movq	%r10, 0x28(%rsp)
-               	movq	-0x378(%rbp), %r10
-               	movq	%r10, 0x30(%rsp)
+               	movq	-0x608(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x378(%rbp)
+               	movq	-0x608(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x370(%rbp)
+               	movq	-0x608(%rbp), %r10
+               	movq	0x10(%r10), %rax
+               	movq	%rax, -0x368(%rbp)
+               	movq	-0x608(%rbp), %r10
+               	movq	0x18(%r10), %rax
+               	movq	%rax, -0x360(%rbp)
+               	leaq	-0x378(%rbp), %rax
+               	movq	%rax, 0x28(%rsp)
+               	movq	-0x618(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x398(%rbp)
+               	movq	-0x618(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x390(%rbp)
+               	movq	-0x618(%rbp), %r10
+               	movq	0x10(%r10), %rax
+               	movq	%rax, -0x388(%rbp)
+               	movq	-0x618(%rbp), %r10
+               	movq	0x18(%r10), %rax
+               	movq	%rax, -0x380(%rbp)
+               	leaq	-0x398(%rbp), %rax
+               	movq	%rax, 0x30(%rsp)
                	movsd	%xmm6, 0x38(%rsp)
-               	movq	-0x398(%rbp), %r10
-               	movq	%r10, 0x40(%rsp)
-               	movq	-0x3a8(%rbp), %r10
-               	movq	%r10, 0x48(%rsp)
-               	movq	-0x3b0(%rbp), %r10
-               	movq	%r10, 0x50(%rsp)
-               	movq	-0x3c0(%rbp), %r10
-               	movq	%r10, 0x58(%rsp)
-               	movq	-0x3d0(%rbp), %r10
-               	movq	%r10, 0x60(%rsp)
+               	movq	-0x638(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x3c8(%rbp)
+               	movq	-0x638(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x3c0(%rbp)
+               	movq	-0x638(%rbp), %r10
+               	movq	0x10(%r10), %rax
+               	movq	%rax, -0x3b8(%rbp)
+               	movq	-0x638(%rbp), %r10
+               	movq	0x18(%r10), %rax
+               	movq	%rax, -0x3b0(%rbp)
+               	movq	-0x638(%rbp), %r10
+               	movq	0x20(%r10), %rax
+               	movq	%rax, -0x3a8(%rbp)
+               	movq	-0x638(%rbp), %r10
+               	movq	0x28(%r10), %rax
+               	movq	%rax, -0x3a0(%rbp)
+               	leaq	-0x3c8(%rbp), %rax
+               	movq	%rax, 0x40(%rsp)
+               	movq	-0x648(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x3f8(%rbp)
+               	movq	-0x648(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x3f0(%rbp)
+               	movq	-0x648(%rbp), %r10
+               	movq	0x10(%r10), %rax
+               	movq	%rax, -0x3e8(%rbp)
+               	movq	-0x648(%rbp), %r10
+               	movq	0x18(%r10), %rax
+               	movq	%rax, -0x3e0(%rbp)
+               	movq	-0x648(%rbp), %r10
+               	movq	0x20(%r10), %rax
+               	movq	%rax, -0x3d8(%rbp)
+               	movq	-0x648(%rbp), %r10
+               	movq	0x28(%r10), %rax
+               	movq	%rax, -0x3d0(%rbp)
+               	leaq	-0x3f8(%rbp), %rax
+               	movq	%rax, 0x48(%rsp)
+               	movq	-0x650(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x410(%rbp)
+               	movq	-0x650(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x408(%rbp)
+               	movq	-0x650(%rbp), %r10
+               	movq	0x10(%r10), %rax
+               	movq	%rax, -0x400(%rbp)
+               	leaq	-0x410(%rbp), %rax
+               	movq	%rax, 0x50(%rsp)
+               	movq	-0x660(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x430(%rbp)
+               	movq	-0x660(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x428(%rbp)
+               	movq	-0x660(%rbp), %r10
+               	movq	0x10(%r10), %rax
+               	movq	%rax, -0x420(%rbp)
+               	movq	-0x660(%rbp), %r10
+               	movq	0x18(%r10), %rax
+               	movq	%rax, -0x418(%rbp)
+               	leaq	-0x430(%rbp), %rax
+               	movq	%rax, 0x58(%rsp)
+               	movq	-0x670(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x460(%rbp)
+               	movq	-0x670(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x458(%rbp)
+               	movq	-0x670(%rbp), %r10
+               	movq	0x10(%r10), %rax
+               	movq	%rax, -0x450(%rbp)
+               	movq	-0x670(%rbp), %r10
+               	movq	0x18(%r10), %rax
+               	movq	%rax, -0x448(%rbp)
+               	movq	-0x670(%rbp), %r10
+               	movq	0x20(%r10), %rax
+               	movq	%rax, -0x440(%rbp)
+               	movq	-0x670(%rbp), %r10
+               	movq	0x28(%r10), %rax
+               	movq	%rax, -0x438(%rbp)
+               	leaq	-0x460(%rbp), %rax
+               	movq	%rax, 0x60(%rsp)
                	movsd	%xmm0, 0x68(%rsp)
-               	movq	-0x3e0(%rbp), %r10
+               	movq	-0x680(%rbp), %r10
                	movq	%r10, 0x70(%rsp)
                	callq	 <L34>
 <L34>:
                	movq	%rax, %r12
-               	movq	-0x3e8(%rbp), %r8
+               	movq	-0x688(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%r12, %rdx
                	callq	 <L35>
 <L35>:
                	addq	$0x1, %r13
                	movq	%rax, %r8
-               	movq	%r8, -0x3e8(%rbp)
+               	movq	%r8, -0x688(%rbp)
                	cmpq	$0x3, %r13
                	jb	 <L20>
 <L36>:
@@ -1832,7 +1957,7 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L38>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xa36>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xd15>
                	leaq	(%r13), %rax
                	movsd	%xmm1, (%rax)
                	movq	%r12, %rax
@@ -1851,7 +1976,7 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L40>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xa80>
+               	subsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xd5f>
                	leaq	0x8(%r13), %rax
                	movsd	%xmm1, (%rax)
                	movq	%r12, %rax
@@ -1870,7 +1995,7 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L42>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xaca>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xda9>
                	leaq	0x10(%r13), %rax
                	movsd	%xmm1, (%rax)
                	leaq	-0xf0(%rbp), %r14
@@ -1892,7 +2017,7 @@ Disassembly of section .text:
                	addsd	%xmm0, %xmm0
 <L44>:
                	movsd	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1]
-               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xb21>
+               	divsd	, %xmm1 <corpus.cases.call.call_rec_large.checksum+0xe00>
                	leaq	0x8(%r14), %rax
                	movsd	%xmm1, (%rax)
                	movl	%r12d, %eax
@@ -1905,60 +2030,60 @@ Disassembly of section .text:
                	movl	%ecx, (%rax)
                	movl	%r12d, %r15d
                	leaq	-0x130(%rbp), %r8
-               	movq	%r8, -0x448(%rbp)
-               	movq	-0x448(%rbp), %r8
+               	movq	%r8, -0x6e8(%rbp)
+               	movq	-0x6e8(%rbp), %r8
                	leaq	(%r8), %rcx
                	movq	%r12, (%rcx)
                	movq	%r12, %rcx
                	xorq	$-0x1, %rcx
-               	movq	-0x448(%rbp), %r8
+               	movq	-0x6e8(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	%rcx, (%rdx)
                	movq	%r12, %rcx
                	imulq	$0x5, %rcx, %rcx
-               	movq	-0x448(%rbp), %r8
+               	movq	-0x6e8(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movq	%rcx, (%rdx)
                	movq	%r12, %rcx
                	shrq	$0x3, %rcx
-               	movq	-0x448(%rbp), %r8
+               	movq	-0x6e8(%rbp), %r8
                	leaq	0x18(%r8), %rdx
                	movq	%rcx, (%rdx)
                	leaq	-0x190(%rbp), %rdi
                	leaq	-0x1a0(%rbp), %r8
-               	movq	%r8, -0x3f0(%rbp)
-               	movq	-0x3f0(%rbp), %r8
+               	movq	%r8, -0x690(%rbp)
+               	movq	-0x690(%rbp), %r8
                	leaq	(%r8), %rdx
                	movq	%r12, (%rdx)
                	movq	%r12, %rdx
                	addq	$0xb, %rdx
-               	movq	-0x3f0(%rbp), %r8
+               	movq	-0x690(%rbp), %r8
                	leaq	0x8(%r8), %rcx
                	movq	%rdx, (%rcx)
                	leaq	(%rdi), %rcx
-               	movq	-0x3f0(%rbp), %r8
+               	movq	-0x690(%rbp), %r8
                	movq	(%r8), %rdx
                	movq	%rdx, (%rcx)
-               	movq	-0x3f0(%rbp), %r8
+               	movq	-0x690(%rbp), %r8
                	movq	0x8(%r8), %rdx
                	movq	%rdx, 0x8(%rcx)
                	leaq	-0x1b0(%rbp), %r8
-               	movq	%r8, -0x3f8(%rbp)
+               	movq	%r8, -0x698(%rbp)
                	movq	%r12, %rdx
                	imulq	$0x7, %rdx, %rdx
-               	movq	-0x3f8(%rbp), %r8
+               	movq	-0x698(%rbp), %r8
                	leaq	(%r8), %rcx
                	movq	%rdx, (%rcx)
                	movq	%r12, %rcx
                	xorq	$-0x1, %rcx
-               	movq	-0x3f8(%rbp), %r8
+               	movq	-0x698(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	%rcx, (%rdx)
                	leaq	0x10(%rdi), %rcx
-               	movq	-0x3f8(%rbp), %r8
+               	movq	-0x698(%rbp), %r8
                	movq	(%r8), %rdx
                	movq	%rdx, (%rcx)
-               	movq	-0x3f8(%rbp), %r8
+               	movq	-0x698(%rbp), %r8
                	movq	0x8(%r8), %rdx
                	movq	%rdx, 0x8(%rcx)
                	movq	%r12, %rcx
@@ -1977,131 +2102,131 @@ Disassembly of section .text:
                	addsd	%xmm6, %xmm6
 <L46>:
                	leaq	-0x240(%rbp), %r8
-               	movq	%r8, -0x400(%rbp)
-               	movq	-0x400(%rbp), %r8
+               	movq	%r8, -0x6a0(%rbp)
+               	movq	-0x6a0(%rbp), %r8
                	leaq	(%r8), %rcx
                	movq	%r12, (%rcx)
                	movq	%r12, %rcx
                	addq	$0x1, %rcx
-               	movq	-0x400(%rbp), %r8
+               	movq	-0x6a0(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	%rcx, (%rdx)
                	movq	%r12, %rcx
                	addq	$0x2, %rcx
-               	movq	-0x400(%rbp), %r8
+               	movq	-0x6a0(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movq	%rcx, (%rdx)
                	movq	%r12, %rcx
                	imulq	$0x9, %rcx, %rcx
-               	movq	-0x400(%rbp), %r8
+               	movq	-0x6a0(%rbp), %r8
                	leaq	0x18(%r8), %rdx
                	movq	%rcx, (%rdx)
                	movq	%r12, %rcx
                	xorq	$-0x1, %rcx
-               	movq	-0x400(%rbp), %r8
+               	movq	-0x6a0(%rbp), %r8
                	leaq	0x20(%r8), %rdx
                	movq	%rcx, (%rdx)
                	movq	%r12, %rcx
                	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
                	xorq	%r11, %rcx
-               	movq	-0x400(%rbp), %r8
+               	movq	-0x6a0(%rbp), %r8
                	leaq	0x28(%r8), %rdx
                	movq	%rcx, (%rdx)
                	leaq	-0x270(%rbp), %r8
-               	movq	%r8, -0x408(%rbp)
-               	movq	-0x408(%rbp), %r8
+               	movq	%r8, -0x6a8(%rbp)
+               	movq	-0x6a8(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%r12, %rdx
                	callq	 <L47>
 <L47>:
-               	movq	-0x408(%rbp), %r8
+               	movq	-0x6a8(%rbp), %r8
                	leaq	0x50(%rsi), %rcx
                	movq	(%rcx), %r8
-               	movq	%r8, -0x418(%rbp)
+               	movq	%r8, -0x6b8(%rbp)
                	leaq	-0x2a0(%rbp), %r8
-               	movq	%r8, -0x410(%rbp)
-               	movq	-0x410(%rbp), %r8
+               	movq	%r8, -0x6b0(%rbp)
+               	movq	-0x6b0(%rbp), %r8
                	leaq	(%r8), %rcx
-               	movq	-0x418(%rbp), %r8
+               	movq	-0x6b8(%rbp), %r8
                	movq	%r8, (%rcx)
-               	movq	-0x418(%rbp), %r8
+               	movq	-0x6b8(%rbp), %r8
                	movq	%r8, %rcx
                	imulq	$0x3, %rcx, %rcx
                	addq	$0x1, %rcx
-               	movq	-0x410(%rbp), %r8
+               	movq	-0x6b0(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x418(%rbp), %r8
+               	movq	-0x6b8(%rbp), %r8
                	movq	%r8, %rcx
                	xorq	$0x12345678, %rcx       # imm = 0x12345678
-               	movq	-0x410(%rbp), %r8
+               	movq	-0x6b0(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movq	%rcx, (%rdx)
                	leaq	0x58(%rsi), %rcx
                	movq	(%rcx), %r8
-               	movq	%r8, -0x428(%rbp)
+               	movq	%r8, -0x6c8(%rbp)
                	leaq	-0x2e0(%rbp), %r8
-               	movq	%r8, -0x420(%rbp)
-               	movq	-0x420(%rbp), %r8
+               	movq	%r8, -0x6c0(%rbp)
+               	movq	-0x6c0(%rbp), %r8
                	leaq	(%r8), %rcx
-               	movq	-0x428(%rbp), %r8
+               	movq	-0x6c8(%rbp), %r8
                	movq	%r8, (%rcx)
-               	movq	-0x428(%rbp), %r8
+               	movq	-0x6c8(%rbp), %r8
                	movq	%r8, %rcx
                	xorq	$-0x1, %rcx
-               	movq	-0x420(%rbp), %r8
+               	movq	-0x6c0(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x428(%rbp), %r8
+               	movq	-0x6c8(%rbp), %r8
                	movq	%r8, %rcx
                	imulq	$0x5, %rcx, %rcx
-               	movq	-0x420(%rbp), %r8
+               	movq	-0x6c0(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x428(%rbp), %r8
+               	movq	-0x6c8(%rbp), %r8
                	movq	%r8, %rcx
                	shrq	$0x3, %rcx
-               	movq	-0x420(%rbp), %r8
+               	movq	-0x6c0(%rbp), %r8
                	leaq	0x18(%r8), %rdx
                	movq	%rcx, (%rdx)
                	leaq	(%rsi), %rcx
                	movq	(%rcx), %r8
-               	movq	%r8, -0x438(%rbp)
-               	leaq	-0x340(%rbp), %r8
-               	movq	%r8, -0x430(%rbp)
-               	movq	-0x430(%rbp), %r8
+               	movq	%r8, -0x6d8(%rbp)
+               	leaq	-0x490(%rbp), %r8
+               	movq	%r8, -0x6d0(%rbp)
+               	movq	-0x6d0(%rbp), %r8
                	leaq	(%r8), %rcx
-               	movq	-0x438(%rbp), %r8
+               	movq	-0x6d8(%rbp), %r8
                	movq	%r8, (%rcx)
-               	movq	-0x438(%rbp), %r8
+               	movq	-0x6d8(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x1, %rcx
-               	movq	-0x430(%rbp), %r8
+               	movq	-0x6d0(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x438(%rbp), %r8
+               	movq	-0x6d8(%rbp), %r8
                	movq	%r8, %rcx
                	addq	$0x2, %rcx
-               	movq	-0x430(%rbp), %r8
+               	movq	-0x6d0(%rbp), %r8
                	leaq	0x10(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x438(%rbp), %r8
+               	movq	-0x6d8(%rbp), %r8
                	movq	%r8, %rcx
                	imulq	$0x9, %rcx, %rcx
-               	movq	-0x430(%rbp), %r8
+               	movq	-0x6d0(%rbp), %r8
                	leaq	0x18(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x438(%rbp), %r8
+               	movq	-0x6d8(%rbp), %r8
                	movq	%r8, %rcx
                	xorq	$-0x1, %rcx
-               	movq	-0x430(%rbp), %r8
+               	movq	-0x6d0(%rbp), %r8
                	leaq	0x20(%r8), %rdx
                	movq	%rcx, (%rdx)
-               	movq	-0x438(%rbp), %r8
+               	movq	-0x6d8(%rbp), %r8
                	movq	%r8, %rcx
                	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
                	xorq	%r11, %rcx
-               	movq	-0x430(%rbp), %r8
+               	movq	-0x6d0(%rbp), %r8
                	leaq	0x28(%r8), %rdx
                	movq	%rcx, (%rdx)
                	leaq	0x8(%rsi), %rcx
@@ -2123,43 +2248,159 @@ Disassembly of section .text:
                	leaq	0x18(%rsi), %rcx
                	movq	(%rcx), %rsi
                	movq	%r12, %rcx
-               	movq	%rbx, %rdx
-               	movq	%r13, %r8
-               	movq	%r14, %r9
+               	movq	(%rbx), %rdx
+               	movq	%rdx, -0x4a8(%rbp)
+               	movq	0x8(%rbx), %rdx
+               	movq	%rdx, -0x4a0(%rbp)
+               	movq	0x10(%rbx), %rdx
+               	movq	%rdx, -0x498(%rbp)
+               	leaq	-0x4a8(%rbp), %rdx
+               	movq	(%r13), %rbx
+               	movq	%rbx, -0x4c0(%rbp)
+               	movq	0x8(%r13), %rbx
+               	movq	%rbx, -0x4b8(%rbp)
+               	movq	0x10(%r13), %rbx
+               	movq	%rbx, -0x4b0(%rbp)
+               	leaq	-0x4c0(%rbp), %rbx
+               	movq	%rbx, %r8
+               	movq	(%r14), %rbx
+               	movq	%rbx, -0x4d8(%rbp)
+               	movq	0x8(%r14), %rbx
+               	movq	%rbx, -0x4d0(%rbp)
+               	movq	0x10(%r14), %rbx
+               	movq	%rbx, -0x4c8(%rbp)
+               	leaq	-0x4d8(%rbp), %rbx
+               	movq	%rbx, %r9
                	movq	%r15, 0x20(%rsp)
-               	movq	-0x448(%rbp), %r10
-               	movq	%r10, 0x28(%rsp)
-               	movq	%rdi, 0x30(%rsp)
+               	movq	-0x6e8(%rbp), %r10
+               	movq	(%r10), %rbx
+               	movq	%rbx, -0x4f8(%rbp)
+               	movq	-0x6e8(%rbp), %r10
+               	movq	0x8(%r10), %rbx
+               	movq	%rbx, -0x4f0(%rbp)
+               	movq	-0x6e8(%rbp), %r10
+               	movq	0x10(%r10), %rbx
+               	movq	%rbx, -0x4e8(%rbp)
+               	movq	-0x6e8(%rbp), %r10
+               	movq	0x18(%r10), %rbx
+               	movq	%rbx, -0x4e0(%rbp)
+               	leaq	-0x4f8(%rbp), %rax
+               	movq	%rax, 0x28(%rsp)
+               	movq	(%rdi), %rax
+               	movq	%rax, -0x518(%rbp)
+               	movq	0x8(%rdi), %rax
+               	movq	%rax, -0x510(%rbp)
+               	movq	0x10(%rdi), %rax
+               	movq	%rax, -0x508(%rbp)
+               	movq	0x18(%rdi), %rax
+               	movq	%rax, -0x500(%rbp)
+               	leaq	-0x518(%rbp), %rax
+               	movq	%rax, 0x30(%rsp)
                	movsd	%xmm6, 0x38(%rsp)
-               	movq	-0x400(%rbp), %r10
-               	movq	%r10, 0x40(%rsp)
-               	movq	-0x408(%rbp), %r10
-               	movq	%r10, 0x48(%rsp)
-               	movq	-0x410(%rbp), %r10
-               	movq	%r10, 0x50(%rsp)
-               	movq	-0x420(%rbp), %r10
-               	movq	%r10, 0x58(%rsp)
-               	movq	-0x430(%rbp), %r10
-               	movq	%r10, 0x60(%rsp)
+               	movq	-0x6a0(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x548(%rbp)
+               	movq	-0x6a0(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x540(%rbp)
+               	movq	-0x6a0(%rbp), %r10
+               	movq	0x10(%r10), %rax
+               	movq	%rax, -0x538(%rbp)
+               	movq	-0x6a0(%rbp), %r10
+               	movq	0x18(%r10), %rax
+               	movq	%rax, -0x530(%rbp)
+               	movq	-0x6a0(%rbp), %r10
+               	movq	0x20(%r10), %rax
+               	movq	%rax, -0x528(%rbp)
+               	movq	-0x6a0(%rbp), %r10
+               	movq	0x28(%r10), %rax
+               	movq	%rax, -0x520(%rbp)
+               	leaq	-0x548(%rbp), %rax
+               	movq	%rax, 0x40(%rsp)
+               	movq	-0x6a8(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x578(%rbp)
+               	movq	-0x6a8(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x570(%rbp)
+               	movq	-0x6a8(%rbp), %r10
+               	movq	0x10(%r10), %rax
+               	movq	%rax, -0x568(%rbp)
+               	movq	-0x6a8(%rbp), %r10
+               	movq	0x18(%r10), %rax
+               	movq	%rax, -0x560(%rbp)
+               	movq	-0x6a8(%rbp), %r10
+               	movq	0x20(%r10), %rax
+               	movq	%rax, -0x558(%rbp)
+               	movq	-0x6a8(%rbp), %r10
+               	movq	0x28(%r10), %rax
+               	movq	%rax, -0x550(%rbp)
+               	leaq	-0x578(%rbp), %rax
+               	movq	%rax, 0x48(%rsp)
+               	movq	-0x6b0(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x590(%rbp)
+               	movq	-0x6b0(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x588(%rbp)
+               	movq	-0x6b0(%rbp), %r10
+               	movq	0x10(%r10), %rax
+               	movq	%rax, -0x580(%rbp)
+               	leaq	-0x590(%rbp), %rax
+               	movq	%rax, 0x50(%rsp)
+               	movq	-0x6c0(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x5b0(%rbp)
+               	movq	-0x6c0(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x5a8(%rbp)
+               	movq	-0x6c0(%rbp), %r10
+               	movq	0x10(%r10), %rax
+               	movq	%rax, -0x5a0(%rbp)
+               	movq	-0x6c0(%rbp), %r10
+               	movq	0x18(%r10), %rax
+               	movq	%rax, -0x598(%rbp)
+               	leaq	-0x5b0(%rbp), %rax
+               	movq	%rax, 0x58(%rsp)
+               	movq	-0x6d0(%rbp), %r10
+               	movq	(%r10), %rax
+               	movq	%rax, -0x5e0(%rbp)
+               	movq	-0x6d0(%rbp), %r10
+               	movq	0x8(%r10), %rax
+               	movq	%rax, -0x5d8(%rbp)
+               	movq	-0x6d0(%rbp), %r10
+               	movq	0x10(%r10), %rax
+               	movq	%rax, -0x5d0(%rbp)
+               	movq	-0x6d0(%rbp), %r10
+               	movq	0x18(%r10), %rax
+               	movq	%rax, -0x5c8(%rbp)
+               	movq	-0x6d0(%rbp), %r10
+               	movq	0x20(%r10), %rax
+               	movq	%rax, -0x5c0(%rbp)
+               	movq	-0x6d0(%rbp), %r10
+               	movq	0x28(%r10), %rax
+               	movq	%rax, -0x5b8(%rbp)
+               	leaq	-0x5e0(%rbp), %rax
+               	movq	%rax, 0x60(%rsp)
                	movsd	%xmm0, 0x68(%rsp)
                	movq	%rsi, 0x70(%rsp)
                	callq	 <L50>
 <L50>:
-               	movq	-0x3e8(%rbp), %r8
+               	movq	-0x688(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%rax, %rdx
                	callq	 <L51>
 <L51>:
-               	movaps	-0x4a0(%rbp), %xmm6
-               	movaps	-0x4b0(%rbp), %xmm14
-               	movaps	-0x4c0(%rbp), %xmm15
-               	movq	-0x458(%rbp), %rbx
-               	movq	-0x460(%rbp), %rdi
-               	movq	-0x468(%rbp), %rsi
-               	movq	-0x470(%rbp), %r12
-               	movq	-0x478(%rbp), %r13
-               	movq	-0x480(%rbp), %r14
-               	movq	-0x488(%rbp), %r15
+               	movaps	-0x740(%rbp), %xmm6
+               	movaps	-0x750(%rbp), %xmm14
+               	movaps	-0x760(%rbp), %xmm15
+               	movq	-0x6f8(%rbp), %rbx
+               	movq	-0x700(%rbp), %rdi
+               	movq	-0x708(%rbp), %rsi
+               	movq	-0x710(%rbp), %r12
+               	movq	-0x718(%rbp), %r13
+               	movq	-0x720(%rbp), %r14
+               	movq	-0x728(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/call/call_ret_large.dis
+++ b/test/golden/x86_64-windows/call/call_ret_large.dis
@@ -1060,20 +1060,20 @@ Disassembly of section .text:
 <corpus.cases.call.call_ret_large.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x590, %rsp            # imm = 0x590
-               	movq	%rbx, -0x4f8(%rbp)
-               	movq	%rdi, -0x500(%rbp)
-               	movq	%rsi, -0x508(%rbp)
-               	movq	%r12, -0x510(%rbp)
-               	movq	%r13, -0x518(%rbp)
-               	movq	%r14, -0x520(%rbp)
-               	movq	%r15, -0x528(%rbp)
-               	movaps	%xmm6, -0x540(%rbp)
-               	movaps	%xmm7, -0x550(%rbp)
-               	movaps	%xmm14, -0x560(%rbp)
-               	movaps	%xmm15, -0x570(%rbp)
+               	subq	$0x750, %rsp            # imm = 0x750
+               	movq	%rbx, -0x6b8(%rbp)
+               	movq	%rdi, -0x6c0(%rbp)
+               	movq	%rsi, -0x6c8(%rbp)
+               	movq	%r12, -0x6d0(%rbp)
+               	movq	%r13, -0x6d8(%rbp)
+               	movq	%r14, -0x6e0(%rbp)
+               	movq	%r15, -0x6e8(%rbp)
+               	movaps	%xmm6, -0x700(%rbp)
+               	movaps	%xmm7, -0x710(%rbp)
+               	movaps	%xmm14, -0x720(%rbp)
+               	movaps	%xmm15, -0x730(%rbp)
                	movq	%rcx, %r8
-               	movq	%r8, -0x488(%rbp)
+               	movq	%r8, -0x650(%rbp)
                	callq	 <L0>
 <L0>:
                	movq	%rax, %rcx
@@ -1112,7 +1112,7 @@ Disassembly of section .text:
                	movq	$0x20, %rdx
                	callq	 <L9>
 <L9>:
-               	leaq	-0x190(%rbp), %rsi
+               	leaq	-0x1c0(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
@@ -1131,7 +1131,7 @@ Disassembly of section .text:
                	imulq	%r11, %rdx
                	movabsq	$0x14057b7ef767814f, %r11 # imm = 0x14057B7EF767814F
                	addq	%r11, %rdx
-               	movq	-0x488(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	addq	%r8, %rdx
                	leaq	(%rsi,%rcx,8), %rdi
                	movq	%rdx, (%rdi)
@@ -1147,7 +1147,7 @@ Disassembly of section .text:
 <L12>:
                	leaq	(%rsi,%r12,8), %rax
                	movq	(%rax), %rcx
-               	movq	-0x488(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	movq	%rcx, %r13
                	addq	%r8, %r13
                	movl	%r13d, %eax
@@ -1160,11 +1160,11 @@ Disassembly of section .text:
                	movq	%r13, %rcx
                	shrq	$0x18, %rcx
                	movl	%ecx, %r8d
-               	movq	%r8, -0x448(%rbp)
+               	movq	%r8, -0x610(%rbp)
                	movq	%r13, %rcx
                	shrq	$0x20, %rcx
                	movl	%ecx, %r8d
-               	movq	%r8, -0x450(%rbp)
+               	movq	%r8, -0x618(%rbp)
                	movq	%rdi, %rcx
                	movl	%eax, %edx
                	callq	 <L13>
@@ -1178,12 +1178,12 @@ Disassembly of section .text:
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rcx
-               	movq	-0x448(%rbp), %r8
+               	movq	-0x610(%rbp), %r8
                	movl	%r8d, %edx
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rcx
-               	movq	-0x450(%rbp), %r8
+               	movq	-0x618(%rbp), %r8
                	movl	%r8d, %edx
                	callq	 <L17>
 <L17>:
@@ -1272,9 +1272,9 @@ Disassembly of section .text:
                	movq	%r13, %r15
                	imulq	$0x5, %r15, %r15
                	movq	%r13, %r8
-               	movq	%r8, -0x458(%rbp)
+               	movq	%r8, -0x620(%rbp)
                	xorq	$-0x1, %r8
-               	movq	%r8, -0x458(%rbp)
+               	movq	%r8, -0x620(%rbp)
                	movq	%rax, %rcx
                	movq	%r13, %rdx
                	callq	 <L30>
@@ -1288,7 +1288,7 @@ Disassembly of section .text:
                	callq	 <L32>
 <L32>:
                	movq	%rax, %rcx
-               	movq	-0x458(%rbp), %r8
+               	movq	-0x620(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L33>
 <L33>:
@@ -1332,7 +1332,7 @@ Disassembly of section .text:
                	divsd	, %xmm7 <corpus.cases.call.call_ret_large.checksum+0x436>
                	movq	%r13, %r8
                	imulq	$0x7, %r8, %r8
-               	movq	%r8, -0x460(%rbp)
+               	movq	%r8, -0x628(%rbp)
                	movq	%rax, %rcx
                	movq	%r13, %rdx
                	callq	 <L38>
@@ -1354,7 +1354,7 @@ Disassembly of section .text:
                	callq	 <L42>
 <L42>:
                	movq	%rax, %rcx
-               	movq	-0x460(%rbp), %r8
+               	movq	-0x628(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L43>
 <L43>:
@@ -1364,15 +1364,15 @@ Disassembly of section .text:
                	addq	$0x2, %r15
                	movq	%r13, %r8
                	imulq	$0x9, %r8, %r8
-               	movq	%r8, -0x468(%rbp)
+               	movq	%r8, -0x630(%rbp)
                	movq	%r13, %r8
-               	movq	%r8, -0x470(%rbp)
+               	movq	%r8, -0x638(%rbp)
                	xorq	$-0x1, %r8
-               	movq	%r8, -0x470(%rbp)
+               	movq	%r8, -0x638(%rbp)
                	movq	%r13, %r8
                	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
                	xorq	%r11, %r8
-               	movq	%r8, -0x478(%rbp)
+               	movq	%r8, -0x640(%rbp)
                	movq	%rax, %rcx
                	movq	%r13, %rdx
                	callq	 <L44>
@@ -1386,25 +1386,25 @@ Disassembly of section .text:
                	callq	 <L46>
 <L46>:
                	movq	%rax, %rcx
-               	movq	-0x468(%rbp), %r8
+               	movq	-0x630(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L47>
 <L47>:
                	movq	%rax, %rcx
-               	movq	-0x470(%rbp), %r8
+               	movq	-0x638(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L48>
 <L48>:
                	movq	%rax, %rcx
-               	movq	-0x478(%rbp), %r8
+               	movq	-0x640(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L49>
 <L49>:
-               	leaq	-0x418(%rbp), %rdx
+               	leaq	-0x5b0(%rbp), %rdx
                	movl	%r13d, %ecx
                	leaq	(%rdx), %r14
                	movl	%ecx, (%r14)
-               	leaq	-0x430(%rbp), %rcx
+               	leaq	-0x5c8(%rbp), %rcx
                	leaq	(%rcx), %r14
                	movq	%r13, (%r14)
                	movq	%r13, %r14
@@ -1423,7 +1423,7 @@ Disassembly of section .text:
                	movq	%r15, 0x8(%r14)
                	movq	0x10(%rcx), %r15
                	movq	%r15, 0x10(%r14)
-               	leaq	-0x440(%rbp), %rcx
+               	leaq	-0x5d8(%rbp), %rcx
                	movq	%r13, %r14
                	imulq	$0xb, %r14, %r14
                	leaq	(%rcx), %r15
@@ -1437,6 +1437,19 @@ Disassembly of section .text:
                	movq	0x8(%rcx), %r14
                	movq	%r14, 0x8(%r13)
                	movq	%rax, %rcx
+               	movq	(%rdx), %rax
+               	movq	%rax, -0x608(%rbp)
+               	movq	0x8(%rdx), %rax
+               	movq	%rax, -0x600(%rbp)
+               	movq	0x10(%rdx), %rax
+               	movq	%rax, -0x5f8(%rbp)
+               	movq	0x18(%rdx), %rax
+               	movq	%rax, -0x5f0(%rbp)
+               	movq	0x20(%rdx), %rax
+               	movq	%rax, -0x5e8(%rbp)
+               	movq	0x28(%rdx), %rax
+               	movq	%rax, -0x5e0(%rbp)
+               	leaq	-0x608(%rbp), %rdx
                	callq	 <L50>
 <L50>:
                	addq	$0x1, %r12
@@ -1444,7 +1457,7 @@ Disassembly of section .text:
                	cmpq	$0x8, %r12
                	jb	 <L12>
 <L51>:
-               	movq	-0x488(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	movq	%r8, %rax
                	addq	$0x1, %rax
                	movq	%rax, %rcx
@@ -1464,19 +1477,19 @@ Disassembly of section .text:
                	movq	(%rax), %rcx
                	movq	%r13, %r8
                	addq	%rcx, %r8
-               	movq	%r8, -0x4e8(%rbp)
+               	movq	%r8, -0x6b0(%rbp)
                	movq	%r14, %r8
                	xorq	%rcx, %r8
-               	movq	%r8, -0x480(%rbp)
+               	movq	%r8, -0x648(%rbp)
                	movq	%r15, %rbx
                	addq	%r13, %rbx
                	movq	%rdi, %rcx
-               	movq	-0x4e8(%rbp), %r8
+               	movq	-0x6b0(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L53>
 <L53>:
                	movq	%rax, %rcx
-               	movq	-0x480(%rbp), %r8
+               	movq	-0x648(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L54>
 <L54>:
@@ -1487,19 +1500,19 @@ Disassembly of section .text:
                	movq	%rax, %rcx
                	addq	$0x1, %r12
                	movq	%rcx, %rdi
-               	movq	-0x4e8(%rbp), %r8
+               	movq	-0x6b0(%rbp), %r8
                	movq	%r8, %r13
-               	movq	-0x480(%rbp), %r8
+               	movq	-0x648(%rbp), %r8
                	movq	%r8, %r14
                	movq	%rbx, %r15
                	cmpq	$0x8, %r12
                	jb	 <L52>
 <L56>:
                	leaq	-0x30(%rbp), %rbx
-               	movq	-0x488(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	movq	%r8, %rax
                	addq	$0x2, %rax
-               	leaq	-0x1c0(%rbp), %rcx
+               	leaq	-0x1f0(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movq	%rax, (%rdx)
                	movq	%rax, %rdx
@@ -1543,7 +1556,19 @@ Disassembly of section .text:
                	movq	(%rax), %r13
                	leaq	-0x60(%rbp), %r14
                	movq	%r14, %rcx
-               	movq	%rbx, %rdx
+               	movq	(%rbx), %rax
+               	movq	%rax, -0x90(%rbp)
+               	movq	0x8(%rbx), %rax
+               	movq	%rax, -0x88(%rbp)
+               	movq	0x10(%rbx), %rax
+               	movq	%rax, -0x80(%rbp)
+               	movq	0x18(%rbx), %rax
+               	movq	%rax, -0x78(%rbp)
+               	movq	0x20(%rbx), %rax
+               	movq	%rax, -0x70(%rbp)
+               	movq	0x28(%rbx), %rax
+               	movq	%rax, -0x68(%rbp)
+               	leaq	-0x90(%rbp), %rdx
                	movq	%r13, %r8
                	callq	 <L58>
 <L58>:
@@ -1569,10 +1594,10 @@ Disassembly of section .text:
                	movq	(%rax), %r15
                	leaq	0x20(%rbx), %rax
                	movq	(%rax), %r8
-               	movq	%r8, -0x490(%rbp)
+               	movq	%r8, -0x658(%rbp)
                	leaq	0x28(%rbx), %rax
                	movq	(%rax), %r8
-               	movq	%r8, -0x498(%rbp)
+               	movq	%r8, -0x660(%rbp)
                	movq	%rdi, %rcx
                	callq	 <L59>
 <L59>:
@@ -1589,12 +1614,12 @@ Disassembly of section .text:
                	callq	 <L62>
 <L62>:
                	movq	%rax, %rcx
-               	movq	-0x490(%rbp), %r8
+               	movq	-0x658(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L63>
 <L63>:
                	movq	%rax, %rcx
-               	movq	-0x498(%rbp), %r8
+               	movq	-0x660(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L64>
 <L64>:
@@ -1603,7 +1628,7 @@ Disassembly of section .text:
                	cmpq	$0x8, %r12
                	jb	 <L57>
 <L65>:
-               	leaq	-0x120(%rbp), %rbx
+               	leaq	-0x150(%rbp), %rbx
                	movq	$0x0, (%rbx)
                	movq	$0x0, 0x8(%rbx)
                	movq	$0x0, 0x10(%rbx)
@@ -1635,9 +1660,9 @@ Disassembly of section .text:
 <L66>:
                	leaq	(%rsi,%rax,8), %rcx
                	movq	(%rcx), %rdx
-               	movq	-0x488(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	addq	%r8, %rdx
-               	leaq	-0x1e0(%rbp), %rcx
+               	leaq	-0x210(%rbp), %rcx
                	leaq	(%rcx), %r12
                	movq	%rdx, (%r12)
                	movq	%rdx, %r12
@@ -1702,58 +1727,71 @@ Disassembly of section .text:
                	cmpq	$0x6, %r12
                	jb	 <L68>
 <L73>:
-               	leaq	-0x150(%rbp), %rdx
-               	movq	$0x0, (%rdx)
-               	movq	$0x0, 0x8(%rdx)
-               	movq	$0x0, 0x10(%rdx)
-               	movq	$0x0, 0x18(%rdx)
-               	movq	$0x0, 0x20(%rdx)
-               	movq	$0x0, 0x28(%rdx)
-               	leaq	(%rdx), %rax
-               	movl	$0x12345678, (%rax)     # imm = 0x12345678
-               	movq	-0x488(%rbp), %r8
-               	movq	%r8, %rax
-               	addq	$0x3, %rax
-               	movq	%rax, %rcx
-               	xorq	$-0x1, %rcx
-               	movq	%rax, %rbx
+               	leaq	-0x180(%rbp), %rax
+               	movq	$0x0, (%rax)
+               	movq	$0x0, 0x8(%rax)
+               	movq	$0x0, 0x10(%rax)
+               	movq	$0x0, 0x18(%rax)
+               	movq	$0x0, 0x20(%rax)
+               	movq	$0x0, 0x28(%rax)
+               	leaq	(%rax), %rcx
+               	movl	$0x12345678, (%rcx)     # imm = 0x12345678
+               	movq	-0x650(%rbp), %r8
+               	movq	%r8, %rcx
+               	addq	$0x3, %rcx
+               	movq	%rcx, %rdx
+               	xorq	$-0x1, %rdx
+               	movq	%rcx, %rbx
                	imulq	$0x3, %rbx, %rbx
                	addq	$0x1, %rbx
                	leaq	(%rsi), %r12
                	movq	(%r12), %r13
-               	leaq	-0x240(%rbp), %r12
-               	movq	%rax, %r14
+               	leaq	-0x288(%rbp), %r12
+               	movq	%rcx, %r14
                	addq	%r13, %r14
                	leaq	(%r12), %r15
                	movq	%r14, (%r15)
-               	xorq	%r13, %rcx
+               	xorq	%r13, %rdx
                	leaq	0x8(%r12), %r13
-               	movq	%rcx, (%r13)
-               	addq	%rax, %rbx
-               	leaq	0x10(%r12), %rax
-               	movq	%rbx, (%rax)
-               	leaq	0x8(%rdx), %rax
-               	movq	(%r12), %rcx
-               	movq	%rcx, (%rax)
-               	movq	0x8(%r12), %rcx
-               	movq	%rcx, 0x8(%rax)
-               	movq	0x10(%r12), %rcx
-               	movq	%rcx, 0x10(%rax)
-               	leaq	-0x250(%rbp), %rax
-               	leaq	0x8(%rsi), %rcx
-               	movq	(%rcx), %rbx
-               	leaq	(%rax), %rcx
+               	movq	%rdx, (%r13)
+               	addq	%rcx, %rbx
+               	leaq	0x10(%r12), %rcx
                	movq	%rbx, (%rcx)
-               	leaq	0x10(%rsi), %rcx
-               	movq	(%rcx), %rbx
                	leaq	0x8(%rax), %rcx
-               	movq	%rbx, (%rcx)
-               	leaq	0x20(%rdx), %rcx
-               	movq	(%rax), %rbx
-               	movq	%rbx, (%rcx)
-               	movq	0x8(%rax), %rbx
-               	movq	%rbx, 0x8(%rcx)
+               	movq	(%r12), %rdx
+               	movq	%rdx, (%rcx)
+               	movq	0x8(%r12), %rdx
+               	movq	%rdx, 0x8(%rcx)
+               	movq	0x10(%r12), %rdx
+               	movq	%rdx, 0x10(%rcx)
+               	leaq	-0x298(%rbp), %rcx
+               	leaq	0x8(%rsi), %rdx
+               	movq	(%rdx), %rbx
+               	leaq	(%rcx), %rdx
+               	movq	%rbx, (%rdx)
+               	leaq	0x10(%rsi), %rdx
+               	movq	(%rdx), %rbx
+               	leaq	0x8(%rcx), %rdx
+               	movq	%rbx, (%rdx)
+               	leaq	0x20(%rax), %rdx
+               	movq	(%rcx), %rbx
+               	movq	%rbx, (%rdx)
+               	movq	0x8(%rcx), %rbx
+               	movq	%rbx, 0x8(%rdx)
                	movq	%rdi, %rcx
+               	movq	(%rax), %rdx
+               	movq	%rdx, -0x2c8(%rbp)
+               	movq	0x8(%rax), %rdx
+               	movq	%rdx, -0x2c0(%rbp)
+               	movq	0x10(%rax), %rdx
+               	movq	%rdx, -0x2b8(%rbp)
+               	movq	0x18(%rax), %rdx
+               	movq	%rdx, -0x2b0(%rbp)
+               	movq	0x20(%rax), %rdx
+               	movq	%rdx, -0x2a8(%rbp)
+               	movq	0x28(%rax), %rdx
+               	movq	%rdx, -0x2a0(%rbp)
+               	leaq	-0x2c8(%rbp), %rdx
                	callq	 <L74>
 <L74>:
                	movq	%rax, %rbx
@@ -1764,75 +1802,95 @@ Disassembly of section .text:
 <L75>:
                	leaq	(%rsi,%rdi,8), %rax
                	movq	(%rax), %rcx
-               	movq	-0x488(%rbp), %r8
+               	movq	-0x650(%rbp), %r8
                	movq	%rcx, %r12
                	addq	%r8, %r12
-               	leaq	-0x1f8(%rbp), %rdx
-               	leaq	(%rdx), %rax
-               	movq	%r12, (%rax)
-               	movq	%r12, %rax
-               	xorq	$-0x1, %rax
-               	leaq	0x8(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rax
-               	imulq	$0x3, %rax, %rax
-               	addq	$0x1, %rax
-               	leaq	0x10(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	leaq	-0x228(%rbp), %r13
+               	leaq	-0x228(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	%r12, (%rcx)
+               	movq	%r12, %rcx
+               	xorq	$-0x1, %rcx
+               	leaq	0x8(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movq	%r12, %rcx
+               	imulq	$0x3, %rcx, %rcx
+               	addq	$0x1, %rcx
+               	leaq	0x10(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	leaq	-0x258(%rbp), %r13
                	movq	%r13, %rcx
+               	movq	(%rax), %rdx
+               	movq	%rdx, -0x270(%rbp)
+               	movq	0x8(%rax), %rdx
+               	movq	%rdx, -0x268(%rbp)
+               	movq	0x10(%rax), %rdx
+               	movq	%rdx, -0x260(%rbp)
+               	leaq	-0x270(%rbp), %rdx
                	callq	 <L76>
 <L76>:
-               	leaq	-0x280(%rbp), %rdx
-               	leaq	(%rdx), %rax
-               	movq	%r12, (%rax)
-               	movq	%r12, %rax
-               	addq	$0x1, %rax
-               	leaq	0x8(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rax
-               	addq	$0x2, %rax
-               	leaq	0x10(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rax
-               	imulq	$0x9, %rax, %rax
-               	leaq	0x18(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rax
-               	xorq	$-0x1, %rax
-               	leaq	0x20(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rax
+               	leaq	-0x2f8(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	%r12, (%rcx)
+               	movq	%r12, %rcx
+               	addq	$0x1, %rcx
+               	leaq	0x8(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movq	%r12, %rcx
+               	addq	$0x2, %rcx
+               	leaq	0x10(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movq	%r12, %rcx
+               	imulq	$0x9, %rcx, %rcx
+               	leaq	0x18(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movq	%r12, %rcx
+               	xorq	$-0x1, %rcx
+               	leaq	0x20(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movq	%r12, %rcx
                	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rax
-               	leaq	0x28(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	leaq	-0x298(%rbp), %r14
+               	xorq	%r11, %rcx
+               	leaq	0x28(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	leaq	-0x310(%rbp), %r14
                	movq	%r14, %rcx
+               	movq	(%rax), %rdx
+               	movq	%rdx, -0x340(%rbp)
+               	movq	0x8(%rax), %rdx
+               	movq	%rdx, -0x338(%rbp)
+               	movq	0x10(%rax), %rdx
+               	movq	%rdx, -0x330(%rbp)
+               	movq	0x18(%rax), %rdx
+               	movq	%rdx, -0x328(%rbp)
+               	movq	0x20(%rax), %rdx
+               	movq	%rdx, -0x320(%rbp)
+               	movq	0x28(%rax), %rdx
+               	movq	%rdx, -0x318(%rbp)
+               	leaq	-0x340(%rbp), %rdx
                	callq	 <L77>
 <L77>:
                	leaq	(%r13), %rax
                	movq	(%rax), %r15
                	leaq	0x8(%r13), %rax
                	movq	(%rax), %r8
-               	movq	%r8, -0x4a0(%rbp)
+               	movq	%r8, -0x668(%rbp)
                	leaq	0x10(%r13), %rax
                	movq	(%rax), %r8
-               	movq	%r8, -0x4a8(%rbp)
+               	movq	%r8, -0x670(%rbp)
                	leaq	0x18(%r13), %rax
                	movq	(%rax), %r8
-               	movq	%r8, -0x4b0(%rbp)
+               	movq	%r8, -0x678(%rbp)
                	leaq	0x20(%r13), %rax
                	movq	(%rax), %r8
-               	movq	%r8, -0x4b8(%rbp)
+               	movq	%r8, -0x680(%rbp)
                	leaq	0x28(%r13), %rax
                	movq	(%rax), %r13
                	leaq	(%r14), %rax
                	movq	(%rax), %r8
-               	movq	%r8, -0x4c0(%rbp)
+               	movq	%r8, -0x688(%rbp)
                	leaq	0x8(%r14), %rax
                	movq	(%rax), %r8
-               	movq	%r8, -0x4c8(%rbp)
+               	movq	%r8, -0x690(%rbp)
                	leaq	0x10(%r14), %rax
                	movq	(%rax), %r14
                	callq	 <L78>
@@ -1842,22 +1900,22 @@ Disassembly of section .text:
                	callq	 <L79>
 <L79>:
                	movq	%rax, %rcx
-               	movq	-0x4a0(%rbp), %r8
+               	movq	-0x668(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L80>
 <L80>:
                	movq	%rax, %rcx
-               	movq	-0x4a8(%rbp), %r8
+               	movq	-0x670(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L81>
 <L81>:
                	movq	%rax, %rcx
-               	movq	-0x4b0(%rbp), %r8
+               	movq	-0x678(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L82>
 <L82>:
                	movq	%rax, %rcx
-               	movq	-0x4b8(%rbp), %r8
+               	movq	-0x680(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L83>
 <L83>:
@@ -1866,12 +1924,12 @@ Disassembly of section .text:
                	callq	 <L84>
 <L84>:
                	movq	%rax, %rcx
-               	movq	-0x4c0(%rbp), %r8
+               	movq	-0x688(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L85>
 <L85>:
                	movq	%rax, %rcx
-               	movq	-0x4c8(%rbp), %r8
+               	movq	-0x690(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L86>
 <L86>:
@@ -1888,37 +1946,56 @@ Disassembly of section .text:
                	callq	 <L89>
 <L89>:
                	movq	%rax, %r13
-               	leaq	-0x2c8(%rbp), %rdx
-               	leaq	(%rdx), %rax
-               	movq	%r12, (%rax)
-               	movq	%r12, %rax
-               	addq	$0x1, %rax
-               	leaq	0x8(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rax
-               	addq	$0x2, %rax
-               	leaq	0x10(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rax
-               	imulq	$0x9, %rax, %rax
-               	leaq	0x18(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rax
-               	xorq	$-0x1, %rax
-               	leaq	0x20(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rax
+               	leaq	-0x370(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	%r12, (%rcx)
+               	movq	%r12, %rcx
+               	addq	$0x1, %rcx
+               	leaq	0x8(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movq	%r12, %rcx
+               	addq	$0x2, %rcx
+               	leaq	0x10(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movq	%r12, %rcx
+               	imulq	$0x9, %rcx, %rcx
+               	leaq	0x18(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movq	%r12, %rcx
+               	xorq	$-0x1, %rcx
+               	leaq	0x20(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movq	%r12, %rcx
                	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rax
-               	leaq	0x28(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	leaq	-0x2e0(%rbp), %r14
+               	xorq	%r11, %rcx
+               	leaq	0x28(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	leaq	-0x388(%rbp), %r14
                	movq	%r14, %rcx
+               	movq	(%rax), %rdx
+               	movq	%rdx, -0x3b8(%rbp)
+               	movq	0x8(%rax), %rdx
+               	movq	%rdx, -0x3b0(%rbp)
+               	movq	0x10(%rax), %rdx
+               	movq	%rdx, -0x3a8(%rbp)
+               	movq	0x18(%rax), %rdx
+               	movq	%rdx, -0x3a0(%rbp)
+               	movq	0x20(%rax), %rdx
+               	movq	%rdx, -0x398(%rbp)
+               	movq	0x28(%rax), %rdx
+               	movq	%rdx, -0x390(%rbp)
+               	leaq	-0x3b8(%rbp), %rdx
                	callq	 <L90>
 <L90>:
-               	leaq	-0x310(%rbp), %r15
+               	leaq	-0x3e8(%rbp), %r15
                	movq	%r15, %rcx
-               	movq	%r14, %rdx
+               	movq	(%r14), %rax
+               	movq	%rax, -0x400(%rbp)
+               	movq	0x8(%r14), %rax
+               	movq	%rax, -0x3f8(%rbp)
+               	movq	0x10(%r14), %rax
+               	movq	%rax, -0x3f0(%rbp)
+               	leaq	-0x400(%rbp), %rdx
                	callq	 <L91>
 <L91>:
                	leaq	(%r15), %rax
@@ -1927,13 +2004,13 @@ Disassembly of section .text:
                	movq	(%rax), %r14
                	leaq	0x10(%r15), %rax
                	movq	(%rax), %r8
-               	movq	%r8, -0x4d0(%rbp)
+               	movq	%r8, -0x698(%rbp)
                	leaq	0x18(%r15), %rax
                	movq	(%rax), %r8
-               	movq	%r8, -0x4d8(%rbp)
+               	movq	%r8, -0x6a0(%rbp)
                	leaq	0x20(%r15), %rax
                	movq	(%rax), %r8
-               	movq	%r8, -0x4e0(%rbp)
+               	movq	%r8, -0x6a8(%rbp)
                	leaq	0x28(%r15), %rax
                	movq	(%rax), %r15
                	movq	%r13, %rcx
@@ -1944,17 +2021,17 @@ Disassembly of section .text:
                	callq	 <L93>
 <L93>:
                	movq	%rax, %rcx
-               	movq	-0x4d0(%rbp), %r8
+               	movq	-0x698(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L94>
 <L94>:
                	movq	%rax, %rcx
-               	movq	-0x4d8(%rbp), %r8
+               	movq	-0x6a0(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L95>
 <L95>:
                	movq	%rax, %rcx
-               	movq	-0x4e0(%rbp), %r8
+               	movq	-0x6a8(%rbp), %r8
                	movq	%r8, %rdx
                	callq	 <L96>
 <L96>:
@@ -1963,25 +2040,44 @@ Disassembly of section .text:
                	callq	 <L97>
 <L97>:
                	movq	%rax, %r13
-               	leaq	-0x328(%rbp), %rdx
-               	leaq	(%rdx), %rax
-               	movq	%r12, (%rax)
-               	movq	%r12, %rax
-               	xorq	$-0x1, %rax
-               	leaq	0x8(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rax
-               	imulq	$0x3, %rax, %rax
-               	addq	$0x1, %rax
-               	leaq	0x10(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	leaq	-0x358(%rbp), %r14
+               	leaq	-0x418(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	%r12, (%rcx)
+               	movq	%r12, %rcx
+               	xorq	$-0x1, %rcx
+               	leaq	0x8(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movq	%r12, %rcx
+               	imulq	$0x3, %rcx, %rcx
+               	addq	$0x1, %rcx
+               	leaq	0x10(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	leaq	-0x448(%rbp), %r14
                	movq	%r14, %rcx
+               	movq	(%rax), %rdx
+               	movq	%rdx, -0x460(%rbp)
+               	movq	0x8(%rax), %rdx
+               	movq	%rdx, -0x458(%rbp)
+               	movq	0x10(%rax), %rdx
+               	movq	%rdx, -0x450(%rbp)
+               	leaq	-0x460(%rbp), %rdx
                	callq	 <L98>
 <L98>:
-               	leaq	-0x370(%rbp), %r15
+               	leaq	-0x478(%rbp), %r15
                	movq	%r15, %rcx
-               	movq	%r14, %rdx
+               	movq	(%r14), %rax
+               	movq	%rax, -0x4a8(%rbp)
+               	movq	0x8(%r14), %rax
+               	movq	%rax, -0x4a0(%rbp)
+               	movq	0x10(%r14), %rax
+               	movq	%rax, -0x498(%rbp)
+               	movq	0x18(%r14), %rax
+               	movq	%rax, -0x490(%rbp)
+               	movq	0x20(%r14), %rax
+               	movq	%rax, -0x488(%rbp)
+               	movq	0x28(%r14), %rax
+               	movq	%rax, -0x480(%rbp)
+               	leaq	-0x4a8(%rbp), %rdx
                	callq	 <L99>
 <L99>:
                	leaq	(%r15), %rax
@@ -2002,38 +2098,63 @@ Disassembly of section .text:
                	callq	 <L102>
 <L102>:
                	movq	%rax, %r13
-               	leaq	-0x3a0(%rbp), %rdx
-               	leaq	(%rdx), %rax
-               	movq	%r12, (%rax)
-               	movq	%r12, %rax
-               	addq	$0x1, %rax
-               	leaq	0x8(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rax
-               	addq	$0x2, %rax
-               	leaq	0x10(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rax
-               	imulq	$0x9, %rax, %rax
-               	leaq	0x18(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rax
-               	xorq	$-0x1, %rax
-               	leaq	0x20(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rax
+               	leaq	-0x4d8(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	%r12, (%rcx)
+               	movq	%r12, %rcx
+               	addq	$0x1, %rcx
+               	leaq	0x8(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movq	%r12, %rcx
+               	addq	$0x2, %rcx
+               	leaq	0x10(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movq	%r12, %rcx
+               	imulq	$0x9, %rcx, %rcx
+               	leaq	0x18(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movq	%r12, %rcx
+               	xorq	$-0x1, %rcx
+               	leaq	0x20(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movq	%r12, %rcx
                	movabsq	$0xaaaaaaaa, %r11       # imm = 0xAAAAAAAA
-               	xorq	%r11, %rax
-               	leaq	0x28(%rdx), %rcx
-               	movq	%rax, (%rcx)
-               	leaq	-0x3d0(%rbp), %r14
+               	xorq	%r11, %rcx
+               	leaq	0x28(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	leaq	-0x508(%rbp), %r14
                	movq	%r14, %rcx
+               	movq	(%rax), %rdx
+               	movq	%rdx, -0x538(%rbp)
+               	movq	0x8(%rax), %rdx
+               	movq	%rdx, -0x530(%rbp)
+               	movq	0x10(%rax), %rdx
+               	movq	%rdx, -0x528(%rbp)
+               	movq	0x18(%rax), %rdx
+               	movq	%rdx, -0x520(%rbp)
+               	movq	0x20(%rax), %rdx
+               	movq	%rdx, -0x518(%rbp)
+               	movq	0x28(%rax), %rdx
+               	movq	%rdx, -0x510(%rbp)
+               	leaq	-0x538(%rbp), %rdx
                	movq	%r12, %r8
                	callq	 <L103>
 <L103>:
-               	leaq	-0x3e8(%rbp), %r15
+               	leaq	-0x550(%rbp), %r15
                	movq	%r15, %rcx
-               	movq	%r14, %rdx
+               	movq	(%r14), %rax
+               	movq	%rax, -0x580(%rbp)
+               	movq	0x8(%r14), %rax
+               	movq	%rax, -0x578(%rbp)
+               	movq	0x10(%r14), %rax
+               	movq	%rax, -0x570(%rbp)
+               	movq	0x18(%r14), %rax
+               	movq	%rax, -0x568(%rbp)
+               	movq	0x20(%r14), %rax
+               	movq	%rax, -0x560(%rbp)
+               	movq	0x28(%r14), %rax
+               	movq	%rax, -0x558(%rbp)
+               	leaq	-0x580(%rbp), %rdx
                	callq	 <L104>
 <L104>:
                	leaq	(%r15), %rax
@@ -2065,17 +2186,17 @@ Disassembly of section .text:
                	jb	 <L75>
 <L108>:
                	movq	%rbx, %rax
-               	movaps	-0x540(%rbp), %xmm6
-               	movaps	-0x550(%rbp), %xmm7
-               	movaps	-0x560(%rbp), %xmm14
-               	movaps	-0x570(%rbp), %xmm15
-               	movq	-0x4f8(%rbp), %rbx
-               	movq	-0x500(%rbp), %rdi
-               	movq	-0x508(%rbp), %rsi
-               	movq	-0x510(%rbp), %r12
-               	movq	-0x518(%rbp), %r13
-               	movq	-0x520(%rbp), %r14
-               	movq	-0x528(%rbp), %r15
+               	movaps	-0x700(%rbp), %xmm6
+               	movaps	-0x710(%rbp), %xmm7
+               	movaps	-0x720(%rbp), %xmm14
+               	movaps	-0x730(%rbp), %xmm15
+               	movq	-0x6b8(%rbp), %rbx
+               	movq	-0x6c0(%rbp), %rdi
+               	movq	-0x6c8(%rbp), %rsi
+               	movq	-0x6d0(%rbp), %r12
+               	movq	-0x6d8(%rbp), %r13
+               	movq	-0x6e0(%rbp), %r14
+               	movq	-0x6e8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/cmp/short_circuit.dis
+++ b/test/golden/x86_64-windows/cmp/short_circuit.dis
@@ -192,27 +192,30 @@ Disassembly of section .text:
                	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x19f>
                	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1a6>
                	movq	%rax, (%rcx)
-               	movl	$0x1, %edx
-               	xorl	%esi, %edx
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x1b7>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x1c2>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x1d1>
-               	movq	(%rax), %rcx
+               	movl	$0x1, %eax
+               	xorl	%esi, %eax
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1b7>
                	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x1da>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1e9>
-               	movq	%rax, (%rcx)
+               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x1c2>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1d1>
+               	movq	(%rcx), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rcx)
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x1da>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x1e9>
+               	movq	%rcx, (%rdx)
+               	cmpb	$0x1, %al
+               	sete	%dl
+               	movzbq	%dl, %rdx
                	movq	%r12, %rcx
                	callq	 <L11>
 <L11>:
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x1f3>
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x1fd>
                	movq	%rax, %rcx
                	callq	 <L12>
 <L12>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x202>
-               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x209>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x20c>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x213>
                	movq	%rax, %r12
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
@@ -234,9 +237,9 @@ Disassembly of section .text:
                	cmpq	$0x4, %r13
                	jb	 <L13>
 <L16>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x258>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x263>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x26a>
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x262>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x26d>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x274>
                	movq	$0x0, %rdx
                	cmpq	$0x4, %rdx
                	jb	 <L17>
@@ -250,26 +253,26 @@ Disassembly of section .text:
                	cmpq	$0x4, %rdx
                	jb	 <L17>
 <L18>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2ab>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2b5>
                	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x2b6>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2bd>
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x2c0>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2c7>
                	movq	(%rax), %rcx
                	addq	$0x1, %rcx
                	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2ce>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x2d5>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x2d8>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x2df>
                	movq	%rax, (%rcx)
                	movq	%r12, %rcx
                	movq	$0x1, %rdx
                	callq	 <L19>
 <L19>:
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x2ee>
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x2f8>
                	movq	%rax, %rcx
                	callq	 <L20>
 <L20>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x2fd>
-               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x304>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x307>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x30e>
                	movq	%rax, %r12
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
@@ -291,9 +294,9 @@ Disassembly of section .text:
                	cmpq	$0x4, %r13
                	jb	 <L21>
 <L24>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x353>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x35e>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x365>
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x35d>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x368>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x36f>
                	movq	$0x0, %rdx
                	cmpq	$0x4, %rdx
                	jb	 <L25>
@@ -307,209 +310,150 @@ Disassembly of section .text:
                	cmpq	$0x4, %rdx
                	jb	 <L25>
 <L26>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x3a6>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x3b1>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x3b8>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x3c9>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x3d0>
-               	movq	%rax, (%rcx)
-               	movl	$0x1, %edx
-               	xorl	%esi, %edx
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x3e1>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x3ec>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x3fb>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x404>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x413>
-               	movq	%rax, (%rcx)
-               	movq	%r12, %rcx
+               	movq	$0x0, %rcx
+               	movq	$0x0, %rdx
                	callq	 <L27>
 <L27>:
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x41d>
-               	movq	%rax, %rcx
-               	callq	 <L28>
+               	cmpb	$0x1, %al
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L28>
+               	movl	$0x1, %eax
+               	xorl	%esi, %eax
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x3dc>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x3e7>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x3f6>
+               	movq	(%rdx), %rbx
+               	addq	$0x1, %rbx
+               	movq	%rbx, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x3ff>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x40e>
+               	movq	%rdx, (%rbx)
+               	cmpb	$0x1, %al
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	jmp	 <L29>
 <L28>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x42c>
-               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x433>
-               	movq	%rax, %r12
-               	movq	$0x0, %r13
-               	cmpq	$0x4, %r13
-               	jb	 <L29>
-               	jmp	 <L32>
+               	movq	%rcx, %rdx
 <L29>:
-               	leaq	(%rbx,%r13,8), %rax
-               	movq	(%rax), %rdx
                	movq	%r12, %rcx
                	callq	 <L30>
 <L30>:
-               	leaq	(%rdi,%r13,8), %rcx
-               	movq	(%rcx), %rdx
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x42a>
                	movq	%rax, %rcx
                	callq	 <L31>
 <L31>:
-               	addq	$0x1, %r13
-               	movq	%rax, %r12
-               	cmpq	$0x4, %r13
-               	jb	 <L29>
-<L32>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x482>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x48d>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x494>
-               	movq	$0x0, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L33>
-               	jmp	 <L34>
-<L33>:
-               	leaq	(%rax,%rdx,8), %rbx
-               	movq	$0x0, (%rbx)
-               	leaq	(%rcx,%rdx,8), %rbx
-               	movq	$0x0, (%rbx)
-               	addq	$0x1, %rdx
-               	cmpq	$0x4, %rdx
-               	jb	 <L33>
-<L34>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4d5>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x4e0>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4e7>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x4f8>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x4ff>
-               	movq	%rax, (%rcx)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x509>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x514>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x523>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x52c>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x53b>
-               	movq	%rax, (%rcx)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x53d>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x548>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x55f>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x560>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x577>
-               	movq	%rax, (%rcx)
-               	testb	%sil, %sil
-               	jne	 <L35>
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x57a>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x585>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x5a4>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x59d>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x5bc>
-               	movq	%rax, (%rcx)
-               	movq	$0x1, %rax
-               	jmp	 <L36>
-<L35>:
-               	movq	%rsi, %rax
-<L36>:
-               	movq	%r12, %rcx
-               	movq	%rax, %rdx
-               	callq	 <L37>
-<L37>:
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5c8>
-               	movq	%rax, %rcx
-               	callq	 <L38>
-<L38>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x5d7>
-               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x5de>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x439>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x440>
                	movq	%rax, %r12
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
-               	jb	 <L39>
-               	jmp	 <L42>
-<L39>:
+               	jb	 <L32>
+               	jmp	 <L35>
+<L32>:
                	leaq	(%rbx,%r13,8), %rax
                	movq	(%rax), %rdx
                	movq	%r12, %rcx
-               	callq	 <L40>
-<L40>:
+               	callq	 <L33>
+<L33>:
                	leaq	(%rdi,%r13,8), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
+               	callq	 <L34>
+<L34>:
                	addq	$0x1, %r13
                	movq	%rax, %r12
                	cmpq	$0x4, %r13
-               	jb	 <L39>
-<L42>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x62d>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x638>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x63f>
+               	jb	 <L32>
+<L35>:
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x48f>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x49a>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x4a1>
                	movq	$0x0, %rdx
                	cmpq	$0x4, %rdx
-               	jb	 <L43>
-               	jmp	 <L44>
-<L43>:
+               	jb	 <L36>
+               	jmp	 <L37>
+<L36>:
                	leaq	(%rax,%rdx,8), %rbx
                	movq	$0x0, (%rbx)
                	leaq	(%rcx,%rdx,8), %rbx
                	movq	$0x0, (%rbx)
                	addq	$0x1, %rdx
                	cmpq	$0x4, %rdx
-               	jb	 <L43>
+               	jb	 <L36>
+<L37>:
+               	movq	$0x0, %rcx
+               	movq	$0x0, %rdx
+               	callq	 <L38>
+<L38>:
+               	cmpb	$0x1, %al
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L39>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x507>
+               	addq	$0x1, %rax
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x512>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x521>
+               	movq	(%rax), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x52a>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x539>
+               	movq	%rax, (%rdx)
+               	movq	$0x1, %rax
+               	jmp	 <L40>
+<L39>:
+               	movq	%rcx, %rax
+<L40>:
+               	testb	%al, %al
+               	jne	 <L41>
+               	jmp	 <L44>
+<L41>:
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x557>
+               	addq	$0x1, %rcx
+               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x562>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x579>
+               	movq	(%rcx), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rcx)
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x57a>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x591>
+               	movq	%rcx, (%rdx)
+               	cmpb	$0x1, %sil
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L42>
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x59e>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x5a9>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5c8>
+               	movq	(%rdx), %rbx
+               	addq	$0x1, %rbx
+               	movq	%rbx, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5c1>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x5e0>
+               	movq	%rdx, (%rbx)
+               	movq	$0x1, %rdx
+               	jmp	 <L43>
+<L42>:
+               	movq	%rcx, %rdx
+<L43>:
+               	movq	%rdx, %rax
 <L44>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x680>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x68b>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x692>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6a3>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x6aa>
-               	movq	%rax, (%rcx)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6b4>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x6bf>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6d6>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6d7>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x6ee>
-               	movq	%rax, (%rcx)
-               	movl	$0x1, %edx
-               	xorl	%esi, %edx
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6ef>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x6fa>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x719>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x712>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x731>
-               	movq	%rax, (%rcx)
                	movq	%r12, %rcx
+               	movq	%rax, %rdx
                	callq	 <L45>
 <L45>:
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x72b>
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x5ef>
                	movq	%rax, %rcx
                	callq	 <L46>
 <L46>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x73a>
-               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x741>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x5fe>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x605>
                	movq	%rax, %r12
                	movq	$0x0, %r13
                	cmpq	$0x4, %r13
@@ -531,9 +475,9 @@ Disassembly of section .text:
                	cmpq	$0x4, %r13
                	jb	 <L47>
 <L50>:
-               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x790>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x79b>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x7a2>
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x654>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x65f>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x666>
                	movq	$0x0, %rdx
                	cmpq	$0x4, %rdx
                	jb	 <L51>
@@ -547,73 +491,181 @@ Disassembly of section .text:
                	cmpq	$0x4, %rdx
                	jb	 <L51>
 <L52>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x7e3>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x7ee>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x7f5>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x806>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x80d>
-               	movq	%rax, (%rcx)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x817>
-               	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x822>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x831>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x83a>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x849>
-               	movq	%rax, (%rcx)
-               	testb	%sil, %sil
-               	jne	 <L53>
-               	jmp	 <L54>
+               	movq	$0x0, %rcx
+               	movq	$0x1, %rdx
+               	callq	 <L53>
 <L53>:
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x859>
+               	cmpb	$0x1, %al
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L54>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6cc>
                	addq	$0x1, %rax
-               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x864>
-               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x87b>
-               	movq	(%rax), %rcx
-               	addq	$0x1, %rcx
-               	movq	%rcx, (%rax)
-               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x87c>
-               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x893>
-               	movq	%rax, (%rcx)
-               	movq	$0x1, %rsi
-<L54>:
-               	movq	%r12, %rcx
-               	movq	%rsi, %rdx
-               	callq	 <L55>
-<L55>:
-               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x89f>
-               	movq	%rax, %rcx
-               	callq	 <L56>
-<L56>:
-               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x8ae>
-               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x8b5>
-               	movq	%rax, %rdi
-               	movq	$0x0, %r12
-               	cmpq	$0x4, %r12
-               	jb	 <L57>
-               	jmp	 <L60>
-<L57>:
-               	leaq	(%rbx,%r12,8), %rax
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x6d7>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6e6>
                	movq	(%rax), %rdx
-               	movq	%rdi, %rcx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x6ef>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x6fe>
+               	movq	%rax, (%rdx)
+               	movq	$0x1, %rax
+               	jmp	 <L55>
+<L54>:
+               	movq	%rcx, %rax
+<L55>:
+               	testb	%al, %al
+               	jne	 <L56>
+               	jmp	 <L57>
+<L56>:
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x71c>
+               	addq	$0x1, %rcx
+               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x727>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x73e>
+               	movq	(%rcx), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rcx)
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x73f>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x756>
+               	movq	%rcx, (%rdx)
+               	movl	$0x1, %ecx
+               	xorl	%esi, %ecx
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x757>
+               	addq	$0x1, %rdx
+               	movq	%rdx,  <corpus.cases.cmp.short_circuit.checksum+0x762>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x781>
+               	movq	(%rdx), %rbx
+               	addq	$0x1, %rbx
+               	movq	%rbx, (%rdx)
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x77a>
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x799>
+               	movq	%rdx, (%rbx)
+               	cmpb	$0x1, %cl
+               	sete	%dl
+               	movzbq	%dl, %rdx
+               	movq	%rdx, %rax
+<L57>:
+               	movq	%r12, %rcx
+               	movq	%rax, %rdx
                	callq	 <L58>
 <L58>:
-               	leaq	(%rsi,%r12,8), %rcx
-               	movq	(%rcx), %rdx
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x7a3>
                	movq	%rax, %rcx
                	callq	 <L59>
 <L59>:
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x7b2>
+               	leaq	, %rdi <corpus.cases.cmp.short_circuit.checksum+0x7b9>
+               	movq	%rax, %r12
+               	movq	$0x0, %r13
+               	cmpq	$0x4, %r13
+               	jb	 <L60>
+               	jmp	 <L63>
+<L60>:
+               	leaq	(%rbx,%r13,8), %rax
+               	movq	(%rax), %rdx
+               	movq	%r12, %rcx
+               	callq	 <L61>
+<L61>:
+               	leaq	(%rdi,%r13,8), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L62>
+<L62>:
+               	addq	$0x1, %r13
+               	movq	%rax, %r12
+               	cmpq	$0x4, %r13
+               	jb	 <L60>
+<L63>:
+               	movq	$0x0,  <corpus.cases.cmp.short_circuit.checksum+0x808>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x813>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x81a>
+               	movq	$0x0, %rdx
+               	cmpq	$0x4, %rdx
+               	jb	 <L64>
+               	jmp	 <L65>
+<L64>:
+               	leaq	(%rax,%rdx,8), %rbx
+               	movq	$0x0, (%rbx)
+               	leaq	(%rcx,%rdx,8), %rbx
+               	movq	$0x0, (%rbx)
+               	addq	$0x1, %rdx
+               	cmpq	$0x4, %rdx
+               	jb	 <L64>
+<L65>:
+               	movq	$0x0, %rcx
+               	movq	$0x0, %rdx
+               	callq	 <L66>
+<L66>:
+               	cmpb	$0x1, %al
+               	sete	%cl
+               	movzbq	%cl, %rcx
+               	testb	%cl, %cl
+               	jne	 <L67>
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x880>
+               	addq	$0x1, %rax
+               	movq	%rax,  <corpus.cases.cmp.short_circuit.checksum+0x88b>
+               	leaq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x89a>
+               	movq	(%rax), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rax)
+               	movq	, %rax <corpus.cases.cmp.short_circuit.checksum+0x8a3>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x8b2>
+               	movq	%rax, (%rdx)
+               	cmpb	$0x1, %sil
+               	sete	%al
+               	movzbq	%al, %rax
+               	jmp	 <L68>
+<L67>:
+               	movq	%rcx, %rax
+<L68>:
+               	testb	%al, %al
+               	jne	 <L69>
+               	jmp	 <L70>
+<L69>:
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x8d4>
+               	addq	$0x1, %rcx
+               	movq	%rcx,  <corpus.cases.cmp.short_circuit.checksum+0x8df>
+               	leaq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x8f6>
+               	movq	(%rcx), %rdx
+               	addq	$0x1, %rdx
+               	movq	%rdx, (%rcx)
+               	movq	, %rcx <corpus.cases.cmp.short_circuit.checksum+0x8f7>
+               	leaq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x90e>
+               	movq	%rcx, (%rdx)
+               	movq	$0x1, %rax
+<L70>:
+               	movq	%r12, %rcx
+               	movq	%rax, %rdx
+               	callq	 <L71>
+<L71>:
+               	movq	, %rdx <corpus.cases.cmp.short_circuit.checksum+0x91a>
+               	movq	%rax, %rcx
+               	callq	 <L72>
+<L72>:
+               	leaq	, %rbx <corpus.cases.cmp.short_circuit.checksum+0x929>
+               	leaq	, %rsi <corpus.cases.cmp.short_circuit.checksum+0x930>
+               	movq	%rax, %rdi
+               	movq	$0x0, %r12
+               	cmpq	$0x4, %r12
+               	jb	 <L73>
+               	jmp	 <L76>
+<L73>:
+               	leaq	(%rbx,%r12,8), %rax
+               	movq	(%rax), %rdx
+               	movq	%rdi, %rcx
+               	callq	 <L74>
+<L74>:
+               	leaq	(%rsi,%r12,8), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L75>
+<L75>:
                	addq	$0x1, %r12
                	movq	%rax, %rdi
                	cmpq	$0x4, %r12
-               	jb	 <L57>
-<L60>:
+               	jb	 <L73>
+<L76>:
                	movq	%rdi, %rax
                	movq	-0x8(%rbp), %rbx
                	movq	-0x10(%rbp), %rdi

--- a/test/golden/x86_64-windows/float/cmp_f32.dis
+++ b/test/golden/x86_64-windows/float/cmp_f32.dis
@@ -283,8 +283,8 @@ Disassembly of section .text:
                	ucomiss	%xmm6, %xmm7
                	seta	%cl
                	movzbq	%cl, %rcx
-               	cmpb	$0x0, %cl
-               	sete	%dl
+               	cmpb	$0x1, %cl
+               	setne	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
                	callq	 <L28>

--- a/test/golden/x86_64-windows/float/cmp_f64.dis
+++ b/test/golden/x86_64-windows/float/cmp_f64.dis
@@ -290,8 +290,8 @@ Disassembly of section .text:
                	ucomisd	%xmm6, %xmm7
                	seta	%cl
                	movzbq	%cl, %rcx
-               	cmpb	$0x0, %cl
-               	sete	%dl
+               	cmpb	$0x1, %cl
+               	setne	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
                	callq	 <L28>

--- a/test/golden/x86_64-windows/float/special_f32.dis
+++ b/test/golden/x86_64-windows/float/special_f32.dis
@@ -268,1267 +268,364 @@ Disassembly of section .text:
 <L32>:
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
                	subss	%xmm8, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L34>
                	movq	%rsi, %rcx
                	callq	 <L33>
 <L33>:
-               	movq	%rax, %rbx
-               	jmp	 <L36>
-<L34>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L35>
-<L35>:
-               	movq	%rax, %rbx
-<L36>:
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
                	subss	%xmm9, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L38>
-               	movq	%rbx, %rcx
+               	movq	%rax, %rcx
+               	callq	 <L34>
+<L34>:
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	mulss	%xmm6, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L35>
+<L35>:
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	mulss	%xmm7, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L36>
+<L36>:
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	mulss	%xmm6, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L37>
 <L37>:
-               	movq	%rax, %rsi
-               	jmp	 <L40>
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	mulss	%xmm7, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L38>
 <L38>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	mulss	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L39>
 <L39>:
-               	movq	%rax, %rsi
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	mulss	%xmm9, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L40>
 <L40>:
                	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	mulss	%xmm6, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L42>
-               	movq	%rsi, %rcx
+               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x3aa>
+               	movq	%rax, %rcx
                	callq	 <L41>
 <L41>:
-               	movq	%rax, %rbx
-               	jmp	 <L44>
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x3be>
+               	movq	%rax, %rcx
+               	callq	 <L42>
 <L42>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
+               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
+               	divss	%xmm6, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L43>
 <L43>:
-               	movq	%rax, %rbx
-<L44>:
                	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	mulss	%xmm7, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L46>
-               	movq	%rbx, %rcx
+               	divss	%xmm7, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L44>
+<L44>:
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	divss	%xmm6, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L45>
 <L45>:
-               	movq	%rax, %rsi
-               	jmp	 <L48>
+               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
+               	divss	%xmm7, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L46>
 <L46>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %rsi
-<L48>:
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	mulss	%xmm6, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L50>
-               	movq	%rsi, %rcx
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rbx
-               	jmp	 <L52>
-<L50>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rbx
-<L52>:
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	mulss	%xmm7, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L54>
-               	movq	%rbx, %rcx
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rsi
-               	jmp	 <L56>
-<L54>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rsi
-<L56>:
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	mulss	%xmm9, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L58>
-               	movq	%rsi, %rcx
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rbx
-               	jmp	 <L60>
-<L58>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rbx
-<L60>:
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	mulss	%xmm9, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L62>
-               	movq	%rbx, %rcx
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rsi
-               	jmp	 <L64>
-<L62>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rsi
-<L64>:
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x532>
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L66>
-               	movq	%rsi, %rcx
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rbx
-               	jmp	 <L68>
-<L66>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rbx
-<L68>:
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x577>
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L70>
-               	movq	%rbx, %rcx
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rsi
-               	jmp	 <L72>
-<L70>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rsi
-<L72>:
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	divss	%xmm6, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L74>
-               	movq	%rsi, %rcx
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rbx
-               	jmp	 <L76>
-<L74>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rbx
-<L76>:
-               	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
-               	divss	%xmm7, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L78>
-               	movq	%rbx, %rcx
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %rsi
-               	jmp	 <L80>
-<L78>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rsi
-<L80>:
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	divss	%xmm6, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L82>
-               	movq	%rsi, %rcx
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rbx
-               	jmp	 <L84>
-<L82>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rbx
-<L84>:
-               	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	divss	%xmm7, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L86>
-               	movq	%rbx, %rcx
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %rsi
-               	jmp	 <L88>
-<L86>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L87>
-<L87>:
-               	movq	%rax, %rsi
-<L88>:
                	ucomiss	%xmm9, %xmm8
                	sete	%dl
                	setnp	%r11b
                	andb	%r11b, %dl
                	movzbq	%dl, %rdx
-               	movq	%rsi, %rcx
-               	callq	 <L89>
-<L89>:
+               	movq	%rax, %rcx
+               	callq	 <L47>
+<L47>:
                	ucomiss	%xmm8, %xmm9
                	seta	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L90>
-<L90>:
+               	callq	 <L48>
+<L48>:
                	ucomiss	%xmm9, %xmm8
                	seta	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L91>
-<L91>:
-               	movq	%rax, %rbx
-               	ucomiss	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L93>
-               	movq	%rbx, %rcx
+               	callq	 <L49>
+<L49>:
+               	movq	%rax, %rcx
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	callq	 <L92>
-<L92>:
-               	movq	%rax, %rsi
-               	jmp	 <L95>
-<L93>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L94>
-<L94>:
-               	movq	%rax, %rsi
-<L95>:
-               	ucomiss	%xmm11, %xmm11
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L97>
-               	movq	%rsi, %rcx
+               	callq	 <L50>
+<L50>:
+               	movq	%rax, %rcx
                	movss	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1,2,3]
-               	callq	 <L96>
-<L96>:
-               	movq	%rax, %rbx
-               	jmp	 <L99>
-<L97>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L98>
-<L98>:
-               	movq	%rax, %rbx
-<L99>:
+               	callq	 <L51>
+<L51>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x785>
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L101>
-               	movq	%rbx, %rcx
-               	callq	 <L100>
-<L100>:
-               	movq	%rax, %rsi
-               	jmp	 <L103>
-<L101>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L102>
-<L102>:
-               	movq	%rax, %rsi
-<L103>:
+               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x470>
+               	movq	%rax, %rcx
+               	callq	 <L52>
+<L52>:
                	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	divss	%xmm8, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L105>
-               	movq	%rsi, %rcx
-               	callq	 <L104>
-<L104>:
-               	movq	%rax, %rbx
-               	jmp	 <L107>
-<L105>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L106>
-<L106>:
-               	movq	%rax, %rbx
-<L107>:
+               	movq	%rax, %rcx
+               	callq	 <L53>
+<L53>:
                	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	divss	%xmm9, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L109>
-               	movq	%rbx, %rcx
-               	callq	 <L108>
-<L108>:
-               	movq	%rax, %rsi
-               	jmp	 <L111>
-<L109>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L110>
-<L110>:
-               	movq	%rax, %rsi
-<L111>:
+               	movq	%rax, %rcx
+               	callq	 <L54>
+<L54>:
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
                	divss	%xmm8, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L113>
-               	movq	%rsi, %rcx
-               	callq	 <L112>
-<L112>:
-               	movq	%rax, %rbx
-               	jmp	 <L115>
-<L113>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L114>
-<L114>:
-               	movq	%rax, %rbx
-<L115>:
+               	movq	%rax, %rcx
+               	callq	 <L55>
+<L55>:
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
                	divss	%xmm9, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L117>
-               	movq	%rbx, %rcx
-               	callq	 <L116>
-<L116>:
-               	movq	%rax, %rsi
-               	jmp	 <L119>
-<L117>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L118>
-<L118>:
-               	movq	%rax, %rsi
-<L119>:
+               	movq	%rax, %rcx
+               	callq	 <L56>
+<L56>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	addss	%xmm6, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L121>
-               	movq	%rsi, %rcx
-               	callq	 <L120>
-<L120>:
-               	movq	%rax, %rbx
-               	jmp	 <L123>
-<L121>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L122>
-<L122>:
-               	movq	%rax, %rbx
-<L123>:
+               	movq	%rax, %rcx
+               	callq	 <L57>
+<L57>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	addss	%xmm10, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L125>
-               	movq	%rbx, %rcx
-               	callq	 <L124>
-<L124>:
-               	movq	%rax, %rsi
-               	jmp	 <L127>
-<L125>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L126>
-<L126>:
-               	movq	%rax, %rsi
-<L127>:
+               	movq	%rax, %rcx
+               	callq	 <L58>
+<L58>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	subss	%xmm11, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L129>
-               	movq	%rsi, %rcx
-               	callq	 <L128>
-<L128>:
-               	movq	%rax, %rbx
-               	jmp	 <L131>
-<L129>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L130>
-<L130>:
-               	movq	%rax, %rbx
-<L131>:
+               	movq	%rax, %rcx
+               	callq	 <L59>
+<L59>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	mulss	%xmm10, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L133>
-               	movq	%rbx, %rcx
-               	callq	 <L132>
-<L132>:
-               	movq	%rax, %rsi
-               	jmp	 <L135>
-<L133>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L134>
-<L134>:
-               	movq	%rax, %rsi
-<L135>:
+               	movq	%rax, %rcx
+               	callq	 <L60>
+<L60>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	mulss	%xmm11, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L137>
-               	movq	%rsi, %rcx
-               	callq	 <L136>
-<L136>:
-               	movq	%rax, %rbx
-               	jmp	 <L139>
-<L137>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L138>
-<L138>:
-               	movq	%rax, %rbx
-<L139>:
+               	movq	%rax, %rcx
+               	callq	 <L61>
+<L61>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	mulss	%xmm7, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L141>
-               	movq	%rbx, %rcx
-               	callq	 <L140>
-<L140>:
-               	movq	%rax, %rsi
-               	jmp	 <L143>
-<L141>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L142>
-<L142>:
-               	movq	%rax, %rsi
-<L143>:
+               	movq	%rax, %rcx
+               	callq	 <L62>
+<L62>:
                	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	divss	%xmm10, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L145>
-               	movq	%rsi, %rcx
-               	callq	 <L144>
-<L144>:
-               	movq	%rax, %rbx
-               	jmp	 <L147>
-<L145>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L146>
-<L146>:
-               	movq	%rax, %rbx
-<L147>:
+               	movq	%rax, %rcx
+               	callq	 <L63>
+<L63>:
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
                	divss	%xmm10, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L149>
-               	movq	%rbx, %rcx
-               	callq	 <L148>
-<L148>:
-               	movq	%rax, %rsi
-               	jmp	 <L151>
-<L149>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L150>
-<L150>:
-               	movq	%rax, %rsi
-<L151>:
+               	movq	%rax, %rcx
+               	callq	 <L64>
+<L64>:
                	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	divss	%xmm11, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L153>
-               	movq	%rsi, %rcx
-               	callq	 <L152>
-<L152>:
-               	movq	%rax, %rbx
-               	jmp	 <L155>
-<L153>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L154>
-<L154>:
-               	movq	%rax, %rbx
-<L155>:
+               	movq	%rax, %rcx
+               	callq	 <L65>
+<L65>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	divss	%xmm6, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L157>
-               	movq	%rbx, %rcx
-               	callq	 <L156>
-<L156>:
-               	movq	%rax, %rsi
-               	jmp	 <L159>
-<L157>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L158>
-<L158>:
-               	movq	%rax, %rsi
-<L159>:
+               	movq	%rax, %rcx
+               	callq	 <L66>
+<L66>:
                	movss	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1,2,3]
                	addss	%xmm13, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L161>
-               	movq	%rsi, %rcx
-               	callq	 <L160>
-<L160>:
-               	movq	%rax, %rbx
-               	jmp	 <L163>
-<L161>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L162>
-<L162>:
-               	movq	%rax, %rbx
-<L163>:
+               	movq	%rax, %rcx
+               	callq	 <L67>
+<L67>:
                	ucomiss	%xmm13, %xmm10
                	seta	%dl
                	movzbq	%dl, %rdx
-               	movq	%rbx, %rcx
-               	callq	 <L164>
-<L164>:
+               	movq	%rax, %rcx
+               	callq	 <L68>
+<L68>:
                	xorps	%xmm1, %xmm1
                	subss	%xmm13, %xmm1
                	ucomiss	%xmm11, %xmm1
                	seta	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L165>
-<L165>:
-               	movq	%rax, %rbx
+               	callq	 <L69>
+<L69>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	subss	%xmm10, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L167>
-               	movq	%rbx, %rcx
-               	callq	 <L166>
-<L166>:
-               	movq	%rax, %rsi
-               	jmp	 <L169>
-<L167>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L168>
-<L168>:
-               	movq	%rax, %rsi
-<L169>:
+               	movq	%rax, %rcx
+               	callq	 <L70>
+<L70>:
                	movss	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1,2,3]
                	addss	%xmm10, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L171>
-               	movq	%rsi, %rcx
-               	callq	 <L170>
-<L170>:
-               	movq	%rax, %rbx
-               	jmp	 <L173>
-<L171>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L172>
-<L172>:
-               	movq	%rax, %rbx
-<L173>:
+               	movq	%rax, %rcx
+               	callq	 <L71>
+<L71>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	mulss	%xmm8, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L175>
-               	movq	%rbx, %rcx
-               	callq	 <L174>
-<L174>:
-               	movq	%rax, %rsi
-               	jmp	 <L177>
-<L175>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L176>
-<L176>:
-               	movq	%rax, %rsi
-<L177>:
+               	movq	%rax, %rcx
+               	callq	 <L72>
+<L72>:
                	movss	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1,2,3]
                	mulss	%xmm9, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L179>
-               	movq	%rsi, %rcx
-               	callq	 <L178>
-<L178>:
-               	movq	%rax, %rbx
-               	jmp	 <L181>
-<L179>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L180>
-<L180>:
-               	movq	%rax, %rbx
-<L181>:
+               	movq	%rax, %rcx
+               	callq	 <L73>
+<L73>:
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
                	divss	%xmm10, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L183>
-               	movq	%rbx, %rcx
-               	callq	 <L182>
-<L182>:
-               	movq	%rax, %rsi
-               	jmp	 <L185>
-<L183>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L184>
-<L184>:
-               	movq	%rax, %rsi
-<L185>:
+               	movq	%rax, %rcx
+               	callq	 <L74>
+<L74>:
                	movss	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1,2,3]
                	divss	%xmm8, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L187>
-               	movq	%rsi, %rcx
-               	callq	 <L186>
-<L186>:
-               	movq	%rax, %rbx
-               	jmp	 <L189>
-<L187>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L188>
-<L188>:
-               	movq	%rax, %rbx
-<L189>:
+               	movq	%rax, %rcx
+               	callq	 <L75>
+<L75>:
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
                	divss	%xmm8, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L191>
-               	movq	%rbx, %rcx
-               	callq	 <L190>
-<L190>:
-               	movq	%rax, %rsi
-               	jmp	 <L193>
-<L191>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L192>
-<L192>:
-               	movq	%rax, %rsi
-<L193>:
-               	movd	%xmm12, %eax
-               	movq	%rsi, %rcx
-               	movl	%eax, %edx
-               	callq	 <L194>
-<L194>:
+               	movq	%rax, %rcx
+               	callq	 <L76>
+<L76>:
+               	movd	%xmm12, %edx
+               	movq	%rax, %rcx
+               	callq	 <L77>
+<L77>:
                	ucomiss	%xmm12, %xmm12
                	setne	%dl
                	setp	%r11b
                	orb	%r11b, %dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L195>
-<L195>:
+               	callq	 <L78>
+<L78>:
                	ucomiss	%xmm12, %xmm12
                	sete	%dl
                	setnp	%r11b
                	andb	%r11b, %dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L196>
-<L196>:
+               	callq	 <L79>
+<L79>:
                	ucomiss	%xmm12, %xmm12
                	seta	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L197>
-<L197>:
+               	callq	 <L80>
+<L80>:
                	ucomiss	%xmm12, %xmm12
                	setae	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L198>
-<L198>:
+               	callq	 <L81>
+<L81>:
                	movss	%xmm12, %xmm7           # xmm7 = xmm12[0],xmm7[1,2,3]
-               	xorps	, %xmm7 <corpus.cases.float.special_f32.checksum+0xe1c>
+               	xorps	, %xmm7 <corpus.cases.float.special_f32.checksum+0x69b>
                	movd	%xmm7, %edx
                	movq	%rax, %rcx
-               	callq	 <L199>
-<L199>:
+               	callq	 <L82>
+<L82>:
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0xe34>
+               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x6b3>
                	movd	%xmm1, %edx
                	movq	%rax, %rcx
-               	callq	 <L200>
-<L200>:
-               	movq	%rax, %rbx
+               	callq	 <L83>
+<L83>:
                	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
                	addss	%xmm6, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L202>
-               	movq	%rbx, %rcx
-               	callq	 <L201>
-<L201>:
-               	movq	%rax, %rsi
-               	jmp	 <L204>
-<L202>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L203>
-<L203>:
-               	movq	%rax, %rsi
-<L204>:
+               	movq	%rax, %rcx
+               	callq	 <L84>
+<L84>:
                	movss	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1,2,3]
                	addss	%xmm12, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L206>
-               	movq	%rsi, %rcx
-               	callq	 <L205>
-<L205>:
-               	movq	%rax, %rbx
-               	jmp	 <L208>
-<L206>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L207>
-<L207>:
-               	movq	%rax, %rbx
-<L208>:
+               	movq	%rax, %rcx
+               	callq	 <L85>
+<L85>:
                	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
                	mulss	%xmm8, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L210>
-               	movq	%rbx, %rcx
-               	callq	 <L209>
-<L209>:
-               	movq	%rax, %rsi
-               	jmp	 <L212>
-<L210>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L211>
-<L211>:
-               	movq	%rax, %rsi
-<L212>:
+               	movq	%rax, %rcx
+               	callq	 <L86>
+<L86>:
                	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
                	subss	%xmm12, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L214>
-               	movq	%rsi, %rcx
-               	callq	 <L213>
-<L213>:
-               	movq	%rax, %rbx
-               	jmp	 <L216>
-<L214>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L215>
-<L215>:
-               	movq	%rax, %rbx
-<L216>:
+               	movq	%rax, %rcx
+               	callq	 <L87>
+<L87>:
                	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
                	divss	%xmm12, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L218>
-               	movq	%rbx, %rcx
-               	callq	 <L217>
-<L217>:
-               	movq	%rax, %rsi
-               	jmp	 <L220>
-<L218>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L219>
-<L219>:
-               	movq	%rax, %rsi
-<L220>:
+               	movq	%rax, %rcx
+               	callq	 <L88>
+<L88>:
                	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
                	divss	%xmm10, %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L222>
-               	movq	%rsi, %rcx
-               	callq	 <L221>
-<L221>:
-               	movq	%rax, %rbx
-               	jmp	 <L224>
-<L222>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L223>
-<L223>:
-               	movq	%rax, %rbx
-<L224>:
-               	movss	-0x58(%rbp), %xmm14
-               	ucomiss	-0x58(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L226>
-               	movq	%rbx, %rcx
+               	movq	%rax, %rcx
+               	callq	 <L89>
+<L89>:
+               	movq	%rax, %rcx
                	movss	-0x58(%rbp), %xmm1
-               	callq	 <L225>
-<L225>:
-               	movq	%rax, %rsi
-               	jmp	 <L228>
-<L226>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L227>
-<L227>:
-               	movq	%rax, %rsi
-<L228>:
-               	movss	-0x48(%rbp), %xmm14
-               	ucomiss	-0x48(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L230>
-               	movq	%rsi, %rcx
+               	callq	 <L90>
+<L90>:
+               	movq	%rax, %rcx
                	movss	-0x48(%rbp), %xmm1
-               	callq	 <L229>
-<L229>:
-               	movq	%rax, %rbx
-               	jmp	 <L232>
-<L230>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L231>
-<L231>:
-               	movq	%rax, %rbx
-<L232>:
-               	movss	-0x38(%rbp), %xmm14
-               	ucomiss	-0x38(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L234>
-               	movq	%rbx, %rcx
+               	callq	 <L91>
+<L91>:
+               	movq	%rax, %rcx
                	movss	-0x38(%rbp), %xmm1
-               	callq	 <L233>
-<L233>:
-               	movq	%rax, %rsi
-               	jmp	 <L236>
-<L234>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L235>
-<L235>:
-               	movq	%rax, %rsi
-<L236>:
+               	callq	 <L92>
+<L92>:
                	movss	-0x48(%rbp), %xmm1
                	addss	-0x58(%rbp), %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L238>
-               	movq	%rsi, %rcx
-               	callq	 <L237>
-<L237>:
-               	movq	%rax, %rbx
-               	jmp	 <L240>
-<L238>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L239>
-<L239>:
-               	movq	%rax, %rbx
-<L240>:
+               	movq	%rax, %rcx
+               	callq	 <L93>
+<L93>:
                	movss	-0x38(%rbp), %xmm1
                	subss	-0x58(%rbp), %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L242>
-               	movq	%rbx, %rcx
-               	callq	 <L241>
-<L241>:
-               	movq	%rax, %rsi
-               	jmp	 <L244>
-<L242>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L243>
-<L243>:
-               	movq	%rax, %rsi
-<L244>:
+               	movq	%rax, %rcx
+               	callq	 <L94>
+<L94>:
                	movss	-0x58(%rbp), %xmm1
                	addss	-0x58(%rbp), %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L246>
-               	movq	%rsi, %rcx
-               	callq	 <L245>
-<L245>:
-               	movq	%rax, %rbx
-               	jmp	 <L248>
-<L246>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L247>
-<L247>:
-               	movq	%rax, %rbx
-<L248>:
+               	movq	%rax, %rcx
+               	callq	 <L95>
+<L95>:
                	movss	-0x58(%rbp), %xmm1
-               	mulss	, %xmm1 <corpus.cases.float.special_f32.checksum+0x117c>
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L250>
-               	movq	%rbx, %rcx
-               	callq	 <L249>
-<L249>:
-               	movq	%rax, %rsi
-               	jmp	 <L252>
-<L250>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L251>
-<L251>:
-               	movq	%rax, %rsi
-<L252>:
+               	mulss	, %xmm1 <corpus.cases.float.special_f32.checksum+0x794>
+               	movq	%rax, %rcx
+               	callq	 <L96>
+<L96>:
                	movss	-0x58(%rbp), %xmm1
-               	mulss	, %xmm1 <corpus.cases.float.special_f32.checksum+0x11c2>
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L254>
-               	movq	%rsi, %rcx
-               	callq	 <L253>
-<L253>:
-               	movq	%rax, %rbx
-               	jmp	 <L256>
-<L254>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L255>
-<L255>:
-               	movq	%rax, %rbx
-<L256>:
+               	mulss	, %xmm1 <corpus.cases.float.special_f32.checksum+0x7a9>
+               	movq	%rax, %rcx
+               	callq	 <L97>
+<L97>:
                	movss	-0x58(%rbp), %xmm1
-               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x1207>
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L258>
-               	movq	%rbx, %rcx
-               	callq	 <L257>
-<L257>:
-               	movq	%rax, %rsi
-               	jmp	 <L260>
-<L258>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L259>
-<L259>:
-               	movq	%rax, %rsi
-<L260>:
+               	xorps	, %xmm1 <corpus.cases.float.special_f32.checksum+0x7bd>
+               	movq	%rax, %rcx
+               	callq	 <L98>
+<L98>:
                	movss	-0x58(%rbp), %xmm1
-               	mulss	, %xmm1 <corpus.cases.float.special_f32.checksum+0x124d>
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L262>
-               	movq	%rsi, %rcx
-               	callq	 <L261>
-<L261>:
-               	movq	%rax, %rbx
-               	jmp	 <L264>
-<L262>:
-               	movq	%rsi, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L263>
-<L263>:
-               	movq	%rax, %rbx
-<L264>:
+               	mulss	, %xmm1 <corpus.cases.float.special_f32.checksum+0x7d2>
+               	movq	%rax, %rcx
+               	callq	 <L99>
+<L99>:
                	movss	-0x48(%rbp), %xmm1
                	divss	-0x38(%rbp), %xmm1
-               	ucomiss	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L266>
-               	movq	%rbx, %rcx
-               	callq	 <L265>
-<L265>:
-               	movq	%rax, %rsi
-               	jmp	 <L268>
-<L266>:
-               	movq	%rbx, %rcx
-               	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L267>
-<L267>:
-               	movq	%rax, %rsi
-<L268>:
+               	movq	%rax, %rcx
+               	callq	 <L100>
+<L100>:
                	movss	-0x58(%rbp), %xmm14
                	ucomiss	%xmm8, %xmm14
                	seta	%dl
                	movzbq	%dl, %rdx
-               	movq	%rsi, %rcx
-               	callq	 <L269>
-<L269>:
+               	movq	%rax, %rcx
+               	callq	 <L101>
+<L101>:
                	movss	-0x58(%rbp), %xmm14
                	ucomiss	%xmm8, %xmm14
                	sete	%dl
@@ -1536,51 +633,51 @@ Disassembly of section .text:
                	andb	%r11b, %dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L270>
-<L270>:
+               	callq	 <L102>
+<L102>:
                	xorps	%xmm1, %xmm1
                	subss	-0x58(%rbp), %xmm1
                	ucomiss	%xmm1, %xmm9
                	seta	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L271>
-<L271>:
+               	callq	 <L103>
+<L103>:
                	movq	%rax, %rbx
                	movsd	-0x38(%rbp), %xmm7
                	movl	$0x0, %esi
                	cmpl	$0x1e, %esi
-               	jb	 <L272>
-               	jmp	 <L277>
-<L272>:
+               	jb	 <L104>
+               	jmp	 <L109>
+<L104>:
                	movss	%xmm7, %xmm9            # xmm9 = xmm7[0],xmm9[1,2,3]
-               	mulss	, %xmm9 <corpus.cases.float.special_f32.checksum+0x1346>
+               	mulss	, %xmm9 <corpus.cases.float.special_f32.checksum+0x869>
                	ucomiss	%xmm9, %xmm9
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L274>
+               	jne	 <L106>
                	movq	%rbx, %rcx
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L273>
-<L273>:
+               	callq	 <L105>
+<L105>:
                	movq	%rax, %r12
-               	jmp	 <L276>
-<L274>:
+               	jmp	 <L108>
+<L106>:
                	movq	%rbx, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L275>
-<L275>:
+               	callq	 <L107>
+<L107>:
                	movq	%rax, %r12
-<L276>:
+<L108>:
                	addl	$0x1, %esi
                	movq	%r12, %rbx
                	movsd	%xmm9, %xmm7            # xmm7 = xmm9[0],xmm7[1]
                	cmpl	$0x1e, %esi
-               	jb	 <L272>
-<L277>:
+               	jb	 <L104>
+<L109>:
                	leaq	-0x20(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
@@ -1604,9 +701,9 @@ Disassembly of section .text:
                	movl	$0x7f800001, (%rax)     # imm = 0x7F800001
                	movl	$0x0, %r12d
                	cmpl	$0x8, %r12d
-               	jb	 <L278>
-               	jmp	 <L280>
-<L278>:
+               	jb	 <L110>
+               	jmp	 <L112>
+<L110>:
                	movl	%r12d, %eax
                	leaq	(%rsi,%rax,4), %rcx
                	movl	(%rcx), %eax
@@ -1615,13 +712,13 @@ Disassembly of section .text:
                	movd	%xmm0, %eax
                	movq	%rbx, %rcx
                	movl	%eax, %edx
-               	callq	 <L279>
-<L279>:
+               	callq	 <L111>
+<L111>:
                	addl	$0x1, %r12d
                	movq	%rax, %rbx
                	cmpl	$0x8, %r12d
-               	jb	 <L278>
-<L280>:
+               	jb	 <L110>
+<L112>:
                	movl	$0x1000000, %eax        # imm = 0x1000000
                	addl	%edi, %eax
                	movl	$0x1000001, %esi        # imm = 0x1000001
@@ -1642,22 +739,22 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L282>
+               	jne	 <L114>
                	movq	%rbx, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L281>
-<L281>:
+               	callq	 <L113>
+<L113>:
                	movq	%rax, %r8
                	movq	%r8, -0x28(%rbp)
-               	jmp	 <L284>
-<L282>:
+               	jmp	 <L116>
+<L114>:
                	movq	%rbx, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L283>
-<L283>:
+               	callq	 <L115>
+<L115>:
                	movq	%rax, %r8
                	movq	%r8, -0x28(%rbp)
-<L284>:
+<L116>:
                	movl	%esi, %r11d
                	cvtsi2ss	%r11, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -1666,22 +763,22 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L286>
+               	jne	 <L118>
                	movq	-0x28(%rbp), %r8
                	movq	%r8, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L285>
-<L285>:
+               	callq	 <L117>
+<L117>:
                	movq	%rax, %rbx
-               	jmp	 <L288>
-<L286>:
+               	jmp	 <L120>
+<L118>:
                	movq	-0x28(%rbp), %r8
                	movq	%r8, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L287>
-<L287>:
+               	callq	 <L119>
+<L119>:
                	movq	%rax, %rbx
-<L288>:
+<L120>:
                	movl	%r12d, %r11d
                	cvtsi2ss	%r11, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -1690,20 +787,20 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L290>
+               	jne	 <L122>
                	movq	%rbx, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L289>
-<L289>:
+               	callq	 <L121>
+<L121>:
                	movq	%rax, %rsi
-               	jmp	 <L292>
-<L290>:
+               	jmp	 <L124>
+<L122>:
                	movq	%rbx, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L291>
-<L291>:
+               	callq	 <L123>
+<L123>:
                	movq	%rax, %rsi
-<L292>:
+<L124>:
                	movl	%r13d, %r11d
                	cvtsi2ss	%r11, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -1712,20 +809,20 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L294>
+               	jne	 <L126>
                	movq	%rsi, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L293>
-<L293>:
+               	callq	 <L125>
+<L125>:
                	movq	%rax, %rbx
-               	jmp	 <L296>
-<L294>:
+               	jmp	 <L128>
+<L126>:
                	movq	%rsi, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L295>
-<L295>:
+               	callq	 <L127>
+<L127>:
                	movq	%rax, %rbx
-<L296>:
+<L128>:
                	movl	%edi, %r11d
                	cvtsi2ss	%r11, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -1734,20 +831,20 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L298>
+               	jne	 <L130>
                	movq	%rbx, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L297>
-<L297>:
+               	callq	 <L129>
+<L129>:
                	movq	%rax, %rsi
-               	jmp	 <L300>
-<L298>:
+               	jmp	 <L132>
+<L130>:
                	movq	%rbx, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L299>
-<L299>:
+               	callq	 <L131>
+<L131>:
                	movq	%rax, %rsi
-<L300>:
+<L132>:
                	movslq	%r14d, %r11
                	cvtsi2ss	%r11, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -1756,20 +853,20 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L302>
+               	jne	 <L134>
                	movq	%rsi, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L301>
-<L301>:
+               	callq	 <L133>
+<L133>:
                	movq	%rax, %rbx
-               	jmp	 <L304>
-<L302>:
+               	jmp	 <L136>
+<L134>:
                	movq	%rsi, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L303>
-<L303>:
+               	callq	 <L135>
+<L135>:
                	movq	%rax, %rbx
-<L304>:
+<L136>:
                	movslq	%r15d, %r11
                	cvtsi2ss	%r11, %xmm0
                	ucomiss	%xmm0, %xmm0
@@ -1778,85 +875,85 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L306>
+               	jne	 <L138>
                	movq	%rbx, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L305>
-<L305>:
+               	callq	 <L137>
+<L137>:
                	movq	%rax, %rsi
-               	jmp	 <L308>
-<L306>:
+               	jmp	 <L140>
+<L138>:
                	movq	%rbx, %rcx
                	movl	$0xffffffff, %edx       # imm = 0xFFFFFFFF
-               	callq	 <L307>
-<L307>:
+               	callq	 <L139>
+<L139>:
                	movq	%rax, %rsi
-<L308>:
-               	movss	, %xmm0 <corpus.cases.float.special_f32.checksum+0x167d>
+<L140>:
+               	movss	, %xmm0 <corpus.cases.float.special_f32.checksum+0xba0>
                	mulss	%xmm6, %xmm0
-               	movss	, %xmm7 <corpus.cases.float.special_f32.checksum+0x1689>
+               	movss	, %xmm7 <corpus.cases.float.special_f32.checksum+0xbac>
                	mulss	%xmm6, %xmm7
-               	movss	, %xmm9 <corpus.cases.float.special_f32.checksum+0x1696>
+               	movss	, %xmm9 <corpus.cases.float.special_f32.checksum+0xbb9>
                	mulss	%xmm6, %xmm9
                	xorps	%xmm10, %xmm10
                	subss	%xmm0, %xmm10
-               	movss	, %xmm11 <corpus.cases.float.special_f32.checksum+0x16ad>
+               	movss	, %xmm11 <corpus.cases.float.special_f32.checksum+0xbd0>
                	mulss	%xmm6, %xmm11
                	cvttss2si	%xmm0, %r11
                	movl	%r11d, %eax
                	movq	%rsi, %rcx
                	movl	%eax, %edx
-               	callq	 <L309>
-<L309>:
+               	callq	 <L141>
+<L141>:
                	cvttss2si	%xmm7, %r11
                	movl	%r11d, %edx
                	movq	%rax, %rcx
-               	callq	 <L310>
-<L310>:
+               	callq	 <L142>
+<L142>:
                	cvttss2si	%xmm9, %r11
                	movl	%r11d, %edx
                	movq	%rax, %rcx
-               	callq	 <L311>
-<L311>:
+               	callq	 <L143>
+<L143>:
                	cvttss2si	%xmm11, %r11
                	movl	%r11d, %edx
                	movq	%rax, %rcx
-               	callq	 <L312>
-<L312>:
+               	callq	 <L144>
+<L144>:
                	cvttss2si	%xmm8, %r11
                	movl	%r11d, %edx
                	movq	%rax, %rcx
-               	callq	 <L313>
-<L313>:
+               	callq	 <L145>
+<L145>:
                	cvttss2si	%xmm10, %r11d
                	movl	%r11d, %edx
                	movq	%rax, %rcx
-               	callq	 <L314>
-<L314>:
+               	callq	 <L146>
+<L146>:
                	cvttss2si	%xmm9, %r11d
                	movl	%r11d, %edx
                	movq	%rax, %rcx
-               	callq	 <L315>
-<L315>:
+               	callq	 <L147>
+<L147>:
                	xorps	%xmm0, %xmm0
                	subss	%xmm11, %xmm0
                	cvttss2si	%xmm0, %r11d
                	movl	%r11d, %edx
                	movq	%rax, %rcx
-               	callq	 <L316>
-<L316>:
+               	callq	 <L148>
+<L148>:
                	cvttss2si	%xmm10, %r11
                	movq	%r11, %rdx
                	movq	%rax, %rcx
-               	callq	 <L317>
-<L317>:
+               	callq	 <L149>
+<L149>:
                	xorps	%xmm0, %xmm0
                	subss	%xmm7, %xmm0
                	cvttss2si	%xmm0, %r11
                	movq	%r11, %rdx
                	movq	%rax, %rcx
-               	callq	 <L318>
-<L318>:
+               	callq	 <L150>
+<L150>:
                	movaps	-0xb0(%rbp), %xmm6
                	movaps	-0xc0(%rbp), %xmm7
                	movaps	-0xd0(%rbp), %xmm8

--- a/test/golden/x86_64-windows/float/special_f64.dis
+++ b/test/golden/x86_64-windows/float/special_f64.dis
@@ -204,1329 +204,379 @@ Disassembly of section .text:
 <L20>:
                	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
                	addsd	%xmm9, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L22>
                	movq	%rdi, %rcx
                	callq	 <L21>
 <L21>:
-               	movq	%rax, %rsi
-               	jmp	 <L24>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	subsd	%xmm8, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L22>
 <L22>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	subsd	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L23>
 <L23>:
-               	movq	%rax, %rsi
-<L24>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
                	subsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L26>
-               	movq	%rsi, %rcx
+               	movq	%rax, %rcx
+               	callq	 <L24>
+<L24>:
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	subsd	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L25>
 <L25>:
-               	movq	%rax, %rdi
-               	jmp	 <L28>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	mulsd	%xmm6, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L26>
 <L26>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	mulsd	%xmm7, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L27>
 <L27>:
-               	movq	%rax, %rdi
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	mulsd	%xmm6, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L28>
 <L28>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	subsd	%xmm9, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L30>
-               	movq	%rdi, %rcx
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	mulsd	%xmm7, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L29>
 <L29>:
-               	movq	%rax, %rsi
-               	jmp	 <L32>
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	mulsd	%xmm9, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L30>
 <L30>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	mulsd	%xmm9, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L31>
 <L31>:
-               	movq	%rax, %rsi
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x36c>
+               	movq	%rax, %rcx
+               	callq	 <L32>
 <L32>:
                	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	subsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L34>
-               	movq	%rsi, %rcx
+               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x380>
+               	movq	%rax, %rcx
                	callq	 <L33>
 <L33>:
-               	movq	%rax, %rdi
-               	jmp	 <L36>
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	divsd	%xmm6, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L34>
 <L34>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
+               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
+               	divsd	%xmm7, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L35>
 <L35>:
-               	movq	%rax, %rdi
+               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
+               	divsd	%xmm6, %xmm1
+               	movq	%rax, %rcx
+               	callq	 <L36>
 <L36>:
                	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	subsd	%xmm9, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L38>
-               	movq	%rdi, %rcx
+               	divsd	%xmm7, %xmm1
+               	movq	%rax, %rcx
                	callq	 <L37>
 <L37>:
-               	movq	%rax, %rsi
-               	jmp	 <L40>
-<L38>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L39>
-<L39>:
-               	movq	%rax, %rsi
-<L40>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	mulsd	%xmm6, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L42>
-               	movq	%rsi, %rcx
-               	callq	 <L41>
-<L41>:
-               	movq	%rax, %rdi
-               	jmp	 <L44>
-<L42>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L43>
-<L43>:
-               	movq	%rax, %rdi
-<L44>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	mulsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L46>
-               	movq	%rdi, %rcx
-               	callq	 <L45>
-<L45>:
-               	movq	%rax, %rsi
-               	jmp	 <L48>
-<L46>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L47>
-<L47>:
-               	movq	%rax, %rsi
-<L48>:
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	mulsd	%xmm6, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L50>
-               	movq	%rsi, %rcx
-               	callq	 <L49>
-<L49>:
-               	movq	%rax, %rdi
-               	jmp	 <L52>
-<L50>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L51>
-<L51>:
-               	movq	%rax, %rdi
-<L52>:
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	mulsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L54>
-               	movq	%rdi, %rcx
-               	callq	 <L53>
-<L53>:
-               	movq	%rax, %rsi
-               	jmp	 <L56>
-<L54>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L55>
-<L55>:
-               	movq	%rax, %rsi
-<L56>:
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	mulsd	%xmm9, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L58>
-               	movq	%rsi, %rcx
-               	callq	 <L57>
-<L57>:
-               	movq	%rax, %rdi
-               	jmp	 <L60>
-<L58>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L59>
-<L59>:
-               	movq	%rax, %rdi
-<L60>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	mulsd	%xmm9, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L62>
-               	movq	%rdi, %rcx
-               	callq	 <L61>
-<L61>:
-               	movq	%rax, %rsi
-               	jmp	 <L64>
-<L62>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L63>
-<L63>:
-               	movq	%rax, %rsi
-<L64>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x5a8>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L66>
-               	movq	%rsi, %rcx
-               	callq	 <L65>
-<L65>:
-               	movq	%rax, %rdi
-               	jmp	 <L68>
-<L66>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L67>
-<L67>:
-               	movq	%rax, %rdi
-<L68>:
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x5f0>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L70>
-               	movq	%rdi, %rcx
-               	callq	 <L69>
-<L69>:
-               	movq	%rax, %rsi
-               	jmp	 <L72>
-<L70>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L71>
-<L71>:
-               	movq	%rax, %rsi
-<L72>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	divsd	%xmm6, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L74>
-               	movq	%rsi, %rcx
-               	callq	 <L73>
-<L73>:
-               	movq	%rax, %rdi
-               	jmp	 <L76>
-<L74>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L75>
-<L75>:
-               	movq	%rax, %rdi
-<L76>:
-               	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
-               	divsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L78>
-               	movq	%rdi, %rcx
-               	callq	 <L77>
-<L77>:
-               	movq	%rax, %rsi
-               	jmp	 <L80>
-<L78>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L79>
-<L79>:
-               	movq	%rax, %rsi
-<L80>:
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	divsd	%xmm6, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L82>
-               	movq	%rsi, %rcx
-               	callq	 <L81>
-<L81>:
-               	movq	%rax, %rdi
-               	jmp	 <L84>
-<L82>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L83>
-<L83>:
-               	movq	%rax, %rdi
-<L84>:
-               	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
-               	divsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L86>
-               	movq	%rdi, %rcx
-               	callq	 <L85>
-<L85>:
-               	movq	%rax, %rsi
-               	jmp	 <L88>
-<L86>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L87>
-<L87>:
-               	movq	%rax, %rsi
-<L88>:
                	ucomisd	%xmm9, %xmm8
                	sete	%dl
                	setnp	%r11b
                	andb	%r11b, %dl
                	movzbq	%dl, %rdx
-               	movq	%rsi, %rcx
-               	callq	 <L89>
-<L89>:
+               	movq	%rax, %rcx
+               	callq	 <L38>
+<L38>:
                	ucomisd	%xmm8, %xmm9
                	seta	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L90>
-<L90>:
+               	callq	 <L39>
+<L39>:
                	ucomisd	%xmm9, %xmm8
                	seta	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L91>
-<L91>:
-               	movq	%rax, %rsi
-               	ucomisd	%xmm10, %xmm10
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L93>
-               	movq	%rsi, %rcx
+               	callq	 <L40>
+<L40>:
+               	movq	%rax, %rcx
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
-               	callq	 <L92>
-<L92>:
-               	movq	%rax, %rdi
-               	jmp	 <L95>
-<L93>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L94>
-<L94>:
-               	movq	%rax, %rdi
-<L95>:
-               	ucomisd	%xmm11, %xmm11
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L97>
-               	movq	%rdi, %rcx
+               	callq	 <L41>
+<L41>:
+               	movq	%rax, %rcx
                	movsd	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1]
-               	callq	 <L96>
-<L96>:
-               	movq	%rax, %rsi
-               	jmp	 <L99>
-<L97>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L98>
-<L98>:
-               	movq	%rax, %rsi
-<L99>:
+               	callq	 <L42>
+<L42>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
-               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x816>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L101>
-               	movq	%rsi, %rcx
-               	callq	 <L100>
-<L100>:
-               	movq	%rax, %rdi
-               	jmp	 <L103>
-<L101>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L102>
-<L102>:
-               	movq	%rax, %rdi
-<L103>:
+               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x435>
+               	movq	%rax, %rcx
+               	callq	 <L43>
+<L43>:
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	divsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L105>
-               	movq	%rdi, %rcx
-               	callq	 <L104>
-<L104>:
-               	movq	%rax, %rsi
-               	jmp	 <L107>
-<L105>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L106>
-<L106>:
-               	movq	%rax, %rsi
-<L107>:
+               	movq	%rax, %rcx
+               	callq	 <L44>
+<L44>:
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	divsd	%xmm9, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L109>
-               	movq	%rsi, %rcx
-               	callq	 <L108>
-<L108>:
-               	movq	%rax, %rdi
-               	jmp	 <L111>
-<L109>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L110>
-<L110>:
-               	movq	%rax, %rdi
-<L111>:
+               	movq	%rax, %rcx
+               	callq	 <L45>
+<L45>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	divsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L113>
-               	movq	%rdi, %rcx
-               	callq	 <L112>
-<L112>:
-               	movq	%rax, %rsi
-               	jmp	 <L115>
-<L113>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L114>
-<L114>:
-               	movq	%rax, %rsi
-<L115>:
+               	movq	%rax, %rcx
+               	callq	 <L46>
+<L46>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	divsd	%xmm9, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L117>
-               	movq	%rsi, %rcx
-               	callq	 <L116>
-<L116>:
-               	movq	%rax, %rdi
-               	jmp	 <L119>
-<L117>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L118>
-<L118>:
-               	movq	%rax, %rdi
-<L119>:
+               	movq	%rax, %rcx
+               	callq	 <L47>
+<L47>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	addsd	%xmm6, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L121>
-               	movq	%rdi, %rcx
-               	callq	 <L120>
-<L120>:
-               	movq	%rax, %rsi
-               	jmp	 <L123>
-<L121>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L122>
-<L122>:
-               	movq	%rax, %rsi
-<L123>:
+               	movq	%rax, %rcx
+               	callq	 <L48>
+<L48>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	addsd	%xmm10, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L125>
-               	movq	%rsi, %rcx
-               	callq	 <L124>
-<L124>:
-               	movq	%rax, %rdi
-               	jmp	 <L127>
-<L125>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L126>
-<L126>:
-               	movq	%rax, %rdi
-<L127>:
+               	movq	%rax, %rcx
+               	callq	 <L49>
+<L49>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	subsd	%xmm11, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L129>
-               	movq	%rdi, %rcx
-               	callq	 <L128>
-<L128>:
-               	movq	%rax, %rsi
-               	jmp	 <L131>
-<L129>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L130>
-<L130>:
-               	movq	%rax, %rsi
-<L131>:
+               	movq	%rax, %rcx
+               	callq	 <L50>
+<L50>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	mulsd	%xmm10, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L133>
-               	movq	%rsi, %rcx
-               	callq	 <L132>
-<L132>:
-               	movq	%rax, %rdi
-               	jmp	 <L135>
-<L133>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L134>
-<L134>:
-               	movq	%rax, %rdi
-<L135>:
+               	movq	%rax, %rcx
+               	callq	 <L51>
+<L51>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	mulsd	%xmm11, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L137>
-               	movq	%rdi, %rcx
-               	callq	 <L136>
-<L136>:
-               	movq	%rax, %rsi
-               	jmp	 <L139>
-<L137>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L138>
-<L138>:
-               	movq	%rax, %rsi
-<L139>:
+               	movq	%rax, %rcx
+               	callq	 <L52>
+<L52>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	mulsd	%xmm7, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L141>
-               	movq	%rsi, %rcx
-               	callq	 <L140>
-<L140>:
-               	movq	%rax, %rdi
-               	jmp	 <L143>
-<L141>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L142>
-<L142>:
-               	movq	%rax, %rdi
-<L143>:
+               	movq	%rax, %rcx
+               	callq	 <L53>
+<L53>:
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	divsd	%xmm10, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L145>
-               	movq	%rdi, %rcx
-               	callq	 <L144>
-<L144>:
-               	movq	%rax, %rsi
-               	jmp	 <L147>
-<L145>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L146>
-<L146>:
-               	movq	%rax, %rsi
-<L147>:
+               	movq	%rax, %rcx
+               	callq	 <L54>
+<L54>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
                	divsd	%xmm10, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L149>
-               	movq	%rsi, %rcx
-               	callq	 <L148>
-<L148>:
-               	movq	%rax, %rdi
-               	jmp	 <L151>
-<L149>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L150>
-<L150>:
-               	movq	%rax, %rdi
-<L151>:
+               	movq	%rax, %rcx
+               	callq	 <L55>
+<L55>:
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	divsd	%xmm11, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L153>
-               	movq	%rdi, %rcx
-               	callq	 <L152>
-<L152>:
-               	movq	%rax, %rsi
-               	jmp	 <L155>
-<L153>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L154>
-<L154>:
-               	movq	%rax, %rsi
-<L155>:
+               	movq	%rax, %rcx
+               	callq	 <L56>
+<L56>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	divsd	%xmm6, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L157>
-               	movq	%rsi, %rcx
-               	callq	 <L156>
-<L156>:
-               	movq	%rax, %rdi
-               	jmp	 <L159>
-<L157>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L158>
-<L158>:
-               	movq	%rax, %rdi
-<L159>:
+               	movq	%rax, %rcx
+               	callq	 <L57>
+<L57>:
                	movsd	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1]
                	addsd	%xmm13, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L161>
-               	movq	%rdi, %rcx
-               	callq	 <L160>
-<L160>:
-               	movq	%rax, %rsi
-               	jmp	 <L163>
-<L161>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L162>
-<L162>:
-               	movq	%rax, %rsi
-<L163>:
+               	movq	%rax, %rcx
+               	callq	 <L58>
+<L58>:
                	ucomisd	%xmm13, %xmm10
                	seta	%dl
                	movzbq	%dl, %rdx
-               	movq	%rsi, %rcx
-               	callq	 <L164>
-<L164>:
+               	movq	%rax, %rcx
+               	callq	 <L59>
+<L59>:
                	xorps	%xmm1, %xmm1
                	subsd	%xmm13, %xmm1
                	ucomisd	%xmm11, %xmm1
                	seta	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L165>
-<L165>:
-               	movq	%rax, %rsi
+               	callq	 <L60>
+<L60>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	subsd	%xmm10, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L167>
-               	movq	%rsi, %rcx
-               	callq	 <L166>
-<L166>:
-               	movq	%rax, %rdi
-               	jmp	 <L169>
-<L167>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L168>
-<L168>:
-               	movq	%rax, %rdi
-<L169>:
+               	movq	%rax, %rcx
+               	callq	 <L61>
+<L61>:
                	movsd	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1]
                	addsd	%xmm10, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L171>
-               	movq	%rdi, %rcx
-               	callq	 <L170>
-<L170>:
-               	movq	%rax, %rsi
-               	jmp	 <L173>
-<L171>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L172>
-<L172>:
-               	movq	%rax, %rsi
-<L173>:
+               	movq	%rax, %rcx
+               	callq	 <L62>
+<L62>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	mulsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L175>
-               	movq	%rsi, %rcx
-               	callq	 <L174>
-<L174>:
-               	movq	%rax, %rdi
-               	jmp	 <L177>
-<L175>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L176>
-<L176>:
-               	movq	%rax, %rdi
-<L177>:
+               	movq	%rax, %rcx
+               	callq	 <L63>
+<L63>:
                	movsd	%xmm11, %xmm1           # xmm1 = xmm11[0],xmm1[1]
                	mulsd	%xmm9, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L179>
-               	movq	%rdi, %rcx
-               	callq	 <L178>
-<L178>:
-               	movq	%rax, %rsi
-               	jmp	 <L181>
-<L179>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L180>
-<L180>:
-               	movq	%rax, %rsi
-<L181>:
+               	movq	%rax, %rcx
+               	callq	 <L64>
+<L64>:
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
                	divsd	%xmm10, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L183>
-               	movq	%rsi, %rcx
-               	callq	 <L182>
-<L182>:
-               	movq	%rax, %rdi
-               	jmp	 <L185>
-<L183>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L184>
-<L184>:
-               	movq	%rax, %rdi
-<L185>:
+               	movq	%rax, %rcx
+               	callq	 <L65>
+<L65>:
                	movsd	%xmm8, %xmm1            # xmm1 = xmm8[0],xmm1[1]
                	divsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L187>
-               	movq	%rdi, %rcx
-               	callq	 <L186>
-<L186>:
-               	movq	%rax, %rsi
-               	jmp	 <L189>
-<L187>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L188>
-<L188>:
-               	movq	%rax, %rsi
-<L189>:
+               	movq	%rax, %rcx
+               	callq	 <L66>
+<L66>:
                	movsd	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1]
                	divsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L191>
-               	movq	%rsi, %rcx
-               	callq	 <L190>
-<L190>:
-               	movq	%rax, %rdi
-               	jmp	 <L193>
-<L191>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L192>
-<L192>:
-               	movq	%rax, %rdi
-<L193>:
+               	movq	%rax, %rcx
+               	callq	 <L67>
+<L67>:
                	movq	%xmm12, %rdx
-               	movq	%rdi, %rcx
-               	callq	 <L194>
-<L194>:
+               	movq	%rax, %rcx
+               	callq	 <L68>
+<L68>:
                	ucomisd	%xmm12, %xmm12
                	setne	%dl
                	setp	%r11b
                	orb	%r11b, %dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L195>
-<L195>:
+               	callq	 <L69>
+<L69>:
                	ucomisd	%xmm12, %xmm12
                	sete	%dl
                	setnp	%r11b
                	andb	%r11b, %dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L196>
-<L196>:
+               	callq	 <L70>
+<L70>:
                	ucomisd	%xmm12, %xmm12
                	seta	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L197>
-<L197>:
+               	callq	 <L71>
+<L71>:
                	ucomisd	%xmm12, %xmm12
                	setae	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L198>
-<L198>:
+               	callq	 <L72>
+<L72>:
                	movsd	%xmm12, %xmm7           # xmm7 = xmm12[0],xmm7[1]
-               	xorps	, %xmm7 <corpus.cases.float.special_f64.checksum+0xef6>
+               	xorps	, %xmm7 <corpus.cases.float.special_f64.checksum+0x666>
                	movq	%xmm7, %rdx
                	movq	%rax, %rcx
-               	callq	 <L199>
-<L199>:
+               	callq	 <L73>
+<L73>:
                	movsd	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1]
-               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0xf0e>
+               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x67e>
                	movq	%xmm1, %rdx
                	movq	%rax, %rcx
-               	callq	 <L200>
-<L200>:
-               	movq	%rax, %rsi
+               	callq	 <L74>
+<L74>:
                	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
                	addsd	%xmm6, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L202>
-               	movq	%rsi, %rcx
-               	callq	 <L201>
-<L201>:
-               	movq	%rax, %rdi
-               	jmp	 <L204>
-<L202>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L203>
-<L203>:
-               	movq	%rax, %rdi
-<L204>:
+               	movq	%rax, %rcx
+               	callq	 <L75>
+<L75>:
                	movsd	%xmm6, %xmm1            # xmm1 = xmm6[0],xmm1[1]
                	addsd	%xmm12, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L206>
-               	movq	%rdi, %rcx
-               	callq	 <L205>
-<L205>:
-               	movq	%rax, %rsi
-               	jmp	 <L208>
-<L206>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L207>
-<L207>:
-               	movq	%rax, %rsi
-<L208>:
+               	movq	%rax, %rcx
+               	callq	 <L76>
+<L76>:
                	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
                	mulsd	%xmm8, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L210>
-               	movq	%rsi, %rcx
-               	callq	 <L209>
-<L209>:
-               	movq	%rax, %rdi
-               	jmp	 <L212>
-<L210>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L211>
-<L211>:
-               	movq	%rax, %rdi
-<L212>:
+               	movq	%rax, %rcx
+               	callq	 <L77>
+<L77>:
                	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
                	subsd	%xmm12, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L214>
-               	movq	%rdi, %rcx
-               	callq	 <L213>
-<L213>:
-               	movq	%rax, %rsi
-               	jmp	 <L216>
-<L214>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L215>
-<L215>:
-               	movq	%rax, %rsi
-<L216>:
+               	movq	%rax, %rcx
+               	callq	 <L78>
+<L78>:
                	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
                	divsd	%xmm12, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L218>
-               	movq	%rsi, %rcx
-               	callq	 <L217>
-<L217>:
-               	movq	%rax, %rdi
-               	jmp	 <L220>
-<L218>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L219>
-<L219>:
-               	movq	%rax, %rdi
-<L220>:
+               	movq	%rax, %rcx
+               	callq	 <L79>
+<L79>:
                	movsd	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1]
                	divsd	%xmm10, %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L222>
-               	movq	%rdi, %rcx
-               	callq	 <L221>
-<L221>:
-               	movq	%rax, %rsi
-               	jmp	 <L224>
-<L222>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L223>
-<L223>:
-               	movq	%rax, %rsi
-<L224>:
-               	movsd	-0x78(%rbp), %xmm14
-               	ucomisd	-0x78(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L226>
-               	movq	%rsi, %rcx
+               	movq	%rax, %rcx
+               	callq	 <L80>
+<L80>:
+               	movq	%rax, %rcx
                	movsd	-0x78(%rbp), %xmm1
-               	callq	 <L225>
-<L225>:
-               	movq	%rax, %rdi
-               	jmp	 <L228>
-<L226>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L227>
-<L227>:
-               	movq	%rax, %rdi
-<L228>:
-               	movsd	-0x68(%rbp), %xmm14
-               	ucomisd	-0x68(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L230>
-               	movq	%rdi, %rcx
+               	callq	 <L81>
+<L81>:
+               	movq	%rax, %rcx
                	movsd	-0x68(%rbp), %xmm1
-               	callq	 <L229>
-<L229>:
-               	movq	%rax, %rsi
-               	jmp	 <L232>
-<L230>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L231>
-<L231>:
-               	movq	%rax, %rsi
-<L232>:
-               	movsd	-0x58(%rbp), %xmm14
-               	ucomisd	-0x58(%rbp), %xmm14
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L234>
-               	movq	%rsi, %rcx
+               	callq	 <L82>
+<L82>:
+               	movq	%rax, %rcx
                	movsd	-0x58(%rbp), %xmm1
-               	callq	 <L233>
-<L233>:
-               	movq	%rax, %rdi
-               	jmp	 <L236>
-<L234>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L235>
-<L235>:
-               	movq	%rax, %rdi
-<L236>:
+               	callq	 <L83>
+<L83>:
                	movsd	-0x68(%rbp), %xmm1
                	addsd	-0x78(%rbp), %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L238>
-               	movq	%rdi, %rcx
-               	callq	 <L237>
-<L237>:
-               	movq	%rax, %rsi
-               	jmp	 <L240>
-<L238>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L239>
-<L239>:
-               	movq	%rax, %rsi
-<L240>:
+               	movq	%rax, %rcx
+               	callq	 <L84>
+<L84>:
                	movsd	-0x58(%rbp), %xmm1
                	subsd	-0x78(%rbp), %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L242>
-               	movq	%rsi, %rcx
-               	callq	 <L241>
-<L241>:
-               	movq	%rax, %rdi
-               	jmp	 <L244>
-<L242>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L243>
-<L243>:
-               	movq	%rax, %rdi
-<L244>:
+               	movq	%rax, %rcx
+               	callq	 <L85>
+<L85>:
                	movsd	-0x78(%rbp), %xmm1
                	addsd	-0x78(%rbp), %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L246>
-               	movq	%rdi, %rcx
-               	callq	 <L245>
-<L245>:
-               	movq	%rax, %rsi
-               	jmp	 <L248>
-<L246>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L247>
-<L247>:
-               	movq	%rax, %rsi
-<L248>:
+               	movq	%rax, %rcx
+               	callq	 <L86>
+<L86>:
                	movsd	-0x78(%rbp), %xmm1
-               	mulsd	, %xmm1 <corpus.cases.float.special_f64.checksum+0x127a>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L250>
-               	movq	%rsi, %rcx
-               	callq	 <L249>
-<L249>:
-               	movq	%rax, %rdi
-               	jmp	 <L252>
-<L250>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L251>
-<L251>:
-               	movq	%rax, %rdi
-<L252>:
+               	mulsd	, %xmm1 <corpus.cases.float.special_f64.checksum+0x75f>
+               	movq	%rax, %rcx
+               	callq	 <L87>
+<L87>:
                	movsd	-0x78(%rbp), %xmm1
-               	mulsd	, %xmm1 <corpus.cases.float.special_f64.checksum+0x12c3>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L254>
-               	movq	%rdi, %rcx
-               	callq	 <L253>
-<L253>:
-               	movq	%rax, %rsi
-               	jmp	 <L256>
-<L254>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L255>
-<L255>:
-               	movq	%rax, %rsi
-<L256>:
+               	mulsd	, %xmm1 <corpus.cases.float.special_f64.checksum+0x774>
+               	movq	%rax, %rcx
+               	callq	 <L88>
+<L88>:
                	movsd	-0x78(%rbp), %xmm1
-               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x130b>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L258>
-               	movq	%rsi, %rcx
-               	callq	 <L257>
-<L257>:
-               	movq	%rax, %rdi
-               	jmp	 <L260>
-<L258>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L259>
-<L259>:
-               	movq	%rax, %rdi
-<L260>:
+               	xorps	, %xmm1 <corpus.cases.float.special_f64.checksum+0x788>
+               	movq	%rax, %rcx
+               	callq	 <L89>
+<L89>:
                	movsd	-0x78(%rbp), %xmm1
-               	mulsd	, %xmm1 <corpus.cases.float.special_f64.checksum+0x1354>
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L262>
-               	movq	%rdi, %rcx
-               	callq	 <L261>
-<L261>:
-               	movq	%rax, %rsi
-               	jmp	 <L264>
-<L262>:
-               	movq	%rdi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L263>
-<L263>:
-               	movq	%rax, %rsi
-<L264>:
+               	mulsd	, %xmm1 <corpus.cases.float.special_f64.checksum+0x79d>
+               	movq	%rax, %rcx
+               	callq	 <L90>
+<L90>:
                	movsd	-0x68(%rbp), %xmm1
                	divsd	-0x58(%rbp), %xmm1
-               	ucomisd	%xmm1, %xmm1
-               	setne	%al
-               	setp	%r11b
-               	orb	%r11b, %al
-               	movzbq	%al, %rax
-               	testb	%al, %al
-               	jne	 <L266>
-               	movq	%rsi, %rcx
-               	callq	 <L265>
-<L265>:
-               	movq	%rax, %rdi
-               	jmp	 <L268>
-<L266>:
-               	movq	%rsi, %rcx
-               	movq	$-0x1, %rdx
-               	callq	 <L267>
-<L267>:
-               	movq	%rax, %rdi
-<L268>:
+               	movq	%rax, %rcx
+               	callq	 <L91>
+<L91>:
                	movsd	-0x78(%rbp), %xmm14
                	ucomisd	%xmm8, %xmm14
                	seta	%dl
                	movzbq	%dl, %rdx
-               	movq	%rdi, %rcx
-               	callq	 <L269>
-<L269>:
+               	movq	%rax, %rcx
+               	callq	 <L92>
+<L92>:
                	movsd	-0x78(%rbp), %xmm14
                	ucomisd	%xmm8, %xmm14
                	sete	%dl
@@ -1534,51 +584,51 @@ Disassembly of section .text:
                	andb	%r11b, %dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L270>
-<L270>:
+               	callq	 <L93>
+<L93>:
                	xorps	%xmm1, %xmm1
                	subsd	-0x78(%rbp), %xmm1
                	ucomisd	%xmm1, %xmm9
                	seta	%dl
                	movzbq	%dl, %rdx
                	movq	%rax, %rcx
-               	callq	 <L271>
-<L271>:
+               	callq	 <L94>
+<L94>:
                	movq	%rax, %rsi
                	movsd	-0x58(%rbp), %xmm7
                	movq	$0x0, %rdi
                	cmpq	$0x3c, %rdi
-               	jb	 <L272>
-               	jmp	 <L277>
-<L272>:
+               	jb	 <L95>
+               	jmp	 <L100>
+<L95>:
                	movsd	%xmm7, %xmm10           # xmm10 = xmm7[0],xmm10[1]
-               	mulsd	, %xmm10 <corpus.cases.float.special_f64.checksum+0x1459>
+               	mulsd	, %xmm10 <corpus.cases.float.special_f64.checksum+0x83a>
                	ucomisd	%xmm10, %xmm10
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L274>
+               	jne	 <L97>
                	movq	%rsi, %rcx
                	movsd	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1]
-               	callq	 <L273>
-<L273>:
+               	callq	 <L96>
+<L96>:
                	movq	%rax, %r12
-               	jmp	 <L276>
-<L274>:
+               	jmp	 <L99>
+<L97>:
                	movq	%rsi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L275>
-<L275>:
+               	callq	 <L98>
+<L98>:
                	movq	%rax, %r12
-<L276>:
+<L99>:
                	addq	$0x1, %rdi
                	movq	%r12, %rsi
                	movsd	%xmm10, %xmm7           # xmm7 = xmm10[0],xmm7[1]
                	cmpq	$0x3c, %rdi
-               	jb	 <L272>
-<L277>:
+               	jb	 <L95>
+<L100>:
                	leaq	-0x40(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
@@ -1612,22 +662,22 @@ Disassembly of section .text:
                	movq	%r11, (%rax)
                	movq	$0x0, %r12
                	cmpq	$0x8, %r12
-               	jb	 <L278>
-               	jmp	 <L280>
-<L278>:
+               	jb	 <L101>
+               	jmp	 <L103>
+<L101>:
                	leaq	(%rdi,%r12,8), %rax
                	movq	(%rax), %rcx
                	addq	%rbx, %rcx
                	movq	%rcx, %xmm0
                	movq	%xmm0, %rdx
                	movq	%rsi, %rcx
-               	callq	 <L279>
-<L279>:
+               	callq	 <L102>
+<L102>:
                	addq	$0x1, %r12
                	movq	%rax, %rsi
                	cmpq	$0x8, %r12
-               	jb	 <L278>
-<L280>:
+               	jb	 <L101>
+<L103>:
                	cvtsd2ss	%xmm13, %xmm0
                	movsd	-0x78(%rbp), %xmm15
                	cvtsd2ss	%xmm15, %xmm7
@@ -1648,32 +698,32 @@ Disassembly of section .text:
                	cvtsd2ss	%xmm11, %xmm9
                	movq	%rsi, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L281>
-<L281>:
+               	callq	 <L104>
+<L104>:
                	movq	%rax, %rcx
                	movss	%xmm7, %xmm1            # xmm1 = xmm7[0],xmm1[1,2,3]
-               	callq	 <L282>
-<L282>:
+               	callq	 <L105>
+<L105>:
                	movq	%rax, %rcx
                	movss	%xmm10, %xmm1           # xmm1 = xmm10[0],xmm1[1,2,3]
-               	callq	 <L283>
-<L283>:
+               	callq	 <L106>
+<L106>:
                	movq	%rax, %rcx
                	movss	%xmm12, %xmm1           # xmm1 = xmm12[0],xmm1[1,2,3]
-               	callq	 <L284>
-<L284>:
+               	callq	 <L107>
+<L107>:
                	movq	%rax, %rcx
                	movss	%xmm13, %xmm1           # xmm1 = xmm13[0],xmm1[1,2,3]
-               	callq	 <L285>
-<L285>:
+               	callq	 <L108>
+<L108>:
                	movq	%rax, %rcx
                	movss	-0x88(%rbp), %xmm1
-               	callq	 <L286>
-<L286>:
+               	callq	 <L109>
+<L109>:
                	movq	%rax, %rcx
                	movss	%xmm9, %xmm1            # xmm1 = xmm9[0],xmm1[1,2,3]
-               	callq	 <L287>
-<L287>:
+               	callq	 <L110>
+<L110>:
                	movq	%rax, %rsi
                	cvtss2sd	%xmm10, %xmm1
                	ucomisd	%xmm1, %xmm1
@@ -1682,19 +732,19 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L289>
+               	jne	 <L112>
                	movq	%rsi, %rcx
-               	callq	 <L288>
-<L288>:
+               	callq	 <L111>
+<L111>:
                	movq	%rax, %rdi
-               	jmp	 <L291>
-<L289>:
+               	jmp	 <L114>
+<L112>:
                	movq	%rsi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L290>
-<L290>:
+               	callq	 <L113>
+<L113>:
                	movq	%rax, %rdi
-<L291>:
+<L114>:
                	movss	-0x88(%rbp), %xmm15
                	cvtss2sd	%xmm15, %xmm1
                	ucomisd	%xmm1, %xmm1
@@ -1703,19 +753,19 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L293>
+               	jne	 <L116>
                	movq	%rdi, %rcx
-               	callq	 <L292>
-<L292>:
+               	callq	 <L115>
+<L115>:
                	movq	%rax, %rsi
-               	jmp	 <L295>
-<L293>:
+               	jmp	 <L118>
+<L116>:
                	movq	%rdi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L294>
-<L294>:
+               	callq	 <L117>
+<L117>:
                	movq	%rax, %rsi
-<L295>:
+<L118>:
                	cvtss2sd	%xmm9, %xmm1
                	ucomisd	%xmm1, %xmm1
                	setne	%al
@@ -1723,19 +773,19 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L297>
+               	jne	 <L120>
                	movq	%rsi, %rcx
-               	callq	 <L296>
-<L296>:
+               	callq	 <L119>
+<L119>:
                	movq	%rax, %rdi
-               	jmp	 <L299>
-<L297>:
+               	jmp	 <L122>
+<L120>:
                	movq	%rsi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L298>
-<L298>:
+               	callq	 <L121>
+<L121>:
                	movq	%rax, %rdi
-<L299>:
+<L122>:
                	movabsq	$0x20000000000000, %rax # imm = 0x20000000000000
                	addq	%rbx, %rax
                	movabsq	$0x20000000000001, %rsi # imm = 0x20000000000001
@@ -1750,168 +800,168 @@ Disassembly of section .text:
                	addq	%rbx, %r15
                	movq	%rax, %r11
                	testq	%r11, %r11
-               	jl	 <L300>
+               	jl	 <L123>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L301>
-<L300>:
+               	jmp	 <L124>
+<L123>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L301>:
+<L124>:
                	ucomisd	%xmm1, %xmm1
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L303>
+               	jne	 <L126>
                	movq	%rdi, %rcx
-               	callq	 <L302>
-<L302>:
+               	callq	 <L125>
+<L125>:
                	movq	%rax, %r8
                	movq	%r8, -0x48(%rbp)
-               	jmp	 <L305>
-<L303>:
+               	jmp	 <L128>
+<L126>:
                	movq	%rdi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L304>
-<L304>:
+               	callq	 <L127>
+<L127>:
                	movq	%rax, %r8
                	movq	%r8, -0x48(%rbp)
-<L305>:
+<L128>:
                	movq	%rsi, %r11
                	testq	%r11, %r11
-               	jl	 <L306>
+               	jl	 <L129>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L307>
-<L306>:
+               	jmp	 <L130>
+<L129>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L307>:
+<L130>:
                	ucomisd	%xmm1, %xmm1
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L309>
+               	jne	 <L132>
                	movq	-0x48(%rbp), %r8
                	movq	%r8, %rcx
-               	callq	 <L308>
-<L308>:
+               	callq	 <L131>
+<L131>:
                	movq	%rax, %rsi
-               	jmp	 <L311>
-<L309>:
+               	jmp	 <L134>
+<L132>:
                	movq	-0x48(%rbp), %r8
                	movq	%r8, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L310>
-<L310>:
+               	callq	 <L133>
+<L133>:
                	movq	%rax, %rsi
-<L311>:
+<L134>:
                	movq	%r12, %r11
                	testq	%r11, %r11
-               	jl	 <L312>
+               	jl	 <L135>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L313>
-<L312>:
+               	jmp	 <L136>
+<L135>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L313>:
+<L136>:
                	ucomisd	%xmm1, %xmm1
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L315>
+               	jne	 <L138>
                	movq	%rsi, %rcx
-               	callq	 <L314>
-<L314>:
+               	callq	 <L137>
+<L137>:
                	movq	%rax, %rdi
-               	jmp	 <L317>
-<L315>:
+               	jmp	 <L140>
+<L138>:
                	movq	%rsi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L316>
-<L316>:
+               	callq	 <L139>
+<L139>:
                	movq	%rax, %rdi
-<L317>:
+<L140>:
                	movq	%r13, %r11
                	testq	%r11, %r11
-               	jl	 <L318>
+               	jl	 <L141>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L319>
-<L318>:
+               	jmp	 <L142>
+<L141>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L319>:
+<L142>:
                	ucomisd	%xmm1, %xmm1
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L321>
+               	jne	 <L144>
                	movq	%rdi, %rcx
-               	callq	 <L320>
-<L320>:
+               	callq	 <L143>
+<L143>:
                	movq	%rax, %rsi
-               	jmp	 <L323>
-<L321>:
+               	jmp	 <L146>
+<L144>:
                	movq	%rdi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L322>
-<L322>:
+               	callq	 <L145>
+<L145>:
                	movq	%rax, %rsi
-<L323>:
+<L146>:
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L324>
+               	jl	 <L147>
                	cvtsi2sd	%r11, %xmm1
-               	jmp	 <L325>
-<L324>:
+               	jmp	 <L148>
+<L147>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
-<L325>:
+<L148>:
                	ucomisd	%xmm1, %xmm1
                	setne	%al
                	setp	%r11b
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L327>
+               	jne	 <L150>
                	movq	%rsi, %rcx
-               	callq	 <L326>
-<L326>:
+               	callq	 <L149>
+<L149>:
                	movq	%rax, %rbx
-               	jmp	 <L329>
-<L327>:
+               	jmp	 <L152>
+<L150>:
                	movq	%rsi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L328>
-<L328>:
+               	callq	 <L151>
+<L151>:
                	movq	%rax, %rbx
-<L329>:
+<L152>:
                	movq	%r14, %r11
                	cvtsi2sd	%r11, %xmm1
                	ucomisd	%xmm1, %xmm1
@@ -1920,19 +970,19 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L331>
+               	jne	 <L154>
                	movq	%rbx, %rcx
-               	callq	 <L330>
-<L330>:
+               	callq	 <L153>
+<L153>:
                	movq	%rax, %rsi
-               	jmp	 <L333>
-<L331>:
+               	jmp	 <L156>
+<L154>:
                	movq	%rbx, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L332>
-<L332>:
+               	callq	 <L155>
+<L155>:
                	movq	%rax, %rsi
-<L333>:
+<L156>:
                	movq	%r15, %r11
                	cvtsi2sd	%r11, %xmm1
                	ucomisd	%xmm1, %xmm1
@@ -1941,131 +991,131 @@ Disassembly of section .text:
                	orb	%r11b, %al
                	movzbq	%al, %rax
                	testb	%al, %al
-               	jne	 <L335>
+               	jne	 <L158>
                	movq	%rsi, %rcx
-               	callq	 <L334>
-<L334>:
+               	callq	 <L157>
+<L157>:
                	movq	%rax, %rbx
-               	jmp	 <L337>
-<L335>:
+               	jmp	 <L160>
+<L158>:
                	movq	%rsi, %rcx
                	movq	$-0x1, %rdx
-               	callq	 <L336>
-<L336>:
+               	callq	 <L159>
+<L159>:
                	movq	%rax, %rbx
-<L337>:
-               	movsd	, %xmm7 <corpus.cases.float.special_f64.checksum+0x1a38>
+<L160>:
+               	movsd	, %xmm7 <corpus.cases.float.special_f64.checksum+0xe19>
                	mulsd	%xmm6, %xmm7
-               	movsd	, %xmm9 <corpus.cases.float.special_f64.checksum+0x1a45>
+               	movsd	, %xmm9 <corpus.cases.float.special_f64.checksum+0xe26>
                	mulsd	%xmm6, %xmm9
-               	movsd	, %xmm10 <corpus.cases.float.special_f64.checksum+0x1a53>
+               	movsd	, %xmm10 <corpus.cases.float.special_f64.checksum+0xe34>
                	mulsd	%xmm6, %xmm10
                	xorps	%xmm11, %xmm11
                	subsd	%xmm7, %xmm11
-               	movsd	, %xmm12 <corpus.cases.float.special_f64.checksum+0x1a6a>
+               	movsd	, %xmm12 <corpus.cases.float.special_f64.checksum+0xe4b>
                	mulsd	%xmm6, %xmm12
-               	ucomisd	, %xmm7 <corpus.cases.float.special_f64.checksum+0x1a77>
-               	jb	 <L338>
+               	ucomisd	, %xmm7 <corpus.cases.float.special_f64.checksum+0xe58>
+               	jb	 <L161>
                	movaps	%xmm7, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1a8a>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xe6b>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L339>
-<L338>:
+               	jmp	 <L162>
+<L161>:
                	cvttsd2si	%xmm7, %r11
-<L339>:
+<L162>:
                	movq	%r11, %rdx
                	movq	%rbx, %rcx
-               	callq	 <L340>
-<L340>:
-               	ucomisd	, %xmm9 <corpus.cases.float.special_f64.checksum+0x1aba>
-               	jb	 <L341>
+               	callq	 <L163>
+<L163>:
+               	ucomisd	, %xmm9 <corpus.cases.float.special_f64.checksum+0xe9b>
+               	jb	 <L164>
                	movaps	%xmm9, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1acd>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xeae>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L342>
-<L341>:
+               	jmp	 <L165>
+<L164>:
                	cvttsd2si	%xmm9, %r11
-<L342>:
+<L165>:
                	movq	%r11, %rdx
                	movq	%rax, %rcx
-               	callq	 <L343>
-<L343>:
-               	ucomisd	, %xmm10 <corpus.cases.float.special_f64.checksum+0x1afd>
-               	jb	 <L344>
+               	callq	 <L166>
+<L166>:
+               	ucomisd	, %xmm10 <corpus.cases.float.special_f64.checksum+0xede>
+               	jb	 <L167>
                	movaps	%xmm10, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1b10>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xef1>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L345>
-<L344>:
+               	jmp	 <L168>
+<L167>:
                	cvttsd2si	%xmm10, %r11
-<L345>:
+<L168>:
                	movq	%r11, %rdx
                	movq	%rax, %rcx
-               	callq	 <L346>
-<L346>:
-               	ucomisd	, %xmm12 <corpus.cases.float.special_f64.checksum+0x1b40>
-               	jb	 <L347>
+               	callq	 <L169>
+<L169>:
+               	ucomisd	, %xmm12 <corpus.cases.float.special_f64.checksum+0xf21>
+               	jb	 <L170>
                	movaps	%xmm12, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1b53>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xf34>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L348>
-<L347>:
+               	jmp	 <L171>
+<L170>:
                	cvttsd2si	%xmm12, %r11
-<L348>:
+<L171>:
                	movq	%r11, %rdx
                	movq	%rax, %rcx
-               	callq	 <L349>
-<L349>:
-               	ucomisd	, %xmm8 <corpus.cases.float.special_f64.checksum+0x1b83>
-               	jb	 <L350>
+               	callq	 <L172>
+<L172>:
+               	ucomisd	, %xmm8 <corpus.cases.float.special_f64.checksum+0xf64>
+               	jb	 <L173>
                	movaps	%xmm8, %xmm14
-               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0x1b96>
+               	subsd	, %xmm14 <corpus.cases.float.special_f64.checksum+0xf77>
                	cvttsd2si	%xmm14, %r11
                	movabsq	$-0x8000000000000000, %r10 # imm = 0x8000000000000000
                	addq	%r10, %r11
-               	jmp	 <L351>
-<L350>:
+               	jmp	 <L174>
+<L173>:
                	cvttsd2si	%xmm8, %r11
-<L351>:
+<L174>:
                	movq	%r11, %rdx
                	movq	%rax, %rcx
-               	callq	 <L352>
-<L352>:
+               	callq	 <L175>
+<L175>:
                	cvttsd2si	%xmm11, %r11
                	movq	%r11, %rdx
                	movq	%rax, %rcx
-               	callq	 <L353>
-<L353>:
+               	callq	 <L176>
+<L176>:
                	cvttsd2si	%xmm10, %r11
                	movq	%r11, %rdx
                	movq	%rax, %rcx
-               	callq	 <L354>
-<L354>:
+               	callq	 <L177>
+<L177>:
                	xorps	%xmm0, %xmm0
                	subsd	%xmm12, %xmm0
                	cvttsd2si	%xmm0, %r11
                	movq	%r11, %rdx
                	movq	%rax, %rcx
-               	callq	 <L355>
-<L355>:
+               	callq	 <L178>
+<L178>:
                	cvttsd2si	%xmm11, %r11d
                	movl	%r11d, %edx
                	movq	%rax, %rcx
-               	callq	 <L356>
-<L356>:
+               	callq	 <L179>
+<L179>:
                	cvttsd2si	%xmm7, %r11
                	movl	%r11d, %edx
                	movq	%rax, %rcx
-               	callq	 <L357>
-<L357>:
+               	callq	 <L180>
+<L180>:
                	movaps	-0xe0(%rbp), %xmm6
                	movaps	-0xf0(%rbp), %xmm7
                	movaps	-0x100(%rbp), %xmm8

--- a/test/golden/x86_64-windows/frame/frame_align.dis
+++ b/test/golden/x86_64-windows/frame/frame_align.dis
@@ -5,10 +5,13 @@ Disassembly of section .text:
 <corpus.cases.frame.frame_align.fold_f32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movss	(%rdx), %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
@@ -32,6 +35,8 @@ Disassembly of section .text:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L3>
 <L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
@@ -40,10 +45,13 @@ Disassembly of section .text:
 <corpus.cases.frame.frame_align.fold_f64x2>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movsd	(%rdx), %xmm1
                	callq	 <L0>
@@ -53,6 +61,8 @@ Disassembly of section .text:
                	movsd	(%rdx), %xmm1
                	callq	 <L1>
 <L1>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
@@ -61,11 +71,14 @@ Disassembly of section .text:
 <corpus.cases.frame.frame_align.fold_u32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movl	(%rdx), %esi
                	movl	%esi, %edx
@@ -89,6 +102,8 @@ Disassembly of section .text:
                	movl	%ebx, %edx
                	callq	 <L3>
 <L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -102,7 +117,7 @@ Disassembly of section .text:
                	movq	%rbx, -0x58(%rbp)
                	movaps	%xmm14, -0x70(%rbp)
                	movaps	%xmm15, -0x80(%rbp)
-               	movaps	%xmm0, %xmm1
+               	movups	(%rcx), %xmm1
                	leaq	-0x7(%rbp), %rax
                	movl	$0x0, (%rax)
                	movw	$0x0, 0x4(%rax)
@@ -173,27 +188,27 @@ Disassembly of section .text:
                	pushq	%rbp
                	movq	%rsp, %rbp
                	andq	$-0x40, %rsp
-               	subq	$0x400, %rsp            # imm = 0x400
-               	movq	%rbx, 0xd8(%rsp)
-               	movq	%rdi, 0xd0(%rsp)
-               	movq	%rsi, 0xc8(%rsp)
-               	movq	%r12, 0xc0(%rsp)
-               	movq	%r13, 0xb8(%rsp)
-               	movq	%r14, 0xb0(%rsp)
-               	movq	%r15, 0xa8(%rsp)
-               	movaps	%xmm6, 0x90(%rsp)
-               	movaps	%xmm7, 0x80(%rsp)
-               	movaps	%xmm8, 0x70(%rsp)
-               	movaps	%xmm9, 0x60(%rsp)
-               	movaps	%xmm10, 0x50(%rsp)
-               	movaps	%xmm14, 0x40(%rsp)
-               	movaps	%xmm15, 0x30(%rsp)
+               	subq	$0x440, %rsp            # imm = 0x440
+               	movq	%rbx, 0xe8(%rsp)
+               	movq	%rdi, 0xe0(%rsp)
+               	movq	%rsi, 0xd8(%rsp)
+               	movq	%r12, 0xd0(%rsp)
+               	movq	%r13, 0xc8(%rsp)
+               	movq	%r14, 0xc0(%rsp)
+               	movq	%r15, 0xb8(%rsp)
+               	movaps	%xmm6, 0xa0(%rsp)
+               	movaps	%xmm7, 0x90(%rsp)
+               	movaps	%xmm8, 0x80(%rsp)
+               	movaps	%xmm9, 0x70(%rsp)
+               	movaps	%xmm10, 0x60(%rsp)
+               	movaps	%xmm14, 0x50(%rsp)
+               	movaps	%xmm15, 0x40(%rsp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
                	movq	%rax, %r8
-               	movq	%r8, 0x120(%rsp)
-               	movq	0x120(%rsp), %r8
+               	movq	%r8, 0x130(%rsp)
+               	movq	0x130(%rsp), %r8
                	movq	%rbx, %r11
                	testq	%r11, %r11
                	jl	 <L1>
@@ -220,23 +235,23 @@ Disassembly of section .text:
                	cvtsi2sd	%r11, %xmm1
                	addsd	%xmm1, %xmm1
 <L4>:
-               	leaq	0x3f0(%rsp), %rsi
+               	leaq	0x430(%rsp), %rsi
                	leaq	(%rsi), %rdi
                	movl	$0x3fc00000, (%rdi)     # imm = 0x3FC00000
-               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x101>
-               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x108>
+               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x104>
+               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x10b>
                	leaq	0x4(%rsi), %rdi
                	movss	%xmm2, (%rdi)
                	leaq	0x8(%rsi), %rdi
                	movl	$0x40700000, (%rdi)     # imm = 0x40700000
-               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x122>
-               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x129>
+               	movss	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x125>
+               	xorps	, %xmm2 <corpus.cases.frame.frame_align.checksum+0x12c>
                	leaq	0xc(%rsi), %rdi
                	movss	%xmm2, (%rdi)
                	movups	(%rsi), %xmm2
-               	leaq	0x3e0(%rsp), %rsi
+               	leaq	0x420(%rsp), %rsi
                	movups	%xmm2, (%rsi)
-               	leaq	0x3d0(%rsp), %rdi
+               	leaq	0x410(%rsp), %rdi
                	leaq	(%rdi), %r12
                	movabsq	$0x3ff4000000000000, %r11 # imm = 0x3FF4000000000000
                	movq	%r11, (%r12)
@@ -244,9 +259,9 @@ Disassembly of section .text:
                	movabsq	$-0x3ff4000000000000, %r11 # imm = 0xC00C000000000000
                	movq	%r11, (%r12)
                	movups	(%rdi), %xmm3
-               	leaq	0x3c0(%rsp), %rdi
+               	leaq	0x400(%rsp), %rdi
                	movups	%xmm3, (%rdi)
-               	leaq	0x3b0(%rsp), %r12
+               	leaq	0x3f0(%rsp), %r12
                	leaq	(%r12), %r13
                	movl	$0xffffffff, (%r13)     # imm = 0xFFFFFFFF
                	leaq	0x4(%r12), %r13
@@ -256,9 +271,9 @@ Disassembly of section .text:
                	leaq	0xc(%r12), %r13
                	movl	$0x12345678, (%r13)     # imm = 0x12345678
                	movups	(%r12), %xmm4
-               	leaq	0x3a0(%rsp), %r12
+               	leaq	0x3e0(%rsp), %r12
                	movups	%xmm4, (%r12)
-               	leaq	0x390(%rsp), %r13
+               	leaq	0x3d0(%rsp), %r13
                	leaq	(%r13), %r14
                	movabsq	$0x3fe0000000000000, %r11 # imm = 0x3FE0000000000000
                	movq	%r11, (%r14)
@@ -266,9 +281,9 @@ Disassembly of section .text:
                	movabsq	$0x4019000000000000, %r11 # imm = 0x4019000000000000
                	movq	%r11, (%r14)
                	movups	(%r13), %xmm6
-               	leaq	0x380(%rsp), %r13
+               	leaq	0x3c0(%rsp), %r13
                	movups	%xmm6, (%r13)
-               	leaq	0x370(%rsp), %r14
+               	leaq	0x3b0(%rsp), %r14
                	leaq	(%r14), %r15
                	movl	$0xc2b2ae3d, (%r15)     # imm = 0xC2B2AE3D
                	leaq	0x4(%r14), %r15
@@ -278,9 +293,9 @@ Disassembly of section .text:
                	leaq	0xc(%r14), %r15
                	movl	$0xfffffffb, (%r15)     # imm = 0xFFFFFFFB
                	movups	(%r14), %xmm7
-               	leaq	0x360(%rsp), %r14
+               	leaq	0x3a0(%rsp), %r14
                	movups	%xmm7, (%r14)
-               	leaq	0x280(%rsp), %r15
+               	leaq	0x2c0(%rsp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
                	movq	$0x0, 0x10(%r15)
@@ -305,53 +320,53 @@ Disassembly of section .text:
                	movq	$0x0, 0xa8(%r15)
                	movq	$0x0, 0xb0(%r15)
                	movq	$0x0, 0xb8(%r15)
-               	leaq	0x240(%rsp), %r8
-               	movq	%r8, 0x128(%rsp)
-               	movq	0x128(%rsp), %r8
+               	leaq	0x280(%rsp), %r8
+               	movq	%r8, 0x138(%rsp)
+               	movq	0x138(%rsp), %r8
                	movq	$0x0, (%r8)
-               	movq	0x128(%rsp), %r8
+               	movq	0x138(%rsp), %r8
                	movq	$0x0, 0x8(%r8)
-               	movq	0x128(%rsp), %r8
+               	movq	0x138(%rsp), %r8
                	movq	$0x0, 0x10(%r8)
-               	movq	0x128(%rsp), %r8
+               	movq	0x138(%rsp), %r8
                	movq	$0x0, 0x18(%r8)
-               	movq	0x128(%rsp), %r8
+               	movq	0x138(%rsp), %r8
                	movq	$0x0, 0x20(%r8)
-               	movq	0x128(%rsp), %r8
+               	movq	0x138(%rsp), %r8
                	movq	$0x0, 0x28(%r8)
-               	movq	0x128(%rsp), %r8
+               	movq	0x138(%rsp), %r8
                	movq	$0x0, 0x30(%r8)
-               	movq	0x128(%rsp), %r8
+               	movq	0x138(%rsp), %r8
                	movq	$0x0, 0x38(%r8)
                	movq	%rbx, %rcx
                	addq	$0x1, %rcx
                	movb	%cl, %r8b
-               	movq	%r8, 0x118(%rsp)
+               	movq	%r8, 0x128(%rsp)
                	movq	%rbx, %rcx
                	addq	$0x3, %rcx
                	movb	%cl, %r8b
-               	movq	%r8, 0x110(%rsp)
+               	movq	%r8, 0x120(%rsp)
                	movq	%rbx, %rcx
                	addq	$0x5, %rcx
                	movb	%cl, %r8b
-               	movq	%r8, 0x108(%rsp)
+               	movq	%r8, 0x118(%rsp)
                	movq	%rbx, %rcx
                	addq	$0x7, %rcx
                	movb	%cl, %r8b
-               	movq	%r8, 0x100(%rsp)
+               	movq	%r8, 0x110(%rsp)
                	movq	%rbx, %rcx
                	addq	$0xfff1, %rcx           # imm = 0xFFF1
                	movw	%cx, %r8w
-               	movq	%r8, 0xf8(%rsp)
+               	movq	%r8, 0x108(%rsp)
                	movq	%rbx, %rcx
                	addq	$0xfb, %rcx
                	movb	%cl, %r8b
-               	movq	%r8, 0xf0(%rsp)
+               	movq	%r8, 0x100(%rsp)
                	leaq	(%rsi), %rcx
                	movss	(%rcx), %xmm5
                	movss	%xmm5, %xmm8            # xmm8 = xmm5[0],xmm8[1,2,3]
                	addss	%xmm0, %xmm8
-               	leaq	0x230(%rsp), %rsi
+               	leaq	0x270(%rsp), %rsi
                	movups	%xmm2, (%rsi)
                	leaq	(%rsi), %rcx
                	movss	%xmm8, (%rcx)
@@ -360,7 +375,7 @@ Disassembly of section .text:
                	movsd	(%rcx), %xmm0
                	movsd	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1]
                	addsd	%xmm1, %xmm2
-               	leaq	0x220(%rsp), %rdi
+               	leaq	0x260(%rsp), %rdi
                	movups	%xmm3, (%rdi)
                	leaq	0x8(%rdi), %rcx
                	movsd	%xmm2, (%rcx)
@@ -369,18 +384,18 @@ Disassembly of section .text:
                	movl	(%rcx), %r12d
                	movl	%ebx, %ecx
                	addl	%ecx, %r12d
-               	leaq	0x210(%rsp), %r8
-               	movq	%r8, 0xe8(%rsp)
-               	movq	0xe8(%rsp), %r8
+               	leaq	0x250(%rsp), %r8
+               	movq	%r8, 0xf8(%rsp)
+               	movq	0xf8(%rsp), %r8
                	movups	%xmm4, (%r8)
-               	movq	0xe8(%rsp), %r8
+               	movq	0xf8(%rsp), %r8
                	leaq	0x8(%r8), %rcx
                	movl	%r12d, (%rcx)
-               	movq	0xe8(%rsp), %r8
+               	movq	0xf8(%rsp), %r8
                	movups	(%r8), %xmm10
                	leaq	(%rsi), %rcx
                	movss	(%rcx), %xmm0
-               	movq	0x120(%rsp), %r8
+               	movq	0x130(%rsp), %r8
                	movq	%r8, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L5>
@@ -414,28 +429,28 @@ Disassembly of section .text:
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rcx
-               	movq	0xe8(%rsp), %r8
+               	movq	0xf8(%rsp), %r8
                	leaq	(%r8), %rsi
                	movl	(%rsi), %edi
                	movl	%edi, %edx
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rcx
-               	movq	0xe8(%rsp), %r8
+               	movq	0xf8(%rsp), %r8
                	leaq	0x4(%r8), %rsi
                	movl	(%rsi), %edi
                	movl	%edi, %edx
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rcx
-               	movq	0xe8(%rsp), %r8
+               	movq	0xf8(%rsp), %r8
                	leaq	0x8(%r8), %rsi
                	movl	(%rsi), %edi
                	movl	%edi, %edx
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rcx
-               	movq	0xe8(%rsp), %r8
+               	movq	0xf8(%rsp), %r8
                	leaq	0xc(%r8), %rsi
                	movl	(%rsi), %edi
                	movl	%edi, %edx
@@ -445,7 +460,7 @@ Disassembly of section .text:
                	movaps	%xmm8, %xmm14
                	addps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x1f0(%rsp), %rsi
+               	leaq	0x230(%rsp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
                	movss	(%rdi), %xmm0
@@ -474,7 +489,7 @@ Disassembly of section .text:
                	movaps	%xmm8, %xmm14
                	mulps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x1e0(%rsp), %rsi
+               	leaq	0x220(%rsp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
                	movss	(%rdi), %xmm0
@@ -513,7 +528,7 @@ Disassembly of section .text:
                	movaps	%xmm9, %xmm14
                	mulpd	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x1d0(%rsp), %rsi
+               	leaq	0x210(%rsp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
                	movsd	(%rdi), %xmm1
@@ -528,7 +543,7 @@ Disassembly of section .text:
                	movaps	%xmm9, %xmm14
                	subpd	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x1c0(%rsp), %rsi
+               	leaq	0x200(%rsp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
                	movsd	(%rdi), %xmm1
@@ -543,7 +558,7 @@ Disassembly of section .text:
                	movaps	%xmm9, %xmm14
                	divpd	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x1b0(%rsp), %rsi
+               	leaq	0x1f0(%rsp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
                	movsd	(%rdi), %xmm1
@@ -579,55 +594,55 @@ Disassembly of section .text:
                	callq	 <L34>
 <L34>:
                	movq	%rax, %r8
-               	movq	%r8, 0xe0(%rsp)
-               	movq	0xe0(%rsp), %r8
-               	movq	0xe8(%rsp), %r8
+               	movq	%r8, 0xf0(%rsp)
+               	movq	0xf0(%rsp), %r8
+               	movq	0xf8(%rsp), %r8
                	leaq	(%r8), %rsi
                	movl	(%rsi), %edi
                	leaq	(%r14), %rsi
                	movl	(%rsi), %r12d
                	imull	%r12d, %edi
-               	movq	0xe8(%rsp), %r8
+               	movq	0xf8(%rsp), %r8
                	leaq	0x4(%r8), %rsi
                	movl	(%rsi), %r12d
                	leaq	0x4(%r14), %rsi
                	movl	(%rsi), %r13d
                	imull	%r13d, %r12d
-               	movq	0xe8(%rsp), %r8
+               	movq	0xf8(%rsp), %r8
                	leaq	0x8(%r8), %rsi
                	movl	(%rsi), %r13d
                	leaq	0x8(%r14), %rsi
                	movl	(%rsi), %ecx
                	imull	%ecx, %r13d
-               	movq	0xe8(%rsp), %r8
+               	movq	0xf8(%rsp), %r8
                	leaq	0xc(%r8), %rcx
                	movl	(%rcx), %esi
                	leaq	0xc(%r14), %rcx
                	movl	(%rcx), %r14d
                	imull	%r14d, %esi
-               	leaq	0x1a0(%rsp), %rcx
+               	leaq	0x1e0(%rsp), %rcx
                	movups	%xmm10, (%rcx)
                	leaq	(%rcx), %r14
                	movl	%edi, (%r14)
                	movups	(%rcx), %xmm0
-               	leaq	0x190(%rsp), %rcx
+               	leaq	0x1d0(%rsp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdi
                	movl	%r12d, (%rdi)
                	movups	(%rcx), %xmm0
-               	leaq	0x180(%rsp), %rcx
+               	leaq	0x1c0(%rsp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdi
                	movl	%r13d, (%rdi)
                	movups	(%rcx), %xmm0
-               	leaq	0x170(%rsp), %rdi
+               	leaq	0x1b0(%rsp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	0xc(%rdi), %rcx
                	movl	%esi, (%rcx)
                	movups	(%rdi), %xmm0
                	leaq	(%rdi), %rcx
                	movl	(%rcx), %esi
-               	movq	0xe0(%rsp), %r8
+               	movq	0xf0(%rsp), %r8
                	movq	%r8, %rcx
                	movl	%esi, %edx
                	callq	 <L35>
@@ -654,7 +669,7 @@ Disassembly of section .text:
                	movaps	%xmm10, %xmm14
                	paddd	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	0x160(%rsp), %rsi
+               	leaq	0x1a0(%rsp), %rsi
                	movups	%xmm0, (%rsi)
                	leaq	(%rsi), %rdi
                	movl	(%rdi), %r12d
@@ -683,7 +698,7 @@ Disassembly of section .text:
                	movaps	%xmm10, %xmm14
                	pxor	%xmm7, %xmm14
                	movaps	%xmm14, %xmm10
-               	leaq	0x150(%rsp), %rsi
+               	leaq	0x190(%rsp), %rsi
                	movups	%xmm10, (%rsi)
                	leaq	(%rsi), %rdi
                	movl	(%rdi), %r12d
@@ -709,10 +724,11 @@ Disassembly of section .text:
                	callq	 <L46>
 <L46>:
                	movq	%rax, %rsi
-               	movaps	%xmm8, %xmm0
+               	movups	%xmm8, 0x180(%rsp)
+               	leaq	0x180(%rsp), %rcx
                	callq	 <L47>
 <L47>:
-               	leaq	0x140(%rsp), %rdi
+               	leaq	0x170(%rsp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	(%rdi), %rcx
                	movss	(%rcx), %xmm0
@@ -742,9 +758,11 @@ Disassembly of section .text:
                	movaps	%xmm8, %xmm14
                	mulps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
+               	movups	%xmm0, 0x160(%rsp)
+               	leaq	0x160(%rsp), %rcx
                	callq	 <L52>
 <L52>:
-               	leaq	0x130(%rsp), %rdi
+               	leaq	0x150(%rsp), %rdi
                	movups	%xmm0, (%rdi)
                	leaq	(%rdi), %rcx
                	movss	(%rcx), %xmm0
@@ -771,25 +789,26 @@ Disassembly of section .text:
                	callq	 <L56>
 <L56>:
                	movq	%rax, %rsi
-               	movq	0x128(%rsp), %r8
+               	movq	0x138(%rsp), %r8
                	leaq	(%r8), %rcx
                	movups	%xmm8, (%rcx)
                	movaps	%xmm8, %xmm14
                	addps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	movq	0x128(%rsp), %r8
+               	movq	0x138(%rsp), %r8
                	leaq	0x10(%r8), %rcx
                	movups	%xmm0, (%rcx)
-               	movaps	%xmm8, %xmm0
+               	movups	%xmm8, 0x140(%rsp)
+               	leaq	0x140(%rsp), %rcx
                	callq	 <L57>
 <L57>:
-               	movq	0x128(%rsp), %r8
+               	movq	0x138(%rsp), %r8
                	leaq	0x20(%r8), %rcx
                	movups	%xmm0, (%rcx)
                	movaps	%xmm8, %xmm14
                	mulps	%xmm8, %xmm14
                	movaps	%xmm14, %xmm8
-               	movq	0x128(%rsp), %r8
+               	movq	0x138(%rsp), %r8
                	leaq	0x30(%r8), %rcx
                	movups	%xmm8, (%rcx)
                	movq	$0x0, %rdi
@@ -799,10 +818,10 @@ Disassembly of section .text:
 <L58>:
                	movq	%rdi, %rcx
                	imulq	$0x10, %rcx, %rcx
-               	movq	0x128(%rsp), %r8
+               	movq	0x138(%rsp), %r8
                	leaq	(%r8,%rcx), %r12
                	movups	(%r12), %xmm0
-               	leaq	0x200(%rsp), %r12
+               	leaq	0x240(%rsp), %r12
                	movups	%xmm0, (%r12)
                	leaq	(%r12), %rcx
                	movss	(%rcx), %xmm0
@@ -897,7 +916,7 @@ Disassembly of section .text:
                	jb	 <L68>
 <L71>:
                	movq	%rbx, %rcx
-               	movq	0x118(%rsp), %r8
+               	movq	0x128(%rsp), %r8
                	movq	%r8, %rdx
                	callq	 <L72>
 <L72>:
@@ -906,46 +925,46 @@ Disassembly of section .text:
                	callq	 <L73>
 <L73>:
                	movq	%rax, %rcx
-               	movq	0x110(%rsp), %r8
+               	movq	0x120(%rsp), %r8
                	movq	%r8, %rdx
                	callq	 <L74>
 <L74>:
                	movq	%rax, %rcx
-               	movq	0x108(%rsp), %r8
+               	movq	0x118(%rsp), %r8
                	movq	%r8, %rdx
                	callq	 <L75>
 <L75>:
                	movq	%rax, %rcx
-               	movq	0x100(%rsp), %r8
+               	movq	0x110(%rsp), %r8
                	movq	%r8, %rdx
                	callq	 <L76>
 <L76>:
                	movq	%rax, %rcx
-               	movq	0xf8(%rsp), %r8
+               	movq	0x108(%rsp), %r8
                	movq	%r8, %rdx
                	callq	 <L77>
 <L77>:
                	movq	%rax, %rcx
-               	movq	0xf0(%rsp), %r8
+               	movq	0x100(%rsp), %r8
                	movq	%r8, %rdx
                	callq	 <L78>
 <L78>:
                	movq	%rax, %rcx
                	movq	%rcx, %rax
-               	movaps	0x90(%rsp), %xmm6
-               	movaps	0x80(%rsp), %xmm7
-               	movaps	0x70(%rsp), %xmm8
-               	movaps	0x60(%rsp), %xmm9
-               	movaps	0x50(%rsp), %xmm10
-               	movaps	0x40(%rsp), %xmm14
-               	movaps	0x30(%rsp), %xmm15
-               	movq	0xd8(%rsp), %rbx
-               	movq	0xd0(%rsp), %rdi
-               	movq	0xc8(%rsp), %rsi
-               	movq	0xc0(%rsp), %r12
-               	movq	0xb8(%rsp), %r13
-               	movq	0xb0(%rsp), %r14
-               	movq	0xa8(%rsp), %r15
+               	movaps	0xa0(%rsp), %xmm6
+               	movaps	0x90(%rsp), %xmm7
+               	movaps	0x80(%rsp), %xmm8
+               	movaps	0x70(%rsp), %xmm9
+               	movaps	0x60(%rsp), %xmm10
+               	movaps	0x50(%rsp), %xmm14
+               	movaps	0x40(%rsp), %xmm15
+               	movq	0xe8(%rsp), %rbx
+               	movq	0xe0(%rsp), %rdi
+               	movq	0xd8(%rsp), %rsi
+               	movq	0xd0(%rsp), %r12
+               	movq	0xc8(%rsp), %r13
+               	movq	0xc0(%rsp), %r14
+               	movq	0xb8(%rsp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/mem/global_data.dis
+++ b/test/golden/x86_64-windows/mem/global_data.dis
@@ -265,10 +265,16 @@ Disassembly of section .text:
                	divq	%rsi
                	movq	%rdx, %rsi
                	leaq	(%rbx,%rsi,2), %rdi
-               	movzwl	(%rdi), %ebx
-               	addl	$0x64, %ebx
-               	movw	%bx, (%rdi)
-               	leaq	, %rbx <corpus.cases.mem.global_data.advance+0x1e8>
+               	movzwl	(%rdi), %esi
+               	addl	$0x64, %esi
+               	movq	%rcx, %rax
+               	movq	$0x3, %rdi
+               	xorl	%edx, %edx
+               	divq	%rdi
+               	movq	%rdx, %rdi
+               	leaq	(%rbx,%rdi,2), %r12
+               	movw	%si, (%r12)
+               	leaq	, %rbx <corpus.cases.mem.global_data.advance+0x200>
                	movl	(%rbx), %esi
                	movl	%ecx, %edi
                	subl	%edi, %esi
@@ -289,16 +295,16 @@ Disassembly of section .text:
 <corpus.cases.mem.global_data.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x130, %rsp            # imm = 0x130
-               	movq	%rbx, -0xb8(%rbp)
-               	movq	%rdi, -0xc0(%rbp)
-               	movq	%rsi, -0xc8(%rbp)
-               	movq	%r12, -0xd0(%rbp)
-               	movq	%r13, -0xd8(%rbp)
-               	movq	%r14, -0xe0(%rbp)
-               	movq	%r15, -0xe8(%rbp)
-               	movaps	%xmm14, -0x100(%rbp)
-               	movaps	%xmm15, -0x110(%rbp)
+               	subq	$0x140, %rsp            # imm = 0x140
+               	movq	%rbx, -0xc8(%rbp)
+               	movq	%rdi, -0xd0(%rbp)
+               	movq	%rsi, -0xd8(%rbp)
+               	movq	%r12, -0xe0(%rbp)
+               	movq	%r13, -0xe8(%rbp)
+               	movq	%r14, -0xf0(%rbp)
+               	movq	%r15, -0xf8(%rbp)
+               	movaps	%xmm14, -0x110(%rbp)
+               	movaps	%xmm15, -0x120(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -474,20 +480,31 @@ Disassembly of section .text:
                	movq	%r8, -0x98(%rbp)
                	movq	-0x98(%rbp), %r8
                	movzwl	(%r8), %ecx
-               	addl	$0x64, %ecx
-               	movq	-0x98(%rbp), %r8
-               	movw	%cx, (%r8)
-               	movq	-0x18(%rbp), %r9
-               	movl	(%r9), %r8d
+               	movl	%ecx, %r8d
+               	addl	$0x64, %r8d
                	movq	%r8, -0xa0(%rbp)
                	movq	-0x30(%rbp), %r8
-               	movl	%r8d, %ecx
+               	movq	%r8, %rax
+               	movq	$0x3, %rcx
+               	xorl	%edx, %edx
+               	divq	%rcx
+               	movq	%rdx, %rcx
+               	leaq	(%r15,%rcx,2), %r8
+               	movq	%r8, -0xa8(%rbp)
+               	movq	-0xa8(%rbp), %r8
                	movq	-0xa0(%rbp), %r9
+               	movw	%r9w, (%r8)
+               	movq	-0x18(%rbp), %r9
+               	movl	(%r9), %r8d
+               	movq	%r8, -0xb0(%rbp)
+               	movq	-0x30(%rbp), %r8
+               	movl	%r8d, %ecx
+               	movq	-0xb0(%rbp), %r9
                	movl	%r9d, %r8d
                	subl	%ecx, %r8d
-               	movq	%r8, -0xa8(%rbp)
+               	movq	%r8, -0xb8(%rbp)
                	movq	-0x18(%rbp), %r8
-               	movq	-0xa8(%rbp), %r9
+               	movq	-0xb8(%rbp), %r9
                	movl	%r9d, (%r8)
                	movq	-0x20(%rbp), %r8
                	movq	%r8, %rcx
@@ -500,11 +517,11 @@ Disassembly of section .text:
                	cmpq	$0x5, %rsi
                	jb	 <L5>
 <L9>:
-               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x3bd>
+               	movq	, %rcx <corpus.cases.mem.global_data.checksum+0x3f0>
                	movabsq	$-0x61c8864680b583eb, %r11 # imm = 0x9E3779B97F4A7C15
                	xorq	%r11, %rcx
-               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x3d1>
-               	movq	, %rbx <corpus.cases.mem.global_data.checksum+0x3d8>
+               	movq	%rcx,  <corpus.cases.mem.global_data.checksum+0x404>
+               	movq	, %rbx <corpus.cases.mem.global_data.checksum+0x40b>
                	movq	-0x20(%rbp), %r8
                	movq	%r8, %rcx
                	movq	%rbx, %rdx
@@ -512,23 +529,23 @@ Disassembly of section .text:
 <L10>:
                	movq	%rax, %rcx
                	leaq	-0x10(%rbp), %rbx
-               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x3f5>
+               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x428>
                	movq	%rsi, (%rbx)
-               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x407>
+               	movq	, %rsi <corpus.cases.mem.global_data.checksum+0x43a>
                	movq	%rsi, 0x8(%rbx)
                	leaq	0x8(%rbx), %rsi
                	movq	(%rsi), %rdi
                	addq	$0x1, %rdi
                	movq	%rdi, (%rsi)
                	movq	(%rbx), %rsi
-               	movq	%rsi,  <corpus.cases.mem.global_data.checksum+0x41b>
+               	movq	%rsi,  <corpus.cases.mem.global_data.checksum+0x44e>
                	movq	0x8(%rbx), %rsi
-               	movq	%rsi,  <corpus.cases.mem.global_data.checksum+0x42e>
-               	leaq	, %rbx <corpus.cases.mem.global_data.checksum+0x42d>
+               	movq	%rsi,  <corpus.cases.mem.global_data.checksum+0x461>
+               	leaq	, %rbx <corpus.cases.mem.global_data.checksum+0x460>
                	movzwl	(%rbx), %esi
-               	leaq	, %rbx <corpus.cases.mem.global_data.checksum+0x439>
+               	leaq	, %rbx <corpus.cases.mem.global_data.checksum+0x46c>
                	movzbl	(%rbx), %edi
-               	leaq	, %rbx <corpus.cases.mem.global_data.checksum+0x449>
+               	leaq	, %rbx <corpus.cases.mem.global_data.checksum+0x47c>
                	movq	(%rbx), %r12
                	movq	%rsi, %rdx
                	callq	 <L11>
@@ -546,15 +563,15 @@ Disassembly of section .text:
 <L14>:
                	movq	%rax, %rcx
                	movq	%rcx, %rax
-               	movaps	-0x100(%rbp), %xmm14
-               	movaps	-0x110(%rbp), %xmm15
-               	movq	-0xb8(%rbp), %rbx
-               	movq	-0xc0(%rbp), %rdi
-               	movq	-0xc8(%rbp), %rsi
-               	movq	-0xd0(%rbp), %r12
-               	movq	-0xd8(%rbp), %r13
-               	movq	-0xe0(%rbp), %r14
-               	movq	-0xe8(%rbp), %r15
+               	movaps	-0x110(%rbp), %xmm14
+               	movaps	-0x120(%rbp), %xmm15
+               	movq	-0xc8(%rbp), %rbx
+               	movq	-0xd0(%rbp), %rdi
+               	movq	-0xd8(%rbp), %rsi
+               	movq	-0xe0(%rbp), %r12
+               	movq	-0xe8(%rbp), %r13
+               	movq	-0xf0(%rbp), %r14
+               	movq	-0xf8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/mem/loadstore.dis
+++ b/test/golden/x86_64-windows/mem/loadstore.dis
@@ -78,14 +78,14 @@ Disassembly of section .text:
 <corpus.cases.mem.loadstore.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x90, %rsp
-               	movq	%rbx, -0x38(%rbp)
-               	movq	%rdi, -0x40(%rbp)
-               	movq	%rsi, -0x48(%rbp)
-               	movq	%r12, -0x50(%rbp)
-               	movq	%r13, -0x58(%rbp)
-               	movq	%r14, -0x60(%rbp)
-               	movq	%r15, -0x68(%rbp)
+               	subq	$0xe0, %rsp
+               	movq	%rbx, -0x88(%rbp)
+               	movq	%rdi, -0x90(%rbp)
+               	movq	%rsi, -0x98(%rbp)
+               	movq	%r12, -0xa0(%rbp)
+               	movq	%r13, -0xa8(%rbp)
+               	movq	%r14, -0xb0(%rbp)
+               	movq	%r15, -0xb8(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -95,7 +95,13 @@ Disassembly of section .text:
                	movq	$0x0, 0x8(%rsi)
                	movq	$0x0, 0x10(%rsi)
                	movq	%rdx, %rcx
-               	movq	%rsi, %rdx
+               	movq	(%rsi), %rdx
+               	movq	%rdx, -0x30(%rbp)
+               	movq	0x8(%rsi), %rdx
+               	movq	%rdx, -0x28(%rbp)
+               	movq	0x10(%rsi), %rdx
+               	movq	%rdx, -0x20(%rbp)
+               	leaq	-0x30(%rbp), %rdx
                	callq	 <L1>
 <L1>:
                	movq	%rax, %rdx
@@ -133,7 +139,13 @@ Disassembly of section .text:
                	leaq	0x10(%rsi), %r12
                	movq	%rdi, (%r12)
                	movq	%rdx, %rcx
-               	movq	%rsi, %rdx
+               	movq	(%rsi), %rdx
+               	movq	%rdx, -0x48(%rbp)
+               	movq	0x8(%rsi), %rdx
+               	movq	%rdx, -0x40(%rbp)
+               	movq	0x10(%rsi), %rdx
+               	movq	%rdx, -0x38(%rbp)
+               	leaq	-0x48(%rbp), %rdx
                	callq	 <L2>
 <L2>:
                	movq	%rax, %r12
@@ -159,7 +171,13 @@ Disassembly of section .text:
                	leaq	0x8(%rsi), %rax
                	movl	%edx, (%rax)
                	movq	%r12, %rcx
-               	movq	%rsi, %rdx
+               	movq	(%rsi), %rax
+               	movq	%rax, -0x60(%rbp)
+               	movq	0x8(%rsi), %rax
+               	movq	%rax, -0x58(%rbp)
+               	movq	0x10(%rsi), %rax
+               	movq	%rax, -0x50(%rbp)
+               	leaq	-0x60(%rbp), %rdx
                	callq	 <L4>
 <L4>:
                	movq	%rax, %r12
@@ -183,7 +201,7 @@ Disassembly of section .text:
                	movq	%r13, %rax
                	shrq	$0x10, %rax
                	movl	%eax, %r8d
-               	movq	%r8, -0x30(%rbp)
+               	movq	%r8, -0x78(%rbp)
                	movq	%r12, %rcx
                	movq	%r14, %rdx
                	callq	 <L7>
@@ -193,7 +211,7 @@ Disassembly of section .text:
                	callq	 <L8>
 <L8>:
                	movq	%rax, %rcx
-               	movq	-0x30(%rbp), %r8
+               	movq	-0x78(%rbp), %r8
                	movl	%r8d, %edx
                	callq	 <L9>
 <L9>:
@@ -209,7 +227,7 @@ Disassembly of section .text:
                	movq	%rax, %rcx
                	callq	 <L12>
 <L12>:
-               	movq	-0x30(%rbp), %r8
+               	movq	-0x78(%rbp), %r8
                	movslq	%r8d, %rdx
                	movq	%rax, %rcx
                	callq	 <L13>
@@ -222,7 +240,7 @@ Disassembly of section .text:
                	movq	%rax, %rcx
                	callq	 <L15>
 <L15>:
-               	movq	-0x30(%rbp), %r8
+               	movq	-0x78(%rbp), %r8
                	movl	%r8d, %edx
                	movq	%rax, %rcx
                	callq	 <L16>
@@ -231,7 +249,7 @@ Disassembly of section .text:
                	cmpq	$0x6, %rsi
                	jb	 <L6>
 <L17>:
-               	leaq	-0x28(%rbp), %rbx
+               	leaq	-0x70(%rbp), %rbx
                	movq	$0x0, (%rbx)
                	movq	$0x0, 0x8(%rbx)
                	movq	$0x0, %rax
@@ -280,13 +298,13 @@ Disassembly of section .text:
                	movq	%rdi, %rdx
                	callq	 <L24>
 <L24>:
-               	movq	-0x38(%rbp), %rbx
-               	movq	-0x40(%rbp), %rdi
-               	movq	-0x48(%rbp), %rsi
-               	movq	-0x50(%rbp), %r12
-               	movq	-0x58(%rbp), %r13
-               	movq	-0x60(%rbp), %r14
-               	movq	-0x68(%rbp), %r15
+               	movq	-0x88(%rbp), %rbx
+               	movq	-0x90(%rbp), %rdi
+               	movq	-0x98(%rbp), %rsi
+               	movq	-0xa0(%rbp), %r12
+               	movq	-0xa8(%rbp), %r13
+               	movq	-0xb0(%rbp), %r14
+               	movq	-0xb8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/mem/rec_layout.dis
+++ b/test/golden/x86_64-windows/mem/rec_layout.dis
@@ -405,14 +405,14 @@ Disassembly of section .text:
 <corpus.cases.mem.rec_layout.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xd0, %rsp
-               	movq	%rbx, -0x78(%rbp)
-               	movq	%rdi, -0x80(%rbp)
-               	movq	%rsi, -0x88(%rbp)
-               	movq	%r12, -0x90(%rbp)
-               	movq	%r13, -0x98(%rbp)
-               	movq	%r14, -0xa0(%rbp)
-               	movq	%r15, -0xa8(%rbp)
+               	subq	$0x340, %rsp            # imm = 0x340
+               	movq	%rbx, -0x2e8(%rbp)
+               	movq	%rdi, -0x2f0(%rbp)
+               	movq	%rsi, -0x2f8(%rbp)
+               	movq	%r12, -0x300(%rbp)
+               	movq	%r13, -0x308(%rbp)
+               	movq	%r14, -0x310(%rbp)
+               	movq	%r15, -0x318(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -498,7 +498,29 @@ Disassembly of section .text:
                	movq	$0x0, 0x40(%rdi)
                	movq	$0x0, 0x48(%rdi)
                	movq	$0x0, 0x50(%rdi)
-               	movq	%rdi, %rdx
+               	movq	(%rdi), %rdx
+               	movq	%rdx, -0xb0(%rbp)
+               	movq	0x8(%rdi), %rdx
+               	movq	%rdx, -0xa8(%rbp)
+               	movq	0x10(%rdi), %rdx
+               	movq	%rdx, -0xa0(%rbp)
+               	movq	0x18(%rdi), %rdx
+               	movq	%rdx, -0x98(%rbp)
+               	movq	0x20(%rdi), %rdx
+               	movq	%rdx, -0x90(%rbp)
+               	movq	0x28(%rdi), %rdx
+               	movq	%rdx, -0x88(%rbp)
+               	movq	0x30(%rdi), %rdx
+               	movq	%rdx, -0x80(%rbp)
+               	movq	0x38(%rdi), %rdx
+               	movq	%rdx, -0x78(%rbp)
+               	movq	0x40(%rdi), %rdx
+               	movq	%rdx, -0x70(%rbp)
+               	movq	0x48(%rdi), %rdx
+               	movq	%rdx, -0x68(%rbp)
+               	movq	0x50(%rdi), %rdx
+               	movq	%rdx, -0x60(%rbp)
+               	leaq	-0xb0(%rbp), %rdx
                	callq	 <L18>
 <L18>:
                	leaq	(%rdi), %rcx
@@ -610,7 +632,29 @@ Disassembly of section .text:
                	leaq	0x50(%rdi), %rbx
                	movl	%ecx, (%rbx)
                	movq	%rax, %rcx
-               	movq	%rdi, %rdx
+               	movq	(%rdi), %rax
+               	movq	%rax, -0x108(%rbp)
+               	movq	0x8(%rdi), %rax
+               	movq	%rax, -0x100(%rbp)
+               	movq	0x10(%rdi), %rax
+               	movq	%rax, -0xf8(%rbp)
+               	movq	0x18(%rdi), %rax
+               	movq	%rax, -0xf0(%rbp)
+               	movq	0x20(%rdi), %rax
+               	movq	%rax, -0xe8(%rbp)
+               	movq	0x28(%rdi), %rax
+               	movq	%rax, -0xe0(%rbp)
+               	movq	0x30(%rdi), %rax
+               	movq	%rax, -0xd8(%rbp)
+               	movq	0x38(%rdi), %rax
+               	movq	%rax, -0xd0(%rbp)
+               	movq	0x40(%rdi), %rax
+               	movq	%rax, -0xc8(%rbp)
+               	movq	0x48(%rdi), %rax
+               	movq	%rax, -0xc0(%rbp)
+               	movq	0x50(%rdi), %rax
+               	movq	%rax, -0xb8(%rbp)
+               	leaq	-0x108(%rbp), %rdx
                	callq	 <L19>
 <L19>:
                	leaq	(%rdi), %rsi
@@ -621,7 +665,29 @@ Disassembly of section .text:
                	xorl	$0xf0f0f0f0, %edx       # imm = 0xF0F0F0F0
                	movl	%edx, (%rcx)
                	movq	%rax, %rcx
-               	movq	%rdi, %rdx
+               	movq	(%rdi), %rax
+               	movq	%rax, -0x160(%rbp)
+               	movq	0x8(%rdi), %rax
+               	movq	%rax, -0x158(%rbp)
+               	movq	0x10(%rdi), %rax
+               	movq	%rax, -0x150(%rbp)
+               	movq	0x18(%rdi), %rax
+               	movq	%rax, -0x148(%rbp)
+               	movq	0x20(%rdi), %rax
+               	movq	%rax, -0x140(%rbp)
+               	movq	0x28(%rdi), %rax
+               	movq	%rax, -0x138(%rbp)
+               	movq	0x30(%rdi), %rax
+               	movq	%rax, -0x130(%rbp)
+               	movq	0x38(%rdi), %rax
+               	movq	%rax, -0x128(%rbp)
+               	movq	0x40(%rdi), %rax
+               	movq	%rax, -0x120(%rbp)
+               	movq	0x48(%rdi), %rax
+               	movq	%rax, -0x118(%rbp)
+               	movq	0x50(%rdi), %rax
+               	movq	%rax, -0x110(%rbp)
+               	leaq	-0x160(%rbp), %rdx
                	callq	 <L20>
 <L20>:
                	leaq	0x28(%rdi), %r12
@@ -632,7 +698,29 @@ Disassembly of section .text:
                	addl	$0x7, %edx
                	movb	%dl, (%rcx)
                	movq	%rax, %rcx
-               	movq	%rdi, %rdx
+               	movq	(%rdi), %rax
+               	movq	%rax, -0x1b8(%rbp)
+               	movq	0x8(%rdi), %rax
+               	movq	%rax, -0x1b0(%rbp)
+               	movq	0x10(%rdi), %rax
+               	movq	%rax, -0x1a8(%rbp)
+               	movq	0x18(%rdi), %rax
+               	movq	%rax, -0x1a0(%rbp)
+               	movq	0x20(%rdi), %rax
+               	movq	%rax, -0x198(%rbp)
+               	movq	0x28(%rdi), %rax
+               	movq	%rax, -0x190(%rbp)
+               	movq	0x30(%rdi), %rax
+               	movq	%rax, -0x188(%rbp)
+               	movq	0x38(%rdi), %rax
+               	movq	%rax, -0x180(%rbp)
+               	movq	0x40(%rdi), %rax
+               	movq	%rax, -0x178(%rbp)
+               	movq	0x48(%rdi), %rax
+               	movq	%rax, -0x170(%rbp)
+               	movq	0x50(%rdi), %rax
+               	movq	%rax, -0x168(%rbp)
+               	leaq	-0x1b8(%rbp), %rdx
                	callq	 <L21>
 <L21>:
                	leaq	0x18(%rsi), %rcx
@@ -640,17 +728,61 @@ Disassembly of section .text:
                	shrq	$0x3, %rdx
                	movq	%rdx, (%rcx)
                	movq	%rax, %rcx
-               	movq	%rdi, %rdx
+               	movq	(%rdi), %rax
+               	movq	%rax, -0x210(%rbp)
+               	movq	0x8(%rdi), %rax
+               	movq	%rax, -0x208(%rbp)
+               	movq	0x10(%rdi), %rax
+               	movq	%rax, -0x200(%rbp)
+               	movq	0x18(%rdi), %rax
+               	movq	%rax, -0x1f8(%rbp)
+               	movq	0x20(%rdi), %rax
+               	movq	%rax, -0x1f0(%rbp)
+               	movq	0x28(%rdi), %rax
+               	movq	%rax, -0x1e8(%rbp)
+               	movq	0x30(%rdi), %rax
+               	movq	%rax, -0x1e0(%rbp)
+               	movq	0x38(%rdi), %rax
+               	movq	%rax, -0x1d8(%rbp)
+               	movq	0x40(%rdi), %rax
+               	movq	%rax, -0x1d0(%rbp)
+               	movq	0x48(%rdi), %rax
+               	movq	%rax, -0x1c8(%rbp)
+               	movq	0x50(%rdi), %rax
+               	movq	%rax, -0x1c0(%rbp)
+               	leaq	-0x210(%rbp), %rdx
                	callq	 <L22>
 <L22>:
                	movl	(%rbx), %ecx
                	imull	$0x3, %ecx, %ecx
                	movl	%ecx, (%rbx)
                	movq	%rax, %rcx
-               	movq	%rdi, %rdx
+               	movq	(%rdi), %rax
+               	movq	%rax, -0x268(%rbp)
+               	movq	0x8(%rdi), %rax
+               	movq	%rax, -0x260(%rbp)
+               	movq	0x10(%rdi), %rax
+               	movq	%rax, -0x258(%rbp)
+               	movq	0x18(%rdi), %rax
+               	movq	%rax, -0x250(%rbp)
+               	movq	0x20(%rdi), %rax
+               	movq	%rax, -0x248(%rbp)
+               	movq	0x28(%rdi), %rax
+               	movq	%rax, -0x240(%rbp)
+               	movq	0x30(%rdi), %rax
+               	movq	%rax, -0x238(%rbp)
+               	movq	0x38(%rdi), %rax
+               	movq	%rax, -0x230(%rbp)
+               	movq	0x40(%rdi), %rax
+               	movq	%rax, -0x228(%rbp)
+               	movq	0x48(%rdi), %rax
+               	movq	%rax, -0x220(%rbp)
+               	movq	0x50(%rdi), %rax
+               	movq	%rax, -0x218(%rbp)
+               	leaq	-0x268(%rbp), %rdx
                	callq	 <L23>
 <L23>:
-               	leaq	-0x6c(%rbp), %rbx
+               	leaq	-0x27c(%rbp), %rbx
                	leaq	(%r12), %rcx
                	movq	(%rcx), %rdx
                	movq	%rdx, (%rbx)
@@ -735,16 +867,38 @@ Disassembly of section .text:
                	movl	0x10(%rbx), %ecx
                	movl	%ecx, 0x10(%rdx)
                	movq	%rax, %rcx
-               	movq	%rdi, %rdx
+               	movq	(%rdi), %rax
+               	movq	%rax, -0x2d8(%rbp)
+               	movq	0x8(%rdi), %rax
+               	movq	%rax, -0x2d0(%rbp)
+               	movq	0x10(%rdi), %rax
+               	movq	%rax, -0x2c8(%rbp)
+               	movq	0x18(%rdi), %rax
+               	movq	%rax, -0x2c0(%rbp)
+               	movq	0x20(%rdi), %rax
+               	movq	%rax, -0x2b8(%rbp)
+               	movq	0x28(%rdi), %rax
+               	movq	%rax, -0x2b0(%rbp)
+               	movq	0x30(%rdi), %rax
+               	movq	%rax, -0x2a8(%rbp)
+               	movq	0x38(%rdi), %rax
+               	movq	%rax, -0x2a0(%rbp)
+               	movq	0x40(%rdi), %rax
+               	movq	%rax, -0x298(%rbp)
+               	movq	0x48(%rdi), %rax
+               	movq	%rax, -0x290(%rbp)
+               	movq	0x50(%rdi), %rax
+               	movq	%rax, -0x288(%rbp)
+               	leaq	-0x2d8(%rbp), %rdx
                	callq	 <L34>
 <L34>:
-               	movq	-0x78(%rbp), %rbx
-               	movq	-0x80(%rbp), %rdi
-               	movq	-0x88(%rbp), %rsi
-               	movq	-0x90(%rbp), %r12
-               	movq	-0x98(%rbp), %r13
-               	movq	-0xa0(%rbp), %r14
-               	movq	-0xa8(%rbp), %r15
+               	movq	-0x2e8(%rbp), %rbx
+               	movq	-0x2f0(%rbp), %rdi
+               	movq	-0x2f8(%rbp), %rsi
+               	movq	-0x300(%rbp), %r12
+               	movq	-0x308(%rbp), %r13
+               	movq	-0x310(%rbp), %r14
+               	movq	-0x318(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/autovec_loop.dis
+++ b/test/golden/x86_64-windows/vec/autovec_loop.dis
@@ -5,17 +5,17 @@ Disassembly of section .text:
 <corpus.cases.vec.autovec_loop.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x9f0, %rsp            # imm = 0x9F0
-               	movq	%rbx, -0x968(%rbp)
-               	movq	%rdi, -0x970(%rbp)
-               	movq	%rsi, -0x978(%rbp)
-               	movq	%r12, -0x980(%rbp)
-               	movq	%r13, -0x988(%rbp)
-               	movq	%r14, -0x990(%rbp)
-               	movq	%r15, -0x998(%rbp)
-               	movaps	%xmm6, -0x9b0(%rbp)
-               	movaps	%xmm14, -0x9c0(%rbp)
-               	movaps	%xmm15, -0x9d0(%rbp)
+               	subq	$0xa00, %rsp            # imm = 0xA00
+               	movq	%rbx, -0x978(%rbp)
+               	movq	%rdi, -0x980(%rbp)
+               	movq	%rsi, -0x988(%rbp)
+               	movq	%r12, -0x990(%rbp)
+               	movq	%r13, -0x998(%rbp)
+               	movq	%r14, -0x9a0(%rbp)
+               	movq	%r15, -0x9a8(%rbp)
+               	movaps	%xmm6, -0x9c0(%rbp)
+               	movaps	%xmm14, -0x9d0(%rbp)
+               	movaps	%xmm15, -0x9e0(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -645,38 +645,51 @@ Disassembly of section .text:
                	movq	$0x0, 0x80(%rdi)
                	movq	$0x0, 0x88(%rdi)
                	movl	$0x0, 0x90(%rdi)
-               	leaq	(%rbx), %rcx
-               	leaq	(%rbx,%r12,4), %r14
-               	leaq	(%rsi), %r8
-               	movq	%r8, -0x930(%rbp)
-               	leaq	(%rsi,%r12,4), %r8
+               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
+               	cmpq	%r11, %r12
+               	setbe	%cl
+               	movzbq	%cl, %rcx
+               	andl	$0x1, %ecx
+               	andl	$0x1, %ecx
+               	andl	$0x1, %ecx
+               	movl	%ecx, %r8d
+               	andl	$0x1, %r8d
                	movq	%r8, -0x920(%rbp)
-               	leaq	(%rdi), %r8
+               	leaq	(%rbx), %r14
+               	leaq	(%rbx,%r12,4), %r15
+               	leaq	(%rsi), %r8
+               	movq	%r8, -0x938(%rbp)
+               	leaq	(%rsi,%r12,4), %r8
                	movq	%r8, -0x928(%rbp)
-               	leaq	(%rdi,%r12,4), %r15
-               	cmpq	%rcx, %r15
+               	leaq	(%rdi), %r8
+               	movq	%r8, -0x930(%rbp)
+               	leaq	(%rdi,%r12,4), %rcx
+               	cmpq	%r14, %rcx
                	setbe	%r8b
                	movzbq	%r8b, %r8
-               	movq	%r8, -0x938(%rbp)
-               	movq	-0x928(%rbp), %r8
-               	cmpq	%r8, %r14
-               	setbe	%cl
-               	movzbq	%cl, %rcx
-               	movq	-0x938(%rbp), %r8
-               	movl	%r8d, %r14d
-               	orl	%ecx, %r14d
+               	movq	%r8, -0x940(%rbp)
                	movq	-0x930(%rbp), %r8
                	cmpq	%r8, %r15
+               	setbe	%r14b
+               	movzbq	%r14b, %r14
+               	movq	-0x940(%rbp), %r8
+               	movl	%r8d, %r15d
+               	orl	%r14d, %r15d
+               	movq	-0x938(%rbp), %r8
+               	cmpq	%r8, %rcx
+               	setbe	%r14b
+               	movzbq	%r14b, %r14
+               	movq	-0x928(%rbp), %r8
+               	movq	-0x930(%rbp), %r9
+               	cmpq	%r9, %r8
                	setbe	%cl
                	movzbq	%cl, %rcx
+               	orl	%ecx, %r14d
+               	andl	%r14d, %r15d
                	movq	-0x920(%rbp), %r8
-               	movq	-0x928(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setbe	%r15b
-               	movzbq	%r15b, %r15
-               	orl	%r15d, %ecx
-               	andl	%ecx, %r14d
-               	testb	%r14b, %r14b
+               	movl	%r8d, %ecx
+               	andl	%r15d, %ecx
+               	testb	%cl, %cl
                	jne	 <L38>
                	movq	$0x0, %rcx
                	cmpq	%r12, %rcx
@@ -696,40 +709,42 @@ Disassembly of section .text:
                	jb	 <L37>
                	jmp	 <L42>
 <L38>:
-               	movq	%r12, %rcx
-               	subq	$0x4, %rcx
-               	movq	$0x0, %r14
-               	cmpq	%rcx, %r14
-               	jle	 <L39>
+               	movq	$0x0, %rcx
+               	movq	%rcx, %r14
+               	addq	$0x4, %r14
+               	cmpq	%r12, %r14
+               	jbe	 <L39>
                	jmp	 <L40>
 <L39>:
-               	leaq	(%rbx,%r14,4), %r15
-               	movups	(%r15), %xmm0
-               	leaq	(%rsi,%r14,4), %r15
-               	movups	(%r15), %xmm1
+               	leaq	(%rbx,%rcx,4), %r14
+               	movups	(%r14), %xmm0
+               	leaq	(%rsi,%rcx,4), %r14
+               	movups	(%r14), %xmm1
                	movaps	%xmm0, %xmm14
                	mulps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	(%rdi,%r14,4), %r15
-               	movups	%xmm0, (%r15)
+               	leaq	(%rdi,%rcx,4), %r14
+               	movups	%xmm0, (%r14)
+               	addq	$0x4, %rcx
+               	movq	%rcx, %r14
                	addq	$0x4, %r14
-               	cmpq	%rcx, %r14
-               	jle	 <L39>
-<L40>:
                	cmpq	%r12, %r14
+               	jbe	 <L39>
+<L40>:
+               	cmpq	%r12, %rcx
                	jb	 <L41>
                	jmp	 <L42>
 <L41>:
-               	leaq	(%rbx,%r14,4), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rsi,%r14,4), %rcx
-               	movss	(%rcx), %xmm1
+               	leaq	(%rbx,%rcx,4), %r14
+               	movss	(%r14), %xmm0
+               	leaq	(%rsi,%rcx,4), %r14
+               	movss	(%r14), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	mulss	%xmm1, %xmm2
-               	leaq	(%rdi,%r14,4), %rcx
-               	movss	%xmm2, (%rcx)
-               	addq	$0x1, %r14
-               	cmpq	%r12, %r14
+               	leaq	(%rdi,%rcx,4), %r14
+               	movss	%xmm2, (%r14)
+               	addq	$0x1, %rcx
+               	cmpq	%r12, %rcx
                	jb	 <L41>
 <L42>:
                	movq	$0x0, %r14
@@ -768,38 +783,51 @@ Disassembly of section .text:
                	movq	$0x0, 0x80(%rdi)
                	movq	$0x0, 0x88(%rdi)
                	movl	$0x0, 0x90(%rdi)
-               	leaq	(%rbx), %rcx
-               	leaq	(%rbx,%r12,4), %r14
-               	leaq	(%rsi), %r8
-               	movq	%r8, -0x950(%rbp)
-               	leaq	(%rsi,%r12,4), %r8
-               	movq	%r8, -0x940(%rbp)
-               	leaq	(%rdi), %r8
+               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
+               	cmpq	%r11, %r12
+               	setbe	%cl
+               	movzbq	%cl, %rcx
+               	andl	$0x1, %ecx
+               	andl	$0x1, %ecx
+               	andl	$0x1, %ecx
+               	movl	%ecx, %r8d
+               	andl	$0x1, %r8d
                	movq	%r8, -0x948(%rbp)
-               	leaq	(%rdi,%r12,4), %r15
-               	cmpq	%rcx, %r15
+               	leaq	(%rbx), %r14
+               	leaq	(%rbx,%r12,4), %r15
+               	leaq	(%rsi), %r8
+               	movq	%r8, -0x960(%rbp)
+               	leaq	(%rsi,%r12,4), %r8
+               	movq	%r8, -0x950(%rbp)
+               	leaq	(%rdi), %r8
+               	movq	%r8, -0x958(%rbp)
+               	leaq	(%rdi,%r12,4), %rcx
+               	cmpq	%r14, %rcx
                	setbe	%r8b
                	movzbq	%r8b, %r8
-               	movq	%r8, -0x958(%rbp)
-               	movq	-0x948(%rbp), %r8
-               	cmpq	%r8, %r14
-               	setbe	%cl
-               	movzbq	%cl, %rcx
+               	movq	%r8, -0x968(%rbp)
                	movq	-0x958(%rbp), %r8
-               	movl	%r8d, %r14d
-               	orl	%ecx, %r14d
-               	movq	-0x950(%rbp), %r8
                	cmpq	%r8, %r15
+               	setbe	%r14b
+               	movzbq	%r14b, %r14
+               	movq	-0x968(%rbp), %r8
+               	movl	%r8d, %r15d
+               	orl	%r14d, %r15d
+               	movq	-0x960(%rbp), %r8
+               	cmpq	%r8, %rcx
+               	setbe	%r14b
+               	movzbq	%r14b, %r14
+               	movq	-0x950(%rbp), %r8
+               	movq	-0x958(%rbp), %r9
+               	cmpq	%r9, %r8
                	setbe	%cl
                	movzbq	%cl, %rcx
-               	movq	-0x940(%rbp), %r8
-               	movq	-0x948(%rbp), %r9
-               	cmpq	%r9, %r8
-               	setbe	%r15b
-               	movzbq	%r15b, %r15
-               	orl	%r15d, %ecx
-               	andl	%ecx, %r14d
-               	testb	%r14b, %r14b
+               	orl	%ecx, %r14d
+               	andl	%r14d, %r15d
+               	movq	-0x948(%rbp), %r8
+               	movl	%r8d, %ecx
+               	andl	%r15d, %ecx
+               	testb	%cl, %cl
                	jne	 <L47>
                	movq	$0x0, %rcx
                	cmpq	%r12, %rcx
@@ -819,40 +847,42 @@ Disassembly of section .text:
                	jb	 <L46>
                	jmp	 <L51>
 <L47>:
-               	movq	%r12, %rcx
-               	subq	$0x4, %rcx
-               	movq	$0x0, %r14
-               	cmpq	%rcx, %r14
-               	jle	 <L48>
+               	movq	$0x0, %rcx
+               	movq	%rcx, %r14
+               	addq	$0x4, %r14
+               	cmpq	%r12, %r14
+               	jbe	 <L48>
                	jmp	 <L49>
 <L48>:
-               	leaq	(%rbx,%r14,4), %r15
-               	movups	(%r15), %xmm0
-               	leaq	(%rsi,%r14,4), %r15
-               	movups	(%r15), %xmm1
+               	leaq	(%rbx,%rcx,4), %r14
+               	movups	(%r14), %xmm0
+               	leaq	(%rsi,%rcx,4), %r14
+               	movups	(%r14), %xmm1
                	movaps	%xmm0, %xmm14
                	divps	%xmm1, %xmm14
                	movaps	%xmm14, %xmm2
-               	leaq	(%rdi,%r14,4), %r15
-               	movups	%xmm2, (%r15)
+               	leaq	(%rdi,%rcx,4), %r14
+               	movups	%xmm2, (%r14)
+               	addq	$0x4, %rcx
+               	movq	%rcx, %r14
                	addq	$0x4, %r14
-               	cmpq	%rcx, %r14
-               	jle	 <L48>
-<L49>:
                	cmpq	%r12, %r14
+               	jbe	 <L48>
+<L49>:
+               	cmpq	%r12, %rcx
                	jb	 <L50>
                	jmp	 <L51>
 <L50>:
-               	leaq	(%rbx,%r14,4), %rcx
-               	movss	(%rcx), %xmm0
-               	leaq	(%rsi,%r14,4), %rcx
-               	movss	(%rcx), %xmm1
+               	leaq	(%rbx,%rcx,4), %r14
+               	movss	(%r14), %xmm0
+               	leaq	(%rsi,%rcx,4), %r14
+               	movss	(%r14), %xmm1
                	movss	%xmm0, %xmm2            # xmm2 = xmm0[0],xmm2[1,2,3]
                	divss	%xmm1, %xmm2
-               	leaq	(%rdi,%r14,4), %rcx
-               	movss	%xmm2, (%rcx)
-               	addq	$0x1, %r14
-               	cmpq	%r12, %r14
+               	leaq	(%rdi,%rcx,4), %r14
+               	movss	%xmm2, (%r14)
+               	addq	$0x1, %rcx
+               	cmpq	%r12, %rcx
                	jb	 <L50>
 <L51>:
                	movq	$0x0, %rbx
@@ -890,16 +920,16 @@ Disassembly of section .text:
 <L57>:
                	movq	%rax, %rcx
                	movq	%rcx, %rax
-               	movaps	-0x9b0(%rbp), %xmm6
-               	movaps	-0x9c0(%rbp), %xmm14
-               	movaps	-0x9d0(%rbp), %xmm15
-               	movq	-0x968(%rbp), %rbx
-               	movq	-0x970(%rbp), %rdi
-               	movq	-0x978(%rbp), %rsi
-               	movq	-0x980(%rbp), %r12
-               	movq	-0x988(%rbp), %r13
-               	movq	-0x990(%rbp), %r14
-               	movq	-0x998(%rbp), %r15
+               	movaps	-0x9c0(%rbp), %xmm6
+               	movaps	-0x9d0(%rbp), %xmm14
+               	movaps	-0x9e0(%rbp), %xmm15
+               	movq	-0x978(%rbp), %rbx
+               	movq	-0x980(%rbp), %rdi
+               	movq	-0x988(%rbp), %rsi
+               	movq	-0x990(%rbp), %r12
+               	movq	-0x998(%rbp), %r13
+               	movq	-0x9a0(%rbp), %r14
+               	movq	-0x9a8(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_cmp_select.dis
+++ b/test/golden/x86_64-windows/vec/vec_cmp_select.dis
@@ -5,11 +5,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_select.fold_u8x16>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movzbl	(%rdx), %esi
                	movq	%rsi, %rdx
@@ -105,6 +108,8 @@ Disassembly of section .text:
                	movq	%rbx, %rdx
                	callq	 <L15>
 <L15>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -114,11 +119,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_select.fold_u16x8>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movzwl	(%rdx), %esi
                	movq	%rsi, %rdx
@@ -166,6 +174,8 @@ Disassembly of section .text:
                	movq	%rbx, %rdx
                	callq	 <L7>
 <L7>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -175,11 +185,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_select.fold_u32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movl	(%rdx), %esi
                	movl	%esi, %edx
@@ -203,6 +216,8 @@ Disassembly of section .text:
                	movl	%ebx, %edx
                	callq	 <L3>
 <L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -212,11 +227,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_select.fold_u64x2>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movq	(%rdx), %rsi
                	movq	%rsi, %rdx
@@ -228,6 +246,8 @@ Disassembly of section .text:
                	movq	%rbx, %rdx
                	callq	 <L1>
 <L1>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -237,10 +257,13 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_select.fold_f32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movss	(%rdx), %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
@@ -264,6 +287,8 @@ Disassembly of section .text:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L3>
 <L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
@@ -272,19 +297,19 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_cmp_select.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x4d0, %rsp            # imm = 0x4D0
-               	movq	%rbx, -0x428(%rbp)
-               	movq	%rdi, -0x430(%rbp)
-               	movq	%rsi, -0x438(%rbp)
-               	movq	%r12, -0x440(%rbp)
-               	movq	%r13, -0x448(%rbp)
-               	movq	%r14, -0x450(%rbp)
-               	movaps	%xmm6, -0x460(%rbp)
-               	movaps	%xmm7, -0x470(%rbp)
-               	movaps	%xmm8, -0x480(%rbp)
-               	movaps	%xmm9, -0x490(%rbp)
-               	movaps	%xmm14, -0x4a0(%rbp)
-               	movaps	%xmm15, -0x4b0(%rbp)
+               	subq	$0x510, %rsp            # imm = 0x510
+               	movq	%rbx, -0x468(%rbp)
+               	movq	%rdi, -0x470(%rbp)
+               	movq	%rsi, -0x478(%rbp)
+               	movq	%r12, -0x480(%rbp)
+               	movq	%r13, -0x488(%rbp)
+               	movq	%r14, -0x490(%rbp)
+               	movaps	%xmm6, -0x4a0(%rbp)
+               	movaps	%xmm7, -0x4b0(%rbp)
+               	movaps	%xmm8, -0x4c0(%rbp)
+               	movaps	%xmm9, -0x4d0(%rbp)
+               	movaps	%xmm14, -0x4e0(%rbp)
+               	movaps	%xmm15, -0x4f0(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -939,266 +964,160 @@ Disassembly of section .text:
                	movaps	%xmm6, %xmm14
                	movaps	%xmm7, %xmm15
                	cmpltps	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x220(%rbp), %rsi
-               	movups	%xmm0, (%rsi)
-               	leaq	(%rsi), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm14, %xmm8
                	movq	%rax, %rcx
+               	movups	%xmm8, -0x220(%rbp)
+               	leaq	-0x220(%rbp), %rdx
                	callq	 <L75>
 <L75>:
-               	leaq	0x4(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L76>
-<L76>:
-               	leaq	0x8(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L77>
-<L77>:
-               	leaq	0xc(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L78>
-<L78>:
                	movaps	%xmm7, %xmm14
                	movaps	%xmm6, %xmm15
                	cmpltps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x230(%rbp), %rsi
-               	movups	%xmm0, (%rsi)
-               	leaq	(%rsi), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L79>
-<L79>:
-               	leaq	0x4(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L80>
-<L80>:
-               	leaq	0x8(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L81>
-<L81>:
-               	leaq	0xc(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L82>
-<L82>:
+               	movups	%xmm0, -0x230(%rbp)
+               	leaq	-0x230(%rbp), %rdx
+               	callq	 <L76>
+<L76>:
                	movaps	%xmm6, %xmm14
                	movaps	%xmm7, %xmm15
                	cmpeqps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x240(%rbp), %rsi
-               	movups	%xmm0, (%rsi)
-               	leaq	(%rsi), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L83>
-<L83>:
-               	leaq	0x4(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L84>
-<L84>:
-               	leaq	0x8(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L85>
-<L85>:
-               	leaq	0xc(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L86>
-<L86>:
+               	movups	%xmm0, -0x240(%rbp)
+               	leaq	-0x240(%rbp), %rdx
+               	callq	 <L77>
+<L77>:
                	movaps	%xmm6, %xmm14
                	movaps	%xmm7, %xmm15
                	cmpneqps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x250(%rbp), %rsi
-               	movups	%xmm0, (%rsi)
-               	leaq	(%rsi), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L87>
-<L87>:
-               	leaq	0x4(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L88>
-<L88>:
-               	leaq	0x8(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L89>
-<L89>:
-               	leaq	0xc(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L90>
-<L90>:
+               	movups	%xmm0, -0x250(%rbp)
+               	leaq	-0x250(%rbp), %rdx
+               	callq	 <L78>
+<L78>:
                	movaps	%xmm6, %xmm14
                	movaps	%xmm7, %xmm15
                	cmpleps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x260(%rbp), %rsi
-               	movups	%xmm0, (%rsi)
-               	leaq	(%rsi), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L91>
-<L91>:
-               	leaq	0x4(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L92>
-<L92>:
-               	leaq	0x8(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L93>
-<L93>:
-               	leaq	0xc(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L94>
-<L94>:
+               	movups	%xmm0, -0x260(%rbp)
+               	leaq	-0x260(%rbp), %rdx
+               	callq	 <L79>
+<L79>:
                	movaps	%xmm7, %xmm14
                	movaps	%xmm6, %xmm15
                	cmpleps	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x270(%rbp), %rsi
-               	movups	%xmm0, (%rsi)
-               	leaq	(%rsi), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L95>
-<L95>:
-               	leaq	0x4(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L96>
-<L96>:
-               	leaq	0x8(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L97>
-<L97>:
-               	leaq	0xc(%rsi), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L98>
-<L98>:
-               	movaps	%xmm6, %xmm14
-               	movaps	%xmm7, %xmm15
-               	cmpltps	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm0, %xmm14
+               	movups	%xmm0, -0x270(%rbp)
+               	leaq	-0x270(%rbp), %rdx
+               	callq	 <L80>
+<L80>:
+               	movaps	%xmm8, %xmm14
                	pand	%xmm6, %xmm14
-               	movaps	%xmm14, %xmm1
-               	movaps	%xmm0, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm2
-               	movaps	%xmm2, %xmm14
-               	pand	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm3
+               	movaps	%xmm14, %xmm1
                	movaps	%xmm1, %xmm14
-               	por	%xmm3, %xmm14
-               	movaps	%xmm14, %xmm8
-               	leaq	-0x280(%rbp), %rsi
-               	movups	%xmm8, (%rsi)
-               	movaps	%xmm0, %xmm14
                	pand	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm2, %xmm14
-               	pand	%xmm6, %xmm14
                	movaps	%xmm14, %xmm2
                	movaps	%xmm0, %xmm14
                	por	%xmm2, %xmm14
-               	movaps	%xmm14, %xmm6
+               	movaps	%xmm14, %xmm9
+               	leaq	-0x280(%rbp), %rsi
+               	movups	%xmm9, (%rsi)
+               	movaps	%xmm8, %xmm14
+               	pand	%xmm7, %xmm14
+               	movaps	%xmm14, %xmm8
+               	movaps	%xmm1, %xmm14
+               	pand	%xmm6, %xmm14
+               	movaps	%xmm14, %xmm1
+               	movaps	%xmm8, %xmm14
+               	por	%xmm1, %xmm14
+               	movaps	%xmm14, %xmm8
                	leaq	-0x290(%rbp), %r13
-               	movups	%xmm6, (%r13)
+               	movups	%xmm8, (%r13)
                	leaq	(%rsi), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L99>
-<L99>:
+               	callq	 <L81>
+<L81>:
                	leaq	0x4(%rsi), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L100>
-<L100>:
+               	callq	 <L82>
+<L82>:
                	leaq	0x8(%rsi), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L101>
-<L101>:
+               	callq	 <L83>
+<L83>:
                	leaq	0xc(%rsi), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L102>
-<L102>:
+               	callq	 <L84>
+<L84>:
                	leaq	(%r13), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L103>
-<L103>:
+               	callq	 <L85>
+<L85>:
                	leaq	0x4(%r13), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L104>
-<L104>:
+               	callq	 <L86>
+<L86>:
                	leaq	0x8(%r13), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L105>
-<L105>:
+               	callq	 <L87>
+<L87>:
                	leaq	0xc(%r13), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L106>
-<L106>:
-               	movaps	%xmm6, %xmm14
-               	subps	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm6
+               	callq	 <L88>
+<L88>:
+               	movaps	%xmm8, %xmm14
+               	subps	%xmm9, %xmm14
+               	movaps	%xmm14, %xmm8
                	leaq	-0x2a0(%rbp), %rsi
-               	movups	%xmm6, (%rsi)
+               	movups	%xmm8, (%rsi)
                	leaq	(%rsi), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L107>
-<L107>:
+               	callq	 <L89>
+<L89>:
                	leaq	0x4(%rsi), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L108>
-<L108>:
+               	callq	 <L90>
+<L90>:
                	leaq	0x8(%rsi), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L109>
-<L109>:
+               	callq	 <L91>
+<L91>:
                	leaq	0xc(%rsi), %rcx
                	movss	(%rcx), %xmm0
                	movq	%rax, %rcx
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
-               	callq	 <L110>
-<L110>:
+               	callq	 <L92>
+<L92>:
                	leaq	-0x2b0(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movabsq	$0x3ff8000000000000, %r11 # imm = 0x3FF8000000000000
@@ -1220,17 +1139,17 @@ Disassembly of section .text:
                	movsd	(%rdx), %xmm1
                	movq	%rbx, %r11
                	testq	%r11, %r11
-               	jl	 <L111>
+               	jl	 <L93>
                	cvtsi2sd	%r11, %xmm2
-               	jmp	 <L112>
-<L111>:
+               	jmp	 <L94>
+<L93>:
                	movq	%r11, %r10
                	shrq	%r10
                	andq	$0x1, %r11
                	orq	%r10, %r11
                	cvtsi2sd	%r11, %xmm2
                	addsd	%xmm2, %xmm2
-<L112>:
+<L94>:
                	movsd	%xmm1, %xmm3            # xmm3 = xmm1[0],xmm3[1]
                	addsd	%xmm2, %xmm3
                	leaq	-0x2e0(%rbp), %rcx
@@ -1247,13 +1166,13 @@ Disassembly of section .text:
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L113>
-<L113>:
+               	callq	 <L95>
+<L95>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L114>
-<L114>:
+               	callq	 <L96>
+<L96>:
                	movaps	%xmm7, %xmm14
                	movaps	%xmm6, %xmm15
                	cmpeqpd	%xmm15, %xmm14
@@ -1263,13 +1182,13 @@ Disassembly of section .text:
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L115>
-<L115>:
+               	callq	 <L97>
+<L97>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L116>
-<L116>:
+               	callq	 <L98>
+<L98>:
                	movaps	%xmm7, %xmm14
                	movaps	%xmm6, %xmm15
                	cmpneqpd	%xmm15, %xmm14
@@ -1279,13 +1198,13 @@ Disassembly of section .text:
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L117>
-<L117>:
+               	callq	 <L99>
+<L99>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L118>
-<L118>:
+               	callq	 <L100>
+<L100>:
                	movaps	%xmm6, %xmm14
                	movaps	%xmm7, %xmm15
                	cmplepd	%xmm15, %xmm14
@@ -1295,13 +1214,13 @@ Disassembly of section .text:
                	leaq	(%rbx), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L119>
-<L119>:
+               	callq	 <L101>
+<L101>:
                	leaq	0x8(%rbx), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L120>
-<L120>:
+               	callq	 <L102>
+<L102>:
                	leaq	-0x330(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movw	$0x1, (%rdx)
@@ -1370,43 +1289,43 @@ Disassembly of section .text:
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L121>
-<L121>:
+               	callq	 <L103>
+<L103>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L122>
-<L122>:
+               	callq	 <L104>
+<L104>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L123>
-<L123>:
+               	callq	 <L105>
+<L105>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L124>
-<L124>:
+               	callq	 <L106>
+<L106>:
                	leaq	0x8(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L125>
-<L125>:
+               	callq	 <L107>
+<L107>:
                	leaq	0xa(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L126>
-<L126>:
+               	callq	 <L108>
+<L108>:
                	leaq	0xc(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L127>
-<L127>:
+               	callq	 <L109>
+<L109>:
                	leaq	0xe(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L128>
-<L128>:
+               	callq	 <L110>
+<L110>:
                	movaps	%xmm6, %xmm14
                	pcmpeqw	%xmm7, %xmm14
                	movaps	%xmm14, %xmm0
@@ -1415,43 +1334,43 @@ Disassembly of section .text:
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L129>
-<L129>:
+               	callq	 <L111>
+<L111>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L130>
-<L130>:
+               	callq	 <L112>
+<L112>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L131>
-<L131>:
+               	callq	 <L113>
+<L113>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L132>
-<L132>:
+               	callq	 <L114>
+<L114>:
                	leaq	0x8(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L133>
-<L133>:
+               	callq	 <L115>
+<L115>:
                	leaq	0xa(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L134>
-<L134>:
+               	callq	 <L116>
+<L116>:
                	leaq	0xc(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L135>
-<L135>:
+               	callq	 <L117>
+<L117>:
                	leaq	0xe(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L136>
-<L136>:
+               	callq	 <L118>
+<L118>:
                	movaps	%xmm6, %xmm14
                	psubusw	%xmm7, %xmm14
                	pxor	%xmm15, %xmm15
@@ -1464,43 +1383,43 @@ Disassembly of section .text:
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L137>
-<L137>:
+               	callq	 <L119>
+<L119>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L138>
-<L138>:
+               	callq	 <L120>
+<L120>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L139>
-<L139>:
+               	callq	 <L121>
+<L121>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L140>
-<L140>:
+               	callq	 <L122>
+<L122>:
                	leaq	0x8(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L141>
-<L141>:
+               	callq	 <L123>
+<L123>:
                	leaq	0xa(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L142>
-<L142>:
+               	callq	 <L124>
+<L124>:
                	leaq	0xc(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L143>
-<L143>:
+               	callq	 <L125>
+<L125>:
                	leaq	0xe(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L144>
-<L144>:
+               	callq	 <L126>
+<L126>:
                	movaps	%xmm7, %xmm14
                	psubusw	%xmm6, %xmm14
                	pxor	%xmm15, %xmm15
@@ -1526,43 +1445,43 @@ Disassembly of section .text:
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L145>
-<L145>:
+               	callq	 <L127>
+<L127>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L146>
-<L146>:
+               	callq	 <L128>
+<L128>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L147>
-<L147>:
+               	callq	 <L129>
+<L129>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L148>
-<L148>:
+               	callq	 <L130>
+<L130>:
                	leaq	0x8(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L149>
-<L149>:
+               	callq	 <L131>
+<L131>:
                	leaq	0xa(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L150>
-<L150>:
+               	callq	 <L132>
+<L132>:
                	leaq	0xc(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L151>
-<L151>:
+               	callq	 <L133>
+<L133>:
                	leaq	0xe(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L152>
-<L152>:
+               	callq	 <L134>
+<L134>:
                	leaq	-0x3d0(%rbp), %rcx
                	leaq	(%rcx), %rdx
                	movb	$0x1, (%rdx)
@@ -1659,23 +1578,28 @@ Disassembly of section .text:
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm8
                	movq	%rax, %rcx
-               	movaps	%xmm8, %xmm1
-               	callq	 <L153>
-<L153>:
+               	movups	%xmm8, -0x430(%rbp)
+               	leaq	-0x430(%rbp), %rdx
+               	callq	 <L135>
+<L135>:
                	movaps	%xmm6, %xmm14
                	pcmpeqb	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rcx
-               	callq	 <L154>
-<L154>:
+               	movups	%xmm0, -0x440(%rbp)
+               	leaq	-0x440(%rbp), %rdx
+               	callq	 <L136>
+<L136>:
                	movaps	%xmm7, %xmm14
                	psubusb	%xmm6, %xmm14
                	pxor	%xmm15, %xmm15
                	pcmpeqb	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
                	movq	%rax, %rcx
-               	callq	 <L155>
-<L155>:
+               	movups	%xmm0, -0x450(%rbp)
+               	leaq	-0x450(%rbp), %rdx
+               	callq	 <L137>
+<L137>:
                	movaps	%xmm8, %xmm14
                	pand	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
@@ -1690,21 +1614,22 @@ Disassembly of section .text:
                	por	%xmm1, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rcx
-               	movaps	%xmm0, %xmm1
-               	callq	 <L156>
-<L156>:
-               	movaps	-0x460(%rbp), %xmm6
-               	movaps	-0x470(%rbp), %xmm7
-               	movaps	-0x480(%rbp), %xmm8
-               	movaps	-0x490(%rbp), %xmm9
-               	movaps	-0x4a0(%rbp), %xmm14
-               	movaps	-0x4b0(%rbp), %xmm15
-               	movq	-0x428(%rbp), %rbx
-               	movq	-0x430(%rbp), %rdi
-               	movq	-0x438(%rbp), %rsi
-               	movq	-0x440(%rbp), %r12
-               	movq	-0x448(%rbp), %r13
-               	movq	-0x450(%rbp), %r14
+               	movups	%xmm0, -0x460(%rbp)
+               	leaq	-0x460(%rbp), %rdx
+               	callq	 <L138>
+<L138>:
+               	movaps	-0x4a0(%rbp), %xmm6
+               	movaps	-0x4b0(%rbp), %xmm7
+               	movaps	-0x4c0(%rbp), %xmm8
+               	movaps	-0x4d0(%rbp), %xmm9
+               	movaps	-0x4e0(%rbp), %xmm14
+               	movaps	-0x4f0(%rbp), %xmm15
+               	movq	-0x468(%rbp), %rbx
+               	movq	-0x470(%rbp), %rdi
+               	movq	-0x478(%rbp), %rsi
+               	movq	-0x480(%rbp), %r12
+               	movq	-0x488(%rbp), %r13
+               	movq	-0x490(%rbp), %r14
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_f32x2.dis
+++ b/test/golden/x86_64-windows/vec/vec_f32x2.dis
@@ -5,10 +5,13 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x2.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movsd	(%rdx), %xmm0
                	leaq	-0x8(%rbp), %rbx
-               	movsd	%xmm1, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movss	(%rdx), %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
@@ -20,6 +23,8 @@ Disassembly of section .text:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L1>
 <L1>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp

--- a/test/golden/x86_64-windows/vec/vec_f32x3.dis
+++ b/test/golden/x86_64-windows/vec/vec_f32x3.dis
@@ -5,13 +5,22 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x3.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	leaq	-0xc(%rbp), %rbx
-               	movups	%xmm1, -0x1c(%rbp)
-               	movq	-0x1c(%rbp), %rdx
+               	subq	$0x80, %rsp
+               	movq	%rbx, -0x38(%rbp)
+               	movaps	%xmm14, -0x50(%rbp)
+               	movaps	%xmm15, -0x60(%rbp)
+               	movq	$0x0, -0x10(%rbp)
+               	movq	$0x0, -0x8(%rbp)
+               	movq	(%rdx), %rbx
+               	movq	%rbx, -0x10(%rbp)
+               	movl	0x8(%rdx), %ebx
+               	movl	%ebx, -0x8(%rbp)
+               	movups	-0x10(%rbp), %xmm0
+               	leaq	-0x1c(%rbp), %rbx
+               	movups	%xmm0, -0x2c(%rbp)
+               	movq	-0x2c(%rbp), %rdx
                	movq	%rdx, (%rbx)
-               	movl	-0x14(%rbp), %edx
+               	movl	-0x24(%rbp), %edx
                	movl	%edx, 0x8(%rbx)
                	leaq	(%rbx), %rdx
                	movss	(%rdx), %xmm0
@@ -30,7 +39,9 @@ Disassembly of section .text:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L2>
 <L2>:
-               	movq	-0x28(%rbp), %rbx
+               	movaps	-0x50(%rbp), %xmm14
+               	movaps	-0x60(%rbp), %xmm15
+               	movq	-0x38(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_f32x4.dis
+++ b/test/golden/x86_64-windows/vec/vec_f32x4.dis
@@ -5,10 +5,13 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f32x4.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movss	(%rdx), %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
@@ -32,6 +35,8 @@ Disassembly of section .text:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L3>
 <L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp

--- a/test/golden/x86_64-windows/vec/vec_f64x2.dis
+++ b/test/golden/x86_64-windows/vec/vec_f64x2.dis
@@ -5,10 +5,13 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_f64x2.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movsd	(%rdx), %xmm1
                	callq	 <L0>
@@ -18,6 +21,8 @@ Disassembly of section .text:
                	movsd	(%rdx), %xmm1
                	callq	 <L1>
 <L1>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp

--- a/test/golden/x86_64-windows/vec/vec_i16x4.dis
+++ b/test/golden/x86_64-windows/vec/vec_i16x4.dis
@@ -5,11 +5,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i16x4.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movsd	(%rdx), %xmm0
                	leaq	-0x8(%rbp), %rbx
-               	movsd	%xmm1, (%rbx)
+               	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movzwl	(%rdx), %esi
                	movq	%rsi, %rdx
@@ -33,6 +36,8 @@ Disassembly of section .text:
                	movq	%rbx, %rdx
                	callq	 <L3>
 <L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -42,19 +47,21 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i16x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x200, %rsp            # imm = 0x200
-               	movq	%rbx, -0x148(%rbp)
-               	movq	%rdi, -0x150(%rbp)
-               	movq	%rsi, -0x158(%rbp)
-               	movq	%r12, -0x160(%rbp)
-               	movaps	%xmm6, -0x170(%rbp)
-               	movaps	%xmm7, -0x180(%rbp)
-               	movaps	%xmm8, -0x190(%rbp)
-               	movaps	%xmm9, -0x1a0(%rbp)
-               	movaps	%xmm10, -0x1b0(%rbp)
-               	movaps	%xmm11, -0x1c0(%rbp)
-               	movaps	%xmm12, -0x1d0(%rbp)
-               	movaps	%xmm13, -0x1e0(%rbp)
+               	subq	$0x250, %rsp            # imm = 0x250
+               	movq	%rbx, -0x178(%rbp)
+               	movq	%rdi, -0x180(%rbp)
+               	movq	%rsi, -0x188(%rbp)
+               	movq	%r12, -0x190(%rbp)
+               	movaps	%xmm6, -0x1a0(%rbp)
+               	movaps	%xmm7, -0x1b0(%rbp)
+               	movaps	%xmm8, -0x1c0(%rbp)
+               	movaps	%xmm9, -0x1d0(%rbp)
+               	movaps	%xmm10, -0x1e0(%rbp)
+               	movaps	%xmm11, -0x1f0(%rbp)
+               	movaps	%xmm12, -0x200(%rbp)
+               	movaps	%xmm13, -0x210(%rbp)
+               	movaps	%xmm14, -0x220(%rbp)
+               	movaps	%xmm15, -0x230(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -381,193 +388,68 @@ Disassembly of section .text:
                	movaps	%xmm7, %xmm14
                	psubw	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x104(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
+               	movups	%xmm0, -0x110(%rbp)
+               	leaq	-0x110(%rbp), %rdx
                	callq	 <L41>
 <L41>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
                	movaps	%xmm8, %xmm14
                	pand	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x10c(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L47>
-<L47>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L48>
-<L48>:
+               	movups	%xmm10, -0x120(%rbp)
+               	leaq	-0x120(%rbp), %rdx
+               	callq	 <L42>
+<L42>:
                	movaps	%xmm8, %xmm14
                	por	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x114(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm11
                	movq	%rax, %rcx
-               	callq	 <L49>
-<L49>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L50>
-<L50>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L51>
-<L51>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L52>
-<L52>:
+               	movups	%xmm11, -0x130(%rbp)
+               	leaq	-0x130(%rbp), %rdx
+               	callq	 <L43>
+<L43>:
                	movaps	%xmm8, %xmm14
                	pxor	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x11c(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L53>
-<L53>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L54>
-<L54>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L55>
-<L55>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L56>
-<L56>:
+               	movups	%xmm0, -0x140(%rbp)
+               	leaq	-0x140(%rbp), %rdx
+               	callq	 <L44>
+<L44>:
                	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x124(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L57>
-<L57>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L58>
-<L58>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L59>
-<L59>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L60>
-<L60>:
+               	movups	%xmm0, -0x150(%rbp)
+               	leaq	-0x150(%rbp), %rdx
+               	callq	 <L45>
+<L45>:
                	movaps	%xmm9, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x12c(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L61>
-<L61>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movups	%xmm0, -0x160(%rbp)
+               	leaq	-0x160(%rbp), %rdx
+               	callq	 <L46>
+<L46>:
+               	movaps	%xmm10, %xmm14
+               	pxor	%xmm11, %xmm14
+               	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
-               	callq	 <L62>
-<L62>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L63>
-<L63>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L64>
-<L64>:
-               	movaps	%xmm8, %xmm14
-               	pand	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm8, %xmm14
-               	por	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm1
-               	movaps	%xmm0, %xmm14
-               	pxor	%xmm1, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x134(%rbp), %rbx
-               	movsd	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L65>
-<L65>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L66>
-<L66>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L67>
-<L67>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L68>
-<L68>:
+               	movups	%xmm10, -0x170(%rbp)
+               	leaq	-0x170(%rbp), %rdx
+               	callq	 <L47>
+<L47>:
                	movq	%rax, %rbx
                	movaps	%xmm7, %xmm10
                	movq	$0x0, %rsi
                	cmpq	$0x6, %rsi
-               	jb	 <L69>
-               	jmp	 <L86>
-<L69>:
+               	jb	 <L48>
+               	jmp	 <L65>
+<L48>:
                	movaps	%xmm8, %xmm14
                	pmullw	%xmm6, %xmm14
                	movaps	%xmm14, %xmm11
@@ -576,23 +458,23 @@ Disassembly of section .text:
                	leaq	(%rdi), %rax
                	movzwl	(%rax), %edx
                	movq	%rbx, %rcx
-               	callq	 <L70>
-<L70>:
+               	callq	 <L49>
+<L49>:
                	leaq	0x2(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L71>
-<L71>:
+               	callq	 <L50>
+<L50>:
                	leaq	0x4(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L72>
-<L72>:
+               	callq	 <L51>
+<L51>:
                	leaq	0x6(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L73>
-<L73>:
+               	callq	 <L52>
+<L52>:
                	movaps	%xmm10, %xmm14
                	pxor	%xmm11, %xmm14
                	movaps	%xmm14, %xmm12
@@ -601,23 +483,23 @@ Disassembly of section .text:
                	leaq	(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L74>
-<L74>:
+               	callq	 <L53>
+<L53>:
                	leaq	0x2(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L75>
-<L75>:
+               	callq	 <L54>
+<L54>:
                	leaq	0x4(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L76>
-<L76>:
+               	callq	 <L55>
+<L55>:
                	leaq	0x6(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L77>
-<L77>:
+               	callq	 <L56>
+<L56>:
                	movaps	%xmm7, %xmm14
                	paddw	%xmm8, %xmm14
                	movaps	%xmm14, %xmm11
@@ -626,23 +508,23 @@ Disassembly of section .text:
                	leaq	(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L78>
-<L78>:
+               	callq	 <L57>
+<L57>:
                	leaq	0x2(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L79>
-<L79>:
+               	callq	 <L58>
+<L58>:
                	leaq	0x4(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L80>
-<L80>:
+               	callq	 <L59>
+<L59>:
                	leaq	0x6(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L81>
-<L81>:
+               	callq	 <L60>
+<L60>:
                	movaps	%xmm8, %xmm14
                	paddw	%xmm9, %xmm14
                	movaps	%xmm14, %xmm13
@@ -651,31 +533,31 @@ Disassembly of section .text:
                	leaq	(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L82>
-<L82>:
+               	callq	 <L61>
+<L61>:
                	leaq	0x2(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L83>
-<L83>:
+               	callq	 <L62>
+<L62>:
                	leaq	0x4(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L84>
-<L84>:
+               	callq	 <L63>
+<L63>:
                	leaq	0x6(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L85>
-<L85>:
+               	callq	 <L64>
+<L64>:
                	addq	$0x1, %rsi
                	movq	%rax, %rbx
                	movaps	%xmm13, %xmm8
                	movaps	%xmm12, %xmm10
                	movaps	%xmm11, %xmm7
                	cmpq	$0x6, %rsi
-               	jb	 <L69>
-<L86>:
+               	jb	 <L48>
+<L65>:
                	leaq	-0x88(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
@@ -706,9 +588,9 @@ Disassembly of section .text:
                	movsd	%xmm8, (%rax)
                	movq	$0x0, %rdi
                	cmpq	$0x6, %rdi
-               	jb	 <L87>
-               	jmp	 <L92>
-<L87>:
+               	jb	 <L66>
+               	jmp	 <L71>
+<L66>:
                	leaq	(%rsi,%rdi,8), %rax
                	movsd	(%rax), %xmm0
                	leaq	-0x90(%rbp), %r12
@@ -716,28 +598,28 @@ Disassembly of section .text:
                	leaq	(%r12), %rax
                	movzwl	(%rax), %edx
                	movq	%rbx, %rcx
-               	callq	 <L88>
-<L88>:
+               	callq	 <L67>
+<L67>:
                	leaq	0x2(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L89>
-<L89>:
+               	callq	 <L68>
+<L68>:
                	leaq	0x4(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L90>
-<L90>:
+               	callq	 <L69>
+<L69>:
                	leaq	0x6(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L91>
-<L91>:
+               	callq	 <L70>
+<L70>:
                	addq	$0x1, %rdi
                	movq	%rax, %rbx
                	cmpq	$0x6, %rdi
-               	jb	 <L87>
-<L92>:
+               	jb	 <L66>
+<L71>:
                	leaq	-0x9c(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movl	$0x0, 0x8(%rdi)
@@ -751,48 +633,50 @@ Disassembly of section .text:
                	movb	$-0x53, (%rcx)
                	movzbl	(%rax), %edx
                	movq	%rbx, %rcx
-               	callq	 <L93>
-<L93>:
+               	callq	 <L72>
+<L72>:
                	movsd	(%rsi), %xmm0
                	leaq	-0xa4(%rbp), %rbx
                	movsd	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L94>
-<L94>:
+               	callq	 <L73>
+<L73>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L95>
-<L95>:
+               	callq	 <L74>
+<L74>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L96>
-<L96>:
+               	callq	 <L75>
+<L75>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L97>
-<L97>:
+               	callq	 <L76>
+<L76>:
                	leaq	0xa(%rdi), %rcx
                	movzbl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L98>
-<L98>:
-               	movaps	-0x170(%rbp), %xmm6
-               	movaps	-0x180(%rbp), %xmm7
-               	movaps	-0x190(%rbp), %xmm8
-               	movaps	-0x1a0(%rbp), %xmm9
-               	movaps	-0x1b0(%rbp), %xmm10
-               	movaps	-0x1c0(%rbp), %xmm11
-               	movaps	-0x1d0(%rbp), %xmm12
-               	movaps	-0x1e0(%rbp), %xmm13
-               	movq	-0x148(%rbp), %rbx
-               	movq	-0x150(%rbp), %rdi
-               	movq	-0x158(%rbp), %rsi
-               	movq	-0x160(%rbp), %r12
+               	callq	 <L77>
+<L77>:
+               	movaps	-0x1a0(%rbp), %xmm6
+               	movaps	-0x1b0(%rbp), %xmm7
+               	movaps	-0x1c0(%rbp), %xmm8
+               	movaps	-0x1d0(%rbp), %xmm9
+               	movaps	-0x1e0(%rbp), %xmm10
+               	movaps	-0x1f0(%rbp), %xmm11
+               	movaps	-0x200(%rbp), %xmm12
+               	movaps	-0x210(%rbp), %xmm13
+               	movaps	-0x220(%rbp), %xmm14
+               	movaps	-0x230(%rbp), %xmm15
+               	movq	-0x178(%rbp), %rbx
+               	movq	-0x180(%rbp), %rdi
+               	movq	-0x188(%rbp), %rsi
+               	movq	-0x190(%rbp), %r12
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_i16x8.dis
+++ b/test/golden/x86_64-windows/vec/vec_i16x8.dis
@@ -5,11 +5,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i16x8.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movzwl	(%rdx), %esi
                	movq	%rsi, %rdx
@@ -57,6 +60,8 @@ Disassembly of section .text:
                	movq	%rbx, %rdx
                	callq	 <L7>
 <L7>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -66,7 +71,7 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i16x8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x320, %rsp            # imm = 0x320
+               	subq	$0x340, %rsp            # imm = 0x340
                	movq	%rbx, -0x268(%rbp)
                	movq	%rdi, -0x270(%rbp)
                	movq	%rsi, -0x278(%rbp)
@@ -79,6 +84,8 @@ Disassembly of section .text:
                	movaps	%xmm11, -0x2e0(%rbp)
                	movaps	%xmm12, -0x2f0(%rbp)
                	movaps	%xmm13, -0x300(%rbp)
+               	movaps	%xmm14, -0x310(%rbp)
+               	movaps	%xmm15, -0x320(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -637,333 +644,68 @@ Disassembly of section .text:
                	movaps	%xmm7, %xmm14
                	psubw	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x200(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
+               	movups	%xmm0, -0x200(%rbp)
+               	leaq	-0x200(%rbp), %rdx
                	callq	 <L81>
 <L81>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L82>
-<L82>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L83>
-<L83>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L84>
-<L84>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L85>
-<L85>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L86>
-<L86>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L87>
-<L87>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L88>
-<L88>:
                	movaps	%xmm8, %xmm14
                	pand	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x210(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
-               	callq	 <L89>
-<L89>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L90>
-<L90>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L91>
-<L91>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L92>
-<L92>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L93>
-<L93>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L94>
-<L94>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L95>
-<L95>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L96>
-<L96>:
+               	movups	%xmm10, -0x210(%rbp)
+               	leaq	-0x210(%rbp), %rdx
+               	callq	 <L82>
+<L82>:
                	movaps	%xmm8, %xmm14
                	por	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x220(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm11
                	movq	%rax, %rcx
-               	callq	 <L97>
-<L97>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L98>
-<L98>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L99>
-<L99>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L100>
-<L100>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L101>
-<L101>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L102>
-<L102>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L103>
-<L103>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L104>
-<L104>:
+               	movups	%xmm11, -0x220(%rbp)
+               	leaq	-0x220(%rbp), %rdx
+               	callq	 <L83>
+<L83>:
                	movaps	%xmm8, %xmm14
                	pxor	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x230(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L105>
-<L105>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L106>
-<L106>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L107>
-<L107>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L108>
-<L108>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L109>
-<L109>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L110>
-<L110>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L111>
-<L111>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L112>
-<L112>:
+               	movups	%xmm0, -0x230(%rbp)
+               	leaq	-0x230(%rbp), %rdx
+               	callq	 <L84>
+<L84>:
                	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x240(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L113>
-<L113>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L114>
-<L114>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L115>
-<L115>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L116>
-<L116>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L117>
-<L117>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L118>
-<L118>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L119>
-<L119>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L120>
-<L120>:
+               	movups	%xmm0, -0x240(%rbp)
+               	leaq	-0x240(%rbp), %rdx
+               	callq	 <L85>
+<L85>:
                	movaps	%xmm9, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x250(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L121>
-<L121>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movups	%xmm0, -0x250(%rbp)
+               	leaq	-0x250(%rbp), %rdx
+               	callq	 <L86>
+<L86>:
+               	movaps	%xmm10, %xmm14
+               	pxor	%xmm11, %xmm14
+               	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
-               	callq	 <L122>
-<L122>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L123>
-<L123>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L124>
-<L124>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L125>
-<L125>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L126>
-<L126>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L127>
-<L127>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L128>
-<L128>:
-               	movaps	%xmm8, %xmm14
-               	pand	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm8, %xmm14
-               	por	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm1
-               	movaps	%xmm0, %xmm14
-               	pxor	%xmm1, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L129>
-<L129>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L130>
-<L130>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L131>
-<L131>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L132>
-<L132>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L133>
-<L133>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L134>
-<L134>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L135>
-<L135>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L136>
-<L136>:
+               	movups	%xmm10, -0x260(%rbp)
+               	leaq	-0x260(%rbp), %rdx
+               	callq	 <L87>
+<L87>:
                	movq	%rax, %rbx
                	movaps	%xmm7, %xmm10
                	movq	$0x0, %rsi
                	cmpq	$0x6, %rsi
-               	jb	 <L137>
-               	jmp	 <L170>
-<L137>:
+               	jb	 <L88>
+               	jmp	 <L121>
+<L88>:
                	movaps	%xmm8, %xmm14
                	pmullw	%xmm6, %xmm14
                	movaps	%xmm14, %xmm11
@@ -972,43 +714,43 @@ Disassembly of section .text:
                	leaq	(%rdi), %rax
                	movzwl	(%rax), %edx
                	movq	%rbx, %rcx
-               	callq	 <L138>
-<L138>:
+               	callq	 <L89>
+<L89>:
                	leaq	0x2(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L139>
-<L139>:
+               	callq	 <L90>
+<L90>:
                	leaq	0x4(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L140>
-<L140>:
+               	callq	 <L91>
+<L91>:
                	leaq	0x6(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L141>
-<L141>:
+               	callq	 <L92>
+<L92>:
                	leaq	0x8(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L142>
-<L142>:
+               	callq	 <L93>
+<L93>:
                	leaq	0xa(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L143>
-<L143>:
+               	callq	 <L94>
+<L94>:
                	leaq	0xc(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L144>
-<L144>:
+               	callq	 <L95>
+<L95>:
                	leaq	0xe(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L145>
-<L145>:
+               	callq	 <L96>
+<L96>:
                	movaps	%xmm10, %xmm14
                	pxor	%xmm11, %xmm14
                	movaps	%xmm14, %xmm12
@@ -1017,43 +759,43 @@ Disassembly of section .text:
                	leaq	(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L146>
-<L146>:
+               	callq	 <L97>
+<L97>:
                	leaq	0x2(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L147>
-<L147>:
+               	callq	 <L98>
+<L98>:
                	leaq	0x4(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L148>
-<L148>:
+               	callq	 <L99>
+<L99>:
                	leaq	0x6(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L149>
-<L149>:
+               	callq	 <L100>
+<L100>:
                	leaq	0x8(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L150>
-<L150>:
+               	callq	 <L101>
+<L101>:
                	leaq	0xa(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L151>
-<L151>:
+               	callq	 <L102>
+<L102>:
                	leaq	0xc(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L152>
-<L152>:
+               	callq	 <L103>
+<L103>:
                	leaq	0xe(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L153>
-<L153>:
+               	callq	 <L104>
+<L104>:
                	movaps	%xmm7, %xmm14
                	paddw	%xmm8, %xmm14
                	movaps	%xmm14, %xmm11
@@ -1062,43 +804,43 @@ Disassembly of section .text:
                	leaq	(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L154>
-<L154>:
+               	callq	 <L105>
+<L105>:
                	leaq	0x2(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L155>
-<L155>:
+               	callq	 <L106>
+<L106>:
                	leaq	0x4(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L156>
-<L156>:
+               	callq	 <L107>
+<L107>:
                	leaq	0x6(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L157>
-<L157>:
+               	callq	 <L108>
+<L108>:
                	leaq	0x8(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L158>
-<L158>:
+               	callq	 <L109>
+<L109>:
                	leaq	0xa(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L159>
-<L159>:
+               	callq	 <L110>
+<L110>:
                	leaq	0xc(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L160>
-<L160>:
+               	callq	 <L111>
+<L111>:
                	leaq	0xe(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L161>
-<L161>:
+               	callq	 <L112>
+<L112>:
                	movaps	%xmm8, %xmm14
                	paddw	%xmm9, %xmm14
                	movaps	%xmm14, %xmm13
@@ -1107,51 +849,51 @@ Disassembly of section .text:
                	leaq	(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L162>
-<L162>:
+               	callq	 <L113>
+<L113>:
                	leaq	0x2(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L163>
-<L163>:
+               	callq	 <L114>
+<L114>:
                	leaq	0x4(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L164>
-<L164>:
+               	callq	 <L115>
+<L115>:
                	leaq	0x6(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L165>
-<L165>:
+               	callq	 <L116>
+<L116>:
                	leaq	0x8(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L166>
-<L166>:
+               	callq	 <L117>
+<L117>:
                	leaq	0xa(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L167>
-<L167>:
+               	callq	 <L118>
+<L118>:
                	leaq	0xc(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L168>
-<L168>:
+               	callq	 <L119>
+<L119>:
                	leaq	0xe(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L169>
-<L169>:
+               	callq	 <L120>
+<L120>:
                	addq	$0x1, %rsi
                	movq	%rax, %rbx
                	movaps	%xmm13, %xmm8
                	movaps	%xmm12, %xmm10
                	movaps	%xmm11, %xmm7
                	cmpq	$0x6, %rsi
-               	jb	 <L137>
-<L170>:
+               	jb	 <L88>
+<L121>:
                	leaq	-0xf0(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
@@ -1177,9 +919,9 @@ Disassembly of section .text:
                	movups	%xmm10, (%rax)
                	movq	$0x0, %rdi
                	cmpq	$0x4, %rdi
-               	jb	 <L171>
-               	jmp	 <L180>
-<L171>:
+               	jb	 <L122>
+               	jmp	 <L131>
+<L122>:
                	movq	%rdi, %rax
                	imulq	$0x10, %rax, %rax
                	leaq	(%rsi,%rax), %rcx
@@ -1189,48 +931,48 @@ Disassembly of section .text:
                	leaq	(%r12), %rax
                	movzwl	(%rax), %edx
                	movq	%rbx, %rcx
-               	callq	 <L172>
-<L172>:
+               	callq	 <L123>
+<L123>:
                	leaq	0x2(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L173>
-<L173>:
+               	callq	 <L124>
+<L124>:
                	leaq	0x4(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L174>
-<L174>:
+               	callq	 <L125>
+<L125>:
                	leaq	0x6(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L175>
-<L175>:
+               	callq	 <L126>
+<L126>:
                	leaq	0x8(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L176>
-<L176>:
+               	callq	 <L127>
+<L127>:
                	leaq	0xa(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L177>
-<L177>:
+               	callq	 <L128>
+<L128>:
                	leaq	0xc(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L178>
-<L178>:
+               	callq	 <L129>
+<L129>:
                	leaq	0xe(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L179>
-<L179>:
+               	callq	 <L130>
+<L130>:
                	addq	$0x1, %rdi
                	movq	%rax, %rbx
                	cmpq	$0x4, %rdi
-               	jb	 <L171>
-<L180>:
+               	jb	 <L122>
+<L131>:
                	leaq	-0x130(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
@@ -1248,56 +990,56 @@ Disassembly of section .text:
                	movl	$0x12345678, (%rcx)     # imm = 0x12345678
                	movl	(%rax), %edx
                	movq	%rbx, %rcx
-               	callq	 <L181>
-<L181>:
+               	callq	 <L132>
+<L132>:
                	movups	(%rsi), %xmm0
                	leaq	-0x140(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L182>
-<L182>:
+               	callq	 <L133>
+<L133>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L183>
-<L183>:
+               	callq	 <L134>
+<L134>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L184>
-<L184>:
+               	callq	 <L135>
+<L135>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L185>
-<L185>:
+               	callq	 <L136>
+<L136>:
                	leaq	0x8(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L186>
-<L186>:
+               	callq	 <L137>
+<L137>:
                	leaq	0xa(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L187>
-<L187>:
+               	callq	 <L138>
+<L138>:
                	leaq	0xc(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L188>
-<L188>:
+               	callq	 <L139>
+<L139>:
                	leaq	0xe(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L189>
-<L189>:
+               	callq	 <L140>
+<L140>:
                	leaq	0x20(%rdi), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L190>
-<L190>:
+               	callq	 <L141>
+<L141>:
                	movaps	-0x290(%rbp), %xmm6
                	movaps	-0x2a0(%rbp), %xmm7
                	movaps	-0x2b0(%rbp), %xmm8
@@ -1306,6 +1048,8 @@ Disassembly of section .text:
                	movaps	-0x2e0(%rbp), %xmm11
                	movaps	-0x2f0(%rbp), %xmm12
                	movaps	-0x300(%rbp), %xmm13
+               	movaps	-0x310(%rbp), %xmm14
+               	movaps	-0x320(%rbp), %xmm15
                	movq	-0x268(%rbp), %rbx
                	movq	-0x270(%rbp), %rdi
                	movq	-0x278(%rbp), %rsi

--- a/test/golden/x86_64-windows/vec/vec_i32x4.dis
+++ b/test/golden/x86_64-windows/vec/vec_i32x4.dis
@@ -5,11 +5,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i32x4.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movl	(%rdx), %esi
                	movl	%esi, %edx
@@ -33,6 +36,8 @@ Disassembly of section .text:
                	movl	%ebx, %edx
                	callq	 <L3>
 <L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -42,7 +47,7 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x490, %rsp            # imm = 0x490
+               	subq	$0x4b0, %rsp            # imm = 0x4B0
                	movq	%rbx, -0x3e8(%rbp)
                	movq	%rdi, -0x3f0(%rbp)
                	movq	%rsi, -0x3f8(%rbp)
@@ -55,6 +60,8 @@ Disassembly of section .text:
                	movaps	%xmm8, -0x450(%rbp)
                	movaps	%xmm9, -0x460(%rbp)
                	movaps	%xmm10, -0x470(%rbp)
+               	movaps	%xmm14, -0x480(%rbp)
+               	movaps	%xmm15, -0x490(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -525,193 +532,68 @@ Disassembly of section .text:
                	movaps	%xmm6, %xmm14
                	psubd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x360(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rcx
+               	movups	%xmm0, -0x360(%rbp)
+               	leaq	-0x360(%rbp), %rdx
                	callq	 <L41>
 <L41>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
                	movaps	%xmm7, %xmm14
                	pand	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x370(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm14, %xmm9
                	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L47>
-<L47>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L48>
-<L48>:
+               	movups	%xmm9, -0x370(%rbp)
+               	leaq	-0x370(%rbp), %rdx
+               	callq	 <L42>
+<L42>:
                	movaps	%xmm7, %xmm14
                	por	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x380(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L51>
-<L51>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L52>
-<L52>:
+               	movups	%xmm10, -0x380(%rbp)
+               	leaq	-0x380(%rbp), %rdx
+               	callq	 <L43>
+<L43>:
                	movaps	%xmm7, %xmm14
                	pxor	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x390(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L53>
-<L53>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L54>
-<L54>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L55>
-<L55>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L56>
-<L56>:
+               	movups	%xmm0, -0x390(%rbp)
+               	leaq	-0x390(%rbp), %rdx
+               	callq	 <L44>
+<L44>:
                	movaps	%xmm7, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x3a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L57>
-<L57>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L58>
-<L58>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L59>
-<L59>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L60>
-<L60>:
+               	movups	%xmm0, -0x3a0(%rbp)
+               	leaq	-0x3a0(%rbp), %rdx
+               	callq	 <L45>
+<L45>:
                	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x3b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L61>
-<L61>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm0, -0x3b0(%rbp)
+               	leaq	-0x3b0(%rbp), %rdx
+               	callq	 <L46>
+<L46>:
+               	movaps	%xmm9, %xmm14
+               	pxor	%xmm10, %xmm14
+               	movaps	%xmm14, %xmm9
                	movq	%rax, %rcx
-               	callq	 <L62>
-<L62>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L63>
-<L63>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L64>
-<L64>:
-               	movaps	%xmm7, %xmm14
-               	pand	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm7, %xmm14
-               	por	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm1
-               	movaps	%xmm0, %xmm14
-               	pxor	%xmm1, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x3c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L65>
-<L65>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L66>
-<L66>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L67>
-<L67>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L68>
-<L68>:
+               	movups	%xmm9, -0x3c0(%rbp)
+               	leaq	-0x3c0(%rbp), %rdx
+               	callq	 <L47>
+<L47>:
                	movq	%rax, %rbx
                	movq	$0x0, %rdi
-<L69>:
+<L48>:
                	leaq	-0xc0(%rbp), %r12
                	movups	%xmm7, (%r12)
                	cmpq	$0x6, %rdi
-               	jb	 <L82>
+               	jb	 <L61>
                	leaq	-0x140(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
@@ -778,9 +660,9 @@ Disassembly of section .text:
                	movq	%rbx, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L70>
-               	jmp	 <L75>
-<L70>:
+               	jb	 <L49>
+               	jmp	 <L54>
+<L49>:
                	movq	%r15, %rax
                	imulq	$0x10, %rax, %rax
                	leaq	(%r13,%rax), %rcx
@@ -793,8 +675,8 @@ Disassembly of section .text:
                	leaq	(%r8), %rcx
                	movl	(%rcx), %edx
                	movq	%r14, %rcx
-               	callq	 <L71>
-<L71>:
+               	callq	 <L50>
+<L50>:
                	movq	%rax, %rcx
                	movq	-0x3e0(%rbp), %r8
                	leaq	0x4(%r8), %rdx
@@ -802,8 +684,8 @@ Disassembly of section .text:
                	movq	%r8, -0x3d0(%rbp)
                	movq	-0x3d0(%rbp), %r8
                	movl	%r8d, %edx
-               	callq	 <L72>
-<L72>:
+               	callq	 <L51>
+<L51>:
                	movq	%rax, %rcx
                	movq	-0x3e0(%rbp), %r8
                	leaq	0x8(%r8), %rdx
@@ -811,20 +693,20 @@ Disassembly of section .text:
                	movq	%r8, -0x3d8(%rbp)
                	movq	-0x3d8(%rbp), %r8
                	movl	%r8d, %edx
-               	callq	 <L73>
-<L73>:
+               	callq	 <L52>
+<L52>:
                	movq	%rax, %rcx
                	movq	-0x3e0(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movl	(%rdx), %eax
                	movl	%eax, %edx
-               	callq	 <L74>
-<L74>:
+               	callq	 <L53>
+<L53>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x4, %r15
-               	jb	 <L70>
-<L75>:
+               	jb	 <L49>
+<L54>:
                	leaq	-0x1c0(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
@@ -842,41 +724,43 @@ Disassembly of section .text:
                	movl	$0x12345678, (%rcx)     # imm = 0x12345678
                	movl	(%rax), %edx
                	movq	%r14, %rcx
-               	callq	 <L76>
-<L76>:
+               	callq	 <L55>
+<L55>:
                	movups	(%r13), %xmm0
                	leaq	-0x1d0(%rbp), %r13
                	movups	%xmm0, (%r13)
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L77>
-<L77>:
+               	callq	 <L56>
+<L56>:
                	leaq	0x4(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L78>
-<L78>:
+               	callq	 <L57>
+<L57>:
                	leaq	0x8(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L79>
-<L79>:
+               	callq	 <L58>
+<L58>:
                	leaq	0xc(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L80>
-<L80>:
+               	callq	 <L59>
+<L59>:
                	leaq	0x20(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L81>
-<L81>:
+               	callq	 <L60>
+<L60>:
                	movaps	-0x430(%rbp), %xmm6
                	movaps	-0x440(%rbp), %xmm7
                	movaps	-0x450(%rbp), %xmm8
                	movaps	-0x460(%rbp), %xmm9
                	movaps	-0x470(%rbp), %xmm10
+               	movaps	-0x480(%rbp), %xmm14
+               	movaps	-0x490(%rbp), %xmm15
                	movq	-0x3e8(%rbp), %rbx
                	movq	-0x3f0(%rbp), %rdi
                	movq	-0x3f8(%rbp), %rsi
@@ -887,7 +771,7 @@ Disassembly of section .text:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L82>:
+<L61>:
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	leaq	(%rsi), %rcx
@@ -931,23 +815,23 @@ Disassembly of section .text:
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rbx, %rcx
-               	callq	 <L83>
-<L83>:
+               	callq	 <L62>
+<L62>:
                	leaq	0x4(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L84>
-<L84>:
+               	callq	 <L63>
+<L63>:
                	leaq	0x8(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L85>
-<L85>:
+               	callq	 <L64>
+<L64>:
                	leaq	0xc(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L86>
-<L86>:
+               	callq	 <L65>
+<L65>:
                	movaps	%xmm6, %xmm14
                	paddd	%xmm9, %xmm14
                	movaps	%xmm14, %xmm10
@@ -956,23 +840,23 @@ Disassembly of section .text:
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L87>
-<L87>:
+               	callq	 <L66>
+<L66>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L88>
-<L88>:
+               	callq	 <L67>
+<L67>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L89>
-<L89>:
+               	callq	 <L68>
+<L68>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L90>
-<L90>:
+               	callq	 <L69>
+<L69>:
                	movaps	%xmm10, %xmm14
                	pxor	%xmm8, %xmm14
                	movaps	%xmm14, %xmm10
@@ -981,23 +865,23 @@ Disassembly of section .text:
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L91>
-<L91>:
+               	callq	 <L70>
+<L70>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L92>
-<L92>:
+               	callq	 <L71>
+<L71>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L93>
-<L93>:
+               	callq	 <L72>
+<L72>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L94>
-<L94>:
+               	callq	 <L73>
+<L73>:
                	movaps	%xmm7, %xmm14
                	paddd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm9
@@ -1006,25 +890,25 @@ Disassembly of section .text:
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L95>
-<L95>:
+               	callq	 <L74>
+<L74>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L96>
-<L96>:
+               	callq	 <L75>
+<L75>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L97>
-<L97>:
+               	callq	 <L76>
+<L76>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L98>
-<L98>:
+               	callq	 <L77>
+<L77>:
                	addq	$0x1, %rdi
                	movq	%rax, %rbx
                	movaps	%xmm9, %xmm7
                	movaps	%xmm10, %xmm6
-               	jmp	 <L69>
+               	jmp	 <L48>

--- a/test/golden/x86_64-windows/vec/vec_i64x2.dis
+++ b/test/golden/x86_64-windows/vec/vec_i64x2.dis
@@ -5,11 +5,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i64x2.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movq	(%rdx), %rsi
                	movq	%rsi, %rdx
@@ -21,6 +24,8 @@ Disassembly of section .text:
                	movq	%rbx, %rdx
                	callq	 <L1>
 <L1>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -30,7 +35,7 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x3c0, %rsp            # imm = 0x3C0
+               	subq	$0x3e0, %rsp            # imm = 0x3E0
                	movq	%rbx, -0x2f8(%rbp)
                	movq	%rdi, -0x300(%rbp)
                	movq	%rsi, -0x308(%rbp)
@@ -45,6 +50,8 @@ Disassembly of section .text:
                	movaps	%xmm10, -0x380(%rbp)
                	movaps	%xmm11, -0x390(%rbp)
                	movaps	%xmm12, -0x3a0(%rbp)
+               	movaps	%xmm14, -0x3b0(%rbp)
+               	movaps	%xmm15, -0x3c0(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -304,124 +311,69 @@ Disassembly of section .text:
                	movaps	%xmm6, %xmm14
                	psubq	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x280(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
                	movq	%rax, %rcx
+               	movups	%xmm0, -0x280(%rbp)
+               	leaq	-0x280(%rbp), %rdx
                	callq	 <L21>
 <L21>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm7, %xmm14
+               	pand	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm9
                	movq	%rax, %rcx
+               	movups	%xmm9, -0x290(%rbp)
+               	leaq	-0x290(%rbp), %rdx
                	callq	 <L22>
 <L22>:
                	movaps	%xmm7, %xmm14
-               	pand	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x290(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
+               	por	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
+               	movups	%xmm10, -0x2a0(%rbp)
+               	leaq	-0x2a0(%rbp), %rdx
                	callq	 <L23>
 <L23>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
-               	movaps	%xmm7, %xmm14
-               	por	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x2a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
                	movaps	%xmm7, %xmm14
                	pxor	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x2b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
+               	movups	%xmm0, -0x2b0(%rbp)
+               	leaq	-0x2b0(%rbp), %rdx
+               	callq	 <L24>
+<L24>:
                	movaps	%xmm7, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x2c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L30>
-<L30>:
+               	movups	%xmm0, -0x2c0(%rbp)
+               	leaq	-0x2c0(%rbp), %rdx
+               	callq	 <L25>
+<L25>:
                	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x2d0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
+               	movups	%xmm0, -0x2d0(%rbp)
+               	leaq	-0x2d0(%rbp), %rdx
+               	callq	 <L26>
+<L26>:
+               	movaps	%xmm9, %xmm14
+               	pxor	%xmm10, %xmm14
+               	movaps	%xmm14, %xmm9
                	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
-               	movaps	%xmm7, %xmm14
-               	pand	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm7, %xmm14
-               	por	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm1
-               	movaps	%xmm0, %xmm14
-               	pxor	%xmm1, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x2e0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L33>
-<L33>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
+               	movups	%xmm9, -0x2e0(%rbp)
+               	leaq	-0x2e0(%rbp), %rdx
+               	callq	 <L27>
+<L27>:
                	movq	%rax, %rbx
                	movaps	%xmm6, %xmm9
                	movq	$0x0, %rdi
-<L35>:
+<L28>:
                	leaq	-0xa0(%rbp), %r12
                	movups	%xmm7, (%r12)
                	cmpq	$0x6, %rdi
-               	jb	 <L44>
+               	jb	 <L37>
                	leaq	-0x100(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
@@ -465,9 +417,9 @@ Disassembly of section .text:
                	movq	%rbx, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L36>
-               	jmp	 <L39>
-<L36>:
+               	jb	 <L29>
+               	jmp	 <L32>
+<L29>:
                	movq	%r15, %rax
                	imulq	$0x10, %rax, %rax
                	leaq	(%r13,%rax), %rcx
@@ -480,20 +432,20 @@ Disassembly of section .text:
                	leaq	(%r8), %rcx
                	movq	(%rcx), %rdx
                	movq	%r14, %rcx
-               	callq	 <L37>
-<L37>:
+               	callq	 <L30>
+<L30>:
                	movq	%rax, %rcx
                	movq	-0x2e8(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	(%rdx), %rax
                	movq	%rax, %rdx
-               	callq	 <L38>
-<L38>:
+               	callq	 <L31>
+<L31>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x4, %r15
-               	jb	 <L36>
-<L39>:
+               	jb	 <L29>
+<L32>:
                	leaq	-0x160(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
@@ -511,26 +463,26 @@ Disassembly of section .text:
                	movl	$0x12345678, (%rcx)     # imm = 0x12345678
                	movl	(%rax), %edx
                	movq	%r14, %rcx
-               	callq	 <L40>
-<L40>:
+               	callq	 <L33>
+<L33>:
                	movups	(%r13), %xmm0
                	leaq	-0x170(%rbp), %r13
                	movups	%xmm0, (%r13)
                	leaq	(%r13), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
+               	callq	 <L34>
+<L34>:
                	leaq	0x8(%r13), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
+               	callq	 <L35>
+<L35>:
                	leaq	0x20(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
+               	callq	 <L36>
+<L36>:
                	movaps	-0x340(%rbp), %xmm6
                	movaps	-0x350(%rbp), %xmm7
                	movaps	-0x360(%rbp), %xmm8
@@ -538,6 +490,8 @@ Disassembly of section .text:
                	movaps	-0x380(%rbp), %xmm10
                	movaps	-0x390(%rbp), %xmm11
                	movaps	-0x3a0(%rbp), %xmm12
+               	movaps	-0x3b0(%rbp), %xmm14
+               	movaps	-0x3c0(%rbp), %xmm15
                	movq	-0x2f8(%rbp), %rbx
                	movq	-0x300(%rbp), %rdi
                	movq	-0x308(%rbp), %rsi
@@ -548,7 +502,7 @@ Disassembly of section .text:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L44>:
+<L37>:
                	leaq	(%r12), %rcx
                	movq	(%rcx), %rdx
                	leaq	(%rsi), %rcx
@@ -572,13 +526,13 @@ Disassembly of section .text:
                	leaq	(%r13), %rcx
                	movq	(%rcx), %rdx
                	movq	%rbx, %rcx
-               	callq	 <L45>
-<L45>:
+               	callq	 <L38>
+<L38>:
                	leaq	0x8(%r13), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
+               	callq	 <L39>
+<L39>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm11
@@ -587,13 +541,13 @@ Disassembly of section .text:
                	leaq	(%r12), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L47>
-<L47>:
+               	callq	 <L40>
+<L40>:
                	leaq	0x8(%r12), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L48>
-<L48>:
+               	callq	 <L41>
+<L41>:
                	movaps	%xmm6, %xmm14
                	paddq	%xmm7, %xmm14
                	movaps	%xmm14, %xmm10
@@ -602,13 +556,13 @@ Disassembly of section .text:
                	leaq	(%r12), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L49>
-<L49>:
+               	callq	 <L42>
+<L42>:
                	leaq	0x8(%r12), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L50>
-<L50>:
+               	callq	 <L43>
+<L43>:
                	movaps	%xmm7, %xmm14
                	paddq	%xmm8, %xmm14
                	movaps	%xmm14, %xmm12
@@ -617,16 +571,16 @@ Disassembly of section .text:
                	leaq	(%r12), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L51>
-<L51>:
+               	callq	 <L44>
+<L44>:
                	leaq	0x8(%r12), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L52>
-<L52>:
+               	callq	 <L45>
+<L45>:
                	addq	$0x1, %rdi
                	movq	%rax, %rbx
                	movaps	%xmm12, %xmm7
                	movaps	%xmm11, %xmm9
                	movaps	%xmm10, %xmm6
-               	jmp	 <L35>
+               	jmp	 <L28>

--- a/test/golden/x86_64-windows/vec/vec_i8x16.dis
+++ b/test/golden/x86_64-windows/vec/vec_i8x16.dis
@@ -5,11 +5,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i8x16.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movzbl	(%rdx), %esi
                	movq	%rsi, %rdx
@@ -105,6 +108,8 @@ Disassembly of section .text:
                	movq	%rbx, %rdx
                	callq	 <L15>
 <L15>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -114,19 +119,21 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_i8x16.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xa50, %rsp            # imm = 0xA50
-               	movq	%rbx, -0x9a8(%rbp)
-               	movq	%rdi, -0x9b0(%rbp)
-               	movq	%rsi, -0x9b8(%rbp)
-               	movq	%r12, -0x9c0(%rbp)
-               	movq	%r13, -0x9c8(%rbp)
-               	movq	%r14, -0x9d0(%rbp)
-               	movq	%r15, -0x9d8(%rbp)
-               	movaps	%xmm6, -0x9f0(%rbp)
-               	movaps	%xmm7, -0xa00(%rbp)
-               	movaps	%xmm8, -0xa10(%rbp)
-               	movaps	%xmm9, -0xa20(%rbp)
-               	movaps	%xmm10, -0xa30(%rbp)
+               	subq	$0xbe0, %rsp            # imm = 0xBE0
+               	movq	%rbx, -0xb18(%rbp)
+               	movq	%rdi, -0xb20(%rbp)
+               	movq	%rsi, -0xb28(%rbp)
+               	movq	%r12, -0xb30(%rbp)
+               	movq	%r13, -0xb38(%rbp)
+               	movq	%r14, -0xb40(%rbp)
+               	movq	%r15, -0xb48(%rbp)
+               	movaps	%xmm6, -0xb60(%rbp)
+               	movaps	%xmm7, -0xb70(%rbp)
+               	movaps	%xmm8, -0xb80(%rbp)
+               	movaps	%xmm9, -0xb90(%rbp)
+               	movaps	%xmm10, -0xba0(%rbp)
+               	movaps	%xmm14, -0xbb0(%rbp)
+               	movaps	%xmm15, -0xbc0(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -306,128 +313,135 @@ Disassembly of section .text:
                	leaq	0xc(%rsi), %rdx
                	movb	%r12b, (%rdx)
                	movups	(%rsi), %xmm8
-               	movaps	%xmm7, %xmm1
+               	movups	%xmm7, -0xc0(%rbp)
+               	leaq	-0xc0(%rbp), %rdx
                	callq	 <L1>
 <L1>:
                	movq	%rax, %rcx
-               	movaps	%xmm8, %xmm1
+               	movups	%xmm8, -0xd0(%rbp)
+               	leaq	-0xd0(%rbp), %rdx
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rcx
                	movaps	%xmm7, %xmm14
                	paddb	%xmm8, %xmm14
                	movaps	%xmm14, %xmm9
-               	leaq	-0xc0(%rbp), %r12
+               	leaq	-0xe0(%rbp), %r12
                	movups	%xmm9, (%r12)
-               	movaps	%xmm9, %xmm1
+               	movups	%xmm9, -0xf0(%rbp)
+               	leaq	-0xf0(%rbp), %rdx
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rcx
                	movaps	%xmm7, %xmm14
                	psubb	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x100(%rbp)
+               	leaq	-0x100(%rbp), %rdx
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rcx
                	movaps	%xmm8, %xmm14
                	psubb	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x110(%rbp)
+               	leaq	-0x110(%rbp), %rdx
                	callq	 <L5>
 <L5>:
                	movq	%rax, %r8
-               	movq	%r8, -0x748(%rbp)
-               	movq	-0x748(%rbp), %r8
+               	movq	%r8, -0x8b8(%rbp)
+               	movq	-0x8b8(%rbp), %r8
                	leaq	(%rbx), %rdx
                	movzbl	(%rdx), %r13d
                	leaq	(%rsi), %rdx
                	movzbl	(%rdx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x750(%rbp)
+               	movq	%r8, -0x8c0(%rbp)
                	leaq	0x1(%rbx), %rdx
                	movzbl	(%rdx), %r14d
                	leaq	0x1(%rsi), %rdx
                	movzbl	(%rdx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x758(%rbp)
+               	movq	%r8, -0x8c8(%rbp)
                	leaq	0x2(%rbx), %rdx
                	movzbl	(%rdx), %r15d
                	leaq	0x2(%rsi), %rdx
                	movzbl	(%rdx), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x760(%rbp)
+               	movq	%r8, -0x8d0(%rbp)
                	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x3(%rsi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x768(%rbp)
+               	movq	%r8, -0x8d8(%rbp)
                	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x4(%rsi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x770(%rbp)
+               	movq	%r8, -0x8e0(%rbp)
                	leaq	0x5(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x5(%rsi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x778(%rbp)
+               	movq	%r8, -0x8e8(%rbp)
                	leaq	0x6(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x6(%rsi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x780(%rbp)
+               	movq	%r8, -0x8f0(%rbp)
                	leaq	0x7(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x7(%rsi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x788(%rbp)
+               	movq	%r8, -0x8f8(%rbp)
                	leaq	0x8(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x8(%rsi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x790(%rbp)
+               	movq	%r8, -0x900(%rbp)
                	leaq	0x9(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x9(%rsi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x798(%rbp)
+               	movq	%r8, -0x908(%rbp)
                	leaq	0xa(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0xa(%rsi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x7a0(%rbp)
+               	movq	%r8, -0x910(%rbp)
                	leaq	0xb(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0xb(%rsi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x7a8(%rbp)
+               	movq	%r8, -0x918(%rbp)
                	leaq	0xc(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0xc(%rsi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x7b0(%rbp)
+               	movq	%r8, -0x920(%rbp)
                	leaq	0xd(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0xd(%rsi), %rcx
@@ -443,190 +457,192 @@ Disassembly of section .text:
                	leaq	0xf(%rsi), %rcx
                	movzbl	(%rcx), %r13d
                	imull	%r13d, %edx
-               	leaq	-0xd0(%rbp), %rcx
+               	leaq	-0x120(%rbp), %rcx
                	movups	%xmm7, (%rcx)
                	leaq	(%rcx), %r13
-               	movq	-0x750(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r13
-               	movq	-0x758(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r13
-               	movq	-0x760(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x100(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r13
-               	movq	-0x768(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x110(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r13
-               	movq	-0x770(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x120(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r13
-               	movq	-0x778(%rbp), %r8
+               	movq	-0x8c0(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x130(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r13
-               	movq	-0x780(%rbp), %r8
+               	leaq	0x1(%rcx), %r13
+               	movq	-0x8c8(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x140(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r13
-               	movq	-0x788(%rbp), %r8
+               	leaq	0x2(%rcx), %r13
+               	movq	-0x8d0(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x150(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r13
-               	movq	-0x790(%rbp), %r8
+               	leaq	0x3(%rcx), %r13
+               	movq	-0x8d8(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x160(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r13
-               	movq	-0x798(%rbp), %r8
+               	leaq	0x4(%rcx), %r13
+               	movq	-0x8e0(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x170(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r13
-               	movq	-0x7a0(%rbp), %r8
+               	leaq	0x5(%rcx), %r13
+               	movq	-0x8e8(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x180(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r13
-               	movq	-0x7a8(%rbp), %r8
+               	leaq	0x6(%rcx), %r13
+               	movq	-0x8f0(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x190(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %r13
-               	movq	-0x7b0(%rbp), %r8
+               	leaq	0x7(%rcx), %r13
+               	movq	-0x8f8(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x1a0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
+               	leaq	0x8(%rcx), %r13
+               	movq	-0x900(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x1b0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x9(%rcx), %r13
+               	movq	-0x908(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x1c0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xa(%rcx), %r13
+               	movq	-0x910(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x1d0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xb(%rcx), %r13
+               	movq	-0x918(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x1e0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xc(%rcx), %r13
+               	movq	-0x920(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x1f0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %r13
                	movb	%r14b, (%r13)
                	movups	(%rcx), %xmm0
-               	leaq	-0x1b0(%rbp), %rcx
+               	leaq	-0x200(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %r13
                	movb	%r15b, (%r13)
                	movups	(%rcx), %xmm0
-               	leaq	-0x1c0(%rbp), %rcx
+               	leaq	-0x210(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %r13
                	movb	%dl, (%r13)
-               	movups	(%rcx), %xmm1
-               	movq	-0x748(%rbp), %r8
+               	movups	(%rcx), %xmm0
+               	movq	-0x8b8(%rbp), %r8
                	movq	%r8, %rcx
+               	movups	%xmm0, -0x220(%rbp)
+               	leaq	-0x220(%rbp), %rdx
                	callq	 <L6>
 <L6>:
                	movq	%rax, %r8
-               	movq	%r8, -0x7b8(%rbp)
-               	movq	-0x7b8(%rbp), %r8
+               	movq	%r8, -0x928(%rbp)
+               	movq	-0x928(%rbp), %r8
                	leaq	(%rbx), %rdx
                	movzbl	(%rdx), %r13d
                	leaq	(%rdi), %rdx
                	movzbl	(%rdx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x7c0(%rbp)
+               	movq	%r8, -0x930(%rbp)
                	leaq	0x1(%rbx), %rdx
                	movzbl	(%rdx), %r14d
                	leaq	0x1(%rdi), %rdx
                	movzbl	(%rdx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x7c8(%rbp)
+               	movq	%r8, -0x938(%rbp)
                	leaq	0x2(%rbx), %rdx
                	movzbl	(%rdx), %r15d
                	leaq	0x2(%rdi), %rdx
                	movzbl	(%rdx), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x7d0(%rbp)
+               	movq	%r8, -0x940(%rbp)
                	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x3(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x7d8(%rbp)
+               	movq	%r8, -0x948(%rbp)
                	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x4(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x7e0(%rbp)
+               	movq	%r8, -0x950(%rbp)
                	leaq	0x5(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x5(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x7e8(%rbp)
+               	movq	%r8, -0x958(%rbp)
                	leaq	0x6(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x6(%rdi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x7f0(%rbp)
+               	movq	%r8, -0x960(%rbp)
                	leaq	0x7(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x7(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x7f8(%rbp)
+               	movq	%r8, -0x968(%rbp)
                	leaq	0x8(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x8(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x800(%rbp)
+               	movq	%r8, -0x970(%rbp)
                	leaq	0x9(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x9(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x808(%rbp)
+               	movq	%r8, -0x978(%rbp)
                	leaq	0xa(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0xa(%rdi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x810(%rbp)
+               	movq	%r8, -0x980(%rbp)
                	leaq	0xb(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0xb(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x818(%rbp)
+               	movq	%r8, -0x988(%rbp)
                	leaq	0xc(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0xc(%rdi), %rcx
@@ -647,182 +663,184 @@ Disassembly of section .text:
                	leaq	0xf(%rdi), %rcx
                	movzbl	(%rcx), %ebx
                	imull	%ebx, %edx
-               	leaq	-0x1d0(%rbp), %rcx
+               	leaq	-0x230(%rbp), %rcx
                	movups	%xmm7, (%rcx)
                	leaq	(%rcx), %rbx
-               	movq	-0x7c0(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %rbx
-               	movq	-0x7c8(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %rbx
-               	movq	-0x7d0(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x200(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %rbx
-               	movq	-0x7d8(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x210(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rbx
-               	movq	-0x7e0(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x220(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %rbx
-               	movq	-0x7e8(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x230(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %rbx
-               	movq	-0x7f0(%rbp), %r8
+               	movq	-0x930(%rbp), %r8
                	movb	%r8b, (%rbx)
                	movups	(%rcx), %xmm0
                	leaq	-0x240(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %rbx
-               	movq	-0x7f8(%rbp), %r8
+               	leaq	0x1(%rcx), %rbx
+               	movq	-0x938(%rbp), %r8
                	movb	%r8b, (%rbx)
                	movups	(%rcx), %xmm0
                	leaq	-0x250(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rbx
-               	movq	-0x800(%rbp), %r8
+               	leaq	0x2(%rcx), %rbx
+               	movq	-0x940(%rbp), %r8
                	movb	%r8b, (%rbx)
                	movups	(%rcx), %xmm0
                	leaq	-0x260(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %rbx
-               	movq	-0x808(%rbp), %r8
+               	leaq	0x3(%rcx), %rbx
+               	movq	-0x948(%rbp), %r8
                	movb	%r8b, (%rbx)
                	movups	(%rcx), %xmm0
                	leaq	-0x270(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %rbx
-               	movq	-0x810(%rbp), %r8
+               	leaq	0x4(%rcx), %rbx
+               	movq	-0x950(%rbp), %r8
                	movb	%r8b, (%rbx)
                	movups	(%rcx), %xmm0
                	leaq	-0x280(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %rbx
-               	movq	-0x818(%rbp), %r8
+               	leaq	0x5(%rcx), %rbx
+               	movq	-0x958(%rbp), %r8
                	movb	%r8b, (%rbx)
                	movups	(%rcx), %xmm0
                	leaq	-0x290(%rbp), %rcx
                	movups	%xmm0, (%rcx)
+               	leaq	0x6(%rcx), %rbx
+               	movq	-0x960(%rbp), %r8
+               	movb	%r8b, (%rbx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2a0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x7(%rcx), %rbx
+               	movq	-0x968(%rbp), %r8
+               	movb	%r8b, (%rbx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2b0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x8(%rcx), %rbx
+               	movq	-0x970(%rbp), %r8
+               	movb	%r8b, (%rbx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2c0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x9(%rcx), %rbx
+               	movq	-0x978(%rbp), %r8
+               	movb	%r8b, (%rbx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2d0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xa(%rcx), %rbx
+               	movq	-0x980(%rbp), %r8
+               	movb	%r8b, (%rbx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2e0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xb(%rcx), %rbx
+               	movq	-0x988(%rbp), %r8
+               	movb	%r8b, (%rbx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2f0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rbx
                	movb	%r13b, (%rbx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x2a0(%rbp), %rcx
+               	leaq	-0x300(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rbx
                	movb	%r14b, (%rbx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x2b0(%rbp), %rcx
+               	leaq	-0x310(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rbx
                	movb	%r15b, (%rbx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x2c0(%rbp), %rcx
+               	leaq	-0x320(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rbx
                	movb	%dl, (%rbx)
-               	movups	(%rcx), %xmm1
-               	movq	-0x7b8(%rbp), %r8
+               	movups	(%rcx), %xmm0
+               	movq	-0x928(%rbp), %r8
                	movq	%r8, %rcx
+               	movups	%xmm0, -0x330(%rbp)
+               	leaq	-0x330(%rbp), %rdx
                	callq	 <L7>
 <L7>:
                	movq	%rax, %r8
-               	movq	%r8, -0x820(%rbp)
-               	movq	-0x820(%rbp), %r8
+               	movq	%r8, -0x990(%rbp)
+               	movq	-0x990(%rbp), %r8
                	leaq	(%rsi), %rdx
                	movzbl	(%rdx), %ebx
                	leaq	(%rdi), %rdx
                	movzbl	(%rdx), %r13d
                	movl	%ebx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x828(%rbp)
+               	movq	%r8, -0x998(%rbp)
                	leaq	0x1(%rsi), %rdx
                	movzbl	(%rdx), %r13d
                	leaq	0x1(%rdi), %rdx
                	movzbl	(%rdx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x830(%rbp)
+               	movq	%r8, -0x9a0(%rbp)
                	leaq	0x2(%rsi), %rdx
                	movzbl	(%rdx), %r14d
                	leaq	0x2(%rdi), %rdx
                	movzbl	(%rdx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x838(%rbp)
+               	movq	%r8, -0x9a8(%rbp)
                	leaq	0x3(%rsi), %rdx
                	movzbl	(%rdx), %r15d
                	leaq	0x3(%rdi), %rdx
                	movzbl	(%rdx), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x840(%rbp)
+               	movq	%r8, -0x9b0(%rbp)
                	leaq	0x4(%rsi), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x4(%rdi), %rcx
                	movzbl	(%rcx), %ebx
                	movl	%edx, %r8d
                	imull	%ebx, %r8d
-               	movq	%r8, -0x848(%rbp)
+               	movq	%r8, -0x9b8(%rbp)
                	leaq	0x5(%rsi), %rcx
                	movzbl	(%rcx), %ebx
                	leaq	0x5(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%ebx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x850(%rbp)
+               	movq	%r8, -0x9c0(%rbp)
                	leaq	0x6(%rsi), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x6(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x858(%rbp)
+               	movq	%r8, -0x9c8(%rbp)
                	leaq	0x7(%rsi), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x7(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x860(%rbp)
+               	movq	%r8, -0x9d0(%rbp)
                	leaq	0x8(%rsi), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x8(%rdi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x868(%rbp)
+               	movq	%r8, -0x9d8(%rbp)
                	leaq	0x9(%rsi), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x9(%rdi), %rcx
                	movzbl	(%rcx), %ebx
                	movl	%edx, %r8d
                	imull	%ebx, %r8d
-               	movq	%r8, -0x870(%rbp)
+               	movq	%r8, -0x9e0(%rbp)
                	leaq	0xa(%rsi), %rcx
                	movzbl	(%rcx), %ebx
                	leaq	0xa(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%ebx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x878(%rbp)
+               	movq	%r8, -0x9e8(%rbp)
                	leaq	0xb(%rsi), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0xb(%rdi), %rcx
@@ -848,174 +866,176 @@ Disassembly of section .text:
                	leaq	0xf(%rdi), %rcx
                	movzbl	(%rcx), %esi
                	imull	%esi, %ebx
-               	leaq	-0x2d0(%rbp), %rcx
+               	leaq	-0x340(%rbp), %rcx
                	movups	%xmm8, (%rcx)
                	leaq	(%rcx), %rsi
-               	movq	-0x828(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %rsi
-               	movq	-0x830(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %rsi
-               	movq	-0x838(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %rsi
-               	movq	-0x840(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x310(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rsi
-               	movq	-0x848(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x320(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %rsi
-               	movq	-0x850(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x330(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %rsi
-               	movq	-0x858(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x340(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %rsi
-               	movq	-0x860(%rbp), %r8
+               	movq	-0x998(%rbp), %r8
                	movb	%r8b, (%rsi)
                	movups	(%rcx), %xmm0
                	leaq	-0x350(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rsi
-               	movq	-0x868(%rbp), %r8
+               	leaq	0x1(%rcx), %rsi
+               	movq	-0x9a0(%rbp), %r8
                	movb	%r8b, (%rsi)
                	movups	(%rcx), %xmm0
                	leaq	-0x360(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %rsi
-               	movq	-0x870(%rbp), %r8
+               	leaq	0x2(%rcx), %rsi
+               	movq	-0x9a8(%rbp), %r8
                	movb	%r8b, (%rsi)
                	movups	(%rcx), %xmm0
                	leaq	-0x370(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %rsi
-               	movq	-0x878(%rbp), %r8
+               	leaq	0x3(%rcx), %rsi
+               	movq	-0x9b0(%rbp), %r8
                	movb	%r8b, (%rsi)
                	movups	(%rcx), %xmm0
                	leaq	-0x380(%rbp), %rcx
                	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %rsi
+               	movq	-0x9b8(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x390(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x5(%rcx), %rsi
+               	movq	-0x9c0(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x3a0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x6(%rcx), %rsi
+               	movq	-0x9c8(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x3b0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x7(%rcx), %rsi
+               	movq	-0x9d0(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x3c0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x8(%rcx), %rsi
+               	movq	-0x9d8(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x3d0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x9(%rcx), %rsi
+               	movq	-0x9e0(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x3e0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xa(%rcx), %rsi
+               	movq	-0x9e8(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x3f0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0xb(%rcx), %rsi
                	movb	%r13b, (%rsi)
                	movups	(%rcx), %xmm0
-               	leaq	-0x390(%rbp), %rcx
+               	leaq	-0x400(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rsi
                	movb	%r14b, (%rsi)
                	movups	(%rcx), %xmm0
-               	leaq	-0x3a0(%rbp), %rcx
+               	leaq	-0x410(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rsi
                	movb	%r15b, (%rsi)
                	movups	(%rcx), %xmm0
-               	leaq	-0x3b0(%rbp), %rcx
+               	leaq	-0x420(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rsi
                	movb	%dl, (%rsi)
                	movups	(%rcx), %xmm0
-               	leaq	-0x3c0(%rbp), %rcx
+               	leaq	-0x430(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rdx
                	movb	%bl, (%rdx)
-               	movups	(%rcx), %xmm1
-               	movq	-0x820(%rbp), %r8
+               	movups	(%rcx), %xmm0
+               	movq	-0x990(%rbp), %r8
                	movq	%r8, %rcx
+               	movups	%xmm0, -0x440(%rbp)
+               	leaq	-0x440(%rbp), %rdx
                	callq	 <L8>
 <L8>:
                	movq	%rax, %r8
-               	movq	%r8, -0x880(%rbp)
-               	movq	-0x880(%rbp), %r8
+               	movq	%r8, -0x9f0(%rbp)
+               	movq	-0x9f0(%rbp), %r8
                	leaq	(%r12), %rdx
                	movzbl	(%rdx), %ebx
                	leaq	(%rdi), %rdx
                	movzbl	(%rdx), %esi
                	movl	%ebx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x888(%rbp)
+               	movq	%r8, -0x9f8(%rbp)
                	leaq	0x1(%r12), %rdx
                	movzbl	(%rdx), %esi
                	leaq	0x1(%rdi), %rdx
                	movzbl	(%rdx), %r13d
                	movl	%esi, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x890(%rbp)
+               	movq	%r8, -0xa00(%rbp)
                	leaq	0x2(%r12), %rdx
                	movzbl	(%rdx), %r13d
                	leaq	0x2(%rdi), %rdx
                	movzbl	(%rdx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x898(%rbp)
+               	movq	%r8, -0xa08(%rbp)
                	leaq	0x3(%r12), %rdx
                	movzbl	(%rdx), %r14d
                	leaq	0x3(%rdi), %rdx
                	movzbl	(%rdx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x8a0(%rbp)
+               	movq	%r8, -0xa10(%rbp)
                	leaq	0x4(%r12), %rdx
                	movzbl	(%rdx), %r15d
                	leaq	0x4(%rdi), %rdx
                	movzbl	(%rdx), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x8a8(%rbp)
+               	movq	%r8, -0xa18(%rbp)
                	leaq	0x5(%r12), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x5(%rdi), %rcx
                	movzbl	(%rcx), %ebx
                	movl	%edx, %r8d
                	imull	%ebx, %r8d
-               	movq	%r8, -0x8b0(%rbp)
+               	movq	%r8, -0xa20(%rbp)
                	leaq	0x6(%r12), %rcx
                	movzbl	(%rcx), %ebx
                	leaq	0x6(%rdi), %rcx
                	movzbl	(%rcx), %esi
                	movl	%ebx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x8b8(%rbp)
+               	movq	%r8, -0xa28(%rbp)
                	leaq	0x7(%r12), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x7(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%esi, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x8c0(%rbp)
+               	movq	%r8, -0xa30(%rbp)
                	leaq	0x8(%r12), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x8(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x8c8(%rbp)
+               	movq	%r8, -0xa38(%rbp)
                	leaq	0x9(%r12), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x9(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x8d0(%rbp)
+               	movq	%r8, -0xa40(%rbp)
                	leaq	0xa(%r12), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0xa(%rdi), %rcx
@@ -1046,162 +1066,177 @@ Disassembly of section .text:
                	leaq	0xf(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	imull	%r14d, %r12d
-               	leaq	-0x3d0(%rbp), %rcx
+               	leaq	-0x450(%rbp), %rcx
                	movups	%xmm9, (%rcx)
                	leaq	(%rcx), %r14
-               	movq	-0x888(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r14
-               	movq	-0x890(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r14
-               	movq	-0x898(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x400(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r14
-               	movq	-0x8a0(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x410(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r14
-               	movq	-0x8a8(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x420(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r14
-               	movq	-0x8b0(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x430(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r14
-               	movq	-0x8b8(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x440(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r14
-               	movq	-0x8c0(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x450(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r14
-               	movq	-0x8c8(%rbp), %r8
+               	movq	-0x9f8(%rbp), %r8
                	movb	%r8b, (%r14)
                	movups	(%rcx), %xmm0
                	leaq	-0x460(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r14
-               	movq	-0x8d0(%rbp), %r8
+               	leaq	0x1(%rcx), %r14
+               	movq	-0xa00(%rbp), %r8
                	movb	%r8b, (%r14)
                	movups	(%rcx), %xmm0
                	leaq	-0x470(%rbp), %rcx
                	movups	%xmm0, (%rcx)
+               	leaq	0x2(%rcx), %r14
+               	movq	-0xa08(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x480(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x3(%rcx), %r14
+               	movq	-0xa10(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x490(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %r14
+               	movq	-0xa18(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x4a0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x5(%rcx), %r14
+               	movq	-0xa20(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x4b0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x6(%rcx), %r14
+               	movq	-0xa28(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x4c0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x7(%rcx), %r14
+               	movq	-0xa30(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x4d0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x8(%rcx), %r14
+               	movq	-0xa38(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x4e0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x9(%rcx), %r14
+               	movq	-0xa40(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x4f0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0xa(%rcx), %r14
                	movb	%r15b, (%r14)
                	movups	(%rcx), %xmm0
-               	leaq	-0x480(%rbp), %rcx
+               	leaq	-0x500(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xb(%rcx), %r14
                	movb	%dl, (%r14)
                	movups	(%rcx), %xmm0
-               	leaq	-0x490(%rbp), %rcx
+               	leaq	-0x510(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rdx
                	movb	%bl, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4a0(%rbp), %rcx
+               	leaq	-0x520(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rdx
                	movb	%sil, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4b0(%rbp), %rcx
+               	leaq	-0x530(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rdx
                	movb	%r13b, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4c0(%rbp), %rcx
+               	leaq	-0x540(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rdx
                	movb	%r12b, (%rdx)
-               	movups	(%rcx), %xmm1
-               	movq	-0x880(%rbp), %r8
+               	movups	(%rcx), %xmm0
+               	movq	-0x9f0(%rbp), %r8
                	movq	%r8, %rcx
+               	movups	%xmm0, -0x550(%rbp)
+               	leaq	-0x550(%rbp), %rdx
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rcx
                	movaps	%xmm6, %xmm14
                	psubb	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x560(%rbp)
+               	leaq	-0x560(%rbp), %rdx
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rcx
                	movaps	%xmm6, %xmm14
                	psubb	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x570(%rbp)
+               	leaq	-0x570(%rbp), %rdx
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rcx
                	movaps	%xmm7, %xmm14
                	pand	%xmm8, %xmm14
                	movaps	%xmm14, %xmm9
-               	movaps	%xmm9, %xmm1
+               	movups	%xmm9, -0x580(%rbp)
+               	leaq	-0x580(%rbp), %rdx
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rcx
                	movaps	%xmm7, %xmm14
                	por	%xmm8, %xmm14
                	movaps	%xmm14, %xmm10
-               	movaps	%xmm10, %xmm1
+               	movups	%xmm10, -0x590(%rbp)
+               	leaq	-0x590(%rbp), %rdx
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rcx
                	movaps	%xmm7, %xmm14
                	pxor	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x5a0(%rbp)
+               	leaq	-0x5a0(%rbp), %rdx
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rcx
                	movaps	%xmm7, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x5b0(%rbp)
+               	leaq	-0x5b0(%rbp), %rdx
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rcx
                	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x5c0(%rbp)
+               	leaq	-0x5c0(%rbp), %rdx
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rcx
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm9
-               	movaps	%xmm9, %xmm1
+               	movups	%xmm9, -0x5d0(%rbp)
+               	leaq	-0x5d0(%rbp), %rdx
                	callq	 <L17>
 <L17>:
                	movq	%rax, %rbx
                	movaps	%xmm6, %xmm9
                	movq	$0x0, %rsi
 <L18>:
-               	leaq	-0x4d0(%rbp), %r12
+               	leaq	-0x5e0(%rbp), %r12
                	movups	%xmm7, (%r12)
                	cmpq	$0x3, %rsi
                	jb	 <L25>
-               	leaq	-0x610(%rbp), %r13
+               	leaq	-0x760(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -1223,91 +1258,91 @@ Disassembly of section .text:
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8d8(%rbp)
+               	movq	%r8, -0xa48(%rbp)
                	leaq	0x1(%r12), %rax
                	movzbl	(%rax), %edx
                	leaq	0x1(%rdi), %rax
                	movzbl	(%rax), %r14d
                	movl	%edx, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x8e0(%rbp)
+               	movq	%r8, -0xa50(%rbp)
                	leaq	0x2(%r12), %rax
                	movzbl	(%rax), %r14d
                	leaq	0x2(%rdi), %rax
                	movzbl	(%rax), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x8e8(%rbp)
+               	movq	%r8, -0xa58(%rbp)
                	leaq	0x3(%r12), %rax
                	movzbl	(%rax), %r15d
                	leaq	0x3(%rdi), %rax
                	movzbl	(%rax), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x8f0(%rbp)
+               	movq	%r8, -0xa60(%rbp)
                	leaq	0x4(%r12), %rax
                	movzbl	(%rax), %ecx
                	leaq	0x4(%rdi), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8f8(%rbp)
+               	movq	%r8, -0xa68(%rbp)
                	leaq	0x5(%r12), %rax
                	movzbl	(%rax), %edx
                	leaq	0x5(%rdi), %rax
                	movzbl	(%rax), %r14d
                	movl	%edx, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x900(%rbp)
+               	movq	%r8, -0xa70(%rbp)
                	leaq	0x6(%r12), %rax
                	movzbl	(%rax), %r14d
                	leaq	0x6(%rdi), %rax
                	movzbl	(%rax), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x908(%rbp)
+               	movq	%r8, -0xa78(%rbp)
                	leaq	0x7(%r12), %rax
                	movzbl	(%rax), %r15d
                	leaq	0x7(%rdi), %rax
                	movzbl	(%rax), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x910(%rbp)
+               	movq	%r8, -0xa80(%rbp)
                	leaq	0x8(%r12), %rax
                	movzbl	(%rax), %ecx
                	leaq	0x8(%rdi), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x918(%rbp)
+               	movq	%r8, -0xa88(%rbp)
                	leaq	0x9(%r12), %rax
                	movzbl	(%rax), %edx
                	leaq	0x9(%rdi), %rax
                	movzbl	(%rax), %r14d
                	movl	%edx, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x920(%rbp)
+               	movq	%r8, -0xa90(%rbp)
                	leaq	0xa(%r12), %rax
                	movzbl	(%rax), %r14d
                	leaq	0xa(%rdi), %rax
                	movzbl	(%rax), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x928(%rbp)
+               	movq	%r8, -0xa98(%rbp)
                	leaq	0xb(%r12), %rax
                	movzbl	(%rax), %r15d
                	leaq	0xb(%rdi), %rax
                	movzbl	(%rax), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x930(%rbp)
+               	movq	%r8, -0xaa0(%rbp)
                	leaq	0xc(%r12), %rax
                	movzbl	(%rax), %ecx
                	leaq	0xc(%rdi), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x938(%rbp)
+               	movq	%r8, -0xaa8(%rbp)
                	leaq	0xd(%r12), %rax
                	movzbl	(%rax), %edx
                	leaq	0xd(%rdi), %rax
@@ -1323,95 +1358,95 @@ Disassembly of section .text:
                	leaq	0xf(%rdi), %rax
                	movzbl	(%rax), %ecx
                	imull	%ecx, %r15d
-               	leaq	-0x620(%rbp), %rax
+               	leaq	-0x770(%rbp), %rax
                	movups	%xmm7, (%rax)
                	leaq	(%rax), %rcx
-               	movq	-0x8d8(%rbp), %r8
+               	movq	-0xa48(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x630(%rbp), %rax
+               	leaq	-0x780(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x1(%rax), %rcx
-               	movq	-0x8e0(%rbp), %r8
+               	movq	-0xa50(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x640(%rbp), %rax
+               	leaq	-0x790(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x2(%rax), %rcx
-               	movq	-0x8e8(%rbp), %r8
+               	movq	-0xa58(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x650(%rbp), %rax
+               	leaq	-0x7a0(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x3(%rax), %rcx
-               	movq	-0x8f0(%rbp), %r8
+               	movq	-0xa60(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x660(%rbp), %rax
+               	leaq	-0x7b0(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x4(%rax), %rcx
-               	movq	-0x8f8(%rbp), %r8
+               	movq	-0xa68(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x670(%rbp), %rax
+               	leaq	-0x7c0(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x5(%rax), %rcx
-               	movq	-0x900(%rbp), %r8
+               	movq	-0xa70(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x680(%rbp), %rax
+               	leaq	-0x7d0(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x6(%rax), %rcx
-               	movq	-0x908(%rbp), %r8
+               	movq	-0xa78(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x690(%rbp), %rax
+               	leaq	-0x7e0(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x7(%rax), %rcx
-               	movq	-0x910(%rbp), %r8
+               	movq	-0xa80(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6a0(%rbp), %rax
+               	leaq	-0x7f0(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x8(%rax), %rcx
-               	movq	-0x918(%rbp), %r8
+               	movq	-0xa88(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6b0(%rbp), %rax
+               	leaq	-0x800(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x9(%rax), %rcx
-               	movq	-0x920(%rbp), %r8
+               	movq	-0xa90(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6c0(%rbp), %rax
+               	leaq	-0x810(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xa(%rax), %rcx
-               	movq	-0x928(%rbp), %r8
+               	movq	-0xa98(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6d0(%rbp), %rax
+               	leaq	-0x820(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xb(%rax), %rcx
-               	movq	-0x930(%rbp), %r8
+               	movq	-0xaa0(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6e0(%rbp), %rax
+               	leaq	-0x830(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xc(%rax), %rcx
-               	movq	-0x938(%rbp), %r8
+               	movq	-0xaa8(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6f0(%rbp), %rax
+               	leaq	-0x840(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xd(%rax), %rcx
                	movb	%dl, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x700(%rbp), %rax
+               	leaq	-0x850(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xe(%rax), %rcx
                	movb	%r14b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x710(%rbp), %rax
+               	leaq	-0x860(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xf(%rax), %rcx
                	movb	%r15b, (%rcx)
@@ -1429,8 +1464,10 @@ Disassembly of section .text:
                	movq	%r15, %rax
                	imulq	$0x10, %rax, %rax
                	leaq	(%r13,%rax), %rcx
-               	movups	(%rcx), %xmm1
+               	movups	(%rcx), %xmm0
                	movq	%r14, %rcx
+               	movups	%xmm0, -0x870(%rbp)
+               	leaq	-0x870(%rbp), %rdx
                	callq	 <L20>
 <L20>:
                	addq	$0x1, %r15
@@ -1438,7 +1475,7 @@ Disassembly of section .text:
                	cmpq	$0x4, %r15
                	jb	 <L19>
 <L21>:
-               	leaq	-0x740(%rbp), %rax
+               	leaq	-0x8a0(%rbp), %rax
                	movq	$0x0, (%rax)
                	movq	$0x0, 0x8(%rax)
                	movq	$0x0, 0x10(%rax)
@@ -1458,26 +1495,30 @@ Disassembly of section .text:
                	movl	%eax, %edx
                	callq	 <L22>
 <L22>:
-               	movups	(%r13), %xmm1
+               	movups	(%r13), %xmm0
                	movq	%rax, %rcx
+               	movups	%xmm0, -0x8b0(%rbp)
+               	leaq	-0x8b0(%rbp), %rdx
                	callq	 <L23>
 <L23>:
                	movl	(%r15), %edx
                	movq	%rax, %rcx
                	callq	 <L24>
 <L24>:
-               	movaps	-0x9f0(%rbp), %xmm6
-               	movaps	-0xa00(%rbp), %xmm7
-               	movaps	-0xa10(%rbp), %xmm8
-               	movaps	-0xa20(%rbp), %xmm9
-               	movaps	-0xa30(%rbp), %xmm10
-               	movq	-0x9a8(%rbp), %rbx
-               	movq	-0x9b0(%rbp), %rdi
-               	movq	-0x9b8(%rbp), %rsi
-               	movq	-0x9c0(%rbp), %r12
-               	movq	-0x9c8(%rbp), %r13
-               	movq	-0x9d0(%rbp), %r14
-               	movq	-0x9d8(%rbp), %r15
+               	movaps	-0xb60(%rbp), %xmm6
+               	movaps	-0xb70(%rbp), %xmm7
+               	movaps	-0xb80(%rbp), %xmm8
+               	movaps	-0xb90(%rbp), %xmm9
+               	movaps	-0xba0(%rbp), %xmm10
+               	movaps	-0xbb0(%rbp), %xmm14
+               	movaps	-0xbc0(%rbp), %xmm15
+               	movq	-0xb18(%rbp), %rbx
+               	movq	-0xb20(%rbp), %rdi
+               	movq	-0xb28(%rbp), %rsi
+               	movq	-0xb30(%rbp), %r12
+               	movq	-0xb38(%rbp), %r13
+               	movq	-0xb40(%rbp), %r14
+               	movq	-0xb48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -1488,84 +1529,84 @@ Disassembly of section .text:
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x940(%rbp)
+               	movq	%r8, -0xab0(%rbp)
                	leaq	0x1(%r12), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x1(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x948(%rbp)
+               	movq	%r8, -0xab8(%rbp)
                	leaq	0x2(%r12), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x2(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x950(%rbp)
+               	movq	%r8, -0xac0(%rbp)
                	leaq	0x3(%r12), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x3(%rdi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x958(%rbp)
+               	movq	%r8, -0xac8(%rbp)
                	leaq	0x4(%r12), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x4(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x960(%rbp)
+               	movq	%r8, -0xad0(%rbp)
                	leaq	0x5(%r12), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x5(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x968(%rbp)
+               	movq	%r8, -0xad8(%rbp)
                	leaq	0x6(%r12), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x6(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x970(%rbp)
+               	movq	%r8, -0xae0(%rbp)
                	leaq	0x7(%r12), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x7(%rdi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x978(%rbp)
+               	movq	%r8, -0xae8(%rbp)
                	leaq	0x8(%r12), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x8(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x980(%rbp)
+               	movq	%r8, -0xaf0(%rbp)
                	leaq	0x9(%r12), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x9(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x988(%rbp)
+               	movq	%r8, -0xaf8(%rbp)
                	leaq	0xa(%r12), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0xa(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x990(%rbp)
+               	movq	%r8, -0xb00(%rbp)
                	leaq	0xb(%r12), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0xb(%rdi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x998(%rbp)
+               	movq	%r8, -0xb08(%rbp)
                	leaq	0xc(%r12), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0xc(%rdi), %rcx
@@ -1586,121 +1627,125 @@ Disassembly of section .text:
                	leaq	0xf(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	imull	%r15d, %r12d
-               	leaq	-0x4e0(%rbp), %rcx
+               	leaq	-0x5f0(%rbp), %rcx
                	movups	%xmm7, (%rcx)
                	leaq	(%rcx), %r15
-               	movq	-0x940(%rbp), %r8
+               	movq	-0xab0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4f0(%rbp), %rcx
+               	leaq	-0x600(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x1(%rcx), %r15
-               	movq	-0x948(%rbp), %r8
+               	movq	-0xab8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x500(%rbp), %rcx
+               	leaq	-0x610(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x2(%rcx), %r15
-               	movq	-0x950(%rbp), %r8
+               	movq	-0xac0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x510(%rbp), %rcx
+               	leaq	-0x620(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x3(%rcx), %r15
-               	movq	-0x958(%rbp), %r8
+               	movq	-0xac8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x520(%rbp), %rcx
+               	leaq	-0x630(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %r15
-               	movq	-0x960(%rbp), %r8
+               	movq	-0xad0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x530(%rbp), %rcx
+               	leaq	-0x640(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x5(%rcx), %r15
-               	movq	-0x968(%rbp), %r8
+               	movq	-0xad8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x540(%rbp), %rcx
+               	leaq	-0x650(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x6(%rcx), %r15
-               	movq	-0x970(%rbp), %r8
+               	movq	-0xae0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x550(%rbp), %rcx
+               	leaq	-0x660(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x7(%rcx), %r15
-               	movq	-0x978(%rbp), %r8
+               	movq	-0xae8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x560(%rbp), %rcx
+               	leaq	-0x670(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %r15
-               	movq	-0x980(%rbp), %r8
+               	movq	-0xaf0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x570(%rbp), %rcx
+               	leaq	-0x680(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x9(%rcx), %r15
-               	movq	-0x988(%rbp), %r8
+               	movq	-0xaf8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x580(%rbp), %rcx
+               	leaq	-0x690(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xa(%rcx), %r15
-               	movq	-0x990(%rbp), %r8
+               	movq	-0xb00(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x590(%rbp), %rcx
+               	leaq	-0x6a0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xb(%rcx), %r15
-               	movq	-0x998(%rbp), %r8
+               	movq	-0xb08(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5a0(%rbp), %rcx
+               	leaq	-0x6b0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %r15
                	movb	%dl, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5b0(%rbp), %rcx
+               	leaq	-0x6c0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rdx
                	movb	%r13b, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5c0(%rbp), %rcx
+               	leaq	-0x6d0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rdx
                	movb	%r14b, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5d0(%rbp), %rcx
+               	leaq	-0x6e0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rdx
                	movb	%r12b, (%rdx)
                	movups	(%rcx), %xmm10
                	movq	%rbx, %rcx
-               	movaps	%xmm10, %xmm1
+               	movups	%xmm10, -0x6f0(%rbp)
+               	leaq	-0x6f0(%rbp), %rdx
                	callq	 <L26>
 <L26>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm9
                	movq	%rax, %rcx
-               	movaps	%xmm9, %xmm1
+               	movups	%xmm9, -0x700(%rbp)
+               	leaq	-0x700(%rbp), %rdx
                	callq	 <L27>
 <L27>:
                	movaps	%xmm6, %xmm14
                	paddb	%xmm7, %xmm14
                	movaps	%xmm14, %xmm6
                	movq	%rax, %rcx
-               	movaps	%xmm6, %xmm1
+               	movups	%xmm6, -0x710(%rbp)
+               	leaq	-0x710(%rbp), %rdx
                	callq	 <L28>
 <L28>:
                	movaps	%xmm7, %xmm14
                	paddb	%xmm8, %xmm14
                	movaps	%xmm14, %xmm7
                	movq	%rax, %rcx
-               	movaps	%xmm7, %xmm1
+               	movups	%xmm7, -0x720(%rbp)
+               	leaq	-0x720(%rbp), %rdx
                	callq	 <L29>
 <L29>:
                	addq	$0x1, %rsi

--- a/test/golden/x86_64-windows/vec/vec_lane_ops.dis
+++ b/test/golden/x86_64-windows/vec/vec_lane_ops.dis
@@ -5,11 +5,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_lane_ops.fold_u32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movl	(%rdx), %esi
                	movl	%esi, %edx
@@ -33,6 +36,8 @@ Disassembly of section .text:
                	movl	%ebx, %edx
                	callq	 <L3>
 <L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -42,10 +47,13 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_lane_ops.fold_f32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movss	(%rdx), %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
@@ -69,6 +77,8 @@ Disassembly of section .text:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L3>
 <L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
@@ -77,10 +87,13 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_lane_ops.fold_f64x2>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movsd	(%rdx), %xmm1
                	callq	 <L0>
@@ -90,6 +103,8 @@ Disassembly of section .text:
                	movsd	(%rdx), %xmm1
                	callq	 <L1>
 <L1>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
@@ -98,11 +113,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_lane_ops.fold_i8x16>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movzbl	(%rdx), %esi
                	movq	%rsi, %rdx
@@ -198,6 +216,8 @@ Disassembly of section .text:
                	movq	%rbx, %rdx
                	callq	 <L15>
 <L15>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -207,20 +227,20 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_lane_ops.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x6c0, %rsp            # imm = 0x6C0
-               	movq	%rbx, -0x608(%rbp)
-               	movq	%rdi, -0x610(%rbp)
-               	movq	%rsi, -0x618(%rbp)
-               	movq	%r12, -0x620(%rbp)
-               	movq	%r13, -0x628(%rbp)
-               	movq	%r14, -0x630(%rbp)
-               	movq	%r15, -0x638(%rbp)
-               	movaps	%xmm6, -0x650(%rbp)
-               	movaps	%xmm7, -0x660(%rbp)
-               	movaps	%xmm8, -0x670(%rbp)
-               	movaps	%xmm9, -0x680(%rbp)
-               	movaps	%xmm14, -0x690(%rbp)
-               	movaps	%xmm15, -0x6a0(%rbp)
+               	subq	$0x700, %rsp            # imm = 0x700
+               	movq	%rbx, -0x648(%rbp)
+               	movq	%rdi, -0x650(%rbp)
+               	movq	%rsi, -0x658(%rbp)
+               	movq	%r12, -0x660(%rbp)
+               	movq	%r13, -0x668(%rbp)
+               	movq	%r14, -0x670(%rbp)
+               	movq	%r15, -0x678(%rbp)
+               	movaps	%xmm6, -0x690(%rbp)
+               	movaps	%xmm7, -0x6a0(%rbp)
+               	movaps	%xmm8, -0x6b0(%rbp)
+               	movaps	%xmm9, -0x6c0(%rbp)
+               	movaps	%xmm14, -0x6d0(%rbp)
+               	movaps	%xmm15, -0x6e0(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -749,8 +769,8 @@ Disassembly of section .text:
                	callq	 <L48>
 <L48>:
                	movq	%rax, %r8
-               	movq	%r8, -0x5f8(%rbp)
-               	movq	-0x5f8(%rbp), %r8
+               	movq	%r8, -0x638(%rbp)
+               	movq	-0x638(%rbp), %r8
                	movups	(%r13), %xmm0
                	leaq	-0x290(%rbp), %rcx
                	movups	%xmm0, (%rcx)
@@ -796,7 +816,7 @@ Disassembly of section .text:
                	movups	(%rdi), %xmm0
                	leaq	(%rdi), %rax
                	movl	(%rax), %edx
-               	movq	-0x5f8(%rbp), %r8
+               	movq	-0x638(%rbp), %r8
                	movq	%r8, %rcx
                	callq	 <L49>
 <L49>:
@@ -1218,16 +1238,17 @@ Disassembly of section .text:
                	movb	%dl, (%rcx)
                	movups	(%rbx), %xmm6
                	movq	%rax, %rcx
-               	movaps	%xmm6, %xmm1
+               	movups	%xmm6, -0x4f0(%rbp)
+               	leaq	-0x4f0(%rbp), %rdx
                	callq	 <L81>
 <L81>:
-               	leaq	-0x4f0(%rbp), %rsi
+               	leaq	-0x500(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
                	leaq	0xf(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x500(%rbp), %rcx
+               	leaq	-0x510(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1236,7 +1257,7 @@ Disassembly of section .text:
                	leaq	0xe(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x510(%rbp), %rcx
+               	leaq	-0x520(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x1(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1245,7 +1266,7 @@ Disassembly of section .text:
                	leaq	0xd(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x520(%rbp), %rcx
+               	leaq	-0x530(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x2(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1254,7 +1275,7 @@ Disassembly of section .text:
                	leaq	0xc(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x530(%rbp), %rcx
+               	leaq	-0x540(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x3(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1263,7 +1284,7 @@ Disassembly of section .text:
                	leaq	0xb(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x540(%rbp), %rcx
+               	leaq	-0x550(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1272,7 +1293,7 @@ Disassembly of section .text:
                	leaq	0xa(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x550(%rbp), %rcx
+               	leaq	-0x560(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x5(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1281,7 +1302,7 @@ Disassembly of section .text:
                	leaq	0x9(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x560(%rbp), %rcx
+               	leaq	-0x570(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x6(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1290,7 +1311,7 @@ Disassembly of section .text:
                	leaq	0x8(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x570(%rbp), %rcx
+               	leaq	-0x580(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x7(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1299,7 +1320,7 @@ Disassembly of section .text:
                	leaq	0x7(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x580(%rbp), %rcx
+               	leaq	-0x590(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1308,7 +1329,7 @@ Disassembly of section .text:
                	leaq	0x6(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x590(%rbp), %rcx
+               	leaq	-0x5a0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x9(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1317,7 +1338,7 @@ Disassembly of section .text:
                	leaq	0x5(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x5a0(%rbp), %rcx
+               	leaq	-0x5b0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xa(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1326,7 +1347,7 @@ Disassembly of section .text:
                	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x5b0(%rbp), %rcx
+               	leaq	-0x5c0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xb(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1335,7 +1356,7 @@ Disassembly of section .text:
                	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x5c0(%rbp), %rcx
+               	leaq	-0x5d0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1344,7 +1365,7 @@ Disassembly of section .text:
                	leaq	0x2(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x5d0(%rbp), %rcx
+               	leaq	-0x5e0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1353,7 +1374,7 @@ Disassembly of section .text:
                	leaq	0x1(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x5e0(%rbp), %rcx
+               	leaq	-0x5f0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rdi
                	movb	%dl, (%rdi)
@@ -1362,14 +1383,16 @@ Disassembly of section .text:
                	leaq	(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	movups	(%rsi), %xmm0
-               	leaq	-0x5f0(%rbp), %rcx
+               	leaq	-0x600(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rbx
                	movb	%dl, (%rbx)
                	movups	(%rcx), %xmm0
                	movups	%xmm0, (%rsi)
-               	movups	(%rsi), %xmm1
+               	movups	(%rsi), %xmm0
                	movq	%rax, %rcx
+               	movups	%xmm0, -0x610(%rbp)
+               	leaq	-0x610(%rbp), %rdx
                	callq	 <L82>
 <L82>:
                	movups	(%rsi), %xmm0
@@ -1377,7 +1400,8 @@ Disassembly of section .text:
                	paddb	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rcx
-               	movaps	%xmm0, %xmm1
+               	movups	%xmm0, -0x620(%rbp)
+               	leaq	-0x620(%rbp), %rdx
                	callq	 <L83>
 <L83>:
                	movups	(%rsi), %xmm0
@@ -1385,22 +1409,23 @@ Disassembly of section .text:
                	pxor	%xmm6, %xmm14
                	movaps	%xmm14, %xmm0
                	movq	%rax, %rcx
-               	movaps	%xmm0, %xmm1
+               	movups	%xmm0, -0x630(%rbp)
+               	leaq	-0x630(%rbp), %rdx
                	callq	 <L84>
 <L84>:
-               	movaps	-0x650(%rbp), %xmm6
-               	movaps	-0x660(%rbp), %xmm7
-               	movaps	-0x670(%rbp), %xmm8
-               	movaps	-0x680(%rbp), %xmm9
-               	movaps	-0x690(%rbp), %xmm14
-               	movaps	-0x6a0(%rbp), %xmm15
-               	movq	-0x608(%rbp), %rbx
-               	movq	-0x610(%rbp), %rdi
-               	movq	-0x618(%rbp), %rsi
-               	movq	-0x620(%rbp), %r12
-               	movq	-0x628(%rbp), %r13
-               	movq	-0x630(%rbp), %r14
-               	movq	-0x638(%rbp), %r15
+               	movaps	-0x690(%rbp), %xmm6
+               	movaps	-0x6a0(%rbp), %xmm7
+               	movaps	-0x6b0(%rbp), %xmm8
+               	movaps	-0x6c0(%rbp), %xmm9
+               	movaps	-0x6d0(%rbp), %xmm14
+               	movaps	-0x6e0(%rbp), %xmm15
+               	movq	-0x648(%rbp), %rbx
+               	movq	-0x650(%rbp), %rdi
+               	movq	-0x658(%rbp), %rsi
+               	movq	-0x660(%rbp), %r12
+               	movq	-0x668(%rbp), %r13
+               	movq	-0x670(%rbp), %r14
+               	movq	-0x678(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_mem.dis
+++ b/test/golden/x86_64-windows/vec/vec_mem.dis
@@ -5,13 +5,22 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_mem.fold3>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x50, %rsp
-               	movq	%rbx, -0x28(%rbp)
-               	leaq	-0xc(%rbp), %rbx
-               	movups	%xmm1, -0x1c(%rbp)
-               	movq	-0x1c(%rbp), %rdx
+               	subq	$0x80, %rsp
+               	movq	%rbx, -0x38(%rbp)
+               	movaps	%xmm14, -0x50(%rbp)
+               	movaps	%xmm15, -0x60(%rbp)
+               	movq	$0x0, -0x10(%rbp)
+               	movq	$0x0, -0x8(%rbp)
+               	movq	(%rdx), %rbx
+               	movq	%rbx, -0x10(%rbp)
+               	movl	0x8(%rdx), %ebx
+               	movl	%ebx, -0x8(%rbp)
+               	movups	-0x10(%rbp), %xmm0
+               	leaq	-0x1c(%rbp), %rbx
+               	movups	%xmm0, -0x2c(%rbp)
+               	movq	-0x2c(%rbp), %rdx
                	movq	%rdx, (%rbx)
-               	movl	-0x14(%rbp), %edx
+               	movl	-0x24(%rbp), %edx
                	movl	%edx, 0x8(%rbx)
                	leaq	(%rbx), %rdx
                	movss	(%rdx), %xmm0
@@ -30,7 +39,9 @@ Disassembly of section .text:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L2>
 <L2>:
-               	movq	-0x28(%rbp), %rbx
+               	movaps	-0x50(%rbp), %xmm14
+               	movaps	-0x60(%rbp), %xmm15
+               	movq	-0x38(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq

--- a/test/golden/x86_64-windows/vec/vec_scalar_mix.dis
+++ b/test/golden/x86_64-windows/vec/vec_scalar_mix.dis
@@ -5,10 +5,13 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_scalar_mix.fold_f32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movss	(%rdx), %xmm0
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
@@ -32,6 +35,8 @@ Disassembly of section .text:
                	movss	%xmm0, %xmm1            # xmm1 = xmm0[0],xmm1[1,2,3]
                	callq	 <L3>
 <L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	%rbp, %rsp
                	popq	%rbp
@@ -40,11 +45,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_scalar_mix.fold_i32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movl	(%rdx), %esi
                	movl	%esi, %edx
@@ -68,6 +76,8 @@ Disassembly of section .text:
                	movl	%ebx, %edx
                	callq	 <L3>
 <L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -77,11 +87,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_scalar_mix.fold_u32x4>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movl	(%rdx), %esi
                	movl	%esi, %edx
@@ -105,6 +118,8 @@ Disassembly of section .text:
                	movl	%ebx, %edx
                	callq	 <L3>
 <L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp

--- a/test/golden/x86_64-windows/vec/vec_u16x8.dis
+++ b/test/golden/x86_64-windows/vec/vec_u16x8.dis
@@ -5,11 +5,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u16x8.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movzwl	(%rdx), %esi
                	movq	%rsi, %rdx
@@ -57,6 +60,8 @@ Disassembly of section .text:
                	movq	%rbx, %rdx
                	callq	 <L7>
 <L7>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -66,7 +71,7 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u16x8.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x320, %rsp            # imm = 0x320
+               	subq	$0x340, %rsp            # imm = 0x340
                	movq	%rbx, -0x268(%rbp)
                	movq	%rdi, -0x270(%rbp)
                	movq	%rsi, -0x278(%rbp)
@@ -79,6 +84,8 @@ Disassembly of section .text:
                	movaps	%xmm11, -0x2e0(%rbp)
                	movaps	%xmm12, -0x2f0(%rbp)
                	movaps	%xmm13, -0x300(%rbp)
+               	movaps	%xmm14, -0x310(%rbp)
+               	movaps	%xmm15, -0x320(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -637,333 +644,68 @@ Disassembly of section .text:
                	movaps	%xmm7, %xmm14
                	psubw	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x200(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
+               	movups	%xmm0, -0x200(%rbp)
+               	leaq	-0x200(%rbp), %rdx
                	callq	 <L81>
 <L81>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L82>
-<L82>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L83>
-<L83>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L84>
-<L84>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L85>
-<L85>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L86>
-<L86>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L87>
-<L87>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L88>
-<L88>:
                	movaps	%xmm8, %xmm14
                	pand	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x210(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
-               	callq	 <L89>
-<L89>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L90>
-<L90>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L91>
-<L91>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L92>
-<L92>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L93>
-<L93>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L94>
-<L94>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L95>
-<L95>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L96>
-<L96>:
+               	movups	%xmm10, -0x210(%rbp)
+               	leaq	-0x210(%rbp), %rdx
+               	callq	 <L82>
+<L82>:
                	movaps	%xmm8, %xmm14
                	por	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x220(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movaps	%xmm14, %xmm11
                	movq	%rax, %rcx
-               	callq	 <L97>
-<L97>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L98>
-<L98>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L99>
-<L99>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L100>
-<L100>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L101>
-<L101>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L102>
-<L102>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L103>
-<L103>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L104>
-<L104>:
+               	movups	%xmm11, -0x220(%rbp)
+               	leaq	-0x220(%rbp), %rdx
+               	callq	 <L83>
+<L83>:
                	movaps	%xmm8, %xmm14
                	pxor	%xmm9, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x230(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L105>
-<L105>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L106>
-<L106>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L107>
-<L107>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L108>
-<L108>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L109>
-<L109>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L110>
-<L110>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L111>
-<L111>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L112>
-<L112>:
+               	movups	%xmm0, -0x230(%rbp)
+               	leaq	-0x230(%rbp), %rdx
+               	callq	 <L84>
+<L84>:
                	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x240(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L113>
-<L113>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L114>
-<L114>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L115>
-<L115>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L116>
-<L116>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L117>
-<L117>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L118>
-<L118>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L119>
-<L119>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L120>
-<L120>:
+               	movups	%xmm0, -0x240(%rbp)
+               	leaq	-0x240(%rbp), %rdx
+               	callq	 <L85>
+<L85>:
                	movaps	%xmm9, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x250(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L121>
-<L121>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
+               	movups	%xmm0, -0x250(%rbp)
+               	leaq	-0x250(%rbp), %rdx
+               	callq	 <L86>
+<L86>:
+               	movaps	%xmm10, %xmm14
+               	pxor	%xmm11, %xmm14
+               	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
-               	callq	 <L122>
-<L122>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L123>
-<L123>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L124>
-<L124>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L125>
-<L125>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L126>
-<L126>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L127>
-<L127>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L128>
-<L128>:
-               	movaps	%xmm8, %xmm14
-               	pand	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm8, %xmm14
-               	por	%xmm9, %xmm14
-               	movaps	%xmm14, %xmm1
-               	movaps	%xmm0, %xmm14
-               	pxor	%xmm1, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x260(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L129>
-<L129>:
-               	leaq	0x2(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L130>
-<L130>:
-               	leaq	0x4(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L131>
-<L131>:
-               	leaq	0x6(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L132>
-<L132>:
-               	leaq	0x8(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L133>
-<L133>:
-               	leaq	0xa(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L134>
-<L134>:
-               	leaq	0xc(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L135>
-<L135>:
-               	leaq	0xe(%rbx), %rcx
-               	movzwl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L136>
-<L136>:
+               	movups	%xmm10, -0x260(%rbp)
+               	leaq	-0x260(%rbp), %rdx
+               	callq	 <L87>
+<L87>:
                	movq	%rax, %rbx
                	movaps	%xmm7, %xmm10
                	movq	$0x0, %rsi
                	cmpq	$0x6, %rsi
-               	jb	 <L137>
-               	jmp	 <L170>
-<L137>:
+               	jb	 <L88>
+               	jmp	 <L121>
+<L88>:
                	movaps	%xmm8, %xmm14
                	pmullw	%xmm6, %xmm14
                	movaps	%xmm14, %xmm11
@@ -972,43 +714,43 @@ Disassembly of section .text:
                	leaq	(%rdi), %rax
                	movzwl	(%rax), %edx
                	movq	%rbx, %rcx
-               	callq	 <L138>
-<L138>:
+               	callq	 <L89>
+<L89>:
                	leaq	0x2(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L139>
-<L139>:
+               	callq	 <L90>
+<L90>:
                	leaq	0x4(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L140>
-<L140>:
+               	callq	 <L91>
+<L91>:
                	leaq	0x6(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L141>
-<L141>:
+               	callq	 <L92>
+<L92>:
                	leaq	0x8(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L142>
-<L142>:
+               	callq	 <L93>
+<L93>:
                	leaq	0xa(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L143>
-<L143>:
+               	callq	 <L94>
+<L94>:
                	leaq	0xc(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L144>
-<L144>:
+               	callq	 <L95>
+<L95>:
                	leaq	0xe(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L145>
-<L145>:
+               	callq	 <L96>
+<L96>:
                	movaps	%xmm10, %xmm14
                	pxor	%xmm11, %xmm14
                	movaps	%xmm14, %xmm12
@@ -1017,43 +759,43 @@ Disassembly of section .text:
                	leaq	(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L146>
-<L146>:
+               	callq	 <L97>
+<L97>:
                	leaq	0x2(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L147>
-<L147>:
+               	callq	 <L98>
+<L98>:
                	leaq	0x4(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L148>
-<L148>:
+               	callq	 <L99>
+<L99>:
                	leaq	0x6(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L149>
-<L149>:
+               	callq	 <L100>
+<L100>:
                	leaq	0x8(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L150>
-<L150>:
+               	callq	 <L101>
+<L101>:
                	leaq	0xa(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L151>
-<L151>:
+               	callq	 <L102>
+<L102>:
                	leaq	0xc(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L152>
-<L152>:
+               	callq	 <L103>
+<L103>:
                	leaq	0xe(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L153>
-<L153>:
+               	callq	 <L104>
+<L104>:
                	movaps	%xmm7, %xmm14
                	paddw	%xmm8, %xmm14
                	movaps	%xmm14, %xmm11
@@ -1062,43 +804,43 @@ Disassembly of section .text:
                	leaq	(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L154>
-<L154>:
+               	callq	 <L105>
+<L105>:
                	leaq	0x2(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L155>
-<L155>:
+               	callq	 <L106>
+<L106>:
                	leaq	0x4(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L156>
-<L156>:
+               	callq	 <L107>
+<L107>:
                	leaq	0x6(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L157>
-<L157>:
+               	callq	 <L108>
+<L108>:
                	leaq	0x8(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L158>
-<L158>:
+               	callq	 <L109>
+<L109>:
                	leaq	0xa(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L159>
-<L159>:
+               	callq	 <L110>
+<L110>:
                	leaq	0xc(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L160>
-<L160>:
+               	callq	 <L111>
+<L111>:
                	leaq	0xe(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L161>
-<L161>:
+               	callq	 <L112>
+<L112>:
                	movaps	%xmm8, %xmm14
                	paddw	%xmm9, %xmm14
                	movaps	%xmm14, %xmm13
@@ -1107,51 +849,51 @@ Disassembly of section .text:
                	leaq	(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L162>
-<L162>:
+               	callq	 <L113>
+<L113>:
                	leaq	0x2(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L163>
-<L163>:
+               	callq	 <L114>
+<L114>:
                	leaq	0x4(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L164>
-<L164>:
+               	callq	 <L115>
+<L115>:
                	leaq	0x6(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L165>
-<L165>:
+               	callq	 <L116>
+<L116>:
                	leaq	0x8(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L166>
-<L166>:
+               	callq	 <L117>
+<L117>:
                	leaq	0xa(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L167>
-<L167>:
+               	callq	 <L118>
+<L118>:
                	leaq	0xc(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L168>
-<L168>:
+               	callq	 <L119>
+<L119>:
                	leaq	0xe(%rdi), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L169>
-<L169>:
+               	callq	 <L120>
+<L120>:
                	addq	$0x1, %rsi
                	movq	%rax, %rbx
                	movaps	%xmm13, %xmm8
                	movaps	%xmm12, %xmm10
                	movaps	%xmm11, %xmm7
                	cmpq	$0x6, %rsi
-               	jb	 <L137>
-<L170>:
+               	jb	 <L88>
+<L121>:
                	leaq	-0xf0(%rbp), %rsi
                	movq	$0x0, (%rsi)
                	movq	$0x0, 0x8(%rsi)
@@ -1177,9 +919,9 @@ Disassembly of section .text:
                	movups	%xmm10, (%rax)
                	movq	$0x0, %rdi
                	cmpq	$0x4, %rdi
-               	jb	 <L171>
-               	jmp	 <L180>
-<L171>:
+               	jb	 <L122>
+               	jmp	 <L131>
+<L122>:
                	movq	%rdi, %rax
                	imulq	$0x10, %rax, %rax
                	leaq	(%rsi,%rax), %rcx
@@ -1189,48 +931,48 @@ Disassembly of section .text:
                	leaq	(%r12), %rax
                	movzwl	(%rax), %edx
                	movq	%rbx, %rcx
-               	callq	 <L172>
-<L172>:
+               	callq	 <L123>
+<L123>:
                	leaq	0x2(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L173>
-<L173>:
+               	callq	 <L124>
+<L124>:
                	leaq	0x4(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L174>
-<L174>:
+               	callq	 <L125>
+<L125>:
                	leaq	0x6(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L175>
-<L175>:
+               	callq	 <L126>
+<L126>:
                	leaq	0x8(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L176>
-<L176>:
+               	callq	 <L127>
+<L127>:
                	leaq	0xa(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L177>
-<L177>:
+               	callq	 <L128>
+<L128>:
                	leaq	0xc(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L178>
-<L178>:
+               	callq	 <L129>
+<L129>:
                	leaq	0xe(%r12), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L179>
-<L179>:
+               	callq	 <L130>
+<L130>:
                	addq	$0x1, %rdi
                	movq	%rax, %rbx
                	cmpq	$0x4, %rdi
-               	jb	 <L171>
-<L180>:
+               	jb	 <L122>
+<L131>:
                	leaq	-0x130(%rbp), %rdi
                	movq	$0x0, (%rdi)
                	movq	$0x0, 0x8(%rdi)
@@ -1248,56 +990,56 @@ Disassembly of section .text:
                	movl	$0x12345678, (%rcx)     # imm = 0x12345678
                	movl	(%rax), %edx
                	movq	%rbx, %rcx
-               	callq	 <L181>
-<L181>:
+               	callq	 <L132>
+<L132>:
                	movups	(%rsi), %xmm0
                	leaq	-0x140(%rbp), %rbx
                	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L182>
-<L182>:
+               	callq	 <L133>
+<L133>:
                	leaq	0x2(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L183>
-<L183>:
+               	callq	 <L134>
+<L134>:
                	leaq	0x4(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L184>
-<L184>:
+               	callq	 <L135>
+<L135>:
                	leaq	0x6(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L185>
-<L185>:
+               	callq	 <L136>
+<L136>:
                	leaq	0x8(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L186>
-<L186>:
+               	callq	 <L137>
+<L137>:
                	leaq	0xa(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L187>
-<L187>:
+               	callq	 <L138>
+<L138>:
                	leaq	0xc(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L188>
-<L188>:
+               	callq	 <L139>
+<L139>:
                	leaq	0xe(%rbx), %rcx
                	movzwl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L189>
-<L189>:
+               	callq	 <L140>
+<L140>:
                	leaq	0x20(%rdi), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L190>
-<L190>:
+               	callq	 <L141>
+<L141>:
                	movaps	-0x290(%rbp), %xmm6
                	movaps	-0x2a0(%rbp), %xmm7
                	movaps	-0x2b0(%rbp), %xmm8
@@ -1306,6 +1048,8 @@ Disassembly of section .text:
                	movaps	-0x2e0(%rbp), %xmm11
                	movaps	-0x2f0(%rbp), %xmm12
                	movaps	-0x300(%rbp), %xmm13
+               	movaps	-0x310(%rbp), %xmm14
+               	movaps	-0x320(%rbp), %xmm15
                	movq	-0x268(%rbp), %rbx
                	movq	-0x270(%rbp), %rdi
                	movq	-0x278(%rbp), %rsi

--- a/test/golden/x86_64-windows/vec/vec_u32x4.dis
+++ b/test/golden/x86_64-windows/vec/vec_u32x4.dis
@@ -5,11 +5,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u32x4.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movl	(%rdx), %esi
                	movl	%esi, %edx
@@ -33,6 +36,8 @@ Disassembly of section .text:
                	movl	%ebx, %edx
                	callq	 <L3>
 <L3>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -42,7 +47,7 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u32x4.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x4b0, %rsp            # imm = 0x4B0
+               	subq	$0x4d0, %rsp            # imm = 0x4D0
                	movq	%rbx, -0x3e8(%rbp)
                	movq	%rdi, -0x3f0(%rbp)
                	movq	%rsi, -0x3f8(%rbp)
@@ -57,6 +62,8 @@ Disassembly of section .text:
                	movaps	%xmm10, -0x470(%rbp)
                	movaps	%xmm11, -0x480(%rbp)
                	movaps	%xmm12, -0x490(%rbp)
+               	movaps	%xmm14, -0x4a0(%rbp)
+               	movaps	%xmm15, -0x4b0(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -527,194 +534,69 @@ Disassembly of section .text:
                	movaps	%xmm6, %xmm14
                	psubd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x360(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rcx
+               	movups	%xmm0, -0x360(%rbp)
+               	leaq	-0x360(%rbp), %rdx
                	callq	 <L41>
 <L41>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L44>
-<L44>:
                	movaps	%xmm7, %xmm14
                	pand	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x370(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm14, %xmm9
                	movq	%rax, %rcx
-               	callq	 <L45>
-<L45>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L47>
-<L47>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L48>
-<L48>:
+               	movups	%xmm9, -0x370(%rbp)
+               	leaq	-0x370(%rbp), %rdx
+               	callq	 <L42>
+<L42>:
                	movaps	%xmm7, %xmm14
                	por	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x380(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
+               	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
-               	callq	 <L49>
-<L49>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L50>
-<L50>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L51>
-<L51>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L52>
-<L52>:
+               	movups	%xmm10, -0x380(%rbp)
+               	leaq	-0x380(%rbp), %rdx
+               	callq	 <L43>
+<L43>:
                	movaps	%xmm7, %xmm14
                	pxor	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x390(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L53>
-<L53>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L54>
-<L54>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L55>
-<L55>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L56>
-<L56>:
+               	movups	%xmm0, -0x390(%rbp)
+               	leaq	-0x390(%rbp), %rdx
+               	callq	 <L44>
+<L44>:
                	movaps	%xmm7, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x3a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L57>
-<L57>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L58>
-<L58>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L59>
-<L59>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L60>
-<L60>:
+               	movups	%xmm0, -0x3a0(%rbp)
+               	leaq	-0x3a0(%rbp), %rdx
+               	callq	 <L45>
+<L45>:
                	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x3b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L61>
-<L61>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
+               	movups	%xmm0, -0x3b0(%rbp)
+               	leaq	-0x3b0(%rbp), %rdx
+               	callq	 <L46>
+<L46>:
+               	movaps	%xmm9, %xmm14
+               	pxor	%xmm10, %xmm14
+               	movaps	%xmm14, %xmm9
                	movq	%rax, %rcx
-               	callq	 <L62>
-<L62>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L63>
-<L63>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L64>
-<L64>:
-               	movaps	%xmm7, %xmm14
-               	pand	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm7, %xmm14
-               	por	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm1
-               	movaps	%xmm0, %xmm14
-               	pxor	%xmm1, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x3c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L65>
-<L65>:
-               	leaq	0x4(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L66>
-<L66>:
-               	leaq	0x8(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L67>
-<L67>:
-               	leaq	0xc(%rbx), %rcx
-               	movl	(%rcx), %edx
-               	movq	%rax, %rcx
-               	callq	 <L68>
-<L68>:
+               	movups	%xmm9, -0x3c0(%rbp)
+               	leaq	-0x3c0(%rbp), %rdx
+               	callq	 <L47>
+<L47>:
                	movq	%rax, %rbx
                	movaps	%xmm6, %xmm9
                	movq	$0x0, %rdi
-<L69>:
+<L48>:
                	leaq	-0xc0(%rbp), %r12
                	movups	%xmm7, (%r12)
                	cmpq	$0x6, %rdi
-               	jb	 <L82>
+               	jb	 <L61>
                	leaq	-0x140(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
@@ -781,9 +663,9 @@ Disassembly of section .text:
                	movq	%rbx, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L70>
-               	jmp	 <L75>
-<L70>:
+               	jb	 <L49>
+               	jmp	 <L54>
+<L49>:
                	movq	%r15, %rax
                	imulq	$0x10, %rax, %rax
                	leaq	(%r13,%rax), %rcx
@@ -796,8 +678,8 @@ Disassembly of section .text:
                	leaq	(%r8), %rcx
                	movl	(%rcx), %edx
                	movq	%r14, %rcx
-               	callq	 <L71>
-<L71>:
+               	callq	 <L50>
+<L50>:
                	movq	%rax, %rcx
                	movq	-0x3e0(%rbp), %r8
                	leaq	0x4(%r8), %rdx
@@ -805,8 +687,8 @@ Disassembly of section .text:
                	movq	%r8, -0x3d0(%rbp)
                	movq	-0x3d0(%rbp), %r8
                	movl	%r8d, %edx
-               	callq	 <L72>
-<L72>:
+               	callq	 <L51>
+<L51>:
                	movq	%rax, %rcx
                	movq	-0x3e0(%rbp), %r8
                	leaq	0x8(%r8), %rdx
@@ -814,20 +696,20 @@ Disassembly of section .text:
                	movq	%r8, -0x3d8(%rbp)
                	movq	-0x3d8(%rbp), %r8
                	movl	%r8d, %edx
-               	callq	 <L73>
-<L73>:
+               	callq	 <L52>
+<L52>:
                	movq	%rax, %rcx
                	movq	-0x3e0(%rbp), %r8
                	leaq	0xc(%r8), %rdx
                	movl	(%rdx), %eax
                	movl	%eax, %edx
-               	callq	 <L74>
-<L74>:
+               	callq	 <L53>
+<L53>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x4, %r15
-               	jb	 <L70>
-<L75>:
+               	jb	 <L49>
+<L54>:
                	leaq	-0x1c0(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
@@ -845,36 +727,36 @@ Disassembly of section .text:
                	movl	$0x12345678, (%rcx)     # imm = 0x12345678
                	movl	(%rax), %edx
                	movq	%r14, %rcx
-               	callq	 <L76>
-<L76>:
+               	callq	 <L55>
+<L55>:
                	movups	(%r13), %xmm0
                	leaq	-0x1d0(%rbp), %r13
                	movups	%xmm0, (%r13)
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L77>
-<L77>:
+               	callq	 <L56>
+<L56>:
                	leaq	0x4(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L78>
-<L78>:
+               	callq	 <L57>
+<L57>:
                	leaq	0x8(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L79>
-<L79>:
+               	callq	 <L58>
+<L58>:
                	leaq	0xc(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L80>
-<L80>:
+               	callq	 <L59>
+<L59>:
                	leaq	0x20(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L81>
-<L81>:
+               	callq	 <L60>
+<L60>:
                	movaps	-0x430(%rbp), %xmm6
                	movaps	-0x440(%rbp), %xmm7
                	movaps	-0x450(%rbp), %xmm8
@@ -882,6 +764,8 @@ Disassembly of section .text:
                	movaps	-0x470(%rbp), %xmm10
                	movaps	-0x480(%rbp), %xmm11
                	movaps	-0x490(%rbp), %xmm12
+               	movaps	-0x4a0(%rbp), %xmm14
+               	movaps	-0x4b0(%rbp), %xmm15
                	movq	-0x3e8(%rbp), %rbx
                	movq	-0x3f0(%rbp), %rdi
                	movq	-0x3f8(%rbp), %rsi
@@ -892,7 +776,7 @@ Disassembly of section .text:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L82>:
+<L61>:
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	leaq	(%rsi), %rcx
@@ -936,23 +820,23 @@ Disassembly of section .text:
                	leaq	(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rbx, %rcx
-               	callq	 <L83>
-<L83>:
+               	callq	 <L62>
+<L62>:
                	leaq	0x4(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L84>
-<L84>:
+               	callq	 <L63>
+<L63>:
                	leaq	0x8(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L85>
-<L85>:
+               	callq	 <L64>
+<L64>:
                	leaq	0xc(%r13), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L86>
-<L86>:
+               	callq	 <L65>
+<L65>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm11
@@ -961,23 +845,23 @@ Disassembly of section .text:
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L87>
-<L87>:
+               	callq	 <L66>
+<L66>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L88>
-<L88>:
+               	callq	 <L67>
+<L67>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L89>
-<L89>:
+               	callq	 <L68>
+<L68>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L90>
-<L90>:
+               	callq	 <L69>
+<L69>:
                	movaps	%xmm6, %xmm14
                	paddd	%xmm7, %xmm14
                	movaps	%xmm14, %xmm10
@@ -986,23 +870,23 @@ Disassembly of section .text:
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L91>
-<L91>:
+               	callq	 <L70>
+<L70>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L92>
-<L92>:
+               	callq	 <L71>
+<L71>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L93>
-<L93>:
+               	callq	 <L72>
+<L72>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L94>
-<L94>:
+               	callq	 <L73>
+<L73>:
                	movaps	%xmm7, %xmm14
                	paddd	%xmm8, %xmm14
                	movaps	%xmm14, %xmm12
@@ -1011,26 +895,26 @@ Disassembly of section .text:
                	leaq	(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L95>
-<L95>:
+               	callq	 <L74>
+<L74>:
                	leaq	0x4(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L96>
-<L96>:
+               	callq	 <L75>
+<L75>:
                	leaq	0x8(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L97>
-<L97>:
+               	callq	 <L76>
+<L76>:
                	leaq	0xc(%r12), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L98>
-<L98>:
+               	callq	 <L77>
+<L77>:
                	addq	$0x1, %rdi
                	movq	%rax, %rbx
                	movaps	%xmm12, %xmm7
                	movaps	%xmm11, %xmm9
                	movaps	%xmm10, %xmm6
-               	jmp	 <L69>
+               	jmp	 <L48>

--- a/test/golden/x86_64-windows/vec/vec_u64x2.dis
+++ b/test/golden/x86_64-windows/vec/vec_u64x2.dis
@@ -5,11 +5,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u64x2.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movq	(%rdx), %rsi
                	movq	%rsi, %rdx
@@ -21,6 +24,8 @@ Disassembly of section .text:
                	movq	%rbx, %rdx
                	callq	 <L1>
 <L1>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -30,7 +35,7 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u64x2.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x3c0, %rsp            # imm = 0x3C0
+               	subq	$0x3e0, %rsp            # imm = 0x3E0
                	movq	%rbx, -0x2f8(%rbp)
                	movq	%rdi, -0x300(%rbp)
                	movq	%rsi, -0x308(%rbp)
@@ -45,6 +50,8 @@ Disassembly of section .text:
                	movaps	%xmm10, -0x380(%rbp)
                	movaps	%xmm11, -0x390(%rbp)
                	movaps	%xmm12, -0x3a0(%rbp)
+               	movaps	%xmm14, -0x3b0(%rbp)
+               	movaps	%xmm15, -0x3c0(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -302,124 +309,69 @@ Disassembly of section .text:
                	movaps	%xmm6, %xmm14
                	psubq	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x280(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
                	movq	%rax, %rcx
+               	movups	%xmm0, -0x280(%rbp)
+               	leaq	-0x280(%rbp), %rdx
                	callq	 <L21>
 <L21>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
+               	movaps	%xmm7, %xmm14
+               	pand	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm9
                	movq	%rax, %rcx
+               	movups	%xmm9, -0x290(%rbp)
+               	leaq	-0x290(%rbp), %rdx
                	callq	 <L22>
 <L22>:
                	movaps	%xmm7, %xmm14
-               	pand	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x290(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
+               	por	%xmm8, %xmm14
+               	movaps	%xmm14, %xmm10
                	movq	%rax, %rcx
+               	movups	%xmm10, -0x2a0(%rbp)
+               	leaq	-0x2a0(%rbp), %rdx
                	callq	 <L23>
 <L23>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L24>
-<L24>:
-               	movaps	%xmm7, %xmm14
-               	por	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x2a0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L25>
-<L25>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L26>
-<L26>:
                	movaps	%xmm7, %xmm14
                	pxor	%xmm8, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x2b0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L27>
-<L27>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L28>
-<L28>:
+               	movups	%xmm0, -0x2b0(%rbp)
+               	leaq	-0x2b0(%rbp), %rdx
+               	callq	 <L24>
+<L24>:
                	movaps	%xmm7, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x2c0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L29>
-<L29>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L30>
-<L30>:
+               	movups	%xmm0, -0x2c0(%rbp)
+               	leaq	-0x2c0(%rbp), %rdx
+               	callq	 <L25>
+<L25>:
                	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
                	movaps	%xmm14, %xmm0
-               	leaq	-0x2d0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L31>
-<L31>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
+               	movups	%xmm0, -0x2d0(%rbp)
+               	leaq	-0x2d0(%rbp), %rdx
+               	callq	 <L26>
+<L26>:
+               	movaps	%xmm9, %xmm14
+               	pxor	%xmm10, %xmm14
+               	movaps	%xmm14, %xmm9
                	movq	%rax, %rcx
-               	callq	 <L32>
-<L32>:
-               	movaps	%xmm7, %xmm14
-               	pand	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm0
-               	movaps	%xmm7, %xmm14
-               	por	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm1
-               	movaps	%xmm0, %xmm14
-               	pxor	%xmm1, %xmm14
-               	movaps	%xmm14, %xmm0
-               	leaq	-0x2e0(%rbp), %rbx
-               	movups	%xmm0, (%rbx)
-               	leaq	(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L33>
-<L33>:
-               	leaq	0x8(%rbx), %rcx
-               	movq	(%rcx), %rdx
-               	movq	%rax, %rcx
-               	callq	 <L34>
-<L34>:
+               	movups	%xmm9, -0x2e0(%rbp)
+               	leaq	-0x2e0(%rbp), %rdx
+               	callq	 <L27>
+<L27>:
                	movq	%rax, %rbx
                	movaps	%xmm6, %xmm9
                	movq	$0x0, %rdi
-<L35>:
+<L28>:
                	leaq	-0xa0(%rbp), %r12
                	movups	%xmm7, (%r12)
                	cmpq	$0x6, %rdi
-               	jb	 <L44>
+               	jb	 <L37>
                	leaq	-0x100(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
@@ -463,9 +415,9 @@ Disassembly of section .text:
                	movq	%rbx, %r14
                	movq	$0x0, %r15
                	cmpq	$0x4, %r15
-               	jb	 <L36>
-               	jmp	 <L39>
-<L36>:
+               	jb	 <L29>
+               	jmp	 <L32>
+<L29>:
                	movq	%r15, %rax
                	imulq	$0x10, %rax, %rax
                	leaq	(%r13,%rax), %rcx
@@ -478,20 +430,20 @@ Disassembly of section .text:
                	leaq	(%r8), %rcx
                	movq	(%rcx), %rdx
                	movq	%r14, %rcx
-               	callq	 <L37>
-<L37>:
+               	callq	 <L30>
+<L30>:
                	movq	%rax, %rcx
                	movq	-0x2e8(%rbp), %r8
                	leaq	0x8(%r8), %rdx
                	movq	(%rdx), %rax
                	movq	%rax, %rdx
-               	callq	 <L38>
-<L38>:
+               	callq	 <L31>
+<L31>:
                	addq	$0x1, %r15
                	movq	%rax, %r14
                	cmpq	$0x4, %r15
-               	jb	 <L36>
-<L39>:
+               	jb	 <L29>
+<L32>:
                	leaq	-0x160(%rbp), %r15
                	movq	$0x0, (%r15)
                	movq	$0x0, 0x8(%r15)
@@ -509,26 +461,26 @@ Disassembly of section .text:
                	movl	$0x12345678, (%rcx)     # imm = 0x12345678
                	movl	(%rax), %edx
                	movq	%r14, %rcx
-               	callq	 <L40>
-<L40>:
+               	callq	 <L33>
+<L33>:
                	movups	(%r13), %xmm0
                	leaq	-0x170(%rbp), %r13
                	movups	%xmm0, (%r13)
                	leaq	(%r13), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L41>
-<L41>:
+               	callq	 <L34>
+<L34>:
                	leaq	0x8(%r13), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L42>
-<L42>:
+               	callq	 <L35>
+<L35>:
                	leaq	0x20(%r15), %rcx
                	movl	(%rcx), %edx
                	movq	%rax, %rcx
-               	callq	 <L43>
-<L43>:
+               	callq	 <L36>
+<L36>:
                	movaps	-0x340(%rbp), %xmm6
                	movaps	-0x350(%rbp), %xmm7
                	movaps	-0x360(%rbp), %xmm8
@@ -536,6 +488,8 @@ Disassembly of section .text:
                	movaps	-0x380(%rbp), %xmm10
                	movaps	-0x390(%rbp), %xmm11
                	movaps	-0x3a0(%rbp), %xmm12
+               	movaps	-0x3b0(%rbp), %xmm14
+               	movaps	-0x3c0(%rbp), %xmm15
                	movq	-0x2f8(%rbp), %rbx
                	movq	-0x300(%rbp), %rdi
                	movq	-0x308(%rbp), %rsi
@@ -546,7 +500,7 @@ Disassembly of section .text:
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
-<L44>:
+<L37>:
                	leaq	(%r12), %rcx
                	movq	(%rcx), %rdx
                	leaq	(%rsi), %rcx
@@ -570,13 +524,13 @@ Disassembly of section .text:
                	leaq	(%r13), %rcx
                	movq	(%rcx), %rdx
                	movq	%rbx, %rcx
-               	callq	 <L45>
-<L45>:
+               	callq	 <L38>
+<L38>:
                	leaq	0x8(%r13), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L46>
-<L46>:
+               	callq	 <L39>
+<L39>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm11
@@ -585,13 +539,13 @@ Disassembly of section .text:
                	leaq	(%r12), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L47>
-<L47>:
+               	callq	 <L40>
+<L40>:
                	leaq	0x8(%r12), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L48>
-<L48>:
+               	callq	 <L41>
+<L41>:
                	movaps	%xmm6, %xmm14
                	paddq	%xmm7, %xmm14
                	movaps	%xmm14, %xmm10
@@ -600,13 +554,13 @@ Disassembly of section .text:
                	leaq	(%r12), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L49>
-<L49>:
+               	callq	 <L42>
+<L42>:
                	leaq	0x8(%r12), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L50>
-<L50>:
+               	callq	 <L43>
+<L43>:
                	movaps	%xmm7, %xmm14
                	paddq	%xmm8, %xmm14
                	movaps	%xmm14, %xmm12
@@ -615,16 +569,16 @@ Disassembly of section .text:
                	leaq	(%r12), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L51>
-<L51>:
+               	callq	 <L44>
+<L44>:
                	leaq	0x8(%r12), %rcx
                	movq	(%rcx), %rdx
                	movq	%rax, %rcx
-               	callq	 <L52>
-<L52>:
+               	callq	 <L45>
+<L45>:
                	addq	$0x1, %rdi
                	movq	%rax, %rbx
                	movaps	%xmm12, %xmm7
                	movaps	%xmm11, %xmm9
                	movaps	%xmm10, %xmm6
-               	jmp	 <L35>
+               	jmp	 <L28>

--- a/test/golden/x86_64-windows/vec/vec_u8x16.dis
+++ b/test/golden/x86_64-windows/vec/vec_u8x16.dis
@@ -5,11 +5,14 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u8x16.fold_vec>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0x40, %rsp
+               	subq	$0x60, %rsp
                	movq	%rbx, -0x18(%rbp)
                	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
                	leaq	-0x10(%rbp), %rbx
-               	movups	%xmm1, (%rbx)
+               	movups	%xmm0, (%rbx)
                	leaq	(%rbx), %rdx
                	movzbl	(%rdx), %esi
                	movq	%rsi, %rdx
@@ -105,6 +108,8 @@ Disassembly of section .text:
                	movq	%rbx, %rdx
                	callq	 <L15>
 <L15>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
                	movq	-0x18(%rbp), %rbx
                	movq	-0x20(%rbp), %rsi
                	movq	%rbp, %rsp
@@ -114,19 +119,21 @@ Disassembly of section .text:
 <corpus.cases.vec.vec_u8x16.checksum>:
                	pushq	%rbp
                	movq	%rsp, %rbp
-               	subq	$0xa50, %rsp            # imm = 0xA50
-               	movq	%rbx, -0x9a8(%rbp)
-               	movq	%rdi, -0x9b0(%rbp)
-               	movq	%rsi, -0x9b8(%rbp)
-               	movq	%r12, -0x9c0(%rbp)
-               	movq	%r13, -0x9c8(%rbp)
-               	movq	%r14, -0x9d0(%rbp)
-               	movq	%r15, -0x9d8(%rbp)
-               	movaps	%xmm6, -0x9f0(%rbp)
-               	movaps	%xmm7, -0xa00(%rbp)
-               	movaps	%xmm8, -0xa10(%rbp)
-               	movaps	%xmm9, -0xa20(%rbp)
-               	movaps	%xmm10, -0xa30(%rbp)
+               	subq	$0xbe0, %rsp            # imm = 0xBE0
+               	movq	%rbx, -0xb18(%rbp)
+               	movq	%rdi, -0xb20(%rbp)
+               	movq	%rsi, -0xb28(%rbp)
+               	movq	%r12, -0xb30(%rbp)
+               	movq	%r13, -0xb38(%rbp)
+               	movq	%r14, -0xb40(%rbp)
+               	movq	%r15, -0xb48(%rbp)
+               	movaps	%xmm6, -0xb60(%rbp)
+               	movaps	%xmm7, -0xb70(%rbp)
+               	movaps	%xmm8, -0xb80(%rbp)
+               	movaps	%xmm9, -0xb90(%rbp)
+               	movaps	%xmm10, -0xba0(%rbp)
+               	movaps	%xmm14, -0xbb0(%rbp)
+               	movaps	%xmm15, -0xbc0(%rbp)
                	movq	%rcx, %rbx
                	callq	 <L0>
 <L0>:
@@ -306,128 +313,135 @@ Disassembly of section .text:
                	leaq	0xc(%rsi), %rdx
                	movb	%r12b, (%rdx)
                	movups	(%rsi), %xmm8
-               	movaps	%xmm7, %xmm1
+               	movups	%xmm7, -0xc0(%rbp)
+               	leaq	-0xc0(%rbp), %rdx
                	callq	 <L1>
 <L1>:
                	movq	%rax, %rcx
-               	movaps	%xmm8, %xmm1
+               	movups	%xmm8, -0xd0(%rbp)
+               	leaq	-0xd0(%rbp), %rdx
                	callq	 <L2>
 <L2>:
                	movq	%rax, %rcx
                	movaps	%xmm7, %xmm14
                	paddb	%xmm8, %xmm14
                	movaps	%xmm14, %xmm9
-               	leaq	-0xc0(%rbp), %r12
+               	leaq	-0xe0(%rbp), %r12
                	movups	%xmm9, (%r12)
-               	movaps	%xmm9, %xmm1
+               	movups	%xmm9, -0xf0(%rbp)
+               	leaq	-0xf0(%rbp), %rdx
                	callq	 <L3>
 <L3>:
                	movq	%rax, %rcx
                	movaps	%xmm7, %xmm14
                	psubb	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x100(%rbp)
+               	leaq	-0x100(%rbp), %rdx
                	callq	 <L4>
 <L4>:
                	movq	%rax, %rcx
                	movaps	%xmm8, %xmm14
                	psubb	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x110(%rbp)
+               	leaq	-0x110(%rbp), %rdx
                	callq	 <L5>
 <L5>:
                	movq	%rax, %r8
-               	movq	%r8, -0x748(%rbp)
-               	movq	-0x748(%rbp), %r8
+               	movq	%r8, -0x8b8(%rbp)
+               	movq	-0x8b8(%rbp), %r8
                	leaq	(%rbx), %rdx
                	movzbl	(%rdx), %r13d
                	leaq	(%rsi), %rdx
                	movzbl	(%rdx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x750(%rbp)
+               	movq	%r8, -0x8c0(%rbp)
                	leaq	0x1(%rbx), %rdx
                	movzbl	(%rdx), %r14d
                	leaq	0x1(%rsi), %rdx
                	movzbl	(%rdx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x758(%rbp)
+               	movq	%r8, -0x8c8(%rbp)
                	leaq	0x2(%rbx), %rdx
                	movzbl	(%rdx), %r15d
                	leaq	0x2(%rsi), %rdx
                	movzbl	(%rdx), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x760(%rbp)
+               	movq	%r8, -0x8d0(%rbp)
                	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x3(%rsi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x768(%rbp)
+               	movq	%r8, -0x8d8(%rbp)
                	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x4(%rsi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x770(%rbp)
+               	movq	%r8, -0x8e0(%rbp)
                	leaq	0x5(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x5(%rsi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x778(%rbp)
+               	movq	%r8, -0x8e8(%rbp)
                	leaq	0x6(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x6(%rsi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x780(%rbp)
+               	movq	%r8, -0x8f0(%rbp)
                	leaq	0x7(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x7(%rsi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x788(%rbp)
+               	movq	%r8, -0x8f8(%rbp)
                	leaq	0x8(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x8(%rsi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x790(%rbp)
+               	movq	%r8, -0x900(%rbp)
                	leaq	0x9(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x9(%rsi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x798(%rbp)
+               	movq	%r8, -0x908(%rbp)
                	leaq	0xa(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0xa(%rsi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x7a0(%rbp)
+               	movq	%r8, -0x910(%rbp)
                	leaq	0xb(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0xb(%rsi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x7a8(%rbp)
+               	movq	%r8, -0x918(%rbp)
                	leaq	0xc(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0xc(%rsi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x7b0(%rbp)
+               	movq	%r8, -0x920(%rbp)
                	leaq	0xd(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0xd(%rsi), %rcx
@@ -443,190 +457,192 @@ Disassembly of section .text:
                	leaq	0xf(%rsi), %rcx
                	movzbl	(%rcx), %r13d
                	imull	%r13d, %edx
-               	leaq	-0xd0(%rbp), %rcx
+               	leaq	-0x120(%rbp), %rcx
                	movups	%xmm7, (%rcx)
                	leaq	(%rcx), %r13
-               	movq	-0x750(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xe0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r13
-               	movq	-0x758(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0xf0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r13
-               	movq	-0x760(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x100(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r13
-               	movq	-0x768(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x110(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r13
-               	movq	-0x770(%rbp), %r8
-               	movb	%r8b, (%r13)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x120(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r13
-               	movq	-0x778(%rbp), %r8
+               	movq	-0x8c0(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x130(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r13
-               	movq	-0x780(%rbp), %r8
+               	leaq	0x1(%rcx), %r13
+               	movq	-0x8c8(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x140(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r13
-               	movq	-0x788(%rbp), %r8
+               	leaq	0x2(%rcx), %r13
+               	movq	-0x8d0(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x150(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r13
-               	movq	-0x790(%rbp), %r8
+               	leaq	0x3(%rcx), %r13
+               	movq	-0x8d8(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x160(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r13
-               	movq	-0x798(%rbp), %r8
+               	leaq	0x4(%rcx), %r13
+               	movq	-0x8e0(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x170(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %r13
-               	movq	-0x7a0(%rbp), %r8
+               	leaq	0x5(%rcx), %r13
+               	movq	-0x8e8(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x180(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %r13
-               	movq	-0x7a8(%rbp), %r8
+               	leaq	0x6(%rcx), %r13
+               	movq	-0x8f0(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x190(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0xc(%rcx), %r13
-               	movq	-0x7b0(%rbp), %r8
+               	leaq	0x7(%rcx), %r13
+               	movq	-0x8f8(%rbp), %r8
                	movb	%r8b, (%r13)
                	movups	(%rcx), %xmm0
                	leaq	-0x1a0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
+               	leaq	0x8(%rcx), %r13
+               	movq	-0x900(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x1b0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x9(%rcx), %r13
+               	movq	-0x908(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x1c0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xa(%rcx), %r13
+               	movq	-0x910(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x1d0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xb(%rcx), %r13
+               	movq	-0x918(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x1e0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xc(%rcx), %r13
+               	movq	-0x920(%rbp), %r8
+               	movb	%r8b, (%r13)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x1f0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %r13
                	movb	%r14b, (%r13)
                	movups	(%rcx), %xmm0
-               	leaq	-0x1b0(%rbp), %rcx
+               	leaq	-0x200(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %r13
                	movb	%r15b, (%r13)
                	movups	(%rcx), %xmm0
-               	leaq	-0x1c0(%rbp), %rcx
+               	leaq	-0x210(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %r13
                	movb	%dl, (%r13)
-               	movups	(%rcx), %xmm1
-               	movq	-0x748(%rbp), %r8
+               	movups	(%rcx), %xmm0
+               	movq	-0x8b8(%rbp), %r8
                	movq	%r8, %rcx
+               	movups	%xmm0, -0x220(%rbp)
+               	leaq	-0x220(%rbp), %rdx
                	callq	 <L6>
 <L6>:
                	movq	%rax, %r8
-               	movq	%r8, -0x7b8(%rbp)
-               	movq	-0x7b8(%rbp), %r8
+               	movq	%r8, -0x928(%rbp)
+               	movq	-0x928(%rbp), %r8
                	leaq	(%rbx), %rdx
                	movzbl	(%rdx), %r13d
                	leaq	(%rdi), %rdx
                	movzbl	(%rdx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x7c0(%rbp)
+               	movq	%r8, -0x930(%rbp)
                	leaq	0x1(%rbx), %rdx
                	movzbl	(%rdx), %r14d
                	leaq	0x1(%rdi), %rdx
                	movzbl	(%rdx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x7c8(%rbp)
+               	movq	%r8, -0x938(%rbp)
                	leaq	0x2(%rbx), %rdx
                	movzbl	(%rdx), %r15d
                	leaq	0x2(%rdi), %rdx
                	movzbl	(%rdx), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x7d0(%rbp)
+               	movq	%r8, -0x940(%rbp)
                	leaq	0x3(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x3(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x7d8(%rbp)
+               	movq	%r8, -0x948(%rbp)
                	leaq	0x4(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x4(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x7e0(%rbp)
+               	movq	%r8, -0x950(%rbp)
                	leaq	0x5(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x5(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x7e8(%rbp)
+               	movq	%r8, -0x958(%rbp)
                	leaq	0x6(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x6(%rdi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x7f0(%rbp)
+               	movq	%r8, -0x960(%rbp)
                	leaq	0x7(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x7(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x7f8(%rbp)
+               	movq	%r8, -0x968(%rbp)
                	leaq	0x8(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x8(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x800(%rbp)
+               	movq	%r8, -0x970(%rbp)
                	leaq	0x9(%rbx), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x9(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x808(%rbp)
+               	movq	%r8, -0x978(%rbp)
                	leaq	0xa(%rbx), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0xa(%rdi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x810(%rbp)
+               	movq	%r8, -0x980(%rbp)
                	leaq	0xb(%rbx), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0xb(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x818(%rbp)
+               	movq	%r8, -0x988(%rbp)
                	leaq	0xc(%rbx), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0xc(%rdi), %rcx
@@ -647,182 +663,184 @@ Disassembly of section .text:
                	leaq	0xf(%rdi), %rcx
                	movzbl	(%rcx), %ebx
                	imull	%ebx, %edx
-               	leaq	-0x1d0(%rbp), %rcx
+               	leaq	-0x230(%rbp), %rcx
                	movups	%xmm7, (%rcx)
                	leaq	(%rcx), %rbx
-               	movq	-0x7c0(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %rbx
-               	movq	-0x7c8(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x1f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %rbx
-               	movq	-0x7d0(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x200(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %rbx
-               	movq	-0x7d8(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x210(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rbx
-               	movq	-0x7e0(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x220(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %rbx
-               	movq	-0x7e8(%rbp), %r8
-               	movb	%r8b, (%rbx)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x230(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %rbx
-               	movq	-0x7f0(%rbp), %r8
+               	movq	-0x930(%rbp), %r8
                	movb	%r8b, (%rbx)
                	movups	(%rcx), %xmm0
                	leaq	-0x240(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %rbx
-               	movq	-0x7f8(%rbp), %r8
+               	leaq	0x1(%rcx), %rbx
+               	movq	-0x938(%rbp), %r8
                	movb	%r8b, (%rbx)
                	movups	(%rcx), %xmm0
                	leaq	-0x250(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rbx
-               	movq	-0x800(%rbp), %r8
+               	leaq	0x2(%rcx), %rbx
+               	movq	-0x940(%rbp), %r8
                	movb	%r8b, (%rbx)
                	movups	(%rcx), %xmm0
                	leaq	-0x260(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %rbx
-               	movq	-0x808(%rbp), %r8
+               	leaq	0x3(%rcx), %rbx
+               	movq	-0x948(%rbp), %r8
                	movb	%r8b, (%rbx)
                	movups	(%rcx), %xmm0
                	leaq	-0x270(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %rbx
-               	movq	-0x810(%rbp), %r8
+               	leaq	0x4(%rcx), %rbx
+               	movq	-0x950(%rbp), %r8
                	movb	%r8b, (%rbx)
                	movups	(%rcx), %xmm0
                	leaq	-0x280(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0xb(%rcx), %rbx
-               	movq	-0x818(%rbp), %r8
+               	leaq	0x5(%rcx), %rbx
+               	movq	-0x958(%rbp), %r8
                	movb	%r8b, (%rbx)
                	movups	(%rcx), %xmm0
                	leaq	-0x290(%rbp), %rcx
                	movups	%xmm0, (%rcx)
+               	leaq	0x6(%rcx), %rbx
+               	movq	-0x960(%rbp), %r8
+               	movb	%r8b, (%rbx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2a0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x7(%rcx), %rbx
+               	movq	-0x968(%rbp), %r8
+               	movb	%r8b, (%rbx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2b0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x8(%rcx), %rbx
+               	movq	-0x970(%rbp), %r8
+               	movb	%r8b, (%rbx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2c0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x9(%rcx), %rbx
+               	movq	-0x978(%rbp), %r8
+               	movb	%r8b, (%rbx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2d0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xa(%rcx), %rbx
+               	movq	-0x980(%rbp), %r8
+               	movb	%r8b, (%rbx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2e0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xb(%rcx), %rbx
+               	movq	-0x988(%rbp), %r8
+               	movb	%r8b, (%rbx)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x2f0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rbx
                	movb	%r13b, (%rbx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x2a0(%rbp), %rcx
+               	leaq	-0x300(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rbx
                	movb	%r14b, (%rbx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x2b0(%rbp), %rcx
+               	leaq	-0x310(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rbx
                	movb	%r15b, (%rbx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x2c0(%rbp), %rcx
+               	leaq	-0x320(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rbx
                	movb	%dl, (%rbx)
-               	movups	(%rcx), %xmm1
-               	movq	-0x7b8(%rbp), %r8
+               	movups	(%rcx), %xmm0
+               	movq	-0x928(%rbp), %r8
                	movq	%r8, %rcx
+               	movups	%xmm0, -0x330(%rbp)
+               	leaq	-0x330(%rbp), %rdx
                	callq	 <L7>
 <L7>:
                	movq	%rax, %r8
-               	movq	%r8, -0x820(%rbp)
-               	movq	-0x820(%rbp), %r8
+               	movq	%r8, -0x990(%rbp)
+               	movq	-0x990(%rbp), %r8
                	leaq	(%rsi), %rdx
                	movzbl	(%rdx), %ebx
                	leaq	(%rdi), %rdx
                	movzbl	(%rdx), %r13d
                	movl	%ebx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x828(%rbp)
+               	movq	%r8, -0x998(%rbp)
                	leaq	0x1(%rsi), %rdx
                	movzbl	(%rdx), %r13d
                	leaq	0x1(%rdi), %rdx
                	movzbl	(%rdx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x830(%rbp)
+               	movq	%r8, -0x9a0(%rbp)
                	leaq	0x2(%rsi), %rdx
                	movzbl	(%rdx), %r14d
                	leaq	0x2(%rdi), %rdx
                	movzbl	(%rdx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x838(%rbp)
+               	movq	%r8, -0x9a8(%rbp)
                	leaq	0x3(%rsi), %rdx
                	movzbl	(%rdx), %r15d
                	leaq	0x3(%rdi), %rdx
                	movzbl	(%rdx), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x840(%rbp)
+               	movq	%r8, -0x9b0(%rbp)
                	leaq	0x4(%rsi), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x4(%rdi), %rcx
                	movzbl	(%rcx), %ebx
                	movl	%edx, %r8d
                	imull	%ebx, %r8d
-               	movq	%r8, -0x848(%rbp)
+               	movq	%r8, -0x9b8(%rbp)
                	leaq	0x5(%rsi), %rcx
                	movzbl	(%rcx), %ebx
                	leaq	0x5(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%ebx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x850(%rbp)
+               	movq	%r8, -0x9c0(%rbp)
                	leaq	0x6(%rsi), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x6(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x858(%rbp)
+               	movq	%r8, -0x9c8(%rbp)
                	leaq	0x7(%rsi), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x7(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x860(%rbp)
+               	movq	%r8, -0x9d0(%rbp)
                	leaq	0x8(%rsi), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x8(%rdi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x868(%rbp)
+               	movq	%r8, -0x9d8(%rbp)
                	leaq	0x9(%rsi), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x9(%rdi), %rcx
                	movzbl	(%rcx), %ebx
                	movl	%edx, %r8d
                	imull	%ebx, %r8d
-               	movq	%r8, -0x870(%rbp)
+               	movq	%r8, -0x9e0(%rbp)
                	leaq	0xa(%rsi), %rcx
                	movzbl	(%rcx), %ebx
                	leaq	0xa(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%ebx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x878(%rbp)
+               	movq	%r8, -0x9e8(%rbp)
                	leaq	0xb(%rsi), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0xb(%rdi), %rcx
@@ -848,174 +866,176 @@ Disassembly of section .text:
                	leaq	0xf(%rdi), %rcx
                	movzbl	(%rcx), %esi
                	imull	%esi, %ebx
-               	leaq	-0x2d0(%rbp), %rcx
+               	leaq	-0x340(%rbp), %rcx
                	movups	%xmm8, (%rcx)
                	leaq	(%rcx), %rsi
-               	movq	-0x828(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %rsi
-               	movq	-0x830(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x2f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %rsi
-               	movq	-0x838(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x300(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %rsi
-               	movq	-0x840(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x310(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %rsi
-               	movq	-0x848(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x320(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %rsi
-               	movq	-0x850(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x330(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %rsi
-               	movq	-0x858(%rbp), %r8
-               	movb	%r8b, (%rsi)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x340(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %rsi
-               	movq	-0x860(%rbp), %r8
+               	movq	-0x998(%rbp), %r8
                	movb	%r8b, (%rsi)
                	movups	(%rcx), %xmm0
                	leaq	-0x350(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %rsi
-               	movq	-0x868(%rbp), %r8
+               	leaq	0x1(%rcx), %rsi
+               	movq	-0x9a0(%rbp), %r8
                	movb	%r8b, (%rsi)
                	movups	(%rcx), %xmm0
                	leaq	-0x360(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %rsi
-               	movq	-0x870(%rbp), %r8
+               	leaq	0x2(%rcx), %rsi
+               	movq	-0x9a8(%rbp), %r8
                	movb	%r8b, (%rsi)
                	movups	(%rcx), %xmm0
                	leaq	-0x370(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0xa(%rcx), %rsi
-               	movq	-0x878(%rbp), %r8
+               	leaq	0x3(%rcx), %rsi
+               	movq	-0x9b0(%rbp), %r8
                	movb	%r8b, (%rsi)
                	movups	(%rcx), %xmm0
                	leaq	-0x380(%rbp), %rcx
                	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %rsi
+               	movq	-0x9b8(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x390(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x5(%rcx), %rsi
+               	movq	-0x9c0(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x3a0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x6(%rcx), %rsi
+               	movq	-0x9c8(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x3b0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x7(%rcx), %rsi
+               	movq	-0x9d0(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x3c0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x8(%rcx), %rsi
+               	movq	-0x9d8(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x3d0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x9(%rcx), %rsi
+               	movq	-0x9e0(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x3e0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0xa(%rcx), %rsi
+               	movq	-0x9e8(%rbp), %r8
+               	movb	%r8b, (%rsi)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x3f0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0xb(%rcx), %rsi
                	movb	%r13b, (%rsi)
                	movups	(%rcx), %xmm0
-               	leaq	-0x390(%rbp), %rcx
+               	leaq	-0x400(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rsi
                	movb	%r14b, (%rsi)
                	movups	(%rcx), %xmm0
-               	leaq	-0x3a0(%rbp), %rcx
+               	leaq	-0x410(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rsi
                	movb	%r15b, (%rsi)
                	movups	(%rcx), %xmm0
-               	leaq	-0x3b0(%rbp), %rcx
+               	leaq	-0x420(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rsi
                	movb	%dl, (%rsi)
                	movups	(%rcx), %xmm0
-               	leaq	-0x3c0(%rbp), %rcx
+               	leaq	-0x430(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rdx
                	movb	%bl, (%rdx)
-               	movups	(%rcx), %xmm1
-               	movq	-0x820(%rbp), %r8
+               	movups	(%rcx), %xmm0
+               	movq	-0x990(%rbp), %r8
                	movq	%r8, %rcx
+               	movups	%xmm0, -0x440(%rbp)
+               	leaq	-0x440(%rbp), %rdx
                	callq	 <L8>
 <L8>:
                	movq	%rax, %r8
-               	movq	%r8, -0x880(%rbp)
-               	movq	-0x880(%rbp), %r8
+               	movq	%r8, -0x9f0(%rbp)
+               	movq	-0x9f0(%rbp), %r8
                	leaq	(%r12), %rdx
                	movzbl	(%rdx), %ebx
                	leaq	(%rdi), %rdx
                	movzbl	(%rdx), %esi
                	movl	%ebx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x888(%rbp)
+               	movq	%r8, -0x9f8(%rbp)
                	leaq	0x1(%r12), %rdx
                	movzbl	(%rdx), %esi
                	leaq	0x1(%rdi), %rdx
                	movzbl	(%rdx), %r13d
                	movl	%esi, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x890(%rbp)
+               	movq	%r8, -0xa00(%rbp)
                	leaq	0x2(%r12), %rdx
                	movzbl	(%rdx), %r13d
                	leaq	0x2(%rdi), %rdx
                	movzbl	(%rdx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x898(%rbp)
+               	movq	%r8, -0xa08(%rbp)
                	leaq	0x3(%r12), %rdx
                	movzbl	(%rdx), %r14d
                	leaq	0x3(%rdi), %rdx
                	movzbl	(%rdx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x8a0(%rbp)
+               	movq	%r8, -0xa10(%rbp)
                	leaq	0x4(%r12), %rdx
                	movzbl	(%rdx), %r15d
                	leaq	0x4(%rdi), %rdx
                	movzbl	(%rdx), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x8a8(%rbp)
+               	movq	%r8, -0xa18(%rbp)
                	leaq	0x5(%r12), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x5(%rdi), %rcx
                	movzbl	(%rcx), %ebx
                	movl	%edx, %r8d
                	imull	%ebx, %r8d
-               	movq	%r8, -0x8b0(%rbp)
+               	movq	%r8, -0xa20(%rbp)
                	leaq	0x6(%r12), %rcx
                	movzbl	(%rcx), %ebx
                	leaq	0x6(%rdi), %rcx
                	movzbl	(%rcx), %esi
                	movl	%ebx, %r8d
                	imull	%esi, %r8d
-               	movq	%r8, -0x8b8(%rbp)
+               	movq	%r8, -0xa28(%rbp)
                	leaq	0x7(%r12), %rcx
                	movzbl	(%rcx), %esi
                	leaq	0x7(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%esi, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x8c0(%rbp)
+               	movq	%r8, -0xa30(%rbp)
                	leaq	0x8(%r12), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x8(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x8c8(%rbp)
+               	movq	%r8, -0xa38(%rbp)
                	leaq	0x9(%r12), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x9(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x8d0(%rbp)
+               	movq	%r8, -0xa40(%rbp)
                	leaq	0xa(%r12), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0xa(%rdi), %rcx
@@ -1046,162 +1066,177 @@ Disassembly of section .text:
                	leaq	0xf(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	imull	%r14d, %r12d
-               	leaq	-0x3d0(%rbp), %rcx
+               	leaq	-0x450(%rbp), %rcx
                	movups	%xmm9, (%rcx)
                	leaq	(%rcx), %r14
-               	movq	-0x888(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3e0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x1(%rcx), %r14
-               	movq	-0x890(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x3f0(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x2(%rcx), %r14
-               	movq	-0x898(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x400(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x3(%rcx), %r14
-               	movq	-0x8a0(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x410(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x4(%rcx), %r14
-               	movq	-0x8a8(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x420(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x5(%rcx), %r14
-               	movq	-0x8b0(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x430(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x6(%rcx), %r14
-               	movq	-0x8b8(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x440(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x7(%rcx), %r14
-               	movq	-0x8c0(%rbp), %r8
-               	movb	%r8b, (%r14)
-               	movups	(%rcx), %xmm0
-               	leaq	-0x450(%rbp), %rcx
-               	movups	%xmm0, (%rcx)
-               	leaq	0x8(%rcx), %r14
-               	movq	-0x8c8(%rbp), %r8
+               	movq	-0x9f8(%rbp), %r8
                	movb	%r8b, (%r14)
                	movups	(%rcx), %xmm0
                	leaq	-0x460(%rbp), %rcx
                	movups	%xmm0, (%rcx)
-               	leaq	0x9(%rcx), %r14
-               	movq	-0x8d0(%rbp), %r8
+               	leaq	0x1(%rcx), %r14
+               	movq	-0xa00(%rbp), %r8
                	movb	%r8b, (%r14)
                	movups	(%rcx), %xmm0
                	leaq	-0x470(%rbp), %rcx
                	movups	%xmm0, (%rcx)
+               	leaq	0x2(%rcx), %r14
+               	movq	-0xa08(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x480(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x3(%rcx), %r14
+               	movq	-0xa10(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x490(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x4(%rcx), %r14
+               	movq	-0xa18(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x4a0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x5(%rcx), %r14
+               	movq	-0xa20(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x4b0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x6(%rcx), %r14
+               	movq	-0xa28(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x4c0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x7(%rcx), %r14
+               	movq	-0xa30(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x4d0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x8(%rcx), %r14
+               	movq	-0xa38(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x4e0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	0x9(%rcx), %r14
+               	movq	-0xa40(%rbp), %r8
+               	movb	%r8b, (%r14)
+               	movups	(%rcx), %xmm0
+               	leaq	-0x4f0(%rbp), %rcx
+               	movups	%xmm0, (%rcx)
                	leaq	0xa(%rcx), %r14
                	movb	%r15b, (%r14)
                	movups	(%rcx), %xmm0
-               	leaq	-0x480(%rbp), %rcx
+               	leaq	-0x500(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xb(%rcx), %r14
                	movb	%dl, (%r14)
                	movups	(%rcx), %xmm0
-               	leaq	-0x490(%rbp), %rcx
+               	leaq	-0x510(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %rdx
                	movb	%bl, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4a0(%rbp), %rcx
+               	leaq	-0x520(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rdx
                	movb	%sil, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4b0(%rbp), %rcx
+               	leaq	-0x530(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rdx
                	movb	%r13b, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4c0(%rbp), %rcx
+               	leaq	-0x540(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rdx
                	movb	%r12b, (%rdx)
-               	movups	(%rcx), %xmm1
-               	movq	-0x880(%rbp), %r8
+               	movups	(%rcx), %xmm0
+               	movq	-0x9f0(%rbp), %r8
                	movq	%r8, %rcx
+               	movups	%xmm0, -0x550(%rbp)
+               	leaq	-0x550(%rbp), %rdx
                	callq	 <L9>
 <L9>:
                	movq	%rax, %rcx
                	movaps	%xmm6, %xmm14
                	psubb	%xmm7, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x560(%rbp)
+               	leaq	-0x560(%rbp), %rdx
                	callq	 <L10>
 <L10>:
                	movq	%rax, %rcx
                	movaps	%xmm6, %xmm14
                	psubb	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x570(%rbp)
+               	leaq	-0x570(%rbp), %rdx
                	callq	 <L11>
 <L11>:
                	movq	%rax, %rcx
                	movaps	%xmm7, %xmm14
                	pand	%xmm8, %xmm14
                	movaps	%xmm14, %xmm9
-               	movaps	%xmm9, %xmm1
+               	movups	%xmm9, -0x580(%rbp)
+               	leaq	-0x580(%rbp), %rdx
                	callq	 <L12>
 <L12>:
                	movq	%rax, %rcx
                	movaps	%xmm7, %xmm14
                	por	%xmm8, %xmm14
                	movaps	%xmm14, %xmm10
-               	movaps	%xmm10, %xmm1
+               	movups	%xmm10, -0x590(%rbp)
+               	leaq	-0x590(%rbp), %rdx
                	callq	 <L13>
 <L13>:
                	movq	%rax, %rcx
                	movaps	%xmm7, %xmm14
                	pxor	%xmm8, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x5a0(%rbp)
+               	leaq	-0x5a0(%rbp), %rdx
                	callq	 <L14>
 <L14>:
                	movq	%rax, %rcx
                	movaps	%xmm7, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x5b0(%rbp)
+               	leaq	-0x5b0(%rbp), %rdx
                	callq	 <L15>
 <L15>:
                	movq	%rax, %rcx
                	movaps	%xmm8, %xmm14
                	pcmpeqd	%xmm15, %xmm15
                	pxor	%xmm15, %xmm14
-               	movaps	%xmm14, %xmm1
+               	movaps	%xmm14, %xmm0
+               	movups	%xmm0, -0x5c0(%rbp)
+               	leaq	-0x5c0(%rbp), %rdx
                	callq	 <L16>
 <L16>:
                	movq	%rax, %rcx
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm9
-               	movaps	%xmm9, %xmm1
+               	movups	%xmm9, -0x5d0(%rbp)
+               	leaq	-0x5d0(%rbp), %rdx
                	callq	 <L17>
 <L17>:
                	movq	%rax, %rbx
                	movaps	%xmm6, %xmm9
                	movq	$0x0, %rsi
 <L18>:
-               	leaq	-0x4d0(%rbp), %r12
+               	leaq	-0x5e0(%rbp), %r12
                	movups	%xmm7, (%r12)
                	cmpq	$0x6, %rsi
                	jb	 <L25>
-               	leaq	-0x610(%rbp), %r13
+               	leaq	-0x760(%rbp), %r13
                	movq	$0x0, (%r13)
                	movq	$0x0, 0x8(%r13)
                	movq	$0x0, 0x10(%r13)
@@ -1223,91 +1258,91 @@ Disassembly of section .text:
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8d8(%rbp)
+               	movq	%r8, -0xa48(%rbp)
                	leaq	0x1(%r12), %rax
                	movzbl	(%rax), %edx
                	leaq	0x1(%rdi), %rax
                	movzbl	(%rax), %r14d
                	movl	%edx, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x8e0(%rbp)
+               	movq	%r8, -0xa50(%rbp)
                	leaq	0x2(%r12), %rax
                	movzbl	(%rax), %r14d
                	leaq	0x2(%rdi), %rax
                	movzbl	(%rax), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x8e8(%rbp)
+               	movq	%r8, -0xa58(%rbp)
                	leaq	0x3(%r12), %rax
                	movzbl	(%rax), %r15d
                	leaq	0x3(%rdi), %rax
                	movzbl	(%rax), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x8f0(%rbp)
+               	movq	%r8, -0xa60(%rbp)
                	leaq	0x4(%r12), %rax
                	movzbl	(%rax), %ecx
                	leaq	0x4(%rdi), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x8f8(%rbp)
+               	movq	%r8, -0xa68(%rbp)
                	leaq	0x5(%r12), %rax
                	movzbl	(%rax), %edx
                	leaq	0x5(%rdi), %rax
                	movzbl	(%rax), %r14d
                	movl	%edx, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x900(%rbp)
+               	movq	%r8, -0xa70(%rbp)
                	leaq	0x6(%r12), %rax
                	movzbl	(%rax), %r14d
                	leaq	0x6(%rdi), %rax
                	movzbl	(%rax), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x908(%rbp)
+               	movq	%r8, -0xa78(%rbp)
                	leaq	0x7(%r12), %rax
                	movzbl	(%rax), %r15d
                	leaq	0x7(%rdi), %rax
                	movzbl	(%rax), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x910(%rbp)
+               	movq	%r8, -0xa80(%rbp)
                	leaq	0x8(%r12), %rax
                	movzbl	(%rax), %ecx
                	leaq	0x8(%rdi), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x918(%rbp)
+               	movq	%r8, -0xa88(%rbp)
                	leaq	0x9(%r12), %rax
                	movzbl	(%rax), %edx
                	leaq	0x9(%rdi), %rax
                	movzbl	(%rax), %r14d
                	movl	%edx, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x920(%rbp)
+               	movq	%r8, -0xa90(%rbp)
                	leaq	0xa(%r12), %rax
                	movzbl	(%rax), %r14d
                	leaq	0xa(%rdi), %rax
                	movzbl	(%rax), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x928(%rbp)
+               	movq	%r8, -0xa98(%rbp)
                	leaq	0xb(%r12), %rax
                	movzbl	(%rax), %r15d
                	leaq	0xb(%rdi), %rax
                	movzbl	(%rax), %ecx
                	movl	%r15d, %r8d
                	imull	%ecx, %r8d
-               	movq	%r8, -0x930(%rbp)
+               	movq	%r8, -0xaa0(%rbp)
                	leaq	0xc(%r12), %rax
                	movzbl	(%rax), %ecx
                	leaq	0xc(%rdi), %rax
                	movzbl	(%rax), %edx
                	movl	%ecx, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x938(%rbp)
+               	movq	%r8, -0xaa8(%rbp)
                	leaq	0xd(%r12), %rax
                	movzbl	(%rax), %edx
                	leaq	0xd(%rdi), %rax
@@ -1323,95 +1358,95 @@ Disassembly of section .text:
                	leaq	0xf(%rdi), %rax
                	movzbl	(%rax), %ecx
                	imull	%ecx, %r15d
-               	leaq	-0x620(%rbp), %rax
+               	leaq	-0x770(%rbp), %rax
                	movups	%xmm7, (%rax)
                	leaq	(%rax), %rcx
-               	movq	-0x8d8(%rbp), %r8
+               	movq	-0xa48(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x630(%rbp), %rax
+               	leaq	-0x780(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x1(%rax), %rcx
-               	movq	-0x8e0(%rbp), %r8
+               	movq	-0xa50(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x640(%rbp), %rax
+               	leaq	-0x790(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x2(%rax), %rcx
-               	movq	-0x8e8(%rbp), %r8
+               	movq	-0xa58(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x650(%rbp), %rax
+               	leaq	-0x7a0(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x3(%rax), %rcx
-               	movq	-0x8f0(%rbp), %r8
+               	movq	-0xa60(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x660(%rbp), %rax
+               	leaq	-0x7b0(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x4(%rax), %rcx
-               	movq	-0x8f8(%rbp), %r8
+               	movq	-0xa68(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x670(%rbp), %rax
+               	leaq	-0x7c0(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x5(%rax), %rcx
-               	movq	-0x900(%rbp), %r8
+               	movq	-0xa70(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x680(%rbp), %rax
+               	leaq	-0x7d0(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x6(%rax), %rcx
-               	movq	-0x908(%rbp), %r8
+               	movq	-0xa78(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x690(%rbp), %rax
+               	leaq	-0x7e0(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x7(%rax), %rcx
-               	movq	-0x910(%rbp), %r8
+               	movq	-0xa80(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6a0(%rbp), %rax
+               	leaq	-0x7f0(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x8(%rax), %rcx
-               	movq	-0x918(%rbp), %r8
+               	movq	-0xa88(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6b0(%rbp), %rax
+               	leaq	-0x800(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0x9(%rax), %rcx
-               	movq	-0x920(%rbp), %r8
+               	movq	-0xa90(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6c0(%rbp), %rax
+               	leaq	-0x810(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xa(%rax), %rcx
-               	movq	-0x928(%rbp), %r8
+               	movq	-0xa98(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6d0(%rbp), %rax
+               	leaq	-0x820(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xb(%rax), %rcx
-               	movq	-0x930(%rbp), %r8
+               	movq	-0xaa0(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6e0(%rbp), %rax
+               	leaq	-0x830(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xc(%rax), %rcx
-               	movq	-0x938(%rbp), %r8
+               	movq	-0xaa8(%rbp), %r8
                	movb	%r8b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x6f0(%rbp), %rax
+               	leaq	-0x840(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xd(%rax), %rcx
                	movb	%dl, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x700(%rbp), %rax
+               	leaq	-0x850(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xe(%rax), %rcx
                	movb	%r14b, (%rcx)
                	movups	(%rax), %xmm0
-               	leaq	-0x710(%rbp), %rax
+               	leaq	-0x860(%rbp), %rax
                	movups	%xmm0, (%rax)
                	leaq	0xf(%rax), %rcx
                	movb	%r15b, (%rcx)
@@ -1429,8 +1464,10 @@ Disassembly of section .text:
                	movq	%r15, %rax
                	imulq	$0x10, %rax, %rax
                	leaq	(%r13,%rax), %rcx
-               	movups	(%rcx), %xmm1
+               	movups	(%rcx), %xmm0
                	movq	%r14, %rcx
+               	movups	%xmm0, -0x870(%rbp)
+               	leaq	-0x870(%rbp), %rdx
                	callq	 <L20>
 <L20>:
                	addq	$0x1, %r15
@@ -1438,7 +1475,7 @@ Disassembly of section .text:
                	cmpq	$0x4, %r15
                	jb	 <L19>
 <L21>:
-               	leaq	-0x740(%rbp), %rax
+               	leaq	-0x8a0(%rbp), %rax
                	movq	$0x0, (%rax)
                	movq	$0x0, 0x8(%rax)
                	movq	$0x0, 0x10(%rax)
@@ -1458,26 +1495,30 @@ Disassembly of section .text:
                	movl	%eax, %edx
                	callq	 <L22>
 <L22>:
-               	movups	(%r13), %xmm1
+               	movups	(%r13), %xmm0
                	movq	%rax, %rcx
+               	movups	%xmm0, -0x8b0(%rbp)
+               	leaq	-0x8b0(%rbp), %rdx
                	callq	 <L23>
 <L23>:
                	movl	(%r15), %edx
                	movq	%rax, %rcx
                	callq	 <L24>
 <L24>:
-               	movaps	-0x9f0(%rbp), %xmm6
-               	movaps	-0xa00(%rbp), %xmm7
-               	movaps	-0xa10(%rbp), %xmm8
-               	movaps	-0xa20(%rbp), %xmm9
-               	movaps	-0xa30(%rbp), %xmm10
-               	movq	-0x9a8(%rbp), %rbx
-               	movq	-0x9b0(%rbp), %rdi
-               	movq	-0x9b8(%rbp), %rsi
-               	movq	-0x9c0(%rbp), %r12
-               	movq	-0x9c8(%rbp), %r13
-               	movq	-0x9d0(%rbp), %r14
-               	movq	-0x9d8(%rbp), %r15
+               	movaps	-0xb60(%rbp), %xmm6
+               	movaps	-0xb70(%rbp), %xmm7
+               	movaps	-0xb80(%rbp), %xmm8
+               	movaps	-0xb90(%rbp), %xmm9
+               	movaps	-0xba0(%rbp), %xmm10
+               	movaps	-0xbb0(%rbp), %xmm14
+               	movaps	-0xbc0(%rbp), %xmm15
+               	movq	-0xb18(%rbp), %rbx
+               	movq	-0xb20(%rbp), %rdi
+               	movq	-0xb28(%rbp), %rsi
+               	movq	-0xb30(%rbp), %r12
+               	movq	-0xb38(%rbp), %r13
+               	movq	-0xb40(%rbp), %r14
+               	movq	-0xb48(%rbp), %r15
                	movq	%rbp, %rsp
                	popq	%rbp
                	retq
@@ -1488,84 +1529,84 @@ Disassembly of section .text:
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x940(%rbp)
+               	movq	%r8, -0xab0(%rbp)
                	leaq	0x1(%r12), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x1(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x948(%rbp)
+               	movq	%r8, -0xab8(%rbp)
                	leaq	0x2(%r12), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x2(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x950(%rbp)
+               	movq	%r8, -0xac0(%rbp)
                	leaq	0x3(%r12), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x3(%rdi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x958(%rbp)
+               	movq	%r8, -0xac8(%rbp)
                	leaq	0x4(%r12), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x4(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x960(%rbp)
+               	movq	%r8, -0xad0(%rbp)
                	leaq	0x5(%r12), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x5(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x968(%rbp)
+               	movq	%r8, -0xad8(%rbp)
                	leaq	0x6(%r12), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0x6(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x970(%rbp)
+               	movq	%r8, -0xae0(%rbp)
                	leaq	0x7(%r12), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0x7(%rdi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x978(%rbp)
+               	movq	%r8, -0xae8(%rbp)
                	leaq	0x8(%r12), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0x8(%rdi), %rcx
                	movzbl	(%rcx), %r13d
                	movl	%edx, %r8d
                	imull	%r13d, %r8d
-               	movq	%r8, -0x980(%rbp)
+               	movq	%r8, -0xaf0(%rbp)
                	leaq	0x9(%r12), %rcx
                	movzbl	(%rcx), %r13d
                	leaq	0x9(%rdi), %rcx
                	movzbl	(%rcx), %r14d
                	movl	%r13d, %r8d
                	imull	%r14d, %r8d
-               	movq	%r8, -0x988(%rbp)
+               	movq	%r8, -0xaf8(%rbp)
                	leaq	0xa(%r12), %rcx
                	movzbl	(%rcx), %r14d
                	leaq	0xa(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	movl	%r14d, %r8d
                	imull	%r15d, %r8d
-               	movq	%r8, -0x990(%rbp)
+               	movq	%r8, -0xb00(%rbp)
                	leaq	0xb(%r12), %rcx
                	movzbl	(%rcx), %r15d
                	leaq	0xb(%rdi), %rcx
                	movzbl	(%rcx), %edx
                	movl	%r15d, %r8d
                	imull	%edx, %r8d
-               	movq	%r8, -0x998(%rbp)
+               	movq	%r8, -0xb08(%rbp)
                	leaq	0xc(%r12), %rcx
                	movzbl	(%rcx), %edx
                	leaq	0xc(%rdi), %rcx
@@ -1586,121 +1627,125 @@ Disassembly of section .text:
                	leaq	0xf(%rdi), %rcx
                	movzbl	(%rcx), %r15d
                	imull	%r15d, %r12d
-               	leaq	-0x4e0(%rbp), %rcx
+               	leaq	-0x5f0(%rbp), %rcx
                	movups	%xmm7, (%rcx)
                	leaq	(%rcx), %r15
-               	movq	-0x940(%rbp), %r8
+               	movq	-0xab0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x4f0(%rbp), %rcx
+               	leaq	-0x600(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x1(%rcx), %r15
-               	movq	-0x948(%rbp), %r8
+               	movq	-0xab8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x500(%rbp), %rcx
+               	leaq	-0x610(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x2(%rcx), %r15
-               	movq	-0x950(%rbp), %r8
+               	movq	-0xac0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x510(%rbp), %rcx
+               	leaq	-0x620(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x3(%rcx), %r15
-               	movq	-0x958(%rbp), %r8
+               	movq	-0xac8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x520(%rbp), %rcx
+               	leaq	-0x630(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x4(%rcx), %r15
-               	movq	-0x960(%rbp), %r8
+               	movq	-0xad0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x530(%rbp), %rcx
+               	leaq	-0x640(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x5(%rcx), %r15
-               	movq	-0x968(%rbp), %r8
+               	movq	-0xad8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x540(%rbp), %rcx
+               	leaq	-0x650(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x6(%rcx), %r15
-               	movq	-0x970(%rbp), %r8
+               	movq	-0xae0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x550(%rbp), %rcx
+               	leaq	-0x660(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x7(%rcx), %r15
-               	movq	-0x978(%rbp), %r8
+               	movq	-0xae8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x560(%rbp), %rcx
+               	leaq	-0x670(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x8(%rcx), %r15
-               	movq	-0x980(%rbp), %r8
+               	movq	-0xaf0(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x570(%rbp), %rcx
+               	leaq	-0x680(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0x9(%rcx), %r15
-               	movq	-0x988(%rbp), %r8
+               	movq	-0xaf8(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x580(%rbp), %rcx
+               	leaq	-0x690(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xa(%rcx), %r15
-               	movq	-0x990(%rbp), %r8
+               	movq	-0xb00(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x590(%rbp), %rcx
+               	leaq	-0x6a0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xb(%rcx), %r15
-               	movq	-0x998(%rbp), %r8
+               	movq	-0xb08(%rbp), %r8
                	movb	%r8b, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5a0(%rbp), %rcx
+               	leaq	-0x6b0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xc(%rcx), %r15
                	movb	%dl, (%r15)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5b0(%rbp), %rcx
+               	leaq	-0x6c0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xd(%rcx), %rdx
                	movb	%r13b, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5c0(%rbp), %rcx
+               	leaq	-0x6d0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xe(%rcx), %rdx
                	movb	%r14b, (%rdx)
                	movups	(%rcx), %xmm0
-               	leaq	-0x5d0(%rbp), %rcx
+               	leaq	-0x6e0(%rbp), %rcx
                	movups	%xmm0, (%rcx)
                	leaq	0xf(%rcx), %rdx
                	movb	%r12b, (%rdx)
                	movups	(%rcx), %xmm10
                	movq	%rbx, %rcx
-               	movaps	%xmm10, %xmm1
+               	movups	%xmm10, -0x6f0(%rbp)
+               	leaq	-0x6f0(%rbp), %rdx
                	callq	 <L26>
 <L26>:
                	movaps	%xmm9, %xmm14
                	pxor	%xmm10, %xmm14
                	movaps	%xmm14, %xmm9
                	movq	%rax, %rcx
-               	movaps	%xmm9, %xmm1
+               	movups	%xmm9, -0x700(%rbp)
+               	leaq	-0x700(%rbp), %rdx
                	callq	 <L27>
 <L27>:
                	movaps	%xmm6, %xmm14
                	paddb	%xmm7, %xmm14
                	movaps	%xmm14, %xmm6
                	movq	%rax, %rcx
-               	movaps	%xmm6, %xmm1
+               	movups	%xmm6, -0x710(%rbp)
+               	leaq	-0x710(%rbp), %rdx
                	callq	 <L28>
 <L28>:
                	movaps	%xmm7, %xmm14
                	paddb	%xmm8, %xmm14
                	movaps	%xmm14, %xmm7
                	movq	%rax, %rcx
-               	movaps	%xmm7, %xmm1
+               	movups	%xmm7, -0x720(%rbp)
+               	leaq	-0x720(%rbp), %rdx
                	callq	 <L29>
 <L29>:
                	addq	$0x1, %rsi


### PR DESCRIPTION
The Windows and Darwin corpus still expected pre-audit instruction streams. This updates 32 Windows, 16 Intel Darwin and 29 ARM Darwin goldens after reviewing every changed case against its compiler source cause. The separate floating remainder goldens remain in #3167.

Exact audit a958714e and integration 21f22603 builds produce identical output for all 89 non-arithmetic cases per target. The deltas reflect aggregate and Win64 vector ABI corrections, nonvolatile scratch preservation, canonical booleans, trapping remainder effects, inline/CSE behavior, vector-loop bounds and Darwin x18 reservation.

Validation:

- Independently decoded all 273 integration objects with pinned LLVM 22.1.8. Every proposed file matches its object and retained artifact byte for byte. Unchanged layer B passes 273/273 with the separately reviewed #3167 arithmetic goldens.
- [Native Intel Darwin and Linux cross proof](https://github.com/briar-systems/mach/actions/runs/33998669742) and [native ARM Darwin proof](https://github.com/briar-systems/mach/actions/runs/33998811705) build both exact sources through seed, A and B. Each source on each Darwin architecture passes 273 structural checks and 182 native C-reference checks. The original run's ARM installer failure is resolved by #3182 and the second run.
- [Windows native integration](https://github.com/briar-systems/mach/actions/runs/33997178061) passes 182 structural and 182 C-reference checks, with 91 explicitly unsupported debug cells. Its only disassembly failures are the 32 files updated here.
- [Darwin x18 counterfactual](https://github.com/briar-systems/mach/actions/runs/33999457330) isolates seven Darwin-only deltas. Disabling only the x18 reservation reproduces all seven old goldens exactly. This is decode evidence only. Native production execution retains the reservation.

Ordinary PR CI on unchanged dev8d99 hits the known #3139 Windows dependency dirty-check failure before the test suite. Seed Git uses the normal runner configuration, then the baseline compiler hides it. The combined integration already repairs that boundary and passes the Windows build and fixpoint. This golden-only PR changes no source involved in that failure.

Per-case source review is recorded in #3179. Compiler sources, cases, C references, decoder flags and skip policy are unchanged. The release integration still owns full compiler and stdlib validation.

Closes #3179.
