### PR TITLE
test(driver): use the selected Linux entry in worker-count fixture

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -204,6 +204,8 @@ The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 #### Driver and build
 
+- The worker-count determinism fixture exports its declared Linux entry symbol on every native host while retaining debug output and the one-versus-six-worker byte comparison (#3191).
+
 - Root dependency overrides select the realization's source kind, URL and exact selector before verification, including when a transitive edge is visited first (#3138).
 - A required artifact planned under `mach test` was built as a test cell.
 - `--quiet` on `mach build` was ignored.

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -11127,7 +11127,7 @@ fun ut_scale_names(alloc: *A.Allocator, names: *str, texts: *str) {
         calls = ut_cc3(alloc, calls, "acc = acc + f", ut_cc3(alloc, idx, "();\n", ""));
         i = i + 1;
     }
-    texts[0] = ut_cc3(alloc, uses, ut_cc3(alloc, "#[symbol(\"", ut_entry_symbol(), "\")]\n"),
+    texts[0] = ut_cc3(alloc, uses, ut_cc3(alloc, "#[symbol(\"", "_start", "\")]\n"),
         ut_cc3(alloc, "fun start() i32 {\n    var acc: i32 = 0;\n", calls, "    ret acc;\n}\n"));
 }
 


### PR DESCRIPTION
The worker-count determinism test builds a declared Linux target, but its source fixture exported the host entry symbol. On Windows this produced an undefined `_start` before either artifact could be compared.

Export `_start` for the fixed Linux fixture. Keep debug enabled and retain the complete output-byte comparison between one and six workers. Native Linux/Windows baseline and mutation proof is being prepared on the current audited integration source.

Closes #3191

Native proof: [run 34001416849](https://github.com/briar-systems/mach/actions/runs/34001416849) verified exact source stack `71c7fec67326b04c0ac288cac46bd01336f4a875` (9c52daaf plus this commit), std `c2e2340`. Both hosts selected one test and passed. Restoring the wrong target entry and inverting the byte comparison each produced one runtime assertion failure, exit 1. Five empty compiler process censuses per host, sequential seed v4.26.5 to A to B, source restored after each mutation. Production change remains `d01feeebbd9b67713fd911886acb98ba88b5e4bb`.
