### PR TITLE
fix(driver): normalize native build step path identities

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,8 @@ The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 ### Fixed
 
+- Build steps compare normalized native output roots, preserving contained Windows drive and UNC paths while retaining canonical manifest paths and escape rejection (#3195).
+
 - Windows and Darwin corpus disassemblies now reflect the audited aggregate and vector ABI, scratch-register preservation, canonical boolean, trapping remainder, inline, vector-loop and Darwin x18 fixes. All 77 updates were independently decoded and reviewed against native C-reference results (#3179).
 
 - Darwin CI installs the Homebrew LLVM formula selected by the committed oracle major, so a newer Homebrew stable release cannot break the pinned disassembly lane (#3181).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,7 +128,7 @@ The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 ### Fixed
 
-- Build steps compare normalized native output roots, preserving contained Windows drive and UNC paths while retaining canonical manifest paths and escape rejection (#3195).
+- Build steps normalize native output roots, snapshots, and declared staging paths before comparison, preserving contained Windows drive and UNC outputs. Absolute output templates retain their leading-marker requirement, and directory declarations use native component boundaries (#3195).
 
 - Windows and Darwin corpus disassemblies now reflect the audited aggregate and vector ABI, scratch-register preservation, canonical boolean, trapping remainder, inline, vector-loop and Darwin x18 fixes. All 77 updates were independently decoded and reviewed against native C-reference results (#3179).
 

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -3873,7 +3873,7 @@ test "mach.lang.driver.config.resolve_step_path:native_output_roots_preserve_bor
         expected[2] = expected[0];
     }
     var i: usize = 0;
-    for (i < roots.len) {
+    for (i < 3) {
         val output_r: R.Result[StepPath, str] = resolve_step_path(?alloc,
             "{project.out}/obj/vend-c/window.o", roots[i], ?v, roots[i], roots[i], "a build step output", false);
         if (R.is_err[StepPath, str](output_r)) {
@@ -3917,7 +3917,7 @@ test "mach.lang.driver.config.resolve_step_path:native_roots_retain_escape_and_m
     denied[6] = "{project.out}/dir//file";
     denied[7] = "../../escape";
     var i: usize = 0;
-    for (i < denied.len) {
+    for (i < 8) {
         val r: R.Result[StepPath, str] = resolve_step_path(?alloc,
             denied[i], root, ?v, root, root, "a build step output", false);
         if (R.is_ok[StepPath, str](r)) {

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -1528,7 +1528,7 @@ fun resolve_step_path(a: *A.Allocator, raw: str, project_out: str, v: *manifest.
         ret R.err[StepPath, str](R.unwrap_err[str, str](clean_root_r));
     }
     val clean_root: str = R.unwrap_ok[str, str](clean_root_r);
-    fin str_free(a, clean_root);
+    fin { str_free(a, clean_root); }
     if (!absolute_path_in_root(clean, clean_root, allow_output_root)) {
         str_free(a, rel);
         str_free(a, clean);

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -519,7 +519,7 @@ fun step_stamp_tree(a: *A.Allocator, proj_out: str) str {
 fun path_in_module_obj_tree(path: str, tree: str) bool {
     if (str_equals(path, tree)) { ret true; }
     if (!str_starts_with(path, tree)) { ret false; }
-    ret path[str_len(tree)] == '/';
+    ret spath.is_separator(path[str_len(tree)]);
 }
 
 fun step_out_reserved_error(a: *A.Allocator, what: str, name: str, path: str, tree: str, owner_desc: str) str {
@@ -1465,7 +1465,9 @@ fun resolve_step_path(a: *A.Allocator, raw: str, project_out: str, v: *manifest.
     val expanded_r: R.Result[str, str] = manifest.expand(a, raw, project_out, v);
     if (R.is_err[str, str](expanded_r)) { ret R.err[StepPath, str](R.unwrap_err[str, str](expanded_r)); }
     val expanded: str = R.unwrap_ok[str, str](expanded_r);
-    if (manifest.is_project_path(expanded)) {
+    val marker: str = "{project.out}";
+    val absolute_output: bool = spath.is_abs(project_out) && str_contains(raw, marker);
+    if (!absolute_output && manifest.is_project_path(expanded)) {
         val abs_r: R.Result[str, str] = spath.resolve(a, execution_root, expanded);
         if (R.is_err[str, str](abs_r)) {
             str_free(a, expanded);
@@ -1474,7 +1476,6 @@ fun resolve_step_path(a: *A.Allocator, raw: str, project_out: str, v: *manifest.
         ret R.ok[StepPath, str](StepPath{root: execution_root, rel: expanded, abs: R.unwrap_ok[str, str](abs_r)});
     }
 
-    val marker: str = "{project.out}";
     val mn: usize = str_len(marker);
     val rn: usize = str_len(raw);
     if (!spath.is_abs(expanded) || !str_starts_with(raw, marker)
@@ -1812,7 +1813,7 @@ fun collect_tree_files(a: *A.Allocator, dir: str, out: *vector.Vector[TreeFile])
     if (R.is_err[fs.Metadata, str](root_meta_r)) { ret R.err[R.Void, str](R.unwrap_err[fs.Metadata, str](root_meta_r)); }
     val root_meta: fs.Metadata = R.unwrap_ok[fs.Metadata, str](root_meta_r);
     if (!fs.meta_is_dir(?root_meta)) { ret R.err[R.Void, str](sfmt(a, "cannot snapshot non-directory tree root '{}'", dir)); }
-    val root_path_r: R.Result[str, str] = str_dup(a, dir);
+    val root_path_r: R.Result[str, str] = spath.clean(a, dir);
     if (R.is_err[str, str](root_path_r)) { ret R.err[R.Void, str](R.unwrap_err[str, str](root_path_r)); }
     var root_entry: TreeFile;
     root_entry.path = R.unwrap_ok[str, str](root_path_r);
@@ -1824,14 +1825,14 @@ fun collect_tree_files(a: *A.Allocator, dir: str, out: *vector.Vector[TreeFile])
     for (root_digest_i < 32) { root_entry.digest[root_digest_i] = 0; root_digest_i = root_digest_i + 1; }
     val root_push_r: R.Result[usize, str] = vector.push[TreeFile](out, root_entry);
     if (R.is_err[usize, str](root_push_r)) { str_free(a, root_entry.path); ret R.err[R.Void, str](R.unwrap_err[usize, str](root_push_r)); }
-    val names_r: R.Result[Vector[str], str] = fs.read_dir(a, dir);
+    val names_r: R.Result[Vector[str], str] = fs.read_dir(a, root_entry.path);
     if (R.is_err[Vector[str], str](names_r)) { ret R.err[R.Void, str](R.unwrap_err[Vector[str], str](names_r)); }
     var names: Vector[str] = R.unwrap_ok[Vector[str], str](names_r);
     sort.sort[str](names.data, names.len, cmp_str);
 
     var i: usize = 0;
     for (i < names.len) {
-        val child_r: R.Result[str, str] = load.join_path(a, dir, names.data[i]);
+        val child_r: R.Result[str, str] = load.join_path(a, root_entry.path, names.data[i]);
         if (R.is_err[str, str](child_r)) {
             free_str_vector(a, ?names);
             ret R.err[R.Void, str](R.unwrap_err[str, str](child_r));
@@ -2243,7 +2244,11 @@ fun step_paths_staged_absolute(a: *A.Allocator, output_root: str, staging_root: 
         if (str_equals(sp.root, output_root)) {
             val abs_r: R.Result[str, str] = spath.resolve(a, staging_root, sp.rel);
             if (R.is_err[str, str](abs_r)) { ret R.err[R.Void, str](R.unwrap_err[str, str](abs_r)); }
-            val abs: str = R.unwrap_ok[str, str](abs_r);
+            val joined: str = R.unwrap_ok[str, str](abs_r);
+            val clean_r: R.Result[str, str] = spath.clean(a, joined);
+            str_free(a, joined);
+            if (R.is_err[str, str](clean_r)) { ret R.err[R.Void, str](R.unwrap_err[str, str](clean_r)); }
+            val abs: str = R.unwrap_ok[str, str](clean_r);
             val push_r: R.Result[usize, str] = vector.push[str](out, abs);
             if (R.is_err[usize, str](push_r)) { str_free(a, abs); ret R.err[R.Void, str](R.unwrap_err[usize, str](push_r)); }
         }
@@ -3936,5 +3941,75 @@ test "mach.lang.driver.config.resolve_step_path:native_roots_retain_escape_and_m
         ret 3;
     }
     str_free(?alloc, R.unwrap_err[StepPath, str](relative_r));
+    ret 0;
+}
+
+test "mach.lang.driver.config.step_outputs:native_snapshot_and_declarations_share_canonical_paths" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val root_r: R.Result[str, str] = t_tree_dir(?alloc, "mach_native_step_effects");
+    if (R.is_err[str, str](root_r)) { ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+    val staging: str = sfmt(?alloc, "{}/./stage", root);
+    if (str_empty(staging)) { ret 1; }
+    fin { str_free(?alloc, staging); }
+    val object_dir: str = sfmt(?alloc, "{}/obj", staging);
+    if (str_empty(object_dir)) { ret 1; }
+    fin { str_free(?alloc, object_dir); }
+    if (O.is_some[str](fs.create_dir_all(?alloc, object_dir, 0o700))) { ret 1; }
+    var before: Vector[TreeFile] = vector.init[TreeFile](?alloc);
+    fin { free_tree_files(?alloc, ?before); }
+    if (R.is_err[R.Void, str](collect_tree_files(?alloc, staging, ?before))) { ret 1; }
+    var i: usize = 0;
+    for (i < before.len) {
+        val clean_r: R.Result[str, str] = spath.clean(?alloc, before.data[i].path);
+        if (R.is_err[str, str](clean_r)) { ret 1; }
+        val clean: str = R.unwrap_ok[str, str](clean_r);
+        val same: bool = str_equals(clean, before.data[i].path);
+        str_free(?alloc, clean);
+        if (!same) { ret 3; }
+        i = i + 1;
+    }
+    var v: manifest.TmplVars = manifest.TmplVars{target: "t", isa: "x86_64", os: "linux", abi: "gnu", profile: "debug", reqs: nil, req_count: 0};
+    val output_r: R.Result[StepPath, str] = resolve_step_path(?alloc,
+        "{project.out}/obj/file", root, ?v, root, root, "a build step output", false);
+    if (R.is_err[StepPath, str](output_r)) { ret 2; }
+    var output: StepPath = R.unwrap_ok[StepPath, str](output_r);
+    var outputs: Vector[StepPath] = vector.init[StepPath](?alloc);
+    fin { step_paths_free(?alloc, ?outputs); }
+    if (R.is_err[usize, str](vector.push[StepPath](?outputs, output))) {
+        step_path_free(?alloc, ?output);
+        ret 1;
+    }
+    var declared: Vector[str] = vector.init[str](?alloc);
+    fin { step_free_inputs(?alloc, ?declared); }
+    if (R.is_err[R.Void, str](step_paths_staged_absolute(?alloc, root, staging, ?outputs, ?declared))) { ret 1; }
+    if (declared.len != 1) { ret 4; }
+    val clean_r: R.Result[str, str] = spath.clean(?alloc, declared.data[0]);
+    if (R.is_err[str, str](clean_r)) { ret 1; }
+    val clean: str = R.unwrap_ok[str, str](clean_r);
+    val canonical: bool = str_equals(clean, declared.data[0]);
+    str_free(?alloc, clean);
+    if (!canonical) { ret 4; }
+    if (O.is_some[str](fs.write_bytes(declared.data[0], "file", 4, 0o600))) { ret 1; }
+    if (R.is_err[R.Void, str](check_step_output_effects(?alloc, ?before, staging, ?declared, "generate"))) { ret 5; }
+    step_free_inputs(?alloc, ?declared);
+    declared = vector.init[str](?alloc);
+    val dir_r: R.Result[str, str] = spath.clean(?alloc, object_dir);
+    if (R.is_err[str, str](dir_r)) { ret 1; }
+    val dir: str = R.unwrap_ok[str, str](dir_r);
+    if (R.is_err[usize, str](vector.push[str](?declared, dir))) { str_free(?alloc, dir); ret 1; }
+    if (R.is_err[R.Void, str](check_step_output_effects(?alloc, ?before, staging, ?declared, "generate"))) { ret 6; }
+    val sibling: str = sfmt(?alloc, "{}/obj-sibling", staging);
+    if (str_empty(sibling)) { ret 1; }
+    fin { str_free(?alloc, sibling); }
+    if (O.is_some[str](fs.write_bytes(sibling, "bad", 3, 0o600))) { ret 1; }
+    val refused: R.Result[R.Void, str] = check_step_output_effects(?alloc, ?before, staging, ?declared, "generate");
+    if (R.is_ok[R.Void, str](refused)) { ret 7; }
+    val message: str = R.unwrap_err[R.Void, str](refused);
+    val named: bool = str_contains(message, "obj-sibling");
+    str_free(?alloc, message);
+    if (!named) { ret 7; }
     ret 0;
 }

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -1521,7 +1521,15 @@ fun resolve_step_path(a: *A.Allocator, raw: str, project_out: str, v: *manifest.
         ret R.err[StepPath, str](R.unwrap_err[str, str](clean_r));
     }
     val clean: str = R.unwrap_ok[str, str](clean_r);
-    if (!absolute_path_in_root(clean, output_root, allow_output_root)) {
+    val clean_root_r: R.Result[str, str] = spath.clean(a, output_root);
+    if (R.is_err[str, str](clean_root_r)) {
+        str_free(a, rel);
+        str_free(a, clean);
+        ret R.err[StepPath, str](R.unwrap_err[str, str](clean_root_r));
+    }
+    val clean_root: str = R.unwrap_ok[str, str](clean_root_r);
+    fin str_free(a, clean_root);
+    if (!absolute_path_in_root(clean, clean_root, allow_output_root)) {
         str_free(a, rel);
         str_free(a, clean);
         ret R.err[StepPath, str](step_path_error(a, field));
@@ -3839,5 +3847,94 @@ test "mach.lang.driver.config.execute_step_invocation:an_unbounded_step_is_never
     val unbounded: R.Result[R.Void, str] = execute_step_invocation(?alloc, "/", program, ?invocation, "slow-step", 0);
     str_free(?alloc, program);
     if (R.is_err[R.Void, str](unbounded)) { ret 2; }
+    ret 0;
+}
+
+test "mach.lang.driver.config.resolve_step_path:native_output_roots_preserve_borrowed_identity" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var v: manifest.TmplVars = manifest.TmplVars{target: "t", isa: "x86_64", os: "linux", abi: "gnu", profile: "debug", reqs: nil, req_count: 0};
+    var roots: [3]str;
+    var expected: [3]str;
+    $if ($mach.build.os == $mach.os.windows) {
+        roots[0] = "C:/project/out";
+        roots[1] = "C:\\project/out";
+        roots[2] = "//server/share/project/out";
+        expected[0] = "C:\\project\\out\\obj\\vend-c\\window.o";
+        expected[1] = expected[0];
+        expected[2] = "\\\\server\\share\\project\\out\\obj\\vend-c\\window.o";
+    }
+    $or {
+        roots[0] = "/project/out";
+        roots[1] = "/project/./out";
+        roots[2] = "/project/old/../out";
+        expected[0] = "/project/out/obj/vend-c/window.o";
+        expected[1] = expected[0];
+        expected[2] = expected[0];
+    }
+    var i: usize = 0;
+    for (i < roots.len) {
+        val output_r: R.Result[StepPath, str] = resolve_step_path(?alloc,
+            "{project.out}/obj/vend-c/window.o", roots[i], ?v, roots[i], roots[i], "a build step output", false);
+        if (R.is_err[StepPath, str](output_r)) {
+            str_free(?alloc, R.unwrap_err[StepPath, str](output_r));
+            ret 2;
+        }
+        var output: StepPath = R.unwrap_ok[StepPath, str](output_r);
+        val output_ok: bool = output.root == roots[i] && str_equals(output.rel, "obj/vend-c/window.o")
+            && str_equals(output.abs, expected[i]);
+        step_path_free(?alloc, ?output);
+        if (!output_ok) { ret 3; }
+        val root_r: R.Result[StepPath, str] = resolve_step_path(?alloc,
+            "{project.out}", roots[i], ?v, roots[i], roots[i], "a build step input", true);
+        if (R.is_err[StepPath, str](root_r)) {
+            str_free(?alloc, R.unwrap_err[StepPath, str](root_r));
+            ret 4;
+        }
+        var root_input: StepPath = R.unwrap_ok[StepPath, str](root_r);
+        val root_ok: bool = root_input.root == roots[i] && str_equals(root_input.rel, ".")
+            && absolute_path_in_root(expected[i], root_input.abs, false);
+        step_path_free(?alloc, ?root_input);
+        if (!root_ok) { ret 5; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+test "mach.lang.driver.config.resolve_step_path:native_roots_retain_escape_and_marker_refusals" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var v: manifest.TmplVars = manifest.TmplVars{target: "t", isa: "x86_64", os: "linux", abi: "gnu", profile: "debug", reqs: nil, req_count: 0};
+    var root: str = "/project/out";
+    $if ($mach.build.os == $mach.os.windows) { root = "C:/project/out"; }
+    var denied: [8]str;
+    denied[0] = "{project.out}/../../escape";
+    denied[1] = "{project.out}/../out-sibling/file";
+    denied[2] = "{project.out}x/file";
+    denied[3] = "foo/{project.out}/file";
+    denied[4] = "{project.out}";
+    denied[5] = "{project.out}/./file";
+    denied[6] = "{project.out}/dir//file";
+    denied[7] = "../../escape";
+    var i: usize = 0;
+    for (i < denied.len) {
+        val r: R.Result[StepPath, str] = resolve_step_path(?alloc,
+            denied[i], root, ?v, root, root, "a build step output", false);
+        if (R.is_ok[StepPath, str](r)) {
+            var accepted: StepPath = R.unwrap_ok[StepPath, str](r);
+            step_path_free(?alloc, ?accepted);
+            ret 2;
+        }
+        str_free(?alloc, R.unwrap_err[StepPath, str](r));
+        i = i + 1;
+    }
+    val relative_r: R.Result[StepPath, str] = resolve_step_path(?alloc,
+        "{project.out}/file", root, ?v, root, "relative", "a build step output", false);
+    if (R.is_ok[StepPath, str](relative_r)) {
+        var accepted: StepPath = R.unwrap_ok[StepPath, str](relative_r);
+        step_path_free(?alloc, ?accepted);
+        ret 3;
+    }
+    str_free(?alloc, R.unwrap_err[StepPath, str](relative_r));
     ret 0;
 }


### PR DESCRIPTION
Windows build steps rejected contained `{project.out}` paths, then reported successfully produced declared files as undeclared because snapshots and declarations used different separator spellings. An absolute output marker embedded inside a relative path could also bypass marker placement validation.

Normalize owned native roots and snapshot/declaration paths at their construction or comparison boundaries. Keep borrowed StepPath.root identity and canonical relative names intact. Route absolute output markers through leading-marker validation and compare native directory descendants with std.path separator semantics.

Three native regressions cover drive/UNC and mixed-separator roots, marker and escape refusal, borrowed root identity, staged file and directory declarations, and sibling rejection. Native proof of exact 12c0a21e on the audited 9c52 integration source passed all five focused baselines on Linux and Windows. Five Linux and seven Windows independent mutations each failed the intended selected test at runtime. All 27 pre-invocation compiler censuses were empty and tracked source was restored. No local Mach compiler invocation.

[Native proof run](https://github.com/briar-systems/mach/actions/runs/34003133618) also builds and runs all 12 unchanged Windows link cells. Ten pass. The remaining two win64-vector-call debug/release cells now reach runtime and expose foreign narrow argument value mismatches, independently of step path handling. All previous undeclared-output failures are resolved. This PR does not claim the complete link suite is green.

Closes #3195.
