### PR TITLE
fix(test): retain frame evidence for shared DWARF ranges

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,8 @@ The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 ### Fixed
 
+- The frame-location link oracle checks every DWARF description sharing a machine range, preventing false failures for backed variables (#3197).
+
 - Windows and Darwin corpus disassemblies now reflect the audited aggregate and vector ABI, scratch-register preservation, canonical boolean, trapping remainder, inline, vector-loop and Darwin x18 fixes. All 77 updates were independently decoded and reviewed against native C-reference results (#3179).
 
 - Darwin CI installs the Homebrew LLVM formula selected by the committed oracle major, so a newer Homebrew stable release cannot break the pinned disassembly lane (#3181).

--- a/test/link/lib/produce.sh
+++ b/test/link/lib/produce.sh
@@ -2799,9 +2799,10 @@ produce_varloc_fbreg() {
         # "  4076a0: sd a0, -0x68(s0)"
         /^[ ]*[0-9a-f]+:/ {
             addr = $1; sub(/:$/, "", addr); a = hex2dec("0x" addr)
+            # multiple debug descriptions can share the same machine range
             for (i = 1; i <= n; i++) {
                 if (a >= flo[i] && a < fhi[i]) {
-                    if (index($0, freg[i]) == 0) { break }
+                    if (index($0, freg[i]) == 0) { continue }
                     s = $0
                     while (match(s, /-?0x[0-9a-f]+/)) {
                         t = substr(s, RSTART, RLENGTH)
@@ -2810,7 +2811,6 @@ produce_varloc_fbreg() {
                         seen[i "/" v] = 1
                         s = substr(s, RSTART + RLENGTH)
                     }
-                    break
                 }
             }
         }


### PR DESCRIPTION
Closes #3197.

The frame-location oracle stopped after the first DWARF description matching an instruction address. When two compile units describe the same function range, later descriptions lost valid evidence and the RISC-V debug fixture incorrectly reported one unbacked location.

Collect observations for every applicable description, retaining each description's own frame register and offsets. The golden stays unchanged. This changes only the oracle and changelog.

Validation with pinned LLVM 22.1.8:

- [Native artifact run34001842327](https://github.com/briar-systems/mach/actions/runs/34001842327) reproduces the old failure and retains the actual matching store and load at s0-40. All six target/profile fixture builds had empty process censuses.
- [Oracle proof34002101340](https://github.com/briar-systems/mach/actions/runs/34002101340) checks those exact binaries. The fixed oracle passes all six. The old parser reproduces RISC-V debug's unbacked=1.
- Five deterministic cases cover duplicate ranges, different frame bases, missing offsets, wrong bases and nonoverlapping ranges. Restoring the old parser fails both positive shared-range cases. Forcing unbacked=0 fails all three negative cases.
- The verifier restores the exact fixed oracle. Shell syntax and diff checks pass. Verification-only scripts are outside this PR and will not merge.
