### PR TITLE
fix(abi): define complete Windows vector carrier transport

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,8 @@ The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 ### Fixed
 
+- Windows vector calls now use one explicit carrier per byte extent: integer bits at 2/4 bytes, `__m64` at 8 bytes, a 128-bit intrinsic at 16 bytes, and an exact-size byte aggregate otherwise. Direct calls, typed indirect calls, parameter capture and returns agree, including hidden result-pointer argument shifts and caller-owned aggregate copies (#3199).
+
 - The frame-location link oracle checks every DWARF description sharing a machine range, preventing false failures for backed variables (#3197).
 
 - Windows and Darwin corpus disassemblies now reflect the audited aggregate and vector ABI, scratch-register preservation, canonical boolean, trapping remainder, inline, vector-loop and Darwin x18 fixes. All 77 updates were independently decoded and reviewed against native C-reference results (#3179).

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -448,3 +448,40 @@ same-named dynamic import.
 - [visibility.md](visibility.md) — `pub` and `ext` modifiers
 - [decorators.md](decorators.md) — `symbol`, `library`, and other codegen decorators
 - [variadics.md](variadics.md) — the comptime pack `...`, which is a Mach calling convention and not this one
+
+## Windows vector carriers
+
+The `win64` ABI maps a vector's lane bytes to the following C carrier. This
+mapping applies to arguments, returns, and typed function pointers, including
+calls between Mach functions. It is independent of the selected C compiler.
+
+| Vector extent | C carrier | Arguments | Return |
+|---|---|---|---|
+| 2 bytes | `unsigned short` | integer register or stack slot | low 16 bits of `RAX` |
+| 4 bytes | `unsigned int` | integer register or stack slot | low 32 bits of `RAX` |
+| 8 bytes | `__m64` | integer register or stack slot | `RAX` |
+| 16 bytes | `__m128`, `__m128i`, or `__m128d` | pointer to a caller-owned, 16-byte-aligned copy | `XMM0` |
+| Any other extent `N` | `struct { unsigned char bytes[N]; }` | pointer to a caller-owned, 16-byte-aligned copy | caller-provided result storage |
+
+Include `<mmintrin.h>` for `__m64` and `<emmintrin.h>` for the 128-bit intrinsic
+carriers. The byte-array carrier has exactly `N` bytes and no trailing padding.
+The result-storage pointer for an aggregate return occupies the first integer
+argument position, shifting the other arguments by one position. The callee
+returns that pointer in `RAX`.
+
+Lane zero occupies the first bytes. Each lane keeps its little-endian integer
+or IEEE floating-point bit representation. Carrier conversion copies bits,
+without numeric conversion, lane widening, or padding between lanes. Signed
+and floating-point lanes therefore use the same transport as unsigned lanes
+of the same width. A C function can inspect or construct lane bytes with a
+union or `memcpy`. Only the vector's `N` bytes belong to the value, even when
+its argument temporary has additional alignment padding.
+
+For example, `i16x4` uses `__m64`, `f32x4` uses a 128-bit intrinsic carrier,
+and `f32x3` uses `struct { unsigned char bytes[12]; }`. The memory layout of
+an enclosing Mach record is a separate contract from this function-boundary
+carrier mapping.
+
+A generic C extension such as `short __attribute__((vector_size(8)))` is not
+a substitute for `__m64`: GCC and Clang assign that extension different Windows
+argument and return conventions. Declare the carrier above at the boundary.

--- a/doc/language/ext-fun.md
+++ b/doc/language/ext-fun.md
@@ -107,7 +107,7 @@ The fixed parameters always follow the target's ordinary calling convention. The
 | **Apple arm64** (`darwin` + `aarch64`) | **Every** tail argument is passed on the **stack**, naturally aligned with an 8-byte minimum. There is no register phase at all — not for integers, not for floats. |
 | **Other AAPCS64** (`linux` + `aarch64`) | Ordinary rule: register-then-stack, exactly as for a named argument. |
 | **System V x86-64** (`linux` / `darwin` + `x86_64`) | Ordinary rule, plus `AL` set to the number of vector registers the call uses. It is set for **every** call to a C-variadic callee, including one whose tail is empty. |
-| **Microsoft x64** (`windows`) | Ordinary rule. A tail float rides **both** its XMM register and the integer register of the same positional slot, since a `va_arg` reader walks only the integer slots. The `ext`-boundary vector-by-reference rule below is unchanged. |
+| **Microsoft x64** (`windows`) | Ordinary rule. A tail float rides **both** its XMM register and the integer register of the same positional slot, since a `va_arg` reader walks only the integer slots. Vectors follow the extent-based carrier mapping below. |
 
 A tail argument keeps its *form* on every target: a record too large to pass by
 value is still passed by reference, and only the hidden pointer's location moves.

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -464,8 +464,9 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
 
     val ret_size:  u64 = type.byte_size_for_machine(ctx.types, ret_type, ctx.layout)::u64;
     val ret_aggr:  bool = context.value_is_aggregate(ctx, ret_type);
-    val ret_mem:   bool = ret_aggr || (context.value_is_vector(ctx, ret_type) && rslot.class == abi.CLASS_SRET);
-    val ret_sret_scalar: bool = rslot.class == abi.CLASS_SRET && !ret_mem;
+    val ret_vector_register: bool = context.value_is_vector(ctx, inst.ty);
+    val ret_mem:   bool = ret_aggr || (context.value_is_vector(ctx, ret_type) && !ret_vector_register && rslot.class == abi.CLASS_SRET);
+    val ret_sret_register: bool = rslot.class == abi.CLASS_SRET && !ret_mem;
 
     var gp_used:   i32 = layout.gp_used;
     var fp_used:   i32 = layout.fp_used;
@@ -486,7 +487,7 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         }
         sret_ptr = res_dst;
     }
-    or (ret_sret_scalar && res_dst != mir.MIR_VREG_NIL) {
+    or (ret_sret_register && res_dst != mir.MIR_VREG_NIL) {
         val sa: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
         if (R.is_err[u32, str](sa)) {
             sig_layout_free(ctx, ?layout);
@@ -625,8 +626,13 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         val rr: R.Result[R.Void, str] = emit_ret_slot_to_vreg(ctx, mb, rslot, dst, ret_aggr, ret_type);
         if (R.is_err[R.Void, str](rr)) { ret rr; }
     }
-    if (ret_sret_scalar && dst != mir.MIR_VREG_NIL) {
-        val lr: R.Result[R.Void, str] = context.emit_load_from_w(ctx, mb, dst, mir.op_mem_value(sret_ptr, 0), ret_size::u8);
+    if (ret_sret_register && dst != mir.MIR_VREG_NIL) {
+        var lr: R.Result[R.Void, str] = R.ok_void[str]();
+        if (ret_vector_register) {
+            lr = context.load_subwidth_vector(ctx, mb, mir.op_vreg(dst), mir.op_mem_value(sret_ptr, 0), ret_type);
+        } or {
+            lr = context.emit_load_from_w(ctx, mb, dst, mir.op_mem_value(sret_ptr, 0), ret_size::u8);
+        }
         if (R.is_err[R.Void, str](lr)) { ret lr; }
     }
     if (dst != mir.MIR_VREG_NIL) {
@@ -789,10 +795,9 @@ fun copy_aggregate_to_temp(ctx: *context.LowerCtx, mb: *mir.MirBlock, src: mir.M
 fun spill_vector_to_temp(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot,
                          val_op: mir.MirOperand, ty: type.IrTypeId, out_addr: *u32) R.Result[R.Void, str] {
     val logical_size:  u64 = type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
-    val register_size: u64 = context.op_width_of(ctx, ty)::u64;
     val size:  u64 = slot.indirect_size;
     val align: u32 = slot.indirect_align;
-    if (size < logical_size || size < register_size || align == 0 || (align & (align - 1)) != 0) {
+    if (size < logical_size || align == 0 || (align & (align - 1)) != 0) {
         ret R.err[R.Void, str]("mir.abi.spill_vector_to_temp: ABI vector placement has invalid indirect storage");
     }
     val res_key: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
@@ -802,7 +807,12 @@ fun spill_vector_to_temp(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.Pa
     val sr: R.Result[R.Void, str] = context.add_spill_slot_aligned(ctx, sk, size, align);
     if (R.is_err[R.Void, str](sr)) { ret sr; }
 
-    val st: R.Result[R.Void, str] = context.store_vector_register(ctx, mb, mir.op_mem_slot(sk, 0), val_op, ty);
+    var st: R.Result[R.Void, str] = R.ok_void[str]();
+    if (context.value_is_vector(ctx, ty)) {
+        st = context.store_subwidth_vector(ctx, mb, mir.op_mem_slot(sk, 0), val_op, ty);
+    } or {
+        st = context.copy_aggregate(ctx, mb, mir.op_mem_slot(sk, 0), val_op, size);
+    }
     if (R.is_err[R.Void, str](st)) { ret st; }
 
     ret context.emit_lea_slot(ctx, mb, mir.op_mem_slot(sk, 0), out_addr);
@@ -922,6 +932,9 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[R.Void,
 
 fun capture_vector_byref(ctx: *context.LowerCtx, mb: *mir.MirBlock, pv: u32,
                          ty: type.IrTypeId, src: mir.MirOperand) R.Result[R.Void, str] {
+    if (!context.value_is_vector(ctx, ty)) {
+        ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), src, ptr_move_width(ctx));
+    }
     val ar: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
     if (R.is_err[u32, str](ar)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](ar)); }
     val addr: u32 = R.unwrap_ok[u32, str](ar);
@@ -1050,7 +1063,10 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
         if (ctx.sret_vreg == mir.MIR_VREG_NIL) {
             ret R.err[R.Void, str]("mir.lower_ir: sret return without a captured result-storage pointer");
         }
-        if (rag || context.value_is_vector(ctx, rt)) {
+        if (context.value_is_vector(ctx, rv.ty)) {
+            val sr: R.Result[R.Void, str] = context.store_subwidth_vector(ctx, mb, mir.op_mem_value(ctx.sret_vreg, 0), rvop, rt);
+            if (R.is_err[R.Void, str](sr)) { ret sr; }
+        } or (rag || context.value_is_vector(ctx, rt)) {
             val cr: R.Result[R.Void, str] = context.copy_aggregate(ctx, mb, mir.op_mem_value(ctx.sret_vreg, 0), rvop, rsz);
             if (R.is_err[R.Void, str](cr)) { ret cr; }
         } or {
@@ -1414,4 +1430,45 @@ test "mach.lang.be.codegen.mir.abi.gp_arg_regs:no_convention_exceeds_the_shared_
 
     if (checked == 0) { ret 1; }
     ret bad;
+}
+
+test "mach.lang.be.codegen.mir.abi.classify_signature:odd_vector_sret_shifts_mixed_arguments" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val mr: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](mr);
+    fin { ir.dnit(?m); }
+    var reg: treg.TargetRegistry = treg.registry_init();
+    fin { treg.registry_dnit(?reg); }
+    if (R.is_err[R.Void, str](treg.register_all(?reg, target_testing.debug_descriptor))) { ret 1; }
+    val tr: R.Result[target.Target, str] = treg.select(?reg, "x86_64", "windows", "win64");
+    if (R.is_err[target.Target, str](tr)) { ret 1; }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+    val byte_r: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 8);
+    val word_r: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 64);
+    val float_r: R.Result[type.IrTypeId, str] = type.intern_float(?m.types, 64);
+    if (R.is_err[type.IrTypeId, str](byte_r) || R.is_err[type.IrTypeId, str](word_r) || R.is_err[type.IrTypeId, str](float_r)) { ret 1; }
+    val vector_r: R.Result[type.IrTypeId, str] = type.intern_vector(?m.types, R.unwrap_ok[type.IrTypeId, str](byte_r), 3);
+    if (R.is_err[type.IrTypeId, str](vector_r)) { ret 1; }
+    val vector: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](vector_r);
+    val word: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](word_r);
+    var params: [5]type.IrTypeId = [5]type.IrTypeId{word, R.unwrap_ok[type.IrTypeId, str](float_r), word, word, vector};
+    val sig_r: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, vector, ?params[0], 5, false);
+    if (R.is_err[type.IrTypeId, str](sig_r)) { ret 1; }
+    var ctx: context.LowerCtx;
+    ctx.alloc = ?alloc;
+    ctx.tgt = ?tgt;
+    ctx.layout = target.layout_machine(?tgt);
+    ctx.m = ?m;
+    ctx.types = ?m.types;
+    var slots: abi.SigLayout;
+    val sr: R.Result[R.Void, str] = classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](sig_r), vector, ?slots);
+    if (R.is_err[R.Void, str](sr)) { ret 1; }
+    fin { sig_layout_free(?ctx, ?slots); }
+    if (slots.ret_slot.class != abi.CLASS_SRET || slots.param_count != 5) { ret 2; }
+    if (slots.params[0].reg != 2 || slots.params[1].reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 2) || slots.params[2].reg != 9) { ret 3; }
+    if (slots.params[3].class != abi.CLASS_STACK || slots.params[3].offset != 32) { ret 4; }
+    if (slots.params[4].class != abi.CLASS_VEC_STACK_BYREF || slots.params[4].offset != 40 || slots.params[4].indirect_size != 3) { ret 5; }
+    ret 0;
 }

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -73,18 +73,18 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
     val slot: i32 = slot_index(gp_used, fp_used);
 
     if (is_vector) {
-        if (size > VEC_REG_BYTES) {
+        if (is_by_value_size(size)) {
             if (slot < PARAM_SLOT_COUNT) {
-                ret abi.make_slot(abi.CLASS_BYREF, slot_gp_reg(slot), 0, 8);
+                ret abi.make_slot(abi.CLASS_GP, slot_gp_reg(slot), 0, size);
             }
-            ret abi.make_slot(abi.CLASS_STACK_BYREF, -1, 0, 8);
+            ret abi.make_slot(abi.CLASS_STACK, -1, 0, size);
         }
         if (slot < PARAM_SLOT_COUNT) {
             ret abi.make_slot_indirect(abi.CLASS_VEC_BYREF, slot_gp_reg(slot), 0, 8,
-                                       VEC_REG_BYTES, VEC_REG_BYTES::u32);
+                                       size, VEC_REG_BYTES::u32);
         }
         ret abi.make_slot_indirect(abi.CLASS_VEC_STACK_BYREF, -1, 0, 8,
-                                   VEC_REG_BYTES, VEC_REG_BYTES::u32);
+                                   size, VEC_REG_BYTES::u32);
     }
 
     if (is_aggregate) {
@@ -120,12 +120,14 @@ pub fun classify_return(size: u64, align: u64,
         ret abi.make_slot(abi.CLASS_GP, -1, 0, 0);
     }
 
-    if (is_vector && size > VEC_REG_BYTES) {
-        ret abi.make_slot(abi.CLASS_SRET, REG_RAX, 0, 8);
-    }
-
     if (is_vector) {
-        ret abi.make_slot(abi.CLASS_FP, REG_XMM0, 0, size);
+        if (is_by_value_size(size)) {
+            ret abi.make_slot(abi.CLASS_GP, REG_RAX, 0, size);
+        }
+        if (size == VEC_REG_BYTES) {
+            ret abi.make_slot(abi.CLASS_FP, REG_XMM0, 0, size);
+        }
+        ret abi.make_slot(abi.CLASS_SRET, REG_RAX, 0, 8);
     }
 
     if (is_aggregate) {
@@ -309,10 +311,10 @@ test "mach.lang.target.abi.win64.classify_arg:vector_by_reference" {
     if (e0.indirect_align != 16)         { ret 1; }
 
     val narrow: abi.ParamSlot = classify_arg(0, 8, 2, false, 0, false, true, 0, 0, 0, 0, abi.agg_none());
-    if (narrow.class != abi.CLASS_VEC_BYREF) { ret 1; }
+    if (narrow.class != abi.CLASS_GP) { ret 1; }
     if (narrow.size != 8)                    { ret 1; }
-    if (narrow.indirect_size != 16)          { ret 1; }
-    if (narrow.indirect_align != 16)         { ret 1; }
+    if (narrow.indirect_size != 0)          { ret 1; }
+    if (narrow.indirect_align != 0)         { ret 1; }
 
     val e3: abi.ParamSlot = classify_arg(3, 16, 16, false, 0, false, true, 3, 0, 0, 0, abi.agg_none());
     if (e3.class != abi.CLASS_VEC_BYREF) { ret 1; }
@@ -448,6 +450,36 @@ test "mach.lang.target.abi.win64.callee_saved:includes_rdi_rsi" {
         if (list[i] == REG_RSP)                              { ret 1; }
         if (list[i] == REG_RBP)                              { ret 1; }
         if (isa.regid_class(list[i]) != isa.REG_CLASS_ID_GP) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+test "mach.lang.target.abi.win64:vector_extent_carriers" {
+    val widths: [18]u64 = [18]u64{2, 3, 4, 5, 7, 8, 9, 12, 15, 16, 17, 20, 24, 32, 64, 65535, 131070, 524280};
+    var i: u32 = 0;
+    for (i < 18) {
+        val width: u64 = widths[i];
+        val integer: bool = width == 2 || width == 4 || width == 8;
+        val first: abi.ParamSlot = classify_arg(0, width, 1, false, 0, false, true, 0, 0, 0, 0, abi.agg_none());
+        val last: abi.ParamSlot = classify_arg(3, width, 1, false, 0, false, true, 3, 0, 0, 0, abi.agg_none());
+        val stack: abi.ParamSlot = classify_arg(4, width, 1, false, 0, false, true, 4, 0, 0, 0, abi.agg_none());
+        val result: abi.ParamSlot = classify_return(width, 1, false, 0, false, true, 0, 0, abi.agg_none());
+        if (first.reg != REG_RCX || last.reg != REG_R9 || stack.reg != -1) { ret 1; }
+        if (integer) {
+            if (first.class != abi.CLASS_GP || last.class != abi.CLASS_GP || stack.class != abi.CLASS_STACK) { ret 2; }
+            if (first.size != width || stack.size != width || first.indirect_size != 0) { ret 3; }
+            if (result.class != abi.CLASS_GP || result.reg != REG_RAX || result.size != width) { ret 4; }
+        } or {
+            if (first.class != abi.CLASS_VEC_BYREF || last.class != abi.CLASS_VEC_BYREF || stack.class != abi.CLASS_VEC_STACK_BYREF) { ret 5; }
+            if (first.size != 8 || stack.size != 8 || first.indirect_size != width || stack.indirect_size != width) { ret 6; }
+            if (first.indirect_align != 16 || stack.indirect_align != 16) { ret 7; }
+            if (width == 16) {
+                if (result.class != abi.CLASS_FP || result.reg != REG_XMM0 || result.size != 16) { ret 8; }
+            } or {
+                if (result.class != abi.CLASS_SRET || result.reg != REG_RAX || result.size != 8) { ret 9; }
+            }
+        }
         i = i + 1;
     }
     ret 0;

--- a/test/link/cases/win64-vector-call/expect.txt
+++ b/test/link/cases/win64-vector-call/expect.txt
@@ -18,4 +18,5 @@ carrier 20=0
 carrier 32=0
 carrier mixed=0
 carrier float bits=0
+carrier capture=0
 foreign signed narrow=-32787

--- a/test/link/cases/win64-vector-call/expect.txt
+++ b/test/link/cases/win64-vector-call/expect.txt
@@ -17,4 +17,5 @@ carrier 16=0
 carrier 20=0
 carrier 32=0
 carrier mixed=0
+carrier float bits=0
 foreign signed narrow=-32787

--- a/test/link/cases/win64-vector-call/expect.txt
+++ b/test/link/cases/win64-vector-call/expect.txt
@@ -8,3 +8,13 @@ foreign narrow stack direct=60 indirect=60
 local narrow stack direct=60 indirect=60
 pair direct=-11 intact=7 8
 pair indirect=-11 intact=7 8
+carrier 2=0
+carrier 3=0
+carrier 4=0
+carrier 8=0
+carrier 12=0
+carrier 16=0
+carrier 20=0
+carrier 32=0
+carrier mixed=0
+foreign signed narrow=-32787

--- a/test/link/cases/win64-vector-call/probe.c
+++ b/test/link/cases/win64-vector-call/probe.c
@@ -96,3 +96,13 @@ __declspec(noinline) carrier3 carrier_mixed(long long a, double b, long long c, 
     v.bytes[0] += (unsigned char)(a + (long long)b + c + d);
     return v;
 }
+
+
+typedef __m64 (*carrier_float_fn)(__m64);
+__declspec(noinline) __m64 carrier_float_identity(__m64 v) { return v; }
+__declspec(noinline) carrier_float_fn carrier_float_select(carrier_float_fn f) { return f; }
+__declspec(noinline) __m64 carrier_float_dispatch(carrier_float_fn f, __m64 v) { return f(v); }
+__declspec(noinline) __m64 carrier_float_stack(long long a, long long b, long long c, long long d, __m64 v) {
+    if (a + b + c + d != 10) ((unsigned char *)&v)[0] ^= 1;
+    return v;
+}

--- a/test/link/cases/win64-vector-call/probe.c
+++ b/test/link/cases/win64-vector-call/probe.c
@@ -2,7 +2,7 @@
 #include <mmintrin.h>
 
 #if defined(_MSC_VER)
-// the standalone probe owns the MSVC floating-point link marker.
+// the standalone probe owns the msvc floating-point link marker.
 int _fltused;
 #endif
 

--- a/test/link/cases/win64-vector-call/probe.c
+++ b/test/link/cases/win64-vector-call/probe.c
@@ -1,6 +1,11 @@
 #include <emmintrin.h>
 #include <mmintrin.h>
 
+#if defined(_MSC_VER)
+// the standalone probe owns the MSVC floating-point link marker.
+int _fltused;
+#endif
+
 typedef __m128i v4si;
 typedef __m64 v4hi;
 typedef long long (*vec_op)(v4si);

--- a/test/link/cases/win64-vector-call/probe.c
+++ b/test/link/cases/win64-vector-call/probe.c
@@ -111,3 +111,16 @@ __declspec(noinline) __m64 carrier_float_stack(long long a, long long b, long lo
     if (a + b + c + d != 10) ((unsigned char *)&v)[0] ^= 1;
     return v;
 }
+
+__declspec(noinline) long long carrier_capture_guard_20(carrier_fn20 f) {
+    _Alignas(16) unsigned char decoy[32];
+    _Alignas(16) carrier20 value;
+    union { void *pointer; unsigned char bytes[8]; } address;
+    address.pointer = decoy;
+    for (unsigned i = 0; i < 32; ++i) decoy[i] = 0xcc;
+    for (unsigned i = 0; i < 20; ++i) value.bytes[i] = (unsigned char)(i + 1);
+    for (unsigned i = 0; i < 8; ++i) value.bytes[i] = address.bytes[i];
+    carrier20 result = f(value);
+    for (unsigned i = 0; i < 20; ++i) if (result.bytes[i] != value.bytes[i]) return 1;
+    return 0;
+}

--- a/test/link/cases/win64-vector-call/probe.c
+++ b/test/link/cases/win64-vector-call/probe.c
@@ -1,5 +1,8 @@
-typedef int v4si __attribute__((vector_size(16)));
-typedef short v4hi __attribute__((vector_size(8)));
+#include <emmintrin.h>
+#include <mmintrin.h>
+
+typedef __m128i v4si;
+typedef __m64 v4hi;
 typedef long long (*vec_op)(v4si);
 typedef long long (*stack_op)(long long, long long, long long, long long, v4si);
 typedef long long (*narrow_op)(v4hi);
@@ -8,7 +11,9 @@ typedef struct { long long a; long long b; } pair;
 typedef long long (*pair_op)(pair);
 
 long long foreign_fold(v4si v) {
-    return v[0] + v[1] * 3 + v[2] * 5 + v[3] * 7;
+    union { v4si bits; int lane[4]; } u;
+    u.bits = v;
+    return u.lane[0] + u.lane[1] * 3 + u.lane[2] * 5 + u.lane[3] * 7;
 }
 
 long long foreign_stack(long long a, long long b, long long c, long long d, v4si v) {
@@ -16,7 +21,9 @@ long long foreign_stack(long long a, long long b, long long c, long long d, v4si
 }
 
 long long foreign_narrow(v4hi v) {
-    return v[0] + v[1] * 3 + v[2] * 5 + v[3] * 7;
+    union { v4hi bits; short lane[4]; } u;
+    u.bits = v;
+    return u.lane[0] + u.lane[1] * 3 + u.lane[2] * 5 + u.lane[3] * 7;
 }
 
 long long foreign_narrow_stack(long long a, long long b, long long c, long long d, v4hi v) {
@@ -28,3 +35,64 @@ __declspec(noinline) stack_op select_stack(stack_op f) { return f; }
 __declspec(noinline) narrow_op select_narrow(narrow_op f) { return f; }
 __declspec(noinline) narrow_stack_op select_narrow_stack(narrow_stack_op f) { return f; }
 __declspec(noinline) pair_op select_pair(pair_op f) { return f; }
+
+typedef unsigned short carrier2;
+typedef struct { unsigned char bytes[3]; } carrier3;
+typedef unsigned int carrier4;
+typedef __m64 carrier8;
+typedef struct { unsigned char bytes[12]; } carrier12;
+typedef __m128i carrier16;
+typedef struct { unsigned char bytes[20]; } carrier20;
+typedef struct { unsigned char bytes[32]; } carrier32;
+
+#define CARRIER(N) \
+    _Static_assert(sizeof(carrier##N) == N, "carrier extent"); \
+    typedef carrier##N (*carrier_fn##N)(carrier##N); \
+    __declspec(noinline) carrier##N carrier_identity_##N(carrier##N v) { return v; } \
+    __declspec(noinline) carrier_fn##N carrier_select_##N(carrier_fn##N f) { return f; } \
+    __declspec(noinline) carrier##N carrier_dispatch_##N(carrier_fn##N f, carrier##N v) { return f(v); } \
+    __declspec(noinline) carrier##N carrier_stack_##N(long long a, long long b, long long c, long long d, carrier##N v) { \
+        unsigned char *bytes = (unsigned char *)&v; \
+        bytes[0] += (unsigned char)(a + b + c + d); \
+        return v; \
+    }
+
+CARRIER(2)
+CARRIER(3)
+CARRIER(4)
+CARRIER(8)
+CARRIER(12)
+CARRIER(16)
+CARRIER(20)
+CARRIER(32)
+
+__attribute__((naked, noinline)) static void *invoke_sret(void (*f)(void), void *out, const void *in) {
+    __asm__("movq %rcx, %r11\n"
+            "movq %rdx, %rcx\n"
+            "movq %r8, %rdx\n"
+            "subq $40, %rsp\n"
+            "call *%r11\n"
+            "addq $40, %rsp\n"
+            "ret");
+}
+
+#define CARRIER_GUARD(N) \
+    __declspec(noinline) long long carrier_guard_##N(carrier_fn##N f, carrier##N v) { \
+        unsigned char result[N + 16]; \
+        unsigned char *source = (unsigned char *)&v; \
+        for (unsigned i = 0; i < N + 16; ++i) result[i] = 0xa5; \
+        if (invoke_sret((void (*)(void))f, result, &v) != result) return 1; \
+        for (unsigned i = 0; i < N; ++i) if (result[i] != source[i]) return 2; \
+        for (unsigned i = N; i < N + 16; ++i) if (result[i] != 0xa5) return 3; \
+        return 0; \
+    }
+
+CARRIER_GUARD(3)
+CARRIER_GUARD(12)
+CARRIER_GUARD(20)
+CARRIER_GUARD(32)
+
+__declspec(noinline) carrier3 carrier_mixed(long long a, double b, long long c, long long d, carrier3 v) {
+    v.bytes[0] += (unsigned char)(a + (long long)b + c + d);
+    return v;
+}

--- a/test/link/cases/win64-vector-call/src/main.mach
+++ b/test/link/cases/win64-vector-call/src/main.mach
@@ -84,6 +84,7 @@ fun main(argc: usize, argv: **u8) i64 {
     p.printlnf("carrier 20={}", check_carrier_20());
     p.printlnf("carrier 32={}", check_carrier_32());
     p.printlnf("carrier mixed={}", check_carrier_mixed());
+    p.printlnf("carrier float bits={}", check_carrier_float());
     val signed_narrow: i16x4 = i16x4{-32768, -2, 3, -4};
     p.printlnf("foreign signed narrow={}", foreign_narrow(signed_narrow));
     ret 0;
@@ -106,8 +107,10 @@ fun check_carrier_2() i64 {
     val d: u8x2 = carrier_stack_2(1, 2, 3, 4, v);
     var i: usize = 0;
     for (i < 2) {
-        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
-        if (d[i] != expected[i]) { ret 2; }
+        if (a[i] != v[i]) { ret 1; }
+        if (b[i] != v[i]) { ret 2; }
+        if (c[i] != v[i]) { ret 3; }
+        if (d[i] != expected[i]) { ret 4; }
         i = i + 1;
     }
     ret 0;
@@ -130,11 +133,13 @@ fun check_carrier_3() i64 {
     val d: u8x3 = carrier_stack_3(1, 2, 3, 4, v);
     var i: usize = 0;
     for (i < 3) {
-        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
-        if (d[i] != expected[i]) { ret 2; }
+        if (a[i] != v[i]) { ret 1; }
+        if (b[i] != v[i]) { ret 2; }
+        if (c[i] != v[i]) { ret 3; }
+        if (d[i] != expected[i]) { ret 4; }
         i = i + 1;
     }
-    if (carrier_guard_3(local_carrier_3, v) != 0) { ret 3; }
+    if (carrier_guard_3(local_carrier_3, v) != 0) { ret 5; }
     ret 0;
 }
 ext fun carrier_guard_3(f: CarrierFn3, v: u8x3) i64;
@@ -156,8 +161,10 @@ fun check_carrier_4() i64 {
     val d: u8x4 = carrier_stack_4(1, 2, 3, 4, v);
     var i: usize = 0;
     for (i < 4) {
-        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
-        if (d[i] != expected[i]) { ret 2; }
+        if (a[i] != v[i]) { ret 1; }
+        if (b[i] != v[i]) { ret 2; }
+        if (c[i] != v[i]) { ret 3; }
+        if (d[i] != expected[i]) { ret 4; }
         i = i + 1;
     }
     ret 0;
@@ -180,8 +187,10 @@ fun check_carrier_8() i64 {
     val d: u8x8 = carrier_stack_8(1, 2, 3, 4, v);
     var i: usize = 0;
     for (i < 8) {
-        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
-        if (d[i] != expected[i]) { ret 2; }
+        if (a[i] != v[i]) { ret 1; }
+        if (b[i] != v[i]) { ret 2; }
+        if (c[i] != v[i]) { ret 3; }
+        if (d[i] != expected[i]) { ret 4; }
         i = i + 1;
     }
     ret 0;
@@ -204,11 +213,13 @@ fun check_carrier_12() i64 {
     val d: u8x12 = carrier_stack_12(1, 2, 3, 4, v);
     var i: usize = 0;
     for (i < 12) {
-        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
-        if (d[i] != expected[i]) { ret 2; }
+        if (a[i] != v[i]) { ret 1; }
+        if (b[i] != v[i]) { ret 2; }
+        if (c[i] != v[i]) { ret 3; }
+        if (d[i] != expected[i]) { ret 4; }
         i = i + 1;
     }
-    if (carrier_guard_12(local_carrier_12, v) != 0) { ret 3; }
+    if (carrier_guard_12(local_carrier_12, v) != 0) { ret 5; }
     ret 0;
 }
 ext fun carrier_guard_12(f: CarrierFn12, v: u8x12) i64;
@@ -230,8 +241,10 @@ fun check_carrier_16() i64 {
     val d: u8x16 = carrier_stack_16(1, 2, 3, 4, v);
     var i: usize = 0;
     for (i < 16) {
-        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
-        if (d[i] != expected[i]) { ret 2; }
+        if (a[i] != v[i]) { ret 1; }
+        if (b[i] != v[i]) { ret 2; }
+        if (c[i] != v[i]) { ret 3; }
+        if (d[i] != expected[i]) { ret 4; }
         i = i + 1;
     }
     ret 0;
@@ -254,11 +267,13 @@ fun check_carrier_20() i64 {
     val d: u8x20 = carrier_stack_20(1, 2, 3, 4, v);
     var i: usize = 0;
     for (i < 20) {
-        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
-        if (d[i] != expected[i]) { ret 2; }
+        if (a[i] != v[i]) { ret 1; }
+        if (b[i] != v[i]) { ret 2; }
+        if (c[i] != v[i]) { ret 3; }
+        if (d[i] != expected[i]) { ret 4; }
         i = i + 1;
     }
-    if (carrier_guard_20(local_carrier_20, v) != 0) { ret 3; }
+    if (carrier_guard_20(local_carrier_20, v) != 0) { ret 5; }
     ret 0;
 }
 ext fun carrier_guard_20(f: CarrierFn20, v: u8x20) i64;
@@ -280,11 +295,13 @@ fun check_carrier_32() i64 {
     val d: u8x32 = carrier_stack_32(1, 2, 3, 4, v);
     var i: usize = 0;
     for (i < 32) {
-        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
-        if (d[i] != expected[i]) { ret 2; }
+        if (a[i] != v[i]) { ret 1; }
+        if (b[i] != v[i]) { ret 2; }
+        if (c[i] != v[i]) { ret 3; }
+        if (d[i] != expected[i]) { ret 4; }
         i = i + 1;
     }
-    if (carrier_guard_32(local_carrier_32, v) != 0) { ret 3; }
+    if (carrier_guard_32(local_carrier_32, v) != 0) { ret 5; }
     ret 0;
 }
 ext fun carrier_guard_32(f: CarrierFn32, v: u8x32) i64;
@@ -295,5 +312,32 @@ fun check_carrier_mixed() i64 {
     val out: u8x3 = carrier_mixed(1, 2.0, 3, 4, v);
     if (out[0] != 11 || out[1] != 2 || out[2] != 3) { ret 1; }
     if (v[0] != 1 || v[1] != 2 || v[2] != 3) { ret 2; }
+    ret 0;
+}
+
+
+def CarrierFloatFn: fun(f32x2) f32x2;
+ext fun carrier_float_identity(v: f32x2) f32x2;
+ext fun carrier_float_select(f: CarrierFloatFn) CarrierFloatFn;
+ext fun carrier_float_dispatch(f: CarrierFloatFn, v: f32x2) f32x2;
+ext fun carrier_float_stack(a: i64, b: i64, c: i64, d: i64, v: f32x2) f32x2;
+#[noinline]
+fun local_carrier_float(v: f32x2) f32x2 { ret v; }
+fun check_carrier_float() i64 {
+    val bits: u32x2 = u32x2{0x80000000, 0x7FC12345};
+    val v: f32x2 = f32x2{bits[0]:~f32, bits[1]:~f32};
+    val indirect: CarrierFloatFn = carrier_float_select(carrier_float_identity);
+    val a: f32x2 = carrier_float_identity(v);
+    val b: f32x2 = indirect(v);
+    val c: f32x2 = carrier_float_dispatch(local_carrier_float, v);
+    val d: f32x2 = carrier_float_stack(1, 2, 3, 4, v);
+    var i: usize = 0;
+    for (i < 2) {
+        if (a[i]:~u32 != bits[i]) { ret 1; }
+        if (b[i]:~u32 != bits[i]) { ret 2; }
+        if (c[i]:~u32 != bits[i]) { ret 3; }
+        if (d[i]:~u32 != bits[i]) { ret 4; }
+        i = i + 1;
+    }
     ret 0;
 }

--- a/test/link/cases/win64-vector-call/src/main.mach
+++ b/test/link/cases/win64-vector-call/src/main.mach
@@ -2,6 +2,15 @@ use std.runtime;
 use std.types.size.usize;
 use p: std.print;
 
+val LANES_2: [2]usize = [2]usize{0, 1};
+val LANES_3: [3]usize = [3]usize{0, 1, 2};
+val LANES_4: [4]usize = [4]usize{0, 1, 2, 3};
+val LANES_8: [8]usize = [8]usize{0, 1, 2, 3, 4, 5, 6, 7};
+val LANES_12: [12]usize = [12]usize{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11};
+val LANES_16: [16]usize = [16]usize{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15};
+val LANES_20: [20]usize = [20]usize{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19};
+val LANES_32: [32]usize = [32]usize{0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31};
+
 def VecOp: fun(i32x4) i64;
 def StackOp: fun(i64, i64, i64, i64, i32x4) i64;
 def NarrowOp: fun(i16x4) i64;
@@ -105,13 +114,11 @@ fun check_carrier_2() i64 {
     val b: u8x2 = indirect(v);
     val c: u8x2 = carrier_dispatch_2(local_carrier_2, v);
     val d: u8x2 = carrier_stack_2(1, 2, 3, 4, v);
-    var i: usize = 0;
-    for (i < 2) {
+    $each i in LANES_2 {
         if (a[i] != v[i]) { ret 1; }
         if (b[i] != v[i]) { ret 2; }
         if (c[i] != v[i]) { ret 3; }
         if (d[i] != expected[i]) { ret 4; }
-        i = i + 1;
     }
     ret 0;
 }
@@ -131,13 +138,11 @@ fun check_carrier_3() i64 {
     val b: u8x3 = indirect(v);
     val c: u8x3 = carrier_dispatch_3(local_carrier_3, v);
     val d: u8x3 = carrier_stack_3(1, 2, 3, 4, v);
-    var i: usize = 0;
-    for (i < 3) {
+    $each i in LANES_3 {
         if (a[i] != v[i]) { ret 1; }
         if (b[i] != v[i]) { ret 2; }
         if (c[i] != v[i]) { ret 3; }
         if (d[i] != expected[i]) { ret 4; }
-        i = i + 1;
     }
     if (carrier_guard_3(local_carrier_3, v) != 0) { ret 5; }
     ret 0;
@@ -159,13 +164,11 @@ fun check_carrier_4() i64 {
     val b: u8x4 = indirect(v);
     val c: u8x4 = carrier_dispatch_4(local_carrier_4, v);
     val d: u8x4 = carrier_stack_4(1, 2, 3, 4, v);
-    var i: usize = 0;
-    for (i < 4) {
+    $each i in LANES_4 {
         if (a[i] != v[i]) { ret 1; }
         if (b[i] != v[i]) { ret 2; }
         if (c[i] != v[i]) { ret 3; }
         if (d[i] != expected[i]) { ret 4; }
-        i = i + 1;
     }
     ret 0;
 }
@@ -185,13 +188,11 @@ fun check_carrier_8() i64 {
     val b: u8x8 = indirect(v);
     val c: u8x8 = carrier_dispatch_8(local_carrier_8, v);
     val d: u8x8 = carrier_stack_8(1, 2, 3, 4, v);
-    var i: usize = 0;
-    for (i < 8) {
+    $each i in LANES_8 {
         if (a[i] != v[i]) { ret 1; }
         if (b[i] != v[i]) { ret 2; }
         if (c[i] != v[i]) { ret 3; }
         if (d[i] != expected[i]) { ret 4; }
-        i = i + 1;
     }
     ret 0;
 }
@@ -211,13 +212,11 @@ fun check_carrier_12() i64 {
     val b: u8x12 = indirect(v);
     val c: u8x12 = carrier_dispatch_12(local_carrier_12, v);
     val d: u8x12 = carrier_stack_12(1, 2, 3, 4, v);
-    var i: usize = 0;
-    for (i < 12) {
+    $each i in LANES_12 {
         if (a[i] != v[i]) { ret 1; }
         if (b[i] != v[i]) { ret 2; }
         if (c[i] != v[i]) { ret 3; }
         if (d[i] != expected[i]) { ret 4; }
-        i = i + 1;
     }
     if (carrier_guard_12(local_carrier_12, v) != 0) { ret 5; }
     ret 0;
@@ -239,13 +238,11 @@ fun check_carrier_16() i64 {
     val b: u8x16 = indirect(v);
     val c: u8x16 = carrier_dispatch_16(local_carrier_16, v);
     val d: u8x16 = carrier_stack_16(1, 2, 3, 4, v);
-    var i: usize = 0;
-    for (i < 16) {
+    $each i in LANES_16 {
         if (a[i] != v[i]) { ret 1; }
         if (b[i] != v[i]) { ret 2; }
         if (c[i] != v[i]) { ret 3; }
         if (d[i] != expected[i]) { ret 4; }
-        i = i + 1;
     }
     ret 0;
 }
@@ -265,13 +262,11 @@ fun check_carrier_20() i64 {
     val b: u8x20 = indirect(v);
     val c: u8x20 = carrier_dispatch_20(local_carrier_20, v);
     val d: u8x20 = carrier_stack_20(1, 2, 3, 4, v);
-    var i: usize = 0;
-    for (i < 20) {
+    $each i in LANES_20 {
         if (a[i] != v[i]) { ret 1; }
         if (b[i] != v[i]) { ret 2; }
         if (c[i] != v[i]) { ret 3; }
         if (d[i] != expected[i]) { ret 4; }
-        i = i + 1;
     }
     if (carrier_guard_20(local_carrier_20, v) != 0) { ret 5; }
     ret 0;
@@ -293,13 +288,11 @@ fun check_carrier_32() i64 {
     val b: u8x32 = indirect(v);
     val c: u8x32 = carrier_dispatch_32(local_carrier_32, v);
     val d: u8x32 = carrier_stack_32(1, 2, 3, 4, v);
-    var i: usize = 0;
-    for (i < 32) {
+    $each i in LANES_32 {
         if (a[i] != v[i]) { ret 1; }
         if (b[i] != v[i]) { ret 2; }
         if (c[i] != v[i]) { ret 3; }
         if (d[i] != expected[i]) { ret 4; }
-        i = i + 1;
     }
     if (carrier_guard_32(local_carrier_32, v) != 0) { ret 5; }
     ret 0;
@@ -331,13 +324,11 @@ fun check_carrier_float() i64 {
     val b: f32x2 = indirect(v);
     val c: f32x2 = carrier_float_dispatch(local_carrier_float, v);
     val d: f32x2 = carrier_float_stack(1, 2, 3, 4, v);
-    var i: usize = 0;
-    for (i < 2) {
+    $each i in LANES_2 {
         if (a[i]:~u32 != bits[i]) { ret 1; }
         if (b[i]:~u32 != bits[i]) { ret 2; }
         if (c[i]:~u32 != bits[i]) { ret 3; }
         if (d[i]:~u32 != bits[i]) { ret 4; }
-        i = i + 1;
     }
     ret 0;
 }

--- a/test/link/cases/win64-vector-call/src/main.mach
+++ b/test/link/cases/win64-vector-call/src/main.mach
@@ -94,6 +94,7 @@ fun main(argc: usize, argv: **u8) i64 {
     p.printlnf("carrier 32={}", check_carrier_32());
     p.printlnf("carrier mixed={}", check_carrier_mixed());
     p.printlnf("carrier float bits={}", check_carrier_float());
+    p.printlnf("carrier capture={}", carrier_capture_guard_20(local_carrier_20));
     val signed_narrow: i16x4 = i16x4{-32768, -2, 3, -4};
     p.printlnf("foreign signed narrow={}", foreign_narrow(signed_narrow));
     ret 0;
@@ -332,3 +333,5 @@ fun check_carrier_float() i64 {
     }
     ret 0;
 }
+
+ext fun carrier_capture_guard_20(f: CarrierFn20) i64;

--- a/test/link/cases/win64-vector-call/src/main.mach
+++ b/test/link/cases/win64-vector-call/src/main.mach
@@ -74,5 +74,226 @@ fun main(argc: usize, argv: **u8) i64 {
     p.printlnf("pair direct={} intact={} {}", pair_direct, q.a, q.b);
     val pair_indirect: i64 = pair(q);
     p.printlnf("pair indirect={} intact={} {}", pair_indirect, q.a, q.b);
+
+    p.printlnf("carrier 2={}", check_carrier_2());
+    p.printlnf("carrier 3={}", check_carrier_3());
+    p.printlnf("carrier 4={}", check_carrier_4());
+    p.printlnf("carrier 8={}", check_carrier_8());
+    p.printlnf("carrier 12={}", check_carrier_12());
+    p.printlnf("carrier 16={}", check_carrier_16());
+    p.printlnf("carrier 20={}", check_carrier_20());
+    p.printlnf("carrier 32={}", check_carrier_32());
+    p.printlnf("carrier mixed={}", check_carrier_mixed());
+    val signed_narrow: i16x4 = i16x4{-32768, -2, 3, -4};
+    p.printlnf("foreign signed narrow={}", foreign_narrow(signed_narrow));
+    ret 0;
+}
+
+def CarrierFn2: fun(u8x2) u8x2;
+ext fun carrier_identity_2(v: u8x2) u8x2;
+ext fun carrier_select_2(f: CarrierFn2) CarrierFn2;
+ext fun carrier_dispatch_2(f: CarrierFn2, v: u8x2) u8x2;
+ext fun carrier_stack_2(a: i64, b: i64, c: i64, d: i64, v: u8x2) u8x2;
+#[noinline]
+fun local_carrier_2(v: u8x2) u8x2 { ret v; }
+fun check_carrier_2() i64 {
+    val v: u8x2 = u8x2{3, 8};
+    val expected: u8x2 = u8x2{13, 8};
+    val indirect: CarrierFn2 = carrier_select_2(carrier_identity_2);
+    val a: u8x2 = carrier_identity_2(v);
+    val b: u8x2 = indirect(v);
+    val c: u8x2 = carrier_dispatch_2(local_carrier_2, v);
+    val d: u8x2 = carrier_stack_2(1, 2, 3, 4, v);
+    var i: usize = 0;
+    for (i < 2) {
+        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
+        if (d[i] != expected[i]) { ret 2; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+def CarrierFn3: fun(u8x3) u8x3;
+ext fun carrier_identity_3(v: u8x3) u8x3;
+ext fun carrier_select_3(f: CarrierFn3) CarrierFn3;
+ext fun carrier_dispatch_3(f: CarrierFn3, v: u8x3) u8x3;
+ext fun carrier_stack_3(a: i64, b: i64, c: i64, d: i64, v: u8x3) u8x3;
+#[noinline]
+fun local_carrier_3(v: u8x3) u8x3 { ret v; }
+fun check_carrier_3() i64 {
+    val v: u8x3 = u8x3{3, 8, 13};
+    val expected: u8x3 = u8x3{13, 8, 13};
+    val indirect: CarrierFn3 = carrier_select_3(carrier_identity_3);
+    val a: u8x3 = carrier_identity_3(v);
+    val b: u8x3 = indirect(v);
+    val c: u8x3 = carrier_dispatch_3(local_carrier_3, v);
+    val d: u8x3 = carrier_stack_3(1, 2, 3, 4, v);
+    var i: usize = 0;
+    for (i < 3) {
+        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
+        if (d[i] != expected[i]) { ret 2; }
+        i = i + 1;
+    }
+    if (carrier_guard_3(local_carrier_3, v) != 0) { ret 3; }
+    ret 0;
+}
+ext fun carrier_guard_3(f: CarrierFn3, v: u8x3) i64;
+
+def CarrierFn4: fun(u8x4) u8x4;
+ext fun carrier_identity_4(v: u8x4) u8x4;
+ext fun carrier_select_4(f: CarrierFn4) CarrierFn4;
+ext fun carrier_dispatch_4(f: CarrierFn4, v: u8x4) u8x4;
+ext fun carrier_stack_4(a: i64, b: i64, c: i64, d: i64, v: u8x4) u8x4;
+#[noinline]
+fun local_carrier_4(v: u8x4) u8x4 { ret v; }
+fun check_carrier_4() i64 {
+    val v: u8x4 = u8x4{3, 8, 13, 18};
+    val expected: u8x4 = u8x4{13, 8, 13, 18};
+    val indirect: CarrierFn4 = carrier_select_4(carrier_identity_4);
+    val a: u8x4 = carrier_identity_4(v);
+    val b: u8x4 = indirect(v);
+    val c: u8x4 = carrier_dispatch_4(local_carrier_4, v);
+    val d: u8x4 = carrier_stack_4(1, 2, 3, 4, v);
+    var i: usize = 0;
+    for (i < 4) {
+        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
+        if (d[i] != expected[i]) { ret 2; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+def CarrierFn8: fun(u8x8) u8x8;
+ext fun carrier_identity_8(v: u8x8) u8x8;
+ext fun carrier_select_8(f: CarrierFn8) CarrierFn8;
+ext fun carrier_dispatch_8(f: CarrierFn8, v: u8x8) u8x8;
+ext fun carrier_stack_8(a: i64, b: i64, c: i64, d: i64, v: u8x8) u8x8;
+#[noinline]
+fun local_carrier_8(v: u8x8) u8x8 { ret v; }
+fun check_carrier_8() i64 {
+    val v: u8x8 = u8x8{3, 8, 13, 18, 23, 28, 33, 38};
+    val expected: u8x8 = u8x8{13, 8, 13, 18, 23, 28, 33, 38};
+    val indirect: CarrierFn8 = carrier_select_8(carrier_identity_8);
+    val a: u8x8 = carrier_identity_8(v);
+    val b: u8x8 = indirect(v);
+    val c: u8x8 = carrier_dispatch_8(local_carrier_8, v);
+    val d: u8x8 = carrier_stack_8(1, 2, 3, 4, v);
+    var i: usize = 0;
+    for (i < 8) {
+        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
+        if (d[i] != expected[i]) { ret 2; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+def CarrierFn12: fun(u8x12) u8x12;
+ext fun carrier_identity_12(v: u8x12) u8x12;
+ext fun carrier_select_12(f: CarrierFn12) CarrierFn12;
+ext fun carrier_dispatch_12(f: CarrierFn12, v: u8x12) u8x12;
+ext fun carrier_stack_12(a: i64, b: i64, c: i64, d: i64, v: u8x12) u8x12;
+#[noinline]
+fun local_carrier_12(v: u8x12) u8x12 { ret v; }
+fun check_carrier_12() i64 {
+    val v: u8x12 = u8x12{3, 8, 13, 18, 23, 28, 33, 38, 43, 48, 53, 58};
+    val expected: u8x12 = u8x12{13, 8, 13, 18, 23, 28, 33, 38, 43, 48, 53, 58};
+    val indirect: CarrierFn12 = carrier_select_12(carrier_identity_12);
+    val a: u8x12 = carrier_identity_12(v);
+    val b: u8x12 = indirect(v);
+    val c: u8x12 = carrier_dispatch_12(local_carrier_12, v);
+    val d: u8x12 = carrier_stack_12(1, 2, 3, 4, v);
+    var i: usize = 0;
+    for (i < 12) {
+        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
+        if (d[i] != expected[i]) { ret 2; }
+        i = i + 1;
+    }
+    if (carrier_guard_12(local_carrier_12, v) != 0) { ret 3; }
+    ret 0;
+}
+ext fun carrier_guard_12(f: CarrierFn12, v: u8x12) i64;
+
+def CarrierFn16: fun(u8x16) u8x16;
+ext fun carrier_identity_16(v: u8x16) u8x16;
+ext fun carrier_select_16(f: CarrierFn16) CarrierFn16;
+ext fun carrier_dispatch_16(f: CarrierFn16, v: u8x16) u8x16;
+ext fun carrier_stack_16(a: i64, b: i64, c: i64, d: i64, v: u8x16) u8x16;
+#[noinline]
+fun local_carrier_16(v: u8x16) u8x16 { ret v; }
+fun check_carrier_16() i64 {
+    val v: u8x16 = u8x16{3, 8, 13, 18, 23, 28, 33, 38, 43, 48, 53, 58, 63, 68, 73, 78};
+    val expected: u8x16 = u8x16{13, 8, 13, 18, 23, 28, 33, 38, 43, 48, 53, 58, 63, 68, 73, 78};
+    val indirect: CarrierFn16 = carrier_select_16(carrier_identity_16);
+    val a: u8x16 = carrier_identity_16(v);
+    val b: u8x16 = indirect(v);
+    val c: u8x16 = carrier_dispatch_16(local_carrier_16, v);
+    val d: u8x16 = carrier_stack_16(1, 2, 3, 4, v);
+    var i: usize = 0;
+    for (i < 16) {
+        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
+        if (d[i] != expected[i]) { ret 2; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+def CarrierFn20: fun(u8x20) u8x20;
+ext fun carrier_identity_20(v: u8x20) u8x20;
+ext fun carrier_select_20(f: CarrierFn20) CarrierFn20;
+ext fun carrier_dispatch_20(f: CarrierFn20, v: u8x20) u8x20;
+ext fun carrier_stack_20(a: i64, b: i64, c: i64, d: i64, v: u8x20) u8x20;
+#[noinline]
+fun local_carrier_20(v: u8x20) u8x20 { ret v; }
+fun check_carrier_20() i64 {
+    val v: u8x20 = u8x20{3, 8, 13, 18, 23, 28, 33, 38, 43, 48, 53, 58, 63, 68, 73, 78, 83, 88, 93, 98};
+    val expected: u8x20 = u8x20{13, 8, 13, 18, 23, 28, 33, 38, 43, 48, 53, 58, 63, 68, 73, 78, 83, 88, 93, 98};
+    val indirect: CarrierFn20 = carrier_select_20(carrier_identity_20);
+    val a: u8x20 = carrier_identity_20(v);
+    val b: u8x20 = indirect(v);
+    val c: u8x20 = carrier_dispatch_20(local_carrier_20, v);
+    val d: u8x20 = carrier_stack_20(1, 2, 3, 4, v);
+    var i: usize = 0;
+    for (i < 20) {
+        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
+        if (d[i] != expected[i]) { ret 2; }
+        i = i + 1;
+    }
+    if (carrier_guard_20(local_carrier_20, v) != 0) { ret 3; }
+    ret 0;
+}
+ext fun carrier_guard_20(f: CarrierFn20, v: u8x20) i64;
+
+def CarrierFn32: fun(u8x32) u8x32;
+ext fun carrier_identity_32(v: u8x32) u8x32;
+ext fun carrier_select_32(f: CarrierFn32) CarrierFn32;
+ext fun carrier_dispatch_32(f: CarrierFn32, v: u8x32) u8x32;
+ext fun carrier_stack_32(a: i64, b: i64, c: i64, d: i64, v: u8x32) u8x32;
+#[noinline]
+fun local_carrier_32(v: u8x32) u8x32 { ret v; }
+fun check_carrier_32() i64 {
+    val v: u8x32 = u8x32{3, 8, 13, 18, 23, 28, 33, 38, 43, 48, 53, 58, 63, 68, 73, 78, 83, 88, 93, 98, 103, 108, 113, 118, 123, 128, 133, 138, 143, 148, 153, 158};
+    val expected: u8x32 = u8x32{13, 8, 13, 18, 23, 28, 33, 38, 43, 48, 53, 58, 63, 68, 73, 78, 83, 88, 93, 98, 103, 108, 113, 118, 123, 128, 133, 138, 143, 148, 153, 158};
+    val indirect: CarrierFn32 = carrier_select_32(carrier_identity_32);
+    val a: u8x32 = carrier_identity_32(v);
+    val b: u8x32 = indirect(v);
+    val c: u8x32 = carrier_dispatch_32(local_carrier_32, v);
+    val d: u8x32 = carrier_stack_32(1, 2, 3, 4, v);
+    var i: usize = 0;
+    for (i < 32) {
+        if (a[i] != v[i] || b[i] != v[i] || c[i] != v[i]) { ret 1; }
+        if (d[i] != expected[i]) { ret 2; }
+        i = i + 1;
+    }
+    if (carrier_guard_32(local_carrier_32, v) != 0) { ret 3; }
+    ret 0;
+}
+ext fun carrier_guard_32(f: CarrierFn32, v: u8x32) i64;
+
+ext fun carrier_mixed(a: i64, b: f64, c: i64, d: i64, v: u8x3) u8x3;
+fun check_carrier_mixed() i64 {
+    val v: u8x3 = u8x3{1, 2, 3};
+    val out: u8x3 = carrier_mixed(1, 2.0, 3, 4, v);
+    if (out[0] != 11 || out[1] != 2 || out[2] != 3) { ret 1; }
+    if (v[0] != 1 || v[1] != 2 || v[2] != 3) { ret 2; }
     ret 0;
 }


### PR DESCRIPTION
Windows foreign calls misread eight-byte vector values because Mach passed an aligned pointer while the native GCC callee consumed integer bits. Generic C vector extensions also disagree between GCC and Clang, so this boundary now names explicit C carriers for every admitted vector extent.

Use integer bits at 2/4 bytes, `__m64` at 8 bytes, a 128-bit intrinsic at 16 bytes, and an exact-size byte aggregate otherwise. Direct calls, typed indirect calls, Mach parameters, and returns share the classification. Odd-width register returns use independent result storage and copy exactly their payload extent. By-reference arguments receive caller-owned, 16-byte-aligned copies, including scalarized wide vectors.

The original Windows link outputs remain. New controls cover 2/3/4/8/12/16/20/32-byte arguments and returns, C-to-Mach callbacks, stack positions, signed lanes, negative-zero/NaN payload bits, hidden-result argument shifting, guarded result storage, and wide-vector pointer capture. The inline classification census also covers every extent family up to 524280 bytes. The freestanding MSVC probe defines its required `_fltused` marker when floating-point controls are enabled.

Native evidence:

- [Final Windows proof](https://github.com/briar-systems/mach/actions/runs/34007992567), verifier `3c226c36`, exact source `b6801df9` and std `3ee8e70`. Source integrates this exact candidate `84337994` into the reviewed compiler baseline. Both focused tests pass. GCC passes all 12 Windows link cells, and explicit Clang/MSVC passes both vector cells, with no skips.
- Eight independent classification/layout mutations each compile and produce the expected single runtime test failure. Three staging mutations each compile both the compiler and fixture, then fail the native runtime assertion in debug and release: full-width SRET overwrite exits 3, pointer/payload confusion exits 1, and truncating the wide argument copy to pointer size exits 1. All six corresponding pristine controls exit 0. All 55 process censuses are empty. Source and fixture mutations are restored individually.
- [Linux proof](https://github.com/briar-systems/mach/actions/runs/34007298585) passes both focused tests and all eight runtime classification/layout mutations, with 12 empty censuses. The final fixture-only refinements do not change compiler source, manifest, or std pin relative to that proof.

Compiler implementation has been unchanged since `1e94d6b5`. Later commits strengthen the native controls and correct their compile-time lane indexing and freestanding C marker. Full compiler integration validation remains a separate release gate. No local Mach invocation.

Closes #3199.
