### PR TITLE
fix(regalloc): reload a spilled destination before source reuse

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -128,6 +128,8 @@ The pin moves from 0.28.1 to 0.37.2 (`565f40ab`).
 
 ### Fixed
 
+- Reload a spilled read/modify/write destination before its first source use, preserving shared scratch identity and reusing the reload for repeated aliases (#3215).
+
 - The frame-location link oracle checks every DWARF description sharing a machine range, preventing false failures for backed variables (#3197).
 
 - Windows and Darwin corpus disassemblies now reflect the audited aggregate and vector ABI, scratch-register preservation, canonical boolean, trapping remainder, inline, vector-loop and Darwin x18 fixes. All 77 updates were independently decoded and reviewed against native C-reference results (#3179).

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -1,4 +1,5 @@
 use std.allocator.page;
+use std.allocator.arena;
 use std.collections.sort;
 use std.format;
 use std.system.panic.panic;
@@ -2550,6 +2551,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
 
     var store_dst_vreg: u32 = mir.MIR_VREG_NIL;
     var store_dst_tmp: i32 = -1;
+    var store_dst_reloaded: bool = false;
 
     var k: u32 = 0;
     for (k < n) {
@@ -2576,6 +2578,11 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                 if (is_fp_vreg(ctx, v) && is_spilled(ctx, v)) {
                     ops[k] = mir.op_mem_slot(v, 0);
                 } or (store_dst_tmp >= 0 && v == store_dst_vreg) {
+                    if (!store_dst_reloaded) {
+                        val er: R.Result[R.Void, str] = emit_reload(ctx, dst, wp, store_dst_tmp::u32, v, mi.loc, mi.inline_site);
+                        if (R.is_err[R.Void, str](er)) { free_ops(ctx, ops, n); ret er; }
+                        store_dst_reloaded = true;
+                    }
                     ops[k] = mir.op_preg(store_dst_tmp::u32);
                 } or (is_spilled(ctx, v)) {
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, is_entry, src_pos);
@@ -3732,5 +3739,112 @@ test "mach.lang.be.codegen.regalloc.verify_rewritten_operands:walks_the_program_
     if (R.is_ok[R.Void, str](verify_rewritten_operands(?tgt, ?f)))  { ret 5; }
     ops[1] = mir.op_mem_preg(tgt.model.stack_ptr_reg::u32, 0);
     if (R.is_err[R.Void, str](verify_rewritten_operands(?tgt, ?f))) { ret 6; }
+    ret 0;
+}
+
+fun t_spilled_update(mode: u32) i32 {
+    var backing: A.Allocator;
+    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    var scratch_arena: arena.Arena;
+    if (O.is_some[str](arena.init(?scratch_arena, ?backing, 65536))) { ret 1; }
+    fin { arena.dnit(?scratch_arena); }
+    var alloc: A.Allocator;
+    if (O.is_some[str](arena.make(?alloc, ?scratch_arena))) { ret 1; }
+    var vregs: [1]mir.MirVReg;
+    vregs[0] = mir.vreg(0, REG_CLASS_GP, false, false);
+    vregs[0].spill_slot = 0;
+    var f: mir.MirFunction;
+    f.vregs = ?vregs[0];
+    f.vreg_count = 1;
+    var scratch: [1]isa.Register;
+    scratch[0].id = 0;
+    var ctx: AllocCtx;
+    ctx.alloc = ?alloc;
+    ctx.f = ?f;
+    ctx.spill_width = 8;
+    ctx.reload_scratch = ?scratch[0];
+    ctx.reload_scratch_count = 1;
+    var tgt: target.Target;
+    val count: u32 = 3;
+    val ar: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](?alloc, count::usize);
+    if (R.is_err[*mir.MirOperand, str](ar)) { ret 1; }
+    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ar);
+    ops[0] = mir.op_vreg(0);
+    ops[1] = mir.op_vreg(0);
+    ops[2] = mir.op_imm(8);
+    var mi: mir.MirInstr = mir.instr(mir.MIR_SUB, ops, count, 8, 8);
+    if (mode == 1) {
+        mi.opcode = mir.MIR_ADD;
+        ops[2] = mir.op_vreg(0);
+    } or (mode == 2) {
+        ops[1] = mir.op_imm(100);
+    }
+    var dst: [5]mir.MirInstr;
+    var written: u32 = 0;
+    fin {
+        var i: u32 = 0;
+        for (i < written) {
+            free_ops(?ctx, dst[i].operands, dst[i].operand_count);
+            i = i + 1;
+        }
+    }
+    val rr: R.Result[R.Void, str] = rewrite_instr(?tgt, ?ctx, ?mi, ?dst[0], ?written, false, 0);
+    if (R.is_err[R.Void, str](rr)) { ret 2; }
+    var slot: i64 = 40;
+    var reg: i64 = 999;
+    var loads: u32 = 0;
+    var stores: u32 = 0;
+    var i: u32 = 0;
+    for (i < written) {
+        val ins: *mir.MirInstr = ?dst[i];
+        val a: *mir.MirOperand = ?ins.operands[0];
+        val b: *mir.MirOperand = ?ins.operands[1];
+        if (ins.opcode == mir.MIR_MOV) {
+            if (a.kind == mir.MIR_OP_PREG && b.kind == mir.MIR_OP_MEM && b.vreg == 0) {
+                reg = slot;
+                loads = loads + 1;
+            } or (a.kind == mir.MIR_OP_MEM && a.vreg == 0 && b.kind == mir.MIR_OP_PREG) {
+                slot = reg;
+                stores = stores + 1;
+            } or { ret 3; }
+        } or {
+            val c: *mir.MirOperand = ?ins.operands[2];
+            if (a.kind != mir.MIR_OP_PREG || a.preg != 0) { ret 3; }
+            var left: i64 = b.imm;
+            var right: i64 = c.imm;
+            if (b.kind == mir.MIR_OP_PREG) {
+                if (b.preg != a.preg) { ret 4; }
+                left = reg;
+            }
+            if (c.kind == mir.MIR_OP_PREG) {
+                if (c.preg != a.preg) { ret 4; }
+                right = reg;
+            }
+            if (ins.opcode == mir.MIR_SUB) { reg = left - right; }
+            or (ins.opcode == mir.MIR_ADD) { reg = left + right; }
+            or { ret 3; }
+        }
+        i = i + 1;
+    }
+    var expected: i64 = 32;
+    if (mode == 1) { expected = 80; }
+    or (mode == 2) { expected = 92; }
+    if (slot != expected) { ret 5; }
+    if (stores != 1) { ret 6; }
+    if (mode == 2) {
+        if (loads != 0 || written != 2) { ret 7; }
+    } or {
+        if (loads != 1 || written != 3) { ret 8; }
+    }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.regalloc.rewrite_instr:spilled_update_reloads_previous_value_once" {
+    val one: i32 = t_spilled_update(0);
+    if (one != 0) { ret one; }
+    val repeated: i32 = t_spilled_update(1);
+    if (repeated != 0) { ret 10 + repeated; }
+    val pure: i32 = t_spilled_update(2);
+    if (pure != 0) { ret 20 + pure; }
     ret 0;
 }


### PR DESCRIPTION
A spilled destination reused as a source now reloads its previous value into the shared destination scratch before the instruction. Repeated source aliases reuse that single reload, while pure definitions remain free of loads. This preserves #1024's register identity fix.

A forced-spill regression evaluates single and repeated aliases plus a pure-definition control. Native integration with compact aggregate loops now builds seed → A → B → C with byte-identical B/C in [34010649318](https://github.com/briar-systems/mach/actions/runs/34010649318). The same run stopped on an unrelated allocation-count assumption in the new bulk test, which has been corrected separately. Focused regression and restoration mutation proof are pending in the next integration verification run. Full compiler bar remains pending.

Closes #3215
