### PR TITLE
docs(language): publish approved tagged-value contract

### DIFF
--- a/doc/design/tagged-values.md
+++ b/doc/design/tagged-values.md
@@ -3,9 +3,9 @@
 Accepted by the owner on 2026-09-08 for #3217. This is the normative implementation
 contract for #3218 and #3219. The existing compiler does not implement these forms.
 
-The owner approved the complete design and confirmed the one-argument `res[E]`
-form after reviewing construction, direct case handling and `try` examples.
-It represents an explicit payloadless success case and an error payload of type E.
+The canonical types are `res[T, E]`, `opt[T]` and distinct `err[E]`. Each has one
+fixed generic arity. `err[E]` represents payloadless success or an error of type E
+and uses the same explicit failure handling as `res[T, E]`.
 
 ## Types and construction
 
@@ -38,8 +38,10 @@ on a payloadless case, multiple selections and an empty literal are errors.
 Payload types and generic arguments remain explicit under the existing rules.
 
 `res[T, E]` is a canonical tag with `err: E` first and `ok: T` second.
-`res[E]` has `err: E` first and payloadless `ok` second. This fixed one-argument
-form does not introduce general type inference or a dummy success type.
+`err[E]` is a distinct canonical tag with `err: E` first and payloadless `ok`
+second. It is not an alias of `opt[E]`. `res` requires exactly two type arguments,
+and `opt` and `err` each require exactly one. There is no defaulted type argument,
+general type inference or dummy success type.
 `opt[T]` has payloadless `none` first and `some: T` second. These types work
 without importing std and use the same tag implementation as user declarations.
 
@@ -49,14 +51,15 @@ tag WriteError {
     native: i32;
 }
 
-fun flush() res[WriteError] {
-    ret res[WriteError]{ok};
+fun flush() err[WriteError] {
+    ret err[WriteError]{ok};
 }
 ```
 
 `ok`, `err`, `some` and `none` are contextual case members, not global keywords.
-There is no `err` primitive and no `Void`, unit value, constructor function or
-automatic error conversion.
+The canonical `err[E]` type is resolved in type positions. Its `err` case follows
+the same contextual member rule as the `err` case of `res[T, E]`. There is no
+`Void`, unit value, constructor function or automatic error conversion.
 
 ## Tests, payload access and mutation
 
@@ -126,7 +129,7 @@ the explicitly typed error and executes the written failure block. That block
 must exit and cannot initialize the destination or provide a fallback value.
 Propagation and conversion remain ordinary visible code.
 
-`try` accepts canonical `res` and `opt` values. Ordinary user-defined tags have
+`try` accepts canonical `res`, `opt` and `err` values. Ordinary user-defined tags have
 no implicit success/failure convention and use explicit case tests.
 
 The operand is a prefix/postfix expression. A larger operand requires parentheses.
@@ -145,13 +148,14 @@ val number: i64 = try lookup(key) or {
 };
 
 try flush() or (error: WriteError) {
-    ret res[WriteError]{err: error};
+    ret err[WriteError]{err: error};
 };
 ```
 
-Options have no error binding. Result failure bindings use the exact error type.
-Payloadless result extraction produces no value and is allowed only as a direct
-expression statement. It cannot be an initializer, argument or arithmetic operand.
+Options have no error binding. Both `res` and `err` failure bindings use the
+exact error type. Successful `try` extracts the `ok` payload from `res` or the
+`some` payload from `opt`. For `err`, the payloadless `ok` case produces no value
+and `try` is allowed only as a direct expression statement. It cannot be an initializer, argument or arithmetic operand.
 
 Every reachable path through the failure block must leave it through an ordinary
 valid `ret`, or `brk`/`cnt` targeting an enclosing loop outside the failure block.
@@ -165,15 +169,16 @@ expression and does not initialize its destination. A replacement initializer
 may read the old selected payload before overwriting it.
 
 The assignment rule preserves the current compiler and audited 4.30 behavior.
-Historical #469/#494 chose LHS-first. The accepted v5 rule is RHS-first. This explicitly supersedes that earlier
-assignment-order decision.
+Historical #469/#494 chose LHS-first. The accepted v5 rule is RHS-first. This
+explicitly supersedes that earlier assignment-order decision.
 
 ## Initialization and representation
 
 Ordinary zero initialization remains uniform. Case code zero selects the first
 declared case and zero-initializes its payload. This applies to locals, globals,
 omitted fields, arrays and comptime values. Canonical option defaults to `none`
-and result defaults to `err` with a zero-initialized error payload. Raw allocated
+and both `res` and `err` default to their `err` case with a zero-initialized
+error payload. Raw allocated
 capacity is not automatically a constructed value.
 
 The discriminator is stored at offset zero in target byte order. Its type is
@@ -210,7 +215,7 @@ selected target's actual storage.
 
 Add three intrinsics, following existing comptime conventions:
 
-- `$is_tag(T)` identifies public tag shapes, including `res` and `opt`.
+- `$is_tag(T)` identifies public tag shapes, including `res`, `opt` and `err`.
 - `$cases(T)` enumerates owner-qualified descriptors in declaration order through
   the existing `$each` construct.
 - `$discriminant_of(T)` produces the actual unsigned discriminator type.
@@ -312,7 +317,7 @@ val fallback: i64 = try parse(input) or (error: ParseError) {
 
 fin {
     try flush() or (error: WriteError) {
-        ret res[WriteError]{err: error};
+        ret err[WriteError]{err: error};
     };                                # rejected, return crosses a fin boundary
 }
 ```

--- a/doc/design/tagged-values.md
+++ b/doc/design/tagged-values.md
@@ -1,0 +1,356 @@
+# Mach v5 tagged values and explicit failure control
+
+Accepted by the owner on 2026-09-08 for #3217. This is the normative implementation
+contract for #3218 and #3219. The existing compiler does not implement these forms.
+
+The owner approved the complete design and confirmed the one-argument `res[E]`
+form after reviewing construction, direct case handling and `try` examples.
+It represents an explicit payloadless success case and an error payload of type E.
+
+## Types and construction
+
+`tag` uses the existing aggregate declaration and generic-parameter conventions.
+A case has a name and either one explicitly typed payload or no payload. Multiple
+values use an ordinary record payload. Empty tags and duplicate case names are
+rejected.
+
+```mach
+tag Reply {
+    empty;
+    value: i64;
+}
+
+tag ParseError {
+    invalid;
+    overflow;
+}
+
+val empty: Reply = Reply{empty};
+val value: Reply = Reply{value: 42};
+val good: res[i64, ParseError] = res[i64, ParseError]{ok: 42};
+val bad: res[i64, ParseError] = res[i64, ParseError]{err: ParseError{invalid}};
+val present: opt[i64] = opt[i64]{some: 42};
+val absent: opt[i64] = opt[i64]{none};
+```
+
+Every tag literal selects exactly one case. A missing required payload, a payload
+on a payloadless case, multiple selections and an empty literal are errors.
+Payload types and generic arguments remain explicit under the existing rules.
+
+`res[T, E]` is a canonical tag with `err: E` first and `ok: T` second.
+`res[E]` has `err: E` first and payloadless `ok` second. This fixed one-argument
+form does not introduce general type inference or a dummy success type.
+`opt[T]` has payloadless `none` first and `some: T` second. These types work
+without importing std and use the same tag implementation as user declarations.
+
+```mach
+tag WriteError {
+    denied;
+    native: i32;
+}
+
+fun flush() res[WriteError] {
+    ret res[WriteError]{ok};
+}
+```
+
+`ok`, `err`, `some` and `none` are contextual case members, not global keywords.
+There is no `err` primitive and no `Void`, unit value, constructor function or
+automatic error conversion.
+
+## Tests, payload access and mutation
+
+```mach
+if (value == Reply.value) {
+    val number: i64 = value.value;
+}
+or {
+    # value is empty here
+}
+```
+
+`Reply.value` is a case selector. It cannot be stored as a `Reply` value.
+Comparing a tag with its own selector tests only its active case. `!=` negates
+that test. This adds neither whole-tag equality nor payload equality or ordering.
+There is no `.kind` field or `match` statement.
+
+Payload access requires a current proof of the selected case. Construction and
+ordinary branch flow establish proofs. Joining branches preserves only facts
+true on every incoming path. Whole-value assignment changes the selected case
+and invalidates earlier proofs. A payload assignment requires its case to be
+selected and does not switch cases.
+
+A write through a possibly overlapping mutable alias, or a call that can modify
+the tested object, invalidates its proof. A separate immutable value snapshot
+keeps its own proof. An immutable pointer binding does not make its pointee
+immutable. Proofs do not depend on optimization level.
+
+```mach
+fun inspect(reply: *Reply) i64 {
+    if (@reply == Reply.value) {
+        replace(reply);
+        ret reply.value;       # rejected because the call invalidated the proof
+    }
+    ret 0;
+}
+
+fun snapshot(reply: *Reply) i64 {
+    val saved: Reply = @reply;
+    if (saved == Reply.value) {
+        replace(reply);
+        ret saved.value;       # accepted because saved owns a separate value
+    }
+    ret 0;
+}
+```
+
+Taking a payload address requires the same proof and a naturally aligned payload
+place. The raw pointer remains valid only while the enclosing object lives and
+that case remains selected. It does not pin a case or extend a lifetime.
+Subsequent raw-pointer use carries this obligation under ordinary low-level
+memory rules. No general borrow checker is introduced.
+
+## Expression-level try
+
+```mach
+fun increment(input: str) res[i64, ParseError] {
+    val number: i64 = try parse(input) or (error: ParseError) {
+        ret res[i64, ParseError]{err: error};
+    };
+    ret res[i64, ParseError]{ok: number + 1};
+}
+```
+
+`try` evaluates its operand once. Success extracts the payload. Failure binds
+the explicitly typed error and executes the written failure block. That block
+must exit and cannot initialize the destination or provide a fallback value.
+Propagation and conversion remain ordinary visible code.
+
+`try` accepts canonical `res` and `opt` values. Ordinary user-defined tags have
+no implicit success/failure convention and use explicit case tests.
+
+The operand is a prefix/postfix expression. A larger operand requires parentheses.
+The `or` block is mandatory. Each independently fallible operand gets its own
+`try`.
+
+```mach
+val total: i64 = (try left() or (error: ParseError) {
+    ret res[i64, ParseError]{err: error};
+}) + (try right() or (error: ParseError) {
+    ret res[i64, ParseError]{err: error};
+});
+
+val number: i64 = try lookup(key) or {
+    ret res[i64, ParseError]{err: ParseError{invalid}};
+};
+
+try flush() or (error: WriteError) {
+    ret res[WriteError]{err: error};
+};
+```
+
+Options have no error binding. Result failure bindings use the exact error type.
+Payloadless result extraction produces no value and is allowed only as a direct
+expression statement. It cannot be an initializer, argument or arithmetic operand.
+
+Every reachable path through the failure block must leave it through an ordinary
+valid `ret`, or `brk`/`cnt` targeting an enclosing loop outside the failure block.
+A break from a loop created inside the failure block does not qualify. Calling a
+function does not implicitly prove that control cannot return. Existing `fin`
+restrictions and cleanup order apply unchanged to the actual exit path.
+
+Call arguments evaluate left to right. Assignment evaluates and captures its RHS
+before evaluating its destination. A failed extraction skips the remaining
+expression and does not initialize its destination. A replacement initializer
+may read the old selected payload before overwriting it.
+
+The assignment rule preserves the current compiler and audited 4.30 behavior.
+Historical #469/#494 chose LHS-first. The accepted v5 rule is RHS-first. This explicitly supersedes that earlier
+assignment-order decision.
+
+## Initialization and representation
+
+Ordinary zero initialization remains uniform. Case code zero selects the first
+declared case and zero-initializes its payload. This applies to locals, globals,
+omitted fields, arrays and comptime values. Canonical option defaults to `none`
+and result defaults to `err` with a zero-initialized error payload. Raw allocated
+capacity is not automatically a constructed value.
+
+The discriminator is stored at offset zero in target byte order. Its type is
+the smallest of `u8`, `u16`, `u32` and `u64` that represents every case ordinal.
+One-case tags still have a discriminator. Codes follow declaration order, with
+no custom codes, niche encoding, tag elision or case reordering. Compiler resource
+and declaration limits remain checked implementation limits.
+
+For natural layout, let `D` be discriminator size, `M` the maximum payload size
+and `PAlign` the maximum payload alignment, or one with no payloads. The common
+payload offset is `align_up(D, PAlign)`. Object alignment is the maximum of the
+discriminator alignment, payload alignment and any explicit alignment. Total
+size is the aligned extent of that common payload area. Payloadless tags contain
+only the discriminator and any required outer padding.
+
+Existing `#[packed]` and `#[align(N)]` rules apply. Packing places the payload
+immediately after the discriminator with base alignment one. Explicit alignment
+raises object alignment and rounds total size. Packing does not repack a nested
+payload. Packed value access uses legal unaligned operations. Taking a typed
+payload pointer must not fabricate a stronger alignment guarantee.
+
+Construction captures the payload before overwriting the destination. It zeroes
+tag-owned gaps, inactive payload suffix and tail padding. The active payload
+retains its ordinary value/representation rules, including any raw union bytes.
+This does not promise recursive canonicalization of foreign payload padding.
+Replacing a larger case clears its now-inactive suffix.
+
+Native ABI transfer preserves exact logical object extents separately from carrier
+width and alignment. Whole-module targets represent logical cases and payload
+types without invented physical registers. Layout reflection describes the
+selected target's actual storage.
+
+## Reflection and conversion
+
+Add three intrinsics, following existing comptime conventions:
+
+- `$is_tag(T)` identifies public tag shapes, including `res` and `opt`.
+- `$cases(T)` enumerates owner-qualified descriptors in declaration order through
+  the existing `$each` construct.
+- `$discriminant_of(T)` produces the actual unsigned discriminator type.
+
+Case descriptors expose `name`, `has_payload`, `type`, `offset` and `code`.
+`name` is the existing comptime NUL-terminated string form. `has_payload` is a
+comptime predicate. `type` retains declared qualifiers. `offset` and `code` use
+the existing `u64` descriptor-integer convention. Accessing `type` or `offset`
+on a payloadless case is an error.
+
+```mach
+$each case in $cases(T) {
+    if (value == T.[case]) {
+        $if (case.has_payload) {
+            consume[case.type](value.[case]);
+        }
+    }
+}
+```
+
+`T.[case]` is the named selector and `value.[case]` is the proof-checked payload
+projection. `T{[case]: payload}` and `T{[case]}` reconstruct through the same
+single-case literal rule after specialization. A descriptor from another nominal
+type or generic instantiation is rejected.
+
+Reuse `$size_of`, `$align_of` and `$offset_of(T, payload_case)`. Layout answers
+come from one checked target layout and become available under the same complete-
+type rules as size/alignment, superseding the old lowering-only offset exception.
+Unresolved or recursive layout is diagnosed rather than replaced with a guess.
+
+`$cases(^T)` is refused and `$is_tag(^T)` is false, matching current shape-query
+conventions. Size, alignment and discriminator-type queries may inspect outer-
+secret types because they expose storage metadata, never the active case.
+
+Different nominal tags remain different types. Representation-changing `::` and
+`:~` casts are rejected when either by-value representation contains a tag,
+including through arrays, records and union alternatives. Same-type identity
+casts remain identity. Transparent aliases preserve the same type. Ordinary
+qualifier conversions retain their existing rules and must preserve the underlying
+tag identity. They cannot introduce another route for declassification.
+
+Ordinary pointer retyping remains an explicit raw-memory operation under the
+existing secrecy/weld rules. A typed tag read requires live, aligned storage,
+a valid case code and a valid selected payload. Raw union projection cannot
+manufacture that validity. Foreign formats must be validated in ordinary code
+and then constructed. There is no implicit validator or runtime decoder.
+
+## Secrecy, ownership and std
+
+A public tag has a public discriminator. Each payload keeps its declared secrecy.
+Outer `^Tag` also protects the active case. Secret-dependent case tests and `try`
+branches remain subject to the constant-time rules.
+
+Storage and transport preserve the union of potentially secret byte ranges across
+all cases. A carrier containing both public discriminator bits and secret payload
+bits cannot be marked wholly public. Extracting the public discriminator must
+preserve its public provenance through late lowering. Public case access does not
+permit reading an inactive secret payload or erasing a secret-welded pointer.
+Copies with a secret selected case use the public fixed type extent and do not
+choose a case-dependent access pattern.
+
+`value:>T` removes only outer secrecy from the same underlying tag value. It
+preserves the selected case and all qualifiers declared inside payloads.
+
+Tags add no moves, destructors, unwinding, allocation or resource rollback.
+Domain errors, formatting, explicit conversions and cleanup belong in std or user
+code. Address-bound owners initialize their final caller-owned storage and are
+not returned by value inside a result.
+
+Public tag layouts and closed case sets are part of std's SemVer contract.
+Changing a closed public case set is a breaking change. The migration ships as
+std 2.0.0 paired with Mach 5.0.0.
+
+## Implementation and acceptance
+
+Additional acceptance examples use the types above and ordinary helper functions.
+
+```mach
+var reply: Reply;                       # empty, because it is declared first
+var result: res[i64, ParseError];       # err with ParseError.invalid
+val invalid: Reply = Reply{empty: 1};   # rejected, no payload exists
+val missing: Reply = Reply{value};      # rejected, payload is required
+val wrong: Reply = Reply.value;         # rejected, selector is not a value
+
+consume(try parse(input) or (error: ParseError) {
+    ret res[i64, ParseError]{err: error};
+}, later());                           # later runs only after successful extraction
+
+for (more) {
+    val item: i64 = try lookup(key) or {
+        cnt;
+    };
+    consume(item);
+}
+
+val fallback: i64 = try parse(input) or (error: ParseError) {
+    log(error);
+};                                    # rejected, failure can fall through
+
+fin {
+    try flush() or (error: WriteError) {
+        ret res[WriteError]{err: error};
+    };                                # rejected, return crosses a fin boundary
+}
+```
+
+For a raw input byte containing a case code, ordinary code can validate and
+construct a value. An unrecognized byte does not become an invalid `Reply`.
+
+```mach
+if (code == 0) {
+    ret opt[Reply]{some: Reply{empty}};
+}
+if (code == 1) {
+    ret opt[Reply]{some: Reply{value: decoded_number}};
+}
+ret opt[Reply]{none};
+```
+
+An equal-size raw-record-to-`Reply` cast is rejected with either `::` or `:~`.
+Wrapping the two sides in arrays, records or union alternatives does not make
+that conversion valid. A pointer retype is a raw operation and does not perform
+the validation shown above.
+
+For `tag SecretReply { failed: i32; value: ^u64; }`, testing a public
+`SecretReply.failed` case and reading its `i32` payload is permitted. Reading
+the secret value as public `u64`, erasing its storage through a public byte
+pointer, or branching on an outer-secret `^SecretReply` is rejected. A saved
+public-payload pointer expires when the enclosing tag changes to another case.
+
+The existing source bootstrap starts with published Mach 4.26.5, builds the
+pinned bridge and audited compiler sources, and checks self-hosting convergence.
+It does not require the withdrawn Mach 4.30.0 release. Published std 1.0.1 remains
+immutable. Implement the shared tag model and canonical types, then `try`, before
+adopting the new forms in the compiler and std. Record a pinned usable compiler
+at that migration boundary and update the existing bootstrap channel accordingly.
+
+Acceptance covers construction, defaults, branch refinement and invalidation,
+explicit failure exits and cleanup, generics and reflection, casts through
+containing types, raw validity obligations, packed/overaligned storage, exact
+ABI transport, public-case/secret-payload carriers and module emitters. Positive
+and negative cases must agree across optimization levels. All retained targets
+must implement the contract before v5 completes.

--- a/doc/design/v5-tooling-plan.md
+++ b/doc/design/v5-tooling-plan.md
@@ -58,6 +58,6 @@ and dependency-name parsing, accurate help and preservation of Git boundaries.
 ## Accepted language contract
 
 The owner accepted the [tagged-value and failure-control contract](tagged-values.md)
-on 2026-09-08. It defines tag, res, opt and expression-level try with explicit
-types, visible failure exits and manual ownership. There is no separate err type.
+on 2026-09-08. It defines tag, res[T, E], opt[T], err[E] and expression-level try with explicit
+types, visible failure exits and manual ownership.
 The contract is approved for implementation through #3218 and #3219.

--- a/doc/design/v5-tooling-plan.md
+++ b/doc/design/v5-tooling-plan.md
@@ -55,9 +55,9 @@ refreshes copied path dependencies and applies the declared update policy.
 Acceptance includes every action invoked outside its project, unambiguous path
 and dependency-name parsing, accurate help and preservation of Git boundaries.
 
-## Separate language discussion
+## Accepted language contract
 
-try, res, opt, err and tag are permitted design candidates, not approved language
-features. Preserve explicit types, visible failure paths and manual ownership
-while evaluating them. No inference, propagation or tagged-union proposal has
-been approved for implementation.
+The owner accepted the [tagged-value and failure-control contract](tagged-values.md)
+on 2026-09-08. It defines tag, res, opt and expression-level try with explicit
+types, visible failure exits and manual ownership. There is no separate err type.
+The contract is approved for implementation through #3218 and #3219.

--- a/src/lang/be/codegen/rules.mach
+++ b/src/lang/be/codegen/rules.mach
@@ -1281,7 +1281,7 @@ test "mach.lang.be.codegen.rules.emit:new_registers_require_explicit_bank_constr
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
     var f: mir.MirFunction;
-    var source: mir.MirInstr;
+    var source: mir.MirInstr = mir.instr(mir.MIR_ADD, nil, 0, 0, 0);
     var dst: [2]mir.MirInstr;
     var builder: ExpansionBuilder;
     builder.allocator = ?alloc;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3567,6 +3567,8 @@ var isa_vt: of.ObjectTarget = t_isa(isa.ARCH_X86_64);
     var text_bytes: [16]u8;
     var k: usize = 0;
     for (k < 16) { text_bytes[k] = (0xE8 + k)::u8; k = k + 1; }
+    bin.write_u32_le(?text_bytes[0], 1, 0);
+    bin.write_u64_le(?text_bytes[0], 8, 0);
     var data_bytes: [4]u8;
     data_bytes[0] = 0xDE; data_bytes[1] = 0xAD; data_bytes[2] = 0xBE; data_bytes[3] = 0xEF;
 
@@ -3643,7 +3645,7 @@ var isa_vt: of.ObjectTarget = t_isa(isa.ARCH_X86_64);
     for (k < 16) {
         var expected: u8 = (0xE8 + k)::u8;
         if ((k >= 1 && k < 5) || k >= 8) { expected = 0; }
-        if (out.sections[0].bytes[k] != expected || text_bytes[k] != (0xE8 + k)::u8) { ret 1; }
+        if (out.sections[0].bytes[k] != expected || text_bytes[k] != expected) { ret 1; }
         k = k + 1;
     }
     if (out.sections[2].bytes != nil) { ret 1; }
@@ -4411,6 +4413,8 @@ test "mach.lang.target.of.coff:defined_weak_comdat_round_trip" {
     var k: usize = 0;
     for (k < 16) { text_bytes[k] = (0x10 + k)::u8; k = k + 1; }
 
+    bin.write_u32_le(?text_bytes[0], 12, 0);
+
     var secs: [1]of.Section;
     secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
     secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
@@ -4499,7 +4503,8 @@ test "mach.lang.target.of.coff:defined_weak_comdat_round_trip" {
     var saw_reloc: bool = false;
     var rj: u32 = 0;
     for (rj < out.reloc_count) {
-        if (of.reloc_symbol_name(?out, ?out.relocations[rj]) == syms[2].name && out.relocations[rj].offset == 4) {
+        if (of.reloc_symbol_name(?out, ?out.relocations[rj]) == syms[2].name && out.relocations[rj].offset == 4
+            && out.relocations[rj].addend == -4) {
             var wsec: u32 = of.SECTION_EXTERNAL;
             var sj: u32 = 0;
             for (sj < out.symbol_count) {

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3589,7 +3589,7 @@ var isa_vt: of.ObjectTarget = t_isa(isa.ARCH_X86_64);
     var relocs: [2]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = of.RK_PC32;
     relocs[0].sym = 2; relocs[0].addend = -4;
-    relocs[1].section = 0; relocs[1].offset = 4; relocs[1].kind = of.RK_ABS64;
+    relocs[1].section = 0; relocs[1].offset = 8; relocs[1].kind = of.RK_ABS64;
     relocs[1].sym = 1; relocs[1].addend = 0;
 
     var img: of.ObjectImage;
@@ -3641,7 +3641,9 @@ var isa_vt: of.ObjectTarget = t_isa(isa.ARCH_X86_64);
     if (out.sections[0].bytes == nil) { ret 1; }
     k = 0;
     for (k < 16) {
-        if (out.sections[0].bytes[k] != (0xE8 + k)::u8) { ret 1; }
+        var expected: u8 = (0xE8 + k)::u8;
+        if ((k >= 1 && k < 5) || k >= 8) { expected = 0; }
+        if (out.sections[0].bytes[k] != expected || text_bytes[k] != (0xE8 + k)::u8) { ret 1; }
         k = k + 1;
     }
     if (out.sections[2].bytes != nil) { ret 1; }
@@ -3671,8 +3673,10 @@ var isa_vt: of.ObjectTarget = t_isa(isa.ARCH_X86_64);
     for (rj < out.reloc_count) {
         if (out.relocations[rj].section != 0) { ret 1; }
         if (out.relocations[rj].offset == 1 && out.relocations[rj].kind == of.RK_PC32
+            && out.relocations[rj].addend == -4
             && of.reloc_symbol_name(?out, ?out.relocations[rj]) == syms[2].name) { saw_pc32 = true; }
-        if (out.relocations[rj].offset == 4 && out.relocations[rj].kind == of.RK_ABS64
+        if (out.relocations[rj].offset == 8 && out.relocations[rj].kind == of.RK_ABS64
+            && out.relocations[rj].addend == 0
             && of.reloc_symbol_name(?out, ?out.relocations[rj]) == syms[1].name) { saw_abs64 = true; }
         rj = rj + 1;
     }
@@ -4312,6 +4316,9 @@ test "mach.lang.target.of.coff.read_inplace_addend:rel32_p4_convention" {
     if (R.is_err[Vector[u8], str](rb)) { ret 1; }
     val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
 
+    val raw: usize = bin.read_u32_le(buf.data, COFF_HEADER_SIZE + 20)::usize;
+    if (bin.read_u32_le(buf.data, raw + 1) != 4) { ret 1; }
+
     var out: of.ObjectImage;
     val pr: R.Result[R.Void, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
     if (R.is_err[R.Void, str](pr)) { ret 1; }
@@ -4322,7 +4329,7 @@ test "mach.lang.target.of.coff.read_inplace_addend:rel32_p4_convention" {
         if (out.relocations[rj].kind == of.RK_PC32 && out.relocations[rj].offset == 1) {
             saw = true;
             if (out.sections[0].bytes == nil)                   { ret 1; }
-            if (bin.read_u32_le(out.sections[0].bytes, 1) != 4) { ret 1; }
+            if (bin.read_u32_le(out.sections[0].bytes, 1) != 0) { ret 1; }
             if (out.relocations[rj].addend != 0) { ret 1; }
         }
         rj = rj + 1;
@@ -4381,7 +4388,7 @@ test "mach.lang.target.of.coff.coff_emit_object:unresolved_reloc_symbol" {
 
 
     if (!R.is_err[R.Void, str](em))                                   { ret 1; }
-    if (!str_contains(R.unwrap_err[R.Void, str](em), "unresolved symbol")) { ret 1; }
+    if (!str_contains(R.unwrap_err[R.Void, str](em), "of: object relocation refers to an absent symbol")) { ret 1; }
     ret 0;
 }
 
@@ -4474,7 +4481,9 @@ test "mach.lang.target.of.coff:defined_weak_comdat_round_trip" {
             if (wb == nil) { ret 1; }
             var wk: usize = 0;
             for (wk < 8) {
-                if (wb[wk] != (0x10 + 8 + wk)::u8) { ret 1; }
+                var expected: u8 = (0x18 + wk)::u8;
+                if (wk >= 4) { expected = 0; }
+                if (wb[wk] != expected) { ret 1; }
                 wk = wk + 1;
             }
         }
@@ -6662,6 +6671,14 @@ test "mach.lang.target.of.coff:comdat_selection_decides_weakness_on_read" {
     var si: usize = 0;
     for (si < 6) {
         buf.data[soff] = sels[si];
+        bin.write_u16_le(buf.data, soff - 2, 0);
+        if (sels[si] == IMAGE_COMDAT_SELECT_ASSOCIATIVE) {
+            var invalid: of.ObjectImage;
+            val rejected: R.Result[R.Void, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?invalid);
+            if (R.is_ok[R.Void, str](rejected)) { of.object_image_dnit(?invalid); ret 10; }
+            if (!str_equals(R.unwrap_err[R.Void, str](rejected), "coff: associative COMDAT section is out of range")) { ret 11; }
+            bin.write_u16_le(buf.data, soff - 2, 1);
+        }
         var out: of.ObjectImage;
         val pr: R.Result[R.Void, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
         if (R.is_err[R.Void, str](pr)) { ret 6; }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -3738,7 +3738,7 @@ var isa_vt: of.ObjectTarget = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, ?seam);
 
 
     if (!R.is_err[R.Void, str](em))                                   { ret 1; }
-    if (!str_contains(R.unwrap_err[R.Void, str](em), "unresolved symbol")) { ret 1; }
+    if (!str_contains(R.unwrap_err[R.Void, str](em), "of: object relocation refers to an absent symbol")) { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
The v5 tagged-value and failure-control rules were still recorded as unapproved proposals. Publish the owner-approved contract for tag, res[T, E], opt[T], distinct err[E] and explicit try/or failure exits, including representation, refinement, secrecy and coordinated bootstrap migration.

Each canonical type has one fixed generic arity. The err[E] type represents payloadless success or a typed error, using the same ok/err cases and failure handling as res[T, E].

Validation: reviewed against the accepted syntax examples and checked the diff for whitespace errors. This documents the implementation contract and does not claim language support in the current compiler.

Closes #3217
