### PR TITLE
test: restore object and MIR validation fixtures

### DIFF
--- a/src/lang/be/codegen/rules.mach
+++ b/src/lang/be/codegen/rules.mach
@@ -1281,7 +1281,7 @@ test "mach.lang.be.codegen.rules.emit:new_registers_require_explicit_bank_constr
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
     var f: mir.MirFunction;
-    var source: mir.MirInstr;
+    var source: mir.MirInstr = mir.instr(mir.MIR_ADD, nil, 0, 0, 0);
     var dst: [2]mir.MirInstr;
     var builder: ExpansionBuilder;
     builder.allocator = ?alloc;

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3567,6 +3567,8 @@ var isa_vt: of.ObjectTarget = t_isa(isa.ARCH_X86_64);
     var text_bytes: [16]u8;
     var k: usize = 0;
     for (k < 16) { text_bytes[k] = (0xE8 + k)::u8; k = k + 1; }
+    bin.write_u32_le(?text_bytes[0], 1, 0);
+    bin.write_u64_le(?text_bytes[0], 8, 0);
     var data_bytes: [4]u8;
     data_bytes[0] = 0xDE; data_bytes[1] = 0xAD; data_bytes[2] = 0xBE; data_bytes[3] = 0xEF;
 
@@ -3643,7 +3645,7 @@ var isa_vt: of.ObjectTarget = t_isa(isa.ARCH_X86_64);
     for (k < 16) {
         var expected: u8 = (0xE8 + k)::u8;
         if ((k >= 1 && k < 5) || k >= 8) { expected = 0; }
-        if (out.sections[0].bytes[k] != expected || text_bytes[k] != (0xE8 + k)::u8) { ret 1; }
+        if (out.sections[0].bytes[k] != expected || text_bytes[k] != expected) { ret 1; }
         k = k + 1;
     }
     if (out.sections[2].bytes != nil) { ret 1; }
@@ -4411,6 +4413,8 @@ test "mach.lang.target.of.coff:defined_weak_comdat_round_trip" {
     var k: usize = 0;
     for (k < 16) { text_bytes[k] = (0x10 + k)::u8; k = k + 1; }
 
+    bin.write_u32_le(?text_bytes[0], 12, 0);
+
     var secs: [1]of.Section;
     secs[0].name = t_intern(?i, ".text"); secs[0].kind = of.SK_TEXT;
     secs[0].bytes = ?text_bytes[0]; secs[0].len = 16; secs[0].align = 16;
@@ -4499,7 +4503,8 @@ test "mach.lang.target.of.coff:defined_weak_comdat_round_trip" {
     var saw_reloc: bool = false;
     var rj: u32 = 0;
     for (rj < out.reloc_count) {
-        if (of.reloc_symbol_name(?out, ?out.relocations[rj]) == syms[2].name && out.relocations[rj].offset == 4) {
+        if (of.reloc_symbol_name(?out, ?out.relocations[rj]) == syms[2].name && out.relocations[rj].offset == 4
+            && out.relocations[rj].addend == -4) {
             var wsec: u32 = of.SECTION_EXTERNAL;
             var sj: u32 = 0;
             for (sj < out.symbol_count) {

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -3589,7 +3589,7 @@ var isa_vt: of.ObjectTarget = t_isa(isa.ARCH_X86_64);
     var relocs: [2]of.Relocation;
     relocs[0].section = 0; relocs[0].offset = 1; relocs[0].kind = of.RK_PC32;
     relocs[0].sym = 2; relocs[0].addend = -4;
-    relocs[1].section = 0; relocs[1].offset = 4; relocs[1].kind = of.RK_ABS64;
+    relocs[1].section = 0; relocs[1].offset = 8; relocs[1].kind = of.RK_ABS64;
     relocs[1].sym = 1; relocs[1].addend = 0;
 
     var img: of.ObjectImage;
@@ -3641,7 +3641,9 @@ var isa_vt: of.ObjectTarget = t_isa(isa.ARCH_X86_64);
     if (out.sections[0].bytes == nil) { ret 1; }
     k = 0;
     for (k < 16) {
-        if (out.sections[0].bytes[k] != (0xE8 + k)::u8) { ret 1; }
+        var expected: u8 = (0xE8 + k)::u8;
+        if ((k >= 1 && k < 5) || k >= 8) { expected = 0; }
+        if (out.sections[0].bytes[k] != expected || text_bytes[k] != (0xE8 + k)::u8) { ret 1; }
         k = k + 1;
     }
     if (out.sections[2].bytes != nil) { ret 1; }
@@ -3671,8 +3673,10 @@ var isa_vt: of.ObjectTarget = t_isa(isa.ARCH_X86_64);
     for (rj < out.reloc_count) {
         if (out.relocations[rj].section != 0) { ret 1; }
         if (out.relocations[rj].offset == 1 && out.relocations[rj].kind == of.RK_PC32
+            && out.relocations[rj].addend == -4
             && of.reloc_symbol_name(?out, ?out.relocations[rj]) == syms[2].name) { saw_pc32 = true; }
-        if (out.relocations[rj].offset == 4 && out.relocations[rj].kind == of.RK_ABS64
+        if (out.relocations[rj].offset == 8 && out.relocations[rj].kind == of.RK_ABS64
+            && out.relocations[rj].addend == 0
             && of.reloc_symbol_name(?out, ?out.relocations[rj]) == syms[1].name) { saw_abs64 = true; }
         rj = rj + 1;
     }
@@ -4312,6 +4316,9 @@ test "mach.lang.target.of.coff.read_inplace_addend:rel32_p4_convention" {
     if (R.is_err[Vector[u8], str](rb)) { ret 1; }
     val buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
 
+    val raw: usize = bin.read_u32_le(buf.data, COFF_HEADER_SIZE + 20)::usize;
+    if (bin.read_u32_le(buf.data, raw + 1) != 4) { ret 1; }
+
     var out: of.ObjectImage;
     val pr: R.Result[R.Void, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
     if (R.is_err[R.Void, str](pr)) { ret 1; }
@@ -4322,7 +4329,7 @@ test "mach.lang.target.of.coff.read_inplace_addend:rel32_p4_convention" {
         if (out.relocations[rj].kind == of.RK_PC32 && out.relocations[rj].offset == 1) {
             saw = true;
             if (out.sections[0].bytes == nil)                   { ret 1; }
-            if (bin.read_u32_le(out.sections[0].bytes, 1) != 4) { ret 1; }
+            if (bin.read_u32_le(out.sections[0].bytes, 1) != 0) { ret 1; }
             if (out.relocations[rj].addend != 0) { ret 1; }
         }
         rj = rj + 1;
@@ -4381,7 +4388,7 @@ test "mach.lang.target.of.coff.coff_emit_object:unresolved_reloc_symbol" {
 
 
     if (!R.is_err[R.Void, str](em))                                   { ret 1; }
-    if (!str_contains(R.unwrap_err[R.Void, str](em), "unresolved symbol")) { ret 1; }
+    if (!str_contains(R.unwrap_err[R.Void, str](em), "of: object relocation refers to an absent symbol")) { ret 1; }
     ret 0;
 }
 
@@ -4474,7 +4481,9 @@ test "mach.lang.target.of.coff:defined_weak_comdat_round_trip" {
             if (wb == nil) { ret 1; }
             var wk: usize = 0;
             for (wk < 8) {
-                if (wb[wk] != (0x10 + 8 + wk)::u8) { ret 1; }
+                var expected: u8 = (0x18 + wk)::u8;
+                if (wk >= 4) { expected = 0; }
+                if (wb[wk] != expected) { ret 1; }
                 wk = wk + 1;
             }
         }
@@ -6662,6 +6671,14 @@ test "mach.lang.target.of.coff:comdat_selection_decides_weakness_on_read" {
     var si: usize = 0;
     for (si < 6) {
         buf.data[soff] = sels[si];
+        bin.write_u16_le(buf.data, soff - 2, 0);
+        if (sels[si] == IMAGE_COMDAT_SELECT_ASSOCIATIVE) {
+            var invalid: of.ObjectImage;
+            val rejected: R.Result[R.Void, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?invalid);
+            if (R.is_ok[R.Void, str](rejected)) { of.object_image_dnit(?invalid); ret 10; }
+            if (!str_equals(R.unwrap_err[R.Void, str](rejected), "coff: associative COMDAT section is out of range")) { ret 11; }
+            bin.write_u16_le(buf.data, soff - 2, 1);
+        }
         var out: of.ObjectImage;
         val pr: R.Result[R.Void, str] = coff_parse_object(?alloc, ?i, buf.data, buf.len, ?out);
         if (R.is_err[R.Void, str](pr)) { ret 6; }

--- a/src/lang/target/of/elf.mach
+++ b/src/lang/target/of/elf.mach
@@ -3738,7 +3738,7 @@ var isa_vt: of.ObjectTarget = t_isa(isa.ARCH_X86_64, EM_X86_64::u32, ?seam);
 
 
     if (!R.is_err[R.Void, str](em))                                   { ret 1; }
-    if (!str_contains(R.unwrap_err[R.Void, str](em), "unresolved symbol")) { ret 1; }
+    if (!str_contains(R.unwrap_err[R.Void, str](em), "of: object relocation refers to an absent symbol")) { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
Restore the seven self-test failures exposed by the landed native-object normalization change and the MIR construction census.

COFF round trips now use separate relocation fields with canonical placeholder bytes, check extracted addends and cleared imported fields, and retain the raw REL32 encoding check. The COMDAT fixture supplies an association target and separately verifies rejection of a missing target. ELF and COFF absent-symbol tests check the shared validator diagnostic. The expansion fixture constructs its source instruction through `mir.instr`.

Validation: all 2,608 compiler tests pass in both debug and release on Linux x86_64 from detached commit `4bffbd12`, using the retained 4.30.0 compiler and std 1.0.1. Cross-platform CI remains required.

Follow-up to #3119. Unblocks the baseline checks for #3217.
