### PR TITLE
docs(release): reconcile v5 gates and policy decisions

### DIFF
--- a/doc/design/dependency-model.md
+++ b/doc/design/dependency-model.md
@@ -130,8 +130,9 @@ An earlier design proposed selecting the highest same-major tagged release above
 every tested commit. That proposal is not an accepted v5 contract. A tested
 commit establishes neither an ordering constraint nor permission to substitute
 later releases. The [release contract reconciliation](v5-release-contract.md)
-presents explicit selection for the owner's decision. Until that decision, the
-manual rule above remains the implementation baseline.
+records the owner-approved explicit-selection policy. The manual rule above is
+the v5 contract. Compatibility ranges may be revisited through a separate
+decision if practical use exposes productivity blockers.
 
 Selectors are `branch/<name>`, `tag/<name>`, and `commit/<full-object-id>`,
 and nothing else: a bare name that git would guess at is exactly the
@@ -154,7 +155,8 @@ gets the legacy `lib.mach` entry under its source directory. The current v5 cand
 that fallback. A bare dependency import needs an unambiguous entry selected by
 explicitly defaulted library artifacts. Multiple defaults may share one entry.
 Full-module imports remain available without a default artifact, including for
-source-only dependencies. G1 requests confirmation of that existing rule.
+source-only dependencies. The owner approved this rule for v5. It may be revisited if practical use exposes
+productivity blockers.
 
 Three things fit the five statements without changing them and are named as
 future slots rather than built: owner-prefixed (dotted) ids if the flat id

--- a/doc/design/dependency-model.md
+++ b/doc/design/dependency-model.md
@@ -22,15 +22,15 @@ repairs were all of the shape "detect the drift and re-resolve", which is
 exactly the work a build must never do.
 
 Git already has a first-class record of "this directory is at this commit":
-the gitlink a superproject commits for a submodule. Making the gitlink the
-pin removes the second record entirely. A dependency's commit is whatever the
-root repository committed for `dep/<id>`; `.gitmodules` is generated from the
-manifest, never read for pins; and nothing generated is an authority. The
-cost is that a project's source distribution is a git clone — a tree without
-`.git` does not build, and verification never degrades in its absence. That
-cost was accepted deliberately: a tarball release that carried a generated
-pin record would reintroduce the second record, so it is a separate ruling if
-it is ever wanted.
+the gitlink a superproject commits for a submodule. In a Git-managed root, the
+staged gitlink is authoritative, so newly realized dependencies can be verified
+before committing. There is no compiler-managed lock file. `.gitmodules`
+registers native submodules and does not provide a second pin authority.
+
+Project roots are identified by their own `mach.toml`. A standalone project or a
+project nested inside an unrelated repository validates dependencies from its
+own realized checkouts. It does not borrow an enclosing repository's dependency
+directory. The command reference describes these authority modes.
 
 ## The root owns a flat closure
 
@@ -43,7 +43,7 @@ has to be re-pinned at every level between it and the root.
 The flat model puts every identity in the transitive closure directly under
 the root's `dep/`, one gitlink each, exactly one level deep. A consumed
 dependency's own `dep/` is never initialized: its gitlinks are still readable
-(they are its tested floors, below) but they are inputs to the root's
+(they are its tested commits, below) but they are inputs to the root's
 closure computation, not checkouts. A package cloned on its own is a root and
 gets its own flat `dep/`. The root manifest declares only direct dependencies
 and overrides; everything transitive reaches `dep/` through closure
@@ -107,7 +107,7 @@ committed gitlink out at its commit, initializing in place the empty
 directory a plain clone leaves for a submodule, and no git command ever runs
 against a gitlink that is not yet a checkout of its own. A consumed
 dependency's gitlinks show up as empty directories under its own `dep/`; they
-are read as its tested floors and are otherwise ignored.
+are read as its tested commits and are otherwise ignored.
 
 A project root is identified by its own `mach.toml`, not by an enclosing
 repository, and `dep/<id>` resolves relative to that root. This was not
@@ -123,15 +123,15 @@ identity reached by more than one path the manual rule is: the root's
 selector wins if declared; otherwise agreement among the requirers is
 taken; otherwise stop, print both chains, and name the root declaration that
 would decide. A consumed dependency's own gitlink for an identity is its
-tested floor — the commit that package was tested against — and it is
+tested commit — the commit that package was tested against — and it is
 readable without initializing that package's `dep/`.
 
-5.0.0 adds a SemVer proposal on top of the manual rule, not in place of it:
-among tagged releases at or above every tested floor and within one major,
-propose the highest; candidates spanning two majors are a clash under the
-one-commit rule. The proposal never bypasses a root override. It is a
-separate commit after the manual rule because the manual rule is its
-fallback, and the fallback has to work first.
+An earlier design proposed selecting the highest same-major tagged release above
+every tested commit. That proposal is not an accepted v5 contract. A tested
+commit establishes neither an ordering constraint nor permission to substitute
+later releases. The [release contract reconciliation](v5-release-contract.md)
+presents explicit selection for the owner's decision. Until that decision, the
+manual rule above remains the implementation baseline.
 
 Selectors are `branch/<name>`, `tag/<name>`, and `commit/<full-object-id>`,
 and nothing else: a bare name that git would guess at is exactly the
@@ -150,8 +150,11 @@ ids they consume; there is no scope vocabulary (no "dev" or "test"
 dependencies), because a scope is a property of the consumer, and the
 consumer already says what it consumes. Public entry is the module a
 dependency's artifacts share. In 4.30.0, a dependency with no artifacts still
-gets the legacy `lib.mach` entry under its source directory. 5.0.0 removes
-that fallback and requires an explicitly defaulted library artifact.
+gets the legacy `lib.mach` entry under its source directory. The current v5 candidate removes
+that fallback. A bare dependency import needs an unambiguous entry selected by
+explicitly defaulted library artifacts. Multiple defaults may share one entry.
+Full-module imports remain available without a default artifact, including for
+source-only dependencies. G1 requests confirmation of that existing rule.
 
 Three things fit the five statements without changing them and are named as
 future slots rather than built: owner-prefixed (dotted) ids if the flat id

--- a/doc/design/release-shape.md
+++ b/doc/design/release-shape.md
@@ -78,8 +78,8 @@ migration. The linked issues contain their acceptance criteria. Remaining syntax
 and representation choices are design work, not declarations of implemented
 features.
 
-Dependency version selection remains an explicit decision in the
-[coordinator reconciliation](v5-release-contract.md).
+Dependency version selection follows the explicit-selector policy approved in
+the [coordinator reconciliation](v5-release-contract.md).
 A tested dependency commit is evidence of testing, not an automatic promise of
 compatibility with every later release. The earlier SemVer proposal is not an
 accepted implementation contract.

--- a/doc/design/release-shape.md
+++ b/doc/design/release-shape.md
@@ -41,7 +41,7 @@ pin in both optimization profiles on the required native hosts.
 The audited 4.30.0 implementation is the starting seed for v5. The new tagged-value and
 failure-control features must be implemented in a usable compiler before its
 own source and std migrate. Their design issue specifies the pinned intermediate
-bootstrap and migration order. Building that implementation does not make it understand new v5 syntax.
+bootstrap and migration order. The audited seed itself does not understand the new v5 syntax.
 
 ## What is on each side
 
@@ -71,14 +71,15 @@ Removed, in 5.0.0:
   ([migration issue](https://github.com/briar-systems/mach/issues/3226)).
 - the implicit `lib.mach` entry for a dependency that declares no artifacts.
 
-V5 also includes checked `tag` values, canonical `res`/`opt`, expression-level
+V5 also includes checked `tag` values, canonical `res`/`opt`/`err`, expression-level
 `try` with explicit failure exits, query ownership and persistent compilation
 caching, the approved manifest and command changes, and the coordinated std
 migration. The linked issues contain their acceptance criteria. Remaining syntax
 and representation choices are design work, not declarations of implemented
 features.
 
-Dependency version selection remains an explicit decision in the coordinator.
+Dependency version selection remains an explicit decision in the
+[coordinator reconciliation](v5-release-contract.md).
 A tested dependency commit is evidence of testing, not an automatic promise of
 compatibility with every later release. The earlier SemVer proposal is not an
 accepted implementation contract.

--- a/doc/design/v5-release-contract.md
+++ b/doc/design/v5-release-contract.md
@@ -1,0 +1,149 @@
+# V5 release contract reconciliation
+
+This records G1 of the local execution roadmap under [#3112](https://github.com/briar-systems/mach/issues/3112).
+It distinguishes owner decisions, implementation evidence and release acceptance.
+The source inspected for the v5 candidate is
+[`c8e4d2bf`](https://github.com/briar-systems/mach/tree/c8e4d2bf04066a033e42e84c23590c7e6528ddd9).
+A registered capability does not establish that its final v5 acceptance passed.
+
+## Decisions awaiting the owner
+
+### Dependency selection
+
+Proposed v5 contract: retain explicit selection and do not introduce automatic
+SemVer upgrades. The root owns one realized commit per project identity and may
+override a dependency's selector, including with a fork carrying that identity.
+Without a root override, requirers must agree. Conflicts name the requiring
+chains and the root declaration that resolves the conflict.
+
+Selectors remain `branch/<name>`, `tag/<name>` and `commit/<full-object-id>`.
+Update resolves moving selectors and records the selected commit. Build verifies
+local state without fetching or updating it. A branch tip is an update input,
+not an offline verification requirement. Exact selectors retain their exactness.
+
+A dependency's gitlink records what it was tested against. It establishes no
+version interval, ancestry-based compatibility promise or minimum compatible
+release. A future range-selection policy would require an explicit range
+contract rather than inferring permission from a tested commit.
+
+The existing dependency design and manifest prose describe an automatic SemVer
+proposal. That proposal is not accepted by #3112 and must not drive implementation
+until the owner decides. F3 owns reconciliation of the final selector contract
+with update, verification and conflict diagnostics.
+
+### Library public entry
+
+Proposed v5 contract: preserve the current candidate's unambiguous-entry rule.
+A bare dependency import uses the entry of an explicitly defaulted `static` or
+`shared` artifact. Multiple default library artifacts are permitted when they
+name the same entry. Executable entries and nondefault libraries do not select
+that public module. An absent or ambiguous public entry rejects the bare import.
+
+Explicit full-module imports remain usable without a default artifact, including
+for source-only dependencies. There is no implicit `lib.mach` fallback. A sole
+library artifact must still declare `default = true` to supply a bare import.
+This is one public entry, not necessarily one library artifact.
+
+Candidate evidence: `manifest.canonical_module` and the public-entry cases in
+`src/lang/driver/tests.mach`. F3 owns final manifest and dependency acceptance.
+
+### SPIR-V boundary
+
+Proposed v5 contract: retain finished-module emission, the four declared Vulkan
+environments and the existing unqualified environment. Debug requests are
+explicitly refused. No GPU execution or GPU runtime support is claimed.
+
+| Environment | Module version |
+|---|---|
+| `vulkan1.0` | SPIR-V 1.0 |
+| `vulkan1.1` | SPIR-V 1.3 |
+| `vulkan1.2` | SPIR-V 1.5 |
+| `vulkan1.3` | SPIR-V 1.6 |
+| No `env` | SPIR-V 1.6 without the named environment's capability ceiling |
+
+These are compiler profile declarations, not a promise that every device enables
+all optional features within that profile. Required capabilities must be visible
+in the emitted module. Unknown environments and unsupported requirements fail
+explicitly. External validation must use the corresponding consumer environment.
+An unqualified module is not implicitly a Vulkan-compatible module.
+
+The artifact is a tree of complete `.spv` modules with no native link phase.
+Static/shared artifacts and `mach test` are refused for this emission shape.
+N4 owns existing value ABI and pointer-to-record acceptance, L6 owns tagged-value
+transport, N5 owns final secrecy guarantees, and R1 owns exact-source module and
+refusal checks. A missing implementation inside this boundary remains required
+work. It cannot be reclassified as unsupported just to make a test pass.
+
+## Retained target matrix
+
+This is the release scope, with the proposed SPIR-V debug boundary above still
+awaiting the owner. N1 and R1 must reconcile every advertised tuple against the
+registry and test coverage. Artifact support follows the selected format and ABI,
+not the Cartesian product of accepted manifest words.
+
+| Family | OS and ABI | Output scope | Debug scope | Acceptance evidence required |
+|---|---|---|---|---|
+| x86-64 | Linux, `sysv64` | ELF executable, archive, relocatable and supported dynamic forms | DWARF | Native execution, C/object interoperability, debug and release fixpoints |
+| AArch64 | Linux, `aapcs64` | ELF executable, archive, relocatable and supported dynamic forms | DWARF | Native ARM execution and ABI evidence, including page-size assumptions |
+| x86-64 | Windows, `win64` | PE/COFF executable, archive, relocatable and supported shared forms | Explicit refusal in current registry | Native Windows execution and PE/COFF interoperability |
+| x86-64 | Darwin, `sysv64` | Mach-O executable, archive, relocatable and supported dynamic forms | DWARF | Native Intel macOS release gate, with PR decode coverage |
+| AArch64 | Darwin, `aapcs64` | Mach-O executable, archive, relocatable and supported dynamic forms | DWARF | Native ARM macOS release gate, signing and ABI checks, with PR decode coverage |
+| RV64 | Linux or freestanding, `lp64`, `lp64f`, `lp64d` compatible with selected ISA | ELF and freestanding raw forms as declared | DWARF for ELF, refusal for raw | ISA/ABI conformance and independent objects, with qemu execution bounded to compute evidence |
+| RV32 | Freestanding, `ilp32`, `ilp32f`, `ilp32d` compatible with selected ISA | Static/relocatable ELF and freestanding static images | DWARF for ELF, refusal for raw | Independent ELF32, relocations, ISA and ABI evidence, no claimed hosted execution |
+| Native freestanding | x86-64 or AArch64 with their matching ABI | Raw images or declared ELF forms, caller-supplied runtime | DWARF for ELF, refusal for raw | Format and selected-machine conformance, no implicit OS services |
+| SPIR-V | Freestanding, `spirv`, environment table above | Finished `.spv` module tree | Proposed explicit refusal | Independent `spirv-val` and decoding, no execution claim |
+
+RISC-V retains the declared I/M/A/F/D/C/Zicsr/Zifencei vocabulary and supported
+versions. ABI floating-point requirements must fit the selected machine.
+Recognizing C does not imply that the emitter generates compressed instructions.
+RV32 dynamic output and E-base machines remain post-v5 under #2894 and #2859.
+Android and MOS 6502 remain withdrawn. Specialized widening integer matmul is
+post-v5 under std #390. Runner names and tool pins remain owned by
+`test/engines.conf` and `test/tools.lock` rather than this prose.
+
+## Enforced CI checks
+
+On 2026-09-08 the dev ruleset was reconciled with emitted checks. It requires:
+
+- Build, test and release for x86-64 Linux, AArch64 Linux and x86-64 Windows.
+- Incremental checks for x86-64 Linux and AArch64 Linux.
+- `test legs` and `targets on ubuntu-latest`, `targets on ubuntu-24.04-arm`, and
+  `targets on windows-latest`.
+- `link pinned (linux)` and `changelog headings`.
+
+These seventeen checks replace the old eleven native requirements plus five
+obsolete `int ...` names. The current target jobs run the codegen and link suites.
+Main requires the same seventeen plus
+`darwin (release gate) / build aarch64-darwin` and
+`darwin (release gate) / build x86_64-darwin`. Each Darwin build depends on its seed
+and performs a native fixpoint and self-test. Exact names were checked against
+[release PR #3107](https://github.com/briar-systems/mach/pull/3107).
+
+Review counts, history protection and admin bypass settings were preserved.
+Required checks must be actual successful checks, not absent or skipped results.
+A workflow rename requires a corresponding ruleset reconciliation.
+
+[Run 34280862248](https://github.com/briar-systems/mach/actions/runs/34280862248)
+passed on dev `143bc0ba`. A later run on the same source,
+[34288169859](https://github.com/briar-systems/mach/actions/runs/34288169859),
+failed when the Windows seed checksum download connection was reset. This was
+before compiler bootstrap. One failed-job rerun was requested. Its outcome must
+be recorded separately from the original failure.
+
+## Bootstrap and completion
+
+Public Mach 4.30 remains withdrawn. The source chain in
+[bootstrap.md](../tooling/bootstrap.md) starts with published 4.26.5, builds the
+main-reachable bridge `878a8f66` and audited source `b65afb97`, and verifies a B/C
+byte fixpoint with immutable std 1.0.1. Historical statements requiring public
+4.30 publication do not override this chain.
+
+The tagged-value design #3217 and register-bank verifier #3117 are closed.
+Their implementation successors and the v5 release remain open. The new language
+must produce a pinned usable compiler before compiler/std source migration.
+Final Mach 5.0.0 and std 2.0.0 require their own exact-source acceptance.
+
+G1 completes when the three owner decisions above are recorded, conflicting
+reference prose is reconciled, and downstream issue owners have the resulting
+contracts. This document does not close implementation issues or certify the
+current candidate as a finished release.

--- a/doc/design/v5-release-contract.md
+++ b/doc/design/v5-release-contract.md
@@ -6,11 +6,16 @@ The source inspected for the v5 candidate is
 [`c8e4d2bf`](https://github.com/briar-systems/mach/tree/c8e4d2bf04066a033e42e84c23590c7e6528ddd9).
 A registered capability does not establish that its final v5 acceptance passed.
 
-## Decisions awaiting the owner
+## Current v5 decisions
+
+The owner approved these decisions on 2026-09-08 as the path forward for v5.
+Dependency selection and public entry may be revisited if practical use exposes
+productivity blockers. That possibility does not leave the current contract
+undecided or authorize implementations to substitute a different policy.
 
 ### Dependency selection
 
-Proposed v5 contract: retain explicit selection and do not introduce automatic
+Accepted v5 contract: retain explicit selection and do not introduce automatic
 SemVer upgrades. The root owns one realized commit per project identity and may
 override a dependency's selector, including with a fork carrying that identity.
 Without a root override, requirers must agree. Conflicts name the requiring
@@ -26,14 +31,13 @@ version interval, ancestry-based compatibility promise or minimum compatible
 release. A future range-selection policy would require an explicit range
 contract rather than inferring permission from a tested commit.
 
-The existing dependency design and manifest prose describe an automatic SemVer
-proposal. That proposal is not accepted by #3112 and must not drive implementation
-until the owner decides. F3 owns reconciliation of the final selector contract
-with update, verification and conflict diagnostics.
+The earlier automatic SemVer proposal is superseded by this explicit-selection
+contract. F3 owns acceptance of update, verification and conflict diagnostics
+against that contract. Any future range policy needs a separate explicit decision.
 
 ### Library public entry
 
-Proposed v5 contract: preserve the current candidate's unambiguous-entry rule.
+Accepted v5 contract: preserve the current candidate's unambiguous-entry rule.
 A bare dependency import uses the entry of an explicitly defaulted `static` or
 `shared` artifact. Multiple default library artifacts are permitted when they
 name the same entry. Executable entries and nondefault libraries do not select
@@ -49,7 +53,7 @@ Candidate evidence: `manifest.canonical_module` and the public-entry cases in
 
 ### SPIR-V boundary
 
-Proposed v5 contract: retain finished-module emission, the four declared Vulkan
+Accepted v5 contract: retain finished-module emission, the four declared Vulkan
 environments and the existing unqualified environment. Debug requests are
 explicitly refused. No GPU execution or GPU runtime support is claimed.
 
@@ -76,8 +80,7 @@ work. It cannot be reclassified as unsupported just to make a test pass.
 
 ## Retained target matrix
 
-This is the release scope, with the proposed SPIR-V debug boundary above still
-awaiting the owner. N1 and R1 must reconcile every advertised tuple against the
+This is the release scope, including the accepted SPIR-V debug refusal above. N1 and R1 must reconcile every advertised tuple against the
 registry and test coverage. Artifact support follows the selected format and ABI,
 not the Cartesian product of accepted manifest words.
 
@@ -91,7 +94,7 @@ not the Cartesian product of accepted manifest words.
 | RV64 | Linux or freestanding, `lp64`, `lp64f`, `lp64d` compatible with selected ISA | ELF and freestanding raw forms as declared | DWARF for ELF, refusal for raw | ISA/ABI conformance and independent objects, with qemu execution bounded to compute evidence |
 | RV32 | Freestanding, `ilp32`, `ilp32f`, `ilp32d` compatible with selected ISA | Static/relocatable ELF and freestanding static images | DWARF for ELF, refusal for raw | Independent ELF32, relocations, ISA and ABI evidence, no claimed hosted execution |
 | Native freestanding | x86-64 or AArch64 with their matching ABI | Raw images or declared ELF forms, caller-supplied runtime | DWARF for ELF, refusal for raw | Format and selected-machine conformance, no implicit OS services |
-| SPIR-V | Freestanding, `spirv`, environment table above | Finished `.spv` module tree | Proposed explicit refusal | Independent `spirv-val` and decoding, no execution claim |
+| SPIR-V | Freestanding, `spirv`, environment table above | Finished `.spv` module tree | Explicit refusal | Independent `spirv-val` and decoding, no execution claim |
 
 RISC-V retains the declared I/M/A/F/D/C/Zicsr/Zifencei vocabulary and supported
 versions. ABI floating-point requirements must fit the selected machine.
@@ -127,8 +130,9 @@ A workflow rename requires a corresponding ruleset reconciliation.
 passed on dev `143bc0ba`. A later run on the same source,
 [34288169859](https://github.com/briar-systems/mach/actions/runs/34288169859),
 failed when the Windows seed checksum download connection was reset. This was
-before compiler bootstrap. One failed-job rerun was requested. Its outcome must
-be recorded separately from the original failure.
+before compiler bootstrap. The single failed-job rerun, attempt 2, subsequently
+passed. The original failure remains download-infrastructure evidence, not a
+compiler failure or a passing test attempt.
 
 ## Bootstrap and completion
 
@@ -143,7 +147,7 @@ Their implementation successors and the v5 release remain open. The new language
 must produce a pinned usable compiler before compiler/std source migration.
 Final Mach 5.0.0 and std 2.0.0 require their own exact-source acceptance.
 
-G1 completes when the three owner decisions above are recorded, conflicting
-reference prose is reconciled, and downstream issue owners have the resulting
-contracts. This document does not close implementation issues or certify the
+G1 records the three approved decisions, reconciled reference prose and CI
+requirements. Downstream implementation owners remain responsible for acceptance
+against these contracts. This document does not close implementation issues or certify the
 current candidate as a finished release.

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -999,11 +999,11 @@ more than one path, one rule decides: the root's selector wins if the root
 declares the identity; otherwise agreement among the requirers is taken;
 otherwise the command stops, prints both chains, and names the root
 declaration that would decide (the diagnostic above). A consumed
-dependency's own gitlink for an identity is its tested floor, readable
-without initializing that dependency's `dep/`. 5.0.0 adds a SemVer proposal on
-top: among tagged releases at or above every tested floor and within one
-major, the highest is proposed; candidates spanning two majors are a clash.
-The proposal never bypasses a root override.
+dependency's own gitlink records a tested commit, readable without initializing
+that dependency's `dep/`. It is not an automatic compatibility floor. The earlier
+proposal to select the highest same-major release is not accepted for v5.
+[The coordinator decision](design/v5-release-contract.md#dependency-selection)
+must settle selection policy before that behavior is implemented.
 
 ### 4.30.0 and 5.0.0
 

--- a/doc/manifest.md
+++ b/doc/manifest.md
@@ -1002,8 +1002,9 @@ declaration that would decide (the diagnostic above). A consumed
 dependency's own gitlink records a tested commit, readable without initializing
 that dependency's `dep/`. It is not an automatic compatibility floor. The earlier
 proposal to select the highest same-major release is not accepted for v5.
-[The coordinator decision](design/v5-release-contract.md#dependency-selection)
-must settle selection policy before that behavior is implemented.
+[The approved coordinator decision](design/v5-release-contract.md#dependency-selection)
+retains explicit selection for v5. Future compatibility-range selection requires
+a separate decision.
 
 ### 4.30.0 and 5.0.0
 


### PR DESCRIPTION
The v5 references described an unaccepted automatic SemVer policy and mixed withdrawn public-bootstrap wording with the retained source bootstrap. This change records the owner-approved v5 decisions and reconciles those references.

Dependency updates use explicit selectors with root overrides and conflict reporting. Bare dependency imports require one unambiguous entry selected by default library artifacts, allowing static/shared defaults to share an entry. SPIR-V retains the declared environments and module output with explicit debug refusal. Dependency selection and public entry may be revisited if practical use reveals productivity blockers.

The release matrix records target, ABI, environment, artifact and debug scope separately from implementation acceptance. GitHub branch protection now requires the current 17 CI checks on dev and those checks plus both native Darwin release gates on main. Review and history protection remain intact. Part of #3112, which stays open until release acceptance.

Validation: 25 relative documentation links resolved and whitespace checks passed. Required context names were checked against actual emitted checks. Ruleset comparison verified that only required context lists changed. The previous Windows seed-download connection reset passed on its single rerun. No compiler code changed and no new local full suite was run.
