### PR TITLE
docs(design): revise tagged values to sel tests and lexical guards (#3217)

### DIFF
--- a/doc/design/tagged-values.md
+++ b/doc/design/tagged-values.md
@@ -160,6 +160,11 @@ a payload does not pin a case or extend a lifetime. No borrow checker, proof
 analysis or runtime validator is introduced. A debug-profile discriminator trap
 on payload access is an open owner decision and not part of this contract.
 
+Assignment evaluates and captures its RHS before evaluating its destination,
+so a replacement initializer may read the old selected payload before
+overwriting it. Historical #469/#494 chose LHS-first. The accepted v5 rule is
+RHS-first and preserves the audited 4.30 behavior.
+
 Guards obey ordinary scoping. A guard opened in a loop body is re-established on
 every iteration by the chain that opens it. `fin` blocks and cleanup order are
 unchanged; an exit inside a guarded block follows the existing `fin` rules.

--- a/doc/design/tagged-values.md
+++ b/doc/design/tagged-values.md
@@ -117,10 +117,11 @@ the chain. Arms of such a chain are conditions of the form `sel P.c` or
 for the rest of the block. A tag with more cases is guarded for the one case the
 chain leaves untested, and for nothing when more than one case remains.
 
-No other condition opens a guard. A compound condition such as
-`sel r.ok && r.ok > 3` is rejected because `r.ok` is read outside a guard.
-Nest instead. Allowing the left operand of `&&` to guard its right operand is
-an additive later decision.
+Inside a condition, the right operand of `&&` is guarded by a `sel P.c` that is
+its left operand, because `&&` short-circuits and the operand is a place. The
+guard covers only that right operand, not the block, unless the whole condition
+is exactly `sel P.c`. `sel r.ok && r.ok > 3` is therefore legal. `||`, `!`
+and any other operator open no guard. Nothing else opens a guard.
 
 ```mach
 fun increment(input: str) res[i64, ParseError] {
@@ -157,8 +158,10 @@ call is the programmer's obligation under the ordinary raw-memory rules, exactly
 as for any pointer today. A payload read whose case is no longer selected is
 undefined behavior of the same class as a stale pointer read. A raw pointer to
 a payload does not pin a case or extend a lifetime. No borrow checker, proof
-analysis or runtime validator is introduced. A debug-profile discriminator trap
-on payload access is an open owner decision and not part of this contract.
+analysis or runtime validator is introduced. In the debug profile only, each
+guarded payload access compares the discriminator and traps on mismatch, in
+the same class as the existing division trap. The release profile emits no
+check. Both profiles accept and reject the same programs.
 
 Assignment evaluates and captures its RHS before evaluating its destination,
 so a replacement initializer may read the old selected payload before
@@ -303,7 +306,9 @@ val wrong: Reply = Reply.value;          # rejected, selector is not a value
 val bad: Reply = Reply{value: 1};        # rejected, record literal form
 
 val n: i64 = r.ok;                       # rejected outside a guard
-if (sel r.ok && r.ok > 3) { }            # rejected, compound condition guards nothing
+if (sel r.ok && r.ok > 3) { }            # accepted, the right operand is guarded
+if (r.ok > 3 && sel r.ok) { }            # rejected, the read precedes the test
+if (sel r.ok || r.ok > 3) { }            # rejected, || opens no guard
 
 if (sel r.err) { log(r.err); }
 val m: i64 = r.ok;                       # rejected, the arm does not exit

--- a/doc/design/tagged-values.md
+++ b/doc/design/tagged-values.md
@@ -1,191 +1,182 @@
 # Mach v5 tagged values and explicit failure control
 
-Accepted by the owner on 2026-09-08 for #3217. This is the normative implementation
-contract for #3218 and #3219. The existing compiler does not implement these forms.
+Accepted by the owner on 2026-09-09 for #3217, superseding the 2026-09-08
+revision. This is the normative implementation contract for #3218 and #3219.
+The earlier revision's flow-sensitive proof analysis, `try` expression and
+compiler-known canonical types are withdrawn. The representation, reflection
+and secrecy contracts are carried forward unchanged.
 
-The canonical types are `res[T, E]`, `opt[T]` and distinct `err[E]`. Each has one
-fixed generic arity. `err[E]` represents payloadless success or an error of type E
-and uses the same explicit failure handling as `res[T, E]`.
+The language surface is five things: `tag` declarations with an explicit
+discriminator, `Type.case{...}` construction, `value.case` payload places under
+a lexical guard, `sel` as the case test, and `def` at function scope. None of
+them is flow-sensitive.
 
-## Types and construction
+## Types and declaration
 
-`tag` uses the existing aggregate declaration and generic-parameter conventions.
-A case has a name and either one explicitly typed payload or no payload. Multiple
-values use an ordinary record payload. Empty tags and duplicate case names are
-rejected.
+`tag` uses the existing aggregate declaration and generic-parameter conventions
+and declares its discriminator type explicitly. A case has a name and either one
+explicitly typed payload or no payload. Multiple values use an ordinary record
+payload. Empty tags, duplicate case names, and a discriminator type that cannot
+represent every case ordinal are rejected. The discriminator type is one of
+`u8`, `u16`, `u32` or `u64`.
 
 ```mach
-tag Reply {
+tag Reply: u8 {
     empty;
     value: i64;
 }
 
-tag ParseError {
+tag ParseError: u8 {
     invalid;
     overflow;
 }
-
-val empty: Reply = Reply{empty};
-val value: Reply = Reply{value: 42};
-val good: res[i64, ParseError] = res[i64, ParseError]{ok: 42};
-val bad: res[i64, ParseError] = res[i64, ParseError]{err: ParseError{invalid}};
-val present: opt[i64] = opt[i64]{some: 42};
-val absent: opt[i64] = opt[i64]{none};
 ```
 
-Every tag literal selects exactly one case. A missing required payload, a payload
-on a payloadless case, multiple selections and an empty literal are errors.
-Payload types and generic arguments remain explicit under the existing rules.
-
-`res[T, E]` is a canonical tag with `err: E` first and `ok: T` second.
-`err[E]` is a distinct canonical tag with `err: E` first and payloadless `ok`
-second. It is not an alias of `opt[E]`. `res` requires exactly two type arguments,
-and `opt` and `err` each require exactly one. There is no defaulted type argument,
-general type inference or dummy success type.
-`opt[T]` has payloadless `none` first and `some: T` second. These types work
-without importing std and use the same tag implementation as user declarations.
+The canonical failure types are ordinary std tags. The compiler knows none of
+their names. `res[T, E]` has `err: E` first and `ok: T` second. `err[E]` has
+`err: E` first and payloadless `ok` second and is distinct from `opt[E]`.
+`opt[T]` has payloadless `none` first and `some: T` second. Each has one fixed
+generic arity. There is no defaulted type argument, general type inference,
+dummy success type, unit value, constructor function or automatic error
+conversion. These declarations replace std `Return` and `Option` and add `err`.
 
 ```mach
-tag WriteError {
-    denied;
-    native: i32;
-}
+pub tag res[T, E]: u8 { err: E; ok: T; }
+pub tag opt[T]: u8    { none; some: T; }
+pub tag err[E]: u8    { err: E; ok; }
+```
 
+`def` is accepted at function scope with its existing form. A local alias is
+visible from its declaration to the end of the enclosing block.
+
+```mach
 fun flush() err[WriteError] {
-    ret err[WriteError]{ok};
+    def E: err[WriteError];
+    ret E.ok{};
 }
 ```
 
-`ok`, `err`, `some` and `none` are contextual case members, not global keywords.
-The canonical `err[E]` type is resolved in type positions. Its `err` case follows
-the same contextual member rule as the `err` case of `res[T, E]`. There is no
-`Void`, unit value, constructor function or automatic error conversion.
+## Construction
 
-## Tests, payload access and mutation
+A tag value is constructed by naming the type, the case and the payload in
+literal braces. The payload is positional because a case has exactly one. A
+payloadless case takes empty braces. There is no other construction form.
 
 ```mach
-if (value == Reply.value) {
-    val number: i64 = value.value;
-}
-or {
-    # value is empty here
-}
+def R: res[i64, ParseError];
+
+val empty: Reply = Reply.empty{};
+val value: Reply = Reply.value{42};
+val good: R = R.ok{42};
+val bad: R = R.err{ParseError.invalid{}};
+val present: opt[i64] = opt[i64].some{42};
+val absent: opt[i64] = opt[i64].none{};
 ```
 
-`Reply.value` is a case selector. It cannot be stored as a `Reply` value.
-Comparing a tag with its own selector tests only its active case. `!=` negates
-that test. This adds neither whole-tag equality nor payload equality or ordering.
-There is no `.kind` field or `match` statement.
+A payload on a payloadless case, a missing payload, more than one payload, and a
+case selector used without braces are errors. `Reply.value` alone is not a
+value. Payload types and generic arguments remain explicit under the existing
+rules. Whole-value assignment replaces the selected case and payload together.
 
-Payload access requires a current proof of the selected case. Construction and
-ordinary branch flow establish proofs. Joining branches preserves only facts
-true on every incoming path. Whole-value assignment changes the selected case
-and invalidates earlier proofs. A payload assignment requires its case to be
-selected and does not switch cases.
+## Case tests
 
-A write through a possibly overlapping mutable alias, or a call that can modify
-the tested object, invalidates its proof. A separate immutable value snapshot
-keeps its own proof. An immutable pointer binding does not make its pointee
-immutable. Proofs do not depend on optimization level.
+`sel place.case` is a boolean expression. It is true when `place` currently
+holds `case`. `sel` reads only the discriminator, never a payload, and has no
+side effects. Its operand is a place: a binding, a field, an index or a
+dereference, followed by exactly one case name. A call or other temporary is
+not a place. It is an ordinary `bool`, so it composes with `!`, `&&` and `||`,
+can initialize a `bool` binding, and can be returned.
 
 ```mach
-fun inspect(reply: *Reply) i64 {
-    if (@reply == Reply.value) {
-        replace(reply);
-        ret reply.value;       # rejected because the call invalidated the proof
-    }
-    ret 0;
-}
+if (sel r.ok)  { ... }
+or (sel r.err) { ... }
 
-fun snapshot(reply: *Reply) i64 {
-    val saved: Reply = @reply;
-    if (saved == Reply.value) {
-        replace(reply);
-        ret saved.value;       # accepted because saved owns a separate value
-    }
-    ret 0;
-}
+val done: bool = sel r.ok;
+if (!sel next.some) { brk; }
+if (sel a.ok && sel b.ok) { ... }
 ```
 
-Taking a payload address requires the same proof and a naturally aligned payload
-place. The raw pointer remains valid only while the enclosing object lives and
-that case remains selected. It does not pin a case or extend a lifetime.
-Subsequent raw-pointer use carries this obligation under ordinary low-level
-memory rules. No general borrow checker is introduced.
+`sel` is a keyword. Existing identifiers named `sel` must be renamed before the
+keyword is reserved. Comparing a tag with `==`, whole-tag equality, payload
+equality, ordering, a `.kind` field, a `match` construct and a `try` construct
+do not exist.
 
-## Expression-level try
+## Payload places and guards
+
+`value.case` is a payload place. Reading it, writing it and taking its address
+are legal only inside a guard for that place and case. A guard is a lexical
+region, not a flow fact.
+
+A chain arm whose condition is exactly `sel P.c` guards `P.c` inside its block.
+
+A chain whose every arm exits guards the remainder of the enclosing block for
+the cases the chain did not test. An arm exits when every reachable path
+through it leaves by `ret`, or by `brk` or `cnt` targeting a loop that encloses
+the chain. Arms of such a chain are conditions of the form `sel P.c` or
+`!sel P.c` on one place `P`. A two-case tag tested on one case guards the other
+for the rest of the block. A tag with more cases is guarded for the one case the
+chain leaves untested, and for nothing when more than one case remains.
+
+No other condition opens a guard. A compound condition such as
+`sel r.ok && r.ok > 3` is rejected because `r.ok` is read outside a guard.
+Nest instead. Allowing the left operand of `&&` to guard its right operand is
+an additive later decision.
 
 ```mach
 fun increment(input: str) res[i64, ParseError] {
-    val number: i64 = try parse(input) or (error: ParseError) {
-        ret res[i64, ParseError]{err: error};
-    };
-    ret res[i64, ParseError]{ok: number + 1};
+    def R: res[i64, ParseError];
+    val r: R = parse(input);
+    if (sel r.err) { ret R.err{r.err}; }
+    ret R.ok{r.ok + 1};
+}
+
+fun describe(e: LoadError) str {
+    if (sel e.missing) { ret "no config"; }
+    or (sel e.io)      { ret io_describe(e.io); }
+    or (sel e.syntax)  { ret format_span(e.syntax); }
+    ret "unreachable";
 }
 ```
 
-`try` evaluates its operand once. Success extracts the payload. Failure binds
-the explicitly typed error and executes the written failure block. That block
-must exit and cannot initialize the destination or provide a fallback value.
-Propagation and conversion remain ordinary visible code.
-
-`try` accepts canonical `res`, `opt` and `err` values. Ordinary user-defined tags have
-no implicit success/failure convention and use explicit case tests.
-
-The operand is a prefix/postfix expression. A larger operand requires parentheses.
-The `or` block is mandatory. Each independently fallible operand gets its own
-`try`.
+Inside a guard the payload place is ordinary storage. Reading it copies under
+the existing value rules, writing it keeps the selected case, and `?value.case`
+yields a typed pointer to naturally aligned storage. A nested payload place such
+as `next.ok.some` requires a guard on `next.ok` before `sel next.ok.some` or
+`next.ok.some` may appear.
 
 ```mach
-val total: i64 = (try left() or (error: ParseError) {
-    ret res[i64, ParseError]{err: error};
-}) + (try right() or (error: ParseError) {
-    ret res[i64, ParseError]{err: error};
-});
-
-val number: i64 = try lookup(key) or {
-    ret res[i64, ParseError]{err: ParseError{invalid}};
-};
-
-try flush() or (error: WriteError) {
-    ret err[WriteError]{err: error};
-};
+if (sel r.ok) {
+    val p: *u8 = ?r.ok.workers;
+    if (@p > max) { @p = max; }
+}
 ```
 
-Options have no error binding. Both `res` and `err` failure bindings use the
-exact error type. Successful `try` extracts the `ok` payload from `res` or the
-`some` payload from `opt`. For `err`, the payloadless `ok` case produces no value
-and `try` is allowed only as a direct expression statement. It cannot be an initializer, argument or arithmetic operand.
+Within a guarded region, whole-value assignment to the guarded place is a
+compile error. Rebind to a new name instead. Mutation through a pointer or by a
+call is the programmer's obligation under the ordinary raw-memory rules, exactly
+as for any pointer today. A payload read whose case is no longer selected is
+undefined behavior of the same class as a stale pointer read. A raw pointer to
+a payload does not pin a case or extend a lifetime. No borrow checker, proof
+analysis or runtime validator is introduced. A debug-profile discriminator trap
+on payload access is an open owner decision and not part of this contract.
 
-Every reachable path through the failure block must leave it through an ordinary
-valid `ret`, or `brk`/`cnt` targeting an enclosing loop outside the failure block.
-A break from a loop created inside the failure block does not qualify. Calling a
-function does not implicitly prove that control cannot return. Existing `fin`
-restrictions and cleanup order apply unchanged to the actual exit path.
-
-Call arguments evaluate left to right. Assignment evaluates and captures its RHS
-before evaluating its destination. A failed extraction skips the remaining
-expression and does not initialize its destination. A replacement initializer
-may read the old selected payload before overwriting it.
-
-The assignment rule preserves the current compiler and audited 4.30 behavior.
-Historical #469/#494 chose LHS-first. The accepted v5 rule is RHS-first. This
-explicitly supersedes that earlier assignment-order decision.
+Guards obey ordinary scoping. A guard opened in a loop body is re-established on
+every iteration by the chain that opens it. `fin` blocks and cleanup order are
+unchanged; an exit inside a guarded block follows the existing `fin` rules.
 
 ## Initialization and representation
 
 Ordinary zero initialization remains uniform. Case code zero selects the first
 declared case and zero-initializes its payload. This applies to locals, globals,
-omitted fields, arrays and comptime values. Canonical option defaults to `none`
-and both `res` and `err` default to their `err` case with a zero-initialized
-error payload. Raw allocated
-capacity is not automatically a constructed value.
+omitted fields, arrays and comptime values. `opt` defaults to `none` and both
+`res` and `err` default to their `err` case with a zero-initialized error
+payload. Raw allocated capacity is not automatically a constructed value.
 
-The discriminator is stored at offset zero in target byte order. Its type is
-the smallest of `u8`, `u16`, `u32` and `u64` that represents every case ordinal.
-One-case tags still have a discriminator. Codes follow declaration order, with
-no custom codes, niche encoding, tag elision or case reordering. Compiler resource
-and declaration limits remain checked implementation limits.
+The discriminator is stored at offset zero in target byte order with the
+declared type. One-case tags still have a discriminator. Codes follow
+declaration order, with no custom codes, niche encoding, tag elision or case
+reordering. Compiler resource and declaration limits remain checked
+implementation limits.
 
 For natural layout, let `D` be discriminator size, `M` the maximum payload size
 and `PAlign` the maximum payload alignment, or one with no payloads. The common
@@ -206,19 +197,20 @@ retains its ordinary value/representation rules, including any raw union bytes.
 This does not promise recursive canonicalization of foreign payload padding.
 Replacing a larger case clears its now-inactive suffix.
 
-Native ABI transfer preserves exact logical object extents separately from carrier
-width and alignment. Whole-module targets represent logical cases and payload
-types without invented physical registers. Layout reflection describes the
-selected target's actual storage.
+Native ABI transfer preserves exact logical object extents separately from
+carrier width and alignment. Whole-module targets represent logical cases and
+payload types without invented physical registers. Layout reflection describes
+the selected target's actual storage.
 
 ## Reflection and conversion
 
 Add three intrinsics, following existing comptime conventions:
 
-- `$is_tag(T)` identifies public tag shapes, including `res`, `opt` and `err`.
+- `$is_tag(T)` identifies tag shapes, including the std `res`, `opt` and `err`
+  declarations, which need no special treatment.
 - `$cases(T)` enumerates owner-qualified descriptors in declaration order through
   the existing `$each` construct.
-- `$discriminant_of(T)` produces the actual unsigned discriminator type.
+- `$discriminant_of(T)` produces the declared discriminator type.
 
 Case descriptors expose `name`, `has_payload`, `type`, `offset` and `code`.
 `name` is the existing comptime NUL-terminated string form. `has_payload` is a
@@ -228,7 +220,7 @@ on a payloadless case is an error.
 
 ```mach
 $each case in $cases(T) {
-    if (value == T.[case]) {
+    if (sel value.[case]) {
         $if (case.has_payload) {
             consume[case.type](value.[case]);
         }
@@ -236,26 +228,28 @@ $each case in $cases(T) {
 }
 ```
 
-`T.[case]` is the named selector and `value.[case]` is the proof-checked payload
-projection. `T{[case]: payload}` and `T{[case]}` reconstruct through the same
-single-case literal rule after specialization. A descriptor from another nominal
-type or generic instantiation is rejected.
+`sel value.[case]` is the test and `value.[case]` is the guarded payload place.
+`T.[case]{payload}` and `T.[case]{}` construct through the same single-case
+literal rule after specialization. A descriptor from another nominal type or
+generic instantiation is rejected.
 
 Reuse `$size_of`, `$align_of` and `$offset_of(T, payload_case)`. Layout answers
-come from one checked target layout and become available under the same complete-
-type rules as size/alignment, superseding the old lowering-only offset exception.
-Unresolved or recursive layout is diagnosed rather than replaced with a guess.
+come from one checked target layout and become available under the same
+complete-type rules as size/alignment, superseding the old lowering-only offset
+exception. Unresolved or recursive layout is diagnosed rather than replaced with
+a guess.
 
 `$cases(^T)` is refused and `$is_tag(^T)` is false, matching current shape-query
-conventions. Size, alignment and discriminator-type queries may inspect outer-
-secret types because they expose storage metadata, never the active case.
+conventions. Size, alignment and discriminator-type queries may inspect
+outer-secret types because they expose storage metadata, never the active case.
 
 Different nominal tags remain different types. Representation-changing `::` and
 `:~` casts are rejected when either by-value representation contains a tag,
 including through arrays, records and union alternatives. Same-type identity
 casts remain identity. Transparent aliases preserve the same type. Ordinary
-qualifier conversions retain their existing rules and must preserve the underlying
-tag identity. They cannot introduce another route for declassification.
+qualifier conversions retain their existing rules and must preserve the
+underlying tag identity. They cannot introduce another route for
+declassification.
 
 Ordinary pointer retyping remains an explicit raw-memory operation under the
 existing secrecy/weld rules. A typed tag read requires live, aligned storage,
@@ -265,25 +259,26 @@ and then constructed. There is no implicit validator or runtime decoder.
 
 ## Secrecy, ownership and std
 
-A public tag has a public discriminator. Each payload keeps its declared secrecy.
-Outer `^Tag` also protects the active case. Secret-dependent case tests and `try`
-branches remain subject to the constant-time rules.
+A public tag has a public discriminator. Each payload keeps its declared
+secrecy. Outer `^Tag` also protects the active case, so `sel` on an
+outer-secret tag is rejected. Secret-dependent `sel` results remain subject to
+the constant-time rules.
 
-Storage and transport preserve the union of potentially secret byte ranges across
-all cases. A carrier containing both public discriminator bits and secret payload
-bits cannot be marked wholly public. Extracting the public discriminator must
-preserve its public provenance through late lowering. Public case access does not
-permit reading an inactive secret payload or erasing a secret-welded pointer.
-Copies with a secret selected case use the public fixed type extent and do not
-choose a case-dependent access pattern.
+Storage and transport preserve the union of potentially secret byte ranges
+across all cases. A carrier containing both public discriminator bits and secret
+payload bits cannot be marked wholly public. Extracting the public discriminator
+must preserve its public provenance through late lowering. Public case access
+does not permit reading an inactive secret payload or erasing a secret-welded
+pointer. Copies with a secret selected case use the public fixed type extent and
+do not choose a case-dependent access pattern.
 
 `value:>T` removes only outer secrecy from the same underlying tag value. It
 preserves the selected case and all qualifiers declared inside payloads.
 
 Tags add no moves, destructors, unwinding, allocation or resource rollback.
-Domain errors, formatting, explicit conversions and cleanup belong in std or user
-code. Address-bound owners initialize their final caller-owned storage and are
-not returned by value inside a result.
+Domain errors, formatting, explicit conversions and cleanup belong in std or
+user code. Address-bound owners initialize their final caller-owned storage and
+are not returned by value inside a result.
 
 Public tag layouts and closed case sets are part of std's SemVer contract.
 Changing a closed public case set is a breaking change. The migration ships as
@@ -291,34 +286,35 @@ std 2.0.0 paired with Mach 5.0.0.
 
 ## Implementation and acceptance
 
-Additional acceptance examples use the types above and ordinary helper functions.
+Additional acceptance examples use the types above and ordinary helper
+functions.
 
 ```mach
-var reply: Reply;                       # empty, because it is declared first
-var result: res[i64, ParseError];       # err with ParseError.invalid
-val invalid: Reply = Reply{empty: 1};   # rejected, no payload exists
-val missing: Reply = Reply{value};      # rejected, payload is required
-val wrong: Reply = Reply.value;         # rejected, selector is not a value
+var reply: Reply;                        # empty, because it is declared first
+var result: res[i64, ParseError];        # err with ParseError.invalid
+val invalid: Reply = Reply.empty{1};     # rejected, no payload exists
+val missing: Reply = Reply.value{};      # rejected, payload is required
+val wrong: Reply = Reply.value;          # rejected, selector is not a value
+val bad: Reply = Reply{value: 1};        # rejected, record literal form
 
-consume(try parse(input) or (error: ParseError) {
-    ret res[i64, ParseError]{err: error};
-}, later());                           # later runs only after successful extraction
+val n: i64 = r.ok;                       # rejected outside a guard
+if (sel r.ok && r.ok > 3) { }            # rejected, compound condition guards nothing
+
+if (sel r.err) { log(r.err); }
+val m: i64 = r.ok;                       # rejected, the arm does not exit
 
 for (more) {
-    val item: i64 = try lookup(key) or {
-        cnt;
-    };
-    consume(item);
+    val item: opt[i64] = lookup(key);
+    if (!sel item.some) { cnt; }
+    consume(item.some);                  # guarded, cnt targets the enclosing loop
 }
 
-val fallback: i64 = try parse(input) or (error: ParseError) {
-    log(error);
-};                                    # rejected, failure can fall through
+if (sel r.ok) {
+    r = R.err{ParseError.invalid{}};     # rejected, whole-value assignment in a guard
+}
 
 fin {
-    try flush() or (error: WriteError) {
-        ret err[WriteError]{err: error};
-    };                                # rejected, return crosses a fin boundary
+    if (sel w.err) { ret err[WriteError].err{w.err}; }   # rejected, return crosses a fin boundary
 }
 ```
 
@@ -326,13 +322,9 @@ For a raw input byte containing a case code, ordinary code can validate and
 construct a value. An unrecognized byte does not become an invalid `Reply`.
 
 ```mach
-if (code == 0) {
-    ret opt[Reply]{some: Reply{empty}};
-}
-if (code == 1) {
-    ret opt[Reply]{some: Reply{value: decoded_number}};
-}
-ret opt[Reply]{none};
+if (code == 0) { ret opt[Reply].some{Reply.empty{}}; }
+if (code == 1) { ret opt[Reply].some{Reply.value{decoded_number}}; }
+ret opt[Reply].none{};
 ```
 
 An equal-size raw-record-to-`Reply` cast is rejected with either `::` or `:~`.
@@ -340,21 +332,25 @@ Wrapping the two sides in arrays, records or union alternatives does not make
 that conversion valid. A pointer retype is a raw operation and does not perform
 the validation shown above.
 
-For `tag SecretReply { failed: i32; value: ^u64; }`, testing a public
-`SecretReply.failed` case and reading its `i32` payload is permitted. Reading
-the secret value as public `u64`, erasing its storage through a public byte
-pointer, or branching on an outer-secret `^SecretReply` is rejected. A saved
+For `tag SecretReply: u8 { failed: i32; value: ^u64; }`, testing the public
+`failed` case with `sel` and reading its `i32` payload is permitted. Reading the
+secret value as public `u64`, erasing its storage through a public byte pointer,
+or applying `sel` to an outer-secret `^SecretReply` is rejected. A saved
 public-payload pointer expires when the enclosing tag changes to another case.
 
 The existing source bootstrap starts with published Mach 4.26.5, builds the
 pinned bridge and audited compiler sources, and checks self-hosting convergence.
-It does not require the withdrawn Mach 4.30.0 release. Published std 1.0.1 remains
-immutable. Implement the shared tag model and canonical types, then `try`, before
-adopting the new forms in the compiler and std. Record a pinned usable compiler
-at that migration boundary and update the existing bootstrap channel accordingly.
+It does not require the withdrawn Mach 4.30.0 release. Published std 1.0.1
+remains immutable. Implement the tag model, construction, `sel`, guards and
+function-scope `def` in a compiler that still builds the current compiler and
+std sources. Rename every existing `sel` identifier in both source trees before
+that compiler reserves the keyword, because the self-host fixpoint compiles the
+compiler's own source with the new lexer. Record a pinned usable compiler at that
+migration boundary and update the existing bootstrap channel in both
+repositories accordingly.
 
-Acceptance covers construction, defaults, branch refinement and invalidation,
-explicit failure exits and cleanup, generics and reflection, casts through
+Acceptance covers construction, defaults, guard opening and closing, exiting
+chains, guarded assignment rejection, generics and reflection, casts through
 containing types, raw validity obligations, packed/overaligned storage, exact
 ABI transport, public-case/secret-payload carriers and module emitters. Positive
 and negative cases must agree across optimization levels. All retained targets


### PR DESCRIPTION
Owner-accepted revision of the v5 tagged-value contract, 2026-09-09. Supersedes the 2026-09-08 text. Relates to #3217 (closed, design), #3218 and #3219 (implementation), #3112 (release gate).

Withdrawn: flow-sensitive active-case proofs, the `try` expression and its rules, compiler-known `res`/`opt`/`err`.

Accepted: `tag Name: u8 { ... }` with an explicit discriminator, `Type.case{payload}` and `Type.case{}` construction, `sel place.case` as a boolean case test, lexical guards (a `sel` arm guards its block, an all-exiting chain guards the remainder for untested cases), whole-value assignment rejected inside a guard, `def` at function scope, and `res`/`opt`/`err` as std tags replacing `Return`/`Option`.

Representation, ABI, reflection and secrecy sections carry forward unchanged apart from wording. The `sel` keyword requires an identifier sweep in both source trees before reservation.
