### PR TITLE
refactor: rename sel identifiers ahead of the v5 keyword (#3219)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- rename `sel` identifiers ahead of the v5 keyword (#3219)
+
 - Every dependency action selects its project with `mach dep <action> <path>`.
   Dependency names follow the path. Missing or extra operands are refused.
   Use `.` for the current project. Pull retains existing local copies and update

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -60,15 +60,15 @@ pub fun plan_invocation(a: *A.Allocator, root: str, cli: *args.CliArgs, goal: re
     }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](res_manifest);
 
-    var sel: manifest.Selection;
-    val sr: R.Result[R.Void, str] = args.selection_from_config(cli, ?sel);
+    var pick: manifest.Selection;
+    val sr: R.Result[R.Void, str] = args.selection_from_config(cli, ?pick);
     if (R.is_err[R.Void, str](sr)) {
         val f: outcome.Fail = outcome.user(R.unwrap_err[R.Void, str](sr));
         session.dnit(ps);
         ret R.err[plan.BuildPlan, outcome.Fail](f);
     }
 
-    val res_req: R.Result[request.BuildRequest, outcome.Fail] = request.compose(a, ?ps.interner, ?m, cli, root, goal, ?sel);
+    val res_req: R.Result[request.BuildRequest, outcome.Fail] = request.compose(a, ?ps.interner, ?m, cli, root, goal, ?pick);
     if (R.is_err[request.BuildRequest, outcome.Fail](res_req)) {
         val f: outcome.Fail = R.unwrap_err[request.BuildRequest, outcome.Fail](res_req);
         session.dnit(ps);

--- a/src/cli/cmd/clean.mach
+++ b/src/cli/cmd/clean.mach
@@ -291,14 +291,14 @@ fun plan_cells_for(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest
         val name_opt: O.Option[str] = intern.lookup(itn, art.name);
         if (O.is_none[str](name_opt)) { ai = ai + 1; cnt; }
 
-        var sel: manifest.Selection;
-        sel.target       = tname;
-        sel.profile      = pname;
-        sel.artifact      = O.unwrap[str](name_opt);
-        sel.want_lib     = art.is_lib;
-        sel.has_artifact = true;
+        var pick: manifest.Selection;
+        pick.target       = tname;
+        pick.profile      = pname;
+        pick.artifact      = O.unwrap[str](name_opt);
+        pick.want_lib     = art.is_lib;
+        pick.has_artifact = true;
 
-        val ur: R.Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(a, itn, m, sel);
+        val ur: R.Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(a, itn, m, pick);
         if (R.is_err[manifest.BuildUnit, str](ur)) {
             if (!have_target_id) { ai = ai + 1; cnt; }
             ret O.some[str](R.unwrap_err[manifest.BuildUnit, str](ur));

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -1755,9 +1755,9 @@ fun t_session_and_mode(a: *A.Allocator, root: str, s: *session.Session, mode: *u
 
 fun t_build_ok(s: *session.Session, root: str) bool {
     if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { ret false; }
-    var sel: manifest.Selection;
-    sel.target = ""; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false; sel.legacy_default = false;
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = ""; pick.profile = ""; pick.artifact = ""; pick.want_lib = false; pick.has_artifact = false; pick.legacy_default = false;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(s, root, ?pick);
     if (R.is_err[project.Project, outcome.Fail](pr)) {
         val f: outcome.Fail = R.unwrap_err[project.Project, outcome.Fail](pr);
         if (f.message != nil) { print.eprint("build: "); print.eprint(f.message); print.eprint("\n"); }

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -438,8 +438,8 @@ pub fun run_typed(argv: **u8, inv: *args.ParsedInvocation) i64 {
         ret 1;
     }
     var config: request.CliArgs = R.unwrap_ok[request.CliArgs, str](config_r);
-    var sel: manifest.Selection;
-    val sel_r: R.Result[R.Void, str] = args.selection_from_config(?config, ?sel);
+    var pick: manifest.Selection;
+    val sel_r: R.Result[R.Void, str] = args.selection_from_config(?config, ?pick);
     if (R.is_err[R.Void, str](sel_r)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[R.Void, str](sel_r));
@@ -494,7 +494,7 @@ pub fun run_typed(argv: **u8, inv: *args.ParsedInvocation) i64 {
         ret 2;
     }
 
-    val res_project: R.Result[driver.Project, outcome.Fail] = driver.build_project(?s, root, ?sel);
+    val res_project: R.Result[driver.Project, outcome.Fail] = driver.build_project(?s, root, ?pick);
     if (diagnostic.len(?s.diags) > 0) {
         var err_w: writer.Writer = fs.writer(fs.STDERR);
         cli_diag.flush(?err_w, ?s, ?s.diags);
@@ -761,9 +761,9 @@ test "mach.cli.cmd.doc.build_project:the_first_declared_fallback_records_the_dep
     if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) {
         session.dnit(?s); fs.remove_all(?alloc, ?root[0]); ret 1;
     }
-    var sel: manifest.Selection;
-    sel.target = "linux"; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false; sel.legacy_default = false;
-    val pr: R.Result[driver.Project, outcome.Fail] = driver.build_project(?s, ?root[0], ?sel);
+    var pick: manifest.Selection;
+    pick.target = "linux"; pick.profile = ""; pick.artifact = ""; pick.want_lib = false; pick.has_artifact = false; pick.legacy_default = false;
+    val pr: R.Result[driver.Project, outcome.Fail] = driver.build_project(?s, ?root[0], ?pick);
     var bad: i32 = 0;
     if (R.is_err[driver.Project, outcome.Fail](pr)) { bad = 1; }
     or {
@@ -849,9 +849,9 @@ test "mach.cli.cmd.doc.generate:creates_missing_output_dirs" {
         session.dnit(?s); fs.remove_all(?alloc, ?root[0]); ret 1;
     }
 
-    var sel: manifest.Selection;
-    sel.target = "linux"; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false; sel.legacy_default = false;
-    val pr: R.Result[driver.Project, outcome.Fail] = driver.build_project(?s, ?root[0], ?sel);
+    var pick: manifest.Selection;
+    pick.target = "linux"; pick.profile = ""; pick.artifact = ""; pick.want_lib = false; pick.has_artifact = false; pick.legacy_default = false;
+    val pr: R.Result[driver.Project, outcome.Fail] = driver.build_project(?s, ?root[0], ?pick);
     if (R.is_err[driver.Project, outcome.Fail](pr)) {
         session.dnit(?s); fs.remove_all(?alloc, ?root[0]); ret 1;
     }

--- a/src/cli/cmd/run.mach
+++ b/src/cli/cmd/run.mach
@@ -113,7 +113,7 @@ pub fun run_typed(argv: **u8, inv: *args.ParsedInvocation) i64 {
     val loc: util.ProjectLocation = R.unwrap_ok[util.ProjectLocation, str](loc_r);
     val root: str = loc.root;
 
-    var sel: manifest.Selection;
+    var pick: manifest.Selection;
     var target_name: *u8 = "";
     if (parsed.has_target) { target_name = argv[parsed.target_idx]; }
     var profile_name: *u8 = "";
@@ -121,13 +121,13 @@ pub fun run_typed(argv: **u8, inv: *args.ParsedInvocation) i64 {
     var artifact_name: *u8  = "";
     var has_artifact:  bool = false;
     if (parsed.has_bin) { artifact_name = argv[parsed.bin_idx]; has_artifact = true; }
-    sel.profile      = profile_name::str;
-    sel.target       = target_name::str;
-    sel.artifact     = artifact_name::str;
-    sel.want_lib     = false;
-    sel.has_artifact = has_artifact;
+    pick.profile      = profile_name::str;
+    pick.target       = target_name::str;
+    pick.artifact     = artifact_name::str;
+    pick.want_lib     = false;
+    pick.has_artifact = has_artifact;
 
-    val res_ra: R.Result[dcfg.RunArtifact, str] = driver.resolve_run_artifact(?alloc, root, ?sel, output);
+    val res_ra: R.Result[dcfg.RunArtifact, str] = driver.resolve_run_artifact(?alloc, root, ?pick, output);
     if (R.is_err[dcfg.RunArtifact, str](res_ra)) {
         print.eprint("error: ");
         print.eprint(R.unwrap_err[dcfg.RunArtifact, str](res_ra));

--- a/src/lang/be/codegen/vector_runtime.mach
+++ b/src/lang/be/codegen/vector_runtime.mach
@@ -521,8 +521,8 @@ test "mach.lang.be.codegen.vector_runtime.reinterpret:f32x4_select_via_mask" {
     var mask: u32x4 = u32x4{ M32, 0, M32, 0 };
     var au: u32x4 = a:~u32x4;
     var bu: u32x4 = b:~u32x4;
-    var sel: u32x4 = (au & mask) | (bu & ~mask);
-    var r: f32x4 = sel:~f32x4;
+    var pick: u32x4 = (au & mask) | (bu & ~mask);
+    var r: f32x4 = pick:~f32x4;
     if (r[0] != 1.0 || r[1] != 20.0 || r[2] != 3.0 || r[3] != 40.0) { ret 1; }
     ret 0;
 }

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -325,7 +325,7 @@ pub fun execute_warm(bp: *plan.BuildPlan, unit_index: usize, s: *session.Session
     st.dynlib_len   = 0;
     st.out_path     = nil;
     st.scope.have    = false;
-    st.scope.sel     = nil;
+    st.scope.pick     = nil;
     st.scope.sel_len = 0;
     st.scope.skipped = 0;
 

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -115,20 +115,20 @@ pub fun plan(a: *A.Allocator, itn: *intern.Interner, reg: *target.TargetRegistry
     val req: *request.BuildRequest = ?bp.request;
 
     if (request.test_goal(req.goal)) {
-        var sel: manifest.Selection;
-        sel.target       = req.target;
-        sel.profile      = req.profile;
-        sel.artifact     = req.artifact;
-        sel.want_lib     = req.want_lib;
-        sel.has_artifact = !str_empty(req.artifact);
-        sel.legacy_default = false;
-        val psr: R.Result[R.Void, str] = manifest.select_primary_artifact(a, itn, m, ?sel);
+        var pick: manifest.Selection;
+        pick.target       = req.target;
+        pick.profile      = req.profile;
+        pick.artifact     = req.artifact;
+        pick.want_lib     = req.want_lib;
+        pick.has_artifact = !str_empty(req.artifact);
+        pick.legacy_default = false;
+        val psr: R.Result[R.Void, str] = manifest.select_primary_artifact(a, itn, m, ?pick);
         if (R.is_err[R.Void, str](psr)) {
             ret R.err[BuildPlan, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](psr)));
         }
-        bp.request.artifact = sel.artifact;
-        bp.request.want_lib = sel.want_lib;
-        bp.request.artifact_by_table_order = sel.legacy_default;
+        bp.request.artifact = pick.artifact;
+        bp.request.want_lib = pick.want_lib;
+        bp.request.artifact_by_table_order = pick.legacy_default;
         val cr: R.Result[R.Void, outcome.Fail] = plan_cell(a, itn, reg, m, req, ?bp,
             req.target, req.artifact, req.want_lib, !str_empty(req.artifact), false);
         if (R.is_err[R.Void, outcome.Fail](cr)) {
@@ -321,13 +321,13 @@ fun oom_plan() R.Result[BuildPlan, outcome.Fail] {
 
 fun cell_declared(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
                   tname: str, aname: str, want_lib: bool) R.Result[bool, str] {
-    var sel: manifest.Selection;
-    sel.target       = tname;
-    sel.profile      = "";
-    sel.artifact     = aname;
-    sel.want_lib     = want_lib;
-    sel.has_artifact = true;
-    ret manifest.cell_supported(a, itn, m, sel);
+    var pick: manifest.Selection;
+    pick.target       = tname;
+    pick.profile      = "";
+    pick.artifact     = aname;
+    pick.want_lib     = want_lib;
+    pick.has_artifact = true;
+    ret manifest.cell_supported(a, itn, m, pick);
 }
 
 pub fun replan_unit(a: *A.Allocator, itn: *intern.Interner, reg: *target.TargetRegistry,
@@ -392,14 +392,14 @@ fun plan_unit(a: *A.Allocator, itn: *intern.Interner, reg: *target.TargetRegistr
               m: *manifest.Manifest, req: *request.BuildRequest,
               tname: str, aname: str, want_lib: bool, has_artifact: bool,
               is_required: bool) R.Result[BuildUnit, outcome.Fail] {
-    var sel: manifest.Selection;
-    sel.target       = tname;
-    sel.profile      = req.profile;
-    sel.artifact     = aname;
-    sel.want_lib     = want_lib;
-    sel.has_artifact = has_artifact;
+    var pick: manifest.Selection;
+    pick.target       = tname;
+    pick.profile      = req.profile;
+    pick.artifact     = aname;
+    pick.want_lib     = want_lib;
+    pick.has_artifact = has_artifact;
 
-    val ur: R.Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(a, itn, m, sel);
+    val ur: R.Result[manifest.BuildUnit, str] = manifest.resolve_build_unit(a, itn, m, pick);
     if (R.is_err[manifest.BuildUnit, str](ur)) {
         ret R.err[BuildUnit, outcome.Fail](outcome.user(R.unwrap_err[manifest.BuildUnit, str](ur)));
     }

--- a/src/lang/build/request.mach
+++ b/src/lang/build/request.mach
@@ -247,19 +247,19 @@ pub fun release(r: *BuildRequest) bool {
 
 pub fun compose(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
                 cli: *CliArgs, root: str, goal: BuildGoal,
-                sel: *manifest.Selection) R.Result[BuildRequest, outcome.Fail] {
+                pick: *manifest.Selection) R.Result[BuildRequest, outcome.Fail] {
     var r: BuildRequest = defaults();
     r.project_root = root;
     r.all_targets  = cli.all_targets;
     r.goal         = goal;
 
-    r.target   = sel.target;
-    r.profile  = sel.profile;
-    r.artifact = sel.artifact;
-    r.want_lib = sel.want_lib;
+    r.target   = pick.target;
+    r.profile  = pick.profile;
+    r.artifact = pick.artifact;
+    r.want_lib = pick.want_lib;
     r.artifact_by_table_order = false;
 
-    val pr_r: R.Result[manifest.ResolvedProfile, str] = manifest.resolve_profile(a, itn, m, sel.profile);
+    val pr_r: R.Result[manifest.ResolvedProfile, str] = manifest.resolve_profile(a, itn, m, pick.profile);
     if (R.is_err[manifest.ResolvedProfile, str](pr_r)) {
         ret R.err[BuildRequest, outcome.Fail](outcome.user(R.unwrap_err[manifest.ResolvedProfile, str](pr_r)));
     }

--- a/src/lang/build/testing.mach
+++ b/src/lang/build/testing.mach
@@ -82,14 +82,14 @@ pub fun classify_wait_failure() validation.ValidationGateResult {
 pub rec TestScope {
     col:     testrunner.Collected;
     have:    bool;
-    sel:     *testrunner.Test;
+    pick:     *testrunner.Test;
     sel_len: u32;
     skipped: u32;
 }
 
 pub fun collect_scope(p: *driver.Project, irs: *ir.Module, sc: *TestScope) R.Result[R.Void, outcome.Fail] {
     sc.have    = false;
-    sc.sel     = nil;
+    sc.pick     = nil;
     sc.sel_len = 0;
     sc.skipped = driver.count_target_gated(p);
 
@@ -111,11 +111,11 @@ pub fun collect_scope(p: *driver.Project, irs: *ir.Module, sc: *TestScope) R.Res
         free_scope(p, sc);
         ret R.err[R.Void, outcome.Fail](outcome.internal("out of memory"));
     }
-    sc.sel = R.unwrap_ok[*testrunner.Test, str](res_sel);
+    sc.pick = R.unwrap_ok[*testrunner.Test, str](res_sel);
     var i: u32 = 0;
     for (i < sc.col.count) {
         if (test_selected(p, ?sc.col.tests[i], include_deps)) {
-            sc.sel[sc.sel_len] = sc.col.tests[i];
+            sc.pick[sc.sel_len] = sc.col.tests[i];
             sc.sel_len = sc.sel_len + 1;
         }
         i = i + 1;
@@ -124,10 +124,10 @@ pub fun collect_scope(p: *driver.Project, irs: *ir.Module, sc: *TestScope) R.Res
 }
 
 pub fun free_scope(p: *driver.Project, sc: *TestScope) {
-    if (sc.sel != nil && sc.have && sc.col.count > 0) {
-        A.deallocate[testrunner.Test](p.alloc, sc.sel, sc.col.count::usize);
+    if (sc.pick != nil && sc.have && sc.col.count > 0) {
+        A.deallocate[testrunner.Test](p.alloc, sc.pick, sc.col.count::usize);
     }
-    sc.sel     = nil;
+    sc.pick     = nil;
     sc.sel_len = 0;
     if (sc.have) {
         testrunner.free(p.s, ?sc.col);
@@ -139,7 +139,7 @@ pub fun record_tests(p: *driver.Project, sc: *TestScope, exe: *u8,
                      bo: *outcome.BuildOutcome, oa: *A.Allocator) R.Result[R.Void, outcome.Fail] {
     var k: u32 = 0;
     for (k < sc.sel_len) {
-        val rc: R.Result[R.Void, outcome.Fail] = record_test(p, ?sc.sel[k], exe, k, bo);
+        val rc: R.Result[R.Void, outcome.Fail] = record_test(p, ?sc.pick[k], exe, k, bo);
         if (R.is_err[R.Void, outcome.Fail](rc)) { ret rc; }
         k = k + 1;
     }
@@ -229,7 +229,7 @@ pub fun link_dispatcher(p: *driver.Project, unit: *plan.BuildUnit, sc: *TestScop
 
     p.s.alloc = ?scratch_alloc;
     val result: R.Result[R.Void, outcome.Fail] = build_dispatch_executable(p, dispatcher, artifact,
-                                              sc.sel, sc.sel_len, shared, shared_len,
+                                              sc.pick, sc.sel_len, shared, shared_len,
                                               dynlibs, dynlib_len);
     p.s.alloc = persistent;
     arena.dnit(?scratch_ar);
@@ -241,7 +241,7 @@ pub fun fingerprint_scope(fb: *dq.FpBuf, p: *driver.Project, sc: *TestScope) R.R
     if (R.is_err[R.Void, str](rc)) { ret rc; }
     var i: u32 = 0;
     for (i < sc.sel_len) {
-        val t: *testrunner.Test = ?sc.sel[i];
+        val t: *testrunner.Test = ?sc.pick[i];
         val rl: R.Result[R.Void, str] = dq.fp_cstr(fb, scope_name(p, t.linkage)); if (R.is_err[R.Void, str](rl)) { ret rl; }
         val rb: R.Result[R.Void, str] = dq.fp_cstr(fb, scope_name(p, t.label));   if (R.is_err[R.Void, str](rb)) { ret rb; }
         val rn: R.Result[R.Void, str] = dq.fp_u32(fb, t.line);                    if (R.is_err[R.Void, str](rn)) { ret rn; }
@@ -270,10 +270,10 @@ fun free_shared(p: *driver.Project, shared: **u8, shared_len: u32, borrowed: u32
 }
 
 fun build_dispatch_executable(p: *driver.Project, dispatcher: *publication.Destination, artifact: *publication.Destination,
-                              sel: *testrunner.Test, sel_len: u32,
+                              pick: *testrunner.Test, sel_len: u32,
                               shared: **u8, shared_len: u32,
                               dynlibs: *of.DynLib, dynlib_len: u32) R.Result[R.Void, outcome.Fail] {
-    val res_synth: R.Result[ir.Module, fail.Fail] = testrunner.synthesize_dispatcher(p.s, sel, sel_len);
+    val res_synth: R.Result[ir.Module, fail.Fail] = testrunner.synthesize_dispatcher(p.s, pick, sel_len);
     if (R.is_err[ir.Module, fail.Fail](res_synth)) {
         ret R.err[R.Void, outcome.Fail](outcome.from_fail(R.unwrap_err[ir.Module, fail.Fail](res_synth)));
     }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -85,13 +85,13 @@ fun query_compute(p: *project.Project, kind: query.QueryKind, key: u64,
     ret R.err[query.QueryOutput, fail.Fail](fail.message("query kind has no driver compute capability"));
 }
 
-pub fun build_project(s: *session.Session, project_root: str, sel: *manifest.Selection) R.Result[project.Project, outcome.Fail] {
+pub fun build_project(s: *session.Session, project_root: str, pick: *manifest.Selection) R.Result[project.Project, outcome.Fail] {
     val mr: R.Result[manifest.Manifest, str] = load_manifest(s, project_root);
     if (R.is_err[manifest.Manifest, str](mr)) {
         ret R.err[project.Project, outcome.Fail](outcome.user(R.unwrap_err[manifest.Manifest, str](mr)));
     }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
-    var esel: manifest.Selection = @sel;
+    var esel: manifest.Selection = @pick;
     val psr: R.Result[R.Void, str] = manifest.select_primary_artifact(s.build_alloc, ?s.interner, ?m, ?esel);
     if (R.is_err[R.Void, str](psr)) {
         manifest.dnit(?m, s.build_alloc);
@@ -102,8 +102,8 @@ pub fun build_project(s: *session.Session, project_root: str, sel: *manifest.Sel
     ret r;
 }
 
-fun build_project_impl(s: *session.Session, project_root: str, sel: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, roots: project.RootSet, run_steps: bool) R.Result[project.Project, outcome.Fail] {
-    val begin_r: R.Result[project.Project, outcome.Fail] = begin_build_impl(s, project_root, sel, m, req, nil, roots);
+fun build_project_impl(s: *session.Session, project_root: str, pick: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, roots: project.RootSet, run_steps: bool) R.Result[project.Project, outcome.Fail] {
+    val begin_r: R.Result[project.Project, outcome.Fail] = begin_build_impl(s, project_root, pick, m, req, nil, roots);
     if (R.is_err[project.Project, outcome.Fail](begin_r)) { ret begin_r; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](begin_r);
 
@@ -146,16 +146,16 @@ pub fun verify_dependencies(s: *session.Session, project_root: str) R.Result[R.V
 }
 
 pub fun begin_build(s: *session.Session, m: *manifest.Manifest, req: *request.BuildRequest, ev: *readout.Progress) R.Result[project.Project, outcome.Fail] {
-    var sel: manifest.Selection;
-    sel.target       = req.target;
-    sel.profile      = req.profile;
-    sel.artifact     = req.artifact;
-    sel.want_lib     = req.want_lib;
-    sel.has_artifact = !str_empty(req.artifact);
-    sel.legacy_default = req.artifact_by_table_order;
+    var pick: manifest.Selection;
+    pick.target       = req.target;
+    pick.profile      = req.profile;
+    pick.artifact     = req.artifact;
+    pick.want_lib     = req.want_lib;
+    pick.has_artifact = !str_empty(req.artifact);
+    pick.legacy_default = req.artifact_by_table_order;
     var roots: project.RootSet = project.ROOT_ARTIFACT;
     if (request.test_goal(req.goal)) { roots = project.ROOT_TEST; }
-    ret begin_build_impl(s, req.project_root, ?sel, m, req, ev, roots);
+    ret begin_build_impl(s, req.project_root, ?pick, m, req, ev, roots);
 }
 
 pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *request.BuildRequest,
@@ -195,7 +195,7 @@ pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *reques
     ret R.ok[project.Project, outcome.Fail](p);
 }
 
-fun begin_build_impl(s: *session.Session, project_root: str, sel: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, ev: *readout.Progress, roots: project.RootSet) R.Result[project.Project, outcome.Fail] {
+fun begin_build_impl(s: *session.Session, project_root: str, pick: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, ev: *readout.Progress, roots: project.RootSet) R.Result[project.Project, outcome.Fail] {
     var p: project.Project;
     project.init_project(?p, s);
     if (req != nil) { p.req = @req; }
@@ -213,7 +213,7 @@ fun begin_build_impl(s: *session.Session, project_root: str, sel: *manifest.Sele
 
     var cfg_r: R.Result[R.Void, str];
     if (m != nil) {
-        cfg_r = dcfg.load_config_manifest(?p, project_root, m, sel, for_union, is_test);
+        cfg_r = dcfg.load_config_manifest(?p, project_root, m, pick, for_union, is_test);
     }
     or {
         val mp_r: R.Result[str, str] = load.join_path(s.alloc, project_root, manifest.MANIFEST_FILE);
@@ -222,7 +222,7 @@ fun begin_build_impl(s: *session.Session, project_root: str, sel: *manifest.Sele
             ret R.err[project.Project, outcome.Fail](outcome.internal(R.unwrap_err[str, str](mp_r)));
         }
         val manifest_path: str = R.unwrap_ok[str, str](mp_r);
-        cfg_r = dcfg.load_project_config(?p, project_root, manifest_path, sel, for_union, is_test);
+        cfg_r = dcfg.load_project_config(?p, project_root, manifest_path, pick, for_union, is_test);
         str_free(s.alloc, manifest_path);
     }
     if (R.is_err[R.Void, str](cfg_r)) {
@@ -497,22 +497,22 @@ fun stack_key_refusal(s: *session.Session, key: str, tname: intern.StrId, of_nam
     ret R.unwrap_ok[str, str](r);
 }
 
-pub fun build_project_sel(s: *session.Session, project_root: str, sel: *manifest.Selection) R.Result[project.Project, outcome.Fail] {
-    ret build_project_impl(s, project_root, sel, nil, nil, project.ROOT_ARTIFACT, true);
+pub fun build_project_sel(s: *session.Session, project_root: str, pick: *manifest.Selection) R.Result[project.Project, outcome.Fail] {
+    ret build_project_impl(s, project_root, pick, nil, nil, project.ROOT_ARTIFACT, true);
 }
 
-pub fun build_project_test(s: *session.Session, project_root: str, sel: *manifest.Selection) R.Result[project.Project, outcome.Fail] {
-    ret build_project_impl(s, project_root, sel, nil, nil, project.ROOT_TEST, true);
+pub fun build_project_test(s: *session.Session, project_root: str, pick: *manifest.Selection) R.Result[project.Project, outcome.Fail] {
+    ret build_project_impl(s, project_root, pick, nil, nil, project.ROOT_TEST, true);
 }
 
 pub fun build_project_union(s: *session.Session, project_root: str) R.Result[project.Project, outcome.Fail] {
-    var sel: manifest.Selection;
-    sel.target       = "";
-    sel.profile      = "";
-    sel.artifact     = "";
-    sel.want_lib     = false;
-    sel.has_artifact = false;
-    ret build_project_impl(s, project_root, ?sel, nil, nil, project.ROOT_UNION, false);
+    var pick: manifest.Selection;
+    pick.target       = "";
+    pick.profile      = "";
+    pick.artifact     = "";
+    pick.want_lib     = false;
+    pick.has_artifact = false;
+    ret build_project_impl(s, project_root, ?pick, nil, nil, project.ROOT_UNION, false);
 }
 
 fun bind_queries(p: *project.Project) R.Result[R.Void, str] {

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -55,7 +55,7 @@ use ddep: mach.lang.driver.deps;
 use mach.lang.driver.union;
 use mach.lang.publication;
 
-pub fun resolve_artifact_path(alloc: *A.Allocator, project_root: str, sel: *manifest.Selection) R.Result[str, str] {
+pub fun resolve_artifact_path(alloc: *A.Allocator, project_root: str, pick: *manifest.Selection) R.Result[str, str] {
     val mp_r: R.Result[str, str] = load.join_path(alloc, project_root, manifest.MANIFEST_FILE);
     if (R.is_err[str, str](mp_r)) { ret R.err[str, str](R.unwrap_err[str, str](mp_r)); }
     val manifest_path: str = R.unwrap_ok[str, str](mp_r);
@@ -70,7 +70,7 @@ pub fun resolve_artifact_path(alloc: *A.Allocator, project_root: str, sel: *mani
     if (R.is_err[manifest.Manifest, str](mr)) { ret R.err[str, str](R.unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
 
-    var eff_sel: manifest.Selection = @sel;
+    var eff_sel: manifest.Selection = @pick;
     val ssr: R.Result[R.Void, str] = manifest.select_sole_target_artifact(
         alloc, ?itn, ?m, ?eff_sel);
     if (R.is_err[R.Void, str](ssr)) {
@@ -101,7 +101,7 @@ pub rec RunArtifact {
     target_name:   str;
 }
 
-pub fun resolve_run_artifact(alloc: *A.Allocator, project_root: str, sel: *manifest.Selection,
+pub fun resolve_run_artifact(alloc: *A.Allocator, project_root: str, pick: *manifest.Selection,
                              output_override: str) R.Result[RunArtifact, str] {
     val mp_r: R.Result[str, str] = load.join_path(alloc, project_root, manifest.MANIFEST_FILE);
     if (R.is_err[str, str](mp_r)) { ret R.err[RunArtifact, str](R.unwrap_err[str, str](mp_r)); }
@@ -117,7 +117,7 @@ pub fun resolve_run_artifact(alloc: *A.Allocator, project_root: str, sel: *manif
     if (R.is_err[manifest.Manifest, str](mr)) { ret R.err[RunArtifact, str](R.unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
 
-    var eff_sel: manifest.Selection = @sel;
+    var eff_sel: manifest.Selection = @pick;
     val ssr: R.Result[R.Void, str] = manifest.select_sole_executable_artifact(alloc, ?itn, ?m, ?eff_sel);
     if (R.is_err[R.Void, str](ssr)) {
         manifest.dnit(?m, alloc);
@@ -178,21 +178,21 @@ pub fun resolve_run_artifact(alloc: *A.Allocator, project_root: str, sel: *manif
     ret R.ok[RunArtifact, str](ra);
 }
 
-pub fun load_project_config(p: *project.Project, project_root: str, manifest_path: str, sel: *manifest.Selection, for_union: bool, is_test: bool) R.Result[R.Void, str] {
+pub fun load_project_config(p: *project.Project, project_root: str, manifest_path: str, pick: *manifest.Selection, for_union: bool, is_test: bool) R.Result[R.Void, str] {
     val toml_r: R.Result[toml.Table, str] = ddep.parse_toml_file(p.alloc, manifest_path);
     if (R.is_err[toml.Table, str](toml_r)) { ret R.err[R.Void, str](R.unwrap_err[toml.Table, str](toml_r)); }
     var t: toml.Table = R.unwrap_ok[toml.Table, str](toml_r);
 
-    val r: R.Result[R.Void, str] = load_config(p, project_root, ?t, sel, for_union, is_test);
+    val r: R.Result[R.Void, str] = load_config(p, project_root, ?t, pick, for_union, is_test);
     toml.dnit(p.alloc, ?t);
     ret r;
 }
 
-fun load_config(p: *project.Project, project_root: str, t: *toml.Table, sel: *manifest.Selection, for_union: bool, is_test: bool) R.Result[R.Void, str] {
+fun load_config(p: *project.Project, project_root: str, t: *toml.Table, pick: *manifest.Selection, for_union: bool, is_test: bool) R.Result[R.Void, str] {
     val mr: R.Result[manifest.Manifest, str] = manifest.parse(p.alloc, ?p.s.interner, t, true);
     if (R.is_err[manifest.Manifest, str](mr)) { ret R.err[R.Void, str](R.unwrap_err[manifest.Manifest, str](mr)); }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
-    val r: R.Result[R.Void, str] = load_config_manifest(p, project_root, ?m, sel, for_union, is_test);
+    val r: R.Result[R.Void, str] = load_config_manifest(p, project_root, ?m, pick, for_union, is_test);
     manifest.dnit(?m, p.alloc);
     ret r;
 }
@@ -267,18 +267,18 @@ fun clone_step(alloc: *A.Allocator, src: *manifest.StepDef, out: *manifest.StepD
     ret R.ok_void[str]();
 }
 
-pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifest.Manifest, sel: *manifest.Selection, for_union: bool, is_test: bool) R.Result[R.Void, str] {
+pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifest.Manifest, pick: *manifest.Selection, for_union: bool, is_test: bool) R.Result[R.Void, str] {
     val abs_root_r: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, project_root);
     if (R.is_err[intern.StrId, str](abs_root_r)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](abs_root_r)); }
     p.config.project_root = R.unwrap_ok[intern.StrId, str](abs_root_r);
 
     var eff_sel: manifest.Selection;
-    eff_sel.target       = sel.target;
-    eff_sel.profile      = sel.profile;
-    eff_sel.artifact     = sel.artifact;
-    eff_sel.want_lib     = sel.want_lib;
-    eff_sel.has_artifact = sel.has_artifact;
-    eff_sel.legacy_default = sel.legacy_default;
+    eff_sel.target       = pick.target;
+    eff_sel.profile      = pick.profile;
+    eff_sel.artifact     = pick.artifact;
+    eff_sel.want_lib     = pick.want_lib;
+    eff_sel.has_artifact = pick.has_artifact;
+    eff_sel.legacy_default = pick.legacy_default;
     if (for_union || is_test) {
         val psr: R.Result[R.Void, str] = manifest.select_primary_artifact(
             p.alloc, ?p.s.interner, m, ?eff_sel);
@@ -3627,8 +3627,8 @@ test "mach.lang.driver.config.resolve_run_artifact:rejects_library_selection" {
     if (R.is_err[str, str](root_r)) { ret 1; }
     val root: str = R.unwrap_ok[str, str](root_r);
 
-    var sel: manifest.Selection = manifest.Selection{target: "", profile: "", artifact: "", want_lib: false, has_artifact: false};
-    val rr: R.Result[RunArtifact, str] = resolve_run_artifact(?alloc, root, ?sel, nil);
+    var pick: manifest.Selection = manifest.Selection{target: "", profile: "", artifact: "", want_lib: false, has_artifact: false};
+    val rr: R.Result[RunArtifact, str] = resolve_run_artifact(?alloc, root, ?pick, nil);
 
     var bad: i32 = 0;
     if (R.is_ok[RunArtifact, str](rr)) { bad = 1; }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -195,14 +195,14 @@ fun ut_union_native_text(alloc: *A.Allocator, text: str) R.Result[str, str] {
 }
 
 fun ut_target_sel(target_name: str) manifest.Selection {
-    var sel: manifest.Selection;
-    sel.target       = target_name;
-    sel.profile      = "";
-    sel.artifact     = "";
-    sel.want_lib     = false;
-    sel.has_artifact = false;
-    sel.legacy_default = false;
-    ret sel;
+    var pick: manifest.Selection;
+    pick.target       = target_name;
+    pick.profile      = "";
+    pick.artifact     = "";
+    pick.want_lib     = false;
+    pick.has_artifact = false;
+    pick.legacy_default = false;
+    ret pick;
 }
 
 fun ut_scaffold_m(alloc: *A.Allocator, manifest_text: str, names: *str, texts: *str, n: u32) R.Result[str, str] {
@@ -480,13 +480,13 @@ fun ut_build_test(s: *session.Session, alloc: *A.Allocator, names: *str, texts: 
     val root: str = R.unwrap_ok[str, str](root_r);
     val rr: R.Result[R.Void, str] = driver.setup_registry(?s.registry);
     if (R.is_err[R.Void, str](rr)) { fs.remove_all(alloc, root); ret R.err[project.Project, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](rr))); }
-    var sel: manifest.Selection;
-    sel.target       = "";
-    sel.profile      = "";
-    sel.artifact     = "";
-    sel.want_lib     = false;
-    sel.has_artifact = false;
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_test(s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target       = "";
+    pick.profile      = "";
+    pick.artifact     = "";
+    pick.want_lib     = false;
+    pick.has_artifact = false;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_test(s, root, ?pick);
     fs.remove_all(alloc, root);
     ret pr;
 }
@@ -2090,7 +2090,7 @@ test "mach.lang.me.pass.scalarize:vector_bitcast_does_not_survive" {
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
 
-    val src: str = "pub fun sel(m: u8x16, a: i8x16, b: i8x16) i8x16 {\n    ret ((m & a:~u8x16) | (~m & b:~u8x16)):~i8x16;\n}\nfun main() i32 { ret 0; }\n";
+    val src: str = "pub fun pick(m: u8x16, a: i8x16, b: i8x16) i8x16 {\n    ret ((m & a:~u8x16) | (~m & b:~u8x16)):~i8x16;\n}\nfun main() i32 { ret 0; }\n";
 
     var bad: i32 = 0;
     val pr: R.Result[project.Project, outcome.Fail] =
@@ -2113,7 +2113,7 @@ test "mach.lang.me.pass.scalarize:vector_bitcast_survives_on_capable_target" {
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
 
-    val src: str = "pub fun sel(m: u8x16, a: i8x16, b: i8x16) i8x16 {\n    ret ((m & a:~u8x16) | (~m & b:~u8x16)):~i8x16;\n}\nfun main() i32 { ret 0; }\n";
+    val src: str = "pub fun pick(m: u8x16, a: i8x16, b: i8x16) i8x16 {\n    ret ((m & a:~u8x16) | (~m & b:~u8x16)):~i8x16;\n}\nfun main() i32 { ret 0; }\n";
 
     var bad: i32 = 0;
     val pr: R.Result[project.Project, outcome.Fail] =
@@ -4004,9 +4004,9 @@ test "mach.lang.driver:union_malformed_condition_reported_once" {
     val root1: str = R.unwrap_ok[str, str](root1_r);
     val rr1: R.Result[R.Void, str] = driver.setup_registry(?s1.registry);
     if (R.is_err[R.Void, str](rr1)) { fs.remove_all(?a1, root1); session.dnit(?s1); ret 1; }
-    var sel: manifest.Selection;
-    sel.target = ""; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false;
-    val p1r: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s1, root1, ?sel);
+    var pick: manifest.Selection;
+    pick.target = ""; pick.profile = ""; pick.artifact = ""; pick.want_lib = false; pick.has_artifact = false;
+    val p1r: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s1, root1, ?pick);
     fs.remove_all(?a1, root1);
     if (R.is_err[project.Project, outcome.Fail](p1r)) { session.dnit(?s1); ret 1; }
     var p1: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p1r);
@@ -4196,9 +4196,9 @@ test "mach.lang.driver:validate_local_links_skips_filtered_cross_target" {
     val root: str = R.unwrap_ok[str, str](root_r);
 
     var bad: i32 = 0;
-    var sel: manifest.Selection;
-    sel.target = "linux"; sel.profile = ""; sel.artifact = "app"; sel.want_lib = false; sel.has_artifact = true;
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = "linux"; pick.profile = ""; pick.artifact = "app"; pick.want_lib = false; pick.has_artifact = true;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 1; }
     or { var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr); project.dnit_project(?p); }
 
@@ -4224,9 +4224,9 @@ test "mach.lang.driver:step_out_in_module_obj_tree_rejected" {
     val root: str = R.unwrap_ok[str, str](root_r);
 
     var bad: i32 = 0;
-    var sel: manifest.Selection;
-    sel.target = "linux"; sel.profile = ""; sel.artifact = "app"; sel.want_lib = false; sel.has_artifact = true;
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = "linux"; pick.profile = ""; pick.artifact = "app"; pick.want_lib = false; pick.has_artifact = true;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     if (R.is_ok[project.Project, outcome.Fail](pr)) {
         var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
         project.dnit_project(?p);
@@ -4261,9 +4261,9 @@ test "mach.lang.driver:step_out_in_stage_tree_rejected" {
     val root: str = R.unwrap_ok[str, str](root_r);
 
     var bad: i32 = 0;
-    var sel: manifest.Selection;
-    sel.target = "linux"; sel.profile = ""; sel.artifact = "app"; sel.want_lib = false; sel.has_artifact = true;
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = "linux"; pick.profile = ""; pick.artifact = "app"; pick.want_lib = false; pick.has_artifact = true;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     if (R.is_ok[project.Project, outcome.Fail](pr)) {
         var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
         project.dnit_project(?p);
@@ -4298,9 +4298,9 @@ test "mach.lang.driver:step_out_in_stamp_tree_rejected" {
     val root: str = R.unwrap_ok[str, str](root_r);
 
     var bad: i32 = 0;
-    var sel: manifest.Selection;
-    sel.target = "linux"; sel.profile = ""; sel.artifact = "app"; sel.want_lib = false; sel.has_artifact = true;
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = "linux"; pick.profile = ""; pick.artifact = "app"; pick.want_lib = false; pick.has_artifact = true;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     if (R.is_ok[project.Project, outcome.Fail](pr)) {
         var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
         project.dnit_project(?p);
@@ -4335,9 +4335,9 @@ test "mach.lang.driver:step_out_beside_module_obj_tree_allowed" {
     val root: str = R.unwrap_ok[str, str](root_r);
 
     var bad: i32 = 0;
-    var sel: manifest.Selection;
-    sel.target = "linux"; sel.profile = ""; sel.artifact = "app"; sel.want_lib = false; sel.has_artifact = true;
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = "linux"; pick.profile = ""; pick.artifact = "app"; pick.want_lib = false; pick.has_artifact = true;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 1; }
     or { var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr); project.dnit_project(?p); }
 
@@ -4362,13 +4362,13 @@ test "mach.lang.driver:build_steps_repeat_cache_hit_skips_reexecution" {
     if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
     val root: str = R.unwrap_ok[str, str](root_r);
 
-    var sel: manifest.Selection;
-    sel.target = "linux"; sel.profile = ""; sel.artifact = "app"; sel.want_lib = false; sel.has_artifact = true;
+    var pick: manifest.Selection;
+    pick.target = "linux"; pick.profile = ""; pick.artifact = "app"; pick.want_lib = false; pick.has_artifact = true;
     var bad: bool = false;
-    val first_r: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    val first_r: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     if (R.is_err[project.Project, outcome.Fail](first_r)) { bad = true; }
     or { var first: project.Project = R.unwrap_ok[project.Project, outcome.Fail](first_r); project.dnit_project(?first); }
-    val second_r: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    val second_r: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     if (R.is_err[project.Project, outcome.Fail](second_r)) { bad = true; }
     or { var second: project.Project = R.unwrap_ok[project.Project, outcome.Fail](second_r); project.dnit_project(?second); }
 
@@ -4411,9 +4411,9 @@ test "mach.lang.driver:build_steps_repeat_reexecutes_on_stale_input" {
         if (O.is_some[str](fs.write_bytes(watched, "a"::*u8, 1, 420))) { bad = true; }
     }
 
-    var sel: manifest.Selection;
-    sel.target = "linux"; sel.profile = ""; sel.artifact = "app"; sel.want_lib = false; sel.has_artifact = true;
-    val first_r: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = "linux"; pick.profile = ""; pick.artifact = "app"; pick.want_lib = false; pick.has_artifact = true;
+    val first_r: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     if (R.is_err[project.Project, outcome.Fail](first_r)) { bad = true; }
     or { var first: project.Project = R.unwrap_ok[project.Project, outcome.Fail](first_r); project.dnit_project(?first); }
 
@@ -4424,7 +4424,7 @@ test "mach.lang.driver:build_steps_repeat_reexecutes_on_stale_input" {
         if (O.is_some[str](fs.write_bytes(watched2, "b"::*u8, 1, 420))) { bad = true; }
     }
 
-    val second_r: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    val second_r: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     if (R.is_err[project.Project, outcome.Fail](second_r)) { bad = true; }
     or { var second: project.Project = R.unwrap_ok[project.Project, outcome.Fail](second_r); project.dnit_project(?second); }
 
@@ -4474,9 +4474,9 @@ test "mach.lang.driver:build_steps_stale_staging_discarded_before_run" {
         if (O.is_some[str](fs.write_bytes(stale, "stale-from-a-crashed-run"::*u8, 24, 420))) { bad = true; }
     }
 
-    var sel: manifest.Selection;
-    sel.target = "linux"; sel.profile = ""; sel.artifact = "app"; sel.want_lib = false; sel.has_artifact = true;
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = "linux"; pick.profile = ""; pick.artifact = "app"; pick.want_lib = false; pick.has_artifact = true;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     if (R.is_ok[project.Project, outcome.Fail](pr)) {
         var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
         project.dnit_project(?p);
@@ -4525,9 +4525,9 @@ test "mach.lang.driver:resolve_artifact_path" {
 
     var bad: i32 = 0;
 
-    var sel: manifest.Selection;
-    sel.target = "linux"; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false;
-    val pr: R.Result[str, str] = dcfg.resolve_artifact_path(?alloc, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = "linux"; pick.profile = ""; pick.artifact = ""; pick.want_lib = false; pick.has_artifact = false;
+    val pr: R.Result[str, str] = dcfg.resolve_artifact_path(?alloc, root, ?pick);
     if (R.is_err[str, str](pr)) { bad = 1; }
     or {
         if (!ut_native_path_is(?alloc, R.unwrap_ok[str, str](pr), root,
@@ -4575,11 +4575,11 @@ test "mach.lang.driver:test_primary_artifact_matches_target" {
     if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
     val root: str = R.unwrap_ok[str, str](root_r);
 
-    var sel: manifest.Selection;
-    sel.target = "windows"; sel.profile = ""; sel.artifact = "";
-    sel.want_lib = false; sel.has_artifact = false;
+    var pick: manifest.Selection;
+    pick.target = "windows"; pick.profile = ""; pick.artifact = "";
+    pick.want_lib = false; pick.has_artifact = false;
     val pr: R.Result[project.Project, outcome.Fail] =
-        driver.build_project_test(?s, root, ?sel);
+        driver.build_project_test(?s, root, ?pick);
     fs.remove_all(?alloc, root);
     if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
@@ -4608,9 +4608,9 @@ test "mach.lang.driver:selected_root_artifact_sets_project_module" {
     if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
     val root: str = R.unwrap_ok[str, str](root_r);
 
-    var sel: manifest.Selection;
-    sel.target = "linux"; sel.profile = ""; sel.artifact = "beta"; sel.want_lib = false; sel.has_artifact = true;
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = "linux"; pick.profile = ""; pick.artifact = "beta"; pick.want_lib = false; pick.has_artifact = true;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     fs.remove_all(?alloc, root);
     if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
@@ -8912,14 +8912,14 @@ fun ut_volatile_counts_release(src: str, vol_loads: *u32, vol_stores: *u32,
     val rr: R.Result[R.Void, str] = driver.setup_registry(?s.registry);
     if (R.is_err[R.Void, str](rr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret false; }
 
-    var sel: manifest.Selection;
-    sel.target       = "";
-    sel.profile      = "release";
-    sel.artifact     = "";
-    sel.want_lib     = false;
-    sel.has_artifact = false;
+    var pick: manifest.Selection;
+    pick.target       = "";
+    pick.profile      = "release";
+    pick.artifact     = "";
+    pick.want_lib     = false;
+    pick.has_artifact = false;
 
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_test(?s, root, ?sel);
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_test(?s, root, ?pick);
     fs.remove_all(?alloc, root);
     if (R.is_err[project.Project, outcome.Fail](pr)) {
         print.print(R.unwrap_err[project.Project, outcome.Fail](pr).message);
@@ -9715,7 +9715,7 @@ test "mach.lang.driver:oblivious_required" {
         "not declared `#[oblivious]`") != 0) { bad = 1; }
     if (ut_lower_rejects("fun secret_add(a: ^u32, b: ^u32) ^u32 { ret a + b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { secret_add(1, 2); ret 0; }\n",
         "`secret_add` performs a constant-time arithmetic operation") != 0) { bad = 1; }
-    if (ut_lower_rejects("fun sel(m: ^u32, a: ^u32, b: ^u32) ^u32 { ret (a & m) | (b & ~m); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { sel(1, 2, 3); ret 0; }\n",
+    if (ut_lower_rejects("fun pick(m: ^u32, a: ^u32, b: ^u32) ^u32 { ret (a & m) | (b & ~m); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { pick(1, 2, 3); ret 0; }\n",
         "bitwise operation") != 0) { bad = 1; }
     if (ut_lower_rejects("fun eq(a: ^u32, b: ^u32) ^u8 { ret a == b; }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { eq(1, 2); ret 0; }\n",
         "comparison") != 0) { bad = 1; }
@@ -10341,7 +10341,7 @@ fun ut_agg_strip_src(buf: *u8) usize {
     w = ut_app(buf, w, "rec Inner { x: u32; y: u32; }\n");
     w = ut_app(buf, w, "rec M { n: Inner; p: *u8; q: ^*u8; v: u32; }\n");
     w = ut_app(buf, w, "#[symbol(\"_start\")]\n");
-    w = ut_app(buf, w, "fun probe(sel: i32, v: i32) i32 {\n");
+    w = ut_app(buf, w, "fun probe(pick: i32, v: i32) i32 {\n");
     w = ut_app(buf, w, "    val v0: u32 = v::u32;\n");
     w = ut_app(buf, w, "    val v1: u32 = (v + 1)::u32;\n");
     w = ut_app(buf, w, "    val v2: u32 = (v + 2)::u32;\n");
@@ -10349,11 +10349,11 @@ fun ut_agg_strip_src(buf: *u8) usize {
     w = ut_app(buf, w, "    var k: ^K;\n");
     w = ut_app(buf, w, "    k.a = v0;\n");
     w = ut_app(buf, w, "    k.b = v1;\n");
-    w = ut_app(buf, w, "    if (sel == 0) { ret sum_k(k)::i32; }\n");
-    w = ut_app(buf, w, "    if (sel == 3) { ret old_k(k)::i32; }\n");
+    w = ut_app(buf, w, "    if (pick == 0) { ret sum_k(k)::i32; }\n");
+    w = ut_app(buf, w, "    if (pick == 3) { ret old_k(k)::i32; }\n");
     w = ut_app(buf, w, "    var arr: ^[4]u32;\n");
     w = ut_app(buf, w, "    arr[0] = v0; arr[1] = v1; arr[2] = v2; arr[3] = v3;\n");
-    w = ut_app(buf, w, "    if (sel == 1) { ret sum_arr(arr)::i32; }\n");
+    w = ut_app(buf, w, "    if (pick == 1) { ret sum_arr(arr)::i32; }\n");
     w = ut_app(buf, w, "    var b1: u8 = 7;\n");
     w = ut_app(buf, w, "    var b2: u8 = 9;\n");
     w = ut_app(buf, w, "    var m: ^M;\n");
@@ -10362,7 +10362,7 @@ fun ut_agg_strip_src(buf: *u8) usize {
     w = ut_app(buf, w, "    m.p = ?b1;\n");
     w = ut_app(buf, w, "    m.q = ?b2;\n");
     w = ut_app(buf, w, "    m.v = 5;\n");
-    w = ut_app(buf, w, "    if (sel == 2) { ret sum_m(m)::i32; }\n");
+    w = ut_app(buf, w, "    if (pick == 2) { ret sum_m(m)::i32; }\n");
     w = ut_app(buf, w, "    ret 0 - 1;\n");
     w = ut_app(buf, w, "}\n");
     w = ut_app(buf, w, "fun sum_k(s: ^K) u32 { val p: K = s:>K; ret p.a + p.b; }\n");
@@ -10379,9 +10379,9 @@ fun ut_agg_strip_src(buf: *u8) usize {
     ret w;
 }
 
-fun ut_agg_strip_run(mem: *u8, sel: u32, v: u32, out: *u32) bool {
+fun ut_agg_strip_run(mem: *u8, pick: u32, v: u32, out: *u32) bool {
     var args: [2]u32;
-    args[0] = sel;
+    args[0] = pick;
     args[1] = v;
     var lo: u32 = 0;
     var hi: u32 = 0;
@@ -13177,15 +13177,15 @@ fun ut_rv32_globals_src(buf: *u8) usize {
     w = ut_app(buf, w, "var gn: i64 = -2147483648;\n");
     w = ut_app(buf, w, "var gb: i64 = 0;\n");
     w = ut_app(buf, w, "#[symbol(\"_start\")]\n");
-    w = ut_app(buf, w, "fun probe(sel: i32, v: i64) i64 {\n");
-    w = ut_app(buf, w, "    if (sel == 0) { ret ga; }\n");
-    w = ut_app(buf, w, "    if (sel == 1) { gb = v; ret gb; }\n");
-    w = ut_app(buf, w, "    if (sel == 2) { ret ga + v; }\n");
-    w = ut_app(buf, w, "    if (sel == 3) { ret ga - v; }\n");
-    w = ut_app(buf, w, "    if (sel == 4) { ret gb; }\n");
-    w = ut_app(buf, w, "    if (sel == 5) { ret gn; }\n");
-    w = ut_app(buf, w, "    if (sel == 6) { ret gn + v; }\n");
-    w = ut_app(buf, w, "    if (sel == 7) { ret gn - v; }\n");
+    w = ut_app(buf, w, "fun probe(pick: i32, v: i64) i64 {\n");
+    w = ut_app(buf, w, "    if (pick == 0) { ret ga; }\n");
+    w = ut_app(buf, w, "    if (pick == 1) { gb = v; ret gb; }\n");
+    w = ut_app(buf, w, "    if (pick == 2) { ret ga + v; }\n");
+    w = ut_app(buf, w, "    if (pick == 3) { ret ga - v; }\n");
+    w = ut_app(buf, w, "    if (pick == 4) { ret gb; }\n");
+    w = ut_app(buf, w, "    if (pick == 5) { ret gn; }\n");
+    w = ut_app(buf, w, "    if (pick == 6) { ret gn + v; }\n");
+    w = ut_app(buf, w, "    if (pick == 7) { ret gn - v; }\n");
     w = ut_app(buf, w, "    ret 0;\n");
     w = ut_app(buf, w, "}\n");
     buf[w] = 0;
@@ -13272,9 +13272,9 @@ fun ut_rv32_build_linked(s: *session.Session, alloc: *A.Allocator, src: str, tgt
     ret ok;
 }
 
-fun ut_rv32_run_g(mem: *u8, sel: u32, v: u64, out: *u64, steps: *u32) bool {
+fun ut_rv32_run_g(mem: *u8, pick: u32, v: u64, out: *u64, steps: *u32) bool {
     var args: [3]u32;
-    args[0] = sel;
+    args[0] = pick;
     args[1] = (v & 0xFFFFFFFF)::u32;
     args[2] = (v >> 32)::u32;
     var lo: u32 = 0;
@@ -13353,27 +13353,27 @@ fun ut_rv32_float_src(buf: *u8) usize {
     var w: usize = 0;
     w = ut_app(buf, w, "var fb: i64 = 0;\n");
     w = ut_app(buf, w, "#[symbol(\"_start\")]\n");
-    w = ut_app(buf, w, "fun probe(sel: i32, v: i64) i64 {\n");
+    w = ut_app(buf, w, "fun probe(pick: i32, v: i64) i64 {\n");
     w = ut_app(buf, w, "    val pd: *f64 = (?fb)::*f64;\n");
     w = ut_app(buf, w, "    val ps: *f32 = (?fb)::*f32;\n");
-    w = ut_app(buf, w, "    if (sel == 0)  { @pd = v::f64;        ret fb; }\n");
-    w = ut_app(buf, w, "    if (sel == 1)  { @pd = (v::u64)::f64; ret fb; }\n");
-    w = ut_app(buf, w, "    if (sel == 2)  { @ps = v::f32;        ret fb; }\n");
-    w = ut_app(buf, w, "    if (sel == 3)  { @ps = (v::u64)::f32; ret fb; }\n");
-    w = ut_app(buf, w, "    if (sel == 4)  { fb = v; ret (@pd)::i64; }\n");
-    w = ut_app(buf, w, "    if (sel == 5)  { fb = v; ret ((@pd)::u64)::i64; }\n");
-    w = ut_app(buf, w, "    if (sel == 6)  { fb = v; ret (@ps)::i64; }\n");
-    w = ut_app(buf, w, "    if (sel == 7)  { fb = v; ret ((@ps)::u64)::i64; }\n");
-    w = ut_app(buf, w, "    if (sel == 8)  { fb = v; @pd = (@pd) + (@pd); ret fb; }\n");
-    w = ut_app(buf, w, "    if (sel == 9)  { fb = v; @pd = (@pd) * (@pd); ret fb; }\n");
-    w = ut_app(buf, w, "    if (sel == 10) { fb = v; @pd = (@pd) - 1.5; ret fb; }\n");
-    w = ut_app(buf, w, "    if (sel == 11) { fb = v; @pd = (@pd) / 3.0; ret fb; }\n");
-    w = ut_app(buf, w, "    if (sel == 12) { fb = v; @ps = (@ps) + (@ps); ret fb; }\n");
-    w = ut_app(buf, w, "    if (sel == 13) { fb = v; @ps = (@ps) * 0.5; ret fb; }\n");
-    w = ut_app(buf, w, "    if (sel == 14) { fb = v; if ((@pd) < 1.0) { ret 1; } ret 0; }\n");
-    w = ut_app(buf, w, "    if (sel == 15) { fb = v; if ((@pd) == (@pd)) { ret 1; } ret 0; }\n");
-    w = ut_app(buf, w, "    if (sel == 16) { fb = v; @pd = ((@ps))::f64; ret fb; }\n");
-    w = ut_app(buf, w, "    if (sel == 17) { fb = v; @ps = ((@pd))::f32; ret fb; }\n");
+    w = ut_app(buf, w, "    if (pick == 0)  { @pd = v::f64;        ret fb; }\n");
+    w = ut_app(buf, w, "    if (pick == 1)  { @pd = (v::u64)::f64; ret fb; }\n");
+    w = ut_app(buf, w, "    if (pick == 2)  { @ps = v::f32;        ret fb; }\n");
+    w = ut_app(buf, w, "    if (pick == 3)  { @ps = (v::u64)::f32; ret fb; }\n");
+    w = ut_app(buf, w, "    if (pick == 4)  { fb = v; ret (@pd)::i64; }\n");
+    w = ut_app(buf, w, "    if (pick == 5)  { fb = v; ret ((@pd)::u64)::i64; }\n");
+    w = ut_app(buf, w, "    if (pick == 6)  { fb = v; ret (@ps)::i64; }\n");
+    w = ut_app(buf, w, "    if (pick == 7)  { fb = v; ret ((@ps)::u64)::i64; }\n");
+    w = ut_app(buf, w, "    if (pick == 8)  { fb = v; @pd = (@pd) + (@pd); ret fb; }\n");
+    w = ut_app(buf, w, "    if (pick == 9)  { fb = v; @pd = (@pd) * (@pd); ret fb; }\n");
+    w = ut_app(buf, w, "    if (pick == 10) { fb = v; @pd = (@pd) - 1.5; ret fb; }\n");
+    w = ut_app(buf, w, "    if (pick == 11) { fb = v; @pd = (@pd) / 3.0; ret fb; }\n");
+    w = ut_app(buf, w, "    if (pick == 12) { fb = v; @ps = (@ps) + (@ps); ret fb; }\n");
+    w = ut_app(buf, w, "    if (pick == 13) { fb = v; @ps = (@ps) * 0.5; ret fb; }\n");
+    w = ut_app(buf, w, "    if (pick == 14) { fb = v; if ((@pd) < 1.0) { ret 1; } ret 0; }\n");
+    w = ut_app(buf, w, "    if (pick == 15) { fb = v; if ((@pd) == (@pd)) { ret 1; } ret 0; }\n");
+    w = ut_app(buf, w, "    if (pick == 16) { fb = v; @pd = ((@ps))::f64; ret fb; }\n");
+    w = ut_app(buf, w, "    if (pick == 17) { fb = v; @ps = ((@pd))::f32; ret fb; }\n");
     w = ut_app(buf, w, "    ret 0;\n");
     w = ut_app(buf, w, "}\n");
     buf[w] = 0;
@@ -13430,9 +13430,9 @@ fun ut_rv32_fbits(i: u32) u64 {
     ret 0;
 }
 
-fun ut_rv32_run_f(mem: *u8, sel: u32, v: u64, out: *u64, steps: *u32) bool {
+fun ut_rv32_run_f(mem: *u8, pick: u32, v: u64, out: *u64, steps: *u32) bool {
     var args: [3]u32;
-    args[0] = sel;
+    args[0] = pick;
     args[1] = (v & 0xFFFFFFFF)::u32;
     args[2] = (v >> 32)::u32;
     var lo: u32 = 0;
@@ -13923,9 +13923,9 @@ test "mach.lang.driver:debug_info_on_a_target_without_a_debug_model_fails_the_ar
     if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
     val root: str = R.unwrap_ok[str, str](root_r);
 
-    var sel: manifest.Selection;
-    sel.target = "windows"; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false; sel.legacy_default = false;
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = "windows"; pick.profile = ""; pick.artifact = ""; pick.want_lib = false; pick.has_artifact = false; pick.legacy_default = false;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     if (R.is_err[project.Project, outcome.Fail](pr)) { print.print(R.unwrap_err[project.Project, outcome.Fail](pr).message); fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
     var bad: i32 = 0;
@@ -14054,9 +14054,9 @@ fun ut_spirv_env_build(alloc: *A.Allocator, env_line: str, needle: str, want_ver
     val root: str = R.unwrap_ok[str, str](root_r);
 
     var bad: i32 = 0;
-    var sel: manifest.Selection;
-    sel.target = "gpu"; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false; sel.legacy_default = false;
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = "gpu"; pick.profile = ""; pick.artifact = ""; pick.want_lib = false; pick.has_artifact = false; pick.legacy_default = false;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     if (R.is_err[project.Project, outcome.Fail](pr)) {
         val f: outcome.Fail = R.unwrap_err[project.Project, outcome.Fail](pr);
         if (str_empty(needle) || f.message == nil || !ut_str_contains(f.message, needle)) { print.print(f.message); print.print("\n"); bad = 2; }
@@ -14377,10 +14377,10 @@ fun ut_attr_probe_allsrc(s: *session.Session, alloc: *A.Allocator, names: *str, 
         ret R.err[str, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](rr)));
     }
 
-    var sel: manifest.Selection;
-    sel.target = target_name; sel.profile = ""; sel.artifact = "";
-    sel.want_lib = false; sel.has_artifact = false;
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_test(s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = target_name; pick.profile = ""; pick.artifact = "";
+    pick.want_lib = false; pick.has_artifact = false;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_test(s, root, ?pick);
     fs.remove_all(alloc, root);
     if (R.is_err[project.Project, outcome.Fail](pr)) {
         ret R.err[str, outcome.Fail](R.unwrap_err[project.Project, outcome.Fail](pr));
@@ -18723,7 +18723,7 @@ test "mach.lang.driver:an_overlay_is_found_through_the_manifest_src" {
 }
 
 fun ut_rv32_xbank_src() str {
-    ret "#[symbol(\"_start\")]\nfun probe(sel: i32, v: i64) i64 {\n    val f: f64 = v :~ f64;\n    if (sel == 0) { ret f :~ i64; }\n    # a round trip through the float bank and back, so BOTH directions run in one\n    # image and a lowering that is wrong in only one of them cannot pass.\n    if (sel == 1) { val g: f64 = (f :~ i64) :~ f64; ret g :~ i64; }\n    # the width the register form DOES exist at on rv32 (fmv.w.x / fmv.x.w), so a\n    # change that routed everything through memory would still be caught here.\n    val n: i32 = v::i32;\n    val s: f32 = n :~ f32;\n    ret (s :~ i32)::i64;\n}\n";
+    ret "#[symbol(\"_start\")]\nfun probe(pick: i32, v: i64) i64 {\n    val f: f64 = v :~ f64;\n    if (pick == 0) { ret f :~ i64; }\n    # a round trip through the float bank and back, so BOTH directions run in one\n    # image and a lowering that is wrong in only one of them cannot pass.\n    if (pick == 1) { val g: f64 = (f :~ i64) :~ f64; ret g :~ i64; }\n    # the width the register form DOES exist at on rv32 (fmv.w.x / fmv.x.w), so a\n    # change that routed everything through memory would still be caught here.\n    val n: i32 = v::i32;\n    val s: f32 = n :~ f32;\n    ret (s :~ i32)::i64;\n}\n";
 }
 
 test "mach.lang.driver:an_rv32_cross_bank_reinterpret_round_trips_on_the_core" {
@@ -19597,9 +19597,9 @@ test "mach.lang.driver:step_target_environment_replaces_a_declared_override" {
     val root: str = R.unwrap_ok[str, str](root_r);
 
     var bad: i32 = 0;
-    var sel: manifest.Selection;
-    sel.target = "linux"; sel.profile = ""; sel.artifact = "app"; sel.want_lib = false; sel.has_artifact = true;
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = "linux"; pick.profile = ""; pick.artifact = "app"; pick.want_lib = false; pick.has_artifact = true;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 1; }
     or { var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr); project.dnit_project(?p); }
 
@@ -20080,8 +20080,8 @@ test "mach.lang.driver:a_test_build_that_picks_the_first_declared_artifact_recor
         cli.profile = nil; cli.bin = nil; cli.lib = nil; cli.all_targets = false; cli.pie = false; cli.subsystem = nil; cli.g = false;
         cli.opt_set = false; cli.opt_release = false; cli.jobs = "1"; cli.include_deps = false;
         cli.link_tokens = vector.init[*u8](?alloc); cli.lib_dirs = vector.init[*u8](?alloc);
-        var sel: manifest.Selection = ut_target_sel("linux");
-        val rr: R.Result[request.BuildRequest, outcome.Fail] = request.compose(?alloc, ?s.interner, ?m, ?cli, root, request.GOAL_TESTS, ?sel);
+        var pick: manifest.Selection = ut_target_sel("linux");
+        val rr: R.Result[request.BuildRequest, outcome.Fail] = request.compose(?alloc, ?s.interner, ?m, ?cli, root, request.GOAL_TESTS, ?pick);
         val br: R.Result[plan.BuildPlan, outcome.Fail] = plan.plan(?alloc, ?s.interner, ?s.registry, ?m, R.unwrap_ok[request.BuildRequest, outcome.Fail](rr));
         if (R.is_err[request.BuildRequest, outcome.Fail](rr) || R.is_err[plan.BuildPlan, outcome.Fail](br)) { bad = 2; }
         or {

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -3258,9 +3258,9 @@ fun t_driver_parse_outcome(alloc: *A.Allocator, root: str, diags_out: *diagnosti
     if (R.is_err[session.Session, str](sr)) { ret O.some[outcome.Fail](outcome.internal("session")); }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
     if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret O.some[outcome.Fail](outcome.internal("registry")); }
-    var sel: manifest.Selection;
-    sel.target = ""; sel.profile = ""; sel.artifact = ""; sel.want_lib = false; sel.has_artifact = false;
-    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target = ""; pick.profile = ""; pick.artifact = ""; pick.want_lib = false; pick.has_artifact = false;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_sel(?s, root, ?pick);
     var failure: O.Option[outcome.Fail] = O.none[outcome.Fail]();
     if (R.is_err[project.Project, outcome.Fail](pr)) {
         var f: outcome.Fail = R.unwrap_err[project.Project, outcome.Fail](pr);

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -2732,14 +2732,14 @@ fun eval_field_member[T](
     if (obj.kind != CT_KIND_FIELD) { ret O.none[R.Result[CTValue, EvalFail]](); }
 
     val mtext: View = span_text(source, member_span);
-    var sel: u8 = FIELD_SEL_NAME;
-    if      (view_eq_str(mtext, "name"))   { sel = FIELD_SEL_NAME; }
-    or      (view_eq_str(mtext, "type"))   { sel = FIELD_SEL_TYPE; }
-    or      (view_eq_str(mtext, "offset")) { sel = FIELD_SEL_OFFSET; }
+    var pick: u8 = FIELD_SEL_NAME;
+    if      (view_eq_str(mtext, "name"))   { pick = FIELD_SEL_NAME; }
+    or      (view_eq_str(mtext, "type"))   { pick = FIELD_SEL_TYPE; }
+    or      (view_eq_str(mtext, "offset")) { pick = FIELD_SEL_OFFSET; }
     or      { ret O.some[R.Result[CTValue, EvalFail]](reject(COMPTIME_FIELD_UNKNOWN_MEMBER_MSG)); }
 
     if (!capabilities_have_types[T](cap_ctx, caps) || caps.field == nil) { ret O.some[R.Result[CTValue, EvalFail]](reject(COMPTIME_FIELD_NO_RESOLVER_MSG)); }
-    val r: R.Result[O.Option[CTValue], EvalFail] = caps.field(cap_ctx, obj.data.fld.owner, obj.data.fld.index, sel);
+    val r: R.Result[O.Option[CTValue], EvalFail] = caps.field(cap_ctx, obj.data.fld.owner, obj.data.fld.index, pick);
     if (R.is_err[O.Option[CTValue], EvalFail](r)) { ret O.some[R.Result[CTValue, EvalFail]](R.err[CTValue, EvalFail](R.unwrap_err[O.Option[CTValue], EvalFail](r))); }
     val o: O.Option[CTValue] = R.unwrap_ok[O.Option[CTValue], EvalFail](r);
     if (O.is_none[CTValue](o)) { ret O.some[R.Result[CTValue, EvalFail]](reject(COMPTIME_FIELD_UNAVAILABLE_MSG)); }

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -849,10 +849,10 @@ pub fun field_lookup(sc: *SemaContext, ty: type.TypeId, name: intern.StrId) O.Op
     ret O.none[type.TypeId]();
 }
 
-pub fun resolve_field_member(sc: *SemaContext, owner: u32, index: u32, sel: u8) R.Result[O.Option[comptime.CTValue], comptime.EvalFail] {
+pub fun resolve_field_member(sc: *SemaContext, owner: u32, index: u32, pick: u8) R.Result[O.Option[comptime.CTValue], comptime.EvalFail] {
     if (sc == nil) { ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.none[comptime.CTValue]()); }
 
-    if (sel == comptime.FIELD_SEL_ZERO_BY_NAME) {
+    if (pick == comptime.FIELD_SEL_ZERO_BY_NAME) {
         ret resolve_omitted_field_zero(sc, owner::type.TypeId, index::intern.StrId);
     }
 
@@ -860,10 +860,10 @@ pub fun resolve_field_member(sc: *SemaContext, owner: u32, index: u32, sel: u8) 
     if (O.is_none[*type.FieldEntry](fa)) { ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.none[comptime.CTValue]()); }
     val fe: *type.FieldEntry = O.unwrap[*type.FieldEntry](fa);
 
-    if (sel == comptime.FIELD_SEL_NAME) {
+    if (pick == comptime.FIELD_SEL_NAME) {
         ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.some[comptime.CTValue](comptime.ct_str(fe.name)));
     }
-    if (sel == comptime.FIELD_SEL_TYPE) {
+    if (pick == comptime.FIELD_SEL_TYPE) {
         ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.some[comptime.CTValue](comptime.ct_type(fe.ty::u32)));
     }
     ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.none[comptime.CTValue]());

--- a/src/lang/fe/sema/tests.mach
+++ b/src/lang/fe/sema/tests.mach
@@ -109,13 +109,13 @@ fun ut_build(alloc: *A.Allocator, root: str, s: *session.Session) R.Result[proje
         ret R.err[project.Project, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](rr)));
     }
 
-    var sel: manifest.Selection;
-    sel.target       = "";
-    sel.profile      = "";
-    sel.artifact     = "";
-    sel.want_lib     = false;
-    sel.has_artifact = false;
-    ret driver.build_project_test(s, root, ?sel);
+    var pick: manifest.Selection;
+    pick.target       = "";
+    pick.profile      = "";
+    pick.artifact     = "";
+    pick.want_lib     = false;
+    pick.has_artifact = false;
+    ret driver.build_project_test(s, root, ?pick);
 }
 
 fun ut_mid(p: *project.Project, s: *session.Session, fqn: str) session.ModuleId {

--- a/src/lang/fuzz/manifest.mach
+++ b/src/lang/fuzz/manifest.mach
@@ -152,16 +152,16 @@ fun resolve_every_cell(alloc: *A.Allocator, itn: *intern.Interner, m: *man.Manif
                 val an: O.Option[str] = intern.lookup(itn, m.artifacts[ai].name);
                 ai = ai + 1;
                 if (!O.is_some[str](an)) { cnt; }
-                var sel: man.Selection;
-                sel.target       = "";
-                sel.profile      = "";
-                sel.artifact     = O.unwrap[str](an);
-                sel.want_lib     = false;
-                sel.has_artifact = true;
+                var pick: man.Selection;
+                pick.target       = "";
+                pick.profile      = "";
+                pick.artifact     = O.unwrap[str](an);
+                pick.want_lib     = false;
+                pick.has_artifact = true;
 
-                val sr: R.Result[R.Void, str] = man.select_sole_target_artifact(alloc, itn, m, ?sel);
+                val sr: R.Result[R.Void, str] = man.select_sole_target_artifact(alloc, itn, m, ?pick);
                 if (R.is_err[R.Void, str](sr)) { cnt; }
-                val br: R.Result[man.BuildUnit, str] = man.resolve_build_unit(alloc, itn, m, sel);
+                val br: R.Result[man.BuildUnit, str] = man.resolve_build_unit(alloc, itn, m, pick);
                 if (R.is_err[man.BuildUnit, str](br)) { cnt; }
                 val bu: man.BuildUnit = R.unwrap_ok[man.BuildUnit, str](br);
                 if (!resolves(itn, bu.entry) || !resolves(itn, bu.bin_path)

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -2950,12 +2950,12 @@ fun profile_resolved(pf: *ProfileDef) ResolvedProfile {
 # alloc: owns error text
 # itn: interns the name
 # m: the manifest
-# sel: the profile name, or "" for the default
-# ret: the profile; err "mach.toml: no profile named '<sel>'" or, with an empty
+# pick: the profile name, or "" for the default
+# ret: the profile; err "mach.toml: no profile named '<pick>'" or, with an empty
 #  name, an error when more than one profile is marked default
-pub fun resolve_profile(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: str) R.Result[ResolvedProfile, str] {
-    if (!str_empty(sel)) {
-        val res_id: R.Result[intern.StrId, str] = intern.intern(itn, sel);
+pub fun resolve_profile(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, pick: str) R.Result[ResolvedProfile, str] {
+    if (!str_empty(pick)) {
+        val res_id: R.Result[intern.StrId, str] = intern.intern(itn, pick);
         if (R.is_err[intern.StrId, str](res_id)) { ret R.err[ResolvedProfile, str](R.unwrap_err[intern.StrId, str](res_id)); }
         val id: intern.StrId = R.unwrap_ok[intern.StrId, str](res_id);
         var i: u32 = 0;
@@ -2963,15 +2963,15 @@ pub fun resolve_profile(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest
             if (m.profiles[i].name == id) { ret R.ok[ResolvedProfile, str](profile_resolved(?m.profiles[i])); }
             i = i + 1;
         }
-        if (m.profile_count == 0 && str_equals(sel, "debug")) {
+        if (m.profile_count == 0 && str_equals(pick, "debug")) {
             var debug: ProfileDef = builtin_profile(itn, "debug", MOPT_DEBUG, true, false, true);
             ret R.ok[ResolvedProfile, str](profile_resolved(?debug));
         }
-        if (m.profile_count == 0 && str_equals(sel, "release")) {
+        if (m.profile_count == 0 && str_equals(pick, "release")) {
             var release: ProfileDef = builtin_profile(itn, "release", MOPT_RELEASE, false, true, false);
             ret R.ok[ResolvedProfile, str](profile_resolved(?release));
         }
-        ret R.err[ResolvedProfile, str](sfmt(alloc, "mach.toml: no profile named '{}'", sel));
+        ret R.err[ResolvedProfile, str](sfmt(alloc, "mach.toml: no profile named '{}'", pick));
     }
 
     if (m.profile_count == 1) {
@@ -3003,23 +3003,23 @@ pub fun resolve_profile(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest
 }
 
 # the artifact a selection names: with `has_artifact`, the one whose name and
-# `is_lib` both match `sel`; otherwise the sole declared artifact
+# `is_lib` both match `pick`; otherwise the sole declared artifact
 # ---
 # itn: interns the name
 # m: the manifest
-# sel: the selection
+# pick: the selection
 # ret: the artifact, or nil when none is declared, the name has no match of
 #  the requested shape, or several artifacts are declared and none was named
-pub fun resolve_artifact(itn: *intern.Interner, m: *Manifest, sel: Selection) *ArtifactDef {
+pub fun resolve_artifact(itn: *intern.Interner, m: *Manifest, pick: Selection) *ArtifactDef {
     if (m.artifact_count == 0) { ret nil; }
 
-    if (sel.has_artifact) {
-        val res_id: R.Result[intern.StrId, str] = intern.intern(itn, sel.artifact);
+    if (pick.has_artifact) {
+        val res_id: R.Result[intern.StrId, str] = intern.intern(itn, pick.artifact);
         if (R.is_err[intern.StrId, str](res_id)) { ret nil; }
         val id: intern.StrId = R.unwrap_ok[intern.StrId, str](res_id);
         var i: u32 = 0;
         for (i < m.artifact_count) {
-            if (m.artifacts[i].name == id && m.artifacts[i].is_lib == sel.want_lib) { ret ?m.artifacts[i]; }
+            if (m.artifacts[i].name == id && m.artifacts[i].is_lib == pick.want_lib) { ret ?m.artifacts[i]; }
             i = i + 1;
         }
         ret nil;
@@ -3809,29 +3809,29 @@ pub fun artifact_supports_target(itn: *intern.Interner, a: *ArtifactDef, tname: 
 # alloc: owns error text
 # itn: resolves names
 # m: the manifest
-# sel: the selection
+# pick: the selection
 # ret: the support bit; err from target resolution, or when `resolve_artifact`
 #  finds nothing
-pub fun cell_supported(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[bool, str] {
-    val res_target: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target, nil);
+pub fun cell_supported(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, pick: Selection) R.Result[bool, str] {
+    val res_target: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, pick.target, nil);
     if (R.is_err[ResolvedTarget, str](res_target)) { ret R.err[bool, str](R.unwrap_err[ResolvedTarget, str](res_target)); }
     val rt: ResolvedTarget = R.unwrap_ok[ResolvedTarget, str](res_target);
 
-    val a: *ArtifactDef = resolve_artifact(itn, m, sel);
-    if (a == nil) { ret R.err[bool, str](artifact_err(alloc, itn, m, sel)); }
+    val a: *ArtifactDef = resolve_artifact(itn, m, pick);
+    if (a == nil) { ret R.err[bool, str](artifact_err(alloc, itn, m, pick)); }
 
     ret R.ok[bool, str](artifact_supports_target(itn, a, rt.target.name));
 }
 
 fun set_selected_artifact(itn: *intern.Interner, a: *ArtifactDef,
-                          sel: *Selection) R.Result[R.Void, str] {
+                          pick: *Selection) R.Result[R.Void, str] {
     val name_opt: O.Option[str] = intern.lookup(itn, a.name);
     if (O.is_none[str](name_opt)) {
         ret R.err[R.Void, str]("selected artifact name not interned");
     }
-    sel.artifact     = O.unwrap[str](name_opt);
-    sel.want_lib     = a.is_lib;
-    sel.has_artifact = true;
+    pick.artifact     = O.unwrap[str](name_opt);
+    pick.want_lib     = a.is_lib;
+    pick.has_artifact = true;
     ret R.ok_void[str]();
 }
 
@@ -3844,10 +3844,10 @@ rec ArtifactCandidates {
 }
 
 fun artifact_candidates_for(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest,
-                            sel: *Selection, executables_only: bool) ArtifactCandidates {
+                            pick: *Selection, executables_only: bool) ArtifactCandidates {
     var c: ArtifactCandidates;
     c.count = 0; c.sole = nil; c.first = nil; c.default_count = 0; c.chosen = nil;
-    val tr: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target, nil);
+    val tr: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, pick.target, nil);
     if (R.is_err[ResolvedTarget, str](tr)) { ret c; }
     val rt: ResolvedTarget = R.unwrap_ok[ResolvedTarget, str](tr);
 
@@ -3867,50 +3867,50 @@ fun artifact_candidates_for(alloc: *A.Allocator, itn: *intern.Interner, m: *Mani
     ret c;
 }
 
-# fill in `sel.artifact` when none was named and several artifacts are declared:
+# fill in `pick.artifact` when none was named and several artifacts are declared:
 # the sole artifact supporting the selected target, else the one marked
-# `default = true`, else the first declared candidate with `sel.legacy_default` set
+# `default = true`, else the first declared candidate with `pick.legacy_default` set
 # ---
 # alloc: owns error text
 # itn: resolves names
 # m: the manifest
-# sel: updated in place; untouched when it already names an artifact or fewer
+# pick: updated in place; untouched when it already names an artifact or fewer
 #  than two are declared
 # ret: ok; err when no artifact supports the target or more than one candidate
 #  is marked default
 pub fun select_primary_artifact(alloc: *A.Allocator, itn: *intern.Interner,
-                                m: *Manifest, sel: *Selection) R.Result[R.Void, str] {
-    if (sel.has_artifact || m.artifact_count < 2) { ret R.ok_void[str](); }
+                                m: *Manifest, pick: *Selection) R.Result[R.Void, str] {
+    if (pick.has_artifact || m.artifact_count < 2) { ret R.ok_void[str](); }
 
-    val c: ArtifactCandidates = artifact_candidates_for(alloc, itn, m, sel, false);
-    if (c.sole != nil)   { ret set_selected_artifact(itn, c.sole, sel); }
-    if (c.chosen != nil) { ret set_selected_artifact(itn, c.chosen, sel); }
+    val c: ArtifactCandidates = artifact_candidates_for(alloc, itn, m, pick, false);
+    if (c.sole != nil)   { ret set_selected_artifact(itn, c.sole, pick); }
+    if (c.chosen != nil) { ret set_selected_artifact(itn, c.chosen, pick); }
     if (c.count == 0) {
         ret R.err[R.Void, str](sfmt(alloc, "mach.toml: no artifact supports the selected target ({})", artifact_candidates(alloc, itn, m)));
     }
     if (c.default_count > 1) {
         ret R.err[R.Void, str]("mach.toml: multiple artifacts supporting the selected target have 'default = true'; exactly one is allowed");
     }
-    sel.legacy_default = true;
-    ret set_selected_artifact(itn, c.first, sel);
+    pick.legacy_default = true;
+    ret set_selected_artifact(itn, c.first, pick);
 }
 
-# `select_primary_artifact` without the fallback: fill in `sel.artifact` only
+# `select_primary_artifact` without the fallback: fill in `pick.artifact` only
 # when the target leaves one candidate or one marked `default = true`, and stay
 # silent otherwise
 # ---
 # alloc: owns error text
 # itn: resolves names
 # m: the manifest
-# sel: updated in place when a choice is clear
+# pick: updated in place when a choice is clear
 # ret: ok unless the artifact name cannot be looked up
 pub fun select_sole_target_artifact(alloc: *A.Allocator, itn: *intern.Interner,
-                                    m: *Manifest, sel: *Selection) R.Result[R.Void, str] {
-    if (sel.has_artifact || m.artifact_count < 2) { ret R.ok_void[str](); }
+                                    m: *Manifest, pick: *Selection) R.Result[R.Void, str] {
+    if (pick.has_artifact || m.artifact_count < 2) { ret R.ok_void[str](); }
 
-    val c: ArtifactCandidates = artifact_candidates_for(alloc, itn, m, sel, false);
-    if (c.sole != nil)   { ret set_selected_artifact(itn, c.sole, sel); }
-    if (c.chosen != nil) { ret set_selected_artifact(itn, c.chosen, sel); }
+    val c: ArtifactCandidates = artifact_candidates_for(alloc, itn, m, pick, false);
+    if (c.sole != nil)   { ret set_selected_artifact(itn, c.sole, pick); }
+    if (c.chosen != nil) { ret set_selected_artifact(itn, c.chosen, pick); }
     ret R.ok_void[str]();
 }
 
@@ -3920,15 +3920,15 @@ pub fun select_sole_target_artifact(alloc: *A.Allocator, itn: *intern.Interner,
 # alloc: owns error text
 # itn: resolves names
 # m: the manifest
-# sel: updated in place when a choice is clear
+# pick: updated in place when a choice is clear
 # ret: ok unless the artifact name cannot be looked up
 pub fun select_sole_executable_artifact(alloc: *A.Allocator, itn: *intern.Interner,
-                                        m: *Manifest, sel: *Selection) R.Result[R.Void, str] {
-    if (sel.has_artifact || m.artifact_count < 2) { ret R.ok_void[str](); }
+                                        m: *Manifest, pick: *Selection) R.Result[R.Void, str] {
+    if (pick.has_artifact || m.artifact_count < 2) { ret R.ok_void[str](); }
 
-    val c: ArtifactCandidates = artifact_candidates_for(alloc, itn, m, sel, true);
-    if (c.sole != nil)   { ret set_selected_artifact(itn, c.sole, sel); }
-    if (c.chosen != nil) { ret set_selected_artifact(itn, c.chosen, sel); }
+    val c: ArtifactCandidates = artifact_candidates_for(alloc, itn, m, pick, true);
+    if (c.sole != nil)   { ret set_selected_artifact(itn, c.sole, pick); }
+    if (c.chosen != nil) { ret set_selected_artifact(itn, c.chosen, pick); }
     ret R.ok_void[str]();
 }
 
@@ -3941,29 +3941,29 @@ pub fun select_sole_executable_artifact(alloc: *A.Allocator, itn: *intern.Intern
 # alloc: owns `libs` and temporary strings
 # itn: interns the expanded paths
 # m: the manifest
-# sel: the selection
+# pick: the selection
 # ret: the unit; err from target, profile or artifact resolution, when the
 #  artifact does not support the target (naming the artifact's targets when
 #  none was selected), or from path expansion
-pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) R.Result[BuildUnit, str] {
+pub fun resolve_build_unit(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, pick: Selection) R.Result[BuildUnit, str] {
     var pin: *ArtifactDef = nil;
-    if (str_empty(sel.target)) { pin = resolve_artifact(itn, m, sel); }
+    if (str_empty(pick.target)) { pin = resolve_artifact(itn, m, pick); }
 
-    val res_target: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, sel.target, pin);
+    val res_target: R.Result[ResolvedTarget, str] = resolve_target(alloc, itn, m, pick.target, pin);
     if (R.is_err[ResolvedTarget, str](res_target)) { ret R.err[BuildUnit, str](R.unwrap_err[ResolvedTarget, str](res_target)); }
     val rt: ResolvedTarget = R.unwrap_ok[ResolvedTarget, str](res_target);
 
-    val res_profile: R.Result[ResolvedProfile, str] = resolve_profile(alloc, itn, m, sel.profile);
+    val res_profile: R.Result[ResolvedProfile, str] = resolve_profile(alloc, itn, m, pick.profile);
     if (R.is_err[ResolvedProfile, str](res_profile)) { ret R.err[BuildUnit, str](R.unwrap_err[ResolvedProfile, str](res_profile)); }
     val rp: ResolvedProfile = R.unwrap_ok[ResolvedProfile, str](res_profile);
 
-    val a: *ArtifactDef = resolve_artifact(itn, m, sel);
-    if (a == nil) { ret R.err[BuildUnit, str](artifact_err(alloc, itn, m, sel)); }
+    val a: *ArtifactDef = resolve_artifact(itn, m, pick);
+    if (a == nil) { ret R.err[BuildUnit, str](artifact_err(alloc, itn, m, pick)); }
 
     if (!artifact_supports_target(itn, a, rt.target.name)) {
         val art_name: str = idstr(itn, a.name);
         val tgt_name: str = idstr(itn, rt.target.name);
-        if (str_empty(sel.target)) {
+        if (str_empty(pick.target)) {
             ret R.err[BuildUnit, str](sfmt(alloc,
                 "mach.toml: artifact '{}' declares no target for this host; select one with --target ({})",
                 art_name, artifact_target_names(alloc, itn, m, a)));
@@ -4169,11 +4169,11 @@ pub fun resolve_test_libs(alloc: *A.Allocator, itn: *intern.Interner, m: *Manife
     ret finish_link_requirements(alloc, buf, max, w, out_items, out_count);
 }
 
-fun artifact_err(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, sel: Selection) str {
+fun artifact_err(alloc: *A.Allocator, itn: *intern.Interner, m: *Manifest, pick: Selection) str {
     if (m.artifact_count == 0) { ret "mach.toml: no [artifact.*] artifacts declared"; }
-    if (sel.has_artifact) {
-        if (sel.want_lib) { ret sfmt(alloc, "mach.toml: no lib named '{}'", sel.artifact); }
-        ret sfmt(alloc, "mach.toml: no bin named '{}'", sel.artifact);
+    if (pick.has_artifact) {
+        if (pick.want_lib) { ret sfmt(alloc, "mach.toml: no lib named '{}'", pick.artifact); }
+        ret sfmt(alloc, "mach.toml: no bin named '{}'", pick.artifact);
     }
     ret sfmt(alloc, "mach.toml: multiple artifacts declared; select one with --bin/--lib ({})",
         artifact_candidates(alloc, itn, m));

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -640,11 +640,11 @@ pub fun resolve_layout_intrinsic(lc: *LowerContext, eid: u32) R.Result[O.Option[
     ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.some[comptime.CTValue](comptime.ct_uint(n::u64)));
 }
 
-pub fun resolve_field_member(lc: *LowerContext, owner: u32, index: u32, sel: u8) R.Result[O.Option[comptime.CTValue], comptime.EvalFail] {
+pub fun resolve_field_member(lc: *LowerContext, owner: u32, index: u32, pick: u8) R.Result[O.Option[comptime.CTValue], comptime.EvalFail] {
     if (lc == nil) { ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.none[comptime.CTValue]()); }
     val owner_ty: type.TypeId = owner::type.TypeId;
 
-    if (sel == comptime.FIELD_SEL_ZERO_BY_NAME) {
+    if (pick == comptime.FIELD_SEL_ZERO_BY_NAME) {
         ret resolve_omitted_field_zero(lc, owner_ty, index::intern.StrId);
     }
 
@@ -652,10 +652,10 @@ pub fun resolve_field_member(lc: *LowerContext, owner: u32, index: u32, sel: u8)
     if (O.is_none[*type.FieldEntry](fa)) { ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.none[comptime.CTValue]()); }
     val fe: *type.FieldEntry = O.unwrap[*type.FieldEntry](fa);
 
-    if (sel == comptime.FIELD_SEL_NAME) {
+    if (pick == comptime.FIELD_SEL_NAME) {
         ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.some[comptime.CTValue](comptime.ct_str(fe.name)));
     }
-    if (sel == comptime.FIELD_SEL_TYPE) {
+    if (pick == comptime.FIELD_SEL_TYPE) {
         ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.some[comptime.CTValue](comptime.ct_type(fe.ty::u32)));
     }
 

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -1009,7 +1009,7 @@ fun write_word(buf: *encode.ByteBuf, pos: usize, word: u32) {
     buf.data[pos + 3] = ((word >> 24) & 0xFF)::u8;
 }
 
-fun sel(use64: bool, base_x: u32, base_w: u32) u32 {
+fun pick(use64: bool, base_x: u32, base_w: u32) u32 {
     if (use64) { ret base_x; }
     ret base_w;
 }
@@ -1020,8 +1020,8 @@ fun is64(width: u8) bool {
 }
 
 fun emit_movewide_seq(st: *encode.EncodeState, rd: u32, value: u64, use64: bool) {
-    val base_z: u32 = sel(use64, MOVZ_X, MOVZ_W);
-    val base_k: u32 = sel(use64, MOVK_X, MOVK_W);
+    val base_z: u32 = pick(use64, MOVZ_X, MOVZ_W);
+    val base_k: u32 = pick(use64, MOVK_X, MOVK_W);
     var chunks: u32 = 2;
     if (use64) { chunks = 4; }
     var v: u64 = value;
@@ -1364,7 +1364,7 @@ fun encode_alu3(st: *encode.EncodeState, mi: *mir.MirInstr, base_x: u32, base_w:
     if (R.is_err[i32, str](rmr)) { ret R.err[R.Void, str](R.unwrap_err[i32, str](rmr)); }
     val rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
 
-    emit_alu3(st, sel(use64, base_x, base_w), rd, rn, rm);
+    emit_alu3(st, pick(use64, base_x, base_w), rd, rn, rm);
     ret R.ok_void[str]();
 }
 
@@ -1384,14 +1384,14 @@ fun encode_addsub(st: *encode.EncodeState, mi: *mir.MirInstr, is_sub: bool) R.Re
     if (rhs.kind == mir.MIR_OP_IMM) {
         val v: i64 = rhs.imm;
         if (v >= 0 && v <= 4095) {
-            var base_i: u32 = sel(use64, ADDI_X, ADDI_W);
-            if (is_sub) { base_i = sel(use64, SUBI_X, SUBI_W); }
+            var base_i: u32 = pick(use64, ADDI_X, ADDI_W);
+            if (is_sub) { base_i = pick(use64, SUBI_X, SUBI_W); }
             emit_addsub_imm(st, base_i, rd, rn, v::u32, 0);
             ret R.ok_void[str]();
         }
         if (v > 0 && (v & 0xFFF) == 0 && (v >> 12) <= 4095) {
-            var base_i: u32 = sel(use64, ADDI_X, ADDI_W);
-            if (is_sub) { base_i = sel(use64, SUBI_X, SUBI_W); }
+            var base_i: u32 = pick(use64, ADDI_X, ADDI_W);
+            if (is_sub) { base_i = pick(use64, SUBI_X, SUBI_W); }
             emit_addsub_imm(st, base_i, rd, rn, (v >> 12)::u32, 1);
             ret R.ok_void[str]();
         }
@@ -1400,8 +1400,8 @@ fun encode_addsub(st: *encode.EncodeState, mi: *mir.MirInstr, is_sub: bool) R.Re
     val rmr: R.Result[i32, str] = resolve_source(st, rhs, SCRATCH0, use64);
     if (R.is_err[i32, str](rmr)) { ret R.err[R.Void, str](R.unwrap_err[i32, str](rmr)); }
     val rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
-    var base_r: u32 = sel(use64, ADD_X, ADD_W);
-    if (is_sub) { base_r = sel(use64, SUB_X, SUB_W); }
+    var base_r: u32 = pick(use64, ADD_X, ADD_W);
+    if (is_sub) { base_r = pick(use64, SUB_X, SUB_W); }
     emit_alu3(st, base_r, rd, rn, rm);
     ret R.ok_void[str]();
 }
@@ -1426,14 +1426,14 @@ fun encode_shift(st: *encode.EncodeState, mi: *mir.MirInstr, kind: u32) R.Result
         if (kind == arm64.LSL::u32) {
             val immr: u32 = (width_bits - sh) & (width_bits - 1);
             val imms: u32 = (width_bits - 1) - sh;
-            emit_bitfield(st, sel(use64, UBFM_X, UBFM_W), rd, rn, immr, imms);
+            emit_bitfield(st, pick(use64, UBFM_X, UBFM_W), rd, rn, immr, imms);
             ret R.ok_void[str]();
         }
         if (kind == arm64.LSR::u32) {
-            emit_bitfield(st, sel(use64, UBFM_X, UBFM_W), rd, rn, sh, width_bits - 1);
+            emit_bitfield(st, pick(use64, UBFM_X, UBFM_W), rd, rn, sh, width_bits - 1);
             ret R.ok_void[str]();
         }
-        emit_bitfield(st, sel(use64, SBFM_X, SBFM_W), rd, rn, sh, width_bits - 1);
+        emit_bitfield(st, pick(use64, SBFM_X, SBFM_W), rd, rn, sh, width_bits - 1);
         ret R.ok_void[str]();
     }
 
@@ -1443,7 +1443,7 @@ fun encode_shift(st: *encode.EncodeState, mi: *mir.MirInstr, kind: u32) R.Result
     var base_x: u32 = LSLV_X; var base_w: u32 = LSLV_W;
     if (kind == arm64.LSR::u32) { base_x = LSRV_X; base_w = LSRV_W; }
     or (kind == arm64.ASR::u32) { base_x = ASRV_X; base_w = ASRV_W; }
-    emit_alu3(st, sel(use64, base_x, base_w), rd, rn, rm);
+    emit_alu3(st, pick(use64, base_x, base_w), rd, rn, rm);
     ret R.ok_void[str]();
 }
 
@@ -1459,7 +1459,7 @@ fun encode_neg_mvn(st: *encode.EncodeState, mi: *mir.MirInstr, base_x: u32, base
     if (R.is_err[i32, str](rmr)) { ret R.err[R.Void, str](R.unwrap_err[i32, str](rmr)); }
     val rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
 
-    emit_alu3(st, sel(use64, base_x, base_w), rd, ZR, rm);
+    emit_alu3(st, pick(use64, base_x, base_w), rd, ZR, rm);
     ret R.ok_void[str]();
 }
 
@@ -1493,7 +1493,7 @@ fun encode_mov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) 
     val rmr: R.Result[i32, str] = req_gpr(src);
     if (R.is_err[i32, str](rmr)) { ret R.err[R.Void, str](R.unwrap_err[i32, str](rmr)); }
     val rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
-    emit_alu3(st, sel(use64, ORR_X, ORR_W), rd, ZR, rm);
+    emit_alu3(st, pick(use64, ORR_X, ORR_W), rd, ZR, rm);
     ret R.ok_void[str]();
 }
 
@@ -1633,7 +1633,7 @@ fun encode_convert(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[R.Void, 
         ret R.ok_void[str]();
     }
     if (mi.opcode == mir.MIR_BITCAST) {
-        emit_alu3(st, sel(is64(dw), ORR_X, ORR_W), rd, ZR, rs);
+        emit_alu3(st, pick(is64(dw), ORR_X, ORR_W), rd, ZR, rs);
         ret R.ok_void[str]();
     }
     if (mi.opcode == mir.MIR_SEXT) {
@@ -1642,7 +1642,7 @@ fun encode_convert(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[R.Void, 
             ret R.ok_void[str]();
         }
         val imms: u32 = (sw::u32 * 8) - 1;
-        emit_bitfield(st, sel(is64(dw), SBFM_X, SBFM_W), rd, rs, 0, imms);
+        emit_bitfield(st, pick(is64(dw), SBFM_X, SBFM_W), rd, rs, 0, imms);
         ret R.ok_void[str]();
     }
     if (sw >= 4) {
@@ -2397,13 +2397,13 @@ fun emit_flag_cmp(st: *encode.EncodeState, lhs_op: *mir.MirOperand, rhs_op: *mir
 
     val rhs_val: i64 = cmp_imm_value(rhs_op.imm, width, signed);
     if (rhs_op.kind == mir.MIR_OP_IMM && rhs_val >= 0 && rhs_val <= 4095) {
-        emit_addsub_imm(st, sel(use64, SUBS_IMM_X, SUBS_IMM_W), ZR, rn, rhs_val::u32, 0);
+        emit_addsub_imm(st, pick(use64, SUBS_IMM_X, SUBS_IMM_W), ZR, rn, rhs_val::u32, 0);
     } or {
         val rmr: R.Result[i32, str] = resolve_source(st, rhs_op, SCRATCH0, use64);
         if (R.is_err[i32, str](rmr)) { ret R.err[R.Void, str](R.unwrap_err[i32, str](rmr)); }
         var rm: u32 = R.unwrap_ok[i32, str](rmr)::u32;
         rm = narrow_cmp_source(st, rm, SCRATCH0, width, signed);
-        emit_alu3(st, sel(use64, SUBS_REG_X, SUBS_REG_W), ZR, rn, rm);
+        emit_alu3(st, pick(use64, SUBS_REG_X, SUBS_REG_W), ZR, rn, rm);
     }
     ret R.ok_void[str]();
 }
@@ -2450,7 +2450,7 @@ fun encode_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) R.Resul
     val cond: u32 = R.unwrap_ok[i32, str](rcr)::u32;
 
     val cbnz_pos: u32 = st.buf.len::u32;
-    emit_branch_block(st, sel(use64, CBNZ_X, CBNZ_W), cond, true, then_block);
+    emit_branch_block(st, pick(use64, CBNZ_X, CBNZ_W), cond, true, then_block);
     val cbnz_next: u32 = st.buf.len::u32;
     val f1: R.Result[R.Void, str] = encode.push_fixup(st, cbnz_pos, cbnz_next, then_block, fn_base);
     if (R.is_err[R.Void, str](f1)) { ret f1; }
@@ -2530,16 +2530,16 @@ fun encode_divide(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[R.Void, s
     val signed: bool = op == mir.MIR_SEL_DIV_S || op == mir.MIR_SEL_REM_S;
     val rem:    bool = op == mir.MIR_SEL_REM_S || op == mir.MIR_SEL_REM_U;
 
-    emit_branch_pcrel(st, sel(use64, CBNZ_X, CBNZ_W), rm, true, 2);
+    emit_branch_pcrel(st, pick(use64, CBNZ_X, CBNZ_W), rm, true, 2);
     emit_imm16(st, BRK_BASE, 0);
 
     if (signed) {
-        emit_addsub_imm(st, sel(use64, ADDS_IMM_X, ADDS_IMM_W), ZR, rm, 1, 0);
+        emit_addsub_imm(st, pick(use64, ADDS_IMM_X, ADDS_IMM_W), ZR, rm, 1, 0);
         emit_branch_pcrel(st, BCOND | CC_NE, 0, false, 5);
         var hw: u32 = 1;
         if (use64) { hw = 3; }
-        emit_movewide(st, sel(use64, MOVZ_X, MOVZ_W), SCRATCH1, hw, 0x8000);
-        emit_alu3(st, sel(use64, SUBS_REG_X, SUBS_REG_W), ZR, rn, SCRATCH1);
+        emit_movewide(st, pick(use64, MOVZ_X, MOVZ_W), SCRATCH1, hw, 0x8000);
+        emit_alu3(st, pick(use64, SUBS_REG_X, SUBS_REG_W), ZR, rn, SCRATCH1);
         emit_branch_pcrel(st, BCOND | CC_NE, 0, false, 2);
         emit_imm16(st, BRK_BASE, 0);
     }
@@ -2548,11 +2548,11 @@ fun encode_divide(st: *encode.EncodeState, mi: *mir.MirInstr) R.Result[R.Void, s
     if (!signed) { dbase_x = UDIV_X; dbase_w = UDIV_W; }
 
     if (rem) {
-        emit_alu3(st, sel(use64, dbase_x, dbase_w), SCRATCH0, rn, rm);
-        emit_madd(st, sel(use64, MSUB_X, MSUB_W), rd, SCRATCH0, rm, rn);
+        emit_alu3(st, pick(use64, dbase_x, dbase_w), SCRATCH0, rn, rm);
+        emit_madd(st, pick(use64, MSUB_X, MSUB_W), rd, SCRATCH0, rm, rn);
         ret R.ok_void[str]();
     }
-    emit_alu3(st, sel(use64, dbase_x, dbase_w), rd, rn, rm);
+    emit_alu3(st, pick(use64, dbase_x, dbase_w), rd, rn, rm);
     ret R.ok_void[str]();
 }
 
@@ -2973,7 +2973,7 @@ fun emit_asm_mov_imm(st: *encode.EncodeState, rd: u32, value: u64, use64: bool) 
         val sh: u64 = 16::u64 * i::u64;
         val chunk: u64 = (v >> sh) & 0xFFFF;
         if ((chunk << sh) == v) {
-            emit_movewide(st, sel(use64, MOVZ_X, MOVZ_W), rd, i, chunk::u32);
+            emit_movewide(st, pick(use64, MOVZ_X, MOVZ_W), rd, i, chunk::u32);
             ret;
         }
         i = i + 1;
@@ -3614,7 +3614,7 @@ fun a64_emit(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, item: *i
     if (pat == A64P_CMP)      { ret a64_emit_cmp(st, item); }
     if (pat == A64P_CSET) {
         val use64: bool = a64_is64(?item.ops[0]);
-        emit_cset(st, sel(use64, CSINC_X, CSINC_W), item.ops[0].reg::u32, a64_cond(item.flags));
+        emit_cset(st, pick(use64, CSINC_X, CSINC_W), item.ops[0].reg::u32, a64_cond(item.flags));
         ret R.ok_void[str]();
     }
     if (pat == A64P_ADRP)  { ret a64_emit_adrp(st, c, item); }
@@ -3638,7 +3638,7 @@ fun a64_emit(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, item: *i
     }
     if (pat == A64P_LDORD) { ret a64_emit_ldord(st, item); }
     if (pat == A64P_STLXR) {
-        val base: u32 = sel(a64_is64(?item.ops[1]), STLXR_X, STLXR_W);
+        val base: u32 = pick(a64_is64(?item.ops[1]), STLXR_X, STLXR_W);
         emit_stxr(st, base, item.ops[0].reg::u32, item.ops[1].reg::u32, item.ops[2].reg::u32);
         ret R.ok_void[str]();
     }
@@ -3652,9 +3652,9 @@ fun a64_emit_mov(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void, str
     val use64: bool = a64_is64(dst);
     if (src.kind == iasm.AOP_REG) {
         if (a64_is_sp(dst) || a64_is_sp(src)) {
-            emit_addsub_imm(st, sel(use64, ADDI_X, ADDI_W), dst.reg::u32, src.reg::u32, 0, 0);
+            emit_addsub_imm(st, pick(use64, ADDI_X, ADDI_W), dst.reg::u32, src.reg::u32, 0, 0);
         } or {
-            emit_alu3(st, sel(use64, ORR_X, ORR_W), dst.reg::u32, ZR, src.reg::u32);
+            emit_alu3(st, pick(use64, ORR_X, ORR_W), dst.reg::u32, ZR, src.reg::u32);
         }
         ret R.ok_void[str]();
     }
@@ -3666,8 +3666,8 @@ fun a64_emit_movewide(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void
     val use64: bool = a64_is64(?item.ops[0]);
     var hw: u32 = 0;
     if (item.nops == 3) { hw = item.ops[2].imm::u32; }
-    var base: u32 = sel(use64, MOVZ_X, MOVZ_W);
-    if (item.code == A64M_MOVK) { base = sel(use64, MOVK_X, MOVK_W); }
+    var base: u32 = pick(use64, MOVZ_X, MOVZ_W);
+    if (item.code == A64M_MOVK) { base = pick(use64, MOVK_X, MOVK_W); }
     emit_movewide(st, base, item.ops[0].reg::u32, hw, item.ops[1].imm::u32);
     ret R.ok_void[str]();
 }
@@ -3680,8 +3680,8 @@ fun a64_emit_addsub(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) 
     val is_sub: bool = item.code == A64M_SUB;
 
     if (op3.kind == iasm.AOP_IMM) {
-        var base: u32 = sel(use64, ADDI_X, ADDI_W);
-        if (is_sub) { base = sel(use64, SUBI_X, SUBI_W); }
+        var base: u32 = pick(use64, ADDI_X, ADDI_W);
+        if (is_sub) { base = pick(use64, SUBI_X, SUBI_W); }
         val v: i64 = op3.imm;
         if (v >= 0 && v <= 4095) {
             emit_addsub_imm(st, base, rd.reg::u32, rn.reg::u32, v::u32, 0);
@@ -3700,14 +3700,14 @@ fun a64_emit_addsub(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) 
         if (R.is_err[intern.StrId, str](sr)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](sr)); }
         val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sr);
         val pos: u32 = st.buf.len::u32;
-        emit_addsub_imm_sym(st, sel(use64, ADDI_X, ADDI_W), rd.reg::u32, rn.reg::u32, sid, printer.MOD_PCREL_LO, 0);
+        emit_addsub_imm_sym(st, pick(use64, ADDI_X, ADDI_W), rd.reg::u32, rn.reg::u32, sid, printer.MOD_PCREL_LO, 0);
         ret encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_ADD_LO12, sid, 0);
     }
     if (a64_is_sp(rd) || a64_is_sp(rn) || a64_is_sp(op3)) {
         ret R.err[R.Void, str]("encode: inline-asm add/sub with SP and a register operand requires the extended-register form (unsupported)");
     }
-    var base_r: u32 = sel(use64, ADD_X, ADD_W);
-    if (is_sub) { base_r = sel(use64, SUB_X, SUB_W); }
+    var base_r: u32 = pick(use64, ADD_X, ADD_W);
+    if (is_sub) { base_r = pick(use64, SUB_X, SUB_W); }
     emit_alu3(st, base_r, rd.reg::u32, rn.reg::u32, op3.reg::u32);
     ret R.ok_void[str]();
 }
@@ -3721,7 +3721,7 @@ fun a64_emit_logical(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void,
     var bw: u32 = AND_W;
     if (item.code == A64M_ORR)      { bx = ORR_X; bw = ORR_W; }
     or (item.code == A64M_EOR)      { bx = EOR_X; bw = EOR_W; }
-    emit_alu3(st, sel(use64, bx, bw), item.ops[0].reg::u32, item.ops[1].reg::u32, item.ops[2].reg::u32);
+    emit_alu3(st, pick(use64, bx, bw), item.ops[0].reg::u32, item.ops[1].reg::u32, item.ops[2].reg::u32);
     ret R.ok_void[str]();
 }
 
@@ -3731,13 +3731,13 @@ fun a64_emit_cmp(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void, str
     val use64: bool = a64_is64(rn);
     if (op2.kind == iasm.AOP_IMM) {
         if (op2.imm < 0 || op2.imm > 4095) { ret R.err[R.Void, str]("encode: inline-asm 'cmp' second operand must be a register or imm12"); }
-        emit_addsub_imm(st, sel(use64, SUBS_IMM_X, SUBS_IMM_W), ZR, rn.reg::u32, op2.imm::u32, 0);
+        emit_addsub_imm(st, pick(use64, SUBS_IMM_X, SUBS_IMM_W), ZR, rn.reg::u32, op2.imm::u32, 0);
         ret R.ok_void[str]();
     }
     if (a64_is_sp(rn) || a64_is_sp(op2)) {
         ret R.err[R.Void, str]("encode: inline-asm 'cmp' with sp and a register operand requires the extended-register form (unsupported)");
     }
-    emit_alu3(st, sel(use64, SUBS_REG_X, SUBS_REG_W), ZR, rn.reg::u32, op2.reg::u32);
+    emit_alu3(st, pick(use64, SUBS_REG_X, SUBS_REG_W), ZR, rn.reg::u32, op2.reg::u32);
     ret R.ok_void[str]();
 }
 
@@ -3785,8 +3785,8 @@ fun a64_emit_branch(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, i
     }
     or (pat == A64P_CBR) {
         val use64: bool = a64_is64(?item.ops[0]);
-        base = sel(use64, CBZ_X, CBZ_W);
-        if (item.code == A64M_CBNZ) { base = sel(use64, CBNZ_X, CBNZ_W); }
+        base = pick(use64, CBZ_X, CBZ_W);
+        if (item.code == A64M_CBNZ) { base = pick(use64, CBNZ_X, CBNZ_W); }
         rt     = item.ops[0].reg::u32;
         has_rt = true;
         word   = pack_cbnz(base, rt);
@@ -3857,13 +3857,13 @@ fun a64_emit_ldstp(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void, s
     val mem: *iasm.Operand = ?item.ops[2];
     val is_load: bool = item.code == A64M_LDP;
     var disp: i64 = 0;
-    var base_word: u32 = sel(is_load, LDP_OFF_X, STP_OFF_X);
+    var base_word: u32 = pick(is_load, LDP_OFF_X, STP_OFF_X);
     if (item.nops == 4) {
         disp      = item.ops[3].imm;
-        base_word = sel(is_load, LDP_POST_X, STP_POST_X);
+        base_word = pick(is_load, LDP_POST_X, STP_POST_X);
     } or {
         disp = mem.imm;
-        if ((mem.flags & iasm.AOF_WRITEBACK) != 0) { base_word = sel(is_load, LDP_PRE_X, STP_PRE_X); }
+        if ((mem.flags & iasm.AOF_WRITEBACK) != 0) { base_word = pick(is_load, LDP_PRE_X, STP_PRE_X); }
     }
     if ((disp & 7) != 0)   { ret R.err[R.Void, str]("encode: inline-asm stp/ldp offset must be a multiple of 8"); }
     val q: i64 = disp / 8;
@@ -3874,9 +3874,9 @@ fun a64_emit_ldstp(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void, s
 
 fun a64_emit_ldord(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void, str] {
     val use64: bool = a64_is64(?item.ops[0]);
-    var base: u32 = sel(use64, LDAXR_X, LDAXR_W);
-    if (item.code == A64M_LDAR)      { base = sel(use64, LDAR_X, LDAR_W); }
-    or (item.code == A64M_STLR)      { base = sel(use64, STLR_X, STLR_W); }
+    var base: u32 = pick(use64, LDAXR_X, LDAXR_W);
+    if (item.code == A64M_LDAR)      { base = pick(use64, LDAR_X, LDAR_W); }
+    or (item.code == A64M_STLR)      { base = pick(use64, STLR_X, STLR_W); }
     emit_ldst(st, base, item.ops[0].reg::u32, item.ops[1].reg::u32, 0);
     ret R.ok_void[str]();
 }
@@ -3899,13 +3899,13 @@ fun a64_emit_shift(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void, s
     if (cnt.kind == iasm.AOP_IMM && !vform) {
         val sh: u32 = cnt.imm::u32 & (width - 1);
         if (is_asr) {
-            emit_bitfield(st, sel(use64, SBFM_X, SBFM_W), rd.reg::u32, rn.reg::u32, sh, width - 1);
+            emit_bitfield(st, pick(use64, SBFM_X, SBFM_W), rd.reg::u32, rn.reg::u32, sh, width - 1);
         } or (is_lsr) {
-            emit_bitfield(st, sel(use64, UBFM_X, UBFM_W), rd.reg::u32, rn.reg::u32, sh, width - 1);
+            emit_bitfield(st, pick(use64, UBFM_X, UBFM_W), rd.reg::u32, rn.reg::u32, sh, width - 1);
         } or {
             val immr: u32 = (width - sh) & (width - 1);
             val imms: u32 = (width - 1) - sh;
-            emit_bitfield(st, sel(use64, UBFM_X, UBFM_W), rd.reg::u32, rn.reg::u32, immr, imms);
+            emit_bitfield(st, pick(use64, UBFM_X, UBFM_W), rd.reg::u32, rn.reg::u32, immr, imms);
         }
         ret R.ok_void[str]();
     }
@@ -3914,7 +3914,7 @@ fun a64_emit_shift(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void, s
     var bw: u32 = LSLV_W;
     if (is_lsr)      { bx = LSRV_X; bw = LSRV_W; }
     or (is_asr)      { bx = ASRV_X; bw = ASRV_W; }
-    emit_alu3(st, sel(use64, bx, bw), rd.reg::u32, rn.reg::u32, cnt.reg::u32);
+    emit_alu3(st, pick(use64, bx, bw), rd.reg::u32, rn.reg::u32, cnt.reg::u32);
     ret R.ok_void[str]();
 }
 

--- a/src/lang/target/of/coff.mach
+++ b/src/lang/target/of/coff.mach
@@ -71,12 +71,12 @@ val IMAGE_COMDAT_SELECT_EXACT_MATCH:  u8 = 4;
 val IMAGE_COMDAT_SELECT_ASSOCIATIVE:  u8 = 5;
 val IMAGE_COMDAT_SELECT_LARGEST:      u8 = 6;
 
-fun comdat_selection_dedups(sel: u8) bool {
-    ret sel == IMAGE_COMDAT_SELECT_ANY
-        || sel == IMAGE_COMDAT_SELECT_SAME_SIZE
-        || sel == IMAGE_COMDAT_SELECT_EXACT_MATCH
-        || sel == IMAGE_COMDAT_SELECT_ASSOCIATIVE
-        || sel == IMAGE_COMDAT_SELECT_LARGEST;
+fun comdat_selection_dedups(pick: u8) bool {
+    ret pick == IMAGE_COMDAT_SELECT_ANY
+        || pick == IMAGE_COMDAT_SELECT_SAME_SIZE
+        || pick == IMAGE_COMDAT_SELECT_EXACT_MATCH
+        || pick == IMAGE_COMDAT_SELECT_ASSOCIATIVE
+        || pick == IMAGE_COMDAT_SELECT_LARGEST;
 }
 
 val IMAGE_REL_AMD64_ADDR64:   u16 = 0x0001;

--- a/test/link/cases/macho-header-span-aarch64/src/main.mach
+++ b/test/link/cases/macho-header-span-aarch64/src/main.mach
@@ -18,7 +18,7 @@
 ext fun Sleep(ms: u32);
 
 #[library("objc")]
-ext fun objc_msgSend(recv: u64, sel: u64);
+ext fun objc_msgSend(recv: u64, msg: u64);
 
 #[library("z")]
 ext fun compressBound(n: u64) u64;

--- a/test/link/cases/macho-header-span-x86_64/src/main.mach
+++ b/test/link/cases/macho-header-span-x86_64/src/main.mach
@@ -18,7 +18,7 @@
 ext fun Sleep(ms: u32);
 
 #[library("objc")]
-ext fun objc_msgSend(recv: u64, sel: u64);
+ext fun objc_msgSend(recv: u64, msg: u64);
 
 #[library("z")]
 ext fun compressBound(n: u64) u64;


### PR DESCRIPTION
Mechanical prerequisite for #3219. Every bare `sel` identifier in compiler and test sources is renamed to `pick` (479 occurrences, 24 files) so the v5 migration compiler can reserve `sel` as the case-test keyword without breaking the self-host fixpoint. Prefixed and suffixed names (`sel_len`, `res_sel`, `FIELD_SEL_*`) are untouched. Test-embedded mach programs are renamed because they are compiled by the compiler under test. The two Mach-O fixtures' `objc_msgSend` parameter becomes `msg`.

Full suite before and after: 2608 passed, 0 failed.
