### PR TITLE
fix(resolve): ignore trivia inside dotted paths (#3229)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Dotted import, re-export and type names resolve identically with spacing or comments around dots. Diagnostics retain the original source spans (#3229).
 
+- Unresolved imports report at their own source coordinates instead of an unlocated message. Internal load failures stay internal instead of collapsing into a user rejection (#3229).
+
 - Relocatable linking preserves native sections, symbols, imports, attributes and
   relocation relations across ELF, Mach-O and COFF. Final linking resolves absolute
   definitions separately from image-relative symbols (#3119).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Dotted import, re-export and type names resolve identically with spacing or comments around dots. Diagnostics retain the original source spans (#3229).
+
 - Relocatable linking preserves native sections, symbols, imports, attributes and
   relocation relations across ELF, Mach-O and COFF. Final linking resolves absolute
   definitions separately from image-relative symbols (#3119).

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -34,6 +34,7 @@ use mach.lang.fe.parser;
 use mach.lang.fe.parser.state;
 use mach.lang.fe.resolve;
 use mach.lang.fe.token;
+use np: mach.lang.fe.path;
 use mach.lang.float;
 use mach.lang.intern;
 use mach.lang.query;
@@ -1289,16 +1290,6 @@ pub rec UseTarget {
     binds_module: bool;
 }
 
-fun span_single_segment(source: str, path: token.Span) bool {
-    var k: usize = path.offset;
-    val end: usize = path.offset + path.len;
-    for (k < end) {
-        if (source[k] == '.') { ret false; }
-        k = k + 1;
-    }
-    ret true;
-}
-
 fun project_module_lookup(p: *project.Project, id: intern.StrId, out_found: *bool, out_module: *intern.StrId) {
     @out_found  = false;
     @out_module = intern.STR_NIL;
@@ -1319,7 +1310,7 @@ fun project_module_lookup(p: *project.Project, id: intern.StrId, out_found: *boo
 }
 
 fun resolve_use_target(p: *project.Project, source: str, path: token.Span) R.Result[UseTarget, str] {
-    val full_r: R.Result[intern.StrId, str] = intern.intern_span(?p.s.interner, source, path);
+    val full_r: R.Result[intern.StrId, str] = np.intern_path(?p.s.interner, source, path);
     if (R.is_err[intern.StrId, str](full_r)) { ret R.err[UseTarget, str](R.unwrap_err[intern.StrId, str](full_r)); }
     val full_id: intern.StrId = R.unwrap_ok[intern.StrId, str](full_r);
 
@@ -1327,7 +1318,7 @@ fun resolve_use_target(p: *project.Project, source: str, path: token.Span) R.Res
     if (R.is_err[intern.StrId, str](leaf_r)) { ret R.err[UseTarget, str](R.unwrap_err[intern.StrId, str](leaf_r)); }
     val leaf: intern.StrId = R.unwrap_ok[intern.StrId, str](leaf_r);
 
-    if (span_single_segment(source, path)) {
+    if (np.prefix(source, path).len == 0) {
         var found:  bool = false;
         var mod_id: intern.StrId = intern.STR_NIL;
         project_module_lookup(p, full_id, ?found, ?mod_id);
@@ -1356,16 +1347,9 @@ fun resolve_use_target(p: *project.Project, source: str, path: token.Span) R.Res
         ret R.ok[UseTarget, str](ut);
     }
 
-    val end: usize = path.offset + path.len;
-    var seg_end: usize = end;
-    for (seg_end > path.offset) {
-        var dot: usize = seg_end;
-        for (dot > path.offset && source[dot - 1] != '.') { dot = dot - 1; }
-        if (dot == path.offset) { ret R.err[UseTarget, str](unresolvable_use_msg(p, source, path, full_id)); }
-        var prefix: token.Span;
-        prefix.offset = path.offset;
-        prefix.len    = (dot - 1) - path.offset;
-        val pid_r: R.Result[intern.StrId, str] = intern.intern_span(?p.s.interner, source, prefix);
+    var prefix: token.Span = np.prefix(source, path);
+    for (prefix.len != 0) {
+        val pid_r: R.Result[intern.StrId, str] = np.intern_path(?p.s.interner, source, prefix);
         if (R.is_err[intern.StrId, str](pid_r)) { ret R.err[UseTarget, str](R.unwrap_err[intern.StrId, str](pid_r)); }
         val pid: intern.StrId = R.unwrap_ok[intern.StrId, str](pid_r);
         if (fqn_names_file(p, pid)) {
@@ -1375,7 +1359,7 @@ fun resolve_use_target(p: *project.Project, source: str, path: token.Span) R.Res
             ut.binds_module = false;
             ret R.ok[UseTarget, str](ut);
         }
-        seg_end = dot - 1;
+        prefix = np.prefix(source, prefix);
     }
     ret R.err[UseTarget, str](unresolvable_use_msg(p, source, path, full_id));
 }
@@ -1383,14 +1367,9 @@ fun resolve_use_target(p: *project.Project, source: str, path: token.Span) R.Res
 fun unresolvable_use_msg(p: *project.Project, source: str, path: token.Span, full_id: intern.StrId) str {
     val generic: str = diag_join_named(p.s, "use path '", full_id, "' does not name a module", "use path does not name a module");
 
-    var root_end: usize = path.offset;
-    val end: usize = path.offset + path.len;
-    for (root_end < end && source[root_end] != '.') { root_end = root_end + 1; }
-    if (root_end >= end) { ret generic; }
-
-    var root_span: token.Span;
-    root_span.offset = path.offset;
-    root_span.len    = root_end - path.offset;
+    if (np.prefix(source, path).len == 0) { ret generic; }
+    var cursor: usize = path.offset;
+    val root_span: token.Span = np.next(source, path, ?cursor);
     val root_r: R.Result[intern.StrId, str] = intern.intern_span(?p.s.interner, source, root_span);
     if (R.is_err[intern.StrId, str](root_r)) { ret generic; }
     val root_id: intern.StrId = R.unwrap_ok[intern.StrId, str](root_r);
@@ -1434,17 +1413,7 @@ fun fqn_names_file(p: *project.Project, fqn: intern.StrId) bool {
 }
 
 fun leaf_name(i: *intern.Interner, source: str, path: token.Span) R.Result[intern.StrId, str] {
-    var seg_start: usize = path.offset;
-    var k: usize = path.offset;
-    val end: usize = path.offset + path.len;
-    for (k < end) {
-        if (source[k] == '.') { seg_start = k + 1; }
-        k = k + 1;
-    }
-    var leaf_span: token.Span;
-    leaf_span.offset = seg_start;
-    leaf_span.len    = end - seg_start;
-    ret intern.intern_span(i, source, leaf_span);
+    ret intern.intern_span(i, source, np.leaf(source, path));
 }
 
 fun record_dep(p: *project.Project, mid: session.ModuleId, dep_mid: session.ModuleId) R.Result[R.Void, str] {

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -21,6 +21,7 @@ use O: std.types.option;
 use R: std.types.result;
 use ctime: std.chrono.time;
 
+use mach.lang.build.outcome;
 use mach.lang.build.request;
 use mach.lang.diagnostic;
 use mach.lang.fe.ast;
@@ -1172,9 +1173,22 @@ fun walk_use_for_load(p: *project.Project, mid: session.ModuleId, du: *decl.Decl
     if (O.is_none[*src.SourceFile](src_opt)) { ret R.err[R.Void, str]("module file_id not found in SourceMap"); }
     val source: str = O.unwrap[*src.SourceFile](src_opt).text;
 
-    val tgt_r: R.Result[UseTarget, str] = resolve_use_target(p, source, du.path);
-    if (R.is_err[UseTarget, str](tgt_r)) { ret R.err[R.Void, str](R.unwrap_err[UseTarget, str](tgt_r)); }
-    val ut: UseTarget = R.unwrap_ok[UseTarget, str](tgt_r);
+    val tgt_r: R.Result[UseTarget, outcome.Fail] = resolve_use_target(p, source, du.path);
+    if (R.is_err[UseTarget, outcome.Fail](tgt_r)) {
+        val error: outcome.Fail = R.unwrap_err[UseTarget, outcome.Fail](tgt_r);
+        if (error.kind == outcome.FAIL_USER) {
+            val reported: R.Result[bool, str] = diagnostic.gate_error(?p.s.gate_diags, ?p.s.diags, ?p.s.interner, m.file_id, du.path, error.message);
+            if (R.is_err[bool, str](reported)) {
+                val message: str = R.unwrap_err[bool, str](reported);
+                fail.internal(?m.load_status, message);
+                ret R.err[R.Void, str](message);
+            }
+            fail.reject(?m.load_status);
+        }
+        or { fail.internal(?m.load_status, error.message); }
+        ret R.err[R.Void, str](error.message);
+    }
+    val ut: UseTarget = R.unwrap_ok[UseTarget, outcome.Fail](tgt_r);
 
     val dep_r: R.Result[session.ModuleId, str] = dfs_load(p, ut.module_fqn);
     if (R.is_err[session.ModuleId, str](dep_r)) { ret R.err[R.Void, str](R.unwrap_err[session.ModuleId, str](dep_r)); }
@@ -1269,9 +1283,14 @@ fun walk_fwd_for_load(p: *project.Project, mid: session.ModuleId, df: *decl.Decl
     if (O.is_none[*src.SourceFile](src_opt)) { ret R.err[R.Void, str]("module file_id not found in SourceMap"); }
     val source: str = O.unwrap[*src.SourceFile](src_opt).text;
 
-    val tgt_r: R.Result[UseTarget, str] = resolve_use_target(p, source, df.path);
-    if (R.is_err[UseTarget, str](tgt_r)) { ret R.ok_void[str](); }
-    val ut: UseTarget = R.unwrap_ok[UseTarget, str](tgt_r);
+    val tgt_r: R.Result[UseTarget, outcome.Fail] = resolve_use_target(p, source, df.path);
+    if (R.is_err[UseTarget, outcome.Fail](tgt_r)) {
+        val error: outcome.Fail = R.unwrap_err[UseTarget, outcome.Fail](tgt_r);
+        if (error.kind == outcome.FAIL_USER) { ret R.ok_void[str](); }
+        fail.internal(?m.load_status, error.message);
+        ret R.err[R.Void, str](error.message);
+    }
+    val ut: UseTarget = R.unwrap_ok[UseTarget, outcome.Fail](tgt_r);
 
     val dep_r: R.Result[session.ModuleId, str] = dfs_load(p, ut.module_fqn);
     if (R.is_err[session.ModuleId, str](dep_r)) { ret R.err[R.Void, str](R.unwrap_err[session.ModuleId, str](dep_r)); }
@@ -1309,13 +1328,13 @@ fun project_module_lookup(p: *project.Project, id: intern.StrId, out_found: *boo
     }
 }
 
-fun resolve_use_target(p: *project.Project, source: str, path: token.Span) R.Result[UseTarget, str] {
+fun resolve_use_target(p: *project.Project, source: str, path: token.Span) R.Result[UseTarget, outcome.Fail] {
     val full_r: R.Result[intern.StrId, str] = np.intern_path(?p.s.interner, source, path);
-    if (R.is_err[intern.StrId, str](full_r)) { ret R.err[UseTarget, str](R.unwrap_err[intern.StrId, str](full_r)); }
+    if (R.is_err[intern.StrId, str](full_r)) { ret R.err[UseTarget, outcome.Fail](outcome.internal(R.unwrap_err[intern.StrId, str](full_r))); }
     val full_id: intern.StrId = R.unwrap_ok[intern.StrId, str](full_r);
 
     val leaf_r: R.Result[intern.StrId, str] = leaf_name(?p.s.interner, source, path);
-    if (R.is_err[intern.StrId, str](leaf_r)) { ret R.err[UseTarget, str](R.unwrap_err[intern.StrId, str](leaf_r)); }
+    if (R.is_err[intern.StrId, str](leaf_r)) { ret R.err[UseTarget, outcome.Fail](outcome.internal(R.unwrap_err[intern.StrId, str](leaf_r))); }
     val leaf: intern.StrId = R.unwrap_ok[intern.StrId, str](leaf_r);
 
     if (np.prefix(source, path).len == 0) {
@@ -1324,18 +1343,18 @@ fun resolve_use_target(p: *project.Project, source: str, path: token.Span) R.Res
         project_module_lookup(p, full_id, ?found, ?mod_id);
         if (found) {
             if (mod_id == intern.STR_NIL) {
-                ret R.err[UseTarget, str](diag_join_named(p.s, "project '", full_id, "' has no public module because its artifacts name different entries; import a full path, or give every [artifact.*] table in its manifest the same entry", "project has no public module because its artifacts name different entries; import a full path, or give every [artifact.*] table in its manifest the same entry"));
+                ret R.err[UseTarget, outcome.Fail](outcome.user(diag_join_named(p.s, "project '", full_id, "' has no public module because its artifacts name different entries; import a full path, or give every [artifact.*] table in its manifest the same entry", "project has no public module because its artifacts name different entries; import a full path, or give every [artifact.*] table in its manifest the same entry")));
             }
             val id_opt:  O.Option[str] = intern.lookup(?p.s.interner, full_id);
             val mod_opt: O.Option[str] = intern.lookup(?p.s.interner, mod_id);
-            if (O.is_none[str](id_opt) || O.is_none[str](mod_opt)) { ret R.err[UseTarget, str]("internal: project id/module not interned"); }
+            if (O.is_none[str](id_opt) || O.is_none[str](mod_opt)) { ret R.err[UseTarget, outcome.Fail](outcome.internal("internal: project id/module not interned")); }
             val fqn_r: R.Result[intern.StrId, str] = compose_module_fqn(p.alloc, ?p.s.interner, O.unwrap[str](id_opt), O.unwrap[str](mod_opt));
-            if (R.is_err[intern.StrId, str](fqn_r)) { ret R.err[UseTarget, str](R.unwrap_err[intern.StrId, str](fqn_r)); }
+            if (R.is_err[intern.StrId, str](fqn_r)) { ret R.err[UseTarget, outcome.Fail](outcome.internal(R.unwrap_err[intern.StrId, str](fqn_r))); }
             var ut: UseTarget;
             ut.module_fqn   = R.unwrap_ok[intern.StrId, str](fqn_r);
             ut.leaf         = leaf;
             ut.binds_module = true;
-            ret R.ok[UseTarget, str](ut);
+            ret R.ok[UseTarget, outcome.Fail](ut);
         }
     }
 
@@ -1344,24 +1363,24 @@ fun resolve_use_target(p: *project.Project, source: str, path: token.Span) R.Res
         ut.module_fqn   = full_id;
         ut.leaf         = leaf;
         ut.binds_module = true;
-        ret R.ok[UseTarget, str](ut);
+        ret R.ok[UseTarget, outcome.Fail](ut);
     }
 
     var prefix: token.Span = np.prefix(source, path);
     for (prefix.len != 0) {
         val pid_r: R.Result[intern.StrId, str] = np.intern_path(?p.s.interner, source, prefix);
-        if (R.is_err[intern.StrId, str](pid_r)) { ret R.err[UseTarget, str](R.unwrap_err[intern.StrId, str](pid_r)); }
+        if (R.is_err[intern.StrId, str](pid_r)) { ret R.err[UseTarget, outcome.Fail](outcome.internal(R.unwrap_err[intern.StrId, str](pid_r))); }
         val pid: intern.StrId = R.unwrap_ok[intern.StrId, str](pid_r);
         if (fqn_names_file(p, pid)) {
             var ut: UseTarget;
             ut.module_fqn   = pid;
             ut.leaf         = leaf;
             ut.binds_module = false;
-            ret R.ok[UseTarget, str](ut);
+            ret R.ok[UseTarget, outcome.Fail](ut);
         }
         prefix = np.prefix(source, prefix);
     }
-    ret R.err[UseTarget, str](unresolvable_use_msg(p, source, path, full_id));
+    ret R.err[UseTarget, outcome.Fail](outcome.user(unresolvable_use_msg(p, source, path, full_id)));
 }
 
 fun unresolvable_use_msg(p: *project.Project, source: str, path: token.Span, full_id: intern.StrId) str {

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -5356,11 +5356,19 @@ test "mach.lang.driver:undeclared_use_root_names_the_missing_dep" {
         bad = 1;
     }
     or {
-        val msg: str = R.unwrap_err[project.Project, outcome.Fail](pr).message;
-        if (!ut_str_contains(msg, "module root 'std'"))       { bad = 1; }
-        if (!ut_str_contains(msg, "declared dependency"))     { bad = 1; }
-        if (!ut_str_contains(msg, "declare it in mach.toml")) { bad = 1; }
-        if (ut_str_contains(msg, "does not name a module"))   { bad = 1; }
+        var seen: bool = false;
+        var i: usize = 0;
+        for (i < diagnostic.len(?s.diags)) {
+            val d: *diagnostic.Diagnostic = ?s.diags.items.data[i];
+            if (d.severity == diagnostic.SEVERITY_ERROR && ut_str_contains(d.message, "module root 'std'")) {
+                seen = true;
+                if (!ut_str_contains(d.message, "declared dependency"))     { bad = 1; }
+                if (!ut_str_contains(d.message, "declare it in mach.toml")) { bad = 1; }
+                if (ut_str_contains(d.message, "does not name a module"))   { bad = 1; }
+            }
+            i = i + 1;
+        }
+        if (!seen) { bad = 1; }
     }
 
     fs.remove_all(?alloc, root);
@@ -6331,15 +6339,28 @@ test "mach.lang.driver:dotted_path_missing_root_rejection_ignores_trivia" {
         bad = 1;
     }
     or {
-        val msg: str = R.unwrap_err[project.Project, outcome.Fail](pr).message;
-        if (!ut_str_contains(msg, "module root 'missing'"))   { bad = 1; }
-        if (!ut_str_contains(msg, "missing.library"))         { bad = 1; }
-        if (ut_str_contains(msg, "other.root"))               { bad = 1; }
+        var seen: bool = false;
+        var i: usize = 0;
+        for (i < diagnostic.len(?s.diags)) {
+            val d: *diagnostic.Diagnostic = ?s.diags.items.data[i];
+            if (d.severity == diagnostic.SEVERITY_ERROR && ut_str_contains(d.message, "module root 'missing'")) {
+                seen = true;
+                if (!ut_str_contains(d.message, "missing.library")) { bad = 1; }
+                if (ut_str_contains(d.message, "other.root"))       { bad = 1; }
+            }
+            i = i + 1;
+        }
+        if (!seen) { bad = 1; }
     }
 
     fs.remove_all(?alloc, root);
     session.dnit(?s);
     ret bad;
+}
+
+test "mach.lang.driver:dotted_path_rejection_keeps_original_source_span" {
+    ret ut_gate_diag_located("use missing # other.root\n . library;\nfun main() i32 { ret 0; }\n",
+        "module root 'missing'", "main.mach", 1, 5, "missing # other.root\n . library");
 }
 
 test "mach.lang.driver:dotted_type_path_rejection_keeps_original_source_span" {

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -6291,6 +6291,62 @@ test "mach.lang.driver:incremental_resolve_reexport_two_hop_propagation" {
     ret bad;
 }
 
+test "mach.lang.driver:dotted_paths_resolve_identically_with_spacing_and_comments" {
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "mid.mach"; names[2] = "leaf.mach";
+    var texts: [3]str;
+    texts[2] = "pub rec Box[T] { value: T; }\npub rec Plain { value: i32; }\npub fun answer() i32 { ret 7; }\n";
+    texts[1] = "fwd uniontest.leaf;\nfwd B: uniontest.leaf.Box;\nfwd uniontest.leaf.Plain;\nfwd uniontest.leaf.answer;\n";
+    texts[0] = "use uniontest.mid;\nuse B: uniontest.mid.B;\nuse uniontest.mid.Plain;\nuse uniontest.mid.answer;\nfun take(p: *mid.leaf.Box[i32]) i32 { ret p.value; }\nfun pass(p: *B[i32], q: *mid.B[i32], r: *Plain) i32 { ret take(p) + take(q) + r.value; }\nfun main() i32 { ret answer(); }\n";
+    if (ut_single_result_n(?names[0], ?texts[0], 3, "", false) != 0) { ret 1; }
+    texts[1] = "fwd uniontest . leaf;\nfwd B: uniontest . leaf . Box;\nfwd uniontest . leaf . Plain;\nfwd uniontest . leaf . answer;\n";
+    texts[0] = "use uniontest . mid;\nuse B: uniontest . mid . B;\nuse uniontest . mid . Plain;\nuse uniontest . mid . answer;\nfun take(p: *mid . leaf . Box[i32]) i32 { ret p.value; }\nfun pass(p: *B[i32], q: *mid . B[i32], r: *Plain) i32 { ret take(p) + take(q) + r.value; }\nfun main() i32 { ret answer(); }\n";
+    if (ut_single_result_n(?names[0], ?texts[0], 3, "", false) != 0) { ret 2; }
+    texts[1] = "fwd uniontest # ignored.module\r\n . leaf;\nfwd B: uniontest . # not.a.module\n leaf . Box;\nfwd uniontest . leaf # .fake\r . Plain;\nfwd uniontest . leaf . # fake.symbol\n answer;\n";
+    texts[0] = "use uniontest # .ignored\n . mid;\nuse B: uniontest . # wrong.module\r\n mid . B;\nuse uniontest . mid # .wrong\n . Plain;\nuse uniontest . mid . # false.leaf\n answer;\nfun take(p: *mid # ignored.path\n . leaf . # ignored.Type\n Box[i32]) i32 { ret p.value; }\nfun pass(p: *B[i32], q: *mid . # ignored.Type\n B[i32], r: *Plain) i32 { ret take(p) + take(q) + r.value; }\nfun main() i32 { ret answer(); }\n";
+    if (ut_single_result_n(?names[0], ?texts[0], 3, "", false) != 0) { ret 3; }
+    ret 0;
+}
+
+test "mach.lang.driver:dotted_path_missing_root_rejection_ignores_trivia" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
+
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "use missing # other.root\n . library;\nfun main() i32 { ret 0; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?s, root);
+    if (R.is_ok[project.Project, outcome.Fail](pr)) {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        project.dnit_project(?p);
+        bad = 1;
+    }
+    or {
+        val msg: str = R.unwrap_err[project.Project, outcome.Fail](pr).message;
+        if (!ut_str_contains(msg, "module root 'missing'"))   { bad = 1; }
+        if (!ut_str_contains(msg, "missing.library"))         { bad = 1; }
+        if (ut_str_contains(msg, "other.root"))               { bad = 1; }
+    }
+
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
+test "mach.lang.driver:dotted_type_path_rejection_keeps_original_source_span" {
+    ret ut_gate_diag_located("fun take(p: *missing # other.root\n . library) i32 { ret 0; }\nfun main() i32 { ret 0; }\n",
+        "unresolved type name `missing`", "main.mach", 1, 14, "missing # other.root\n . library");
+}
+
 test "mach.lang.driver:resolve_fwd_reference_visible_before_textual_declaration" {
     var names: [3]str;
     names[0] = "main.mach"; names[1] = "mid.mach"; names[2] = "leaf.mach";

--- a/src/lang/fe/path.mach
+++ b/src/lang/fe/path.mach
@@ -1,0 +1,152 @@
+use A: std.allocator;
+use R: std.types.result;
+use std.types.size.usize;
+use std.types.string.str;
+use mach.lang.fe.token;
+use mach.lang.intern;
+
+# paths are parser accepted identifier and dot sequences with original trivia intact
+pub fun next(source: str, path: token.Span, cursor: *usize) token.Span {
+    val end: usize = path.offset + path.len;
+    var pos: usize = @cursor;
+    for (pos < end) {
+        val c: u8 = source[pos];
+        if (c == '#') {
+            for (pos < end && source[pos] != '\n' && source[pos] != '\r') { pos = pos + 1; }
+        }
+        or (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '.') { pos = pos + 1; }
+        or { brk; }
+    }
+    val start: usize = pos;
+    for (pos < end) {
+        val c: u8 = source[pos];
+        if (c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '.' || c == '#') { brk; }
+        pos = pos + 1;
+    }
+    @cursor = pos;
+    ret token.Span{offset: start, len: pos - start};
+}
+
+pub fun leaf(source: str, path: token.Span) token.Span {
+    var cursor: usize = path.offset;
+    var found: token.Span = token.Span{offset: path.offset, len: 0};
+    for (cursor < path.offset + path.len) {
+        val segment: token.Span = next(source, path, ?cursor);
+        if (segment.len == 0) { brk; }
+        found = segment;
+    }
+    ret found;
+}
+
+pub fun prefix(source: str, path: token.Span) token.Span {
+    var cursor: usize = path.offset;
+    var previous: token.Span = token.Span{offset: path.offset, len: 0};
+    var found: token.Span = previous;
+    for (cursor < path.offset + path.len) {
+        val segment: token.Span = next(source, path, ?cursor);
+        if (segment.len == 0) { brk; }
+        found.len = previous.offset + previous.len - path.offset;
+        previous = segment;
+    }
+    ret found;
+}
+
+pub fun intern_path(itn: *intern.Interner, source: str, path: token.Span) R.Result[intern.StrId, str] {
+    var cursor: usize = path.offset;
+    var length: usize = 0;
+    for (cursor < path.offset + path.len) {
+        val segment: token.Span = next(source, path, ?cursor);
+        if (segment.len == 0) { brk; }
+        if (length != 0) { length = length + 1; }
+        length = length + segment.len;
+    }
+    if (length == 0 || length == path.len) { ret intern.intern_span(itn, source, path); }
+    val allocated: R.Result[*u8, str] = A.allocate[u8](itn.a, length);
+    if (R.is_err[*u8, str](allocated)) { ret R.err[intern.StrId, str](R.unwrap_err[*u8, str](allocated)); }
+    val bytes: *u8 = R.unwrap_ok[*u8, str](allocated);
+    fin { A.deallocate[u8](itn.a, bytes, length); }
+    cursor = path.offset;
+    var written: usize = 0;
+    for (cursor < path.offset + path.len) {
+        val segment: token.Span = next(source, path, ?cursor);
+        if (segment.len == 0) { brk; }
+        if (written != 0) { bytes[written] = '.'; written = written + 1; }
+        var b: usize = 0;
+        for (b < segment.len) { bytes[written] = source[segment.offset + b]; written = written + 1; b = b + 1; }
+    }
+    ret intern.intern_bytes(itn, bytes, length);
+}
+
+use T: std.allocator.testing;
+use O: std.types.option;
+use std.types.string.str_len;
+use std.types.string.str_equals;
+use std.types.string.str_region_equals;
+
+fun t_intern_refusal(ordinal: usize, attempts: *usize) i32 {
+    var t: T.Testing;
+    if (O.is_some[str](T.make(?t))) { ret 1; }
+    fin { T.dnit(?t); }
+    var itn: intern.Interner = intern.init(T.allocator_of(?t));
+    val text: str = "root # not.a.segment\r\n . module . # false.leaf\n Name";
+    T.fail_at_ordinal(?t, ordinal);
+    val result: R.Result[intern.StrId, str] = intern_path(?itn, text, token.Span{offset: 0, len: str_len(text)});
+    @attempts = T.attempt_count(?t);
+    T.fail_at_ordinal(?t, 0);
+    var code: i32 = 0;
+    if (R.is_ok[intern.StrId, str](result)) {
+        if (ordinal != 0) { code = 2; }
+        val name: O.Option[str] = intern.lookup(?itn, R.unwrap_ok[intern.StrId, str](result));
+        if (O.is_none[str](name) || !str_equals(O.unwrap[str](name), "root.module.Name")) { code = 3; }
+    }
+    or {
+        if (ordinal == 0 || !str_equals(R.unwrap_err[intern.StrId, str](result), "out of memory")) { code = 4; }
+    }
+    intern.dnit(?itn);
+    if (T.leaked(?t) || T.double_free_count(?t) != 0 || T.tracking_exhausted(?t)) { ret 5; }
+    ret code;
+}
+
+test "mach.lang.fe.path:canonical_name_allocation_refusal_releases_temporary_owner" {
+    var attempts: usize = 0;
+    val baseline: i32 = t_intern_refusal(0, ?attempts);
+    if (baseline != 0) { ret baseline; }
+    if (attempts == 0) { ret 6; }
+    var ordinal: usize = 1;
+    for (ordinal <= attempts) {
+        var refused_attempts: usize = 0;
+        val refused: i32 = t_intern_refusal(ordinal, ?refused_attempts);
+        if (refused != 0) { ret refused; }
+        ordinal = ordinal + 1;
+    }
+    ret 0;
+}
+
+test "mach.lang.fe.path:leaf_and_prefix_coordinates_after_trivia" {
+    val lf_text: str = "root # ignored.module\n . leaf";
+    val lf_span: token.Span = token.Span{offset: 0, len: str_len(lf_text)};
+    val lf_leaf: token.Span = leaf(lf_text, lf_span);
+    if (!str_region_equals(lf_text, lf_leaf.offset, lf_leaf.len, "leaf")) { ret 1; }
+    val lf_pref: token.Span = prefix(lf_text, lf_span);
+    if (!str_region_equals(lf_text, lf_pref.offset, lf_pref.len, "root")) { ret 2; }
+
+    val crlf_text: str = "root # ignored.module\r\n . leaf";
+    val crlf_span: token.Span = token.Span{offset: 0, len: str_len(crlf_text)};
+    val crlf_leaf: token.Span = leaf(crlf_text, crlf_span);
+    if (!str_region_equals(crlf_text, crlf_leaf.offset, crlf_leaf.len, "leaf")) { ret 3; }
+    val crlf_pref: token.Span = prefix(crlf_text, crlf_span);
+    if (!str_region_equals(crlf_text, crlf_pref.offset, crlf_pref.len, "root")) { ret 4; }
+
+    val cr_text: str = "root # ignored.module\r . leaf";
+    val cr_span: token.Span = token.Span{offset: 0, len: str_len(cr_text)};
+    val cr_leaf: token.Span = leaf(cr_text, cr_span);
+    if (!str_region_equals(cr_text, cr_leaf.offset, cr_leaf.len, "leaf")) { ret 5; }
+    val cr_pref: token.Span = prefix(cr_text, cr_span);
+    if (!str_region_equals(cr_text, cr_pref.offset, cr_pref.len, "root")) { ret 6; }
+
+    val dep_text: str = "lib . # wrong.leaf\n Old";
+    val dep_span: token.Span = token.Span{offset: 0, len: str_len(dep_text)};
+    val dep_leaf: token.Span = leaf(dep_text, dep_span);
+    if (!str_region_equals(dep_text, dep_leaf.offset, dep_leaf.len, "Old")) { ret 7; }
+    ret 0;
+}

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -29,6 +29,7 @@ use atype: mach.lang.fe.ast.type;
 use mach.lang.fe.comptime;
 use mach.lang.fe.pool;
 use mach.lang.fe.token;
+use np: mach.lang.fe.path;
 use mach.lang.float;
 use mach.lang.intern;
 use mach.lang.session;
@@ -926,7 +927,7 @@ fun collect_use(rc: *ResolveContext, decl_id: id.DeclId, du: *decl.DeclUse, scop
         ret R.ok_void[str]();
     }
 
-    val r_path: R.Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, du.path);
+    val r_path: R.Result[intern.StrId, str] = np.intern_path(?rc.s.interner, rc.source, du.path);
     if (R.is_err[intern.StrId, str](r_path)) { fail.internal(?rc.status, R.unwrap_err[intern.StrId, str](r_path));
         ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](r_path));
     }
@@ -1027,48 +1028,12 @@ fun imported_symbol_for(rc: *ResolveContext, ps: *PublicSymbol) R.Result[SymbolI
     ret R.ok[SymbolId, str](sid);
 }
 
-fun last_dot_offset(rc: *ResolveContext, path: token.Span) usize {
-    val start: usize = path.offset;
-    val end:   usize = path.offset + path.len;
-    var dot:   usize = start;
-    var found: bool  = false;
-    var i:     usize = start;
-    for (i < end) {
-        if (rc.source[i] == '.') {
-            dot   = i;
-            found = true;
-        }
-        i = i + 1;
-    }
-    if (!found) { ret start; }
-    ret dot;
-}
-
 fun leaf_span(rc: *ResolveContext, path: token.Span) token.Span {
-    val end: usize = path.offset + path.len;
-    val dot: usize = last_dot_offset(rc, path);
-    var out: token.Span;
-    if (dot == path.offset && rc.source[path.offset] != '.') {
-        out.offset = path.offset;
-        out.len    = path.len;
-        ret out;
-    }
-    out.offset = dot + 1;
-    out.len    = end - (dot + 1);
-    ret out;
+    ret np.leaf(rc.source, path);
 }
 
 fun prefix_span(rc: *ResolveContext, path: token.Span) token.Span {
-    val dot: usize = last_dot_offset(rc, path);
-    var out: token.Span;
-    if (dot == path.offset && rc.source[path.offset] != '.') {
-        out.offset = path.offset;
-        out.len    = 0;
-        ret out;
-    }
-    out.offset = path.offset;
-    out.len    = dot - path.offset;
-    ret out;
+    ret np.prefix(rc.source, path);
 }
 
 fun find_module_exports(rc: *ResolveContext, path: intern.StrId) *ModuleExports {
@@ -1126,13 +1091,13 @@ fun bind_member_qualified(rc: *ResolveContext, eid: id.ExprId, member: *expr.Exp
 }
 
 fun find_module_exports_span(rc: *ResolveContext, span: token.Span) *ModuleExports {
-    val r: R.Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, span);
+    val r: R.Result[intern.StrId, str] = np.intern_path(?rc.s.interner, rc.source, span);
     if (R.is_err[intern.StrId, str](r)) { fail.internal(?rc.status, R.unwrap_err[intern.StrId, str](r)); ret nil; }
     ret find_module_exports(rc, R.unwrap_ok[intern.StrId, str](r));
 }
 
 fun resolve_prefix_module(rc: *ResolveContext, prefix: token.Span) *ModuleExports {
-    val r: R.Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, prefix);
+    val r: R.Result[intern.StrId, str] = np.intern_path(?rc.s.interner, rc.source, prefix);
     if (R.is_err[intern.StrId, str](r)) { fail.internal(?rc.status, R.unwrap_err[intern.StrId, str](r)); ret nil; }
     val prefix_id: intern.StrId = R.unwrap_ok[intern.StrId, str](r);
 
@@ -1240,7 +1205,7 @@ fun collect_fwd(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, flag
         ret R.ok_void[str]();
     }
 
-    val r_full: R.Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, df.path);
+    val r_full: R.Result[intern.StrId, str] = np.intern_path(?rc.s.interner, rc.source, df.path);
     if (R.is_err[intern.StrId, str](r_full)) { fail.internal(?rc.status, R.unwrap_err[intern.StrId, str](r_full));
         ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](r_full));
     }
@@ -2337,29 +2302,23 @@ fun resolve_type_path(rc: *ResolveContext, named: *atype.TypeNamed, full: token.
     val path: token.Span = named.name;
     if (path.len == 0) { ret SYMBOL_NIL; }
 
-    var seg_start: usize = path.offset;
-    val end:       usize = path.offset + path.len;
-    var seg_end:   usize = seg_start;
+    var cursor: usize = path.offset;
+    val end: usize = path.offset + path.len;
 
     var current_module: session.ModuleId = session.MODULE_NIL;
     var current_sym:    SymbolId      = SYMBOL_NIL;
     var first:          bool          = true;
 
-    for (seg_start < end) {
-        seg_end = seg_start;
-        for (seg_end < end && rc.source[seg_end] != '.') {
-            seg_end = seg_end + 1;
-        }
-        var seg_span: token.Span;
-        seg_span.offset = seg_start;
-        seg_span.len    = seg_end - seg_start;
+    for (cursor < end) {
+        val seg_span: token.Span = np.next(rc.source, path, ?cursor);
+        if (seg_span.len == 0) { brk; }
 
         val r: R.Result[intern.StrId, str] = intern.intern_span(?rc.s.interner, rc.source, seg_span);
         if (R.is_err[intern.StrId, str](r)) { fail.internal(?rc.status, R.unwrap_err[intern.StrId, str](r)); ret SYMBOL_NIL; }
         val seg_name: intern.StrId = R.unwrap_ok[intern.StrId, str](r);
 
         if (first) {
-            val is_single: bool = seg_end >= end;
+            val is_single: bool = cursor >= end;
             if (is_single) {
                 val rs: R.Result[TypeSpelling, str] = type_spelling(rc, seg_name);
                 if (R.is_err[TypeSpelling, str](rs)) { fail.internal(?rc.status, R.unwrap_err[TypeSpelling, str](rs)); ret SYMBOL_NIL; }
@@ -2380,7 +2339,7 @@ fun resolve_type_path(rc: *ResolveContext, named: *atype.TypeNamed, full: token.
         }
 
         if (current_sym == SYMBOL_NIL) {
-            if (seg_start == path.offset && seg_end >= end) {
+            if (seg_span.offset == path.offset && cursor >= end) {
                 val re: R.Result[R.Void, str] = report_named(rc, full, "unresolved type name `", seg_name, "`");
                 if (R.is_ok[R.Void, str](re)) { attach_suggestion(rc, full, seg_name); }
             }
@@ -2390,7 +2349,7 @@ fun resolve_type_path(rc: *ResolveContext, named: *atype.TypeNamed, full: token.
             ret SYMBOL_NIL;
         }
 
-        if (seg_end >= end) { brk; }
+        if (cursor >= end) { brk; }
 
         val sym: *Symbol = ?rc.symbols[current_sym];
         if (sym.kind == SYM_USE) {
@@ -2400,8 +2359,6 @@ fun resolve_type_path(rc: *ResolveContext, named: *atype.TypeNamed, full: token.
             record_report(rc, full, "expected a module alias before `.`");
             ret SYMBOL_NIL;
         }
-
-        seg_start = seg_end + 1;
     }
 
     ret current_sym;


### PR DESCRIPTION
Imports, re-exports and qualified type names now resolve from their identifier
segments, so spacing or line comments around dots cannot change resolution.
Diagnostics keep the original source spans.

## What landed

- `src/lang/fe/path.mach`: a frontend path tokenizer. `next` skips parser-accepted
  trivia (spaces, tabs, CR, LF, `#` comments to end of line) and yields the next
  identifier segment. `leaf` and `prefix` extract segment spans. `intern_path`
  interns the canonical dotted form, releasing temporaries on allocation refusal.
- `src/lang/driver/load.mach`: `resolve_use_target`, `unresolvable_use_msg` and
  `leaf_name` traverse segments instead of slicing raw source, so comment text no
  longer leaks into undeclared-root messages.
- `src/lang/fe/resolve.mach`: `find_module_exports_span`, `resolve_prefix_module`,
  `collect_use`, `collect_fwd` and `resolve_type_path` intern canonically while
  error reporting stays on the full original span.
- `resolve_use_target` returns a classified `outcome.Fail`. User rejections are
  emitted as located gate diagnostics at the import path's own span. Internal
  failures keep their internal classification instead of collapsing into a user
  rejection.

Two existing checks read the unlocated propagated message for an unresolvable
import root. That message is now a located diagnostic, so both read the emitted
diagnostic instead, keeping every original assertion including the negative ones.

## Verification

Seed compiler `/home/octalide/.local/bin/mach`, dep/std at `168a9f76`.

| check | result |
| --- | --- |
| `mach test . --jobs 8` | 2614 passed, 0 failed |
| `--filter dotted_` | 5 passed |
| `--filter mach.lang.fe.path:` | 2 passed |
| `--filter mach.lang.fe.resolve:` | 5 passed |
| `git diff --check dev...HEAD` | clean |

The restored `dotted_path_rejection_keeps_original_source_span` check was proven
load-bearing by mutating the span handed to `gate_error`, which failed it at the
column assertion. The mutation was reverted.

## Owed elsewhere

Asserting the emitted diagnostic for a deprecated leaf identifier written after a
comment needs `#[deprecated]` support, which does not exist on `dev` and belongs
to #3129. That assertion is owed by #3129 and is not part of this branch.

Closes #3229
