### PR TITLE
ci(bootstrap): add the one-way v5 transition stage (#3112)

### DIFF
--- a/.github/actions/setup-mach/bootstrap.py
+++ b/.github/actions/setup-mach/bootstrap.py
@@ -9,9 +9,15 @@ import tempfile
 
 
 census = runpy.run_path(str(Path(__file__).with_name('census.py')))['census']
+# (name, compiler source, std pin, mode). 'single' stages are one-way bridges built
+# once by the previous compiler. 'fixpoint' stages build A, B and C and require B == C.
+# the transition bridge is f2569491's source with the pre-suffix manifest of 52a53af8:
+# it parses under 4.30, implements the v5 manifest, and cannot rebuild itself against
+# a published std, so it is one-way. it lives on branch bootstrap/v5-transition.
 STAGES = [
-    ('bridge', '878a8f66a90127360dc23de4480241934fc1bf0d', '3ee8e709a8ed7baff6e93780ce9b3582a907a91f'),
-    ('audited', 'b65afb9704218e89998af5f71050ca315e7709a9', '168a9f760d7c0f7a182f3b0685081e62f1a4f682'),
+    ('bridge', '878a8f66a90127360dc23de4480241934fc1bf0d', '3ee8e709a8ed7baff6e93780ce9b3582a907a91f', 'single'),
+    ('audited', 'b65afb9704218e89998af5f71050ca315e7709a9', '168a9f760d7c0f7a182f3b0685081e62f1a4f682', 'fixpoint'),
+    ('transition', 'cd283ceeae8deb1ffbe760980f2d1db3ef22a7ac', '168a9f760d7c0f7a182f3b0685081e62f1a4f682', 'single'),
 ]
 
 
@@ -32,6 +38,15 @@ def run(label, command, source, evidence):
         raise RuntimeError(label + ' failed with exit ' + str(result.returncode))
 
 
+def required_stage():
+    # the source tree names the chain stage that compiles it; absent means the audited compiler
+    marker = Path('.mach-bootstrap')
+    name = marker.read_text(encoding='utf-8').strip() if marker.exists() else 'audited'
+    if name not in [stage[0] for stage in STAGES] or name == 'bridge':
+        raise ValueError('.mach-bootstrap names an unknown stage: ' + name)
+    return name
+
+
 def main():
     destination = Path('.mach-toolchain').resolve()
     evidence = destination / 'evidence'
@@ -44,11 +59,14 @@ def main():
         raise ValueError('bootstrap requires the published v4.26.5 seed')
     for name in ['release.json', 'SHA256SUMS', 'provenance.json']:
         shutil.copy2(seed_dir / name, evidence / ('seed-' + name))
-    provenance = dict(seed=seed, seed_sha256=digest(compiler), profile='debug', stages=[], fixpoint=False)
+    last = required_stage()
+    provenance = dict(seed=seed, seed_sha256=digest(compiler), profile='debug', required=last, stages=[], fixpoint=False)
     record = evidence / 'provenance.json'
     record.write_text(json.dumps(provenance, indent=2), encoding='utf-8')
     with tempfile.TemporaryDirectory(prefix='mach-bootstrap-', dir=os.environ.get('RUNNER_TEMP')) as scratch:
-        for name, source_ref, std_ref in STAGES:
+        for name, source_ref, std_ref, mode in STAGES:
+            if STAGES.index((name, source_ref, std_ref, mode)) > [stage[0] for stage in STAGES].index(last):
+                break
             source = Path(scratch) / name
             subprocess.run(['git', 'clone', '--quiet', 'https://github.com/briar-systems/mach', str(source)], check=True)
             subprocess.run(['git', 'checkout', '--detach', source_ref], cwd=source, check=True)
@@ -57,16 +75,16 @@ def main():
                 raise RuntimeError('bootstrap source differs from its committed pins')
             stage = dict(name=name, compiler=source_ref, std=std_ref, binaries={})
             provenance['stages'].append(stage)
-            for letter in (['H'] if name == 'bridge' else ['A', 'B', 'C']):
+            for letter in (['H'] if mode == 'single' else ['A', 'B', 'C']):
                 output = source / ('m' + letter + suffix)
                 run(name + '-' + letter, [str(compiler), 'build', '.', '--profile', 'debug', '-o', output.name], source, evidence)
                 stage['binaries'][letter] = digest(output)
                 compiler = output
                 record.write_text(json.dumps(provenance, indent=2), encoding='utf-8')
-            if name == 'audited':
+            if mode == 'fixpoint':
                 compiler = source / ('mB' + suffix)
                 if compiler.read_bytes() != (source / ('mC' + suffix)).read_bytes():
-                    raise RuntimeError('audited compiler B and C differ')
+                    raise RuntimeError(name + ' compiler B and C differ')
                 stage['fixpoint'] = True
             for checkout in [source, source / 'dep/std']:
                 if git(checkout, 'status', '--porcelain', '--untracked-files=no'):
@@ -74,7 +92,7 @@ def main():
         census('bootstrap-complete', evidence)
         installed = destination / ('mach' + suffix)
         shutil.copy2(compiler, installed)
-        provenance.update(fixpoint=True, sha256=digest(installed))
+        provenance.update(fixpoint=all(stage.get('fixpoint', False) for stage in provenance['stages'] if stage['name'] == 'audited'), sha256=digest(installed))
         record.write_text(json.dumps(provenance, indent=2), encoding='utf-8')
         with Path(os.environ['GITHUB_PATH']).open('a', encoding='utf-8') as output:
             output.write(str(destination) + '\n')

--- a/doc/design/release-shape.md
+++ b/doc/design/release-shape.md
@@ -21,7 +21,7 @@ main commit `b65afb9704218e89998af5f71050ca315e7709a9` with std **1.0.1**
 reachable from main. The bridge contains the same compiler source and manifest
 as the earlier audit bridge. No retired proof branch is required.
 
-There are four builds: one bridge build followed by audited A, B and C. The
+A one-way transition stage follows: audited B builds `cd283ceeae8deb1ffbe760980f2d1db3ef22a7ac` (f2569491's source with the pre-suffix manifest of 52a53af8, branch `bootstrap/v5-transition`) once, and that compiler builds the development source, whose manifest and std pin the audited compiler cannot parse. There are five builds: one bridge build, audited A, B and C, and one transition build. A root `.mach-bootstrap` file names the stage a source tree requires (absent means `audited`), so `dev` keeps building with the audited compiler while the integration branch names `transition`. The
 bootstrap uses the debug profile, with optimization and compiler debug symbols
 disabled. Both repositories install audited B only after B and C match byte for
 byte. Ordinary CI then runs its existing debug and release checks with that

--- a/doc/tooling/bootstrap.md
+++ b/doc/tooling/bootstrap.md
@@ -28,10 +28,22 @@ git -C bootstrap-main submodule update --init --recursive
 (cd bootstrap-main && ./mB build . --profile debug -o mC)
 cmp bootstrap-main/mB bootstrap-main/mC
 ./bootstrap-main/mB info --version
+
+git clone --no-checkout https://github.com/briar-systems/mach bootstrap-transition
+git -C bootstrap-transition checkout --detach cd283ceeae8deb1ffbe760980f2d1db3ef22a7ac
+git -C bootstrap-transition submodule update --init --recursive
+(cd bootstrap-transition && ../bootstrap-main/mB build . --profile debug -o mT)
 ```
 
-The final command must print `4.30.0`. Use `bootstrap-main/mB` as the compiler
-for your development checkout, after initializing that checkout's submodules
+The version command must print `4.30.0`. The transition stage is one-way: the
+audited compiler builds `bootstrap-transition/mT` once. That source is f2569491
+with the pre-suffix manifest of 52a53af8, kept on branch `bootstrap/v5-transition`.
+It parses under 4.30 and implements the v5 manifest, but it cannot rebuild
+itself against a published std, so it is never asked to. A source tree names the
+stage that compiles it in a root `.mach-bootstrap` file containing `audited` or
+`transition`; an absent file means `audited`. `dev` builds with the audited
+compiler. The v5 integration branch names `transition`. Use the compiler that
+your checkout names, after initializing that checkout's submodules
 with `git submodule update --init --recursive`. The bridge pins std
 `3ee8e709a8ed7baff6e93780ce9b3582a907a91f`. The audited source pins std
 `168a9f760d7c0f7a182f3b0685081e62f1a4f682` (1.0.1).


### PR DESCRIPTION
The audited 4.30 compiler at the end of the bootstrap chain cannot parse the v5 manifest (`{artifact.suffix}`, strict profiles) that feat/3218 inherited from the pre-language candidate, so every `targets` lane on #3236 fails before compiling.

Adds a pinned one-way transition stage after `audited`: `cd283cee` on branch `bootstrap/v5-transition`, which is f2569491's cycle-free source with 52a53af8's pre-suffix manifest and std 1.0.1. Proven locally: 4.30 builds it, and its compiler builds the feat/3218 head at `ae6db67e`. It is one-way because its source needs a std that has both the strict manifest and the pre-migration filesystem API, and no published std has both (the candidate pinned unpublished std commits 58ca9ea1, c08f0f83 and dcb33e1c, which exist nowhere on the remote).

`STAGES` entries now carry a mode: `single` (one build, like the existing bridge) or `fixpoint` (A/B/C with B == C). The provenance `fixpoint` flag now reflects the audited stage. Docs updated in `doc/tooling/bootstrap.md` and `doc/design/release-shape.md`.

This PR's own CI exercises the new chain on every native host. dev source builds under the transition compiler exactly as it does under 4.30.
