### PR TITLE
test: stop listing after frontend collection without code generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Test listing stops after collecting tests. It no longer generates or links
+  machine code, and it produces no test executable (#3230).
+
 - Dotted import, re-export and type names resolve identically with spacing or comments around dots. Diagnostics retain the original source spans (#3229).
 
 - Unresolved imports report at their own source coordinates instead of an unlocated message. Internal load failures stay internal instead of collapsing into a user rejection (#3229).

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -640,6 +640,7 @@ fun derive_phases(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
     if (R.is_err[R.Void, outcome.Fail](r4)) { ret r4; }
     val r5: R.Result[R.Void, outcome.Fail] = push_phase(u, PH_LOWER);
     if (R.is_err[R.Void, outcome.Fail](r5)) { ret r5; }
+    if (req.goal == request.GOAL_TEST_LIST) { ret R.ok_void[outcome.Fail](); }
     val r6: R.Result[R.Void, outcome.Fail] = push_phase(u, PH_CODEGEN);
     if (R.is_err[R.Void, outcome.Fail](r6)) { ret r6; }
 
@@ -2379,9 +2380,21 @@ test "mach.lang.build.plan.plan:phases_follow_goal" {
     val pl: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, rq);
     if (R.is_err[BuildPlan, outcome.Fail](pl)) { ret 1; }
     val ul: *BuildUnit = ?R.unwrap_ok[BuildPlan, outcome.Fail](pl).units.data[0];
-    if (ul.phases.len != 4)               { ret 1; }
-    if (ul.phases.data[3] != PH_CODEGEN)  { ret 1; }
+    if (ul.phases.len != 3)               { ret 1; }
+    if (ul.phases.data[0] != PH_LOAD)     { ret 1; }
+    if (ul.phases.data[1] != PH_SEMA)     { ret 1; }
+    if (ul.phases.data[2] != PH_LOWER)    { ret 1; }
     if (!str_empty(ul.out_path))          { ret 1; }
+
+    rq.emit_ir  = true;
+    rq.emit_asm = true;
+    val pe: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, rq);
+    if (R.is_err[BuildPlan, outcome.Fail](pe)) { ret 1; }
+    val ue: *BuildUnit = ?R.unwrap_ok[BuildPlan, outcome.Fail](pe).units.data[0];
+    if (ue.phases.len != 3 || ue.phases.data[2] != PH_LOWER) { ret 1; }
+    if (!str_empty(ue.out_path))          { ret 1; }
+    rq.emit_ir  = false;
+    rq.emit_asm = false;
 
     rq.goal = request.GOAL_TESTS;
     val pt: R.Result[BuildPlan, outcome.Fail] = plan(?alloc, ?itn, ?reg, ?m, rq);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -16280,6 +16280,12 @@ test "mach.lang.driver.readout:a_phase_counts_what_it_processed" {
     var bad: i32 = 0;
     val r: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, ?alloc, ?ev);
     if (R.is_err[outcome.BuildOutcome, outcome.Fail](r)) { bad = 1; }
+    or {
+        var listed: outcome.BuildOutcome = R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r);
+        if (listed.severity != outcome.BUILD_OK || listed.tests.len != 1) { bad = 1; }
+        or { if (!str_empty(listed.tests.data[0].exe)) { bad = 1; } }
+        outcome.outcome_dnit(?listed);
+    }
 
     val ld: u32 = readout.PH_LOAD::u32;
     val rs: u32 = readout.PH_RESOLVE::u32;
@@ -16303,8 +16309,8 @@ test "mach.lang.driver.readout:a_phase_counts_what_it_processed" {
     if (sm.occurrences > 0 && sm.processed != sm.item_count)   { bad = 1; }
     if (lwm.occurrences > 0 && lwm.processed != lwm.item_count) { bad = 1; }
     if (om.occurrences > 0 && om.processed != om.item_count)   { bad = 1; }
-    if (cm.occurrences > 0 && cm.processed != cm.item_count)   { bad = 1; }
-    if (em.occurrences > 0 && em.processed != em.item_count)   { bad = 1; }
+    if (cm.occurrences != 0 || em.occurrences != 0
+        || ev.metrics[readout.PH_LINK::u32].occurrences != 0) { bad = 1; }
 
     readout.dnit(?ev);
     fs.remove_all(?alloc, root);


### PR DESCRIPTION
Extracted from the local pre-language candidate (`d2bbbfba`), narrowed to this issue.

## What landed

- `derive_phases` ends the plan at `PH_LOWER` for `GOAL_TEST_LIST`. Listing no longer schedules `PH_CODEGEN`, and the early return also keeps `PH_EMIT` out when `--emit-ir`/`--emit-asm` are requested. Nothing links, and no test executable is produced.
- Test listing still runs load, sema and lower, which is what `list_tests` needs to collect the case inventory from the lowered modules. Diagnostics are unchanged.
- Regression coverage carried from the candidate:
  - `mach.lang.build.plan.plan:phases_follow_goal` now asserts the three test-list phases in order and an empty output path, plus the same shape with IR and assembly emission requested.
  - `mach.lang.driver.readout:a_phase_counts_what_it_processed` asserts the listed outcome is OK with one case and an empty `exe`, and that the codegen, emit and link phases record no occurrences at all.

The candidate commit also introduced `GOAL_CHECK` and `mach check` (#3224). None of that is included here.

## Verification

Built from the 4.30.0 seed, tests run through the freshly built compiler.

| check | result |
| --- | --- |
| `./out/audit/mach test . --jobs 8` | 2614 passed, 0 failed |
| `--filter phases_follow_goal` | 1 passed |
| `--filter a_phase_counts_what_it_processed` | 1 passed |
| `git diff --check dev...HEAD` | clean |

Both guards were mutation-tested: deleting the one-line early return in `derive_phases` fails both filtered tests, and they pass again once it is restored.

Closes #3230
