### PR TITLE
driver: count processed modules in the phase that performed the work

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Name resolution reports one phase row per build. A deferred comptime gate no
+  longer makes the resolver report every module again for each pass it takes,
+  and each module's resolve time is accumulated across those passes (#3231).
+
 - Dotted import, re-export and type names resolve identically with spacing or comments around dots. Diagnostics retain the original source spans (#3229).
 
 - Unresolved imports report at their own source coordinates instead of an unlocated message. Internal load failures stay internal instead of collapsing into a user rejection (#3229).

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -334,7 +334,9 @@ fun run_load_phase_roots(p: *project.Project, extra_roots: *intern.StrId,
         ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](cfg_in_r)));
     }
 
+    readout.phase_begin(p.events, readout.PH_RESOLVE);
     val resolve_r: R.Result[R.Void, outcome.Fail] = resolve_deferred_gate_load(p);
+    close_resolve_row(p);
     if (R.is_err[R.Void, outcome.Fail](resolve_r)) { ret resolve_r; }
 
     val emb_r: R.Result[R.Void, str] = union.register_embed_inputs(p);
@@ -348,6 +350,17 @@ fun run_load_phase_roots(p: *project.Project, extra_roots: *intern.StrId,
     }
 
     ret R.ok_void[outcome.Fail]();
+}
+
+fun close_resolve_row(p: *project.Project) {
+    var i: u32 = 0;
+    for (i < p.topo_len) {
+        val m: *project.ModuleEntry = ?p.modules[p.topo[i]::u32];
+        readout.item_dur(p.events, readout.PH_RESOLVE, project.fqn_name(p, m.fqn), m.resolve_elapsed);
+        m.resolve_elapsed = 0;
+        i = i + 1;
+    }
+    readout.phase_end(p.events, readout.PH_RESOLVE, p.topo_len, "module", "modules");
 }
 
 fun resolve_deferred_gate_load(p: *project.Project) R.Result[R.Void, outcome.Fail] {

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -413,6 +413,7 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[sessio
     m.dep_cap           = 0;
     m.resolve_result    = nil;
     m.resolved          = false;
+    m.resolve_elapsed   = 0;
     m.gate_result       = nil;
     m.tuple_gates       = nil;
     m.tuple_gate_count  = 0;

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -77,7 +77,6 @@ pub fun run_resolve_pass(p: *project.Project) R.Result[R.Void, fail.Fail] {
     val tf: R.Result[R.Void, str] = query.set_input(?p.s.queries, query.Q_GATE_TERMINAL, 0, ?tflag, 1);
     if (R.is_err[R.Void, str](tf)) { ret fail.lift[R.Void](tf); }
 
-    readout.phase_begin(p.events, readout.PH_RESOLVE);
     var i: u32 = 0;
     for (i < p.topo_len) {
         val mid: session.ModuleId = p.topo[i];
@@ -87,7 +86,6 @@ pub fun run_resolve_pass(p: *project.Project) R.Result[R.Void, fail.Fail] {
         }
         i = i + 1;
     }
-    readout.phase_end(p.events, readout.PH_RESOLVE, p.topo_len, "module", "modules");
     ret R.ok_void[fail.Fail]();
 }
 
@@ -108,7 +106,7 @@ fun run_resolve_one(p: *project.Project, mid: session.ModuleId) R.Result[R.Void,
 
     m.resolve_result = rr;
     m.resolved       = true;
-    readout.item(p.events, readout.PH_RESOLVE, project.fqn_name(p, m.fqn), t_item);
+    if (p.events != nil) { m.resolve_elapsed = m.resolve_elapsed + ctime.time_sub(ctime.monotonic(), t_item); }
     ret R.ok_void[fail.Fail]();
 }
 

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -16,6 +16,7 @@ use R: std.types.result;
 use mach.lang.fe.ast;
 use mach.lang.fail;
 use mach.lang.readout;
+use cdur: std.chrono.duration;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.sema;
@@ -167,6 +168,7 @@ pub rec ModuleEntry {
     dep_cap:           u32;
     resolve_result:    *resolve.ResolveResult;
     resolved:          bool;
+    resolve_elapsed:   cdur.Duration;
     gate_result:       *sema.SemaResult;
     tuple_gates:       *TupleGateResult;
     tuple_gate_count:  u32;

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -16312,6 +16312,67 @@ test "mach.lang.driver.readout:a_phase_counts_what_it_processed" {
     ret bad;
 }
 
+test "mach.lang.driver.readout:a_deferred_gate_resolves_each_module_once" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
+
+    var names: [3]str;
+    names[0] = "main.mach"; names[1] = "helper.mach"; names[2] = "extra.mach";
+    var texts: [3]str;
+    # the gate reads a constant from a module bound below it, so the first
+    # resolve pass defers the gate and a second pass decides it
+    texts[0] = ut_cc3(?alloc,
+        "$if (helper.FLAG == 1) {\n    use uniontest.extra;\n}\n\nuse uniontest.helper;\n\n#[symbol(\"",
+        ut_entry_symbol(), "\")]\nfun start() i32 { ret 0; }\n");
+    texts[1] = "pub val FLAG: u8 = 1;\n\ntest \"flag\" { ret 0; }\n";
+    texts[2] = "pub fun extra() i32 { ret 3; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 3);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = root;
+    rq.goal         = request.GOAL_OBJECTS;
+    val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
+
+    var ev: readout.Progress;
+    readout.init(?ev, ?alloc, readout.LEVEL_PHASES);
+
+    var bad: i32 = 0;
+    val r: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, ?alloc, ?ev);
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r)) { bad = 1; }
+    or {
+        var listed: outcome.BuildOutcome = R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r);
+        if (listed.severity != outcome.BUILD_OK) { bad = 1; }
+        outcome.outcome_dnit(?listed);
+    }
+
+    val lm: *readout.PhaseMetrics = ?ev.metrics[readout.PH_LOAD::u32];
+    val rm: *readout.PhaseMetrics = ?ev.metrics[readout.PH_RESOLVE::u32];
+
+    # the gated arm brings its module in after the load row closes, which is
+    # what makes this fixture take a second resolve pass
+    if (lm.processed >= rm.processed) { bad = 1; }
+
+    if (rm.occurrences != 1)           { bad = 1; }
+    if (rm.processed != 3)             { bad = 1; }
+    if (rm.item_count != rm.processed) { bad = 1; }
+
+    readout.dnit(?ev);
+    fs.remove_all(?alloc, root);
+    session.dnit(?s);
+    ret bad;
+}
+
 fun ut_spv_has_bare_decor(w: *u32, n: u32, id: u32, decor: u32) bool {
     var i: u32 = 0;
     for (i < n) {


### PR DESCRIPTION
Extracted from the local pre-language candidate, narrowed to what is still a defect on `dev`.

## What landed

Candidate commit `174471c1` "fix(readout): aggregate resolver work into one phase row", rebuilt against the current driver:

- `ModuleEntry` carries `resolve_elapsed`, and `run_resolve_one` accumulates a module's resolve time there instead of emitting a progress item per pass.
- `run_resolve_pass` no longer opens or closes a phase row. The driver opens one resolve row around the whole gate-deferral loop and closes it in `close_resolve_row`, emitting one item per module with the time of every pass it took.
- The candidate hung the row on a `fin` at function scope, which would have folded embed and export registration into the resolve row as well. This version calls `close_resolve_row` on the single return path of the deferral loop instead, so the row covers exactly the resolution work.

Before the fix, a comptime gate that cannot be decided on the first pass sends the loader back through name resolution, and every pass opened its own row. A three-module project with one deferred gate reported two resolve rows and five module resolutions:

```
load        2 modules
resolve     2 modules
resolve     3 modules
```

After it, one row of three.

## What was left behind, and why

The issue also names serial optimization omitting processed-module events and parallel lowering counting a module twice. Both come from `c2fbd635`, which restructures lowering around the inline-body query for #3110. On `dev` those two phases already count correctly, so nothing from that commit is needed here. Measured on a 46-module build with the compiler built from `dev`, at item verbosity:

| jobs | lower items | optimize items | modules |
| --- | --- | --- | --- |
| 1 | 46 | 46 | 46 |
| 4 | 46 | 46 | 46 |

Adjacent finding, not fixed here: the load row closes before the gate-deferral loop runs, so a module that only enters the build through a gated `use` is never counted by the load phase. That is why the fixture in the new test sees `load 2 modules` against `resolve 3 modules`. Fixing it means moving where the load row closes, which is a larger change than this issue's acceptance.

## Regression coverage

New: `mach.lang.driver.readout:a_deferred_gate_resolves_each_module_once` builds a three-module project whose gate reads a constant from a module bound below it, forcing a second resolve pass, and asserts one resolve row, three processed modules, and one item per processed module.

## Verification

Built from the 4.30.0 seed, tests run through the freshly built compiler.

| check | result |
| --- | --- |
| `./out/audit/mach test . --jobs 8` | 2615 passed, 0 failed (2614 on `dev` plus the new test) |
| `--filter a_deferred_gate_resolves_each_module_once` | 1 passed |
| `--filter a_phase_counts_what_it_processed` | 1 passed |
| `--filter rows_are_one_per_phase` | 2 passed |
| `git diff --check dev...HEAD` | clean |

The guard was mutation-tested: restoring the per-pass resolve row in `run_resolve_pass` fails the new test, and it passes again once the row is removed.

Closes #3231
