### PR TITLE
query/editor: accept transitive validation, owned products and buffer lifecycle (#3220, #2999)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Dependency names follow the path. Missing or extra operands are refused.
   Use `.` for the current project. Pull retains existing local copies and update
   refreshes them. Dependency commands preserve the project's Git history.
+- Query products validate their inputs transitively before reuse, own their diagnostics and release replaced or failed candidates through their finalizers. Equal recomputed dependencies keep their revision, changed diagnostics with equal bytes stay observable, external revisions and the selected target invalidate what read them, and a failed dependency never leaves a stale successful product. Importers depend on a dependency's public surface, so a body-only edit reuses their typed results (#3220).
 - Editor analysis returns an owned diagnostic/source snapshot with explicit phase and target selection. Raw products have checked serial-view lifetimes. Closing a buffer retires its overlay, source payload and cached dependents while retaining its FileId. Buffer slots are reused, and checked editor teardown preserves owners on preparation failure (#2999).
 
 ## [4.30.0] - 2026-09-07

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Dependency names follow the path. Missing or extra operands are refused.
   Use `.` for the current project. Pull retains existing local copies and update
   refreshes them. Dependency commands preserve the project's Git history.
+- Editor analysis returns an owned diagnostic/source snapshot with explicit phase and target selection. Raw products have checked serial-view lifetimes. Closing a buffer retires its overlay, source payload and cached dependents while retaining its FileId. Buffer slots are reused, and checked editor teardown preserves owners on preparation failure (#2999).
 
 ## [4.30.0] - 2026-09-07
 

--- a/doc/design/query-semantic-results.md
+++ b/doc/design/query-semantic-results.md
@@ -1,0 +1,98 @@
+# Semantic results: the query contract for language products
+
+Status: accepted with #3220 and #2999. Binding for every product the
+language work adds to the query database (tag layouts, case guards,
+canonical tag tables, or any later semantic result).
+
+## What a product declares
+
+A product is one query kind registered once per session through the
+registration surface in `src/lang/query.mach`:
+
+- `register_input` for bytes the host sets directly (`set_input`). An
+  input carries its own revision and no dependencies.
+- `register_derived` for a product whose bytes the compute callback
+  builds and the database owns. Equal bytes on recomputation keep the
+  previous revision.
+- `register_derived_owned` when the bytes are a handle to storage the
+  product allocated. The finalizer releases that storage whenever the
+  database drops the bytes: replacement, failed publication, retirement
+  and teardown. An owned product never aliases a previous value; if the
+  new value equals the old one the candidate is released through the
+  finalizer and the published entry keeps its identity and revision.
+- `register_derived_equatable` for owned products with a structural
+  comparator; use it when byte identity would make every recomputation
+  look changed (IR modules are the existing example).
+- `register_metadata` for a revision the database cannot store: an
+  external file, a manifest overlay, a tool version. The provider reads
+  `(present, revision)` on demand and is sampled once per operation.
+
+Every product therefore declares three things: how its inputs are
+observed (below), which revision it carries (the database stamps it on
+publication), and who owns its bytes (the database, through the
+finalizer when one is registered).
+
+## How a product joins invalidation
+
+Dependencies are recorded by reading, never by hand. Inside its compute
+callback a product calls `get` (or `depend`) for every query it reads
+and `observe` for every metadata revision it consults. The database
+records the edge on the computing owner together with the dependency's
+revision and diagnostics revision. A validation pass never records
+edges on the query it is validating for.
+
+Validation is transitive. Before a cached product is reused, each
+dependency is itself validated or recomputed, depth first, inside the
+current operation. A dependency that recomputes to an equal value keeps
+its revision and stops propagation (early cutoff). A dependency whose
+value or diagnostics changed advances its revision, so every product
+above it recomputes. A dependency that fails makes the requesting
+product fail; the previous value is never served. Cycles are detected
+on the computing stack before any recursive validation.
+
+Diagnostics are part of the product. Each derived product owns the
+diagnostic store its compute wrote into. Equal bytes with different
+diagnostics still advance the diagnostics revision, and dependents
+observe it. Presentation (`collect`) replays diagnostics in dependency
+order once per origin, cold or warm.
+
+A new product kind therefore joins invalidation by doing only this:
+pick a registration that states ownership, read every input through
+`get`/`observe`, write diagnostics only to the store the callback
+receives, and return bytes the finalizer can release. Nothing else in
+the engine needs to change, and no kind may cache across operations
+outside the database.
+
+## Operations and consumers
+
+All reads happen inside an operation (`begin` ... `end`). `end` verifies
+that every sampled metadata revision is unchanged and refuses success
+otherwise. Inputs cannot change and products cannot be retired while an
+operation or its uncollected presentation is live. The build, check and
+editor consumers share the same revision-stamped products; a consumer
+identifies a result by its source revision and the selected target
+input (`Q_TARGET`), which is an ordinary input and invalidates every
+product that read it.
+
+## What the editor lifecycle guarantees
+
+- `open`/`update` publish the buffer text as the `Q_FILE_TEXT` input and
+  the session overlay atomically; a failed preparation leaves every
+  buffer, overlay and view as it was.
+- `analyze` runs one phase and returns an owned snapshot: diagnostics,
+  the source versions they cite, the selected target and configuration.
+  The snapshot outlives the session. Raw products (`ast_of`,
+  `resolve_of`, `sema_of`) borrow a serial view that expires on the next
+  mutation, target change, close or query use, and report expiry
+  instead of dangling.
+- `close` retires the buffer through `prepare_retirement` /
+  `commit_retirement`: dependents are freed before their inputs, the
+  overlay and source payload are released, the `FileId` survives and is
+  reused by the next open of the same path, and unrelated buffers,
+  their inputs and their products keep their revisions. A close during
+  an outstanding operation or presentation is refused and changes
+  nothing.
+- A semantic product added later inherits all of this: it is retired
+  with the buffers it depends on, presented with the diagnostics it
+  wrote, and never reused across a target or source revision it did not
+  observe.

--- a/doc/tooling/editor-api.md
+++ b/doc/tooling/editor-api.md
@@ -1,196 +1,121 @@
-# Editor query surface (`mach.lang.editor`)
+# Editor API (`mach.lang.editor`)
 
-The compiler-as-library entry point for editor tooling: language servers,
-plugins, single-file linters. `mach-lsp` is its consumer. It analyzes one
-in-memory buffer at a time and, when that buffer belongs to a project, does so
-**project-aware**: the buffer is analyzed as the module it is inside its
-project, through the same target-aware load, resolve, and sema services the
-driver uses, with the project's real dependency set. A buffer outside any
-project is analyzed on its own.
+The editor facade analyzes unsaved buffers through the compiler's frontend and
+query cache. The caller owns a `session.Session` and its allocator. One
+`EditorSession` borrows that Session for serial use. Neither object may move
+while its address is borrowed. There is no concurrent request support.
 
-This module, the CLI, and the manifest schema are the supported surface of the
-compiler. They are source-stable within a major version and not binary-stable;
-everything else under `src/` is internal and carries no promise.
+## Buffer ownership
 
-It is built on the same front-end phases the driver uses (`source`, `lexer`,
-`parser`, `resolve`, `sema`, `diagnostic`) and reuses the session services
-(`SourceMap`, the diagnostic store, interners). Every entry tolerates a
-malformed buffer: it records diagnostics and returns a usable partial result
-rather than bailing at the first error.
+`open(es, path, text)` copies an overlay and source payload and returns a stable
+`FileId`. `update(es, file, text)` replaces an open buffer. Identical text is a
+no-op. `close(es, file)` removes its overlay, cached dependent products and
+source payload. Closing an unopened file returns `ok(false)`.
 
-## Lifecycle
+File identity and path metadata survive close. Reopening the same canonical
+path returns the same `FileId` with a fresh source revision. Buffer slots are
+reused independently of FileIds and grow to peak simultaneous opens. A closed
+buffer stops contributing an extra project root. If another module imports
+that file, a later project analysis reads its current disk contents.
 
-```
-session.Session              // caller owns; provides SourceMap + diagnostic store
-  └─ editor.EditorSession    // borrows the session, owns per-buffer analysis
-       ├─ Buffer (per FileId)   // owned Ast / ResolveResult / SemaResult, or borrowed from the project
-       └─ Project               // loaded on demand for a buffer inside a project root
-```
+Open, update, close and teardown prepare every fallible allocation before
+publishing their changes. An error preserves the open buffers and current
+views, including their overlays and project state. Internal table capacity can
+remain reserved after a refusal. Retry is permitted.
 
-```mach
-var s: session.Session = unwrap_ok[...](session.init(?alloc));
-var es: editor.EditorSession = editor.init(?s);
-// ... drive es ...
-editor.dnit(?es);   // frees every buffer's owned analysis and the loaded project
-session.dnit(?s);   // tears the session down (editor never touches it)
-```
+`dnit(es) -> Result[Void, str]` retires all editor-owned inputs together, then
+frees the editor's structural state. Check this result. Failure leaves the
+editor and Session intact. Success leaves unrelated Session cache entries and
+stable source identities intact. Destroy the Session only after successful
+editor teardown. There is no separate public close-all protocol.
 
-The session must outlive the editor session. `editor.dnit` releases only what
-the editor owns: per-buffer analysis it computed itself, and the project it
-loaded. The borrowed `SourceMap` and diagnostic store belong to the session.
+## Analysis request and owned result
 
-## API
+Create an `AnalysisRequest` with `analysis_request(file, phase)` and call
+`analyze(es, request) -> Result[AnalysisResult, outcome.Fail]`.
 
-| Function | Signature | Purpose |
-|---|---|---|
-| `init` | `fun(*session.Session) EditorSession` | construct the facade over a session |
-| `dnit` | `fun(*EditorSession)` | release owned per-buffer analysis and the loaded project |
-| `open` | `fun(*EditorSession, str, str) Result[source.FileId, str]` | register an unsaved buffer (path, text); return its `FileId` |
-| `update` | `fun(*EditorSession, source.FileId, str) Result[bool, str]` | replace a buffer's text; `true` when the text changed, dropping cached analysis |
-| `tokenize` | `fun(*EditorSession, source.FileId) Result[lexer.TokenStream, str]` | lex; lex errors land on the diagnostic store (caller frees the stream) |
-| `parse` | `fun(*EditorSession, source.FileId) Result[*ast.Ast, str]` | best-effort parse; the project's AST for a project module |
-| `resolve` | `fun(*EditorSession, source.FileId) Result[*res.ResolveResult, str]` | name-resolution side tables; project-aware |
-| `analyze` | `fun(*EditorSession, source.FileId) Result[*context.SemaResult, str]` | type-check; project-aware |
-| `diagnostics` | `fun(*EditorSession, source.FileId) Result[*diagnostic.DiagnosticStore, str]` | reset, then lex and parse; the session store holding this buffer's syntactic diagnostics |
-| `ast_of` | `fun(*EditorSession, source.FileId) *ast.Ast` | cached `Ast`, or nil |
-| `resolve_of` | `fun(*EditorSession, source.FileId) *res.ResolveResult` | cached `ResolveResult`, or nil |
-| `sema_of` | `fun(*EditorSession, source.FileId) *context.SemaResult` | cached `SemaResult`, or nil |
-| `expr_type_of` | `fun(*EditorSession, source.FileId, id.ExprId) type.TypeId` | the checked type of an expression (`TYPE_NIL` for `EXPR_NIL`, `TYPE_ERROR` when unavailable) |
-| `decl_type_of` | `fun(*EditorSession, source.FileId, id.DeclId) type.TypeId` | the checked type of a declaration |
-| `resolved_type_of` | `fun(*EditorSession, source.FileId, id.TypeId) type.TypeId` | the semantic type a syntactic type node resolved to |
-| `build` | `fun(*EditorSession, *request.BuildRequest) Result[outcome.BuildOutcome, outcome.Fail]` | run a full build of the buffer's project through the build engine |
-| `fail_dnit` | `fun(*EditorSession, *outcome.Fail)` | release a `Fail` returned by `build` |
+| Phase | Work |
+|---|---|
+| `PHASE_PARSE` | Lex and parse the selected source roots. No import traversal, gate evaluation, name resolution or type checking. |
+| `PHASE_RESOLVE` | Discover active dependencies and resolve names and gates. No ordinary sema pass. |
+| `PHASE_SEMA` | Resolve and type-check. |
 
-`open` loads the buffer text into the session's `SourceMap` as an **overlay**:
-when the project is loaded, the module at that path is read from the buffer,
-not from disk, so unsaved edits are what get analyzed. `open` and `update`
-both mark the project dirty, so the next project-aware query reloads it.
-`update` returns `false` when the new text equals the old and keeps the cached
-analysis.
+For a file under its nearest manifest's `src` directory, `request.build` uses
+the existing `BuildRequest` selection and effective options. This is the same
+project/configuration boundary as the driver. Opening that project still
+validates its configuration and dependency manifests. Parse-only analysis does
+not read dependency source files. Currently open files belonging to that same
+nearest project form the extra analysis roots. An open nested project's file
+does not become an extra root of its parent project.
 
-Every analysis entry (`tokenize`, `parse`, `resolve`, `diagnostics`) first
-resets the session's diagnostic store, so the store holds only the diagnostics
-of the most recent query.
+For a standalone file, `standalone_target` optionally borrows a resolved
+`target.Target`. Its registry-owned definitions must remain live with the
+Session. Omitting it selects the registered host target. A project target name
+cannot select a standalone target. Conversely, a standalone target cannot
+replace a project's target selection. Effective build mode and PIE come from
+`request.build`, whose profile options must already be composed. Request
+strings and vectors are borrowed only during the call.
 
-## Project-aware analysis
+A successful `Result` means the owned analysis envelope was produced. Inspect
+`AnalysisResult.status` for accepted, rejected or internal phase status.
+Operational project failures retain their `outcome.Fail` category in
+`result.failure`. Diagnostic counts do not determine phase status. A rejected
+standalone parse can still expose a partial AST. A fatal project acquisition
+can leave no raw product, while retaining the owned failure diagnostics.
 
-`parse`, `resolve`, and `analyze` decide how to analyze a buffer from its path:
+The result owns:
 
-1. Walk up from the buffer's directory to the nearest `mach.toml`. That
-   directory is the project root.
-2. If the buffer lies under that project's `src` directory, compose its module
-   FQN and load the project (manifest, dependencies, every module the buffer's
-   module reaches) exactly as `mach build` would, with the buffer's overlay
-   text in place of the file. The query then returns the project's own `Ast`,
-   `ResolveResult`, or `SemaResult` for that module: cross-module references
-   through `use` bind to their real declarations, and `$if` gates evaluate
-   against the project's selected target.
-3. Otherwise (no manifest above the buffer, or a file outside `src`) the buffer
-   is analyzed **in isolation** with an empty dependency set: local
-   declarations bind, and anything reached through a `use` resolves to
-   `SYMBOL_NIL`. The comptime context is seeded with host defaults.
+- Its diagnostic store, including related locations, fix edits and lost-diagnostic evidence.
+- The requested source version and every other source version referenced by those locations.
+- A copied failure message, source revision, requested phase and target metadata.
+- For an opened project, its root, resolved profile name and the existing canonical build-configuration bytes.
 
-A project load failure (an invalid manifest, a missing dependency) is returned
-as the query's error string; it is the same message `mach build` would print.
-The project is cached across queries and reloaded when a buffer changes, when
-a buffer from a different project root is queried, or when a module not yet
-among the loaded roots is queried.
+`target_available` is false when the requested target context was not acquired.
+The API does not substitute host metadata for a failed project target.
 
-Only the target the project selects by default is loaded; there is no
-per-query target override on this surface.
+Release each result exactly once with `analysis_dnit`. Do not copy it as an
+independent owner. Its allocator must outlive it. Owned diagnostics, source
+versions and metadata remain usable after buffer update/close, subsequent
+analysis and Session destruction. `analysis_source(result, file)` finds the
+owned `SourceFile` for a diagnostic location. Use `source.position` on that
+file, rather than looking up current Session text.
 
-## Diagnostics
+If the envelope cannot be allocated, `analyze` returns an operational failure.
+Release that failure with `fail_dnit`, as for failures returned by `build`.
+The current Session still owns any diagnostics the frontend produced.
 
-`diagnostics` runs `tokenize → emit-lex-errors → parse` and returns the
-session's store of **syntactic** diagnostics only. Each `diag.Diagnostic`
-carries `(severity, loc, message, note, help, related[])`: `loc` is a
-`Location` (`file_id`, `span`) for the primary report, `note` and `help` are
-optional trailing lines, and `related` is a growable array (`related_len`
-entries) of secondary `Location`s each with an optional `label`. Map each
-`loc.span` to a position with `source.position`:
+## Raw product lifetime
 
-```mach
-val store: *diagnostic.DiagnosticStore = unwrap_ok[...](editor.diagnostics(?es, fid));
-var i: usize = 0;
-for (i < store.len) {
-    val d: *diagnostic.Diagnostic = ?store.items[i];
-    val sf: *source.SourceFile = unwrap[...](source.get(?s.sources, d.loc.file_id));
-    val pos: source.Position = source.position(sf, d.loc.span.offset); // 1-based line/col
-    // d.severity, pos.line, pos.col, d.message -> LSP Diagnostic
-    i = i + 1;
-}
-```
+`ast_of(result)`, `resolve_of(result)` and `sema_of(result)` return checked
+`Result` borrows. Their products belong to the current serial Session view.
+They do not own a retained AST or IR generation. Both the EditorSession and
+Session must still exist when calling these accessors.
 
-`help` and `related` are populated by the **resolve** and **sema** stages (a
-suggestion rides `help`, rendered `= help:`; a prior binding rides `related`,
-e.g. `previous definition here`), so an integrator wanting them drives
-`resolve` or `analyze` and reads the session store afterwards. The parse-only
-`diagnostics` slice never sets them. Map a `related` entry's `loc` to a
-position the same way, and surface its `label` as an LSP `relatedInformation`
-item.
+A successful buffer mutation, close or teardown expires the view. Starting a
+new analysis, build or query operation, or replacing Session source/module/type
+projections, also expires it. A checked accessor then returns an expiry error.
+Pointers already obtained must not be dereferenced after that boundary.
+`analysis_dnit` ends the result's own lifetime too.
 
-## Position lookup: offset to id
+The phase must include the requested product. A valid view can return a nil
+product after rejected acquisition. `expr_type_of`, `decl_type_of` and
+`resolved_type_of` perform the same lifetime and sema-phase checks before
+reading side tables. Node IDs are meaningful only with their matching AST.
+Resolve consumers must distinguish `SYMBOL_NIL` and `SYMBOL_REJECTED` before
+indexing the symbol array.
 
-Hover, go-to-definition, and references pivot on finding the AST node under a
-byte offset, then reading the side tables. `mach.lang.fe.ast` provides the
-lookups, each returning the *tightest* (smallest-span) enclosing node, or the
-id-type sentinel when none covers the offset:
+`tokenize(result)` lexes the result's owned source version without mutating the
+Session. The caller owns the returned token storage and frees it with
+`lexer.dnit(stream, result.alloc)`. Its source bytes borrow the result, so free
+the token stream before `analysis_dnit`.
 
-```mach
-pub fun offset_to_expr(a: *ast.Ast, offset: usize) id.ExprId   // or id.EXPR_NIL
-pub fun offset_to_stmt(a: *ast.Ast, offset: usize) id.StmtId   // or id.STMT_NIL
-pub fun offset_to_decl(a: *ast.Ast, offset: usize) id.DeclId   // or id.DECL_NIL
-pub fun offset_to_type(a: *ast.Ast, offset: usize) id.TypeId   // or id.TYPE_NIL
-```
+## Building
 
-From an `ExprId`, the resolve side tables give the binding and the sema
-tables give the type:
+`build(es, request)` runs the existing warm build engine with current overlays.
+It expires previous raw analysis views. The returned `BuildOutcome` retains
+its existing ownership contract. Release an error message with `fail_dnit`.
+No analysis phase invokes build generators or the backend.
 
-```mach
-val eid: id.ExprId = ast.offset_to_expr(a, offset);
-if (eid != id.EXPR_NIL) {
-    val sid: res.SymbolId = rr.expr_resolved[eid];     // SYMBOL_NIL if unbound
-    if (sid != res.SYMBOL_NIL) {
-        val sym: *res.Symbol = ?rr.symbols[sid];
-        // sym.decl (DeclId in sym.origin's module), sym.kind, sym.name
-    }
-    val ty: type.TypeId = editor.expr_type_of(?es, fid, eid);   // after analyze
-}
-```
-
-`rr.expr_resolved`, `rr.type_resolved`, and `rr.decl_symbol` are parallel to
-`a.exprs`, `a.types`, and `a.decls` respectively. For a project module the
-`ResolveResult` is the project's, so `sym.origin` may name another module of
-the project or of a dependency.
-
-## Partial-result tolerance
-
-Every phase is best-effort by construction:
-
-- The **lexer** records malformed input as `LexError`s on the stream instead
-  of aborting; `lexer.emit_diagnostics` (and the editor's `tokenize`/`parse`)
-  drains them onto the diagnostic store.
-- The **parser** is explicitly malformed-input tolerant: it emits diagnostics
-  and synthesizes `*_KIND_ERROR` nodes while continuing, so a broken buffer
-  still yields a partial `Ast` with a set `root_module`.
-- **resolve** records name-resolution diagnostics and leaves the offending
-  side-table slots as `SYMBOL_NIL`, producing usable tables over a broken tree.
-
-A buffer with a missing `)` and a stray backtick still parses to a tree
-containing its function declaration, surfaces both the lex and the parse
-error, and resolves to populated side tables.
-
-## Building from the editor
-
-`build` runs a complete build of the project named by the request's
-`project_root`: it loads the manifest, plans the artifact cells, and executes
-them through the same engine `mach build` uses, so an editor can offer "build"
-without spawning the CLI. The outcome and its `Fail` are the driver's own
-types; a `Fail` whose kind is `FAIL_REPORTED` means the diagnostics were
-already recorded on the session store, and `fail_dnit` releases whatever the
-editor duplicated for the other kinds.
-
-## See also
-
-- [../cli.md](../cli.md) — the command-line surface the editor mirrors
-- [../manifest.md](../manifest.md) — the project the editor discovers
+The editor API, CLI and manifest are supported compiler surfaces. They are
+source-stable within a major version, not binary-stable. This v5 lifecycle
+replaces the old pointer-only editor operations without compatibility adapters.

--- a/src/cli/cmd/init.mach
+++ b/src/cli/cmd/init.mach
@@ -36,6 +36,7 @@ use mach.lang.diagnostic;
 use mach.lang.driver;
 use ddep: mach.lang.driver.deps;
 use mach.lang.editor;
+use mach.lang.fail;
 use mach.lang.fe.ast;
 use mach.lang.intern;
 use mach.lang.manifest;
@@ -1343,20 +1344,23 @@ fun t_source_parses(alloc: *A.Allocator, text: str) bool {
     var es: editor.EditorSession = editor.init(?s);
 
     val open_r: R.Result[source.FileId, str] = editor.open(?es, "/mach-init-standalone-parse-check/entry.mach", text);
-    if (R.is_err[source.FileId, str](open_r)) { editor.dnit(?es); session.dnit(?s); ret false; }
+    if (R.is_err[source.FileId, str](open_r)) { R.unwrap_ok[R.Void, str](editor.dnit(?es)); session.dnit(?s); ret false; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](open_r);
 
-    val parse_r: R.Result[*ast.Ast, str] = editor.parse(?es, fid);
-    var ok: bool = true;
-    if (R.is_err[*ast.Ast, str](parse_r)) { ok = false; }
-
-    val diag_r: R.Result[*diagnostic.DiagnosticStore, str] = editor.diagnostics(?es, fid);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](diag_r)) { ok = false; }
+    var req: editor.AnalysisRequest = editor.analysis_request(fid, editor.PHASE_PARSE);
+    val analyzed: R.Result[editor.AnalysisResult, outcome.Fail] = editor.analyze(?es, ?req);
+    var ok: bool = false;
+    if (R.is_ok[editor.AnalysisResult, outcome.Fail](analyzed)) {
+        var result: editor.AnalysisResult = R.unwrap_ok[editor.AnalysisResult, outcome.Fail](analyzed);
+        ok = result.status.kind == fail.ACCEPTED && !diagnostic.has_errors(result.diagnostics);
+        editor.analysis_dnit(?result);
+    }
     or {
-        if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](diag_r))) { ok = false; }
+        var failure: outcome.Fail = R.unwrap_err[editor.AnalysisResult, outcome.Fail](analyzed);
+        editor.fail_dnit(?es, ?failure);
     }
 
-    editor.dnit(?es);
+    R.unwrap_ok[R.Void, str](editor.dnit(?es));
     session.dnit(?s);
     ret ok;
 }

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -36,6 +36,7 @@ use mach.lang.be.linker;
 use mach.lang.be.obj;
 use mach.lang.diagnostic;
 use mach.lang.driver;
+use passes: mach.lang.driver.passes;
 use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.ir;
@@ -47,11 +48,6 @@ use mach.lang.target.of;
 use mach.lang.fail;
 
 rec UnitState {
-    irs:          *ir.Module;
-    ir_ready:     *bool;
-    images:       *of.ObjectImage;
-    image_ready:  *bool;
-
     obj_paths:    **u8;
     obj_len:      u32;
     dynlibs:      *of.DynLib;
@@ -309,16 +305,16 @@ pub fun execute_warm(bp: *plan.BuildPlan, unit_index: usize, s: *session.Session
 
     val begin_r: R.Result[driver.Project, outcome.Fail] = driver.begin_build(s, ?m, ?req, ev);
     if (R.is_err[driver.Project, outcome.Fail](begin_r)) {
-        val r: R.Result[outcome.BuildOutcome, outcome.Fail] = warm_fail(?bo, R.unwrap_err[driver.Project, outcome.Fail](begin_r));
-        ret r;
+        val diags_r: R.Result[R.Void, str] = outcome.record_diagnostics(?bo, ?s.sources, ?s.diags);
+        if (R.is_err[R.Void, str](diags_r)) {
+            outcome.outcome_dnit(?bo);
+            ret R.err[outcome.BuildOutcome, outcome.Fail](outcome.internal("failed to snapshot build diagnostics"));
+        }
+        ret warm_fail(?bo, R.unwrap_err[driver.Project, outcome.Fail](begin_r));
     }
     var p: driver.Project = R.unwrap_ok[driver.Project, outcome.Fail](begin_r);
 
     var st: UnitState;
-    st.irs          = nil;
-    st.ir_ready     = nil;
-    st.images       = nil;
-    st.image_ready  = nil;
     st.obj_paths    = nil;
     st.obj_len      = 0;
     st.dynlibs      = nil;
@@ -347,11 +343,19 @@ pub fun execute_warm(bp: *plan.BuildPlan, unit_index: usize, s: *session.Session
 
     if (st.out_path != nil) { st.out_path = unit.out_path::*u8; }
     val released: O.Option[txn.Error] = release_outputs(?p, ?st);
+    val refreshed: R.Result[R.Void, outcome.Fail] = driver.refresh_diagnostics(?p);
     var event_error: str = nil;
     if (R.is_err[R.Void, outcome.Fail](result)) {
         var f: outcome.Fail = R.unwrap_err[R.Void, outcome.Fail](result);
         val fail_r: R.Result[R.Void, str] = outcome.record_fail(?bo, ?f);
         if (R.is_err[R.Void, str](fail_r)) { event_error = "failed to record build failure"; }
+    }
+    if (R.is_err[R.Void, outcome.Fail](refreshed)) {
+        var failure: outcome.Fail = R.unwrap_err[R.Void, outcome.Fail](refreshed);
+        val recorded: R.Result[R.Void, str] = outcome.record_fail(?bo, ?failure);
+        if (R.is_err[R.Void, str](recorded)) { event_error = "failed to record diagnostic refresh failure"; }
+        outcome.fold_fail(?bo, ?failure);
+        if (R.is_ok[R.Void, outcome.Fail](result)) { result = refreshed; }
     }
     if (O.is_some[txn.Error](released)) {
         val error: txn.Error = O.unwrap[txn.Error](released);
@@ -373,7 +377,6 @@ pub fun execute_warm(bp: *plan.BuildPlan, unit_index: usize, s: *session.Session
     }
     btest.free_scope(?p, ?st.scope);
     pcg_sweep_staged(?p);
-    driver.lower_sweep_staged(?p);
     driver.dnit_project(?p);
 
     if (event_error != nil) {
@@ -572,7 +575,7 @@ fun run_phase(ph: plan.PhaseKind, p: *driver.Project, unit: *plan.BuildUnit, st:
     if (ph == plan.PH_STEPS)     { result = driver.run_steps_phase(p); }
     if (ph == plan.PH_DEP_STEPS) { result = driver.run_dep_steps_phase(p); }
     if (ph == plan.PH_LOAD)      { result = load_phase(p); }
-    if (ph == plan.PH_SEMA)      { result = sema_phase(p, st); }
+    if (ph == plan.PH_SEMA)      { result = driver.run_sema_pass(p); }
     if (ph == plan.PH_LOWER)     { result = lower_phase(p, st, bo, ev); }
     if (ph == plan.PH_CODEGEN) {
         result = plan_outputs(p, unit, st);
@@ -598,41 +601,42 @@ fun load_phase(p: *driver.Project) R.Result[R.Void, outcome.Fail] {
     ret R.ok_void[outcome.Fail]();
 }
 
-fun ensure_views(p: *driver.Project, st: *UnitState) R.Result[R.Void, outcome.Fail] {
-    if (st.irs != nil) { ret R.ok_void[outcome.Fail](); }
-    val n: usize = p.module_len::usize;
-
-    val res_irs: R.Result[*ir.Module, str] = A.allocate[ir.Module](p.alloc, n);
-    if (R.is_err[*ir.Module, str](res_irs)) { ret R.err[R.Void, outcome.Fail](outcome.internal("out of memory")); }
-    st.irs = R.unwrap_ok[*ir.Module, str](res_irs);
-
-    val res_ir_ready: R.Result[*bool, str] = A.allocate[bool](p.alloc, n);
-    if (R.is_err[*bool, str](res_ir_ready)) { ret R.err[R.Void, outcome.Fail](outcome.internal("out of memory")); }
-    st.ir_ready = R.unwrap_ok[*bool, str](res_ir_ready);
-
-    val res_images: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](p.alloc, n);
-    if (R.is_err[*of.ObjectImage, str](res_images)) { ret R.err[R.Void, outcome.Fail](outcome.internal("out of memory")); }
-    st.images = R.unwrap_ok[*of.ObjectImage, str](res_images);
-
-    val res_image_ready: R.Result[*bool, str] = A.allocate[bool](p.alloc, n);
-    if (R.is_err[*bool, str](res_image_ready)) { ret R.err[R.Void, outcome.Fail](outcome.internal("out of memory")); }
-    st.image_ready = R.unwrap_ok[*bool, str](res_image_ready);
-
+fun collect_test_scope(p: *driver.Project, st: *UnitState) R.Result[R.Void, outcome.Fail] {
+    val allocated: R.Result[*ir.Module, str] = A.zallocate[ir.Module](p.alloc, p.module_len::usize);
+    if (R.is_err[*ir.Module, str](allocated)) {
+        ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[*ir.Module, str](allocated)));
+    }
+    val headers: *ir.Module = R.unwrap_ok[*ir.Module, str](allocated);
+    fin { A.deallocate[ir.Module](p.alloc, headers, p.module_len::usize); }
     var i: u32 = 0;
-    for (i < p.module_len) {
-        st.ir_ready[i]    = false;
-        st.image_ready[i] = false;
-        st.irs[i].function_len = 0;
+    for (i < p.emit_len) {
+        val mid: session.ModuleId = p.topo[i];
+        val current: *ir.Module = p.modules[mid::u32].ir_module;
+        if (current == nil) { ret R.err[R.Void, outcome.Fail](outcome.internal("test collection requires a current lowered module")); }
+        headers[mid::u32] = @current;
         i = i + 1;
     }
-    ret R.ok_void[outcome.Fail]();
+    ret btest.collect_scope(p, headers, ?st.scope);
 }
 
-fun sema_phase(p: *driver.Project, st: *UnitState) R.Result[R.Void, outcome.Fail] {
-    val vr: R.Result[R.Void, outcome.Fail] = ensure_views(p, st);
-    if (R.is_err[R.Void, outcome.Fail](vr)) { ret vr; }
-
-    ret driver.run_sema_pass(p);
+fun current_image_headers(p: *driver.Project) R.Result[*of.ObjectImage, outcome.Fail] {
+    val allocated: R.Result[*of.ObjectImage, str] = A.zallocate[of.ObjectImage](p.alloc, p.module_len::usize);
+    if (R.is_err[*of.ObjectImage, str](allocated)) {
+        ret R.err[*of.ObjectImage, outcome.Fail](outcome.internal(R.unwrap_err[*of.ObjectImage, str](allocated)));
+    }
+    val headers: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](allocated);
+    var i: u32 = 0;
+    for (i < p.emit_len) {
+        val mid: session.ModuleId = p.topo[i];
+        val current: *of.ObjectImage = p.modules[mid::u32].object_image;
+        if (current == nil) {
+            A.deallocate[of.ObjectImage](p.alloc, headers, p.module_len::usize);
+            ret R.err[*of.ObjectImage, outcome.Fail](outcome.internal("image publication requires a current codegen module"));
+        }
+        headers[mid::u32] = @current;
+        i = i + 1;
+    }
+    ret R.ok[*of.ObjectImage, outcome.Fail](headers);
 }
 
 fun lower_phase(p: *driver.Project, st: *UnitState, bo: *outcome.BuildOutcome, ev: *readout.Progress) R.Result[R.Void, outcome.Fail] {
@@ -658,14 +662,10 @@ fun lower_phase(p: *driver.Project, st: *UnitState, bo: *outcome.BuildOutcome, e
         }
     }
 
-    i = 0;
-    for (i < p.emit_len) {
-        val mid: session.ModuleId    = p.topo[i];
-        val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
-        val irm: *ir.Module          = m.ir_module;
-        st.irs[mid::u32]      = @irm;
-        st.ir_ready[mid::u32] = true;
-        i = i + 1;
+    if (p.req.goal == request.GOAL_TESTS || p.req.goal == request.GOAL_TEST_LIST) {
+        val collected: R.Result[R.Void, outcome.Fail] = collect_test_scope(p, st);
+        if (R.is_err[R.Void, outcome.Fail](collected)) { ret collected; }
+        bo.tests_skipped = st.scope.skipped;
     }
 
     readout.phase_end(ev, readout.PH_LOWER, p.emit_len, "module", "modules");
@@ -675,26 +675,44 @@ fun lower_phase(p: *driver.Project, st: *UnitState, bo: *outcome.BuildOutcome, e
 
 fun codegen_phase(p: *driver.Project, st: *UnitState, ev: *readout.Progress) R.Result[R.Void, outcome.Fail] {
     readout.phase_begin(ev, readout.PH_CODEGEN);
+    val prepared: R.Result[R.Void, outcome.Fail] = passes.prepare_codegen_pass(p);
+    if (R.is_err[R.Void, outcome.Fail](prepared)) { ret prepared; }
 
-    if (pcg_enabled(p)) {
-        val rp: R.Result[R.Void, fail.Fail] = run_codegen_parallel(p);
-        if (R.is_err[R.Void, fail.Fail](rp)) {
-            ret R.err[R.Void, outcome.Fail](outcome.from_fail(R.unwrap_err[R.Void, fail.Fail](rp)));
-        }
-    }
-
-    val res_codegen: R.Result[R.Void, outcome.Fail] = driver.run_codegen_pass(p);
-    if (R.is_err[R.Void, outcome.Fail](res_codegen)) { ret res_codegen; }
-
+    var roots: Vector[query.QueryKey] = vector.init[query.QueryKey](p.alloc);
+    fin { vector.dnit[query.QueryKey](?roots); }
+    val frontend: R.Result[R.Void, outcome.Fail] = driver.append_frontend_roots(p, ?roots);
+    if (R.is_err[R.Void, outcome.Fail](frontend)) { ret frontend; }
     var i: u32 = 0;
     for (i < p.emit_len) {
-        val mid: session.ModuleId    = p.topo[i];
-        val m:   *driver.ModuleEntry = ?p.modules[mid::u32];
-        val img: *of.ObjectImage     = m.object_image;
-        st.images[mid::u32]      = @img;
-        st.image_ready[mid::u32] = true;
+        val m: *driver.ModuleEntry = ?p.modules[p.topo[i]::u32];
+        val key: u64 = passes.back_half_key_for(p, m);
+        val lowered: R.Result[usize, str] = vector.push[query.QueryKey](?roots,
+            query.QueryKey{kind: query.Q_LOWER, key: key});
+        if (R.is_err[usize, str](lowered)) {
+            ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[usize, str](lowered)));
+        }
+        val emitted: R.Result[usize, str] = vector.push[query.QueryKey](?roots,
+            query.QueryKey{kind: query.Q_CODEGEN, key: key});
+        if (R.is_err[usize, str](emitted)) {
+            ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[usize, str](emitted)));
+        }
         i = i + 1;
     }
+    val started: R.Result[query.Operation, outcome.Fail] = driver.begin_query_phase(p);
+    if (R.is_err[query.Operation, outcome.Fail](started)) {
+        ret R.err[R.Void, outcome.Fail](R.unwrap_err[query.Operation, outcome.Fail](started));
+    }
+    val operation: query.Operation = R.unwrap_ok[query.Operation, outcome.Fail](started);
+    var result: R.Result[R.Void, outcome.Fail] = passes.acquire_codegen_inputs(p);
+    if (R.is_ok[R.Void, outcome.Fail](result) && pcg_enabled(p)) {
+        val parallel: R.Result[R.Void, fail.Fail] = run_codegen_parallel(p);
+        if (R.is_err[R.Void, fail.Fail](parallel)) {
+            result = R.err[R.Void, outcome.Fail](outcome.from_fail(R.unwrap_err[R.Void, fail.Fail](parallel)));
+        }
+    }
+    if (R.is_ok[R.Void, outcome.Fail](result)) { result = passes.run_codegen_pass(p); }
+    result = driver.finish_query_phase(p, operation, roots.data, roots.len, result);
+    if (R.is_err[R.Void, outcome.Fail](result)) { ret result; }
 
     readout.phase_end(ev, readout.PH_CODEGEN, p.emit_len, "module", "modules");
     ret R.ok_void[outcome.Fail]();
@@ -742,9 +760,6 @@ fun emit_phase(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
     }
 
     if (goal == request.GOAL_TESTS) {
-        val cr: R.Result[R.Void, outcome.Fail] = btest.collect_scope(p, st.irs, ?st.scope);
-        if (R.is_err[R.Void, outcome.Fail](cr)) { ret cr; }
-        bo.tests_skipped = st.scope.skipped;
         if (st.scope.sel_len == 0) {
             readout.phase_end(ev, readout.PH_EMIT, 0, "object", "objects");
             ret R.ok_void[outcome.Fail]();
@@ -755,7 +770,11 @@ fun emit_phase(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
         || goal == request.GOAL_OBJECTS
         || goal == request.GOAL_TESTS;
     if (objects) {
-        val oc: R.Result[R.Void, outcome.Fail] = emit.write_objects(p, st.images, st.objects, ?st.obj_paths);
+        val borrowed: R.Result[*of.ObjectImage, outcome.Fail] = current_image_headers(p);
+        if (R.is_err[*of.ObjectImage, outcome.Fail](borrowed)) { ret R.void_of[*of.ObjectImage, outcome.Fail](borrowed); }
+        val images: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, outcome.Fail](borrowed);
+        fin { A.deallocate[of.ObjectImage](p.alloc, images, p.module_len::usize); }
+        val oc: R.Result[R.Void, outcome.Fail] = emit.write_objects(p, images, st.objects, ?st.obj_paths);
         if (R.is_err[R.Void, outcome.Fail](oc)) { ret oc; }
         st.obj_len = p.emit_len;
     }
@@ -834,7 +853,11 @@ fun link_phase(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
 
     if (te.mode == driver.MODE_LIBRARY) {
         if (te.lib_kind == manifest.LIBKIND_STATIC) {
-            val arc_r: R.Result[R.Void, outcome.Fail] = emit.emit_static_archive(p, st.artifact, st.images, st.obj_paths, ?st.out_path);
+            val borrowed: R.Result[*of.ObjectImage, outcome.Fail] = current_image_headers(p);
+            if (R.is_err[*of.ObjectImage, outcome.Fail](borrowed)) { ret R.void_of[*of.ObjectImage, outcome.Fail](borrowed); }
+            val images: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, outcome.Fail](borrowed);
+            fin { A.deallocate[of.ObjectImage](p.alloc, images, p.module_len::usize); }
+            val arc_r: R.Result[R.Void, outcome.Fail] = emit.emit_static_archive(p, st.artifact, images, st.obj_paths, ?st.out_path);
             if (R.is_err[R.Void, outcome.Fail](arc_r)) { ret arc_r; }
             readout.phase_end(ev, readout.PH_LINK, 1, "archive", "archives");
             ret R.ok_void[outcome.Fail]();
@@ -883,7 +906,11 @@ fun link_phase(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState,
     val from_image: bool = p.target.of.links_from_image;
     var res_link: R.Result[R.Void, outcome.Fail] = R.ok_void[outcome.Fail]();
     if (from_image) {
-        res_link = emit.link_mixed_images(p, st.images, ?st.obj_paths[ext_from], ext_count, st.dynlibs, st.dynlib_len, st.artifact, loaded.options);
+        val borrowed: R.Result[*of.ObjectImage, outcome.Fail] = current_image_headers(p);
+        if (R.is_err[*of.ObjectImage, outcome.Fail](borrowed)) { emit.dnit_image_options(p.alloc, ?loaded); ret R.void_of[*of.ObjectImage, outcome.Fail](borrowed); }
+        val images: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, outcome.Fail](borrowed);
+        fin { A.deallocate[of.ObjectImage](p.alloc, images, p.module_len::usize); }
+        res_link = emit.link_mixed_images(p, images, ?st.obj_paths[ext_from], ext_count, st.dynlibs, st.dynlib_len, st.artifact, loaded.options);
     }
     if (!from_image) {
         res_link = emit.link_executable(p, st.obj_paths, st.obj_len, st.dynlibs, st.dynlib_len, st.artifact, loaded.options);
@@ -978,7 +1005,11 @@ fun link_flat(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState, ev: *re
         ret R.ok_void[outcome.Fail]();
     }
 
-    val res_link: R.Result[R.Void, outcome.Fail] = emit.link_flat_images(p, st.images, st.artifact,
+    val borrowed: R.Result[*of.ObjectImage, outcome.Fail] = current_image_headers(p);
+    if (R.is_err[*of.ObjectImage, outcome.Fail](borrowed)) { ret R.void_of[*of.ObjectImage, outcome.Fail](borrowed); }
+    val images: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, outcome.Fail](borrowed);
+    fin { A.deallocate[of.ObjectImage](p.alloc, images, p.module_len::usize); }
+    val res_link: R.Result[R.Void, outcome.Fail] = emit.link_flat_images(p, images, st.artifact,
         of.image_options_default(p.req.subsystem));
     if (R.is_err[R.Void, outcome.Fail](res_link)) { ret res_link; }
 
@@ -992,9 +1023,6 @@ fun link_flat(p: *driver.Project, unit: *plan.BuildUnit, st: *UnitState, ev: *re
 }
 
 fun list_tests(p: *driver.Project, st: *UnitState, bo: *outcome.BuildOutcome, oa: *A.Allocator) R.Result[R.Void, outcome.Fail] {
-    val cr: R.Result[R.Void, outcome.Fail] = btest.collect_scope(p, st.irs, ?st.scope);
-    if (R.is_err[R.Void, outcome.Fail](cr)) { ret cr; }
-    bo.tests_skipped = st.scope.skipped;
     ret btest.record_tests(p, ?st.scope, nil, bo, oa);
 }
 
@@ -1239,7 +1267,12 @@ fun run_codegen_parallel(p: *driver.Project) R.Result[R.Void, fail.Fail] {
     var stale_len: u32 = 0;
     var ti: u32 = 0;
     for (ti < emit_len) {
-        if (!driver.codegen_reusable(p, p.topo[ti])) {
+        val reusable: R.Result[bool, fail.Fail] = passes.codegen_reusable(p, p.topo[ti]);
+        if (R.is_err[bool, fail.Fail](reusable)) {
+            A.deallocate[u32](p.alloc, stale, emit_len::usize);
+            ret R.err[R.Void, fail.Fail](R.unwrap_err[bool, fail.Fail](reusable));
+        }
+        if (!R.unwrap_ok[bool, fail.Fail](reusable)) {
             stale[stale_len] = ti;
             stale_len = stale_len + 1;
         }

--- a/src/lang/build/outcome.mach
+++ b/src/lang/build/outcome.mach
@@ -348,7 +348,7 @@ pub fun record_diagnostics(bo: *BuildOutcome, sources: *source.SourceMap, diags:
     if (bo == nil || sources == nil || diags == nil) {
         ret R.err[R.Void, str]("build diagnostics require an outcome, sources, and diagnostic store");
     }
-    if (diagnostic.len(diags) == 0) { ret R.ok_void[str](); }
+    if (diagnostic.len(diags) == 0 && diagnostic.lost_count(diags) == 0) { ret R.ok_void[str](); }
 
     val sources_r: R.Result[*source.SourceMap, str] = source.snapshot_from(sources, bo.events.a);
     if (R.is_err[*source.SourceMap, str](sources_r)) {

--- a/src/lang/diagnostic.mach
+++ b/src/lang/diagnostic.mach
@@ -68,6 +68,7 @@ pub def FixId: usize;
 
 pub rec Diagnostic {
     seq:      u64;
+    gate_key: GateDiagKey;
     severity: Severity;
     loc:      Location;
     message:  str;
@@ -89,6 +90,7 @@ pub rec DiagMark {
 pub rec DiagnosticStore {
     a:           *A.Allocator;
     items:       Vector[Diagnostic];
+    gates:       map.Map[GateDiagKey, bool];
     error_count: usize;
     lost:        usize;
     next_seq:    u64;
@@ -110,6 +112,7 @@ pub fun store_init(a: *A.Allocator) DiagnosticStore {
     var store: DiagnosticStore;
     store.a           = a;
     store.items       = vector.init[Diagnostic](a);
+    store.gates       = map.init[GateDiagKey, bool](a, gate_diag_key_hash, gate_diag_key_eq);
     store.error_count = 0;
     store.lost        = 0;
     store.next_seq     = 0;
@@ -181,6 +184,10 @@ pub fun truncate(store: *DiagnosticStore, m: DiagMark) R.Result[R.Void, str] {
     for (i < store.items.len) {
         val d: *Diagnostic = ?store.items.data[i];
         if (d.severity == SEVERITY_ERROR) { store.error_count = store.error_count - 1; }
+        if (d.gate_key.msg != intern.STR_NIL) {
+            val removed: R.Result[bool, str] = map.remove[GateDiagKey, bool](?store.gates, ?d.gate_key);
+            if (R.is_err[bool, str](removed)) { ret R.void_of[bool, str](removed); }
+        }
         free_diagnostic(store.a, d);
         i = i + 1;
     }
@@ -196,6 +203,7 @@ pub fun store_dnit(store: *DiagnosticStore) {
     zero.epoch = store.epoch;
     truncate(store, zero);
     vector.dnit[Diagnostic](?store.items);
+    map.dnit[GateDiagKey, bool](?store.gates);
     store.error_count = 0;
     store.lost        = 0;
 }
@@ -500,6 +508,7 @@ pub fun commit(b: *DiagnosticBuilder, store: *DiagnosticStore) R.Result[Diagnost
 
     var d: Diagnostic;
     d.seq      = store.next_seq;
+    d.gate_key = GateDiagKey{ msg: intern.STR_NIL };
     d.severity = b.severity;
     d.loc      = b.loc;
     d.message  = b.message;
@@ -593,14 +602,14 @@ pub fun record_fix_committed(store: *DiagnosticStore, id: DiagnosticId, label: s
     if (R.is_err[FixId, str](r)) { note_lost(store); }
 }
 
-pub fun record_gate_error(l: *GateDiagLedger, store: *DiagnosticStore, itn: *intern.Interner,
+pub fun record_gate_error(store: *DiagnosticStore, itn: *intern.Interner,
                           file_id: source.FileId, span: token.Span, message: str) {
-    record(store, R.void_of[bool, str](gate_error(l, store, itn, file_id, span, message)));
+    record(store, R.void_of[bool, str](gate_error(store, itn, file_id, span, message)));
 }
 
-pub fun record_gate_commit(l: *GateDiagLedger, store: *DiagnosticStore, itn: *intern.Interner,
+pub fun record_gate_commit(store: *DiagnosticStore, itn: *intern.Interner,
                            b: *DiagnosticBuilder) {
-    record(store, R.void_of[bool, str](gate_commit(l, store, itn, b)));
+    record(store, R.void_of[bool, str](gate_commit(store, itn, b)));
 }
 
 fun record(store: *DiagnosticStore, r: R.Result[R.Void, str]) {
@@ -625,7 +634,6 @@ pub val GATE_NEVER_DECIDED_SUFFIX: str =
     "` is not a compile-time constant anywhere this module can see";
 
 pub fun gate_error_named(
-    l:       *GateDiagLedger,
     store:   *DiagnosticStore,
     itn:     *intern.Interner,
     file_id: source.FileId,
@@ -635,15 +643,15 @@ pub fun gate_error_named(
 ) R.Result[bool, str] {
     val no: O.Option[str] = intern.lookup(itn, name_id);
     if (O.is_none[str](no)) {
-        ret gate_error(l, store, itn, file_id, span, fallback);
+        ret gate_error(store, itn, file_id, span, fallback);
     }
     val joined: R.Result[str, str] =
         str_join(store.a, GATE_NEVER_DECIDED_PREFIX, O.unwrap[str](no), GATE_NEVER_DECIDED_SUFFIX);
     if (R.is_err[str, str](joined)) {
-        ret gate_error(l, store, itn, file_id, span, fallback);
+        ret gate_error(store, itn, file_id, span, fallback);
     }
     val msg: str = R.unwrap_ok[str, str](joined);
-    val committed_r: R.Result[bool, str] = gate_error(l, store, itn, file_id, span, msg);
+    val committed_r: R.Result[bool, str] = gate_error(store, itn, file_id, span, msg);
     str_free(store.a, msg);
     ret committed_r;
 }
@@ -704,12 +712,71 @@ fun copy_diagnostic_into(dst: *DiagnosticStore, d: *Diagnostic) R.Result[R.Void,
     ret R.ok_void[str]();
 }
 
+fun location_equal(left: Location, right: Location) bool {
+    ret left.file_id == right.file_id && left.span.offset == right.span.offset && left.span.len == right.span.len;
+}
+
+fun diagnostic_equal(left: *Diagnostic, right: *Diagnostic) bool {
+    if (left.severity != right.severity || !location_equal(left.loc, right.loc)
+        || !str_equals(left.message, right.message) || left.children.len != right.children.len
+        || left.related.len != right.related.len || left.fixes.len != right.fixes.len) { ret false; }
+    var i: usize = 0;
+    for (i < left.children.len) {
+        val l: *Child = ?left.children.data[i];
+        val r: *Child = ?right.children.data[i];
+        if (l.kind != r.kind || !str_equals(l.text, r.text)) { ret false; }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < left.related.len) {
+        val l: *Related = ?left.related.data[i];
+        val r: *Related = ?right.related.data[i];
+        if (!location_equal(l.loc, r.loc) || !str_equals(l.label, r.label)) { ret false; }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < left.fixes.len) {
+        val l: *Fix = ?left.fixes.data[i];
+        val r: *Fix = ?right.fixes.data[i];
+        if (!str_equals(l.label, r.label) || l.edits.len != r.edits.len) { ret false; }
+        var j: usize = 0;
+        for (j < l.edits.len) {
+            val le: *Edit = ?l.edits.data[j];
+            val re: *Edit = ?r.edits.data[j];
+            if (!location_equal(le.loc, re.loc) || !str_equals(le.replacement, re.replacement)) { ret false; }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    ret true;
+}
+
+# compare observable diagnostic content without allocation or store identity
+pub fun content_equal(left: *DiagnosticStore, right: *DiagnosticStore) R.Result[bool, str] {
+    if ((left != nil && left.lost != 0) || (right != nil && right.lost != 0)) {
+        ret R.err[bool, str]("cannot compare diagnostics after an allocation failure");
+    }
+    var ln: usize = 0;
+    var rn: usize = 0;
+    if (left != nil) { ln = left.items.len; }
+    if (right != nil) { rn = right.items.len; }
+    if (ln != rn) { ret R.ok[bool, str](false); }
+    var i: usize = 0;
+    for (i < ln) {
+        if (!diagnostic_equal(?left.items.data[i], ?right.items.data[i])) { ret R.ok[bool, str](false); }
+        i = i + 1;
+    }
+    ret R.ok[bool, str](true);
+}
+
 pub fun snapshot_from(src: *DiagnosticStore, from: usize, a: *A.Allocator) R.Result[*DiagnosticStore, str] {
     val alloc_r: R.Result[*DiagnosticStore, str] = A.allocate[DiagnosticStore](a, 1);
     if (R.is_err[*DiagnosticStore, str](alloc_r)) { ret alloc_r; }
     val snap: *DiagnosticStore = R.unwrap_ok[*DiagnosticStore, str](alloc_r);
     @snap = store_init(a);
 
+    snap.lost = src.lost;
+    snap.error_count = src.lost;
     if (from >= src.items.len) { ret R.ok[*DiagnosticStore, str](snap); }
 
     var i: usize = from;
@@ -745,6 +812,8 @@ pub fun replay_into(dst: *DiagnosticStore, src: *DiagnosticStore) R.Result[R.Voi
         }
         i = i + 1;
     }
+    dst.lost = dst.lost + src.lost;
+    dst.error_count = dst.error_count + src.lost;
     ret R.ok_void[str]();
 }
 
@@ -781,23 +850,7 @@ fun gate_diag_key_eq(pa: ptr, pb: ptr) bool {
      && a.msg == b.msg;
 }
 
-pub rec GateDiagLedger {
-    entries: map.Map[GateDiagKey, bool];
-}
-
-pub fun ledger_init(a: *A.Allocator) GateDiagLedger {
-    var l: GateDiagLedger;
-    l.entries = map.init[GateDiagKey, bool](a, gate_diag_key_hash, gate_diag_key_eq);
-    ret l;
-}
-
-pub fun ledger_dnit(l: *GateDiagLedger) {
-    if (l == nil) { ret; }
-    map.dnit[GateDiagKey, bool](?l.entries);
-}
-
 pub fun gate_commit(
-    l:     *GateDiagLedger,
     store: *DiagnosticStore,
     itn:   *intern.Interner,
     b:     *DiagnosticBuilder
@@ -819,7 +872,7 @@ pub fun gate_commit(
     key.severity   = b.severity;
     key.msg        = mid;
 
-    if (map.contains[GateDiagKey, bool](?l.entries, ?key)) {
+    if (map.contains[GateDiagKey, bool](?store.gates, ?key)) {
         builder_dnit(b);
         ret R.ok[bool, str](false);
     }
@@ -832,14 +885,15 @@ pub fun gate_commit(
         ret R.err[bool, str](R.unwrap_err[DiagnosticId, str](cr));
     }
 
-    val insert_r: R.Result[bool, str] = map.insert[GateDiagKey, bool](?l.entries, key, true);
+    val committed: DiagnosticId = R.unwrap_ok[DiagnosticId, str](cr);
+    val insert_r: R.Result[bool, str] = map.insert[GateDiagKey, bool](?store.gates, key, true);
     if (R.is_err[bool, str](insert_r)) { ret insert_r; }
+    store.items.data[committed.index].gate_key = key;
 
     ret R.ok[bool, str](true);
 }
 
 pub fun gate_error(
-    l:       *GateDiagLedger,
     store:   *DiagnosticStore,
     itn:     *intern.Interner,
     file_id: source.FileId,
@@ -852,7 +906,7 @@ pub fun gate_error(
         ret R.err[bool, str](R.unwrap_err[DiagnosticBuilder, str](b_r));
     }
     var b: DiagnosticBuilder = R.unwrap_ok[DiagnosticBuilder, str](b_r);
-    ret gate_commit(l, store, itn, ?b);
+    ret gate_commit(store, itn, ?b);
 }
 
 fun test_span(offset: usize, len: usize) token.Span {
@@ -1257,24 +1311,23 @@ test "mach.lang.diagnostic.gate_error:dedups_by_key_and_lets_distinct_facets_thr
     page.make(?a);
     var store: DiagnosticStore = store_init(?a);
     var itn: intern.Interner = intern.init(?a);
-    var ledger: GateDiagLedger = ledger_init(?a);
+
     val sp: token.Span = test_span(0, 4);
 
-    val r1: R.Result[bool, str] = gate_error(?ledger, ?store, ?itn, 1::source.FileId, sp, "must have type u8");
-    if (R.is_err[bool, str](r1) || !R.unwrap_ok[bool, str](r1)) { ledger_dnit(?ledger); intern.dnit(?itn); store_dnit(?store); ret 1; }
+    val r1: R.Result[bool, str] = gate_error(?store, ?itn, 1::source.FileId, sp, "must have type u8");
+    if (R.is_err[bool, str](r1) || !R.unwrap_ok[bool, str](r1)) { intern.dnit(?itn); store_dnit(?store); ret 1; }
 
-    val r2: R.Result[bool, str] = gate_error(?ledger, ?store, ?itn, 1::source.FileId, sp, "must have type u8");
-    if (R.is_err[bool, str](r2) || R.unwrap_ok[bool, str](r2)) { ledger_dnit(?ledger); intern.dnit(?itn); store_dnit(?store); ret 2; }
+    val r2: R.Result[bool, str] = gate_error(?store, ?itn, 1::source.FileId, sp, "must have type u8");
+    if (R.is_err[bool, str](r2) || R.unwrap_ok[bool, str](r2)) { intern.dnit(?itn); store_dnit(?store); ret 2; }
 
-    val r3: R.Result[bool, str] = gate_error(?ledger, ?store, ?itn, 1::source.FileId, sp, "a different message");
-    if (R.is_err[bool, str](r3) || !R.unwrap_ok[bool, str](r3)) { ledger_dnit(?ledger); intern.dnit(?itn); store_dnit(?store); ret 3; }
+    val r3: R.Result[bool, str] = gate_error(?store, ?itn, 1::source.FileId, sp, "a different message");
+    if (R.is_err[bool, str](r3) || !R.unwrap_ok[bool, str](r3)) { intern.dnit(?itn); store_dnit(?store); ret 3; }
 
-    val r4: R.Result[bool, str] = gate_error(?ledger, ?store, ?itn, 2::source.FileId, sp, "must have type u8");
-    if (R.is_err[bool, str](r4) || !R.unwrap_ok[bool, str](r4)) { ledger_dnit(?ledger); intern.dnit(?itn); store_dnit(?store); ret 4; }
+    val r4: R.Result[bool, str] = gate_error(?store, ?itn, 2::source.FileId, sp, "must have type u8");
+    if (R.is_err[bool, str](r4) || !R.unwrap_ok[bool, str](r4)) { intern.dnit(?itn); store_dnit(?store); ret 4; }
 
-    if (len(?store) != 3) { ledger_dnit(?ledger); intern.dnit(?itn); store_dnit(?store); ret 5; }
+    if (len(?store) != 3) { intern.dnit(?itn); store_dnit(?store); ret 5; }
 
-    ledger_dnit(?ledger);
     intern.dnit(?itn);
     store_dnit(?store);
     ret 0;
@@ -1292,13 +1345,12 @@ test "mach.lang.diagnostic.gate_error:surfaces_ledger_insert_failure" {
 
         var store: DiagnosticStore = store_init(T.allocator_of(?failing));
         var itn: intern.Interner = intern.init(T.allocator_of(?failing));
-        var ledger: GateDiagLedger = ledger_init(T.allocator_of(?failing));
+
         val sp: token.Span = test_span(0, 4);
 
-        val r: R.Result[bool, str] = gate_error(?ledger, ?store, ?itn, 1::source.FileId, sp, "x");
+        val r: R.Result[bool, str] = gate_error(?store, ?itn, 1::source.FileId, sp, "x");
         if (R.is_err[bool, str](r) && len(?store) == 1) { found = true; }
 
-        ledger_dnit(?ledger);
         intern.dnit(?itn);
         store_dnit(?store);
         if (T.tracking_exhausted(?failing)) { T.dnit(?failing); ret 1; }
@@ -1348,5 +1400,31 @@ test "mach.lang.diagnostic.record:a_lost_append_is_a_durable_rejection" {
     if (lost_count(?clean) != 0)  { store_dnit(?clean); ret 1; }
 
     store_dnit(?clean);
+    ret 0;
+}
+
+test "mach.lang.diagnostic.gate_error:dedup_follows_the_sink_and_retained_diagnostics" {
+    var a: A.Allocator;
+    page.make(?a);
+    var itn: intern.Interner = intern.init(?a);
+    fin { intern.dnit(?itn); }
+    var first: DiagnosticStore = store_init(?a);
+    fin { store_dnit(?first); }
+    var second: DiagnosticStore = store_init(?a);
+    fin { store_dnit(?second); }
+    val sp: token.Span = test_span(3, 2);
+    val initial: R.Result[bool, str] = gate_error(?first, ?itn, 1, sp, "kept");
+    if (R.is_err[bool, str](initial) || !R.unwrap_ok[bool, str](initial)) { ret 1; }
+    val before_tail: DiagMark = mark(?first);
+    val tail: R.Result[bool, str] = gate_error(?first, ?itn, 1, sp, "removed");
+    if (R.is_err[bool, str](tail) || !R.unwrap_ok[bool, str](tail)) { ret 2; }
+    if (R.is_err[R.Void, str](truncate(?first, before_tail))) { ret 3; }
+    val retained: R.Result[bool, str] = gate_error(?first, ?itn, 1, sp, "kept");
+    if (R.is_err[bool, str](retained) || R.unwrap_ok[bool, str](retained)) { ret 4; }
+    val replaced: R.Result[bool, str] = gate_error(?first, ?itn, 1, sp, "removed");
+    if (R.is_err[bool, str](replaced) || !R.unwrap_ok[bool, str](replaced)) { ret 5; }
+    val independent: R.Result[bool, str] = gate_error(?second, ?itn, 1, sp, "kept");
+    if (R.is_err[bool, str](independent) || !R.unwrap_ok[bool, str](independent)) { ret 6; }
+    if (len(?first) != 2 || len(?second) != 1) { ret 7; }
     ret 0;
 }

--- a/src/lang/diagnostic.mach
+++ b/src/lang/diagnostic.mach
@@ -665,6 +665,9 @@ pub fun fix_label_replace(a: *A.Allocator, name: str) R.Result[str, str] {
 }
 
 fun copy_diagnostic_into(dst: *DiagnosticStore, d: *Diagnostic) R.Result[R.Void, str] {
+    if (d.gate_key.msg != intern.STR_NIL && map.contains[GateDiagKey, bool](?dst.gates, ?d.gate_key)) {
+        ret R.ok_void[str]();
+    }
     val b_r: R.Result[DiagnosticBuilder, str] = builder_init(dst.a, d.severity, d.loc.file_id, d.loc.span, d.message);
     if (R.is_err[DiagnosticBuilder, str](b_r)) { ret R.err[R.Void, str](R.unwrap_err[DiagnosticBuilder, str](b_r)); }
     var b: DiagnosticBuilder = R.unwrap_ok[DiagnosticBuilder, str](b_r);
@@ -708,6 +711,11 @@ fun copy_diagnostic_into(dst: *DiagnosticStore, d: *Diagnostic) R.Result[R.Void,
     if (R.is_err[DiagnosticId, str](commit_r)) {
         builder_dnit(?b);
         ret R.err[R.Void, str](R.unwrap_err[DiagnosticId, str](commit_r));
+    }
+    if (d.gate_key.msg != intern.STR_NIL) {
+        val inserted: R.Result[bool, str] = map.insert[GateDiagKey, bool](?dst.gates, d.gate_key, true);
+        if (R.is_err[bool, str](inserted)) { ret R.void_of[bool, str](inserted); }
+        dst.items.data[R.unwrap_ok[DiagnosticId, str](commit_r).index].gate_key = d.gate_key;
     }
     ret R.ok_void[str]();
 }
@@ -1426,5 +1434,35 @@ test "mach.lang.diagnostic.gate_error:dedup_follows_the_sink_and_retained_diagno
     val independent: R.Result[bool, str] = gate_error(?second, ?itn, 1, sp, "kept");
     if (R.is_err[bool, str](independent) || !R.unwrap_ok[bool, str](independent)) { ret 6; }
     if (len(?first) != 2 || len(?second) != 1) { ret 7; }
+    ret 0;
+}
+
+
+test "mach.lang.diagnostic.gate_error:snapshots_preserve_replay_and_truncation_identity" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    var itn: intern.Interner = intern.init(?a);
+    fin { intern.dnit(?itn); }
+    var src: DiagnosticStore = store_init(?a);
+    fin { store_dnit(?src); }
+    var dst: DiagnosticStore = store_init(?a);
+    fin { store_dnit(?dst); }
+    var span: token.Span;
+    span.offset = 3;
+    span.len = 1;
+    val original: R.Result[bool, str] = gate_error(?src, ?itn, 1, span, "invalid gate");
+    if (R.is_err[bool, str](original)) { ret 2; }
+    val snapshot_r: R.Result[*DiagnosticStore, str] = snapshot_from(?src, 0, ?a);
+    if (R.is_err[*DiagnosticStore, str](snapshot_r)) { ret 3; }
+    val snapshot: *DiagnosticStore = R.unwrap_ok[*DiagnosticStore, str](snapshot_r);
+    fin { store_dnit(snapshot); A.deallocate[DiagnosticStore](?a, snapshot, 1); }
+    val before: DiagMark = mark(?dst);
+    if (R.is_err[R.Void, str](replay_into(?dst, snapshot))) { ret 4; }
+    if (R.is_err[R.Void, str](replay_into(?dst, ?src))) { ret 5; }
+    val repeated: R.Result[bool, str] = gate_error(?dst, ?itn, 1, span, "invalid gate");
+    if (R.is_err[bool, str](repeated) || R.unwrap_ok[bool, str](repeated) || len(?dst) != 1) { ret 6; }
+    if (R.is_err[R.Void, str](truncate(?dst, before))) { ret 7; }
+    if (R.is_err[R.Void, str](replay_into(?dst, snapshot))) { ret 8; }
+    if (len(?dst) != 1 || error_count(?dst) != 1) { ret 9; }
     ret 0;
 }

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -486,6 +486,17 @@ fun load_phase_impl(p: *project.Project, extra_roots: *intern.StrId,
         ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](cfg_in_r)));
     }
 
+    readout.phase_begin(p.events, readout.PH_RESOLVE);
+    fin {
+        var i: u32 = 0;
+        for (i < p.topo_len) {
+            val m: *project.ModuleEntry = ?p.modules[p.topo[i]::u32];
+            readout.item_dur(p.events, readout.PH_RESOLVE, project.fqn_name(p, m.fqn), m.resolve_elapsed);
+            m.resolve_elapsed = 0;
+            i = i + 1;
+        }
+        readout.phase_end(p.events, readout.PH_RESOLVE, p.topo_len, "module", "modules");
+    }
     val resolve_r: R.Result[R.Void, outcome.Fail] = resolve_deferred_gate_load(p);
     if (R.is_err[R.Void, outcome.Fail](resolve_r)) { ret resolve_r; }
 

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -306,8 +306,19 @@ pub fun begin_build(s: *session.Session, m: *manifest.Manifest, req: *request.Bu
     ret begin_build_impl(s, req.project_root, ?pick, m, req, ev, roots);
 }
 
+pub def FrontendPhase: u8;
+pub val FRONTEND_PARSE: FrontendPhase = 0;
+pub val FRONTEND_RESOLVE: FrontendPhase = 1;
+pub val FRONTEND_SEMA: FrontendPhase = 2;
+
 pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *request.BuildRequest,
                         extra_roots: *intern.StrId, extra_root_count: u32) R.Result[project.Project, outcome.Fail] {
+    ret analyze_project_until(s, m, req, extra_roots, extra_root_count, FRONTEND_SEMA);
+}
+
+pub fun analyze_project_until(s: *session.Session, m: *manifest.Manifest, req: *request.BuildRequest,
+                        extra_roots: *intern.StrId, extra_root_count: u32, phase: FrontendPhase) R.Result[project.Project, outcome.Fail] {
+    if (phase > FRONTEND_SEMA) { ret R.err[project.Project, outcome.Fail](outcome.user("unknown frontend analysis phase")); }
     if (extra_root_count > 0 && extra_roots == nil) {
         ret R.err[project.Project, outcome.Fail](outcome.internal(
             "driver: frontend analysis root count requires a root array"));
@@ -325,11 +336,23 @@ pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *reques
     if (R.is_err[project.Project, outcome.Fail](begin_r)) { ret begin_r; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](begin_r);
 
+    if (phase == FRONTEND_PARSE) {
+        val parsed: R.Result[R.Void, outcome.Fail] = parse_project_roots(?p, extra_roots, extra_root_count);
+        if (R.is_err[R.Void, outcome.Fail](parsed)) { ret project_failure(?p, R.unwrap_err[R.Void, outcome.Fail](parsed)); }
+        ret R.ok[project.Project, outcome.Fail](p);
+    }
+
     val load_r: R.Result[R.Void, outcome.Fail] =
         run_load_phase_roots(?p, extra_roots, extra_root_count);
     if (R.is_err[R.Void, outcome.Fail](load_r)) {
         val failure: outcome.Fail = R.unwrap_err[R.Void, outcome.Fail](load_r);
         ret project_failure(?p, failure);
+    }
+
+    if (phase == FRONTEND_RESOLVE) {
+        val current: R.Result[bool, outcome.Fail] = resolve_query_phase(?p, false, false);
+        if (R.is_err[bool, outcome.Fail](current)) { ret project_failure(?p, R.unwrap_err[bool, outcome.Fail](current)); }
+        ret R.ok[project.Project, outcome.Fail](p);
     }
 
     val sema_r: R.Result[R.Void, outcome.Fail] = run_sema_pass(?p);
@@ -339,6 +362,30 @@ pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *reques
     }
 
     ret R.ok[project.Project, outcome.Fail](p);
+}
+
+fun parse_project_roots(p: *project.Project, roots: *intern.StrId, count: u32) R.Result[R.Void, outcome.Fail] {
+    val selected: R.Result[R.Void, str] = dcfg.select_target(p, p.target_entry);
+    if (R.is_err[R.Void, str](selected)) { ret finish_nonquery_phase(p, R.err[R.Void, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](selected)))); }
+    var entry: intern.StrId = intern.STR_NIL;
+    var selected_roots: *intern.StrId = roots;
+    var selected_count: u32 = count;
+    if (selected_count == 0) {
+        val name: R.Result[intern.StrId, str] = load.entry_module_fqn(p, p.target_entry);
+        if (R.is_err[intern.StrId, str](name)) { ret finish_nonquery_phase(p, R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[intern.StrId, str](name)))); }
+        entry = R.unwrap_ok[intern.StrId, str](name);
+        selected_roots = ?entry;
+        selected_count = 1;
+    }
+    var i: u32 = 0;
+    for (i < selected_count) {
+        val loaded: R.Result[session.ModuleId, str] = load.parse_root(p, selected_roots[i]);
+        if (R.is_err[session.ModuleId, str](loaded)) {
+            ret load.collect_loaded_parses(p, R.err[R.Void, outcome.Fail](load_failure(p, R.unwrap_err[session.ModuleId, str](loaded))));
+        }
+        i = i + 1;
+    }
+    ret load.collect_loaded_parses(p, R.ok_void[outcome.Fail]());
 }
 
 fun begin_build_impl(s: *session.Session, project_root: str, pick: *manifest.Selection, m: *manifest.Manifest, req: *request.BuildRequest, ev: *readout.Progress, roots: project.RootSet) R.Result[project.Project, outcome.Fail] {

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -1,4 +1,5 @@
 use std.text.string.str_free;
+use std.text.string.str_dup;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -11,6 +12,8 @@ use O: std.types.option;
 use R: std.types.result;
 
 use std.data.toml;
+use std.collections.vector;
+use std.collections.vector.Vector;
 
 use mach.lang.be.codegen.dwarf;
 use mach.lang.build.outcome;
@@ -23,6 +26,7 @@ use mach.lang.me.pipeline;
 use mach.lang.query;
 use mach.lang.readout;
 use mach.lang.session;
+use mach.lang.source;
 use mach.lang.target;
 use mach.lang.target.isa;
 use mach.lang.target.of;
@@ -43,18 +47,16 @@ fwd project.TARGET_OPT_RELEASE;
 fwd project.dnit_project;
 fwd project.fqn_name;
 fwd project.link_name_for;
+fwd project.begin_query_phase;
+fwd project.finish_query_phase;
+fwd project.refresh_diagnostics;
 
 fwd union.count_target_gated;
 
-fwd passes.run_sema_pass;
-fwd passes.run_lower_pass;
-fwd passes.run_codegen_pass;
-fwd passes.run_link_pass;
 fwd passes.codegen_reusable;
 fwd passes.CodeSources;
 fwd passes.code_sources;
 fwd passes.sources_dnit;
-fwd passes.lower_sweep_staged;
 fwd passes.module_in_current_project;
 fwd passes.debug_info_of;
 fwd passes.frontend_status;
@@ -71,17 +73,153 @@ pub fun setup_registry(reg: *target.TargetRegistry) R.Result[R.Void, str] {
     ret target.register_all(reg, provide_debug_descriptor);
 }
 
+fun append_phase_roots(p: *project.Project, roots: *Vector[query.QueryKey],
+                       kind: query.QueryKind, count: u32) R.Result[R.Void, outcome.Fail] {
+    var i: u32 = 0;
+    for (i < count) {
+        val m: *project.ModuleEntry = ?p.modules[p.topo[i]::u32];
+        var key: u64 = m.stable_id::u64;
+        if (kind == query.Q_PARSE) { key = m.file_id::u64; }
+        or (kind == query.Q_LOWER || kind == query.Q_CODEGEN) { key = passes.back_half_key_for(p, m); }
+        val added: R.Result[usize, str] = vector.push[query.QueryKey](roots, query.QueryKey{ kind: kind, key: key });
+        if (R.is_err[usize, str](added)) {
+            ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[usize, str](added)));
+        }
+        i = i + 1;
+    }
+    ret R.ok_void[outcome.Fail]();
+}
+
+pub fun append_frontend_roots(p: *project.Project, roots: *Vector[query.QueryKey]) R.Result[R.Void, outcome.Fail] {
+    val parsed: R.Result[R.Void, outcome.Fail] = append_phase_roots(p, roots, query.Q_PARSE, p.topo_len);
+    if (R.is_err[R.Void, outcome.Fail](parsed)) { ret parsed; }
+    val resolved: R.Result[R.Void, outcome.Fail] = append_phase_roots(p, roots, query.Q_RESOLVE, p.topo_len);
+    if (R.is_err[R.Void, outcome.Fail](resolved)) { ret resolved; }
+    ret append_phase_roots(p, roots, query.Q_SEMA, p.topo_len);
+}
+
+fun append_backend_roots(p: *project.Project, roots: *Vector[query.QueryKey],
+                        codegen: bool) R.Result[R.Void, outcome.Fail] {
+    val frontend: R.Result[R.Void, outcome.Fail] = append_frontend_roots(p, roots);
+    if (R.is_err[R.Void, outcome.Fail](frontend)) { ret frontend; }
+    val surface: R.Result[R.Void, outcome.Fail] = append_phase_roots(p, roots, query.Q_LOWERED_SURFACE, p.emit_len);
+    if (R.is_err[R.Void, outcome.Fail](surface)) { ret surface; }
+    val lowered: R.Result[R.Void, outcome.Fail] = append_phase_roots(p, roots, query.Q_LOWER, p.emit_len);
+    if (R.is_err[R.Void, outcome.Fail](lowered)) { ret lowered; }
+    if (codegen) { ret append_phase_roots(p, roots, query.Q_CODEGEN, p.emit_len); }
+    ret R.ok_void[outcome.Fail]();
+}
+
+fun run_query_pass(p: *project.Project, roots: *Vector[query.QueryKey],
+                   run: fun(*project.Project) R.Result[R.Void, outcome.Fail]) R.Result[R.Void, outcome.Fail] {
+    val begun: R.Result[query.Operation, outcome.Fail] = project.begin_query_phase(p);
+    if (R.is_err[query.Operation, outcome.Fail](begun)) {
+        ret R.err[R.Void, outcome.Fail](R.unwrap_err[query.Operation, outcome.Fail](begun));
+    }
+    val result: R.Result[R.Void, outcome.Fail] = run(p);
+    ret project.finish_query_phase(p, R.unwrap_ok[query.Operation, outcome.Fail](begun), roots.data, roots.len, result);
+}
+
+fun finish_nonquery_phase(p: *project.Project,
+                         result: R.Result[R.Void, outcome.Fail]) R.Result[R.Void, outcome.Fail] {
+    val refreshed: R.Result[R.Void, outcome.Fail] = project.refresh_diagnostics(p);
+    if (R.is_err[R.Void, outcome.Fail](refreshed)) {
+        diagnostic.note_lost(?p.diags);
+        diagnostic.note_lost(?p.s.diags);
+        if (R.is_ok[R.Void, outcome.Fail](result)) { ret refreshed; }
+    }
+    ret result;
+}
+
+fun project_failure(p: *project.Project, failure: outcome.Fail) R.Result[project.Project, outcome.Fail] {
+    var stable: outcome.Fail = failure;
+    if (failure.message != nil && failure.message != p.s.query_failure_message
+        && (p.s.query_presentation == nil || failure.message != p.s.query_presentation.message)) {
+        val copied: R.Result[str, str] = str_dup(p.s.queries.a, failure.message);
+        if (R.is_err[str, str](copied)) {
+            stable.message = R.unwrap_err[str, str](copied);
+            diagnostic.note_lost(?p.diags);
+        }
+        or {
+            if (p.s.query_failure_message != nil) { str_free(p.s.queries.a, p.s.query_failure_message); }
+            p.s.query_failure_message = R.unwrap_ok[str, str](copied);
+            stable.message = p.s.query_failure_message;
+        }
+    }
+    val published: R.Result[R.Void, outcome.Fail] = finish_nonquery_phase(p, R.err[R.Void, outcome.Fail](stable));
+    project.dnit_project(p);
+    ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](published));
+}
+
+pub fun run_sema_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
+    val prepared: R.Result[R.Void, outcome.Fail] = passes.prepare_sema_pass(p);
+    if (R.is_err[R.Void, outcome.Fail](prepared)) { ret prepared; }
+    var roots: Vector[query.QueryKey] = vector.init[query.QueryKey](p.alloc);
+    fin { vector.dnit[query.QueryKey](?roots); }
+    val rooted: R.Result[R.Void, outcome.Fail] = append_frontend_roots(p, ?roots);
+    if (R.is_err[R.Void, outcome.Fail](rooted)) { ret rooted; }
+    ret run_query_pass(p, ?roots, passes.run_sema_pass);
+}
+
+pub fun run_lower_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
+    val prepared: R.Result[R.Void, outcome.Fail] = passes.prepare_lower_pass(p);
+    if (R.is_err[R.Void, outcome.Fail](prepared)) { ret prepared; }
+    var roots: Vector[query.QueryKey] = vector.init[query.QueryKey](p.alloc);
+    fin { vector.dnit[query.QueryKey](?roots); }
+    val rooted: R.Result[R.Void, outcome.Fail] = append_backend_roots(p, ?roots, false);
+    if (R.is_err[R.Void, outcome.Fail](rooted)) { ret rooted; }
+    ret run_query_pass(p, ?roots, passes.run_lower_pass);
+}
+
+pub fun run_codegen_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
+    val prepared: R.Result[R.Void, outcome.Fail] = passes.prepare_codegen_pass(p);
+    if (R.is_err[R.Void, outcome.Fail](prepared)) { ret prepared; }
+    var roots: Vector[query.QueryKey] = vector.init[query.QueryKey](p.alloc);
+    fin { vector.dnit[query.QueryKey](?roots); }
+    val rooted: R.Result[R.Void, outcome.Fail] = append_backend_roots(p, ?roots, true);
+    if (R.is_err[R.Void, outcome.Fail](rooted)) { ret rooted; }
+    ret run_query_pass(p, ?roots, passes.run_codegen_pass);
+}
+
+pub fun run_link_pass(p: *project.Project) R.Result[bool, outcome.Fail] {
+    val prepared: R.Result[R.Void, outcome.Fail] = passes.prepare_link_pass(p);
+    if (R.is_err[R.Void, outcome.Fail](prepared)) {
+        ret R.err[bool, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](prepared));
+    }
+    var roots: Vector[query.QueryKey] = vector.init[query.QueryKey](p.alloc);
+    fin { vector.dnit[query.QueryKey](?roots); }
+    val rooted: R.Result[R.Void, outcome.Fail] = append_backend_roots(p, ?roots, true);
+    if (R.is_err[R.Void, outcome.Fail](rooted)) {
+        ret R.err[bool, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](rooted));
+    }
+    val linked: R.Result[usize, str] = vector.push[query.QueryKey](?roots, query.QueryKey{ kind: query.Q_LINK, key: 0 });
+    if (R.is_err[usize, str](linked)) {
+        ret R.err[bool, outcome.Fail](outcome.internal(R.unwrap_err[usize, str](linked)));
+    }
+    val begun: R.Result[query.Operation, outcome.Fail] = project.begin_query_phase(p);
+    if (R.is_err[query.Operation, outcome.Fail](begun)) {
+        ret R.err[bool, outcome.Fail](R.unwrap_err[query.Operation, outcome.Fail](begun));
+    }
+    val result: R.Result[bool, outcome.Fail] = passes.run_link_pass(p);
+    val finished: R.Result[R.Void, outcome.Fail] = project.finish_query_phase(p,
+        R.unwrap_ok[query.Operation, outcome.Fail](begun), roots.data, roots.len, R.void_of[bool, outcome.Fail](result));
+    if (R.is_err[R.Void, outcome.Fail](finished)) {
+        ret R.err[bool, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](finished));
+    }
+    ret result;
+}
+
 fun query_compute(p: *project.Project, kind: query.QueryKind, key: u64,
-                  alloc: *A.Allocator) R.Result[query.QueryOutput, fail.Fail] {
-    if (kind == query.Q_PARSE)           { ret load.q_parse_compute(p, key, alloc); }
-    if (kind == query.Q_RESOLVE)         { ret passes.q_resolve_compute(p, key, alloc); }
-    if (kind == query.Q_EXPORTS)         { ret load.q_exports_compute(p, key, alloc); }
-    if (kind == query.Q_SEMA)            { ret passes.q_sema_compute(p, key, alloc); }
-    if (kind == query.Q_TYPED_EXPORTS)   { ret passes.q_typed_exports_compute(p, key, alloc); }
-    if (kind == query.Q_LOWERED_SURFACE) { ret passes.q_lowered_surface_compute(p, key, alloc); }
-    if (kind == query.Q_LOWER)           { ret passes.q_lower_compute(p, key, alloc); }
-    if (kind == query.Q_CODEGEN)         { ret passes.q_codegen_compute(p, key, alloc); }
-    if (kind == query.Q_LINK)            { ret passes.q_link_compute(p, key, alloc); }
+                  alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
+    if (kind == query.Q_PARSE)           { ret load.q_parse_compute(p, key, alloc, diags); }
+    if (kind == query.Q_RESOLVE)         { ret passes.q_resolve_compute(p, key, alloc, diags); }
+    if (kind == query.Q_EXPORTS)         { ret load.q_exports_compute(p, key, alloc, diags); }
+    if (kind == query.Q_SEMA)            { ret passes.q_sema_compute(p, key, alloc, diags); }
+    if (kind == query.Q_TYPED_EXPORTS)   { ret passes.q_typed_exports_compute(p, key, alloc, diags); }
+    if (kind == query.Q_LOWERED_SURFACE) { ret passes.q_lowered_surface_compute(p, key, alloc, diags); }
+    if (kind == query.Q_LOWER)           { ret passes.q_lower_compute(p, key, alloc, diags); }
+    if (kind == query.Q_CODEGEN)         { ret passes.q_codegen_compute(p, key, alloc, diags); }
+    if (kind == query.Q_LINK)            { ret passes.q_link_compute(p, key, alloc, diags); }
     ret R.err[query.QueryOutput, fail.Fail](fail.message("query kind has no driver compute capability"));
 }
 
@@ -110,20 +248,17 @@ fun build_project_impl(s: *session.Session, project_root: str, pick: *manifest.S
     if (run_steps) {
         val res_dep_steps: R.Result[R.Void, outcome.Fail] = run_dep_steps_phase(?p);
         if (R.is_err[R.Void, outcome.Fail](res_dep_steps)) {
-            project.dnit_project(?p);
-            ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](res_dep_steps));
+            ret project_failure(?p, R.unwrap_err[R.Void, outcome.Fail](res_dep_steps));
         }
         val res_steps: R.Result[R.Void, outcome.Fail] = run_steps_phase(?p);
         if (R.is_err[R.Void, outcome.Fail](res_steps)) {
-            project.dnit_project(?p);
-            ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](res_steps));
+            ret project_failure(?p, R.unwrap_err[R.Void, outcome.Fail](res_steps));
         }
     }
 
     val load_r: R.Result[R.Void, outcome.Fail] = run_load_phase(?p);
     if (R.is_err[R.Void, outcome.Fail](load_r)) {
-        project.dnit_project(?p);
-        ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](load_r));
+        ret project_failure(?p, R.unwrap_err[R.Void, outcome.Fail](load_r));
     }
 
     ret R.ok[project.Project, outcome.Fail](p);
@@ -137,12 +272,25 @@ pub fun verify_dependencies(s: *session.Session, project_root: str) R.Result[R.V
     project.init_project(?p, s);
     p.req.project_root = project_root;
     val dep_id_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "dep");
-    if (R.is_err[intern.StrId, str](dep_id_r)) { manifest.dnit(?m, s.build_alloc); ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](dep_id_r)); }
+    if (R.is_err[intern.StrId, str](dep_id_r)) {
+        project.dnit_project(?p);
+        manifest.dnit(?m, s.build_alloc);
+        ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](dep_id_r));
+    }
     p.config.dir_dep = R.unwrap_ok[intern.StrId, str](dep_id_r);
     val dr: R.Result[R.Void, str] = ddep.resolve_deps(?p, ?m, project_root);
+    if (R.is_err[R.Void, str](dr)) {
+        val rejected: R.Result[project.Project, outcome.Fail] = project_failure(?p, outcome.user(R.unwrap_err[R.Void, str](dr)));
+        manifest.dnit(?m, s.build_alloc);
+        ret R.err[R.Void, str](R.unwrap_err[project.Project, outcome.Fail](rejected).message);
+    }
+    val published: R.Result[R.Void, outcome.Fail] = finish_nonquery_phase(?p, R.ok_void[outcome.Fail]());
     project.dnit_project(?p);
     manifest.dnit(?m, s.build_alloc);
-    ret dr;
+    if (R.is_err[R.Void, outcome.Fail](published)) {
+        ret R.err[R.Void, str](R.unwrap_err[R.Void, outcome.Fail](published).message);
+    }
+    ret R.ok_void[str]();
 }
 
 pub fun begin_build(s: *session.Session, m: *manifest.Manifest, req: *request.BuildRequest, ev: *readout.Progress) R.Result[project.Project, outcome.Fail] {
@@ -181,15 +329,13 @@ pub fun analyze_project(s: *session.Session, m: *manifest.Manifest, req: *reques
         run_load_phase_roots(?p, extra_roots, extra_root_count);
     if (R.is_err[R.Void, outcome.Fail](load_r)) {
         val failure: outcome.Fail = R.unwrap_err[R.Void, outcome.Fail](load_r);
-        project.dnit_project(?p);
-        ret R.err[project.Project, outcome.Fail](failure);
+        ret project_failure(?p, failure);
     }
 
-    val sema_r: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val sema_r: R.Result[R.Void, outcome.Fail] = run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](sema_r)) {
         val failure: outcome.Fail = R.unwrap_err[R.Void, outcome.Fail](sema_r);
-        project.dnit_project(?p);
-        ret R.err[project.Project, outcome.Fail](failure);
+        ret project_failure(?p, failure);
     }
 
     ret R.ok[project.Project, outcome.Fail](p);
@@ -207,8 +353,7 @@ fun begin_build_impl(s: *session.Session, project_root: str, pick: *manifest.Sel
 
     val q_r: R.Result[R.Void, str] = bind_queries(?p);
     if (R.is_err[R.Void, str](q_r)) {
-        project.dnit_project(?p);
-        ret R.err[project.Project, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](q_r)));
+        ret project_failure(?p, outcome.internal(R.unwrap_err[R.Void, str](q_r)));
     }
 
     var cfg_r: R.Result[R.Void, str];
@@ -218,22 +363,19 @@ fun begin_build_impl(s: *session.Session, project_root: str, pick: *manifest.Sel
     or {
         val mp_r: R.Result[str, str] = load.join_path(s.alloc, project_root, manifest.MANIFEST_FILE);
         if (R.is_err[str, str](mp_r)) {
-            project.dnit_project(?p);
-            ret R.err[project.Project, outcome.Fail](outcome.internal(R.unwrap_err[str, str](mp_r)));
+            ret project_failure(?p, outcome.internal(R.unwrap_err[str, str](mp_r)));
         }
         val manifest_path: str = R.unwrap_ok[str, str](mp_r);
         cfg_r = dcfg.load_project_config(?p, project_root, manifest_path, pick, for_union, is_test);
         str_free(s.alloc, manifest_path);
     }
     if (R.is_err[R.Void, str](cfg_r)) {
-        project.dnit_project(?p);
-        ret R.err[project.Project, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](cfg_r)));
+        ret project_failure(?p, outcome.user(R.unwrap_err[R.Void, str](cfg_r)));
     }
 
     val te: *project.TargetEntry = p.target_entry;
     if (te == nil) {
-        project.dnit_project(?p);
-        ret R.err[project.Project, outcome.Fail](outcome.internal("internal: manifest selected no target"));
+        ret project_failure(?p, outcome.internal("internal: manifest selected no target"));
     }
 
     if (req == nil) {
@@ -242,15 +384,20 @@ fun begin_build_impl(s: *session.Session, project_root: str, pick: *manifest.Sel
         if (te.opt == project.TARGET_OPT_RELEASE) { p.req.opt = pipeline.OPT_RELEASE; }
     }
 
+    val published: R.Result[R.Void, outcome.Fail] = finish_nonquery_phase(?p, R.ok_void[outcome.Fail]());
+    if (R.is_err[R.Void, outcome.Fail](published)) {
+        ret project_failure(?p, R.unwrap_err[R.Void, outcome.Fail](published));
+    }
+
     ret R.ok[project.Project, outcome.Fail](p);
 }
 
 pub fun run_steps_phase(p: *project.Project) R.Result[R.Void, outcome.Fail] {
     val res_steps: R.Result[R.Void, str] = dcfg.execute_steps(p.alloc, p, p.req.project_root);
     if (R.is_err[R.Void, str](res_steps)) {
-        ret R.err[R.Void, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](res_steps)));
+        ret finish_nonquery_phase(p, R.err[R.Void, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](res_steps))));
     }
-    ret R.ok_void[outcome.Fail]();
+    ret finish_nonquery_phase(p, R.ok_void[outcome.Fail]());
 }
 
 pub fun run_dep_steps_phase(p: *project.Project) R.Result[R.Void, outcome.Fail] {
@@ -260,9 +407,9 @@ pub fun run_dep_steps_phase(p: *project.Project) R.Result[R.Void, outcome.Fail] 
     val abi_s: str = O.unwrap[str](intern.lookup(?p.s.interner, te.abi_name));
     val res_dep_steps: R.Result[R.Void, str] = dcfg.execute_dep_steps(p, isa_s, os_s, abi_s);
     if (R.is_err[R.Void, str](res_dep_steps)) {
-        ret R.err[R.Void, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](res_dep_steps)));
+        ret finish_nonquery_phase(p, R.err[R.Void, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](res_dep_steps))));
     }
-    ret R.ok_void[outcome.Fail]();
+    ret finish_nonquery_phase(p, R.ok_void[outcome.Fail]());
 }
 
 pub fun run_load_phase(p: *project.Project) R.Result[R.Void, outcome.Fail] {
@@ -271,6 +418,11 @@ pub fun run_load_phase(p: *project.Project) R.Result[R.Void, outcome.Fail] {
 
 fun run_load_phase_roots(p: *project.Project, extra_roots: *intern.StrId,
                          extra_root_count: u32) R.Result[R.Void, outcome.Fail] {
+    ret finish_nonquery_phase(p, load_phase_impl(p, extra_roots, extra_root_count));
+}
+
+fun load_phase_impl(p: *project.Project, extra_roots: *intern.StrId,
+                    extra_root_count: u32) R.Result[R.Void, outcome.Fail] {
     val te: *project.TargetEntry = p.target_entry;
 
     val fp_r: R.Result[R.Void, str] = dcfg.select_target(p, te);
@@ -287,7 +439,7 @@ fun run_load_phase_roots(p: *project.Project, extra_roots: *intern.StrId,
     readout.phase_begin(p.events, readout.PH_LOAD);
     val load_r: R.Result[session.ModuleId, str] = load.dfs_load(p, entry_fqn);
     if (R.is_err[session.ModuleId, str](load_r)) {
-        ret R.err[R.Void, outcome.Fail](load_failure(p, R.unwrap_err[session.ModuleId, str](load_r)));
+        ret load.collect_loaded_parses(p, R.err[R.Void, outcome.Fail](load_failure(p, R.unwrap_err[session.ModuleId, str](load_r))));
     }
 
     if (p.roots == project.ROOT_UNION) {
@@ -295,7 +447,7 @@ fun run_load_phase_roots(p: *project.Project, extra_roots: *intern.StrId,
         for (ei < p.union_entry_count) {
             val ear: R.Result[session.ModuleId, str] = load.dfs_load(p, p.union_entries[ei]);
             if (R.is_err[session.ModuleId, str](ear)) {
-                ret R.err[R.Void, outcome.Fail](load_failure(p, R.unwrap_err[session.ModuleId, str](ear)));
+                ret load.collect_loaded_parses(p, R.err[R.Void, outcome.Fail](load_failure(p, R.unwrap_err[session.ModuleId, str](ear))));
             }
             ei = ei + 1;
         }
@@ -307,7 +459,7 @@ fun run_load_phase_roots(p: *project.Project, extra_roots: *intern.StrId,
     for (xi < extra_root_count) {
         val xr: R.Result[session.ModuleId, str] = load.dfs_load(p, extra_roots[xi]);
         if (R.is_err[session.ModuleId, str](xr)) {
-            ret R.err[R.Void, outcome.Fail](load_failure(p, R.unwrap_err[session.ModuleId, str](xr)));
+            ret load.collect_loaded_parses(p, R.err[R.Void, outcome.Fail](load_failure(p, R.unwrap_err[session.ModuleId, str](xr))));
         }
         xi = xi + 1;
     }
@@ -315,7 +467,7 @@ fun run_load_phase_roots(p: *project.Project, extra_roots: *intern.StrId,
     if (p.roots == project.ROOT_TEST) {
         val allsrc_r: R.Result[R.Void, str] = union.load_all_own_src(p);
         if (R.is_err[R.Void, str](allsrc_r)) {
-            ret R.err[R.Void, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](allsrc_r)));
+            ret load.collect_loaded_parses(p, R.err[R.Void, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](allsrc_r))));
         }
     }
 
@@ -342,6 +494,11 @@ fun run_load_phase_roots(p: *project.Project, extra_roots: *intern.StrId,
         ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](emb_r)));
     }
 
+    val final_resolve: R.Result[bool, outcome.Fail] = resolve_query_phase(p, false, false);
+    if (R.is_err[bool, outcome.Fail](final_resolve)) {
+        ret R.err[R.Void, outcome.Fail](R.unwrap_err[bool, outcome.Fail](final_resolve));
+    }
+
     val exp_r: R.Result[R.Void, str] = union.register_export_names(p);
     if (R.is_err[R.Void, str](exp_r)) {
         ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](exp_r)));
@@ -350,25 +507,77 @@ fun run_load_phase_roots(p: *project.Project, extra_roots: *intern.StrId,
     ret R.ok_void[outcome.Fail]();
 }
 
+pub fun run_gate_pass(p: *project.Project) R.Result[bool, outcome.Fail] {
+    ret resolve_query_phase(p, true, false);
+}
+
+fun resolve_query_phase(p: *project.Project, gates: bool, provisional: bool) R.Result[bool, outcome.Fail] {
+    val prepared: R.Result[R.Void, fail.Fail] = passes.prepare_resolve_pass(p);
+    if (R.is_err[R.Void, fail.Fail](prepared)) {
+        ret R.err[bool, outcome.Fail](outcome.from_fail(R.unwrap_err[R.Void, fail.Fail](prepared)));
+    }
+    var roots: Vector[query.QueryKey] = vector.init[query.QueryKey](p.alloc);
+    fin { vector.dnit[query.QueryKey](?roots); }
+    var i: u32 = 0;
+    for (i < p.module_len) {
+        val m: *project.ModuleEntry = ?p.modules[i];
+        if (m.file_id == source.FILE_NIL) { i = i + 1; cnt; }
+        val added: R.Result[usize, str] = vector.push[query.QueryKey](?roots,
+            query.QueryKey{ kind: query.Q_PARSE, key: m.file_id::u64 });
+        if (R.is_err[usize, str](added)) {
+            ret R.err[bool, outcome.Fail](outcome.internal(R.unwrap_err[usize, str](added)));
+        }
+        i = i + 1;
+    }
+    val parse_count: usize = roots.len;
+    val resolved: R.Result[R.Void, outcome.Fail] = append_phase_roots(p, ?roots, query.Q_RESOLVE, p.topo_len);
+    if (R.is_err[R.Void, outcome.Fail](resolved)) {
+        ret R.err[bool, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](resolved));
+    }
+    val exported: R.Result[R.Void, outcome.Fail] = append_phase_roots(p, ?roots, query.Q_EXPORTS, p.topo_len);
+    if (R.is_err[R.Void, outcome.Fail](exported)) {
+        ret R.err[bool, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](exported));
+    }
+    val begun: R.Result[query.Operation, outcome.Fail] = project.begin_query_phase(p);
+    if (R.is_err[query.Operation, outcome.Fail](begun)) {
+        ret R.err[bool, outcome.Fail](R.unwrap_err[query.Operation, outcome.Fail](begun));
+    }
+    var computed: R.Result[R.Void, fail.Fail] = load.acquire_loaded_parses(p);
+    if (R.is_ok[R.Void, fail.Fail](computed)) { computed = passes.run_resolve_pass(p); }
+    var result: R.Result[R.Void, outcome.Fail] = R.ok_void[outcome.Fail]();
+    var changed: bool = false;
+    if (R.is_err[R.Void, fail.Fail](computed)) {
+        result = R.err[R.Void, outcome.Fail](outcome.from_fail(R.unwrap_err[R.Void, fail.Fail](computed)));
+    }
+    or (gates) {
+        val evaluated: R.Result[bool, str] = passes.run_gate_pass(p);
+        if (R.is_err[bool, str](evaluated)) {
+            result = R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[bool, str](evaluated)));
+        }
+        or { changed = R.unwrap_ok[bool, str](evaluated); }
+    }
+    var count: usize = roots.len;
+    if (provisional && R.is_ok[R.Void, outcome.Fail](result)) { count = parse_count; }
+    val finished: R.Result[R.Void, outcome.Fail] = project.finish_query_phase(p,
+        R.unwrap_ok[query.Operation, outcome.Fail](begun), roots.data, count, result);
+    if (R.is_err[R.Void, outcome.Fail](finished)) {
+        ret R.err[bool, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](finished));
+    }
+    ret R.ok[bool, outcome.Fail](changed);
+}
+
 fun resolve_deferred_gate_load(p: *project.Project) R.Result[R.Void, outcome.Fail] {
     for (true) {
         val gc: R.Result[R.Void, str] = load.check_gated_const_imports(p);
         if (R.is_err[R.Void, str](gc)) { ret gate_load_user_fail(fail.lift[R.Void](gc)); }
         val deferred_before: u32 = load.deferred_gate_count(p);
         val decided_before:  u32 = passes.decided_gate_count(p);
-        val diag_mark: diagnostic.DiagMark = diagnostic.mark(?p.s.diags);
-        val rr: R.Result[R.Void, fail.Fail] = passes.run_resolve_pass(p);
-        if (R.is_err[R.Void, fail.Fail](rr)) { passes.clear_gate_results(p); ret gate_load_user_fail(rr); }
-        if (deferred_before > 0) {
-            val tr: R.Result[R.Void, str] = diagnostic.truncate(?p.s.diags, diag_mark);
-            if (R.is_err[R.Void, str](tr)) { passes.clear_gate_results(p); ret gate_load_user_fail(fail.lift[R.Void](tr)); }
-        }
-        val changed_r: R.Result[bool, str] = passes.run_gate_pass(p);
-        if (R.is_err[bool, str](changed_r)) {
+        val changed_r: R.Result[bool, outcome.Fail] = resolve_query_phase(p, true, deferred_before > 0);
+        if (R.is_err[bool, outcome.Fail](changed_r)) {
             passes.clear_gate_results(p);
-            ret gate_load_user_fail(fail.lift[R.Void](R.void_of[bool, str](changed_r)));
+            ret R.err[R.Void, outcome.Fail](R.unwrap_err[bool, outcome.Fail](changed_r));
         }
-        var changed: bool = R.unwrap_ok[bool, str](changed_r);
+        var changed: bool = R.unwrap_ok[bool, outcome.Fail](changed_r);
         if (passes.decided_gate_count(p) != decided_before) { changed = true; }
         val deferred: u32 = load.deferred_gate_count(p);
         if (deferred == 0) {
@@ -377,11 +586,11 @@ fun resolve_deferred_gate_load(p: *project.Project) R.Result[R.Void, outcome.Fai
         }
         if (!changed) {
             p.gate_terminal = true;
-            val fr: R.Result[R.Void, fail.Fail] = passes.run_resolve_pass(p);
+            val fr: R.Result[bool, outcome.Fail] = resolve_query_phase(p, false, false);
             p.gate_terminal = false;
-            if (R.is_err[R.Void, fail.Fail](fr)) {
+            if (R.is_err[bool, outcome.Fail](fr)) {
                 passes.clear_gate_results(p);
-                ret gate_load_user_fail(fr);
+                ret R.err[R.Void, outcome.Fail](R.unwrap_err[bool, outcome.Fail](fr));
             }
             passes.clear_gate_results(p);
             val status: fail.PhaseStatus = passes.frontend_status(p);
@@ -406,7 +615,7 @@ fun resolve_deferred_gate_load(p: *project.Project) R.Result[R.Void, outcome.Fai
         if (R.is_err[bool, str](resumed_r)) {
             if (emit_roots != nil) { A.deallocate[session.ModuleId](p.alloc, emit_roots, emit_root_count::usize); }
             passes.clear_gate_results(p);
-            ret gate_load_user_fail(fail.lift[R.Void](R.void_of[bool, str](resumed_r)));
+            ret load.collect_loaded_parses(p, gate_load_user_fail(fail.lift[R.Void](R.void_of[bool, str](resumed_r))));
         }
         val tr: R.Result[R.Void, str] = load.rebuild_topo(p, emit_roots, emit_root_count);
         if (emit_roots != nil) { A.deallocate[session.ModuleId](p.alloc, emit_roots, emit_root_count::usize); }
@@ -517,7 +726,7 @@ pub fun build_project_union(s: *session.Session, project_root: str) R.Result[pro
 
 fun bind_queries(p: *project.Project) R.Result[R.Void, str] {
     val rt_r: R.Result[query.QueryRuntime[project.Project], str] =
-        query.runtime[project.Project](?p.s.queries, ?p.s.diags, query_compute);
+        query.runtime[project.Project](?p.s.queries, query_compute);
     if (R.is_err[query.QueryRuntime[project.Project], str](rt_r)) {
         ret R.err[R.Void, str](R.unwrap_err[query.QueryRuntime[project.Project], str](rt_r));
     }

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -459,7 +459,7 @@ fun emit_deprecated_key_warnings(p: *project.Project, prefix: str, m: *manifest.
         var span: token.Span;
         span.offset = 0;
         span.len    = 0;
-        diagnostic.record_warning(?p.s.diags, 0xFFFFFFFF::src.FileId, span, msg);
+        diagnostic.record_warning(?p.diags, 0xFFFFFFFF::src.FileId, span, msg);
         str_free(p.alloc, msg);
         i = i + 1;
     }
@@ -474,7 +474,7 @@ fun emit_legacy_default_warning(p: *project.Project, axis: str, table: str, flag
     var span: token.Span;
     span.offset = 0;
     span.len    = 0;
-    diagnostic.record_warning(?p.s.diags, 0xFFFFFFFF::src.FileId, span, buf);
+    diagnostic.record_warning(?p.diags, 0xFFFFFFFF::src.FileId, span, buf);
     str_free(p.alloc, buf);
 }
 
@@ -491,7 +491,7 @@ fun emit_native_warning(p: *project.Project, target_name: intern.StrId) {
     var span: token.Span;
     span.offset = 0;
     span.len    = 0;
-    diagnostic.record_warning(?p.s.diags, 0xFFFFFFFF::src.FileId, span, buf);
+    diagnostic.record_warning(?p.diags, 0xFFFFFFFF::src.FileId, span, buf);
 
     str_free(p.alloc, buf);
     str_free(p.alloc, tuple);

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -270,6 +270,18 @@ fun mark_tuple_reachable(p: *project.Project, mid: session.ModuleId) R.Result[bo
     ret R.ok[bool, str](changed);
 }
 
+pub fun parse_root(p: *project.Project, fqn: intern.StrId) R.Result[session.ModuleId, str] {
+    val existing: R.Result[*session.ModuleId, str] = map.get[intern.StrId, session.ModuleId](?p.by_fqn, ?fqn);
+    if (R.is_ok[*session.ModuleId, str](existing)) { ret R.ok[session.ModuleId, str](@R.unwrap_ok[*session.ModuleId, str](existing)); }
+    val registered: R.Result[session.ModuleId, str] = register_module_slot(p, fqn);
+    if (R.is_err[session.ModuleId, str](registered)) { ret registered; }
+    val mid: session.ModuleId = R.unwrap_ok[session.ModuleId, str](registered);
+    val parsed: R.Result[R.Void, str] = parse_module(p, mid, fqn);
+    if (R.is_err[R.Void, str](parsed)) { ret R.err[session.ModuleId, str](R.unwrap_err[R.Void, str](parsed)); }
+    p.load_status[mid::u32] = project.LOAD_DONE;
+    ret R.ok[session.ModuleId, str](mid);
+}
+
 pub fun dfs_load(p: *project.Project, fqn: intern.StrId) R.Result[session.ModuleId, str] {
     val existing_r: R.Result[*session.ModuleId, str] = map.get[intern.StrId, session.ModuleId](?p.by_fqn, ?fqn);
     if (R.is_ok[*session.ModuleId, str](existing_r)) {
@@ -296,6 +308,9 @@ pub fun dfs_load(p: *project.Project, fqn: intern.StrId) R.Result[session.Module
         ret R.err[session.ModuleId, str](R.unwrap_err[R.Void, str](parse_r));
     }
     readout.item(p.events, readout.PH_LOAD, project.fqn_name(p, fqn), t_load);
+    val gates: R.Result[R.Void, str] = comptime.prepare_gates(?p.modules[mid::u32].ctx,
+        p.modules[mid::u32].a.expr_len::u32, p.modules[mid::u32].a.decl_len::u32);
+    if (R.is_err[R.Void, str](gates)) { ret R.err[session.ModuleId, str](R.unwrap_err[R.Void, str](gates)); }
 
     val saved_gated: bool = p.in_gated_decl_walk;
     p.in_gated_decl_walk = false;
@@ -568,10 +583,7 @@ fun parse_module(p: *project.Project, mid: session.ModuleId, fqn: intern.StrId) 
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
     m.file_id = file_id;
 
-    val acquired: R.Result[R.Void, str] = acquire_load_view(p, mid, 0);
-    if (R.is_err[R.Void, str](acquired)) { ret acquired; }
-    ret comptime.prepare_gates(?p.modules[mid::u32].ctx,
-        p.modules[mid::u32].a.expr_len::u32, p.modules[mid::u32].a.decl_len::u32);
+    ret acquire_load_view(p, mid, 0);
 }
 
 fun acquire_parse_view(p: *project.Project, mid: session.ModuleId) R.Result[R.Void, fail.Fail] {

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -23,6 +23,7 @@ use ctime: std.chrono.time;
 
 use mach.lang.build.outcome;
 use mach.lang.build.request;
+use std.collections.vector;
 use mach.lang.diagnostic;
 use mach.lang.fe.ast;
 use mach.lang.fe.ast.decl;
@@ -340,7 +341,6 @@ fun module_context(p: *project.Project, req: *request.BuildRequest) R.Result[com
         p.compiler_name,
         p.compiler_ver
     );
-    comptime.set_diagnostics(?ctx, ?p.s.diags);
     comptime.set_target_defs(?ctx, p.target.isa.defs);
     comptime.set_va_list(?ctx, p.target.va_list_size, p.target.va_list_align);
     comptime.set_union_build(?ctx, p.union);
@@ -421,8 +421,6 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[sessio
     m.sema_result       = nil;
     m.ir_module         = nil;
     m.object_image      = nil;
-    m.staged_ir         = nil;
-    m.staged_home       = nil;
     m.staged_image      = nil;
     m.target_gated      = false;
     m.load_outcome      = comptime.GATE_ACTIVE;
@@ -569,27 +567,68 @@ fun parse_module(p: *project.Project, mid: session.ModuleId, fqn: intern.StrId) 
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
     m.file_id = file_id;
 
-    val e_r: R.Result[*query.QueryEntry, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_PARSE, file_id::u64);
-    if (R.is_err[*query.QueryEntry, fail.Fail](e_r)) {
-        val f: fail.Fail = R.unwrap_err[*query.QueryEntry, fail.Fail](e_r);
-        if (f.kind == fail.REPORTED) { fail.reject(?m.parse_status); }
-        or { fail.internal(?m.parse_status, f.message); }
-        ret R.err[R.Void, str](f.message);
-    }
-    val a: *ast.Ast = ast_handle_decode(R.unwrap_ok[*query.QueryEntry, fail.Fail](e_r));
-    if (a == nil) { ret R.err[R.Void, str]("Q_PARSE produced no AST handle"); }
-    m.a = a;
-    m.parse_status = (R.unwrap_ok[*query.QueryEntry, fail.Fail](e_r).value::ptr::*ParsedModule).status;
-    ret comptime.prepare_gates(?m.ctx, a.expr_len::u32, a.decl_len::u32);
+    val acquired: R.Result[R.Void, str] = acquire_load_view(p, mid, 0);
+    if (R.is_err[R.Void, str](acquired)) { ret acquired; }
+    ret comptime.prepare_gates(?p.modules[mid::u32].ctx,
+        p.modules[mid::u32].a.expr_len::u32, p.modules[mid::u32].a.decl_len::u32);
 }
 
-pub fun q_parse_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, fail.Fail] {
+fun acquire_parse_view(p: *project.Project, mid: session.ModuleId) R.Result[R.Void, fail.Fail] {
+    val m: *project.ModuleEntry = ?p.modules[mid::u32];
+    val acquired: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_PARSE, m.file_id::u64);
+    if (R.is_err[query.QueryView, fail.Fail](acquired)) {
+        val failure: fail.Fail = R.unwrap_err[query.QueryView, fail.Fail](acquired);
+        if (failure.kind == fail.REPORTED) { fail.reject(?m.parse_status); }
+        or { fail.internal(?m.parse_status, failure.message); }
+        ret R.err[R.Void, fail.Fail](failure);
+    }
+    val owner: query.QueryView = R.unwrap_ok[query.QueryView, fail.Fail](acquired);
+    val a: *ast.Ast = ast_handle_decode(owner);
+    if (a == nil) { ret R.err[R.Void, fail.Fail](fail.message("Q_PARSE produced no AST handle")); }
+    m.a = a;
+    m.parse_status = (owner.value::ptr::*ParsedModule).status;
+    ret R.ok_void[fail.Fail]();
+}
+
+fun acquire_load_view(p: *project.Project, mid: session.ModuleId, incarnation: u64) R.Result[R.Void, str] {
+    val begun: R.Result[query.Operation, outcome.Fail] = project.begin_query_phase(p);
+    if (R.is_err[query.Operation, outcome.Fail](begun)) { ret R.err[R.Void, str](R.unwrap_err[query.Operation, outcome.Fail](begun).message); }
+    val operation: query.Operation = R.unwrap_ok[query.Operation, outcome.Fail](begun);
+    var result: R.Result[R.Void, outcome.Fail] = R.ok_void[outcome.Fail]();
+    val acquired: R.Result[R.Void, fail.Fail] = acquire_parse_view(p, mid);
+    if (R.is_err[R.Void, fail.Fail](acquired)) { result = R.err[R.Void, outcome.Fail](outcome.from_fail(R.unwrap_err[R.Void, fail.Fail](acquired))); }
+    or (incarnation != 0 && p.modules[mid::u32].a.incarnation != incarnation) {
+        result = R.err[R.Void, outcome.Fail](outcome.internal("module syntax changed during dependency discovery"));
+    }
+    var root: query.QueryKey = query.QueryKey{ kind: query.Q_PARSE, key: p.modules[mid::u32].file_id::u64 };
+    var count: usize = 0;
+    if (R.is_err[R.Void, outcome.Fail](result)) { count = 1; }
+    val finished: R.Result[R.Void, outcome.Fail] = project.finish_query_phase(p, operation, ?root, count, result);
+    if (R.is_err[R.Void, outcome.Fail](finished)) { ret R.err[R.Void, str](R.unwrap_err[R.Void, outcome.Fail](finished).message); }
+    ret R.ok_void[str]();
+}
+
+pub fun parsed_definition(ctx: ptr, mid: session.ModuleId) R.Result[resolve.ParsedDefinition, fail.Fail] {
+    val p: *project.Project = ctx::*project.Project;
+    if (p == nil || mid == session.MODULE_NIL || mid::u32 >= p.module_len) {
+        ret R.err[resolve.ParsedDefinition, fail.Fail](fail.message("parsed definition module is not in the active project"));
+    }
+    val file_id: src.FileId = p.modules[mid::u32].file_id;
+    val acquired: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_PARSE, file_id::u64);
+    if (R.is_err[query.QueryView, fail.Fail](acquired)) { ret R.err[resolve.ParsedDefinition, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](acquired)); }
+    val a: *ast.Ast = ast_handle_decode(R.unwrap_ok[query.QueryView, fail.Fail](acquired));
+    if (a == nil) { ret R.err[resolve.ParsedDefinition, fail.Fail](fail.message("parsed definition query produced no AST owner")); }
+    p.modules[mid::u32].a = a;
+    ret R.ok[resolve.ParsedDefinition, fail.Fail](resolve.ParsedDefinition{ a: a, owner: resolve.type_owner(p.s, mid, file_id), incarnation: a.incarnation });
+}
+
+pub fun q_parse_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
     val db: *query.QueryDb = ?p.s.queries;
     val s: *session.Session = p.s;
     val file_id: src.FileId = key::u32;
 
-    val rd: R.Result[R.Void, str] = query.record_dep(db, query.Q_PARSE, key, query.Q_FILE_TEXT, key);
-    if (R.is_err[R.Void, str](rd)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rd))); }
+    val rd: R.Result[R.Void, fail.Fail] = query.depend[project.Project](?p.queries, p, query.Q_FILE_TEXT, key);
+    if (R.is_err[R.Void, fail.Fail](rd)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rd)); }
 
     val file_opt: O.Option[*src.SourceFile] = src.get(?s.sources, file_id);
     if (O.is_none[*src.SourceFile](file_opt)) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_PARSE: FileId not registered with the session")); }
@@ -606,15 +645,23 @@ pub fun q_parse_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.Re
     }
     val a: *ast.Ast = R.unwrap_ok[*ast.Ast, str](ar);
     a[0] = ast.init(alloc, file_id);
+    val incarnation: R.Result[u64, str] = session.next_parse_incarnation(s);
+    if (R.is_err[u64, str](incarnation)) {
+        ast.dnit(a);
+        A.deallocate[ast.Ast](alloc, a, 1);
+        lexer.dnit(?stream, alloc);
+        ret fail.lift[query.QueryOutput](R.err[query.QueryOutput, str](R.unwrap_err[u64, str](incarnation)));
+    }
+    a.incarnation = R.unwrap_ok[u64, str](incarnation);
 
-    val le_r: R.Result[R.Void, str] = lexer.emit_diagnostics(?stream, ?s.diags);
+    val le_r: R.Result[R.Void, str] = lexer.emit_diagnostics(?stream, diags);
     if (R.is_err[R.Void, str](le_r)) {
         ast.dnit(a);
         A.deallocate[ast.Ast](alloc, a, 1::usize);
         lexer.dnit(?stream, alloc);
         ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](le_r)));
     }
-    val parse_r: R.Result[fail.PhaseStatus, state.ParseFail] = parser.parse(?stream, a, ?s.diags);
+    val parse_r: R.Result[fail.PhaseStatus, state.ParseFail] = parser.parse(?stream, a, diags);
     lexer.dnit(?stream, alloc);
     if (R.is_err[fail.PhaseStatus, state.ParseFail](parse_r)) {
         ast.dnit(a);
@@ -657,15 +704,15 @@ fun ast_handle_encode(alloc: *A.Allocator, a: *ast.Ast, status: fail.PhaseStatus
     ret R.ok[query.QueryOutput, str](out);
 }
 
-fun ast_handle_decode(e: *query.QueryEntry) *ast.Ast {
+fun ast_handle_decode(e: query.QueryView) *ast.Ast {
     if (e.value == nil || e.value_len::usize < $size_of(ParsedModule)) { ret nil; }
     ret (e.value::ptr::*ParsedModule).a;
 }
 
-pub fun q_exports_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, fail.Fail] {
-    val e_r: R.Result[*query.QueryEntry, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_RESOLVE, key);
-    if (R.is_err[*query.QueryEntry, fail.Fail](e_r)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[*query.QueryEntry, fail.Fail](e_r)); }
-    val rr: *resolve.ResolveResult = dq.resolve_handle_decode(R.unwrap_ok[*query.QueryEntry, fail.Fail](e_r));
+pub fun q_exports_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
+    val e_r: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_RESOLVE, key);
+    if (R.is_err[query.QueryView, fail.Fail](e_r)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](e_r)); }
+    val rr: *resolve.ResolveResult = dq.resolve_handle_decode(R.unwrap_ok[query.QueryView, fail.Fail](e_r));
     if (rr == nil) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_EXPORTS: module has no resolve result")); }
 
     var fb: dq.FpBuf;
@@ -674,7 +721,21 @@ pub fun q_exports_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.
     fb.len   = 0;
     fb.cap   = 0;
 
-    val wr: R.Result[R.Void, str] = fp_pub_surface(?fb, rr);
+    var definition_revision: query.Revision = 0;
+    var i: u32 = 0;
+    for (i < rr.public_constant_count) {
+        if (rr.public_constants[i].present && rr.public_constants[i].value.kind == comptime.CT_KIND_CONST_ELEM) {
+            val mid: session.ModuleId = session.module_id_for_stable(p.s, key::u32::session.StableModuleId);
+            if (mid == session.MODULE_NIL) { dq.fp_free(?fb); ret R.err[query.QueryOutput, fail.Fail](fail.message("constant definition is not loaded")); }
+            val observed: R.Result[query.Revision, fail.Fail] = query.revision[project.Project](?p.queries, p,
+                query.Q_PARSE, p.modules[mid::u32].file_id::u64);
+            if (R.is_err[query.Revision, fail.Fail](observed)) { dq.fp_free(?fb); ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[query.Revision, fail.Fail](observed)); }
+            definition_revision = R.unwrap_ok[query.Revision, fail.Fail](observed);
+            brk;
+        }
+        i = i + 1;
+    }
+    val wr: R.Result[R.Void, str] = dq.fp_public_surface(?fb, rr, key::u32::session.StableModuleId, definition_revision);
     if (R.is_err[R.Void, str](wr)) {
         if (fb.buf != nil && fb.cap > 0) { A.deallocate[u8](alloc, fb.buf, fb.cap::usize); }
         ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](wr)));
@@ -683,35 +744,9 @@ pub fun q_exports_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.
     ret fail.lift[query.QueryOutput](dq.fp_take(?fb));
 }
 
-fun fp_pub_surface(fb: *dq.FpBuf, rr: *resolve.ResolveResult) R.Result[R.Void, str] {
-    val pc: R.Result[R.Void, str] = dq.fp_u32(fb, rr.pub_count);
-    if (R.is_err[R.Void, str](pc)) { ret pc; }
-    if (rr.symbols == nil)       { ret R.ok_void[str](); }
-    var i: u32 = 0;
-    for (i < rr.pub_count) {
-        val sym: *resolve.Symbol = ?rr.symbols[i];
-        val rk: R.Result[R.Void, str] = dq.fp_u8(fb, sym.kind::u8);             if (R.is_err[R.Void, str](rk)) { ret rk; }
-        val rn: R.Result[R.Void, str] = dq.fp_u32(fb, sym.name::u32);          if (R.is_err[R.Void, str](rn)) { ret rn; }
-        val rdl: R.Result[R.Void, str] = dq.fp_u32(fb, sym.decl::u32);         if (R.is_err[R.Void, str](rdl)) { ret rdl; }
-        val ro: R.Result[R.Void, str] = dq.fp_u32(fb, sym.origin_stable::u32); if (R.is_err[R.Void, str](ro)) { ret ro; }
-        var slot_fp: u32 = sym.slot;
-        if (sym.kind == resolve.SYM_USE) { slot_fp = sym.slot_stable::u32; }
-        val rs: R.Result[R.Void, str] = dq.fp_u32(fb, slot_fp);                if (R.is_err[R.Void, str](rs)) { ret rs; }
-        i = i + 1;
-    }
-
-    val rl: R.Result[R.Void, str] = dq.fp_u32(fb, rr.pub_const_fp_len);
-    if (R.is_err[R.Void, str](rl)) { ret rl; }
-    var b: u32 = 0;
-    for (b < rr.pub_const_fp_len) {
-        val rb: R.Result[R.Void, str] = dq.fp_u8(fb, rr.pub_const_fp[b]);
-        if (R.is_err[R.Void, str](rb)) { ret rb; }
-        b = b + 1;
-    }
-    ret R.ok_void[str]();
-}
-
 fun walk_module_for_load(p: *project.Project, mid: session.ModuleId) R.Result[comptime.GateOutcome, str] {
+    val acquired: R.Result[R.Void, str] = acquire_load_view(p, mid, 0);
+    if (R.is_err[R.Void, str](acquired)) { ret R.err[comptime.GateOutcome, str](R.unwrap_err[R.Void, str](acquired)); }
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
     val m_opt: O.Option[*module.Module] = ast.get_module(m.a, m.a.root_module);
     if (O.is_none[*module.Module](m_opt)) { ret R.err[comptime.GateOutcome, str]("module root not set on Ast"); }
@@ -762,10 +797,31 @@ pub fun deferred_gate_count(p: *project.Project) u32 {
 }
 
 fun walk_decl_list_for_load(p: *project.Project, mid: session.ModuleId, start: u32, len: u32) R.Result[comptime.GateOutcome, str] {
+    val refreshed: R.Result[R.Void, str] = acquire_load_view(p, mid, 0);
+    if (R.is_err[R.Void, str](refreshed)) { ret R.err[comptime.GateOutcome, str](R.unwrap_err[R.Void, str](refreshed)); }
+    val a: *ast.Ast = p.modules[mid::u32].a;
+    val incarnation: u64 = a.incarnation;
+    if (start::usize > a.decl_id_len || len::usize > a.decl_id_len - start::usize) {
+        ret R.err[comptime.GateOutcome, str]("load declaration list exceeds its parsed owner");
+    }
+    var work: vector.Vector[id.DeclId] = vector.init[id.DeclId](p.alloc);
+    fin { vector.dnit[id.DeclId](?work); }
+    var wi: u32 = 0;
+    for (wi < len) {
+        val saved: R.Result[usize, str] = vector.push[id.DeclId](?work, a.decl_ids[start + wi]);
+        if (R.is_err[usize, str](saved)) { ret R.err[comptime.GateOutcome, str](R.unwrap_err[usize, str](saved)); }
+        wi = wi + 1;
+    }
+    var sequence: u64 = p.s.queries.operation_sequence;
     var deferred: bool = false;
     var i: u32 = 0;
     for (i < len) {
-        val did: id.DeclId = (?p.modules[mid::u32]).a.decl_ids[start + i];
+        if (p.s.queries.operation_sequence != sequence) {
+            val current: R.Result[R.Void, str] = acquire_load_view(p, mid, incarnation);
+            if (R.is_err[R.Void, str](current)) { ret R.err[comptime.GateOutcome, str](R.unwrap_err[R.Void, str](current)); }
+            sequence = p.s.queries.operation_sequence;
+        }
+        val did: id.DeclId = work.data[i];
         val r: R.Result[comptime.GateOutcome, str] = walk_one_decl_for_load(p, mid, did);
         if (R.is_err[comptime.GateOutcome, str](r)) { ret r; }
         val outcome: comptime.GateOutcome = R.unwrap_ok[comptime.GateOutcome, str](r);
@@ -781,7 +837,8 @@ fun walk_one_decl_for_load(p: *project.Project, mid: session.ModuleId, did: id.D
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
     val d_opt: O.Option[*decl.Decl] = ast.get_decl(m.a, did);
     if (O.is_none[*decl.Decl](d_opt)) { ret R.err[comptime.GateOutcome, str]("DeclId out of range during walk"); }
-    val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
+    var copied: decl.Decl = @O.unwrap[*decl.Decl](d_opt);
+    val d: *decl.Decl = ?copied;
 
     if (d.kind == decl.DECL_KIND_COMPTIME_IF) {
         ret walk_comptime_if_for_load(p, mid, did, ?d.data.comptime_if);
@@ -900,7 +957,7 @@ fun comptime_branch_active_load(p: *project.Project, mid: session.ModuleId, br: 
     lc.p   = p;
     lc.mid = mid;
     val caps_r: R.Result[comptime.PhaseCapabilities[LoadMemberCtx], str] =
-        comptime.loading_capabilities[LoadMemberCtx](resolve_module_member_const_load);
+        comptime.loading_capabilities[LoadMemberCtx](resolve_module_member_const_load, ?p.diags);
     if (R.is_err[comptime.PhaseCapabilities[LoadMemberCtx], str](caps_r)) {
         ret R.err[comptime.GateOutcome, str](R.unwrap_err[comptime.PhaseCapabilities[LoadMemberCtx], str](caps_r));
     }
@@ -919,7 +976,7 @@ fun comptime_branch_active_load(p: *project.Project, mid: session.ModuleId, br: 
     if (v.outcome == comptime.GATE_AWAITING_LAYOUT) {
         if (!emit_diag) { ret R.ok[comptime.GateOutcome, str](comptime.GATE_AWAITING_LAYOUT); }
         fail.reject(?m.load_status);
-        val committed_r: R.Result[bool, str] = diagnostic.gate_error(?p.s.gate_diags, ?p.s.diags, ?p.s.interner, m.file_id, v.span, v.message);
+        val committed_r: R.Result[bool, str] = diagnostic.gate_error(?p.diags, ?p.s.interner, m.file_id, v.span, v.message);
         if (R.is_err[bool, str](committed_r)) { ret R.err[comptime.GateOutcome, str](R.unwrap_err[bool, str](committed_r)); }
         ret R.ok[comptime.GateOutcome, str](comptime.GATE_FAILED);
     }
@@ -927,7 +984,7 @@ fun comptime_branch_active_load(p: *project.Project, mid: session.ModuleId, br: 
         if (emit_diag) { fail.reject(?m.load_status); }
         if (emit_diag && str_len(v.message) > 0) {
             fail.reject(?m.load_status);
-            val committed_r: R.Result[bool, str] = diagnostic.gate_error(?p.s.gate_diags, ?p.s.diags, ?p.s.interner, m.file_id, v.span, v.message);
+            val committed_r: R.Result[bool, str] = diagnostic.gate_error(?p.diags, ?p.s.interner, m.file_id, v.span, v.message);
             if (R.is_err[bool, str](committed_r)) { ret R.err[comptime.GateOutcome, str](R.unwrap_err[bool, str](committed_r)); }
         }
         ret R.ok[comptime.GateOutcome, str](comptime.GATE_REJECTED);
@@ -935,12 +992,12 @@ fun comptime_branch_active_load(p: *project.Project, mid: session.ModuleId, br: 
     if (v.outcome == comptime.GATE_FAILED) {
         if (emit_diag && v.depends != intern.STR_NIL) {
             fail.reject(?m.load_status);
-            val committed_r: R.Result[bool, str] = diagnostic.gate_error_named(?p.s.gate_diags, ?p.s.diags, ?p.s.interner, m.file_id, v.span, v.depends, v.message);
+            val committed_r: R.Result[bool, str] = diagnostic.gate_error_named(?p.diags, ?p.s.interner, m.file_id, v.span, v.depends, v.message);
             if (R.is_err[bool, str](committed_r)) { ret R.err[comptime.GateOutcome, str](R.unwrap_err[bool, str](committed_r)); }
         }
         or (emit_diag) {
             fail.reject(?m.load_status);
-            val committed_r: R.Result[bool, str] = diagnostic.gate_error(?p.s.gate_diags, ?p.s.diags, ?p.s.interner, m.file_id, v.span, v.message);
+            val committed_r: R.Result[bool, str] = diagnostic.gate_error(?p.diags, ?p.s.interner, m.file_id, v.span, v.message);
             if (R.is_err[bool, str](committed_r)) { ret R.err[comptime.GateOutcome, str](R.unwrap_err[bool, str](committed_r)); }
         }
         ret R.ok[comptime.GateOutcome, str](comptime.GATE_FAILED);
@@ -1089,9 +1146,20 @@ fun walk_comptime_if_union(p: *project.Project, mid: session.ModuleId, did: id.D
         ti = ti + 1;
     }
 
+    val incarnation: u64 = m.a.incarnation;
+    var sequence: u64 = p.s.queries.operation_sequence;
     var bi: u32 = 0;
     for (bi < n) {
         if (taken[bi]) {
+            if (p.s.queries.operation_sequence != sequence) {
+                val current: R.Result[R.Void, str] = acquire_load_view(p, mid, incarnation);
+                if (R.is_err[R.Void, str](current)) {
+                    A.deallocate[bool](p.alloc, coverage, coverage_len);
+                    A.deallocate[bool](p.alloc, taken, n::usize);
+                    ret R.err[comptime.GateOutcome, str](R.unwrap_err[R.Void, str](current));
+                }
+                sequence = p.s.queries.operation_sequence;
+            }
             val br: *decl.ComptimeBranch = ?(?p.modules[mid::u32]).a.comptime_branches[ci.branches_start + bi];
             val saved_filter: *bool = p.union_tuple_filter;
             p.union_tuple_filter = ?coverage[bi::usize * tuple_count];
@@ -1177,7 +1245,7 @@ fun walk_use_for_load(p: *project.Project, mid: session.ModuleId, du: *decl.Decl
     if (R.is_err[UseTarget, outcome.Fail](tgt_r)) {
         val error: outcome.Fail = R.unwrap_err[UseTarget, outcome.Fail](tgt_r);
         if (error.kind == outcome.FAIL_USER) {
-            val reported: R.Result[bool, str] = diagnostic.gate_error(?p.s.gate_diags, ?p.s.diags, ?p.s.interner, m.file_id, du.path, error.message);
+            val reported: R.Result[bool, str] = diagnostic.gate_error(?p.diags, ?p.s.interner, m.file_id, du.path, error.message);
             if (R.is_err[bool, str](reported)) {
                 val message: str = R.unwrap_err[bool, str](reported);
                 fail.internal(?m.load_status, message);
@@ -1189,6 +1257,14 @@ fun walk_use_for_load(p: *project.Project, mid: session.ModuleId, du: *decl.Decl
         ret R.err[R.Void, str](error.message);
     }
     val ut: UseTarget = R.unwrap_ok[UseTarget, outcome.Fail](tgt_r);
+    var bound: intern.StrId = intern.STR_NIL;
+    if (ut.binds_module) {
+        val name: R.Result[intern.StrId, str] = use_bound_name(p, source, du, ut);
+        if (R.is_err[intern.StrId, str](name)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](name)); }
+        bound = R.unwrap_ok[intern.StrId, str](name);
+    }
+    val alias: bool = du.alias.len > 0;
+    val span: token.Span = du.path;
 
     val dep_r: R.Result[session.ModuleId, str] = dfs_load(p, ut.module_fqn);
     if (R.is_err[session.ModuleId, str](dep_r)) { ret R.err[R.Void, str](R.unwrap_err[session.ModuleId, str](dep_r)); }
@@ -1199,19 +1275,11 @@ fun walk_use_for_load(p: *project.Project, mid: session.ModuleId, du: *decl.Decl
 
     if (propagate_target_gate(p, mid, dep_mid)) { ret R.ok_void[str](); }
 
-    if (ut.binds_module) {
-        val name_r: R.Result[intern.StrId, str] = use_bound_name(p, source, du, ut);
-        if (R.is_err[intern.StrId, str](name_r)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](name_r)); }
-        ret record_mod_ref(p, mid, R.unwrap_ok[intern.StrId, str](name_r), dep_mid);
-    }
-
-    if (du.alias.len > 0) {
-        ret R.ok_void[str]();
-    }
-
-    val rec_r: R.Result[R.Void, str] = record_const_import(p, mid, ut.leaf, dep_mid, du.path);
+    if (ut.binds_module) { ret record_mod_ref(p, mid, bound, dep_mid); }
+    if (alias) { ret R.ok_void[str](); }
+    val rec_r: R.Result[R.Void, str] = record_const_import(p, mid, ut.leaf, dep_mid, span);
     if (R.is_err[R.Void, str](rec_r)) { ret rec_r; }
-    ret merge_pub_consts(p, mid, dep_mid, ut.leaf, du.path);
+    ret merge_pub_consts(p, mid, dep_mid, ut.leaf, span);
 }
 
 fun record_const_import(p: *project.Project, mid: session.ModuleId, name: intern.StrId, dep_mid: session.ModuleId, span: token.Span) R.Result[R.Void, str] {
@@ -1496,7 +1564,7 @@ pub fun check_gated_const_imports(p: *project.Project) R.Result[R.Void, str] {
             if (pc.gated) {
                 val msg: str = gated_const_message(p.s, ?m.load_status, ci.name, dep.fqn);
                 fail.reject(?m.load_status);
-                val committed_r: R.Result[bool, str] = diagnostic.gate_error(?p.s.gate_diags, ?p.s.diags, ?p.s.interner, m.file_id, ci.span, msg);
+                val committed_r: R.Result[bool, str] = diagnostic.gate_error(?p.diags, ?p.s.interner, m.file_id, ci.span, msg);
                 if (R.is_err[bool, str](committed_r)) { ret R.void_of[bool, str](committed_r); }
             }
             j = j + 1;
@@ -1515,7 +1583,7 @@ fun merge_pub_consts(p: *project.Project, mid: session.ModuleId, dep_mid: sessio
     if (pc.gated && p.union) {
         val msg: str = gated_const_message(p.s, ?m.load_status, leaf, dep.fqn);
         fail.reject(?m.load_status);
-        ret R.void_of[bool, str](diagnostic.gate_error(?p.s.gate_diags, ?p.s.diags, ?p.s.interner, m.file_id, span, msg));
+        ret R.void_of[bool, str](diagnostic.gate_error(?p.diags, ?p.s.interner, m.file_id, span, msg));
     }
     ret comptime.bind(?m.ctx, leaf, pc.value);
 }
@@ -1538,7 +1606,7 @@ pub fun remerge_tuple_pub_consts(p: *project.Project, mid: session.ModuleId, ti:
         if (pc.gated && p.union) {
             val msg: str = gated_const_message(p.s, ?m.load_status, ci.name, dep.fqn);
             fail.reject(?m.load_status);
-            val committed_r: R.Result[bool, str] = diagnostic.gate_error(?p.s.gate_diags, ?p.s.diags, ?p.s.interner, m.file_id, ci.span, msg);
+            val committed_r: R.Result[bool, str] = diagnostic.gate_error(?p.diags, ?p.s.interner, m.file_id, ci.span, msg);
             if (R.is_err[bool, str](committed_r)) { ret R.err[bool, str](R.unwrap_err[bool, str](committed_r)); }
             bound = bound + 1;
             i = i + 1;
@@ -1620,7 +1688,7 @@ fun resolve_module_member_const_load(lc: *LoadMemberCtx, eid: id.ExprId) R.Resul
     if (pc.gated && lc.p.union) {
         val msg: str = gated_const_message(lc.p.s, ?m.load_status, name, dep.fqn);
         fail.reject(?m.load_status);
-        val committed_r: R.Result[bool, str] = diagnostic.gate_error(?lc.p.s.gate_diags, ?lc.p.s.diags, ?lc.p.s.interner, m.file_id, node.data.member.name, msg);
+        val committed_r: R.Result[bool, str] = diagnostic.gate_error(?lc.p.diags, ?lc.p.s.interner, m.file_id, node.data.member.name, msg);
         if (R.is_err[bool, str](committed_r)) { ret R.err[O.Option[comptime.CTValue], comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_INTERNAL, R.unwrap_err[bool, str](committed_r))); }
         ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.none[comptime.CTValue]());
     }
@@ -1640,7 +1708,7 @@ pub fun eval_for_load(
     lc.mid = mid;
     val lcp: *LoadMemberCtx = ?lc;
     val caps_r: R.Result[comptime.PhaseCapabilities[LoadMemberCtx], str] =
-        comptime.loading_capabilities[LoadMemberCtx](resolve_module_member_const_load);
+        comptime.loading_capabilities[LoadMemberCtx](resolve_module_member_const_load, ?p.diags);
     if (R.is_err[comptime.PhaseCapabilities[LoadMemberCtx], str](caps_r)) {
         var f: comptime.EvalFail;
         f.kind    = comptime.EVAL_FAIL_INTERNAL;
@@ -1851,30 +1919,87 @@ fun topo_push(p: *project.Project, mid: session.ModuleId) R.Result[R.Void, str] 
 }
 
 pub fun register_module_asts(p: *project.Project) R.Result[R.Void, str] {
+    var roots: vector.Vector[query.QueryKey] = vector.init[query.QueryKey](p.alloc);
+    fin { vector.dnit[query.QueryKey](?roots); }
     var i: u32 = 0;
     for (i < p.module_len) {
         val m: *project.ModuleEntry = ?p.modules[i];
-        val r: R.Result[R.Void, str] = session.register_module_identity(p.s, i, m.a, m.fqn, m.stable_id);
-        if (R.is_err[R.Void, str](r)) { unpublish_modules(p, i); ret r; }
-
-        var num: u32 = i::u32;
+        if (m.file_id == src.FILE_NIL) { i = i + 1; cnt; }
+        var num: u32 = i;
         val rn: R.Result[R.Void, str] = query.set_input(?p.s.queries, query.Q_MODULE_NUMBER, m.stable_id::u64, (?num)::*u8, 4);
-        if (R.is_err[R.Void, str](rn)) {
-            session.unregister_module_identity(p.s, i, m.stable_id);
-            unpublish_modules(p, i);
-            ret rn;
-        }
+        if (R.is_err[R.Void, str](rn)) { ret rn; }
+        val saved: R.Result[usize, str] = vector.push[query.QueryKey](?roots, query.QueryKey{ kind: query.Q_PARSE, key: m.file_id::u64 });
+        if (R.is_err[usize, str](saved)) { ret R.err[R.Void, str](R.unwrap_err[usize, str](saved)); }
         i = i + 1;
+    }
+    val begun: R.Result[query.Operation, outcome.Fail] = project.begin_query_phase(p);
+    if (R.is_err[query.Operation, outcome.Fail](begun)) { ret R.err[R.Void, str](R.unwrap_err[query.Operation, outcome.Fail](begun).message); }
+    val operation: query.Operation = R.unwrap_ok[query.Operation, outcome.Fail](begun);
+    var result: R.Result[R.Void, outcome.Fail] = R.ok_void[outcome.Fail]();
+    i = 0;
+    for (i < p.module_len) {
+        if (p.modules[i].file_id == src.FILE_NIL) { i = i + 1; cnt; }
+        val acquired: R.Result[R.Void, fail.Fail] = acquire_parse_view(p, i::session.ModuleId);
+        if (R.is_err[R.Void, fail.Fail](acquired)) { result = R.err[R.Void, outcome.Fail](outcome.from_fail(R.unwrap_err[R.Void, fail.Fail](acquired))); brk; }
+        val m: *project.ModuleEntry = ?p.modules[i];
+        val registered: R.Result[R.Void, str] = session.register_module_identity(p.s, i, m.a, m.fqn, m.stable_id);
+        if (R.is_err[R.Void, str](registered)) { result = R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](registered))); brk; }
+        i = i + 1;
+    }
+    val finished: R.Result[R.Void, outcome.Fail] = project.finish_query_phase(p, operation, roots.data, roots.len, result);
+    if (R.is_err[R.Void, outcome.Fail](finished)) {
+        var j: u32 = 0;
+        for (j < i) { session.unregister_module_identity(p.s, j, p.modules[j].stable_id); j = j + 1; }
+        ret R.err[R.Void, str](R.unwrap_err[R.Void, outcome.Fail](finished).message);
     }
     ret R.ok_void[str]();
 }
 
-fun unpublish_modules(p: *project.Project, published: u32) {
-    var j: u32 = 0;
-    for (j < published) {
-        val m: *project.ModuleEntry = ?p.modules[j];
-        session.unregister_module_identity(p.s, j, m.stable_id);
-        query.invalidate(?p.s.queries, query.Q_MODULE_NUMBER, m.stable_id::u64);
-        j = j + 1;
+pub fun acquire_loaded_parses(p: *project.Project) R.Result[R.Void, fail.Fail] {
+    var i: u32 = 0;
+    for (i < p.module_len) {
+        if (p.modules[i].file_id != src.FILE_NIL) {
+            val acquired: R.Result[R.Void, fail.Fail] = acquire_parse_view(p, i::session.ModuleId);
+            if (R.is_err[R.Void, fail.Fail](acquired)) { ret acquired; }
+        }
+        i = i + 1;
     }
+    ret R.ok_void[fail.Fail]();
+}
+
+pub fun collect_loaded_parses(p: *project.Project, primary: R.Result[R.Void, outcome.Fail]) R.Result[R.Void, outcome.Fail] {
+    var roots: vector.Vector[query.QueryKey] = vector.init[query.QueryKey](p.alloc);
+    fin { vector.dnit[query.QueryKey](?roots); }
+    var i: u32 = 0;
+    for (i < p.module_len) {
+        val file: src.FileId = p.modules[i].file_id;
+        if (file != src.FILE_NIL) {
+            val added: R.Result[usize, str] = vector.push[query.QueryKey](?roots, query.QueryKey{ kind: query.Q_PARSE, key: file::u64 });
+            if (R.is_err[usize, str](added)) {
+                diagnostic.note_lost(?p.s.diags);
+                if (R.is_err[R.Void, outcome.Fail](primary)) { ret primary; }
+                ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[usize, str](added)));
+            }
+        }
+        i = i + 1;
+    }
+    val begun: R.Result[query.Operation, outcome.Fail] = project.begin_query_phase(p);
+    if (R.is_err[query.Operation, outcome.Fail](begun)) {
+        if (R.is_err[R.Void, outcome.Fail](primary)) { ret primary; }
+        ret R.err[R.Void, outcome.Fail](R.unwrap_err[query.Operation, outcome.Fail](begun));
+    }
+    val operation: query.Operation = R.unwrap_ok[query.Operation, outcome.Fail](begun);
+    var result: R.Result[R.Void, outcome.Fail] = primary;
+    i = 0;
+    for (i < p.module_len) {
+        if (p.modules[i].file_id != src.FILE_NIL) {
+            val acquired: R.Result[R.Void, fail.Fail] = acquire_parse_view(p, i::session.ModuleId);
+            if (R.is_err[R.Void, fail.Fail](acquired)) {
+                if (R.is_ok[R.Void, outcome.Fail](result)) { result = R.err[R.Void, outcome.Fail](outcome.from_fail(R.unwrap_err[R.Void, fail.Fail](acquired))); }
+                brk;
+            }
+        }
+        i = i + 1;
+    }
+    ret project.finish_query_phase(p, operation, roots.data, roots.len, result);
 }

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -616,10 +616,13 @@ pub fun parsed_definition(ctx: ptr, mid: session.ModuleId) R.Result[resolve.Pars
     val file_id: src.FileId = p.modules[mid::u32].file_id;
     val acquired: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_PARSE, file_id::u64);
     if (R.is_err[query.QueryView, fail.Fail](acquired)) { ret R.err[resolve.ParsedDefinition, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](acquired)); }
-    val a: *ast.Ast = ast_handle_decode(R.unwrap_ok[query.QueryView, fail.Fail](acquired));
+    val owner: query.QueryView = R.unwrap_ok[query.QueryView, fail.Fail](acquired);
+    val a: *ast.Ast = ast_handle_decode(owner);
     if (a == nil) { ret R.err[resolve.ParsedDefinition, fail.Fail](fail.message("parsed definition query produced no AST owner")); }
+    val status: fail.PhaseStatus = (owner.value::ptr::*ParsedModule).status;
     p.modules[mid::u32].a = a;
-    ret R.ok[resolve.ParsedDefinition, fail.Fail](resolve.ParsedDefinition{ a: a, owner: resolve.type_owner(p.s, mid, file_id), incarnation: a.incarnation });
+    p.modules[mid::u32].parse_status = status;
+    ret R.ok[resolve.ParsedDefinition, fail.Fail](resolve.ParsedDefinition{ a: a, status: status, owner: resolve.type_owner(p.s, mid, file_id), incarnation: a.incarnation });
 }
 
 pub fun q_parse_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -413,6 +413,7 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) R.Result[sessio
     m.dep_cap           = 0;
     m.resolve_result    = nil;
     m.resolved          = false;
+    m.resolve_elapsed = 0;
     m.gate_result       = nil;
     m.tuple_gates       = nil;
     m.tuple_gate_count  = 0;

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -44,6 +44,7 @@ use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.ir;
+use ir_equal: mach.lang.me.ir.equal;
 use mach.lang.me.analysis.oblivious;
 use mach.lang.me.lower;
 use mach.lang.me.lower.testrunner;
@@ -1042,7 +1043,7 @@ pub fun prepare_lower_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
         if (R.is_err[R.Void, str](rls)) { ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](rls))); }
     }
     if (!query.is_registered(?p.s.queries, query.Q_LOWER)) {
-        val rl: R.Result[R.Void, str] = query.register_derived_owned(?p.s.queries, query.Q_LOWER, q_lower_finalize);
+        val rl: R.Result[R.Void, str] = query.register_derived_equatable(?p.s.queries, query.Q_LOWER, q_lower_finalize, lower_output_equal);
         if (R.is_err[R.Void, str](rl)) { ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](rl))); }
     }
 
@@ -2633,4 +2634,11 @@ test "mach.lang.driver.passes: planner environment cache input tracks values and
     if (!t_planner_environment_digest(?a, (?entries[0])::**u8, ?changed[0])) { ret 5; }
     if (!ut_digest_differs(?initial[0], ?changed[0])) { ret 6; }
     ret 0;
+}
+
+fun lower_output_equal(a: *u8, a_len: u32, b: *u8, b_len: u32) bool {
+    val left: *ir.Module = ir_handle_decode(query.QueryView{value: a, value_len: a_len});
+    val right: *ir.Module = ir_handle_decode(query.QueryView{value: b, value_len: b_len});
+    if (left == nil || right == nil) { ret false; }
+    ret ir_equal.content_equal(left, right);
 }

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -106,7 +106,6 @@ pub fun prepare_resolve_pass(p: *project.Project) R.Result[R.Void, fail.Fail] {
 }
 
 pub fun run_resolve_pass(p: *project.Project) R.Result[R.Void, fail.Fail] {
-    readout.phase_begin(p.events, readout.PH_RESOLVE);
     var i: u32 = 0;
     for (i < p.topo_len) {
         val mid: session.ModuleId = p.topo[i];
@@ -116,7 +115,6 @@ pub fun run_resolve_pass(p: *project.Project) R.Result[R.Void, fail.Fail] {
         }
         i = i + 1;
     }
-    readout.phase_end(p.events, readout.PH_RESOLVE, p.topo_len, "module", "modules");
     ret R.ok_void[fail.Fail]();
 }
 
@@ -137,7 +135,7 @@ fun run_resolve_one(p: *project.Project, mid: session.ModuleId) R.Result[R.Void,
 
     m.resolve_result = rr;
     m.resolved       = true;
-    readout.item(p.events, readout.PH_RESOLVE, project.fqn_name(p, m.fqn), t_item);
+    if (p.events != nil) { m.resolve_elapsed = m.resolve_elapsed + ctime.time_sub(ctime.monotonic(), t_item); }
     ret R.ok_void[fail.Fail]();
 }
 

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -1309,6 +1309,7 @@ pub fun q_lower_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diag
     if (R.is_err[intern.StrId, fail.Fail](main_id)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[intern.StrId, fail.Fail](main_id)); }
     val t_opt: ctime.Time = readout.span_begin(p.events);
     val optimized: R.Result[R.Void, fail.Fail] = lower_optimize(p, irmod, R.unwrap_ok[intern.StrId, fail.Fail](main_id));
+    readout.item(p.events, readout.PH_OPTIMIZE, project.fqn_name(p, irmod.name), t_opt);
     readout.span_end(p.events, readout.PH_OPTIMIZE, readout.PH_LOWER, t_opt);
     if (R.is_err[R.Void, fail.Fail](optimized)) { ret R.err[query.QueryOutput, fail.Fail](lower_stable_fail(p, R.unwrap_err[R.Void, fail.Fail](optimized))); }
     transferred = true;
@@ -1338,9 +1339,7 @@ fun lower_raw(p: *project.Project, mid: session.ModuleId, home: *ir.ModuleHome, 
 
     val res_obl: R.Result[bool, str] = oblivious.check_module(box, ?s.interner, diags, s.alloc);
     if (R.is_err[bool, str](res_obl)) { ret R.err[*ir.Module, fail.Fail](fail.message(R.unwrap_err[bool, str](res_obl))); }
-    if (!R.unwrap_ok[bool, str](res_obl)) {
-        ret R.err[*ir.Module, fail.Fail](fail.message("oblivious-required check: a function computes on a secret without `#[oblivious]`"));
-    }
+    if (!R.unwrap_ok[bool, str](res_obl)) { ret R.err[*ir.Module, fail.Fail](fail.reported()); }
     ret R.ok[*ir.Module, fail.Fail](box);
 }
 
@@ -1529,8 +1528,6 @@ fun run_lower_batch(p: *project.Project, slots: *PlwSlot, emit_len: u32) R.Resul
         val mid: session.ModuleId = slots[si].mid;
         val m:   *project.ModuleEntry = ?p.modules[mid::u32];
 
-        val t_item: ctime.Time = readout.item_begin(p.events);
-
         val prepared: R.Result[query.PreparedQuery, fail.Fail] = query.prepare[project.Project](?p.queries, p,
             query.Q_LOWER, back_half_key_for(p, m), q_lower_raw_compute);
         if (R.is_err[query.PreparedQuery, fail.Fail](prepared)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[query.PreparedQuery, fail.Fail](prepared)); }
@@ -1540,7 +1537,6 @@ fun run_lower_batch(p: *project.Project, slots: *PlwSlot, emit_len: u32) R.Resul
         if (R.is_err[query.QueryView, str](view)) { ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[query.QueryView, str](view))); }
         slots[si].m = ir_handle_decode(R.unwrap_ok[query.QueryView, str](view));
         if (slots[si].m == nil) { ret R.err[R.Void, fail.Fail](fail.message("prepared lowering has no IR owner")); }
-        readout.item(p.events, readout.PH_LOWER, project.fqn_name(p, m.fqn), t_item);
         si = si + 1;
     }
 

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -2130,27 +2130,20 @@ fun capture_surface_graph(p: *project.Project, surface: *scx.ModuleSema) R.Resul
         p.modules[surface.module::u32].ctx.env.target_defs, p, prepared_surface_recipe);
 }
 
+pub fun capture_build_config(p: *project.Project, alloc: *A.Allocator) R.Result[query.QueryOutput, str] {
+    var fb: dq.FpBuf = dq.FpBuf{ alloc: alloc };
+    fin { dq.fp_free(?fb); }
+    val written: R.Result[R.Void, str] = write_build_config(?fb, p);
+    if (R.is_err[R.Void, str](written)) { ret R.err[query.QueryOutput, str](R.unwrap_err[R.Void, str](written)); }
+    ret dq.fp_take(?fb);
+}
+
 pub fun set_build_config_input(p: *project.Project) R.Result[R.Void, str] {
-    var fb: dq.FpBuf;
-    fb.alloc = p.s.alloc;
-    fb.buf   = nil;
-    fb.len   = 0;
-    fb.cap   = 0;
-
-    val w: R.Result[R.Void, str] = write_build_config(?fb, p);
-    if (R.is_err[R.Void, str](w)) {
-        if (fb.buf != nil && fb.cap > 0) { A.deallocate[u8](p.s.alloc, fb.buf, fb.cap::usize); }
-        ret w;
-    }
-
-    val fl: R.Result[u32, str] = dq.fp_input_len(?fb);
-    if (R.is_err[u32, str](fl)) {
-        dq.fp_free(?fb);
-        ret R.err[R.Void, str](R.unwrap_err[u32, str](fl));
-    }
-    val si: R.Result[R.Void, str] = query.set_input(?p.s.queries, query.Q_TARGET, 0, fb.buf, R.unwrap_ok[u32, str](fl));
-    if (fb.buf != nil && fb.cap > 0) { A.deallocate[u8](p.s.alloc, fb.buf, fb.cap::usize); }
-    ret si;
+    val captured: R.Result[query.QueryOutput, str] = capture_build_config(p, p.s.alloc);
+    if (R.is_err[query.QueryOutput, str](captured)) { ret R.void_of[query.QueryOutput, str](captured); }
+    val bytes: query.QueryOutput = R.unwrap_ok[query.QueryOutput, str](captured);
+    fin { if (bytes.bytes != nil) { A.deallocate[u8](p.s.alloc, bytes.bytes, bytes.len::usize); } }
+    ret query.set_input(?p.s.queries, query.Q_TARGET, 0, bytes.bytes, bytes.len);
 }
 
 fun write_build_config(fb: *dq.FpBuf, p: *project.Project) R.Result[R.Void, str] {

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -1,4 +1,5 @@
 use std.crypto.hash.sha256;
+use std.collections.vector;
 use std.encoding.binary;
 use std.allocator.page;
 use std.types.bool.bool;
@@ -37,6 +38,8 @@ use mach.lang.fe.ast.stmt;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.sema;
+use scx: mach.lang.fe.sema.context;
+use mach.lang.fe.sema.fields;
 use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.manifest;
@@ -62,7 +65,29 @@ use dq: mach.lang.driver.query;
 use mach.lang.driver.load;
 use mach.lang.fail;
 
-pub fun run_resolve_pass(p: *project.Project) R.Result[R.Void, fail.Fail] {
+pub fun read_definition(raw: ptr, mid: session.ModuleId, phase: scx.DefinitionPhase) R.Result[scx.Definition, fail.Fail] {
+    val p: *project.Project = raw::*project.Project;
+    val parsed: R.Result[resolve.ParsedDefinition, fail.Fail] = load.parsed_definition(raw, mid);
+    if (R.is_err[resolve.ParsedDefinition, fail.Fail](parsed)) { ret R.err[scx.Definition, fail.Fail](R.unwrap_err[resolve.ParsedDefinition, fail.Fail](parsed)); }
+    var result: scx.Definition = scx.Definition{ parsed: R.unwrap_ok[resolve.ParsedDefinition, fail.Fail](parsed), origin: mid };
+    if (phase >= scx.DEFINITION_RESOLVED) {
+        val acquired: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_RESOLVE, p.modules[mid::u32].stable_id::u64);
+        if (R.is_err[query.QueryView, fail.Fail](acquired)) { ret R.err[scx.Definition, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](acquired)); }
+        result.rr = dq.resolve_handle_decode(R.unwrap_ok[query.QueryView, fail.Fail](acquired));
+        if (result.rr == nil) { ret R.err[scx.Definition, fail.Fail](fail.message("current definition has no resolved query owner")); }
+        resolve.remap_result(result.rr, p.s);
+        p.modules[mid::u32].resolve_result = result.rr;
+    }
+    if (phase == scx.DEFINITION_TYPED) {
+        val acquired: R.Result[*sema.SemaResult, fail.Fail] = acquire_sema(p, mid);
+        if (R.is_err[*sema.SemaResult, fail.Fail](acquired)) { ret R.err[scx.Definition, fail.Fail](R.unwrap_err[*sema.SemaResult, fail.Fail](acquired)); }
+        result.sr = R.unwrap_ok[*sema.SemaResult, fail.Fail](acquired);
+        result.ctx = ?p.modules[mid::u32].ctx;
+    }
+    ret R.ok[scx.Definition, fail.Fail](result);
+}
+
+pub fun prepare_resolve_pass(p: *project.Project) R.Result[R.Void, fail.Fail] {
     if (!query.is_registered(?p.s.queries, query.Q_RESOLVE)) {
         val rr: R.Result[R.Void, str] = query.register_derived_owned(?p.s.queries, query.Q_RESOLVE, q_resolve_finalize);
         if (R.is_err[R.Void, str](rr)) { ret fail.lift[R.Void](rr); }
@@ -77,6 +102,10 @@ pub fun run_resolve_pass(p: *project.Project) R.Result[R.Void, fail.Fail] {
     val tf: R.Result[R.Void, str] = query.set_input(?p.s.queries, query.Q_GATE_TERMINAL, 0, ?tflag, 1);
     if (R.is_err[R.Void, str](tf)) { ret fail.lift[R.Void](tf); }
 
+    ret R.ok_void[fail.Fail]();
+}
+
+pub fun run_resolve_pass(p: *project.Project) R.Result[R.Void, fail.Fail] {
     readout.phase_begin(p.events, readout.PH_RESOLVE);
     var i: u32 = 0;
     for (i < p.topo_len) {
@@ -96,13 +125,13 @@ fun run_resolve_one(p: *project.Project, mid: session.ModuleId) R.Result[R.Void,
 
     val t_item: ctime.Time = readout.item_begin(p.events);
 
-    val e_r: R.Result[*query.QueryEntry, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_RESOLVE, m.stable_id::u64);
-    if (R.is_err[*query.QueryEntry, fail.Fail](e_r)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[*query.QueryEntry, fail.Fail](e_r)); }
-    val rr: *resolve.ResolveResult = dq.resolve_handle_decode(R.unwrap_ok[*query.QueryEntry, fail.Fail](e_r));
+    val e_r: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_RESOLVE, m.stable_id::u64);
+    if (R.is_err[query.QueryView, fail.Fail](e_r)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](e_r)); }
+    val rr: *resolve.ResolveResult = dq.resolve_handle_decode(R.unwrap_ok[query.QueryView, fail.Fail](e_r));
     if (rr == nil) { ret R.err[R.Void, fail.Fail](fail.message("Q_RESOLVE produced no result handle")); }
 
-    val ex_r: R.Result[*query.QueryEntry, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_EXPORTS, m.stable_id::u64);
-    if (R.is_err[*query.QueryEntry, fail.Fail](ex_r)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[*query.QueryEntry, fail.Fail](ex_r)); }
+    val ex_r: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_EXPORTS, m.stable_id::u64);
+    if (R.is_err[query.QueryView, fail.Fail](ex_r)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](ex_r)); }
 
     resolve.remap_result(rr, p.s);
 
@@ -112,7 +141,7 @@ fun run_resolve_one(p: *project.Project, mid: session.ModuleId) R.Result[R.Void,
     ret R.ok_void[fail.Fail]();
 }
 
-pub fun q_resolve_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, fail.Fail] {
+pub fun q_resolve_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
     val db: *query.QueryDb = ?p.s.queries;
     val s: *session.Session = p.s;
 
@@ -120,15 +149,13 @@ pub fun q_resolve_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.
     val mid: session.ModuleId = session.module_id_for_stable(s, stable);
     if (mid == session.MODULE_NIL) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_RESOLVE: stable id not loaded this build")); }
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
-    val a: *ast.Ast = m.a;
-    if (a == nil) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_RESOLVE: module has no parsed AST")); }
-
-    val rp: R.Result[R.Void, str] = query.record_dep(db, query.Q_RESOLVE, key, query.Q_PARSE, a.file_id::u64);
-    if (R.is_err[R.Void, str](rp)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rp))); }
-    val rt: R.Result[R.Void, str] = query.record_dep(db, query.Q_RESOLVE, key, query.Q_TARGET, 0);
-    if (R.is_err[R.Void, str](rt)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rt))); }
-    val rgt: R.Result[R.Void, str] = query.record_dep(db, query.Q_RESOLVE, key, query.Q_GATE_TERMINAL, 0);
-    if (R.is_err[R.Void, str](rgt)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rgt))); }
+    val parsed: R.Result[resolve.ParsedDefinition, fail.Fail] = load.parsed_definition(p::ptr, mid);
+    if (R.is_err[resolve.ParsedDefinition, fail.Fail](parsed)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[resolve.ParsedDefinition, fail.Fail](parsed)); }
+    val a: *ast.Ast = R.unwrap_ok[resolve.ParsedDefinition, fail.Fail](parsed).a;
+    val rt: R.Result[R.Void, fail.Fail] = query.depend[project.Project](?p.queries, p, query.Q_TARGET, 0);
+    if (R.is_err[R.Void, fail.Fail](rt)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rt)); }
+    val rgt: R.Result[R.Void, fail.Fail] = query.depend[project.Project](?p.queries, p, query.Q_GATE_TERMINAL, 0);
+    if (R.is_err[R.Void, fail.Fail](rgt)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rgt)); }
 
     val deps_r: R.Result[resolve.ResolveDeps, str] = build_resolve_deps_owned(p, m);
     if (R.is_err[resolve.ResolveDeps, str](deps_r)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[resolve.ResolveDeps, str](deps_r))); }
@@ -139,16 +166,16 @@ pub fun q_resolve_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.
         val dep_mid: session.ModuleId = deps.entries[di].module;
         if (dep_mid::u32 < p.module_len) {
             val dep_stable: session.StableModuleId = p.modules[dep_mid::u32].stable_id;
-            val ge: R.Result[*query.QueryEntry, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_EXPORTS, dep_stable::u64);
-            if (R.is_err[*query.QueryEntry, fail.Fail](ge)) {
+            val ge: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_EXPORTS, dep_stable::u64);
+            if (R.is_err[query.QueryView, fail.Fail](ge)) {
                 free_resolve_deps(s.alloc, ?deps);
-                ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[*query.QueryEntry, fail.Fail](ge));
+                ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](ge));
             }
         }
         di = di + 1;
     }
 
-    val rr_r: R.Result[resolve.ResolveResult, fail.Fail] = resolve.resolve(s, a, ?deps, ?m.ctx, mid, p.gate_terminal);
+    val rr_r: R.Result[resolve.ResolveResult, fail.Fail] = resolve.resolve(s, a, ?deps, ?m.ctx, mid, p.gate_terminal, diags);
     free_resolve_deps(s.alloc, ?deps);
     if (R.is_err[resolve.ResolveResult, fail.Fail](rr_r)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[resolve.ResolveResult, fail.Fail](rr_r)); }
     var result: resolve.ResolveResult = R.unwrap_ok[resolve.ResolveResult, fail.Fail](rr_r);
@@ -198,7 +225,7 @@ fun resolve_list_contains(list: *session.ModuleId, list_len: u32, id: session.Mo
     ret false;
 }
 
-pub fun run_sema_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
+pub fun prepare_sema_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
     if (!query.is_registered(?p.s.queries, query.Q_SEMA)) {
         val rsm: R.Result[R.Void, str] = query.register_derived_owned(?p.s.queries, query.Q_SEMA, q_sema_finalize);
         if (R.is_err[R.Void, str](rsm)) { ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](rsm))); }
@@ -208,8 +235,10 @@ pub fun run_sema_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
         if (R.is_err[R.Void, str](rte)) { ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](rte))); }
     }
 
-    type.field_epoch_bump(?p.s.types);
+    ret R.ok_void[outcome.Fail]();
+}
 
+pub fun run_sema_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
     readout.phase_begin(p.events, readout.PH_SEMA);
     var i: u32 = 0;
     for (i < p.topo_len) {
@@ -225,21 +254,36 @@ pub fun run_sema_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
     ret R.ok_void[outcome.Fail]();
 }
 
+pub fun acquire_sema(p: *project.Project, mid: session.ModuleId) R.Result[*sema.SemaResult, fail.Fail] {
+    if (mid == session.MODULE_NIL || mid::u32 >= p.module_len) {
+        ret R.err[*sema.SemaResult, fail.Fail](fail.message("semantic definition module is not in the active project"));
+    }
+    val stable: session.StableModuleId = p.modules[mid::u32].stable_id;
+    val acquired: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_SEMA, stable::u64);
+    if (R.is_err[query.QueryView, fail.Fail](acquired)) { ret R.err[*sema.SemaResult, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](acquired)); }
+    val result: *sema.SemaResult = sema_handle_decode(R.unwrap_ok[query.QueryView, fail.Fail](acquired));
+    if (result == nil) { ret R.err[*sema.SemaResult, fail.Fail](fail.message("semantic query produced no result owner")); }
+    val installed: R.Result[R.Void, str] = fields.install(p.s, ?result.field_graph);
+    if (R.is_err[R.Void, str](installed)) { ret R.err[*sema.SemaResult, fail.Fail](fail.message(R.unwrap_err[R.Void, str](installed))); }
+    p.modules[mid::u32].sema_result = result;
+    ret R.ok[*sema.SemaResult, fail.Fail](result);
+}
+
 fun run_sema_one(p: *project.Project, mid: session.ModuleId) R.Result[R.Void, fail.Fail] {
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
 
     val t_item: ctime.Time = readout.item_begin(p.events);
 
-    val e_r: R.Result[*query.QueryEntry, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_SEMA, m.stable_id::u64);
-    if (R.is_err[*query.QueryEntry, fail.Fail](e_r)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[*query.QueryEntry, fail.Fail](e_r)); }
-    val sr: *sema.SemaResult = sema_handle_decode(R.unwrap_ok[*query.QueryEntry, fail.Fail](e_r));
-    if (sr == nil) { ret R.err[R.Void, fail.Fail](fail.message("Q_SEMA produced no result handle")); }
+    val acquired: R.Result[scx.Definition, fail.Fail] = read_definition(p::ptr, mid, scx.DEFINITION_TYPED);
+    if (R.is_err[scx.Definition, fail.Fail](acquired)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[scx.Definition, fail.Fail](acquired)); }
+    val current: scx.Definition = R.unwrap_ok[scx.Definition, fail.Fail](acquired);
+    val sr: *sema.SemaResult = current.sr;
 
-    val tx_r: R.Result[*query.QueryEntry, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_TYPED_EXPORTS, m.stable_id::u64);
-    if (R.is_err[*query.QueryEntry, fail.Fail](tx_r)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[*query.QueryEntry, fail.Fail](tx_r)); }
+    val tx_r: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_TYPED_EXPORTS, m.stable_id::u64);
+    if (R.is_err[query.QueryView, fail.Fail](tx_r)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](tx_r)); }
 
     val rp: R.Result[R.Void, str] = session.register_module_phase(p.s, mid, sr::ptr,
-        m.resolve_result::ptr, (?m.ctx)::ptr);
+        current.rr::ptr, current.ctx::ptr);
     if (R.is_err[R.Void, str](rp)) { ret fail.lift[R.Void](rp); }
 
     m.sema_result = sr;
@@ -247,7 +291,7 @@ fun run_sema_one(p: *project.Project, mid: session.ModuleId) R.Result[R.Void, fa
     ret R.ok_void[fail.Fail]();
 }
 
-pub fun q_sema_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, fail.Fail] {
+pub fun q_sema_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
     val db: *query.QueryDb = ?p.s.queries;
     val s: *session.Session = p.s;
 
@@ -255,52 +299,34 @@ pub fun q_sema_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.Res
     val mid: session.ModuleId = session.module_id_for_stable(s, stable);
     if (mid == session.MODULE_NIL) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_SEMA: stable id not loaded this build")); }
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
-    val a: *ast.Ast = m.a;
-    if (a == nil) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_SEMA: module has no parsed AST")); }
-    val rr: *resolve.ResolveResult = m.resolve_result;
-    if (rr == nil) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_SEMA: module has no resolve result")); }
+    val parsed: R.Result[resolve.ParsedDefinition, fail.Fail] = load.parsed_definition(p::ptr, mid);
+    if (R.is_err[resolve.ParsedDefinition, fail.Fail](parsed)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[resolve.ParsedDefinition, fail.Fail](parsed)); }
+    val a: *ast.Ast = R.unwrap_ok[resolve.ParsedDefinition, fail.Fail](parsed).a;
+    val resolved: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_RESOLVE, key);
+    if (R.is_err[query.QueryView, fail.Fail](resolved)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](resolved)); }
+    val rr: *resolve.ResolveResult = dq.resolve_handle_decode(R.unwrap_ok[query.QueryView, fail.Fail](resolved));
+    if (rr == nil) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_SEMA: acquired query has no resolve result")); }
+    m.resolve_result = rr;
+    val rt: R.Result[R.Void, fail.Fail] = query.depend[project.Project](?p.queries, p, query.Q_TARGET, 0);
+    if (R.is_err[R.Void, fail.Fail](rt)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rt)); }
+    val rn: R.Result[R.Void, fail.Fail] = query.depend[project.Project](?p.queries, p, query.Q_MODULE_NUMBER, key);
+    if (R.is_err[R.Void, fail.Fail](rn)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rn)); }
 
-    val rrd: R.Result[R.Void, str] = query.record_dep(db, query.Q_SEMA, key, query.Q_RESOLVE, key);
-    if (R.is_err[R.Void, str](rrd)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rrd))); }
-    val rt: R.Result[R.Void, str] = query.record_dep(db, query.Q_SEMA, key, query.Q_TARGET, 0);
-    if (R.is_err[R.Void, str](rt)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rt))); }
-    val rn: R.Result[R.Void, str] = query.record_dep(db, query.Q_SEMA, key, query.Q_MODULE_NUMBER, key);
-    if (R.is_err[R.Void, str](rn)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rn))); }
+    val sdeps_r: R.Result[sema.SemaDeps, fail.Fail] = build_sema_deps_query(p, m);
+    if (R.is_err[sema.SemaDeps, fail.Fail](sdeps_r)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[sema.SemaDeps, fail.Fail](sdeps_r)); }
+    var sdeps: sema.SemaDeps = R.unwrap_ok[sema.SemaDeps, fail.Fail](sdeps_r);
 
-    val deps_r: R.Result[resolve.ResolveDeps, str] = build_resolve_deps_owned(p, m);
-    if (R.is_err[resolve.ResolveDeps, str](deps_r)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[resolve.ResolveDeps, str](deps_r))); }
-    var deps: resolve.ResolveDeps = R.unwrap_ok[resolve.ResolveDeps, str](deps_r);
-    var di: u32 = 0;
-    for (di < deps.count) {
-        val dep_mid: session.ModuleId = deps.entries[di].module;
-        if (dep_mid::u32 < p.module_len) {
-            val dep_stable: session.StableModuleId = p.modules[dep_mid::u32].stable_id;
-            val ge: R.Result[*query.QueryEntry, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_TYPED_EXPORTS, dep_stable::u64);
-            if (R.is_err[*query.QueryEntry, fail.Fail](ge)) {
-                free_resolve_deps(s.alloc, ?deps);
-                ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[*query.QueryEntry, fail.Fail](ge));
-            }
-        }
-        di = di + 1;
-    }
-    free_resolve_deps(s.alloc, ?deps);
-
-    val sdeps_r: R.Result[sema.SemaDeps, str] = build_sema_deps_query(p);
-    if (R.is_err[sema.SemaDeps, str](sdeps_r)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[sema.SemaDeps, str](sdeps_r))); }
-    var sdeps: sema.SemaDeps = R.unwrap_ok[sema.SemaDeps, str](sdeps_r);
-
-    val sem_r: R.Result[sema.SemaResult, fail.Fail] = sema.sema(s, a, rr, ?sdeps, ?m.ctx, mid);
+    val sem_r: R.Result[sema.SemaResult, fail.Fail] = sema.sema(s, a, rr, ?sdeps, ?m.ctx, mid, diags);
     free_sema_deps_query(s.alloc, ?sdeps);
     if (R.is_err[sema.SemaResult, fail.Fail](sem_r)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[sema.SemaResult, fail.Fail](sem_r)); }
     var result: sema.SemaResult = R.unwrap_ok[sema.SemaResult, fail.Fail](sem_r);
 
     var ei: u32 = 0;
     for (ei < result.embed_path_count) {
-        val re: R.Result[R.Void, str] = query.record_dep(db, query.Q_SEMA, key,
-                                                       query.Q_EMBED_FILE, result.embed_paths[ei]::u64);
-        if (R.is_err[R.Void, str](re)) {
+        val re: R.Result[R.Void, fail.Fail] = query.depend[project.Project](?p.queries, p, query.Q_EMBED_FILE, result.embed_paths[ei]::u64);
+        if (R.is_err[R.Void, fail.Fail](re)) {
             sema.dnit_result(?result);
-            ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](re)));
+            ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](re));
         }
         ei = ei + 1;
     }
@@ -341,56 +367,67 @@ fun sema_handle_encode(alloc: *A.Allocator, r: *sema.SemaResult) R.Result[query.
     ret R.ok[query.QueryOutput, fail.Fail](out);
 }
 
-fun sema_handle_decode(e: *query.QueryEntry) *sema.SemaResult {
+fun sema_handle_decode(e: query.QueryView) *sema.SemaResult {
     if (e.value == nil || e.value_len::usize < $size_of(ptr)) { ret nil; }
     val slot: *ptr = e.value::ptr::*ptr;
     ret slot[0]::*sema.SemaResult;
 }
 
-fun build_sema_deps_query(p: *project.Project) R.Result[sema.SemaDeps, str] {
-    var deps: sema.SemaDeps;
-    deps.entries = nil;
-    deps.count   = 0;
-
-    var ready_count: u32 = 0;
-    var j: u32 = 0;
-    for (j < p.module_len) {
-        if (p.modules[j].sema_result != nil) { ready_count = ready_count + 1; }
-        j = j + 1;
-    }
-    if (ready_count == 0) { ret R.ok[sema.SemaDeps, str](deps); }
-
-    val r: R.Result[*sema.ModuleSema, str] = A.allocate[sema.ModuleSema](p.s.alloc, ready_count::usize);
-    if (R.is_err[*sema.ModuleSema, str](r)) { ret R.err[sema.SemaDeps, str](R.unwrap_err[*sema.ModuleSema, str](r)); }
-    val arr: *sema.ModuleSema = R.unwrap_ok[*sema.ModuleSema, str](r);
-
-    var i: u32 = 0;
-    var k: u32 = 0;
-    for (i < p.module_len) {
-        val sr: *sema.SemaResult = p.modules[i].sema_result;
-        if (sr != nil) {
-            var ms: sema.ModuleSema;
-            ms.path       = p.modules[i].fqn;
-            ms.module     = i::session.ModuleId;
-            ms.decl_type  = sr.decl_type;
-            ms.decl_count = sr.decl_count;
-            ms.ctx        = ?p.modules[i].ctx;
-            arr[k] = ms;
-            k = k + 1;
+fun build_sema_deps_query(p: *project.Project, m: *project.ModuleEntry) R.Result[sema.SemaDeps, fail.Fail] {
+    var deps: sema.SemaDeps = sema.SemaDeps{};
+    deps.definitions = scx.DefinitionReader{ ctx: p::ptr, read: read_definition };
+    val closure: R.Result[LowerClosure, str] = collect_lower_closure(p, m);
+    if (R.is_err[LowerClosure, str](closure)) { ret R.err[sema.SemaDeps, fail.Fail](fail.message(R.unwrap_err[LowerClosure, str](closure))); }
+    var imports: LowerClosure = R.unwrap_ok[LowerClosure, str](closure);
+    fin { free_lower_closure(p.s.alloc, ?imports); }
+    if (imports.count == 0) { ret R.ok[sema.SemaDeps, fail.Fail](deps); }
+    val allocated: R.Result[*sema.ModuleSema, str] = A.allocate[sema.ModuleSema](p.s.alloc, imports.count::usize);
+    if (R.is_err[*sema.ModuleSema, str](allocated)) { ret R.err[sema.SemaDeps, fail.Fail](fail.message(R.unwrap_err[*sema.ModuleSema, str](allocated))); }
+    deps.entries = R.unwrap_ok[*sema.ModuleSema, str](allocated);
+    deps.count = imports.count;
+    var initialized: u32 = 0;
+    var transferred: bool = false;
+    fin {
+        if (!transferred) {
+            var i: u32 = 0;
+            for (i < initialized) { scx.module_sema_dnit(?deps.entries[i]); i = i + 1; }
+            A.deallocate[sema.ModuleSema](p.s.alloc, deps.entries, deps.count::usize);
         }
-        i = i + 1;
     }
-
-    deps.entries = arr;
-    deps.count   = ready_count;
-    ret R.ok[sema.SemaDeps, str](deps);
+    for (initialized < imports.count) {
+        val mid: session.ModuleId = imports.list[initialized];
+        val captured: R.Result[scx.ModuleSema, fail.Fail] = read_typed_surface(p, mid, p.s.alloc);
+        if (R.is_err[scx.ModuleSema, fail.Fail](captured)) { ret R.err[sema.SemaDeps, fail.Fail](R.unwrap_err[scx.ModuleSema, fail.Fail](captured)); }
+        deps.entries[initialized] = R.unwrap_ok[scx.ModuleSema, fail.Fail](captured);
+        initialized = initialized + 1;
+    }
+    transferred = true;
+    ret R.ok[sema.SemaDeps, fail.Fail](deps);
 }
 
 fun free_sema_deps_query(alloc: *A.Allocator, deps: *sema.SemaDeps) {
-    if (deps.entries == nil) { ret; }
-    A.deallocate[sema.ModuleSema](alloc, deps.entries, deps.count::usize);
+    var i: u32 = 0;
+    for (i < deps.count) { scx.module_sema_dnit(?deps.entries[i]); i = i + 1; }
+    if (deps.entries != nil) { A.deallocate[sema.ModuleSema](alloc, deps.entries, deps.count::usize); }
     deps.entries = nil;
-    deps.count   = 0;
+    deps.count = 0;
+}
+
+pub fun read_typed_surface(p: *project.Project, mid: session.ModuleId, a: *A.Allocator) R.Result[scx.ModuleSema, fail.Fail] {
+    if (mid == session.MODULE_NIL || mid::u32 >= p.module_len) { ret R.err[scx.ModuleSema, fail.Fail](fail.message("typed surface module is not loaded")); }
+    val acquired: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p,
+        query.Q_TYPED_EXPORTS, p.modules[mid::u32].stable_id::u64);
+    if (R.is_err[query.QueryView, fail.Fail](acquired)) { ret R.err[scx.ModuleSema, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](acquired)); }
+    val view: query.QueryView = R.unwrap_ok[query.QueryView, fail.Fail](acquired);
+    val decoded: R.Result[scx.ModuleSema, str] = dq.typed_surface_decode(a, view.value, view.value_len, p.modules[mid::u32].fqn, mid);
+    if (R.is_err[scx.ModuleSema, str](decoded)) { ret fail.lift[scx.ModuleSema](decoded); }
+    var owned: scx.ModuleSema = R.unwrap_ok[scx.ModuleSema, str](decoded);
+    val installed: R.Result[R.Void, str] = fields.install(p.s, ?owned.graph);
+    if (R.is_err[R.Void, str](installed)) {
+        scx.module_sema_dnit(?owned);
+        ret R.err[scx.ModuleSema, fail.Fail](fail.message(R.unwrap_err[R.Void, str](installed)));
+    }
+    ret R.ok[scx.ModuleSema, fail.Fail](owned);
 }
 
 pub fun decided_gate_count(p: *project.Project) u32 {
@@ -428,7 +465,7 @@ pub fun run_gate_pass(p: *project.Project) R.Result[bool, str] {
             if (m.ctx.gate_states[gi] != comptime.GATE_STATE_UNKNOWN) { before = before + 1; }
             gi = gi + 1;
         }
-        val gr: R.Result[sema.SemaResult, fail.Fail] = sema.resolve_gates(p.s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
+        val gr: R.Result[sema.SemaResult, fail.Fail] = sema.resolve_gates(p.s, m.a, m.resolve_result, ?deps, ?m.ctx, mid, ?p.diags);
         free_sema_deps_query(p.s.alloc, ?deps);
         if (R.is_err[sema.SemaResult, fail.Fail](gr)) {
             ret R.err[bool, str](R.unwrap_err[sema.SemaResult, fail.Fail](gr).message);
@@ -664,21 +701,21 @@ fun run_one_union_tuple(p: *project.Project, ti: u32) R.Result[bool, str] {
             }
             ug = ug + 1;
         }
-        val diag_mark: diagnostic.DiagMark = diagnostic.mark(?p.s.diags);
+        val diag_mark: diagnostic.DiagMark = diagnostic.mark(?p.diags);
         val deps_r: R.Result[resolve.ResolveDeps, str] = build_resolve_deps_owned(p, m);
         if (R.is_err[resolve.ResolveDeps, str](deps_r)) {
             leave_union_tuple(p, ti);
             ret R.err[bool, str](R.unwrap_err[resolve.ResolveDeps, str](deps_r));
         }
         var deps: resolve.ResolveDeps = R.unwrap_ok[resolve.ResolveDeps, str](deps_r);
-        val rr: R.Result[resolve.ResolveResult, fail.Fail] = resolve.resolve(p.s, m.a, ?deps, ?m.ctx, mid, false);
+        val rr: R.Result[resolve.ResolveResult, fail.Fail] = resolve.resolve(p.s, m.a, ?deps, ?m.ctx, mid, false, ?p.diags);
         free_resolve_deps(p.s.alloc, ?deps);
         if (R.is_err[resolve.ResolveResult, fail.Fail](rr)) {
             leave_union_tuple(p, ti);
             ret R.err[bool, str](R.unwrap_err[resolve.ResolveResult, fail.Fail](rr).message);
         }
         if (unresolved_before > 0) {
-            val tr: R.Result[R.Void, str] = diagnostic.truncate(?p.s.diags, diag_mark);
+            val tr: R.Result[R.Void, str] = diagnostic.truncate(?p.diags, diag_mark);
             if (R.is_err[R.Void, str](tr)) {
                 leave_union_tuple(p, ti);
                 ret R.err[bool, str](R.unwrap_err[R.Void, str](tr));
@@ -710,7 +747,7 @@ fun run_one_union_tuple(p: *project.Project, ti: u32) R.Result[bool, str] {
             if (m.ctx.gate_states[gi] != comptime.GATE_STATE_UNKNOWN) { before = before + 1; }
             gi = gi + 1;
         }
-        val sr: R.Result[sema.SemaResult, fail.Fail] = sema.resolve_gates(p.s, m.a, m.resolve_result, ?sema_deps, ?m.ctx, mid);
+        val sr: R.Result[sema.SemaResult, fail.Fail] = sema.resolve_gates(p.s, m.a, m.resolve_result, ?sema_deps, ?m.ctx, mid, ?p.diags);
         free_sema_deps_query(p.s.alloc, ?sema_deps);
         if (R.is_err[sema.SemaResult, fail.Fail](sr)) {
             leave_union_tuple(p, ti);
@@ -756,6 +793,7 @@ fun run_union_gate_pass(p: *project.Project) R.Result[bool, str] {
 
 fun build_gate_deps(p: *project.Project, m: *project.ModuleEntry) R.Result[sema.SemaDeps, str] {
     var deps: sema.SemaDeps;
+    deps.definitions = scx.DefinitionReader{ ctx: p::ptr, read: read_definition };
     deps.entries = nil;
     deps.count = 0;
     val rr: R.Result[resolve.ResolveDeps, str] = build_resolve_deps_owned(p, m);
@@ -804,11 +842,16 @@ fun build_gate_deps(p: *project.Project, m: *project.ModuleEntry) R.Result[sema.
             i = i + 1;
             cnt;
         }
-        entries[w].path = p.modules[mid::u32].fqn;
-        entries[w].module = mid;
-        entries[w].decl_type = result.decl_type;
-        entries[w].decl_count = result.decl_count;
-        entries[w].ctx = ?p.modules[mid::u32].ctx;
+        val captured: R.Result[scx.ModuleSema, fail.Fail] = build_type_surface(p, mid,
+            p.modules[mid::u32].resolve_result, result, true, p.s.alloc);
+        if (R.is_err[scx.ModuleSema, fail.Fail](captured)) {
+            var j: u32 = 0;
+            for (j < w) { scx.module_sema_dnit(?entries[j]); j = j + 1; }
+            A.deallocate[sema.ModuleSema](p.s.alloc, entries, dep_count::usize);
+            free_resolve_deps(p.s.alloc, ?resolve_deps);
+            ret R.err[sema.SemaDeps, str](R.unwrap_err[scx.ModuleSema, fail.Fail](captured).message);
+        }
+        entries[w] = R.unwrap_ok[scx.ModuleSema, fail.Fail](captured);
         w = w + 1;
         i = i + 1;
     }
@@ -847,20 +890,22 @@ pub fun invalidate_resolve_pass(p: *project.Project) R.Result[R.Void, str] {
     ret R.ok_void[str]();
 }
 
-pub fun q_typed_exports_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, fail.Fail] {
+pub fun q_typed_exports_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
     val s: *session.Session = p.s;
 
     val stable: session.StableModuleId = key::u32::session.StableModuleId;
     val mid: session.ModuleId = session.module_id_for_stable(s, stable);
     if (mid == session.MODULE_NIL) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_TYPED_EXPORTS: stable id not loaded this build")); }
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
-    val rr: *resolve.ResolveResult = m.resolve_result;
-    if (rr == nil) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_TYPED_EXPORTS: module has no resolve result")); }
-
-    val e_r: R.Result[*query.QueryEntry, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_SEMA, key);
-    if (R.is_err[*query.QueryEntry, fail.Fail](e_r)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[*query.QueryEntry, fail.Fail](e_r)); }
-    val sr: *sema.SemaResult = sema_handle_decode(R.unwrap_ok[*query.QueryEntry, fail.Fail](e_r));
-    if (sr == nil) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_TYPED_EXPORTS: module has no sema result")); }
+    val acquired: R.Result[*sema.SemaResult, fail.Fail] = acquire_sema(p, mid);
+    if (R.is_err[*sema.SemaResult, fail.Fail](acquired)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[*sema.SemaResult, fail.Fail](acquired)); }
+    val sr: *sema.SemaResult = R.unwrap_ok[*sema.SemaResult, fail.Fail](acquired);
+    val resolved: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_RESOLVE, key);
+    if (R.is_err[query.QueryView, fail.Fail](resolved)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](resolved)); }
+    val rr: *resolve.ResolveResult = dq.resolve_handle_decode(R.unwrap_ok[query.QueryView, fail.Fail](resolved));
+    if (rr == nil) { ret R.err[query.QueryOutput, fail.Fail](fail.message("typed surface has no acquired resolved owner")); }
+    if (rr.status.kind != fail.ACCEPTED) { ret R.err[query.QueryOutput, fail.Fail](fail.phase_failure(rr.status)); }
+    if (sr.status.kind != fail.ACCEPTED) { ret R.err[query.QueryOutput, fail.Fail](fail.phase_failure(sr.status)); }
 
     var fb: dq.FpBuf;
     fb.alloc = alloc;
@@ -868,7 +913,14 @@ pub fun q_typed_exports_compute(p: *project.Project, key: u64, alloc: *A.Allocat
     fb.len   = 0;
     fb.cap   = 0;
 
-    val wr: R.Result[R.Void, str] = fp_typed_surface(?fb, s, mid, rr, sr);
+    val captured: R.Result[scx.ModuleSema, fail.Fail] = build_type_surface(p, mid, rr, sr, false, alloc);
+    if (R.is_err[scx.ModuleSema, fail.Fail](captured)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[scx.ModuleSema, fail.Fail](captured)); }
+    var surface: scx.ModuleSema = R.unwrap_ok[scx.ModuleSema, fail.Fail](captured);
+    fin { scx.module_sema_dnit(?surface); }
+    val graph: R.Result[fields.Graph, fail.Fail] = capture_surface_graph(p, ?surface);
+    if (R.is_err[fields.Graph, fail.Fail](graph)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[fields.Graph, fail.Fail](graph)); }
+    surface.graph = R.unwrap_ok[fields.Graph, fail.Fail](graph);
+    val wr: R.Result[R.Void, str] = dq.typed_surface_encode(?fb, ?surface);
     if (R.is_err[R.Void, str](wr)) {
         if (fb.buf != nil && fb.cap > 0) { A.deallocate[u8](alloc, fb.buf, fb.cap::usize); }
         ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](wr)));
@@ -899,9 +951,9 @@ pub fun back_half_key_for(p: *project.Project, m: *project.ModuleEntry) u64 {
     ret back_half_key(m.stable_id, test_build(p));
 }
 
-pub fun codegen_reusable(p: *project.Project, mid: session.ModuleId) bool {
+pub fun codegen_reusable(p: *project.Project, mid: session.ModuleId) R.Result[bool, fail.Fail] {
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
-    ret query.peek_valid(?p.s.queries, query.Q_CODEGEN, back_half_key_for(p, m));
+    ret query.reusable[project.Project](?p.queries, p, query.Q_CODEGEN, back_half_key_for(p, m));
 }
 
 pub fun test_build(p: *project.Project) bool {
@@ -957,13 +1009,8 @@ test "mach.lang.driver.passes.intern_producer:name_version" {
 }
 
 pub fun run_lower_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
-    val imp_r: R.Result[R.Void, str] = union.register_import_libraries(p);
-    if (R.is_err[R.Void, str](imp_r)) {
-        ret R.err[R.Void, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](imp_r)));
-    }
-
-    val pr: R.Result[R.Void, outcome.Fail] = lower_prepare(p);
-    if (R.is_err[R.Void, outcome.Fail](pr)) { ret pr; }
+    val prepared: R.Result[R.Void, outcome.Fail] = acquire_lower_inputs(p);
+    if (R.is_err[R.Void, outcome.Fail](prepared)) { ret prepared; }
 
     if (lower_parallel_enabled(p)) {
 
@@ -986,7 +1033,10 @@ pub fun run_lower_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
     ret R.ok_void[outcome.Fail]();
 }
 
-fun lower_prepare(p: *project.Project) R.Result[R.Void, outcome.Fail] {
+pub fun prepare_lower_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
+    val imports: R.Result[R.Void, str] = union.register_import_libraries(p);
+    if (R.is_err[R.Void, str](imports)) { ret R.err[R.Void, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](imports))); }
+
     if (!query.is_registered(?p.s.queries, query.Q_LOWERED_SURFACE)) {
         val rls: R.Result[R.Void, str] = query.register_derived(?p.s.queries, query.Q_LOWERED_SURFACE);
         if (R.is_err[R.Void, str](rls)) { ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](rls))); }
@@ -997,21 +1047,37 @@ fun lower_prepare(p: *project.Project) R.Result[R.Void, outcome.Fail] {
     }
 
 
+    ret R.ok_void[outcome.Fail]();
+}
+
+fun acquire_frontend_inputs(p: *project.Project) R.Result[R.Void, outcome.Fail] {
+    var i: u32 = 0;
+    for (i < p.topo_len) {
+        val acquired: R.Result[scx.Definition, fail.Fail] = read_definition(p::ptr, p.topo[i], scx.DEFINITION_TYPED);
+        if (R.is_err[scx.Definition, fail.Fail](acquired)) { ret R.err[R.Void, outcome.Fail](outcome.from_fail(R.unwrap_err[scx.Definition, fail.Fail](acquired))); }
+        i = i + 1;
+    }
+    ret R.ok_void[outcome.Fail]();
+}
+
+fun acquire_lower_inputs(p: *project.Project) R.Result[R.Void, outcome.Fail] {
+    val frontend: R.Result[R.Void, outcome.Fail] = acquire_frontend_inputs(p);
+    if (R.is_err[R.Void, outcome.Fail](frontend)) { ret frontend; }
     var i: u32 = 0;
     for (i < p.emit_len) {
         val m: *project.ModuleEntry = ?p.modules[p.topo[i]::u32];
-        val sf_r: R.Result[*query.QueryEntry, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_LOWERED_SURFACE, m.stable_id::u64);
-        if (R.is_err[*query.QueryEntry, fail.Fail](sf_r)) {
-            ret R.err[R.Void, outcome.Fail](outcome.from_fail(R.unwrap_err[*query.QueryEntry, fail.Fail](sf_r)));
+        val sf_r: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_LOWERED_SURFACE, m.stable_id::u64);
+        if (R.is_err[query.QueryView, fail.Fail](sf_r)) {
+            ret R.err[R.Void, outcome.Fail](outcome.from_fail(R.unwrap_err[query.QueryView, fail.Fail](sf_r)));
         }
         i = i + 1;
     }
     ret R.ok_void[outcome.Fail]();
 }
 
-fun lower_reusable(p: *project.Project, mid: session.ModuleId) bool {
+fun lower_reusable(p: *project.Project, mid: session.ModuleId) R.Result[bool, fail.Fail] {
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
-    ret query.peek_valid(?p.s.queries, query.Q_LOWER, back_half_key_for(p, m));
+    ret query.reusable[project.Project](?p.queries, p, query.Q_LOWER, back_half_key_for(p, m));
 }
 
 test "mach.lang.driver.passes:internal_failure_is_not_hidden_by_a_user_error" {
@@ -1058,16 +1124,16 @@ pub fun frontend_status(p: *project.Project) fail.PhaseStatus {
 fun run_lower_one(p: *project.Project, mid: session.ModuleId) R.Result[R.Void, fail.Fail] {
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
 
-    val e_r: R.Result[*query.QueryEntry, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_LOWER, back_half_key_for(p, m));
-    if (R.is_err[*query.QueryEntry, fail.Fail](e_r)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[*query.QueryEntry, fail.Fail](e_r)); }
-    val irm: *ir.Module = ir_handle_decode(R.unwrap_ok[*query.QueryEntry, fail.Fail](e_r));
+    val e_r: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_LOWER, back_half_key_for(p, m));
+    if (R.is_err[query.QueryView, fail.Fail](e_r)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](e_r)); }
+    val irm: *ir.Module = ir_handle_decode(R.unwrap_ok[query.QueryView, fail.Fail](e_r));
     if (irm == nil) { ret R.err[R.Void, fail.Fail](fail.message("Q_LOWER produced no result handle")); }
 
     m.ir_module = irm;
     ret R.ok_void[fail.Fail]();
 }
 
-pub fun q_lowered_surface_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, fail.Fail] {
+pub fun q_lowered_surface_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
     val db: *query.QueryDb = ?p.s.queries;
     val s: *session.Session = p.s;
 
@@ -1075,11 +1141,9 @@ pub fun q_lowered_surface_compute(p: *project.Project, key: u64, alloc: *A.Alloc
     val mid: session.ModuleId = session.module_id_for_stable(s, stable);
     if (mid == session.MODULE_NIL) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_LOWERED_SURFACE: stable id not loaded this build")); }
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
-    val a: *ast.Ast = m.a;
-    if (a == nil) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_LOWERED_SURFACE: module has no parsed AST")); }
-
-    val rd: R.Result[R.Void, str] = query.record_dep(db, query.Q_LOWERED_SURFACE, key, query.Q_RESOLVE, key);
-    if (R.is_err[R.Void, str](rd)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rd))); }
+    val definition: R.Result[scx.Definition, fail.Fail] = read_definition(p::ptr, mid, scx.DEFINITION_RESOLVED);
+    if (R.is_err[scx.Definition, fail.Fail](definition)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[scx.Definition, fail.Fail](definition)); }
+    val a: *ast.Ast = R.unwrap_ok[scx.Definition, fail.Fail](definition).parsed.a;
 
     val sf_o: O.Option[*src.SourceFile] = src.get(?s.sources, a.file_id);
     if (O.is_none[*src.SourceFile](sf_o)) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_LOWERED_SURFACE: module source not loaded")); }
@@ -1194,55 +1258,23 @@ fun decl_has_decorator_named(a: *ast.Ast, text: str, d: *decl.Decl, name: str) b
     ret false;
 }
 
-pub fun q_lower_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, fail.Fail] {
-    val db: *query.QueryDb = ?p.s.queries;
+fun lower_candidate_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
     val s: *session.Session = p.s;
-
     val stable: session.StableModuleId = key::u32::session.StableModuleId;
     val test_mode: bool = back_half_key_is_test(key);
     val mid: session.ModuleId = session.module_id_for_stable(s, stable);
     if (mid == session.MODULE_NIL) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_LOWER: stable id not loaded this build")); }
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
-    val a: *ast.Ast = m.a;
-    if (a == nil) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_LOWER: module has no parsed AST")); }
-    val sr: *sema.SemaResult = m.sema_result;
-    if (sr == nil) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_LOWER: module has no sema result")); }
-
-    val rsd: R.Result[R.Void, str] = query.record_dep(db, query.Q_LOWER, key, query.Q_SEMA, stable::u64);
-    if (R.is_err[R.Void, str](rsd)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rsd))); }
-    val rt: R.Result[R.Void, str] = query.record_dep(db, query.Q_LOWER, key, query.Q_TARGET, 0);
-    if (R.is_err[R.Void, str](rt)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rt))); }
-
-    val cl_r: R.Result[LowerClosure, str] = collect_lower_closure(p, m);
-    if (R.is_err[LowerClosure, str](cl_r)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[LowerClosure, str](cl_r))); }
-    var cl: LowerClosure = R.unwrap_ok[LowerClosure, str](cl_r);
-    var di: u32 = 0;
-    for (di < cl.count) {
-        val dep_mid: session.ModuleId = cl.list[di];
-        val dep_stable: session.StableModuleId = p.modules[dep_mid::u32].stable_id;
-        val ge: R.Result[*query.QueryEntry, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_LOWERED_SURFACE, dep_stable::u64);
-        if (R.is_err[*query.QueryEntry, fail.Fail](ge)) {
-            free_lower_closure(s.alloc, ?cl);
-            ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[*query.QueryEntry, fail.Fail](ge));
-        }
-        di = di + 1;
-    }
-    free_lower_closure(s.alloc, ?cl);
-
-    if (m.staged_ir != nil) {
-        val sir:  *ir.Module     = m.staged_ir;
-        val shome: *ir.ModuleHome = m.staged_home;
-        m.staged_ir   = nil;
-        m.staged_home = nil;
-        ret ir_handle_encode(alloc, sir, shome);
-    }
-
+    val definition: R.Result[scx.Definition, fail.Fail] = read_definition(p::ptr, mid, scx.DEFINITION_TYPED);
+    if (R.is_err[scx.Definition, fail.Fail](definition)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[scx.Definition, fail.Fail](definition)); }
+    val rt: R.Result[R.Void, fail.Fail] = query.depend[project.Project](?p.queries, p, query.Q_TARGET, 0);
+    if (R.is_err[R.Void, fail.Fail](rt)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rt)); }
     val hr: R.Result[*ir.ModuleHome, str] = ir_home_new(alloc);
     if (R.is_err[*ir.ModuleHome, str](hr)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[*ir.ModuleHome, str](hr))); }
     val home: *ir.ModuleHome = R.unwrap_ok[*ir.ModuleHome, str](hr);
 
     val t_low: ctime.Time = readout.item_begin(p.events);
-    val rr_raw: R.Result[*ir.Module, fail.Fail] = lower_raw(p, mid, home, test_mode);
+    val rr_raw: R.Result[*ir.Module, fail.Fail] = lower_raw(p, mid, home, test_mode, diags);
     if (R.is_err[*ir.Module, fail.Fail](rr_raw)) {
         val stable: fail.Fail = lower_stable_fail(p, R.unwrap_err[*ir.Module, fail.Fail](rr_raw));
         ir_release(alloc, home);
@@ -1251,30 +1283,47 @@ pub fun q_lower_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.Re
     readout.item(p.events, readout.PH_LOWER, project.fqn_name(p, m.fqn), t_low);
     val irmod: *ir.Module = R.unwrap_ok[*ir.Module, fail.Fail](rr_raw);
 
-    val nid: R.Result[intern.StrId, fail.Fail] = neutralize_id(p, test_mode);
-    if (R.is_err[intern.StrId, fail.Fail](nid)) {
-        ir_release(alloc, home);
-        ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[intern.StrId, fail.Fail](nid));
-    }
-    val t_opt: ctime.Time = readout.span_begin(p.events);
-    val ro: R.Result[R.Void, fail.Fail] = lower_optimize(p, irmod, R.unwrap_ok[intern.StrId, fail.Fail](nid));
-    readout.item(p.events, readout.PH_OPTIMIZE, project.fqn_name(p, m.fqn), t_opt);
-    readout.span_end(p.events, readout.PH_OPTIMIZE, readout.PH_LOWER, t_opt);
-    if (R.is_err[R.Void, fail.Fail](ro)) {
-        val stable: fail.Fail = lower_stable_fail(p, R.unwrap_err[R.Void, fail.Fail](ro));
-        ir_release(alloc, home);
-        ret R.err[query.QueryOutput, fail.Fail](stable);
-    }
-
     ret ir_handle_encode(alloc, irmod, home);
 }
 
-fun lower_raw(p: *project.Project, mid: session.ModuleId, home: *ir.ModuleHome, test_mode: bool) R.Result[*ir.Module, fail.Fail] {
+fun q_lower_raw_compute(p: *project.Project, kind: query.QueryKind, key: u64,
+                       alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
+    if (kind != query.Q_LOWER) { ret R.err[query.QueryOutput, fail.Fail](fail.message("raw lowering requires its Q_LOWER owner")); }
+    ret lower_candidate_compute(p, key, alloc, diags);
+}
+
+pub fun q_lower_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
+    val raw: R.Result[query.QueryOutput, fail.Fail] = lower_candidate_compute(p, key, alloc, diags);
+    if (R.is_err[query.QueryOutput, fail.Fail](raw)) { ret raw; }
+    val output: query.QueryOutput = R.unwrap_ok[query.QueryOutput, fail.Fail](raw);
+    var transferred: bool = false;
+    fin {
+        if (!transferred) {
+            q_lower_finalize(output.bytes, output.len, alloc);
+            A.deallocate[u8](alloc, output.bytes, output.len::usize);
+        }
+    }
+    val irmod: *ir.Module = ir_handle_decode(query.QueryView{ value: output.bytes, value_len: output.len });
+    val main_id: R.Result[intern.StrId, fail.Fail] = neutralize_id(p, back_half_key_is_test(key));
+    if (R.is_err[intern.StrId, fail.Fail](main_id)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[intern.StrId, fail.Fail](main_id)); }
+    val t_opt: ctime.Time = readout.span_begin(p.events);
+    val optimized: R.Result[R.Void, fail.Fail] = lower_optimize(p, irmod, R.unwrap_ok[intern.StrId, fail.Fail](main_id));
+    readout.span_end(p.events, readout.PH_OPTIMIZE, readout.PH_LOWER, t_opt);
+    if (R.is_err[R.Void, fail.Fail](optimized)) { ret R.err[query.QueryOutput, fail.Fail](lower_stable_fail(p, R.unwrap_err[R.Void, fail.Fail](optimized))); }
+    transferred = true;
+    ret raw;
+}
+
+fun lower_raw(p: *project.Project, mid: session.ModuleId, home: *ir.ModuleHome, test_mode: bool, diags: *diagnostic.DiagnosticStore) R.Result[*ir.Module, fail.Fail] {
     val s:   *session.Session   = p.s;
     val m:   *project.ModuleEntry = ?p.modules[mid::u32];
 
+    val captured: R.Result[sema.SemaDeps, fail.Fail] = build_sema_deps_query(p, m);
+    if (R.is_err[sema.SemaDeps, fail.Fail](captured)) { ret R.err[*ir.Module, fail.Fail](R.unwrap_err[sema.SemaDeps, fail.Fail](captured)); }
+    var deps: sema.SemaDeps = R.unwrap_ok[sema.SemaDeps, fail.Fail](captured);
+    fin { free_sema_deps_query(p.s.alloc, ?deps); }
     val req_r: R.Result[lower.LowerRequest, fail.Fail] = lower.request(s, ?p.target, ?home.alloc, m.a, m.fqn, mid,
-        m.sema_result, m.resolve_result, ?m.ctx, test_mode, p.req.debug);
+        m.sema_result, m.resolve_result, ?m.ctx, test_mode, p.req.debug, diags, ?deps);
     if (R.is_err[lower.LowerRequest, fail.Fail](req_r)) { ret R.err[*ir.Module, fail.Fail](R.unwrap_err[lower.LowerRequest, fail.Fail](req_r)); }
     var req: lower.LowerRequest = R.unwrap_ok[lower.LowerRequest, fail.Fail](req_r);
 
@@ -1286,7 +1335,7 @@ fun lower_raw(p: *project.Project, mid: session.ModuleId, home: *ir.ModuleHome, 
     val box: *ir.Module = R.unwrap_ok[*ir.Module, str](br);
     box[0] = R.unwrap_ok[ir.Module, fail.Fail](res_lower);
 
-    val res_obl: R.Result[bool, str] = oblivious.check_module(box, ?s.interner, ?s.diags, s.alloc);
+    val res_obl: R.Result[bool, str] = oblivious.check_module(box, ?s.interner, diags, s.alloc);
     if (R.is_err[bool, str](res_obl)) { ret R.err[*ir.Module, fail.Fail](fail.message(R.unwrap_err[bool, str](res_obl))); }
     if (!R.unwrap_ok[bool, str](res_obl)) {
         ret R.err[*ir.Module, fail.Fail](fail.message("oblivious-required check: a function computes on a secret without `#[oblivious]`"));
@@ -1374,7 +1423,7 @@ fun ir_handle_encode(alloc: *A.Allocator, r: *ir.Module, home: *ir.ModuleHome) R
     ret R.ok[query.QueryOutput, fail.Fail](out);
 }
 
-fun ir_handle_decode(e: *query.QueryEntry) *ir.Module {
+fun ir_handle_decode(e: query.QueryView) *ir.Module {
     if (e.value == nil || e.value_len < ir_handle_len()) { ret nil; }
     val slot: *ptr = e.value::ptr::*ptr;
     ret slot[0]::*ir.Module;
@@ -1385,6 +1434,8 @@ fun lower_parallel_enabled(p: *project.Project) bool {
 }
 
 rec PlwSlot {
+    prepared: query.PreparedQuery;
+    live: bool;
     mid:    session.ModuleId;
     m:      *ir.Module;
     failed: bool;
@@ -1424,18 +1475,40 @@ fun plw_worker_main(arg: *u8) {
 }
 
 fun run_lower_parallel(p: *project.Project) R.Result[R.Void, fail.Fail] {
-    val emit_len: u32 = p.emit_len;
-    if (emit_len == 0) { ret R.ok_void[fail.Fail](); }
+    val count: u32 = p.emit_len;
+    if (count == 0) { ret R.ok_void[fail.Fail](); }
+    val allocated: R.Result[*PlwSlot, str] = A.allocate[PlwSlot](p.alloc, count::usize);
+    if (R.is_err[*PlwSlot, str](allocated)) { ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[*PlwSlot, str](allocated))); }
+    val slots: *PlwSlot = R.unwrap_ok[*PlwSlot, str](allocated);
+    fin { A.deallocate[PlwSlot](p.alloc, slots, count::usize); }
+    var i: u32 = 0;
+    for (i < count) { slots[i] = PlwSlot{}; i = i + 1; }
+    var result: R.Result[R.Void, fail.Fail] = run_lower_batch(p, slots, count);
+    i = 0;
+    for (i < count) {
+        if (slots[i].live) {
+            val cancelled: R.Result[R.Void, str] = query.cancel_prepared(?p.s.queries, slots[i].prepared);
+            if (R.is_err[R.Void, str](cancelled)) {
+                if (R.is_ok[R.Void, fail.Fail](result) || R.unwrap_err[R.Void, fail.Fail](result).kind == fail.REPORTED) {
+                    result = R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[R.Void, str](cancelled)));
+                }
+            }
+        }
+        i = i + 1;
+    }
+    ret result;
+}
 
-    val rslots: R.Result[*PlwSlot, str] = A.allocate[PlwSlot](p.alloc, emit_len::usize);
-    if (R.is_err[*PlwSlot, str](rslots)) { ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[*PlwSlot, str](rslots))); }
-    val slots: *PlwSlot = R.unwrap_ok[*PlwSlot, str](rslots);
-
+fun run_lower_batch(p: *project.Project, slots: *PlwSlot, emit_len: u32) R.Result[R.Void, fail.Fail] {
     var slot_len: u32 = 0;
     var ti: u32 = 0;
     for (ti < emit_len) {
         val mid: session.ModuleId = p.topo[ti];
-        if (!lower_reusable(p, mid)) {
+        val reusable: R.Result[bool, fail.Fail] = lower_reusable(p, mid);
+        if (R.is_err[bool, fail.Fail](reusable)) {
+            ret R.err[R.Void, fail.Fail](R.unwrap_err[bool, fail.Fail](reusable));
+        }
+        if (!R.unwrap_ok[bool, fail.Fail](reusable)) {
             slots[slot_len].mid = mid;
             slots[slot_len].m   = nil;
             slots[slot_len].failed = false;
@@ -1445,7 +1518,6 @@ fun run_lower_parallel(p: *project.Project) R.Result[R.Void, fail.Fail] {
         ti = ti + 1;
     }
     if (slot_len <= 1) {
-        A.deallocate[PlwSlot](p.alloc, slots, emit_len::usize);
         ret R.ok_void[fail.Fail]();
     }
 
@@ -1458,25 +1530,15 @@ fun run_lower_parallel(p: *project.Project) R.Result[R.Void, fail.Fail] {
 
         val t_item: ctime.Time = readout.item_begin(p.events);
 
-        val hr: R.Result[*ir.ModuleHome, str] = ir_home_new(p.s.alloc);
-        if (R.is_err[*ir.ModuleHome, str](hr)) {
-            lower_sweep_staged(p);
-            A.deallocate[PlwSlot](p.alloc, slots, emit_len::usize);
-            ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[*ir.ModuleHome, str](hr)));
-        }
-        val home: *ir.ModuleHome = R.unwrap_ok[*ir.ModuleHome, str](hr);
-
-        val rr_raw: R.Result[*ir.Module, fail.Fail] = lower_raw(p, mid, home, test_mode);
-        if (R.is_err[*ir.Module, fail.Fail](rr_raw)) {
-            val stable: fail.Fail = lower_stable_fail(p, R.unwrap_err[*ir.Module, fail.Fail](rr_raw));
-            ir_release(p.s.alloc, home);
-            lower_sweep_staged(p);
-            A.deallocate[PlwSlot](p.alloc, slots, emit_len::usize);
-            ret R.err[R.Void, fail.Fail](stable);
-        }
-        m.staged_ir   = R.unwrap_ok[*ir.Module, fail.Fail](rr_raw);
-        m.staged_home = home;
-        slots[si].m   = m.staged_ir;
+        val prepared: R.Result[query.PreparedQuery, fail.Fail] = query.prepare[project.Project](?p.queries, p,
+            query.Q_LOWER, back_half_key_for(p, m), q_lower_raw_compute);
+        if (R.is_err[query.PreparedQuery, fail.Fail](prepared)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[query.PreparedQuery, fail.Fail](prepared)); }
+        slots[si].prepared = R.unwrap_ok[query.PreparedQuery, fail.Fail](prepared);
+        slots[si].live = true;
+        val view: R.Result[query.QueryView, str] = query.prepared_view(?p.s.queries, slots[si].prepared);
+        if (R.is_err[query.QueryView, str](view)) { ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[query.QueryView, str](view))); }
+        slots[si].m = ir_handle_decode(R.unwrap_ok[query.QueryView, str](view));
+        if (slots[si].m == nil) { ret R.err[R.Void, fail.Fail](fail.message("prepared lowering has no IR owner")); }
         readout.item(p.events, readout.PH_LOWER, project.fqn_name(p, m.fqn), t_item);
         si = si + 1;
     }
@@ -1487,8 +1549,6 @@ fun run_lower_parallel(p: *project.Project) R.Result[R.Void, fail.Fail] {
 
     val nid: R.Result[intern.StrId, fail.Fail] = neutralize_id(p, test_mode);
     if (R.is_err[intern.StrId, fail.Fail](nid)) {
-        lower_sweep_staged(p);
-        A.deallocate[PlwSlot](p.alloc, slots, emit_len::usize);
         ret R.err[R.Void, fail.Fail](R.unwrap_err[intern.StrId, fail.Fail](nid));
     }
 
@@ -1506,8 +1566,6 @@ fun run_lower_parallel(p: *project.Project) R.Result[R.Void, fail.Fail] {
     if (extra > 0) {
         val rt: R.Result[*thread.Thread, str] = A.allocate[thread.Thread](p.alloc, extra::usize);
         if (R.is_err[*thread.Thread, str](rt)) {
-            lower_sweep_staged(p);
-            A.deallocate[PlwSlot](p.alloc, slots, emit_len::usize);
             ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[*thread.Thread, str](rt)));
         }
         threads = R.unwrap_ok[*thread.Thread, str](rt);
@@ -1538,29 +1596,21 @@ fun run_lower_parallel(p: *project.Project) R.Result[R.Void, fail.Fail] {
     var ei: u32 = 0;
     for (ei < slot_len) {
         if (slots[ei].failed) {
-            val stable: fail.Fail = lower_stable_fail(p, slots[ei].fail);
-            lower_sweep_staged(p);
-            A.deallocate[PlwSlot](p.alloc, slots, emit_len::usize);
-            ret R.err[R.Void, fail.Fail](stable);
+            val result: R.Result[R.Void, fail.Fail] = query.complete_prepared(?p.s.queries, slots[ei].prepared,
+                R.err[R.Void, fail.Fail](slots[ei].fail));
+            slots[ei].live = false;
+            ret result;
         }
         ei = ei + 1;
     }
-
-    A.deallocate[PlwSlot](p.alloc, slots, emit_len::usize);
-    ret R.ok_void[fail.Fail]();
-}
-
-pub fun lower_sweep_staged(p: *project.Project) {
-    var i: u32 = 0;
-    for (i < p.module_len) {
-        val m: *project.ModuleEntry = ?p.modules[i];
-        if (m.staged_home != nil) {
-            ir_release(p.s.alloc, m.staged_home);
-            m.staged_home = nil;
-        }
-        m.staged_ir = nil;
-        i = i + 1;
+    ei = 0;
+    for (ei < slot_len) {
+        val result: R.Result[R.Void, fail.Fail] = query.complete_prepared(?p.s.queries, slots[ei].prepared, R.ok_void[fail.Fail]());
+        slots[ei].live = false;
+        if (R.is_err[R.Void, fail.Fail](result)) { ret result; }
+        ei = ei + 1;
     }
+    ret R.ok_void[fail.Fail]();
 }
 
 fun ensure_lower_visit_capacity(p: *project.Project, needed: u32) R.Result[R.Void, str] {
@@ -1645,7 +1695,7 @@ fun free_lower_closure(alloc: *A.Allocator, cl: *LowerClosure) {
     cl.cap   = 0;
 }
 
-pub fun run_codegen_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
+pub fun prepare_codegen_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
     if (!query.is_registered(?p.s.queries, query.Q_CODEGEN)) {
         val rcg: R.Result[R.Void, str] = query.register_derived_owned(?p.s.queries, query.Q_CODEGEN, q_codegen_finalize);
         if (R.is_err[R.Void, str](rcg)) { ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](rcg))); }
@@ -1657,6 +1707,27 @@ pub fun run_codegen_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
         ret R.err[R.Void, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](pf)));
     }
 
+    ret R.ok_void[outcome.Fail]();
+}
+
+pub fun acquire_codegen_inputs(p: *project.Project) R.Result[R.Void, outcome.Fail] {
+    var clear: u32 = 0;
+    for (clear < p.module_len) { p.modules[clear].ir_module = nil; clear = clear + 1; }
+    val frontend: R.Result[R.Void, outcome.Fail] = acquire_frontend_inputs(p);
+    if (R.is_err[R.Void, outcome.Fail](frontend)) { ret frontend; }
+    var i: u32 = 0;
+    for (i < p.emit_len) {
+        val mid: session.ModuleId = p.topo[i];
+        val acquired: R.Result[R.Void, fail.Fail] = run_lower_one(p, mid);
+        if (R.is_err[R.Void, fail.Fail](acquired)) { ret R.err[R.Void, outcome.Fail](outcome.from_fail(R.unwrap_err[R.Void, fail.Fail](acquired))); }
+        i = i + 1;
+    }
+    ret R.ok_void[outcome.Fail]();
+}
+
+pub fun run_codegen_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
+    val inputs: R.Result[R.Void, outcome.Fail] = acquire_codegen_inputs(p);
+    if (R.is_err[R.Void, outcome.Fail](inputs)) { ret inputs; }
     var i: u32 = 0;
     for (i < p.emit_len) {
         val mid: session.ModuleId = p.topo[i];
@@ -1796,16 +1867,16 @@ fun global_definer_of(p: *project.Project, name: intern.StrId) u32 {
 fun run_codegen_one(p: *project.Project, mid: session.ModuleId) R.Result[R.Void, fail.Fail] {
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
 
-    val e_r: R.Result[*query.QueryEntry, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_CODEGEN, back_half_key_for(p, m));
-    if (R.is_err[*query.QueryEntry, fail.Fail](e_r)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[*query.QueryEntry, fail.Fail](e_r)); }
-    val img: *of.ObjectImage = image_handle_decode(R.unwrap_ok[*query.QueryEntry, fail.Fail](e_r));
+    val e_r: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_CODEGEN, back_half_key_for(p, m));
+    if (R.is_err[query.QueryView, fail.Fail](e_r)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](e_r)); }
+    val img: *of.ObjectImage = image_handle_decode(R.unwrap_ok[query.QueryView, fail.Fail](e_r));
     if (img == nil) { ret R.err[R.Void, fail.Fail](fail.message("Q_CODEGEN produced no result handle")); }
 
     m.object_image = img;
     ret R.ok_void[fail.Fail]();
 }
 
-pub fun q_codegen_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, fail.Fail] {
+pub fun q_codegen_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
     val db: *query.QueryDb = ?p.s.queries;
     val s: *session.Session = p.s;
 
@@ -1813,15 +1884,15 @@ pub fun q_codegen_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.
     val mid: session.ModuleId = session.module_id_for_stable(s, stable);
     if (mid == session.MODULE_NIL) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_CODEGEN: stable id not loaded this build")); }
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
-    val irmod: *ir.Module = m.ir_module;
+    val lower_owner: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_LOWER, key);
+    if (R.is_err[query.QueryView, fail.Fail](lower_owner)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](lower_owner)); }
+    val irmod: *ir.Module = ir_handle_decode(R.unwrap_ok[query.QueryView, fail.Fail](lower_owner));
     if (irmod == nil) { ret R.err[query.QueryOutput, fail.Fail](fail.message("Q_CODEGEN: module has no lowered IR")); }
-
-    val rl: R.Result[R.Void, str] = query.record_dep(db, query.Q_CODEGEN, key, query.Q_LOWER, key);
-    if (R.is_err[R.Void, str](rl)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rl))); }
-    val rt: R.Result[R.Void, str] = query.record_dep(db, query.Q_CODEGEN, key, query.Q_TARGET, 0);
-    if (R.is_err[R.Void, str](rt)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rt))); }
-    val rpp: R.Result[R.Void, str] = query.record_dep(db, query.Q_CODEGEN, key, query.Q_CODEGEN_FLAGS, 0);
-    if (R.is_err[R.Void, str](rpp)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rpp))); }
+    m.ir_module = irmod;
+    val rt: R.Result[R.Void, fail.Fail] = query.depend[project.Project](?p.queries, p, query.Q_TARGET, 0);
+    if (R.is_err[R.Void, fail.Fail](rt)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rt)); }
+    val rpp: R.Result[R.Void, fail.Fail] = query.depend[project.Project](?p.queries, p, query.Q_CODEGEN_FLAGS, 0);
+    if (R.is_err[R.Void, fail.Fail](rpp)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rpp)); }
 
     val srcs_r: R.Result[CodeSources, str] = code_sources(p, mid, s.alloc);
     if (R.is_err[CodeSources, str](srcs_r)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[CodeSources, str](srcs_r))); }
@@ -1829,11 +1900,10 @@ pub fun q_codegen_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.
     var di: u32 = 0;
     for (di < srcs.set.len) {
         val dm: *project.ModuleEntry = ?p.modules[srcs.ids[di]::u32];
-        val rd: R.Result[R.Void, str] = query.record_dep(db, query.Q_CODEGEN, key, query.Q_LOWER,
-                                                       back_half_key_for(p, dm));
-        if (R.is_err[R.Void, str](rd)) {
+        val rd: R.Result[R.Void, fail.Fail] = query.depend[project.Project](?p.queries, p, query.Q_LOWER, back_half_key_for(p, dm));
+        if (R.is_err[R.Void, fail.Fail](rd)) {
             sources_dnit(s.alloc, ?srcs);
-            ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rd)));
+            ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rd));
         }
         di = di + 1;
     }
@@ -1894,26 +1964,32 @@ fun image_handle_encode(alloc: *A.Allocator, r: *of.ObjectImage) R.Result[query.
     ret R.ok[query.QueryOutput, fail.Fail](out);
 }
 
-fun image_handle_decode(e: *query.QueryEntry) *of.ObjectImage {
+fun image_handle_decode(e: query.QueryView) *of.ObjectImage {
     if (e.value == nil || e.value_len::usize < $size_of(ptr)) { ret nil; }
     val slot: *ptr = e.value::ptr::*ptr;
     ret slot[0]::*of.ObjectImage;
 }
 
-pub fun run_link_pass(p: *project.Project) R.Result[bool, outcome.Fail] {
+pub fun prepare_link_pass(p: *project.Project) R.Result[R.Void, outcome.Fail] {
     if (!query.is_registered(?p.s.queries, query.Q_LINK)) {
         val rln: R.Result[R.Void, str] = query.register_derived(?p.s.queries, query.Q_LINK);
-        if (R.is_err[R.Void, str](rln)) { ret R.err[bool, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](rln))); }
+        if (R.is_err[R.Void, str](rln)) { ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](rln))); }
     }
 
+    ret R.ok_void[outcome.Fail]();
+}
+
+pub fun run_link_pass(p: *project.Project) R.Result[bool, outcome.Fail] {
+    val images: R.Result[R.Void, outcome.Fail] = run_codegen_pass(p);
+    if (R.is_err[R.Void, outcome.Fail](images)) { ret R.err[bool, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](images)); }
     val prior: query.Revision = query.peek_revision(?p.s.queries, query.Q_LINK, 0);
-    val e_r: R.Result[*query.QueryEntry, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_LINK, 0);
-    if (R.is_err[*query.QueryEntry, fail.Fail](e_r)) { ret R.err[bool, outcome.Fail](outcome.from_fail(R.unwrap_err[*query.QueryEntry, fail.Fail](e_r))); }
-    val now: query.Revision = R.unwrap_ok[*query.QueryEntry, fail.Fail](e_r).last_changed;
+    val e_r: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_LINK, 0);
+    if (R.is_err[query.QueryView, fail.Fail](e_r)) { ret R.err[bool, outcome.Fail](outcome.from_fail(R.unwrap_err[query.QueryView, fail.Fail](e_r))); }
+    val now: query.Revision = R.unwrap_ok[query.QueryView, fail.Fail](e_r).last_changed;
     ret R.ok[bool, outcome.Fail](now != prior);
 }
 
-pub fun q_link_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.Result[query.QueryOutput, fail.Fail] {
+pub fun q_link_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
     val db: *query.QueryDb = ?p.s.queries;
     val s: *session.Session = p.s;
 
@@ -1922,76 +1998,139 @@ pub fun q_link_compute(p: *project.Project, key: u64, alloc: *A.Allocator) R.Res
     fb.buf   = nil;
     fb.len   = 0;
     fb.cap   = 0;
+    fin { dq.fp_free(?fb); }
 
-    val rt: R.Result[query.Revision, str] = query.record_dep_rev(db, query.Q_LINK, key, query.Q_TARGET, 0);
-    if (R.is_err[query.Revision, str](rt)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[query.Revision, str](rt)); }
-    val wt: R.Result[R.Void, str] = dq.fp_u64(?fb, R.unwrap_ok[query.Revision, str](rt));
-    if (R.is_err[R.Void, str](wt)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[R.Void, str](wt)); }
+    val rt: R.Result[query.Revision, fail.Fail] = query.revision[project.Project](?p.queries, p, query.Q_TARGET, 0);
+    if (R.is_err[query.Revision, fail.Fail](rt)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[query.Revision, fail.Fail](rt)); }
+    val wt: R.Result[R.Void, str] = dq.fp_u64(?fb, R.unwrap_ok[query.Revision, fail.Fail](rt));
+    if (R.is_err[R.Void, str](wt)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](wt))); }
 
-    val rc: R.Result[query.Revision, str] = query.record_dep_rev(db, query.Q_LINK, key, query.Q_LINK_CONFIG, 0);
-    if (R.is_err[query.Revision, str](rc)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[query.Revision, str](rc)); }
-    val wc: R.Result[R.Void, str] = dq.fp_u64(?fb, R.unwrap_ok[query.Revision, str](rc));
-    if (R.is_err[R.Void, str](wc)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[R.Void, str](wc)); }
+    val rc: R.Result[query.Revision, fail.Fail] = query.revision[project.Project](?p.queries, p, query.Q_LINK_CONFIG, 0);
+    if (R.is_err[query.Revision, fail.Fail](rc)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[query.Revision, fail.Fail](rc)); }
+    val wc: R.Result[R.Void, str] = dq.fp_u64(?fb, R.unwrap_ok[query.Revision, fail.Fail](rc));
+    if (R.is_err[R.Void, str](wc)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](wc))); }
 
     val wn: R.Result[R.Void, str] = dq.fp_u32(?fb, p.emit_len);
-    if (R.is_err[R.Void, str](wn)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[R.Void, str](wn)); }
+    if (R.is_err[R.Void, str](wn)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](wn))); }
     var i: u32 = 0;
     for (i < p.emit_len) {
         val m: *project.ModuleEntry = ?p.modules[(p.topo[i])::u32];
-        val rd: R.Result[query.Revision, str] = query.record_dep_rev(db, query.Q_LINK, key, query.Q_CODEGEN, back_half_key_for(p, m));
-        if (R.is_err[query.Revision, str](rd)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[query.Revision, str](rd)); }
-        val wm: R.Result[R.Void, str] = dq.fp_u64(?fb, R.unwrap_ok[query.Revision, str](rd));
-        if (R.is_err[R.Void, str](wm)) { ret link_fp_fail(?fb, alloc, R.unwrap_err[R.Void, str](wm)); }
+        val rd: R.Result[query.Revision, fail.Fail] = query.revision[project.Project](?p.queries, p, query.Q_CODEGEN, back_half_key_for(p, m));
+        if (R.is_err[query.Revision, fail.Fail](rd)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[query.Revision, fail.Fail](rd)); }
+        val wm: R.Result[R.Void, str] = dq.fp_u64(?fb, R.unwrap_ok[query.Revision, fail.Fail](rd));
+        if (R.is_err[R.Void, str](wm)) { ret R.err[query.QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](wm))); }
         i = i + 1;
     }
 
     ret fail.lift[query.QueryOutput](dq.fp_take(?fb));
 }
 
-fun link_fp_fail(fb: *dq.FpBuf, alloc: *A.Allocator, msg: str) R.Result[query.QueryOutput, fail.Fail] {
-    if (fb.buf != nil && fb.cap > 0) { A.deallocate[u8](alloc, fb.buf, fb.cap::usize); }
-    ret R.err[query.QueryOutput, fail.Fail](fail.message(msg));
+fun own_type_export(p: *project.Project, mid: session.ModuleId, symbol: *resolve.Symbol,
+                    sr: *sema.SemaResult, ctx: *comptime.ComptimeCtx) R.Result[scx.TypeExport, str] {
+    var row: scx.TypeExport = scx.TypeExport{
+        origin: p.modules[mid::u32].stable_id, canon: symbol.canon, ty: type.TYPE_NIL,
+        constant: resolve.ExportConstant{ name: symbol.canon }
+    };
+    if (symbol.definition_kind == resolve.SYM_USE) { ret R.ok[scx.TypeExport, str](row); }
+    if (symbol.origin != mid || sr == nil || symbol.decl == id.DECL_NIL || symbol.decl >= sr.decl_count) {
+        ret R.err[scx.TypeExport, str]("typed export has no matching current declaration");
+    }
+    row.ty = sr.decl_type[symbol.decl];
+    if (symbol.definition_kind == resolve.SYM_VAL) {
+        val found: O.Option[comptime.NamedConst] = comptime.lookup(ctx, symbol.canon);
+        if (O.is_some[comptime.NamedConst](found)) {
+            val constant: comptime.NamedConst = O.unwrap[comptime.NamedConst](found);
+            row.constant.present = true;
+            row.constant.gated = constant.gated;
+            row.constant.value = constant.value;
+            if (constant.value.kind == comptime.CT_KIND_CONST_ELEM) {
+                row.definition_incarnation = p.modules[mid::u32].a.incarnation;
+            }
+        }
+    }
+    ret R.ok[scx.TypeExport, str](row);
 }
 
-fun fp_typed_surface(fb: *dq.FpBuf, s: *session.Session, mid: session.ModuleId, rr: *resolve.ResolveResult, sr: *sema.SemaResult) R.Result[R.Void, str] {
-    val pc: R.Result[R.Void, str] = dq.fp_u32(fb, rr.pub_count);
-    if (R.is_err[R.Void, str](pc)) { ret pc; }
-    if (rr.symbols == nil)       { ret R.ok_void[str](); }
+fun imported_type_export(p: *project.Project, symbol: *resolve.Symbol, gates: bool) R.Result[scx.TypeExport, fail.Fail] {
+    val mid: session.ModuleId = symbol.origin;
+    if (mid == session.MODULE_NIL || mid::u32 >= p.module_len) { ret R.err[scx.TypeExport, fail.Fail](fail.message("forwarded type origin is not loaded")); }
+    if (gates) {
+        val m: *project.ModuleEntry = ?p.modules[mid::u32];
+        if (m.resolve_result == nil || m.gate_result == nil) { ret R.err[scx.TypeExport, fail.Fail](fail.message("forwarded gate type has no current header owner")); }
+        var i: u32 = 0;
+        for (i < m.resolve_result.symbol_count) {
+            val current: *resolve.Symbol = ?m.resolve_result.symbols[i];
+            if (current.origin == mid && current.canon == symbol.canon && current.kind == symbol.definition_kind) {
+                ret fail.lift[scx.TypeExport](own_type_export(p, mid, current, m.gate_result, ?m.ctx));
+            }
+            i = i + 1;
+        }
+        ret R.err[scx.TypeExport, fail.Fail](fail.message("forwarded gate type has no current canonical declaration"));
+    }
+    val acquired: R.Result[scx.ModuleSema, fail.Fail] = read_typed_surface(p, mid, p.s.alloc);
+    if (R.is_err[scx.ModuleSema, fail.Fail](acquired)) { ret R.err[scx.TypeExport, fail.Fail](R.unwrap_err[scx.ModuleSema, fail.Fail](acquired)); }
+    var surface: scx.ModuleSema = R.unwrap_ok[scx.ModuleSema, fail.Fail](acquired);
+    fin { scx.module_sema_dnit(?surface); }
+    val origin: session.StableModuleId = p.modules[mid::u32].stable_id;
+    var i: usize = 0;
+    for (i < surface.exports.len) {
+        val row: scx.TypeExport = surface.exports.data[i];
+        if (row.origin == origin && row.canon == symbol.canon) { ret R.ok[scx.TypeExport, fail.Fail](row); }
+        i = i + 1;
+    }
+    ret R.err[scx.TypeExport, fail.Fail](fail.message("forwarded type has no acquired canonical public surface"));
+}
 
+fun build_type_surface(p: *project.Project, mid: session.ModuleId, rr: *resolve.ResolveResult,
+                       sr: *sema.SemaResult, gates: bool, a: *A.Allocator) R.Result[scx.ModuleSema, fail.Fail] {
+    var surface: scx.ModuleSema = scx.module_sema_init(a, p.modules[mid::u32].fqn, mid);
+    var transferred: bool = false;
+    fin { if (!transferred) { scx.module_sema_dnit(?surface); } }
     var i: u32 = 0;
     for (i < rr.pub_count) {
-        val sym: *resolve.Symbol = ?rr.symbols[i];
-        val rk: R.Result[R.Void, str] = dq.fp_u8(fb, sym.kind::u8);    if (R.is_err[R.Void, str](rk)) { ret rk; }
-        val rn: R.Result[R.Void, str] = dq.fp_u32(fb, sym.name::u32);  if (R.is_err[R.Void, str](rn)) { ret rn; }
-        if (sym.origin == mid && sym.decl::u32 < sr.decl_count) {
-            val ty: type.TypeId = sr.decl_type[sym.decl];
-            val rty: R.Result[R.Void, str] = dq.fp_u32(fb, ty::u32);   if (R.is_err[R.Void, str](rty)) { ret rty; }
-            val rf:  R.Result[R.Void, str] = fp_type_fields(fb, s, ty); if (R.is_err[R.Void, str](rf)) { ret rf; }
-        }
-        or {
-            val rty: R.Result[R.Void, str] = dq.fp_u32(fb, 0xFFFFFFFF); if (R.is_err[R.Void, str](rty)) { ret rty; }
-            val rf:  R.Result[R.Void, str] = dq.fp_u32(fb, 0);          if (R.is_err[R.Void, str](rf)) { ret rf; }
-        }
+        val symbol: *resolve.Symbol = ?rr.symbols[i];
+        var captured: R.Result[scx.TypeExport, fail.Fail];
+        if (symbol.origin == mid) { captured = fail.lift[scx.TypeExport](own_type_export(p, mid, symbol, sr, ?p.modules[mid::u32].ctx)); }
+        or { captured = imported_type_export(p, symbol, gates); }
+        if (R.is_err[scx.TypeExport, fail.Fail](captured)) { ret R.err[scx.ModuleSema, fail.Fail](R.unwrap_err[scx.TypeExport, fail.Fail](captured)); }
+        val added: R.Result[usize, str] = vector.push[scx.TypeExport](?surface.exports, R.unwrap_ok[scx.TypeExport, fail.Fail](captured));
+        if (R.is_err[usize, str](added)) { ret R.err[scx.ModuleSema, fail.Fail](fail.message(R.unwrap_err[usize, str](added))); }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    transferred = true;
+    ret R.ok[scx.ModuleSema, fail.Fail](surface);
 }
 
-fun fp_type_fields(fb: *dq.FpBuf, s: *session.Session, ty: type.TypeId) R.Result[R.Void, str] {
-    if (ty == type.TYPE_NIL || ty == type.TYPE_ERROR) { ret dq.fp_u32(fb, 0); }
-    val ft_opt: O.Option[*type.FieldTable] = type.field_table_for(?s.types, ty);
-    if (O.is_none[*type.FieldTable](ft_opt)) { ret dq.fp_u32(fb, 0); }
-    val ft: *type.FieldTable = O.unwrap[*type.FieldTable](ft_opt);
-    val rc: R.Result[R.Void, str] = dq.fp_u32(fb, ft.fields_len);
-    if (R.is_err[R.Void, str](rc)) { ret rc; }
-    var i: u32 = 0;
-    for (i < ft.fields_len) {
-        val fe: *type.FieldEntry = type.field_entry_at(?s.types, ft, i);
-        val rn: R.Result[R.Void, str] = dq.fp_u32(fb, fe.name::u32); if (R.is_err[R.Void, str](rn)) { ret rn; }
-        val rt: R.Result[R.Void, str] = dq.fp_u32(fb, fe.ty::u32);   if (R.is_err[R.Void, str](rt)) { ret rt; }
+fun prepared_surface_recipe(p: *project.Project, ty: type.TypeId) R.Result[R.Void, fail.Fail] {
+    if (O.is_none[*type.FieldTable](type.field_table_for(?p.s.types, ty))) {
+        ret R.err[R.Void, fail.Fail](fail.message("public nominal recipe was not prepared by its acquired semantic owner"));
+    }
+    ret R.ok_void[fail.Fail]();
+}
+
+fun capture_surface_graph(p: *project.Project, surface: *scx.ModuleSema) R.Result[fields.Graph, fail.Fail] {
+    var roots: vector.Vector[type.TypeId] = vector.init[type.TypeId](surface.exports.a);
+    fin { vector.dnit[type.TypeId](?roots); }
+    var i: usize = 0;
+    for (i < surface.exports.len) {
+        val row: *scx.TypeExport = ?surface.exports.data[i];
+        val added: R.Result[usize, str] = vector.push[type.TypeId](?roots, row.ty);
+        if (R.is_err[usize, str](added)) { ret R.err[fields.Graph, fail.Fail](fail.message(R.unwrap_err[usize, str](added))); }
+        if (row.constant.present) {
+            val value: comptime.CTValue = row.constant.value;
+            var extra: type.TypeId = type.TYPE_NIL;
+            if (value.kind == comptime.CT_KIND_TYPE) { extra = value.data.t::type.TypeId; }
+            or (value.kind == comptime.CT_KIND_FIELD) { extra = value.data.fld.owner::type.TypeId; }
+            or (value.kind == comptime.CT_KIND_PACK_ELEM) { extra = value.data.pelem.ty::type.TypeId; }
+            or (value.kind == comptime.CT_KIND_CONST_ELEM) { extra = value.data.celem.ty::type.TypeId; }
+            val added: R.Result[usize, str] = vector.push[type.TypeId](?roots, extra);
+            if (R.is_err[usize, str](added)) { ret R.err[fields.Graph, fail.Fail](fail.message(R.unwrap_err[usize, str](added))); }
+        }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    var group: fields.Roots = fields.Roots{ data: roots.data, len: roots.len };
+    ret fields.capture[project.Project](p.s, surface.exports.a, ?group, 1, fields.RECIPES,
+        p.modules[surface.module::u32].ctx.env.target_defs, p, prepared_surface_recipe);
 }
 
 pub fun set_build_config_input(p: *project.Project) R.Result[R.Void, str] {
@@ -2311,10 +2450,11 @@ fun build_module_exports(p: *project.Project, dep_id: session.ModuleId, dep: *pr
     for (i < pcount) {
         val sym: *resolve.Symbol = ?dep.resolve_result.symbols[i];
         var ps: resolve.PublicSymbol;
-        ps.kind   = sym.kind;
+        ps.kind   = sym.definition_kind;
         ps.name   = sym.name;
         ps.canon  = sym.canon;
-        ps.decl   = sym.decl;
+        ps.file = sym.definition_file;
+        ps.generic_arity = sym.generic_arity;
         ps.slot   = sym.slot;
         ps.origin = sym.origin;
         syms[i] = ps;

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -2456,6 +2456,8 @@ fun build_module_exports(p: *project.Project, dep_id: session.ModuleId, dep: *pr
         ps.canon  = sym.canon;
         ps.file = sym.definition_file;
         ps.generic_arity = sym.generic_arity;
+        ps.has_comptime_params = sym.has_comptime_params;
+        ps.has_pack_param = sym.has_pack_param;
         ps.slot   = sym.slot;
         ps.origin = sym.origin;
         syms[i] = ps;

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -301,7 +301,9 @@ pub fun q_sema_compute(p: *project.Project, key: u64, alloc: *A.Allocator, diags
     val m: *project.ModuleEntry = ?p.modules[mid::u32];
     val parsed: R.Result[resolve.ParsedDefinition, fail.Fail] = load.parsed_definition(p::ptr, mid);
     if (R.is_err[resolve.ParsedDefinition, fail.Fail](parsed)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[resolve.ParsedDefinition, fail.Fail](parsed)); }
-    val a: *ast.Ast = R.unwrap_ok[resolve.ParsedDefinition, fail.Fail](parsed).a;
+    val definition: resolve.ParsedDefinition = R.unwrap_ok[resolve.ParsedDefinition, fail.Fail](parsed);
+    if (definition.status.kind != fail.ACCEPTED) { ret R.err[query.QueryOutput, fail.Fail](fail.phase_failure(definition.status)); }
+    val a: *ast.Ast = definition.a;
     val resolved: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, query.Q_RESOLVE, key);
     if (R.is_err[query.QueryView, fail.Fail](resolved)) { ret R.err[query.QueryOutput, fail.Fail](R.unwrap_err[query.QueryView, fail.Fail](resolved)); }
     val rr: *resolve.ResolveResult = dq.resolve_handle_decode(R.unwrap_ok[query.QueryView, fail.Fail](resolved));

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -17,6 +17,7 @@ use R: std.types.result;
 use mach.lang.fe.ast;
 use mach.lang.fail;
 use mach.lang.readout;
+use std.chrono.duration;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.sema;
@@ -170,6 +171,7 @@ pub rec ModuleEntry {
     dep_cap:           u32;
     resolve_result:    *resolve.ResolveResult;
     resolved:          bool;
+    resolve_elapsed: duration.Duration;
     gate_result:       *sema.SemaResult;
     tuple_gates:       *TupleGateResult;
     tuple_gate_count:  u32;

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -8,6 +8,7 @@ use std.types.string.str_empty;
 use std.types.string.str_len;
 use std.types.string.str_join;
 use std.text.string.str_free;
+use std.text.string.str_dup;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -21,6 +22,8 @@ use mach.lang.fe.resolve;
 use mach.lang.fe.sema;
 use mach.lang.fe.token;
 use mach.lang.build.request;
+use mach.lang.build.outcome;
+use mach.lang.diagnostic;
 use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.ir;
@@ -175,8 +178,6 @@ pub rec ModuleEntry {
     sema_result:       *sema.SemaResult;
     ir_module:         *ir.Module;
     object_image:      *of.ObjectImage;
-    staged_ir:         *ir.Module;
-    staged_home:       *ir.ModuleHome;
     staged_image:      *of.ObjectImage;
     stable_id:         session.StableModuleId;
     target_gated:      bool;
@@ -213,6 +214,7 @@ pub rec Project {
     alloc:        *A.Allocator;
     req:          request.BuildRequest;
     queries:      query.QueryRuntime[Project];
+    diags:        diagnostic.DiagnosticStore;
     config:       ProjectConfig;
     target_entry: *TargetEntry;
     target:       target.Target;
@@ -255,6 +257,117 @@ pub rec Project {
     gate_tuple_index:   u32;
     in_gated_decl_walk: bool;
     gate_terminal:      bool;
+}
+
+pub fun begin_query_phase(p: *Project) R.Result[query.Operation, outcome.Fail] {
+    val reset: R.Result[R.Void, str] = session.reset_type_projection(p.s);
+    if (R.is_err[R.Void, str](reset)) {
+        ret R.err[query.Operation, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](reset)));
+    }
+    val begun: R.Result[query.Operation, str] = query.begin(?p.s.queries);
+    if (R.is_err[query.Operation, str](begun)) {
+        ret R.err[query.Operation, outcome.Fail](outcome.internal(R.unwrap_err[query.Operation, str](begun)));
+    }
+    ret R.ok[query.Operation, outcome.Fail](R.unwrap_ok[query.Operation, str](begun));
+}
+
+pub fun refresh_diagnostics(p: *Project) R.Result[R.Void, outcome.Fail] {
+    var staged: diagnostic.DiagnosticStore = diagnostic.store_init(p.s.alloc);
+    var copied: R.Result[R.Void, str] = diagnostic.replay_into(?staged, ?p.diags);
+    if (R.is_ok[R.Void, str](copied) && p.s.query_presentation != nil) {
+        copied = diagnostic.replay_into(?staged, ?p.s.query_presentation.diags);
+    }
+    if (R.is_err[R.Void, str](copied)) {
+        diagnostic.store_dnit(?staged);
+        ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](copied)));
+    }
+    diagnostic.store_dnit(?p.s.diags);
+    p.s.diags = staged;
+    ret R.ok_void[outcome.Fail]();
+}
+
+pub fun finish_query_phase(p: *Project, operation: query.Operation,
+                          roots: *query.QueryKey, count: usize,
+                          result: R.Result[R.Void, outcome.Fail]) R.Result[R.Void, outcome.Fail] {
+    val db: *query.QueryDb = ?p.s.queries;
+    val ended: R.Result[R.Void, fail.Fail] = query.end(db, operation);
+    var final_result: R.Result[R.Void, outcome.Fail] = result;
+    var operation_failure: bool = false;
+    var message: str = nil;
+    var lost: bool = false;
+    if (R.is_err[R.Void, fail.Fail](ended)) {
+        val failure: outcome.Fail = outcome.from_fail(R.unwrap_err[R.Void, fail.Fail](ended));
+        if (R.is_ok[R.Void, outcome.Fail](result)
+            || (failure.kind == outcome.FAIL_INTERNAL && R.unwrap_err[R.Void, outcome.Fail](result).kind != outcome.FAIL_INTERNAL)) {
+            final_result = R.err[R.Void, outcome.Fail](failure);
+            operation_failure = true;
+        }
+    }
+    if (!operation_failure && R.is_err[R.Void, outcome.Fail](result)) {
+        var failure: outcome.Fail = R.unwrap_err[R.Void, outcome.Fail](result);
+        if (failure.message != nil) {
+            val copied: R.Result[str, str] = str_dup(db.a, failure.message);
+            if (R.is_err[str, str](copied)) {
+                failure.message = R.unwrap_err[str, str](copied);
+                lost = true;
+            }
+            or {
+                message = R.unwrap_ok[str, str](copied);
+                failure.message = message;
+            }
+            final_result = R.err[R.Void, outcome.Fail](failure);
+        }
+    }
+
+    val collected: R.Result[*query.Presentation, str] = query.collect(db, operation, roots, count, p.s.alloc);
+    if (R.is_err[*query.Presentation, str](collected)) {
+        val taken: R.Result[str, str] = query.take_failure_message(db, operation);
+        if (R.is_ok[str, str](taken) && R.unwrap_ok[str, str](taken) != nil) {
+            if (operation_failure) { message = R.unwrap_ok[str, str](taken); }
+            or { str_free(db.a, R.unwrap_ok[str, str](taken)); }
+        }
+        or (R.is_err[str, str](taken)) { lost = true; }
+        val discarded: R.Result[R.Void, str] = query.discard(db, operation);
+        if (R.is_err[R.Void, str](discarded)) { lost = true; }
+        if (R.is_ok[R.Void, outcome.Fail](final_result)) {
+            final_result = R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[*query.Presentation, str](collected)));
+        }
+        lost = true;
+    }
+    or {
+        val presentation: *query.Presentation = R.unwrap_ok[*query.Presentation, str](collected);
+        if (p.s.query_presentation != nil) { query.presentation_dnit(p.s.query_presentation); }
+        p.s.query_presentation = presentation;
+        val refreshed: R.Result[R.Void, outcome.Fail] = refresh_diagnostics(p);
+        if (R.is_err[R.Void, outcome.Fail](refreshed)) {
+            if (R.is_ok[R.Void, outcome.Fail](final_result)) { final_result = refreshed; }
+            lost = true;
+        }
+    }
+    if (p.s.query_failure_message != nil) { str_free(db.a, p.s.query_failure_message); }
+    p.s.query_failure_message = message;
+    if (lost) {
+        diagnostic.note_lost(?p.diags);
+        diagnostic.note_lost(?p.s.diags);
+    }
+    if (R.is_err[R.Void, fail.Fail](ended)) {
+        var i: u32 = 0;
+        for (i < p.module_len) {
+            val m: *ModuleEntry = ?p.modules[i];
+            m.a = nil;
+            m.resolve_result = nil;
+            m.sema_result = nil;
+            m.ir_module = nil;
+            m.object_image = nil;
+            i = i + 1;
+        }
+        i = 0;
+        for (i < p.s.module_ast_count) { p.s.module_asts[i] = nil; i = i + 1; }
+        map.clear[session.ModuleId, ptr](?p.s.module_resolve);
+        map.clear[session.ModuleId, ptr](?p.s.module_sema);
+        map.clear[session.ModuleId, ptr](?p.s.module_comptime);
+    }
+    ret final_result;
 }
 
 pub fun span_eq_str(source: str, span: token.Span, s: str) bool {
@@ -360,18 +473,23 @@ pub fun dnit_project(p: *Project) {
         A.deallocate[intern.StrId](p.alloc, p.union_entries, p.union_entry_count::usize);
     }
     map.dnit[intern.StrId, session.ModuleId](?p.by_fqn);
+    diagnostic.store_dnit(?p.diags);
     deallocate_config(?p.config, p.alloc);
 
     session.reset_module_registry(p.s);
 }
 
 pub fun init_project(p: *Project, s: *session.Session) {
+    if (s.query_presentation != nil) { query.presentation_dnit(s.query_presentation); s.query_presentation = nil; }
+    if (s.query_failure_message != nil) { str_free(s.queries.a, s.query_failure_message); s.query_failure_message = nil; }
+    diagnostic.store_dnit(?s.diags);
+    s.diags = diagnostic.store_init(s.alloc);
     p.s             = s;
     p.alloc         = s.build_alloc;
     p.req           = request.defaults();
     p.queries.db    = nil;
-    p.queries.diags = nil;
     p.queries.caps.compute = nil;
+    p.diags         = diagnostic.store_init(p.alloc);
     p.target_entry  = nil;
     p.union              = false;
     p.union_tuples       = nil;

--- a/src/lang/driver/query.mach
+++ b/src/lang/driver/query.mach
@@ -1,5 +1,6 @@
 use std.crypto.hash.sha256;
 use std.memory;
+use std.collections.vector;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -16,6 +17,15 @@ use R: std.types.result;
 
 use mach.lang.build.fingerprint;
 use mach.lang.fe.resolve;
+use scx: mach.lang.fe.sema.context;
+use mach.lang.fe.sema.fields;
+use mach.lang.type;
+use mach.lang.fe.comptime;
+use mach.lang.fe.ast.id;
+use mach.lang.float;
+use mach.lang.intern;
+use mach.lang.session;
+use mach.lang.source;
 use mach.lang.query;
 use mach.lang.target.of;
 
@@ -121,7 +131,7 @@ pub fun resolve_handle_encode(alloc: *A.Allocator, r: *resolve.ResolveResult) R.
     ret R.ok[query.QueryOutput, str](out);
 }
 
-pub fun resolve_handle_decode(e: *query.QueryEntry) *resolve.ResolveResult {
+pub fun resolve_handle_decode(e: query.QueryView) *resolve.ResolveResult {
     if (e.value == nil || e.value_len::usize < $size_of(ptr)) { ret nil; }
     val slot: *ptr = e.value::ptr::*ptr;
     ret slot[0]::*resolve.ResolveResult;
@@ -357,4 +367,421 @@ test "mach.lang.driver.query:fp_domain_u8_matches_fingerprint_encoder_framing" {
     binary.encoder_dnit(?e);
     if (fb.buf != nil && fb.cap > 0) { A.deallocate[u8](?alloc, fb.buf, fb.cap); }
     ret 0;
+}
+
+pub fun fp_constant(fb: *FpBuf, item: *resolve.ExportConstant, origin: session.StableModuleId,
+                    definition_revision: query.Revision) R.Result[R.Void, str] {
+    val name: R.Result[R.Void, str] = fp_u32(fb, item.name::u32);
+    if (R.is_err[R.Void, str](name)) { ret name; }
+    var present: u8 = 0;
+    if (item.present) { present = 1; }
+    val presence: R.Result[R.Void, str] = fp_u8(fb, present);
+    if (R.is_err[R.Void, str](presence) || !item.present) { ret presence; }
+    var gated: u8 = 0;
+    if (item.gated) { gated = 1; }
+    val gate: R.Result[R.Void, str] = fp_u8(fb, gated);
+    if (R.is_err[R.Void, str](gate)) { ret gate; }
+    val value: *comptime.CTValue = ?item.value;
+    val kind: R.Result[R.Void, str] = fp_u8(fb, value.kind);
+    if (R.is_err[R.Void, str](kind)) { ret kind; }
+    var low: u64 = 0;
+    var high: u64 = 0;
+    var width: u8 = 0;
+    var unsigned: u8 = 0;
+    if (value.kind == comptime.CT_KIND_INT) {
+        low = value.data.i::u64;
+        width = value.int_width;
+        if (value.int_unsigned) { unsigned = 1; }
+    } or (value.kind == comptime.CT_KIND_FLOAT) {
+        low = float.f64_bits(value.data.f);
+        width = value.float_width;
+    } or (value.kind == comptime.CT_KIND_STR) {
+        low = value.data.s::u64;
+    } or (value.kind == comptime.CT_KIND_TYPE) {
+        low = value.data.t::u64;
+    } or (value.kind == comptime.CT_KIND_FIELD) {
+        low = value.data.fld.owner::u64;
+        high = value.data.fld.index::u64;
+    } or (value.kind == comptime.CT_KIND_PACK_ELEM) {
+        low = value.data.pelem.index::u64;
+        high = value.data.pelem.ty::u64;
+    } or (value.kind == comptime.CT_KIND_CONST_ELEM) {
+        low = value.data.celem.elem::u64;
+        high = value.data.celem.ty::u64;
+        if (definition_revision == 0 || origin == session.STABLE_MODULE_NIL) {
+            ret R.err[R.Void, str]("constant element surface requires its current definition revision");
+        }
+    } or { ret R.err[R.Void, str]("constant surface has an unknown value kind"); }
+    val signedness: R.Result[R.Void, str] = fp_u8(fb, unsigned);
+    if (R.is_err[R.Void, str](signedness)) { ret signedness; }
+    val bits: R.Result[R.Void, str] = fp_u8(fb, width);
+    if (R.is_err[R.Void, str](bits)) { ret bits; }
+    val lo: R.Result[R.Void, str] = fp_u64(fb, low);
+    if (R.is_err[R.Void, str](lo)) { ret lo; }
+    val hi: R.Result[R.Void, str] = fp_u64(fb, high);
+    if (R.is_err[R.Void, str](hi)) { ret hi; }
+    if (value.kind == comptime.CT_KIND_CONST_ELEM) {
+        val module: R.Result[R.Void, str] = fp_u32(fb, origin::u32);
+        if (R.is_err[R.Void, str](module)) { ret module; }
+        ret fp_u64(fb, definition_revision);
+    }
+    ret R.ok_void[str]();
+}
+
+pub fun fp_public_surface(fb: *FpBuf, rr: *resolve.ResolveResult, origin: session.StableModuleId,
+                          definition_revision: query.Revision) R.Result[R.Void, str] {
+    val count: R.Result[R.Void, str] = fp_u32(fb, rr.pub_count);
+    if (R.is_err[R.Void, str](count)) { ret count; }
+    var i: u32 = 0;
+    for (i < rr.pub_count) {
+        val symbol: *resolve.Symbol = ?rr.symbols[i];
+        val kind: R.Result[R.Void, str] = fp_u8(fb, symbol.definition_kind);
+        if (R.is_err[R.Void, str](kind)) { ret kind; }
+        val name: R.Result[R.Void, str] = fp_u32(fb, symbol.name::u32);
+        if (R.is_err[R.Void, str](name)) { ret name; }
+        val canon: R.Result[R.Void, str] = fp_u32(fb, symbol.canon::u32);
+        if (R.is_err[R.Void, str](canon)) { ret canon; }
+        val file: R.Result[R.Void, str] = fp_u32(fb, symbol.definition_file::u32);
+        if (R.is_err[R.Void, str](file)) { ret file; }
+        val arity: R.Result[R.Void, str] = fp_u32(fb, symbol.generic_arity);
+        if (R.is_err[R.Void, str](arity)) { ret arity; }
+        var slot: u32 = symbol.slot;
+        if (symbol.definition_kind == resolve.SYM_USE) { slot = symbol.slot_stable::u32; }
+        val slot_r: R.Result[R.Void, str] = fp_u32(fb, slot);
+        if (R.is_err[R.Void, str](slot_r)) { ret slot_r; }
+        val module: R.Result[R.Void, str] = fp_u32(fb, symbol.origin_stable::u32);
+        if (R.is_err[R.Void, str](module)) { ret module; }
+        i = i + 1;
+    }
+    val constants: R.Result[R.Void, str] = fp_u32(fb, rr.public_constant_count);
+    if (R.is_err[R.Void, str](constants)) { ret constants; }
+    i = 0;
+    for (i < rr.public_constant_count) {
+        val item: R.Result[R.Void, str] = fp_constant(fb, ?rr.public_constants[i], origin, definition_revision);
+        if (R.is_err[R.Void, str](item)) { ret item; }
+        i = i + 1;
+    }
+    ret R.ok_void[str]();
+}
+
+pub fun public_symbols_decode(a: *A.Allocator, s: *session.Session, bytes: *u8, len: u32,
+                              path: intern.StrId, module: session.ModuleId) R.Result[resolve.ModuleExports, str] {
+    if (len < 8) { ret R.err[resolve.ModuleExports, str]("public symbol surface is truncated"); }
+    var decoder: binary.Decoder = binary.decoder(bytes, len::usize, binary.LITTLE);
+    val count: R.Result[u32, str] = binary.read_u32(?decoder);
+    if (R.is_err[u32, str](count)) { ret R.err[resolve.ModuleExports, str](R.unwrap_err[u32, str](count)); }
+    val n: u32 = R.unwrap_ok[u32, str](count);
+    if (n > (len - 8) / 25) { ret R.err[resolve.ModuleExports, str]("public symbol surface is truncated"); }
+    var out: resolve.ModuleExports = resolve.ModuleExports{ path: path, module: module };
+    if (n == 0) { ret R.ok[resolve.ModuleExports, str](out); }
+    val allocated: R.Result[*resolve.PublicSymbol, str] = A.allocate[resolve.PublicSymbol](a, n::usize);
+    if (R.is_err[*resolve.PublicSymbol, str](allocated)) { ret R.err[resolve.ModuleExports, str](R.unwrap_err[*resolve.PublicSymbol, str](allocated)); }
+    val symbols: *resolve.PublicSymbol = R.unwrap_ok[*resolve.PublicSymbol, str](allocated);
+    var transferred: bool = false;
+    fin { if (!transferred) { A.deallocate[resolve.PublicSymbol](a, symbols, n::usize); } }
+    var i: u32 = 0;
+    for (i < n) {
+        val kind: R.Result[u8, str] = binary.read_u8(?decoder);
+        val name: R.Result[u32, str] = binary.read_u32(?decoder);
+        val canon: R.Result[u32, str] = binary.read_u32(?decoder);
+        val file: R.Result[u32, str] = binary.read_u32(?decoder);
+        val arity: R.Result[u32, str] = binary.read_u32(?decoder);
+        val slot: R.Result[u32, str] = binary.read_u32(?decoder);
+        val origin: R.Result[u32, str] = binary.read_u32(?decoder);
+        if (R.is_err[u8, str](kind) || R.is_err[u32, str](name) || R.is_err[u32, str](canon)
+            || R.is_err[u32, str](file) || R.is_err[u32, str](arity) || R.is_err[u32, str](slot) || R.is_err[u32, str](origin)) {
+            ret R.err[resolve.ModuleExports, str]("public symbol surface is truncated");
+        }
+        var symbol: resolve.PublicSymbol = resolve.PublicSymbol{};
+        symbol.kind = R.unwrap_ok[u8, str](kind);
+        symbol.name = R.unwrap_ok[u32, str](name)::intern.StrId;
+        symbol.canon = R.unwrap_ok[u32, str](canon)::intern.StrId;
+        symbol.file = R.unwrap_ok[u32, str](file)::source.FileId;
+        symbol.generic_arity = R.unwrap_ok[u32, str](arity);
+        symbol.slot = R.unwrap_ok[u32, str](slot);
+        val stable: session.StableModuleId = R.unwrap_ok[u32, str](origin)::session.StableModuleId;
+        symbol.origin = session.module_id_for_stable(s, stable);
+        if (stable != session.STABLE_MODULE_NIL && symbol.origin == session.MODULE_NIL) {
+            ret R.err[resolve.ModuleExports, str]("public symbol origin is not loaded");
+        }
+        if (symbol.kind == resolve.SYM_USE) {
+            val slot_stable: session.StableModuleId = symbol.slot::session.StableModuleId;
+            symbol.slot = session.module_id_for_stable(s, slot_stable)::u32;
+            if (slot_stable != session.STABLE_MODULE_NIL && symbol.slot == session.MODULE_NIL::u32) {
+                ret R.err[resolve.ModuleExports, str]("public module slot is not loaded");
+            }
+        }
+        symbols[i] = symbol;
+        i = i + 1;
+    }
+    out.symbols = symbols;
+    out.count = n;
+    transferred = true;
+    ret R.ok[resolve.ModuleExports, str](out);
+}
+
+test "mach.lang.driver.query.public_surface:canonical_name_is_owned_and_module_slots_are_remapped" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    val initialized: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](initialized)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?s); }
+    if (R.is_err[R.Void, str](session.register_stable_mid(?s, 17, 2))) { ret 2; }
+    if (R.is_err[R.Void, str](session.register_stable_mid(?s, 18, 3))) { ret 3; }
+    var symbol: resolve.Symbol = resolve.Symbol{ kind: resolve.SYM_USE, definition_kind: resolve.SYM_USE, name: 5, canon: 6,
+        decl: 7, slot: 1, origin: 0, origin_stable: 17, slot_stable: 18 };
+    var result: resolve.ResolveResult = resolve.ResolveResult{ symbols: ?symbol, pub_count: 1 };
+    var before: FpBuf = FpBuf{ alloc: ?alloc };
+    fin { fp_free(?before); }
+    var after: FpBuf = FpBuf{ alloc: ?alloc };
+    fin { fp_free(?after); }
+    if (R.is_err[R.Void, str](fp_public_surface(?before, ?result, 17, 0))) { ret 4; }
+    symbol.canon = 0x78563412;
+    if (R.is_err[R.Void, str](fp_public_surface(?after, ?result, 17, 0))) { ret 5; }
+    if (before.len != 29 || after.len != 29 || fp_bytes_eq(before.buf, after.buf, before.len)) { ret 6; }
+    if (after.buf[9] != 0x12 || after.buf[10] != 0x34 || after.buf[11] != 0x56 || after.buf[12] != 0x78) { ret 7; }
+    symbol.canon = 99;
+    symbol.slot_stable = session.STABLE_MODULE_NIL;
+    val decoded: R.Result[resolve.ModuleExports, str] = public_symbols_decode(?alloc, ?s, after.buf, after.len::u32, 4, 2);
+    if (R.is_err[resolve.ModuleExports, str](decoded)) { ret 8; }
+    val exports: resolve.ModuleExports = R.unwrap_ok[resolve.ModuleExports, str](decoded);
+    fin { A.deallocate[resolve.PublicSymbol](?alloc, exports.symbols, exports.count::usize); }
+    if (exports.count != 1 || exports.symbols[0].canon != 0x78563412) { ret 9; }
+    if (exports.symbols[0].origin != 2 || exports.symbols[0].slot != 3) { ret 10; }
+    ret 0;
+}
+
+test "mach.lang.driver.query.constant_surface:float_width_and_definition_revisions_are_observable" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var item: resolve.ExportConstant = resolve.ExportConstant{ name: 1, present: true };
+    item.value.kind = comptime.CT_KIND_FLOAT;
+    item.value.float_width = float.FLOAT_W_32;
+    item.value.data.f = 1.5;
+    var narrow: FpBuf = FpBuf{ alloc: ?alloc };
+    fin { fp_free(?narrow); }
+    var wide: FpBuf = FpBuf{ alloc: ?alloc };
+    fin { fp_free(?wide); }
+    if (R.is_err[R.Void, str](fp_constant(?narrow, ?item, 2, 0))) { ret 1; }
+    item.value.float_width = float.FLOAT_W_64;
+    if (R.is_err[R.Void, str](fp_constant(?wide, ?item, 2, 0))) { ret 2; }
+    if (narrow.len != 25 || wide.len != 25 || narrow.buf[8] != 32 || wide.buf[8] != 64) { ret 3; }
+    if (fp_bytes_eq(narrow.buf, wide.buf, narrow.len)) { ret 4; }
+    fp_free(?narrow);
+    fp_free(?wide);
+    item.value = comptime.const_elem_value(7, 9);
+    if (R.is_err[R.Void, str](fp_constant(?narrow, ?item, 2, 100))) { ret 5; }
+    if (R.is_err[R.Void, str](fp_constant(?wide, ?item, 2, 101))) { ret 6; }
+    if (narrow.len != 37 || wide.len != 37 || fp_bytes_eq(narrow.buf, wide.buf, narrow.len)) { ret 7; }
+    fp_free(?wide);
+    if (!R.is_err[R.Void, str](fp_constant(?wide, ?item, 2, 0))) { ret 8; }
+    ret 0;
+}
+
+test "mach.lang.driver.query.public_surface:definition_kind_changes_without_a_spelling_change" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var symbol: resolve.Symbol = resolve.Symbol{ kind: resolve.SYM_IMPORTED,
+        definition_kind: resolve.SYM_FUN, name: 11, canon: 12, decl: 3,
+        origin: 0, origin_stable: 4, slot_stable: session.STABLE_MODULE_NIL };
+    var result: resolve.ResolveResult = resolve.ResolveResult{ symbols: ?symbol, pub_count: 1 };
+    var function: FpBuf = FpBuf{ alloc: ?alloc };
+    fin { fp_free(?function); }
+    var value: FpBuf = FpBuf{ alloc: ?alloc };
+    fin { fp_free(?value); }
+    if (R.is_err[R.Void, str](fp_public_surface(?function, ?result, 4, 1))) { ret 2; }
+    symbol.definition_kind = resolve.SYM_VAL;
+    if (R.is_err[R.Void, str](fp_public_surface(?value, ?result, 4, 1))) { ret 3; }
+    if (function.len != value.len || function.len != 29) { ret 4; }
+    if (fp_bytes_eq(function.buf, value.buf, function.len)) { ret 5; }
+    if (function.buf[4] != resolve.SYM_FUN || value.buf[4] != resolve.SYM_VAL) { ret 6; }
+    ret 0;
+}
+
+fun constant_decode(decoder: *binary.Decoder, origin: session.StableModuleId,
+                    incarnation: *u64) R.Result[resolve.ExportConstant, str] {
+    var item: resolve.ExportConstant = resolve.ExportConstant{};
+    @incarnation = 0;
+    val name: R.Result[u32, str] = binary.read_u32(decoder);
+    val present: R.Result[u8, str] = binary.read_u8(decoder);
+    if (R.is_err[u32, str](name) || R.is_err[u8, str](present)) { ret R.err[resolve.ExportConstant, str]("constant surface is truncated"); }
+    item.name = R.unwrap_ok[u32, str](name)::intern.StrId;
+    val presence: u8 = R.unwrap_ok[u8, str](present);
+    if (presence > 1) { ret R.err[resolve.ExportConstant, str]("constant presence is invalid"); }
+    if (presence == 0) { ret R.ok[resolve.ExportConstant, str](item); }
+    item.present = true;
+    val gated: R.Result[u8, str] = binary.read_u8(decoder);
+    val kind: R.Result[u8, str] = binary.read_u8(decoder);
+    val unsigned: R.Result[u8, str] = binary.read_u8(decoder);
+    val width: R.Result[u8, str] = binary.read_u8(decoder);
+    val low: R.Result[u64, str] = binary.read_u64(decoder);
+    val high: R.Result[u64, str] = binary.read_u64(decoder);
+    if (R.is_err[u8, str](gated) || R.is_err[u8, str](kind) || R.is_err[u8, str](unsigned)
+        || R.is_err[u8, str](width) || R.is_err[u64, str](low) || R.is_err[u64, str](high)) {
+        ret R.err[resolve.ExportConstant, str]("constant surface is truncated");
+    }
+    if (R.unwrap_ok[u8, str](gated) > 1 || R.unwrap_ok[u8, str](unsigned) > 1) {
+        ret R.err[resolve.ExportConstant, str]("constant flags are invalid");
+    }
+    item.gated = R.unwrap_ok[u8, str](gated) != 0;
+    item.value.kind = R.unwrap_ok[u8, str](kind);
+    val lo: u64 = R.unwrap_ok[u64, str](low);
+    val hi: u64 = R.unwrap_ok[u64, str](high);
+    val bits: u8 = R.unwrap_ok[u8, str](width);
+    if (item.value.kind == comptime.CT_KIND_INT) {
+        item.value.data.i = lo::i64;
+        item.value.int_unsigned = R.unwrap_ok[u8, str](unsigned) != 0;
+        item.value.int_width = bits;
+    } or (item.value.kind == comptime.CT_KIND_FLOAT) {
+        item.value.data.f = float.bits_f64(lo);
+        item.value.float_width = bits;
+    } or (item.value.kind == comptime.CT_KIND_STR) {
+        item.value.data.s = lo::intern.StrId;
+    } or (item.value.kind == comptime.CT_KIND_TYPE) {
+        item.value.data.t = lo::u32;
+    } or (item.value.kind == comptime.CT_KIND_FIELD) {
+        item.value.data.fld.owner = lo::u32;
+        item.value.data.fld.index = hi::u32;
+    } or (item.value.kind == comptime.CT_KIND_PACK_ELEM) {
+        item.value.data.pelem.index = lo::u32;
+        item.value.data.pelem.ty = hi::u32;
+    } or (item.value.kind == comptime.CT_KIND_CONST_ELEM) {
+        item.value.data.celem.elem = lo::u32;
+        item.value.data.celem.ty = hi::u32;
+        val module: R.Result[u32, str] = binary.read_u32(decoder);
+        val revision: R.Result[u64, str] = binary.read_u64(decoder);
+        if (R.is_err[u32, str](module) || R.is_err[u64, str](revision)
+            || R.unwrap_ok[u32, str](module) != origin::u32 || R.unwrap_ok[u64, str](revision) == 0) {
+            ret R.err[resolve.ExportConstant, str]("constant element has no matching parsed definition");
+        }
+        @incarnation = R.unwrap_ok[u64, str](revision);
+    } or { ret R.err[resolve.ExportConstant, str]("constant surface has an unknown value kind"); }
+    ret R.ok[resolve.ExportConstant, str](item);
+}
+
+pub fun typed_surface_encode(fb: *FpBuf, surface: *scx.ModuleSema) R.Result[R.Void, str] {
+    if (surface.exports.len > 0xFFFFFFFF::usize || surface.graph.nodes.len > 0xFFFFFFFF::usize) {
+        ret R.err[R.Void, str]("typed surface exceeds its row count extent");
+    }
+    val count: R.Result[R.Void, str] = fp_u32(fb, surface.exports.len::u32);
+    if (R.is_err[R.Void, str](count)) { ret count; }
+    var i: usize = 0;
+    for (i < surface.exports.len) {
+        val row: *scx.TypeExport = ?surface.exports.data[i];
+        val origin: R.Result[R.Void, str] = fp_u32(fb, row.origin::u32);
+        if (R.is_err[R.Void, str](origin)) { ret origin; }
+        val canon: R.Result[R.Void, str] = fp_u32(fb, row.canon::u32);
+        if (R.is_err[R.Void, str](canon)) { ret canon; }
+        val ty: R.Result[R.Void, str] = fp_u32(fb, row.ty::u32);
+        if (R.is_err[R.Void, str](ty)) { ret ty; }
+        val constant: R.Result[R.Void, str] = fp_constant(fb, ?row.constant, row.origin, row.definition_incarnation);
+        if (R.is_err[R.Void, str](constant)) { ret constant; }
+        i = i + 1;
+    }
+    val nodes: R.Result[R.Void, str] = fp_u32(fb, surface.graph.nodes.len::u32);
+    if (R.is_err[R.Void, str](nodes)) { ret nodes; }
+    i = 0;
+    for (i < surface.graph.nodes.len) {
+        val node: *fields.Node = ?surface.graph.nodes.data[i];
+        if (node.entries.len > 0xFFFFFFFF::usize) { ret R.err[R.Void, str]("typed field recipe exceeds its field count extent"); }
+        val ty: R.Result[R.Void, str] = fp_u32(fb, node.ty::u32);
+        if (R.is_err[R.Void, str](ty)) { ret ty; }
+        var flags: u8 = 0;
+        if (node.has_align) { flags = flags | 1; }
+        if (node.packed) { flags = flags | 2; }
+        if (node.volatile_) { flags = flags | 4; }
+        val attributes: R.Result[R.Void, str] = fp_u8(fb, flags);
+        if (R.is_err[R.Void, str](attributes)) { ret attributes; }
+        val align: R.Result[R.Void, str] = fp_u32(fb, node.align);
+        if (R.is_err[R.Void, str](align)) { ret align; }
+        val count: R.Result[R.Void, str] = fp_u32(fb, node.entries.len::u32);
+        if (R.is_err[R.Void, str](count)) { ret count; }
+        var j: usize = 0;
+        for (j < node.entries.len) {
+            val field: type.FieldEntry = node.entries.data[j];
+            val name: R.Result[R.Void, str] = fp_u32(fb, field.name::u32);
+            if (R.is_err[R.Void, str](name)) { ret name; }
+            val field_type: R.Result[R.Void, str] = fp_u32(fb, field.ty::u32);
+            if (R.is_err[R.Void, str](field_type)) { ret field_type; }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    ret R.ok_void[str]();
+}
+
+pub fun typed_surface_decode(a: *A.Allocator, bytes: *u8, len: u32,
+                            path: intern.StrId, mid: session.ModuleId) R.Result[scx.ModuleSema, str] {
+    var surface: scx.ModuleSema = scx.module_sema_init(a, path, mid);
+    var transferred: bool = false;
+    fin { if (!transferred) { scx.module_sema_dnit(?surface); } }
+    var decoder: binary.Decoder = binary.decoder(bytes, len::usize, binary.LITTLE);
+    val count: R.Result[u32, str] = binary.read_u32(?decoder);
+    if (R.is_err[u32, str](count)) { ret R.err[scx.ModuleSema, str]("typed surface is truncated"); }
+    val rows: u32 = R.unwrap_ok[u32, str](count);
+    if (rows::usize > binary.remaining(?decoder) / 17) { ret R.err[scx.ModuleSema, str]("typed symbol rows are truncated"); }
+    var i: u32 = 0;
+    for (i < rows) {
+        val origin: R.Result[u32, str] = binary.read_u32(?decoder);
+        val canon: R.Result[u32, str] = binary.read_u32(?decoder);
+        val ty: R.Result[u32, str] = binary.read_u32(?decoder);
+        if (R.is_err[u32, str](origin) || R.is_err[u32, str](canon) || R.is_err[u32, str](ty)) {
+            ret R.err[scx.ModuleSema, str]("typed symbol row is truncated");
+        }
+        var row: scx.TypeExport = scx.TypeExport{
+            origin: R.unwrap_ok[u32, str](origin)::session.StableModuleId,
+            canon: R.unwrap_ok[u32, str](canon)::intern.StrId,
+            ty: R.unwrap_ok[u32, str](ty)::type.TypeId
+        };
+        val constant: R.Result[resolve.ExportConstant, str] = constant_decode(?decoder, row.origin, ?row.definition_incarnation);
+        if (R.is_err[resolve.ExportConstant, str](constant)) { ret R.err[scx.ModuleSema, str](R.unwrap_err[resolve.ExportConstant, str](constant)); }
+        row.constant = R.unwrap_ok[resolve.ExportConstant, str](constant);
+        val appended: R.Result[usize, str] = vector.push[scx.TypeExport](?surface.exports, row);
+        if (R.is_err[usize, str](appended)) { ret R.err[scx.ModuleSema, str](R.unwrap_err[usize, str](appended)); }
+        i = i + 1;
+    }
+    val node_count: R.Result[u32, str] = binary.read_u32(?decoder);
+    if (R.is_err[u32, str](node_count)) { ret R.err[scx.ModuleSema, str]("typed recipe count is truncated"); }
+    val nodes: u32 = R.unwrap_ok[u32, str](node_count);
+    if (nodes::usize > binary.remaining(?decoder) / 13) { ret R.err[scx.ModuleSema, str]("typed recipes are truncated"); }
+    i = 0;
+    for (i < nodes) {
+        val ty: R.Result[u32, str] = binary.read_u32(?decoder);
+        val flags: R.Result[u8, str] = binary.read_u8(?decoder);
+        val align: R.Result[u32, str] = binary.read_u32(?decoder);
+        val count: R.Result[u32, str] = binary.read_u32(?decoder);
+        if (R.is_err[u32, str](ty) || R.is_err[u8, str](flags) || R.is_err[u32, str](align) || R.is_err[u32, str](count)) {
+            ret R.err[scx.ModuleSema, str]("typed recipe is truncated");
+        }
+        val attributes: u8 = R.unwrap_ok[u8, str](flags);
+        val field_count: u32 = R.unwrap_ok[u32, str](count);
+        if (attributes > 7 || field_count::usize > binary.remaining(?decoder) / 8) {
+            ret R.err[scx.ModuleSema, str]("typed recipe attributes or field extent are invalid");
+        }
+        var node: fields.Node = fields.Node{
+            ty: R.unwrap_ok[u32, str](ty)::type.TypeId,
+            entries: vector.init[type.FieldEntry](a), has_align: (attributes & 1) != 0,
+            align: R.unwrap_ok[u32, str](align), packed: (attributes & 2) != 0, volatile_: (attributes & 4) != 0
+        };
+        var node_transferred: bool = false;
+        fin { if (!node_transferred) { vector.dnit[type.FieldEntry](?node.entries); } }
+        var j: u32 = 0;
+        for (j < field_count) {
+            val name: R.Result[u32, str] = binary.read_u32(?decoder);
+            val field_type: R.Result[u32, str] = binary.read_u32(?decoder);
+            if (R.is_err[u32, str](name) || R.is_err[u32, str](field_type)) { ret R.err[scx.ModuleSema, str]("typed field is truncated"); }
+            val field: type.FieldEntry = type.FieldEntry{ name: R.unwrap_ok[u32, str](name)::intern.StrId, ty: R.unwrap_ok[u32, str](field_type)::type.TypeId };
+            val added: R.Result[usize, str] = vector.push[type.FieldEntry](?node.entries, field);
+            if (R.is_err[usize, str](added)) { ret R.err[scx.ModuleSema, str](R.unwrap_err[usize, str](added)); }
+            j = j + 1;
+        }
+        val added: R.Result[usize, str] = vector.push[fields.Node](?surface.graph.nodes, node);
+        if (R.is_err[usize, str](added)) { ret R.err[scx.ModuleSema, str](R.unwrap_err[usize, str](added)); }
+        node_transferred = true;
+        i = i + 1;
+    }
+    if (binary.remaining(?decoder) != 0) { ret R.err[scx.ModuleSema, str]("typed surface has trailing bytes"); }
+    transferred = true;
+    ret R.ok[scx.ModuleSema, str](surface);
 }

--- a/src/lang/driver/query.mach
+++ b/src/lang/driver/query.mach
@@ -445,6 +445,10 @@ pub fun fp_public_surface(fb: *FpBuf, rr: *resolve.ResolveResult, origin: sessio
         if (R.is_err[R.Void, str](file)) { ret file; }
         val arity: R.Result[R.Void, str] = fp_u32(fb, symbol.generic_arity);
         if (R.is_err[R.Void, str](arity)) { ret arity; }
+        val comptime: R.Result[R.Void, str] = fp_u8(fb, symbol.has_comptime_params::u8);
+        if (R.is_err[R.Void, str](comptime)) { ret comptime; }
+        val pack: R.Result[R.Void, str] = fp_u8(fb, symbol.has_pack_param::u8);
+        if (R.is_err[R.Void, str](pack)) { ret pack; }
         var slot: u32 = symbol.slot;
         if (symbol.definition_kind == resolve.SYM_USE) { slot = symbol.slot_stable::u32; }
         val slot_r: R.Result[R.Void, str] = fp_u32(fb, slot);
@@ -471,7 +475,7 @@ pub fun public_symbols_decode(a: *A.Allocator, s: *session.Session, bytes: *u8, 
     val count: R.Result[u32, str] = binary.read_u32(?decoder);
     if (R.is_err[u32, str](count)) { ret R.err[resolve.ModuleExports, str](R.unwrap_err[u32, str](count)); }
     val n: u32 = R.unwrap_ok[u32, str](count);
-    if (n > (len - 8) / 25) { ret R.err[resolve.ModuleExports, str]("public symbol surface is truncated"); }
+    if (n > (len - 8) / 27) { ret R.err[resolve.ModuleExports, str]("public symbol surface is truncated"); }
     var out: resolve.ModuleExports = resolve.ModuleExports{ path: path, module: module };
     if (n == 0) { ret R.ok[resolve.ModuleExports, str](out); }
     val allocated: R.Result[*resolve.PublicSymbol, str] = A.allocate[resolve.PublicSymbol](a, n::usize);
@@ -486,18 +490,24 @@ pub fun public_symbols_decode(a: *A.Allocator, s: *session.Session, bytes: *u8, 
         val canon: R.Result[u32, str] = binary.read_u32(?decoder);
         val file: R.Result[u32, str] = binary.read_u32(?decoder);
         val arity: R.Result[u32, str] = binary.read_u32(?decoder);
+        val comptime: R.Result[u8, str] = binary.read_u8(?decoder);
+        val pack: R.Result[u8, str] = binary.read_u8(?decoder);
         val slot: R.Result[u32, str] = binary.read_u32(?decoder);
         val origin: R.Result[u32, str] = binary.read_u32(?decoder);
         if (R.is_err[u8, str](kind) || R.is_err[u32, str](name) || R.is_err[u32, str](canon)
             || R.is_err[u32, str](file) || R.is_err[u32, str](arity) || R.is_err[u32, str](slot) || R.is_err[u32, str](origin)) {
             ret R.err[resolve.ModuleExports, str]("public symbol surface is truncated");
         }
+        if (R.is_err[u8, str](comptime) || R.is_err[u8, str](pack)) { ret R.err[resolve.ModuleExports, str]("public symbol surface is truncated"); }
         var symbol: resolve.PublicSymbol = resolve.PublicSymbol{};
         symbol.kind = R.unwrap_ok[u8, str](kind);
         symbol.name = R.unwrap_ok[u32, str](name)::intern.StrId;
         symbol.canon = R.unwrap_ok[u32, str](canon)::intern.StrId;
         symbol.file = R.unwrap_ok[u32, str](file)::source.FileId;
         symbol.generic_arity = R.unwrap_ok[u32, str](arity);
+        if (R.unwrap_ok[u8, str](comptime) > 1 || R.unwrap_ok[u8, str](pack) > 1) { ret R.err[resolve.ModuleExports, str]("public symbol call shape is invalid"); }
+        symbol.has_comptime_params = R.unwrap_ok[u8, str](comptime) != 0;
+        symbol.has_pack_param = R.unwrap_ok[u8, str](pack) != 0;
         symbol.slot = R.unwrap_ok[u32, str](slot);
         val stable: session.StableModuleId = R.unwrap_ok[u32, str](origin)::session.StableModuleId;
         symbol.origin = session.module_id_for_stable(s, stable);
@@ -539,7 +549,7 @@ test "mach.lang.driver.query.public_surface:canonical_name_is_owned_and_module_s
     if (R.is_err[R.Void, str](fp_public_surface(?before, ?result, 17, 0))) { ret 4; }
     symbol.canon = 0x78563412;
     if (R.is_err[R.Void, str](fp_public_surface(?after, ?result, 17, 0))) { ret 5; }
-    if (before.len != 29 || after.len != 29 || fp_bytes_eq(before.buf, after.buf, before.len)) { ret 6; }
+    if (before.len != 35 || after.len != 35 || fp_bytes_eq(before.buf, after.buf, before.len)) { ret 6; }
     if (after.buf[9] != 0x12 || after.buf[10] != 0x34 || after.buf[11] != 0x56 || after.buf[12] != 0x78) { ret 7; }
     symbol.canon = 99;
     symbol.slot_stable = session.STABLE_MODULE_NIL;
@@ -593,7 +603,7 @@ test "mach.lang.driver.query.public_surface:definition_kind_changes_without_a_sp
     if (R.is_err[R.Void, str](fp_public_surface(?function, ?result, 4, 1))) { ret 2; }
     symbol.definition_kind = resolve.SYM_VAL;
     if (R.is_err[R.Void, str](fp_public_surface(?value, ?result, 4, 1))) { ret 3; }
-    if (function.len != value.len || function.len != 29) { ret 4; }
+    if (function.len != value.len || function.len != 35) { ret 4; }
     if (fp_bytes_eq(function.buf, value.buf, function.len)) { ret 5; }
     if (function.buf[4] != resolve.SYM_FUN || value.buf[4] != resolve.SYM_VAL) { ret 6; }
     ret 0;

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -1254,6 +1254,15 @@ fun ut_count_errors(d: *diagnostic.DiagnosticStore) u32 {
     ret c;
 }
 
+fun ut_project_was_rejected(result: R.Result[project.Project, outcome.Fail]) bool {
+    if (R.is_ok[project.Project, outcome.Fail](result)) {
+        var accepted: project.Project = R.unwrap_ok[project.Project, outcome.Fail](result);
+        project.dnit_project(?accepted);
+        ret false;
+    }
+    ret R.unwrap_err[project.Project, outcome.Fail](result).kind == outcome.FAIL_REPORTED;
+}
+
 fun ut_diag_has(d: *diagnostic.DiagnosticStore, needle: str) bool {
     var i: usize = 0;
     for (i < diagnostic.len(d)) {
@@ -1332,10 +1341,17 @@ fun ut_single_result_n(names: *str, texts: *str, n: u32, needle: str, want_diag:
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
     val pr: R.Result[project.Project, outcome.Fail] = ut_single_sema_n(?s, ?alloc, names, texts, n);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
+    if (R.is_err[project.Project, outcome.Fail](pr)) {
+        val expected: bool = want_diag
+            && R.unwrap_err[project.Project, outcome.Fail](pr).kind == outcome.FAIL_REPORTED
+            && ut_diag_has(?s.diags, needle);
+        session.dnit(?s);
+        if (expected) { ret 0; }
+        ret 1;
+    }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
     var ok: bool = ut_count_errors(?p.s.diags) == 0;
-    if (want_diag) { ok = ut_diag_has(?p.s.diags, needle); }
+    if (want_diag) { ok = false; }
     project.dnit_project(?p);
     session.dnit(?s);
     if (ok) { ret 0; }
@@ -1366,69 +1382,53 @@ fun ut_single_diag2(main: str, lib: str, needle: str) i32 {
     ret ut_single_result_n(?names[0], ?texts[0], 2, needle, true);
 }
 
-fun ut_vec_diag(src: str, needle: str) i32 {
+fun ut_vec_diagnostic_n(names: *str, texts: *str, n: u32, needle: str, note: bool) i32 {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
-    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_sema(?s, ?alloc, src);
+    fin { session.dnit(?s); }
+    val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, names, texts, n);
     if (R.is_err[project.Project, outcome.Fail](pr)) {
-        print.print(R.unwrap_err[project.Project, outcome.Fail](pr).message);
-        print.print("\n");
-        session.dnit(?s);
+        if (R.unwrap_err[project.Project, outcome.Fail](pr).kind != outcome.FAIL_REPORTED) { ret 1; }
+        if (note) { if (ut_diag_note_has(?s.diags, needle)) { ret 0; } }
+        or { if (ut_diag_has(?s.diags, needle)) { ret 0; } }
         ret 1;
     }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val hit: bool = ut_diag_has(?p.s.diags, needle);
-    if (!hit) {
-        var di: usize = 0;
-        for (di < diagnostic.len(?p.s.diags)) { print.print(p.s.diags.items.data[di].message); print.print("\n"); di = di + 1; }
-    }
-    project.dnit_project(?p);
-    session.dnit(?s);
+    fin { project.dnit_project(?p); }
+    val checked: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
+    if (R.is_ok[R.Void, outcome.Fail](checked)) {
+        if (!note) { ret 1; }
+    } or (R.unwrap_err[R.Void, outcome.Fail](checked).kind != outcome.FAIL_REPORTED) { ret 1; }
+    var hit: bool = ut_diag_has(?s.diags, needle);
+    if (note) { hit = ut_diag_note_has(?s.diags, needle); }
     if (hit) { ret 0; }
+    var di: usize = 0;
+    for (di < diagnostic.len(?s.diags)) {
+        print.println(s.diags.items.data[di].message);
+        di = di + 1;
+    }
     ret 1;
+}
+
+fun ut_vec_diag(src: str, needle: str) i32 {
+    var names: [1]str = [1]str{ "main.mach" };
+    var texts: [1]str = [1]str{ src };
+    ret ut_vec_diagnostic_n(?names[0], ?texts[0], 1, needle, false);
 }
 
 fun ut_vec_note(src: str, needle: str) i32 {
-    var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
-    val sr: R.Result[session.Session, str] = session.init(?alloc);
-    if (R.is_err[session.Session, str](sr)) { ret 1; }
-    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
-    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_sema(?s, ?alloc, src);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
-    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val hit: bool = ut_diag_note_has(?p.s.diags, needle);
-    project.dnit_project(?p);
-    session.dnit(?s);
-    if (hit) { ret 0; }
-    ret 1;
+    var names: [1]str = [1]str{ "main.mach" };
+    var texts: [1]str = [1]str{ src };
+    ret ut_vec_diagnostic_n(?names[0], ?texts[0], 1, needle, true);
 }
 
 fun ut_vec_diag2(main: str, lib: str, needle: str) i32 {
-    var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
-    val sr: R.Result[session.Session, str] = session.init(?alloc);
-    if (R.is_err[session.Session, str](sr)) { ret 1; }
-    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
-
-    var names: [2]str;
-    names[0] = "main.mach";
-    names[1] = "lib.mach";
-    var texts: [2]str;
-    texts[0] = main;
-    texts[1] = lib;
-
-    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_sema_n(?s, ?alloc, ?names[0], ?texts[0], 2);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
-    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val hit: bool = ut_diag_has(?p.s.diags, needle);
-    project.dnit_project(?p);
-    session.dnit(?s);
-    if (hit) { ret 0; }
-    ret 1;
+    var names: [2]str = [2]str{ "main.mach", "lib.mach" };
+    var texts: [2]str = [2]str{ main, lib };
+    ret ut_vec_diagnostic_n(?names[0], ?texts[0], 2, needle, false);
 }
 
 fun ut_sema_clean2(main: str, lib: str) bool {
@@ -3308,12 +3308,14 @@ test "mach.lang.driver:gate_diagnostic_dedups_across_decl_and_body_inference" {
     var texts: [1]str;
     texts[0] = "def Flag: u8x4;\nval C: Flag = u8x4{1, 2, 3, 4};\n$if (C) { }\nfun main() i32 { ret 0; }\n";
     val pr: R.Result[project.Project, outcome.Fail] = ut_single_sema_n(?s, ?alloc, ?names[0], ?texts[0], 1);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
-    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    if (R.is_ok[project.Project, outcome.Fail](pr)) {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
+    if (R.unwrap_err[project.Project, outcome.Fail](pr).kind != outcome.FAIL_REPORTED) { session.dnit(?s); ret 1; }
     var bad: i32 = 0;
-    if (!ut_diag_has(?p.s.diags, "a vector is not a truth value")) { bad = 2; }
-    if (diagnostic.len(?p.s.diags) != 1) { bad = 3; }
-    project.dnit_project(?p);
+    if (!ut_diag_has(?s.diags, "a vector is not a truth value")) { bad = 2; }
+    if (diagnostic.len(?s.diags) != 1) { bad = 3; }
     session.dnit(?s);
     ret bad;
 }
@@ -3652,10 +3654,8 @@ test "mach.lang.driver:imported_pub_val_array_length" {
     val npr: R.Result[project.Project, outcome.Fail] = ut_sema2(?sNeg, ?alloc,
         "use a: uniontest.a;\nfun main() i32 {\n    var buf: [a.CAP]u8;\n    ret 0;\n}\n",
         "pub var CAP: u64 = 16;\n");
-    if (R.is_err[project.Project, outcome.Fail](npr)) { session.dnit(?sNeg); ret 1; }
-    var pNeg: project.Project = R.unwrap_ok[project.Project, outcome.Fail](npr);
-    if (!ut_diag_has(?pNeg.s.diags, "array length is not a comptime constant")) { bad = 1; }
-    project.dnit_project(?pNeg);
+    if (!ut_project_was_rejected(npr)) { session.dnit(?sNeg); ret 1; }
+    if (!ut_diag_has(?sNeg.diags, "array length is not a comptime constant")) { bad = 1; }
     session.dnit(?sNeg);
 
     ret bad;
@@ -6160,17 +6160,21 @@ test "mach.lang.driver:incremental_resolve_pub_surface_change_equals_scratch" {
     val st_main: session.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.main");
     val lc_main_1: query.Revision = ut_resolve_lc(?sA, st_main);
     val rr_main_1: *resolve.ResolveResult = ut_rr_of(?pA1, ?sA, "uniontest.main");
-    var fa_decl_1: u32 = 0xFFFFFFFF;
+    var fa_found_1: bool = false;
     var si: u32 = 0;
     for (si < rr_main_1.symbol_count) {
-        if (rr_main_1.symbols[si].kind == resolve.SYM_IMPORTED) { fa_decl_1 = rr_main_1.symbols[si].decl::u32; }
+        if (rr_main_1.symbols[si].kind == resolve.SYM_IMPORTED
+            && str_equals(O.unwrap[str](intern.lookup(?sA.interner, rr_main_1.symbols[si].canon)), "fa")) {
+            fa_found_1 = true;
+            if (rr_main_1.symbols[si].decl != aid.DECL_NIL) { bad = 1; }
+        }
         si = si + 1;
     }
     project.dnit_project(?pA1);
 
     val src_dir: str = ut_cc3(?alloc, root, "/", "src");
     val leaf_path: str = ut_cc3(?alloc, src_dir, "/", "leaf.mach");
-    val leaf_v2: str = "pub fun fz() i32 { ret 0; }\npub fun fa() i32 { ret 1; }\n";
+    val leaf_v2: str = "pub fun fz() *u8 { ret nil; }\npub fun fa() i32 { ret 1; }\n";
     if (O.is_some[str](fs.write_bytes(leaf_path, leaf_v2, str_len(leaf_v2), 420))) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
 
     val pA2r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
@@ -6180,13 +6184,19 @@ test "mach.lang.driver:incremental_resolve_pub_surface_change_equals_scratch" {
 
     if (lc_main_2 == lc_main_1) { bad = 1; }
     val rr_main_2: *resolve.ResolveResult = ut_rr_of(?pA2, ?sA, "uniontest.main");
-    var fa_decl_2: u32 = 0xFFFFFFFF;
+    var fa_found_2: bool = false;
     si = 0;
     for (si < rr_main_2.symbol_count) {
-        if (rr_main_2.symbols[si].kind == resolve.SYM_IMPORTED) { fa_decl_2 = rr_main_2.symbols[si].decl::u32; }
+        if (rr_main_2.symbols[si].kind == resolve.SYM_IMPORTED
+            && str_equals(O.unwrap[str](intern.lookup(?sA.interner, rr_main_2.symbols[si].canon)), "fa")) {
+            fa_found_2 = true;
+            if (rr_main_2.symbols[si].decl != aid.DECL_NIL) { bad = 1; }
+        }
         si = si + 1;
     }
-    if (fa_decl_2 == fa_decl_1) { bad = 1; }
+    if (!fa_found_1 || !fa_found_2) { bad = 1; }
+
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?pA2))) { bad = 1; }
 
     val sr2: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr2)) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
@@ -6313,7 +6323,7 @@ test "mach.lang.driver:incremental_resolve_reexport_two_hop_propagation" {
     if (R.is_err[project.Project, outcome.Fail](pA2r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pA2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pA2r);
     if (ut_resolve_lc(?sA, st_mid)  == lc_mid_1)  { bad = 1; }
-    if (ut_resolve_lc(?sA, st_main) == lc_main_1) { bad = 1; }
+    if (ut_resolve_lc(?sA, st_main) != lc_main_1) { bad = 1; }
 
     val sr2: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr2)) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
@@ -6722,7 +6732,7 @@ test "mach.lang.driver:incremental_sema_firewall_body_edit_equals_scratch" {
     var names: [2]str;
     names[0] = "main.mach"; names[1] = "leaf.mach";
     var texts: [2]str;
-    texts[0] = "use uniontest.leaf.fa;\nfun main() i32 { val x = fa(); ret x; }\n";
+    texts[0] = "use uniontest.leaf.fa;\nfun main() i32 { val x: i32 = fa(); ret x; }\n";
     texts[1] = "pub fun fa() i32 { ret 1; }\n";
 
     val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
@@ -6753,8 +6763,8 @@ test "mach.lang.driver:incremental_sema_firewall_body_edit_equals_scratch" {
     val lc_main_2: query.Revision = ut_sema_lc(?sA, st_main);
     val lc_leaf_2: query.Revision = ut_sema_lc(?sA, st_leaf);
 
-    if (lc_main_2 != lc_main_1) { bad = 1; }
-    if (lc_leaf_2 == lc_leaf_1) { bad = 1; }
+    if (lc_main_2 != lc_main_1) { bad = 2; }
+    if (lc_leaf_2 == lc_leaf_1) { bad = 3; }
 
     val sr2: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr2)) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
@@ -6765,8 +6775,8 @@ test "mach.lang.driver:incremental_sema_firewall_body_edit_equals_scratch" {
     var pB: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pBr);
     if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?pB))) { project.dnit_project(?pB); session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
 
-    if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.main"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
-    if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.leaf"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.leaf"))) { bad = 1; }
+    if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.main"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.main"))) { bad = 4; }
+    if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.leaf"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.leaf"))) { bad = 5; }
 
     project.dnit_project(?pB);
     session.dnit(?sB);
@@ -8204,6 +8214,10 @@ fun ut_sema_errs(text: str) i32 {
         errs = -1;
         val sem: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
         if (R.is_ok[R.Void, outcome.Fail](sem)) { errs = ut_count_errors(?s.diags)::i32; }
+        or (R.unwrap_err[R.Void, outcome.Fail](sem).kind == outcome.FAIL_REPORTED) {
+            val reported: u32 = ut_count_errors(?s.diags);
+            if (reported > 0) { errs = reported::i32; }
+        }
     }
 
     project.dnit_project(?p);
@@ -8408,6 +8422,7 @@ fun ut_sema_rejects_with(text: str, needle: str) bool {
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret false; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
 
     var names: [1]str;
     names[0] = "main.mach";
@@ -8415,16 +8430,17 @@ fun ut_sema_rejects_with(text: str, needle: str) bool {
     texts[0] = text;
 
     val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret false; }
+    if (R.is_err[project.Project, outcome.Fail](pr)) {
+        ret R.unwrap_err[project.Project, outcome.Fail](pr).kind == outcome.FAIL_REPORTED
+            && ut_diag_has(?s.diags, needle);
+    }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    fin { project.dnit_project(?p); }
 
-    var hit: bool = false;
     val sem: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
-    if (R.is_ok[R.Void, outcome.Fail](sem)) { hit = ut_diag_has(?s.diags, needle); }
-
-    project.dnit_project(?p);
-    session.dnit(?s);
-    ret hit;
+    ret R.is_err[R.Void, outcome.Fail](sem)
+        && R.unwrap_err[R.Void, outcome.Fail](sem).kind == outcome.FAIL_REPORTED
+        && ut_diag_has(?s.diags, needle);
 }
 
 test "mach.lang.driver:val_assignment_refused" {
@@ -8660,10 +8676,8 @@ test "mach.lang.driver:addr_of_cross_module_generic_rejected" {
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
     val pr: R.Result[project.Project, outcome.Fail] = ut_sema2(?s, ?alloc,
         "use a: uniontest.a;\nfun main() i64 { val p: ptr = ?a.ident; ret p::i64; }\n", a_src);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
-    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    if (!ut_project_was_rejected(pr)) { session.dnit(?s); ret 1; }
     if (!ut_diag_has(?s.diags, "cannot take the address of an uninstantiated generic function")) { bad = 1; }
-    project.dnit_project(?p);
     session.dnit(?s);
 
     val sr2: R.Result[session.Session, str] = session.init(?alloc);
@@ -8709,12 +8723,10 @@ test "mach.lang.driver:distinct_name_type_mismatch_keeps_its_note" {
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
     val pr: R.Result[project.Project, outcome.Fail] = ut_sema2(?s, ?alloc,
         "use a: uniontest.a;\nrec P { a: u8; }\nfun main() i64 { var x: P; var y: a.Other; x = y; ret 0; }\n", a_src);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
-    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    if (!ut_project_was_rejected(pr)) { session.dnit(?s); ret 1; }
     if (!ut_diag_has(?s.diags, "type mismatch: expected P, found Other"))      { bad = 1; }
     if (!ut_diag_note_has(?s.diags, "mach has no implicit widening"))          { bad = 1; }
     if (ut_diag_note_has(?s.diags, need))                                     { bad = 1; }
-    project.dnit_project(?p);
     session.dnit(?s);
 
     val sr2: R.Result[session.Session, str] = session.init(?alloc);
@@ -8722,12 +8734,10 @@ test "mach.lang.driver:distinct_name_type_mismatch_keeps_its_note" {
     var s2: session.Session = R.unwrap_ok[session.Session, str](sr2);
     val pr2: R.Result[project.Project, outcome.Fail] = ut_sema2(?s2, ?alloc,
         "fun main() i64 { var x: u8; var y: i64; x = y; ret 0; }\n", a_src);
-    if (R.is_err[project.Project, outcome.Fail](pr2)) { session.dnit(?s2); ret 1; }
-    var p2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr2);
+    if (!ut_project_was_rejected(pr2)) { session.dnit(?s2); ret 1; }
     if (!ut_diag_has(?s2.diags, "type mismatch: expected u8, found i64"))      { bad = 1; }
     if (!ut_diag_note_has(?s2.diags, "mach has no implicit widening"))         { bad = 1; }
     if (ut_diag_note_has(?s2.diags, need))                                     { bad = 1; }
-    project.dnit_project(?p2);
     session.dnit(?s2);
     ret bad;
 }
@@ -8737,11 +8747,9 @@ fun ut_pair_note(alloc: *A.Allocator, main_s: str, a_src: str, needle: str) i32 
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
     val pr: R.Result[project.Project, outcome.Fail] = ut_sema2(?s, alloc, main_s, a_src);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
-    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    if (!ut_project_was_rejected(pr)) { session.dnit(?s); ret 1; }
     var rc: i32 = 1;
     if (ut_diag_note_has(?s.diags, needle)) { rc = 0; }
-    project.dnit_project(?p);
     session.dnit(?s);
     ret rc;
 }
@@ -8802,19 +8810,17 @@ test "mach.lang.driver:generic_param_identity_isolated_per_module" {
     names[1] = "lib.mach";
     var texts: [2]str;
     texts[0] = "fun second_generic[Beta](u: Beta) i64 { val y: i64 = u; ret y; }\nuse lib: uniontest.lib;\nfun main() i64 { ret lib.anchor(); }\n";
-    texts[1] = "fun first_generic[Alpha](t: Alpha) i64 { val x: i64 = t; ret x; }\npub fun anchor() i64 { ret 0; }\n";
+    texts[1] = "fun first_generic[Alpha](t: Alpha) i64 { val x: Alpha = t; ret 0; }\npub fun anchor() i64 { ret 0; }\n";
 
     val pr: R.Result[project.Project, outcome.Fail] = ut_vec_sema_n(?s, ?alloc, ?names[0], ?texts[0], 2);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
-    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    if (!ut_project_was_rejected(pr)) { session.dnit(?s); ret 1; }
 
-    val alpha_hits: u32 = ut_diag_count(?p.s.diags, "found Alpha");
-    val beta_hits:  u32 = ut_diag_count(?p.s.diags, "found Beta");
+    val alpha_hits: u32 = ut_diag_count(?s.diags, "found Alpha");
+    val beta_hits:  u32 = ut_diag_count(?s.diags, "found Beta");
 
-    project.dnit_project(?p);
     session.dnit(?s);
 
-    if (alpha_hits == 1 && beta_hits == 1) { ret 0; }
+    if (alpha_hits == 0 && beta_hits == 1) { ret 0; }
     ret 1;
 }
 
@@ -11892,13 +11898,13 @@ fun ut_readout_rows_case(jobs: u32) i32 {
     for (i < 8) {
         val ph: u32 = phs[i]::u32;
         val pm: *readout.PhaseMetrics = ?ev.metrics[ph];
-        if (pm.occurrences != 1)  { bad = 1; }
-        if (pm.elapsed <= 0)      { bad = 1; }
-        if (pm.item_count == 0)   { bad = 1; }
-        if (pm.item_elapsed <= 0) { bad = 1; }
-        if (pm.workers == 0)      { bad = 1; }
+        if (pm.occurrences != 1)  { bad = 10 + i::i32; }
+        if (pm.elapsed <= 0)      { bad = 20 + i::i32; }
+        if (pm.item_count == 0)   { bad = 30 + i::i32; }
+        if (pm.item_elapsed <= 0) { bad = 40 + i::i32; }
+        if (pm.workers == 0)      { bad = 50 + i::i32; }
 
-        if (pm.elapsed * pm.workers::cdur.Duration < pm.item_elapsed) { bad = 1; }
+        if (pm.elapsed * pm.workers::cdur.Duration < pm.item_elapsed) { bad = 60 + i::i32; }
 
         sum = sum + pm.elapsed;
         i = i + 1;
@@ -11906,8 +11912,8 @@ fun ut_readout_rows_case(jobs: u32) i32 {
 
     if (ev.other < 0) { bad = 1; }
     val acc: cdur.Duration = sum + ev.other;
-    if (acc > wall)     { bad = 1; }
-    if (acc * 2 < wall) { bad = 1; }
+    if (acc > wall)     { bad = 70; }
+    if (acc * 2 < wall) { bad = 71; }
 
     readout.dnit(?ev);
     fs.remove_all(?alloc, root);
@@ -12255,13 +12261,11 @@ test "mach.lang.driver:qualified_member_unexported_still_errors" {
     val pr: R.Result[project.Project, outcome.Fail] = ut_sema2(?s, ?alloc,
         "use a: uniontest.a;\nval NOPE: i64 = 1;\nfun main() i32 { ret a.NOPE::i32; }\n",
         "pub val X: i64 = 909;\n");
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
-    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    if (!ut_project_was_rejected(pr)) { session.dnit(?s); ret 1; }
 
     var bad: i32 = 0;
-    if (!ut_diag_has(?p.s.diags, "no symbol")) { bad = 1; }
+    if (!ut_diag_has(?s.diags, "no symbol")) { bad = 1; }
 
-    project.dnit_project(?p);
     session.dnit(?s);
     ret bad;
 }
@@ -12452,13 +12456,11 @@ fun ut_ct_lower_errs(src: str) i32 {
     if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret -1; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
-    var errs: i32 = -1;
-    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
-    if (R.is_ok[R.Void, outcome.Fail](se)) {
-        val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
-        errs = ut_count_errors(?s.diags)::i32;
-        if (R.is_err[R.Void, outcome.Fail](le) && errs == 0) { errs = 1; }
-    }
+    var checked: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
+    if (R.is_ok[R.Void, outcome.Fail](checked)) { checked = driver.run_lower_pass(?p); }
+    var errs: i32 = ut_count_errors(?s.diags)::i32;
+    if (R.is_err[R.Void, outcome.Fail](checked)
+        && (R.unwrap_err[R.Void, outcome.Fail](checked).kind != outcome.FAIL_REPORTED || errs == 0)) { errs = -1; }
 
     project.dnit_project(?p);
     session.dnit(?s);
@@ -12484,13 +12486,12 @@ fun ut_ct_lower_diag_n(names: *str, texts: *str, n: u32, needle: str) i32 {
     if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
+    var checked: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
+    if (R.is_ok[R.Void, outcome.Fail](checked)) { checked = driver.run_lower_pass(?p); }
     var code: i32 = 1;
-    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
-    if (R.is_ok[R.Void, outcome.Fail](se)) {
-        val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
-        if (R.is_err[R.Void, outcome.Fail](le)) { code = 1; }
-        if (ut_diag_has(?p.s.diags, needle))  { code = 0; }
-    }
+    if ((R.is_ok[R.Void, outcome.Fail](checked)
+        || R.unwrap_err[R.Void, outcome.Fail](checked).kind == outcome.FAIL_REPORTED)
+        && ut_diag_has(?s.diags, needle)) { code = 0; }
 
     project.dnit_project(?p);
     session.dnit(?s);
@@ -12775,26 +12776,26 @@ test "mach.lang.driver:dotted_linkage_name_shapes" {
 
     val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
 
-    if (ut_defined_fn_exact(?s, m, "uniontest.lib.wrap$uniontest.lib.Leaf") != 1) { bad = 1; }
-    if (ut_defined_fn_exact(?s, m, "uniontest.lib.wrap$uniontest.lib.Box$$uniontest.lib.Leaf") != 1) { bad = 1; }
-    if (ut_defined_fn_exact(?s, m, "uniontest.lib.wrap$uniontest.lib.Box$$uniontest.lib.Box$$$uniontest.lib.Leaf") != 1) { bad = 1; }
-    if (ut_defined_fn_exact(?s, m, "uniontest.lib.wrap$p$uniontest.lib.Leaf") != 1) { bad = 1; }
-    if (ut_defined_fn_exact(?s, m, "uniontest.lib.wrap$arr4$u8") != 1) { bad = 1; }
-    if (ut_defined_fn_exact(?s, m, "uniontest.lib.wrap$sec$u32") != 1) { bad = 1; }
-    if (ut_defined_fn_exact(?s, m, "uniontest.lib.wrap$fn$$i64$$i64$$i64") != 1) { bad = 1; }
-    if (ut_defined_fn_exact(?s, m, "uniontest.lib.pair$uniontest.lib.Box$$uniontest.lib.Leaf$i64") != 1) { bad = 1; }
-    if (ut_defined_fn_exact(?s, m, "uniontest.lib.pair$p$uniontest.lib.Box$$uniontest.lib.Leaf$u8") != 1) { bad = 1; }
-    if (ut_defined_fn_exact(?s, m, "uniontest.lib.tag$7") != 1) { bad = 1; }
-    if (ut_defined_fn_exact(?s, m, "uniontest.lib.tag$n3") != 1) { bad = 1; }
-    if (ut_defined_fn_exact(?s, m, "uniontest.lib.gsum$u32$pack$i64$i64") != 1) { bad = 1; }
+    if (ut_defined_fn_exact(?s, m, "uniontest.lib.wrap$uniontest.lib.Leaf") != 1) { bad = 2; }
+    if (ut_defined_fn_exact(?s, m, "uniontest.lib.wrap$uniontest.lib.Box$$uniontest.lib.Leaf") != 1) { bad = 3; }
+    if (ut_defined_fn_exact(?s, m, "uniontest.lib.wrap$uniontest.lib.Box$$uniontest.lib.Box$$$uniontest.lib.Leaf") != 1) { bad = 4; }
+    if (ut_defined_fn_exact(?s, m, "uniontest.lib.wrap$p$uniontest.lib.Leaf") != 1) { bad = 5; }
+    if (ut_defined_fn_exact(?s, m, "uniontest.lib.wrap$arr4$u8") != 1) { bad = 6; }
+    if (ut_defined_fn_exact(?s, m, "uniontest.lib.wrap$sec$u32") != 1) { bad = 7; }
+    if (ut_defined_fn_exact(?s, m, "uniontest.lib.wrap$fn$$i64$$i64$$i64") != 1) { bad = 8; }
+    if (ut_defined_fn_exact(?s, m, "uniontest.lib.pair$uniontest.lib.Box$$uniontest.lib.Leaf$i64") != 1) { bad = 9; }
+    if (ut_defined_fn_exact(?s, m, "uniontest.lib.pair$p$uniontest.lib.Box$$uniontest.lib.Leaf$u8") != 1) { bad = 10; }
+    if (ut_defined_fn_exact(?s, m, "uniontest.lib.tag$7") != 1) { bad = 11; }
+    if (ut_defined_fn_exact(?s, m, "uniontest.lib.tag$n3") != 1) { bad = 12; }
+    if (ut_defined_fn_exact(?s, m, "uniontest.lib.gsum$u32$pack$i64$i64") != 1) { bad = 13; }
 
-    if (ut_defined_fn_count(?s, m, "uniontest.lib.wrap$") != 7) { bad = 1; }
+    if (ut_defined_fn_count(?s, m, "uniontest.lib.wrap$") != 7) { bad = 14; }
 
     val lib_m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.lib");
     val def_id: intern.StrId = ut_fn_name_of(?s, lib_m, ".plain", false);
     val ref_id: intern.StrId = ut_fn_name_of(?s, m, ".plain", true);
-    if (def_id == intern.STR_NIL || def_id != ref_id) { bad = 1; }
-    if (ut_defined_fn_exact(?s, lib_m, "uniontest.lib.plain") != 1) { bad = 1; }
+    if (def_id == intern.STR_NIL || def_id != ref_id) { bad = 15; }
+    if (ut_defined_fn_exact(?s, lib_m, "uniontest.lib.plain") != 1) { bad = 16; }
 
     project.dnit_project(?p);
     session.dnit(?s);
@@ -13909,10 +13910,11 @@ fun ut_embed_diag(main_src: str, asset: str, needle: str) i32 {
     texts[1] = asset;
 
     val pr: R.Result[project.Project, outcome.Fail] = ut_vec_sema_n(?s, ?alloc, ?names[0], ?texts[0], 2);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
-    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val hit: bool = ut_diag_has(?p.s.diags, needle);
-    project.dnit_project(?p);
+    if (R.is_ok[project.Project, outcome.Fail](pr)) {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
+    val hit: bool = R.unwrap_err[project.Project, outcome.Fail](pr).kind == outcome.FAIL_REPORTED && ut_diag_has(?s.diags, needle);
     session.dnit(?s);
     if (hit) { ret 0; }
     ret 1;
@@ -13944,10 +13946,11 @@ fun ut_embed_unreadable_diag() i32 {
     if (O.is_some[str](fs.write_bytes(a_path, "abc", 3::usize, 0))) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
 
     val pr: R.Result[project.Project, outcome.Fail] = ut_sema_build(?s, root);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
-    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val hit: bool = ut_diag_has(?s.diags, "permission denied");
-    project.dnit_project(?p);
+    if (R.is_ok[project.Project, outcome.Fail](pr)) {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        project.dnit_project(?p); fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    }
+    val hit: bool = R.unwrap_err[project.Project, outcome.Fail](pr).kind == outcome.FAIL_REPORTED && ut_diag_has(?s.diags, "permission denied");
     fs.remove_all(?alloc, root);
     session.dnit(?s);
     if (hit) { ret 0; }
@@ -16331,32 +16334,32 @@ test "mach.lang.driver.readout:a_phase_counts_what_it_processed" {
 
     var bad: i32 = 0;
     val r: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, ?alloc, ?ev);
-    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r)) { bad = 1; }
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r)) { bad = 2; }
 
     val ld: u32 = readout.PH_LOAD::u32;
     val rs: u32 = readout.PH_RESOLVE::u32;
 
     val lm: *readout.PhaseMetrics = ?ev.metrics[ld];
     val rm: *readout.PhaseMetrics = ?ev.metrics[rs];
-    if (lm.occurrences == 0) { bad = 1; }
-    if (rm.occurrences == 0) { bad = 1; }
+    if (lm.occurrences == 0) { bad = 3; }
+    if (rm.occurrences == 0) { bad = 4; }
 
-    if (lm.dropped == 0) { bad = 1; }
+    if (lm.dropped == 0) { bad = 5; }
 
-    if (lm.processed != lm.item_count) { bad = 1; }
+    if (lm.processed != lm.item_count) { bad = 6; }
 
-    if (lm.processed != rm.processed + lm.dropped) { bad = 1; }
+    if (lm.processed != rm.processed + lm.dropped) { bad = 7; }
 
     val sm: *readout.PhaseMetrics = ?ev.metrics[readout.PH_SEMA::u32];
     val lwm: *readout.PhaseMetrics = ?ev.metrics[readout.PH_LOWER::u32];
     val om: *readout.PhaseMetrics = ?ev.metrics[readout.PH_OPTIMIZE::u32];
     val cm: *readout.PhaseMetrics = ?ev.metrics[readout.PH_CODEGEN::u32];
     val em: *readout.PhaseMetrics = ?ev.metrics[readout.PH_EMIT::u32];
-    if (sm.occurrences > 0 && sm.processed != sm.item_count)   { bad = 1; }
-    if (lwm.occurrences > 0 && lwm.processed != lwm.item_count) { bad = 1; }
-    if (om.occurrences > 0 && om.processed != om.item_count)   { bad = 1; }
-    if (cm.occurrences > 0 && cm.processed != cm.item_count)   { bad = 1; }
-    if (em.occurrences > 0 && em.processed != em.item_count)   { bad = 1; }
+    if (sm.occurrences > 0 && sm.processed != sm.item_count)   { bad = 8; }
+    if (lwm.occurrences > 0 && lwm.processed != lwm.item_count) { bad = 9; }
+    if (om.occurrences > 0 && om.processed != om.item_count)   { bad = 10; }
+    if (cm.occurrences > 0 && cm.processed != cm.item_count)   { bad = 11; }
+    if (em.occurrences > 0 && em.processed != em.item_count)   { bad = 12; }
 
     readout.dnit(?ev);
     fs.remove_all(?alloc, root);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -900,6 +900,61 @@ test "mach.lang.driver:analyze_project_loads_overlay_extra_root_through_pub_cons
     ret bad;
 }
 
+test "mach.lang.driver:analyze_project_selected_target_change_invalidates_typed_products" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
+
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "$if ($mach.build.os == $mach.os.windows) { val K: i32 = 2; } $or { val K: i32 = 1; }\nfun main() i32 { ret K; }\n";
+    val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    fin { fs.remove_all(?alloc, root); }
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) { ret 1; }
+    var mf: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    fin { manifest.dnit(?mf, ?alloc); }
+    var req: request.BuildRequest = request.defaults();
+    req.project_root = root;
+    req.target       = "linux";
+    req.artifact     = "uniontest";
+    req.goal         = request.GOAL_OBJECTS;
+
+    val host_r: R.Result[project.Project, outcome.Fail] = driver.analyze_project(?s, ?mf, ?req, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](host_r)) { ret 2; }
+    var host: project.Project = R.unwrap_ok[project.Project, outcome.Fail](host_r);
+    val stable: session.StableModuleId = ut_stable(?host, ?s, "uniontest.main");
+    if (stable == session.STABLE_MODULE_NIL) { project.dnit_project(?host); ret 3; }
+    if (host.modules[ut_mid(?host, ?s, "uniontest.main")::u32].ctx.env.target_os_id != os.OS_LINUX::u32) { project.dnit_project(?host); ret 4; }
+    project.dnit_project(?host);
+    val target_1: query.Revision = query.peek_revision(?s.queries, query.Q_TARGET, 0);
+    val sema_1: query.Revision = ut_sema_lc(?s, stable);
+    if (target_1 == 0 || sema_1 == 0) { ret 5; }
+
+    req.target = "windows";
+    val other_r: R.Result[project.Project, outcome.Fail] = driver.analyze_project(?s, ?mf, ?req, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](other_r)) { ret 6; }
+    var other: project.Project = R.unwrap_ok[project.Project, outcome.Fail](other_r);
+    val os_2: u32 = other.modules[ut_mid(?other, ?s, "uniontest.main")::u32].ctx.env.target_os_id;
+    project.dnit_project(?other);
+    if (os_2 != os.OS_WINDOWS::u32) { ret 7; }
+    val target_2: query.Revision = query.peek_revision(?s.queries, query.Q_TARGET, 0);
+    val sema_2: query.Revision = ut_sema_lc(?s, stable);
+    if (target_2 == target_1 || sema_2 == sema_1) { ret 8; }
+
+    val again_r: R.Result[project.Project, outcome.Fail] = driver.analyze_project(?s, ?mf, ?req, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](again_r)) { ret 9; }
+    var again: project.Project = R.unwrap_ok[project.Project, outcome.Fail](again_r);
+    project.dnit_project(?again);
+    if (query.peek_revision(?s.queries, query.Q_TARGET, 0) != target_2 || ut_sema_lc(?s, stable) != sema_2) { ret 10; }
+    ret 0;
+}
+
 test "mach.lang.driver:analyze_project_resets_and_replays_cached_diagnostics" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -7714,7 +7714,7 @@ test "mach.lang.driver:incremental_lower_surface_excludes_test_body" {
     project.dnit_project(?p2);
 
     if (sf_leaf_2 != sf_leaf_1) { bad = 1; }
-    if (lo_leaf_2 == lo_leaf_1) { bad = 1; }
+    if (lo_leaf_2 != lo_leaf_1) { bad = 1; }
     if (lo_main_2 != lo_main_1) { bad = 1; }
 
     fs.remove_all(?alloc, root);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -5916,7 +5916,8 @@ test "mach.lang.driver:incremental_overlay_reparses_exactly_overlaid_module" {
     if (ut_ast(?p3, ?s, "uniontest.a")    != a2)    { bad = 1; }
     project.dnit_project(?p3);
 
-    if (!session.clear_overlay(?s, a_path)) { bad = 1; }
+    val cleared: R.Result[bool, str] = session.clear_overlay(?s, a_path);
+    if (R.is_err[bool, str](cleared) || !R.unwrap_ok[bool, str](cleared)) { bad = 1; }
     val p4r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?s, root);
     if (R.is_err[project.Project, outcome.Fail](p4r)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var p4: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p4r);

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -582,7 +582,7 @@ test "mach.lang.driver:test_gated_orphan_excluded" {
     if (ut_in_topo(?p, ?s, "uniontest.gated")) { bad = 1; }
     if (union.count_target_gated(?p) != 1)           { bad = 1; }
     if (!ut_in_topo(?p, ?s, "uniontest.main")) { bad = 1; }
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se))               { bad = 1; }
     if (ut_count_errors(?p.s.diags) != 0)      { bad = 1; }
 
@@ -667,7 +667,7 @@ test "mach.lang.driver:test_reachable_error_still_fatal" {
     if (ut_gated(?p, ?s, "uniontest.bad"))    { bad = 1; }
     if (!ut_in_topo(?p, ?s, "uniontest.bad")) { bad = 1; }
     if (union.count_target_gated(?p) != 0)          { bad = 1; }
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se))              { bad = 1; }
     if (ut_count_errors(?p.s.diags) == 0)     { bad = 1; }
 
@@ -769,7 +769,7 @@ test "mach.lang.driver:analyze_project_retains_selected_frontend" {
     manifest.dnit(?mf, ?alloc);
 
     var bad: i32 = 0;
-    if (p.queries.db != ?s.queries || p.queries.diags != ?s.diags) { bad = 2; }
+    if (p.queries.db != ?s.queries) { bad = 2; }
     if (ut_count_errors(?s.diags) != 0) { bad = 3; }
     if (ut_has(?p, ?s, "ctxcase.alpha"))  { bad = 4; }
     if (ut_has(?p, ?s, "ctxcase.orphan")) { bad = 5; }
@@ -1052,7 +1052,7 @@ test "mach.lang.driver:analyze_project_failure_cleans_partial_state" {
                 val me: *project.ModuleEntry = ?p.modules[mid::u32];
                 if (!me.resolved || me.resolve_result == nil || me.sema_result == nil) { bad = 1; }
             }
-            if (p.queries.db != ?s.queries || p.queries.diags != ?s.diags) { bad = 1; }
+            if (p.queries.db != ?s.queries) { bad = 1; }
             project.dnit_project(?p);
         }
     }
@@ -1304,7 +1304,7 @@ fun ut_vec_sema_n(s: *session.Session, alloc: *A.Allocator, names: *str, texts: 
     val pr: R.Result[project.Project, outcome.Fail] = ut_build(s, alloc, names, texts, n);
     if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](se)); }
     ret R.ok[project.Project, outcome.Fail](p);
 }
@@ -1320,7 +1320,7 @@ fun ut_single_sema_n(s: *session.Session, alloc: *A.Allocator, names: *str, text
     fs.remove_all(alloc, root);
     if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](se)); }
     ret R.ok[project.Project, outcome.Fail](p);
 }
@@ -1688,11 +1688,11 @@ fun ut_codegen_artifact_valid(p: *project.Project) bool {
 
 fun ut_run_codegen_case(p: *project.Project, case_name: str, case_id: CodegenTestCase,
                         excluded: CodegenTestCase, expected: CodegenTestExpected) CodegenTestOutcome {
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(p);
     if (R.is_err[R.Void, outcome.Fail](se)) {
         ret ut_codegen_outcome(CODEGEN_TEST_COMPILER_REJECTION, CODEGEN_TEST_SEMA, case_id, case_name);
     }
-    val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(p);
+    val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(p);
     if (R.is_err[R.Void, outcome.Fail](le)) {
         ret ut_codegen_outcome(CODEGEN_TEST_COMPILER_REJECTION, CODEGEN_TEST_LOWER, case_id, case_name);
     }
@@ -1707,7 +1707,7 @@ fun ut_run_codegen_case(p: *project.Project, case_name: str, case_id: CodegenTes
         ret ut_codegen_outcome(CODEGEN_TEST_NAMED_CASE_EXECUTED, CODEGEN_TEST_SELECT, case_id, case_name);
     }
 
-    val ce: R.Result[R.Void, outcome.Fail] = passes.run_codegen_pass(p);
+    val ce: R.Result[R.Void, outcome.Fail] = driver.run_codegen_pass(p);
     if (R.is_err[R.Void, outcome.Fail](ce)) {
         ret ut_codegen_outcome(CODEGEN_TEST_COMPILER_REJECTION, CODEGEN_TEST_CODEGEN, case_id, case_name);
     }
@@ -1752,11 +1752,11 @@ fun ut_vec_codegen_defined(src: str, case_name: str, case_id: CodegenTestCase) i
 }
 
 fun ut_run_codegen_err(p: *project.Project, needle: str) i32 {
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(p);
     if (R.is_err[R.Void, outcome.Fail](se)) { ret 1; }
-    val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(p);
+    val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(p);
     if (R.is_err[R.Void, outcome.Fail](le)) { ret 1; }
-    val ce: R.Result[R.Void, outcome.Fail] = passes.run_codegen_pass(p);
+    val ce: R.Result[R.Void, outcome.Fail] = driver.run_codegen_pass(p);
     if (R.is_err[R.Void, outcome.Fail](ce)
         && ut_str_contains(R.unwrap_err[R.Void, outcome.Fail](ce).message, needle)) { ret 0; }
     ret 1;
@@ -1770,11 +1770,11 @@ fun ut_run_codegen_without(p: *project.Project, case_name: str, case_id: Codegen
 }
 
 fun ut_run_codegen_ok(p: *project.Project) i32 {
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(p);
     if (R.is_err[R.Void, outcome.Fail](se)) { ret 1; }
-    val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(p);
+    val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(p);
     if (R.is_err[R.Void, outcome.Fail](le)) { ret 1; }
-    val ce: R.Result[R.Void, outcome.Fail] = passes.run_codegen_pass(p);
+    val ce: R.Result[R.Void, outcome.Fail] = driver.run_codegen_pass(p);
     if (R.is_err[R.Void, outcome.Fail](ce)) { ret 1; }
     ret 0;
 }
@@ -1872,9 +1872,9 @@ fun ut_lower_rejects(src: str, needle: str) i32 {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var code: i32 = 1;
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_ok[R.Void, outcome.Fail](se)) {
-        val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+        val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
         if (R.is_err[R.Void, outcome.Fail](le) && ut_diag_has(?p.s.diags, needle)) { code = 0; }
     }
     project.dnit_project(?p);
@@ -1905,9 +1905,9 @@ fun ut_lower_ok(src: str) i32 {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var code: i32 = 1;
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_ok[R.Void, outcome.Fail](se)) {
-        val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+        val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
         if (R.is_ok[R.Void, outcome.Fail](le)) { code = 0; }
     }
     project.dnit_project(?p);
@@ -1931,9 +1931,9 @@ fun ut_lower_rejects_at(src: str, needle: str, want_offset: usize, want_len: usi
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var code: i32 = 1;
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_ok[R.Void, outcome.Fail](se)) {
-        val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+        val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
         if (R.is_err[R.Void, outcome.Fail](le)) {
             var i: usize = 0;
             for (i < diagnostic.len(?p.s.diags)) {
@@ -2013,9 +2013,9 @@ fun ut_vec_lower(s: *session.Session, alloc: *A.Allocator, src: str, target_name
     fs.remove_all(alloc, root);
     if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](se)); }
-    val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+    val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](le)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](le)); }
     ret R.ok[project.Project, outcome.Fail](p);
 }
@@ -3101,7 +3101,7 @@ test "mach.lang.driver:union_tuple_dependent_dependency_const_fails_closed" {
         ret bad;
     }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) { bad = 1; }
     if (ut_diag_count(?p.s.diags, "tuple-dependent public constants are not yet supported") != 1) { bad = 1; }
     if (ut_diag_has(?p.s.diags, "XTRUE")) { bad = 1; }
@@ -3138,7 +3138,7 @@ test "mach.lang.driver:union_tuple_dependent_dependency_const_via_bare_member_fa
         ret bad;
     }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) { bad = 1; }
     if (ut_diag_count(?p.s.diags, "tuple-dependent public constants are not yet supported") != 1) { bad = 1; }
     if (ut_diag_has(?p.s.diags, "XTRUE")) { bad = 1; }
@@ -3175,7 +3175,7 @@ test "mach.lang.driver:union_gated_walk_does_not_taint_freshly_loaded_dependency
     if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
     var bad: i32 = 0;
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) { bad = 1; }
     if (ut_diag_has(?p.s.diags, "tuple-dependent public constants are not yet supported")) { bad = 1; }
     if (!ut_diag_has(?p.s.diags, "XTRUE")) { bad = 1; }
@@ -3348,10 +3348,10 @@ test "mach.lang.driver:union_tuple_gate_frames_are_stable_across_passes" {
         ti = ti + 1;
     }
     var bad: i32 = 0;
-    val r1: R.Result[bool, str] = passes.run_gate_pass(?p);
-    if (R.is_err[bool, str](r1)) { bad = 4; }
-    val r2: R.Result[bool, str] = passes.run_gate_pass(?p);
-    if (R.is_err[bool, str](r2)) { bad = 5; }
+    val r1: R.Result[bool, outcome.Fail] = driver.run_gate_pass(?p);
+    if (R.is_err[bool, outcome.Fail](r1)) { bad = 4; }
+    val r2: R.Result[bool, outcome.Fail] = driver.run_gate_pass(?p);
+    if (R.is_err[bool, outcome.Fail](r2)) { bad = 5; }
     ti = 0;
     var next_entries_len: u32 = 0;
     var next_entries_cap: u32 = 0;
@@ -3626,7 +3626,7 @@ fun ut_sema2(s: *session.Session, alloc: *A.Allocator, main_src: str, a_src: str
     val pr: R.Result[project.Project, outcome.Fail] = ut_build(s, alloc, ?names[0], ?texts[0], 2);
     if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](se)); }
     ret R.ok[project.Project, outcome.Fail](p);
 }
@@ -4873,6 +4873,44 @@ test "mach.lang.driver:dep_git_checkout_uses_parent_gitlink_authority" {
     ret bad;
 }
 
+rec UtQuerySnapshot {
+    value: *u8;
+    value_len: u32;
+    last_changed: query.Revision;
+}
+
+fun ut_query_snapshot(a: *A.Allocator, p: *project.Project, kind: query.QueryKind, key: u64) R.Result[UtQuerySnapshot, str] {
+    val begun: R.Result[query.Operation, outcome.Fail] = project.begin_query_phase(p);
+    if (R.is_err[query.Operation, outcome.Fail](begun)) { ret R.err[UtQuerySnapshot, str](R.unwrap_err[query.Operation, outcome.Fail](begun).message); }
+    val operation: query.Operation = R.unwrap_ok[query.Operation, outcome.Fail](begun);
+    var snapshot: UtQuerySnapshot;
+    var error: str = nil;
+    val acquired: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, p, kind, key);
+    if (R.is_err[query.QueryView, fail.Fail](acquired)) { error = "query snapshot acquisition failed"; }
+    or {
+        val view: query.QueryView = R.unwrap_ok[query.QueryView, fail.Fail](acquired);
+        snapshot.value_len = view.value_len;
+        snapshot.last_changed = view.last_changed;
+        if (view.value_len != 0) {
+            val allocated: R.Result[*u8, str] = A.allocate[u8](a, view.value_len::usize);
+            if (R.is_err[*u8, str](allocated)) { error = "query snapshot allocation failed"; }
+            or {
+                snapshot.value = R.unwrap_ok[*u8, str](allocated);
+                memory.raw_copy(snapshot.value::ptr, view.value::ptr, view.value_len::usize);
+            }
+        }
+    }
+    val ended: R.Result[R.Void, fail.Fail] = query.end(?p.s.queries, operation);
+    if (R.is_err[R.Void, fail.Fail](ended)) { error = "query snapshot operation failed"; }
+    val discarded: R.Result[R.Void, str] = query.discard(?p.s.queries, operation);
+    if (R.is_err[R.Void, str](discarded)) { error = "query snapshot presentation discard failed"; }
+    if (error != nil) {
+        if (snapshot.value != nil) { A.deallocate[u8](a, snapshot.value, snapshot.value_len::usize); }
+        ret R.err[UtQuerySnapshot, str](error);
+    }
+    ret R.ok[UtQuerySnapshot, str](snapshot);
+}
+
 fun ut_path_copy_revision(s: *session.Session, root: str, expected: str) R.Result[query.Revision, str] {
     val built: R.Result[project.Project, outcome.Fail] = driver.build_project_union(s, root);
     if (R.is_err[project.Project, outcome.Fail](built)) {
@@ -4884,9 +4922,10 @@ fun ut_path_copy_revision(s: *session.Session, root: str, expected: str) R.Resul
     for (i < p.module_len) {
         val file: O.Option[*src.SourceFile] = src.get(?s.sources, p.modules[i].file_id);
         if (O.is_some[*src.SourceFile](file) && str_equals(O.unwrap[*src.SourceFile](file).text, expected)) {
-            val qr: R.Result[*query.QueryEntry, str] = query.peek(?s.queries, query.Q_FILE_TEXT, p.modules[i].file_id::u64);
-            if (R.is_err[*query.QueryEntry, str](qr)) { ret R.err[query.Revision, str](R.unwrap_err[*query.QueryEntry, str](qr)); }
-            val q: *query.QueryEntry = R.unwrap_ok[*query.QueryEntry, str](qr);
+            val qr: R.Result[UtQuerySnapshot, str] = ut_query_snapshot(p.alloc, ?p, query.Q_FILE_TEXT, p.modules[i].file_id::u64);
+            if (R.is_err[UtQuerySnapshot, str](qr)) { ret R.err[query.Revision, str](R.unwrap_err[UtQuerySnapshot, str](qr)); }
+            val q: UtQuerySnapshot = R.unwrap_ok[UtQuerySnapshot, str](qr);
+            fin { if (q.value != nil) { A.deallocate[u8](p.alloc, q.value, q.value_len::usize); } }
             if (q.value_len::usize != str_len(expected)
                 || !memory.raw_equal(q.value::ptr, expected::ptr, str_len(expected))) {
                 ret R.err[query.Revision, str]("dependency query does not contain the realized source bytes");
@@ -5924,15 +5963,12 @@ test "mach.lang.driver:incremental_qexports_firewalls_body_edit" {
     var p1: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p1r);
     val stable: session.StableModuleId = ut_stable(?p1, ?s, "uniontest.main");
     if (stable == session.STABLE_MODULE_NIL) { bad = 1; }
-    val q1: R.Result[*query.QueryEntry, str] = query.peek(?s.queries, query.Q_EXPORTS, stable::u64);
-    if (R.is_err[*query.QueryEntry, str](q1)) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
-    val ent1: *query.QueryEntry = R.unwrap_ok[*query.QueryEntry, str](q1);
+    val q1: R.Result[UtQuerySnapshot, str] = ut_query_snapshot(?alloc, ?p1, query.Q_EXPORTS, stable::u64);
+    if (R.is_err[UtQuerySnapshot, str](q1)) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    val ent1: UtQuerySnapshot = R.unwrap_ok[UtQuerySnapshot, str](q1);
     val lc1: query.Revision = ent1.last_changed;
     val len1: u32 = ent1.value_len;
-    val fr: R.Result[*u8, str] = A.allocate[u8](?alloc, len1::usize);
-    if (R.is_err[*u8, str](fr)) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
-    val fp1: *u8 = R.unwrap_ok[*u8, str](fr);
-    memory.raw_copy(fp1::ptr, ent1.value::ptr, len1::usize);
+    val fp1: *u8 = ent1.value;
     if (len1 == 0) { bad = 1; }
     project.dnit_project(?p1);
 
@@ -5945,12 +5981,13 @@ test "mach.lang.driver:incremental_qexports_firewalls_body_edit" {
     val p2r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?s, root);
     if (R.is_err[project.Project, outcome.Fail](p2r)) { A.deallocate[u8](?alloc, fp1, len1::usize); fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var p2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p2r);
-    val q2: R.Result[*query.QueryEntry, str] = query.peek(?s.queries, query.Q_EXPORTS, stable::u64);
-    if (R.is_err[*query.QueryEntry, str](q2)) { project.dnit_project(?p2); A.deallocate[u8](?alloc, fp1, len1::usize); fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
-    val ent2: *query.QueryEntry = R.unwrap_ok[*query.QueryEntry, str](q2);
+    val q2: R.Result[UtQuerySnapshot, str] = ut_query_snapshot(?alloc, ?p2, query.Q_EXPORTS, stable::u64);
+    if (R.is_err[UtQuerySnapshot, str](q2)) { project.dnit_project(?p2); A.deallocate[u8](?alloc, fp1, len1::usize); fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    val ent2: UtQuerySnapshot = R.unwrap_ok[UtQuerySnapshot, str](q2);
     if (ent2.last_changed != lc1) { bad = 1; }
     if (ent2.value_len != len1) { bad = 1; }
     or (!memory.raw_equal(ent2.value::ptr, fp1::ptr, len1::usize)) { bad = 1; }
+    if (ent2.value != nil) { A.deallocate[u8](?alloc, ent2.value, ent2.value_len::usize); }
     project.dnit_project(?p2);
 
     val surf_edit: str = "pub fun f(a: i32) i32 { ret a; }\npub fun g() i32 { ret 0; }\n";
@@ -5960,11 +5997,12 @@ test "mach.lang.driver:incremental_qexports_firewalls_body_edit" {
     val p3r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?s, root);
     if (R.is_err[project.Project, outcome.Fail](p3r)) { A.deallocate[u8](?alloc, fp1, len1::usize); fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var p3: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p3r);
-    val q3: R.Result[*query.QueryEntry, str] = query.peek(?s.queries, query.Q_EXPORTS, stable::u64);
-    if (R.is_err[*query.QueryEntry, str](q3)) { project.dnit_project(?p3); A.deallocate[u8](?alloc, fp1, len1::usize); fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
-    val ent3: *query.QueryEntry = R.unwrap_ok[*query.QueryEntry, str](q3);
+    val q3: R.Result[UtQuerySnapshot, str] = ut_query_snapshot(?alloc, ?p3, query.Q_EXPORTS, stable::u64);
+    if (R.is_err[UtQuerySnapshot, str](q3)) { project.dnit_project(?p3); A.deallocate[u8](?alloc, fp1, len1::usize); fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    val ent3: UtQuerySnapshot = R.unwrap_ok[UtQuerySnapshot, str](q3);
     if (ent3.last_changed == lc1) { bad = 1; }
     if (ent3.value_len == len1 && memory.raw_equal(ent3.value::ptr, fp1::ptr, len1::usize)) { bad = 1; }
+    if (ent3.value != nil) { A.deallocate[u8](?alloc, ent3.value, ent3.value_len::usize); }
     project.dnit_project(?p3);
 
     A.deallocate[u8](?alloc, fp1, len1::usize);
@@ -5974,9 +6012,9 @@ test "mach.lang.driver:incremental_qexports_firewalls_body_edit" {
 }
 
 fun ut_resolve_lc(s: *session.Session, stable: session.StableModuleId) query.Revision {
-    val e: R.Result[*query.QueryEntry, str] = query.peek(?s.queries, query.Q_RESOLVE, stable::u64);
-    if (R.is_err[*query.QueryEntry, str](e)) { ret 0xFFFFFFFFFFFFFFFF; }
-    ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
+    val revision: query.Revision = query.peek_revision(?s.queries, query.Q_RESOLVE, stable::u64);
+    if (revision == 0) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret revision;
 }
 
 fun ut_name_text_equal(sa: *session.Session, na: intern.StrId, sb: *session.Session, nb: intern.StrId) bool {
@@ -6413,7 +6451,7 @@ test "mach.lang.driver:resolve_fwd_renamed_reexport_links_across_module_boundary
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?p, "out/app"::*u8, "app"::*u8, 0, nil, 0, nil, 0, nil))) {
         project.dnit_project(?p); fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
     }
-    val rl: R.Result[bool, outcome.Fail] = passes.run_link_pass(?p);
+    val rl: R.Result[bool, outcome.Fail] = driver.run_link_pass(?p);
     if (R.is_err[bool, outcome.Fail](rl)) { bad = 1; }
     project.dnit_project(?p);
     fs.remove_all(?alloc, root);
@@ -6446,7 +6484,7 @@ test "mach.lang.driver:resolve_fwd_renamed_reexport_link_name_independent_of_imp
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?p, "out/app"::*u8, "app"::*u8, 0, nil, 0, nil, 0, nil))) {
         project.dnit_project(?p); fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
     }
-    val rl: R.Result[bool, outcome.Fail] = passes.run_link_pass(?p);
+    val rl: R.Result[bool, outcome.Fail] = driver.run_link_pass(?p);
     if (R.is_err[bool, outcome.Fail](rl)) { bad = 1; }
     project.dnit_project(?p);
     fs.remove_all(?alloc, root);
@@ -6465,33 +6503,33 @@ test "mach.lang.driver:resolve_fwd_renamed_reexport_does_not_admit_canonical_spe
 }
 
 fun ut_sema_lc(s: *session.Session, stable: session.StableModuleId) query.Revision {
-    val e: R.Result[*query.QueryEntry, str] = query.peek(?s.queries, query.Q_SEMA, stable::u64);
-    if (R.is_err[*query.QueryEntry, str](e)) { ret 0xFFFFFFFFFFFFFFFF; }
-    ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
+    val revision: query.Revision = query.peek_revision(?s.queries, query.Q_SEMA, stable::u64);
+    if (revision == 0) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret revision;
 }
 
 fun ut_lower_lc(s: *session.Session, stable: session.StableModuleId) query.Revision {
-    val e: R.Result[*query.QueryEntry, str] = query.peek(?s.queries, query.Q_LOWER, stable::u64);
-    if (R.is_err[*query.QueryEntry, str](e)) { ret 0xFFFFFFFFFFFFFFFF; }
-    ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
+    val revision: query.Revision = query.peek_revision(?s.queries, query.Q_LOWER, stable::u64);
+    if (revision == 0) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret revision;
 }
 
 fun ut_surface_lc(s: *session.Session, stable: session.StableModuleId) query.Revision {
-    val e: R.Result[*query.QueryEntry, str] = query.peek(?s.queries, query.Q_LOWERED_SURFACE, stable::u64);
-    if (R.is_err[*query.QueryEntry, str](e)) { ret 0xFFFFFFFFFFFFFFFF; }
-    ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
+    val revision: query.Revision = query.peek_revision(?s.queries, query.Q_LOWERED_SURFACE, stable::u64);
+    if (revision == 0) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret revision;
 }
 
 fun ut_codegen_lc(s: *session.Session, stable: session.StableModuleId) query.Revision {
-    val e: R.Result[*query.QueryEntry, str] = query.peek(?s.queries, query.Q_CODEGEN, stable::u64);
-    if (R.is_err[*query.QueryEntry, str](e)) { ret 0xFFFFFFFFFFFFFFFF; }
-    ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
+    val revision: query.Revision = query.peek_revision(?s.queries, query.Q_CODEGEN, stable::u64);
+    if (revision == 0) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret revision;
 }
 
 fun ut_lower_lc_key(s: *session.Session, key: u64) query.Revision {
-    val e: R.Result[*query.QueryEntry, str] = query.peek(?s.queries, query.Q_LOWER, key);
-    if (R.is_err[*query.QueryEntry, str](e)) { ret 0xFFFFFFFFFFFFFFFF; }
-    ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
+    val revision: query.Revision = query.peek_revision(?s.queries, query.Q_LOWER, key);
+    if (revision == 0) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret revision;
 }
 
 fun ut_mod_main_neutralized(s: *session.Session, m: *ir.Module) i32 {
@@ -6548,15 +6586,27 @@ fun ut_mod_flag_count(m: *ir.Module, flag: u32) u32 {
 }
 
 fun ut_link_lc(s: *session.Session) query.Revision {
-    val e: R.Result[*query.QueryEntry, str] = query.peek(?s.queries, query.Q_LINK, 0);
-    if (R.is_err[*query.QueryEntry, str](e)) { ret 0xFFFFFFFFFFFFFFFF; }
-    ret R.unwrap_ok[*query.QueryEntry, str](e).last_changed;
+    val revision: query.Revision = query.peek_revision(?s.queries, query.Q_LINK, 0);
+    if (revision == 0) { ret 0xFFFFFFFFFFFFFFFF; }
+    ret revision;
 }
 
-fun ut_module_fqn_text_equal(sa: *session.Session, ma: session.ModuleId, sb: *session.Session, mb: session.ModuleId) bool {
-    if (ma == session.MODULE_NIL && mb == session.MODULE_NIL) { ret true; }
-    if (ma == session.MODULE_NIL || mb == session.MODULE_NIL) { ret false; }
-    ret ut_name_text_equal(sa, session.module_fqn(sa, ma), sb, session.module_fqn(sb, mb));
+fun ut_type_owner_equal(sa: *session.Session, a: type.TypeOwner, sb: *session.Session, b: type.TypeOwner) bool {
+    if ((a.module == session.STABLE_MODULE_NIL) != (b.module == session.STABLE_MODULE_NIL)) { ret false; }
+    if (a.module != session.STABLE_MODULE_NIL) {
+        val ma: session.ModuleId = session.module_id_for_stable(sa, a.module);
+        val mb: session.ModuleId = session.module_id_for_stable(sb, b.module);
+        if (ma == session.MODULE_NIL || mb == session.MODULE_NIL) { ret false; }
+        val fa: intern.StrId = session.module_fqn(sa, ma);
+        val fb: intern.StrId = session.module_fqn(sb, mb);
+        if (fa == intern.STR_NIL || fb == intern.STR_NIL || !ut_name_text_equal(sa, fa, sb, fb)) { ret false; }
+    }
+    if ((a.file == src.FILE_NIL) != (b.file == src.FILE_NIL)) { ret false; }
+    if (a.file == src.FILE_NIL) { ret true; }
+    val fa: O.Option[*src.SourceFile] = src.get(?sa.sources, a.file);
+    val fb: O.Option[*src.SourceFile] = src.get(?sb.sources, b.file);
+    if (O.is_none[*src.SourceFile](fa) || O.is_none[*src.SourceFile](fb)) { ret false; }
+    ret str_equals(O.unwrap[*src.SourceFile](fa).path, O.unwrap[*src.SourceFile](fb).path);
 }
 
 fun ty_struct_equal(sa: *session.Session, ta: type.TypeId, sb: *session.Session, tb: type.TypeId) bool {
@@ -6596,18 +6646,21 @@ fun ty_struct_equal(sa: *session.Session, ta: type.TypeId, sb: *session.Session,
         ret true;
     }
     if (k == type.TYPE_REC || k == type.TYPE_UNI) {
-        if (a.data.nominal.decl != b.data.nominal.decl) { ret false; }
-        ret ut_module_fqn_text_equal(sa, a.data.nominal.origin, sb, b.data.nominal.origin);
+        if ((a.data.nominal.incarnation == 0) != (b.data.nominal.incarnation == 0)) { ret false; }
+        if (!ut_name_text_equal(sa, a.data.nominal.name, sb, b.data.nominal.name)) { ret false; }
+        if (!ut_name_text_equal(sa, a.data.nominal.syntax, sb, b.data.nominal.syntax)) { ret false; }
+        ret ut_type_owner_equal(sa, a.data.nominal.owner, sb, b.data.nominal.owner);
     }
     if (k == type.TYPE_GENERIC_PARAM) {
-        if (a.data.generic_param.owner != b.data.generic_param.owner) { ret false; }
+        if (a.data.generic_param.owner_kind != b.data.generic_param.owner_kind) { ret false; }
         if (a.data.generic_param.index != b.data.generic_param.index) { ret false; }
-        ret ut_module_fqn_text_equal(sa, a.data.generic_param.origin, sb, b.data.generic_param.origin);
+        if (!ut_name_text_equal(sa, a.data.generic_param.name, sb, b.data.generic_param.name)) { ret false; }
+        if (!ut_name_text_equal(sa, a.data.generic_param.owner_name, sb, b.data.generic_param.owner_name)) { ret false; }
+        ret ut_type_owner_equal(sa, a.data.generic_param.owner, sb, b.data.generic_param.owner);
     }
     if (k == type.TYPE_INSTANCE) {
-        if (a.data.instance.target_decl != b.data.instance.target_decl)                                      { ret false; }
-        if (a.data.instance.args_len != b.data.instance.args_len)                                            { ret false; }
-        if (!ut_module_fqn_text_equal(sa, a.data.instance.target_origin, sb, b.data.instance.target_origin)) { ret false; }
+        if (a.data.instance.args_len != b.data.instance.args_len) { ret false; }
+        if (!ty_struct_equal(sa, a.data.instance.nominal, sb, b.data.instance.nominal)) { ret false; }
         var i: u32 = 0;
         for (i < a.data.instance.args_len) {
             val pa: O.Option[type.TypeId] = type.get_param(?sa.types, a.data.instance.args_start + i);
@@ -6683,7 +6736,7 @@ test "mach.lang.driver:incremental_sema_firewall_body_edit_equals_scratch" {
     val pA1r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](pA1r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pA1: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pA1r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?pA1))) { project.dnit_project(?pA1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?pA1))) { project.dnit_project(?pA1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val st_main: session.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.main");
     val st_leaf: session.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.leaf");
     val lc_main_1: query.Revision = ut_sema_lc(?sA, st_main);
@@ -6698,7 +6751,7 @@ test "mach.lang.driver:incremental_sema_firewall_body_edit_equals_scratch" {
     val pA2r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](pA2r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pA2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pA2r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?pA2))) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?pA2))) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val lc_main_2: query.Revision = ut_sema_lc(?sA, st_main);
     val lc_leaf_2: query.Revision = ut_sema_lc(?sA, st_leaf);
 
@@ -6712,7 +6765,7 @@ test "mach.lang.driver:incremental_sema_firewall_body_edit_equals_scratch" {
     val pBr: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sB, root);
     if (R.is_err[project.Project, outcome.Fail](pBr)) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pB: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pBr);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?pB))) { project.dnit_project(?pB); session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?pB))) { project.dnit_project(?pB); session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
 
     if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.main"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
     if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.leaf"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.leaf"))) { bad = 1; }
@@ -6748,7 +6801,7 @@ test "mach.lang.driver:incremental_sema_return_type_change_equals_scratch" {
     val pA1r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](pA1r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pA1: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pA1r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?pA1))) { project.dnit_project(?pA1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?pA1))) { project.dnit_project(?pA1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val st_main: session.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.main");
     val lc_main_1: query.Revision = ut_sema_lc(?sA, st_main);
     project.dnit_project(?pA1);
@@ -6761,7 +6814,7 @@ test "mach.lang.driver:incremental_sema_return_type_change_equals_scratch" {
     val pA2r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](pA2r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pA2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pA2r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?pA2))) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?pA2))) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
 
     if (ut_sema_lc(?sA, st_main) == lc_main_1) { bad = 1; }
 
@@ -6772,7 +6825,7 @@ test "mach.lang.driver:incremental_sema_return_type_change_equals_scratch" {
     val pBr: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sB, root);
     if (R.is_err[project.Project, outcome.Fail](pBr)) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pB: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pBr);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?pB))) { project.dnit_project(?pB); session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?pB))) { project.dnit_project(?pB); session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
 
     if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.main"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
     if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.leaf"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.leaf"))) { bad = 1; }
@@ -6808,7 +6861,7 @@ test "mach.lang.driver:incremental_sema_field_type_change_equals_scratch" {
     val pA1r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](pA1r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pA1: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pA1r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?pA1))) { project.dnit_project(?pA1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?pA1))) { project.dnit_project(?pA1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val st_main: session.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.main");
     val lc_sema_main_1: query.Revision = ut_sema_lc(?sA, st_main);
     val lc_res_main_1:  query.Revision = ut_resolve_lc(?sA, st_main);
@@ -6822,7 +6875,7 @@ test "mach.lang.driver:incremental_sema_field_type_change_equals_scratch" {
     val pA2r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](pA2r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pA2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pA2r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?pA2))) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?pA2))) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
 
     if (ut_resolve_lc(?sA, st_main) != lc_res_main_1) { bad = 1; }
     if (ut_sema_lc(?sA, st_main) == lc_sema_main_1) { bad = 1; }
@@ -6834,7 +6887,7 @@ test "mach.lang.driver:incremental_sema_field_type_change_equals_scratch" {
     val pBr: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sB, root);
     if (R.is_err[project.Project, outcome.Fail](pBr)) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pB: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pBr);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?pB))) { project.dnit_project(?pB); session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?pB))) { project.dnit_project(?pB); session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
 
     if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.main"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
     if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.leaf"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.leaf"))) { bad = 1; }
@@ -6871,7 +6924,7 @@ test "mach.lang.driver:incremental_sema_reshape_renumber_recheck" {
     val pA1r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](pA1r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pA1: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pA1r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?pA1))) { project.dnit_project(?pA1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?pA1))) { project.dnit_project(?pA1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val mid_a1: session.ModuleId = ut_mid(?pA1, ?sA, "uniontest.a");
     val st_main: session.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.main");
     val st_a:    session.StableModuleId = ut_stable(?pA1, ?sA, "uniontest.a");
@@ -6887,7 +6940,7 @@ test "mach.lang.driver:incremental_sema_reshape_renumber_recheck" {
     val pA2r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](pA2r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pA2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pA2r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?pA2))) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?pA2))) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
 
     if (ut_mid(?pA2, ?sA, "uniontest.a") == mid_a1) { bad = 1; }
     if (ut_sema_lc(?sA, st_a) == lc_a_1) { bad = 1; }
@@ -6900,7 +6953,7 @@ test "mach.lang.driver:incremental_sema_reshape_renumber_recheck" {
     val pBr: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sB, root);
     if (R.is_err[project.Project, outcome.Fail](pBr)) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pB: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pBr);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?pB))) { project.dnit_project(?pB); session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?pB))) { project.dnit_project(?pB); session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
 
     if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.a"),    ?sB, ut_sr_of(?pB, ?sB, "uniontest.a")))    { bad = 1; }
     if (!sr_struct_equal(?sA, ut_sr_of(?pA2, ?sA, "uniontest.main"), ?sB, ut_sr_of(?pB, ?sB, "uniontest.main"))) { bad = 1; }
@@ -6936,8 +6989,8 @@ test "mach.lang.driver:incremental_lower_reuse_no_change" {
     val p1r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](p1r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p1: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p1r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p1)))  { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p1))) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p1)))  { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p1))) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val st_main: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
     val st_leaf: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.leaf");
     val lc_main_1: query.Revision = ut_lower_lc(?sA, st_main);
@@ -6947,8 +7000,8 @@ test "mach.lang.driver:incremental_lower_reuse_no_change" {
     val p2r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](p2r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p2r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p2)))  { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p2))) { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p2)))  { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p2))) { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val lc_main_2: query.Revision = ut_lower_lc(?sA, st_main);
     val lc_leaf_2: query.Revision = ut_lower_lc(?sA, st_leaf);
     project.dnit_project(?p2);
@@ -6978,8 +7031,8 @@ test "mach.lang.driver:global_aggregate_arg_is_aggregate_typed" {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var bad: i32 = 1;
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
 
     val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
     if (mid != session.MODULE_NIL) {
@@ -7093,8 +7146,8 @@ test "mach.lang.driver:generic_instance_call_inlines_at_release" {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var bad: i32 = 1;
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
 
     val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
     if (mid != session.MODULE_NIL) {
@@ -7146,8 +7199,8 @@ test "mach.lang.driver:generic_template_emits_no_bare_body" {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var bad: i32 = 1;
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
 
     val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
     if (mid != session.MODULE_NIL) {
@@ -7191,8 +7244,8 @@ fun ut_noinline_survives_object(target_name: str) i32 {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var bad: i32 = 1;
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
 
     val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
     if (mid != session.MODULE_NIL) {
@@ -7322,8 +7375,8 @@ fun ut_naked_spans(target_name: str, src: str, naked_out: *i64, bare_out: *i64) 
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var bad: i32 = 1;
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
 
     val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
     if (mid != session.MODULE_NIL) {
@@ -7392,8 +7445,8 @@ test "mach.lang.driver:naked_propagates_to_a_generic_instance" {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var bad: i32 = 1;
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
 
     val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
     if (mid != session.MODULE_NIL) {
@@ -7470,8 +7523,8 @@ test "mach.lang.driver:incremental_lower_isolated_edit_reuses_sibling" {
     val p1r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](p1r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p1: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p1r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p1)))  { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p1))) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p1)))  { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p1))) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val st_main: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
     val st_a:    session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.a");
     val st_b:    session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.b");
@@ -7488,8 +7541,8 @@ test "mach.lang.driver:incremental_lower_isolated_edit_reuses_sibling" {
     val p2r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](p2r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p2r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p2)))  { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p2))) { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p2)))  { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p2))) { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val lc_main_2: query.Revision = ut_lower_lc(?sA, st_main);
     val lc_a_2:    query.Revision = ut_lower_lc(?sA, st_a);
     val lc_b_2:    query.Revision = ut_lower_lc(?sA, st_b);
@@ -7526,8 +7579,8 @@ test "mach.lang.driver:incremental_lower_entry_edit_reuses_dep" {
     val p1r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](p1r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p1: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p1r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p1)))  { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p1))) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p1)))  { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p1))) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val st_main: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
     val st_leaf: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.leaf");
     val lc_main_1: query.Revision = ut_lower_lc(?sA, st_main);
@@ -7542,8 +7595,8 @@ test "mach.lang.driver:incremental_lower_entry_edit_reuses_dep" {
     val p2r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](p2r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p2r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p2)))  { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p2))) { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p2)))  { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p2))) { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val lc_main_2: query.Revision = ut_lower_lc(?sA, st_main);
     val lc_leaf_2: query.Revision = ut_lower_lc(?sA, st_leaf);
     project.dnit_project(?p2);
@@ -7791,9 +7844,9 @@ test "mach.lang.driver:incremental_codegen_reuse_and_recompute" {
     val p1r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](p1r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p1: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p1r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p1)))    { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p1)))   { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_codegen_pass(?p1))) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p1)))    { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p1)))   { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_codegen_pass(?p1))) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val st_main: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
     val st_a:    session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.a");
     val st_b:    session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.b");
@@ -7805,9 +7858,9 @@ test "mach.lang.driver:incremental_codegen_reuse_and_recompute" {
     val p2r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](p2r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p2r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p2)))    { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p2)))   { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_codegen_pass(?p2))) { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p2)))    { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p2)))   { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_codegen_pass(?p2))) { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (ut_codegen_lc(?sA, st_main) != cg_main_1) { bad = 1; }
     if (ut_codegen_lc(?sA, st_a)    != cg_a_1)    { bad = 1; }
     if (ut_codegen_lc(?sA, st_b)    != cg_b_1)    { bad = 1; }
@@ -7821,9 +7874,9 @@ test "mach.lang.driver:incremental_codegen_reuse_and_recompute" {
     val p3r: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?sA, root);
     if (R.is_err[project.Project, outcome.Fail](p3r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p3: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p3r);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p3)))    { project.dnit_project(?p3); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p3)))   { project.dnit_project(?p3); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_codegen_pass(?p3))) { project.dnit_project(?p3); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p3)))    { project.dnit_project(?p3); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p3)))   { project.dnit_project(?p3); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_codegen_pass(?p3))) { project.dnit_project(?p3); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (ut_codegen_lc(?sA, st_a) == cg_a_1) { bad = 1; }
     if (ut_codegen_lc(?sA, st_b) != cg_b_1) { bad = 1; }
     project.dnit_project(?p3);
@@ -7837,11 +7890,11 @@ fun ut_back_half(s: *session.Session, root: str) R.Result[project.Project, outco
     val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_union(s, root);
     if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val rs: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val rs: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](rs)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](rs)); }
-    val rl: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+    val rl: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](rl)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](rl)); }
-    val rc: R.Result[R.Void, outcome.Fail] = passes.run_codegen_pass(?p);
+    val rc: R.Result[R.Void, outcome.Fail] = driver.run_codegen_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](rc)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](rc)); }
     ret R.ok[project.Project, outcome.Fail](p);
 }
@@ -7873,7 +7926,7 @@ test "mach.lang.driver:incremental_link_reuse_and_fingerprint" {
     val st_b:    session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.b");
     val st_main: session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?p1, "out/app"::*u8, "app"::*u8, 0, nil, 0, nil, 0, nil))) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val r1: R.Result[bool, outcome.Fail] = passes.run_link_pass(?p1);
+    val r1: R.Result[bool, outcome.Fail] = driver.run_link_pass(?p1);
     if (R.is_err[bool, outcome.Fail](r1)) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (!R.unwrap_ok[bool, outcome.Fail](r1)) { bad = 1; }
     val lk1: query.Revision = ut_link_lc(?sA);
@@ -7883,7 +7936,7 @@ test "mach.lang.driver:incremental_link_reuse_and_fingerprint" {
     if (R.is_err[project.Project, outcome.Fail](p2r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p2r);
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?p2, "out/app"::*u8, "app"::*u8, 0, nil, 0, nil, 0, nil))) { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val r2: R.Result[bool, outcome.Fail] = passes.run_link_pass(?p2);
+    val r2: R.Result[bool, outcome.Fail] = driver.run_link_pass(?p2);
     if (R.is_err[bool, outcome.Fail](r2)) { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (R.unwrap_ok[bool, outcome.Fail](r2)) { bad = 1; }
     val lk2: query.Revision = ut_link_lc(?sA);
@@ -7899,7 +7952,7 @@ test "mach.lang.driver:incremental_link_reuse_and_fingerprint" {
     if (R.is_err[project.Project, outcome.Fail](p3r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p3: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p3r);
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?p3, "out/app"::*u8, "app"::*u8, 0, nil, 0, nil, 0, nil))) { project.dnit_project(?p3); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val r3: R.Result[bool, outcome.Fail] = passes.run_link_pass(?p3);
+    val r3: R.Result[bool, outcome.Fail] = driver.run_link_pass(?p3);
     if (R.is_err[bool, outcome.Fail](r3)) { project.dnit_project(?p3); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (!R.unwrap_ok[bool, outcome.Fail](r3)) { bad = 1; }
     val lk3: query.Revision = ut_link_lc(?sA);
@@ -7913,7 +7966,7 @@ test "mach.lang.driver:incremental_link_reuse_and_fingerprint" {
     val cg_b_before:    query.Revision = ut_codegen_lc(?sA, st_b);
     val cg_main_before: query.Revision = ut_codegen_lc(?sA, st_main);
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?p4, "out/other"::*u8, "app"::*u8, 0, nil, 0, nil, 0, nil))) { project.dnit_project(?p4); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val r4: R.Result[bool, outcome.Fail] = passes.run_link_pass(?p4);
+    val r4: R.Result[bool, outcome.Fail] = driver.run_link_pass(?p4);
     if (R.is_err[bool, outcome.Fail](r4)) { project.dnit_project(?p4); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (!R.unwrap_ok[bool, outcome.Fail](r4))                    { bad = 1; }
     if (ut_link_lc(?sA) == lk3)                         { bad = 1; }
@@ -7941,7 +7994,7 @@ test "mach.lang.driver:incremental_link_reuse_and_fingerprint" {
     if (R.is_err[project.Project, outcome.Fail](p5r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p5: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p5r);
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?p5, "out/other"::*u8, "app"::*u8, 0, nil, 0, nil, 0, ?loaded))) { project.dnit_project(?p5); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val r5: R.Result[bool, outcome.Fail] = passes.run_link_pass(?p5);
+    val r5: R.Result[bool, outcome.Fail] = driver.run_link_pass(?p5);
     if (R.is_err[bool, outcome.Fail](r5) || !R.unwrap_ok[bool, outcome.Fail](r5)) { bad = 1; }
     val lk5: query.Revision = ut_link_lc(?sA);
     project.dnit_project(?p5);
@@ -7950,7 +8003,7 @@ test "mach.lang.driver:incremental_link_reuse_and_fingerprint" {
     if (R.is_err[project.Project, outcome.Fail](p6r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p6: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p6r);
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?p6, "out/other"::*u8, "app"::*u8, 0, nil, 0, nil, 0, ?loaded))) { project.dnit_project(?p6); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val r6: R.Result[bool, outcome.Fail] = passes.run_link_pass(?p6);
+    val r6: R.Result[bool, outcome.Fail] = driver.run_link_pass(?p6);
     if (R.is_err[bool, outcome.Fail](r6) || R.unwrap_ok[bool, outcome.Fail](r6)
         || ut_link_lc(?sA) != lk5) { bad = 1; }
     project.dnit_project(?p6);
@@ -7960,7 +8013,7 @@ test "mach.lang.driver:incremental_link_reuse_and_fingerprint" {
     if (R.is_err[project.Project, outcome.Fail](p7r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p7: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p7r);
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?p7, "out/other"::*u8, "app"::*u8, 0, nil, 0, nil, 0, ?loaded))) { project.dnit_project(?p7); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val r7: R.Result[bool, outcome.Fail] = passes.run_link_pass(?p7);
+    val r7: R.Result[bool, outcome.Fail] = driver.run_link_pass(?p7);
     if (R.is_err[bool, outcome.Fail](r7) || !R.unwrap_ok[bool, outcome.Fail](r7)
         || ut_link_lc(?sA) == lk5) { bad = 1; }
     project.dnit_project(?p7);
@@ -7998,7 +8051,7 @@ test "mach.lang.driver:incremental_link_external_content_fingerprint" {
     if (R.is_err[project.Project, outcome.Fail](pAr)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pA: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pAr);
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?pA, "out/app"::*u8, "app"::*u8, 0, ?ext_a[0], 1, nil, 0, nil))) { project.dnit_project(?pA); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val rlA: R.Result[bool, outcome.Fail] = passes.run_link_pass(?pA);
+    val rlA: R.Result[bool, outcome.Fail] = driver.run_link_pass(?pA);
     if (R.is_err[bool, outcome.Fail](rlA)) { project.dnit_project(?pA); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (!R.unwrap_ok[bool, outcome.Fail](rlA)) { bad = 1; }
     val lkA: query.Revision = ut_link_lc(?sA);
@@ -8008,7 +8061,7 @@ test "mach.lang.driver:incremental_link_external_content_fingerprint" {
     if (R.is_err[project.Project, outcome.Fail](pBr)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pB: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pBr);
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?pB, "out/app"::*u8, "app"::*u8, 0, ?ext_a[0], 1, nil, 0, nil))) { project.dnit_project(?pB); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val rlB: R.Result[bool, outcome.Fail] = passes.run_link_pass(?pB);
+    val rlB: R.Result[bool, outcome.Fail] = driver.run_link_pass(?pB);
     if (R.is_err[bool, outcome.Fail](rlB)) { project.dnit_project(?pB); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (R.unwrap_ok[bool, outcome.Fail](rlB)) { bad = 1; }
     if (ut_link_lc(?sA) != lkA)      { bad = 1; }
@@ -8019,7 +8072,7 @@ test "mach.lang.driver:incremental_link_external_content_fingerprint" {
     if (R.is_err[project.Project, outcome.Fail](pCr)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pC: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pCr);
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?pC, "out/app"::*u8, "app"::*u8, 0, ?ext_a[0], 1, nil, 0, nil))) { project.dnit_project(?pC); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val rlC: R.Result[bool, outcome.Fail] = passes.run_link_pass(?pC);
+    val rlC: R.Result[bool, outcome.Fail] = driver.run_link_pass(?pC);
     if (R.is_err[bool, outcome.Fail](rlC)) { project.dnit_project(?pC); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (!R.unwrap_ok[bool, outcome.Fail](rlC)) { bad = 1; }
     val lkC: query.Revision = ut_link_lc(?sA);
@@ -8033,7 +8086,7 @@ test "mach.lang.driver:incremental_link_external_content_fingerprint" {
     if (R.is_err[project.Project, outcome.Fail](pDr)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pD: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pDr);
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?pD, "out/app"::*u8, "app"::*u8, 0, ?ext_b[0], 1, nil, 0, nil))) { project.dnit_project(?pD); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val rlD: R.Result[bool, outcome.Fail] = passes.run_link_pass(?pD);
+    val rlD: R.Result[bool, outcome.Fail] = driver.run_link_pass(?pD);
     if (R.is_err[bool, outcome.Fail](rlD)) { project.dnit_project(?pD); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (!R.unwrap_ok[bool, outcome.Fail](rlD)) { bad = 1; }
     val lkD: query.Revision = ut_link_lc(?sA);
@@ -8050,7 +8103,7 @@ test "mach.lang.driver:incremental_link_external_content_fingerprint" {
     if (R.is_err[project.Project, outcome.Fail](pEr)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pE: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pEr);
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?pE, "out/app"::*u8, "app"::*u8, 0, ?ext_b[0], 1, ?libs[0], 1, nil))) { project.dnit_project(?pE); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val rlE: R.Result[bool, outcome.Fail] = passes.run_link_pass(?pE);
+    val rlE: R.Result[bool, outcome.Fail] = driver.run_link_pass(?pE);
     if (R.is_err[bool, outcome.Fail](rlE)) { project.dnit_project(?pE); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (!R.unwrap_ok[bool, outcome.Fail](rlE)) { bad = 1; }
     val lkE: query.Revision = ut_link_lc(?sA);
@@ -8064,7 +8117,7 @@ test "mach.lang.driver:incremental_link_external_content_fingerprint" {
     if (R.is_err[project.Project, outcome.Fail](pFr)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var pF: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pFr);
     if (R.is_err[R.Void, outcome.Fail](bengine.set_link_config_input(?pF, "out/app"::*u8, "app"::*u8, 0, ?ext_b[0], 1, ?libs[0], 1, nil))) { project.dnit_project(?pF); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    val rlF: R.Result[bool, outcome.Fail] = passes.run_link_pass(?pF);
+    val rlF: R.Result[bool, outcome.Fail] = driver.run_link_pass(?pF);
     if (R.is_err[bool, outcome.Fail](rlF)) { project.dnit_project(?pF); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (!R.unwrap_ok[bool, outcome.Fail](rlF)) { bad = 1; }
     if (ut_link_lc(?sA) == lkE)       { bad = 1; }
@@ -8098,8 +8151,8 @@ test "mach.lang.driver:incremental_test_mode_neutralization_variant" {
     if (R.is_err[project.Project, outcome.Fail](p1r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p1: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p1r);
     p1.req.goal = request.GOAL_TESTS;
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p1)))  { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p1))) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p1)))  { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p1))) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val st_main:  session.StableModuleId = ut_stable(?p1, ?sA, "uniontest.main");
     val mid1: session.ModuleId = ut_mid(?p1, ?sA, "uniontest.main");
     if (mid1 == session.MODULE_NIL) { project.dnit_project(?p1); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
@@ -8116,8 +8169,8 @@ test "mach.lang.driver:incremental_test_mode_neutralization_variant" {
     if (R.is_err[project.Project, outcome.Fail](p2r)) { fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var p2: project.Project = R.unwrap_ok[project.Project, outcome.Fail](p2r);
     p2.req.goal = request.GOAL_EXECUTE;
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p2)))  { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p2))) { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p2)))  { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p2))) { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val mid2: session.ModuleId = ut_mid(?p2, ?sA, "uniontest.main");
     if (mid2 == session.MODULE_NIL) { project.dnit_project(?p2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     if (ut_mod_main_neutralized(?sA, p2.modules[mid2::u32].ir_module) != 0) { bad = 3; }
@@ -8151,7 +8204,7 @@ fun ut_sema_errs(text: str) i32 {
     var errs: i32 = ut_count_errors(?s.diags)::i32;
     if (errs == 0) {
         errs = -1;
-        val sem: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+        val sem: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
         if (R.is_ok[R.Void, outcome.Fail](sem)) { errs = ut_count_errors(?s.diags)::i32; }
     }
 
@@ -8181,9 +8234,9 @@ fun ut_lower_errs(text: str) i32 {
     var errs: i32 = ut_count_errors(?s.diags)::i32;
     if (errs == 0) {
         errs = -1;
-        val sem: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+        val sem: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
         if (R.is_ok[R.Void, outcome.Fail](sem)) {
-            val low: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+            val low: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
             errs = ut_count_errors(?s.diags)::i32;
             if (R.is_err[R.Void, outcome.Fail](low) && errs == 0) { errs = 1; }
         }
@@ -8213,9 +8266,9 @@ fun ut_arith_operand_mismatches(text: str) i32 {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var out: i32 = -1;
-    val sem: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val sem: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_ok[R.Void, outcome.Fail](sem) && ut_count_errors(?s.diags) == 0) {
-        val low: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+        val low: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
         if (R.is_ok[R.Void, outcome.Fail](low) && ut_count_errors(?s.diags) == 0) {
             var arith:      u32 = 0;
             var mismatched: u32 = 0;
@@ -8311,7 +8364,7 @@ fun ut_sema_extent_is(text: str, name: str, size: u32, align: u32) i32 {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var bad: i32 = 1;
-    val sem: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val sem: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_ok[R.Void, outcome.Fail](sem)) {
         val tid: O.Option[type.TypeId] = ut_nominal_typeid(?s, name);
         if (O.is_some[type.TypeId](tid)) {
@@ -8368,7 +8421,7 @@ fun ut_sema_rejects_with(text: str, needle: str) bool {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var hit: bool = false;
-    val sem: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val sem: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_ok[R.Void, outcome.Fail](sem)) { hit = ut_diag_has(?s.diags, needle); }
 
     project.dnit_project(?p);
@@ -8455,8 +8508,8 @@ fun ut_condition_truth_ops(text: str, cbrs: *u32, nots: *u32) bool {
     val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
     if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret false; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p))
-     || R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p))) {
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p))
+     || R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p))) {
         project.dnit_project(?p);
         session.dnit(?s);
         ret false;
@@ -8855,13 +8908,13 @@ fun ut_volatile_counts(src: str, vol_loads: *u32, vol_stores: *u32,
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var ok: bool = false;
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) {
         print.print(R.unwrap_err[R.Void, outcome.Fail](se).message);
         print.print("\n");
     }
     or {
-        val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+        val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
         if (R.is_err[R.Void, outcome.Fail](le)) {
             print.print(R.unwrap_err[R.Void, outcome.Fail](le).message);
             print.print("\n");
@@ -9007,13 +9060,13 @@ fun ut_volatile_counts_release(src: str, vol_loads: *u32, vol_stores: *u32,
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var ok: bool = false;
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) {
         print.print(R.unwrap_err[R.Void, outcome.Fail](se).message);
         print.print("\n");
     }
     or {
-        val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+        val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
         if (R.is_err[R.Void, outcome.Fail](le)) {
             print.print(R.unwrap_err[R.Void, outcome.Fail](le).message);
             print.print("\n");
@@ -9182,8 +9235,8 @@ test "mach.lang.driver:secrecy_layout_matches_lowering" {
     val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
     if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p)) ||
-        R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p))) {
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p)) ||
+        R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p))) {
         project.dnit_project(?p);
         session.dnit(?s);
         ret 1;
@@ -9569,7 +9622,7 @@ test "mach.lang.driver:float_type_compiles_x86_64" {
     if (R.is_err[project.Project, outcome.Fail](pr)) { bad = 1; }
     or {
         var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-        val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+        val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
         if (R.is_err[R.Void, outcome.Fail](se)) { bad = 1; }
         or (ut_count_errors(?s.diags) != 0) { bad = 1; }
         project.dnit_project(?p);
@@ -9910,6 +9963,11 @@ test "mach.lang.driver:generic_instance_reached_through_generic" {
     if (ut_sema_errs("fun inner[U](v: U) u32 { var acc: *u8 = nil; acc = 7; ret 0; }\nfun outer[T](v: T) u32 { ret inner[T](v); }\n#[symbol(\"main\")]\nfun main(argc: i64, argv: **u8) i32 { outer[u32](1); ret 0; }\n") != 1) { bad = 1; }
 
     ret bad;
+}
+
+test "mach.lang.driver:growing_pointer_generic_family_has_finite_concrete_layout" {
+    if (!ut_sema_clean("rec Node[T] { next: *Node[*T]; value: T; }\nfun main() i32 { var n: Node[u32]; n.next = nil; n.value = 7; ret n.value::i32; }\n")) { ret 1; }
+    ret 0;
 }
 
 test "mach.lang.driver:fields_refuses_generic_union" {
@@ -10276,9 +10334,9 @@ fun ut_ir_text(text: str, out: *u8, cap: usize, out_len: *usize) i32 {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var code: i32 = 1;
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_ok[R.Void, outcome.Fail](se)) {
-        val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+        val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
         if (R.is_ok[R.Void, outcome.Fail](le)) {
             var b: UtIrTextBuf;
             b.data = out;
@@ -11937,9 +11995,9 @@ fun ut_lower_n(s: *session.Session, alloc: *A.Allocator, names: *str, texts: *st
     fs.remove_all(alloc, root);
     if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](se)); }
-    val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+    val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](le)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](le)); }
     ret R.ok[project.Project, outcome.Fail](p);
 }
@@ -12401,9 +12459,9 @@ fun ut_ct_lower_errs(src: str) i32 {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var errs: i32 = -1;
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_ok[R.Void, outcome.Fail](se)) {
-        val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+        val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
         errs = ut_count_errors(?s.diags)::i32;
         if (R.is_err[R.Void, outcome.Fail](le) && errs == 0) { errs = 1; }
     }
@@ -12433,9 +12491,9 @@ fun ut_ct_lower_diag_n(names: *str, texts: *str, n: u32, needle: str) i32 {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var code: i32 = 1;
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_ok[R.Void, outcome.Fail](se)) {
-        val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+        val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
         if (R.is_err[R.Void, outcome.Fail](le)) { code = 1; }
         if (ut_diag_has(?p.s.diags, needle))  { code = 0; }
     }
@@ -12771,8 +12829,8 @@ test "mach.lang.driver:test_decl_linkage_name" {
     if (R.is_err[project.Project, outcome.Fail](pr)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
     p.req.goal = request.GOAL_TESTS;
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p)))  { bad = 1; }
-    or (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p))) { bad = 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p)))  { bad = 1; }
+    or (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p))) { bad = 1; }
     or {
         val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
         if (ut_defined_fn_exact(?s, m, "uniontest.main.\"probe\"") != 1) { bad = 1; }
@@ -14139,9 +14197,9 @@ fun ut_spirv_env_build(alloc: *A.Allocator, env_line: str, needle: str, want_ver
         if (str_empty(needle) || f.message == nil || !ut_str_contains(f.message, needle)) { print.print(f.message); print.print("\n"); bad = 2; }
     } or {
         var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-        val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
-        val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
-        val ce: R.Result[R.Void, outcome.Fail] = passes.run_codegen_pass(?p);
+        val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
+        val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
+        val ce: R.Result[R.Void, outcome.Fail] = driver.run_codegen_pass(?p);
         if (R.is_err[R.Void, outcome.Fail](se) || R.is_err[R.Void, outcome.Fail](le)) { bad = 3; }
         or (!str_empty(needle)) {
             if (R.is_ok[R.Void, outcome.Fail](ce)) { bad = 4; }
@@ -14281,7 +14339,7 @@ fun ut_sema_build(s: *session.Session, root: str) R.Result[project.Project, outc
     val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_union(s, root);
     if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](se)); }
     ret R.ok[project.Project, outcome.Fail](p);
 }
@@ -14290,9 +14348,9 @@ fun ut_lower_build(s: *session.Session, root: str) R.Result[project.Project, out
     val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_union(s, root);
     if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](se)); }
-    val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+    val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](le)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](le)); }
     ret R.ok[project.Project, outcome.Fail](p);
 }
@@ -14416,12 +14474,12 @@ fun ut_attr_probe(s: *session.Session, alloc: *A.Allocator, names: *str, texts: 
     }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) {
         project.dnit_project(?p);
         ret R.err[str, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](se));
     }
-    val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+    val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](le)) {
         project.dnit_project(?p);
         ret R.err[str, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](le));
@@ -14469,12 +14527,12 @@ fun ut_attr_probe_allsrc(s: *session.Session, alloc: *A.Allocator, names: *str, 
         ret R.err[str, outcome.Fail](outcome.user("fixture loaded no uncompiled module"));
     }
 
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) {
         project.dnit_project(?p);
         ret R.err[str, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](se));
     }
-    val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+    val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](le)) {
         project.dnit_project(?p);
         ret R.err[str, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](le));
@@ -14703,8 +14761,8 @@ test "mach.lang.driver:fallthrough_return_is_well_typed" {
     if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
-    if (R.is_err[R.Void, outcome.Fail](passes.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
-    if (R.is_err[R.Void, outcome.Fail](passes.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p)))  { project.dnit_project(?p); session.dnit(?s); ret 1; }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p))) { project.dnit_project(?p); session.dnit(?s); ret 1; }
 
     var bad: i32 = 1;
     val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
@@ -15031,9 +15089,9 @@ fun ut_spv_lower(s: *session.Session, alloc: *A.Allocator,
     if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
-    val sr2: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val sr2: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](sr2)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](sr2)); }
-    val lr: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+    val lr: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](lr)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](lr)); }
     ret R.ok[project.Project, outcome.Fail](p);
 }
@@ -15296,8 +15354,8 @@ fun ut_va_diag(target_name: str, src: str, needle: str) bool {
         ret fired_early;
     }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    if (R.is_ok[R.Void, outcome.Fail](passes.run_sema_pass(?p))) {
-        passes.run_lower_pass(?p);
+    if (R.is_ok[R.Void, outcome.Fail](driver.run_sema_pass(?p))) {
+        driver.run_lower_pass(?p);
     }
     val fired: bool = ut_diag_has(?p.s.diags, needle);
     project.dnit_project(?p);
@@ -16585,8 +16643,8 @@ fun ut_dwarf_addr_reloc_width(target_name: str, section: str) u32 {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var width: u32 = 0;
-    if (R.is_ok[R.Void, outcome.Fail](passes.run_sema_pass(?p))
-        && R.is_ok[R.Void, outcome.Fail](passes.run_lower_pass(?p))) {
+    if (R.is_ok[R.Void, outcome.Fail](driver.run_sema_pass(?p))
+        && R.is_ok[R.Void, outcome.Fail](driver.run_lower_pass(?p))) {
         val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
         if (mid != session.MODULE_NIL) {
             val me: *project.ModuleEntry = ?p.modules[mid::u32];
@@ -16657,8 +16715,8 @@ fun ut_dwarf_nested_inline_debug_build() bool {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var ok: bool = false;
-    if (R.is_ok[R.Void, outcome.Fail](passes.run_sema_pass(?p))
-        && R.is_ok[R.Void, outcome.Fail](passes.run_lower_pass(?p))) {
+    if (R.is_ok[R.Void, outcome.Fail](driver.run_sema_pass(?p))
+        && R.is_ok[R.Void, outcome.Fail](driver.run_lower_pass(?p))) {
         val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
         if (mid != session.MODULE_NIL) {
             val me: *project.ModuleEntry = ?p.modules[mid::u32];
@@ -16750,8 +16808,8 @@ test "mach.lang.be.codegen.pack_symbols:emitted_function_symbol_carries_its_real
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var bad: i32 = 1;
-    if (R.is_ok[R.Void, outcome.Fail](passes.run_sema_pass(?p))
-        && R.is_ok[R.Void, outcome.Fail](passes.run_lower_pass(?p))) {
+    if (R.is_ok[R.Void, outcome.Fail](driver.run_sema_pass(?p))
+        && R.is_ok[R.Void, outcome.Fail](driver.run_lower_pass(?p))) {
         val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
         if (mid != session.MODULE_NIL) {
             val me: *project.ModuleEntry = ?p.modules[mid::u32];
@@ -18040,9 +18098,9 @@ fun ut_o2_lower(s: *session.Session, alloc: *A.Allocator, src: str, target_name:
     fs.remove_all(alloc, root);
     if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](se)); }
-    val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+    val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](le)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](le)); }
     ret R.ok[project.Project, outcome.Fail](p);
 }
@@ -18594,9 +18652,9 @@ fun ut_lower_diag(src: str, needle: str) i32 {
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
 
     var code: i32 = 1;
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_ok[R.Void, outcome.Fail](se)) {
-        passes.run_lower_pass(?p);
+        driver.run_lower_pass(?p);
         if (ut_diag_has(?p.s.diags, needle)) { code = 0; }
     }
     project.dnit_project(?p);
@@ -19047,13 +19105,13 @@ fun ut_codegen_fail_msg(s: *session.Session, root: str, tgt: str) str {
     }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
     var out: str = "";
-    val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](se)) { out = R.unwrap_err[R.Void, outcome.Fail](se).message; }
     or {
-        val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+        val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
         if (R.is_err[R.Void, outcome.Fail](le)) { out = R.unwrap_err[R.Void, outcome.Fail](le).message; }
         or {
-            val ce: R.Result[R.Void, outcome.Fail] = passes.run_codegen_pass(?p);
+            val ce: R.Result[R.Void, outcome.Fail] = driver.run_codegen_pass(?p);
             if (R.is_err[R.Void, outcome.Fail](ce)) { out = R.unwrap_err[R.Void, outcome.Fail](ce).message; }
         }
     }
@@ -19521,14 +19579,15 @@ test "mach.lang.driver.passes.q_link:records_the_test_qualified_codegen_key" {
     if (R.is_err[outcome.BuildOutcome, outcome.Fail](r1)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     if (R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r1).severity != outcome.BUILD_OK) { bad = 1; }
 
-    val e_r: R.Result[*query.QueryEntry, str] = query.peek(?s.queries, query.Q_LINK, 0);
-    if (R.is_err[*query.QueryEntry, str](e_r)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
-    val e: *query.QueryEntry = R.unwrap_ok[*query.QueryEntry, str](e_r);
+    val keys_r: R.Result[Vector[query.QueryKey], str] = query.cached_dependency_keys(?s.queries, query.Q_LINK, 0, ?alloc);
+    if (R.is_err[Vector[query.QueryKey], str](keys_r)) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
+    var keys: Vector[query.QueryKey] = R.unwrap_ok[Vector[query.QueryKey], str](keys_r);
+    fin { vector.dnit[query.QueryKey](?keys); }
 
     var codegen_deps: u32 = 0;
-    var i: u32 = 0;
-    for (i < e.dep_len) {
-        val d: *query.Dep = ?e.deps[i];
+    var i: usize = 0;
+    for (i < keys.len) {
+        val d: query.QueryKey = keys.data[i];
         if (d.kind == query.Q_CODEGEN) {
             codegen_deps = codegen_deps + 1;
             if (!passes.back_half_key_is_test(d.key)) { bad = 1; }
@@ -19961,13 +20020,13 @@ test "mach.lang.driver:one_gate_decides_the_same_in_every_phase" {
     if (bad == 0 && ut_module_gate_state(?p, ?s, "uniontest.main", cond) != comptime.GATE_STATE_TRUE) { bad = 8; }
 
     if (bad == 0) {
-        val se: R.Result[R.Void, outcome.Fail] = passes.run_sema_pass(?p);
+        val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
         if (R.is_err[R.Void, outcome.Fail](se)) { bad = 9; }
         or (ut_count_errors(?p.s.diags) != 0) { bad = 10; }
         or (ut_module_gate_state(?p, ?s, "uniontest.main", cond) != comptime.GATE_STATE_TRUE) { bad = 11; }
     }
     if (bad == 0) {
-        val le: R.Result[R.Void, outcome.Fail] = passes.run_lower_pass(?p);
+        val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
         if (R.is_err[R.Void, outcome.Fail](le)) { bad = 12; }
         or (ut_module_gate_state(?p, ?s, "uniontest.main", cond) != comptime.GATE_STATE_TRUE) { bad = 13; }
     }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -668,7 +668,7 @@ test "mach.lang.driver:test_reachable_error_still_fatal" {
     if (!ut_in_topo(?p, ?s, "uniontest.bad")) { bad = 1; }
     if (union.count_target_gated(?p) != 0)          { bad = 1; }
     val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
-    if (R.is_err[R.Void, outcome.Fail](se))              { bad = 1; }
+    if (R.is_ok[R.Void, outcome.Fail](se) || R.unwrap_err[R.Void, outcome.Fail](se).kind != outcome.FAIL_REPORTED) { bad = 1; }
     if (ut_count_errors(?p.s.diags) == 0)     { bad = 1; }
 
     project.dnit_project(?p);
@@ -926,46 +926,46 @@ test "mach.lang.driver:analyze_project_resets_and_replays_cached_diagnostics" {
 
     val cold_r: R.Result[project.Project, outcome.Fail] =
         driver.analyze_project(?s, ?mf, ?req, nil, 0);
-    if (R.is_err[project.Project, outcome.Fail](cold_r)) {
+    if (!ut_project_was_rejected(cold_r)) {
         manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
         session.dnit(?s); ret 1;
     }
-    var cold_p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](cold_r);
-    val mid: session.ModuleId = ut_mid(?cold_p, ?s, "uniontest.main");
-    if (mid == session.MODULE_NIL || diagnostic.len(?s.diags) == 0) {
-        project.dnit_project(?cold_p); manifest.dnit(?mf, ?alloc);
-        fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
+    val fqn_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "uniontest.main");
+    if (R.is_err[intern.StrId, str](fqn_r)) {
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
     }
-    val stable: session.StableModuleId = cold_p.modules[mid::u32].stable_id;
+    val stable: session.StableModuleId = session.stable_module_id_lookup(?s, R.unwrap_ok[intern.StrId, str](fqn_r));
+    if (stable == session.STABLE_MODULE_NIL || diagnostic.len(?s.diags) == 0) {
+        manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
+        session.dnit(?s); ret 1;
+    }
     val resolve_rev: query.Revision = query.peek_revision(?s.queries, query.Q_RESOLVE, stable::u64);
     val sema_rev: query.Revision = query.peek_revision(?s.queries, query.Q_SEMA, stable::u64);
     if (resolve_rev == 0 || sema_rev == 0) {
-        project.dnit_project(?cold_p); manifest.dnit(?mf, ?alloc);
+        manifest.dnit(?mf, ?alloc);
         fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
     }
     val snapshot_r: R.Result[*diagnostic.DiagnosticStore, str] =
         diagnostic.snapshot_from(?s.diags, 0, ?alloc);
     if (R.is_err[*diagnostic.DiagnosticStore, str](snapshot_r)) {
-        project.dnit_project(?cold_p); manifest.dnit(?mf, ?alloc);
+        manifest.dnit(?mf, ?alloc);
         fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
     }
     val snapshot: *diagnostic.DiagnosticStore = R.unwrap_ok[*diagnostic.DiagnosticStore, str](snapshot_r);
-    project.dnit_project(?cold_p);
 
     val warm_r: R.Result[project.Project, outcome.Fail] =
         driver.analyze_project(?s, ?mf, ?req, nil, 0);
-    if (R.is_err[project.Project, outcome.Fail](warm_r)) {
+    if (!ut_project_was_rejected(warm_r)) {
         diagnostic.store_dnit(snapshot); A.deallocate[diagnostic.DiagnosticStore](?alloc, snapshot, 1::usize);
         manifest.dnit(?mf, ?alloc); fs.remove_all(?alloc, root);
         session.dnit(?s); ret 1;
     }
-    var warm_p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](warm_r);
     var bad: i32 = 0;
     if (!ut_diag_list_eq(?s.diags, snapshot)) { bad = 1; }
     if (query.peek_revision(?s.queries, query.Q_RESOLVE, stable::u64) != resolve_rev) { bad = 1; }
     if (query.peek_revision(?s.queries, query.Q_SEMA, stable::u64) != sema_rev) { bad = 1; }
 
-    project.dnit_project(?warm_p);
     diagnostic.store_dnit(snapshot);
     A.deallocate[diagnostic.DiagnosticStore](?alloc, snapshot, 1::usize);
     manifest.dnit(?mf, ?alloc);
@@ -2854,11 +2854,9 @@ test "mach.lang.driver:module_level_layout_gate_awaits_registration" {
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
     val src: str = "rec Pair { a: u64; b: u64; }\n$if ($offset_of(Pair, a) == 0) { $error(\"Y\"); } $or { $error(\"N\"); }\nfun main() i32 { ret 0; }\n";
     val pr: R.Result[project.Project, outcome.Fail] = ut_vec_sema(?s, ?alloc, src);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 5; }
-    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-    if (!ut_diag_has(?p.s.diags, "`$offset_of` has no value in a comptime condition")) { bad = 6; }
-    if (diagnostic.len(?p.s.diags) != 1) { bad = 7; }
-    project.dnit_project(?p);
+    if (!ut_project_was_rejected(pr)) { session.dnit(?s); ret 5; }
+    if (!ut_diag_has(?s.diags, "`$offset_of` has no value in a comptime condition")) { bad = 6; }
+    if (diagnostic.len(?s.diags) != 1) { bad = 7; }
     session.dnit(?s);
 
     ret bad;
@@ -3102,7 +3100,7 @@ test "mach.lang.driver:union_tuple_dependent_dependency_const_fails_closed" {
     }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
     val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
-    if (R.is_err[R.Void, outcome.Fail](se)) { bad = 1; }
+    if (R.is_ok[R.Void, outcome.Fail](se) || R.unwrap_err[R.Void, outcome.Fail](se).kind != outcome.FAIL_REPORTED) { bad = 1; }
     if (ut_diag_count(?p.s.diags, "tuple-dependent public constants are not yet supported") != 1) { bad = 1; }
     if (ut_diag_has(?p.s.diags, "XTRUE")) { bad = 1; }
     if (ut_diag_has(?p.s.diags, "XFALSE")) { bad = 1; }
@@ -3139,7 +3137,7 @@ test "mach.lang.driver:union_tuple_dependent_dependency_const_via_bare_member_fa
     }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
     val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
-    if (R.is_err[R.Void, outcome.Fail](se)) { bad = 1; }
+    if (R.is_ok[R.Void, outcome.Fail](se) || R.unwrap_err[R.Void, outcome.Fail](se).kind != outcome.FAIL_REPORTED) { bad = 1; }
     if (ut_diag_count(?p.s.diags, "tuple-dependent public constants are not yet supported") != 1) { bad = 1; }
     if (ut_diag_has(?p.s.diags, "XTRUE")) { bad = 1; }
     if (ut_diag_has(?p.s.diags, "XFALSE")) { bad = 1; }
@@ -3176,7 +3174,7 @@ test "mach.lang.driver:union_gated_walk_does_not_taint_freshly_loaded_dependency
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
     var bad: i32 = 0;
     val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
-    if (R.is_err[R.Void, outcome.Fail](se)) { bad = 1; }
+    if (R.is_ok[R.Void, outcome.Fail](se) || R.unwrap_err[R.Void, outcome.Fail](se).kind != outcome.FAIL_REPORTED) { bad = 1; }
     if (ut_diag_has(?p.s.diags, "tuple-dependent public constants are not yet supported")) { bad = 1; }
     if (!ut_diag_has(?p.s.diags, "XTRUE")) { bad = 1; }
     if (ut_diag_has(?p.s.diags, "XFALSE")) { bad = 1; }
@@ -6789,7 +6787,7 @@ test "mach.lang.driver:incremental_sema_return_type_change_equals_scratch" {
     var names: [2]str;
     names[0] = "main.mach"; names[1] = "leaf.mach";
     var texts: [2]str;
-    texts[0] = "use uniontest.leaf.fa;\nfun main() i32 { val x = fa(); ret x::i32; }\n";
+    texts[0] = "use uniontest.leaf.fa;\nfun main() i32 { ret fa()::i32; }\n";
     texts[1] = "pub fun fa() i32 { ret 1; }\n";
 
     val root_r: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
@@ -18637,29 +18635,9 @@ test "mach.lang.driver:retained_reload_cycle_with_a_dependency_is_steady" {
 }
 
 fun ut_lower_diag(src: str, needle: str) i32 {
-    var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
-    val sr: R.Result[session.Session, str] = session.init(?alloc);
-    if (R.is_err[session.Session, str](sr)) { ret 1; }
-    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
-
-    var names: [1]str;
-    names[0] = "main.mach";
-    var texts: [1]str;
-    texts[0] = src;
-    val pr: R.Result[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
-    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-
-    var code: i32 = 1;
-    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
-    if (R.is_ok[R.Void, outcome.Fail](se)) {
-        driver.run_lower_pass(?p);
-        if (ut_diag_has(?p.s.diags, needle)) { code = 0; }
-    }
-    project.dnit_project(?p);
-    session.dnit(?s);
-    ret code;
+    var names: [1]str = [1]str{ "main.mach" };
+    var texts: [1]str = [1]str{ src };
+    ret ut_ct_lower_diag_n(?names[0], ?texts[0], 1, needle);
 }
 
 test "mach.lang.fe.sema:layout_intrinsic_adopts_the_binding_width" {

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -11900,10 +11900,6 @@ fun ut_readout_rows_case(jobs: u32) i32 {
 
         if (pm.elapsed * pm.workers::cdur.Duration < pm.item_elapsed) { bad = 1; }
 
-        if (ph != readout.PH_EMIT::u32 && ph != readout.PH_LINK::u32) {
-            if (pm.item_elapsed * 8 < pm.elapsed) { bad = 1; }
-        }
-
         sum = sum + pm.elapsed;
         i = i + 1;
     }

--- a/src/lang/driver/union.mach
+++ b/src/lang/driver/union.mach
@@ -174,7 +174,7 @@ fun warn_union_target_skipped(p: *project.Project, os_name: str, isa_name: str, 
     var span: token.Span;
     span.offset = 0;
     span.len    = 0;
-    diagnostic.record_warning(?p.s.diags, 0xFFFFFFFF::src.FileId, span, buf);
+    diagnostic.record_warning(?p.diags, 0xFFFFFFFF::src.FileId, span, buf);
 
     str_free(p.alloc, buf);
 }
@@ -547,21 +547,33 @@ fun register_ext_global(p: *project.Project, mid: session.ModuleId, source: str,
 }
 
 pub fun register_embed_inputs(p: *project.Project) R.Result[R.Void, str] {
+    var paths: vector.Vector[str] = vector.init[str](p.s.alloc);
+    fin {
+        var i: usize = 0;
+        for (i < paths.len) { str_free(p.s.alloc, paths.data[i]); i = i + 1; }
+        vector.dnit[str](?paths);
+    }
     var i: u32 = 0;
     for (i < p.module_len) {
         val m: *project.ModuleEntry = ?p.modules[i];
         val m_opt: O.Option[*module.Module] = ast.get_module(m.a, m.a.root_module);
         if (O.is_some[*module.Module](m_opt)) {
             val mod_node: *module.Module = O.unwrap[*module.Module](m_opt);
-            val r: R.Result[R.Void, str] = refresh_embeds_in(p, m, mod_node.decls_start, mod_node.decls_len);
+            val r: R.Result[R.Void, str] = collect_embeds_in(p, m, mod_node.decls_start, mod_node.decls_len, ?paths);
             if (R.is_err[R.Void, str](r)) { ret r; }
         }
         i = i + 1;
     }
+    var pi: usize = 0;
+    for (pi < paths.len) {
+        val refreshed: R.Result[intern.StrId, str] = embed.refresh(?p.s.embeds, ?p.s.queries, ?p.s.interner, paths.data[pi]);
+        if (R.is_err[intern.StrId, str](refreshed)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](refreshed)); }
+        pi = pi + 1;
+    }
     ret R.ok_void[str]();
 }
 
-fun refresh_embeds_in(p: *project.Project, m: *project.ModuleEntry, start: u32, len: u32) R.Result[R.Void, str] {
+fun collect_embeds_in(p: *project.Project, m: *project.ModuleEntry, start: u32, len: u32, paths: *vector.Vector[str]) R.Result[R.Void, str] {
     var i: u32 = 0;
     for (i < len) {
         val did: id.DeclId = m.a.decl_ids[start + i];
@@ -574,7 +586,7 @@ fun refresh_embeds_in(p: *project.Project, m: *project.ModuleEntry, start: u32, 
             var b: u32 = 0;
             for (b < d.data.comptime_if.branches_len) {
                 val br: *decl.ComptimeBranch = ?m.a.comptime_branches[d.data.comptime_if.branches_start + b];
-                val r: R.Result[R.Void, str] = refresh_embeds_in(p, m, br.body_start, br.body_len);
+                val r: R.Result[R.Void, str] = collect_embeds_in(p, m, br.body_start, br.body_len, paths);
                 if (R.is_err[R.Void, str](r)) { ret r; }
                 b = b + 1;
             }
@@ -586,7 +598,7 @@ fun refresh_embeds_in(p: *project.Project, m: *project.ModuleEntry, start: u32, 
         for (di < d.decorators_len) {
             val dec: *decl.Decorator = ?m.a.decorators[d.decorators_start + di];
             if (embed_named(p, m, dec)) {
-                val r: R.Result[R.Void, str] = refresh_one(p, m, dec);
+                val r: R.Result[R.Void, str] = collect_embed_path(p, m, dec, paths);
                 if (R.is_err[R.Void, str](r)) { ret r; }
             }
             di = di + 1;
@@ -603,7 +615,7 @@ fun embed_named(p: *project.Project, m: *project.ModuleEntry, dec: *decl.Decorat
     ret str_region_equals(source, dec.name.offset, dec.name.len, "embed");
 }
 
-fun refresh_one(p: *project.Project, m: *project.ModuleEntry, dec: *decl.Decorator) R.Result[R.Void, str] {
+fun collect_embed_path(p: *project.Project, m: *project.ModuleEntry, dec: *decl.Decorator, paths: *vector.Vector[str]) R.Result[R.Void, str] {
     val src_opt: O.Option[*src.SourceFile] = src.get(?p.s.sources, m.file_id);
     if (O.is_none[*src.SourceFile](src_opt)) { ret R.ok_void[str](); }
     val f: *src.SourceFile = O.unwrap[*src.SourceFile](src_opt);
@@ -630,8 +642,10 @@ fun refresh_one(p: *project.Project, m: *project.ModuleEntry, dec: *decl.Decorat
     }
     val resolved: str = R.unwrap_ok[str, manifest.TemplateError](pr);
 
-    val rr: R.Result[intern.StrId, str] = embed.refresh(?p.s.embeds, ?p.s.queries, ?p.s.interner, resolved);
-    str_free(p.s.alloc, resolved);
-    if (R.is_err[intern.StrId, str](rr)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](rr)); }
+    val saved: R.Result[usize, str] = vector.push[str](paths, resolved);
+    if (R.is_err[usize, str](saved)) {
+        str_free(p.s.alloc, resolved);
+        ret R.err[R.Void, str](R.unwrap_err[usize, str](saved));
+    }
     ret R.ok_void[str]();
 }

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -375,11 +375,12 @@ pub fun analyze(es: *EditorSession, fid: source.FileId) R.Result[*context.SemaRe
         ret R.err[*context.SemaResult, str](R.unwrap_err[R.Void, str](res_register));
     }
 
-    var deps: context.SemaDeps;
+    var deps: context.SemaDeps = context.SemaDeps{};
+    deps.definitions = context.DefinitionReader{ ctx: es::ptr, read: buffer_definition };
     deps.entries = nil;
     deps.count   = 0;
 
-    val res_sema: R.Result[context.SemaResult, fail.Fail] = sema.sema(es.s, b.a, rr, ?deps, ?b.ctx, fid::session.ModuleId);
+    val res_sema: R.Result[context.SemaResult, fail.Fail] = sema.sema(es.s, b.a, rr, ?deps, ?b.ctx, fid::session.ModuleId, ?es.s.diags);
     if (R.is_err[context.SemaResult, fail.Fail](res_sema)) {
         ret R.err[*context.SemaResult, str](R.unwrap_err[context.SemaResult, fail.Fail](res_sema).message);
     }
@@ -823,11 +824,29 @@ fun parse_inner(es: *EditorSession, fid: source.FileId) R.Result[*ast.Ast, str] 
     ret R.ok[*ast.Ast, str](a);
 }
 
+fun buffer_definition(raw: ptr, origin: session.ModuleId, phase: context.DefinitionPhase) R.Result[context.Definition, fail.Fail] {
+    val es: *EditorSession = raw::*EditorSession;
+    if (es == nil || origin::u32 >= es.buf_len) {
+        ret R.err[context.Definition, fail.Fail](fail.message("current definition is not an open editor buffer"));
+    }
+    val b: *Buffer = ?es.buffers[origin::u32];
+    if (!b.in_use || !b.owned || b.a == nil) {
+        ret R.err[context.Definition, fail.Fail](fail.message("editor definition has no current standalone parsed owner"));
+    }
+    var result: context.Definition = context.Definition{
+        parsed: res.ParsedDefinition{ a: b.a, owner: res.type_owner(es.s, origin, b.file_id), incarnation: b.a.incarnation },
+        origin: origin
+    };
+    if (phase >= context.DEFINITION_RESOLVED) { result.rr = b.rr; }
+    if (phase == context.DEFINITION_TYPED) { result.sr = b.sr; result.ctx = ?b.ctx; }
+    ret R.ok[context.Definition, fail.Fail](result);
+}
+
 fun buffer_resolve(es: *EditorSession, b: *Buffer, deps: *res.ResolveDeps) R.Result[*res.ResolveResult, str] {
     rr_drop(es, b);
     ctx_seed(es, b);
 
-    val res_resolve: R.Result[res.ResolveResult, fail.Fail] = res.resolve(es.s, b.a, deps, ?b.ctx, b.file_id::session.ModuleId, true);
+    val res_resolve: R.Result[res.ResolveResult, fail.Fail] = res.resolve(es.s, b.a, deps, ?b.ctx, b.file_id::session.ModuleId, true, ?es.s.diags);
     if (R.is_err[res.ResolveResult, fail.Fail](res_resolve)) {
         ret R.err[*res.ResolveResult, str](R.unwrap_err[res.ResolveResult, fail.Fail](res_resolve).message);
     }
@@ -903,6 +922,12 @@ fun ast_alloc(es: *EditorSession, fid: source.FileId) R.Result[*ast.Ast, str] {
     if (R.is_err[*ast.Ast, str](res_alloc)) { ret res_alloc; }
     val a: *ast.Ast = R.unwrap_ok[*ast.Ast, str](res_alloc);
     @a = ast.init(es.alloc, fid);
+    val incarnation: R.Result[u64, str] = session.next_parse_incarnation(es.s);
+    if (R.is_err[u64, str](incarnation)) {
+        A.deallocate[ast.Ast](es.alloc, a, 1);
+        ret R.err[*ast.Ast, str](R.unwrap_err[u64, str](incarnation));
+    }
+    a.incarnation = R.unwrap_ok[u64, str](incarnation);
     ret R.ok[*ast.Ast, str](a);
 }
 
@@ -920,7 +945,6 @@ fun host_ctx(es: *EditorSession) comptime.ComptimeCtx {
         intern.STR_NIL,
         intern.STR_NIL
     );
-    comptime.set_diagnostics(?c, ?es.s.diags);
     val vl: O.Option[os.VaList] = target.host_va_list();
     if (O.is_some[os.VaList](vl)) {
         comptime.set_va_list(?c, O.unwrap[os.VaList](vl).size, O.unwrap[os.VaList](vl).align);
@@ -1050,11 +1074,12 @@ fun t_run_sema(es: *EditorSession, fid: source.FileId, pw: u32) R.Result[*diagno
 
     diags_reset(es);
 
-    var deps: context.SemaDeps;
+    var deps: context.SemaDeps = context.SemaDeps{};
+    deps.definitions = context.DefinitionReader{ ctx: es::ptr, read: buffer_definition };
     deps.entries = nil;
     deps.count   = 0;
 
-    val res_sema: R.Result[context.SemaResult, fail.Fail] = sema.sema(es.s, b.a, rr, ?deps, ?b.ctx, fid::session.ModuleId);
+    val res_sema: R.Result[context.SemaResult, fail.Fail] = sema.sema(es.s, b.a, rr, ?deps, ?b.ctx, fid::session.ModuleId, ?es.s.diags);
     if (R.is_err[context.SemaResult, fail.Fail](res_sema)) {
         ret R.err[*diagnostic.DiagnosticStore, str](R.unwrap_err[context.SemaResult, fail.Fail](res_sema).message);
     }
@@ -1104,10 +1129,11 @@ fun t_exports(es: *EditorSession, fid: source.FileId, fqn: str) R.Result[res.Mod
     for (i < pub_len) {
         val sym: *res.Symbol = ?b.rr.symbols[i];
         var ps: res.PublicSymbol;
-        ps.kind   = sym.kind;
+        ps.kind   = sym.definition_kind;
         ps.name   = sym.name;
         ps.canon  = sym.canon;
-        ps.decl   = sym.decl;
+        ps.file = sym.definition_file;
+        ps.generic_arity = sym.generic_arity;
         ps.slot   = sym.slot;
         ps.origin = sym.origin;
         syms[i] = ps;
@@ -2606,7 +2632,7 @@ test "mach.lang.editor.resolve:reload_reflects_edited_dependency" {
     ret bad;
 }
 
-test "mach.lang.editor.resolve:bracket_ambiguity_survives_as_parsed_after_resolve" {
+test "mach.lang.editor.resolve:bracket_value_resolution_preserves_the_parsed_owner" {
     var alloc: A.Allocator;
     val res_session: R.Result[session.Session, str] = t_session(?alloc);
     if (R.is_err[session.Session, str](res_session)) { ret 1; }
@@ -2640,20 +2666,20 @@ test "mach.lang.editor.resolve:bracket_ambiguity_survives_as_parsed_after_resolv
 
     val live_kind_after_resolve: expr.ExprKind = a.exprs[target].kind;
 
-    val opt_parsed: O.Option[expr.Expr] = res.as_parsed(rr, a, target);
-    if (O.is_none[expr.Expr](opt_parsed)) { dnit(?es); session.dnit(?s); ret 5; }
-    val parsed_kind_after_resolve: expr.ExprKind = O.unwrap[expr.Expr](opt_parsed).kind;
+    val interpreted: R.Result[expr.Expr, str] = res.expression(rr, a, target);
+    if (R.is_err[expr.Expr, str](interpreted)) { dnit(?es); session.dnit(?s); ret 5; }
+    val resolved_kind: expr.ExprKind = R.unwrap_ok[expr.Expr, str](interpreted).kind;
 
     var bad: i32 = 0;
-    if (live_kind_after_resolve == pre_kind)       { bad = 6; }
-    or (parsed_kind_after_resolve != pre_kind)     { bad = 7; }
+    if (live_kind_after_resolve != pre_kind) { bad = 6; }
+    or (resolved_kind != expr.EXPR_KIND_INDEX) { bad = 7; }
 
     dnit(?es);
     session.dnit(?s);
     ret bad;
 }
 
-test "mach.lang.editor.resolve:bracket_call_ambiguity_survives_as_parsed_after_resolve" {
+test "mach.lang.editor.resolve:generic_call_resolution_preserves_the_parsed_owner" {
     var alloc: A.Allocator;
     val res_session: R.Result[session.Session, str] = t_session(?alloc);
     if (R.is_err[session.Session, str](res_session)) { ret 1; }
@@ -2689,20 +2715,20 @@ test "mach.lang.editor.resolve:bracket_call_ambiguity_survives_as_parsed_after_r
 
     val live_index_callee_after_resolve: id.ExprId = a.exprs[target].data.call.index_callee;
 
-    val opt_parsed: O.Option[expr.Expr] = res.as_parsed(rr, a, target);
-    if (O.is_none[expr.Expr](opt_parsed)) { dnit(?es); session.dnit(?s); ret 5; }
-    val parsed_index_callee_after_resolve: id.ExprId = O.unwrap[expr.Expr](opt_parsed).data.call.index_callee;
+    val interpreted: R.Result[expr.Expr, str] = res.expression(rr, a, target);
+    if (R.is_err[expr.Expr, str](interpreted)) { dnit(?es); session.dnit(?s); ret 5; }
+    val resolved_index_callee: id.ExprId = R.unwrap_ok[expr.Expr, str](interpreted).data.call.index_callee;
 
     var bad: i32 = 0;
-    if (live_index_callee_after_resolve != id.EXPR_NIL)         { bad = 6; }
-    or (parsed_index_callee_after_resolve != pre_index_callee)  { bad = 7; }
+    if (live_index_callee_after_resolve != pre_index_callee) { bad = 6; }
+    or (resolved_index_callee != id.EXPR_NIL) { bad = 7; }
 
     dnit(?es);
     session.dnit(?s);
     ret bad;
 }
 
-test "mach.lang.editor.resolve:bracket_call_repoint_survives_as_parsed_after_resolve" {
+test "mach.lang.editor.resolve:indexed_call_resolution_preserves_the_parsed_owner" {
     var alloc: A.Allocator;
     val res_session: R.Result[session.Session, str] = t_session(?alloc);
     if (R.is_err[session.Session, str](res_session)) { ret 1; }
@@ -2739,15 +2765,14 @@ test "mach.lang.editor.resolve:bracket_call_repoint_survives_as_parsed_after_res
 
     val live_callee_after_resolve: id.ExprId = a.exprs[target].data.call.callee;
 
-    val opt_parsed: O.Option[expr.Expr] = res.as_parsed(rr, a, target);
-    if (O.is_none[expr.Expr](opt_parsed)) { dnit(?es); session.dnit(?s); ret 5; }
-    val parsed_callee_after_resolve:       id.ExprId = O.unwrap[expr.Expr](opt_parsed).data.call.callee;
-    val parsed_index_callee_after_resolve: id.ExprId = O.unwrap[expr.Expr](opt_parsed).data.call.index_callee;
+    val interpreted: R.Result[expr.Expr, str] = res.expression(rr, a, target);
+    if (R.is_err[expr.Expr, str](interpreted)) { dnit(?es); session.dnit(?s); ret 5; }
+    val resolved_callee: id.ExprId = R.unwrap_ok[expr.Expr, str](interpreted).data.call.callee;
 
     var bad: i32 = 0;
-    if (live_callee_after_resolve != pre_index_callee)              { bad = 6; }
-    or (parsed_callee_after_resolve != pre_callee)                  { bad = 7; }
-    or (parsed_index_callee_after_resolve != pre_index_callee)      { bad = 8; }
+    if (live_callee_after_resolve != pre_callee) { bad = 6; }
+    or (resolved_callee != pre_index_callee) { bad = 7; }
+    or (a.exprs[target].data.call.index_callee != pre_index_callee) { bad = 8; }
 
     dnit(?es);
     session.dnit(?s);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -4199,3 +4199,70 @@ test "mach.lang.editor.analyze:project_phase_does_not_run_later_frontend_work" {
     analysis_dnit(?typed);
     ret 0;
 }
+
+test "mach.lang.editor.close:refuses_during_an_outstanding_query_and_keeps_every_buffer" {
+    var alloc: A.Allocator;
+    var s: session.Session = R.unwrap_ok[session.Session, str](t_session(?alloc));
+    fin { session.dnit(?s); }
+    var es: EditorSession = init(?s);
+    fin { t_dnit(?es); }
+    val kept: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, "/mach-editor-outstanding/kept.mach", "val kept: i32 = 1;"));
+    val target: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, "/mach-editor-outstanding/target.mach", "val gone: i32 = 2;"));
+    var req: AnalysisRequest = analysis_request(target, PHASE_PARSE);
+    var result: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](analyze(?es, ?req));
+    fin { analysis_dnit(?result); }
+    val revision: u64 = O.unwrap[*source.SourceFile](source.get(?s.sources, target)).revision;
+    val opened: R.Result[query.Operation, str] = query.begin(?s.queries);
+    if (R.is_err[query.Operation, str](opened)) { ret 1; }
+    val operation: query.Operation = R.unwrap_ok[query.Operation, str](opened);
+    val refused: R.Result[bool, str] = close(?es, target);
+    if (R.is_ok[bool, str](refused)) { query.end(?s.queries, operation); query.discard(?s.queries, operation); ret 2; }
+    if (slot_live(?es, target) == nil || slot_live(?es, kept) == nil) { query.end(?s.queries, operation); query.discard(?s.queries, operation); ret 3; }
+    val current: *source.SourceFile = O.unwrap[*source.SourceFile](source.get(?s.sources, target));
+    if (!current.present || current.revision != revision || O.is_none[str](session.overlay_get(?s, "/mach-editor-outstanding/target.mach"))) {
+        query.end(?s.queries, operation); query.discard(?s.queries, operation); ret 4;
+    }
+    if (R.is_err[R.Void, fail.Fail](query.end(?s.queries, operation))) { ret 5; }
+    if (R.is_err[R.Void, str](query.discard(?s.queries, operation))) { ret 6; }
+    val closed: R.Result[bool, str] = close(?es, target);
+    if (R.is_err[bool, str](closed) || !R.unwrap_ok[bool, str](closed)) { ret 7; }
+    if (slot_live(?es, target) != nil || slot_live(?es, kept) == nil) { ret 8; }
+    if (O.unwrap[*source.SourceFile](source.get(?s.sources, target)).present) { ret 9; }
+    if (O.is_some[str](session.overlay_get(?s, "/mach-editor-outstanding/target.mach"))) { ret 10; }
+    if (R.is_ok[*ast.Ast, str](ast_of(?result)) || diagnostic.len(result.diagnostics) != 0 || O.is_none[*source.SourceFile](analysis_source(?result, target))) { ret 11; }
+    ret 0;
+}
+
+test "mach.lang.editor.close:repeated_open_update_close_leaves_unrelated_products_and_identities_valid" {
+    var alloc: A.Allocator;
+    var s: session.Session = R.unwrap_ok[session.Session, str](t_session(?alloc));
+    fin { session.dnit(?s); }
+    var es: EditorSession = init(?s);
+    fin { t_dnit(?es); }
+    val kept: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, "/mach-editor-unrelated/kept.mach", "val kept: i32 = 1;"));
+    val kept_input: query.Revision = query.peek_revision(?s.queries, query.Q_FILE_TEXT, kept::u64);
+    val kept_source: u64 = O.unwrap[*source.SourceFile](source.get(?s.sources, kept)).revision;
+    if (kept_input == 0) { ret 1; }
+    var first: source.FileId = source.FILE_NIL;
+    var turn: u32 = 0;
+    for (turn < 3) {
+        val fid: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, "/mach-editor-unrelated/churn.mach", "val churn: i32 = 2;"));
+        if (turn == 0) { first = fid; }
+        or (fid != first) { ret 2; }
+        if (query.peek_revision(?s.queries, query.Q_FILE_TEXT, fid::u64) == 0) { ret 3; }
+        if (!R.unwrap_ok[bool, str](update(?es, fid, "val churn: i32 = 3;"))) { ret 4; }
+        var req: AnalysisRequest = analysis_request(fid, PHASE_PARSE);
+        var result: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](analyze(?es, ?req));
+        if (result.status.kind != fail.ACCEPTED) { analysis_dnit(?result); ret 5; }
+        analysis_dnit(?result);
+        if (!R.unwrap_ok[bool, str](close(?es, fid))) { ret 6; }
+        if (query.peek_revision(?s.queries, query.Q_FILE_TEXT, fid::u64) != 0 || query.shard_len(?s.queries, query.Q_FILE_TEXT) != 1) { ret 7; }
+        if (O.unwrap[*source.SourceFile](source.get(?s.sources, fid)).present) { ret 8; }
+        if (query.peek_revision(?s.queries, query.Q_FILE_TEXT, kept::u64) != kept_input) { ret 9; }
+        if (O.unwrap[*source.SourceFile](source.get(?s.sources, kept)).revision != kept_source || slot_live(?es, kept) == nil) { ret 10; }
+        if (es.buf_len != BUFFERS_SEED) { ret 11; }
+        turn = turn + 1;
+    }
+    if (O.is_none[str](session.overlay_get(?s, "/mach-editor-unrelated/kept.mach")) || s.overlay_len != 1) { ret 12; }
+    ret 0;
+}

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1134,6 +1134,8 @@ fun t_exports(es: *EditorSession, fid: source.FileId, fqn: str) R.Result[res.Mod
         ps.canon  = sym.canon;
         ps.file = sym.definition_file;
         ps.generic_arity = sym.generic_arity;
+        ps.has_comptime_params = sym.has_comptime_params;
+        ps.has_pack_param = sym.has_pack_param;
         ps.slot   = sym.slot;
         ps.origin = sym.origin;
         syms[i] = ps;

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -1,6 +1,12 @@
 use std.allocator.arena;
 use std.allocator.page;
+use std.collections.vector;
+use std.collections.sort;
+use std.format;
+use std.collections.vector.Vector;
 use fs: std.filesystem;
+use io_error: std.io.error;
+use host_os: std.system.os;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -31,6 +37,7 @@ use mach.lang.diagnostic;
 use mach.lang.fail;
 use mach.lang.driver;
 use mach.lang.driver.load;
+use mach.lang.driver.passes;
 use mach.lang.driver.project;
 use mach.lang.fe.ast;
 use mach.lang.fe.ast.expr;
@@ -44,58 +51,38 @@ use mach.lang.fe.sema;
 use mach.lang.fe.sema.context;
 use mach.lang.intern;
 use mach.lang.manifest;
+use mach.lang.me.pipeline;
 use mach.lang.query;
 use mach.lang.session;
 use mach.lang.source;
 use mach.lang.target;
 use mach.lang.target.isa;
+use mach.lang.target.abi;
 use mach.lang.target.os;
 use mach.lang.type;
 
-# the per-file analysis state an editor session keeps, one slot per FileId
-# ---
-# file_id: the SourceMap file this slot analyzes; equal to the slot index
-# in_use: false until open registers the slot; ast_of, resolve_of, and sema_of read only live slots
-# owned: true when a, rr, and sr were produced for this buffer alone and are freed by the session;
-#  false when they point into the loaded project's module entry
-# a: the parsed tree, or nil before parse
-# rr: the resolve side tables, or nil before resolve
-# sr: the sema result, or nil before analyze
-# ctx: the comptime context resolve evaluates `$if` predicates against; reseeded with host
-#  defaults on every resolve
+# one reusable slot for a currently open file
 pub rec Buffer {
     file_id: source.FileId;
     in_use:  bool;
     owned:   bool;
     a:       *ast.Ast;
     parse_status: fail.PhaseStatus;
+    context_ready: bool;
     rr:      *res.ResolveResult;
     sr:      *context.SemaResult;
     ctx:     comptime.ComptimeCtx;
 }
 
-# the editor facade over one session.Session: open buffers plus the project loaded around them
-# ---
-# s: the borrowed session; owns the SourceMap, DiagnosticStore, and interner, and must outlive
-#  the editor session
-# alloc: the session allocator every buffer allocation goes through
-# buffers: slot array indexed by FileId, grown by open
-# buf_len: slot count
-# proj_backing: page allocator under the project arena
-# proj_arena: the arena the loaded project lives in; reset on every reload
-# proj_alloc: the allocator view of proj_arena
-# proj_loaded: true while proj holds an analyzed project
-# proj: the analyzed project of proj_root; valid only when proj_loaded
-# proj_root: the directory holding the mach.toml found above the last opened buffer, or nil
-# proj_dirty: set by open and update; the next parse or resolve of a project buffer reloads the project
-# proj_roots: the module fqns opened so far, passed to the driver as analysis roots
-# proj_root_count: entries of proj_roots in use
-# proj_root_cap: allocated extent of proj_roots
+# one serial facade over a borrowed session, with compact open-buffer slots
 pub rec EditorSession {
     s:       *session.Session;
     alloc:   *A.Allocator;
     buffers: *Buffer;
     buf_len: u32;
+    view_generation: u64;
+    active_request: *AnalysisRequest;
+    operation_failure: O.Option[outcome.Fail];
 
     proj_backing:    A.Allocator;
     proj_arena:      arena.Arena;
@@ -109,18 +96,315 @@ pub rec EditorSession {
     proj_root_cap:   u32;
 }
 
+pub def AnalysisPhase: driver.FrontendPhase;
+pub val PHASE_PARSE: AnalysisPhase = driver.FRONTEND_PARSE;
+pub val PHASE_RESOLVE: AnalysisPhase = driver.FRONTEND_RESOLVE;
+pub val PHASE_SEMA: AnalysisPhase = driver.FRONTEND_SEMA;
+
+pub rec AnalysisRequest {
+    file: source.FileId;
+    phase: AnalysisPhase;
+    build: request.BuildRequest;
+    standalone_target: *target.Target;
+}
+
+pub rec AnalysisTarget {
+    os: u32;
+    arch: u32;
+    abi: u32;
+    mode: u32;
+    pie: u32;
+    pointer_width: u32;
+    vector_bits: u32;
+    has_float: bool;
+    va_list_size: u32;
+    va_list_align: u32;
+}
+
+pub rec AnalysisSource {
+    id: source.FileId;
+    file: source.SourceFile;
+}
+
+pub rec AnalysisResult {
+    alloc: *A.Allocator;
+    editor: *EditorSession;
+    session: *session.Session;
+    view_generation: u64;
+    session_generation: u64;
+    query_operation: u64;
+    query_revision: query.Revision;
+    file: source.FileId;
+    source_revision: u64;
+    phase: AnalysisPhase;
+    status: fail.PhaseStatus;
+    failure: O.Option[outcome.Fail];
+    target: AnalysisTarget;
+    target_available: bool;
+    configuration: query.QueryOutput;
+    project_root: str;
+    profile: str;
+    message: str;
+    diagnostics: *diagnostic.DiagnosticStore;
+    sources: Vector[AnalysisSource];
+}
+
+pub fun analysis_request(file: source.FileId, phase: AnalysisPhase) AnalysisRequest {
+    ret AnalysisRequest{ file: file, phase: phase, build: request.defaults() };
+}
+
+pub fun analysis_dnit(result: *AnalysisResult) {
+    if (result.alloc == nil) { ret; }
+    if (result.diagnostics != nil) {
+        diagnostic.store_dnit(result.diagnostics);
+        A.deallocate[diagnostic.DiagnosticStore](result.alloc, result.diagnostics, 1);
+    }
+    var i: usize = 0;
+    for (i < result.sources.len) {
+        source.dnit_file(?result.sources.data[i].file, result.alloc);
+        i = i + 1;
+    }
+    vector.dnit[AnalysisSource](?result.sources);
+    if (result.configuration.bytes != nil) { A.deallocate[u8](result.alloc, result.configuration.bytes, result.configuration.len::usize); }
+    str_free(result.alloc, result.project_root);
+    str_free(result.alloc, result.profile);
+    str_free(result.alloc, result.message);
+    @result = AnalysisResult{};
+}
+
+pub fun analysis_source(result: *AnalysisResult, file: source.FileId) O.Option[*source.SourceFile] {
+    var i: usize = 0;
+    for (i < result.sources.len) {
+        if (result.sources.data[i].id == file) { ret O.some[*source.SourceFile](?result.sources.data[i].file); }
+        i = i + 1;
+    }
+    ret O.none[*source.SourceFile]();
+}
+
+fun result_buffer(result: *AnalysisResult) R.Result[*Buffer, str] {
+    val es: *EditorSession = result.editor;
+    if (result.alloc == nil || es == nil || result.session != es.s
+        || result.view_generation != es.view_generation || result.session_generation != es.s.view_generation
+        || result.session_generation == ~(0::u64) || result.query_operation != es.s.queries.operation_sequence
+        || result.query_revision != es.s.queries.revision) { ret R.err[*Buffer, str]("editor analysis view has expired"); }
+    val b: *Buffer = slot_live(es, result.file);
+    if (b == nil) { ret R.err[*Buffer, str]("editor analysis buffer has retired"); }
+    val file: O.Option[*source.SourceFile] = source.get(?es.s.sources, result.file);
+    if (O.is_none[*source.SourceFile](file) || !O.unwrap[*source.SourceFile](file).present
+        || O.unwrap[*source.SourceFile](file).revision != result.source_revision) { ret R.err[*Buffer, str]("editor analysis source has changed"); }
+    ret R.ok[*Buffer, str](b);
+}
+
+# raw products borrow the current serial view until the next mutation-capable session call
+pub fun ast_of(result: *AnalysisResult) R.Result[*ast.Ast, str] {
+    val buffer: R.Result[*Buffer, str] = result_buffer(result);
+    if (R.is_err[*Buffer, str](buffer)) { ret R.err[*ast.Ast, str](R.unwrap_err[*Buffer, str](buffer)); }
+    ret R.ok[*ast.Ast, str](R.unwrap_ok[*Buffer, str](buffer).a);
+}
+
+pub fun resolve_of(result: *AnalysisResult) R.Result[*res.ResolveResult, str] {
+    val buffer: R.Result[*Buffer, str] = result_buffer(result);
+    if (R.is_err[*Buffer, str](buffer)) { ret R.err[*res.ResolveResult, str](R.unwrap_err[*Buffer, str](buffer)); }
+    if (result.phase < PHASE_RESOLVE) { ret R.err[*res.ResolveResult, str]("analysis did not request resolution"); }
+    ret R.ok[*res.ResolveResult, str](R.unwrap_ok[*Buffer, str](buffer).rr);
+}
+
+pub fun sema_of(result: *AnalysisResult) R.Result[*context.SemaResult, str] {
+    val buffer: R.Result[*Buffer, str] = result_buffer(result);
+    if (R.is_err[*Buffer, str](buffer)) { ret R.err[*context.SemaResult, str](R.unwrap_err[*Buffer, str](buffer)); }
+    if (result.phase != PHASE_SEMA) { ret R.err[*context.SemaResult, str]("analysis did not request type checking"); }
+    ret R.ok[*context.SemaResult, str](R.unwrap_ok[*Buffer, str](buffer).sr);
+}
+
+fun snapshot_source(result: *AnalysisResult, s: *session.Session, file: source.FileId) R.Result[R.Void, str] {
+    if (file == source.FILE_NIL || O.is_some[*source.SourceFile](analysis_source(result, file))) { ret R.ok_void[str](); }
+    val current: O.Option[*source.SourceFile] = source.get(?s.sources, file);
+    if (O.is_none[*source.SourceFile](current) || !O.unwrap[*source.SourceFile](current).present) {
+        ret R.err[R.Void, str]("analysis diagnostic refers to an unavailable source version");
+    }
+    val copied: R.Result[source.SourceFile, str] = source.copy_file(O.unwrap[*source.SourceFile](current), result.alloc);
+    if (R.is_err[source.SourceFile, str](copied)) { ret R.void_of[source.SourceFile, str](copied); }
+    var entry: AnalysisSource = AnalysisSource{ id: file, file: R.unwrap_ok[source.SourceFile, str](copied) };
+    val added: R.Result[usize, str] = vector.push[AnalysisSource](?result.sources, entry);
+    if (R.is_err[usize, str](added)) {
+        source.dnit_file(?entry.file, result.alloc);
+        ret R.err[R.Void, str](R.unwrap_err[usize, str](added));
+    }
+    ret R.ok_void[str]();
+}
+
+fun target_snapshot(env: *comptime.ComptimeEnv) AnalysisTarget {
+    ret AnalysisTarget{
+        os: env.target_os_id, arch: env.target_arch_id, abi: env.target_abi_id,
+        mode: env.build_mode_id, pie: env.build_pie, pointer_width: env.pointer_width,
+        vector_bits: env.vector_bits, has_float: env.has_float,
+        va_list_size: env.va_list_size, va_list_align: env.va_list_align
+    };
+}
+
+fun snapshot_analysis(es: *EditorSession, req: *AnalysisRequest, status: fail.PhaseStatus,
+                      failure: O.Option[outcome.Fail]) R.Result[AnalysisResult, str] {
+    var result: AnalysisResult = AnalysisResult{
+        alloc: es.alloc, editor: es, session: es.s, file: req.file, phase: req.phase,
+        status: status, failure: failure, sources: vector.init[AnalysisSource](es.alloc)
+    };
+    var complete: bool = false;
+    fin { if (!complete) { analysis_dnit(?result); } }
+    val diagnostics: R.Result[*diagnostic.DiagnosticStore, str] = diagnostic.snapshot_from(?es.s.diags, 0, es.alloc);
+    if (R.is_err[*diagnostic.DiagnosticStore, str](diagnostics)) { ret R.err[AnalysisResult, str](R.unwrap_err[*diagnostic.DiagnosticStore, str](diagnostics)); }
+    result.diagnostics = R.unwrap_ok[*diagnostic.DiagnosticStore, str](diagnostics);
+    val copied: R.Result[R.Void, str] = snapshot_source(?result, es.s, req.file);
+    if (R.is_err[R.Void, str](copied)) { ret R.err[AnalysisResult, str](R.unwrap_err[R.Void, str](copied)); }
+    var i: usize = 0;
+    for (i < diagnostic.len(result.diagnostics)) {
+        val d: *diagnostic.Diagnostic = ?result.diagnostics.items.data[i];
+        val main: R.Result[R.Void, str] = snapshot_source(?result, es.s, d.loc.file_id);
+        if (R.is_err[R.Void, str](main)) { ret R.err[AnalysisResult, str](R.unwrap_err[R.Void, str](main)); }
+        var j: usize = 0;
+        for (j < d.related.len) {
+            val related: R.Result[R.Void, str] = snapshot_source(?result, es.s, d.related.data[j].loc.file_id);
+            if (R.is_err[R.Void, str](related)) { ret R.err[AnalysisResult, str](R.unwrap_err[R.Void, str](related)); }
+            j = j + 1;
+        }
+        j = 0;
+        for (j < d.fixes.len) {
+            var k: usize = 0;
+            for (k < d.fixes.data[j].edits.len) {
+                val edit: R.Result[R.Void, str] = snapshot_source(?result, es.s, d.fixes.data[j].edits.data[k].loc.file_id);
+                if (R.is_err[R.Void, str](edit)) { ret R.err[AnalysisResult, str](R.unwrap_err[R.Void, str](edit)); }
+                k = k + 1;
+            }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    val b: *Buffer = slot_live(es, req.file);
+    if (b.context_ready) { result.target = target_snapshot(?b.ctx.env); result.target_available = true; }
+    if (es.proj_loaded) {
+        val config: R.Result[query.QueryOutput, str] = passes.capture_build_config(?es.proj, es.alloc);
+        if (R.is_err[query.QueryOutput, str](config)) { ret R.err[AnalysisResult, str](R.unwrap_err[query.QueryOutput, str](config)); }
+        result.configuration = R.unwrap_ok[query.QueryOutput, str](config);
+        val root: R.Result[str, str] = str_copy(es.alloc, es.proj_root);
+        if (R.is_err[str, str](root)) { ret R.err[AnalysisResult, str](R.unwrap_err[str, str](root)); }
+        result.project_root = R.unwrap_ok[str, str](root);
+        var mid: u32 = 0;
+        for (mid < es.proj.module_len) {
+            if (es.proj.modules[mid].file_id == req.file) {
+                result.target = target_snapshot(?es.proj.modules[mid].ctx.env);
+                result.target_available = true;
+                brk;
+            }
+            mid = mid + 1;
+        }
+    }
+    var profile_name: str = req.build.profile;
+    if (es.proj_loaded) {
+        val name: O.Option[str] = intern.lookup(?es.s.interner, es.proj.config.profile);
+        if (O.is_none[str](name)) { ret R.err[AnalysisResult, str]("analysis profile has no stable spelling"); }
+        profile_name = O.unwrap[str](name);
+    }
+    val profile: R.Result[str, str] = str_copy(es.alloc, profile_name);
+    if (R.is_err[str, str](profile)) { ret R.err[AnalysisResult, str](R.unwrap_err[str, str](profile)); }
+    result.profile = R.unwrap_ok[str, str](profile);
+    var message: str = status.message;
+    if (O.is_some[outcome.Fail](failure)) { message = O.unwrap[outcome.Fail](failure).message; }
+    val owned_message: R.Result[str, str] = str_copy(es.alloc, message);
+    if (R.is_err[str, str](owned_message)) { ret R.err[AnalysisResult, str](R.unwrap_err[str, str](owned_message)); }
+    result.message = R.unwrap_ok[str, str](owned_message);
+    result.status.message = result.message;
+    if (O.is_some[outcome.Fail](failure)) {
+        var owned_failure: outcome.Fail = O.unwrap[outcome.Fail](failure);
+        owned_failure.message = result.message;
+        result.failure = O.some[outcome.Fail](owned_failure);
+    }
+    result.source_revision = O.unwrap[*source.SourceFile](analysis_source(?result, req.file)).revision;
+    result.view_generation = es.view_generation;
+    result.session_generation = es.s.view_generation;
+    result.query_operation = es.s.queries.operation_sequence;
+    result.query_revision = es.s.queries.revision;
+    complete = true;
+    ret R.ok[AnalysisResult, str](result);
+}
+
+# returned diagnostics own their source versions; raw products borrow this serial session view
+pub fun analyze(es: *EditorSession, req: *AnalysisRequest) R.Result[AnalysisResult, outcome.Fail] {
+    if (req == nil || req.phase > PHASE_SEMA || slot_live(es, req.file) == nil) {
+        ret R.err[AnalysisResult, outcome.Fail](fail_owned(es, outcome.user("analysis requires an open buffer and a valid phase")));
+    }
+    if (es.active_request != nil || es.s.queries.operation_active || es.s.queries.presentation_pending) {
+        ret R.err[AnalysisResult, outcome.Fail](fail_owned(es, outcome.internal("editor analysis cannot nest active query use")));
+    }
+    if (es.view_generation == ~(0::u64) || es.s.view_generation == ~(0::u64)) {
+        ret R.err[AnalysisResult, outcome.Fail](fail_owned(es, outcome.internal("editor view generation exhausted")));
+    }
+    es.view_generation = es.view_generation + 1;
+    views_drop(es);
+    es.proj_dirty = true;
+    es.active_request = req;
+    es.operation_failure = O.none[outcome.Fail]();
+    fin {
+        es.active_request = nil;
+        es.operation_failure = O.none[outcome.Fail]();
+        if (es.proj_loaded) { es.proj.req = request.defaults(); }
+    }
+    var work: R.Result[R.Void, str] = R.ok_void[str]();
+    if (req.phase == PHASE_PARSE) { work = R.void_of[*ast.Ast, str](parse_buffer(es, req.file)); }
+    or (req.phase == PHASE_RESOLVE) { work = R.void_of[*res.ResolveResult, str](resolve_buffer(es, req.file)); }
+    or { work = R.void_of[*context.SemaResult, str](analyze_buffer(es, req.file)); }
+    val b: *Buffer = slot_live(es, req.file);
+    if (b.owned && req.phase == PHASE_PARSE) {
+        val seeded: R.Result[R.Void, str] = ctx_seed(es, b);
+        if (R.is_ok[R.Void, str](work)) { work = seeded; }
+    }
+    var status: fail.PhaseStatus = b.parse_status;
+    if (req.phase >= PHASE_RESOLVE && b.rr != nil) { fail.merge(?status, b.rr.status); }
+    if (req.phase == PHASE_SEMA && b.sr != nil) { fail.merge(?status, b.sr.status); }
+    var failure: O.Option[outcome.Fail] = es.operation_failure;
+    if (R.is_err[R.Void, str](work)) {
+        if (O.is_none[outcome.Fail](failure)) { failure = O.some[outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](work))); }
+        val f: outcome.Fail = O.unwrap[outcome.Fail](failure);
+        if (f.kind == outcome.FAIL_REPORTED || f.kind == outcome.FAIL_USER) { fail.reject(?status); }
+        or { fail.internal(?status, f.message); }
+    }
+    if (es.s.view_generation == ~(0::u64)) {
+        ret R.err[AnalysisResult, outcome.Fail](fail_owned(es, outcome.internal("editor view generation exhausted")));
+    }
+    val result: R.Result[AnalysisResult, str] = snapshot_analysis(es, req, status, failure);
+    if (R.is_err[AnalysisResult, str](result)) {
+        ret R.err[AnalysisResult, outcome.Fail](fail_owned(es, outcome.internal(R.unwrap_err[AnalysisResult, str](result))));
+    }
+    ret R.ok[AnalysisResult, outcome.Fail](R.unwrap_ok[AnalysisResult, str](result));
+}
+
+pub fun expr_type_of(result: *AnalysisResult, eid: id.ExprId) R.Result[type.TypeId, str] {
+    val checked: R.Result[*context.SemaResult, str] = sema_of(result);
+    if (R.is_err[*context.SemaResult, str](checked)) { ret R.err[type.TypeId, str](R.unwrap_err[*context.SemaResult, str](checked)); }
+    ret R.ok[type.TypeId, str](buffer_expr_type(result.editor, result.file, eid));
+}
+
+pub fun decl_type_of(result: *AnalysisResult, did: id.DeclId) R.Result[type.TypeId, str] {
+    val checked: R.Result[*context.SemaResult, str] = sema_of(result);
+    if (R.is_err[*context.SemaResult, str](checked)) { ret R.err[type.TypeId, str](R.unwrap_err[*context.SemaResult, str](checked)); }
+    ret R.ok[type.TypeId, str](buffer_decl_type(result.editor, result.file, did));
+}
+
+pub fun resolved_type_of(result: *AnalysisResult, tid: id.TypeId) R.Result[type.TypeId, str] {
+    val checked: R.Result[*context.SemaResult, str] = sema_of(result);
+    if (R.is_err[*context.SemaResult, str](checked)) { ret R.err[type.TypeId, str](R.unwrap_err[*context.SemaResult, str](checked)); }
+    ret R.ok[type.TypeId, str](buffer_resolved_type(result.editor, result.file, tid));
+}
+
 val BUFFERS_SEED: u32 = 8;
 
-# construct an editor session over a session
-# ---
-# s: the session to borrow; dnit never touches it
-# ret: a session with no buffers and no loaded project
 pub fun init(s: *session.Session) EditorSession {
     var es: EditorSession;
     es.s       = s;
     es.alloc   = s.alloc;
     es.buffers = nil;
     es.buf_len = 0;
+    es.view_generation = 1;
+    es.active_request = nil;
+    es.operation_failure = O.none[outcome.Fail]();
 
     es.proj_loaded     = false;
     es.proj_root        = nil;
@@ -131,11 +415,7 @@ pub fun init(s: *session.Session) EditorSession {
     ret es;
 }
 
-# release everything the editor session owns: every buffer's analysis, the buffer array,
-# and the loaded project; the borrowed session is left intact
-# ---
-# es: the session to tear down; nil is ignored
-pub fun dnit(es: *EditorSession) {
+fun destroy(es: *EditorSession) {
     if (es == nil) { ret; }
     if (es.buffers != nil && es.buf_len > 0) {
         var i: u32 = 0;
@@ -167,20 +447,41 @@ pub fun dnit(es: *EditorSession) {
 # text: the buffer's full text
 # ret: the FileId every other entry takes, or the SourceMap, slot, or overlay error
 pub fun open(es: *EditorSession, path: str, text: str) R.Result[source.FileId, str] {
-    val res_fid: R.Result[source.FileId, str] = session.load_source(es.s, path, text);
-    if (R.is_err[source.FileId, str](res_fid)) { ret res_fid; }
-    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
-
-    val res_slot: R.Result[*Buffer, str] = slot_ensure(es, fid);
-    if (R.is_err[*Buffer, str](res_slot)) {
-        ret R.err[source.FileId, str](R.unwrap_err[*Buffer, str](res_slot));
+    if (es.s.queries.operation_active || es.s.queries.presentation_pending) {
+        ret R.err[source.FileId, str]("cannot change an editor buffer during query use");
     }
-
-    val res_ov: R.Result[R.Void, str] = session.set_overlay(es.s, path, text);
-    if (R.is_err[R.Void, str](res_ov)) {
-        ret R.err[source.FileId, str](R.unwrap_err[R.Void, str](res_ov));
+    if (es.view_generation == ~(0::u64)) { ret R.err[source.FileId, str]("editor view generation exhausted"); }
+    if (str_len(text) > 0xFFFFFFFF::usize) { ret R.err[source.FileId, str]("source input exceeds the query byte extent"); }
+    val overlay_r: R.Result[session.PreparedOverlay, str] = session.prepare_overlay(es.s, path, text, false);
+    if (R.is_err[session.PreparedOverlay, str](overlay_r)) {
+        ret R.err[source.FileId, str](R.unwrap_err[session.PreparedOverlay, str](overlay_r));
     }
-    es.proj_dirty = true;
+    var overlay: session.PreparedOverlay = R.unwrap_ok[session.PreparedOverlay, str](overlay_r);
+    fin { session.discard_overlay(?overlay); }
+    val source_r: R.Result[source.PreparedLoad, str] = source.prepare_load(?es.s.sources, ?es.s.interner, overlay.key, text);
+    if (R.is_err[source.PreparedLoad, str](source_r)) {
+        ret R.err[source.FileId, str](R.unwrap_err[source.PreparedLoad, str](source_r));
+    }
+    var prepared: source.PreparedLoad = R.unwrap_ok[source.PreparedLoad, str](source_r);
+    fin { source.discard_load(?prepared); }
+    val reserved: R.Result[u32, str] = slot_reserve(es, prepared.id);
+    if (R.is_err[u32, str](reserved)) { ret R.err[source.FileId, str](R.unwrap_err[u32, str](reserved)); }
+    val index: u32 = R.unwrap_ok[u32, str](reserved);
+    val changed: bool = prepared.changed || overlay.changed || !es.buffers[index].in_use;
+    val input: R.Result[R.Void, str] = query.set_input(?es.s.queries, query.Q_FILE_TEXT, prepared.id::u64, text::*u8, str_len(text)::u32);
+    if (R.is_err[R.Void, str](input)) { ret R.err[source.FileId, str](R.unwrap_err[R.Void, str](input)); }
+    if (changed) { views_drop(es); }
+    val fid: source.FileId = source.commit_load(?prepared);
+    session.commit_overlay(?overlay);
+    val b: *Buffer = ?es.buffers[index];
+    if (!b.in_use) {
+        @b = Buffer{ file_id: fid, in_use: true, owned: true, parse_status: fail.accepted() };
+        b.ctx = host_ctx(es);
+    }
+    if (changed) {
+        es.view_generation = es.view_generation + 1;
+        es.proj_dirty = true;
+    }
     ret R.ok[source.FileId, str](fid);
 }
 
@@ -192,35 +493,103 @@ pub fun open(es: *EditorSession, path: str, text: str) R.Result[source.FileId, s
 # ret: ok(true) when the text changed; ok(false) when the buffer is not open or the text
 #  is identical, in which case nothing is dropped; or the SourceMap or overlay error
 pub fun update(es: *EditorSession, fid: source.FileId, text: str) R.Result[bool, str] {
-    val b: *Buffer = slot_live(es, fid);
-    if (b == nil) { ret R.ok[bool, str](false); }
+    if (slot_live(es, fid) == nil) { ret R.ok[bool, str](false); }
+    val file: O.Option[*source.SourceFile] = source.get(?es.s.sources, fid);
+    if (O.is_none[*source.SourceFile](file)) { ret R.err[bool, str]("open editor buffer has no source identity"); }
+    val generation: u64 = es.view_generation;
+    val updated: R.Result[source.FileId, str] = open(es, O.unwrap[*source.SourceFile](file).path, text);
+    if (R.is_err[source.FileId, str](updated)) { ret R.err[bool, str](R.unwrap_err[source.FileId, str](updated)); }
+    ret R.ok[bool, str](es.view_generation != generation);
+}
 
-    val changed_r: R.Result[bool, str] = source.update(?es.s.sources, fid, text);
-    if (R.is_err[bool, str](changed_r))     { ret changed_r; }
-    if (!R.unwrap_ok[bool, str](changed_r)) { ret R.ok[bool, str](false); }
+fun removal_order(a: *session.PreparedOverlay, b: *session.PreparedOverlay) i64 {
+    if (a.index > b.index) { ret -1; }
+    if (a.index < b.index) { ret 1; }
+    ret 0;
+}
 
-    analysis_drop(es, b);
-
-    val opt_file: O.Option[*source.SourceFile] = source.get(?es.s.sources, fid);
-    if (O.is_some[*source.SourceFile](opt_file)) {
-        val file: *source.SourceFile = O.unwrap[*source.SourceFile](opt_file);
-        val res_ov: R.Result[R.Void, str] = session.set_overlay(es.s, file.path, text);
-        if (R.is_err[R.Void, str](res_ov)) { ret R.err[bool, str](R.unwrap_err[R.Void, str](res_ov)); }
+fun retire_buffers(es: *EditorSession, fid: source.FileId, all: bool) R.Result[R.Void, str] {
+    if (es.view_generation == ~(0::u64)) { ret R.err[R.Void, str]("editor view generation exhausted"); }
+    var roots: Vector[query.QueryKey] = vector.init[query.QueryKey](es.alloc);
+    fin { vector.dnit[query.QueryKey](?roots); }
+    var overlays: Vector[session.PreparedOverlay] = vector.init[session.PreparedOverlay](es.alloc);
+    fin {
+        var j: usize = 0;
+        for (j < overlays.len) { session.discard_overlay(?overlays.data[j]); j = j + 1; }
+        vector.dnit[session.PreparedOverlay](?overlays);
     }
+    var i: u32 = 0;
+    for (i < es.buf_len) {
+        val b: *Buffer = ?es.buffers[i];
+        if (b.in_use && (all || b.file_id == fid)) {
+            val checked: R.Result[R.Void, str] = source.prepare_release(?es.s.sources, b.file_id);
+            if (R.is_err[R.Void, str](checked)) { ret checked; }
+            val file: *source.SourceFile = O.unwrap[*source.SourceFile](source.get(?es.s.sources, b.file_id));
+            val overlay_r: R.Result[session.PreparedOverlay, str] = session.prepare_overlay(es.s, file.path, nil, true);
+            if (R.is_err[session.PreparedOverlay, str](overlay_r)) { ret R.err[R.Void, str](R.unwrap_err[session.PreparedOverlay, str](overlay_r)); }
+            var overlay: session.PreparedOverlay = R.unwrap_ok[session.PreparedOverlay, str](overlay_r);
+            val added: R.Result[usize, str] = vector.push[session.PreparedOverlay](?overlays, overlay);
+            if (R.is_err[usize, str](added)) {
+                session.discard_overlay(?overlay);
+                ret R.err[R.Void, str](R.unwrap_err[usize, str](added));
+            }
+            val rooted: R.Result[usize, str] = vector.push[query.QueryKey](?roots,
+                query.QueryKey{ kind: query.Q_FILE_TEXT, key: b.file_id::u64 });
+            if (R.is_err[usize, str](rooted)) { ret R.err[R.Void, str](R.unwrap_err[usize, str](rooted)); }
+        }
+        i = i + 1;
+    }
+    if (roots.len == 0) {
+        if (es.s.queries.operation_active || es.s.queries.presentation_pending) {
+            ret R.err[R.Void, str]("cannot retire editor state during query use");
+        }
+        views_drop(es);
+        es.view_generation = es.view_generation + 1;
+        ret R.ok_void[str]();
+    }
+    sort.sort[session.PreparedOverlay](overlays.data, overlays.len, removal_order);
+    val retired_r: R.Result[query.PreparedRetirement, str] = query.prepare_retirement(?es.s.queries, roots.data, roots.len);
+    if (R.is_err[query.PreparedRetirement, str](retired_r)) { ret R.err[R.Void, str](R.unwrap_err[query.PreparedRetirement, str](retired_r)); }
+    var retired: query.PreparedRetirement = R.unwrap_ok[query.PreparedRetirement, str](retired_r);
+    fin { query.discard_retirement(?retired); }
+    val valid: R.Result[R.Void, str] = query.validate_retirement(?retired);
+    if (R.is_err[R.Void, str](valid)) { ret valid; }
+    views_drop(es);
+    R.unwrap_ok[R.Void, str](query.commit_retirement(?retired));
+    var j: usize = 0;
+    for (j < roots.len) {
+        session.commit_overlay(?overlays.data[j]);
+        val closed: source.FileId = roots.data[j].key::source.FileId;
+        source.release_payload(?es.s.sources, closed);
+        @slot_live(es, closed) = Buffer{};
+        j = j + 1;
+    }
+    es.proj_root_count = 0;
     es.proj_dirty = true;
+    es.view_generation = es.view_generation + 1;
+    ret R.ok_void[str]();
+}
+
+pub fun close(es: *EditorSession, fid: source.FileId) R.Result[bool, str] {
+    if (slot_live(es, fid) == nil) { ret R.ok[bool, str](false); }
+    val retired: R.Result[R.Void, str] = retire_buffers(es, fid, false);
+    if (R.is_err[R.Void, str](retired)) { ret R.err[bool, str](R.unwrap_err[R.Void, str](retired)); }
     ret R.ok[bool, str](true);
 }
 
-# lex an open buffer; lex errors are recorded as diagnostics, not failures
-# resets the session diagnostics first
-# ---
-# es: the editor session
-# fid: the buffer's FileId
-# ret: the token stream, which the caller frees with lexer.dnit, or "editor: buffer not open"
-#  or the allocation error
-pub fun tokenize(es: *EditorSession, fid: source.FileId) R.Result[lexer.TokenStream, str] {
-    diags_reset(es);
-    ret tokenize_inner(es, fid);
+pub fun dnit(es: *EditorSession) R.Result[R.Void, str] {
+    if (es == nil) { ret R.ok_void[str](); }
+    val retired: R.Result[R.Void, str] = retire_buffers(es, source.FILE_NIL, true);
+    if (R.is_err[R.Void, str](retired)) { ret retired; }
+    destroy(es);
+    ret R.ok_void[str]();
+}
+
+# token storage is caller-owned; source bytes borrow the owned analysis result
+pub fun tokenize(result: *AnalysisResult) R.Result[lexer.TokenStream, str] {
+    val file: O.Option[*source.SourceFile] = analysis_source(result, result.file);
+    if (O.is_none[*source.SourceFile](file)) { ret R.err[lexer.TokenStream, str]("analysis has no owned source version"); }
+    ret lexer.tokenize(O.unwrap[*source.SourceFile](file).text, result.alloc, result.file);
 }
 
 # parse an open buffer, best effort: syntax errors become diagnostics and the tree is still
@@ -232,7 +601,7 @@ pub fun tokenize(es: *EditorSession, fid: source.FileId) R.Result[lexer.TokenStr
 # fid: the buffer's FileId
 # ret: the tree, owned by the session or by the loaded project, or the buffer-not-open,
 #  project-load, or fatal-parse error
-pub fun parse(es: *EditorSession, fid: source.FileId) R.Result[*ast.Ast, str] {
+fun parse_buffer(es: *EditorSession, fid: source.FileId) R.Result[*ast.Ast, str] {
     diags_reset(es);
 
     val b: *Buffer = slot_live(es, fid);
@@ -265,7 +634,7 @@ pub fun parse(es: *EditorSession, fid: source.FileId) R.Result[*ast.Ast, str] {
 # fid: the buffer's FileId
 # ret: the side tables, cached until the next update, or the buffer-not-open, project-load,
 #  parse, or resolve error
-pub fun resolve(es: *EditorSession, fid: source.FileId) R.Result[*res.ResolveResult, str] {
+fun resolve_buffer(es: *EditorSession, fid: source.FileId) R.Result[*res.ResolveResult, str] {
     diags_reset(es);
 
     val b: *Buffer = slot_live(es, fid);
@@ -307,7 +676,7 @@ pub fun resolve(es: *EditorSession, fid: source.FileId) R.Result[*res.ResolveRes
 # es: the editor session
 # fid: the buffer's FileId
 # ret: the session's diagnostic store, borrowed, or the buffer-not-open or fatal-parse error
-pub fun diagnostics(es: *EditorSession, fid: source.FileId) R.Result[*diagnostic.DiagnosticStore, str] {
+fun diagnostics_buffer(es: *EditorSession, fid: source.FileId) R.Result[*diagnostic.DiagnosticStore, str] {
     diags_reset(es);
 
     val res_parse: R.Result[*ast.Ast, str] = parse_inner(es, fid);
@@ -322,7 +691,7 @@ pub fun diagnostics(es: *EditorSession, fid: source.FileId) R.Result[*diagnostic
 # es: the editor session
 # fid: the buffer's FileId
 # ret: the tree from the last parse or resolve, or nil when the buffer is not open or not yet parsed
-pub fun ast_of(es: *EditorSession, fid: source.FileId) *ast.Ast {
+fun buffer_ast(es: *EditorSession, fid: source.FileId) *ast.Ast {
     val b: *Buffer = slot_live(es, fid);
     if (b == nil) { ret nil; }
     ret b.a;
@@ -333,7 +702,7 @@ pub fun ast_of(es: *EditorSession, fid: source.FileId) *ast.Ast {
 # es: the editor session
 # fid: the buffer's FileId
 # ret: the side tables from the last resolve, or nil when the buffer is not open or not yet resolved
-pub fun resolve_of(es: *EditorSession, fid: source.FileId) *res.ResolveResult {
+fun buffer_resolve_of(es: *EditorSession, fid: source.FileId) *res.ResolveResult {
     val b: *Buffer = slot_live(es, fid);
     if (b == nil) { ret nil; }
     ret b.rr;
@@ -347,8 +716,8 @@ pub fun resolve_of(es: *EditorSession, fid: source.FileId) *res.ResolveResult {
 # fid: the buffer's FileId
 # ret: the sema result, cached until the next update, or the resolve, registration, sema,
 #  or allocation error
-pub fun analyze(es: *EditorSession, fid: source.FileId) R.Result[*context.SemaResult, str] {
-    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(es, fid);
+fun analyze_buffer(es: *EditorSession, fid: source.FileId) R.Result[*context.SemaResult, str] {
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve_buffer(es, fid);
     if (R.is_err[*res.ResolveResult, str](res_resolve)) {
         ret R.err[*context.SemaResult, str](R.unwrap_err[*res.ResolveResult, str](res_resolve));
     }
@@ -370,6 +739,7 @@ pub fun analyze(es: *EditorSession, fid: source.FileId) R.Result[*context.SemaRe
         ret R.ok[*context.SemaResult, str](b.sr);
     }
 
+    sema_drop(es, b);
     val res_register: R.Result[R.Void, str] = session.register_module_ast(es.s, fid::session.ModuleId, b.a);
     if (R.is_err[R.Void, str](res_register)) {
         ret R.err[*context.SemaResult, str](R.unwrap_err[R.Void, str](res_register));
@@ -382,6 +752,7 @@ pub fun analyze(es: *EditorSession, fid: source.FileId) R.Result[*context.SemaRe
 
     val res_sema: R.Result[context.SemaResult, fail.Fail] = sema.sema(es.s, b.a, rr, ?deps, ?b.ctx, fid::session.ModuleId, ?es.s.diags);
     if (R.is_err[context.SemaResult, fail.Fail](res_sema)) {
+        es.operation_failure = O.some[outcome.Fail](outcome.from_fail(R.unwrap_err[context.SemaResult, fail.Fail](res_sema)));
         ret R.err[*context.SemaResult, str](R.unwrap_err[context.SemaResult, fail.Fail](res_sema).message);
     }
 
@@ -402,7 +773,7 @@ pub fun analyze(es: *EditorSession, fid: source.FileId) R.Result[*context.SemaRe
 # es: the editor session
 # fid: the buffer's FileId
 # ret: the result from the last analyze, or nil when the buffer is not open or not yet analyzed
-pub fun sema_of(es: *EditorSession, fid: source.FileId) *context.SemaResult {
+fun buffer_sema(es: *EditorSession, fid: source.FileId) *context.SemaResult {
     val b: *Buffer = slot_live(es, fid);
     if (b == nil) { ret nil; }
     ret b.sr;
@@ -415,7 +786,7 @@ pub fun sema_of(es: *EditorSession, fid: source.FileId) *context.SemaResult {
 # eid: an expression id of the buffer's tree
 # ret: the TypeId; TYPE_NIL for EXPR_NIL; TYPE_ERROR when the buffer is not open, not
 #  analyzed, or eid is out of range
-pub fun expr_type_of(es: *EditorSession, fid: source.FileId, eid: id.ExprId) type.TypeId {
+fun buffer_expr_type(es: *EditorSession, fid: source.FileId, eid: id.ExprId) type.TypeId {
     if (eid == id.EXPR_NIL) { ret type.TYPE_NIL; }
     val b: *Buffer = slot_live(es, fid);
     if (b == nil || b.sr == nil || b.sr.expr_type == nil) { ret type.TYPE_ERROR; }
@@ -430,7 +801,7 @@ pub fun expr_type_of(es: *EditorSession, fid: source.FileId, eid: id.ExprId) typ
 # did: a declaration id of the buffer's tree
 # ret: the TypeId; TYPE_NIL for DECL_NIL; TYPE_ERROR when the buffer is not open, not
 #  analyzed, or did is out of range
-pub fun decl_type_of(es: *EditorSession, fid: source.FileId, did: id.DeclId) type.TypeId {
+fun buffer_decl_type(es: *EditorSession, fid: source.FileId, did: id.DeclId) type.TypeId {
     if (did == id.DECL_NIL) { ret type.TYPE_NIL; }
     val b: *Buffer = slot_live(es, fid);
     if (b == nil || b.sr == nil || b.sr.decl_type == nil) { ret type.TYPE_ERROR; }
@@ -445,7 +816,7 @@ pub fun decl_type_of(es: *EditorSession, fid: source.FileId, did: id.DeclId) typ
 # tid: a type node id of the buffer's tree
 # ret: the TypeId; TYPE_NIL for the TYPE_NIL node id; TYPE_ERROR when the buffer is not open,
 #  not analyzed, or tid is out of range
-pub fun resolved_type_of(es: *EditorSession, fid: source.FileId, tid: id.TypeId) type.TypeId {
+fun buffer_resolved_type(es: *EditorSession, fid: source.FileId, tid: id.TypeId) type.TypeId {
     if (tid == id.TYPE_NIL) { ret type.TYPE_NIL; }
     val b: *Buffer = slot_live(es, fid);
     if (b == nil || b.sr == nil || b.sr.type_resolved_ty == nil) { ret type.TYPE_ERROR; }
@@ -463,6 +834,15 @@ val OOM_FAIL_MESSAGE: str = "out of memory";
 # ret: the build outcome, or a Fail whose message is a copy owned by the editor session;
 #  release it with fail_dnit
 pub fun build(es: *EditorSession, req: *request.BuildRequest) R.Result[outcome.BuildOutcome, outcome.Fail] {
+    if (es.active_request != nil || es.s.queries.operation_active || es.s.queries.presentation_pending) {
+        ret R.err[outcome.BuildOutcome, outcome.Fail](fail_owned(es, outcome.internal("editor build cannot nest active query use")));
+    }
+    if (es.view_generation == ~(0::u64)) {
+        ret R.err[outcome.BuildOutcome, outcome.Fail](fail_owned(es, outcome.internal("editor view generation exhausted")));
+    }
+    es.view_generation = es.view_generation + 1;
+    views_drop(es);
+    es.proj_dirty = true;
     val s: *session.Session = es.s;
 
     val reg_r: R.Result[R.Void, str] = driver.setup_registry(?s.registry);
@@ -529,7 +909,7 @@ fun fail_owned(es: *EditorSession, f: outcome.Fail) outcome.Fail {
     ret out;
 }
 
-# release the message of a Fail returned by build
+# release an operational failure returned by analyze or build
 # ---
 # es: the editor session that returned the Fail
 # f: the Fail; nil, a reported Fail, an empty message, and the out-of-memory message are no-ops
@@ -551,50 +931,67 @@ fun diags_reset(es: *EditorSession) {
     es.s.diags = diagnostic.store_init(es.alloc);
 }
 
-fun discover_project_root(alloc: *A.Allocator, file_path: str) O.Option[str] {
+fun discover_project_root(alloc: *A.Allocator, file_path: str) R.Result[O.Option[str], str] {
     val start_r: R.Result[str, str] = path.parent(alloc, file_path);
-    if (R.is_err[str, str](start_r)) { ret O.none[str](); }
+    if (R.is_err[str, str](start_r)) { ret R.err[O.Option[str], str](R.unwrap_err[str, str](start_r)); }
     var dir: str = R.unwrap_ok[str, str](start_r);
+    fin { str_free(alloc, dir); }
     for (true) {
         val mf_r: R.Result[str, str] = load.join_path(alloc, dir, manifest.MANIFEST_FILE);
-        if (R.is_ok[str, str](mf_r)) {
-            val mf: str = R.unwrap_ok[str, str](mf_r);
-            val found: bool = fs.is_file(mf);
-            str_free(alloc, mf);
-            if (found) { ret O.some[str](dir); }
+        if (R.is_err[str, str](mf_r)) { ret R.err[O.Option[str], str](R.unwrap_err[str, str](mf_r)); }
+        val mf: str = R.unwrap_ok[str, str](mf_r);
+        val opened: R.Result[fs.File, io_error.Error] = fs.open(mf);
+        str_free(alloc, mf);
+        if (R.is_ok[fs.File, io_error.Error](opened)) {
+            var file: fs.File = R.unwrap_ok[fs.File, io_error.Error](opened);
+            val metadata: R.Result[fs.Metadata, io_error.Error] = fs.stat_of_error(file);
+            val closed: O.Option[io_error.Error] = fs.close(?file);
+            if (R.is_err[fs.Metadata, io_error.Error](metadata)) {
+                ret R.err[O.Option[str], str](io_error.message(R.unwrap_err[fs.Metadata, io_error.Error](metadata)));
+            }
+            if (O.is_some[io_error.Error](closed)) { ret R.err[O.Option[str], str](io_error.message(O.unwrap[io_error.Error](closed))); }
+            if (R.unwrap_ok[fs.Metadata, io_error.Error](metadata).kind != fs.KIND_FILE) {
+                ret R.err[O.Option[str], str]("project manifest is not a regular file");
+            }
+            val found: str = dir;
+            dir = nil;
+            ret R.ok[O.Option[str], str](O.some[str](found));
+        }
+        if (R.unwrap_err[fs.File, io_error.Error](opened).code != host_os.ENOENT) {
+            ret R.err[O.Option[str], str](io_error.message(R.unwrap_err[fs.File, io_error.Error](opened)));
         }
         val parent_r: R.Result[str, str] = path.parent(alloc, dir);
-        if (R.is_err[str, str](parent_r)) { str_free(alloc, dir); ret O.none[str](); }
-        val nd: str = R.unwrap_ok[str, str](parent_r);
-        if (str_equals(nd, dir)) { str_free(alloc, dir); str_free(alloc, nd); ret O.none[str](); }
+        if (R.is_err[str, str](parent_r)) { ret R.err[O.Option[str], str](R.unwrap_err[str, str](parent_r)); }
+        val next: str = R.unwrap_ok[str, str](parent_r);
+        if (str_equals(next, dir)) { str_free(alloc, next); ret R.ok[O.Option[str], str](O.none[str]()); }
         str_free(alloc, dir);
-        dir = nd;
+        dir = next;
     }
-    ret O.none[str]();
+    ret R.ok[O.Option[str], str](O.none[str]());
 }
 
-fun relative_under(alloc: *A.Allocator, file_path: str, root: str, src_text: str) O.Option[str] {
+fun relative_under(alloc: *A.Allocator, file_path: str, root: str, src_text: str) R.Result[O.Option[str], str] {
     val prefix_r: R.Result[str, str] = load.join_path(alloc, root, src_text);
-    if (R.is_err[str, str](prefix_r)) { ret O.none[str](); }
+    if (R.is_err[str, str](prefix_r)) { ret R.err[O.Option[str], str](R.unwrap_err[str, str](prefix_r)); }
     val prefix: str = R.unwrap_ok[str, str](prefix_r);
     val plen: usize = str_len(prefix);
     val flen: usize = str_len(file_path);
     if (flen <= plen || !path.is_separator(file_path[plen])) {
         str_free(alloc, prefix);
-        ret O.none[str]();
+        ret R.ok[O.Option[str], str](O.none[str]());
     }
     var i: usize = 0;
     for (i < plen) {
         if (file_path[i] != prefix[i] && !(path.is_separator(file_path[i]) && path.is_separator(prefix[i]))) {
             str_free(alloc, prefix);
-            ret O.none[str]();
+            ret R.ok[O.Option[str], str](O.none[str]());
         }
         i = i + 1;
     }
     str_free(alloc, prefix);
     val rel_r: R.Result[str, str] = str_copy_slice(alloc, file_path, plen + 1, flen - plen - 1);
-    if (R.is_err[str, str](rel_r)) { ret O.none[str](); }
-    ret O.some[str](R.unwrap_ok[str, str](rel_r));
+    if (R.is_err[str, str](rel_r)) { ret R.err[O.Option[str], str](R.unwrap_err[str, str](rel_r)); }
+    ret R.ok[O.Option[str], str](O.some[str](R.unwrap_ok[str, str](rel_r)));
 }
 
 fun proj_roots_has(es: *EditorSession, fqn: intern.StrId) bool {
@@ -606,28 +1003,65 @@ fun proj_roots_has(es: *EditorSession, fqn: intern.StrId) bool {
     ret false;
 }
 
-fun proj_roots_add(es: *EditorSession, fqn: intern.StrId) R.Result[R.Void, str] {
-    if (proj_roots_has(es, fqn)) { ret R.ok_void[str](); }
-    val needed: u32 = es.proj_root_count + 1;
-    if (needed > es.proj_root_cap) {
-        var new_cap: u32 = es.proj_root_cap;
-        if (new_cap == 0) { new_cap = 8; }
-        for (new_cap < needed) { new_cap = new_cap * 2; }
-        if (es.proj_roots == nil) {
-            val r: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](es.alloc, new_cap::usize);
-            if (R.is_err[*intern.StrId, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*intern.StrId, str](r)); }
-            es.proj_roots = R.unwrap_ok[*intern.StrId, str](r);
+fun proj_roots_rebuild(es: *EditorSession, root: str, id_text: str, src_text: str) R.Result[R.Void, str] {
+    val allocated: R.Result[*intern.StrId, str] = A.allocate[intern.StrId](es.alloc, es.buf_len::usize);
+    if (R.is_err[*intern.StrId, str](allocated)) { ret R.void_of[*intern.StrId, str](allocated); }
+    val roots: *intern.StrId = R.unwrap_ok[*intern.StrId, str](allocated);
+    var complete: bool = false;
+    fin { if (!complete) { A.deallocate[intern.StrId](es.alloc, roots, es.buf_len::usize); } }
+    var count: u32 = 0;
+    var i: u32 = 0;
+    for (i < es.buf_len) {
+        if (es.buffers[i].in_use) {
+            val file: O.Option[*source.SourceFile] = source.get(?es.s.sources, es.buffers[i].file_id);
+            if (O.is_none[*source.SourceFile](file)) { ret R.err[R.Void, str]("open editor buffer has no source identity"); }
+            val owner_r: R.Result[O.Option[str], str] = discover_project_root(es.alloc, O.unwrap[*source.SourceFile](file).path);
+            if (R.is_err[O.Option[str], str](owner_r)) { ret R.err[R.Void, str](R.unwrap_err[O.Option[str], str](owner_r)); }
+            val owner: O.Option[str] = R.unwrap_ok[O.Option[str], str](owner_r);
+            if (O.is_none[str](owner)) { i = i + 1; cnt; }
+            val same: bool = str_equals(O.unwrap[str](owner), root);
+            str_free(es.alloc, O.unwrap[str](owner));
+            if (!same) { i = i + 1; cnt; }
+            val relative: R.Result[O.Option[str], str] = relative_under(es.alloc,
+                O.unwrap[*source.SourceFile](file).path, root, src_text);
+            if (R.is_err[O.Option[str], str](relative)) { ret R.err[R.Void, str](R.unwrap_err[O.Option[str], str](relative)); }
+            if (O.is_some[str](R.unwrap_ok[O.Option[str], str](relative))) {
+                val rel: str = O.unwrap[str](R.unwrap_ok[O.Option[str], str](relative));
+                val name: R.Result[intern.StrId, str] = load.compose_module_fqn(es.alloc, ?es.s.interner, id_text, rel);
+                str_free(es.alloc, rel);
+                if (R.is_err[intern.StrId, str](name)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](name)); }
+                roots[count] = R.unwrap_ok[intern.StrId, str](name);
+                count = count + 1;
+            }
         }
-        or {
-            val r: R.Result[*intern.StrId, str] = A.reallocate[intern.StrId](es.alloc, es.proj_roots, es.proj_root_cap::usize, new_cap::usize);
-            if (R.is_err[*intern.StrId, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*intern.StrId, str](r)); }
-            es.proj_roots = R.unwrap_ok[*intern.StrId, str](r);
-        }
-        es.proj_root_cap = new_cap;
+        i = i + 1;
     }
-    es.proj_roots[es.proj_root_count] = fqn;
-    es.proj_root_count = es.proj_root_count + 1;
+    if (es.proj_roots != nil) { A.deallocate[intern.StrId](es.alloc, es.proj_roots, es.proj_root_cap::usize); }
+    es.proj_roots = roots;
+    es.proj_root_count = count;
+    es.proj_root_cap = es.buf_len;
+    complete = true;
     ret R.ok_void[str]();
+}
+
+fun views_drop(es: *EditorSession) {
+    var i: u32 = 0;
+    for (i < es.buf_len) {
+        if (es.buffers[i].in_use) { analysis_drop(es, ?es.buffers[i]); }
+        i = i + 1;
+    }
+    val had_project: bool = es.proj_loaded;
+    proj_teardown(es);
+    if (!had_project) { session.reset_module_registry(es.s); }
+    if (es.s.query_presentation != nil) {
+        query.presentation_dnit(es.s.query_presentation);
+        es.s.query_presentation = nil;
+    }
+    if (es.s.query_failure_message != nil) {
+        str_free(es.s.queries.a, es.s.query_failure_message);
+        es.s.query_failure_message = nil;
+    }
+    diags_reset(es);
 }
 
 fun proj_teardown(es: *EditorSession) {
@@ -642,7 +1076,9 @@ fun proj_ensure(es: *EditorSession, fid: source.FileId) R.Result[O.Option[*proje
     if (O.is_none[*source.SourceFile](file_opt)) { ret R.ok[O.Option[*project.ModuleEntry], str](O.none[*project.ModuleEntry]()); }
     val file_path: str = O.unwrap[*source.SourceFile](file_opt).path;
 
-    val root_opt: O.Option[str] = discover_project_root(es.alloc, file_path);
+    val discovered: R.Result[O.Option[str], str] = discover_project_root(es.alloc, file_path);
+    if (R.is_err[O.Option[str], str](discovered)) { ret R.err[O.Option[*project.ModuleEntry], str](R.unwrap_err[O.Option[str], str](discovered)); }
+    val root_opt: O.Option[str] = R.unwrap_ok[O.Option[str], str](discovered);
     if (O.is_none[str](root_opt)) { ret R.ok[O.Option[*project.ModuleEntry], str](O.none[*project.ModuleEntry]()); }
     val root: str = O.unwrap[str](root_opt);
 
@@ -658,6 +1094,8 @@ fun proj_ensure(es: *EditorSession, fid: source.FileId) R.Result[O.Option[*proje
     var src_text:     str = nil;
     var m:            manifest.Manifest;
     var have_manifest: bool = false;
+    val manifest_alloc: *A.Allocator = es.s.build_alloc;
+    fin { if (have_manifest) { manifest.dnit(?m, manifest_alloc); } }
 
     if (need_manifest) {
         val m_r: R.Result[manifest.Manifest, str] = driver.load_manifest(es.s, root);
@@ -687,12 +1125,20 @@ fun proj_ensure(es: *EditorSession, fid: source.FileId) R.Result[O.Option[*proje
         src_text = O.unwrap[str](src_opt);
     }
 
-    val rel_opt: O.Option[str] = relative_under(es.alloc, file_path, root, src_text);
+    val relative: R.Result[O.Option[str], str] = relative_under(es.alloc, file_path, root, src_text);
+    if (R.is_err[O.Option[str], str](relative)) { str_free(es.alloc, root); ret R.err[O.Option[*project.ModuleEntry], str](R.unwrap_err[O.Option[str], str](relative)); }
+    val rel_opt: O.Option[str] = R.unwrap_ok[O.Option[str], str](relative);
     if (O.is_none[str](rel_opt)) {
         str_free(es.alloc, root);
         ret R.ok[O.Option[*project.ModuleEntry], str](O.none[*project.ModuleEntry]());
     }
     val rel: str = O.unwrap[str](rel_opt);
+    if (es.active_request != nil && es.active_request.standalone_target != nil) {
+        str_free(es.alloc, rel);
+        str_free(es.alloc, root);
+        es.operation_failure = O.some[outcome.Fail](outcome.user("project analysis selects its target through the build request"));
+        ret R.err[O.Option[*project.ModuleEntry], str]("project analysis selects its target through the build request");
+    }
 
     val fqn_r: R.Result[intern.StrId, str] = load.compose_module_fqn(es.alloc, ?es.s.interner, id_text, rel);
     str_free(es.alloc, rel);
@@ -710,12 +1156,10 @@ fun proj_ensure(es: *EditorSession, fid: source.FileId) R.Result[O.Option[*proje
         ret R.ok[O.Option[*project.ModuleEntry], str](project.module_by_fqn(?es.proj, fqn));
     }
 
-    if (!has_root) {
-        val ar: R.Result[R.Void, str] = proj_roots_add(es, fqn);
-        if (R.is_err[R.Void, str](ar)) {
-            str_free(es.alloc, root);
-            ret R.err[O.Option[*project.ModuleEntry], str](R.unwrap_err[R.Void, str](ar));
-        }
+    val rebuilt: R.Result[R.Void, str] = proj_roots_rebuild(es, root, id_text, src_text);
+    if (R.is_err[R.Void, str](rebuilt)) {
+        str_free(es.alloc, root);
+        ret R.err[O.Option[*project.ModuleEntry], str](R.unwrap_err[R.Void, str](rebuilt));
     }
 
     if (!have_manifest) {
@@ -725,6 +1169,7 @@ fun proj_ensure(es: *EditorSession, fid: source.FileId) R.Result[O.Option[*proje
             ret R.err[O.Option[*project.ModuleEntry], str](R.unwrap_err[manifest.Manifest, str](m_r));
         }
         m = R.unwrap_ok[manifest.Manifest, str](m_r);
+        have_manifest = true;
     }
 
     proj_teardown(es);
@@ -747,24 +1192,27 @@ fun proj_ensure(es: *EditorSession, fid: source.FileId) R.Result[O.Option[*proje
     es.s.build_alloc = ?es.proj_alloc;
 
     var req: request.BuildRequest = request.defaults();
+    if (es.active_request != nil) { req = es.active_request.build; }
     req.project_root = root;
 
-    val ap_r: R.Result[project.Project, outcome.Fail] = driver.analyze_project(es.s, ?m, ?req, es.proj_roots, es.proj_root_count);
+    var phase: driver.FrontendPhase = driver.FRONTEND_SEMA;
+    if (es.active_request != nil) { phase = es.active_request.phase; }
+    val ap_r: R.Result[project.Project, outcome.Fail] = driver.analyze_project_until(es.s, ?m, ?req, es.proj_roots, es.proj_root_count, phase);
     es.s.build_alloc = prior_build;
 
     if (R.is_err[project.Project, outcome.Fail](ap_r)) {
         val f: outcome.Fail = R.unwrap_err[project.Project, outcome.Fail](ap_r);
+        es.operation_failure = O.some[outcome.Fail](f);
         var emsg: str = "editor: failed to load project";
         if (f.message != nil && str_len(f.message) > 0) { emsg = f.message; }
-        val dup_r: R.Result[str, str] = str_copy(es.alloc, emsg);
         arena.dnit(?es.proj_arena);
         str_free(es.alloc, root);
-        if (R.is_err[str, str](dup_r)) { ret R.err[O.Option[*project.ModuleEntry], str](R.unwrap_err[str, str](dup_r)); }
-        ret R.err[O.Option[*project.ModuleEntry], str](R.unwrap_ok[str, str](dup_r));
+        ret R.err[O.Option[*project.ModuleEntry], str](emsg);
     }
 
     es.proj_loaded  = true;
     es.proj         = R.unwrap_ok[project.Project, outcome.Fail](ap_r);
+    if (es.proj_root != nil) { str_free(es.alloc, es.proj_root); }
     es.proj_root    = root;
     es.proj_dirty   = false;
 
@@ -813,9 +1261,11 @@ fun parse_inner(es: *EditorSession, fid: source.FileId) R.Result[*ast.Ast, str] 
     lexer.dnit(?stream, es.alloc);
 
     if (R.is_err[fail.PhaseStatus, state.ParseFail](parse_r)) {
-        ast.dnit(a);
-        A.deallocate[ast.Ast](es.alloc, a, 1);
         val f: state.ParseFail = R.unwrap_err[fail.PhaseStatus, state.ParseFail](parse_r);
+        b.a = a;
+        es.operation_failure = O.some[outcome.Fail](outcome.from_fail(state.failure(f)));
+        if (f.kind == state.PARSE_FAIL_DEPTH) { fail.reject(?b.parse_status); }
+        or { fail.internal(?b.parse_status, f.message); }
         ret R.err[*ast.Ast, str](f.message);
     }
 
@@ -826,11 +1276,11 @@ fun parse_inner(es: *EditorSession, fid: source.FileId) R.Result[*ast.Ast, str] 
 
 fun buffer_definition(raw: ptr, origin: session.ModuleId, phase: context.DefinitionPhase) R.Result[context.Definition, fail.Fail] {
     val es: *EditorSession = raw::*EditorSession;
-    if (es == nil || origin::u32 >= es.buf_len) {
+    if (es == nil) {
         ret R.err[context.Definition, fail.Fail](fail.message("current definition is not an open editor buffer"));
     }
-    val b: *Buffer = ?es.buffers[origin::u32];
-    if (!b.in_use || !b.owned || b.a == nil) {
+    val b: *Buffer = slot_live(es, origin::source.FileId);
+    if (b == nil || !b.owned || b.a == nil) {
         ret R.err[context.Definition, fail.Fail](fail.message("editor definition has no current standalone parsed owner"));
     }
     var result: context.Definition = context.Definition{
@@ -844,10 +1294,12 @@ fun buffer_definition(raw: ptr, origin: session.ModuleId, phase: context.Definit
 
 fun buffer_resolve(es: *EditorSession, b: *Buffer, deps: *res.ResolveDeps) R.Result[*res.ResolveResult, str] {
     rr_drop(es, b);
-    ctx_seed(es, b);
+    val seeded: R.Result[R.Void, str] = ctx_seed(es, b);
+    if (R.is_err[R.Void, str](seeded)) { ret R.err[*res.ResolveResult, str](R.unwrap_err[R.Void, str](seeded)); }
 
     val res_resolve: R.Result[res.ResolveResult, fail.Fail] = res.resolve(es.s, b.a, deps, ?b.ctx, b.file_id::session.ModuleId, true, ?es.s.diags);
     if (R.is_err[res.ResolveResult, fail.Fail](res_resolve)) {
+        es.operation_failure = O.some[outcome.Fail](outcome.from_fail(R.unwrap_err[res.ResolveResult, fail.Fail](res_resolve)));
         ret R.err[*res.ResolveResult, str](R.unwrap_err[res.ResolveResult, fail.Fail](res_resolve).message);
     }
 
@@ -864,57 +1316,43 @@ fun buffer_resolve(es: *EditorSession, b: *Buffer, deps: *res.ResolveDeps) R.Res
 }
 
 fun slot_get(es: *EditorSession, fid: source.FileId) *Buffer {
-    if (es.buffers == nil || fid::u32 >= es.buf_len) { ret nil; }
-    ret ?es.buffers[fid::u32];
+    var i: u32 = 0;
+    for (i < es.buf_len) {
+        if (es.buffers[i].in_use && es.buffers[i].file_id == fid) { ret ?es.buffers[i]; }
+        i = i + 1;
+    }
+    ret nil;
 }
 
 fun slot_live(es: *EditorSession, fid: source.FileId) *Buffer {
-    val b: *Buffer = slot_get(es, fid);
-    if (b == nil || !b.in_use) { ret nil; }
-    ret b;
+    ret slot_get(es, fid);
 }
 
-fun slot_ensure(es: *EditorSession, fid: source.FileId) R.Result[*Buffer, str] {
-    val needed: u32 = fid::u32 + 1;
-    if (needed > es.buf_len) {
-        var new_len: u32 = es.buf_len;
-        if (new_len == 0) { new_len = BUFFERS_SEED; }
-        for (new_len < needed) { new_len = new_len * 2; }
-
-        if (es.buffers == nil) {
-            val res_alloc: R.Result[*Buffer, str] = A.allocate[Buffer](es.alloc, new_len::usize);
-            if (R.is_err[*Buffer, str](res_alloc)) { ret res_alloc; }
-            es.buffers = R.unwrap_ok[*Buffer, str](res_alloc);
-        }
-        or {
-            val res_realloc: R.Result[*Buffer, str] = A.reallocate[Buffer](es.alloc, es.buffers, es.buf_len::usize, new_len::usize);
-            if (R.is_err[*Buffer, str](res_realloc)) { ret res_realloc; }
-            es.buffers = R.unwrap_ok[*Buffer, str](res_realloc);
-        }
-
-        var i: u32 = es.buf_len;
-        for (i < new_len) {
-            val nb: *Buffer = ?es.buffers[i];
-            nb.file_id = i::source.FileId;
-            nb.in_use  = false;
-            nb.owned   = true;
-            nb.a       = nil;
-            nb.parse_status = fail.accepted();
-            nb.rr      = nil;
-            nb.sr      = nil;
-            nb.ctx     = host_ctx(es);
-            i = i + 1;
-        }
-        es.buf_len = new_len;
+fun slot_reserve(es: *EditorSession, fid: source.FileId) R.Result[u32, str] {
+    var i: u32 = 0;
+    var vacant: u32 = ~(0::u32);
+    for (i < es.buf_len) {
+        if (es.buffers[i].in_use && es.buffers[i].file_id == fid) { ret R.ok[u32, str](i); }
+        if (!es.buffers[i].in_use && vacant == ~(0::u32)) { vacant = i; }
+        i = i + 1;
     }
-
-    val b: *Buffer = ?es.buffers[fid::u32];
-    if (b.in_use) {
-        analysis_drop(es, b);
+    if (vacant != ~(0::u32)) { ret R.ok[u32, str](vacant); }
+    if (es.buf_len > (~(0::u32)) / 2) { ret R.err[u32, str]("editor buffer capacity exhausted"); }
+    var new_len: u32 = es.buf_len * 2;
+    if (new_len == 0) { new_len = BUFFERS_SEED; }
+    var grown: R.Result[*Buffer, str];
+    if (es.buffers == nil) { grown = A.allocate[Buffer](es.alloc, new_len::usize); }
+    or { grown = A.reallocate[Buffer](es.alloc, es.buffers, es.buf_len::usize, new_len::usize); }
+    if (R.is_err[*Buffer, str](grown)) { ret R.err[u32, str](R.unwrap_err[*Buffer, str](grown)); }
+    es.buffers = R.unwrap_ok[*Buffer, str](grown);
+    i = es.buf_len;
+    for (i < new_len) {
+        es.buffers[i] = Buffer{};
+        i = i + 1;
     }
-    b.file_id = fid;
-    b.in_use  = true;
-    ret R.ok[*Buffer, str](b);
+    val index: u32 = es.buf_len;
+    es.buf_len = new_len;
+    ret R.ok[u32, str](index);
 }
 
 fun ast_alloc(es: *EditorSession, fid: source.FileId) R.Result[*ast.Ast, str] {
@@ -952,9 +1390,43 @@ fun host_ctx(es: *EditorSession) comptime.ComptimeCtx {
     ret c;
 }
 
-fun ctx_seed(es: *EditorSession, b: *Buffer) {
+fun ctx_seed(es: *EditorSession, b: *Buffer) R.Result[R.Void, str] {
+    if (es.active_request == nil) {
+        comptime.dnit(?b.ctx);
+        b.ctx = host_ctx(es);
+        b.context_ready = true;
+        ret R.ok_void[str]();
+    }
+    val req: *AnalysisRequest = es.active_request;
+    if (str_len(req.build.target) != 0) {
+        es.operation_failure = O.some[outcome.Fail](outcome.user("a standalone buffer requires a resolved target, not a project target name"));
+        ret R.err[R.Void, str]("a standalone buffer requires a resolved target, not a project target name");
+    }
+    val registry: R.Result[R.Void, str] = driver.setup_registry(?es.s.registry);
+    if (R.is_err[R.Void, str](registry)) { ret registry; }
+    var host_request: target.TargetRequest = target.target_request(
+        isa.arch_name_for(target.host_arch_id()), os.os_name_for(target.host_os_id()), abi.abi_name_for(target.host_abi_id()));
+    var host: target.Target;
+    var selected: *target.Target = req.standalone_target;
+    if (selected == nil) {
+        val resolved: R.Result[target.Target, str] = target.resolve(?es.s.registry, ?host_request);
+        if (R.is_err[target.Target, str](resolved)) { ret R.void_of[target.Target, str](resolved); }
+        host = R.unwrap_ok[target.Target, str](resolved);
+        selected = ?host;
+    }
+    if (selected.isa == nil) { ret R.err[R.Void, str]("standalone analysis requires a resolved target with an instruction set"); }
+    var mode: u32 = comptime.MODE_DEBUG;
+    if (request.release(?req.build)) { mode = comptime.MODE_RELEASE; }
+    var pie: u32 = 0;
+    if (req.build.pie) { pie = 1; }
     comptime.dnit(?b.ctx);
-    b.ctx = host_ctx(es);
+    b.ctx = comptime.init(es.alloc, selected.os_id, selected.arch_id, selected.abi_id,
+        mode, pie, selected.isa.pointer_width, selected.model.vector_bits, selected.model.has_float,
+        intern.STR_NIL, intern.STR_NIL);
+    comptime.set_target_defs(?b.ctx, selected.isa.defs);
+    comptime.set_va_list(?b.ctx, selected.va_list_size, selected.va_list_align);
+    b.context_ready = true;
+    ret R.ok_void[str]();
 }
 
 fun sema_drop(es: *EditorSession, b: *Buffer) {
@@ -987,6 +1459,7 @@ fun analysis_drop(es: *EditorSession, b: *Buffer) {
     }
     comptime.dnit(?b.ctx);
     b.parse_status = fail.accepted();
+    b.context_ready = false;
     b.owned = true;
 }
 
@@ -994,6 +1467,10 @@ fun buffer_free(es: *EditorSession, b: *Buffer) {
     if (!b.in_use) { ret; }
     analysis_drop(es, b);
     b.in_use = false;
+}
+
+fun t_dnit(es: *EditorSession) {
+    R.unwrap_ok[R.Void, str](dnit(es));
 }
 
 fun t_session(a: *A.Allocator) R.Result[session.Session, str] {
@@ -1057,7 +1534,7 @@ fun diag_count(list: *diagnostic.DiagnosticStore, sub: str) u32 {
 }
 
 fun t_run_sema(es: *EditorSession, fid: source.FileId, pw: u32) R.Result[*diagnostic.DiagnosticStore, str] {
-    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(es, fid);
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve_buffer(es, fid);
     if (R.is_err[*res.ResolveResult, str](res_resolve)) {
         ret R.err[*diagnostic.DiagnosticStore, str](R.unwrap_err[*res.ResolveResult, str](res_resolve));
     }
@@ -1093,7 +1570,7 @@ fun t_resolve_deps(es: *EditorSession, fid: source.FileId, deps: *res.ResolveDep
     val b: *Buffer = slot_live(es, fid);
     if (b == nil) { ret R.err[*res.ResolveResult, str]("editor: buffer not open"); }
     if (b.a == nil) {
-        val res_parse: R.Result[*ast.Ast, str] = parse(es, fid);
+        val res_parse: R.Result[*ast.Ast, str] = parse_buffer(es, fid);
         if (R.is_err[*ast.Ast, str](res_parse)) {
             ret R.err[*res.ResolveResult, str](R.unwrap_err[*ast.Ast, str](res_parse));
         }
@@ -1154,19 +1631,19 @@ test "mach.lang.editor.parse:clean_buffer" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "buf.mach", "fun f(a: i64) i64 { ret a; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_ast: R.Result[*ast.Ast, str] = parse(?es, fid);
-    if (R.is_err[*ast.Ast, str](res_ast)) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_ast: R.Result[*ast.Ast, str] = parse_buffer(?es, fid);
+    if (R.is_err[*ast.Ast, str](res_ast)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val a: *ast.Ast = R.unwrap_ok[*ast.Ast, str](res_ast);
-    if (a.decl_len == 0) { dnit(?es); session.dnit(?s); ret 1; }
+    if (a.decl_len == 0) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = diagnostics(?es, fid);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                           { dnit(?es); session.dnit(?s); ret 1; }
-    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags))) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = diagnostics_buffer(?es, fid);
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                           { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags))) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1179,26 +1656,26 @@ test "mach.lang.editor.diagnostics:partial_on_broken_buffer" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "broken.mach", "fun g(a: i64 { ret a ` ; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = diagnostics(?es, fid);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = diagnostics_buffer(?es, fid);
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val list: *diagnostic.DiagnosticStore = R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags);
-    if (!diagnostic.has_errors(list)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diagnostic.has_errors(list)) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    val a: *ast.Ast = ast_of(?es, fid);
-    if (a == nil)        { dnit(?es); session.dnit(?s); ret 1; }
-    if (a.decl_len == 0) { dnit(?es); session.dnit(?s); ret 1; }
+    val a: *ast.Ast = buffer_ast(?es, fid);
+    if (a == nil)        { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (a.decl_len == 0) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    if (ast.offset_to_decl(a, 2) == id.DECL_NIL) { dnit(?es); session.dnit(?s); ret 1; }
+    if (ast.offset_to_decl(a, 2) == id.DECL_NIL) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](res_resolve)) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val rrp: *res.ResolveResult = R.unwrap_ok[*res.ResolveResult, str](res_resolve);
-    if (rrp.decl_count != a.decl_len::u32) { dnit(?es); session.dnit(?s); ret 1; }
+    if (rrp.decl_count != a.decl_len::u32) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1211,23 +1688,23 @@ test "mach.lang.editor.update:drops_cached_analysis" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "buf.mach", "fun a() {}\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_parse_1: R.Result[*ast.Ast, str] = parse(?es, fid);
-    if (R.is_err[*ast.Ast, str](res_parse_1)) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_parse_1: R.Result[*ast.Ast, str] = parse_buffer(?es, fid);
+    if (R.is_err[*ast.Ast, str](res_parse_1)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val decls_1: usize = R.unwrap_ok[*ast.Ast, str](res_parse_1).decl_len;
 
     val res_update: R.Result[bool, str] = update(?es, fid, "fun a() {}\nfun b() {}\n");
-    if (R.is_err[bool, str](res_update))     { dnit(?es); session.dnit(?s); ret 1; }
-    if (!R.unwrap_ok[bool, str](res_update)) { dnit(?es); session.dnit(?s); ret 1; }
-    if (ast_of(?es, fid) != nil) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[bool, str](res_update))     { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!R.unwrap_ok[bool, str](res_update)) { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (buffer_ast(?es, fid) != nil) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    val res_parse_2: R.Result[*ast.Ast, str] = parse(?es, fid);
-    if (R.is_err[*ast.Ast, str](res_parse_2))                        { dnit(?es); session.dnit(?s); ret 1; }
-    if (R.unwrap_ok[*ast.Ast, str](res_parse_2).decl_len <= decls_1) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_parse_2: R.Result[*ast.Ast, str] = parse_buffer(?es, fid);
+    if (R.is_err[*ast.Ast, str](res_parse_2))                        { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (R.unwrap_ok[*ast.Ast, str](res_parse_2).decl_len <= decls_1) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1240,32 +1717,32 @@ test "mach.lang.editor.resolve:reexported_module_alias" {
     var es: EditorSession = init(?s);
 
     val res_inner: R.Result[source.FileId, str] = open(?es, "inner.mach", "pub rec Thing { x: i64; }\n");
-    if (R.is_err[source.FileId, str](res_inner)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_inner)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val inner: source.FileId = R.unwrap_ok[source.FileId, str](res_inner);
 
     var empty: res.ResolveDeps;
     empty.entries = nil;
     empty.count   = 0;
-    if (R.is_err[*res.ResolveResult, str](t_resolve_deps(?es, inner, ?empty))) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*res.ResolveResult, str](t_resolve_deps(?es, inner, ?empty))) { t_dnit(?es); session.dnit(?s); ret 1; }
     val res_ex_inner: R.Result[res.ModuleExports, str] = t_exports(?es, inner, "t.inner");
-    if (R.is_err[res.ModuleExports, str](res_ex_inner)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[res.ModuleExports, str](res_ex_inner)) { t_dnit(?es); session.dnit(?s); ret 1; }
     var ex_inner: res.ModuleExports = R.unwrap_ok[res.ModuleExports, str](res_ex_inner);
 
     val res_surface: R.Result[source.FileId, str] = open(?es, "surface.mach", "fwd al: t.inner;\n");
-    if (R.is_err[source.FileId, str](res_surface)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_surface)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val surface: source.FileId = R.unwrap_ok[source.FileId, str](res_surface);
 
     var sdeps: res.ResolveDeps;
     sdeps.entries = ?ex_inner;
     sdeps.count   = 1;
-    if (R.is_err[*res.ResolveResult, str](t_resolve_deps(?es, surface, ?sdeps))) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*res.ResolveResult, str](t_resolve_deps(?es, surface, ?sdeps))) { t_dnit(?es); session.dnit(?s); ret 1; }
     val res_ex_surface: R.Result[res.ModuleExports, str] = t_exports(?es, surface, "t.surface");
-    if (R.is_err[res.ModuleExports, str](res_ex_surface)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[res.ModuleExports, str](res_ex_surface)) { t_dnit(?es); session.dnit(?s); ret 1; }
     var ex_surface: res.ModuleExports = R.unwrap_ok[res.ModuleExports, str](res_ex_surface);
 
     val res_consumer: R.Result[source.FileId, str] = open(?es, "consumer.mach",
         "use al: t.surface.al;\nfun take(p: al.Thing) i64 { ret p.x; }\n");
-    if (R.is_err[source.FileId, str](res_consumer)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_consumer)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val consumer: source.FileId = R.unwrap_ok[source.FileId, str](res_consumer);
 
     var cdeps_arr: [2]res.ModuleExports;
@@ -1276,14 +1753,14 @@ test "mach.lang.editor.resolve:reexported_module_alias" {
     cdeps.count   = 2;
 
     diags_reset(?es);
-    if (R.is_err[*res.ResolveResult, str](t_resolve_deps(?es, consumer, ?cdeps))) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*res.ResolveResult, str](t_resolve_deps(?es, consumer, ?cdeps))) { t_dnit(?es); session.dnit(?s); ret 1; }
 
     val is_clean: bool = !diagnostic.has_errors(?es.s.diags);
     A.deallocate[res.PublicSymbol](es.alloc, ex_inner.symbols, ex_inner.count::usize);
     A.deallocate[res.PublicSymbol](es.alloc, ex_surface.symbols, ex_surface.count::usize);
-    if (!is_clean) { dnit(?es); session.dnit(?s); ret 1; }
+    if (!is_clean) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1297,45 +1774,45 @@ test "mach.lang.editor.analyze:expr_type_bridges_to_field_table" {
 
     val src: str = "rec P { x: i64; y: i64; }\nfun f(p: P) i64 { ret p.x; }\n";
     val res_fid: R.Result[source.FileId, str] = open(?es, "p.mach", src);
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_an: R.Result[*context.SemaResult, str] = analyze(?es, fid);
-    if (R.is_err[*context.SemaResult, str](res_an)) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_an: R.Result[*context.SemaResult, str] = analyze_buffer(?es, fid);
+    if (R.is_err[*context.SemaResult, str](res_an)) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    val a: *ast.Ast = ast_of(?es, fid);
-    if (a == nil) { dnit(?es); session.dnit(?s); ret 1; }
+    val a: *ast.Ast = buffer_ast(?es, fid);
+    if (a == nil) { t_dnit(?es); session.dnit(?s); ret 1; }
 
     val res_idx: O.Option[usize] = str_index_of(src, "p.x");
-    if (O.is_none[usize](res_idx)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (O.is_none[usize](res_idx)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val off_p: usize = O.unwrap[usize](res_idx);
 
     val eid_p: id.ExprId = ast.offset_to_expr(a, off_p);
-    if (eid_p == id.EXPR_NIL) { dnit(?es); session.dnit(?s); ret 1; }
-    val ty_p: type.TypeId = expr_type_of(?es, fid, eid_p);
-    if (ty_p == type.TYPE_ERROR || ty_p == type.TYPE_NIL) { dnit(?es); session.dnit(?s); ret 1; }
+    if (eid_p == id.EXPR_NIL) { t_dnit(?es); session.dnit(?s); ret 1; }
+    val ty_p: type.TypeId = buffer_expr_type(?es, fid, eid_p);
+    if (ty_p == type.TYPE_ERROR || ty_p == type.TYPE_NIL) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    if (O.is_none[*type.FieldTable](type.field_table_for(?s.types, ty_p))) { dnit(?es); session.dnit(?s); ret 1; }
-    if (type.field_count(?s.types, ty_p) != 2)                             { dnit(?es); session.dnit(?s); ret 1; }
+    if (O.is_none[*type.FieldTable](type.field_table_for(?s.types, ty_p))) { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (type.field_count(?s.types, ty_p) != 2)                             { t_dnit(?es); session.dnit(?s); ret 1; }
 
     val i64_opt: O.Option[type.TypeId] = type.prim(?s.types, type.TYPE_I64);
-    if (O.is_none[type.TypeId](i64_opt)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (O.is_none[type.TypeId](i64_opt)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val i64_id: type.TypeId = O.unwrap[type.TypeId](i64_opt);
 
     val f0_opt: O.Option[*type.FieldEntry] = type.field_at(?s.types, ty_p, 0);
-    if (O.is_none[*type.FieldEntry](f0_opt)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (O.is_none[*type.FieldEntry](f0_opt)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val f0: *type.FieldEntry = O.unwrap[*type.FieldEntry](f0_opt);
-    if (f0.ty != i64_id) { dnit(?es); session.dnit(?s); ret 1; }
+    if (f0.ty != i64_id) { t_dnit(?es); session.dnit(?s); ret 1; }
 
     val eid_px: id.ExprId = ast.offset_to_expr(a, off_p + 2);
-    if (eid_px == id.EXPR_NIL)                  { dnit(?es); session.dnit(?s); ret 1; }
-    if (expr_type_of(?es, fid, eid_px) != i64_id) { dnit(?es); session.dnit(?s); ret 1; }
+    if (eid_px == id.EXPR_NIL)                  { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (buffer_expr_type(?es, fid, eid_px) != i64_id) { t_dnit(?es); session.dnit(?s); ret 1; }
 
     val res_up: R.Result[bool, str] = update(?es, fid, "fun g() i64 { ret 0; }\n");
-    if (R.is_err[bool, str](res_up)) { dnit(?es); session.dnit(?s); ret 1; }
-    if (sema_of(?es, fid) != nil)    { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[bool, str](res_up)) { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (buffer_sema(?es, fid) != nil)    { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1349,14 +1826,14 @@ test "mach.lang.editor.sema:nested_generic_param_substituted" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "box.mach",
         "rec Box[T] { outer: rec { inner: rec { v: T; }; }; }\nfun main() i64 { var b: Box[u32]; b.outer.inner.v = 5; ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
-    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags))) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags))) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1370,14 +1847,14 @@ test "mach.lang.editor.sema:array_length_overflow_rejected" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "arr.mach",
         "fun main() i64 { var a: [0x100000001]u8; ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                       { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "array length exceeds")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                       { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "array length exceeds")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1390,14 +1867,14 @@ test "mach.lang.editor.sema:unannotated_val_error_once" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "dbl.mach", "val bad = 1 + nil;\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                   { dnit(?es); session.dnit(?s); ret 1; }
-    if (diag_count(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "incompatible operand types") != 1) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                   { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diag_count(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "incompatible operand types") != 1) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1411,14 +1888,14 @@ test "mach.lang.editor.sema:mixed_sign_int_compare" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "mix.mach",
         "fun main() i64 { var a: i32 = 0; var b: u64 = 0; val c: u8 = a < b; ret c::i64; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                               { dnit(?es); session.dnit(?s); ret 1; }
-    if (diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "type mismatch")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                               { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "type mismatch")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1432,14 +1909,14 @@ test "mach.lang.editor.sema:mixed_width_float_compare" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "fmix.mach",
         "fun main() i64 { var a: f32 = 0.0; var b: f64 = 0.0; val c: u8 = a < b; ret c::i64; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                               { dnit(?es); session.dnit(?s); ret 1; }
-    if (diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "type mismatch")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                               { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "type mismatch")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1453,14 +1930,14 @@ test "mach.lang.editor.sema:int_float_compare_rejected" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "if.mach",
         "fun main() i64 { var a: i32 = 0; var f: f64 = 0.0; val c: u8 = a < f; ret c::i64; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                              { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "cast one operand explicitly")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                              { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "cast one operand explicitly")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1474,17 +1951,17 @@ test "mach.lang.editor.sema:literal_out_of_range_unsigned" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "oor.mach",
         "fun main() i64 { val x: u8 = 300; ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val list: *diagnostic.DiagnosticStore = R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags);
-    if (!diag_has(list, "literal 300 is out of range for u8 (0..255)")) { dnit(?es); session.dnit(?s); ret 1; }
-    if (diag_has(list, "type mismatch"))                                { dnit(?es); session.dnit(?s); ret 1; }
-    if (diag_note_has(list, "no implicit widening"))                    { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(list, "literal 300 is out of range for u8 (0..255)")) { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diag_has(list, "type mismatch"))                                { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diag_note_has(list, "no implicit widening"))                    { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1498,14 +1975,14 @@ test "mach.lang.editor.sema:literal_out_of_range_signed" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "oors.mach",
         "fun main() i64 { val y: i8 = 200; ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                    { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "literal 200 is out of range for i8 (-128..127)")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                    { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "literal 200 is out of range for i8 (-128..127)")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1519,16 +1996,16 @@ test "mach.lang.editor.sema:literal_out_of_range_negative" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "oorn.mach",
         "fun main() i64 { val z: i8 = -129; val w: u8 = -1; ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val list: *diagnostic.DiagnosticStore = R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags);
-    if (!diag_has(list, "literal -129 is out of range for i8 (-128..127)")) { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(list, "literal -1 is out of range for u8 (0..255)"))      { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(list, "literal -129 is out of range for i8 (-128..127)")) { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(list, "literal -1 is out of range for u8 (0..255)"))      { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1542,17 +2019,17 @@ test "mach.lang.editor.sema:widening_mismatch_preserved" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "widen.mach",
         "fun main() i64 { var a: i64 = 5; val b: u8 = a; ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val list: *diagnostic.DiagnosticStore = R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags);
-    if (!diag_has(list, "type mismatch: expected u8, found i64")) { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_note_has(list, "mach has no implicit widening"))    { dnit(?es); session.dnit(?s); ret 1; }
-    if (diag_has(list, "out of range"))                          { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(list, "type mismatch: expected u8, found i64")) { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_note_has(list, "mach has no implicit widening"))    { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diag_has(list, "out of range"))                          { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1566,16 +2043,16 @@ test "mach.lang.editor.sema:literal_out_of_range_u64_max_into_signed" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "allones.mach",
         "fun main() i64 { val x: i64 = 0xFFFFFFFFFFFFFFFF; val m: u64 = 0xFFFFFFFFFFFFFFFF; ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val list: *diagnostic.DiagnosticStore = R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags);
-    if (!diag_has(list, "literal 18446744073709551615 is out of range for i64 (-9223372036854775808..9223372036854775807)")) { dnit(?es); session.dnit(?s); ret 1; }
-    if (diag_count(list, "out of range") != 1) { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(list, "literal 18446744073709551615 is out of range for i64 (-9223372036854775808..9223372036854775807)")) { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diag_count(list, "out of range") != 1) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1589,14 +2066,14 @@ test "mach.lang.editor.sema:literal_out_of_range_secret_type" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "secret.mach",
         "fun main() i64 { var sx: ^u8 = 300; ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "literal 300 is out of range for ^u8 (0..255)")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "literal 300 is out of range for ^u8 (0..255)")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1610,17 +2087,17 @@ test "mach.lang.editor.resolve:unresolved_ident_suggestion" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "ident.mach",
         "fun helper() i64 { ret 0; }\nfun main() i64 { ret helpr(); }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](res_resolve)) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve)) { t_dnit(?es); session.dnit(?s); ret 1; }
 
     val list: *diagnostic.DiagnosticStore = ?es.s.diags;
-    if (!diag_has(list, "unresolved identifier `helpr`")) { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_help_has(list, "did you mean `helper`?"))   { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(list, "unresolved identifier `helpr`")) { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_help_has(list, "did you mean `helper`?"))   { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1634,17 +2111,17 @@ test "mach.lang.editor.resolve:unresolved_type_suggestion" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "type.mach",
         "rec Widget { x: i64; }\nfun main(w: Widgt) i64 { ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](res_resolve)) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve)) { t_dnit(?es); session.dnit(?s); ret 1; }
 
     val list: *diagnostic.DiagnosticStore = ?es.s.diags;
-    if (!diag_has(list, "unresolved type name `Widgt`")) { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_help_has(list, "did you mean `Widget`?"))  { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(list, "unresolved type name `Widgt`")) { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_help_has(list, "did you mean `Widget`?"))  { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1658,15 +2135,15 @@ test "mach.lang.editor.resolve:duplicate_definition_secondary_span" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "dup.mach",
         "fun foo() i64 { ret 0; }\nfun foo() i64 { ret 1; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](res_resolve)) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve)) { t_dnit(?es); session.dnit(?s); ret 1; }
 
     val list: *diagnostic.DiagnosticStore = ?es.s.diags;
-    if (!diag_has(list, "duplicate definition: `foo`"))     { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_related_has(list, "previous definition here")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(list, "duplicate definition: `foo`"))     { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_related_has(list, "previous definition here")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
     var found: bool = false;
     var i: usize = 0;
@@ -1679,9 +2156,9 @@ test "mach.lang.editor.resolve:duplicate_definition_secondary_span" {
         }
         i = i + 1;
     }
-    if (!found) { dnit(?es); session.dnit(?s); ret 1; }
+    if (!found) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1694,18 +2171,18 @@ test "mach.lang.editor.tokenize:stray_control_char" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "ctrl.mach", "fun main() i64 { ret 0; }\n\x0B\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_tokens: R.Result[lexer.TokenStream, str] = tokenize(?es, fid);
-    if (R.is_err[lexer.TokenStream, str](res_tokens)) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_tokens: R.Result[lexer.TokenStream, str] = tokenize_inner(?es, fid);
+    if (R.is_err[lexer.TokenStream, str](res_tokens)) { t_dnit(?es); session.dnit(?s); ret 1; }
     var stream: lexer.TokenStream = R.unwrap_ok[lexer.TokenStream, str](res_tokens);
 
     val hit: bool = diag_has(?es.s.diags, "stray control character in source");
     lexer.dnit(?stream, es.alloc);
-    if (!hit) { dnit(?es); session.dnit(?s); ret 1; }
+    if (!hit) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1718,15 +2195,15 @@ test "mach.lang.editor.parse:invalid_decl_starter" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "decl.mach", "garbage\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_ast: R.Result[*ast.Ast, str] = parse(?es, fid);
-    if (R.is_err[*ast.Ast, str](res_ast)) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_ast: R.Result[*ast.Ast, str] = parse_buffer(?es, fid);
+    if (R.is_err[*ast.Ast, str](res_ast)) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    if (!diag_has(?es.s.diags, "expected a declaration; valid starters: use, fwd, fun, rec, uni, val, var, def, test")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(?es.s.diags, "expected a declaration; valid starters: use, fwd, fun, rec, uni, val, var, def, test")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1740,14 +2217,14 @@ test "mach.lang.editor.sema:value_used_as_type" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "nt.mach",
         "fun f() i64 { ret 0; }\nfun main(p: f) i64 { ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                           { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "`f` does not name a type")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                           { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "`f` does not name a type")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1760,14 +2237,14 @@ test "mach.lang.editor.sema:unknown_decorator" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "ud.mach", "#[bogus] fun f() i64 { ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                                                                  { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "unknown decorator; valid directives are symbol, section, inline, noinline, align, packed, volatile, library, oblivious, scalar")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                                                                  { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "unknown decorator; valid directives are symbol, section, inline, noinline, align, packed, volatile, library, oblivious, scalar")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1780,14 +2257,14 @@ test "mach.lang.editor.sema:noinline_decorator_wrong_target" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "ni.mach", "#[noinline] pub var g: i64 = 0;\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                                    { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "`noinline` decorator applies only to functions")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                                    { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "`noinline` decorator applies only to functions")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1800,14 +2277,14 @@ test "mach.lang.editor.sema:noinline_takes_no_arguments" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "ni2.mach", "#[noinline(1)] fun f() i64 { ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                                { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "`noinline` decorator takes no arguments")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                                { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "`noinline` decorator takes no arguments")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1820,14 +2297,14 @@ test "mach.lang.editor.sema:inline_noinline_conflict_rejected" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "ic.mach", "#[inline] #[noinline] fun f() i64 { ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                                                                     { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "`inline` and `noinline` decorators cannot both apply to the same function")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                                                                     { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "`inline` and `noinline` decorators cannot both apply to the same function")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1840,14 +2317,14 @@ test "mach.lang.editor.sema:scalar_noinline_composes" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "sn.mach", "#[scalar] #[noinline] fun f() i64 { ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                           { dnit(?es); session.dnit(?s); ret 1; }
-    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags))) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                           { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags))) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1860,14 +2337,14 @@ test "mach.lang.editor.sema:decorator_wrong_target" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "wt.mach", "#[align(8)] fun f() i64 { ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                                                 { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "`align` decorator applies only to records, unions, and globals")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                                                 { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "`align` decorator applies only to records, unions, and globals")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1881,15 +2358,15 @@ test "mach.lang.editor.sema:section_decorator_target" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "se.mach",
         "#[section(\".s\")] pub var g: u64 = 0;\n#[section(\".s\")] fun f() i64 { ret 0; }\n#[section(\".s\")] def D: u64;\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val list: *diagnostic.DiagnosticStore = R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags);
-    if (!diag_has(list, "`section` decorator applies only to functions and globals")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(list, "`section` decorator applies only to functions and globals")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1902,14 +2379,14 @@ test "mach.lang.editor.sema:negative_align_reported" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "na.mach", "#[align(-8)] rec R { a: u8; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                                { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "`align` value must be a non-zero power of two")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                                { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "`align` value must be a non-zero power of two")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1922,14 +2399,14 @@ test "mach.lang.editor.sema:align_on_def_alias_rejected" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "da.mach", "#[align(8)] def D: u64;\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                                                 { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "`align` decorator applies only to records, unions, and globals")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                                                 { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "`align` decorator applies only to records, unions, and globals")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1943,14 +2420,14 @@ test "mach.lang.editor.sema:variadic_pack_declares" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "pk.mach",
         "fun take(va: ...) i64 { var n: i64 = va.len::i64; $each a in va { } ret n; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                           { dnit(?es); session.dnit(?s); ret 1; }
-    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags))) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                           { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags))) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1964,14 +2441,14 @@ test "mach.lang.editor.sema:each_over_non_pack_rejected" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "bad.mach",
         "fun f() i64 { var x: i64 = 0; $each a in x { } ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                            { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "must be `$fields(T)`, a variadic pack, or a constant array")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                            { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "must be `$fields(T)`, a variadic pack, or a constant array")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -1985,14 +2462,14 @@ test "mach.lang.editor.sema:each_over_const_array_accepted" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "arr.mach",
         "val A: [3]i64 = [3]i64{1, 2, 3}; fun f() i64 { var t: i64 = 0; $each x in A { t = t + x; } ret t; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                           { dnit(?es); session.dnit(?s); ret 1; }
-    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags))) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                           { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags))) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2006,14 +2483,14 @@ test "mach.lang.editor.sema:each_over_var_array_rejected" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "var.mach",
         "var A: [3]i64 = [3]i64{1, 2, 3}; fun f() i64 { var t: i64 = 0; $each x in A { t = t + x; } ret t; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                              { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "must be an immutable `val`")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                              { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "must be an immutable `val`")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2027,14 +2504,14 @@ test "mach.lang.editor.sema:call_collects_pack_args" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "col.mach",
         "fun take(tag: i64, va: ...) i64 { ret tag; } fun sum(va: ...) i64 { ret 0; } fun main() i64 { ret take(1, 2, 3) + sum() + sum(4, 5); }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                           { dnit(?es); session.dnit(?s); ret 1; }
-    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags))) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                           { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags))) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2048,14 +2525,14 @@ test "mach.lang.editor.sema:pack_below_fixed_arity_rejected" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "few.mach",
         "fun take(tag: i64, va: ...) i64 { ret tag; } fun main() i64 { ret take(); }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                    { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "arity mismatch: expected at least")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                    { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "arity mismatch: expected at least")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2069,14 +2546,14 @@ test "mach.lang.editor.sema:pack_forward_spread" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "fwd.mach",
         "fun inner(tag: i64, va: ...) i64 { ret tag; } fun fwd(va: ...) i64 { ret inner(7, va...); } fun bare(va: ...) i64 { ret fwd(va...); }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                           { dnit(?es); session.dnit(?s); ret 1; }
-    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags))) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                           { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags))) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2090,14 +2567,14 @@ test "mach.lang.editor.sema:spread_into_fixed_rejected" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "intofixed.mach",
         "fun point(x: i64, y: i64) i64 { ret x; } fun outer(va: ...) i64 { ret point(va...); }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                            { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "cannot spread `...` into fixed parameters")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                            { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "cannot spread `...` into fixed parameters")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2111,14 +2588,14 @@ test "mach.lang.editor.sema:spread_non_pack_rejected" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "nonpack.mach",
         "fun g(va: ...) i64 { ret 0; } fun f() i64 { var z: i64 = 0; ret g(z...); }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                  { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "may only spread a variadic pack")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                  { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "may only spread a variadic pack")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2132,14 +2609,14 @@ test "mach.lang.editor.sema:spread_mixed_args_rejected" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "mixed.mach",
         "fun inner(va: ...) i64 { ret 0; } fun outer(va: ...) i64 { ret inner(1, va...); }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                         { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "sole trailing argument")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                         { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "sole trailing argument")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2153,14 +2630,14 @@ test "mach.lang.editor.sema:call_non_function" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "nc.mach",
         "fun main() i64 { var x: i64 = 0; ret x(); }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                        { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "not callable: `i64` is not a function")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                                        { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "not callable: `i64` is not a function")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2174,18 +2651,18 @@ test "mach.lang.editor.sema:reinterpret_pointer_width" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "pw.mach",
         "fun main() i64 { var p: *u8; var x: u32; x = p:~u32; ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags_4: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 4);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags_4))                                 { dnit(?es); session.dnit(?s); ret 1; }
-    if (diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags_4), "bit reinterpret")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags_4))                                 { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags_4), "bit reinterpret")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
     val res_diags_8: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags_8))                                  { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags_8), "bit reinterpret")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags_8))                                  { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags_8), "bit reinterpret")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2198,16 +2675,16 @@ test "mach.lang.editor.open:ctx_seeded_from_host" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "buf.mach", "fun f() {}\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val b: *Buffer = slot_live(?es, fid);
-    if (b == nil) { dnit(?es); session.dnit(?s); ret 1; }
-    if (b.ctx.env.target_os_id != target.host_os_id())          { dnit(?es); session.dnit(?s); ret 1; }
-    if (b.ctx.env.target_arch_id != target.host_arch_id())      { dnit(?es); session.dnit(?s); ret 1; }
-    if (b.ctx.env.pointer_width != target.host_pointer_width()) { dnit(?es); session.dnit(?s); ret 1; }
+    if (b == nil) { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (b.ctx.env.target_os_id != target.host_os_id())          { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (b.ctx.env.target_arch_id != target.host_arch_id())      { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (b.ctx.env.pointer_width != target.host_pointer_width()) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2220,21 +2697,21 @@ test "mach.lang.editor.resolve:repeated_resets_diags" {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "buf.mach", "fun f() i64 { ret undef; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_resolve_1: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](res_resolve_1)) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_resolve_1: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve_1)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val len_1: usize = diagnostic.len(?es.s.diags);
-    if (len_1 == 0) { dnit(?es); session.dnit(?s); ret 1; }
+    if (len_1 == 0) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    val res_resolve_2: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](res_resolve_2)) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_resolve_2: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve_2)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val len_2: usize = diagnostic.len(?es.s.diags);
 
-    if (len_2 != len_1) { dnit(?es); session.dnit(?s); ret 1; }
+    if (len_2 != len_1) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2248,14 +2725,14 @@ test "mach.lang.editor.resolve:local_shadows_comptime_const" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "shadow.mach",
         "pub val N: i64 = 4;\nfun g(x: i64) i64 {\n    val N: i64 = x;\n    $if (N > 2) { ret 1; }\n    ret 0;\n}\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](res_resolve))     { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(?es.s.diags, "names a runtime binding")) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve))     { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(?es.s.diags, "names a runtime binding")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2269,14 +2746,14 @@ test "mach.lang.editor.resolve:param_shadows_comptime_const" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "pshadow.mach",
         "pub val N: i64 = 4;\nfun g(N: i64) i64 {\n    $if (N > 2) { ret 1; }\n    ret 0;\n}\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](res_resolve))     { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(?es.s.diags, "names a runtime binding")) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve))     { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(?es.s.diags, "names a runtime binding")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2290,14 +2767,14 @@ test "mach.lang.editor.resolve:bare_dollar_ident_gate_rejected" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "bareident.mach",
         "fun g() i64 {\n    $if ($mode) { ret 1; }\n    ret 0;\n}\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](res_resolve))                       { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(?es.s.diags, "comptime parameters are referenced without")) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve))                       { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(?es.s.diags, "comptime parameters are referenced without")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2311,31 +2788,31 @@ test "mach.lang.editor.comptime_if:declaration_free_gate_sees_types" {
 
     val res_ok: R.Result[source.FileId, str] = open(?es, "gateok.mach",
         "rec H { a: i64; b: i64; }\nval LIMIT: i64 = 16;\n$if ($size_of(H) != 16) { $error(\"size wrong\"); }\n$if ($size_of(H) > LIMIT) { $error(\"too large\"); }\n$if (!$is_record(H)) { $error(\"not a record\"); }\n$if ($type_of(LIMIT) != i64) { $error(\"limit not i64\"); }\nfun main() i64 { ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_ok)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_ok)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid_ok: source.FileId = R.unwrap_ok[source.FileId, str](res_ok);
 
-    val res_rok: R.Result[*res.ResolveResult, str] = resolve(?es, fid_ok);
-    if (R.is_err[*res.ResolveResult, str](res_rok)) { dnit(?es); session.dnit(?s); ret 1; }
-    if (diagnostic.has_errors(?es.s.diags))         { dnit(?es); session.dnit(?s); ret 1; }
+    val res_rok: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid_ok);
+    if (R.is_err[*res.ResolveResult, str](res_rok)) { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diagnostic.has_errors(?es.s.diags))         { t_dnit(?es); session.dnit(?s); ret 1; }
 
     val res_dok: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid_ok, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_dok))                                     { dnit(?es); session.dnit(?s); ret 1; }
-    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_dok)))           { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_dok))                                     { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_dok)))           { t_dnit(?es); session.dnit(?s); ret 1; }
 
     val res_bad: R.Result[source.FileId, str] = open(?es, "gatebad.mach",
         "rec H { a: i64; b: i64; }\n$if ($size_of(H) == 16) { $error(\"H measures 16\"); }\nfun main() i64 { ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_bad)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_bad)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid_bad: source.FileId = R.unwrap_ok[source.FileId, str](res_bad);
 
-    val res_rbad: R.Result[*res.ResolveResult, str] = resolve(?es, fid_bad);
-    if (R.is_err[*res.ResolveResult, str](res_rbad)) { dnit(?es); session.dnit(?s); ret 1; }
-    if (diagnostic.has_errors(?es.s.diags))          { dnit(?es); session.dnit(?s); ret 1; }
+    val res_rbad: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid_bad);
+    if (R.is_err[*res.ResolveResult, str](res_rbad)) { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diagnostic.has_errors(?es.s.diags))          { t_dnit(?es); session.dnit(?s); ret 1; }
 
     val res_dbad: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid_bad, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_dbad))                                { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_dbad), "H measures 16")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_dbad))                                { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_dbad), "H measures 16")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2349,15 +2826,15 @@ test "mach.lang.editor.comptime_if:mixed_chain_stays_at_resolve" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "mixed.mach",
         "rec H { a: i64; b: i64; }\n$if ($size_of(H) != 16) { $error(\"size wrong\"); }\n$or { val PAD: i64 = 0; }\nfun main() i64 { ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](res_resolve))       { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(?es.s.diags, "declares something"))         { dnit(?es); session.dnit(?s); ret 1; }
-    if (diag_has(?es.s.diags, "size wrong"))                  { dnit(?es); session.dnit(?s); ret 1; }
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve))       { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(?es.s.diags, "declares something"))         { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diag_has(?es.s.diags, "size wrong"))                  { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2371,14 +2848,14 @@ test "mach.lang.editor.comptime_if:declaring_gate_refuses_type_question" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "declaring.mach",
         "rec H { a: i64; b: i64; }\n$if ($size_of(H) != 16) { fun spin() i64 { ret 0; } }\nfun main() i64 { ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](res_resolve))   { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(?es.s.diags, "declares something"))     { dnit(?es); session.dnit(?s); ret 1; }
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve))   { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(?es.s.diags, "declares something"))     { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2391,15 +2868,15 @@ test "mach.lang.editor.comptime_if:conditional_use_selected_at_resolve" {
     var es: EditorSession = init(?s);
 
     val res_inner: R.Result[source.FileId, str] = open(?es, "tag.mach", "pub val TAG: i64 = 7;\n");
-    if (R.is_err[source.FileId, str](res_inner)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_inner)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val inner: source.FileId = R.unwrap_ok[source.FileId, str](res_inner);
 
     var empty: res.ResolveDeps;
     empty.entries = nil;
     empty.count   = 0;
-    if (R.is_err[*res.ResolveResult, str](t_resolve_deps(?es, inner, ?empty))) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*res.ResolveResult, str](t_resolve_deps(?es, inner, ?empty))) { t_dnit(?es); session.dnit(?s); ret 1; }
     val res_ex: R.Result[res.ModuleExports, str] = t_exports(?es, inner, "t.tag");
-    if (R.is_err[res.ModuleExports, str](res_ex)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[res.ModuleExports, str](res_ex)) { t_dnit(?es); session.dnit(?s); ret 1; }
     var ex: res.ModuleExports = R.unwrap_ok[res.ModuleExports, str](res_ex);
 
     var deps: res.ResolveDeps;
@@ -2408,18 +2885,18 @@ test "mach.lang.editor.comptime_if:conditional_use_selected_at_resolve" {
 
     val res_take: R.Result[source.FileId, str] = open(?es, "take.mach",
         "$if (1 == 1) { use al: t.tag; }\n$or { $error(\"tag unavailable\"); }\nfun main() i64 { ret al.TAG; }\n");
-    if (R.is_err[source.FileId, str](res_take)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_take)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val take: source.FileId = R.unwrap_ok[source.FileId, str](res_take);
 
     diags_reset(?es);
-    if (R.is_err[*res.ResolveResult, str](t_resolve_deps(?es, take, ?deps))) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*res.ResolveResult, str](t_resolve_deps(?es, take, ?deps))) { t_dnit(?es); session.dnit(?s); ret 1; }
     val took_clean: bool = !diagnostic.has_errors(?es.s.diags);
 
     val res_skip: R.Result[source.FileId, str] = open(?es, "skip.mach",
         "$if (1 == 0) { use al: t.tag; }\n$or { }\nfun main() i64 { ret al.TAG; }\n");
     if (R.is_err[source.FileId, str](res_skip)) {
         A.deallocate[res.PublicSymbol](es.alloc, ex.symbols, ex.count::usize);
-        dnit(?es); session.dnit(?s); ret 1;
+        t_dnit(?es); session.dnit(?s); ret 1;
     }
     val skip: source.FileId = R.unwrap_ok[source.FileId, str](res_skip);
 
@@ -2428,10 +2905,10 @@ test "mach.lang.editor.comptime_if:conditional_use_selected_at_resolve" {
     val skipped: bool = R.is_ok[*res.ResolveResult, str](res_rskip) && diagnostic.has_errors(?es.s.diags);
 
     A.deallocate[res.PublicSymbol](es.alloc, ex.symbols, ex.count::usize);
-    if (!took_clean) { dnit(?es); session.dnit(?s); ret 1; }
-    if (!skipped)    { dnit(?es); session.dnit(?s); ret 1; }
+    if (!took_clean) { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!skipped)    { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2445,14 +2922,14 @@ test "mach.lang.editor.sema:nil_coerces_to_fun" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "nilfun.mach",
         "def F: fun(u32);\npub var gq: fun(u32) = nil;\npub var gr: F = nil::F;\nrec T { cb: fun(); k: F; }\nfun take(c: fun(u32)) u8 { if (c == nil) { ret 1; } ret 0; }\nfun give() fun(u32) { ret nil; }\nfun givec() F { ret nil::F; }\nfun main() i64 { var lq: fun(u32) = nil; var lr: F = nil::F; var t: T = T{ cb: nil, k: nil::F }; if (gq != nil) { ret 1; } if (lr != nil) { ret 2; } if (t.k != nil) { ret 3; } ret take(lq)::i64; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                               { dnit(?es); session.dnit(?s); ret 1; }
-    if (diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "type mismatch")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                               { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "type mismatch")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2466,14 +2943,14 @@ test "mach.lang.editor.sema:nil_into_non_pointer_rejected" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "nilint.mach",
         "fun main() i64 { var bad: u32 = nil; ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                { dnit(?es); session.dnit(?s); ret 1; }
-    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "type mismatch")) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags))                                { t_dnit(?es); session.dnit(?s); ret 1; }
+    if (!diag_has(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags), "type mismatch")) { t_dnit(?es); session.dnit(?s); ret 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret 0;
 }
@@ -2541,7 +3018,9 @@ test "mach.lang.editor.relative_under:host_separators_preserve_component_boundar
     }
     i = 0;
     for (i < 9) {
-        val found: O.Option[str] = relative_under(?alloc, files[i], roots[i], "src");
+        val relative: R.Result[O.Option[str], str] = relative_under(?alloc, files[i], roots[i], "src");
+        if (R.is_err[O.Option[str], str](relative)) { ret 8; }
+        val found: O.Option[str] = R.unwrap_ok[O.Option[str], str](relative);
         if (O.is_some[str](found)) {
             val rel: str = O.unwrap[str](found);
             val good: bool = expected[i] != nil && str_equals(rel, expected[i]);
@@ -2567,27 +3046,27 @@ test "mach.lang.editor.resolve:cross_module_import_resolves_with_real_project" {
     texts[0] = "use edbuild.helper.square;\nfun main() i32 { ret square(3); }\n";
     texts[1] = "pub fun square(x: i32) i32 { ret x * x; }\n";
     val root_r: R.Result[str, str] = t_scaffold(?alloc, ?names[0], ?texts[0], 2);
-    if (R.is_err[str, str](root_r)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[str, str](root_r)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val root: str = R.unwrap_ok[str, str](root_r);
 
     val mp_r: R.Result[str, str] = str_join(?alloc, root, "/src/main.mach");
-    if (R.is_err[str, str](mp_r)) { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[str, str](mp_r)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     val res_fid: R.Result[source.FileId, str] = open(?es, R.unwrap_ok[str, str](mp_r), texts[0]);
-    if (R.is_err[source.FileId, str](res_fid)) { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     var bad: i32 = 0;
 
-    val rr_res: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
+    val rr_res: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
     if (R.is_err[*res.ResolveResult, str](rr_res)) { bad = 1; }
     or (diag_has(?s.diags, "undeclared") || diag_has(?s.diags, "unresolved")) { bad = 1; }
 
-    val sr_res: R.Result[*context.SemaResult, str] = analyze(?es, fid);
+    val sr_res: R.Result[*context.SemaResult, str] = analyze_buffer(?es, fid);
     if (R.is_err[*context.SemaResult, str](sr_res)) { bad = 1; }
     or (diag_has(?s.diags, "undeclared") || diag_has(?s.diags, "unresolved") || diagnostic.error_count(?s.diags) != 0) { bad = 1; }
 
     fs.remove_all(?alloc, root);
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret bad;
 }
@@ -2605,31 +3084,31 @@ test "mach.lang.editor.resolve:reload_reflects_edited_dependency" {
     texts[0] = "use edbuild.helper.square;\nfun main() i32 { ret square(3); }\n";
     texts[1] = "pub fun square(x: i32) i32 { ret x * x; }\n";
     val root_r: R.Result[str, str] = t_scaffold(?alloc, ?names[0], ?texts[0], 2);
-    if (R.is_err[str, str](root_r)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[str, str](root_r)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val root: str = R.unwrap_ok[str, str](root_r);
 
     val mp_r: R.Result[str, str] = str_join(?alloc, root, "/src/main.mach");
-    if (R.is_err[str, str](mp_r)) { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[str, str](mp_r)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     val main_path: str = R.unwrap_ok[str, str](mp_r);
     val res_fid: R.Result[source.FileId, str] = open(?es, main_path, texts[0]);
-    if (R.is_err[source.FileId, str](res_fid)) { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     var bad: i32 = 0;
 
-    val r1: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
+    val r1: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
     if (R.is_err[*res.ResolveResult, str](r1)) { bad = 1; }
     or (diag_has(?s.diags, "undeclared") || diag_has(?s.diags, "unresolved")) { bad = 1; }
 
     val res_up: R.Result[bool, str] = update(?es, fid, "use edbuild.helper.cube;\nfun main() i32 { ret cube(2); }\n");
-    if (R.is_err[bool, str](res_up)) { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[bool, str](res_up)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
 
-    val r2: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
+    val r2: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
     if (R.is_err[*res.ResolveResult, str](r2)) { bad = 1; }
     or (!diag_has(?s.diags, "undeclared") && !diag_has(?s.diags, "unresolved")) { bad = 1; }
 
     fs.remove_all(?alloc, root);
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret bad;
 }
@@ -2643,13 +3122,13 @@ test "mach.lang.editor.resolve:bracket_value_resolution_preserves_the_parsed_own
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "buf.mach",
         "var Foo: [8]i32;\nvar Marker: i32 = 5;\nfun main() i32 { val r: i32 = Foo[Marker]; ret r; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 50; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 50; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_parse: R.Result[*ast.Ast, str] = parse(?es, fid);
-    if (R.is_err[*ast.Ast, str](res_parse)) { dnit(?es); session.dnit(?s); ret 52; }
-    val a: *ast.Ast = ast_of(?es, fid);
-    if (a == nil) { dnit(?es); session.dnit(?s); ret 51; }
+    val res_parse: R.Result[*ast.Ast, str] = parse_buffer(?es, fid);
+    if (R.is_err[*ast.Ast, str](res_parse)) { t_dnit(?es); session.dnit(?s); ret 52; }
+    val a: *ast.Ast = buffer_ast(?es, fid);
+    if (a == nil) { t_dnit(?es); session.dnit(?s); ret 51; }
 
     var target: id.ExprId = id.EXPR_NIL;
     var ei: usize = 0;
@@ -2657,26 +3136,26 @@ test "mach.lang.editor.resolve:bracket_value_resolution_preserves_the_parsed_own
         if (a.exprs[ei].kind == expr.EXPR_KIND_GENERIC_INSTANCE) { target = ei::id.ExprId; }
         ei = ei + 1;
     }
-    if (target == id.EXPR_NIL) { dnit(?es); session.dnit(?s); ret 2; }
+    if (target == id.EXPR_NIL) { t_dnit(?es); session.dnit(?s); ret 2; }
 
     val pre_kind: expr.ExprKind = a.exprs[target].kind;
 
-    val r1: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](r1)) { dnit(?es); session.dnit(?s); ret 3; }
-    val rr: *res.ResolveResult = resolve_of(?es, fid);
-    if (rr == nil) { dnit(?es); session.dnit(?s); ret 4; }
+    val r1: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](r1)) { t_dnit(?es); session.dnit(?s); ret 3; }
+    val rr: *res.ResolveResult = buffer_resolve_of(?es, fid);
+    if (rr == nil) { t_dnit(?es); session.dnit(?s); ret 4; }
 
     val live_kind_after_resolve: expr.ExprKind = a.exprs[target].kind;
 
     val interpreted: R.Result[expr.Expr, str] = res.expression(rr, a, target);
-    if (R.is_err[expr.Expr, str](interpreted)) { dnit(?es); session.dnit(?s); ret 5; }
+    if (R.is_err[expr.Expr, str](interpreted)) { t_dnit(?es); session.dnit(?s); ret 5; }
     val resolved_kind: expr.ExprKind = R.unwrap_ok[expr.Expr, str](interpreted).kind;
 
     var bad: i32 = 0;
     if (live_kind_after_resolve != pre_kind) { bad = 6; }
     or (resolved_kind != expr.EXPR_KIND_INDEX) { bad = 7; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret bad;
 }
@@ -2690,13 +3169,13 @@ test "mach.lang.editor.resolve:generic_call_resolution_preserves_the_parsed_owne
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "buf.mach",
         "fun foo[T](x: T) T { ret x; }\nvar Marker: i32 = 5;\nfun main() i32 { ret foo[Marker](5); }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 50; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 50; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_parse: R.Result[*ast.Ast, str] = parse(?es, fid);
-    if (R.is_err[*ast.Ast, str](res_parse)) { dnit(?es); session.dnit(?s); ret 52; }
-    val a: *ast.Ast = ast_of(?es, fid);
-    if (a == nil) { dnit(?es); session.dnit(?s); ret 51; }
+    val res_parse: R.Result[*ast.Ast, str] = parse_buffer(?es, fid);
+    if (R.is_err[*ast.Ast, str](res_parse)) { t_dnit(?es); session.dnit(?s); ret 52; }
+    val a: *ast.Ast = buffer_ast(?es, fid);
+    if (a == nil) { t_dnit(?es); session.dnit(?s); ret 51; }
 
     var target: id.ExprId = id.EXPR_NIL;
     var ei: usize = 0;
@@ -2706,26 +3185,26 @@ test "mach.lang.editor.resolve:generic_call_resolution_preserves_the_parsed_owne
         }
         ei = ei + 1;
     }
-    if (target == id.EXPR_NIL) { dnit(?es); session.dnit(?s); ret 2; }
+    if (target == id.EXPR_NIL) { t_dnit(?es); session.dnit(?s); ret 2; }
 
     val pre_index_callee: id.ExprId = a.exprs[target].data.call.index_callee;
 
-    val r1: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](r1)) { dnit(?es); session.dnit(?s); ret 3; }
-    val rr: *res.ResolveResult = resolve_of(?es, fid);
-    if (rr == nil) { dnit(?es); session.dnit(?s); ret 4; }
+    val r1: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](r1)) { t_dnit(?es); session.dnit(?s); ret 3; }
+    val rr: *res.ResolveResult = buffer_resolve_of(?es, fid);
+    if (rr == nil) { t_dnit(?es); session.dnit(?s); ret 4; }
 
     val live_index_callee_after_resolve: id.ExprId = a.exprs[target].data.call.index_callee;
 
     val interpreted: R.Result[expr.Expr, str] = res.expression(rr, a, target);
-    if (R.is_err[expr.Expr, str](interpreted)) { dnit(?es); session.dnit(?s); ret 5; }
+    if (R.is_err[expr.Expr, str](interpreted)) { t_dnit(?es); session.dnit(?s); ret 5; }
     val resolved_index_callee: id.ExprId = R.unwrap_ok[expr.Expr, str](interpreted).data.call.index_callee;
 
     var bad: i32 = 0;
     if (live_index_callee_after_resolve != pre_index_callee) { bad = 6; }
     or (resolved_index_callee != id.EXPR_NIL) { bad = 7; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret bad;
 }
@@ -2739,13 +3218,13 @@ test "mach.lang.editor.resolve:indexed_call_resolution_preserves_the_parsed_owne
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "buf.mach",
         "var arr: [8]i32;\nvar Marker: i32 = 5;\nfun main() i32 { ret arr[Marker](5); }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 50; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 50; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_parse: R.Result[*ast.Ast, str] = parse(?es, fid);
-    if (R.is_err[*ast.Ast, str](res_parse)) { dnit(?es); session.dnit(?s); ret 52; }
-    val a: *ast.Ast = ast_of(?es, fid);
-    if (a == nil) { dnit(?es); session.dnit(?s); ret 51; }
+    val res_parse: R.Result[*ast.Ast, str] = parse_buffer(?es, fid);
+    if (R.is_err[*ast.Ast, str](res_parse)) { t_dnit(?es); session.dnit(?s); ret 52; }
+    val a: *ast.Ast = buffer_ast(?es, fid);
+    if (a == nil) { t_dnit(?es); session.dnit(?s); ret 51; }
 
     var target: id.ExprId = id.EXPR_NIL;
     var ei: usize = 0;
@@ -2755,20 +3234,20 @@ test "mach.lang.editor.resolve:indexed_call_resolution_preserves_the_parsed_owne
         }
         ei = ei + 1;
     }
-    if (target == id.EXPR_NIL) { dnit(?es); session.dnit(?s); ret 2; }
+    if (target == id.EXPR_NIL) { t_dnit(?es); session.dnit(?s); ret 2; }
 
     val pre_callee:       id.ExprId = a.exprs[target].data.call.callee;
     val pre_index_callee: id.ExprId = a.exprs[target].data.call.index_callee;
 
-    val r1: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](r1)) { dnit(?es); session.dnit(?s); ret 3; }
-    val rr: *res.ResolveResult = resolve_of(?es, fid);
-    if (rr == nil) { dnit(?es); session.dnit(?s); ret 4; }
+    val r1: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](r1)) { t_dnit(?es); session.dnit(?s); ret 3; }
+    val rr: *res.ResolveResult = buffer_resolve_of(?es, fid);
+    if (rr == nil) { t_dnit(?es); session.dnit(?s); ret 4; }
 
     val live_callee_after_resolve: id.ExprId = a.exprs[target].data.call.callee;
 
     val interpreted: R.Result[expr.Expr, str] = res.expression(rr, a, target);
-    if (R.is_err[expr.Expr, str](interpreted)) { dnit(?es); session.dnit(?s); ret 5; }
+    if (R.is_err[expr.Expr, str](interpreted)) { t_dnit(?es); session.dnit(?s); ret 5; }
     val resolved_callee: id.ExprId = R.unwrap_ok[expr.Expr, str](interpreted).data.call.callee;
 
     var bad: i32 = 0;
@@ -2776,7 +3255,7 @@ test "mach.lang.editor.resolve:indexed_call_resolution_preserves_the_parsed_owne
     or (resolved_callee != pre_index_callee) { bad = 7; }
     or (a.exprs[target].data.call.index_callee != pre_index_callee) { bad = 8; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret bad;
 }
@@ -2794,24 +3273,24 @@ test "mach.lang.editor.resolve:orphan_module_unreachable_from_entry_still_loads"
     texts[0] = "fun main() i32 { ret 0; }\n";
     texts[1] = "pub fun triple(x: i32) i32 { ret x * 3; }\n";
     val root_r: R.Result[str, str] = t_scaffold(?alloc, ?names[0], ?texts[0], 2);
-    if (R.is_err[str, str](root_r)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[str, str](root_r)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val root: str = R.unwrap_ok[str, str](root_r);
 
     val op_r: R.Result[str, str] = str_join(?alloc, root, "/src/orphan.mach");
-    if (R.is_err[str, str](op_r)) { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[str, str](op_r)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     val res_fid: R.Result[source.FileId, str] = open(?es, R.unwrap_ok[str, str](op_r), texts[1]);
-    if (R.is_err[source.FileId, str](res_fid)) { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     var bad: i32 = 0;
 
-    val rr_res: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
+    val rr_res: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
     if (R.is_err[*res.ResolveResult, str](rr_res)) { bad = 1; }
     or (diag_has(?s.diags, "undeclared") || diag_has(?s.diags, "unresolved")) { bad = 1; }
-    or (ast_of(?es, fid) == nil) { bad = 1; }
+    or (buffer_ast(?es, fid) == nil) { bad = 1; }
 
     fs.remove_all(?alloc, root);
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret bad;
 }
@@ -2830,13 +3309,13 @@ test "mach.lang.editor.build:warm_rebuild_over_unsaved_buffer" {
     texts[1] = "pub fun fa() i32 { ret 1; }\n";
     texts[2] = "pub fun fb() i32 { ret 2; }\n";
     val root_r: R.Result[str, str] = t_scaffold(?alloc, ?names[0], ?texts[0], 3);
-    if (R.is_err[str, str](root_r)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[str, str](root_r)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val root: str = R.unwrap_ok[str, str](root_r);
 
     val ap_r: R.Result[str, str] = str_join(?alloc, root, "/src/a.mach");
-    if (R.is_err[str, str](ap_r)) { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[str, str](ap_r)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     val res_fid: R.Result[source.FileId, str] = open(?es, R.unwrap_ok[str, str](ap_r), texts[1]);
-    if (R.is_err[source.FileId, str](res_fid)) { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     val fid_a: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     var rq: request.BuildRequest = request.defaults();
@@ -2845,7 +3324,7 @@ test "mach.lang.editor.build:warm_rebuild_over_unsaved_buffer" {
     var bad: i32 = 0;
 
     val r1: R.Result[outcome.BuildOutcome, outcome.Fail] = build(?es, ?rq);
-    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r1)) { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r1)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     val bo1: outcome.BuildOutcome = R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r1);
     if (bo1.severity != outcome.BUILD_OK)                { bad = 1; }
     if (bo1.artifacts.len != 1) { bad = 1; }
@@ -2862,7 +3341,7 @@ test "mach.lang.editor.build:warm_rebuild_over_unsaved_buffer" {
     if (sema_a_1 == 0 || cg_a_1 == 0 || cg_b_1 == 0 || lk_1 == 0) { bad = 1; }
 
     val r2: R.Result[outcome.BuildOutcome, outcome.Fail] = build(?es, ?rq);
-    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r2)) { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r2)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     if (R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r2).severity != outcome.BUILD_OK) { bad = 1; }
     if (query.peek_revision(?s.queries, query.Q_SEMA,    st_a::u64) != sema_a_1) { bad = 1; }
     if (query.peek_revision(?s.queries, query.Q_CODEGEN, st_a::u64) != cg_a_1)   { bad = 1; }
@@ -2870,11 +3349,11 @@ test "mach.lang.editor.build:warm_rebuild_over_unsaved_buffer" {
     if (query.peek_revision(?s.queries, query.Q_LINK, 0)            != lk_1)     { bad = 1; }
 
     val res_up: R.Result[bool, str] = update(?es, fid_a, "pub fun fa() i32 { val t: i32 = 1; ret t; }\n");
-    if (R.is_err[bool, str](res_up))     { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[bool, str](res_up))     { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     if (!R.unwrap_ok[bool, str](res_up)) { bad = 1; }
 
     val r3: R.Result[outcome.BuildOutcome, outcome.Fail] = build(?es, ?rq);
-    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r3)) { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](r3)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     val bo3: outcome.BuildOutcome = R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](r3);
     if (bo3.severity != outcome.BUILD_OK)                { bad = 1; }
     if (bo3.artifacts.len != 1) { bad = 1; }
@@ -2884,7 +3363,7 @@ test "mach.lang.editor.build:warm_rebuild_over_unsaved_buffer" {
     if (query.peek_revision(?s.queries, query.Q_LINK, 0)            == lk_1)   { bad = 1; }
 
     fs.remove_all(?alloc, root);
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret bad;
 }
@@ -2910,7 +3389,7 @@ test "mach.lang.editor.build:missing_manifest_fails_user" {
     }
     if (s.build_alloc != prior_build) { bad = 1; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret bad;
 }
@@ -2993,7 +3472,7 @@ test "mach.lang.editor.fail_dnit:repeated_failed_builds_leave_no_owned_message_o
         i = i + 1;
     }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
 
     if (cnt.live != 0) { bad = 1; }
@@ -3060,14 +3539,14 @@ fun t_analyzes_clean(alloc: *A.Allocator, name: str, src: str) bool {
     var es: EditorSession = init(?s);
 
     val res_fid: R.Result[source.FileId, str] = open(?es, name, src);
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret false; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret false; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { dnit(?es); session.dnit(?s); ret false; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { t_dnit(?es); session.dnit(?s); ret false; }
     val clean: bool = !diagnostic.has_errors(R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags));
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret clean;
 }
@@ -3081,11 +3560,11 @@ test "mach.lang.editor.fix:a_spelling_correction_is_a_mechanical_edit" {
 
     val src: str = "fun helper() i64 { ret 0; }\nfun main() i64 { ret helpr(); }\n";
     val res_fid: R.Result[source.FileId, str] = open(?es, "ident.mach", src);
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_resolve: R.Result[*res.ResolveResult, str] = resolve(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](res_resolve)) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_resolve: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
+    if (R.is_err[*res.ResolveResult, str](res_resolve)) { t_dnit(?es); session.dnit(?s); ret 1; }
 
     var bad: i32 = 0;
     val list: *diagnostic.DiagnosticStore = ?es.s.diags;
@@ -3093,7 +3572,7 @@ test "mach.lang.editor.fix:a_spelling_correction_is_a_mechanical_edit" {
     if (!diag_help_has(list, "did you mean `helper`?") && bad == 0) { bad = 1; }
 
     val fx: *diagnostic.Fix = t_first_fix(list);
-    if (fx == nil) { dnit(?es); session.dnit(?s); ret 2; }
+    if (fx == nil) { t_dnit(?es); session.dnit(?s); ret 2; }
 
     if (fx.edits.len != 1                                              && bad == 0) { bad = 3; }
     if (!str_equals(fx.label, "replace with `helper`")                && bad == 0) { bad = 4; }
@@ -3101,10 +3580,10 @@ test "mach.lang.editor.fix:a_spelling_correction_is_a_mechanical_edit" {
     if (!str_region_equals(src, fx.edits.data[0].loc.span.offset, fx.edits.data[0].loc.span.len, "helpr") && bad == 0) { bad = 6; }
 
     val fixed: str = t_apply_fix(?alloc, src, fx);
-    if (fixed == nil) { dnit(?es); session.dnit(?s); ret 7; }
+    if (fixed == nil) { t_dnit(?es); session.dnit(?s); ret 7; }
     if (!t_analyzes_clean(?alloc, "ident.mach", fixed) && bad == 0) { bad = 8; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret bad;
 }
@@ -3168,18 +3647,18 @@ test "mach.lang.editor.fix:a_mismatch_a_cast_cannot_repair_offers_nothing" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "rec.mach",
         "rec P { x: i64; }\nrec Q { x: i64; }\nfun main() i64 { var p: P; var q: Q; q = p; ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val list: *diagnostic.DiagnosticStore = R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags);
 
     var bad: i32 = 0;
     if (!diagnostic.has_errors(list) && bad == 0) { bad = 2; }
     if (t_any_fix(list)              && bad == 0) { bad = 3; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret bad;
 }
@@ -3193,18 +3672,18 @@ test "mach.lang.editor.type:a_c_variadic_function_is_nameable_as_a_type" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "va.mach",
         "ext fun printf(fmt: *u8, ...) i32;\ndef Printf: fun(*u8, ...) i32;\nfun main() i32 { val p: Printf = printf; ret p(\"x\"::*u8, 1); }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val list: *diagnostic.DiagnosticStore = R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags);
 
     var bad: i32 = 0;
     if (diagnostic.has_errors(list)                    && bad == 0) { bad = 2; }
     if (diag_has(list, "was removed in v2.0.0")        && bad == 0) { bad = 3; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret bad;
 }
@@ -3218,18 +3697,18 @@ test "mach.lang.editor.type:a_variadic_type_does_not_unify_with_its_fixed_arity_
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "vafix.mach",
         "ext fun printf(fmt: *u8, ...) i32;\ndef Fixed: fun(*u8) i32;\nfun main() i32 { val p: Fixed = printf; ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
     val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = t_run_sema(?es, fid, 8);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val list: *diagnostic.DiagnosticStore = R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags);
 
     var bad: i32 = 0;
     if (!diagnostic.has_errors(list)                                     && bad == 0) { bad = 2; }
     if (!diag_has(list, "fun(*u8, ...) i32")                             && bad == 0) { bad = 3; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret bad;
 }
@@ -3243,18 +3722,18 @@ test "mach.lang.editor.type:a_leading_variadic_marker_is_refused_in_a_type" {
 
     val res_fid: R.Result[source.FileId, str] = open(?es, "lead.mach",
         "def Bad: fun(...) i32;\nfun main() i32 { ret 0; }\n");
-    if (R.is_err[source.FileId, str](res_fid)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
 
-    val res_parse: R.Result[*ast.Ast, str] = parse(?es, fid);
-    if (R.is_err[*ast.Ast, str](res_parse)) { dnit(?es); session.dnit(?s); ret 1; }
+    val res_parse: R.Result[*ast.Ast, str] = parse_buffer(?es, fid);
+    if (R.is_err[*ast.Ast, str](res_parse)) { t_dnit(?es); session.dnit(?s); ret 1; }
 
     var bad: i32 = 0;
     val list: *diagnostic.DiagnosticStore = ?es.s.diags;
     if (!diag_has(list, "a C-variadic function type needs at least one fixed parameter before `...`") && bad == 0) { bad = 2; }
     if (diag_has(list, "was removed in v2.0.0")                                                       && bad == 0) { bad = 3; }
 
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret bad;
 }
@@ -3325,7 +3804,7 @@ test "mach.lang.editor.parse:driver_and_editor_share_one_parse_outcome" {
     var names: [1]str; names[0] = "main.mach";
     var texts: [1]str; texts[0] = "val s: str = \"abc\nfun g(a: i64 { ret a ` ; }\nfun main() i32 { ret 0; }\n";
     val root_r: R.Result[str, str] = t_scaffold(?alloc, ?names[0], ?texts[0], 1);
-    if (R.is_err[str, str](root_r)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[str, str](root_r)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val root: str = R.unwrap_ok[str, str](root_r);
 
     var drv: diagnostic.DiagnosticStore = diagnostic.store_init(?alloc);
@@ -3334,14 +3813,14 @@ test "mach.lang.editor.parse:driver_and_editor_share_one_parse_outcome" {
     if (O.is_some[outcome.Fail](drv_fail) && O.unwrap[outcome.Fail](drv_fail).kind != outcome.FAIL_REPORTED) { bad = 1; }
 
     val mp_r: R.Result[str, str] = str_join(?alloc, root, "/src/main.mach");
-    if (R.is_err[str, str](mp_r)) { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[str, str](mp_r)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     val res_fid: R.Result[source.FileId, str] = open(?es, R.unwrap_ok[str, str](mp_r), texts[0]);
-    if (R.is_err[source.FileId, str](res_fid)) { fs.remove_all(?alloc, root); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[source.FileId, str](res_fid)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
-    val res_ast: R.Result[*ast.Ast, str] = parse(?es, fid);
+    val res_ast: R.Result[*ast.Ast, str] = parse_buffer(?es, fid);
     if (R.is_err[*ast.Ast, str](res_ast)) { bad = 1; }
     or (R.unwrap_ok[*ast.Ast, str](res_ast).decl_len == 0) { bad = 1; }
-    val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = diagnostics(?es, fid);
+    val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = diagnostics_buffer(?es, fid);
     if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { bad = 1; }
     or {
         val ed: *diagnostic.DiagnosticStore = R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags);
@@ -3362,11 +3841,11 @@ test "mach.lang.editor.parse:driver_and_editor_share_one_parse_outcome" {
     fs.remove_all(?alloc, root);
 
     val deep_o: O.Option[str] = t_deep_source(?alloc, 2100);
-    if (O.is_none[str](deep_o)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (O.is_none[str](deep_o)) { t_dnit(?es); session.dnit(?s); ret 1; }
     var deep_names: [1]str; deep_names[0] = "main.mach";
     var deep_texts: [1]str; deep_texts[0] = O.unwrap[str](deep_o);
     val root2_r: R.Result[str, str] = t_scaffold(?alloc, ?deep_names[0], ?deep_texts[0], 1);
-    if (R.is_err[str, str](root2_r)) { dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[str, str](root2_r)) { t_dnit(?es); session.dnit(?s); ret 1; }
     val root2: str = R.unwrap_ok[str, str](root2_r);
 
     var drv2: diagnostic.DiagnosticStore = diagnostic.store_init(?alloc);
@@ -3377,10 +3856,10 @@ test "mach.lang.editor.parse:driver_and_editor_share_one_parse_outcome" {
         || O.unwrap[outcome.Fail](drv2_fail).message != nil) { bad = 3; }
 
     val mp2_r: R.Result[str, str] = str_join(?alloc, root2, "/src/main.mach");
-    if (R.is_err[str, str](mp2_r)) { fs.remove_all(?alloc, root2); dnit(?es); session.dnit(?s); ret 1; }
+    if (R.is_err[str, str](mp2_r)) { fs.remove_all(?alloc, root2); t_dnit(?es); session.dnit(?s); ret 1; }
     val res_fid2: R.Result[source.FileId, str] = open(?es, R.unwrap_ok[str, str](mp2_r), deep_texts[0]);
-    if (R.is_err[source.FileId, str](res_fid2)) { fs.remove_all(?alloc, root2); dnit(?es); session.dnit(?s); ret 1; }
-    val res_ast2: R.Result[*ast.Ast, str] = parse(?es, R.unwrap_ok[source.FileId, str](res_fid2));
+    if (R.is_err[source.FileId, str](res_fid2)) { fs.remove_all(?alloc, root2); t_dnit(?es); session.dnit(?s); ret 1; }
+    val res_ast2: R.Result[*ast.Ast, str] = parse_buffer(?es, R.unwrap_ok[source.FileId, str](res_fid2));
     if (R.is_ok[*ast.Ast, str](res_ast2)) { bad = 4; }
     if (diagnostic.len(?drv2) != 1 || diagnostic.len(?s.diags) != 1) { bad = 5; }
     or {
@@ -3395,13 +3874,13 @@ test "mach.lang.editor.parse:driver_and_editor_share_one_parse_outcome" {
     }
 
     fs.remove_all(?alloc, root2);
-    dnit(?es);
+    t_dnit(?es);
     session.dnit(?s);
     ret bad;
 }
 
 
-test "mach.lang.editor.parse:project_failure_message_copy_preserves_allocation_refusal" {
+test "mach.lang.editor.analyze:owned_rejection_snapshot_preserves_allocation_refusal" {
     var backing: A.Allocator;
     if (O.is_some[str](page.make(?backing))) { ret 1; }
     val text: O.Option[str] = t_deep_source(?backing, state.MAX_NEST_DEPTH + 1);
@@ -3427,23 +3906,264 @@ test "mach.lang.editor.parse:project_failure_message_copy_preserves_allocation_r
         counting_init(?cnt, ?backing);
         var es: EditorSession = init(?s);
         es.alloc = ?cnt.allocator;
-        fin { dnit(?es); }
+        fin { t_dnit(?es); }
         val opened: R.Result[source.FileId, str] = open(?es, R.unwrap_ok[str, str](path_r), texts[0]);
         if (R.is_err[source.FileId, str](opened)) { ret 6; }
         cnt.calls = 0;
         if (pass == 1) { cnt.fail_at = total; }
-        val r: R.Result[*ast.Ast, str] = parse(?es, R.unwrap_ok[source.FileId, str](opened));
-        if (R.is_ok[*ast.Ast, str](r)) { ret 7; }
+        var req: AnalysisRequest = analysis_request(R.unwrap_ok[source.FileId, str](opened), PHASE_PARSE);
+        val r: R.Result[AnalysisResult, outcome.Fail] = analyze(?es, ?req);
         if (pass == 0) {
+            if (R.is_err[AnalysisResult, outcome.Fail](r)) { ret 7; }
+            var result: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](r);
+            fin { analysis_dnit(?result); }
             total = cnt.calls;
-            if (total == 0 || !str_equals(R.unwrap_err[*ast.Ast, str](r), "editor: failed to load project")) { ret 8; }
-            str_free(?cnt.allocator, R.unwrap_err[*ast.Ast, str](r));
+            if (total == 0 || cnt.last_size != 1 || result.status.kind != fail.REJECTED
+                || O.is_none[outcome.Fail](result.failure)
+                || O.unwrap[outcome.Fail](result.failure).kind != outcome.FAIL_REPORTED
+                || !diag_has(result.diagnostics, "input nests deeper than this parser descends")) { ret 8; }
         } or {
-            if (!str_equals(R.unwrap_err[*ast.Ast, str](r), "out of memory")) { ret 9; }
-            if (cnt.calls != total) { ret 10; }
+            if (R.is_ok[AnalysisResult, outcome.Fail](r)) {
+                var result: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](r);
+                analysis_dnit(?result);
+                ret 9;
+            }
+            var f: outcome.Fail = R.unwrap_err[AnalysisResult, outcome.Fail](r);
+            fin { fail_dnit(?es, ?f); }
+            if (f.kind != outcome.FAIL_INTERNAL || !str_equals(f.message, "out of memory")) { ret 10; }
+            if (cnt.calls != total + 1) { ret 11; }
         }
-        if (cnt.last_size != str_len("editor: failed to load project") + 1) { ret 11; }
         pass = pass + 1;
     }
+    ret 0;
+}
+
+
+test "mach.lang.editor.close:reuses_slots_and_reopens_the_same_source_identity" {
+    var alloc: A.Allocator;
+    var s: session.Session = R.unwrap_ok[session.Session, str](t_session(?alloc));
+    fin { session.dnit(?s); }
+    var es: EditorSession = init(?s);
+    fin { t_dnit(?es); }
+    val kept: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, "/mach-editor-retirement/kept.mach", "val kept: i32 = 1;"));
+    val first: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, "/mach-editor-retirement/first.mach", "val old: i32 = 2;"));
+    val revision: u64 = O.unwrap[*source.SourceFile](source.get(?s.sources, first)).revision;
+    if (!R.unwrap_ok[bool, str](close(?es, first))) { ret 1; }
+    if (O.unwrap[*source.SourceFile](source.get(?s.sources, first)).present) { ret 2; }
+    var i: u32 = 0;
+    for (i < 40) {
+        val name: str = R.unwrap_ok[str, str](format.sprint(?alloc, "/mach-editor-retirement/file{}.mach", i));
+        fin { str_free(?alloc, name); }
+        val fid: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, name, "val value: i32 = 3;"));
+        if (!R.unwrap_ok[bool, str](close(?es, fid))) { ret 3; }
+        if (es.buf_len != BUFFERS_SEED || slot_live(?es, kept) == nil) { ret 4; }
+        i = i + 1;
+    }
+    val reopened: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, "/mach-editor-retirement/first.mach", "val new: i32 = 4;"));
+    if (reopened != first || O.unwrap[*source.SourceFile](source.get(?s.sources, first)).revision <= revision) { ret 5; }
+    if (!str_equals(O.unwrap[*source.SourceFile](source.get(?s.sources, first)).text, "val new: i32 = 4;")) { ret 6; }
+    if (R.unwrap_ok[bool, str](close(?es, 0xFFFFFFFE::source.FileId))) { ret 7; }
+    ret 0;
+}
+
+test "mach.lang.editor.analyze:owned_diagnostics_survive_retirement_and_raw_views_expire" {
+    var alloc: A.Allocator;
+    var s: session.Session = R.unwrap_ok[session.Session, str](t_session(?alloc));
+    var es: EditorSession = init(?s);
+    val text: str = "fun f(a: i64 { ret a; }";
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, "/mach-editor-owned-result/file.mach", text));
+    var req: AnalysisRequest = analysis_request(fid, PHASE_PARSE);
+    var result: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](analyze(?es, ?req));
+    fin { analysis_dnit(?result); }
+    if (result.status.kind != fail.REJECTED || diagnostic.len(result.diagnostics) == 0 || result.sources.len != 1) { ret 1; }
+    val before: R.Result[*ast.Ast, str] = ast_of(?result);
+    if (R.is_err[*ast.Ast, str](before) || R.unwrap_ok[*ast.Ast, str](before) == nil) { ret 2; }
+    if (!R.unwrap_ok[bool, str](update(?es, fid, "fun f() i64 { ret 1; }"))) { ret 3; }
+    if (R.is_ok[*ast.Ast, str](ast_of(?result))) { ret 4; }
+    if (!R.unwrap_ok[bool, str](close(?es, fid))) { ret 5; }
+    t_dnit(?es);
+    session.dnit(?s);
+    val saved: *source.SourceFile = O.unwrap[*source.SourceFile](analysis_source(?result, fid));
+    if (!str_equals(saved.text, text) || diagnostic.len(result.diagnostics) == 0) { ret 6; }
+    var tokens: lexer.TokenStream = R.unwrap_ok[lexer.TokenStream, str](tokenize(?result));
+    lexer.dnit(?tokens, result.alloc);
+    ret 0;
+}
+
+test "mach.lang.editor.analyze:explicit_target_changes_context_and_expires_previous_view" {
+    var alloc: A.Allocator;
+    var s: session.Session = R.unwrap_ok[session.Session, str](t_session(?alloc));
+    fin { session.dnit(?s); }
+    var es: EditorSession = init(?s);
+    fin { t_dnit(?es); }
+    R.unwrap_ok[R.Void, str](driver.setup_registry(?s.registry));
+    var tr32: target.TargetRequest = target.target_request("riscv32", "linux", "ilp32d");
+    var tr64: target.TargetRequest = target.target_request("riscv64", "linux", "lp64d");
+    var t32: target.Target = R.unwrap_ok[target.Target, str](target.resolve(?s.registry, ?tr32));
+    var t64: target.Target = R.unwrap_ok[target.Target, str](target.resolve(?s.registry, ?tr64));
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, "/mach-editor-target/file.mach",
+        "$if ($mach.build.pointer_width == 4) { val selected: i32 = 32; } $or { val selected: i32 = 64; }"));
+    var req: AnalysisRequest = analysis_request(fid, PHASE_RESOLVE);
+    req.standalone_target = ?t32;
+    var first: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](analyze(?es, ?req));
+    fin { analysis_dnit(?first); }
+    if (first.status.kind != fail.ACCEPTED || !first.target_available || first.target.pointer_width != 4) { ret 1; }
+    if (R.is_err[*res.ResolveResult, str](resolve_of(?first))) { ret 2; }
+    req.standalone_target = ?t64;
+    req.build.opt = pipeline.OPT_RELEASE;
+    var second: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](analyze(?es, ?req));
+    fin { analysis_dnit(?second); }
+    if (second.status.kind != fail.ACCEPTED || second.target.pointer_width != 8 || second.target.mode != comptime.MODE_RELEASE) { ret 3; }
+    if (R.is_ok[*res.ResolveResult, str](resolve_of(?first))) { ret 4; }
+    if (first.target.pointer_width != 4 || first.target.mode != comptime.MODE_DEBUG) { ret 5; }
+    ret 0;
+}
+
+fun t_atomic_buffer_action(es: *EditorSession, fid: source.FileId, action: u8) R.Result[R.Void, str] {
+    if (action == 0) { ret R.void_of[source.FileId, str](open(es, "/mach-editor-atomic/new.mach", "val fresh: i32 = 8;")); }
+    if (action == 1) { ret R.void_of[bool, str](update(es, fid, "val replaced: i32 = 9;")); }
+    if (action == 2) { ret R.void_of[bool, str](close(es, fid)); }
+    ret dnit(es);
+}
+
+test "mach.lang.editor.lifecycle:allocation_refusal_preserves_open_buffers_and_retry" {
+    var backing: A.Allocator;
+    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    var action: u8 = 0;
+    for (action < 4) {
+        var total: usize = 0;
+        var refusal: usize = 0;
+        for (refusal == 0 || refusal <= total) {
+            var cnt: CountingAllocator;
+            counting_init(?cnt, ?backing);
+            var s: session.Session = R.unwrap_ok[session.Session, str](session.init(?cnt.allocator));
+            var es: EditorSession = init(?s);
+            val path: str = "/mach-editor-atomic/old.mach";
+            val text: str = "val retained: i32 = 7;";
+            val fid: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, path, text));
+            val other: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, "/mach-editor-atomic/other.mach", "val other: i32 = 6;"));
+            var req: AnalysisRequest = analysis_request(fid, PHASE_PARSE);
+            var result: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](analyze(?es, ?req));
+            val revision: u64 = O.unwrap[*source.SourceFile](source.get(?s.sources, fid)).revision;
+            val generation: u64 = es.view_generation;
+            cnt.calls = 0;
+            cnt.fail_at = refusal;
+            val applied: R.Result[R.Void, str] = t_atomic_buffer_action(?es, fid, action);
+            cnt.fail_at = 0;
+            if (refusal == 0) {
+                if (R.is_err[R.Void, str](applied)) { ret 2; }
+                total = cnt.calls;
+                if (total == 0) { ret 3; }
+            }
+            or {
+                if (R.is_ok[R.Void, str](applied)) { ret 4; }
+                if (es.view_generation != generation || slot_live(?es, other) == nil || slot_live(?es, fid) == nil) { ret 5; }
+                val current: *source.SourceFile = O.unwrap[*source.SourceFile](source.get(?s.sources, fid));
+                if (current.revision != revision || !current.present || !str_equals(current.text, text)) { ret 6; }
+                val overlay: O.Option[str] = session.overlay_get(?s, path);
+                if (O.is_none[str](overlay) || !str_equals(O.unwrap[str](overlay), text)) { ret 7; }
+                if (R.is_err[*ast.Ast, str](ast_of(?result))) { ret 8; }
+                if (R.is_err[R.Void, str](t_atomic_buffer_action(?es, fid, action))) { ret 9; }
+            }
+            analysis_dnit(?result);
+            if (action != 3) { t_dnit(?es); }
+            if (s.overlay_len != 0) { ret 10; }
+            session.dnit(?s);
+            if (cnt.live != 0) { ret 11; }
+            refusal = refusal + 1;
+        }
+        action = action + 1;
+    }
+    ret 0;
+}
+
+
+test "mach.lang.editor.close:removes_extra_roots_and_reloads_closed_dependencies_from_disk" {
+    var alloc: A.Allocator;
+    var s: session.Session = R.unwrap_ok[session.Session, str](t_session(?alloc));
+    fin { session.dnit(?s); }
+    var es: EditorSession = init(?s);
+    fin { t_dnit(?es); }
+    var names: [3]str = [3]str{ "main.mach", "helper.mach", "orphan.mach" };
+    var texts: [3]str = [3]str{
+        "use edbuild.helper; fun main() i32 { ret helper.square(3); }",
+        "pub fun square(x: i32) i32 { ret x * x; }",
+        "fun orphan() i32 { ret 1; }"
+    };
+    val root: str = R.unwrap_ok[str, str](t_scaffold(?alloc, ?names[0], ?texts[0], 3));
+    fin { fs.remove_all(?alloc, root); }
+    val main_path: str = R.unwrap_ok[str, str](str_join(?alloc, root, "/src/main.mach"));
+    fin { str_free(?alloc, main_path); }
+    val dep_path: str = R.unwrap_ok[str, str](str_join(?alloc, root, "/src/helper.mach"));
+    fin { str_free(?alloc, dep_path); }
+    val orphan_path: str = R.unwrap_ok[str, str](str_join(?alloc, root, "/src/orphan.mach"));
+    fin { str_free(?alloc, orphan_path); }
+    val main: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, main_path,
+        "use edbuild.helper; fun main() i32 { ret helper.cube(3); }"));
+    val dep: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, dep_path,
+        "pub fun cube(x: i32) i32 { ret x * x * x; }"));
+    val orphan: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, orphan_path,
+        "fun orphan() i32 { ret missing; }"));
+    var req: AnalysisRequest = analysis_request(main, PHASE_SEMA);
+    req.build.target = "linux";
+    var bad: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](analyze(?es, ?req));
+    if (bad.status.kind != fail.REJECTED || !diag_has(bad.diagnostics, "missing")) { ret 1; }
+    analysis_dnit(?bad);
+    R.unwrap_ok[bool, str](close(?es, orphan));
+    if (slot_live(?es, main) == nil || slot_live(?es, dep) == nil || slot_live(?es, orphan) != nil) { ret 2; }
+    var valid: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](analyze(?es, ?req));
+    if (valid.status.kind != fail.ACCEPTED || valid.configuration.len == 0 || es.proj_root_count != 2) { ret 3; }
+    analysis_dnit(?valid);
+    R.unwrap_ok[bool, str](close(?es, dep));
+    var disk: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](analyze(?es, ?req));
+    if (disk.status.kind != fail.REJECTED || !diag_has(disk.diagnostics, "cube")) { ret 4; }
+    analysis_dnit(?disk);
+    if (!str_equals(O.unwrap[*source.SourceFile](source.get(?s.sources, dep)).text, texts[1])) { ret 5; }
+    R.unwrap_ok[bool, str](update(?es, main, texts[0]));
+    var restored: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](analyze(?es, ?req));
+    if (restored.status.kind != fail.ACCEPTED || es.proj_root_count != 1) { ret 6; }
+    analysis_dnit(?restored);
+    val reopened: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, dep_path,
+        "pub fun square(x: i32) i32 { ret x + x; }"));
+    if (reopened != dep) { ret 7; }
+    var fresh: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](analyze(?es, ?req));
+    if (fresh.status.kind != fail.ACCEPTED || es.proj_root_count != 2) { ret 8; }
+    analysis_dnit(?fresh);
+    ret 0;
+}
+
+
+test "mach.lang.editor.analyze:project_phase_does_not_run_later_frontend_work" {
+    var alloc: A.Allocator;
+    var s: session.Session = R.unwrap_ok[session.Session, str](t_session(?alloc));
+    fin { session.dnit(?s); }
+    var es: EditorSession = init(?s);
+    fin { t_dnit(?es); }
+    var names: [1]str = [1]str{ "main.mach" };
+    var texts: [1]str = [1]str{ "use edbuild.absent; fun main() i32 { ret missing; }" };
+    val root: str = R.unwrap_ok[str, str](t_scaffold(?alloc, ?names[0], ?texts[0], 1));
+    fin { fs.remove_all(?alloc, root); }
+    val path: str = R.unwrap_ok[str, str](str_join(?alloc, root, "/src/main.mach"));
+    fin { str_free(?alloc, path); }
+    val fid: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, path, texts[0]));
+    var req: AnalysisRequest = analysis_request(fid, PHASE_PARSE);
+    req.build.target = "linux";
+    var parsed: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](analyze(?es, ?req));
+    if (parsed.status.kind != fail.ACCEPTED || diagnostic.has_errors(parsed.diagnostics)
+        || es.proj.module_len != 1 || query.shard_len(?s.queries, query.Q_RESOLVE) != 0
+        || query.shard_len(?s.queries, query.Q_SEMA) != 0) { ret 1; }
+    if (R.is_ok[*res.ResolveResult, str](resolve_of(?parsed))) { ret 2; }
+    analysis_dnit(?parsed);
+    R.unwrap_ok[bool, str](update(?es, fid, "fun main() i32 { ret \"wrong\"; }"));
+    req.phase = PHASE_RESOLVE;
+    var resolved: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](analyze(?es, ?req));
+    if (resolved.status.kind != fail.ACCEPTED || diagnostic.has_errors(resolved.diagnostics)
+        || query.shard_len(?s.queries, query.Q_SEMA) != 0) { ret 3; }
+    if (R.is_ok[*context.SemaResult, str](sema_of(?resolved))) { ret 4; }
+    analysis_dnit(?resolved);
+    req.phase = PHASE_SEMA;
+    var typed: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](analyze(?es, ?req));
+    if (typed.status.kind != fail.REJECTED || !diag_has(typed.diagnostics, "type mismatch")) { ret 5; }
+    analysis_dnit(?typed);
     ret 0;
 }

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -3096,16 +3096,31 @@ test "mach.lang.editor.resolve:reload_reflects_edited_dependency" {
 
     var bad: i32 = 0;
 
-    val r1: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](r1)) { bad = 1; }
-    or (diag_has(?s.diags, "undeclared") || diag_has(?s.diags, "unresolved")) { bad = 1; }
+    var req: AnalysisRequest = analysis_request(fid, PHASE_RESOLVE);
+    val r1: R.Result[AnalysisResult, outcome.Fail] = analyze(?es, ?req);
+    if (R.is_err[AnalysisResult, outcome.Fail](r1)) { bad = 1; }
+    or {
+        var first: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](r1);
+        fin { analysis_dnit(?first); }
+        if (first.status.kind != fail.ACCEPTED || diagnostic.len(first.diagnostics) != 0) { bad = 2; }
+        val resolved: R.Result[*res.ResolveResult, str] = resolve_of(?first);
+        if (R.is_err[*res.ResolveResult, str](resolved) || R.unwrap_ok[*res.ResolveResult, str](resolved) == nil) { bad = 3; }
+    }
 
     val res_up: R.Result[bool, str] = update(?es, fid, "use edbuild.helper.cube;\nfun main() i32 { ret cube(2); }\n");
     if (R.is_err[bool, str](res_up)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
 
-    val r2: R.Result[*res.ResolveResult, str] = resolve_buffer(?es, fid);
-    if (R.is_err[*res.ResolveResult, str](r2)) { bad = 1; }
-    or (!diag_has(?s.diags, "undeclared") && !diag_has(?s.diags, "unresolved")) { bad = 1; }
+    val r2: R.Result[AnalysisResult, outcome.Fail] = analyze(?es, ?req);
+    if (R.is_err[AnalysisResult, outcome.Fail](r2)) { bad = 4; }
+    or {
+        var edited: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](r2);
+        fin { analysis_dnit(?edited); }
+        if (edited.status.kind != fail.REJECTED || !diag_has(edited.diagnostics, "cube")) { bad = 5; }
+        val version: O.Option[*source.SourceFile] = analysis_source(?edited, fid);
+        if (O.is_none[*source.SourceFile](version)
+            || !str_equals(O.unwrap[*source.SourceFile](version).text,
+                "use edbuild.helper.cube;\nfun main() i32 { ret cube(2); }\n")) { bad = 6; }
+    }
 
     fs.remove_all(?alloc, root);
     t_dnit(?es);
@@ -3817,13 +3832,17 @@ test "mach.lang.editor.parse:driver_and_editor_share_one_parse_outcome" {
     val res_fid: R.Result[source.FileId, str] = open(?es, R.unwrap_ok[str, str](mp_r), texts[0]);
     if (R.is_err[source.FileId, str](res_fid)) { fs.remove_all(?alloc, root); t_dnit(?es); session.dnit(?s); ret 1; }
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
-    val res_ast: R.Result[*ast.Ast, str] = parse_buffer(?es, fid);
-    if (R.is_err[*ast.Ast, str](res_ast)) { bad = 1; }
-    or (R.unwrap_ok[*ast.Ast, str](res_ast).decl_len == 0) { bad = 1; }
-    val res_diags: R.Result[*diagnostic.DiagnosticStore, str] = diagnostics_buffer(?es, fid);
-    if (R.is_err[*diagnostic.DiagnosticStore, str](res_diags)) { bad = 1; }
+    var req: AnalysisRequest = analysis_request(fid, PHASE_PARSE);
+    val parsed: R.Result[AnalysisResult, outcome.Fail] = analyze(?es, ?req);
+    if (R.is_err[AnalysisResult, outcome.Fail](parsed)) { bad = 1; }
     or {
-        val ed: *diagnostic.DiagnosticStore = R.unwrap_ok[*diagnostic.DiagnosticStore, str](res_diags);
+        var result: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](parsed);
+        fin { analysis_dnit(?result); }
+        val res_ast: R.Result[*ast.Ast, str] = ast_of(?result);
+        if (result.status.kind != fail.REJECTED || R.is_err[*ast.Ast, str](res_ast)
+            || R.unwrap_ok[*ast.Ast, str](res_ast) == nil
+            || R.unwrap_ok[*ast.Ast, str](res_ast).decl_len == 0) { bad = 1; }
+        val ed: *diagnostic.DiagnosticStore = result.diagnostics;
         if (diagnostic.len(ed) < 2 || diagnostic.len(?drv) < diagnostic.len(ed)) { bad = 1; }
         or (!str_contains(R.unwrap_ok[*diagnostic.Diagnostic, str](diagnostic.get(ed, 0)).message, "unterminated string")) { bad = 1; }
         or {
@@ -3859,18 +3878,27 @@ test "mach.lang.editor.parse:driver_and_editor_share_one_parse_outcome" {
     if (R.is_err[str, str](mp2_r)) { fs.remove_all(?alloc, root2); t_dnit(?es); session.dnit(?s); ret 1; }
     val res_fid2: R.Result[source.FileId, str] = open(?es, R.unwrap_ok[str, str](mp2_r), deep_texts[0]);
     if (R.is_err[source.FileId, str](res_fid2)) { fs.remove_all(?alloc, root2); t_dnit(?es); session.dnit(?s); ret 1; }
-    val res_ast2: R.Result[*ast.Ast, str] = parse_buffer(?es, R.unwrap_ok[source.FileId, str](res_fid2));
-    if (R.is_ok[*ast.Ast, str](res_ast2)) { bad = 4; }
-    if (diagnostic.len(?drv2) != 1 || diagnostic.len(?s.diags) != 1) { bad = 5; }
+    req.file = R.unwrap_ok[source.FileId, str](res_fid2);
+    val parsed2: R.Result[AnalysisResult, outcome.Fail] = analyze(?es, ?req);
+    if (R.is_err[AnalysisResult, outcome.Fail](parsed2)) { bad = 4; }
     or {
-        val dd: *diagnostic.Diagnostic = ?drv2.items.data[0];
-        val ed: *diagnostic.Diagnostic = ?s.diags.items.data[0];
-        if (dd.severity != diagnostic.SEVERITY_ERROR || ed.severity != diagnostic.SEVERITY_ERROR
-            || !str_contains(dd.message, "input nests deeper than this parser descends")
-            || !str_equals(dd.message, ed.message)) { bad = 6; }
-        if (ed.loc.file_id != R.unwrap_ok[source.FileId, str](res_fid2)
-            || dd.loc.span.offset != ed.loc.span.offset || dd.loc.span.len != ed.loc.span.len
-            || ed.loc.span.len == 0) { bad = 7; }
+        var result: AnalysisResult = R.unwrap_ok[AnalysisResult, outcome.Fail](parsed2);
+        fin { analysis_dnit(?result); }
+        val res_ast2: R.Result[*ast.Ast, str] = ast_of(?result);
+        if (result.status.kind != fail.REJECTED || O.is_none[outcome.Fail](result.failure)
+            || O.unwrap[outcome.Fail](result.failure).kind != outcome.FAIL_REPORTED
+            || R.is_err[*ast.Ast, str](res_ast2) || R.unwrap_ok[*ast.Ast, str](res_ast2) != nil) { bad = 4; }
+        if (diagnostic.len(?drv2) != 1 || diagnostic.len(result.diagnostics) != 1) { bad = 5; }
+        or {
+            val dd: *diagnostic.Diagnostic = ?drv2.items.data[0];
+            val ed: *diagnostic.Diagnostic = ?result.diagnostics.items.data[0];
+            if (dd.severity != diagnostic.SEVERITY_ERROR || ed.severity != diagnostic.SEVERITY_ERROR
+                || !str_contains(dd.message, "input nests deeper than this parser descends")
+                || !str_equals(dd.message, ed.message)) { bad = 6; }
+            if (ed.loc.file_id != req.file
+                || dd.loc.span.offset != ed.loc.span.offset || dd.loc.span.len != ed.loc.span.len
+                || ed.loc.span.len == 0) { bad = 7; }
+        }
     }
 
     fs.remove_all(?alloc, root2);
@@ -3997,10 +4025,14 @@ test "mach.lang.editor.analyze:explicit_target_changes_context_and_expires_previ
     var es: EditorSession = init(?s);
     fin { t_dnit(?es); }
     R.unwrap_ok[R.Void, str](driver.setup_registry(?s.registry));
-    var tr32: target.TargetRequest = target.target_request("riscv32", "linux", "ilp32d");
+    var tr32: target.TargetRequest = target.target_request("riscv32", "freestanding", "ilp32d");
     var tr64: target.TargetRequest = target.target_request("riscv64", "linux", "lp64d");
-    var t32: target.Target = R.unwrap_ok[target.Target, str](target.resolve(?s.registry, ?tr32));
-    var t64: target.Target = R.unwrap_ok[target.Target, str](target.resolve(?s.registry, ?tr64));
+    val selected32: R.Result[target.Target, str] = target.resolve(?s.registry, ?tr32);
+    if (R.is_err[target.Target, str](selected32)) { ret 6; }
+    val selected64: R.Result[target.Target, str] = target.resolve(?s.registry, ?tr64);
+    if (R.is_err[target.Target, str](selected64)) { ret 7; }
+    var t32: target.Target = R.unwrap_ok[target.Target, str](selected32);
+    var t64: target.Target = R.unwrap_ok[target.Target, str](selected64);
     val fid: source.FileId = R.unwrap_ok[source.FileId, str](open(?es, "/mach-editor-target/file.mach",
         "$if ($mach.build.pointer_width == 4) { val selected: i32 = 32; } $or { val selected: i32 = 64; }"));
     var req: AnalysisRequest = analysis_request(fid, PHASE_RESOLVE);

--- a/src/lang/fe/ast.mach
+++ b/src/lang/fe/ast.mach
@@ -38,6 +38,7 @@ rec TypeIdDomain {
 pub rec Ast {
     a:           *A.Allocator;
     file_id:     source.FileId;
+    incarnation: u64;
     root_module: id.ModuleNodeId;
 
     modules:    *module.Module;
@@ -105,6 +106,7 @@ pub fun init(a: *A.Allocator, file_id: source.FileId) Ast {
     var ast: Ast;
     ast.a           = a;
     ast.file_id     = file_id;
+    ast.incarnation = 0;
     ast.root_module = id.MODULE_NODE_NIL;
 
     ast.modules    = nil;

--- a/src/lang/fe/ast/interpretation.mach
+++ b/src/lang/fe/ast/interpretation.mach
@@ -1,0 +1,87 @@
+use std.types.size.usize;
+use std.types.string.str;
+
+use O: std.types.option;
+use R: std.types.result;
+
+use mach.lang.fe.ast;
+use mach.lang.fe.ast.expr;
+use mach.lang.fe.ast.id;
+
+pub def Choice: u8;
+pub val PARSED: Choice = 0;
+pub val GENERIC: Choice = 1;
+pub val INDEX_CALL: Choice = 2;
+pub val INDEX_VALUE: Choice = 3;
+pub val REJECTED: Choice = 4;
+
+pub fun get(a: *ast.Ast, choices: *Choice, count: usize, eid: id.ExprId) R.Result[expr.Expr, str] {
+    if (a == nil || count != a.expr_len || (choices == nil && count != 0)) {
+        ret R.err[expr.Expr, str]("resolved expression view does not match its parsed owner");
+    }
+    val found: O.Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (O.is_none[*expr.Expr](found)) { ret R.err[expr.Expr, str]("resolved expression identity is out of range"); }
+    var node: expr.Expr = @O.unwrap[*expr.Expr](found);
+    val choice: Choice = choices[eid];
+    if (choice == PARSED) { ret R.ok[expr.Expr, str](node); }
+    if (node.kind != expr.EXPR_KIND_CALL && node.kind != expr.EXPR_KIND_GENERIC_INSTANCE) {
+        ret R.err[expr.Expr, str]("bracket interpretation does not belong to a bracket expression");
+    }
+    if (choice == GENERIC) {
+        node.data.call.index_callee = id.EXPR_NIL;
+        ret R.ok[expr.Expr, str](node);
+    }
+    if (choice == REJECTED) {
+        node.kind = expr.EXPR_KIND_ERROR;
+        ret R.ok[expr.Expr, str](node);
+    }
+    val indexed: O.Option[*expr.Expr] = ast.get_expr(a, node.data.call.index_callee);
+    if (O.is_none[*expr.Expr](indexed) || O.unwrap[*expr.Expr](indexed).kind != expr.EXPR_KIND_INDEX) {
+        ret R.err[expr.Expr, str]("bracket interpretation has no parsed index alternative");
+    }
+    if (choice == INDEX_CALL && node.kind == expr.EXPR_KIND_CALL) {
+        node.data.call.callee = node.data.call.index_callee;
+        node.data.call.index_callee = id.EXPR_NIL;
+        node.data.call.type_args_start = 0;
+        node.data.call.type_args_len = 0;
+        ret R.ok[expr.Expr, str](node);
+    }
+    if (choice == INDEX_VALUE && node.kind == expr.EXPR_KIND_GENERIC_INSTANCE) {
+        node.kind = expr.EXPR_KIND_INDEX;
+        node.data.index = O.unwrap[*expr.Expr](indexed).data.index;
+        ret R.ok[expr.Expr, str](node);
+    }
+    ret R.err[expr.Expr, str]("invalid bracket interpretation choice");
+}
+
+test "mach.lang.fe.ast.interpretation:separate_choices_preserve_the_same_parsed_call" {
+    var nodes: [3]expr.Expr;
+    nodes[0].kind = expr.EXPR_KIND_IDENT;
+    nodes[1].kind = expr.EXPR_KIND_INDEX;
+    nodes[1].data.index.object = 0;
+    nodes[1].data.index.index = 0;
+    nodes[2].kind = expr.EXPR_KIND_CALL;
+    nodes[2].data.call.callee = 0;
+    nodes[2].data.call.index_callee = 1;
+    nodes[2].data.call.type_args_start = 7;
+    nodes[2].data.call.type_args_len = 2;
+    nodes[2].data.call.args_start = 9;
+    nodes[2].data.call.args_len = 3;
+    var a: ast.Ast;
+    a.exprs = ?nodes[0];
+    a.expr_len = 3;
+    var generic: [3]Choice = [3]Choice{ PARSED, PARSED, GENERIC };
+    var indexed: [3]Choice = [3]Choice{ PARSED, PARSED, INDEX_CALL };
+    val generic_r: R.Result[expr.Expr, str] = get(?a, ?generic[0], 3, 2);
+    val indexed_r: R.Result[expr.Expr, str] = get(?a, ?indexed[0], 3, 2);
+    if (R.is_err[expr.Expr, str](generic_r) || R.is_err[expr.Expr, str](indexed_r)) { ret 1; }
+    val g: expr.Expr = R.unwrap_ok[expr.Expr, str](generic_r);
+    val i: expr.Expr = R.unwrap_ok[expr.Expr, str](indexed_r);
+    if (g.data.call.callee != 0 || g.data.call.index_callee != id.EXPR_NIL || g.data.call.type_args_len != 2) { ret 2; }
+    if (i.data.call.callee != 1 || i.data.call.type_args_len != 0 || i.data.call.args_start != 9 || i.data.call.args_len != 3) { ret 3; }
+    if (nodes[2].data.call.callee != 0 || nodes[2].data.call.index_callee != 1 || nodes[2].data.call.type_args_start != 7) { ret 4; }
+    if (!R.is_err[expr.Expr, str](get(?a, ?generic[0], 2, 2))) { ret 5; }
+    indexed[2] = 0xFF;
+    if (!R.is_err[expr.Expr, str](get(?a, ?indexed[0], 3, 2))) { ret 6; }
+    ret 0;
+}

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -11,6 +11,7 @@ use std.types.view.View;
 use std.types.string.str_contains;
 use std.types.string.str_equals;
 use std.types.string.str_len;
+use std.text.string.str_free;
 use std.types.view.view;
 use std.types.view.view_eq_str;
 use std.types.view.view_contains_char;
@@ -23,6 +24,7 @@ use mach.lang.fe.ast;
 use mach.lang.fe.ast.decl;
 use mach.lang.fe.ast.expr;
 use mach.lang.fe.ast.id;
+use mach.lang.fe.ast.interpretation;
 use atype: mach.lang.fe.ast.type;
 use mach.lang.fe.token;
 use mach.lang.float;
@@ -167,6 +169,8 @@ pub rec NoCapabilityContext {
 }
 
 pub rec PhaseCapabilities[T] {
+    expression: fun(*T, *ast.Ast, id.ExprId) R.Result[expr.Expr, EvalFail];
+    diags:     *diagnostic.DiagnosticStore;
     kind:      PhaseCapabilityKind;
     member:    fun(*T, id.ExprId) R.Result[O.Option[CTValue], EvalFail];
     type_:     fun(*T, id.ExprId) R.Result[O.Option[u32], EvalFail];
@@ -176,9 +180,11 @@ pub rec PhaseCapabilities[T] {
     ident:     fun(*T, id.ExprId) bool;
 }
 
-fun capabilities_empty[T](kind: PhaseCapabilityKind) PhaseCapabilities[T] {
+fun capabilities_empty[T](kind: PhaseCapabilityKind, diags: *diagnostic.DiagnosticStore) PhaseCapabilities[T] {
     var caps: PhaseCapabilities[T];
     caps.kind   = kind;
+    caps.diags  = diags;
+    caps.expression = parsed_expression[T];
     caps.member = nil;
     caps.type_  = nil;
     caps.field  = nil;
@@ -188,11 +194,26 @@ fun capabilities_empty[T](kind: PhaseCapabilityKind) PhaseCapabilities[T] {
     ret caps;
 }
 
-pub fun no_capabilities() PhaseCapabilities[NoCapabilityContext] {
-    ret capabilities_empty[NoCapabilityContext](PHASE_CAP_NONE);
+fun parsed_expression[T](ctx: *T, a: *ast.Ast, eid: id.ExprId) R.Result[expr.Expr, EvalFail] {
+    if (a == nil) { ret R.err[expr.Expr, EvalFail](eval_error(EVAL_FAIL_INTERNAL, "comptime expression has no parsed owner")); }
+    val found: O.Option[*expr.Expr] = ast.get_expr(a, eid);
+    if (O.is_none[*expr.Expr](found)) { ret R.err[expr.Expr, EvalFail](eval_error(EVAL_FAIL_INTERNAL, "comptime expression identity is out of range")); }
+    ret R.ok[expr.Expr, EvalFail](@O.unwrap[*expr.Expr](found));
+}
+
+fun read_expression[T](ctx: *T, caps: PhaseCapabilities[T], a: *ast.Ast, eid: id.ExprId) R.Result[expr.Expr, EvalFail] {
+    if (!capabilities_complete[T](caps) || (ctx == nil && caps.kind != PHASE_CAP_NONE)) {
+        ret R.err[expr.Expr, EvalFail](eval_error(EVAL_FAIL_INTERNAL, "comptime expression requires its active phase capability"));
+    }
+    ret caps.expression(ctx, a, eid);
+}
+
+pub fun no_capabilities(diags: *diagnostic.DiagnosticStore) PhaseCapabilities[NoCapabilityContext] {
+    ret capabilities_empty[NoCapabilityContext](PHASE_CAP_NONE, diags);
 }
 
 fun capabilities_complete[T](caps: PhaseCapabilities[T]) bool {
+    if (caps.expression == nil) { ret false; }
     val no_types: bool = caps.type_ == nil && caps.field == nil && caps.query == nil && caps.layout == nil;
     if (caps.kind == PHASE_CAP_NONE) {
         ret caps.member == nil && no_types && caps.ident == nil;
@@ -220,25 +241,30 @@ fun capabilities_publish[T](caps: PhaseCapabilities[T]) R.Result[PhaseCapabiliti
     ret R.ok[PhaseCapabilities[T], str](caps);
 }
 
-pub fun loading_capabilities[T](member: fun(*T, id.ExprId) R.Result[O.Option[CTValue], EvalFail]) R.Result[PhaseCapabilities[T], str] {
-    var caps: PhaseCapabilities[T] = capabilities_empty[T](PHASE_CAP_LOADING);
+pub fun loading_capabilities[T](member: fun(*T, id.ExprId) R.Result[O.Option[CTValue], EvalFail], diags: *diagnostic.DiagnosticStore) R.Result[PhaseCapabilities[T], str] {
+    var caps: PhaseCapabilities[T] = capabilities_empty[T](PHASE_CAP_LOADING, diags);
     caps.member = member;
     ret capabilities_publish[T](caps);
 }
 
-pub fun resolution_capabilities[T](ident: fun(*T, id.ExprId) bool) R.Result[PhaseCapabilities[T], str] {
-    var caps: PhaseCapabilities[T] = capabilities_empty[T](PHASE_CAP_RESOLUTION);
+pub fun resolution_capabilities[T](ident: fun(*T, id.ExprId) bool,
+    expression: fun(*T, *ast.Ast, id.ExprId) R.Result[expr.Expr, EvalFail], diags: *diagnostic.DiagnosticStore) R.Result[PhaseCapabilities[T], str] {
+    var caps: PhaseCapabilities[T] = capabilities_empty[T](PHASE_CAP_RESOLUTION, diags);
     caps.ident = ident;
+    caps.expression = expression;
     ret capabilities_publish[T](caps);
 }
 
 pub fun semantic_name_capabilities[T](
     member: fun(*T, id.ExprId) R.Result[O.Option[CTValue], EvalFail],
-    ident:  fun(*T, id.ExprId) bool
+    ident:  fun(*T, id.ExprId) bool,
+    expression: fun(*T, *ast.Ast, id.ExprId) R.Result[expr.Expr, EvalFail],
+    diags:  *diagnostic.DiagnosticStore
 ) R.Result[PhaseCapabilities[T], str] {
-    var caps: PhaseCapabilities[T] = capabilities_empty[T](PHASE_CAP_SEMANTIC_NAMES);
+    var caps: PhaseCapabilities[T] = capabilities_empty[T](PHASE_CAP_SEMANTIC_NAMES, diags);
     caps.member = member;
     caps.ident  = ident;
+    caps.expression = expression;
     ret capabilities_publish[T](caps);
 }
 
@@ -248,15 +274,18 @@ pub fun semantic_type_capabilities[T](
     field:  fun(*T, u32, u32, u8) R.Result[O.Option[CTValue], EvalFail],
     query:  fun(*T, u32, u8) R.Result[O.Option[CTValue], EvalFail],
     layout: fun(*T, u32) R.Result[O.Option[CTValue], EvalFail],
-    ident:  fun(*T, id.ExprId) bool
+    ident:  fun(*T, id.ExprId) bool,
+    expression: fun(*T, *ast.Ast, id.ExprId) R.Result[expr.Expr, EvalFail],
+    diags:  *diagnostic.DiagnosticStore
 ) R.Result[PhaseCapabilities[T], str] {
-    var caps: PhaseCapabilities[T] = capabilities_empty[T](PHASE_CAP_SEMANTIC_TYPES);
+    var caps: PhaseCapabilities[T] = capabilities_empty[T](PHASE_CAP_SEMANTIC_TYPES, diags);
     caps.member = member;
     caps.type_  = type_;
     caps.field  = field;
     caps.query  = query;
     caps.layout = layout;
     caps.ident  = ident;
+    caps.expression = expression;
     ret capabilities_publish[T](caps);
 }
 
@@ -266,15 +295,18 @@ pub fun lowering_capabilities[T](
     field:  fun(*T, u32, u32, u8) R.Result[O.Option[CTValue], EvalFail],
     query:  fun(*T, u32, u8) R.Result[O.Option[CTValue], EvalFail],
     layout: fun(*T, u32) R.Result[O.Option[CTValue], EvalFail],
-    ident:  fun(*T, id.ExprId) bool
+    ident:  fun(*T, id.ExprId) bool,
+    expression: fun(*T, *ast.Ast, id.ExprId) R.Result[expr.Expr, EvalFail],
+    diags:  *diagnostic.DiagnosticStore
 ) R.Result[PhaseCapabilities[T], str] {
-    var caps: PhaseCapabilities[T] = capabilities_empty[T](PHASE_CAP_LOWERING);
+    var caps: PhaseCapabilities[T] = capabilities_empty[T](PHASE_CAP_LOWERING, diags);
     caps.member = member;
     caps.type_  = type_;
     caps.field  = field;
     caps.query  = query;
     caps.layout = layout;
     caps.ident  = ident;
+    caps.expression = expression;
     ret capabilities_publish[T](caps);
 }
 
@@ -618,7 +650,6 @@ pub rec ComptimeEnv {
     target_platform: intern.StrId;
     bin_name:       intern.StrId;
     union_build:    bool;
-    diags:          *diagnostic.DiagnosticStore;
 }
 
 pub rec ComptimeCtx {
@@ -688,7 +719,6 @@ pub fun init(
     c.env.target_platform = intern.STR_NIL;
     c.env.bin_name        = intern.STR_NIL;
     c.env.union_build     = false;
-    c.env.diags           = nil;
 
     c.entries          = nil;
     c.entries_len      = 0;
@@ -703,10 +733,6 @@ pub fun init(
     c.load_walked      = nil;
     c.gate_decl_count  = 0;
     ret c;
-}
-
-pub fun set_diagnostics(c: *ComptimeCtx, diags: *diagnostic.DiagnosticStore) {
-    c.env.diags = diags;
 }
 
 pub fun set_union_build(c: *ComptimeCtx, v: bool) {
@@ -991,9 +1017,10 @@ pub fun evaluate_at_float_width[T](
 ) R.Result[CTValue, EvalFail] {
     if (e == id.EXPR_NIL) { ret reject("missing expression"); }
 
-    val n_opt: O.Option[*expr.Expr] = ast.get_expr(a, e);
-    if (O.is_none[*expr.Expr](n_opt)) { ret reject("ExprId out of range"); }
-    val node: *expr.Expr = O.unwrap[*expr.Expr](n_opt);
+    val expression: R.Result[expr.Expr, EvalFail] = read_expression[T](cap_ctx, caps, a, e);
+    if (R.is_err[expr.Expr, EvalFail](expression)) { ret R.err[CTValue, EvalFail](R.unwrap_err[expr.Expr, EvalFail](expression)); }
+    var node_value: expr.Expr = R.unwrap_ok[expr.Expr, EvalFail](expression);
+    val node: *expr.Expr = ?node_value;
     val k: expr.ExprKind = node.kind;
 
     if (k == expr.EXPR_KIND_LIT_INT)   { ret eval_lit_int(source, node.span); }
@@ -1025,7 +1052,7 @@ pub fun evaluate_at_float_width[T](
         ret reject(COMPTIME_BARE_IDENT_MSG);
     }
     if (k == expr.EXPR_KIND_MEMBER) {
-        if (is_comptime_path(a, e)) { ret eval_path(c, a, source, e, interner); }
+        if (is_comptime_path(a, e)) { ret eval_path(c, a, source, e, interner, caps.diags); }
         val cel: O.Option[R.Result[CTValue, EvalFail]] =
             eval_const_elem_member[T](c, cap_ctx, caps, a, source, node.data.member.object, node.data.member.name, interner, fw);
         if (O.is_some[R.Result[CTValue, EvalFail]](cel)) { ret O.unwrap[R.Result[CTValue, EvalFail]](cel); }
@@ -1741,6 +1768,7 @@ pub val GATE_PROBE_NO_OBSERVER_MSG: str =
     "internal: this phase did not supply the observer a compile-time dependency probe needs";
 
 pub rec GateProbes[T] {
+    expression: fun(*T, *ast.Ast, id.ExprId) R.Result[expr.Expr, EvalFail];
     comptime_param:     fun(*T, id.ExprId) bool;
     each_loopvar:       fun(*T, id.ExprId) bool;
     field_loopvar:      fun(*T, id.ExprId) bool;
@@ -1752,9 +1780,11 @@ pub fun gate_probes[T](
     comptime_param:     fun(*T, id.ExprId) bool,
     each_loopvar:       fun(*T, id.ExprId) bool,
     field_loopvar:      fun(*T, id.ExprId) bool,
-    field_type_operand: fun(*T, id.ExprId) bool
+    field_type_operand: fun(*T, id.ExprId) bool,
+    expression: fun(*T, *ast.Ast, id.ExprId) R.Result[expr.Expr, EvalFail]
 ) GateProbes[T] {
     var p: GateProbes[T];
+    p.expression = expression;
     p.comptime_param     = comptime_param;
     p.each_loopvar       = each_loopvar;
     p.field_loopvar      = field_loopvar;
@@ -1763,16 +1793,18 @@ pub fun gate_probes[T](
     ret p;
 }
 
-pub fun gate_node_action_probes[T](action: fun(*T, id.ExprId, *expr.Expr) GateNodeVerdict) GateProbes[T] {
-    var p: GateProbes[T] = gate_probes[T](nil, nil, nil, nil);
+pub fun gate_node_action_probes[T](action: fun(*T, id.ExprId, *expr.Expr) GateNodeVerdict,
+    expression: fun(*T, *ast.Ast, id.ExprId) R.Result[expr.Expr, EvalFail]) GateProbes[T] {
+    var p: GateProbes[T] = gate_probes[T](nil, nil, nil, nil, expression);
     p.node_action = action;
     ret p;
 }
 
 pub fun gate_walk[T](a: *ast.Ast, source: str, obs: *T,
                      action: fun(*T, id.ExprId, *expr.Expr) GateNodeVerdict,
+                     expression: fun(*T, *ast.Ast, id.ExprId) R.Result[expr.Expr, EvalFail],
                      eid: id.ExprId) R.Result[bool, str] {
-    ret gate_depends_on[T](a, source, obs, gate_node_action_probes[T](action), GATE_PROBE_NODE_ACTION, eid);
+    ret gate_depends_on[T](a, source, obs, gate_node_action_probes[T](action, expression), GATE_PROBE_NODE_ACTION, eid);
 }
 
 pub fun gate_chain_depends_on[T](
@@ -1798,7 +1830,7 @@ pub fun gate_chain_depends_on[T](
 
 pub fun gate_needs_typed_selection(a: *ast.Ast, source: str, eid: id.ExprId) R.Result[bool, str] {
     ret gate_depends_on[NoCapabilityContext](a, source, nil,
-        gate_probes[NoCapabilityContext](nil, nil, nil, nil),
+        gate_probes[NoCapabilityContext](nil, nil, nil, nil, parsed_expression[NoCapabilityContext]),
         GATE_PROBE_TARGET_DEPENDENT, eid);
 }
 
@@ -1866,18 +1898,21 @@ fun gate_u8_message(v: CTValue) str {
     ret GATE_U8_MSG;
 }
 
-rec GateNameProbe {
+rec GateNameProbe[T] {
+    cap_ctx: *T;
+    caps: PhaseCapabilities[T];
+    failure: O.Option[str];
     c:        *ComptimeCtx;
     source:   str;
     interner: *intern.Interner;
     found:    intern.StrId;
 }
 
-fun gate_name_probe_node(g: *GateNameProbe, eid: id.ExprId, e: *expr.Expr) GateNodeVerdict {
-    if (g.found != intern.STR_NIL)      { ret GATE_NODE_PRUNE; }
+fun gate_name_probe_node[T](g: *GateNameProbe[T], eid: id.ExprId, e: *expr.Expr) GateNodeVerdict {
+    if (g.found != intern.STR_NIL || O.is_some[str](g.failure)) { ret GATE_NODE_PRUNE; }
     if (e.kind != expr.EXPR_KIND_IDENT) { ret GATE_NODE_NO; }
     val r: R.Result[intern.StrId, str] = intern.intern_span(g.interner, g.source, e.span);
-    if (R.is_err[intern.StrId, str](r)) { ret GATE_NODE_NO; }
+    if (R.is_err[intern.StrId, str](r)) { g.failure = O.some[str](R.unwrap_err[intern.StrId, str](r)); ret GATE_NODE_PRUNE; }
     val name: intern.StrId = R.unwrap_ok[intern.StrId, str](r);
     if (O.is_some[NamedConst](lookup(g.c, name)))        { ret GATE_NODE_NO; }
     if (O.is_some[NamedConst](lookup_define(g.c, name))) { ret GATE_NODE_NO; }
@@ -1885,17 +1920,26 @@ fun gate_name_probe_node(g: *GateNameProbe, eid: id.ExprId, e: *expr.Expr) GateN
     ret GATE_NODE_PRUNE;
 }
 
-pub fun gate_unresolved_dependency(c: *ComptimeCtx, a: *ast.Ast, source: str,
-                                   interner: *intern.Interner, cond: id.ExprId) intern.StrId {
-    if (c == nil || interner == nil) { ret intern.STR_NIL; }
-    var g: GateNameProbe;
+fun gate_name_expression[T](g: *GateNameProbe[T], a: *ast.Ast, eid: id.ExprId) R.Result[expr.Expr, EvalFail] {
+    ret read_expression[T](g.cap_ctx, g.caps, a, eid);
+}
+
+pub fun gate_unresolved_dependency[T](c: *ComptimeCtx, cap_ctx: *T, caps: PhaseCapabilities[T],
+    a: *ast.Ast, source: str, interner: *intern.Interner, cond: id.ExprId) R.Result[intern.StrId, str] {
+    if (c == nil || interner == nil) { ret R.err[intern.StrId, str]("gate dependency name has no active context"); }
+    var g: GateNameProbe[T];
+    g.cap_ctx  = cap_ctx;
+    g.caps     = caps;
+    g.failure  = O.none[str]();
     g.c        = c;
     g.source   = source;
     g.interner = interner;
     g.found    = intern.STR_NIL;
-    val matched_r: R.Result[bool, str] = gate_walk[GateNameProbe](a, source, ?g, gate_name_probe_node, cond);
-    if (R.is_err[bool, str](matched_r)) { ret intern.STR_NIL; }
-    ret g.found;
+    val matched_r: R.Result[bool, str] = gate_walk[GateNameProbe[T]](a, source, ?g,
+        gate_name_probe_node[T], gate_name_expression[T], cond);
+    if (R.is_err[bool, str](matched_r)) { ret R.err[intern.StrId, str](R.unwrap_err[bool, str](matched_r)); }
+    if (O.is_some[str](g.failure)) { ret R.err[intern.StrId, str](O.unwrap[str](g.failure)); }
+    ret R.ok[intern.StrId, str](g.found);
 }
 
 pub fun evaluate_gate[T](
@@ -1952,7 +1996,9 @@ pub fun evaluate_gate[T](
         if (gate_failure_awaits_phase[T](cap_ctx, caps, f.kind)) {
             ret R.ok[GateVerdict, str](gate_verdict_failed(GATE_AWAITING_PHASE, f, span, intern.STR_NIL));
         }
-        val depends: intern.StrId = gate_unresolved_dependency(c, a, source, interner, cond);
+        val depends_r: R.Result[intern.StrId, str] = gate_unresolved_dependency[T](c, cap_ctx, caps, a, source, interner, cond);
+        if (R.is_err[intern.StrId, str](depends_r)) { ret R.err[GateVerdict, str](R.unwrap_err[intern.StrId, str](depends_r)); }
+        val depends: intern.StrId = R.unwrap_ok[intern.StrId, str](depends_r);
         if (!terminal) {
             ret R.ok[GateVerdict, str](gate_verdict_failed(GATE_DEFERRED, f, span, depends));
         }
@@ -1995,11 +2041,13 @@ pub fun gate_depends_on[T](
     a: *ast.Ast, source: str, obs: *T, probes: GateProbes[T], probe: GateProbe, eid: id.ExprId
 ) R.Result[bool, str] {
     if (eid == id.EXPR_NIL) { ret R.ok[bool, str](false); }
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) {
-        ret R.err[bool, str]("gate condition ExprId out of range in the dependency visitor");
+    if (probes.expression == nil) { ret R.err[bool, str]("gate dependency visitor has no expression reader"); }
+    val e_opt: R.Result[expr.Expr, EvalFail] = probes.expression(obs, a, eid);
+    if (R.is_err[expr.Expr, EvalFail](e_opt)) {
+        ret R.err[bool, str](R.unwrap_err[expr.Expr, EvalFail](e_opt).message);
     }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, EvalFail](e_opt);
+    val e: *expr.Expr = ?e_value;
 
     val here: R.Result[GateNodeVerdict, str] = gate_probe_node[T](a, source, obs, probes, probe, eid, e);
     if (R.is_err[GateNodeVerdict, str](here)) {
@@ -2824,7 +2872,8 @@ fun eval_path(
     a:        *ast.Ast,
     source:   str,
     e:        id.ExprId,
-    interner: *intern.Interner
+    interner: *intern.Interner,
+    diags:    *diagnostic.DiagnosticStore
 ) R.Result[CTValue, EvalFail] {
     var stack: [16]token.Span;
     var depth: u32 = 0;
@@ -2849,13 +2898,13 @@ fun eval_path(
         ret reject("comptime path must start with a `$` identifier");
     }
 
-    ret resolve_comptime_path(c, source, ?stack[0], depth, interner);
+    ret resolve_comptime_path(c, source, ?stack[0], depth, interner, diags);
 }
 
-fun resolve_comptime_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32, interner: *intern.Interner) R.Result[CTValue, EvalFail] {
+fun resolve_comptime_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32, interner: *intern.Interner, diags: *diagnostic.DiagnosticStore) R.Result[CTValue, EvalFail] {
     if (depth == 0) { ret reject("empty comptime path"); }
     val root: View = span_text(source, stack[depth - 1]);
-    if (view_eq_str(root, "mach"))    { ret resolve_mach_path(c, source, stack, depth, interner); }
+    if (view_eq_str(root, "mach"))    { ret resolve_mach_path(c, source, stack, depth, interner, diags); }
     if (view_eq_str(root, "project")) { ret resolve_project_path(c, source, stack, depth, interner); }
     if (view_eq_str(root, "bin"))     { ret resolve_bin_path(c, source, stack, depth); }
     ret reject(COMPTIME_BARE_IDENT_MSG);
@@ -2909,7 +2958,7 @@ pub fun comptime_ident_name(full: token.Span) token.Span {
     ret s;
 }
 
-fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32, interner: *intern.Interner) R.Result[CTValue, EvalFail] {
+fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u32, interner: *intern.Interner, diags: *diagnostic.DiagnosticStore) R.Result[CTValue, EvalFail] {
     if (depth == 0) { ret reject("empty comptime path"); }
 
     if (depth == 2 && seg_is(source, stack, 0, "version")) {
@@ -2939,7 +2988,7 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     }
     if (depth == 3 && seg_is(source, stack, 1, "abi")) {
         val name: View = span_text(source, stack[0]);
-        val r: R.Result[u32, str] = abi_tag_for(c, name);
+        val r: R.Result[u32, str] = abi_tag_for(c, name, diags);
         if (R.is_err[u32, str](r)) { ret reject(R.unwrap_err[u32, str](r)); }
         ret int_value(R.unwrap_ok[u32, str](r)::i64);
     }
@@ -3048,24 +3097,25 @@ val DEPRECATED_ABIS: [DEPRECATED_ABI_N]DeprecatedAbi = [DEPRECATED_ABI_N]Depreca
     DeprecatedAbi{ spelling: "sysv", replacement: "sysv64" },
 };
 
-fun deprecate_abi(c: *ComptimeCtx, spelling: str, replacement: str) R.Result[u32, str] {
-    if (c.env.diags != nil) {
+fun deprecate_abi(c: *ComptimeCtx, spelling: str, replacement: str, diags: *diagnostic.DiagnosticStore) R.Result[u32, str] {
+    if (diags != nil) {
         val msg: R.Result[str, str] = format.sprint(c.env.alloc,
             "`$mach.abi.{}` is deprecated and resolves to `$mach.abi.{}`; the registry spells this ABI `{}`, and the deprecated spelling is removed in the next major release",
             spelling, replacement, replacement);
         if (R.is_err[str, str](msg)) { ret R.err[u32, str](R.unwrap_err[str, str](msg)); }
+        fin { str_free(c.env.alloc, R.unwrap_ok[str, str](msg)); }
         var span: token.Span;
         span.offset = 0;
         span.len    = 0;
         val emitted: R.Result[R.Void, str] =
-            diagnostic.warning(c.env.diags, 0xFFFFFFFF::source.FileId, span,
+            diagnostic.warning(diags, 0xFFFFFFFF::source.FileId, span,
                                R.unwrap_ok[str, str](msg));
         if (R.is_err[R.Void, str](emitted)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](emitted)); }
     }
     ret R.ok[u32, str](abi.abi_id_for(replacement));
 }
 
-fun abi_tag_for(c: *ComptimeCtx, name: View) R.Result[u32, str] {
+fun abi_tag_for(c: *ComptimeCtx, name: View, diags: *diagnostic.DiagnosticStore) R.Result[u32, str] {
     var i: usize = 0;
     for (i < abi.abi_catalog_len()) {
         val spelling: str = abi.abi_catalog_name(i);
@@ -3075,7 +3125,7 @@ fun abi_tag_for(c: *ComptimeCtx, name: View) R.Result[u32, str] {
     var d: usize = 0;
     for (d < DEPRECATED_ABI_N) {
         if (view_eq_str(name, DEPRECATED_ABIS[d].spelling)) {
-            ret deprecate_abi(c, DEPRECATED_ABIS[d].spelling, DEPRECATED_ABIS[d].replacement);
+            ret deprecate_abi(c, DEPRECATED_ABIS[d].spelling, DEPRECATED_ABIS[d].replacement, diags);
         }
         d = d + 1;
     }
@@ -3409,7 +3459,7 @@ test "mach.lang.fe.comptime.tag_for:registry_names_are_the_only_names" {
     i = 0;
     for (i < abi.abi_catalog_len()) {
         val spelling: str = abi.abi_catalog_name(i);
-        val r: R.Result[u32, str] = abi_tag_for(?quiet, t_view(spelling));
+        val r: R.Result[u32, str] = abi_tag_for(?quiet, t_view(spelling), nil);
         if (R.is_err[u32, str](r)) { ret 1; }
         if (R.unwrap_ok[u32, str](r) != abi.abi_id_for(spelling)) { ret 1; }
         if (R.unwrap_ok[u32, str](r) == abi.ABI_UNKNOWN)          { ret 1; }
@@ -3433,16 +3483,15 @@ test "mach.lang.fe.comptime.tag_for:registry_names_are_the_only_names" {
     if (!R.is_err[u32, str](arch_tag_for(t_view("riscv"))))  { ret 1; }
     if (!R.is_err[u32, str](os_tag_for(t_view("unknown"))))  { ret 1; }
 
-    val current: R.Result[u32, str] = abi_tag_for(?quiet, t_view("sysv64"));
+    val current: R.Result[u32, str] = abi_tag_for(?quiet, t_view("sysv64"), nil);
     if (R.is_err[u32, str](current)) { ret 1; }
 
     var store: diagnostic.DiagnosticStore = diagnostic.store_init(?alloc);
     var loud: ComptimeCtx = init(?alloc, 0, 0, 0, 0, 0, 8, 128, true,
                                  intern.STR_NIL, intern.STR_NIL);
-    set_diagnostics(?loud, ?store);
     if (diagnostic.len(?store) != 0) { ret 1; }
 
-    val deprecated: R.Result[u32, str] = abi_tag_for(?loud, t_view("sysv"));
+    val deprecated: R.Result[u32, str] = abi_tag_for(?loud, t_view("sysv"), ?store);
     if (R.is_err[u32, str](deprecated)) { ret 1; }
     if (R.unwrap_ok[u32, str](deprecated) != R.unwrap_ok[u32, str](current)) { ret 1; }
     if (R.unwrap_ok[u32, str](deprecated) != abi.ABI_SYSV)                   { ret 1; }
@@ -3456,7 +3505,7 @@ test "mach.lang.fe.comptime.tag_for:registry_names_are_the_only_names" {
     if (!str_contains(d.message, "sysv64"))         { ret 1; }
     if (!str_contains(d.message, "deprecated"))     { ret 1; }
 
-    val current_again: R.Result[u32, str] = abi_tag_for(?loud, t_view("sysv64"));
+    val current_again: R.Result[u32, str] = abi_tag_for(?loud, t_view("sysv64"), ?store);
     if (R.is_err[u32, str](current_again))   { ret 1; }
     if (diagnostic.len(?store) != 1)         { ret 1; }
     ret 0;
@@ -3522,7 +3571,7 @@ fun t_capability_nested(state: *TCapabilityNested, eid: id.ExprId) R.Result[O.Op
 
 test "mach.lang.fe.comptime.capabilities:mismatched_phase_does_not_dispatch" {
     var calls: u32 = 0;
-    val caps_r: R.Result[PhaseCapabilities[u32], str] = loading_capabilities[u32](t_capability_member);
+    val caps_r: R.Result[PhaseCapabilities[u32], str] = loading_capabilities[u32](t_capability_member, nil);
     if (R.is_err[PhaseCapabilities[u32], str](caps_r)) { ret 1; }
     var caps: PhaseCapabilities[u32] = R.unwrap_ok[PhaseCapabilities[u32], str](caps_r);
     val accepted: R.Result[CTValue, EvalFail] = eval_module_member[u32](?calls, caps, id.EXPR_NIL);
@@ -3531,11 +3580,11 @@ test "mach.lang.fe.comptime.capabilities:mismatched_phase_does_not_dispatch" {
     val mismatched: R.Result[CTValue, EvalFail] = eval_module_member[u32](?calls, caps, id.EXPR_NIL);
     if (!R.is_err[CTValue, EvalFail](mismatched) || calls != 1) { ret 1; }
     val missing: R.Result[CTValue, EvalFail] =
-        eval_module_member[NoCapabilityContext](nil, no_capabilities(), id.EXPR_NIL);
+        eval_module_member[NoCapabilityContext](nil, no_capabilities(nil), id.EXPR_NIL);
     if (!R.is_err[CTValue, EvalFail](missing) || calls != 1) { ret 1; }
     val nil_context: R.Result[CTValue, EvalFail] = eval_module_member[u32](nil, caps, id.EXPR_NIL);
     if (!R.is_err[CTValue, EvalFail](nil_context) || calls != 1) { ret 1; }
-    if (!R.is_err[PhaseCapabilities[u32], str](loading_capabilities[u32](nil))) { ret 1; }
+    if (!R.is_err[PhaseCapabilities[u32], str](loading_capabilities[u32](nil, nil))) { ret 1; }
     caps.kind = PHASE_CAP_LOADING;
     caps.ident = t_capability_ident;
     val incomplete: R.Result[CTValue, EvalFail] = eval_module_member[u32](?calls, caps, id.EXPR_NIL);
@@ -3547,9 +3596,9 @@ test "mach.lang.fe.comptime.capabilities:nested_sessions_keep_their_phase_value"
     var state: TCapabilityNested;
     state.outer_calls = 0;
     state.inner_calls = 0;
-    val inner_r: R.Result[PhaseCapabilities[u32], str] = loading_capabilities[u32](t_capability_member);
+    val inner_r: R.Result[PhaseCapabilities[u32], str] = loading_capabilities[u32](t_capability_member, nil);
     val outer_r: R.Result[PhaseCapabilities[TCapabilityNested], str] =
-        loading_capabilities[TCapabilityNested](t_capability_nested);
+        loading_capabilities[TCapabilityNested](t_capability_nested, nil);
     if (R.is_err[PhaseCapabilities[u32], str](inner_r)
      || R.is_err[PhaseCapabilities[TCapabilityNested], str](outer_r)) { ret 1; }
     state.inner = R.unwrap_ok[PhaseCapabilities[u32], str](inner_r);
@@ -3780,14 +3829,14 @@ test "mach.lang.fe.comptime.resolve_mach_path:build_platform" {
     if (R.is_err[intern.StrId, str](pid_r)) { ret 1; }
     val pid: intern.StrId = R.unwrap_ok[intern.StrId, str](pid_r);
     c.env.target_platform = pid;
-    if (t_str_id(resolve_mach_path(?c, sp, ?stack[0], t_dotted(sp, ?stack[0]), ?itab)) != pid) { ret 1; }
+    if (t_str_id(resolve_mach_path(?c, sp, ?stack[0], t_dotted(sp, ?stack[0]), ?itab, nil)) != pid) { ret 1; }
 
     c.env.target_platform = intern.STR_NIL;
     val empty_r: R.Result[intern.StrId, str] = intern.intern(?itab, "");
     if (R.is_err[intern.StrId, str](empty_r)) { ret 1; }
     val empty_id: intern.StrId = R.unwrap_ok[intern.StrId, str](empty_r);
     if (empty_id == intern.STR_NIL) { ret 1; }
-    if (t_str_id(resolve_mach_path(?c, sp, ?stack[0], t_dotted(sp, ?stack[0]), ?itab)) != empty_id) { ret 1; }
+    if (t_str_id(resolve_mach_path(?c, sp, ?stack[0], t_dotted(sp, ?stack[0]), ?itab, nil)) != empty_id) { ret 1; }
     ret 0;
 }
 
@@ -4044,7 +4093,7 @@ test "mach.lang.fe.comptime.eval_ident:deferred_float_is_not_absent" {
     if (R.is_err[intern.StrId, str](id_r)) { dnit(?c); ret 1; }
     val aliased: intern.StrId = R.unwrap_ok[intern.StrId, str](id_r);
 
-    val r0: R.Result[CTValue, EvalFail] = eval_ident[NoCapabilityContext](?c, nil, no_capabilities(), source, id.EXPR_NIL, s_alias, ?itn);
+    val r0: R.Result[CTValue, EvalFail] = eval_ident[NoCapabilityContext](?c, nil, no_capabilities(nil), source, id.EXPR_NIL, s_alias, ?itn);
     if (!R.is_err[CTValue, EvalFail](r0))                                              { dnit(?c); ret 1; }
     if (R.unwrap_err[CTValue, EvalFail](r0).message == COMPTIME_ALIAS_FLOAT_MSG)               { dnit(?c); ret 1; }
 
@@ -4052,18 +4101,18 @@ test "mach.lang.fe.comptime.eval_ident:deferred_float_is_not_absent" {
     if (R.is_err[R.Void, str](d))            { dnit(?c); ret 1; }
     if (!float_width_deferred(?c, aliased)) { dnit(?c); ret 1; }
 
-    val r1: R.Result[CTValue, EvalFail] = eval_ident[NoCapabilityContext](?c, nil, no_capabilities(), source, id.EXPR_NIL, s_alias, ?itn);
+    val r1: R.Result[CTValue, EvalFail] = eval_ident[NoCapabilityContext](?c, nil, no_capabilities(nil), source, id.EXPR_NIL, s_alias, ?itn);
     if (!R.is_err[CTValue, EvalFail](r1))                                { dnit(?c); ret 1; }
     if (R.unwrap_err[CTValue, EvalFail](r1).message != COMPTIME_ALIAS_FLOAT_MSG) { dnit(?c); ret 1; }
 
-    val r2: R.Result[CTValue, EvalFail] = eval_ident[NoCapabilityContext](?c, nil, no_capabilities(), source, id.EXPR_NIL, s_absent, ?itn);
+    val r2: R.Result[CTValue, EvalFail] = eval_ident[NoCapabilityContext](?c, nil, no_capabilities(nil), source, id.EXPR_NIL, s_absent, ?itn);
     if (!R.is_err[CTValue, EvalFail](r2))                                { dnit(?c); ret 1; }
     if (R.unwrap_err[CTValue, EvalFail](r2).message == COMPTIME_ALIAS_FLOAT_MSG) { dnit(?c); ret 1; }
 
     val bv: CTValue = R.unwrap_ok[CTValue, EvalFail](int_value(3));
     val b: R.Result[R.Void, str] = bind(?c, aliased, bv);
     if (R.is_err[R.Void, str](b)) { dnit(?c); ret 1; }
-    val r3: R.Result[CTValue, EvalFail] = eval_ident[NoCapabilityContext](?c, nil, no_capabilities(), source, id.EXPR_NIL, s_alias, ?itn);
+    val r3: R.Result[CTValue, EvalFail] = eval_ident[NoCapabilityContext](?c, nil, no_capabilities(nil), source, id.EXPR_NIL, s_alias, ?itn);
     if (R.is_err[CTValue, EvalFail](r3))                            { dnit(?c); ret 1; }
     if (R.unwrap_ok[CTValue, EvalFail](r3).data.i != 3)             { dnit(?c); ret 1; }
 
@@ -4085,7 +4134,7 @@ test "mach.lang.fe.comptime.eval_ident:true_and_false_are_ordinary_bindings" {
     s_false.offset = 5::usize;
     s_false.len    = 5::usize;
 
-    val unbound: R.Result[CTValue, EvalFail] = eval_ident[NoCapabilityContext](?c, nil, no_capabilities(), source, id.EXPR_NIL, s_true, ?itn);
+    val unbound: R.Result[CTValue, EvalFail] = eval_ident[NoCapabilityContext](?c, nil, no_capabilities(nil), source, id.EXPR_NIL, s_true, ?itn);
     if (!R.is_err[CTValue, EvalFail](unbound)) { dnit(?c); ret 1; }
 
     val true_id_r: R.Result[intern.StrId, str] = intern.intern_span(?itn, source, s_true);
@@ -4098,12 +4147,12 @@ test "mach.lang.fe.comptime.eval_ident:true_and_false_are_ordinary_bindings" {
     val bind_false: R.Result[R.Void, str] = bind(?c, R.unwrap_ok[intern.StrId, str](false_id_r), ct_u8(0));
     if (R.is_err[R.Void, str](bind_false)) { dnit(?c); ret 1; }
 
-    val true_r: R.Result[CTValue, EvalFail] = eval_ident[NoCapabilityContext](?c, nil, no_capabilities(), source, id.EXPR_NIL, s_true, ?itn);
+    val true_r: R.Result[CTValue, EvalFail] = eval_ident[NoCapabilityContext](?c, nil, no_capabilities(nil), source, id.EXPR_NIL, s_true, ?itn);
     if (R.is_err[CTValue, EvalFail](true_r)) { dnit(?c); ret 1; }
     val true_v: CTValue = R.unwrap_ok[CTValue, EvalFail](true_r);
     if (!is_u8(true_v) || true_v.data.i != 1) { dnit(?c); ret 1; }
 
-    val false_r: R.Result[CTValue, EvalFail] = eval_ident[NoCapabilityContext](?c, nil, no_capabilities(), source, id.EXPR_NIL, s_false, ?itn);
+    val false_r: R.Result[CTValue, EvalFail] = eval_ident[NoCapabilityContext](?c, nil, no_capabilities(nil), source, id.EXPR_NIL, s_false, ?itn);
     if (R.is_err[CTValue, EvalFail](false_r)) { dnit(?c); ret 1; }
     val false_v: CTValue = R.unwrap_ok[CTValue, EvalFail](false_r);
     if (!is_u8(false_v) || false_v.data.i != 0) { dnit(?c); ret 1; }
@@ -4293,7 +4342,7 @@ test "mach.lang.fe.comptime.gate_depends_on:unlisted_expression_kind_fails_close
     val nest_r: R.Result[id.ExprId, str] = ast.add_expr(?a, nested);
     if (R.is_err[id.ExprId, str](nest_r)) { ast.dnit(?a); ret 1; }
 
-    val probes: GateProbes[NoCapabilityContext] = gate_probes[NoCapabilityContext](nil, nil, nil, nil);
+    val probes: GateProbes[NoCapabilityContext] = gate_probes[NoCapabilityContext](nil, nil, nil, nil, parsed_expression[NoCapabilityContext]);
     var bad: i32 = 0;
 
     val listed: R.Result[bool, str] = gate_depends_on[NoCapabilityContext](?a, "", nil, probes,
@@ -4332,7 +4381,7 @@ test "mach.lang.fe.comptime.capabilities:callback_allocation_failure_preserves_i
     var t: T.Testing;
     if (O.is_some[str](T.make(?t))) { ret 1; }
     fin { T.dnit(?t); }
-    val cr: R.Result[PhaseCapabilities[A.Allocator], str] = loading_capabilities[A.Allocator](t_capability_refusing);
+    val cr: R.Result[PhaseCapabilities[A.Allocator], str] = loading_capabilities[A.Allocator](t_capability_refusing, nil);
     if (R.is_err[PhaseCapabilities[A.Allocator], str](cr)) { ret 2; }
     val caps: PhaseCapabilities[A.Allocator] = R.unwrap_ok[PhaseCapabilities[A.Allocator], str](cr);
     T.fail_at_ordinal(?t, 1);
@@ -4341,4 +4390,103 @@ test "mach.lang.fe.comptime.capabilities:callback_allocation_failure_preserves_i
     if (R.unwrap_err[CTValue, EvalFail](r).kind != EVAL_FAIL_INTERNAL) { ret 4; }
     if (T.attempt_count(?t) != 1 || T.leaked(?t) || T.double_free_count(?t) != 0) { ret 5; }
     ret 0;
+}
+
+
+rec GateChoiceFixture {
+    choices: *interpretation.Choice;
+    count: usize;
+}
+
+fun t_gate_choice_expression(f: *GateChoiceFixture, a: *ast.Ast, eid: id.ExprId) R.Result[expr.Expr, EvalFail] {
+    val read: R.Result[expr.Expr, str] = interpretation.get(a, f.choices, f.count, eid);
+    if (R.is_err[expr.Expr, str](read)) {
+        ret R.err[expr.Expr, EvalFail](eval_error(EVAL_FAIL_INTERNAL, R.unwrap_err[expr.Expr, str](read)));
+    }
+    ret R.ok[expr.Expr, EvalFail](R.unwrap_ok[expr.Expr, str](read));
+}
+
+fun t_gate_choice_action(f: *GateChoiceFixture, eid: id.ExprId, e: *expr.Expr) GateNodeVerdict {
+    if (eid == 1) { ret GATE_NODE_YES; }
+    ret GATE_NODE_NO;
+}
+
+test "mach.lang.fe.comptime.gate_depends_on:resolved_brackets_visit_only_the_selected_expression" {
+    var nodes: [4]expr.Expr;
+    nodes[0].kind = expr.EXPR_KIND_IDENT;
+    nodes[1].kind = expr.EXPR_KIND_IDENT;
+    nodes[2].kind = expr.EXPR_KIND_INDEX;
+    nodes[2].data.index.object = 0;
+    nodes[2].data.index.index = 1;
+    nodes[3].kind = expr.EXPR_KIND_CALL;
+    nodes[3].data.call.callee = 0;
+    nodes[3].data.call.index_callee = 2;
+    nodes[3].data.call.args_start = 0;
+    nodes[3].data.call.args_len = 0;
+    nodes[3].data.call.type_args_start = 0;
+    nodes[3].data.call.type_args_len = 1;
+    var a: ast.Ast;
+    a.exprs = ?nodes[0];
+    a.expr_len = 4;
+    var choices: [4]interpretation.Choice;
+    choices[0] = interpretation.PARSED;
+    choices[1] = interpretation.PARSED;
+    choices[2] = interpretation.PARSED;
+    choices[3] = interpretation.GENERIC;
+    var f: GateChoiceFixture;
+    f.choices = ?choices[0];
+    f.count = 4;
+    val generic: R.Result[bool, str] = gate_walk[GateChoiceFixture](?a, "", ?f,
+        t_gate_choice_action, t_gate_choice_expression, 3);
+    if (R.is_err[bool, str](generic) || R.unwrap_ok[bool, str](generic)) { ret 1; }
+    choices[3] = interpretation.INDEX_CALL;
+    val indexed: R.Result[bool, str] = gate_walk[GateChoiceFixture](?a, "", ?f,
+        t_gate_choice_action, t_gate_choice_expression, 3);
+    if (R.is_err[bool, str](indexed) || !R.unwrap_ok[bool, str](indexed)) { ret 2; }
+    if (nodes[3].data.call.callee != 0 || nodes[3].data.call.index_callee != 2 || nodes[3].data.call.type_args_len != 1) { ret 3; }
+    val missing: R.Result[bool, str] = gate_walk[GateChoiceFixture](?a, "", ?f,
+        t_gate_choice_action, nil, 3);
+    if (!R.is_err[bool, str](missing)) { ret 4; }
+    f.count = 3;
+    val wrong_owner: R.Result[bool, str] = gate_walk[GateChoiceFixture](?a, "", ?f,
+        t_gate_choice_action, t_gate_choice_expression, 3);
+    if (!R.is_err[bool, str](wrong_owner)) { ret 5; }
+    ret 0;
+}
+
+
+test "mach.lang.fe.comptime.gate_unresolved_dependency:allocation_refusal_is_not_an_absent_name" {
+    var tracked: T.Testing;
+    if (O.is_some[str](T.make(?tracked))) { ret 1; }
+    fin { T.dnit(?tracked); }
+    val alloc: *A.Allocator = T.allocator_of(?tracked);
+    var itn: intern.Interner = intern.init(alloc);
+    var c: ComptimeCtx = init(alloc, 0, 0, 0, 0, 0, 8, 128, true, intern.STR_NIL, intern.STR_NIL);
+    var node: expr.Expr;
+    node.kind = expr.EXPR_KIND_IDENT;
+    node.span.offset = 0;
+    node.span.len = 7;
+    var a: ast.Ast;
+    a.exprs = ?node;
+    a.expr_len = 1;
+    val caps: PhaseCapabilities[NoCapabilityContext] = no_capabilities(nil);
+    T.fail_at_ordinal(?tracked, 1);
+    val refused: R.Result[intern.StrId, str] = gate_unresolved_dependency[NoCapabilityContext](
+        ?c, nil, caps, ?a, "missing", ?itn, 0);
+    var bad: i32 = 0;
+    if (!R.is_err[intern.StrId, str](refused)) { bad = 2; }
+    or (!str_equals(R.unwrap_err[intern.StrId, str](refused), "out of memory")) { bad = 3; }
+    if (T.attempt_count(?tracked) != 1 || itn.len != 0) { bad = 4; }
+    T.fail_at_ordinal(?tracked, 0);
+    val found: R.Result[intern.StrId, str] = gate_unresolved_dependency[NoCapabilityContext](
+        ?c, nil, caps, ?a, "missing", ?itn, 0);
+    if (R.is_err[intern.StrId, str](found)) { bad = 5; }
+    or {
+        val name: O.Option[str] = intern.lookup(?itn, R.unwrap_ok[intern.StrId, str](found));
+        if (O.is_none[str](name) || !str_equals(O.unwrap[str](name), "missing")) { bad = 6; }
+    }
+    dnit(?c);
+    intern.dnit(?itn);
+    if (T.leaked(?tracked) || T.double_free_count(?tracked) != 0) { bad = 7; }
+    ret bad;
 }

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -105,6 +105,7 @@ pub rec ExportConstant {
 
 pub rec ParsedDefinition {
     a: *ast.Ast;
+    status: fail.PhaseStatus;
     owner: type.TypeOwner;
     incarnation: u64;
 }

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -69,6 +69,8 @@ pub rec Symbol {
     definition_kind: SymKind;
     definition_file: src.FileId;
     generic_arity: u32;
+    has_comptime_params: bool;
+    has_pack_param: bool;
     flags:  u8;
     name:   intern.StrId;
     canon:  intern.StrId;
@@ -85,6 +87,8 @@ pub rec PublicSymbol {
     canon:  intern.StrId;
     file: src.FileId;
     generic_arity: u32;
+    has_comptime_params: bool;
+    has_pack_param: bool;
     slot:   u32;
     origin: session.ModuleId;
 }
@@ -558,7 +562,17 @@ fun add_symbol(rc: *ResolveContext, kind: SymKind, flags: u8, name: intern.StrId
         val defining: O.Option[*decl.Decl] = ast.get_decl(rc.a, decl_id);
         if (O.is_some[*decl.Decl](defining)) {
             val d: *decl.Decl = O.unwrap[*decl.Decl](defining);
-            if (d.kind == decl.DECL_KIND_FUN) { sym.generic_arity = d.data.fun_.generics_len; }
+            if (d.kind == decl.DECL_KIND_FUN) {
+                sym.generic_arity = d.data.fun_.generics_len;
+                var pi: u32 = 0;
+                for (pi < d.data.fun_.params_len) {
+                    val parameter: *decl.TypedName = ?rc.a.typed_names[d.data.fun_.params_start + pi];
+                    if (parameter.comptime) { sym.has_comptime_params = true; }
+                    val pt: O.Option[*atype.Type] = ast.get_type(rc.a, parameter.ty);
+                    if (O.is_some[*atype.Type](pt) && O.unwrap[*atype.Type](pt).kind == atype.TYPE_KIND_PACK) { sym.has_pack_param = true; }
+                    pi = pi + 1;
+                }
+            }
             or (d.kind == decl.DECL_KIND_REC) { sym.generic_arity = d.data.rec_.generics_len; }
             or (d.kind == decl.DECL_KIND_UNI) { sym.generic_arity = d.data.uni_.generics_len; }
         }
@@ -1066,6 +1080,8 @@ fun imported_symbol_for(rc: *ResolveContext, ps: *PublicSymbol) R.Result[SymbolI
     rc.symbols[sid].definition_kind = ps.kind;
     rc.symbols[sid].definition_file = ps.file;
     rc.symbols[sid].generic_arity = ps.generic_arity;
+    rc.symbols[sid].has_comptime_params = ps.has_comptime_params;
+    rc.symbols[sid].has_pack_param = ps.has_pack_param;
     val ins: R.Result[bool, str] = map.insert[u64, SymbolId](?rc.imported_cache, key, sid);
     if (R.is_err[bool, str](ins)) { ret R.err[SymbolId, str](R.unwrap_err[bool, str](ins)); }
     ret R.ok[SymbolId, str](sid);
@@ -1311,6 +1327,8 @@ fun collect_fwd(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, flag
     val sid: SymbolId = R.unwrap_ok[SymbolId, str](r_sym);
     rc.symbols[sid].definition_file = ps.file;
     rc.symbols[sid].generic_arity = ps.generic_arity;
+    rc.symbols[sid].has_comptime_params = ps.has_comptime_params;
+    rc.symbols[sid].has_pack_param = ps.has_pack_param;
 
     val r_add: R.Result[R.Void, str] = scope_add(rc, rc.module_scope, name_id, sid);
     if (R.is_err[R.Void, str](r_add)) { ret r_add; }

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -22,6 +22,7 @@ use mach.lang.fail;
 use mach.lang.fe.ast;
 use mach.lang.fe.ast.decl;
 use mach.lang.fe.ast.expr;
+use mach.lang.fe.ast.interpretation;
 use mach.lang.fe.ast.id;
 use mach.lang.fe.ast.module;
 use mach.lang.fe.ast.stmt;
@@ -65,6 +66,9 @@ pub val SYM_FLAG_MODULE: u8 = 4;
 
 pub rec Symbol {
     kind:   SymKind;
+    definition_kind: SymKind;
+    definition_file: src.FileId;
+    generic_arity: u32;
     flags:  u8;
     name:   intern.StrId;
     canon:  intern.StrId;
@@ -79,7 +83,8 @@ pub rec PublicSymbol {
     kind:   SymKind;
     name:   intern.StrId;
     canon:  intern.StrId;
-    decl:   id.DeclId;
+    file: src.FileId;
+    generic_arity: u32;
     slot:   u32;
     origin: session.ModuleId;
 }
@@ -89,6 +94,19 @@ pub rec ModuleExports {
     module:  session.ModuleId;
     symbols: *PublicSymbol;
     count:   u32;
+}
+
+pub rec ExportConstant {
+    name: intern.StrId;
+    present: bool;
+    gated: bool;
+    value: comptime.CTValue;
+}
+
+pub rec ParsedDefinition {
+    a: *ast.Ast;
+    owner: type.TypeOwner;
+    incarnation: u64;
 }
 
 pub rec ResolveDeps {
@@ -114,14 +132,10 @@ rec Scope {
 val INITIAL_SCOPE_ENTRY_CAP: u32 = 8;
 val INITIAL_SCOPES_CAP:      u32 = 8;
 val INITIAL_SYMBOLS_CAP:     u32 = 32;
-val INITIAL_BRACKET_SNAPSHOT_CAP: usize = 4;
 
-pub rec BracketSnapshot {
-    eid:  id.ExprId;
-    node: expr.Expr;
-}
 
 rec ResolveContext {
+    diags: *diagnostic.DiagnosticStore;
     status: fail.PhaseStatus;
     s:          *session.Session;
     a:          *ast.Ast;
@@ -157,9 +171,8 @@ rec ResolveContext {
 
     module_index: map.Map[intern.StrId, SymbolId];
 
-    bracket_before:     *BracketSnapshot;
-    bracket_before_len: usize;
-    bracket_before_cap: usize;
+    expr_choices: *interpretation.Choice;
+    expr_choices_count: usize;
 }
 
 val PRIM_COUNT: u32 = 11;
@@ -179,12 +192,11 @@ pub rec ResolveResult {
 
     param_index:   map.Map[u64, SymbolId];
 
-    pub_const_fp:     *u8;
-    pub_const_fp_len: u32;
+    public_constants: *ExportConstant;
+    public_constant_count: u32;
 
-    bracket_before:     *BracketSnapshot;
-    bracket_before_len: usize;
-    bracket_before_cap: usize;
+    expr_choices: *interpretation.Choice;
+    expr_choices_count: usize;
 }
 
 pub fun param_symbol(r: *ResolveResult, decl: id.DeclId, slot: u32) SymbolId {
@@ -199,6 +211,10 @@ fun stable_of_module(s: *session.Session, mid: session.ModuleId) session.StableM
     val fqn: intern.StrId = session.module_fqn(s, mid);
     if (fqn == intern.STR_NIL) { ret session.STABLE_MODULE_NIL; }
     ret session.stable_module_id_lookup(s, fqn);
+}
+
+pub fun type_owner(s: *session.Session, mid: session.ModuleId, file: src.FileId) type.TypeOwner {
+    ret type.TypeOwner{ module: stable_of_module(s, mid), file: file };
 }
 
 pub fun remap_result(r: *ResolveResult, s: *session.Session) {
@@ -228,11 +244,11 @@ pub fun dnit_result(r: *ResolveResult) {
     if (r.decl_symbol != nil) {
         A.deallocate[SymbolId](r.alloc, r.decl_symbol, r.decl_count::usize);
     }
-    if (r.pub_const_fp != nil && r.pub_const_fp_len > 0) {
-        A.deallocate[u8](r.alloc, r.pub_const_fp, r.pub_const_fp_len::usize);
+    if (r.public_constants != nil && r.public_constant_count > 0) {
+        A.deallocate[ExportConstant](r.alloc, r.public_constants, r.public_constant_count::usize);
     }
-    if (r.bracket_before != nil && r.bracket_before_cap > 0) {
-        A.deallocate[BracketSnapshot](r.alloc, r.bracket_before, r.bracket_before_cap);
+    if (r.expr_choices != nil && r.expr_choices_count != 0) {
+        A.deallocate[interpretation.Choice](r.alloc, r.expr_choices, r.expr_choices_count);
     }
     map.dnit[u64, SymbolId](?r.param_index);
     r.symbols       = nil;
@@ -244,11 +260,10 @@ pub fun dnit_result(r: *ResolveResult) {
     r.expr_count    = 0;
     r.type_count    = 0;
     r.decl_count    = 0;
-    r.pub_const_fp     = nil;
-    r.pub_const_fp_len = 0;
-    r.bracket_before     = nil;
-    r.bracket_before_len = 0;
-    r.bracket_before_cap = 0;
+    r.public_constants = nil;
+    r.public_constant_count = 0;
+    r.expr_choices = nil;
+    r.expr_choices_count = 0;
 }
 
 pub fun resolve(
@@ -257,10 +272,11 @@ pub fun resolve(
     deps:       *ResolveDeps,
     ctx:        *comptime.ComptimeCtx,
     own_module: session.ModuleId,
-    terminal:   bool
+    terminal:   bool,
+    diags:      *diagnostic.DiagnosticStore
 ) R.Result[ResolveResult, fail.Fail] {
     var rc: ResolveContext;
-    val init_r: R.Result[R.Void, str] = init_context(?rc, s, a, deps, ctx, own_module, terminal);
+    val init_r: R.Result[R.Void, str] = init_context(?rc, s, a, deps, ctx, own_module, terminal, diags);
     if (R.is_err[R.Void, str](init_r)) {
         ret R.err[ResolveResult, fail.Fail](fail.message(R.unwrap_err[R.Void, str](init_r)));
     }
@@ -308,15 +324,17 @@ fun init_context(
     deps:       *ResolveDeps,
     ctx:        *comptime.ComptimeCtx,
     own_module: session.ModuleId,
-    terminal:   bool
+    terminal:   bool,
+    diags:      *diagnostic.DiagnosticStore
 ) R.Result[R.Void, str] {
     rc.status     = fail.accepted();
     rc.s          = s;
+    rc.diags      = diags;
     rc.a          = a;
     rc.deps       = deps;
     rc.ctx        = ctx;
     val caps_r: R.Result[comptime.PhaseCapabilities[ResolveContext], str] =
-        comptime.resolution_capabilities[ResolveContext](comptime_ident_is_runtime);
+        comptime.resolution_capabilities[ResolveContext](comptime_ident_is_runtime, comptime_expression, diags);
     if (R.is_err[comptime.PhaseCapabilities[ResolveContext], str](caps_r)) {
         ret R.err[R.Void, str](R.unwrap_err[comptime.PhaseCapabilities[ResolveContext], str](caps_r));
     }
@@ -356,9 +374,8 @@ fun init_context(
     rc.vec_cache      = map.init[intern.StrId, SymbolId](s.alloc, map.hash_u32, map.eq_u32);
     rc.module_index   = map.init[intern.StrId, SymbolId](s.alloc, map.hash_u32, map.eq_u32);
 
-    rc.bracket_before     = nil;
-    rc.bracket_before_len = 0;
-    rc.bracket_before_cap = 0;
+    rc.expr_choices = nil;
+    rc.expr_choices_count = 0;
 
     val sa: R.Result[*Symbol, str] = A.allocate[Symbol](s.alloc, INITIAL_SYMBOLS_CAP::usize);
     if (R.is_err[*Symbol, str](sa)) { fail.internal(?rc.status, R.unwrap_err[*Symbol, str](sa));
@@ -381,6 +398,15 @@ fun init_context(
         if (R.is_err[*SymbolId, str](r)) { fail.internal(?rc.status, R.unwrap_err[*SymbolId, str](r)); dnit_context(rc); ret R.err[R.Void, str](R.unwrap_err[*SymbolId, str](r)); }
         rc.expr_resolved = R.unwrap_ok[*SymbolId, str](r);
         memory.fill[SymbolId](rc.expr_resolved, SYMBOL_NIL, a.expr_len);
+        val choices: R.Result[*interpretation.Choice, str] = A.allocate[interpretation.Choice](s.alloc, a.expr_len);
+        if (R.is_err[*interpretation.Choice, str](choices)) {
+            fail.internal(?rc.status, R.unwrap_err[*interpretation.Choice, str](choices));
+            dnit_context(rc);
+            ret R.err[R.Void, str](R.unwrap_err[*interpretation.Choice, str](choices));
+        }
+        rc.expr_choices = R.unwrap_ok[*interpretation.Choice, str](choices);
+        rc.expr_choices_count = a.expr_len;
+        memory.fill[interpretation.Choice](rc.expr_choices, interpretation.PARSED, a.expr_len);
     }
     if (a.type_len > 0) {
         val r: R.Result[*SymbolId, str] = A.allocate[SymbolId](s.alloc, a.type_len);
@@ -422,8 +448,8 @@ fun dnit_context(rc: *ResolveContext) {
     if (rc.decl_symbol != nil) {
         A.deallocate[SymbolId](rc.s.alloc, rc.decl_symbol, rc.a.decl_len);
     }
-    if (rc.bracket_before != nil && rc.bracket_before_cap > 0) {
-        A.deallocate[BracketSnapshot](rc.s.alloc, rc.bracket_before, rc.bracket_before_cap);
+    if (rc.expr_choices != nil && rc.expr_choices_count != 0) {
+        A.deallocate[interpretation.Choice](rc.s.alloc, rc.expr_choices, rc.expr_choices_count);
     }
     map.dnit[u64, SymbolId](?rc.imported_cache);
     map.dnit[intern.StrId, SymbolId](?rc.vec_cache);
@@ -523,6 +549,19 @@ fun add_symbol(rc: *ResolveContext, kind: SymKind, flags: u8, name: intern.StrId
     }
     var sym: Symbol;
     sym.kind   = kind;
+    sym.definition_kind = kind;
+    sym.definition_file = src.FILE_NIL;
+    sym.generic_arity = 0;
+    if (rc.a != nil && origin == rc.own_module) {
+        sym.definition_file = rc.a.file_id;
+        val defining: O.Option[*decl.Decl] = ast.get_decl(rc.a, decl_id);
+        if (O.is_some[*decl.Decl](defining)) {
+            val d: *decl.Decl = O.unwrap[*decl.Decl](defining);
+            if (d.kind == decl.DECL_KIND_FUN) { sym.generic_arity = d.data.fun_.generics_len; }
+            or (d.kind == decl.DECL_KIND_REC) { sym.generic_arity = d.data.rec_.generics_len; }
+            or (d.kind == decl.DECL_KIND_UNI) { sym.generic_arity = d.data.uni_.generics_len; }
+        }
+    }
     sym.flags  = flags;
     sym.name   = name;
     sym.canon  = canon;
@@ -578,18 +617,18 @@ fun declare(
 }
 
 fun report_prior_binding(rc: *ResolveContext, prior: SymbolId) {
-    val id_r: R.Result[diagnostic.DiagnosticId, str] = diagnostic.last_id(?rc.s.diags);
+    val id_r: R.Result[diagnostic.DiagnosticId, str] = diagnostic.last_id(rc.diags);
     if (R.is_err[diagnostic.DiagnosticId, str](id_r)) { ret; }
     val did: diagnostic.DiagnosticId = R.unwrap_ok[diagnostic.DiagnosticId, str](id_r);
 
     if (rc.symbols[prior].origin == rc.own_module && rc.symbols[prior].decl != id.DECL_NIL) {
         val prev: token.Span = prior_name_span(rc, rc.symbols[prior].decl);
         if (prev.len != 0) {
-            diagnostic.record_related_committed(?rc.s.diags, did, rc.a.file_id, prev, "previous definition here");
+            diagnostic.record_related_committed(rc.diags, did, rc.a.file_id, prev, "previous definition here");
             ret;
         }
     }
-    diagnostic.record_note_committed(?rc.s.diags, did, "a name with this spelling is already bound here");
+    diagnostic.record_note_committed(rc.diags, did, "a name with this spelling is already bound here");
 }
 
 fun prior_name_span(rc: *ResolveContext, decl_id: id.DeclId) token.Span {
@@ -903,7 +942,7 @@ fun render_gate_verdict(rc: *ResolveContext, v: comptime.GateVerdict) R.Result[c
     if (v.outcome == comptime.GATE_FAILED) {
         if (v.depends != intern.STR_NIL) {
             fail.reject(?rc.status);
-            val committed_r: R.Result[bool, str] = diagnostic.gate_error_named(?rc.s.gate_diags, ?rc.s.diags,
+            val committed_r: R.Result[bool, str] = diagnostic.gate_error_named(rc.diags,
                 ?rc.s.interner, rc.a.file_id, v.span, v.depends, v.message);
             if (R.is_err[bool, str](committed_r)) { ret R.err[comptime.GateOutcome, str](R.unwrap_err[bool, str](committed_r)); }
             ret R.ok[comptime.GateOutcome, str](comptime.GATE_FAILED);
@@ -918,7 +957,7 @@ fun render_gate_verdict(rc: *ResolveContext, v: comptime.GateVerdict) R.Result[c
 fun emit_gate_message(rc: *ResolveContext, v: comptime.GateVerdict) R.Result[R.Void, str] {
     fail.reject(?rc.status);
     if (str_len(v.message) == 0) { ret R.ok_void[str](); }
-    ret R.void_of[bool, str](diagnostic.gate_error(?rc.s.gate_diags, ?rc.s.diags, ?rc.s.interner, rc.a.file_id, v.span, v.message));
+    ret R.void_of[bool, str](diagnostic.gate_error(rc.diags, ?rc.s.interner, rc.a.file_id, v.span, v.message));
 }
 
 
@@ -1009,7 +1048,7 @@ fun bind_imported_symbol(rc: *ResolveContext, decl_id: id.DeclId, bind_span: tok
 }
 
 fun imported_symbol_for(rc: *ResolveContext, ps: *PublicSymbol) R.Result[SymbolId, str] {
-    val key: u64 = (ps.origin::u64 << 32) | ps.decl::u64;
+    val key: u64 = (ps.origin::u64 << 32) | ps.canon::u64;
     val cached: R.Result[*SymbolId, str] = map.get[u64, SymbolId](?rc.imported_cache, ?key);
     if (R.is_ok[*SymbolId, str](cached)) {
         ret R.ok[SymbolId, str](@R.unwrap_ok[*SymbolId, str](cached));
@@ -1020,9 +1059,12 @@ fun imported_symbol_for(rc: *ResolveContext, ps: *PublicSymbol) R.Result[SymbolI
         kind = SYM_USE;
         slot = ps.slot;
     }
-    val r: R.Result[SymbolId, str] = add_symbol(rc, kind, 0, ps.name, ps.canon, ps.decl, slot, ps.origin);
+    val r: R.Result[SymbolId, str] = add_symbol(rc, kind, 0, ps.name, ps.canon, id.DECL_NIL, slot, ps.origin);
     if (R.is_err[SymbolId, str](r)) { fail.internal(?rc.status, R.unwrap_err[SymbolId, str](r)); ret r; }
     val sid: SymbolId = R.unwrap_ok[SymbolId, str](r);
+    rc.symbols[sid].definition_kind = ps.kind;
+    rc.symbols[sid].definition_file = ps.file;
+    rc.symbols[sid].generic_arity = ps.generic_arity;
     val ins: R.Result[bool, str] = map.insert[u64, SymbolId](?rc.imported_cache, key, sid);
     if (R.is_err[bool, str](ins)) { ret R.err[SymbolId, str](R.unwrap_err[bool, str](ins)); }
     ret R.ok[SymbolId, str](sid);
@@ -1263,9 +1305,11 @@ fun collect_fwd(rc: *ResolveContext, decl_id: id.DeclId, df: *decl.DeclFwd, flag
     var slot: u32 = 0;
     if (ps.kind == SYM_USE) { slot = ps.slot; }
 
-    val r_sym: R.Result[SymbolId, str] = add_symbol(rc, ps.kind, SYM_FLAG_PUB, name_id, ps.canon, ps.decl, slot, ps.origin);
+    val r_sym: R.Result[SymbolId, str] = add_symbol(rc, ps.kind, SYM_FLAG_PUB, name_id, ps.canon, id.DECL_NIL, slot, ps.origin);
     if (R.is_err[SymbolId, str](r_sym)) { fail.internal(?rc.status, R.unwrap_err[SymbolId, str](r_sym)); ret R.err[R.Void, str](R.unwrap_err[SymbolId, str](r_sym)); }
     val sid: SymbolId = R.unwrap_ok[SymbolId, str](r_sym);
+    rc.symbols[sid].definition_file = ps.file;
+    rc.symbols[sid].generic_arity = ps.generic_arity;
 
     val r_add: R.Result[R.Void, str] = scope_add(rc, rc.module_scope, name_id, sid);
     if (R.is_err[R.Void, str](r_add)) { ret r_add; }
@@ -1334,7 +1378,7 @@ fun resolve_gate_probes() comptime.GateProbes[ResolveContext] {
         gate_probe_ident_is_comptime_param,
         gate_probe_ident_is_each_loopvar,
         gate_probe_member_is_field_loopvar,
-        gate_probe_is_field_type_operand);
+        gate_probe_is_field_type_operand, comptime_expression);
 }
 
 fun gate_chain_defers_to_instantiation(rc: *ResolveContext, branches_start: u32, branches_len: u32) R.Result[bool, str] {
@@ -1766,31 +1810,19 @@ fun bind_expr_list(rc: *ResolveContext, start: u32, len: u32) R.Result[R.Void, s
     ret R.ok_void[str]();
 }
 
-fun snapshot_bracket(rc: *ResolveContext, eid: id.ExprId, node: *expr.Expr) R.Result[R.Void, str] {
-    if (rc.bracket_before_len == rc.bracket_before_cap) {
-        val g: R.Result[*BracketSnapshot, str] = pool.grow[BracketSnapshot](
-            rc.s.alloc, rc.bracket_before, rc.bracket_before_cap,
-            INITIAL_BRACKET_SNAPSHOT_CAP, ?rc.bracket_before_cap);
-        if (R.is_err[*BracketSnapshot, str](g)) { fail.internal(?rc.status, R.unwrap_err[*BracketSnapshot, str](g)); ret R.err[R.Void, str](R.unwrap_err[*BracketSnapshot, str](g)); }
-        rc.bracket_before = R.unwrap_ok[*BracketSnapshot, str](g);
+fun comptime_expression(rc: *ResolveContext, a: *ast.Ast, eid: id.ExprId) R.Result[expr.Expr, comptime.EvalFail] {
+    if (rc == nil || rc.a != a) { ret R.err[expr.Expr, comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_INTERNAL, "resolution expression belongs to a different parsed owner")); }
+    val result: R.Result[expr.Expr, str] = interpretation.get(a, rc.expr_choices, rc.expr_choices_count, eid);
+    if (R.is_err[expr.Expr, str](result)) {
+        fail.internal(?rc.status, R.unwrap_err[expr.Expr, str](result));
+        ret R.err[expr.Expr, comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_INTERNAL, R.unwrap_err[expr.Expr, str](result)));
     }
-    var snap: BracketSnapshot;
-    snap.eid  = eid;
-    snap.node = @node;
-    rc.bracket_before[rc.bracket_before_len] = snap;
-    rc.bracket_before_len = rc.bracket_before_len + 1;
-    ret R.ok_void[str]();
+    ret R.ok[expr.Expr, comptime.EvalFail](R.unwrap_ok[expr.Expr, str](result));
 }
 
-pub fun as_parsed(rr: *ResolveResult, a: *ast.Ast, eid: id.ExprId) O.Option[expr.Expr] {
-    var i: usize = 0;
-    for (i < rr.bracket_before_len) {
-        if (rr.bracket_before[i].eid == eid) { ret O.some[expr.Expr](rr.bracket_before[i].node); }
-        i = i + 1;
-    }
-    val opt_e: O.Option[*expr.Expr] = ast.get_expr(a, eid);
-    if (O.is_none[*expr.Expr](opt_e)) { ret O.none[expr.Expr](); }
-    ret O.some[expr.Expr](@O.unwrap[*expr.Expr](opt_e));
+pub fun expression(rr: *ResolveResult, a: *ast.Ast, eid: id.ExprId) R.Result[expr.Expr, str] {
+    if (rr == nil) { ret R.err[expr.Expr, str]("resolved expression requires a resolver result"); }
+    ret interpretation.get(a, rr.expr_choices, rr.expr_choices_count, eid);
 }
 
 fun resolve_bracket_call(rc: *ResolveContext, eid: id.ExprId) R.Result[R.Void, str] {
@@ -1809,9 +1841,7 @@ fun resolve_bracket_call(rc: *ResolveContext, eid: id.ExprId) R.Result[R.Void, s
     if (R.is_err[R.Void, str](rc_e)) { ret rc_e; }
 
     if (callee_accepts_type_args(rc, callee)) {
-        val sn0: R.Result[R.Void, str] = snapshot_bracket(rc, eid, e);
-        if (R.is_err[R.Void, str](sn0)) { ret sn0; }
-        e.data.call.index_callee = id.EXPR_NIL;
+        rc.expr_choices[eid] = interpretation.GENERIC;
         ret bind_generic_call(rc, type_args_start, type_args_len, args_start, args_len);
     }
 
@@ -1821,12 +1851,7 @@ fun resolve_bracket_call(rc: *ResolveContext, eid: id.ExprId) R.Result[R.Void, s
     val rs: R.Result[R.Void, str] = bind_expr(rc, idxn.data.index.index);
     if (R.is_err[R.Void, str](rs)) { ret rs; }
 
-    val sn1: R.Result[R.Void, str] = snapshot_bracket(rc, eid, e);
-    if (R.is_err[R.Void, str](sn1)) { ret sn1; }
-    e.data.call.callee          = index_callee;
-    e.data.call.index_callee    = id.EXPR_NIL;
-    e.data.call.type_args_start = 0;
-    e.data.call.type_args_len   = 0;
+    rc.expr_choices[eid] = interpretation.INDEX_CALL;
     ret bind_expr_list(rc, args_start, args_len);
 }
 
@@ -1845,7 +1870,7 @@ fun resolve_bracket_value(rc: *ResolveContext, eid: id.ExprId) R.Result[R.Void, 
     if (R.is_err[R.Void, str](ro)) { ret ro; }
 
     if (object_names_function(rc, object)) {
-        e.data.call.index_callee = id.EXPR_NIL;
+        rc.expr_choices[eid] = interpretation.GENERIC;
         ret bind_generic_call(rc, type_args_start, type_args_len, 0, 0);
     }
 
@@ -1853,9 +1878,7 @@ fun resolve_bracket_value(rc: *ResolveContext, eid: id.ExprId) R.Result[R.Void, 
         val re: R.Result[R.Void, str] = report(rc, span,
             "type arguments in value position name a generic instance, but this does not name a generic function");
         if (R.is_err[R.Void, str](re)) { ret re; }
-        val sn: R.Result[R.Void, str] = snapshot_bracket(rc, eid, e);
-        if (R.is_err[R.Void, str](sn)) { ret sn; }
-        e.kind = expr.EXPR_KIND_ERROR;
+        rc.expr_choices[eid] = interpretation.REJECTED;
         ret R.ok_void[str]();
     }
 
@@ -1865,11 +1888,7 @@ fun resolve_bracket_value(rc: *ResolveContext, eid: id.ExprId) R.Result[R.Void, 
     val rs: R.Result[R.Void, str] = bind_expr(rc, idxn.data.index.index);
     if (R.is_err[R.Void, str](rs)) { ret rs; }
 
-    val idx_payload: expr.ExprIndex = idxn.data.index;
-    val sn2: R.Result[R.Void, str] = snapshot_bracket(rc, eid, e);
-    if (R.is_err[R.Void, str](sn2)) { ret sn2; }
-    e.kind       = expr.EXPR_KIND_INDEX;
-    e.data.index = idx_payload;
+    rc.expr_choices[eid] = interpretation.INDEX_VALUE;
     ret R.ok_void[str]();
 }
 
@@ -1882,13 +1901,7 @@ fun object_names_function(rc: *ResolveContext, object: id.ExprId) bool {
     val sid: SymbolId = rc.expr_resolved[object];
     if (sid == SYMBOL_NIL || sid >= rc.sym_len) { ret false; }
     val sym: *Symbol = ?rc.symbols[sid];
-    if (sym.kind == SYM_FUN)      { ret true; }
-    if (sym.kind != SYM_IMPORTED) { ret false; }
-    val origin_ast: *ast.Ast = session.module_ast(rc.s, sym.origin);
-    if (origin_ast == nil) { ret false; }
-    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, sym.decl);
-    if (O.is_none[*decl.Decl](opt_d)) { ret false; }
-    ret O.unwrap[*decl.Decl](opt_d).kind == decl.DECL_KIND_FUN;
+    ret sym.definition_kind == SYM_FUN;
 }
 
 fun bind_generic_call(rc: *ResolveContext, type_args_start: u32, type_args_len: u32, args_start: u32, args_len: u32) R.Result[R.Void, str] {
@@ -1973,19 +1986,19 @@ fun attach_suggestion(rc: *ResolveContext, span: token.Span, target: intern.StrI
     if (O.is_none[str](bo)) { ret; }
     val bname: str = O.unwrap[str](bo);
 
-    val id_r: R.Result[diagnostic.DiagnosticId, str] = diagnostic.last_id(?rc.s.diags);
+    val id_r: R.Result[diagnostic.DiagnosticId, str] = diagnostic.last_id(rc.diags);
     if (R.is_err[diagnostic.DiagnosticId, str](id_r)) { ret; }
     val did: diagnostic.DiagnosticId = R.unwrap_ok[diagnostic.DiagnosticId, str](id_r);
 
     val note_r: R.Result[str, str] = diagnostic.suggestion_build(rc.s.alloc, bname);
     if (R.is_err[str, str](note_r)) { fail.internal(?rc.status, R.unwrap_err[str, str](note_r)); ret; }
     val note: str = R.unwrap_ok[str, str](note_r);
-    diagnostic.record_help_committed(?rc.s.diags, did, note);
+    diagnostic.record_help_committed(rc.diags, did, note);
 
     val flabel_r: R.Result[str, str] = diagnostic.fix_label_replace(rc.s.alloc, bname);
     if (R.is_ok[str, str](flabel_r)) {
         val flabel: str = R.unwrap_ok[str, str](flabel_r);
-        diagnostic.record_fix_committed(?rc.s.diags, did, flabel, rc.a.file_id, span, bname);
+        diagnostic.record_fix_committed(rc.diags, did, flabel, rc.a.file_id, span, bname);
         str_free(rc.s.alloc, flabel);
     }
     str_free(rc.s.alloc, note);
@@ -2471,13 +2484,13 @@ fun build_result(rc: *ResolveContext) R.Result[ResolveResult, fail.Fail] {
         pk = pk + 1;
     }
 
-    var fp_len: u32 = 0;
-    val fp_r: R.Result[*u8, str] = pub_const_fp_build(rc, out_syms, pub_count, ?fp_len);
-    if (R.is_err[*u8, str](fp_r)) { fail.internal(?rc.status, R.unwrap_err[*u8, str](fp_r));
+    var constant_count: u32 = 0;
+    val constants: R.Result[*ExportConstant, str] = public_constants_copy(rc, out_syms, pub_count, ?constant_count);
+    if (R.is_err[*ExportConstant, str](constants)) { fail.internal(?rc.status, R.unwrap_err[*ExportConstant, str](constants));
         map.dnit[u64, SymbolId](?param_index);
         A.deallocate[Symbol](rc.s.alloc, out_syms, rc.sym_len::usize);
         dnit_context(rc);
-        ret R.err[ResolveResult, fail.Fail](fail.message(R.unwrap_err[*u8, str](fp_r)));
+        ret R.err[ResolveResult, fail.Fail](fail.message(R.unwrap_err[*ExportConstant, str](constants)));
     }
 
     var out: ResolveResult;
@@ -2493,101 +2506,61 @@ fun build_result(rc: *ResolveContext) R.Result[ResolveResult, fail.Fail] {
     out.type_count    = rc.a.type_len::u32;
     out.decl_count    = rc.a.decl_len::u32;
     out.param_index   = param_index;
-    out.pub_const_fp     = R.unwrap_ok[*u8, str](fp_r);
-    out.pub_const_fp_len = fp_len;
+    out.public_constants = R.unwrap_ok[*ExportConstant, str](constants);
+    out.public_constant_count = constant_count;
 
-    out.bracket_before     = rc.bracket_before;
-    out.bracket_before_len = rc.bracket_before_len;
-    out.bracket_before_cap = rc.bracket_before_cap;
+    out.expr_choices = rc.expr_choices;
+    out.expr_choices_count = rc.expr_choices_count;
 
     rc.expr_resolved = nil;
     rc.type_resolved = nil;
     rc.decl_symbol   = nil;
-    rc.bracket_before     = nil;
-    rc.bracket_before_len = 0;
-    rc.bracket_before_cap = 0;
+    rc.expr_choices = nil;
+    rc.expr_choices_count = 0;
 
     dnit_context(rc);
     ret R.ok[ResolveResult, fail.Fail](out);
 }
 
-val PUB_CONST_FP_ENTRY: u32 = 15;
-
-fun ct_value_bits(v: *comptime.CTValue) u64 {
-    if (v.kind == comptime.CT_KIND_STR)  { ret v.data.s::u64; }
-    if (v.kind == comptime.CT_KIND_TYPE) { ret v.data.t::u64; }
-    ret v.data.i::u64;
-}
-
-fun pub_const_fp_build(rc: *ResolveContext, syms: *Symbol, pub_count: u32, out_len: *u32) R.Result[*u8, str] {
-    @out_len = 0;
+fun public_constants_copy(rc: *ResolveContext, symbols: *Symbol, count: u32,
+                          copied_count: *u32) R.Result[*ExportConstant, str] {
+    @copied_count = 0;
     var n: u32 = 0;
     var i: u32 = 0;
-    for (i < pub_count) {
-        if (syms[i].kind == SYM_VAL && (syms[i].flags & SYM_FLAG_MODULE) != 0) { n = n + 1; }
+    for (i < count) {
+        if (symbols[i].kind == SYM_VAL && (symbols[i].flags & SYM_FLAG_MODULE) != 0) { n = n + 1; }
         i = i + 1;
     }
-    if (n == 0) { ret R.ok[*u8, str](nil); }
-
-    val total: u32 = n * PUB_CONST_FP_ENTRY;
-    val r: R.Result[*u8, str] = A.allocate[u8](rc.s.alloc, total::usize);
-    if (R.is_err[*u8, str](r)) { fail.internal(?rc.status, R.unwrap_err[*u8, str](r)); ret r; }
-    val buf: *u8 = R.unwrap_ok[*u8, str](r);
-
-    var off: u32 = 0;
+    if (n == 0) { ret R.ok[*ExportConstant, str](nil); }
+    val allocated: R.Result[*ExportConstant, str] = A.allocate[ExportConstant](rc.s.alloc, n::usize);
+    if (R.is_err[*ExportConstant, str](allocated)) { ret allocated; }
+    val constants: *ExportConstant = R.unwrap_ok[*ExportConstant, str](allocated);
+    var written: u32 = 0;
     i = 0;
-    for (i < pub_count) {
-        val sym: *Symbol = ?syms[i];
-        if (sym.kind == SYM_VAL && (sym.flags & SYM_FLAG_MODULE) != 0) {
-            fp_put_u32(buf, off, sym.name::u32); off = off + 4;
-            val nc: O.Option[comptime.NamedConst] = comptime.lookup(rc.ctx, sym.name);
-            if (O.is_some[comptime.NamedConst](nc)) {
-                var named: comptime.NamedConst = O.unwrap[comptime.NamedConst](nc);
-                val v: *comptime.CTValue = ?named.value;
-                buf[off] = v.kind::u8; off = off + 1;
-                if (v.kind == comptime.CT_KIND_INT) {
-                    if (v.int_unsigned) { buf[off] = 1; } or { buf[off] = 0; }
-                    off = off + 1;
-                    buf[off] = v.int_width; off = off + 1;
-                }
-                or {
-                    buf[off] = 0; off = off + 1;
-                    buf[off] = 0; off = off + 1;
-                }
-                fp_put_u64(buf, off, ct_value_bits(v)); off = off + 8;
+    for (i < count) {
+        val symbol: *Symbol = ?symbols[i];
+        if (symbol.kind == SYM_VAL && (symbol.flags & SYM_FLAG_MODULE) != 0) {
+            var item: ExportConstant = ExportConstant{};
+            item.name = symbol.name;
+            val named: O.Option[comptime.NamedConst] = comptime.lookup(rc.ctx, symbol.name);
+            if (O.is_some[comptime.NamedConst](named)) {
+                val constant: comptime.NamedConst = O.unwrap[comptime.NamedConst](named);
+                item.present = true;
+                item.gated = constant.gated;
+                item.value = constant.value;
             }
-            or {
-                buf[off] = 0xFF; off = off + 1;
-                buf[off] = 0;    off = off + 1;
-                buf[off] = 0;    off = off + 1;
-                fp_put_u64(buf, off, 0); off = off + 8;
-            }
+            constants[written] = item;
+            written = written + 1;
         }
         i = i + 1;
     }
-
-    @out_len = total;
-    ret R.ok[*u8, str](buf);
-}
-
-fun fp_put_u32(buf: *u8, off: u32, v: u32) {
-    buf[off]     = (v & 0xFF)::u8;
-    buf[off + 1] = ((v >> 8) & 0xFF)::u8;
-    buf[off + 2] = ((v >> 16) & 0xFF)::u8;
-    buf[off + 3] = ((v >> 24) & 0xFF)::u8;
-}
-
-fun fp_put_u64(buf: *u8, off: u32, v: u64) {
-    var j: u32 = 0;
-    for (j < 8) {
-        buf[off + j] = ((v >> (j * 8)) & 0xFF)::u8;
-        j = j + 1;
-    }
+    @copied_count = n;
+    ret allocated;
 }
 
 fun report(rc: *ResolveContext, span: token.Span, message: str) R.Result[R.Void, str] {
     fail.reject(?rc.status);
-    val r: R.Result[R.Void, str] = diagnostic.error(?rc.s.diags, rc.a.file_id, span, message);
+    val r: R.Result[R.Void, str] = diagnostic.error(rc.diags, rc.a.file_id, span, message);
     if (R.is_err[R.Void, str](r)) { fail.internal(?rc.status, R.unwrap_err[R.Void, str](r)); }
     ret r;
 }
@@ -2613,6 +2586,7 @@ fun t_vector_refusal_owner(refuse: bool) i32 {
     fin { ast.dnit(?a); }
     var rc: ResolveContext;
     rc.s = ?s;
+    rc.diags = ?s.diags;
     rc.a = ?a;
     rc.status = fail.accepted();
     var span: token.Span;
@@ -2654,6 +2628,7 @@ test "mach.lang.fe.resolve:diagnostic_refusal_marks_partial_result_internal" {
     fin { ast.dnit(?a); }
     var rc: ResolveContext;
     rc.s = ?s;
+    rc.diags = ?s.diags;
     rc.a = ?a;
     rc.status = fail.accepted();
     var span: token.Span;
@@ -2720,6 +2695,7 @@ fun t_symbol_growth_boundary(exhausted: bool) i32 {
     storage[0].kind = SYM_FUN;
     var rc: ResolveContext;
     rc.s = ?s;
+    rc.diags = ?s.diags;
     rc.status = fail.accepted();
     rc.symbols = ?storage[0];
     rc.sym_cap = 0x80000000;

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -12,6 +12,7 @@ use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.fail;
+use mach.lang.diagnostic;
 use mach.lang.fe.ast;
 use mach.lang.fe.ast.decl;
 use mach.lang.fe.ast.expr;
@@ -29,6 +30,7 @@ use mach.lang.fe.sema.generics;
 use mach.lang.fe.sema.abitype;
 use mach.lang.fe.sema.handle;
 use mach.lang.fe.sema.infer;
+use mach.lang.fe.sema.fields;
 use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.session;
@@ -58,21 +60,21 @@ fwd context.field_table_publish;
 fwd context.field_table_for;
 fwd context.field_lookup;
 
-fun semantic_name_caps() R.Result[comptime.PhaseCapabilities[context.SemaContext], str] {
+fun semantic_name_caps(diags: *diagnostic.DiagnosticStore) R.Result[comptime.PhaseCapabilities[context.SemaContext], str] {
     ret comptime.semantic_name_capabilities[context.SemaContext](
         context.resolve_module_member_const,
-        context.comptime_ident_is_runtime
+        context.comptime_ident_is_runtime, context.comptime_expression, diags
     );
 }
 
-fun semantic_type_caps() R.Result[comptime.PhaseCapabilities[context.SemaContext], str] {
+fun semantic_type_caps(diags: *diagnostic.DiagnosticStore) R.Result[comptime.PhaseCapabilities[context.SemaContext], str] {
     ret comptime.semantic_type_capabilities[context.SemaContext](
         context.resolve_module_member_const,
         context.resolve_type_comparison_operand,
         context.resolve_field_member,
         infer.resolve_type_query,
         infer.resolve_layout_intrinsic,
-        context.comptime_ident_is_runtime
+        context.comptime_ident_is_runtime, context.comptime_expression, diags
     );
 }
 
@@ -82,13 +84,14 @@ pub fun sema(
     rr:         *resolve.ResolveResult,
     deps:       *context.SemaDeps,
     ctx:        *comptime.ComptimeCtx,
-    own_module: session.ModuleId
+    own_module: session.ModuleId,
+    diags:      *diagnostic.DiagnosticStore
 ) R.Result[context.SemaResult, fail.Fail] {
     var sc: context.SemaContext;
     var uni_reports: context.UniReports;
     uni_reports.len = 0;
 
-    val res_init: R.Result[R.Void, str] = init_context(?sc, s, a, rr, deps, ctx, own_module);
+    val res_init: R.Result[R.Void, str] = init_context(?sc, s, a, rr, deps, ctx, own_module, diags);
     if (R.is_err[R.Void, str](res_init)) {
         ret R.err[context.SemaResult, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_init)));
     }
@@ -129,7 +132,7 @@ pub fun sema(
     sc.uni_reports = ?uni_reports;
     check_annotation_uni_secrecy_all(?sc);
 
-    val caps_r: R.Result[comptime.PhaseCapabilities[context.SemaContext], str] = semantic_type_caps();
+    val caps_r: R.Result[comptime.PhaseCapabilities[context.SemaContext], str] = semantic_type_caps(diags);
     if (R.is_err[comptime.PhaseCapabilities[context.SemaContext], str](caps_r)) {
         dnit_context(?sc);
         ret R.err[context.SemaResult, fail.Fail](fail.message(R.unwrap_err[comptime.PhaseCapabilities[context.SemaContext], str](caps_r)));
@@ -157,10 +160,11 @@ pub fun resolve_gates(
     rr:         *resolve.ResolveResult,
     deps:       *context.SemaDeps,
     ctx:        *comptime.ComptimeCtx,
-    own_module: session.ModuleId
+    own_module: session.ModuleId,
+    diags:      *diagnostic.DiagnosticStore
 ) R.Result[context.SemaResult, fail.Fail] {
     var sc: context.SemaContext;
-    val ri: R.Result[R.Void, str] = init_context(?sc, s, a, rr, deps, ctx, own_module);
+    val ri: R.Result[R.Void, str] = init_context(?sc, s, a, rr, deps, ctx, own_module, diags);
     if (R.is_err[R.Void, str](ri)) {
         ret R.err[context.SemaResult, fail.Fail](fail.message(R.unwrap_err[R.Void, str](ri)));
     }
@@ -183,7 +187,7 @@ pub fun resolve_gates(
         dnit_context(?sc);
         ret R.err[context.SemaResult, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rg)));
     }
-    ret build_result(?sc);
+    ret finish_result(?sc, fields.init(s.alloc));
 }
 
 pub fun reinfer_pack_each_body(
@@ -199,18 +203,20 @@ pub fun reinfer_pack_each_body(
     body_len:    u32,
     subst:       *type.TypeId,
     subst_len:   u32,
-    insts:       *context.InstWorklist
+    insts:       *context.InstWorklist,
+    diags:       *diagnostic.DiagnosticStore
 ) R.Result[R.Void, fail.Fail] {
     if (insts == nil) { ret R.err[R.Void, fail.Fail](fail.message("internal: #2177 deferred-body re-inference: no constant-time re-validation worklist supplied (invariant violated)")); }
 
     var sc: context.SemaContext;
     sc.status     = fail.accepted();
     sc.s          = s;
+    sc.diags      = diags;
     sc.a          = a;
     sc.rr         = rr;
     sc.deps       = deps;
     sc.ctx        = ctx;
-    val caps_r: R.Result[comptime.PhaseCapabilities[context.SemaContext], str] = semantic_type_caps();
+    val caps_r: R.Result[comptime.PhaseCapabilities[context.SemaContext], str] = semantic_type_caps(diags);
     if (R.is_err[comptime.PhaseCapabilities[context.SemaContext], str](caps_r)) {
         ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[comptime.PhaseCapabilities[context.SemaContext], str](caps_r)));
     }
@@ -259,16 +265,18 @@ pub fun reinfer_instance_body(
     fn_ret:      type.TypeId,
     body:        id.StmtId,
     subst:       *type.TypeId,
-    subst_len:   u32
+    subst_len:   u32,
+    diags:       *diagnostic.DiagnosticStore
 ) R.Result[R.Void, fail.Fail] {
     var sc: context.SemaContext;
     sc.status = fail.accepted();
     sc.s          = s;
+    sc.diags      = diags;
     sc.a          = a;
     sc.rr         = rr;
     sc.deps       = deps;
     sc.ctx        = ctx;
-    val caps_r: R.Result[comptime.PhaseCapabilities[context.SemaContext], str] = semantic_type_caps();
+    val caps_r: R.Result[comptime.PhaseCapabilities[context.SemaContext], str] = semantic_type_caps(diags);
     if (R.is_err[comptime.PhaseCapabilities[context.SemaContext], str](caps_r)) {
         ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[comptime.PhaseCapabilities[context.SemaContext], str](caps_r)));
     }
@@ -326,13 +334,7 @@ fun drain_revalidations(sc: *context.SemaContext) R.Result[R.Void, str] {
     if (sc.insts == nil)                       { ret R.ok_void[str](); }
     if (sc.insts.drained >= sc.insts.len)      { ret R.ok_void[str](); }
 
-    val dr: R.Result[context.SemaDeps, str] = collect_module_deps(sc.s);
-    if (R.is_err[context.SemaDeps, str](dr)) { ret R.err[R.Void, str](R.unwrap_err[context.SemaDeps, str](dr)); }
-    var full_deps: context.SemaDeps = R.unwrap_ok[context.SemaDeps, str](dr);
-
-    val r: R.Result[R.Void, str] = drain_instances(sc, ?full_deps);
-    free_module_deps(sc.s, ?full_deps);
-    ret r;
+    ret drain_instances(sc, sc.deps);
 }
 
 fun drain_instances(sc: *context.SemaContext, deps: *context.SemaDeps) R.Result[R.Void, str] {
@@ -374,13 +376,19 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
         o_type_resolved = sc.type_resolved_ty;
         o_expr_type     = sc.expr_type;
     } or {
-        oa = session.module_ast(sc.s, origin);
-        if (oa == nil) { ret R.err[R.Void, str]("internal: #2157 CT re-validation: origin module AST unavailable (dependency-ordering invariant violated)"); }
-        orr  = (session.module_resolve_ptr(sc.s, origin))::*resolve.ResolveResult;
-        octx = (session.module_comptime_ptr(sc.s, origin))::*comptime.ComptimeCtx;
-        val osp: ptr = session.module_sema_ptr(sc.s, origin);
-        if (osp == nil || orr == nil || octx == nil) { ret R.err[R.Void, str]("internal: #2157 CT re-validation: origin module sema/resolve/comptime snapshot unavailable (dependency-ordering invariant violated)"); }
-        val osr: *context.SemaResult = osp::*context.SemaResult;
+        if (deps == nil) { ret R.err[R.Void, str]("generic revalidation has no definition acquisition capability"); }
+        val acquired: R.Result[context.Definition, fail.Fail] = context.acquire_definition(?deps.definitions, origin, context.DEFINITION_TYPED);
+        if (R.is_err[context.Definition, fail.Fail](acquired)) {
+            val failure: fail.Fail = R.unwrap_err[context.Definition, fail.Fail](acquired);
+            if (failure.kind == fail.REPORTED) { fail.reject(?sc.status); }
+            or { fail.internal(?sc.status, failure.message); }
+            ret R.err[R.Void, str](failure.message);
+        }
+        val definition: context.Definition = R.unwrap_ok[context.Definition, fail.Fail](acquired);
+        oa = definition.parsed.a;
+        orr = definition.rr;
+        octx = definition.ctx;
+        val osr: *context.SemaResult = definition.sr;
         o_decl_type     = osr.decl_type;
         o_type_resolved = osr.type_resolved_ty;
         o_expr_type     = osr.expr_type;
@@ -415,11 +423,12 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     tsc.status = fail.accepted();
     fin { fail.merge(?sc.status, tsc.status); }
     tsc.s                = sc.s;
+    tsc.diags            = sc.diags;
     tsc.a                = oa;
     tsc.rr               = orr;
     tsc.deps             = deps;
     tsc.ctx              = octx;
-    val caps_r: R.Result[comptime.PhaseCapabilities[context.SemaContext], str] = semantic_type_caps();
+    val caps_r: R.Result[comptime.PhaseCapabilities[context.SemaContext], str] = semantic_type_caps(sc.diags);
     if (R.is_err[comptime.PhaseCapabilities[context.SemaContext], str](caps_r)) {
         free_typeids(sc.s.alloc, scratch_expr, oa.expr_len);
         free_typeids(sc.s.alloc, scratch_decl, oa.decl_len);
@@ -469,55 +478,9 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     ret res;
 }
 
-pub fun collect_module_deps(s: *session.Session) R.Result[context.SemaDeps, str] {
-    var deps: context.SemaDeps;
-    deps.entries = nil;
-    deps.count   = 0;
-
-    val n: u32 = session.module_count(s);
-    if (n == 0) { ret R.ok[context.SemaDeps, str](deps); }
-
-    val res_arr: R.Result[*context.ModuleSema, str] = A.allocate[context.ModuleSema](s.alloc, n::usize);
-    if (R.is_err[*context.ModuleSema, str](res_arr)) {
-        ret R.err[context.SemaDeps, str](R.unwrap_err[*context.ModuleSema, str](res_arr));
-    }
-    val arr: *context.ModuleSema = R.unwrap_ok[*context.ModuleSema, str](res_arr);
-
-    var i: u32 = 0;
-    for (i < n) {
-        var ms: context.ModuleSema;
-        ms.path       = session.module_fqn(s, i::session.ModuleId);
-        ms.module     = i::session.ModuleId;
-        ms.decl_type  = nil;
-        ms.decl_count = 0;
-        ms.ctx        = (session.module_comptime_ptr(s, i::session.ModuleId))::*comptime.ComptimeCtx;
-
-        val sp: ptr = session.module_sema_ptr(s, i::session.ModuleId);
-        if (sp != nil) {
-            val sr: *context.SemaResult = sp::*context.SemaResult;
-            ms.decl_type  = sr.decl_type;
-            ms.decl_count = sr.decl_count;
-        }
-
-        arr[i] = ms;
-        i = i + 1;
-    }
-
-    deps.entries = arr;
-    deps.count   = n;
-    ret R.ok[context.SemaDeps, str](deps);
-}
-
-pub fun free_module_deps(s: *session.Session, deps: *context.SemaDeps) {
-    if (deps.entries != nil && deps.count > 0) {
-        A.deallocate[context.ModuleSema](s.alloc, deps.entries, deps.count::usize);
-    }
-    deps.entries = nil;
-    deps.count   = 0;
-}
-
 pub fun dnit_result(r: *context.SemaResult) {
     if (r == nil) { ret; }
+    fields.dnit(?r.field_graph);
     if (r.expr_type != nil && r.expr_count > 0) {
         A.deallocate[type.TypeId](r.alloc, r.expr_type, r.expr_count::usize);
     }
@@ -548,15 +511,17 @@ fun init_context(
     rr:         *resolve.ResolveResult,
     deps:       *context.SemaDeps,
     ctx:        *comptime.ComptimeCtx,
-    own_module: session.ModuleId
+    own_module: session.ModuleId,
+    diags:      *diagnostic.DiagnosticStore
 ) R.Result[R.Void, str] {
     sc.status = fail.accepted();
     sc.s          = s;
+    sc.diags      = diags;
     sc.a          = a;
     sc.rr         = rr;
     sc.deps       = deps;
     sc.ctx        = ctx;
-    val caps_r: R.Result[comptime.PhaseCapabilities[context.SemaContext], str] = semantic_name_caps();
+    val caps_r: R.Result[comptime.PhaseCapabilities[context.SemaContext], str] = semantic_name_caps(diags);
     if (R.is_err[comptime.PhaseCapabilities[context.SemaContext], str](caps_r)) {
         ret R.err[R.Void, str](R.unwrap_err[comptime.PhaseCapabilities[context.SemaContext], str](caps_r));
     }
@@ -1053,9 +1018,9 @@ fun infer_decls_comptime_if(sc: *context.SemaContext, ci: *decl.DeclComptimeIf) 
             sc.in_comptime_gate = true;
             val gate_ty: type.TypeId = infer.infer_expr(sc, br.cond);
             if (gate_ty == type.TYPE_ERROR) { sc.in_comptime_gate = saved_gate; ret R.ok_void[str](); }
-            val gate_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, br.cond);
-            val gate_ok: bool = O.is_none[*expr.Expr](gate_opt)
-                || check.check_condition(sc, gate_ty, O.unwrap[*expr.Expr](gate_opt).span);
+            val gate_opt: R.Result[expr.Expr, str] = context.expression(sc, br.cond);
+            val gate_ok: bool = R.is_err[expr.Expr, str](gate_opt)
+                || check.check_condition(sc, gate_ty, R.unwrap_ok[expr.Expr, str](gate_opt).span);
             sc.in_comptime_gate = saved_gate;
             if (!gate_ok) { ret R.ok_void[str](); }
         }
@@ -1210,9 +1175,10 @@ fun require_string_arg(sc: *context.SemaContext, dec: *decl.Decorator, count_msg
         context.report(sc, dec.name, count_msg);
         ret;
     }
-    val opt_arg: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start]);
-    if (O.is_some[*expr.Expr](opt_arg)) {
-        val arg: *expr.Expr = O.unwrap[*expr.Expr](opt_arg);
+    val opt_arg: R.Result[expr.Expr, str] = context.expression(sc, sc.a.expr_ids[dec.args_start]);
+    if (R.is_ok[expr.Expr, str](opt_arg)) {
+        var arg_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_arg);
+        val arg: *expr.Expr = ?arg_value;
         if (arg.kind != expr.EXPR_KIND_LIT_STR) {
             context.report(sc, arg.span, kind_msg);
         }
@@ -1238,9 +1204,10 @@ fun validate_iface_target(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.De
 
 fun validate_builtin_value(sc: *context.SemaContext, dec: *decl.Decorator) {
     if (dec.args_len != 1) { ret; }
-    val opt_arg: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start]);
-    if (O.is_none[*expr.Expr](opt_arg)) { ret; }
-    val arg: *expr.Expr = O.unwrap[*expr.Expr](opt_arg);
+    val opt_arg: R.Result[expr.Expr, str] = context.expression(sc, sc.a.expr_ids[dec.args_start]);
+    if (R.is_err[expr.Expr, str](opt_arg)) { ret; }
+    var arg_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_arg);
+    val arg: *expr.Expr = ?arg_value;
     if (arg.kind != expr.EXPR_KIND_LIT_STR || arg.span.len < 2::usize) { ret; }
     val off: usize = arg.span.offset + 1::usize;
     val len: usize = arg.span.len - 2::usize;
@@ -1257,9 +1224,10 @@ fun validate_builtin_value(sc: *context.SemaContext, dec: *decl.Decorator) {
 
 fun validate_stage_value(sc: *context.SemaContext, dec: *decl.Decorator) {
     if (dec.args_len != 1) { ret; }
-    val opt_arg: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start]);
-    if (O.is_none[*expr.Expr](opt_arg)) { ret; }
-    val arg: *expr.Expr = O.unwrap[*expr.Expr](opt_arg);
+    val opt_arg: R.Result[expr.Expr, str] = context.expression(sc, sc.a.expr_ids[dec.args_start]);
+    if (R.is_err[expr.Expr, str](opt_arg)) { ret; }
+    var arg_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_arg);
+    val arg: *expr.Expr = ?arg_value;
     if (arg.kind != expr.EXPR_KIND_LIT_STR || arg.span.len < 2::usize) { ret; }
     val off: usize = arg.span.offset + 1::usize;
     val len: usize = arg.span.len - 2::usize;
@@ -1272,9 +1240,10 @@ fun validate_stage_value(sc: *context.SemaContext, dec: *decl.Decorator) {
 fun validate_storage_quals(sc: *context.SemaContext, dec: *decl.Decorator) {
     var i: u32 = 2;
     for (i < dec.args_len) {
-        val opt_arg: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start + i]);
-        if (O.is_none[*expr.Expr](opt_arg)) { i = i + 1; cnt; }
-        val arg: *expr.Expr = O.unwrap[*expr.Expr](opt_arg);
+        val opt_arg: R.Result[expr.Expr, str] = context.expression(sc, sc.a.expr_ids[dec.args_start + i]);
+        if (R.is_err[expr.Expr, str](opt_arg)) { i = i + 1; cnt; }
+        var arg_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_arg);
+        val arg: *expr.Expr = ?arg_value;
         if (arg.kind != expr.EXPR_KIND_LIT_STR || arg.span.len < 2::usize) {
             context.report(sc, arg.span, "a `storage` memory qualifier must be a string literal; `storage` takes the descriptor set and binding followed by qualifiers, as in `#[storage(0, 3, \"readonly\")]`");
             i = i + 1; cnt;
@@ -1297,13 +1266,16 @@ fun validate_op(sc: *context.SemaContext, d: *decl.Decl, dec: *decl.Decorator) {
         context.report(sc, dec.name, "`op` decorator takes three string arguments: the target, the instruction set, and the instruction name");
         ret;
     }
-    val opt_tgt: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start]);
-    val opt_set: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start + 1]);
-    val opt_nam: O.Option[*expr.Expr] = ast.get_expr(sc.a, sc.a.expr_ids[dec.args_start + 2]);
-    if (O.is_none[*expr.Expr](opt_tgt) || O.is_none[*expr.Expr](opt_set) || O.is_none[*expr.Expr](opt_nam)) { ret; }
-    val tgt_e: *expr.Expr = O.unwrap[*expr.Expr](opt_tgt);
-    val set_e: *expr.Expr = O.unwrap[*expr.Expr](opt_set);
-    val nam_e: *expr.Expr = O.unwrap[*expr.Expr](opt_nam);
+    val opt_tgt: R.Result[expr.Expr, str] = context.expression(sc, sc.a.expr_ids[dec.args_start]);
+    val opt_set: R.Result[expr.Expr, str] = context.expression(sc, sc.a.expr_ids[dec.args_start + 1]);
+    val opt_nam: R.Result[expr.Expr, str] = context.expression(sc, sc.a.expr_ids[dec.args_start + 2]);
+    if (R.is_err[expr.Expr, str](opt_tgt) || R.is_err[expr.Expr, str](opt_set) || R.is_err[expr.Expr, str](opt_nam)) { ret; }
+    var tgt_e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_tgt);
+    val tgt_e: *expr.Expr = ?tgt_e_value;
+    var set_e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_set);
+    val set_e: *expr.Expr = ?set_e_value;
+    var nam_e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_nam);
+    val nam_e: *expr.Expr = ?nam_e_value;
     if (tgt_e.kind != expr.EXPR_KIND_LIT_STR || set_e.kind != expr.EXPR_KIND_LIT_STR
         || nam_e.kind != expr.EXPR_KIND_LIT_STR) {
         context.report(sc, dec.name, "`op` decorator arguments must be string literals: all three are matched against the target registry rather than evaluated");
@@ -1786,9 +1758,9 @@ fun infer_bodies_deferred_chain(sc: *context.SemaContext, ci: *decl.DeclComptime
         if (br.cond == id.EXPR_NIL) {
             ret infer_bodies_in_list(sc, br.body_start, br.body_len);
         }
-        val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, br.cond);
-        if (O.is_none[*expr.Expr](e_opt)) { ret R.err[R.Void, str]("comptime branch cond ExprId out of range"); }
-        val cond_span: token.Span = O.unwrap[*expr.Expr](e_opt).span;
+        val e_opt: R.Result[expr.Expr, str] = context.expression(sc, br.cond);
+        if (R.is_err[expr.Expr, str](e_opt)) { ret R.err[R.Void, str]("comptime branch cond ExprId out of range"); }
+        val cond_span: token.Span = R.unwrap_ok[expr.Expr, str](e_opt).span;
 
         val saved_gate: bool = sc.in_comptime_gate;
         sc.in_comptime_gate = true;
@@ -2059,15 +2031,15 @@ fun infer_const_array_each_local(sc: *context.SemaContext, ce: *stmt.StmtComptim
 
 fun infer_const_array_each_imported(sc: *context.SemaContext, ce: *stmt.StmtComptimeEach, span: token.Span,
                                     fn_ret: type.TypeId, sym: *resolve.Symbol, elem_ty: type.TypeId, count: u32) R.Result[R.Void, str] {
-    val oa: *ast.Ast = session.module_ast(sc.s, sym.origin);
-    if (oa == nil) { ret R.err[R.Void, str]("internal: `$each` imported array origin AST unavailable (dependency-ordering invariant violated)"); }
-    val orr: *resolve.ResolveResult = (session.module_resolve_ptr(sc.s, sym.origin))::*resolve.ResolveResult;
-    val octx: *comptime.ComptimeCtx = (session.module_comptime_ptr(sc.s, sym.origin))::*comptime.ComptimeCtx;
-    val osp: ptr = session.module_sema_ptr(sc.s, sym.origin);
-    if (osp == nil || orr == nil || octx == nil) { ret R.err[R.Void, str]("internal: `$each` imported array origin sema/resolve/comptime snapshot unavailable (dependency-ordering invariant violated)"); }
-    val osr: *context.SemaResult = osp::*context.SemaResult;
+    val acquired: R.Result[context.DefinedSymbol, fail.Fail] = context.imported_definition(sc, sym, context.DEFINITION_TYPED);
+    if (R.is_err[context.DefinedSymbol, fail.Fail](acquired)) { ret R.err[R.Void, str](R.unwrap_err[context.DefinedSymbol, fail.Fail](acquired).message); }
+    val current: context.DefinedSymbol = R.unwrap_ok[context.DefinedSymbol, fail.Fail](acquired);
+    val oa: *ast.Ast = current.definition.parsed.a;
+    val orr: *resolve.ResolveResult = current.definition.rr;
+    val octx: *comptime.ComptimeCtx = current.definition.ctx;
+    val osr: *context.SemaResult = current.definition.sr;
 
-    val od_opt: O.Option[*decl.Decl] = ast.get_decl(oa, sym.decl);
+    val od_opt: O.Option[*decl.Decl] = ast.get_decl(oa, current.symbol.decl);
     if (O.is_none[*decl.Decl](od_opt)) {
         context.report(sc, span, "a `$each` array sequence must name an array `val`");
         ret R.ok_void[str]();
@@ -2081,7 +2053,7 @@ fun infer_const_array_each_imported(sc: *context.SemaContext, ce: *stmt.StmtComp
         ret R.ok_void[str]();
     }
 
-    val opt_info: O.Option[comptime.ArrayLitInfo] = comptime.decl_array_lit(oa, sym.decl);
+    val opt_info: O.Option[comptime.ArrayLitInfo] = comptime.decl_array_lit(oa, current.symbol.decl);
     if (O.is_none[comptime.ArrayLitInfo](opt_info)) {
         context.report(sc, span, "a `$each` array sequence must be initialized with an array literal");
         ret R.ok_void[str]();
@@ -2100,11 +2072,12 @@ fun infer_const_array_each_imported(sc: *context.SemaContext, ce: *stmt.StmtComp
     tsc.status = fail.accepted();
     fin { fail.merge(?sc.status, tsc.status); }
     tsc.s                = sc.s;
+    tsc.diags            = sc.diags;
     tsc.a                = oa;
     tsc.rr               = orr;
     tsc.deps             = sc.deps;
     tsc.ctx              = octx;
-    val caps_r: R.Result[comptime.PhaseCapabilities[context.SemaContext], str] = semantic_type_caps();
+    val caps_r: R.Result[comptime.PhaseCapabilities[context.SemaContext], str] = semantic_type_caps(sc.diags);
     if (R.is_err[comptime.PhaseCapabilities[context.SemaContext], str](caps_r)) {
         ret R.err[R.Void, str](R.unwrap_err[comptime.PhaseCapabilities[context.SemaContext], str](caps_r));
     }
@@ -2218,7 +2191,7 @@ fun gate_probe_is_field_type_operand(sc: *context.SemaContext, eid: id.ExprId) b
 
 fun sema_gate_probes() comptime.GateProbes[context.SemaContext] {
     ret comptime.gate_probes[context.SemaContext](
-        gate_probe_ident_is_comptime_param, nil, nil, gate_probe_is_field_type_operand);
+        gate_probe_ident_is_comptime_param, nil, nil, gate_probe_is_field_type_operand, context.comptime_expression);
 }
 
 fun gate_chain_depends(sc: *context.SemaContext, probe: comptime.GateProbe,
@@ -2252,9 +2225,9 @@ fun infer_stmt_comptime_if(sc: *context.SemaContext, start: u32, len: u32, fn_re
                 val gate_ty: type.TypeId = infer.infer_expr(sc, arm.cond);
                 if (gate_ty == type.TYPE_ERROR) { chain_bad = true; }
                 or {
-                    val gate_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, arm.cond);
-                    if (O.is_some[*expr.Expr](gate_opt)
-                     && !check.check_condition(sc, gate_ty, O.unwrap[*expr.Expr](gate_opt).span)) { chain_bad = true; }
+                    val gate_opt: R.Result[expr.Expr, str] = context.expression(sc, arm.cond);
+                    if (R.is_ok[expr.Expr, str](gate_opt)
+                     && !check.check_condition(sc, gate_ty, R.unwrap_ok[expr.Expr, str](gate_opt).span)) { chain_bad = true; }
                 }
                 sc.in_comptime_gate = saved_gate;
                 val cg: R.Result[R.Void, str] = check_comptime_gate(sc, arm.cond);
@@ -2281,9 +2254,9 @@ fun infer_stmt_comptime_if(sc: *context.SemaContext, start: u32, len: u32, fn_re
             sc.in_comptime_gate = true;
             val gate_ty: type.TypeId = infer.infer_expr(sc, br.cond);
             if (gate_ty == type.TYPE_ERROR) { sc.in_comptime_gate = saved_gate; ret R.ok_void[str](); }
-            val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, br.cond);
-            val gate_ok: bool = O.is_none[*expr.Expr](e_opt)
-                || check.check_condition(sc, gate_ty, O.unwrap[*expr.Expr](e_opt).span);
+            val e_opt: R.Result[expr.Expr, str] = context.expression(sc, br.cond);
+            val gate_ok: bool = R.is_err[expr.Expr, str](e_opt)
+                || check.check_condition(sc, gate_ty, R.unwrap_ok[expr.Expr, str](e_opt).span);
             sc.in_comptime_gate = saved_gate;
             if (!gate_ok) { ret R.ok_void[str](); }
         }
@@ -2328,9 +2301,9 @@ fun prune_type_comparison_chain(sc: *context.SemaContext, start: u32, len: u32, 
         sc.in_comptime_gate = true;
         val gate_ty: type.TypeId = infer.infer_expr(sc, arm.cond);
         if (gate_ty == type.TYPE_ERROR) { sc.in_comptime_gate = saved_gate; ret R.ok[bool, str](true); }
-        val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, arm.cond);
-        val gate_ok: bool = O.is_none[*expr.Expr](e_opt)
-            || check.check_condition(sc, gate_ty, O.unwrap[*expr.Expr](e_opt).span);
+        val e_opt: R.Result[expr.Expr, str] = context.expression(sc, arm.cond);
+        val gate_ok: bool = R.is_err[expr.Expr, str](e_opt)
+            || check.check_condition(sc, gate_ty, R.unwrap_ok[expr.Expr, str](e_opt).span);
         sc.in_comptime_gate = saved_gate;
         if (!gate_ok) { ret R.ok[bool, str](true); }
 
@@ -2355,7 +2328,7 @@ fun prune_type_comparison_chain(sc: *context.SemaContext, start: u32, len: u32, 
 
 fun check_comptime_gate(sc: *context.SemaContext, eid: id.ExprId) R.Result[R.Void, str] {
     if (eid == id.EXPR_NIL) { ret R.ok_void[str](); }
-    val matched_r: R.Result[bool, str] = comptime.gate_walk[context.SemaContext](sc.a, sc.source, sc, gate_operand_check, eid);
+    val matched_r: R.Result[bool, str] = comptime.gate_walk[context.SemaContext](sc.a, sc.source, sc, gate_operand_check, context.comptime_expression, eid);
     if (R.is_err[bool, str](matched_r)) { ret R.err[R.Void, str](R.unwrap_err[bool, str](matched_r)); }
     ret R.ok_void[str]();
 }
@@ -2502,7 +2475,34 @@ fun build_result(sc: *context.SemaContext) R.Result[context.SemaResult, fail.Fai
         dnit_context(sc);
         ret R.err[context.SemaResult, fail.Fail](f);
     }
+    var graph: fields.Graph = fields.init(sc.s.alloc);
+    if (sc.status.kind == fail.ACCEPTED) {
+        var roots: [3]fields.Roots;
+        roots[0] = fields.Roots{ data: sc.expr_type, len: sc.a.expr_len };
+        roots[1] = fields.Roots{ data: sc.type_resolved_ty, len: sc.a.type_len };
+        roots[2] = fields.Roots{ data: sc.decl_type, len: sc.a.decl_len };
+        val captured: R.Result[fields.Graph, fail.Fail] = fields.capture[context.SemaContext](sc.s, sc.s.alloc,
+            ?roots[0], 3, fields.MATERIALIZED, sc.ctx.env.target_defs, sc, infer.prepare_nominal_recipe);
+        if (R.is_err[fields.Graph, fail.Fail](captured)) {
+            val reason: fail.Fail = R.unwrap_err[fields.Graph, fail.Fail](captured);
+            dnit_context(sc);
+            ret R.err[context.SemaResult, fail.Fail](reason);
+        }
+        graph = R.unwrap_ok[fields.Graph, fail.Fail](captured);
+    }
+    ret finish_result(sc, graph);
+}
+
+fun finish_result(sc: *context.SemaContext, graph: fields.Graph) R.Result[context.SemaResult, fail.Fail] {
+    if (sc.status.kind == fail.INTERNAL) {
+        val reason: fail.Fail = fail.phase_failure(sc.status);
+        var owned: fields.Graph = graph;
+        fields.dnit(?owned);
+        dnit_context(sc);
+        ret R.err[context.SemaResult, fail.Fail](reason);
+    }
     var out: context.SemaResult;
+    out.field_graph      = graph;
     out.status           = sc.status;
     out.alloc            = sc.s.alloc;
     out.expr_type        = sc.expr_type;

--- a/src/lang/fe/sema/check.mach
+++ b/src/lang/fe/sema/check.mach
@@ -63,12 +63,12 @@ pub fun check_coercible(sc: *context.SemaContext, expected: type.TypeId, eid: id
 fun attach_cast_fix(sc: *context.SemaContext, expected: type.TypeId, actual: type.TypeId, eid: id.ExprId) {
     if (!cast_would_compile(sc, actual, expected)) { ret; }
 
-    val opt_expr: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](opt_expr)) { ret; }
-    val span: token.Span = O.unwrap[*expr.Expr](opt_expr).span;
+    val opt_expr: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](opt_expr)) { ret; }
+    val span: token.Span = R.unwrap_ok[expr.Expr, str](opt_expr).span;
     if (span.len == 0) { ret; }
 
-    val id_r: R.Result[diagnostic.DiagnosticId, str] = diagnostic.last_id(?sc.s.diags);
+    val id_r: R.Result[diagnostic.DiagnosticId, str] = diagnostic.last_id(sc.diags);
     if (R.is_err[diagnostic.DiagnosticId, str](id_r)) { ret; }
     val did: diagnostic.DiagnosticId = R.unwrap_ok[diagnostic.DiagnosticId, str](id_r);
 
@@ -87,11 +87,11 @@ fun attach_cast_fix(sc: *context.SemaContext, expected: type.TypeId, actual: typ
     tail.offset = span.offset + span.len;
     tail.len    = 0;
 
-    if (expr_binds_tighter_than_cast(O.unwrap[*expr.Expr](opt_expr).kind)) {
+    if (expr_binds_tighter_than_cast(R.unwrap_ok[expr.Expr, str](opt_expr).kind)) {
         val sfx_r: R.Result[str, str] = format.sprint(sc.s.alloc, "::{}", ts);
         if (R.is_ok[str, str](sfx_r)) {
             val sfx: str = R.unwrap_ok[str, str](sfx_r);
-            diagnostic.record_fix_committed(?sc.s.diags, did, label, sc.a.file_id, tail, sfx);
+            diagnostic.record_fix_committed(sc.diags, did, label, sc.a.file_id, tail, sfx);
             A.deallocate[char](sc.s.alloc, sfx, str_len(sfx) + 1);
         }
     }
@@ -99,11 +99,11 @@ fun attach_cast_fix(sc: *context.SemaContext, expected: type.TypeId, actual: typ
         val sfx_r: R.Result[str, str] = format.sprint(sc.s.alloc, ")::{}", ts);
         if (R.is_ok[str, str](sfx_r)) {
             val sfx: str = R.unwrap_ok[str, str](sfx_r);
-            val fix_r: R.Result[diagnostic.FixId, str] = diagnostic.attach_fix_committed(?sc.s.diags, did, label, sc.a.file_id, head, "(");
+            val fix_r: R.Result[diagnostic.FixId, str] = diagnostic.attach_fix_committed(sc.diags, did, label, sc.a.file_id, head, "(");
             if (R.is_ok[diagnostic.FixId, str](fix_r)) {
                 val fid: diagnostic.FixId = R.unwrap_ok[diagnostic.FixId, str](fix_r);
-                val edit_r: R.Result[R.Void, str] = diagnostic.attach_fix_edit_committed(?sc.s.diags, did, fid, sc.a.file_id, tail, sfx);
-                if (R.is_err[R.Void, str](edit_r)) { diagnostic.remove_fix_committed(?sc.s.diags, did, fid); }
+                val edit_r: R.Result[R.Void, str] = diagnostic.attach_fix_edit_committed(sc.diags, did, fid, sc.a.file_id, tail, sfx);
+                if (R.is_err[R.Void, str](edit_r)) { diagnostic.remove_fix_committed(sc.diags, did, fid); }
             }
             A.deallocate[char](sc.s.alloc, sfx, str_len(sfx) + 1);
         }
@@ -291,11 +291,7 @@ pub fun check_comptime_call(sc: *context.SemaContext, callee_sig: type.TypeId, c
 
 pub fun imported_module_const_sym(sc: *context.SemaContext, sym: *resolve.Symbol) bool {
     if (sym.kind != resolve.SYM_IMPORTED) { ret false; }
-    val origin_ast: *ast.Ast = session.module_ast(sc.s, sym.origin);
-    if (origin_ast == nil) { ret false; }
-    val opt_decl: O.Option[*decl.Decl] = ast.get_decl(origin_ast, sym.decl);
-    if (O.is_none[*decl.Decl](opt_decl)) { ret false; }
-    ret O.unwrap[*decl.Decl](opt_decl).kind == decl.DECL_KIND_VAL;
+    ret sym.definition_kind == resolve.SYM_VAL;
 }
 
 pub fun check_index(sc: *context.SemaContext, object: type.TypeId, index: type.TypeId, span: token.Span) O.Option[type.TypeId] {
@@ -751,9 +747,9 @@ fun param_is_pack(sc: *context.SemaContext, param_idx: u32) bool {
 }
 
 fun arg_is_spread(sc: *context.SemaContext, eid: id.ExprId) bool {
-    val opt_expr: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](opt_expr)) { ret false; }
-    ret O.unwrap[*expr.Expr](opt_expr).kind == expr.EXPR_KIND_SPREAD;
+    val opt_expr: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](opt_expr)) { ret false; }
+    ret R.unwrap_ok[expr.Expr, str](opt_expr).kind == expr.EXPR_KIND_SPREAD;
 }
 
 fun validate_pack_spreads(sc: *context.SemaContext, has_pack: bool, fixed_len: u32, args_start: u32, args_len: u32, span: token.Span) bool {
@@ -796,7 +792,7 @@ fun arg_probe_ident_is_comptime_param(sc: *context.SemaContext, eid: id.ExprId) 
 fun arg_references_comptime_param(sc: *context.SemaContext, eid: id.ExprId, span: token.Span) bool {
     if (eid == id.EXPR_NIL) { ret false; }
     val depends_r: R.Result[bool, str] = comptime.gate_depends_on[context.SemaContext](sc.a, sc.source, sc,
-        comptime.gate_probes[context.SemaContext](arg_probe_ident_is_comptime_param, nil, nil, nil),
+        comptime.gate_probes[context.SemaContext](arg_probe_ident_is_comptime_param, nil, nil, nil, context.comptime_expression),
         comptime.GATE_PROBE_COMPTIME_PARAM, eid);
     if (R.is_err[bool, str](depends_r)) {
         report(sc, span, R.unwrap_err[bool, str](depends_r));
@@ -810,7 +806,7 @@ fun callee_origin_ast(sc: *context.SemaContext, callee: id.ExprId) *ast.Ast {
     if (O.is_none[*resolve.Symbol](opt_sym)) { ret nil; }
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](opt_sym);
     if (sym.origin == sc.own_module) { ret sc.a; }
-    ret session.module_ast(sc.s, sym.origin);
+    ret context.definition_ast(sc, sym.origin);
 }
 
 fun deref_one(sc: *context.SemaContext, object: type.TypeId) type.TypeId {
@@ -832,9 +828,9 @@ fun expr_type_of(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
 }
 
 fun expr_span_of(sc: *context.SemaContext, eid: id.ExprId, fallback: token.Span) token.Span {
-    val opt_expr: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](opt_expr)) { ret fallback; }
-    ret O.unwrap[*expr.Expr](opt_expr).span;
+    val opt_expr: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](opt_expr)) { ret fallback; }
+    ret R.unwrap_ok[expr.Expr, str](opt_expr).span;
 }
 
 fun report(sc: *context.SemaContext, span: token.Span, message: str) {
@@ -928,10 +924,10 @@ fun declaring_module_fqn(sc: *context.SemaContext, t: type.TypeId) intern.StrId 
     if (O.is_none[*type.Type](opt)) { ret intern.STR_NIL; }
     val ty: *type.Type = O.unwrap[*type.Type](opt);
     if (ty.kind == type.TYPE_REC || ty.kind == type.TYPE_UNI) {
-        ret session.module_fqn(sc.s, ty.data.nominal.origin);
+        ret session.module_fqn(sc.s, session.module_id_for_stable(sc.s, ty.data.nominal.owner.module));
     }
     if (ty.kind == type.TYPE_INSTANCE) {
-        ret session.module_fqn(sc.s, ty.data.instance.target_origin);
+        ret declaring_module_fqn(sc, ty.data.instance.nominal);
     }
     ret intern.STR_NIL;
 }

--- a/src/lang/fe/sema/coerce.mach
+++ b/src/lang/fe/sema/coerce.mach
@@ -89,9 +89,10 @@ pub fun try_coerce_literal(sc: *context.SemaContext, eid: id.ExprId, to: type.Ty
 fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated: bool, probe: bool) CoerceResult {
     if (eid == id.EXPR_NIL) { ret not_applicable(); }
 
-    val opt_e: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](opt_e)) { ret not_applicable(); }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](opt_e);
+    val opt_e: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](opt_e)) { ret not_applicable(); }
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_e);
+    val e: *expr.Expr = ?e_value;
 
     if (e.kind == expr.EXPR_KIND_LIT_INT) {
         if (e.data.lit_int.suffix != expr.LIT_SUFFIX_NONE) {

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -1,6 +1,7 @@
 use std.allocator.page;
 use std.chrono.duration;
 use std.collections.map;
+use std.collections.vector;
 use std.crypto.hash.fnv1a;
 use std.format;
 use std.print;
@@ -27,13 +28,16 @@ use mach.lang.fe.ast.stmt;
 use mach.lang.fe.ast.id;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
+use mach.lang.fe.sema.fields;
 use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.layout;
 use mach.lang.session;
+use mach.lang.source;
 use mach.lang.type;
 
 pub rec SemaResult {
+    field_graph: fields.Graph;
     status: fail.PhaseStatus;
     alloc:            *A.Allocator;
     expr_type:        *type.TypeId;
@@ -51,15 +55,142 @@ pub val EMBED_LEN_NONE: u64 = 0xFFFFFFFFFFFFFFFF;
 
 pub val EMBED_LEN_FAILED: u64 = 0xFFFFFFFFFFFFFFFE;
 
+pub rec TypeExport {
+    origin: session.StableModuleId;
+    canon: intern.StrId;
+    ty: type.TypeId;
+    constant: resolve.ExportConstant;
+    definition_incarnation: u64;
+}
+
 pub rec ModuleSema {
-    path:       intern.StrId;
-    module:     session.ModuleId;
-    decl_type:  *type.TypeId;
-    decl_count: u32;
-    ctx:        *comptime.ComptimeCtx;
+    path: intern.StrId;
+    module: session.ModuleId;
+    exports: vector.Vector[TypeExport];
+    graph: fields.Graph;
+}
+
+pub fun module_sema_init(a: *A.Allocator, path: intern.StrId, module: session.ModuleId) ModuleSema {
+    ret ModuleSema{ path: path, module: module, exports: vector.init[TypeExport](a), graph: fields.init(a) };
+}
+
+pub fun module_sema_dnit(module: *ModuleSema) {
+    vector.dnit[TypeExport](?module.exports);
+    fields.dnit(?module.graph);
+}
+
+pub def DefinitionPhase: u8;
+pub val DEFINITION_PARSED: DefinitionPhase = 0;
+pub val DEFINITION_RESOLVED: DefinitionPhase = 1;
+pub val DEFINITION_TYPED: DefinitionPhase = 2;
+
+pub rec Definition {
+    parsed: resolve.ParsedDefinition;
+    origin: session.ModuleId;
+    rr: *resolve.ResolveResult;
+    sr: *SemaResult;
+    ctx: *comptime.ComptimeCtx;
+}
+
+pub rec DefinitionReader {
+    ctx: ptr;
+    read: fun(ptr, session.ModuleId, DefinitionPhase) R.Result[Definition, fail.Fail];
+}
+
+pub rec DefinedSymbol {
+    definition: Definition;
+    symbol: resolve.Symbol;
+}
+
+pub fun acquire_definition(reader: *DefinitionReader, origin: session.ModuleId,
+                           phase: DefinitionPhase) R.Result[Definition, fail.Fail] {
+    if (reader == nil || reader.ctx == nil || reader.read == nil || phase > DEFINITION_TYPED) {
+        ret R.err[Definition, fail.Fail](fail.message("current definition acquisition requires an active phase capability"));
+    }
+    val acquired: R.Result[Definition, fail.Fail] = reader.read(reader.ctx, origin, phase);
+    if (R.is_err[Definition, fail.Fail](acquired)) { ret acquired; }
+    val current: Definition = R.unwrap_ok[Definition, fail.Fail](acquired);
+    if (current.origin != origin || current.parsed.a == nil || current.parsed.incarnation == 0
+        || current.parsed.incarnation != current.parsed.a.incarnation
+        || current.parsed.owner.file != current.parsed.a.file_id) {
+        ret R.err[Definition, fail.Fail](fail.message("current definition has inconsistent parsed ownership"));
+    }
+    if (phase >= DEFINITION_RESOLVED && current.rr == nil) {
+        ret R.err[Definition, fail.Fail](fail.message("current definition has no acquired resolution product"));
+    }
+    if (phase == DEFINITION_TYPED && (current.sr == nil || current.ctx == nil)) {
+        ret R.err[Definition, fail.Fail](fail.message("current definition has no acquired semantic product"));
+    }
+    if (phase >= DEFINITION_RESOLVED && current.rr.status.kind != fail.ACCEPTED) {
+        ret R.err[Definition, fail.Fail](fail.phase_failure(current.rr.status));
+    }
+    if (phase == DEFINITION_TYPED && current.sr.status.kind != fail.ACCEPTED) {
+        ret R.err[Definition, fail.Fail](fail.phase_failure(current.sr.status));
+    }
+    ret acquired;
+}
+
+pub fun acquire_symbol(reader: *DefinitionReader, requested: *resolve.Symbol,
+                       phase: DefinitionPhase) R.Result[DefinedSymbol, fail.Fail] {
+    if (requested == nil || phase < DEFINITION_RESOLVED) {
+        ret R.err[DefinedSymbol, fail.Fail](fail.message("symbol definition requires resolved acquisition"));
+    }
+    val acquired: R.Result[Definition, fail.Fail] = acquire_definition(reader, requested.origin, phase);
+    if (R.is_err[Definition, fail.Fail](acquired)) { ret R.err[DefinedSymbol, fail.Fail](R.unwrap_err[Definition, fail.Fail](acquired)); }
+    val current: Definition = R.unwrap_ok[Definition, fail.Fail](acquired);
+    var found: resolve.SymbolId = resolve.SYMBOL_NIL;
+    var i: u32 = 0;
+    for (i < current.rr.symbol_count) {
+        val symbol: *resolve.Symbol = ?current.rr.symbols[i];
+        if (symbol.origin == requested.origin && symbol.kind == requested.definition_kind
+            && symbol.canon == requested.canon && symbol.decl != id.DECL_NIL) {
+            if (found != resolve.SYMBOL_NIL && current.rr.symbols[found].decl != symbol.decl) {
+                ret R.err[DefinedSymbol, fail.Fail](fail.message("current canonical definition is ambiguous"));
+            }
+            found = i;
+        }
+        i = i + 1;
+    }
+    if (found == resolve.SYMBOL_NIL || current.rr.symbols[found].decl >= current.parsed.a.decl_len::u32) {
+        ret R.err[DefinedSymbol, fail.Fail](fail.message("current canonical definition is absent from its resolved owner"));
+    }
+    ret R.ok[DefinedSymbol, fail.Fail](DefinedSymbol{ definition: current, symbol: current.rr.symbols[found] });
+}
+
+pub fun imported_definition(sc: *SemaContext, sym: *resolve.Symbol,
+                           phase: DefinitionPhase) R.Result[DefinedSymbol, fail.Fail] {
+    if (sym.origin == sc.own_module || sc.deps == nil) {
+        val reason: fail.Fail = fail.message("foreign definition acquisition cannot refresh the active semantic owner");
+        fail.internal(?sc.status, reason.message);
+        ret R.err[DefinedSymbol, fail.Fail](reason);
+    }
+    val result: R.Result[DefinedSymbol, fail.Fail] = acquire_symbol(?sc.deps.definitions, sym, phase);
+    if (R.is_err[DefinedSymbol, fail.Fail](result)) {
+        val reason: fail.Fail = R.unwrap_err[DefinedSymbol, fail.Fail](result);
+        if (reason.kind == fail.REPORTED) { fail.reject(?sc.status); }
+        or { fail.internal(?sc.status, reason.message); }
+    }
+    ret result;
+}
+
+pub fun symbol_definition(sc: *SemaContext, sym: *resolve.Symbol,
+                          phase: DefinitionPhase) R.Result[DefinedSymbol, fail.Fail] {
+    if (sym.origin != sc.own_module) { ret imported_definition(sc, sym, phase); }
+    if (sc.a == nil || sc.rr == nil || sym.decl == id.DECL_NIL || sym.decl >= sc.a.decl_len::u32) {
+        val reason: fail.Fail = fail.message("symbol has no declaration in the active semantic owner");
+        fail.internal(?sc.status, reason.message);
+        ret R.err[DefinedSymbol, fail.Fail](reason);
+    }
+    val parsed: resolve.ParsedDefinition = resolve.ParsedDefinition{
+        a: sc.a, owner: resolve.type_owner(sc.s, sc.own_module, sc.a.file_id), incarnation: sc.a.incarnation
+    };
+    ret R.ok[DefinedSymbol, fail.Fail](DefinedSymbol{
+        definition: Definition{ parsed: parsed, origin: sc.own_module, rr: sc.rr, ctx: sc.ctx }, symbol: @sym
+    });
 }
 
 pub rec SemaDeps {
+    definitions: DefinitionReader;
     entries: *ModuleSema;
     count:   u32;
 }
@@ -135,6 +266,7 @@ pub fun uni_report_mark(ur: *UniReports, key: type.TypeId) bool {
 }
 
 pub rec SemaContext {
+    diags: *diagnostic.DiagnosticStore;
     status: fail.PhaseStatus;
     s:          *session.Session;
     a:          *ast.Ast;
@@ -200,6 +332,21 @@ pub fun resolved_type_of(sc: *SemaContext, ast_tid: id.TypeId) type.TypeId {
     ret apply_subst(sc, sc.type_resolved_ty[ast_tid]);
 }
 
+pub fun expression(sc: *SemaContext, eid: id.ExprId) R.Result[expr.Expr, str] {
+    val result: R.Result[expr.Expr, str] = resolve.expression(sc.rr, sc.a, eid);
+    if (R.is_err[expr.Expr, str](result)) { fail.internal(?sc.status, R.unwrap_err[expr.Expr, str](result)); }
+    ret result;
+}
+
+pub fun comptime_expression(sc: *SemaContext, a: *ast.Ast, eid: id.ExprId) R.Result[expr.Expr, comptime.EvalFail] {
+    if (sc == nil || sc.a != a) { ret R.err[expr.Expr, comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_INTERNAL, "semantic expression belongs to a different parsed owner")); }
+    val result: R.Result[expr.Expr, str] = expression(sc, eid);
+    if (R.is_err[expr.Expr, str](result)) {
+        ret R.err[expr.Expr, comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_INTERNAL, R.unwrap_err[expr.Expr, str](result)));
+    }
+    ret R.ok[expr.Expr, comptime.EvalFail](R.unwrap_ok[expr.Expr, str](result));
+}
+
 pub fun apply_subst(sc: *SemaContext, tid: type.TypeId) type.TypeId {
     if (sc.subst == nil || sc.subst_len == 0 || sc.subst_fn == nil) { ret tid; }
     ret type_result(sc, sc.subst_fn(sc.s, tid, sc.subst, sc.subst_len));
@@ -219,9 +366,15 @@ pub fun arg_triggers_revalidation(sc: *SemaContext, tid: type.TypeId) bool {
 
 fun module_rr_for(sc: *SemaContext, origin: session.ModuleId) *resolve.ResolveResult {
     if (origin == sc.own_module) { ret sc.rr; }
-    val p: ptr = session.module_resolve_ptr(sc.s, origin);
-    if (p == nil) { ret nil; }
-    ret p::*resolve.ResolveResult;
+    if (sc.deps == nil) { fail.internal(?sc.status, "semantic definition has no dependency reader"); ret nil; }
+    val acquired: R.Result[Definition, fail.Fail] = acquire_definition(?sc.deps.definitions, origin, DEFINITION_RESOLVED);
+    if (R.is_err[Definition, fail.Fail](acquired)) {
+        val reason: fail.Fail = R.unwrap_err[Definition, fail.Fail](acquired);
+        if (reason.kind == fail.REPORTED) { fail.reject(?sc.status); }
+        or { fail.internal(?sc.status, reason.message); }
+        ret nil;
+    }
+    ret R.unwrap_ok[Definition, fail.Fail](acquired).rr;
 }
 
 fun callee_is_c_variadic(sc: *SemaContext, rr: *resolve.ResolveResult, callee_eid: id.ExprId) bool {
@@ -230,13 +383,12 @@ fun callee_is_c_variadic(sc: *SemaContext, rr: *resolve.ResolveResult, callee_ei
     val sid: resolve.SymbolId = rr.expr_resolved[callee_eid];
     if (sid == resolve.SYMBOL_NIL || sid >= rr.symbol_count)       { ret false; }
     val sym: *resolve.Symbol = ?rr.symbols[sid];
-    if (sym.decl == id.DECL_NIL) { ret false; }
-
-    var da: *ast.Ast = sc.a;
-    if (sym.origin != sc.own_module) { da = session.module_ast(sc.s, sym.origin); }
-    if (da == nil) { ret false; }
-
-    val d_opt: O.Option[*decl.Decl] = ast.get_decl(da, sym.decl);
+    if (sym.kind != resolve.SYM_FUN && sym.kind != resolve.SYM_IMPORTED) { ret false; }
+    if (sym.kind == resolve.SYM_IMPORTED && sym.definition_kind != resolve.SYM_FUN) { ret false; }
+    val acquired: R.Result[DefinedSymbol, fail.Fail] = symbol_definition(sc, sym, DEFINITION_RESOLVED);
+    if (R.is_err[DefinedSymbol, fail.Fail](acquired)) { ret false; }
+    val current: DefinedSymbol = R.unwrap_ok[DefinedSymbol, fail.Fail](acquired);
+    val d_opt: O.Option[*decl.Decl] = ast.get_decl(current.definition.parsed.a, current.symbol.decl);
     if (O.is_none[*decl.Decl](d_opt)) { ret false; }
     val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
     if (d.kind != decl.DECL_KIND_FUN) { ret false; }
@@ -264,15 +416,23 @@ fun callee_body_reaches(sc: *SemaContext, rr: *resolve.ResolveResult, callee_eid
     val sid: resolve.SymbolId = rr.expr_resolved[callee_eid];
     if (sid == resolve.SYMBOL_NIL || sid >= rr.symbol_count)       { ret false; }
     val sym: *resolve.Symbol = ?rr.symbols[sid];
-    if (sym.decl == id.DECL_NIL) { ret false; }
-    ret decl_reaches_c_variadic(sc, sym.origin, sym.decl, want_spread, seen);
+    if (sym.kind != resolve.SYM_FUN && sym.kind != resolve.SYM_IMPORTED) { ret false; }
+    if (sym.kind == resolve.SYM_IMPORTED && sym.definition_kind != resolve.SYM_FUN) { ret false; }
+    val acquired: R.Result[DefinedSymbol, fail.Fail] = symbol_definition(sc, sym, DEFINITION_RESOLVED);
+    if (R.is_err[DefinedSymbol, fail.Fail](acquired)) { ret false; }
+    val current: DefinedSymbol = R.unwrap_ok[DefinedSymbol, fail.Fail](acquired);
+    ret decl_reaches_c_variadic(sc, current.symbol.origin, current.symbol.decl, want_spread, seen);
 }
 
 fun expr_has_c_variadic_call(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveResult, eid: id.ExprId, want_spread: bool, seen: *ReachSeen) bool {
     if (eid == id.EXPR_NIL) { ret false; }
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) { ret false; }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    val e_opt: R.Result[expr.Expr, str] = resolve.expression(rr, a, eid);
+    if (R.is_err[expr.Expr, str](e_opt)) {
+        fail.internal(?sc.status, R.unwrap_err[expr.Expr, str](e_opt));
+        ret false;
+    }
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](e_opt);
+    val e: *expr.Expr = ?e_value;
     val k: expr.ExprKind = e.kind;
 
     if (k == expr.EXPR_KIND_CALL) {
@@ -379,8 +539,7 @@ fun decl_body_reaches_c_variadic(sc: *SemaContext, origin: session.ModuleId, did
 fun decl_reaches_c_variadic(sc: *SemaContext, origin: session.ModuleId, did: id.DeclId,
                             want_spread: bool, seen: *ReachSeen) bool {
     if (!reach_visit(seen, origin, did)) { ret false; }
-    var a: *ast.Ast = sc.a;
-    if (origin != sc.own_module) { a = session.module_ast(sc.s, origin); }
+    val a: *ast.Ast = definition_ast(sc, origin);
     if (a == nil) { ret false; }
     val rr: *resolve.ResolveResult = module_rr_for(sc, origin);
     if (rr == nil) { ret false; }
@@ -453,8 +612,7 @@ fun stmt_calls_c_variadic(sc: *SemaContext, a: *ast.Ast, rr: *resolve.ResolveRes
 }
 
 fun decl_body_has_type_directive(sc: *SemaContext, origin: session.ModuleId, did: id.DeclId) bool {
-    var a: *ast.Ast = sc.a;
-    if (origin != sc.own_module) { a = session.module_ast(sc.s, origin); }
+    val a: *ast.Ast = definition_ast(sc, origin);
     if (a == nil) { ret false; }
 
     val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, did);
@@ -689,23 +847,36 @@ pub fun module_sema_for(sc: *SemaContext, module: session.ModuleId) O.Option[*Mo
     ret O.none[*ModuleSema]();
 }
 
+pub fun public_type_for(sc: *SemaContext, sym: *resolve.Symbol) O.Option[TypeExport] {
+    if (sc.deps == nil) { ret O.none[TypeExport](); }
+    val owner: session.StableModuleId = resolve.type_owner(sc.s, sym.origin, sym.definition_file).module;
+    var i: u32 = 0;
+    for (i < sc.deps.count) {
+        val module: *ModuleSema = ?sc.deps.entries[i];
+        var j: usize = 0;
+        for (j < module.exports.len) {
+            val item: TypeExport = module.exports.data[j];
+            if (item.origin == owner && item.canon == sym.canon) { ret O.some[TypeExport](item); }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    ret O.none[TypeExport]();
+}
+
 pub fun decl_type_for(sc: *SemaContext, sym: *resolve.Symbol) type.TypeId {
-    if (sym.decl == id.DECL_NIL) { ret type.TYPE_ERROR; }
-
-    if (sym.kind == resolve.SYM_PARAM)   { ret param_type_for(sc, sym); }
+    if (sym.kind == resolve.SYM_PARAM) { ret param_type_for(sc, sym); }
     if (sym.kind == resolve.SYM_GENERIC) { ret generic_param_type_for(sc, sym); }
-
     if (sym.origin == sc.own_module) {
-        if (sc.decl_type == nil)            { ret type.TYPE_ERROR; }
-        if (sym.decl >= sc.a.decl_len::u32) { ret type.TYPE_ERROR; }
+        if (sc.decl_type == nil || sym.decl == id.DECL_NIL || sym.decl >= sc.a.decl_len::u32) { ret type.TYPE_ERROR; }
         ret sc.decl_type[sym.decl];
     }
-
-    val ms_opt: O.Option[*ModuleSema] = module_sema_for(sc, sym.origin);
-    if (O.is_none[*ModuleSema](ms_opt)) { ret type.TYPE_ERROR; }
-    val ms: *ModuleSema = O.unwrap[*ModuleSema](ms_opt);
-    if (ms.decl_type == nil || sym.decl >= ms.decl_count) { ret type.TYPE_ERROR; }
-    ret ms.decl_type[sym.decl];
+    val exported: O.Option[TypeExport] = public_type_for(sc, sym);
+    if (O.is_none[TypeExport](exported)) {
+        fail.internal(?sc.status, "imported type has no acquired public surface");
+        ret type.TYPE_ERROR;
+    }
+    ret O.unwrap[TypeExport](exported).ty;
 }
 
 pub fun symbol_for_expr(sc: *SemaContext, eid: id.ExprId) O.Option[*resolve.Symbol] {
@@ -748,11 +919,11 @@ pub fun report(sc: *SemaContext, span: token.Span, message: str) {
     if (sc.silent) { ret; }
     fail.reject(?sc.status);
     if (sc.in_comptime_gate) {
-        val r: R.Result[bool, str] = diagnostic.gate_error(?sc.s.gate_diags, ?sc.s.diags, ?sc.s.interner, sc.a.file_id, span, message);
+        val r: R.Result[bool, str] = diagnostic.gate_error(sc.diags, ?sc.s.interner, sc.a.file_id, span, message);
         if (R.is_err[bool, str](r)) { fail.internal(?sc.status, R.unwrap_err[bool, str](r)); }
         ret;
     }
-    val r: R.Result[R.Void, str] = diagnostic.error(?sc.s.diags, sc.a.file_id, span, message);
+    val r: R.Result[R.Void, str] = diagnostic.error(sc.diags, sc.a.file_id, span, message);
     if (R.is_err[R.Void, str](r)) { fail.internal(?sc.status, R.unwrap_err[R.Void, str](r)); }
 }
 
@@ -778,7 +949,7 @@ pub fun reported_since(sc: *SemaContext, mark: u64) bool {
 
 pub fun report_warning(sc: *SemaContext, span: token.Span, message: str) {
     if (sc.silent || sc.in_comptime_gate) { ret; }
-    val r: R.Result[R.Void, str] = diagnostic.warning(?sc.s.diags, sc.a.file_id, span, message);
+    val r: R.Result[R.Void, str] = diagnostic.warning(sc.diags, sc.a.file_id, span, message);
     if (R.is_err[R.Void, str](r)) { fail.internal(?sc.status, R.unwrap_err[R.Void, str](r)); }
 }
 
@@ -794,12 +965,12 @@ pub fun report_note(sc: *SemaContext, span: token.Span, message: str, note: str)
     if (R.is_err[R.Void, str](ar)) { diagnostic.builder_dnit(?b); fail.internal(?sc.status, R.unwrap_err[R.Void, str](ar)); ret; }
 
     if (sc.in_comptime_gate) {
-        val r: R.Result[bool, str] = diagnostic.gate_commit(?sc.s.gate_diags, ?sc.s.diags, ?sc.s.interner, ?b);
+        val r: R.Result[bool, str] = diagnostic.gate_commit(sc.diags, ?sc.s.interner, ?b);
         if (R.is_err[bool, str](r)) { fail.internal(?sc.status, R.unwrap_err[bool, str](r)); }
         ret;
     }
 
-    val cr: R.Result[diagnostic.DiagnosticId, str] = diagnostic.commit(?b, ?sc.s.diags);
+    val cr: R.Result[diagnostic.DiagnosticId, str] = diagnostic.commit(?b, sc.diags);
     if (R.is_err[diagnostic.DiagnosticId, str](cr)) { diagnostic.builder_dnit(?b); fail.internal(?sc.status, R.unwrap_err[diagnostic.DiagnosticId, str](cr)); ret; }
 }
 
@@ -943,25 +1114,33 @@ pub fun resolve_module_member_const(sc: *SemaContext, eid: id.ExprId) R.Result[O
     if (sym.kind != resolve.SYM_IMPORTED) {
         ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.none[comptime.CTValue]());
     }
-    val ms_opt: O.Option[*ModuleSema] = module_sema_for(sc, sym.origin);
-    var octx: *comptime.ComptimeCtx = nil;
-    if (O.is_some[*ModuleSema](ms_opt)) { octx = O.unwrap[*ModuleSema](ms_opt).ctx; }
-    if (octx == nil) { octx = (session.module_comptime_ptr(sc.s, sym.origin))::*comptime.ComptimeCtx; }
-    if (octx == nil) { ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.none[comptime.CTValue]()); }
-    val nc: O.Option[comptime.NamedConst] = comptime.lookup(octx, sym.name);
-    if (O.is_none[comptime.NamedConst](nc)) {
+    val exported: O.Option[TypeExport] = public_type_for(sc, sym);
+    if (O.is_none[TypeExport](exported) || !O.unwrap[TypeExport](exported).constant.present) {
         ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.none[comptime.CTValue]());
     }
-    val named: comptime.NamedConst = O.unwrap[comptime.NamedConst](nc);
+    val item: TypeExport = O.unwrap[TypeExport](exported);
+    val named: resolve.ExportConstant = item.constant;
+    if (named.value.kind == comptime.CT_KIND_CONST_ELEM) {
+        val current: R.Result[DefinedSymbol, fail.Fail] = imported_definition(sc, sym, DEFINITION_RESOLVED);
+        if (R.is_err[DefinedSymbol, fail.Fail](current)) {
+            val reason: fail.Fail = R.unwrap_err[DefinedSymbol, fail.Fail](current);
+            var kind: comptime.EvalFailKind = comptime.EVAL_FAIL_INTERNAL;
+            if (reason.kind == fail.REPORTED) { kind = comptime.EVAL_FAIL_REJECTED; }
+            ret R.err[O.Option[comptime.CTValue], comptime.EvalFail](comptime.eval_error(kind, reason.message));
+        }
+        if (R.unwrap_ok[DefinedSymbol, fail.Fail](current).definition.parsed.incarnation != item.definition_incarnation) {
+            fail.internal(?sc.status, "constant element does not belong to the acquired parsed definition");
+            ret R.err[O.Option[comptime.CTValue], comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_INTERNAL, sc.status.message));
+        }
+    }
     if (named.gated && sc.ctx.env.union_build) {
-        var dep_path: intern.StrId = intern.STR_NIL;
-        if (O.is_some[*ModuleSema](ms_opt)) { dep_path = O.unwrap[*ModuleSema](ms_opt).path; }
+        val dep_path: intern.StrId = session.module_fqn(sc.s, sym.origin);
         val msg: str = gated_member_const_message(sc, sym.name, dep_path);
-        val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+        val e_opt: R.Result[expr.Expr, str] = expression(sc, eid);
         var span: token.Span;
         span.offset = 0;
         span.len    = 0;
-        if (O.is_some[*expr.Expr](e_opt)) { span = O.unwrap[*expr.Expr](e_opt).span; }
+        if (R.is_ok[expr.Expr, str](e_opt)) { span = R.unwrap_ok[expr.Expr, str](e_opt).span; }
         report(sc, span, msg);
         if (sc.status.kind == fail.INTERNAL) {
             ret R.err[O.Option[comptime.CTValue], comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_INTERNAL, sc.status.message));
@@ -980,8 +1159,59 @@ fun param_type_for(sc: *SemaContext, sym: *resolve.Symbol) type.TypeId {
     ret resolved_type_of(sc, tn.ty);
 }
 
+pub fun own_nominal_declaration(sc: *SemaContext, nominal: *type.Type) R.Result[id.DeclId, fail.Fail] {
+    if (sc.rr == nil || sc.a == nil) { ret R.err[id.DeclId, fail.Fail](fail.message("nominal definition requires the active resolved owner")); }
+    val owner: type.TypeOwner = resolve.type_owner(sc.s, sc.own_module, sc.a.file_id);
+    if (nominal.data.nominal.owner.module != owner.module || nominal.data.nominal.owner.file != owner.file) {
+        ret R.err[id.DeclId, fail.Fail](fail.message("nominal definition belongs to another source owner"));
+    }
+    var found: id.DeclId = id.DECL_NIL;
+    var i: u32 = 0;
+    for (i < sc.rr.symbol_count) {
+        val symbol: *resolve.Symbol = ?sc.rr.symbols[i];
+        var matches: bool = symbol.kind == resolve.SYM_REC && nominal.kind == type.TYPE_REC;
+        if (symbol.kind == resolve.SYM_UNI && nominal.kind == type.TYPE_UNI) { matches = true; }
+        if (matches && symbol.origin == sc.own_module && symbol.canon == nominal.data.nominal.name) {
+            if (found != id.DECL_NIL && found != symbol.decl) { ret R.err[id.DeclId, fail.Fail](fail.message("nominal definition is ambiguous in the active resolved owner")); }
+            found = symbol.decl;
+        }
+        i = i + 1;
+    }
+    if (found == id.DECL_NIL || found >= sc.a.decl_len::u32) { ret R.err[id.DeclId, fail.Fail](fail.message("nominal definition is absent from the active resolved owner")); }
+    ret R.ok[id.DeclId, fail.Fail](found);
+}
+
+pub fun definition_ast(sc: *SemaContext, origin: session.ModuleId) *ast.Ast {
+    if (origin == sc.own_module) { ret sc.a; }
+    if (sc.deps == nil) { fail.internal(?sc.status, "semantic definition has no dependency reader"); ret nil; }
+    val acquired: R.Result[Definition, fail.Fail] = acquire_definition(?sc.deps.definitions, origin, DEFINITION_PARSED);
+    if (R.is_err[Definition, fail.Fail](acquired)) {
+        val reason: fail.Fail = R.unwrap_err[Definition, fail.Fail](acquired);
+        if (reason.kind == fail.REPORTED) { fail.reject(?sc.status); }
+        or { fail.internal(?sc.status, reason.message); }
+        ret nil;
+    }
+    ret R.unwrap_ok[Definition, fail.Fail](acquired).parsed.a;
+}
+
 pub fun generic_param_type_for(sc: *SemaContext, sym: *resolve.Symbol) type.TypeId {
-    val res_intern: R.Result[type.TypeId, str] = type.intern_generic_param(?sc.s.types, sym.name, sym.origin, sym.decl, sym.slot);
+    val a: *ast.Ast = definition_ast(sc, sym.origin);
+    if (a == nil) { ret type.TYPE_ERROR; }
+    val selected: O.Option[*decl.Decl] = ast.get_decl(a, sym.decl);
+    if (O.is_none[*decl.Decl](selected)) { fail.internal(?sc.status, "generic parameter has no current owning declaration"); ret type.TYPE_ERROR; }
+    val declaration: *decl.Decl = O.unwrap[*decl.Decl](selected);
+    var name: token.Span;
+    var kind: type.TypeKind = type.TYPE_FUN;
+    if (declaration.kind == decl.DECL_KIND_FUN) { name = declaration.data.fun_.name; }
+    or (declaration.kind == decl.DECL_KIND_REC) { name = declaration.data.rec_.name; kind = type.TYPE_REC; }
+    or (declaration.kind == decl.DECL_KIND_UNI) { name = declaration.data.uni_.name; kind = type.TYPE_UNI; }
+    or { fail.internal(?sc.status, "generic parameter owner has the wrong declaration kind"); ret type.TYPE_ERROR; }
+    val text: O.Option[*source.SourceFile] = source.get(?sc.s.sources, a.file_id);
+    if (O.is_none[*source.SourceFile](text)) { fail.internal(?sc.status, "generic parameter owner has no source"); ret type.TYPE_ERROR; }
+    val canonical: R.Result[intern.StrId, str] = intern.intern_span(?sc.s.interner, O.unwrap[*source.SourceFile](text).text, name);
+    if (R.is_err[intern.StrId, str](canonical)) { fail.internal(?sc.status, R.unwrap_err[intern.StrId, str](canonical)); ret type.TYPE_ERROR; }
+    val res_intern: R.Result[type.TypeId, str] = type.intern_generic_param(?sc.s.types, sym.name,
+        resolve.type_owner(sc.s, sym.origin, a.file_id), R.unwrap_ok[intern.StrId, str](canonical), kind, sym.slot);
     if (R.is_err[type.TypeId, str](res_intern)) { fail.internal(?sc.status, R.unwrap_err[type.TypeId, str](res_intern)); ret type.TYPE_ERROR; }
     ret apply_subst(sc, R.unwrap_ok[type.TypeId, str](res_intern));
 }
@@ -1059,7 +1289,7 @@ fun record_distinct_instances(sc: *SemaContext, first: u32, count: u32) R.Result
     var i: u32 = first;
     for (i < first + count) {
         val res_nom: R.Result[type.TypeId, str] =
-            type.intern_nominal(?sc.s.types, i::intern.StrId, 0::session.ModuleId, i::id.DeclId, type.TYPE_REC);
+            type.intern_nominal(?sc.s.types, i::intern.StrId, type.TypeOwner{ module: 0, file: 1 }, type.TYPE_REC);
         if (R.is_err[type.TypeId, str](res_nom)) { fail.internal(?sc.status, R.unwrap_err[type.TypeId, str](res_nom)); ret R.err[R.Void, str](R.unwrap_err[type.TypeId, str](res_nom)); }
         var arg: type.TypeId = R.unwrap_ok[type.TypeId, str](res_nom);
 
@@ -1084,6 +1314,7 @@ fun time_record_fresh(count: u32) i64 {
     var sc: SemaContext;
     sc.status        = fail.accepted();
     sc.s             = ?sess;
+    sc.diags = ?sess.diags;
     sc.collect_insts = true;
     sc.insts         = nil;
     sc.inst_depth    = 0;

--- a/src/lang/fe/sema/fields.mach
+++ b/src/lang/fe/sema/fields.mach
@@ -1,0 +1,471 @@
+use T: std.allocator.testing;
+use std.collections.sort;
+use std.collections.vector;
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+
+use A: std.allocator;
+use O: std.types.option;
+use R: std.types.result;
+
+use mach.lang.fe.ast.id;
+use mach.lang.intern;
+use mach.lang.fail;
+use mach.lang.session;
+use mach.lang.target.isa;
+use mach.lang.type;
+
+pub rec Node {
+    ty: type.TypeId;
+    entries: vector.Vector[type.FieldEntry];
+    has_align: bool;
+    align: u32;
+    packed: bool;
+    volatile_: bool;
+}
+
+pub rec Roots {
+    data: *type.TypeId;
+    len: usize;
+}
+
+pub def CaptureMode: u8;
+
+pub val RECIPES: CaptureMode = 0;
+pub val MATERIALIZED: CaptureMode = 1;
+
+pub rec Graph {
+    nodes: vector.Vector[Node];
+}
+
+pub fun init(a: *A.Allocator) Graph {
+    ret Graph{ nodes: vector.init[Node](a) };
+}
+
+pub fun dnit(graph: *Graph) {
+    var i: usize = 0;
+    for (i < graph.nodes.len) {
+        vector.dnit[type.FieldEntry](?graph.nodes.data[i].entries);
+        i = i + 1;
+    }
+    vector.dnit[Node](?graph.nodes);
+}
+
+fun node_compare(left: *Node, right: *Node) i64 {
+    if (left.ty < right.ty) { ret -1; }
+    if (left.ty > right.ty) { ret 1; }
+    ret 0;
+}
+
+fun enqueue(ti: *type.TypeInterner, scan: *type.TypeScan, pending: *vector.Vector[type.TypeId],
+            ty: type.TypeId) R.Result[R.Void, str] {
+    if (ty == type.TYPE_NIL || ty == type.TYPE_ERROR) { ret R.ok_void[str](); }
+    if (O.is_none[*type.Type](type.get(ti, ty))) { ret R.err[R.Void, str]("field graph contains an invalid type identity"); }
+    val marked: R.Result[type.VisitMark, str] = type.type_scan_mark(ti, scan, ty);
+    if (R.is_err[type.VisitMark, str](marked)) { ret R.void_of[type.VisitMark, str](marked); }
+    if (R.unwrap_ok[type.VisitMark, str](marked) == type.VISIT_SEEN) { ret R.ok_void[str](); }
+    ret R.void_of[usize, str](vector.push[type.TypeId](pending, ty));
+}
+
+fun enqueue_parameters(ti: *type.TypeInterner, scan: *type.TypeScan, pending: *vector.Vector[type.TypeId],
+                       start: u32, len: u32) R.Result[R.Void, str] {
+    var i: u32 = 0;
+    for (i < len) {
+        val parameter: O.Option[type.TypeId] = type.get_param(ti, start + i);
+        if (O.is_none[type.TypeId](parameter)) { ret R.err[R.Void, str]("field graph contains an invalid type parameter run"); }
+        val added: R.Result[R.Void, str] = enqueue(ti, scan, pending, O.unwrap[type.TypeId](parameter));
+        if (R.is_err[R.Void, str](added)) { ret added; }
+        i = i + 1;
+    }
+    ret R.ok_void[str]();
+}
+
+fun enqueue_handle(ti: *type.TypeInterner, scan: *type.TypeScan, pending: *vector.Vector[type.TypeId],
+                   handle: type.TypeHandle, defs: *isa.TargetDefs) R.Result[R.Void, str] {
+    if (handle.ctor == isa.NO_TYPE_CTOR) { ret R.ok_void[str](); }
+    if (defs == nil) { ret R.err[R.Void, str]("field graph handle has no acquired constructor schema"); }
+    val schema: *isa.TypeDef = isa.type_def_by_tag(defs, handle.ctor);
+    if (schema == nil || schema.arity != handle.ops_len || (schema.arity != 0 && schema.operands == nil)) {
+        ret R.err[R.Void, str]("field graph handle disagrees with its constructor schema");
+    }
+    if (handle.ops_start > ti.handle_ops_len || handle.ops_len > ti.handle_ops_len - handle.ops_start) {
+        ret R.err[R.Void, str]("field graph handle has an invalid operand run");
+    }
+    var i: u32 = 0;
+    for (i < schema.arity) {
+        if (schema.operands[i] != isa.TYPE_OPERAND_WORD) {
+            val child: type.TypeId = ti.handle_ops[handle.ops_start + i]::type.TypeId;
+            val info: O.Option[*type.Type] = type.get(ti, child);
+            if (O.is_none[*type.Type](info) || O.unwrap[*type.Type](info).kind != type.TYPE_HANDLE
+                || O.unwrap[*type.Type](info).data.handle.ctor != schema.operands[i]) {
+                ret R.err[R.Void, str]("field graph handle operand does not match its required constructor");
+            }
+            val added: R.Result[R.Void, str] = enqueue(ti, scan, pending, child);
+            if (R.is_err[R.Void, str](added)) { ret added; }
+        }
+        i = i + 1;
+    }
+    ret R.ok_void[str]();
+}
+
+fun capture_node(s: *session.Session, graph: *Graph, scan: *type.TypeScan,
+                 pending: *vector.Vector[type.TypeId], ty: type.TypeId) R.Result[R.Void, str] {
+    var node: Node;
+    node.ty = ty;
+    node.entries = vector.init[type.FieldEntry](graph.nodes.a);
+    node.has_align = false;
+    node.align = 0;
+    node.packed = session.type_is_packed(s, ty::u32);
+    node.volatile_ = session.type_is_volatile(s, ty::u32);
+    val alignment: O.Option[u32] = session.type_align(s, ty::u32);
+    if (O.is_some[u32](alignment)) { node.has_align = true; node.align = O.unwrap[u32](alignment); }
+    var transferred: bool = false;
+    fin { if (!transferred) { vector.dnit[type.FieldEntry](?node.entries); } }
+    val table: O.Option[*type.FieldTable] = type.field_table_for(?s.types, ty);
+    if (O.is_none[*type.FieldTable](table)) { ret R.err[R.Void, str]("prepared nominal field recipe is unavailable"); }
+    {
+        val current: *type.FieldTable = O.unwrap[*type.FieldTable](table);
+        var i: u32 = 0;
+        for (i < current.fields_len) {
+            val field: *type.FieldEntry = type.field_entry_at(?s.types, current, i);
+            if (field == nil) { ret R.err[R.Void, str]("field graph contains an invalid field run"); }
+            val copied: R.Result[usize, str] = vector.push[type.FieldEntry](?node.entries, @field);
+            if (R.is_err[usize, str](copied)) { ret R.void_of[usize, str](copied); }
+            val added: R.Result[R.Void, str] = enqueue(?s.types, scan, pending, field.ty);
+            if (R.is_err[R.Void, str](added)) { ret added; }
+            i = i + 1;
+        }
+    }
+    val appended: R.Result[usize, str] = vector.push[Node](?graph.nodes, node);
+    if (R.is_err[usize, str](appended)) { ret R.void_of[usize, str](appended); }
+    transferred = true;
+    ret R.ok_void[str]();
+}
+
+pub fun capture[T](s: *session.Session, a: *A.Allocator, roots: *Roots, count: usize, mode: CaptureMode, defs: *isa.TargetDefs, ctx: *T,
+                   prepare: fun(*T, type.TypeId) R.Result[R.Void, fail.Fail]) R.Result[Graph, fail.Fail] {
+    if (mode != RECIPES && mode != MATERIALIZED) { ret fail.lift[Graph](R.err[Graph, str]("invalid field graph capture mode")); }
+    if (roots == nil && count != 0) { ret fail.lift[Graph](R.err[Graph, str]("field graph roots are nil")); }
+    if (ctx == nil || prepare == nil) { ret fail.lift[Graph](R.err[Graph, str]("field graph capture requires an active preparation capability")); }
+    var graph: Graph = init(a);
+    var complete: bool = false;
+    fin { if (!complete) { dnit(?graph); } }
+    var scan: type.TypeScan;
+    val scanning: R.Result[R.Void, str] = type.type_scan_begin(?s.types, ?scan);
+    if (R.is_err[R.Void, str](scanning)) { ret fail.lift[Graph](R.err[Graph, str](R.unwrap_err[R.Void, str](scanning))); }
+    fin { type.type_scan_end(?s.types, ?scan); }
+    var pending: vector.Vector[type.TypeId] = vector.init[type.TypeId](a);
+    fin { vector.dnit[type.TypeId](?pending); }
+    var i: usize = 0;
+    for (i < count) {
+        val group: Roots = roots[i];
+        if (group.data == nil && group.len != 0) { ret fail.lift[Graph](R.err[Graph, str]("field graph root group is nil")); }
+        var j: usize = 0;
+        for (j < group.len) {
+            val added: R.Result[R.Void, str] = enqueue(?s.types, ?scan, ?pending, group.data[j]);
+            if (R.is_err[R.Void, str](added)) { ret fail.lift[Graph](R.err[Graph, str](R.unwrap_err[R.Void, str](added))); }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < pending.len) {
+        val ty: type.TypeId = pending.data[i];
+        val initial: O.Option[*type.Type] = type.get(?s.types, ty);
+        if (O.is_none[*type.Type](initial)) { ret fail.lift[Graph](R.err[Graph, str]("field graph contains an invalid type identity")); }
+        val kind: type.TypeKind = O.unwrap[*type.Type](initial).kind;
+        if (kind == type.TYPE_REC || kind == type.TYPE_UNI) {
+            val prepared: R.Result[R.Void, fail.Fail] = prepare(ctx, ty);
+            if (R.is_err[R.Void, fail.Fail](prepared)) { ret R.err[Graph, fail.Fail](R.unwrap_err[R.Void, fail.Fail](prepared)); }
+        }
+        val info: O.Option[*type.Type] = type.get(?s.types, ty);
+        if (O.is_none[*type.Type](info)) { ret fail.lift[Graph](R.err[Graph, str]("field graph type disappeared during capture")); }
+        val node: *type.Type = O.unwrap[*type.Type](info);
+        var child: type.TypeId = type.TYPE_NIL;
+        if (node.kind == type.TYPE_POINTER) { child = node.data.pointer.base; }
+        or (node.kind == type.TYPE_ARRAY) { child = node.data.array.base; }
+        or (node.kind == type.TYPE_SECRET) { child = node.data.secret.base; }
+        or (node.kind == type.TYPE_FUN) {
+            child = node.data.fn.ret_type;
+            val parameters: R.Result[R.Void, str] = enqueue_parameters(?s.types, ?scan, ?pending,
+                node.data.fn.params_start, node.data.fn.params_len);
+            if (R.is_err[R.Void, str](parameters)) { ret fail.lift[Graph](R.err[Graph, str](R.unwrap_err[R.Void, str](parameters))); }
+        }
+        or (node.kind == type.TYPE_INSTANCE) {
+            child = node.data.instance.nominal;
+            val parameters: R.Result[R.Void, str] = enqueue_parameters(?s.types, ?scan, ?pending,
+                node.data.instance.args_start, node.data.instance.args_len);
+            if (R.is_err[R.Void, str](parameters)) { ret fail.lift[Graph](R.err[Graph, str](R.unwrap_err[R.Void, str](parameters))); }
+        }
+        or (node.kind == type.TYPE_HANDLE) {
+            val operands: R.Result[R.Void, str] = enqueue_handle(?s.types, ?scan, ?pending, node.data.handle, defs);
+            if (R.is_err[R.Void, str](operands)) { ret fail.lift[Graph](R.err[Graph, str](R.unwrap_err[R.Void, str](operands))); }
+        }
+        val added: R.Result[R.Void, str] = enqueue(?s.types, ?scan, ?pending, child);
+        if (R.is_err[R.Void, str](added)) { ret fail.lift[Graph](R.err[Graph, str](R.unwrap_err[R.Void, str](added))); }
+        if (node.kind == type.TYPE_REC || node.kind == type.TYPE_UNI
+            || (mode == MATERIALIZED && node.kind == type.TYPE_INSTANCE
+                && O.is_some[*type.FieldTable](type.field_table_for(?s.types, ty)))) {
+            val copied: R.Result[R.Void, str] = capture_node(s, ?graph, ?scan, ?pending, ty);
+            if (R.is_err[R.Void, str](copied)) { ret fail.lift[Graph](R.err[Graph, str](R.unwrap_err[R.Void, str](copied))); }
+        }
+        i = i + 1;
+    }
+    sort.sort[Node](graph.nodes.data, graph.nodes.len, node_compare);
+    complete = true;
+    ret R.ok[Graph, fail.Fail](graph);
+}
+
+fun same_fields(s: *session.Session, table: *type.FieldTable, node: *Node) bool {
+    if (table.fields_len::usize != node.entries.len) { ret false; }
+    var i: u32 = 0;
+    for (i < table.fields_len) {
+        val entry: *type.FieldEntry = type.field_entry_at(?s.types, table, i);
+        if (entry == nil || entry.name != node.entries.data[i].name || entry.ty != node.entries.data[i].ty) { ret false; }
+        i = i + 1;
+    }
+    val alignment: O.Option[u32] = session.type_align(s, node.ty::u32);
+    if (O.is_some[u32](alignment) != node.has_align) { ret false; }
+    if (node.has_align && O.unwrap[u32](alignment) != node.align) { ret false; }
+    ret session.type_is_packed(s, node.ty::u32) == node.packed
+        && session.type_is_volatile(s, node.ty::u32) == node.volatile_;
+}
+
+pub fun install(s: *session.Session, graph: *Graph) R.Result[R.Void, str] {
+    var i: usize = 0;
+    for (i < graph.nodes.len) {
+        val node: *Node = ?graph.nodes.data[i];
+        val existing: O.Option[*type.FieldTable] = type.field_table_for(?s.types, node.ty);
+        if (O.is_some[*type.FieldTable](existing)) {
+            if (!same_fields(s, O.unwrap[*type.FieldTable](existing), node)) {
+                ret R.err[R.Void, str]("field projection disagrees with an acquired definition");
+            }
+            i = i + 1;
+            cnt;
+        }
+        if (node.entries.len > 0xFFFFFFFF::usize) { ret R.err[R.Void, str]("field projection exceeds the field count limit"); }
+        val staged: R.Result[u32, str] = type.field_table_stage(?s.types, node.entries.len::u32);
+        if (R.is_err[u32, str](staged)) { ret R.void_of[u32, str](staged); }
+        var j: usize = 0;
+        for (j < node.entries.len) {
+            val entry: type.FieldEntry = node.entries.data[j];
+            val copied: R.Result[R.Void, str] = type.field_table_stage_push(?s.types, entry.name, entry.ty);
+            if (R.is_err[R.Void, str](copied)) { ret copied; }
+            j = j + 1;
+        }
+        if (node.has_align) {
+            val aligned: R.Result[R.Void, str] = session.register_type_align(s, node.ty::u32, node.align);
+            if (R.is_err[R.Void, str](aligned)) { ret aligned; }
+        }
+        if (node.packed) {
+            val packed: R.Result[R.Void, str] = session.register_type_packed(s, node.ty::u32);
+            if (R.is_err[R.Void, str](packed)) { ret packed; }
+        }
+        if (node.volatile_) {
+            val volatile_: R.Result[R.Void, str] = session.register_type_volatile(s, node.ty::u32);
+            if (R.is_err[R.Void, str](volatile_)) { ret volatile_; }
+        }
+        val published: R.Result[R.Void, str] = type.field_table_publish(?s.types, node.ty,
+            R.unwrap_ok[u32, str](staged), node.entries.len::u32);
+        if (R.is_err[R.Void, str](published)) { ret published; }
+        i = i + 1;
+    }
+    ret R.ok_void[str]();
+}
+
+
+fun t_prepared(s: *session.Session, ty: type.TypeId) R.Result[R.Void, fail.Fail] {
+    ret R.ok_void[fail.Fail]();
+}
+
+fun t_one_field(s: *session.Session, owner: type.TypeId, field_type: type.TypeId) R.Result[R.Void, str] {
+    val staged: R.Result[u32, str] = type.field_table_stage(?s.types, 1);
+    if (R.is_err[u32, str](staged)) { ret R.void_of[u32, str](staged); }
+    val pushed: R.Result[R.Void, str] = type.field_table_stage_push(?s.types, 1::intern.StrId, field_type);
+    if (R.is_err[R.Void, str](pushed)) { ret pushed; }
+    ret type.field_table_publish(?s.types, owner, R.unwrap_ok[u32, str](staged), 1);
+}
+
+test "mach.lang.fe.sema.fields:circular_graph_owns_fields_and_remaps_rebuilt_projection_runs" {
+    var tracker: T.Testing;
+    if (O.is_some[str](T.make(?tracker))) { ret 1; }
+    fin { T.dnit(?tracker); }
+    val allocated: *A.Allocator = T.allocator_of(?tracker);
+    val initialized: R.Result[session.Session, str] = session.init(allocated);
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    var session_live: bool = true;
+    fin { if (session_live) { session.dnit(?s); } }
+    val first_r: R.Result[type.TypeId, str] = type.intern_nominal(?s.types, 1::intern.StrId, type.TypeOwner{ module: 0, file: 0 }, type.TYPE_REC);
+    val second_r: R.Result[type.TypeId, str] = type.intern_nominal(?s.types, 2::intern.StrId, type.TypeOwner{ module: 0, file: 0 }, type.TYPE_REC);
+    if (R.is_err[type.TypeId, str](first_r) || R.is_err[type.TypeId, str](second_r)) { ret 3; }
+    val first: type.TypeId = R.unwrap_ok[type.TypeId, str](first_r);
+    val second: type.TypeId = R.unwrap_ok[type.TypeId, str](second_r);
+    val to_first_r: R.Result[type.TypeId, str] = type.intern_pointer(?s.types, first);
+    val to_second_r: R.Result[type.TypeId, str] = type.intern_pointer(?s.types, second);
+    if (R.is_err[type.TypeId, str](to_first_r) || R.is_err[type.TypeId, str](to_second_r)) { ret 4; }
+    val to_first: type.TypeId = R.unwrap_ok[type.TypeId, str](to_first_r);
+    val to_second: type.TypeId = R.unwrap_ok[type.TypeId, str](to_second_r);
+    if (R.is_err[R.Void, str](t_one_field(?s, second, to_first))
+        || R.is_err[R.Void, str](t_one_field(?s, first, to_second))) { ret 5; }
+    if (R.is_err[R.Void, str](session.register_type_align(?s, first::u32, 16))
+        || R.is_err[R.Void, str](session.register_type_packed(?s, first::u32))
+        || R.is_err[R.Void, str](session.register_type_volatile(?s, first::u32))) { ret 6; }
+    val prior: O.Option[*type.FieldTable] = type.field_table_for(?s.types, first);
+    if (O.is_none[*type.FieldTable](prior)) { ret 7; }
+    val prior_start: u32 = O.unwrap[*type.FieldTable](prior).fields_start;
+    var root: type.TypeId = first;
+    var roots: Roots = Roots{ data: ?root, len: 1 };
+    val captured: R.Result[Graph, fail.Fail] = capture[session.Session](?s, allocated, ?roots, 1, MATERIALIZED, nil, ?s, t_prepared);
+    if (R.is_err[Graph, fail.Fail](captured)) { ret 8; }
+    var graph: Graph = R.unwrap_ok[Graph, fail.Fail](captured);
+    var graph_live: bool = true;
+    fin { if (graph_live) { dnit(?graph); } }
+    if (graph.nodes.len != 2 || graph.nodes.data[0].ty != first || graph.nodes.data[1].ty != second) { ret 9; }
+    var baseline: usize = 0;
+    var iteration: u32 = 0;
+    for (iteration < 32) {
+        if (R.is_err[R.Void, str](session.reset_type_projection(?s))) { ret 10; }
+        if (type.field_count(?s.types, first) != 0 || session.type_is_packed(?s, first::u32)
+            || session.type_is_volatile(?s, first::u32) || O.is_some[u32](session.type_align(?s, first::u32))) { ret 10; }
+        if (R.is_err[R.Void, str](install(?s, ?graph))) { ret 11; }
+        val current: O.Option[*type.FieldTable] = type.field_table_for(?s.types, first);
+        if (O.is_none[*type.FieldTable](current) || O.unwrap[*type.FieldTable](current).fields_start == prior_start) { ret 12; }
+        val field: O.Option[*type.FieldEntry] = type.field_at(?s.types, first, 0);
+        if (O.is_none[*type.FieldEntry](field) || O.unwrap[*type.FieldEntry](field).ty != to_second) { ret 13; }
+        if (!session.type_is_packed(?s, first::u32) || !session.type_is_volatile(?s, first::u32)) { ret 14; }
+        val alignment: O.Option[u32] = session.type_align(?s, first::u32);
+        if (O.is_none[u32](alignment) || O.unwrap[u32](alignment) != 16) { ret 15; }
+        val before: usize = T.live_count(?tracker);
+        if (R.is_err[R.Void, str](install(?s, ?graph)) || T.live_count(?tracker) != before) { ret 16; }
+        if (iteration == 1) { baseline = T.live_count(?tracker); }
+        if (iteration > 1 && T.live_count(?tracker) != baseline) { ret 17; }
+        iteration = iteration + 1;
+    }
+    dnit(?graph);
+    graph_live = false;
+    session.dnit(?s);
+    session_live = false;
+    if (T.live_count(?tracker) != 0 || T.double_free_count(?tracker) != 0) { ret 18; }
+    ret 0;
+}
+
+rec RecipeProbe {
+    s: *session.Session;
+    calls: u32;
+}
+
+fun t_recipe_prepare(probe: *RecipeProbe, ty: type.TypeId) R.Result[R.Void, fail.Fail] {
+    val found: O.Option[*type.Type] = type.get(?probe.s.types, ty);
+    if (O.is_none[*type.Type](found)) { ret R.err[R.Void, fail.Fail](fail.message("recipe type is missing")); }
+    val kind: type.TypeKind = O.unwrap[*type.Type](found).kind;
+    if (kind != type.TYPE_REC && kind != type.TYPE_UNI) {
+        ret R.err[R.Void, fail.Fail](fail.message("capture tried to materialize an instance"));
+    }
+    probe.calls = probe.calls + 1;
+    ret R.ok_void[fail.Fail]();
+}
+
+fun t_instance_pointer(s: *session.Session, nominal: type.TypeId, argument: type.TypeId) R.Result[type.TypeId, str] {
+    var args: [1]type.TypeId;
+    args[0] = argument;
+    val instance: R.Result[type.TypeId, str] = type.intern_instance(?s.types, nominal, ?args[0], 1);
+    if (R.is_err[type.TypeId, str](instance)) { ret instance; }
+    ret type.intern_pointer(?s.types, R.unwrap_ok[type.TypeId, str](instance));
+}
+
+test "mach.lang.fe.sema.fields:growing_pointer_recipe_does_not_expand_incidental_instances" {
+    var tracker: T.Testing;
+    if (O.is_some[str](T.make(?tracker))) { ret 1; }
+    fin { T.dnit(?tracker); }
+    val alloc: *A.Allocator = T.allocator_of(?tracker);
+    val initialized: R.Result[session.Session, str] = session.init(alloc);
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?s); }
+    val nom_r: R.Result[type.TypeId, str] = type.intern_nominal(?s.types, 1::intern.StrId, type.TypeOwner{ module: 0, file: 0 }, type.TYPE_REC);
+    val gp_r: R.Result[type.TypeId, str] = type.intern_generic_param(?s.types, 2::intern.StrId, type.TypeOwner{ module: 0, file: 0 }, 1::intern.StrId, type.TYPE_REC, 0);
+    if (R.is_err[type.TypeId, str](nom_r) || R.is_err[type.TypeId, str](gp_r)) { ret 3; }
+    val nominal: type.TypeId = R.unwrap_ok[type.TypeId, str](nom_r);
+    val argument_pointer: R.Result[type.TypeId, str] = type.intern_pointer(?s.types, R.unwrap_ok[type.TypeId, str](gp_r));
+    if (R.is_err[type.TypeId, str](argument_pointer)) { ret 4; }
+    val next_template: R.Result[type.TypeId, str] = t_instance_pointer(?s, nominal, R.unwrap_ok[type.TypeId, str](argument_pointer));
+    if (R.is_err[type.TypeId, str](next_template)) { ret 5; }
+    val template_type: type.TypeId = R.unwrap_ok[type.TypeId, str](next_template);
+    if (R.is_err[R.Void, str](t_one_field(?s, nominal, template_type))) { ret 6; }
+    val primitive: O.Option[type.TypeId] = type.prim(?s.types, type.TYPE_U32);
+    if (O.is_none[type.TypeId](primitive)) { ret 7; }
+    var args: [1]type.TypeId;
+    args[0] = O.unwrap[type.TypeId](primitive);
+    val instance_r: R.Result[type.TypeId, str] = type.intern_instance(?s.types, nominal, ?args[0], 1);
+    if (R.is_err[type.TypeId, str](instance_r)) { ret 8; }
+    var instance: type.TypeId = R.unwrap_ok[type.TypeId, str](instance_r);
+    var roots: Roots = Roots{ data: ?instance, len: 1 };
+    var probe: RecipeProbe = RecipeProbe{ s: ?s, calls: 0 };
+    val cold_r: R.Result[Graph, fail.Fail] = capture[RecipeProbe](?s, alloc, ?roots, 1, RECIPES, nil, ?probe, t_recipe_prepare);
+    if (R.is_err[Graph, fail.Fail](cold_r)) { ret 9; }
+    var cold: Graph = R.unwrap_ok[Graph, fail.Fail](cold_r);
+    fin { dnit(?cold); }
+    if (probe.calls != 1 || cold.nodes.len != 1 || cold.nodes.data[0].ty != nominal) { ret 10; }
+    if (cold.nodes.data[0].entries.len != 1 || cold.nodes.data[0].entries.data[0].ty != template_type) { ret 11; }
+    if (O.is_some[*type.FieldTable](type.field_table_for(?s.types, instance))) { ret 12; }
+    val to_primitive: R.Result[type.TypeId, str] = type.intern_pointer(?s.types, args[0]);
+    if (R.is_err[type.TypeId, str](to_primitive)) { ret 13; }
+    val next_concrete: R.Result[type.TypeId, str] = t_instance_pointer(?s, nominal, R.unwrap_ok[type.TypeId, str](to_primitive));
+    if (R.is_err[type.TypeId, str](next_concrete)) { ret 14; }
+    if (R.is_err[R.Void, str](t_one_field(?s, instance, R.unwrap_ok[type.TypeId, str](next_concrete)))) { ret 15; }
+    probe.calls = 0;
+    val warm_r: R.Result[Graph, fail.Fail] = capture[RecipeProbe](?s, alloc, ?roots, 1, RECIPES, nil, ?probe, t_recipe_prepare);
+    if (R.is_err[Graph, fail.Fail](warm_r)) { ret 16; }
+    var warm: Graph = R.unwrap_ok[Graph, fail.Fail](warm_r);
+    fin { dnit(?warm); }
+    if (probe.calls != 1 || warm.nodes.len != cold.nodes.len || warm.nodes.data[0].ty != nominal) { ret 17; }
+    if (warm.nodes.data[0].entries.len != 1 || warm.nodes.data[0].entries.data[0].ty != template_type) { ret 18; }
+    probe.calls = 0;
+    val full_r: R.Result[Graph, fail.Fail] = capture[RecipeProbe](?s, alloc, ?roots, 1, MATERIALIZED, nil, ?probe, t_recipe_prepare);
+    if (R.is_err[Graph, fail.Fail](full_r)) { ret 19; }
+    var full: Graph = R.unwrap_ok[Graph, fail.Fail](full_r);
+    fin { dnit(?full); }
+    if (probe.calls != 1 || full.nodes.len != 2) { ret 20; }
+    ret 0;
+}
+
+test "mach.lang.fe.sema.fields:handle_edges_follow_constructor_schema_and_skip_literal_words" {
+    var tracker: T.Testing;
+    if (O.is_some[str](T.make(?tracker))) { ret 1; }
+    fin { T.dnit(?tracker); }
+    val initialized: R.Result[session.Session, str] = session.init(T.allocator_of(?tracker));
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?s); }
+    var word_schema: u32 = isa.TYPE_OPERAND_WORD;
+    var wrapper_schema: [2]u32 = [2]u32{ isa.TYPE_OPERAND_WORD, 10 };
+    var constructors: [2]isa.TypeDef;
+    constructors[0] = isa.type_def("word", 10, ?word_schema, 1, nil);
+    constructors[1] = isa.type_def("wrapper", 11, ?wrapper_schema[0], 2, nil);
+    var defs: isa.TargetDefs = isa.TargetDefs{ types: ?constructors[0], type_count: 2 };
+    var literal: u32 = 0xFFFFFFFD;
+    val leaf: R.Result[type.TypeId, str] = type.intern_handle(?s.types, 1, 10, ?literal, 1);
+    if (R.is_err[type.TypeId, str](leaf)) { ret 3; }
+    var operands: [2]u32 = [2]u32{ literal, R.unwrap_ok[type.TypeId, str](leaf)::u32 };
+    val wrapper: R.Result[type.TypeId, str] = type.intern_handle(?s.types, 2, 11, ?operands[0], 2);
+    if (R.is_err[type.TypeId, str](wrapper)) { ret 4; }
+    var root: type.TypeId = R.unwrap_ok[type.TypeId, str](wrapper);
+    var roots: Roots = Roots{ data: ?root, len: 1 };
+    val captured: R.Result[Graph, fail.Fail] = capture[session.Session](?s, s.alloc, ?roots, 1, RECIPES, ?defs, ?s, t_prepared);
+    if (R.is_err[Graph, fail.Fail](captured)) { ret 5; }
+    var graph: Graph = R.unwrap_ok[Graph, fail.Fail](captured);
+    dnit(?graph);
+    constructors[0].operands = ?wrapper_schema[1];
+    val refused: R.Result[Graph, fail.Fail] = capture[session.Session](?s, s.alloc, ?roots, 1, RECIPES, ?defs, ?s, t_prepared);
+    if (R.is_ok[Graph, fail.Fail](refused)) {
+        graph = R.unwrap_ok[Graph, fail.Fail](refused);
+        dnit(?graph);
+        ret 6;
+    }
+    if (R.unwrap_err[Graph, fail.Fail](refused).kind != fail.MESSAGE) { ret 7; }
+    ret 0;
+}

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -16,6 +16,7 @@ use mach.lang.fail;
 use mach.lang.fe.ast;
 use mach.lang.fe.ast.decl;
 use mach.lang.fe.ast.id;
+use mach.lang.fe.resolve;
 use atype: mach.lang.fe.ast.type;
 use sema: mach.lang.fe.sema.context;
 use mach.lang.fe.token;
@@ -45,8 +46,7 @@ fun gparam_walk_end(g: *GenericOp, w: *GParamWalk) {
 
 pub fun instantiate(
     sc:             *sema.SemaContext,
-    generic_decl:   id.DeclId,
-    generic_origin: session.ModuleId,
+    sym:            *resolve.Symbol,
     args:           *type.TypeId,
     arg_count:      u32,
     span:           token.Span
@@ -55,12 +55,12 @@ pub fun instantiate(
     op.s = sc.s;
     op.status = ?sc.status;
     val g: *GenericOp = ?op;
-    if (generic_decl == id.DECL_NIL) {
+    if (sym.definition_kind != resolve.SYM_REC && sym.definition_kind != resolve.SYM_UNI) {
         sema.report(sc, span, "not a generic: declaration is not generic");
         ret R.ok[type.TypeId, str](type.TYPE_ERROR);
     }
 
-    if (!check_arity(sc, generic_decl, generic_origin, arg_count, span)) {
+    if (!check_arity(sc, sym, arg_count, span)) {
         ret R.ok[type.TypeId, str](type.TYPE_ERROR);
     }
 
@@ -73,47 +73,27 @@ pub fun instantiate(
         i = i + 1;
     }
 
-    val gnom: type.TypeId = generic_nominal_of_inner(g, generic_origin, generic_decl);
+    val gnom: type.TypeId = generic_nominal_of_inner(sc, sym);
     if (sc.status.kind == fail.INTERNAL) { ret R.err[type.TypeId, str](sc.status.message); }
-    ret type.intern_instance(?sc.s.types, gnom, generic_origin, generic_decl, args, arg_count);
+    ret type.intern_instance(?sc.s.types, gnom, args, arg_count);
 }
 
 pub fun check_arity(
     sc:             *sema.SemaContext,
-    generic_decl:   id.DeclId,
-    generic_origin: session.ModuleId,
+    sym:            *resolve.Symbol,
     arg_count:      u32,
     span:           token.Span
 ) bool {
-    val a: *ast.Ast = declaring_ast(sc, generic_origin);
-    if (a == nil) { ret true; }
-
-    val opt_want: O.Option[u32] = generic_count_in(a, generic_decl);
-    if (O.is_none[u32](opt_want)) {
+    if (sym.definition_kind != resolve.SYM_FUN && sym.definition_kind != resolve.SYM_REC && sym.definition_kind != resolve.SYM_UNI) {
         sema.report(sc, span, "not a generic: declaration takes no type parameters");
         ret false;
     }
-
-    val want: u32 = O.unwrap[u32](opt_want);
+    val want: u32 = sym.generic_arity;
     if (arg_count != want) {
         report_type_arg_count(sc, span, "wrong number of type arguments", want, arg_count);
         ret false;
     }
     ret true;
-}
-
-pub fun declared_arity(sc: *sema.SemaContext, generic_decl: id.DeclId, generic_origin: session.ModuleId) u32 {
-    val a: *ast.Ast = declaring_ast(sc, generic_origin);
-    if (a == nil) { ret 0; }
-
-    val opt_want: O.Option[u32] = generic_count_in(a, generic_decl);
-    if (O.is_none[u32](opt_want)) { ret 0; }
-    ret O.unwrap[u32](opt_want);
-}
-
-fun declaring_ast(sc: *sema.SemaContext, origin: session.ModuleId) *ast.Ast {
-    if (origin == sc.own_module) { ret sc.a; }
-    ret session.module_ast(sc.s, origin);
 }
 
 fun substitute_inner(g: *GenericOp, body_type: type.TypeId, args: *type.TypeId, arg_count: u32) type.TypeId {
@@ -175,10 +155,7 @@ fun ensure_fields_inner(g: *GenericOp, tid: type.TypeId) {
     val t: *type.Type = O.unwrap[*type.Type](opt_type);
     if (t.kind != type.TYPE_INSTANCE) { ret; }
 
-    val origin: session.ModuleId = t.data.instance.target_origin;
-    val gdecl:  id.DeclId        = t.data.instance.target_decl;
-
-    val gnom: type.TypeId = generic_nominal_of_inner(g, origin, gdecl);
+    val gnom: type.TypeId = t.data.instance.nominal;
     if (gnom == type.TYPE_ERROR) { ret; }
 
     build_instance_table(g, tid, gnom);
@@ -636,8 +613,7 @@ fun secret_reach_walk(g: *GenericOp, tid: type.TypeId, scan: *type.TypeScan) boo
         val mark: type.VisitMark = R.unwrap_ok[type.VisitMark, str](mark_r);
         if (mark == type.VISIT_SEEN)   { ret false; }
 
-        val origin:     session.ModuleId = t.data.instance.target_origin;
-        val decl_id:    id.DeclId        = t.data.instance.target_decl;
+        val gnom: type.TypeId = t.data.instance.nominal;
         val args_start: u32              = t.data.instance.args_start;
         val args_len:   u32              = t.data.instance.args_len;
 
@@ -648,7 +624,6 @@ fun secret_reach_walk(g: *GenericOp, tid: type.TypeId, scan: *type.TypeScan) boo
             i = i + 1;
         }
 
-        val gnom: type.TypeId = generic_nominal_of_inner(g, origin, decl_id);
         if (gnom == type.TYPE_ERROR) { ret true; }
         ret secret_reach_walk(g, gnom, scan);
     }
@@ -774,8 +749,7 @@ fun uni_inst_walk_instance(sc: *sema.SemaContext, tid: type.TypeId, args: *type.
     val opt_t: O.Option[*type.Type] = type.get(?s.types, tid);
     if (O.is_none[*type.Type](opt_t)) { ret; }
     val t: *type.Type = O.unwrap[*type.Type](opt_t);
-    val origin:     session.ModuleId = t.data.instance.target_origin;
-    val decl_id:    id.DeclId        = t.data.instance.target_decl;
+    val gnom: type.TypeId = t.data.instance.nominal;
     val args_start: u32              = t.data.instance.args_start;
     val args_len:   u32              = t.data.instance.args_len;
 
@@ -802,7 +776,6 @@ fun uni_inst_walk_instance(sc: *sema.SemaContext, tid: type.TypeId, args: *type.
         i = i + 1;
     }
 
-    val gnom: type.TypeId = generic_nominal_of_inner(g, origin, decl_id);
     if (gnom == type.TYPE_ERROR) {
         sema.report_internal(sc, span, "internal: #2225 union-secrecy instance walk: generic instance target declaration unavailable (pristine-type invariant violated)");
         A.deallocate[type.TypeId](s.alloc, raw, args_len::usize);
@@ -944,10 +917,8 @@ fun nominal_visit_key(g: *GenericOp, nom: type.TypeId, args: *type.TypeId, arg_l
     if (O.is_none[*type.Type](opt_nom)) { ret nom; }
     val t: *type.Type = O.unwrap[*type.Type](opt_nom);
     if (t.kind != type.TYPE_REC && t.kind != type.TYPE_UNI) { ret nom; }
-    val origin:  session.ModuleId = t.data.nominal.origin;
-    val decl_id: id.DeclId        = t.data.nominal.decl;
 
-    val r: R.Result[type.TypeId, str] = type.intern_instance(?s.types, nom, origin, decl_id, args, arg_len);
+    val r: R.Result[type.TypeId, str] = type.intern_instance(?s.types, nom, args, arg_len);
     if (R.is_err[type.TypeId, str](r)) { fail.internal(g.status, R.unwrap_err[type.TypeId, str](r)); ret nom; }
     ret R.unwrap_ok[type.TypeId, str](r);
 }
@@ -967,33 +938,17 @@ fun type_mentions_gparam(g: *GenericOp, tid: type.TypeId) bool {
     ret mentioned;
 }
 
-fun generic_nominal_of_inner(g: *GenericOp, origin: session.ModuleId, gdecl: id.DeclId) type.TypeId {
-    val s: *session.Session = g.s;
-    val ga: *ast.Ast = session.module_ast(s, origin);
-    if (ga == nil) { ret type.TYPE_ERROR; }
-
-    val opt_decl: O.Option[*decl.Decl] = ast.get_decl(ga, gdecl);
-    if (O.is_none[*decl.Decl](opt_decl)) { ret type.TYPE_ERROR; }
-    val d: *decl.Decl = O.unwrap[*decl.Decl](opt_decl);
-
-    var gname: intern.StrId  = intern.STR_NIL;
-    var gkind: type.TypeKind = type.TYPE_REC;
-    if (d.kind == decl.DECL_KIND_REC) {
-        gname = intern_name_in(g, ga, d.data.rec_.name);
-        gkind = type.TYPE_REC;
-    }
-    or (d.kind == decl.DECL_KIND_UNI) {
-        gname = intern_name_in(g, ga, d.data.uni_.name);
-        gkind = type.TYPE_UNI;
-    }
-    or {
+fun generic_nominal_of_inner(sc: *sema.SemaContext, sym: *resolve.Symbol) type.TypeId {
+    var kind: type.TypeKind = type.TYPE_REC;
+    if (sym.definition_kind == resolve.SYM_UNI) { kind = type.TYPE_UNI; }
+    if (sym.definition_file == source.FILE_NIL) {
+        fail.internal(?sc.status, "generic nominal has no defining source identity");
         ret type.TYPE_ERROR;
     }
-
-    if (g.status.kind == fail.INTERNAL) { ret type.TYPE_ERROR; }
-    val res_nominal: R.Result[type.TypeId, str] = type.intern_nominal(?s.types, gname, origin, gdecl, gkind);
-    if (R.is_err[type.TypeId, str](res_nominal)) { fail.internal(g.status, R.unwrap_err[type.TypeId, str](res_nominal)); ret type.TYPE_ERROR; }
-    ret R.unwrap_ok[type.TypeId, str](res_nominal);
+    val nominal: R.Result[type.TypeId, str] = type.intern_nominal(?sc.s.types, sym.canon,
+        resolve.type_owner(sc.s, sym.origin, sym.definition_file), kind);
+    if (R.is_err[type.TypeId, str](nominal)) { fail.internal(?sc.status, R.unwrap_err[type.TypeId, str](nominal)); ret type.TYPE_ERROR; }
+    ret R.unwrap_ok[type.TypeId, str](nominal);
 }
 
 fun build_instance_table(g: *GenericOp, instance: type.TypeId, gnom: type.TypeId) {
@@ -1142,8 +1097,6 @@ fun substitute_fun(g: *GenericOp, t: *type.Type, args: *type.TypeId, arg_count: 
 fun substitute_instance(g: *GenericOp, t: *type.Type, args: *type.TypeId, arg_count: u32, original: type.TypeId) type.TypeId {
     val s: *session.Session = g.s;
     val nominal:    type.TypeId      = t.data.instance.nominal;
-    val origin:     session.ModuleId = t.data.instance.target_origin;
-    val decl_id:    id.DeclId        = t.data.instance.target_decl;
     val args_start: u32              = t.data.instance.args_start;
     val args_len:   u32              = t.data.instance.args_len;
 
@@ -1172,17 +1125,15 @@ fun substitute_instance(g: *GenericOp, t: *type.Type, args: *type.TypeId, arg_co
         ret original;
     }
 
-    val res_instance: R.Result[type.TypeId, str] = type.intern_instance(?s.types, nominal, origin, decl_id, arg_buf, args_len);
+    val res_instance: R.Result[type.TypeId, str] = type.intern_instance(?s.types, nominal, arg_buf, args_len);
     A.deallocate[type.TypeId](s.alloc, arg_buf, args_len::usize);
     ret unwrap_or_error(g, res_instance);
 }
 
 fun substitute_aggregate(g: *GenericOp, t: *type.Type, args: *type.TypeId, arg_count: u32, original: type.TypeId) type.TypeId {
     val s: *session.Session = g.s;
-    val origin:  session.ModuleId = t.data.nominal.origin;
-    val decl_id: id.DeclId        = t.data.nominal.decl;
 
-    val res_instance: R.Result[type.TypeId, str] = type.intern_instance(?s.types, original, origin, decl_id, args, arg_count);
+    val res_instance: R.Result[type.TypeId, str] = type.intern_instance(?s.types, original, args, arg_count);
     if (R.is_err[type.TypeId, str](res_instance)) { fail.internal(g.status, R.unwrap_err[type.TypeId, str](res_instance)); ret type.TYPE_ERROR; }
     val instance: type.TypeId = R.unwrap_ok[type.TypeId, str](res_instance);
 
@@ -1291,17 +1242,6 @@ fun intern_name_in(g: *GenericOp, ga: *ast.Ast, span: token.Span) intern.StrId {
     ret R.unwrap_ok[intern.StrId, str](res_intern);
 }
 
-fun generic_count_in(a: *ast.Ast, decl_id: id.DeclId) O.Option[u32] {
-    val opt_decl: O.Option[*decl.Decl] = ast.get_decl(a, decl_id);
-    if (O.is_none[*decl.Decl](opt_decl)) { ret O.none[u32](); }
-    val d: *decl.Decl = O.unwrap[*decl.Decl](opt_decl);
-
-    if (d.kind == decl.DECL_KIND_FUN) { ret O.some[u32](d.data.fun_.generics_len); }
-    if (d.kind == decl.DECL_KIND_REC) { ret O.some[u32](d.data.rec_.generics_len); }
-    if (d.kind == decl.DECL_KIND_UNI) { ret O.some[u32](d.data.uni_.generics_len); }
-    ret O.none[u32]();
-}
-
 fun unwrap_or_error(g: *GenericOp, res: R.Result[type.TypeId, str]) type.TypeId {
     val s: *session.Session = g.s;
     if (R.is_err[type.TypeId, str](res)) { fail.internal(g.status, R.unwrap_err[type.TypeId, str](res)); ret type.TYPE_ERROR; }
@@ -1381,7 +1321,7 @@ test "mach.lang.fe.sema.generics.nominal_has_gparam:missing_field_table_fails_cl
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var sA: session.Session = R.unwrap_ok[session.Session, str](sr);
 
-    val rn: R.Result[type.TypeId, str] = type.intern_nominal(?sA.types, intern.STR_NIL, 999::session.ModuleId, 999::id.DeclId, type.TYPE_REC);
+    val rn: R.Result[type.TypeId, str] = type.intern_nominal(?sA.types, intern.STR_NIL, type.TypeOwner{ module: 999, file: 1 }, type.TYPE_REC);
     if (R.is_err[type.TypeId, str](rn)) { session.dnit(?sA); ret 1; }
     val nom: type.TypeId = R.unwrap_ok[type.TypeId, str](rn);
 
@@ -1481,14 +1421,4 @@ pub fun module_reaches_secret(s: *session.Session, resolved: *type.TypeId, len: 
     val value: bool = module_reaches_secret_inner(?op, resolved, len);
     if (status.kind == fail.INTERNAL) { ret R.err[bool, str](status.message); }
     ret R.ok[bool, str](value);
-}
-
-pub fun generic_nominal_of(s: *session.Session, origin: session.ModuleId, gdecl: id.DeclId) R.Result[type.TypeId, str] {
-    var status: fail.PhaseStatus = fail.accepted();
-    var op: GenericOp;
-    op.s = s;
-    op.status = ?status;
-    val value: type.TypeId = generic_nominal_of_inner(?op, origin, gdecl);
-    if (status.kind == fail.INTERNAL) { ret R.err[type.TypeId, str](status.message); }
-    ret R.ok[type.TypeId, str](value);
 }

--- a/src/lang/fe/sema/handle.mach
+++ b/src/lang/fe/sema/handle.mach
@@ -298,15 +298,19 @@ fun type_at(sc: *context.SemaContext, did: id.DeclId, d: *decl.Decl, depth: u32)
     val name: intern.StrId = intern_name(sc, d.data.def_.name);
     var tid: type.TypeId = type.TYPE_ERROR;
     if (r.status == READ_INERT) {
-        var site: [2]u32;
-        site[0] = sc.own_module::u32;
-        site[1] = did::u32;
-        val res: R.Result[type.TypeId, str] = type.intern_handle(?sc.s.types, name, isa.NO_TYPE_CTOR, ?site[0], 2);
+        val owner: type.TypeOwner = resolve.type_owner(sc.s, sc.own_module, sc.a.file_id);
+        var site: [3]u32;
+        site[0] = owner.module::u32;
+        site[1] = owner.file::u32;
+        site[2] = name::u32;
+        val res: R.Result[type.TypeId, str] = type.intern_handle(?sc.s.types, name, isa.NO_TYPE_CTOR, ?site[0], 3);
         if (R.is_ok[type.TypeId, str](res)) { tid = R.unwrap_ok[type.TypeId, str](res); }
+        or { fail.internal(?sc.status, R.unwrap_err[type.TypeId, str](res)); }
     }
     or {
         val res: R.Result[type.TypeId, str] = type.intern_handle(?sc.s.types, name, r.ctor, r.ops, r.len);
         if (R.is_ok[type.TypeId, str](res)) { tid = R.unwrap_ok[type.TypeId, str](res); }
+        or { fail.internal(?sc.status, R.unwrap_err[type.TypeId, str](res)); }
     }
     release(sc, r);
     ret tid;

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -10,6 +10,7 @@ use std.types.string.str_len;
 use std.types.string.str_region_equals;
 
 use A: std.allocator;
+use T: std.allocator.testing;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -31,6 +32,7 @@ use mach.lang.fe.sema.abitype;
 use mach.lang.fe.sema.handle;
 use mach.lang.fe.sema.generics;
 use mach.lang.fe.sema.typename;
+use mach.lang.fe.sema.recipe;
 use mach.lang.layout;
 use mach.lang.fe.token;
 use mach.lang.intern;
@@ -103,7 +105,7 @@ fun infer_fun_sig(sc: *context.SemaContext, f: *decl.DeclFun) type.TypeId {
 
 fun infer_nominal(sc: *context.SemaContext, did: id.DeclId, name_span: token.Span, r: *decl.DeclRec, kind: type.TypeKind) type.TypeId {
     val name_id: intern.StrId = intern_span_or_nil(sc, name_span);
-    val tr: R.Result[type.TypeId, str] = type.intern_nominal(?sc.s.types, name_id, sc.own_module, did, kind);
+    val tr: R.Result[type.TypeId, str] = type.intern_nominal(?sc.s.types, name_id, resolve.type_owner(sc.s, sc.own_module, sc.a.file_id), kind);
     if (R.is_err[type.TypeId, str](tr)) { fail.internal(?sc.status, R.unwrap_err[type.TypeId, str](tr)); ret type.TYPE_ERROR; }
     val ty: type.TypeId = R.unwrap_ok[type.TypeId, str](tr);
 
@@ -113,7 +115,7 @@ fun infer_nominal(sc: *context.SemaContext, did: id.DeclId, name_span: token.Spa
 
 fun infer_nominal_uni(sc: *context.SemaContext, did: id.DeclId, name_span: token.Span, u: *decl.DeclUni, kind: type.TypeKind) type.TypeId {
     val name_id: intern.StrId = intern_span_or_nil(sc, name_span);
-    val tr: R.Result[type.TypeId, str] = type.intern_nominal(?sc.s.types, name_id, sc.own_module, did, kind);
+    val tr: R.Result[type.TypeId, str] = type.intern_nominal(?sc.s.types, name_id, resolve.type_owner(sc.s, sc.own_module, sc.a.file_id), kind);
     if (R.is_err[type.TypeId, str](tr)) { fail.internal(?sc.status, R.unwrap_err[type.TypeId, str](tr)); ret type.TYPE_ERROR; }
     val ty: type.TypeId = R.unwrap_ok[type.TypeId, str](tr);
 
@@ -129,9 +131,10 @@ fun elaborate_nominal(sc: *context.SemaContext, did: id.DeclId, ty: type.TypeId,
     if (st == context.LAYOUT_ACTIVE) { ret O.some[intern.StrId](nominal_name_id(sc, did)); }
 
     layout_state_set(sc, did, context.LAYOUT_ACTIVE);
-    if (!build_field_table(sc, ty, fields_start, fields_len)) {
+    val fields: R.Result[R.Void, str] = build_field_table(sc, ty, fields_start, fields_len);
+    if (R.is_err[R.Void, str](fields)) {
         layout_state_set(sc, did, context.LAYOUT_FAILED);
-        context.report(sc, decl_name_span(sc, did), FIELD_TABLE_FAILED_MSG);
+        fail.internal(?sc.status, R.unwrap_err[R.Void, str](fields));
         ret O.none[intern.StrId]();
     }
     record_type_align(sc, did, ty);
@@ -140,8 +143,6 @@ fun elaborate_nominal(sc: *context.SemaContext, did: id.DeclId, ty: type.TypeId,
     layout_state_set(sc, did, context.LAYOUT_READY);
     ret O.none[intern.StrId]();
 }
-
-pub val FIELD_TABLE_FAILED_MSG: str = "internal: out of memory recording this type's fields; the type is published as failed rather than with the fields that fit, because a partial field table would place every later field at the wrong offset";
 
 fun decl_name_span(sc: *context.SemaContext, did: id.DeclId) token.Span {
     val d_opt: O.Option[*decl.Decl] = ast.get_decl(sc.a, did);
@@ -191,8 +192,12 @@ fun ensure_layout_walk(sc: *context.SemaContext, tid: type.TypeId, depth: u32) O
     if (t.kind == type.TYPE_ARRAY) { ret ensure_layout_walk(sc, t.data.array.base, depth + 1); }
 
     if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI) {
-        if (t.data.nominal.origin != sc.own_module) { ret O.none[intern.StrId](); }
-        val did: id.DeclId = t.data.nominal.decl;
+        val owner: type.TypeOwner = resolve.type_owner(sc.s, sc.own_module, sc.a.file_id);
+        if (t.data.nominal.owner.module != owner.module || t.data.nominal.owner.file != owner.file
+            || t.data.nominal.incarnation != 0) { ret O.none[intern.StrId](); }
+        val selected: R.Result[id.DeclId, fail.Fail] = context.own_nominal_declaration(sc, t);
+        if (R.is_err[id.DeclId, fail.Fail](selected)) { fail.internal(?sc.status, R.unwrap_err[id.DeclId, fail.Fail](selected).message); ret O.none[intern.StrId](); }
+        val did: id.DeclId = R.unwrap_ok[id.DeclId, fail.Fail](selected);
         val d_opt: O.Option[*decl.Decl] = ast.get_decl(sc.a, did);
         if (O.is_none[*decl.Decl](d_opt)) { ret O.none[intern.StrId](); }
         val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
@@ -218,6 +223,28 @@ fun ensure_layout_walk(sc: *context.SemaContext, tid: type.TypeId, depth: u32) O
     }
 
     ret O.none[intern.StrId]();
+}
+
+pub fun prepare_nominal_recipe(sc: *context.SemaContext, ty: type.TypeId) R.Result[R.Void, fail.Fail] {
+    if (O.is_some[*type.FieldTable](type.field_table_for(?sc.s.types, ty))) { ret R.ok_void[fail.Fail](); }
+    val selected: O.Option[*type.Type] = type.get(?sc.s.types, ty);
+    if (O.is_none[*type.Type](selected)) { ret R.err[R.Void, fail.Fail](fail.message("nominal recipe has no semantic type")); }
+    val nominal: *type.Type = O.unwrap[*type.Type](selected);
+    val definition: R.Result[id.DeclId, fail.Fail] = context.own_nominal_declaration(sc, nominal);
+    if (R.is_err[id.DeclId, fail.Fail](definition)) { ret R.void_of[id.DeclId, fail.Fail](definition); }
+    val did: id.DeclId = R.unwrap_ok[id.DeclId, fail.Fail](definition);
+    val d: *decl.Decl = ?sc.a.decls[did];
+    var start: u32 = 0;
+    var len: u32 = 0;
+    if (d.kind == decl.DECL_KIND_REC) { start = d.data.rec_.fields_start; len = d.data.rec_.fields_len; }
+    or (d.kind == decl.DECL_KIND_UNI) { start = d.data.uni_.fields_start; len = d.data.uni_.fields_len; }
+    or { ret R.err[R.Void, fail.Fail](fail.message("nominal recipe definition has the wrong kind")); }
+    val cycle: O.Option[intern.StrId] = elaborate_nominal(sc, did, ty, start, len);
+    if (sc.status.kind != fail.ACCEPTED) { ret R.err[R.Void, fail.Fail](fail.phase_failure(sc.status)); }
+    if (O.is_some[intern.StrId](cycle) || O.is_none[*type.FieldTable](type.field_table_for(?sc.s.types, ty))) {
+        ret R.err[R.Void, fail.Fail](fail.message("nominal recipe preparation did not produce a complete table"));
+    }
+    ret R.ok_void[fail.Fail]();
 }
 
 fun ensure_layout_fields(sc: *context.SemaContext, ty: type.TypeId, depth: u32) O.Option[intern.StrId] {
@@ -335,11 +362,11 @@ fun fold_layout_intrinsic(sc: *context.SemaContext, eid: id.ExprId, span: token.
 pub fun resolve_layout_intrinsic(sc: *context.SemaContext, eid: u32) R.Result[O.Option[comptime.CTValue], comptime.EvalFail] {
     if (sc == nil) { ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.none[comptime.CTValue]()); }
     val e: id.ExprId = eid::id.ExprId;
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, e);
-    if (O.is_none[*expr.Expr](e_opt)) {
+    val e_opt: R.Result[expr.Expr, str] = context.expression(sc, e);
+    if (R.is_err[expr.Expr, str](e_opt)) {
         ret R.ok[O.Option[comptime.CTValue], comptime.EvalFail](O.none[comptime.CTValue]());
     }
-    val span: token.Span = O.unwrap[*expr.Expr](e_opt).span;
+    val span: token.Span = R.unwrap_ok[expr.Expr, str](e_opt).span;
 
     val lay: O.Option[O.Option[comptime.CTValue]] = fold_layout_intrinsic(sc, e, span);
     if (sc.status.kind == fail.INTERNAL) {
@@ -698,12 +725,16 @@ fun record_type_align(sc: *context.SemaContext, did: id.DeclId, ty: type.TypeId)
     }
 }
 
-fun build_field_table(sc: *context.SemaContext, ty: type.TypeId, fields_start: u32, fields_len: u32) bool {
-    if (O.is_some[*context.FieldTable](context.field_table_for(sc, ty))) { ret true; }
+fun build_field_table(sc: *context.SemaContext, ty: type.TypeId, fields_start: u32, fields_len: u32) R.Result[R.Void, str] {
+    if (O.is_some[*context.FieldTable](context.field_table_for(sc, ty))) { ret R.ok_void[str](); }
 
-    val start_r: R.Result[u32, str] = context.field_table_stage(sc, fields_len);
-    if (R.is_err[u32, str](start_r)) { ret false; }
-    val start: u32 = R.unwrap_ok[u32, str](start_r);
+    var fields: *type.FieldEntry = nil;
+    if (fields_len != 0) {
+        val allocated: R.Result[*type.FieldEntry, str] = A.allocate[type.FieldEntry](sc.s.alloc, fields_len::usize);
+        if (R.is_err[*type.FieldEntry, str](allocated)) { ret R.void_of[*type.FieldEntry, str](allocated); }
+        fields = R.unwrap_ok[*type.FieldEntry, str](allocated);
+    }
+    fin { if (fields != nil) { A.deallocate[type.FieldEntry](sc.s.alloc, fields, fields_len::usize); } }
 
     var i: u32 = 0;
     for (i < fields_len) {
@@ -713,12 +744,22 @@ fun build_field_table(sc: *context.SemaContext, ty: type.TypeId, fields_start: u
         if (fty == type.TYPE_NIL && sc.subst == nil && tn.ty != id.TYPE_NIL) {
             fty = resolve_type_ref(sc, tn.ty);
         }
-        val push_r: R.Result[R.Void, str] = context.field_table_stage_push(sc, fname, fty);
-        if (R.is_err[R.Void, str](push_r)) { ret false; }
+        if (sc.status.kind == fail.INTERNAL) { ret R.err[R.Void, str](sc.status.message); }
+        fields[i] = type.FieldEntry{ name: fname, ty: fty };
         i = i + 1;
     }
 
-    ret R.is_ok[R.Void, str](context.field_table_publish(sc, ty, start, fields_len));
+    val start_r: R.Result[u32, str] = context.field_table_stage(sc, fields_len);
+    if (R.is_err[u32, str](start_r)) { ret R.void_of[u32, str](start_r); }
+    val start: u32 = R.unwrap_ok[u32, str](start_r);
+    i = 0;
+    for (i < fields_len) {
+        val push_r: R.Result[R.Void, str] = context.field_table_stage_push(sc, fields[i].name, fields[i].ty);
+        if (R.is_err[R.Void, str](push_r)) { ret push_r; }
+        i = i + 1;
+    }
+
+    ret context.field_table_publish(sc, ty, start, fields_len);
 }
 
 fun infer_binding(sc: *context.SemaContext, b: *decl.DeclBind) type.TypeId {
@@ -733,9 +774,10 @@ fun infer_binding(sc: *context.SemaContext, b: *decl.DeclBind) type.TypeId {
 
 pub fun infer_expr(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
     if (eid == id.EXPR_NIL) { ret type.TYPE_ERROR; }
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) { ret type.TYPE_ERROR; }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    val e_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](e_opt)) { ret type.TYPE_ERROR; }
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](e_opt);
+    val e: *expr.Expr = ?e_value;
 
     var t: type.TypeId = type.TYPE_ERROR;
 
@@ -851,9 +893,9 @@ fun report_unbound_ident(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
         fail.reject(?sc.status);
         ret type.TYPE_ERROR;
     }
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_some[*expr.Expr](e_opt)) {
-        context.report_internal(sc, O.unwrap[*expr.Expr](e_opt).span, "internal: this identifier reached type inference unbound; the name resolver neither bound it nor reported it");
+    val e_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_ok[expr.Expr, str](e_opt)) {
+        context.report_internal(sc, R.unwrap_ok[expr.Expr, str](e_opt).span, "internal: this identifier reached type inference unbound; the name resolver neither bound it nor reported it");
     }
     ret type.TYPE_ERROR;
 }
@@ -920,10 +962,12 @@ fun direct_elem_loop_var_type(sc: *context.SemaContext, sym: *resolve.Symbol) ty
 
 fun ident_is_comptime_param_fn(sc: *context.SemaContext, sym: *resolve.Symbol) bool {
     if (sym.kind != resolve.SYM_FUN && sym.kind != resolve.SYM_IMPORTED) { ret false; }
-    if (sym.decl == id.DECL_NIL)                                         { ret false; }
-    val a: *ast.Ast = symbol_ast(sc, sym);
-    if (a == nil) { ret false; }
-    val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, sym.decl);
+    if (sym.kind != resolve.SYM_IMPORTED && sym.decl == id.DECL_NIL) { ret false; }
+    val acquired: R.Result[context.DefinedSymbol, fail.Fail] = context.symbol_definition(sc, sym, context.DEFINITION_RESOLVED);
+    if (R.is_err[context.DefinedSymbol, fail.Fail](acquired)) { ret false; }
+    val current: context.DefinedSymbol = R.unwrap_ok[context.DefinedSymbol, fail.Fail](acquired);
+    val a: *ast.Ast = current.definition.parsed.a;
+    val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, current.symbol.decl);
     if (O.is_none[*decl.Decl](d_opt)) { ret false; }
     val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
     if (d.kind != decl.DECL_KIND_FUN) { ret false; }
@@ -937,9 +981,9 @@ fun ident_is_comptime_param_fn(sc: *context.SemaContext, sym: *resolve.Symbol) b
 }
 
 fun report_never_value(sc: *context.SemaContext, eid: id.ExprId, sym: *resolve.Symbol) bool {
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) { ret false; }
-    val span: token.Span = O.unwrap[*expr.Expr](e_opt).span;
+    val e_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](e_opt)) { ret false; }
+    val span: token.Span = R.unwrap_ok[expr.Expr, str](e_opt).span;
 
     if (sym.kind == resolve.SYM_USE) {
         context.report(sc, span, "a module alias is not a value; name one of the module's members");
@@ -984,18 +1028,21 @@ fun report_never_value(sc: *context.SemaContext, eid: id.ExprId, sym: *resolve.S
 }
 
 fun symbol_decl_kind(sc: *context.SemaContext, sym: *resolve.Symbol) decl.DeclKind {
-    if (sym.decl == id.DECL_NIL) { ret decl.DECL_KIND_ERROR; }
-    val a: *ast.Ast = symbol_ast(sc, sym);
-    if (a == nil) { ret decl.DECL_KIND_ERROR; }
-    val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, sym.decl);
-    if (O.is_none[*decl.Decl](d_opt)) { ret decl.DECL_KIND_ERROR; }
-    ret O.unwrap[*decl.Decl](d_opt).kind;
+    var kind: resolve.SymKind = sym.kind;
+    if (kind == resolve.SYM_IMPORTED) { kind = sym.definition_kind; }
+    if (kind == resolve.SYM_FUN) { ret decl.DECL_KIND_FUN; }
+    if (kind == resolve.SYM_VAL) { ret decl.DECL_KIND_VAL; }
+    if (kind == resolve.SYM_VAR) { ret decl.DECL_KIND_VAR; }
+    if (kind == resolve.SYM_REC) { ret decl.DECL_KIND_REC; }
+    if (kind == resolve.SYM_UNI) { ret decl.DECL_KIND_UNI; }
+    if (kind == resolve.SYM_DEF) { ret decl.DECL_KIND_DEF; }
+    ret decl.DECL_KIND_ERROR;
 }
 
 fun report_comptime_param_fn_ref(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_some[*expr.Expr](e_opt)) {
-        context.report(sc, O.unwrap[*expr.Expr](e_opt).span, "cannot reference a comptime-parameter function as a value");
+    val e_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_ok[expr.Expr, str](e_opt)) {
+        context.report(sc, R.unwrap_ok[expr.Expr, str](e_opt).span, "cannot reference a comptime-parameter function as a value");
     }
     ret type.TYPE_ERROR;
 }
@@ -1209,9 +1256,9 @@ fun type_name_expr_type(sc: *context.SemaContext, eid: id.ExprId, span: token.Sp
 
 pub fun is_field_type_operand(sc: *context.SemaContext, eid: id.ExprId) bool {
     if (!comptime.is_field_type_member(sc.a, sc.source, eid)) { ret false; }
-    val n_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](n_opt)) { ret false; }
-    val obj: id.ExprId = O.unwrap[*expr.Expr](n_opt).data.member.object;
+    val n_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](n_opt)) { ret false; }
+    val obj: id.ExprId = R.unwrap_ok[expr.Expr, str](n_opt).data.member.object;
     val r: R.Result[comptime.CTValue, comptime.EvalFail] = comptime.evaluate[context.SemaContext](sc.ctx, sc, sc.caps, sc.a, sc.source, obj, ?sc.s.interner);
     context.record_eval_result(sc, r);
     if (R.is_err[comptime.CTValue, comptime.EvalFail](r)) { ret false; }
@@ -1219,9 +1266,9 @@ pub fun is_field_type_operand(sc: *context.SemaContext, eid: id.ExprId) bool {
 }
 
 fun field_type_operand_type(sc: *context.SemaContext, eid: id.ExprId) type.TypeId {
-    val n_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](n_opt)) { ret type.TYPE_ERROR; }
-    val obj: id.ExprId = O.unwrap[*expr.Expr](n_opt).data.member.object;
+    val n_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](n_opt)) { ret type.TYPE_ERROR; }
+    val obj: id.ExprId = R.unwrap_ok[expr.Expr, str](n_opt).data.member.object;
     val r: R.Result[comptime.CTValue, comptime.EvalFail] = comptime.evaluate[context.SemaContext](sc.ctx, sc, sc.caps, sc.a, sc.source, obj, ?sc.s.interner);
     context.record_eval_result(sc, r);
     if (R.is_err[comptime.CTValue, comptime.EvalFail](r)) { ret type.TYPE_ERROR; }
@@ -1250,9 +1297,10 @@ fun infer_assign(sc: *context.SemaContext, b: *expr.ExprBinary, span: token.Span
 
 fun is_assignable_place(sc: *context.SemaContext, eid: id.ExprId, ty: type.TypeId) bool {
     if (eid == id.EXPR_NIL) { ret false; }
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) { ret false; }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    val e_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](e_opt)) { ret false; }
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](e_opt);
+    val e: *expr.Expr = ?e_value;
     val place_kind: expr.ExprKind = ast.expr_place_kind(e);
     if (place_kind == expr.EXPR_KIND_CALL) { ret is_aggregate(sc, ty); }
     if (place_kind == expr.EXPR_KIND_IDENT || place_kind == expr.EXPR_KIND_MEMBER) {
@@ -1299,9 +1347,10 @@ fun immutable_binding_for_target(sc: *context.SemaContext, eid: id.ExprId) O.Opt
         if (sym.kind == resolve.SYM_VAR || sym.kind == resolve.SYM_PARAM) { ret O.none[*resolve.Symbol](); }
     }
 
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) { ret O.none[*resolve.Symbol](); }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    val e_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](e_opt)) { ret O.none[*resolve.Symbol](); }
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](e_opt);
+    val e: *expr.Expr = ?e_value;
 
     if (e.kind == expr.EXPR_KIND_MEMBER) { ret binding_through_object(sc, e.data.member.object); }
     if (e.kind == expr.EXPR_KIND_INDEX)  { ret binding_through_object(sc, e.data.index.object); }
@@ -1317,15 +1366,8 @@ fun binding_through_object(sc: *context.SemaContext, obj: id.ExprId) O.Option[*r
 }
 
 fun symbol_is_val_binding(sc: *context.SemaContext, sym: *resolve.Symbol) bool {
-    if (sym.kind == resolve.SYM_VAL)      { ret true; }
-    if (sym.kind != resolve.SYM_IMPORTED) { ret false; }
-    if (sym.decl == id.DECL_NIL)          { ret false; }
-
-    val a: *ast.Ast = symbol_ast(sc, sym);
-    if (a == nil) { ret false; }
-    val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, sym.decl);
-    if (O.is_none[*decl.Decl](d_opt)) { ret false; }
-    ret O.unwrap[*decl.Decl](d_opt).kind == decl.DECL_KIND_VAL;
+    ret sym.kind == resolve.SYM_VAL
+        || (sym.kind == resolve.SYM_IMPORTED && sym.definition_kind == resolve.SYM_VAL);
 }
 
 fun symbol_at_expr_is(sc: *context.SemaContext, eid: id.ExprId, sym: *resolve.Symbol) bool {
@@ -1358,9 +1400,10 @@ fun check_readonly_storage(sc: *context.SemaContext, eid: id.ExprId, span: token
         context.report(sc, span, "cannot store through a `#[storage(set, binding, \"readonly\")]` binding: the qualifier declares that no stage writes it, which is what lets the emitter mark it `NonWritable` and a vertex stage read it without `vertexPipelineStoresAndAtomics`. drop the `\"readonly\"` qualifier to write it");
         ret;
     }
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) { ret; }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    val e_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](e_opt)) { ret; }
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](e_opt);
+    val e: *expr.Expr = ?e_value;
     if (e.kind == expr.EXPR_KIND_MEMBER) { check_readonly_storage(sc, e.data.member.object, span); ret; }
     if (e.kind == expr.EXPR_KIND_INDEX)  { check_readonly_storage(sc, e.data.index.object, span); ret; }
     if (e.kind == expr.EXPR_KIND_UNARY && e.data.unary.op == expr.UN_DEREF) {
@@ -1374,11 +1417,12 @@ fun expr_names_readonly_storage(sc: *context.SemaContext, eid: id.ExprId) bool {
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](so);
     if (sym.kind != resolve.SYM_VAR && sym.kind != resolve.SYM_VAL
         && sym.kind != resolve.SYM_IMPORTED) { ret false; }
-    if (sym.decl == id.DECL_NIL) { ret false; }
-
-    val a: *ast.Ast = symbol_ast(sc, sym);
-    if (a == nil) { ret false; }
-    val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, sym.decl);
+    if (sym.kind != resolve.SYM_IMPORTED && sym.decl == id.DECL_NIL) { ret false; }
+    val acquired: R.Result[context.DefinedSymbol, fail.Fail] = context.symbol_definition(sc, sym, context.DEFINITION_RESOLVED);
+    if (R.is_err[context.DefinedSymbol, fail.Fail](acquired)) { ret false; }
+    val current: context.DefinedSymbol = R.unwrap_ok[context.DefinedSymbol, fail.Fail](acquired);
+    val a: *ast.Ast = current.definition.parsed.a;
+    val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, current.symbol.decl);
     if (O.is_none[*decl.Decl](d_opt)) { ret false; }
     val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
     if (d.kind != decl.DECL_KIND_VAL && d.kind != decl.DECL_KIND_VAR) { ret false; }
@@ -1428,9 +1472,10 @@ fun check_lit_int_range(sc: *context.SemaContext, e: *expr.Expr, t: type.TypeId,
 }
 
 fun infer_negated_int_literal(sc: *context.SemaContext, eid: id.ExprId, span: token.Span) O.Option[type.TypeId] {
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) { ret O.none[type.TypeId](); }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    val e_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](e_opt)) { ret O.none[type.TypeId](); }
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](e_opt);
+    val e: *expr.Expr = ?e_value;
     if (e.kind != expr.EXPR_KIND_LIT_INT)              { ret O.none[type.TypeId](); }
     if (e.data.lit_int.suffix == expr.LIT_SUFFIX_NONE) { ret O.none[type.TypeId](); }
 
@@ -1514,9 +1559,10 @@ fun report_address_of_rvalue(sc: *context.SemaContext, span: token.Span, rvalue:
 
 # nil when the operand is a place; otherwise what kind of rvalue it is
 fun address_operand_rvalue(sc: *context.SemaContext, eid: id.ExprId) str {
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) { ret nil; }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    val e_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](e_opt)) { ret nil; }
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](e_opt);
+    val e: *expr.Expr = ?e_value;
     val k: expr.ExprKind = ast.expr_place_kind(e);
     if (k == expr.EXPR_KIND_IDENT || k == expr.EXPR_KIND_UNARY) { ret nil; }
     if (e.kind == expr.EXPR_KIND_GENERIC_INSTANCE) { ret nil; }
@@ -1556,9 +1602,9 @@ fun address_base_label(inner: str, call_label: str, other_label: str) str {
 }
 
 fun operand_is_comptime_param(sc: *context.SemaContext, eid: id.ExprId) bool {
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](e_opt))                             { ret false; }
-    if (O.unwrap[*expr.Expr](e_opt).kind != expr.EXPR_KIND_IDENT) { ret false; }
+    val e_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](e_opt))                             { ret false; }
+    if (R.unwrap_ok[expr.Expr, str](e_opt).kind != expr.EXPR_KIND_IDENT) { ret false; }
     val so: O.Option[*resolve.Symbol] = context.symbol_for_expr(sc, eid);
     if (O.is_none[*resolve.Symbol](so)) { ret false; }
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](so);
@@ -1566,9 +1612,9 @@ fun operand_is_comptime_param(sc: *context.SemaContext, eid: id.ExprId) bool {
 }
 
 fun operand_is_uninstantiated_generic(sc: *context.SemaContext, eid: id.ExprId) bool {
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) { ret false; }
-    val k: expr.ExprKind = O.unwrap[*expr.Expr](e_opt).kind;
+    val e_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](e_opt)) { ret false; }
+    val k: expr.ExprKind = R.unwrap_ok[expr.Expr, str](e_opt).kind;
     if (k != expr.EXPR_KIND_IDENT && k != expr.EXPR_KIND_MEMBER) { ret false; }
 
     val cf: O.Option[*decl.DeclFun] = callee_fun_decl(sc, eid);
@@ -1577,9 +1623,10 @@ fun operand_is_uninstantiated_generic(sc: *context.SemaContext, eid: id.ExprId) 
 }
 
 fun operand_is_packed_field(sc: *context.SemaContext, eid: id.ExprId) bool {
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) { ret false; }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    val e_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](e_opt)) { ret false; }
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](e_opt);
+    val e: *expr.Expr = ?e_value;
 
     if (e.kind == expr.EXPR_KIND_MEMBER) {
         if (expr_type_is_packed(sc, e.data.member.object)) { ret true; }
@@ -1668,8 +1715,11 @@ fun callee_packs_to_c_tail(sc: *context.SemaContext, callee: id.ExprId) bool {
     val so: O.Option[*resolve.Symbol] = context.symbol_for_expr(sc, callee);
     if (O.is_none[*resolve.Symbol](so)) { ret false; }
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](so);
-    if (sym.decl == id.DECL_NIL) { ret false; }
-    ret context.decl_body_spreads_pack_to_c_variadic(sc, sym.origin, sym.decl);
+    if (sym.kind != resolve.SYM_FUN && !(sym.kind == resolve.SYM_IMPORTED && sym.definition_kind == resolve.SYM_FUN)) { ret false; }
+    val acquired: R.Result[context.DefinedSymbol, fail.Fail] = context.symbol_definition(sc, sym, context.DEFINITION_RESOLVED);
+    if (R.is_err[context.DefinedSymbol, fail.Fail](acquired)) { ret false; }
+    val current: context.DefinedSymbol = R.unwrap_ok[context.DefinedSymbol, fail.Fail](acquired);
+    ret context.decl_body_spreads_pack_to_c_variadic(sc, current.symbol.origin, current.symbol.decl);
 }
 
 fun callee_fun_decl(sc: *context.SemaContext, callee: id.ExprId) O.Option[*decl.DeclFun] {
@@ -1677,11 +1727,12 @@ fun callee_fun_decl(sc: *context.SemaContext, callee: id.ExprId) O.Option[*decl.
     if (O.is_none[*resolve.Symbol](so)) { ret O.none[*decl.DeclFun](); }
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](so);
     if (sym.kind != resolve.SYM_FUN && sym.kind != resolve.SYM_IMPORTED) { ret O.none[*decl.DeclFun](); }
-    if (sym.decl == id.DECL_NIL)                                         { ret O.none[*decl.DeclFun](); }
-
-    val a: *ast.Ast = symbol_ast(sc, sym);
-    if (a == nil) { ret O.none[*decl.DeclFun](); }
-    val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, sym.decl);
+    if (sym.kind != resolve.SYM_IMPORTED && sym.decl == id.DECL_NIL) { ret O.none[*decl.DeclFun](); }
+    val acquired: R.Result[context.DefinedSymbol, fail.Fail] = context.symbol_definition(sc, sym, context.DEFINITION_RESOLVED);
+    if (R.is_err[context.DefinedSymbol, fail.Fail](acquired)) { ret O.none[*decl.DeclFun](); }
+    val current: context.DefinedSymbol = R.unwrap_ok[context.DefinedSymbol, fail.Fail](acquired);
+    val a: *ast.Ast = current.definition.parsed.a;
+    val d_opt: O.Option[*decl.Decl] = ast.get_decl(a, current.symbol.decl);
     if (O.is_none[*decl.Decl](d_opt)) { ret O.none[*decl.DeclFun](); }
     val d: *decl.Decl = O.unwrap[*decl.Decl](d_opt);
     if (d.kind != decl.DECL_KIND_FUN) { ret O.none[*decl.DeclFun](); }
@@ -1704,9 +1755,10 @@ fun decl_has_comptime_param(sc: *context.SemaContext, callee: id.ExprId, f: *dec
 }
 
 fun infer_comptime_intrinsic(sc: *context.SemaContext, c: *expr.ExprCall, span: token.Span) type.TypeId {
-    val ce_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, c.callee);
-    if (O.is_none[*expr.Expr](ce_opt)) { ret type.TYPE_NIL; }
-    val ce: *expr.Expr = O.unwrap[*expr.Expr](ce_opt);
+    val ce_opt: R.Result[expr.Expr, str] = context.expression(sc, c.callee);
+    if (R.is_err[expr.Expr, str](ce_opt)) { ret type.TYPE_NIL; }
+    var ce_value: expr.Expr = R.unwrap_ok[expr.Expr, str](ce_opt);
+    val ce: *expr.Expr = ?ce_value;
     if (ce.kind != expr.EXPR_KIND_COMPTIME_IDENT) { ret type.TYPE_NIL; }
 
     val name: intern.StrId = comptime_ident_name(sc, ce.span);
@@ -1778,9 +1830,9 @@ fun infer_comptime_intrinsic(sc: *context.SemaContext, c: *expr.ExprCall, span: 
 }
 
 fun intrinsic_operand_type(sc: *context.SemaContext, eid: id.ExprId, span: token.Span) type.TypeId {
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(sc.a, eid);
+    val e_opt: R.Result[expr.Expr, str] = context.expression(sc, eid);
 
-    if (O.is_some[*expr.Expr](e_opt) && comptime.is_field_type_member(sc.a, sc.source, eid)) {
+    if (R.is_ok[expr.Expr, str](e_opt) && comptime.is_field_type_member(sc.a, sc.source, eid)) {
         val fv: R.Result[comptime.CTValue, comptime.EvalFail] = comptime.evaluate[context.SemaContext](sc.ctx, sc, sc.caps, sc.a, sc.source, eid, ?sc.s.interner);
         context.record_eval_result(sc, fv);
         if (R.is_err[comptime.CTValue, comptime.EvalFail](fv)) {
@@ -1795,11 +1847,12 @@ fun intrinsic_operand_type(sc: *context.SemaContext, eid: id.ExprId, span: token
         ret v.data.t::type.TypeId;
     }
 
-    if (O.is_none[*expr.Expr](e_opt) || O.unwrap[*expr.Expr](e_opt).kind != expr.EXPR_KIND_TYPE_REF) {
+    if (R.is_err[expr.Expr, str](e_opt) || R.unwrap_ok[expr.Expr, str](e_opt).kind != expr.EXPR_KIND_TYPE_REF) {
         context.report_internal(sc, span, "internal: a comptime intrinsic argument was not parsed as a type");
         ret type.TYPE_ERROR;
     }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](e_opt);
+    val e: *expr.Expr = ?e_value;
 
     # type errors include deferred generic operands, and allocation errors carry their own status.
     ret resolve_type_ref(sc, e.data.type_ref.ty);
@@ -1952,7 +2005,7 @@ fun compute_generic_signature(sc: *context.SemaContext, c: *expr.ExprCall, ct: t
         i = i + 1;
     }
 
-    if (!generics.check_arity(sc, sym.decl, sym.origin, c.type_args_len, span)) {
+    if (!generics.check_arity(sc, sym, c.type_args_len, span)) {
         free_params(sc, args, c.type_args_len);
         ret type.TYPE_ERROR;
     }
@@ -1991,7 +2044,10 @@ fun compute_generic_signature(sc: *context.SemaContext, c: *expr.ExprCall, ct: t
 }
 
 fun queue_generic_instance(sc: *context.SemaContext, sym: *resolve.Symbol, args: *type.TypeId, arg_len: u32, sig: type.TypeId, span: token.Span) bool {
-    val rr: R.Result[u8, str] = context.record_instance(sc, sym.origin, sym.decl, args, arg_len, sig, sym.name, span);
+    val acquired: R.Result[context.DefinedSymbol, fail.Fail] = context.symbol_definition(sc, sym, context.DEFINITION_RESOLVED);
+    if (R.is_err[context.DefinedSymbol, fail.Fail](acquired)) { ret false; }
+    val current: context.DefinedSymbol = R.unwrap_ok[context.DefinedSymbol, fail.Fail](acquired);
+    val rr: R.Result[u8, str] = context.record_instance(sc, sym.origin, current.symbol.decl, args, arg_len, sig, sym.name, span);
     if (R.is_err[u8, str](rr)) {
         context.report(sc, span, R.unwrap_err[u8, str](rr));
         ret false;
@@ -2492,7 +2548,7 @@ fun binding_type_for(sc: *context.SemaContext, sym: *resolve.Symbol, span: token
 
 fun type_for_symbol(sc: *context.SemaContext, sym: *resolve.Symbol, span: token.Span) type.TypeId {
     if (sym.kind == resolve.SYM_REC || sym.kind == resolve.SYM_UNI || sym.kind == resolve.SYM_IMPORTED) {
-        val arity: u32 = generics.declared_arity(sc, sym.decl, sym.origin);
+        val arity: u32 = sym.generic_arity;
         if (arity > 0) {
             check.report_missing_type_args(sc, span, sym.name, arity);
             ret type.TYPE_ERROR;
@@ -2509,7 +2565,8 @@ fun type_for_symbol(sc: *context.SemaContext, sym: *resolve.Symbol, span: token.
     if (sym.kind == resolve.SYM_REC || sym.kind == resolve.SYM_UNI) {
         var kind: type.TypeKind = type.TYPE_REC;
         if (sym.kind == resolve.SYM_UNI) { kind = type.TYPE_UNI; }
-        val r: R.Result[type.TypeId, str] = type.intern_nominal(?sc.s.types, sym.name, sym.origin, sym.decl, kind);
+        if (sym.definition_file == source.FILE_NIL) { fail.internal(?sc.status, "nominal symbol has no defining source identity"); ret type.TYPE_ERROR; }
+        val r: R.Result[type.TypeId, str] = type.intern_nominal(?sc.s.types, sym.canon, resolve.type_owner(sc.s, sym.origin, sym.definition_file), kind);
         if (R.is_err[type.TypeId, str](r)) { fail.internal(?sc.status, R.unwrap_err[type.TypeId, str](r)); ret type.TYPE_ERROR; }
         ret R.unwrap_ok[type.TypeId, str](r);
     }
@@ -2555,7 +2612,7 @@ fun instantiate_named(sc: *context.SemaContext, sym: *resolve.Symbol, named: *at
         i = i + 1;
     }
 
-    val r: R.Result[type.TypeId, str] = generics.instantiate(sc, sym.decl, sym.origin, args, named.args_len, span);
+    val r: R.Result[type.TypeId, str] = generics.instantiate(sc, sym, args, named.args_len, span);
     free_params(sc, args, named.args_len);
     if (R.is_err[type.TypeId, str](r)) { fail.internal(?sc.status, R.unwrap_err[type.TypeId, str](r)); ret type.TYPE_ERROR; }
     ret R.unwrap_ok[type.TypeId, str](r);
@@ -2676,54 +2733,30 @@ fun resolve_type_anon(sc: *context.SemaContext, tid: id.TypeId, fields_start: u3
     val key: intern.StrId = anon_struct_key(sc, fields_start, fields_len, kind);
     if (key == intern.STR_NIL) { ret type.TYPE_ERROR; }
 
-    val r: R.Result[type.TypeId, str] = type.intern_nominal(?sc.s.types, name_id, session.MODULE_NIL, key::id.DeclId, kind);
+    val r: R.Result[type.TypeId, str] = type.intern_anonymous(?sc.s.types, name_id, resolve.type_owner(sc.s, sc.own_module, sc.a.file_id), sc.a.incarnation, key, kind);
     if (R.is_err[type.TypeId, str](r)) { fail.internal(?sc.status, R.unwrap_err[type.TypeId, str](r)); ret type.TYPE_ERROR; }
     val ty: type.TypeId = R.unwrap_ok[type.TypeId, str](r);
 
-    build_field_table(sc, ty, fields_start, fields_len);
+    val fields: R.Result[R.Void, str] = build_field_table(sc, ty, fields_start, fields_len);
+    if (R.is_err[R.Void, str](fields)) { fail.internal(?sc.status, R.unwrap_err[R.Void, str](fields)); ret type.TYPE_ERROR; }
     ret ty;
 }
 
 fun anon_struct_key(sc: *context.SemaContext, fields_start: u32, fields_len: u32, kind: type.TypeKind) intern.StrId {
-    val cap: usize = (2 + fields_len::usize * 2) * 8;
-    val br: R.Result[*u8, str] = A.allocate[u8](sc.s.alloc, cap);
-    if (R.is_err[*u8, str](br)) { fail.internal(?sc.status, R.unwrap_err[*u8, str](br)); ret intern.STR_NIL; }
-    val buf: *u8 = R.unwrap_ok[*u8, str](br);
-
-    var len: usize = 0;
-    len = put_hex_u32(buf, len, cap, kind::u32);
-    len = put_hex_u32(buf, len, cap, fields_len);
-
+    val allocated: R.Result[*type.FieldEntry, str] = A.allocate[type.FieldEntry](sc.s.alloc, fields_len::usize);
+    if (R.is_err[*type.FieldEntry, str](allocated)) { fail.internal(?sc.status, R.unwrap_err[*type.FieldEntry, str](allocated)); ret intern.STR_NIL; }
+    val entries: *type.FieldEntry = R.unwrap_ok[*type.FieldEntry, str](allocated);
+    fin { A.deallocate[type.FieldEntry](sc.s.alloc, entries, fields_len::usize); }
     var i: u32 = 0;
     for (i < fields_len) {
-        val tn: *decl.TypedName = ?sc.a.typed_names[fields_start + i];
-        val fname: intern.StrId = intern_span_or_nil(sc, tn.name);
-        val fty: type.TypeId = context.resolved_type_of(sc, tn.ty);
-        len = put_hex_u32(buf, len, cap, fname::u32);
-        len = put_hex_u32(buf, len, cap, fty::u32);
+        val tn: decl.TypedName = sc.a.typed_names[fields_start + i];
+        entries[i] = type.FieldEntry{ name: intern_span_or_nil(sc, tn.name), ty: context.resolved_type_of(sc, tn.ty) };
+        if (sc.status.kind != fail.ACCEPTED || entries[i].ty == type.TYPE_ERROR) { ret intern.STR_NIL; }
         i = i + 1;
     }
-
-    val r: R.Result[intern.StrId, str] = intern.intern_bytes(?sc.s.interner, buf::str, len);
-    A.deallocate[u8](sc.s.alloc, buf, cap);
-    if (R.is_err[intern.StrId, str](r)) { fail.internal(?sc.status, R.unwrap_err[intern.StrId, str](r)); ret intern.STR_NIL; }
-    ret R.unwrap_ok[intern.StrId, str](r);
-}
-
-fun put_hex_u32(buf: *u8, off: usize, cap: usize, v: u32) usize {
-    var pos: usize = off;
-    var i: u32 = 0;
-    for (i < 8) {
-        if (pos >= cap) { ret pos; }
-        val shift: u32 = (7 - i) * 4;
-        val nib: u32 = (v >> shift) & 0xF;
-        var c: u8 = nib::u8 + 0x30;
-        if (nib > 9) { c = nib::u8 - 10 + 0x61; }
-        buf[pos] = c;
-        pos = pos + 1;
-        i = i + 1;
-    }
-    ret pos;
+    val encoded: R.Result[intern.StrId, str] = recipe.anonymous(sc.s, sc.ctx.env.target_defs, kind, entries, fields_len);
+    if (R.is_err[intern.StrId, str](encoded)) { fail.internal(?sc.status, R.unwrap_err[intern.StrId, str](encoded)); ret intern.STR_NIL; }
+    ret R.unwrap_ok[intern.StrId, str](encoded);
 }
 
 fun synth_anon_name(sc: *context.SemaContext, kind: type.TypeKind) intern.StrId {
@@ -2780,23 +2813,17 @@ fun is_aggregate(sc: *context.SemaContext, ty: type.TypeId) bool {
     val t: *type.Type = O.unwrap[*type.Type](opt);
     if (t.kind == type.TYPE_REC || t.kind == type.TYPE_UNI || t.kind == type.TYPE_ARRAY) { ret true; }
     if (t.kind == type.TYPE_INSTANCE) {
-        ret instance_is_aggregate(sc, t.data.instance.target_origin, t.data.instance.target_decl);
+        val nominal: O.Option[*type.Type] = type.get(?sc.s.types, t.data.instance.nominal);
+        if (O.is_none[*type.Type](nominal)) { fail.internal(?sc.status, "generic instance has no nominal type"); ret false; }
+        val kind: type.TypeKind = O.unwrap[*type.Type](nominal).kind;
+        ret kind == type.TYPE_REC || kind == type.TYPE_UNI;
     }
     ret false;
 }
 
-fun instance_is_aggregate(sc: *context.SemaContext, origin: session.ModuleId, dcl: id.DeclId) bool {
-    val ga: *ast.Ast = session.module_ast(sc.s, origin);
-    if (ga == nil) { ret false; }
-    val od: O.Option[*decl.Decl] = ast.get_decl(ga, dcl);
-    if (O.is_none[*decl.Decl](od)) { ret false; }
-    val dk: decl.DeclKind = O.unwrap[*decl.Decl](od).kind;
-    ret dk == decl.DECL_KIND_REC || dk == decl.DECL_KIND_UNI;
-}
 
 fun symbol_ast(sc: *context.SemaContext, sym: *resolve.Symbol) *ast.Ast {
-    if (sym.origin == sc.own_module) { ret sc.a; }
-    ret session.module_ast(sc.s, sym.origin);
+    ret context.definition_ast(sc, sym.origin);
 }
 
 fun unify_literals(sc: *context.SemaContext, lhs: id.ExprId, lt: type.TypeId, rhs: id.ExprId, rt: type.TypeId, span: token.Span) O.Option[type.TypeId] {
@@ -2847,4 +2874,106 @@ fun allocate_params(sc: *context.SemaContext, count: u32) R.Result[*type.TypeId,
 
 fun free_params(sc: *context.SemaContext, params: *type.TypeId, count: u32) {
     A.deallocate[type.TypeId](sc.s.alloc, params, count::usize);
+}
+
+fun t_field_recipe_attempt(ordinal: usize, anonymous: bool, attempts: *usize) i32 {
+    var tracker: T.Testing;
+    if (O.is_some[str](T.make(?tracker))) { ret 1; }
+    fin { T.dnit(?tracker); }
+    val alloc: *A.Allocator = T.allocator_of(?tracker);
+    val initialized: R.Result[session.Session, str] = session.init(alloc);
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    var live: bool = true;
+    fin { if (live) { session.dnit(?s); } }
+    var a: ast.Ast = ast.init(alloc, 0);
+    var ast_live: bool = true;
+    fin { if (ast_live) { ast.dnit(?a); } }
+    val name: R.Result[intern.StrId, str] = intern.intern(?s.interner, "R");
+    val field_name: R.Result[intern.StrId, str] = intern.intern(?s.interner, "field");
+    if (R.is_err[intern.StrId, str](name) || R.is_err[intern.StrId, str](field_name)) { ret 3; }
+    val primitive: O.Option[type.TypeId] = type.prim(?s.types, type.TYPE_U32);
+    if (O.is_none[type.TypeId](primitive)) { ret 4; }
+    var syntax: atype.Type = atype.Type{};
+    syntax.kind = atype.TYPE_KIND_NAMED;
+    val syntax_id: R.Result[id.TypeId, str] = ast.add_type(?a, syntax);
+    if (R.is_err[id.TypeId, str](syntax_id)) { ret 5; }
+    var field: decl.TypedName = decl.TypedName{};
+    field.name = token.Span{ offset: 2, len: 5 };
+    field.ty = R.unwrap_ok[id.TypeId, str](syntax_id);
+    val field_id: R.Result[u32, str] = ast.add_typed_name(?a, field);
+    if (R.is_err[u32, str](field_id)) { ret 6; }
+    var declaration: decl.Decl = decl.Decl{};
+    declaration.kind = decl.DECL_KIND_REC;
+    declaration.data.rec_.name = token.Span{ offset: 0, len: 1 };
+    declaration.data.rec_.fields_start = R.unwrap_ok[u32, str](field_id);
+    declaration.data.rec_.fields_len = 1;
+    val did: R.Result[id.DeclId, str] = ast.add_decl(?a, declaration);
+    if (R.is_err[id.DeclId, str](did)) { ret 7; }
+    val nominal: R.Result[type.TypeId, str] = type.intern_nominal(?s.types,
+        R.unwrap_ok[intern.StrId, str](name), type.TypeOwner{ module: session.STABLE_MODULE_NIL, file: a.file_id }, type.TYPE_REC);
+    if (R.is_err[type.TypeId, str](nominal)) { ret 8; }
+    var resolved: [1]type.TypeId;
+    resolved[0] = O.unwrap[type.TypeId](primitive);
+    var state: [1]u8;
+    state[0] = context.LAYOUT_PENDING;
+    var sc: context.SemaContext = context.SemaContext{};
+    sc.s = ?s;
+    sc.a = ?a;
+    sc.diags = ?s.diags;
+    sc.status = fail.accepted();
+    sc.source = "R field";
+    sc.type_resolved_ty = ?resolved[0];
+    sc.layout_state = ?state[0];
+    val before: usize = T.attempt_count(?tracker);
+    if (ordinal != 0) { T.fail_at_ordinal(?tracker, before + ordinal); }
+    var result: type.TypeId = type.TYPE_ERROR;
+    if (anonymous) {
+        result = resolve_type_anon(?sc, 0, 0, 1, type.TYPE_REC);
+    }
+    or {
+        result = infer_decl(?sc, R.unwrap_ok[id.DeclId, str](did));
+    }
+    @attempts = T.attempt_count(?tracker) - before;
+    T.clear_failure(?tracker);
+    if (ordinal == 0) {
+        if (sc.status.kind != fail.ACCEPTED || type.field_count(?s.types, result) != 1) { ret 9; }
+        val published: O.Option[*type.FieldEntry] = type.field_at(?s.types, result, 0);
+        if (O.is_none[*type.FieldEntry](published)) { ret 10; }
+        val entry: *type.FieldEntry = O.unwrap[*type.FieldEntry](published);
+        if (entry.name != R.unwrap_ok[intern.StrId, str](field_name) || entry.ty != resolved[0]) { ret 11; }
+    }
+    or {
+        if (@attempts < ordinal || sc.status.kind != fail.INTERNAL) { ret 12; }
+        if (!str_equals(sc.status.message, "out of memory")) { ret 13; }
+        if (anonymous && result != type.TYPE_ERROR) { ret 14; }
+        if (!anonymous && (state[0] != context.LAYOUT_FAILED
+            || O.is_some[*type.FieldTable](type.field_table_for(?s.types, R.unwrap_ok[type.TypeId, str](nominal))))) { ret 15; }
+    }
+    if (diagnostic.len(?s.diags) != 0) { ret 16; }
+    ast.dnit(?a);
+    ast_live = false;
+    session.dnit(?s);
+    live = false;
+    if (T.live_count(?tracker) != 0 || T.double_free_count(?tracker) != 0 || T.tracking_exhausted(?tracker)) { ret 17; }
+    ret 0;
+}
+
+test "mach.lang.fe.sema.infer:nominal_and_anonymous_field_recipe_oom_is_internal" {
+    var mode: u32 = 0;
+    for (mode < 2) {
+        var total: usize = 0;
+        val baseline: i32 = t_field_recipe_attempt(0, mode == 1, ?total);
+        if (baseline != 0) { ret baseline; }
+        if (total == 0) { ret 18; }
+        var ordinal: usize = 1;
+        for (ordinal <= total) {
+            var attempted: usize = 0;
+            val refused: i32 = t_field_recipe_attempt(ordinal, mode == 1, ?attempted);
+            if (refused != 0) { ret refused; }
+            ordinal = ordinal + 1;
+        }
+        mode = mode + 1;
+    }
+    ret 0;
 }

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -2882,6 +2882,9 @@ fun t_field_recipe_attempt(ordinal: usize, anonymous: bool, attempts: *usize) i3
     var live: bool = true;
     fin { if (live) { session.dnit(?s); } }
     var a: ast.Ast = ast.init(alloc, 0);
+    val incarnation: R.Result[u64, str] = session.next_parse_incarnation(?s);
+    if (R.is_err[u64, str](incarnation)) { ast.dnit(?a); ret 3; }
+    a.incarnation = R.unwrap_ok[u64, str](incarnation);
     var ast_live: bool = true;
     fin { if (ast_live) { ast.dnit(?a); } }
     val name: R.Result[intern.StrId, str] = intern.intern(?s.interner, "R");
@@ -2913,6 +2916,9 @@ fun t_field_recipe_attempt(ordinal: usize, anonymous: bool, attempts: *usize) i3
     var state: [1]u8;
     state[0] = context.LAYOUT_PENDING;
     var sc: context.SemaContext = context.SemaContext{};
+    var evaluation: comptime.ComptimeCtx = comptime.init(alloc, 0, 0, 0, comptime.MODE_DEBUG, 0, 8, 128, true, intern.STR_NIL, intern.STR_NIL);
+    fin { comptime.dnit(?evaluation); }
+    sc.ctx = ?evaluation;
     sc.s = ?s;
     sc.a = ?a;
     sc.diags = ?s.diags;

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1716,6 +1716,7 @@ fun callee_packs_to_c_tail(sc: *context.SemaContext, callee: id.ExprId) bool {
     if (O.is_none[*resolve.Symbol](so)) { ret false; }
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](so);
     if (sym.kind != resolve.SYM_FUN && !(sym.kind == resolve.SYM_IMPORTED && sym.definition_kind == resolve.SYM_FUN)) { ret false; }
+    if (!sym.has_pack_param) { ret false; }
     val acquired: R.Result[context.DefinedSymbol, fail.Fail] = context.symbol_definition(sc, sym, context.DEFINITION_RESOLVED);
     if (R.is_err[context.DefinedSymbol, fail.Fail](acquired)) { ret false; }
     val current: context.DefinedSymbol = R.unwrap_ok[context.DefinedSymbol, fail.Fail](acquired);
@@ -1728,6 +1729,7 @@ fun callee_fun_decl(sc: *context.SemaContext, callee: id.ExprId) O.Option[*decl.
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](so);
     if (sym.kind != resolve.SYM_FUN && sym.kind != resolve.SYM_IMPORTED) { ret O.none[*decl.DeclFun](); }
     if (sym.kind != resolve.SYM_IMPORTED && sym.decl == id.DECL_NIL) { ret O.none[*decl.DeclFun](); }
+    if (sym.generic_arity == 0 && !sym.has_comptime_params) { ret O.none[*decl.DeclFun](); }
     val acquired: R.Result[context.DefinedSymbol, fail.Fail] = context.symbol_definition(sc, sym, context.DEFINITION_RESOLVED);
     if (R.is_err[context.DefinedSymbol, fail.Fail](acquired)) { ret O.none[*decl.DeclFun](); }
     val current: context.DefinedSymbol = R.unwrap_ok[context.DefinedSymbol, fail.Fail](acquired);
@@ -1744,14 +1746,7 @@ fun decl_has_comptime_param(sc: *context.SemaContext, callee: id.ExprId, f: *dec
     if (O.is_none[*resolve.Symbol](so)) { ret false; }
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](so);
 
-    val a: *ast.Ast = symbol_ast(sc, sym);
-    if (a == nil) { ret false; }
-    var i: u32 = 0;
-    for (i < f.params_len) {
-        if (a.typed_names[f.params_start + i].comptime) { ret true; }
-        i = i + 1;
-    }
-    ret false;
+    ret sym.has_comptime_params;
 }
 
 fun infer_comptime_intrinsic(sc: *context.SemaContext, c: *expr.ExprCall, span: token.Span) type.TypeId {

--- a/src/lang/fe/sema/recipe.mach
+++ b/src/lang/fe/sema/recipe.mach
@@ -1,0 +1,200 @@
+use std.collections.vector;
+use std.types.size.usize;
+use std.types.string.str;
+use std.types.string.str_len;
+use O: std.types.option;
+use R: std.types.result;
+use mach.lang.intern;
+use mach.lang.session;
+use mach.lang.source;
+use mach.lang.target.isa;
+use mach.lang.type;
+
+rec Encoder {
+    s: *session.Session;
+    defs: *isa.TargetDefs;
+    bytes: vector.Vector[u8];
+    failure: O.Option[str];
+}
+
+fun byte(out: *Encoder, value: u8) {
+    if (O.is_some[str](out.failure)) { ret; }
+    val appended: R.Result[usize, str] = vector.push[u8](?out.bytes, value);
+    if (R.is_err[usize, str](appended)) { out.failure = O.some[str](R.unwrap_err[usize, str](appended)); }
+}
+
+fun word(out: *Encoder, value: u64) {
+    if (O.is_some[str](out.failure)) { ret; }
+    var shift: u32 = 64;
+    for (shift > 0) {
+        shift = shift - 4;
+        val digit: u8 = ((value >> shift) & 15)::u8;
+        if (digit < 10) { byte(out, '0' + digit); }
+        or { byte(out, 'a' + digit - 10); }
+    }
+}
+
+fun text(out: *Encoder, value: str) {
+    if (O.is_some[str](out.failure)) { ret; }
+    val count: usize = str_len(value);
+    word(out, count::u64);
+    var i: usize = 0;
+    for (i < count) {
+        val high: u8 = value[i] >> 4;
+        val low: u8 = value[i] & 15;
+        if (high < 10) { byte(out, '0' + high); } or { byte(out, 'a' + high - 10); }
+        if (low < 10) { byte(out, '0' + low); } or { byte(out, 'a' + low - 10); }
+        i = i + 1;
+    }
+}
+
+fun name(out: *Encoder, value: intern.StrId) {
+    if (O.is_some[str](out.failure)) { ret; }
+    val found: O.Option[str] = intern.lookup(?out.s.interner, value);
+    if (O.is_none[str](found)) { out.failure = O.some[str]("canonical type recipe has no interned name"); ret; }
+    text(out, O.unwrap[str](found));
+}
+
+fun nested_recipe(out: *Encoder, value: intern.StrId) {
+    if (O.is_some[str](out.failure)) { ret; }
+    val found: O.Option[str] = intern.lookup(?out.s.interner, value);
+    if (O.is_none[str](found)) { out.failure = O.some[str]("anonymous type has no owned canonical recipe"); ret; }
+    val recipe: str = O.unwrap[str](found);
+    val count: usize = str_len(recipe);
+    word(out, count::u64);
+    var i: usize = 0;
+    for (i < count) { byte(out, recipe[i]); i = i + 1; }
+}
+
+fun owner(out: *Encoder, value: type.TypeOwner) {
+    if (O.is_some[str](out.failure)) { ret; }
+    if (value.module != session.STABLE_MODULE_NIL) {
+        val mid: session.ModuleId = session.module_id_for_stable(out.s, value.module);
+        if (mid == session.MODULE_NIL) { out.failure = O.some[str]("canonical type owner is not acquired"); ret; }
+        byte(out, 'm');
+        name(out, session.module_fqn(out.s, mid));
+        ret;
+    }
+    val file: O.Option[*source.SourceFile] = source.get(?out.s.sources, value.file);
+    if (O.is_none[*source.SourceFile](file)) { out.failure = O.some[str]("canonical standalone type owner has no source identity"); ret; }
+    byte(out, 'f');
+    text(out, O.unwrap[*source.SourceFile](file).path);
+}
+
+fun parameters(out: *Encoder, start: u32, count: u32) {
+    if (O.is_some[str](out.failure)) { ret; }
+    if (start > out.s.types.params_len || count > out.s.types.params_len - start) {
+        out.failure = O.some[str]("canonical type recipe has an invalid parameter run");
+        ret;
+    }
+    word(out, count::u64);
+    var i: u32 = 0;
+    for (i < count) { encode_type(out, out.s.types.params[start + i]); i = i + 1; }
+}
+
+fun handle(out: *Encoder, value: type.TypeHandle) {
+    if (O.is_some[str](out.failure)) { ret; }
+    val ti: *type.TypeInterner = ?out.s.types;
+    if (value.ops_start > ti.handle_ops_len || value.ops_len > ti.handle_ops_len - value.ops_start) {
+        out.failure = O.some[str]("canonical handle has an invalid operand run");
+        ret;
+    }
+    if (value.ctor == isa.NO_TYPE_CTOR) {
+        if (value.ops_len != 3) { out.failure = O.some[str]("inert handle has no stable declaration identity"); ret; }
+        owner(out, type.TypeOwner{ module: ti.handle_ops[value.ops_start]::session.StableModuleId,
+            file: ti.handle_ops[value.ops_start + 1]::source.FileId });
+        name(out, ti.handle_ops[value.ops_start + 2]::intern.StrId);
+        ret;
+    }
+    if (out.defs == nil) { out.failure = O.some[str]("canonical handle requires its constructor schema"); ret; }
+    val schema: *isa.TypeDef = isa.type_def_by_tag(out.defs, value.ctor);
+    if (schema == nil || schema.arity != value.ops_len || (schema.arity != 0 && schema.operands == nil)) {
+        out.failure = O.some[str]("canonical handle disagrees with its constructor schema");
+        ret;
+    }
+    word(out, value.ctor::u64);
+    text(out, schema.name);
+    word(out, schema.arity::u64);
+    var i: u32 = 0;
+    for (i < schema.arity) {
+        val operand: u32 = ti.handle_ops[value.ops_start + i];
+        word(out, schema.operands[i]::u64);
+        if (schema.operands[i] == isa.TYPE_OPERAND_WORD) { word(out, operand::u64); }
+        or {
+            val nested: O.Option[*type.Type] = type.get(ti, operand::type.TypeId);
+            if (O.is_none[*type.Type](nested) || O.unwrap[*type.Type](nested).kind != type.TYPE_HANDLE
+                || O.unwrap[*type.Type](nested).data.handle.ctor != schema.operands[i]) {
+                out.failure = O.some[str]("canonical handle operand has the wrong constructor");
+                ret;
+            }
+            encode_type(out, operand::type.TypeId);
+        }
+        i = i + 1;
+    }
+}
+
+fun encode_type(out: *Encoder, tid: type.TypeId) {
+    if (O.is_some[str](out.failure)) { ret; }
+    if (tid == type.TYPE_NIL) { byte(out, 'n'); ret; }
+    val found: O.Option[*type.Type] = type.get(?out.s.types, tid);
+    if (O.is_none[*type.Type](found)) { out.failure = O.some[str]("canonical type recipe has an invalid type"); ret; }
+    val value: type.Type = @O.unwrap[*type.Type](found);
+    byte(out, 't');
+    word(out, value.kind::u64);
+    if (value.kind::u32 < type.PRIM_COUNT || value.kind == type.TYPE_PACK) { ret; }
+    if (value.kind == type.TYPE_POINTER) { encode_type(out, value.data.pointer.base); ret; }
+    if (value.kind == type.TYPE_SECRET) { encode_type(out, value.data.secret.base); ret; }
+    if (value.kind == type.TYPE_ARRAY) { word(out, value.data.array.count::u64); encode_type(out, value.data.array.base); ret; }
+    if (value.kind == type.TYPE_VECTOR) { word(out, value.data.vector.element::u64); word(out, value.data.vector.lanes::u64); ret; }
+    if (value.kind == type.TYPE_FUN) {
+        word(out, value.data.fn.c_variadic::u64);
+        encode_type(out, value.data.fn.ret_type);
+        parameters(out, value.data.fn.params_start, value.data.fn.params_len);
+        ret;
+    }
+    if (value.kind == type.TYPE_REC || value.kind == type.TYPE_UNI) {
+        owner(out, value.data.nominal.owner);
+        name(out, value.data.nominal.name);
+        if (value.data.nominal.incarnation == 0) { byte(out, 'd'); }
+        or { byte(out, 'a'); nested_recipe(out, value.data.nominal.syntax); }
+        ret;
+    }
+    if (value.kind == type.TYPE_GENERIC_PARAM) {
+        owner(out, value.data.generic_param.owner);
+        name(out, value.data.generic_param.owner_name);
+        name(out, value.data.generic_param.name);
+        word(out, value.data.generic_param.owner_kind::u64);
+        word(out, value.data.generic_param.index::u64);
+        ret;
+    }
+    if (value.kind == type.TYPE_INSTANCE) {
+        encode_type(out, value.data.instance.nominal);
+        parameters(out, value.data.instance.args_start, value.data.instance.args_len);
+        ret;
+    }
+    if (value.kind == type.TYPE_HANDLE) { handle(out, value.data.handle); ret; }
+    if (value.kind == type.TYPE_ABI) {
+        name(out, value.data.abi.name);
+        word(out, value.data.abi.tag::u64);
+        word(out, value.data.abi.size::u64);
+        word(out, value.data.abi.align::u64);
+        ret;
+    }
+    out.failure = O.some[str]("canonical type recipe has an unknown type kind");
+}
+
+pub fun anonymous(s: *session.Session, defs: *isa.TargetDefs, kind: type.TypeKind,
+                  fields: *type.FieldEntry, count: u32) R.Result[intern.StrId, str] {
+    var out: Encoder = Encoder{ s: s, defs: defs, bytes: vector.init[u8](s.alloc), failure: O.none[str]() };
+    fin { vector.dnit[u8](?out.bytes); }
+    word(?out, kind::u64);
+    word(?out, count::u64);
+    var i: u32 = 0;
+    for (i < count) {
+        name(?out, fields[i].name);
+        encode_type(?out, fields[i].ty);
+        i = i + 1;
+    }
+    if (O.is_some[str](out.failure)) { ret R.err[intern.StrId, str](O.unwrap[str](out.failure)); }
+    ret intern.intern_bytes(?s.interner, out.bytes.data::str, out.bytes.len);
+}

--- a/src/lang/fe/sema/tests.mach
+++ b/src/lang/fe/sema/tests.mach
@@ -24,6 +24,7 @@ use mach.lang.driver;
 use mach.lang.driver.project;
 use mach.lang.fe.ast;
 use mach.lang.fe.ast.id;
+use mach.lang.fe.ast.decl;
 use mach.lang.fe.ast.expr;
 use mach.lang.fe.sema.infer;
 use mach.lang.fe.resolve;
@@ -582,40 +583,55 @@ test "mach.lang.fe.sema:align_registration_failure_rejects_module_at_every_ordin
 test "mach.lang.fe.sema.context:generic_param_type_for_respects_declaring_module" {
     var backing: A.Allocator;
     if (O.is_some[str](page.make(?backing))) { ret 1; }
-    val sr: R.Result[session.Session, str] = session.init(?backing);
-    if (R.is_err[session.Session, str](sr)) { ret 1; }
-    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
-
-    var sc: context.SemaContext;
-    sc.s         = ?s;
-    sc.diags = ?s.diags;
-    sc.subst     = nil;
-    sc.subst_len = 0;
-    sc.subst_fn  = nil;
-    sc.status = fail.accepted();
-
+    var names: [2]str = [2]str{ "main.mach", "lib.mach" };
+    var texts: [2]str = [2]str{
+        "use semaharness.lib;\nfun same[T](x: T) T { ret x; }\nfun main() i32 { ret 0; }\n",
+        "pub fun same[T](x: T) T { ret x; }\n"
+    };
+    val root_r: R.Result[str, str] = ut_scaffold(?backing, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](root_r)) { ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    fin { fs.remove_all(?backing, root); }
+    var s: session.Session;
+    val pr: R.Result[project.Project, outcome.Fail] = ut_build(?backing, root, ?s);
+    fin { session.dnit(?s); }
+    if (R.is_err[project.Project, outcome.Fail](pr)) { ret 1; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    fin { project.dnit_project(?p); }
     val name_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, "T");
-    if (R.is_err[intern.StrId, str](name_r)) { session.dnit(?s); ret 1; }
-    val name: intern.StrId = R.unwrap_ok[intern.StrId, str](name_r);
-
-    var sym_a: resolve.Symbol;
-    sym_a.name   = name;
-    sym_a.decl   = 0::id.DeclId;
-    sym_a.slot   = 0;
-    sym_a.origin = 1::session.ModuleId;
-
-    var sym_b: resolve.Symbol;
-    sym_b.name   = name;
-    sym_b.decl   = 0::id.DeclId;
-    sym_b.slot   = 0;
-    sym_b.origin = 2::session.ModuleId;
-
-    val ta: type.TypeId = context.generic_param_type_for(?sc, ?sym_a);
-    val tb: type.TypeId = context.generic_param_type_for(?sc, ?sym_b);
-
-    session.dnit(?s);
-
-    if (ta == tb) { ret 1; }
+    if (R.is_err[intern.StrId, str](name_r)) { ret 1; }
+    var owners: [2]str = [2]str{ "semaharness.main", "semaharness.lib" };
+    var types: [2]type.TypeId;
+    var i: u32 = 0;
+    for (i < 2) {
+        val mid: session.ModuleId = ut_mid(?p, ?s, owners[i]);
+        val m: *project.ModuleEntry = ut_module(?p, ?s, owners[i]);
+        if (m == nil || mid == session.MODULE_NIL) { ret 1; }
+        var sc: context.SemaContext;
+        sc.s = ?s;
+        sc.diags = ?s.diags;
+        sc.a = m.a;
+        sc.own_module = mid;
+        sc.status = fail.accepted();
+        var sym: resolve.Symbol;
+        sym.name = R.unwrap_ok[intern.StrId, str](name_r);
+        sym.origin = mid;
+        sym.slot = 0;
+        sym.decl = id.DECL_NIL;
+        var di: usize = 0;
+        for (di < m.a.decl_len) {
+            if (m.a.decls[di].kind == decl.DECL_KIND_FUN && m.a.decls[di].data.fun_.generics_len == 1) {
+                sym.decl = di::id.DeclId;
+            }
+            di = di + 1;
+        }
+        if (sym.decl == id.DECL_NIL) { ret 1; }
+        types[i] = context.generic_param_type_for(?sc, ?sym);
+        if (types[i] == type.TYPE_ERROR || sc.status.kind != fail.ACCEPTED) { ret 1; }
+        if (context.generic_param_type_for(?sc, ?sym) != types[i]) { ret 1; }
+        i = i + 1;
+    }
+    if (types[0] == types[1]) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/fe/sema/tests.mach
+++ b/src/lang/fe/sema/tests.mach
@@ -219,7 +219,7 @@ test "mach.lang.fe.sema:sema_survives_allocation_failure_at_every_point" {
     val m: *project.ModuleEntry = ut_module(?p, ?s, "semaharness.main");
     if (m == nil || mid == session.MODULE_NIL) { driver.dnit_project(?p); session.dnit(?s); ret 1; }
 
-    var deps: sema.SemaDeps;
+    var deps: sema.SemaDeps = sema.SemaDeps{};
     deps.entries = nil;
     deps.count   = 0;
 
@@ -229,7 +229,7 @@ test "mach.lang.fe.sema:sema_survives_allocation_failure_at_every_point" {
     var alloc0: A.Allocator;
     if (!fp_make(?probe0, ?alloc0, 0)) { s.alloc = real_alloc; driver.dnit_project(?p); session.dnit(?s); ret 1; }
     s.alloc = ?alloc0;
-    val r0: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
+    val r0: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid, ?s.diags);
     if (R.is_ok[context.SemaResult, fail.Fail](r0)) {
         var res0: context.SemaResult = R.unwrap_ok[context.SemaResult, fail.Fail](r0);
         sema.dnit_result(?res0);
@@ -248,7 +248,7 @@ test "mach.lang.fe.sema:sema_survives_allocation_failure_at_every_point" {
         if (fp_make(?probe, ?alloc, fail_at)) {
             val pre_len: usize = diagnostic.len(?s.diags);
             s.alloc = ?alloc;
-            val r: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
+            val r: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid, ?s.diags);
             if (R.is_ok[context.SemaResult, fail.Fail](r)) {
                 var res: context.SemaResult = R.unwrap_ok[context.SemaResult, fail.Fail](r);
                 sema.dnit_result(?res);
@@ -320,6 +320,7 @@ test "mach.lang.fe.sema.context:report_marks_rejected_under_diagnostic_allocatio
     var sc: context.SemaContext;
     sc.status          = fail.accepted();
     sc.s               = ?s;
+    sc.diags = ?s.diags;
     sc.a                = m.a;
     sc.silent           = false;
     sc.in_comptime_gate = false;
@@ -386,7 +387,7 @@ test "mach.lang.fe.sema.context:real_semantic_error_still_rejects_module_under_d
     val m: *project.ModuleEntry = ut_module(?p, ?s, "semaharness.main");
     if (m == nil || mid == session.MODULE_NIL) { driver.dnit_project(?p); session.dnit(?s); ret 1; }
 
-    var deps: sema.SemaDeps;
+    var deps: sema.SemaDeps = sema.SemaDeps{};
     deps.entries = nil;
     deps.count   = 0;
 
@@ -395,7 +396,7 @@ test "mach.lang.fe.sema.context:real_semantic_error_still_rejects_module_under_d
     if (!fp_make(?probe0, ?alloc0, 0)) { driver.dnit_project(?p); session.dnit(?s); ret 1; }
     diagnostic.store_dnit(?s.diags);
     s.diags = diagnostic.store_init(?alloc0);
-    val r0: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
+    val r0: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid, ?s.diags);
     if (R.is_ok[context.SemaResult, fail.Fail](r0)) {
         var res0: context.SemaResult = R.unwrap_ok[context.SemaResult, fail.Fail](r0);
         sema.dnit_result(?res0);
@@ -412,7 +413,7 @@ test "mach.lang.fe.sema.context:real_semantic_error_still_rejects_module_under_d
         var alloc: A.Allocator;
         if (fp_make(?probe, ?alloc, fail_at)) {
             s.diags = diagnostic.store_init(?alloc);
-            val r: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
+            val r: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid, ?s.diags);
             if (R.is_ok[context.SemaResult, fail.Fail](r)) {
                 var res: context.SemaResult = R.unwrap_ok[context.SemaResult, fail.Fail](r);
                 if (res.status.kind == fail.ACCEPTED || probe.calls >= fail_at) { bad = true; }
@@ -437,7 +438,7 @@ test "mach.lang.fe.sema.context:real_semantic_error_still_rejects_module_under_d
 
 fun ut_sweep_registration_failure(s: *session.Session, m: *project.ModuleEntry, mid: session.ModuleId,
                                   target: *map.Map[u32, u32], backing: *A.Allocator) bool {
-    var deps: sema.SemaDeps;
+    var deps: sema.SemaDeps = sema.SemaDeps{};
     deps.entries = nil;
     deps.count   = 0;
 
@@ -446,7 +447,7 @@ fun ut_sweep_registration_failure(s: *session.Session, m: *project.ModuleEntry, 
     var alloc0: A.Allocator;
     if (!fp_make(?probe0, ?alloc0, 0)) { ret false; }
     @target = map.init[u32, u32](?alloc0, map.hash_u32, map.eq_u32);
-    val r0: R.Result[context.SemaResult, fail.Fail] = sema.sema(s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
+    val r0: R.Result[context.SemaResult, fail.Fail] = sema.sema(s, m.a, m.resolve_result, ?deps, ?m.ctx, mid, ?s.diags);
     if (R.is_ok[context.SemaResult, fail.Fail](r0)) {
         var res0: context.SemaResult = R.unwrap_ok[context.SemaResult, fail.Fail](r0);
         sema.dnit_result(?res0);
@@ -465,7 +466,7 @@ fun ut_sweep_registration_failure(s: *session.Session, m: *project.ModuleEntry, 
             s.diags = diagnostic.store_init(backing);
             map.dnit[u32, u32](target);
             @target = map.init[u32, u32](?alloc, map.hash_u32, map.eq_u32);
-            val r: R.Result[context.SemaResult, fail.Fail] = sema.sema(s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
+            val r: R.Result[context.SemaResult, fail.Fail] = sema.sema(s, m.a, m.resolve_result, ?deps, ?m.ctx, mid, ?s.diags);
             if (R.is_ok[context.SemaResult, fail.Fail](r)) {
                 var res: context.SemaResult = R.unwrap_ok[context.SemaResult, fail.Fail](r);
                 if (res.status.kind == fail.ACCEPTED || probe.calls >= fail_at) { bad = true; }
@@ -587,6 +588,7 @@ test "mach.lang.fe.sema.context:generic_param_type_for_respects_declaring_module
 
     var sc: context.SemaContext;
     sc.s         = ?s;
+    sc.diags = ?s.diags;
     sc.subst     = nil;
     sc.subst_len = 0;
     sc.subst_fn  = nil;
@@ -642,7 +644,7 @@ fun ut_sweep(src: str, forbidden: str) i32 {
     val m:   *project.ModuleEntry = ut_module(?p, ?s, "semaharness.main");
     if (m == nil || mid == session.MODULE_NIL) { driver.dnit_project(?p); session.dnit(?s); ret 1; }
 
-    var deps: sema.SemaDeps;
+    var deps: sema.SemaDeps = sema.SemaDeps{};
     deps.entries = nil;
     deps.count   = 0;
 
@@ -653,7 +655,7 @@ fun ut_sweep(src: str, forbidden: str) i32 {
     if (!fp_make(?probe0, ?alloc0, 0)) { driver.dnit_project(?p); session.dnit(?s); ret 1; }
     s.alloc = ?alloc0;
     val pre0: usize = diagnostic.len(?s.diags);
-    val r0: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
+    val r0: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid, ?s.diags);
     if (R.is_ok[context.SemaResult, fail.Fail](r0)) {
         var res0: context.SemaResult = R.unwrap_ok[context.SemaResult, fail.Fail](r0);
         sema.dnit_result(?res0);
@@ -681,7 +683,7 @@ fun ut_sweep(src: str, forbidden: str) i32 {
         if (!fp_make(?probe, ?alloc, fail_at)) { driver.dnit_project(?p); session.dnit(?s); ret 1; }
         val pre: usize = diagnostic.len(?s.diags);
         s.alloc = ?alloc;
-        val r: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
+        val r: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid, ?s.diags);
         val accepted: bool = R.is_ok[context.SemaResult, fail.Fail](r);
         if (accepted) {
             var res: context.SemaResult = R.unwrap_ok[context.SemaResult, fail.Fail](r);
@@ -781,11 +783,11 @@ fun ut_sema_diag_has(src: str, needle: str) bool {
     val m:   *project.ModuleEntry = ut_module(?p, ?s, "semaharness.main");
     if (m == nil || mid == session.MODULE_NIL) { driver.dnit_project(?p); session.dnit(?s); ret false; }
 
-    var deps: sema.SemaDeps;
+    var deps: sema.SemaDeps = sema.SemaDeps{};
     deps.entries = nil;
     deps.count   = 0;
 
-    val r: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
+    val r: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid, ?s.diags);
     if (R.is_ok[context.SemaResult, fail.Fail](r)) {
         var res: context.SemaResult = R.unwrap_ok[context.SemaResult, fail.Fail](r);
         sema.dnit_result(?res);
@@ -875,7 +877,7 @@ test "mach.lang.fe.sema:diagnostic_allocation_failure_is_internal_without_count_
     val m:   *project.ModuleEntry = ut_module(?p, ?s, "semaharness.main");
     if (m == nil || mid == session.MODULE_NIL) { driver.dnit_project(?p); session.dnit(?s); ret 1; }
 
-    var deps: sema.SemaDeps;
+    var deps: sema.SemaDeps = sema.SemaDeps{};
     deps.entries = nil;
     deps.count   = 0;
 
@@ -893,7 +895,7 @@ test "mach.lang.fe.sema:diagnostic_allocation_failure_is_internal_without_count_
         diagnostic.store_dnit(?s.diags);
         s.diags = diagnostic.store_init(T.allocator_of(?failing));
 
-        val r: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
+        val r: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid, ?s.diags);
         if (R.is_ok[context.SemaResult, fail.Fail](r)) {
             var res: context.SemaResult = R.unwrap_ok[context.SemaResult, fail.Fail](r);
             sema.dnit_result(?res);
@@ -946,10 +948,10 @@ fun ut_sema_error_free(src: str) bool {
     val mid: session.ModuleId     = ut_mid(?p, ?s, "semaharness.main");
     val m:   *project.ModuleEntry = ut_module(?p, ?s, "semaharness.main");
     if (m == nil || mid == session.MODULE_NIL) { driver.dnit_project(?p); session.dnit(?s); ret false; }
-    var deps: sema.SemaDeps;
+    var deps: sema.SemaDeps = sema.SemaDeps{};
     deps.entries = nil;
     deps.count   = 0;
-    val r: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid);
+    val r: R.Result[context.SemaResult, fail.Fail] = sema.sema(?s, m.a, m.resolve_result, ?deps, ?m.ctx, mid, ?s.diags);
     if (R.is_ok[context.SemaResult, fail.Fail](r)) {
         var res: context.SemaResult = R.unwrap_ok[context.SemaResult, fail.Fail](r);
         sema.dnit_result(?res);
@@ -1002,7 +1004,7 @@ fun t_substitution_internal_after_rejection(reject_first: bool, silent: bool) i3
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
     fin { session.dnit(?s); }
     val gp: R.Result[type.TypeId, str] = type.intern_generic_param(?s.types, intern.STR_NIL,
-        0::session.ModuleId, 0::id.DeclId, 0);
+        type.TypeOwner{ module: 0, file: 1 }, 0::intern.StrId, type.TYPE_FUN, 0);
     if (R.is_err[type.TypeId, str](gp)) { ret 3; }
     var params: [1]type.TypeId;
     params[0] = R.unwrap_ok[type.TypeId, str](gp);
@@ -1016,6 +1018,7 @@ fun t_substitution_internal_after_rejection(reject_first: bool, silent: bool) i3
     fin { ast.dnit(?a); }
     var sc: context.SemaContext;
     sc.s = ?s;
+    sc.diags = ?s.diags;
     sc.a = ?a;
     sc.status = fail.accepted();
     sc.silent = false;
@@ -1119,6 +1122,7 @@ fun t_binding_outcome(mode: u8) i32 {
     if (rejected == id.EXPR_NIL || bound == id.EXPR_NIL) { ret 6; }
     var sc: context.SemaContext;
     sc.s = ?s;
+    sc.diags = ?s.diags;
     sc.a = m.a;
     sc.rr = rr;
     sc.expr_type = nil;

--- a/src/lang/me/ir/equal.mach
+++ b/src/lang/me/ir/equal.mach
@@ -1,0 +1,252 @@
+use std.collections.map;
+use std.memory;
+use std.types.bool.bool;
+use std.types.bool.true;
+use std.types.bool.false;
+use std.types.size.usize;
+use std.types.string.str;
+use O: std.types.option;
+use R: std.types.result;
+use mach.lang.source;
+use mach.lang.me.ir;
+use mach.lang.me.ir.value;
+use mach.lang.me.ir.type;
+use mach.lang.me.ir.instruction;
+
+pub fun content_equal(a: *ir.Module, b: *ir.Module) bool {
+    if (a.name != b.name || a.function_len != b.function_len || a.global_len != b.global_len
+        || a.types.len != b.types.len || a.vector_ops_scalarized != b.vector_ops_scalarized) { ret false; }
+    if (O.is_some[u32](a.init_fn) != O.is_some[u32](b.init_fn)) { ret false; }
+    if (O.is_some[u32](a.init_fn) && O.unwrap[u32](a.init_fn) != O.unwrap[u32](b.init_fn)) { ret false; }
+    if (!map_equal[u32](?a.fn_by_name, ?b.fn_by_name, number_equal)
+        || !map_equal[u32](?a.global_by_name, ?b.global_by_name, number_equal)) { ret false; }
+    var i: u32 = 0;
+    for (i < a.types.len) {
+        if (!type.content_equal(?a.types.types[i], ?b.types.types[i])) { ret false; }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < a.function_len) {
+        if (!function_equal(?a.functions[i], ?b.functions[i])) { ret false; }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < a.global_len) {
+        if (!global_equal(?a.globals[i], ?b.globals[i])) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+fun values_equal(a: *value.Value, b: *value.Value, n: u32) bool {
+    var i: u32 = 0;
+    for (i < n) {
+        if (!value_equal(?a[i], ?b[i])) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+fun value_equal(a: *value.Value, b: *value.Value) bool {
+    if (a.kind != b.kind || a.ty != b.ty || a.secret != b.secret) { ret false; }
+    if (a.kind == value.VAL_INSTR) { ret a.data.instr == b.data.instr; }
+    if (a.kind == value.VAL_PARAM) { ret a.data.param_ix == b.data.param_ix; }
+    if (a.kind == value.VAL_CONST_INT) { ret a.data.int_lit == b.data.int_lit; }
+    if (a.kind == value.VAL_CONST_FLOAT) { ret a.data.float_lit:~u64 == b.data.float_lit:~u64; }
+    if (a.kind == value.VAL_CONST_NULL) { ret true; }
+    if (a.kind == value.VAL_GLOBAL) { ret a.data.global_ix == b.data.global_ix; }
+    if (a.kind == value.VAL_FN) { ret a.data.fn_ix == b.data.fn_ix; }
+    if (a.kind == value.VAL_CONST_BYTES) {
+        ret a.data.bytes.len == b.data.bytes.len && memory.equal[u8](a.data.bytes.ptr, b.data.bytes.ptr, a.data.bytes.len::usize);
+    }
+    if (a.kind == value.VAL_CONST_AGG) {
+        val x: *value.ValueAgg = ?a.data.agg;
+        val y: *value.ValueAgg = ?b.data.agg;
+        if (x.len != y.len || x.reloc_count != y.reloc_count || !memory.equal[u8](x.bytes, y.bytes, x.len::usize)) { ret false; }
+        var i: u32 = 0;
+        for (i < x.reloc_count) {
+            val p: *value.AggReloc = ?x.relocs[i];
+            val q: *value.AggReloc = ?y.relocs[i];
+            if (p.offset != q.offset || p.symbol != q.symbol || p.addend != q.addend || p.is_fn != q.is_fn) { ret false; }
+            i = i + 1;
+        }
+        ret true;
+    }
+    ret false;
+}
+
+fun map_equal[T](a: *map.Map[u32, T], b: *map.Map[u32, T], equal: fun(*T, *T) bool) bool {
+    if (a.len != b.len) { ret false; }
+    var i: usize = 0;
+    for (i < a.cap) {
+        if (a.states[i] == 1) {
+            val found: R.Result[*T, str] = map.get[u32, T](b, ?a.keys[i]);
+            if (R.is_err[*T, str](found) || !equal(?a.values[i], R.unwrap_ok[*T, str](found))) { ret false; }
+        }
+        i = i + 1;
+    }
+    ret true;
+}
+
+fun number_equal(a: *u32, b: *u32) bool { ret @a == @b; }
+
+fun global_equal(a: *ir.Global, b: *ir.Global) bool {
+    if (a.name != b.name) { ret false; }
+    if (a.ty != b.ty) { ret false; }
+    if (a.is_mut != b.is_mut) { ret false; }
+    if (a.is_pub != b.is_pub) { ret false; }
+    if (a.is_extern != b.is_extern) { ret false; }
+    if (a.is_import != b.is_import) { ret false; }
+    if (a.is_local != b.is_local) { ret false; }
+    if (a.is_embed != b.is_embed) { ret false; }
+    if (a.align != b.align) { ret false; }
+    if (a.section != b.section) { ret false; }
+    if (a.iface != b.iface) { ret false; }
+    if (a.iface_a != b.iface_a) { ret false; }
+    if (a.iface_b != b.iface_b) { ret false; }
+    if (a.iface_flags != b.iface_flags) { ret false; }
+    ret value_equal(?a.init, ?b.init);
+}
+
+fun debug_var_equal(a: *ir.DbgVar, b: *ir.DbgVar) bool {
+    if (a.name != b.name) { ret false; }
+    if (a.ty != b.ty) { ret false; }
+    if (a.ty_sem != b.ty_sem) { ret false; }
+    if (a.is_param != b.is_param) { ret false; }
+    if (a.scope != b.scope) { ret false; }
+    ret true;
+}
+
+fun asm_equal(a: *ir.IrAsm, b: *ir.IrAsm) bool {
+    if (a.isa != b.isa) { ret false; }
+    if (a.body != b.body) { ret false; }
+    if (a.bind_count != b.bind_count) { ret false; }
+    var i: u32 = 0;
+    for (i < a.bind_count) {
+        if (a.binds[i].name != b.binds[i].name || a.binds[i].instr != b.binds[i].instr || a.binds[i].secret != b.binds[i].secret) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+fun instruction_equal(a: *instruction.Instruction, b: *instruction.Instruction) bool {
+    if (a.kind != b.kind) { ret false; }
+    if (a.ty != b.ty) { ret false; }
+    if (a.operand_count != b.operand_count) { ret false; }
+    if (a.flags != b.flags) { ret false; }
+    if (a.aux_ty != b.aux_ty) { ret false; }
+    if (a.loc.file != b.loc.file) { ret false; }
+    if (a.loc.offset != b.loc.offset) { ret false; }
+    if (a.secret != b.secret) { ret false; }
+    ret values_equal(a.operands, b.operands, a.operand_count);
+}
+
+fun block_equal(a: *ir.Block, b: *ir.Block) bool {
+    if (a.id != b.id) { ret false; }
+    if (a.instr_count != b.instr_count) { ret false; }
+    if (a.phi_count != b.phi_count) { ret false; }
+    if (a.terminator != b.terminator) { ret false; }
+    if (a.pred_count != b.pred_count) { ret false; }
+    ret memory.equal[u32](a.instructions, b.instructions, a.instr_count::usize)
+        && memory.equal[u32](a.phis, b.phis, a.phi_count::usize)
+        && memory.equal[u32](a.preds, b.preds, a.pred_count::usize);
+}
+
+fun function_equal(a: *ir.Function, b: *ir.Function) bool {
+    if (a.name != b.name) { ret false; }
+    if (a.sig != b.sig) { ret false; }
+    if (a.param_count != b.param_count) { ret false; }
+    if (a.block_count != b.block_count) { ret false; }
+    if (a.instr_len != b.instr_len) { ret false; }
+    if (a.flags != b.flags) { ret false; }
+    if (a.is_import != b.is_import) { ret false; }
+    if (a.label != b.label) { ret false; }
+    if (a.line != b.line) { ret false; }
+    if (a.section != b.section) { ret false; }
+    if (a.stage != b.stage) { ret false; }
+    if (a.wg_x != b.wg_x) { ret false; }
+    if (a.wg_y != b.wg_y) { ret false; }
+    if (a.wg_z != b.wg_z) { ret false; }
+    if (a.op_set != b.op_set) { ret false; }
+    if (a.op_code != b.op_code) { ret false; }
+    if (a.disp != b.disp) { ret false; }
+    if (a.ret_sem != b.ret_sem) { ret false; }
+    if (a.dbg_expr_len != b.dbg_expr_len) { ret false; }
+    if (a.inline_site_len != b.inline_site_len) { ret false; }
+    if (!values_equal(a.params, b.params, a.param_count)) { ret false; }
+    if (!map_equal[ir.IrAsm](?a.asm_blocks, ?b.asm_blocks, asm_equal)
+        || !map_equal[ir.DbgVar](?a.dbg_vars, ?b.dbg_vars, debug_var_equal)
+        || !map_equal[ir.DbgVar](?a.alloca_dbg_vars, ?b.alloca_dbg_vars, debug_var_equal)
+        || !map_equal[u32](?a.dbg_expr_ids, ?b.dbg_expr_ids, number_equal)
+        || !map_equal[u32](?a.instr_inline_site, ?b.instr_inline_site, number_equal)) { ret false; }
+    var i: u32 = 0;
+    for (i < a.block_count) {
+        if (!block_equal(?a.blocks[i], ?b.blocks[i])) { ret false; }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < a.instr_len) {
+        if (!instruction_equal(?a.instrs[i], ?b.instrs[i])) { ret false; }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < a.dbg_expr_len) {
+        val x: *ir.DbgExpr = ?a.dbg_exprs[i];
+        val y: *ir.DbgExpr = ?b.dbg_exprs[i];
+        if (x.op_count != y.op_count) { ret false; }
+        var j: u32 = 0;
+        for (j < x.op_count) {
+            if (x.ops[j].op != y.ops[j].op || x.ops[j].arg != y.ops[j].arg) { ret false; }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < a.inline_site_len) {
+        val x: *ir.InlineSite = ?a.inline_sites[i];
+        val y: *ir.InlineSite = ?b.inline_sites[i];
+        if (x.callee != y.callee || x.call_loc.file != y.call_loc.file || x.call_loc.offset != y.call_loc.offset || x.parent != y.parent) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+
+test "mach.lang.me.ir.equal:owned_bytes_relocations_and_float_bits_are_observable" {
+    var xbytes: [2]u8 = [2]u8{1, 2};
+    var ybytes: [2]u8 = [2]u8{1, 2};
+    var x: value.Value = value.const_bytes(?xbytes[0], 2, 1);
+    var y: value.Value = value.const_bytes(?ybytes[0], 2, 1);
+    if (!value_equal(?x, ?y)) { ret 1; }
+    ybytes[1] = 3;
+    if (value_equal(?x, ?y)) { ret 2; }
+    ybytes[1] = 2;
+    var xr: value.AggReloc = value.AggReloc{symbol: 7, addend: 4};
+    var yr: value.AggReloc = xr;
+    x = value.const_agg(?xbytes[0], 2, ?xr, 1, 1, 1);
+    y = value.const_agg(?ybytes[0], 2, ?yr, 1, 8, 1);
+    if (!value_equal(?x, ?y)) { ret 3; }
+    yr.addend = 5;
+    if (value_equal(?x, ?y)) { ret 4; }
+    val nan: u64 = 0x7ff8000000000001;
+    x = value.const_float(nan:~f64, 2);
+    y = value.const_float(nan:~f64, 2);
+    if (!value_equal(?x, ?y)) { ret 5; }
+    val negative_zero: u64 = 0x8000000000000000;
+    x = value.const_float(0.0, 2);
+    y = value.const_float(negative_zero:~f64, 2);
+    if (value_equal(?x, ?y)) { ret 6; }
+    ret 0;
+}
+
+test "mach.lang.me.ir.equal:instruction_source_and_secrecy_are_observable" {
+    var x: instruction.Instruction = instruction.Instruction{kind: instruction.OP_RET, loc: source.SrcLoc{file: 3, offset: 11}};
+    var y: instruction.Instruction = x;
+    if (!instruction_equal(?x, ?y)) { ret 1; }
+    y.loc.offset = 12;
+    if (instruction_equal(?x, ?y)) { ret 2; }
+    y = x;
+    y.secret = true;
+    if (instruction_equal(?x, ?y)) { ret 3; }
+    ret 0;
+}

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -499,6 +499,10 @@ fun hash_ir_type(p: ptr) u64 {
     ret h;
 }
 
+pub fun content_equal(a: *IrType, b: *IrType) bool {
+    ret eq_ir_type(a::ptr, b::ptr);
+}
+
 fun eq_ir_type(pa: ptr, pb: ptr) bool {
     val a: *IrType = pa::*IrType;
     val b: *IrType = pb::*IrType;

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -133,9 +133,9 @@ fun emit_one_instance(lc: *context.LowerContext, s: *session.Session,
                       decl_id: id.DeclId, origin: session.ModuleId,
                       args: *type.TypeId, arg_len: u32, name: intern.StrId,
                       current: u32) R.Result[R.Void, fail.Fail] {
-    val sc_o: O.Option[context.ModuleScope] = context.origin_scope(s, origin);
-    if (O.is_none[context.ModuleScope](sc_o)) { ret R.ok_void[fail.Fail](); }
-    var sc: context.ModuleScope = O.unwrap[context.ModuleScope](sc_o);
+    val acquired: R.Result[context.ModuleScope, fail.Fail] = context.origin_scope(lc, origin);
+    if (R.is_err[context.ModuleScope, fail.Fail](acquired)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[context.ModuleScope, fail.Fail](acquired)); }
+    var sc: context.ModuleScope = R.unwrap_ok[context.ModuleScope, fail.Fail](acquired);
 
     val opt_decl: O.Option[*adecl.Decl] = ast.get_decl(sc.a, decl_id);
     if (O.is_none[*adecl.Decl](opt_decl)) { ret R.ok_void[fail.Fail](); }
@@ -185,11 +185,9 @@ fun emit_one_value_instance(lc: *context.LowerContext, s: *session.Session,
                             decl_id: id.DeclId, origin: session.ModuleId,
                             vals: *comptime.CTValue, names: *intern.StrId, val_len: u32,
                             name: intern.StrId) R.Result[R.Void, fail.Fail] {
-    val sc_o: O.Option[context.ModuleScope] = context.origin_scope(s, origin);
-    if (O.is_none[context.ModuleScope](sc_o)) {
-        ret R.err[R.Void, fail.Fail](fail.message("lower: value-instance origin module is not registered"));
-    }
-    val sc: context.ModuleScope = O.unwrap[context.ModuleScope](sc_o);
+    val acquired: R.Result[context.ModuleScope, fail.Fail] = context.origin_scope(lc, origin);
+    if (R.is_err[context.ModuleScope, fail.Fail](acquired)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[context.ModuleScope, fail.Fail](acquired)); }
+    var sc: context.ModuleScope = R.unwrap_ok[context.ModuleScope, fail.Fail](acquired);
 
     val opt_decl: O.Option[*adecl.Decl] = ast.get_decl(sc.a, decl_id);
     if (O.is_none[*adecl.Decl](opt_decl)) { ret R.err[R.Void, fail.Fail](fail.message("lower: value-instance origin declaration not found")); }
@@ -265,11 +263,9 @@ fun emit_one_pack_instance(lc: *context.LowerContext, s: *session.Session,
                            decl_id: id.DeclId, origin: session.ModuleId,
                            args: *type.TypeId, arg_len: u32,
                            types: *type.TypeId, type_len: u32, name: intern.StrId) R.Result[R.Void, fail.Fail] {
-    val sc_o: O.Option[context.ModuleScope] = context.origin_scope(s, origin);
-    if (O.is_none[context.ModuleScope](sc_o)) {
-        ret R.err[R.Void, fail.Fail](fail.message("lower: pack-instance origin module is not registered"));
-    }
-    var sc: context.ModuleScope = O.unwrap[context.ModuleScope](sc_o);
+    val acquired: R.Result[context.ModuleScope, fail.Fail] = context.origin_scope(lc, origin);
+    if (R.is_err[context.ModuleScope, fail.Fail](acquired)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[context.ModuleScope, fail.Fail](acquired)); }
+    var sc: context.ModuleScope = R.unwrap_ok[context.ModuleScope, fail.Fail](acquired);
 
     val opt_decl: O.Option[*adecl.Decl] = ast.get_decl(sc.a, decl_id);
     if (O.is_none[*adecl.Decl](opt_decl)) { ret R.err[R.Void, fail.Fail](fail.message("lower: pack-instance origin declaration not found")); }

--- a/src/lang/me/lower/constagg.mach
+++ b/src/lang/me/lower/constagg.mach
@@ -8,7 +8,6 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
-use mach.lang.fe.ast;
 use aexpr: mach.lang.fe.ast.expr;
 use mach.lang.fe.ast.id;
 use mach.lang.fe.comptime;
@@ -64,9 +63,10 @@ fun reloc_push(ctx: *lower.LowerContext, rb: *RelocBuf, r: value.AggReloc) O.Opt
 }
 
 pub fun try_const_aggregate(ctx: *lower.LowerContext, eid: id.ExprId, gty: ir_type.IrTypeId) R.Result[O.Option[value.Value], fail.Fail] {
-    val opt_e: O.Option[*aexpr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_none[*aexpr.Expr](opt_e)) { ret R.ok[O.Option[value.Value], fail.Fail](O.none[value.Value]()); }
-    val e: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_e);
+    val opt_e: R.Result[aexpr.Expr, str] = lower.expression(ctx, eid);
+    if (R.is_err[aexpr.Expr, str](opt_e)) { ret R.err[O.Option[value.Value], fail.Fail](fail.message(R.unwrap_err[aexpr.Expr, str](opt_e))); }
+    var e_value: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](opt_e);
+    val e: *aexpr.Expr = ?e_value;
 
     var is_agg: bool = e.kind == aexpr.EXPR_KIND_STRUCT_LIT || e.kind == aexpr.EXPR_KIND_ARRAY_LIT;
     if (ir_is_ptr_or_fn(ctx, gty) && is_const_addr_init(ctx, eid, e)) { is_agg = true; }
@@ -116,9 +116,10 @@ fun place(ctx: *lower.LowerContext, eid: id.ExprId, ity: ir_type.IrTypeId, blob:
 }
 
 fun place_struct(ctx: *lower.LowerContext, eid: id.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32, rb: *RelocBuf) R.Result[FoldResult, fail.Fail] {
-    val opt_e: O.Option[*aexpr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_none[*aexpr.Expr](opt_e)) { ret R.err[FoldResult, fail.Fail](fail.message("constagg: struct leaf expr out of range")); }
-    val e: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_e);
+    val opt_e: R.Result[aexpr.Expr, str] = lower.expression(ctx, eid);
+    if (R.is_err[aexpr.Expr, str](opt_e)) { ret R.err[FoldResult, fail.Fail](fail.message(R.unwrap_err[aexpr.Expr, str](opt_e))); }
+    var e_value: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](opt_e);
+    val e: *aexpr.Expr = ?e_value;
     if (e.kind != aexpr.EXPR_KIND_STRUCT_LIT) { ret R.ok[FoldResult, fail.Fail](FOLD_FALLBACK); }
 
     val rec_ty: type.TypeId = lower.expr_type_of(ctx, eid);
@@ -144,9 +145,10 @@ fun place_struct(ctx: *lower.LowerContext, eid: id.ExprId, ity: ir_type.IrTypeId
 }
 
 fun place_array(ctx: *lower.LowerContext, eid: id.ExprId, ity: ir_type.IrTypeId, blob: *u8, base: u32, rb: *RelocBuf) R.Result[FoldResult, fail.Fail] {
-    val opt_e: O.Option[*aexpr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_none[*aexpr.Expr](opt_e)) { ret R.err[FoldResult, fail.Fail](fail.message("constagg: array leaf expr out of range")); }
-    val e: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_e);
+    val opt_e: R.Result[aexpr.Expr, str] = lower.expression(ctx, eid);
+    if (R.is_err[aexpr.Expr, str](opt_e)) { ret R.err[FoldResult, fail.Fail](fail.message(R.unwrap_err[aexpr.Expr, str](opt_e))); }
+    var e_value: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](opt_e);
+    val e: *aexpr.Expr = ?e_value;
     if (e.kind != aexpr.EXPR_KIND_ARRAY_LIT) { ret R.ok[FoldResult, fail.Fail](FOLD_FALLBACK); }
 
     val opt_t: O.Option[*ir_type.IrType] = ir_type.get(?ctx.m.types, ity);
@@ -171,9 +173,10 @@ fun place_array(ctx: *lower.LowerContext, eid: id.ExprId, ity: ir_type.IrTypeId,
 }
 
 fun place_ptr(ctx: *lower.LowerContext, eid: id.ExprId, blob: *u8, base: u32, rb: *RelocBuf) R.Result[FoldResult, fail.Fail] {
-    val opt_e: O.Option[*aexpr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_none[*aexpr.Expr](opt_e)) { ret R.err[FoldResult, fail.Fail](fail.message("constagg: pointer leaf expr out of range")); }
-    val e: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_e);
+    val opt_e: R.Result[aexpr.Expr, str] = lower.expression(ctx, eid);
+    if (R.is_err[aexpr.Expr, str](opt_e)) { ret R.err[FoldResult, fail.Fail](fail.message(R.unwrap_err[aexpr.Expr, str](opt_e))); }
+    var e_value: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](opt_e);
+    val e: *aexpr.Expr = ?e_value;
 
     if (e.kind == aexpr.EXPR_KIND_LIT_NIL) { ret R.ok[FoldResult, fail.Fail](FOLD_OK); }
 
@@ -214,8 +217,9 @@ fun place_ptr(ctx: *lower.LowerContext, eid: id.ExprId, blob: *u8, base: u32, rb
 }
 
 fun place_fn(ctx: *lower.LowerContext, eid: id.ExprId, blob: *u8, base: u32, rb: *RelocBuf) R.Result[FoldResult, fail.Fail] {
-    val opt_e: O.Option[*aexpr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_some[*aexpr.Expr](opt_e) && O.unwrap[*aexpr.Expr](opt_e).kind == aexpr.EXPR_KIND_LIT_NIL) {
+    val opt_e: R.Result[aexpr.Expr, str] = lower.expression(ctx, eid);
+    if (R.is_err[aexpr.Expr, str](opt_e)) { ret R.err[FoldResult, fail.Fail](fail.message(R.unwrap_err[aexpr.Expr, str](opt_e))); }
+    if (R.unwrap_ok[aexpr.Expr, str](opt_e).kind == aexpr.EXPR_KIND_LIT_NIL) {
         ret R.ok[FoldResult, fail.Fail](FOLD_OK);
     }
 
@@ -236,9 +240,10 @@ fun place_addr_of(ctx: *lower.LowerContext, operand: id.ExprId, blob: *u8, base:
             ret push_sym_reloc(ctx, rb, base, O.unwrap[intern.StrId](opt_name), addend, expr.references_function(ctx, cur));
         }
 
-        val opt_ce: O.Option[*aexpr.Expr] = ast.get_expr(ctx.scope.a, cur);
-        if (O.is_none[*aexpr.Expr](opt_ce)) { ret R.ok[FoldResult, fail.Fail](FOLD_FALLBACK); }
-        val ce: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_ce);
+        val opt_ce: R.Result[aexpr.Expr, str] = lower.expression(ctx, cur);
+        if (R.is_err[aexpr.Expr, str](opt_ce)) { ret R.err[FoldResult, fail.Fail](fail.message(R.unwrap_err[aexpr.Expr, str](opt_ce))); }
+        var ce_value: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](opt_ce);
+        val ce: *aexpr.Expr = ?ce_value;
 
         if (ce.kind == aexpr.EXPR_KIND_INDEX) {
             val res_off: R.Result[O.Option[i64], fail.Fail] = index_elem_offset(ctx, ce);
@@ -299,21 +304,21 @@ fun place_scalar(ctx: *lower.LowerContext, eid: id.ExprId, ity: ir_type.IrTypeId
     val size: u32 = ir_type.byte_size_for_machine(?ctx.m.types, ity, resolved_target.layout_machine(ctx.tgt));
     if (size == 0 || size > 8) { ret R.err[FoldResult, fail.Fail](fail.message("constagg: scalar leaf has unsupported size")); }
 
-    val opt_ie: O.Option[*aexpr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_some[*aexpr.Expr](opt_ie)) {
-        val ie: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_ie);
-        if (ie.kind == aexpr.EXPR_KIND_CALL) {
-            val opt_intr: O.Option[R.Result[value.Value, fail.Fail]] = expr.try_lower_comptime_intrinsic(ctx, eid, ie);
-            if (O.is_some[R.Result[value.Value, fail.Fail]](opt_intr)) {
-                val res_intr: R.Result[value.Value, fail.Fail] = O.unwrap[R.Result[value.Value, fail.Fail]](opt_intr);
-                if (R.is_err[value.Value, fail.Fail](res_intr)) { ret R.err[FoldResult, fail.Fail](R.unwrap_err[value.Value, fail.Fail](res_intr)); }
-                val intr_val: value.Value = R.unwrap_ok[value.Value, fail.Fail](res_intr);
-                if (intr_val.kind != value.VAL_CONST_INT) { ret R.ok[FoldResult, fail.Fail](FOLD_FALLBACK); }
-                write_bits(blob, base, intr_val.data.int_lit, size);
-                ret R.ok[FoldResult, fail.Fail](FOLD_OK);
-            }
-            ret R.ok[FoldResult, fail.Fail](FOLD_FALLBACK);
+    val opt_ie: R.Result[aexpr.Expr, str] = lower.expression(ctx, eid);
+    if (R.is_err[aexpr.Expr, str](opt_ie)) { ret R.err[FoldResult, fail.Fail](fail.message(R.unwrap_err[aexpr.Expr, str](opt_ie))); }
+    var ie_value: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](opt_ie);
+    val ie: *aexpr.Expr = ?ie_value;
+    if (ie.kind == aexpr.EXPR_KIND_CALL) {
+        val opt_intr: O.Option[R.Result[value.Value, fail.Fail]] = expr.try_lower_comptime_intrinsic(ctx, eid, ie);
+        if (O.is_some[R.Result[value.Value, fail.Fail]](opt_intr)) {
+            val res_intr: R.Result[value.Value, fail.Fail] = O.unwrap[R.Result[value.Value, fail.Fail]](opt_intr);
+            if (R.is_err[value.Value, fail.Fail](res_intr)) { ret R.err[FoldResult, fail.Fail](R.unwrap_err[value.Value, fail.Fail](res_intr)); }
+            val intr_val: value.Value = R.unwrap_ok[value.Value, fail.Fail](res_intr);
+            if (intr_val.kind != value.VAL_CONST_INT) { ret R.ok[FoldResult, fail.Fail](FOLD_FALLBACK); }
+            write_bits(blob, base, intr_val.data.int_lit, size);
+            ret R.ok[FoldResult, fail.Fail](FOLD_OK);
         }
+        ret R.ok[FoldResult, fail.Fail](FOLD_FALLBACK);
     }
 
     val res_ctval: R.Result[comptime.CTValue, comptime.EvalFail] =
@@ -341,9 +346,10 @@ fun place_scalar(ctx: *lower.LowerContext, eid: id.ExprId, ity: ir_type.IrTypeId
 }
 
 fun place_cast_leaf(ctx: *lower.LowerContext, eid: id.ExprId, blob: *u8, base: u32, size: u32) R.Result[FoldResult, fail.Fail] {
-    val opt_e: O.Option[*aexpr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_none[*aexpr.Expr](opt_e)) { ret R.ok[FoldResult, fail.Fail](FOLD_FALLBACK); }
-    val e: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_e);
+    val opt_e: R.Result[aexpr.Expr, str] = lower.expression(ctx, eid);
+    if (R.is_err[aexpr.Expr, str](opt_e)) { ret R.err[FoldResult, fail.Fail](fail.message(R.unwrap_err[aexpr.Expr, str](opt_e))); }
+    var e_value: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](opt_e);
+    val e: *aexpr.Expr = ?e_value;
 
     val opt_cast: O.Option[R.Result[value.Value, fail.Fail]] = expr.try_lower_comptime_cast(ctx, eid, e);
     if (O.is_none[R.Result[value.Value, fail.Fail]](opt_cast)) { ret R.ok[FoldResult, fail.Fail](FOLD_FALLBACK); }

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -25,6 +25,7 @@ use mach.lang.fe.ast.id;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.sema;
+use scx: mach.lang.fe.sema.context;
 use mach.lang.fe.sema.generics;
 use mach.lang.fe.sema.infer;
 use mach.lang.fe.sema.typename;
@@ -114,6 +115,8 @@ pub rec ScopeMark {
 }
 
 pub rec LowerRequest {
+    deps: *sema.SemaDeps;
+    diags: *diagnostic.DiagnosticStore;
     s:         *session.Session;
     tgt:       *target.Target;
     malloc:    *A.Allocator;
@@ -123,6 +126,8 @@ pub rec LowerRequest {
 }
 
 pub rec LowerContext {
+    deps: *sema.SemaDeps;
+    diags: *diagnostic.DiagnosticStore;
     status: fail.PhaseStatus;
     s:           *session.Session;
     tgt:         *target.Target;
@@ -200,7 +205,8 @@ pub fun module_scope(
     fqn:         intern.StrId,
     sema_result: *sema.SemaResult,
     rr:          *resolve.ResolveResult,
-    ctx:         *comptime.ComptimeCtx
+    ctx:         *comptime.ComptimeCtx,
+    definitions: *scx.DefinitionReader
 ) R.Result[ModuleScope, fail.Fail] {
     if (s == nil)   { ret R.err[ModuleScope, fail.Fail](fail.message("lower: a module scope requires a session")); }
     if (a == nil)   { ret R.err[ModuleScope, fail.Fail](fail.message("lower: module scope has no parsed AST")); }
@@ -208,20 +214,14 @@ pub fun module_scope(
     if (rr == nil)  { ret R.err[ModuleScope, fail.Fail](fail.message("lower: module scope has no name-resolution result")); }
     if (ctx == nil) { ret R.err[ModuleScope, fail.Fail](fail.message("lower: module scope has no comptime context")); }
 
-    if (session.module_ast(s, own_module) != a) {
-        ret R.err[ModuleScope, fail.Fail](fail.message("lower: module scope AST belongs to another module"));
+    val acquired: R.Result[scx.Definition, fail.Fail] = scx.acquire_definition(definitions, own_module, scx.DEFINITION_TYPED);
+    if (R.is_err[scx.Definition, fail.Fail](acquired)) { ret R.err[ModuleScope, fail.Fail](R.unwrap_err[scx.Definition, fail.Fail](acquired)); }
+    val current: scx.Definition = R.unwrap_ok[scx.Definition, fail.Fail](acquired);
+    if (current.parsed.a != a || current.sr != sema_result || current.rr != rr || current.ctx != ctx) {
+        ret R.err[ModuleScope, fail.Fail](fail.message("lower: module scope does not match its acquired definition"));
     }
     if (session.module_fqn(s, own_module) != fqn) {
         ret R.err[ModuleScope, fail.Fail](fail.message("lower: module scope name belongs to another module"));
-    }
-    if ((session.module_sema_ptr(s, own_module))::*sema.SemaResult != sema_result) {
-        ret R.err[ModuleScope, fail.Fail](fail.message("lower: module scope semantic result belongs to another module"));
-    }
-    if ((session.module_resolve_ptr(s, own_module))::*resolve.ResolveResult != rr) {
-        ret R.err[ModuleScope, fail.Fail](fail.message("lower: module scope name-resolution result belongs to another module"));
-    }
-    if ((session.module_comptime_ptr(s, own_module))::*comptime.ComptimeCtx != ctx) {
-        ret R.err[ModuleScope, fail.Fail](fail.message("lower: module scope comptime context belongs to another module"));
     }
 
     var sc: ModuleScope = scope_nil();
@@ -235,19 +235,13 @@ pub fun module_scope(
     ret R.ok[ModuleScope, fail.Fail](sc);
 }
 
-pub fun origin_scope(s: *session.Session, origin: session.ModuleId) O.Option[ModuleScope] {
-    val oa: *ast.Ast = session.module_ast(s, origin);
-    if (oa == nil) { ret O.none[ModuleScope](); }
-    val osema: *sema.SemaResult = (session.module_sema_ptr(s, origin))::*sema.SemaResult;
-    if (osema == nil) { ret O.none[ModuleScope](); }
-    val orr: *resolve.ResolveResult = (session.module_resolve_ptr(s, origin))::*resolve.ResolveResult;
-    if (orr == nil) { ret O.none[ModuleScope](); }
-    val octx: *comptime.ComptimeCtx = (session.module_comptime_ptr(s, origin))::*comptime.ComptimeCtx;
-    if (octx == nil) { ret O.none[ModuleScope](); }
-
-    val r: R.Result[ModuleScope, fail.Fail] = module_scope(s, origin, oa, session.module_fqn(s, origin), osema, orr, octx);
-    if (R.is_err[ModuleScope, fail.Fail](r)) { ret O.none[ModuleScope](); }
-    ret O.some[ModuleScope](R.unwrap_ok[ModuleScope, fail.Fail](r));
+pub fun origin_scope(lc: *LowerContext, origin: session.ModuleId) R.Result[ModuleScope, fail.Fail] {
+    if (origin == lc.scope.own_module) { ret R.ok[ModuleScope, fail.Fail](lc.scope); }
+    if (lc.deps == nil) { ret R.err[ModuleScope, fail.Fail](fail.message("lower: foreign definition requires scoped dependencies")); }
+    val acquired: R.Result[scx.Definition, fail.Fail] = scx.acquire_definition(?lc.deps.definitions, origin, scx.DEFINITION_TYPED);
+    if (R.is_err[scx.Definition, fail.Fail](acquired)) { ret R.err[ModuleScope, fail.Fail](R.unwrap_err[scx.Definition, fail.Fail](acquired)); }
+    val current: scx.Definition = R.unwrap_ok[scx.Definition, fail.Fail](acquired);
+    ret module_scope(lc.s, origin, current.parsed.a, session.module_fqn(lc.s, origin), current.sr, current.rr, current.ctx, ?lc.deps.definitions);
 }
 
 pub fun request(
@@ -261,16 +255,21 @@ pub fun request(
     rr:          *resolve.ResolveResult,
     ctx:         *comptime.ComptimeCtx,
     test_mode:   bool,
-    debug:       bool
+    debug:       bool,
+    diags:       *diagnostic.DiagnosticStore,
+    deps:        *sema.SemaDeps
 ) R.Result[LowerRequest, fail.Fail] {
     if (tgt == nil)    { ret R.err[LowerRequest, fail.Fail](fail.message("lower: a lowering request requires a resolved target")); }
     if (malloc == nil) { ret R.err[LowerRequest, fail.Fail](fail.message("lower: a lowering request requires an allocator")); }
 
-    val sr: R.Result[ModuleScope, fail.Fail] = module_scope(s, own_module, a, fqn, sema_result, rr, ctx);
+    if (deps == nil) { ret R.err[LowerRequest, fail.Fail](fail.message("lower: a lowering request requires scoped dependencies")); }
+    val sr: R.Result[ModuleScope, fail.Fail] = module_scope(s, own_module, a, fqn, sema_result, rr, ctx, ?deps.definitions);
     if (R.is_err[ModuleScope, fail.Fail](sr)) { ret R.err[LowerRequest, fail.Fail](R.unwrap_err[ModuleScope, fail.Fail](sr)); }
 
     var req: LowerRequest;
     req.s         = s;
+    req.deps      = deps;
+    req.diags     = diags;
     req.tgt       = tgt;
     req.malloc    = malloc;
     req.module    = R.unwrap_ok[ModuleScope, fail.Fail](sr);
@@ -326,6 +325,8 @@ pub fun init_context(lc: *LowerContext, req: *LowerRequest, m: *ir.Module) R.Res
     val s: *session.Session = req.s;
     lc.status      = fail.accepted();
     lc.s           = s;
+    lc.deps        = req.deps;
+    lc.diags       = req.diags;
     lc.tgt         = req.tgt;
     lc.scope       = req.module;
     lc.scopes      = nil;
@@ -344,7 +345,7 @@ pub fun init_context(lc: *LowerContext, req: *LowerRequest, m: *ir.Module) R.Res
         resolve_field_member,
         resolve_type_query,
         resolve_layout_intrinsic,
-        comptime_ident_is_runtime
+        comptime_ident_is_runtime, comptime_expression, req.diags
     );
     if (R.is_err[comptime.PhaseCapabilities[LowerContext], str](caps_r)) {
         ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[comptime.PhaseCapabilities[LowerContext], str](caps_r)));
@@ -508,9 +509,40 @@ pub fun dnit_context(lc: *LowerContext) {
     lc.pack_ret_type = type.TYPE_NIL;
 }
 
+pub fun symbol_definition(lc: *LowerContext, sym: *resolve.Symbol) R.Result[scx.DefinedSymbol, fail.Fail] {
+    if (sym.origin == lc.scope.own_module) {
+        if (sym.decl == id.DECL_NIL || sym.decl >= lc.scope.a.decl_len::u32) {
+            val reason: fail.Fail = fail.message("lower: symbol has no declaration in its active owner");
+            fail.internal(?lc.status, reason.message);
+            ret R.err[scx.DefinedSymbol, fail.Fail](reason);
+        }
+        val parsed: resolve.ParsedDefinition = resolve.ParsedDefinition{
+            a: lc.scope.a, owner: resolve.type_owner(lc.s, sym.origin, lc.scope.a.file_id), incarnation: lc.scope.a.incarnation
+        };
+        ret R.ok[scx.DefinedSymbol, fail.Fail](scx.DefinedSymbol{
+            definition: scx.Definition{ parsed: parsed, origin: sym.origin, rr: lc.scope.rr,
+                sr: lc.scope.sema_result, ctx: lc.scope.ctx }, symbol: @sym
+        });
+    }
+    if (lc.deps == nil) {
+        val reason: fail.Fail = fail.message("lower: foreign symbol requires scoped dependencies");
+        fail.internal(?lc.status, reason.message);
+        ret R.err[scx.DefinedSymbol, fail.Fail](reason);
+    }
+    val acquired: R.Result[scx.DefinedSymbol, fail.Fail] = scx.acquire_symbol(?lc.deps.definitions, sym, scx.DEFINITION_TYPED);
+    if (R.is_err[scx.DefinedSymbol, fail.Fail](acquired)) {
+        val reason: fail.Fail = R.unwrap_err[scx.DefinedSymbol, fail.Fail](acquired);
+        if (reason.kind == fail.REPORTED) { fail.reject(?lc.status); }
+        or { fail.internal(?lc.status, reason.message); }
+    }
+    ret acquired;
+}
+
 pub fun declaring_comptime_ctx(lc: *LowerContext, sym: *resolve.Symbol) *comptime.ComptimeCtx {
     if (sym.origin == lc.scope.own_module) { ret lc.scope.ctx; }
-    ret (session.module_comptime_ptr(lc.s, sym.origin))::*comptime.ComptimeCtx;
+    val acquired: R.Result[scx.DefinedSymbol, fail.Fail] = symbol_definition(lc, sym);
+    if (R.is_err[scx.DefinedSymbol, fail.Fail](acquired)) { ret nil; }
+    ret R.unwrap_ok[scx.DefinedSymbol, fail.Fail](acquired).definition.ctx;
 }
 
 pub fun gated_lower_member_const_message(lc: *LowerContext, name: intern.StrId, dep_fqn: intern.StrId) str {
@@ -536,7 +568,7 @@ pub fun gated_lower_member_const_message(lc: *LowerContext, name: intern.StrId, 
 
 pub fun report_gate(lc: *LowerContext, span: token.Span, message: str) fail.Fail {
     fail.reject(?lc.status);
-    val r: R.Result[bool, str] = diagnostic.gate_error(?lc.s.gate_diags, ?lc.s.diags,
+    val r: R.Result[bool, str] = diagnostic.gate_error(lc.diags,
         ?lc.s.interner, lc.scope.a.file_id, span, message);
     if (R.is_err[bool, str](r)) { fail.internal(?lc.status, R.unwrap_err[bool, str](r)); }
     ret fail.phase_failure(lc.status);
@@ -546,6 +578,29 @@ pub fun record_eval_result(lc: *LowerContext, r: R.Result[comptime.CTValue, comp
     if (R.is_ok[comptime.CTValue, comptime.EvalFail](r)) { ret; }
     val f: comptime.EvalFail = R.unwrap_err[comptime.CTValue, comptime.EvalFail](r);
     if (f.kind == comptime.EVAL_FAIL_INTERNAL) { fail.internal(?lc.status, f.message); }
+}
+
+pub fun expression(lc: *LowerContext, eid: id.ExprId) R.Result[aexpr.Expr, str] {
+    val result: R.Result[aexpr.Expr, str] = resolve.expression(lc.scope.rr, lc.scope.a, eid);
+    if (R.is_err[aexpr.Expr, str](result)) {
+        fail.internal(?lc.status, R.unwrap_err[aexpr.Expr, str](result));
+        ret result;
+    }
+    if (R.unwrap_ok[aexpr.Expr, str](result).kind == aexpr.EXPR_KIND_ERROR) {
+        val message: str = "lowering cannot consume a rejected expression";
+        fail.internal(?lc.status, message);
+        ret R.err[aexpr.Expr, str](message);
+    }
+    ret result;
+}
+
+fun comptime_expression(lc: *LowerContext, a: *ast.Ast, eid: id.ExprId) R.Result[aexpr.Expr, comptime.EvalFail] {
+    if (lc == nil || lc.scope.a != a) { ret R.err[aexpr.Expr, comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_INTERNAL, "lowering expression belongs to a different parsed owner")); }
+    val result: R.Result[aexpr.Expr, str] = expression(lc, eid);
+    if (R.is_err[aexpr.Expr, str](result)) {
+        ret R.err[aexpr.Expr, comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_INTERNAL, R.unwrap_err[aexpr.Expr, str](result)));
+    }
+    ret R.ok[aexpr.Expr, comptime.EvalFail](R.unwrap_ok[aexpr.Expr, str](result));
 }
 
 pub fun resolve_module_member_const(lc: *LowerContext, eid: id.ExprId) R.Result[O.Option[comptime.CTValue], comptime.EvalFail] {
@@ -571,11 +626,11 @@ pub fun resolve_module_member_const(lc: *LowerContext, eid: id.ExprId) R.Result[
     val named: comptime.NamedConst = O.unwrap[comptime.NamedConst](nc);
     if (named.gated && lc.scope.env.union_build) {
         val msg: str = gated_lower_member_const_message(lc, sym.name, session.module_fqn(lc.s, sym.origin));
-        val e_opt: O.Option[*aexpr.Expr] = ast.get_expr(lc.scope.a, eid);
+        val e_opt: R.Result[aexpr.Expr, str] = expression(lc, eid);
         var span: token.Span;
         span.offset = 0;
         span.len    = 0;
-        if (O.is_some[*aexpr.Expr](e_opt)) { span = O.unwrap[*aexpr.Expr](e_opt).span; }
+        if (R.is_ok[aexpr.Expr, str](e_opt)) { span = R.unwrap_ok[aexpr.Expr, str](e_opt).span; }
         val f: fail.Fail = report_gate(lc, span, msg);
         ret R.err[O.Option[comptime.CTValue], comptime.EvalFail](comptime.eval_from_fail(f, msg));
     }
@@ -1372,11 +1427,9 @@ pub fun pack_instance_sig(lc: *LowerContext, d: *adecl.Decl, fixed_count: u32,
 
 pub fun instance_ref_sig(lc: *LowerContext, decl_id: id.DeclId, origin: session.ModuleId,
                          args: *type.TypeId, arg_len: u32) R.Result[ir_type.IrTypeId, fail.Fail] {
-    val sc_o: O.Option[ModuleScope] = origin_scope(lc.s, origin);
-    if (O.is_none[ModuleScope](sc_o)) {
-        ret R.err[ir_type.IrTypeId, fail.Fail](fail.message("lower: instance-reference origin module is not registered"));
-    }
-    var sc: ModuleScope = O.unwrap[ModuleScope](sc_o);
+    val acquired: R.Result[ModuleScope, fail.Fail] = origin_scope(lc, origin);
+    if (R.is_err[ModuleScope, fail.Fail](acquired)) { ret R.err[ir_type.IrTypeId, fail.Fail](R.unwrap_err[ModuleScope, fail.Fail](acquired)); }
+    var sc: ModuleScope = R.unwrap_ok[ModuleScope, fail.Fail](acquired);
     sc.subst     = args;
     sc.subst_len = arg_len;
 
@@ -1395,11 +1448,9 @@ pub fun instance_ref_sig(lc: *LowerContext, decl_id: id.DeclId, origin: session.
 pub fun pack_instance_ref_sig(lc: *LowerContext, decl_id: id.DeclId, origin: session.ModuleId,
                               args: *type.TypeId, arg_len: u32,
                               types: *type.TypeId, type_len: u32) R.Result[ir_type.IrTypeId, fail.Fail] {
-    val sc_o: O.Option[ModuleScope] = origin_scope(lc.s, origin);
-    if (O.is_none[ModuleScope](sc_o)) {
-        ret R.err[ir_type.IrTypeId, fail.Fail](fail.message("lower: pack-instance-reference origin module is not registered"));
-    }
-    var sc: ModuleScope = O.unwrap[ModuleScope](sc_o);
+    val acquired: R.Result[ModuleScope, fail.Fail] = origin_scope(lc, origin);
+    if (R.is_err[ModuleScope, fail.Fail](acquired)) { ret R.err[ir_type.IrTypeId, fail.Fail](R.unwrap_err[ModuleScope, fail.Fail](acquired)); }
+    var sc: ModuleScope = R.unwrap_ok[ModuleScope, fail.Fail](acquired);
     val opt_d: O.Option[*adecl.Decl] = ast.get_decl(sc.a, decl_id);
     if (O.is_none[*adecl.Decl](opt_d)) { ret R.err[ir_type.IrTypeId, fail.Fail](fail.message("lower: pack-instance-reference origin declaration not found")); }
     val d: *adecl.Decl = O.unwrap[*adecl.Decl](opt_d);
@@ -1650,6 +1701,7 @@ fun time_enqueue_fresh(count: u32) i64 {
     var lc: LowerContext;
     lc.status = fail.accepted();
     lc.s            = ?s;
+    lc.diags = ?s.diags;
     lc.scope        = scope_nil();
     lc.inst_len     = 0;
     lc.inst_cap     = 0;
@@ -1696,6 +1748,7 @@ test "mach.lang.me.lower.context.scope_leave:refuses_a_stale_or_out_of_order_mar
     var lc: LowerContext;
     lc.status = fail.accepted();
     lc.s                = ?s;
+    lc.diags = ?s.diags;
     lc.scopes           = nil;
     lc.scope_len        = 0;
     lc.scope_cap        = 0;
@@ -1747,21 +1800,35 @@ test "mach.lang.me.lower.context.scope_leave:refuses_a_stale_or_out_of_order_mar
     ret code;
 }
 
+fun fixture_definition(raw: ptr, origin: session.ModuleId, phase: scx.DefinitionPhase) R.Result[scx.Definition, fail.Fail] {
+    val current: *scx.Definition = raw::*scx.Definition;
+    if (current == nil || current.origin != origin) {
+        ret R.err[scx.Definition, fail.Fail](fail.message("fixture definition owner differs"));
+    }
+    ret R.ok[scx.Definition, fail.Fail](@current);
+}
+
 test "mach.lang.me.lower.context.module_scope:refuses_a_piece_that_belongs_to_another_module" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
 
     var a1:  ast.Ast;
     var a2:  ast.Ast;
-    var sm1: sema.SemaResult;
-    var sm2: sema.SemaResult;
+    var sm1: sema.SemaResult = sema.SemaResult{};
+    var sm2: sema.SemaResult = sema.SemaResult{};
     var rr1: resolve.ResolveResult;
     var rr2: resolve.ResolveResult;
     var cc1: comptime.ComptimeCtx;
     var cc2: comptime.ComptimeCtx;
+
+    a1.incarnation = 1;
+    a1.file_id = 0::source.FileId;
+    rr1.status = fail.accepted();
+    sm1.status = fail.accepted();
 
     val mid: session.ModuleId = 0::session.ModuleId;
     val fqn: intern.StrId     = 7::intern.StrId;
@@ -1771,26 +1838,34 @@ test "mach.lang.me.lower.context.module_scope:refuses_a_piece_that_belongs_to_an
     val rp: R.Result[R.Void, str] = session.register_module_phase(?s, mid, (?sm1)::ptr, (?rr1)::ptr, (?cc1)::ptr);
     if (R.is_err[R.Void, str](rp)) { ret 1; }
 
+    var current: scx.Definition = scx.Definition{
+        parsed: resolve.ParsedDefinition{ a: ?a1, owner: resolve.type_owner(?s, mid, a1.file_id), incarnation: a1.incarnation },
+        origin: mid, rr: ?rr1, sr: ?sm1, ctx: ?cc1
+    };
+    var deps: sema.SemaDeps = sema.SemaDeps{
+        definitions: scx.DefinitionReader{ ctx: (?current)::ptr, read: fixture_definition }
+    };
+
     var code: i32 = 0;
 
     cc1.env.pointer_width = 99;
-    val good: R.Result[ModuleScope, fail.Fail] = module_scope(?s, mid, ?a1, fqn, ?sm1, ?rr1, ?cc1);
+    val good: R.Result[ModuleScope, fail.Fail] = module_scope(?s, mid, ?a1, fqn, ?sm1, ?rr1, ?cc1, ?deps.definitions);
     if (R.is_err[ModuleScope, fail.Fail](good)) { ret 1; }
     val sc: ModuleScope = R.unwrap_ok[ModuleScope, fail.Fail](good);
     if (sc.env.pointer_width != 99) { code = 1; }
     cc1.env.pointer_width = 12;
     if (sc.env.pointer_width != 99) { code = 1; }
 
-    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a2, fqn, ?sm1, ?rr1, ?cc1)))               { code = 1; }
-    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a1, 8::intern.StrId, ?sm1, ?rr1, ?cc1)))   { code = 1; }
-    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a1, fqn, ?sm2, ?rr1, ?cc1)))               { code = 1; }
-    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a1, fqn, ?sm1, ?rr2, ?cc1)))               { code = 1; }
-    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a1, fqn, ?sm1, ?rr1, ?cc2)))               { code = 1; }
-    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, nil, fqn, ?sm1, ?rr1, ?cc1)))               { code = 1; }
-    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a1, fqn, nil, ?rr1, ?cc1)))                { code = 1; }
-    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a1, fqn, ?sm1, nil, ?cc1)))                { code = 1; }
-    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a1, fqn, ?sm1, ?rr1, nil)))                { code = 1; }
-    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, 1::session.ModuleId, ?a1, fqn, ?sm1, ?rr1, ?cc1))) { code = 1; }
+    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a2, fqn, ?sm1, ?rr1, ?cc1, ?deps.definitions)))               { code = 1; }
+    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a1, 8::intern.StrId, ?sm1, ?rr1, ?cc1, ?deps.definitions)))   { code = 1; }
+    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a1, fqn, ?sm2, ?rr1, ?cc1, ?deps.definitions)))               { code = 1; }
+    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a1, fqn, ?sm1, ?rr2, ?cc1, ?deps.definitions)))               { code = 1; }
+    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a1, fqn, ?sm1, ?rr1, ?cc2, ?deps.definitions)))               { code = 1; }
+    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, nil, fqn, ?sm1, ?rr1, ?cc1, ?deps.definitions)))               { code = 1; }
+    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a1, fqn, nil, ?rr1, ?cc1, ?deps.definitions)))                { code = 1; }
+    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a1, fqn, ?sm1, nil, ?cc1, ?deps.definitions)))                { code = 1; }
+    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, mid, ?a1, fqn, ?sm1, ?rr1, nil, ?deps.definitions)))                { code = 1; }
+    if (R.is_ok[ModuleScope, fail.Fail](module_scope(?s, 1::session.ModuleId, ?a1, fqn, ?sm1, ?rr1, ?cc1, ?deps.definitions))) { code = 1; }
 
     ret code;
 }
@@ -1801,13 +1876,19 @@ test "mach.lang.me.lower.context.request:refuses_a_module_product_that_does_not_
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
 
     var a1:  ast.Ast;
     var a2:  ast.Ast;
-    var sm1: sema.SemaResult;
+    var sm1: sema.SemaResult = sema.SemaResult{};
     var rr1: resolve.ResolveResult;
     var cc1: comptime.ComptimeCtx;
     var tgt: target.Target;
+
+    a1.incarnation = 1;
+    a1.file_id = 0::source.FileId;
+    rr1.status = fail.accepted();
+    sm1.status = fail.accepted();
 
     val mid: session.ModuleId = 0::session.ModuleId;
     val fqn: intern.StrId     = 7::intern.StrId;
@@ -1817,16 +1898,24 @@ test "mach.lang.me.lower.context.request:refuses_a_module_product_that_does_not_
     val rp: R.Result[R.Void, str] = session.register_module_phase(?s, mid, (?sm1)::ptr, (?rr1)::ptr, (?cc1)::ptr);
     if (R.is_err[R.Void, str](rp)) { ret 1; }
 
+    var current: scx.Definition = scx.Definition{
+        parsed: resolve.ParsedDefinition{ a: ?a1, owner: resolve.type_owner(?s, mid, a1.file_id), incarnation: a1.incarnation },
+        origin: mid, rr: ?rr1, sr: ?sm1, ctx: ?cc1
+    };
+    var deps: sema.SemaDeps = sema.SemaDeps{
+        definitions: scx.DefinitionReader{ ctx: (?current)::ptr, read: fixture_definition }
+    };
+
     var code: i32 = 0;
 
-    val good: R.Result[LowerRequest, fail.Fail] = request(?s, ?tgt, ?alloc, ?a1, fqn, mid, ?sm1, ?rr1, ?cc1, false, false);
+    val good: R.Result[LowerRequest, fail.Fail] = request(?s, ?tgt, ?alloc, ?a1, fqn, mid, ?sm1, ?rr1, ?cc1, false, false, nil, ?deps);
     if (R.is_err[LowerRequest, fail.Fail](good)) { ret 1; }
     val req: LowerRequest = R.unwrap_ok[LowerRequest, fail.Fail](good);
     if (req.module.a != ?a1 || req.module.own_module != mid) { code = 1; }
 
-    if (R.is_ok[LowerRequest, fail.Fail](request(?s, nil, ?alloc, ?a1, fqn, mid, ?sm1, ?rr1, ?cc1, false, false))) { code = 1; }
-    if (R.is_ok[LowerRequest, fail.Fail](request(?s, ?tgt, nil, ?a1, fqn, mid, ?sm1, ?rr1, ?cc1, false, false)))   { code = 1; }
-    if (R.is_ok[LowerRequest, fail.Fail](request(?s, ?tgt, ?alloc, ?a2, fqn, mid, ?sm1, ?rr1, ?cc1, false, false))) { code = 1; }
+    if (R.is_ok[LowerRequest, fail.Fail](request(?s, nil, ?alloc, ?a1, fqn, mid, ?sm1, ?rr1, ?cc1, false, false, nil, ?deps))) { code = 1; }
+    if (R.is_ok[LowerRequest, fail.Fail](request(?s, ?tgt, nil, ?a1, fqn, mid, ?sm1, ?rr1, ?cc1, false, false, nil, ?deps)))   { code = 1; }
+    if (R.is_ok[LowerRequest, fail.Fail](request(?s, ?tgt, ?alloc, ?a2, fqn, mid, ?sm1, ?rr1, ?cc1, false, false, nil, ?deps))) { code = 1; }
 
     ret code;
 }
@@ -1859,6 +1948,7 @@ test "mach.lang.me.lower.context.enqueue_pack_instance:refuses_past_the_instance
     var lc: LowerContext;
     lc.status = fail.accepted();
     lc.s            = ?s;
+    lc.diags = ?s.diags;
     lc.pinst_len    = 0;
     lc.pinst_cap    = 0;
     lc.pinsts       = nil;

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -187,16 +187,9 @@ pub fun lower_pack_instance(ctx: *context.LowerContext, did: id.DeclId, d: *decl
 fun reinfer_instance_typing(ctx: *context.LowerContext, d: *decl.Decl, fn_ret: type.TypeId) R.Result[R.Void, fail.Fail] {
     if (ctx.scope.subst == nil || ctx.scope.subst_len == 0) { ret R.ok_void[fail.Fail](); }
 
-    val res_deps: R.Result[sema.SemaDeps, str] = sema.collect_module_deps(ctx.s);
-    if (R.is_err[sema.SemaDeps, str](res_deps)) {
-        ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[sema.SemaDeps, str](res_deps)));
-    }
-    var deps: sema.SemaDeps = R.unwrap_ok[sema.SemaDeps, str](res_deps);
-
-    val res: R.Result[R.Void, fail.Fail] = sema.reinfer_instance_body(ctx.s, ctx.scope.a, ctx.scope.rr, ?deps, ctx.scope.ctx,
+    val res: R.Result[R.Void, fail.Fail] = sema.reinfer_instance_body(ctx.s, ctx.scope.a, ctx.scope.rr, ctx.deps, ctx.scope.ctx,
         ctx.scope.own_module, ctx.scope.sema_result, fn_ret, d.data.fun_.body,
-        ctx.scope.subst, ctx.scope.subst_len);
-    sema.free_module_deps(ctx.s, ?deps);
+        ctx.scope.subst, ctx.scope.subst_len, ctx.diags);
     if (R.is_err[R.Void, fail.Fail](res)) { ret res; }
     ret R.ok_void[fail.Fail]();
 }
@@ -244,7 +237,9 @@ pub fun lower_global(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, 
             ret R.err[R.Void, fail.Fail](R.unwrap_err[*embed.EmbedFile, fail.Fail](er));
         }
         val e: *embed.EmbedFile = R.unwrap_ok[*embed.EmbedFile, fail.Fail](er);
-        init_val = value.const_bytes(e.bytes, e.len, gty);
+        val bytes_r: R.Result[*u8, str] = copy_embed_bytes(ctx.m.alloc, e.bytes, e.len);
+        if (R.is_err[*u8, str](bytes_r)) { ret fail.lift[R.Void](R.void_of[*u8, str](bytes_r)); }
+        init_val = value.const_bytes(R.unwrap_ok[*u8, str](bytes_r), e.len, gty);
         is_embed = true;
     }
     or (d.data.bind.init != id.EXPR_NIL) {
@@ -259,7 +254,7 @@ pub fun lower_global(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, 
             }
             or {
                 val res_diag2: R.Result[R.Void, str] =
-                    diagnostic.error(?ctx.s.diags, ctx.scope.a.file_id, d.data.bind.name, fold_err);
+                    diagnostic.error(ctx.diags, ctx.scope.a.file_id, d.data.bind.name, fold_err);
                 if (R.is_err[R.Void, str](res_diag2)) { ret fail.lift[R.Void](res_diag2); }
             }
         }
@@ -314,6 +309,16 @@ pub fun lower_global(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, 
     val res_idx: R.Result[u32, fail.Fail] = append_global(ctx, g);
     if (R.is_err[u32, fail.Fail](res_idx)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[u32, fail.Fail](res_idx)); }
     ret R.ok_void[fail.Fail]();
+}
+
+fun copy_embed_bytes(alloc: *A.Allocator, bytes: *u8, len: u32) R.Result[*u8, str] {
+    if (len == 0) { ret R.ok[*u8, str](nil); }
+    val copied: R.Result[*u8, str] = A.allocate[u8](alloc, len::usize);
+    if (R.is_err[*u8, str](copied)) { ret copied; }
+    val out: *u8 = R.unwrap_ok[*u8, str](copied);
+    var i: u32 = 0;
+    for (i < len) { out[i] = bytes[i]; i = i + 1; }
+    ret R.ok[*u8, str](out);
 }
 
 fun lower_weak_instance(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, name: intern.StrId, ret_sem: type.TypeId) R.Result[R.Void, fail.Fail] {
@@ -497,17 +502,17 @@ fun is_internal_err(msg: str) bool {
 fun diag_named(ctx: *context.LowerContext, span: token.Span, name_id: intern.StrId, prefix: str, suffix: str, fallback: str) R.Result[R.Void, fail.Fail] {
     val opt_name: O.Option[str] = intern.lookup(?ctx.s.interner, name_id);
     if (O.is_none[str](opt_name)) {
-        ret fail.lift[R.Void](diagnostic.error(?ctx.s.diags, ctx.scope.a.file_id, span, fallback));
+        ret fail.lift[R.Void](diagnostic.error(ctx.diags, ctx.scope.a.file_id, span, fallback));
     }
     val name: str = O.unwrap[str](opt_name);
 
     val res_msg: R.Result[str, str] = str_join(ctx.s.alloc, prefix, name, suffix);
     if (R.is_err[str, str](res_msg)) {
-        ret fail.lift[R.Void](diagnostic.error(?ctx.s.diags, ctx.scope.a.file_id, span, fallback));
+        ret fail.lift[R.Void](diagnostic.error(ctx.diags, ctx.scope.a.file_id, span, fallback));
     }
     val buf: str = R.unwrap_ok[str, str](res_msg);
 
-    val res_emit: R.Result[R.Void, str] = diagnostic.error(?ctx.s.diags, ctx.scope.a.file_id, span, buf);
+    val res_emit: R.Result[R.Void, str] = diagnostic.error(ctx.diags, ctx.scope.a.file_id, span, buf);
     A.deallocate[u8](ctx.s.alloc, buf::*u8, str_len(buf) + 1);
     ret fail.lift[R.Void](res_emit);
 }
@@ -759,9 +764,10 @@ fun fold_global_init(ctx: *context.LowerContext, eid: id.ExprId, gty: ir_type.Ir
         ret expr.const_value_of_init(ctx, eid, cv);
     }
 
-    val opt_init: O.Option[*aexpr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_none[*aexpr.Expr](opt_init)) { ret R.err[value.Value, fail.Fail](fail.message("lower: global initialiser expression out of range")); }
-    val ie: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_init);
+    val opt_init: R.Result[aexpr.Expr, str] = context.expression(ctx, eid);
+    if (R.is_err[aexpr.Expr, str](opt_init)) { ret R.err[value.Value, fail.Fail](fail.message("lower: global initialiser expression out of range")); }
+    var ie_value: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](opt_init);
+    val ie: *aexpr.Expr = ?ie_value;
 
     val opt_cast: O.Option[R.Result[value.Value, fail.Fail]] = expr.try_lower_comptime_cast(ctx, eid, ie);
     if (O.is_some[R.Result[value.Value, fail.Fail]](opt_cast)) { ret O.unwrap[R.Result[value.Value, fail.Fail]](opt_cast); }
@@ -777,9 +783,10 @@ fun fold_global_init(ctx: *context.LowerContext, eid: id.ExprId, gty: ir_type.Ir
 fun is_null_init(ctx: *context.LowerContext, eid: id.ExprId) bool {
     var cur: id.ExprId = eid;
     for (true) {
-        val opt_expr: O.Option[*aexpr.Expr] = ast.get_expr(ctx.scope.a, cur);
-        if (O.is_none[*aexpr.Expr](opt_expr)) { ret false; }
-        val e: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_expr);
+        val opt_expr: R.Result[aexpr.Expr, str] = context.expression(ctx, cur);
+        if (R.is_err[aexpr.Expr, str](opt_expr)) { ret false; }
+        var e_value: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](opt_expr);
+        val e: *aexpr.Expr = ?e_value;
         if (e.kind == aexpr.EXPR_KIND_LIT_NIL) { ret true; }
         if (e.kind != aexpr.EXPR_KIND_CAST)    { ret false; }
         cur = e.data.cast.value;
@@ -879,9 +886,10 @@ fun decl_storage_flags(ctx: *context.LowerContext, d: *decl.Decl) u32 {
     for (true) {
         val opt_arg: O.Option[id.ExprId] = decorator_arg_eid(ctx, d, "storage", ord);
         if (O.is_none[id.ExprId](opt_arg)) { ret flags; }
-        val opt_val: O.Option[*aexpr.Expr] = ast.get_expr(ctx.scope.a, O.unwrap[id.ExprId](opt_arg));
-        if (O.is_none[*aexpr.Expr](opt_val)) { ret flags; }
-        val ve: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_val);
+        val opt_val: R.Result[aexpr.Expr, str] = context.expression(ctx, O.unwrap[id.ExprId](opt_arg));
+        if (R.is_err[aexpr.Expr, str](opt_val)) { ret flags; }
+        var ve_value: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](opt_val);
+        val ve: *aexpr.Expr = ?ve_value;
         if (ve.kind != aexpr.EXPR_KIND_LIT_STR || ve.span.len < 2::usize) { ret flags; }
         val off: usize = ve.span.offset + 1::usize;
         val len: usize = ve.span.len - 2::usize;
@@ -894,9 +902,10 @@ fun decl_storage_flags(ctx: *context.LowerContext, d: *decl.Decl) u32 {
 fun decl_builtin_of(ctx: *context.LowerContext, d: *decl.Decl) u32 {
     val opt_arg: O.Option[id.ExprId] = decorator_arg_eid(ctx, d, "builtin", 0);
     if (O.is_none[id.ExprId](opt_arg)) { ret ir.BUILTIN_POSITION; }
-    val opt_val: O.Option[*aexpr.Expr] = ast.get_expr(ctx.scope.a, O.unwrap[id.ExprId](opt_arg));
-    if (O.is_none[*aexpr.Expr](opt_val)) { ret ir.BUILTIN_POSITION; }
-    val ve: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_val);
+    val opt_val: R.Result[aexpr.Expr, str] = context.expression(ctx, O.unwrap[id.ExprId](opt_arg));
+    if (R.is_err[aexpr.Expr, str](opt_val)) { ret ir.BUILTIN_POSITION; }
+    var ve_value: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](opt_val);
+    val ve: *aexpr.Expr = ?ve_value;
     if (ve.kind != aexpr.EXPR_KIND_LIT_STR || ve.span.len < 2::usize) { ret ir.BUILTIN_POSITION; }
     val src: str = context.module_source(ctx);
     val off: usize = ve.span.offset + 1::usize;
@@ -929,9 +938,10 @@ fun decorator_uint(ctx: *context.LowerContext, d: *decl.Decl, name: str, ord: u3
 fun decl_stage_of(ctx: *context.LowerContext, d: *decl.Decl) u8 {
     val opt_arg: O.Option[id.ExprId] = decorator_arg_eid(ctx, d, "stage", 0);
     if (O.is_none[id.ExprId](opt_arg)) { ret ir.STAGE_NONE; }
-    val opt_val: O.Option[*aexpr.Expr] = ast.get_expr(ctx.scope.a, O.unwrap[id.ExprId](opt_arg));
-    if (O.is_none[*aexpr.Expr](opt_val)) { ret ir.STAGE_NONE; }
-    val ve: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_val);
+    val opt_val: R.Result[aexpr.Expr, str] = context.expression(ctx, O.unwrap[id.ExprId](opt_arg));
+    if (R.is_err[aexpr.Expr, str](opt_val)) { ret ir.STAGE_NONE; }
+    var ve_value: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](opt_val);
+    val ve: *aexpr.Expr = ?ve_value;
     if (ve.kind != aexpr.EXPR_KIND_LIT_STR || ve.span.len < 2::usize) { ret ir.STAGE_NONE; }
     val src: str = context.module_source(ctx);
     val off: usize = ve.span.offset + 1::usize;
@@ -959,9 +969,10 @@ fun decl_workgroup_dim(ctx: *context.LowerContext, d: *decl.Decl, ord: u32) u32 
 fun decl_section_of(ctx: *context.LowerContext, d: *decl.Decl) intern.StrId {
     val opt_arg: O.Option[id.ExprId] = decorator_arg_eid(ctx, d, "section", 0);
     if (O.is_none[id.ExprId](opt_arg)) { ret intern.STR_NIL; }
-    val opt_val: O.Option[*aexpr.Expr] = ast.get_expr(ctx.scope.a, O.unwrap[id.ExprId](opt_arg));
-    if (O.is_none[*aexpr.Expr](opt_val)) { ret intern.STR_NIL; }
-    val ve: *aexpr.Expr = O.unwrap[*aexpr.Expr](opt_val);
+    val opt_val: R.Result[aexpr.Expr, str] = context.expression(ctx, O.unwrap[id.ExprId](opt_arg));
+    if (R.is_err[aexpr.Expr, str](opt_val)) { ret intern.STR_NIL; }
+    var ve_value: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](opt_val);
+    val ve: *aexpr.Expr = ?ve_value;
     if (ve.kind != aexpr.EXPR_KIND_LIT_STR || ve.span.len < 2::usize) { ret intern.STR_NIL; }
 
     var inner: token.Span = ve.span;
@@ -1064,25 +1075,25 @@ fun global_align_of(ctx: *context.LowerContext, d: *decl.Decl) R.Result[u32, fai
 
     val res_fold: R.Result[value.Value, fail.Fail] = fold_global_init(ctx, arg, u64t, intern.STR_NIL);
     if (R.is_err[value.Value, fail.Fail](res_fold)) {
-        val res_diag: R.Result[R.Void, str] = diagnostic.error(?ctx.s.diags, ctx.scope.a.file_id, d.data.bind.name, "`align` decorator requires a compile-time constant argument");
+        val res_diag: R.Result[R.Void, str] = diagnostic.error(ctx.diags, ctx.scope.a.file_id, d.data.bind.name, "`align` decorator requires a compile-time constant argument");
         if (R.is_err[R.Void, str](res_diag)) { ret R.err[u32, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_diag))); }
         ret R.ok[u32, fail.Fail](0);
     }
     val v: value.Value = R.unwrap_ok[value.Value, fail.Fail](res_fold);
     if (v.kind != value.VAL_CONST_INT) {
-        val res_diag: R.Result[R.Void, str] = diagnostic.error(?ctx.s.diags, ctx.scope.a.file_id, d.data.bind.name, "`align` decorator requires an integer argument");
+        val res_diag: R.Result[R.Void, str] = diagnostic.error(ctx.diags, ctx.scope.a.file_id, d.data.bind.name, "`align` decorator requires an integer argument");
         if (R.is_err[R.Void, str](res_diag)) { ret R.err[u32, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_diag))); }
         ret R.ok[u32, fail.Fail](0);
     }
 
     val n: u64 = v.data.int_lit;
     if (n == 0 || (n & (n - 1)) != 0) {
-        val res_diag: R.Result[R.Void, str] = diagnostic.error(?ctx.s.diags, ctx.scope.a.file_id, d.data.bind.name, "`align` value must be a non-zero power of two");
+        val res_diag: R.Result[R.Void, str] = diagnostic.error(ctx.diags, ctx.scope.a.file_id, d.data.bind.name, "`align` value must be a non-zero power of two");
         if (R.is_err[R.Void, str](res_diag)) { ret R.err[u32, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_diag))); }
         ret R.ok[u32, fail.Fail](0);
     }
     if (n > 0xFFFFFFFF) {
-        val res_diag: R.Result[R.Void, str] = diagnostic.error(?ctx.s.diags, ctx.scope.a.file_id, d.data.bind.name, "`align` value exceeds the maximum alignment");
+        val res_diag: R.Result[R.Void, str] = diagnostic.error(ctx.diags, ctx.scope.a.file_id, d.data.bind.name, "`align` value exceeds the maximum alignment");
         if (R.is_err[R.Void, str](res_diag)) { ret R.err[u32, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_diag))); }
         ret R.ok[u32, fail.Fail](0);
     }

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -24,6 +24,7 @@ use atype: mach.lang.fe.ast.type;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.sema.generics;
+use scx: mach.lang.fe.sema.context;
 use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.me.ir;
@@ -42,11 +43,12 @@ use mach.lang.float;
 use mach.lang.type;
 
 pub fun lower_rvalue(ctx: *context.LowerContext, eid: id.ExprId) R.Result[value.Value, fail.Fail] {
-    val opt_e: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_none[*expr.Expr](opt_e)) {
+    val opt_e: R.Result[expr.Expr, str] = context.expression(ctx, eid);
+    if (R.is_err[expr.Expr, str](opt_e)) {
         ret R.err[value.Value, fail.Fail](fail.message("lower: expression id out of range"));
     }
-    val e: *expr.Expr    = O.unwrap[*expr.Expr](opt_e);
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_e);
+    val e: *expr.Expr = ?e_value;
 
     val saved_loc: source.SrcLoc = builder.current_loc(?ctx.builder);
     builder.set_loc(?ctx.builder, source.loc(ctx.scope.a.file_id, e.span.offset));
@@ -96,20 +98,22 @@ fun stamp_secret(ctx: *context.LowerContext, eid: id.ExprId, v: value.Value) val
 }
 
 fun compare_operand_secret(ctx: *context.LowerContext, eid: id.ExprId) bool {
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) { ret false; }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    val e_opt: R.Result[expr.Expr, str] = context.expression(ctx, eid);
+    if (R.is_err[expr.Expr, str](e_opt)) { ret false; }
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](e_opt);
+    val e: *expr.Expr = ?e_value;
     if (e.kind != expr.EXPR_KIND_BINARY)     { ret false; }
     if (!is_compare_binop(e.data.binary.op)) { ret false; }
     ret context.expr_is_secret(ctx, e.data.binary.lhs) || context.expr_is_secret(ctx, e.data.binary.rhs);
 }
 
 pub fun lower_lvalue(ctx: *context.LowerContext, eid: id.ExprId) R.Result[value.Value, fail.Fail] {
-    val opt_e: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_none[*expr.Expr](opt_e)) {
+    val opt_e: R.Result[expr.Expr, str] = context.expression(ctx, eid);
+    if (R.is_err[expr.Expr, str](opt_e)) {
         ret R.err[value.Value, fail.Fail](fail.message("lower: lvalue id out of range"));
     }
-    val e: *expr.Expr    = O.unwrap[*expr.Expr](opt_e);
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_e);
+    val e: *expr.Expr = ?e_value;
 
     val saved_loc: source.SrcLoc = builder.current_loc(?ctx.builder);
     builder.set_loc(?ctx.builder, source.loc(ctx.scope.a.file_id, e.span.offset));
@@ -165,7 +169,7 @@ pub fun lower_lit_str(ctx: *context.LowerContext, e: *expr.Expr) R.Result[value.
 
     val res_sid: R.Result[intern.StrId, fail.Fail] = intern_str_lit(ctx, inner);
     if (R.is_err[intern.StrId, fail.Fail](res_sid)) {
-        diagnostic.record_error(?ctx.s.diags, ctx.scope.a.file_id, e.span, R.unwrap_err[intern.StrId, fail.Fail](res_sid).message);
+        diagnostic.record_error(ctx.diags, ctx.scope.a.file_id, e.span, R.unwrap_err[intern.StrId, fail.Fail](res_sid).message);
         ret R.err[value.Value, fail.Fail](fail.reported());
     }
     val opt_bytes: O.Option[str] = intern.lookup(?ctx.s.interner, R.unwrap_ok[intern.StrId, fail.Fail](res_sid));
@@ -333,9 +337,10 @@ fun comptime_each_direct_value(ctx: *context.LowerContext, sid: resolve.SymbolId
 }
 
 fun const_elem_field_expr(ctx: *context.LowerContext, elem_eid: id.ExprId, member_span: token.Span) id.ExprId {
-    val el_opt: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, elem_eid);
-    if (O.is_none[*expr.Expr](el_opt)) { ret id.EXPR_NIL; }
-    val el: *expr.Expr = O.unwrap[*expr.Expr](el_opt);
+    val el_opt: R.Result[expr.Expr, str] = context.expression(ctx, elem_eid);
+    if (R.is_err[expr.Expr, str](el_opt)) { ret id.EXPR_NIL; }
+    var el_value: expr.Expr = R.unwrap_ok[expr.Expr, str](el_opt);
+    val el: *expr.Expr = ?el_value;
     if (el.kind != expr.EXPR_KIND_STRUCT_LIT) { ret id.EXPR_NIL; }
 
     val src: str = context.module_source(ctx);
@@ -366,9 +371,9 @@ fun load_pack_elem(ctx: *context.LowerContext, eid: id.ExprId, ord: u32) R.Resul
 }
 
 fun is_spread_expr(ctx: *context.LowerContext, eid: id.ExprId) bool {
-    val opt_e: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_none[*expr.Expr](opt_e)) { ret false; }
-    ret O.unwrap[*expr.Expr](opt_e).kind == expr.EXPR_KIND_SPREAD;
+    val opt_e: R.Result[expr.Expr, str] = context.expression(ctx, eid);
+    if (R.is_err[expr.Expr, str](opt_e)) { ret false; }
+    ret R.unwrap_ok[expr.Expr, str](opt_e).kind == expr.EXPR_KIND_SPREAD;
 }
 
 fun call_has_spread(ctx: *context.LowerContext, e: *expr.Expr) bool {
@@ -406,8 +411,11 @@ fun comptime_param_value(ctx: *context.LowerContext, sid: resolve.SymbolId) O.Op
 fun reference_linkage_name(ctx: *context.LowerContext, sym: *resolve.Symbol) R.Result[intern.StrId, fail.Fail] {
     val fqn: intern.StrId = session.module_fqn(ctx.s, sym.origin);
     var export: O.Option[intern.StrId] = O.none[intern.StrId]();
-    if (sym.decl != id.DECL_NIL) {
-        export = session.export_name(ctx.s, sym.origin, sym.decl::u32);
+    if (sym.kind == resolve.SYM_IMPORTED || sym.decl != id.DECL_NIL) {
+        val acquired: R.Result[scx.DefinedSymbol, fail.Fail] = context.symbol_definition(ctx, sym);
+        if (R.is_err[scx.DefinedSymbol, fail.Fail](acquired)) { ret R.err[intern.StrId, fail.Fail](R.unwrap_err[scx.DefinedSymbol, fail.Fail](acquired)); }
+        val current: scx.DefinedSymbol = R.unwrap_ok[scx.DefinedSymbol, fail.Fail](acquired);
+        export = session.export_name(ctx.s, current.symbol.origin, current.symbol.decl::u32);
     }
     ret mangle.linkage_name(ctx.s, fqn, sym.canon, export);
 }
@@ -473,15 +481,18 @@ fun symbol_reference(ctx: *context.LowerContext, eid: id.ExprId, sid: resolve.Sy
 }
 
 fun module_const_value(ctx: *context.LowerContext, sym: *resolve.Symbol) R.Result[O.Option[comptime.CTValue], fail.Fail] {
-    val oa: *ast.Ast = session.module_ast(ctx.s, sym.origin);
+    val acquired: R.Result[scx.DefinedSymbol, fail.Fail] = context.symbol_definition(ctx, sym);
+    if (R.is_err[scx.DefinedSymbol, fail.Fail](acquired)) { ret R.err[O.Option[comptime.CTValue], fail.Fail](R.unwrap_err[scx.DefinedSymbol, fail.Fail](acquired)); }
+    val current: scx.DefinedSymbol = R.unwrap_ok[scx.DefinedSymbol, fail.Fail](acquired);
+    val oa: *ast.Ast = current.definition.parsed.a;
     if (oa == nil) { ret R.err[O.Option[comptime.CTValue], fail.Fail](fail.message("lower: module-level reference: origin module AST unavailable (invariant violated)")); }
-    val opt_d: O.Option[*decl.Decl] = ast.get_decl(oa, sym.decl);
+    val opt_d: O.Option[*decl.Decl] = ast.get_decl(oa, current.symbol.decl);
     if (O.is_none[*decl.Decl](opt_d)) { ret R.err[O.Option[comptime.CTValue], fail.Fail](fail.message("lower: module-level reference: decl id out of range in origin AST (invariant violated)")); }
     if (O.unwrap[*decl.Decl](opt_d).kind != decl.DECL_KIND_VAL) { ret R.ok[O.Option[comptime.CTValue], fail.Fail](O.none[comptime.CTValue]()); }
 
-    val dctx: *comptime.ComptimeCtx = context.declaring_comptime_ctx(ctx, sym);
+    val dctx: *comptime.ComptimeCtx = current.definition.ctx;
     if (dctx == nil) { ret R.err[O.Option[comptime.CTValue], fail.Fail](fail.message("lower: module-level reference: declaring module comptime context unavailable (invariant violated)")); }
-    val opt_nc: O.Option[comptime.NamedConst] = comptime.lookup(dctx, sym.name);
+    val opt_nc: O.Option[comptime.NamedConst] = comptime.lookup(dctx, current.symbol.canon);
     if (O.is_none[comptime.NamedConst](opt_nc)) { ret R.ok[O.Option[comptime.CTValue], fail.Fail](O.none[comptime.CTValue]()); }
 
     val named: comptime.NamedConst = O.unwrap[comptime.NamedConst](opt_nc);
@@ -511,9 +522,12 @@ pub fun references_function(ctx: *context.LowerContext, eid: id.ExprId) bool {
 
 fun references_import_data(ctx: *context.LowerContext, sym: *resolve.Symbol) bool {
     if (sym.kind != resolve.SYM_IMPORTED) { ret false; }
-    val origin_ast: *ast.Ast = session.module_ast(ctx.s, sym.origin);
+    val acquired: R.Result[scx.DefinedSymbol, fail.Fail] = context.symbol_definition(ctx, sym);
+    if (R.is_err[scx.DefinedSymbol, fail.Fail](acquired)) { ret false; }
+    val current: scx.DefinedSymbol = R.unwrap_ok[scx.DefinedSymbol, fail.Fail](acquired);
+    val origin_ast: *ast.Ast = current.definition.parsed.a;
     if (origin_ast == nil) { ret false; }
-    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, sym.decl);
+    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, current.symbol.decl);
     if (O.is_none[*decl.Decl](opt_d)) { ret false; }
     val d: *decl.Decl = O.unwrap[*decl.Decl](opt_d);
     if (d.kind != decl.DECL_KIND_VAL && d.kind != decl.DECL_KIND_VAR) { ret false; }
@@ -522,9 +536,12 @@ fun references_import_data(ctx: *context.LowerContext, sym: *resolve.Symbol) boo
 
 fun stamp_spirv_op(ctx: *context.LowerContext, sym: *resolve.Symbol, v: value.Value) {
     if (v.kind != value.VAL_FN || v.data.fn_ix >= ctx.m.function_len) { ret; }
-    val origin_ast: *ast.Ast = session.module_ast(ctx.s, sym.origin);
+    val acquired: R.Result[scx.DefinedSymbol, fail.Fail] = context.symbol_definition(ctx, sym);
+    if (R.is_err[scx.DefinedSymbol, fail.Fail](acquired)) { ret; }
+    val current: scx.DefinedSymbol = R.unwrap_ok[scx.DefinedSymbol, fail.Fail](acquired);
+    val origin_ast: *ast.Ast = current.definition.parsed.a;
     if (origin_ast == nil) { ret; }
-    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, sym.decl);
+    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, current.symbol.decl);
     if (O.is_none[*decl.Decl](opt_d)) { ret; }
     val fi: u32 = v.data.fn_ix;
     val set_v: u32 = context.decl_target_op(origin_ast, context.ast_source(ctx, origin_ast),
@@ -535,9 +552,12 @@ fun stamp_spirv_op(ctx: *context.LowerContext, sym: *resolve.Symbol, v: value.Va
 
 fun references_import_function(ctx: *context.LowerContext, sym: *resolve.Symbol) bool {
     if (sym.kind != resolve.SYM_IMPORTED) { ret false; }
-    val origin_ast: *ast.Ast = session.module_ast(ctx.s, sym.origin);
+    val acquired: R.Result[scx.DefinedSymbol, fail.Fail] = context.symbol_definition(ctx, sym);
+    if (R.is_err[scx.DefinedSymbol, fail.Fail](acquired)) { ret false; }
+    val current: scx.DefinedSymbol = R.unwrap_ok[scx.DefinedSymbol, fail.Fail](acquired);
+    val origin_ast: *ast.Ast = current.definition.parsed.a;
     if (origin_ast == nil) { ret false; }
-    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, sym.decl);
+    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, current.symbol.decl);
     if (O.is_none[*decl.Decl](opt_d)) { ret false; }
     val d: *decl.Decl = O.unwrap[*decl.Decl](opt_d);
     if (d.kind != decl.DECL_KIND_FUN) { ret false; }
@@ -546,9 +566,12 @@ fun references_import_function(ctx: *context.LowerContext, sym: *resolve.Symbol)
 
 fun enqueue_inline_import(ctx: *context.LowerContext, sym: *resolve.Symbol, link: intern.StrId) R.Result[R.Void, fail.Fail] {
     if (sym.kind != resolve.SYM_IMPORTED) { ret R.ok_void[fail.Fail](); }
-    val origin_ast: *ast.Ast = session.module_ast(ctx.s, sym.origin);
+    val acquired: R.Result[scx.DefinedSymbol, fail.Fail] = context.symbol_definition(ctx, sym);
+    if (R.is_err[scx.DefinedSymbol, fail.Fail](acquired)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[scx.DefinedSymbol, fail.Fail](acquired)); }
+    val current: scx.DefinedSymbol = R.unwrap_ok[scx.DefinedSymbol, fail.Fail](acquired);
+    val origin_ast: *ast.Ast = current.definition.parsed.a;
     if (origin_ast == nil) { ret R.ok_void[fail.Fail](); }
-    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, sym.decl);
+    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, current.symbol.decl);
     if (O.is_none[*decl.Decl](opt_d)) { ret R.ok_void[fail.Fail](); }
     val d: *decl.Decl = O.unwrap[*decl.Decl](opt_d);
     if (d.kind != decl.DECL_KIND_FUN)             { ret R.ok_void[fail.Fail](); }
@@ -558,7 +581,7 @@ fun enqueue_inline_import(ctx: *context.LowerContext, sym: *resolve.Symbol, link
     if (fun_decl_is_template(origin_ast, d))      { ret R.ok_void[fail.Fail](); }
     if (!decl_has_origin_decorator(ctx, origin_ast, d, "inline")) { ret R.ok_void[fail.Fail](); }
 
-    ret context.enqueue_instance(ctx, sym.decl, sym.origin, nil, 0, link, sym.name);
+    ret context.enqueue_instance(ctx, current.symbol.decl, sym.origin, nil, 0, link, sym.name);
 }
 
 fun fun_decl_is_template(a: *ast.Ast, d: *decl.Decl) bool {
@@ -588,15 +611,8 @@ fun decl_has_origin_decorator(ctx: *context.LowerContext, a: *ast.Ast, d: *decl.
 }
 
 fun names_function(ctx: *context.LowerContext, sym: *resolve.Symbol) bool {
-    if (sym.kind == resolve.SYM_FUN) { ret true; }
-    if (sym.kind == resolve.SYM_VAL || sym.kind == resolve.SYM_VAR
-        || sym.kind == resolve.SYM_PARAM) { ret false; }
-    if (sym.kind != resolve.SYM_IMPORTED) { ret false; }
-    val origin_ast: *ast.Ast = session.module_ast(ctx.s, sym.origin);
-    if (origin_ast == nil) { ret false; }
-    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, sym.decl);
-    if (O.is_none[*decl.Decl](opt_d)) { ret false; }
-    ret O.unwrap[*decl.Decl](opt_d).kind == decl.DECL_KIND_FUN;
+    ret sym.kind == resolve.SYM_FUN
+        || (sym.kind == resolve.SYM_IMPORTED && sym.definition_kind == resolve.SYM_FUN);
 }
 
 fun symbol_lvalue(ctx: *context.LowerContext, eid: id.ExprId, sid: resolve.SymbolId) R.Result[value.Value, fail.Fail] {
@@ -653,9 +669,9 @@ fun lower_ident_lvalue(ctx: *context.LowerContext, eid: id.ExprId) R.Result[valu
 }
 
 fun try_lower_const_elem_member(ctx: *context.LowerContext, e: *expr.Expr) O.Option[R.Result[value.Value, fail.Fail]] {
-    val obj_opt: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, e.data.member.object);
-    if (O.is_none[*expr.Expr](obj_opt))                             { ret O.none[R.Result[value.Value, fail.Fail]](); }
-    if (O.unwrap[*expr.Expr](obj_opt).kind != expr.EXPR_KIND_IDENT) { ret O.none[R.Result[value.Value, fail.Fail]](); }
+    val obj_opt: R.Result[expr.Expr, str] = context.expression(ctx, e.data.member.object);
+    if (R.is_err[expr.Expr, str](obj_opt))                             { ret O.none[R.Result[value.Value, fail.Fail]](); }
+    if (R.unwrap_ok[expr.Expr, str](obj_opt).kind != expr.EXPR_KIND_IDENT) { ret O.none[R.Result[value.Value, fail.Fail]](); }
 
     val osid: resolve.SymbolId = context.expr_symbol_of(ctx, e.data.member.object);
     val opt_elem: O.Option[id.ExprId] = const_elem_expr(ctx, osid);
@@ -905,9 +921,10 @@ fun interned_literal(ctx: *context.LowerContext, text: str) intern.StrId {
 }
 
 pub fun try_lower_comptime_intrinsic(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) O.Option[R.Result[value.Value, fail.Fail]] {
-    val opt_ce: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, e.data.call.callee);
-    if (O.is_none[*expr.Expr](opt_ce)) { ret O.none[R.Result[value.Value, fail.Fail]](); }
-    val ce: *expr.Expr = O.unwrap[*expr.Expr](opt_ce);
+    val opt_ce: R.Result[expr.Expr, str] = context.expression(ctx, e.data.call.callee);
+    if (R.is_err[expr.Expr, str](opt_ce)) { ret O.none[R.Result[value.Value, fail.Fail]](); }
+    var ce_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_ce);
+    val ce: *expr.Expr = ?ce_value;
     if (ce.kind != expr.EXPR_KIND_COMPTIME_IDENT) { ret O.none[R.Result[value.Value, fail.Fail]](); }
 
     val ns: token.Span = comptime.comptime_ident_name(ce.span);
@@ -965,11 +982,11 @@ pub fun try_lower_comptime_intrinsic(ctx: *context.LowerContext, eid: id.ExprId,
     }
     if (is_offset) {
         val f_eid: id.ExprId = ctx.scope.a.expr_ids[e.data.call.args_start + 1];
-        val opt_f: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, f_eid);
-        if (O.is_none[*expr.Expr](opt_f)) {
+        val opt_f: R.Result[expr.Expr, str] = context.expression(ctx, f_eid);
+        if (R.is_err[expr.Expr, str](opt_f)) {
             ret O.some[R.Result[value.Value, fail.Fail]](R.err[value.Value, fail.Fail](fail.message("lower: offset_of field argument out of range")));
         }
-        val field_ix: u32 = field_index_in_type(ctx, op_ty, O.unwrap[*expr.Expr](opt_f).span);
+        val field_ix: u32 = field_index_in_type(ctx, op_ty, R.unwrap_ok[expr.Expr, str](opt_f).span);
         n = ir_type.byte_offset_for_machine(?ctx.m.types, op_ir, field_ix, resolved_target.layout_machine(ctx.tgt));
     }
 
@@ -1002,9 +1019,10 @@ pub fun try_lower_comptime_cast(ctx: *context.LowerContext, eid: id.ExprId, e: *
 }
 
 fun fold_const_scalar(ctx: *context.LowerContext, eid: id.ExprId) O.Option[R.Result[comptime.CTValue, comptime.EvalFail]] {
-    val opt_e: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_none[*expr.Expr](opt_e)) { ret O.none[R.Result[comptime.CTValue, comptime.EvalFail]](); }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](opt_e);
+    val opt_e: R.Result[expr.Expr, str] = context.expression(ctx, eid);
+    if (R.is_err[expr.Expr, str](opt_e)) { ret O.none[R.Result[comptime.CTValue, comptime.EvalFail]](); }
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_e);
+    val e: *expr.Expr = ?e_value;
 
     if (e.kind != expr.EXPR_KIND_CAST) {
         val res_eval: R.Result[comptime.CTValue, comptime.EvalFail] =
@@ -1227,14 +1245,12 @@ fun callee_decl_fun(ctx: *context.LowerContext, callee: id.ExprId) O.Option[*dec
     if (O.is_none[*resolve.Symbol](opt_sym)) { ret O.none[*decl.DeclFun](); }
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](opt_sym);
     if (sym.kind != resolve.SYM_FUN && sym.kind != resolve.SYM_IMPORTED) { ret O.none[*decl.DeclFun](); }
-    if (sym.decl == id.DECL_NIL)                                         { ret O.none[*decl.DeclFun](); }
-
-    var origin_ast: *ast.Ast = ctx.scope.a;
-    if (sym.origin != ctx.scope.own_module) {
-        origin_ast = session.module_ast(ctx.s, sym.origin);
-        if (origin_ast == nil) { ret O.none[*decl.DeclFun](); }
-    }
-    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, sym.decl);
+    if (sym.kind == resolve.SYM_IMPORTED && sym.definition_kind != resolve.SYM_FUN) { ret O.none[*decl.DeclFun](); }
+    val acquired: R.Result[scx.DefinedSymbol, fail.Fail] = context.symbol_definition(ctx, sym);
+    if (R.is_err[scx.DefinedSymbol, fail.Fail](acquired)) { ret O.none[*decl.DeclFun](); }
+    val current: scx.DefinedSymbol = R.unwrap_ok[scx.DefinedSymbol, fail.Fail](acquired);
+    val origin_ast: *ast.Ast = current.definition.parsed.a;
+    val opt_d: O.Option[*decl.Decl] = ast.get_decl(origin_ast, current.symbol.decl);
     if (O.is_none[*decl.Decl](opt_d)) { ret O.none[*decl.DeclFun](); }
     val d: *decl.Decl = O.unwrap[*decl.Decl](opt_d);
     if (d.kind != decl.DECL_KIND_FUN) { ret O.none[*decl.DeclFun](); }
@@ -1268,7 +1284,9 @@ fun callee_ast(ctx: *context.LowerContext, callee: id.ExprId) *ast.Ast {
     if (O.is_none[*resolve.Symbol](opt_sym)) { ret nil; }
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](opt_sym);
     if (sym.origin == ctx.scope.own_module) { ret ctx.scope.a; }
-    ret session.module_ast(ctx.s, sym.origin);
+    val acquired: R.Result[scx.DefinedSymbol, fail.Fail] = context.symbol_definition(ctx, sym);
+    if (R.is_err[scx.DefinedSymbol, fail.Fail](acquired)) { ret nil; }
+    ret R.unwrap_ok[scx.DefinedSymbol, fail.Fail](acquired).definition.parsed.a;
 }
 
 fun lower_value_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr, f: *decl.DeclFun) R.Result[value.Value, fail.Fail] {
@@ -1278,6 +1296,9 @@ fun lower_value_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr
         ret R.err[value.Value, fail.Fail](fail.message("lower: unresolved comptime-param call target"));
     }
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](opt_sym);
+    val acquired: R.Result[scx.DefinedSymbol, fail.Fail] = context.symbol_definition(ctx, sym);
+    if (R.is_err[scx.DefinedSymbol, fail.Fail](acquired)) { ret R.err[value.Value, fail.Fail](R.unwrap_err[scx.DefinedSymbol, fail.Fail](acquired)); }
+    val current: scx.DefinedSymbol = R.unwrap_ok[scx.DefinedSymbol, fail.Fail](acquired);
     val origin_ast: *ast.Ast = callee_ast(ctx, e.data.call.callee);
     if (origin_ast == nil) { ret R.err[value.Value, fail.Fail](fail.message("lower: comptime-param callee AST unavailable")); }
 
@@ -1313,7 +1334,7 @@ fun lower_value_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr
             val opt_fv: O.Option[comptime.CTValue] = fold_comptime_arg(ctx, arg_eid);
             if (O.is_none[comptime.CTValue](opt_fv)) {
                 val arg_span: token.Span = expr_span_of(ctx, arg_eid);
-                diagnostic.record_error(?ctx.s.diags, ctx.scope.a.file_id, arg_span, "comptime argument is not a compile-time constant");
+                diagnostic.record_error(ctx.diags, ctx.scope.a.file_id, arg_span, "comptime argument is not a compile-time constant");
                 A.deallocate[comptime.CTValue](ctx.s.alloc, vals, ct_len::usize);
                 A.deallocate[intern.StrId](ctx.s.alloc, names, ct_len::usize);
                 ret R.err[value.Value, fail.Fail](fail.reported());
@@ -1348,12 +1369,12 @@ fun lower_value_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr
     }
     val link: intern.StrId = R.unwrap_ok[intern.StrId, fail.Fail](res_link);
 
-    val res_enq: R.Result[R.Void, fail.Fail] = context.enqueue_value_instance(ctx, sym.decl, sym.origin, vals, names, ct_len, link);
+    val res_enq: R.Result[R.Void, fail.Fail] = context.enqueue_value_instance(ctx, current.symbol.decl, sym.origin, vals, names, ct_len, link);
     A.deallocate[comptime.CTValue](ctx.s.alloc, vals, ct_len::usize);
     A.deallocate[intern.StrId](ctx.s.alloc, names, ct_len::usize);
     if (R.is_err[R.Void, fail.Fail](res_enq)) { ret R.err[value.Value, fail.Fail](R.unwrap_err[R.Void, fail.Fail](res_enq)); }
 
-    val res_sig: R.Result[ir_type.IrTypeId, fail.Fail] = context.instance_ref_sig(ctx, sym.decl, sym.origin, nil, 0);
+    val res_sig: R.Result[ir_type.IrTypeId, fail.Fail] = context.instance_ref_sig(ctx, current.symbol.decl, sym.origin, nil, 0);
     if (R.is_err[ir_type.IrTypeId, fail.Fail](res_sig)) { ret R.err[value.Value, fail.Fail](R.unwrap_err[ir_type.IrTypeId, fail.Fail](res_sig)); }
     ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, fail.Fail](res_sig), false);
 }
@@ -1375,7 +1396,7 @@ fun fold_comptime_arg(ctx: *context.LowerContext, eid: id.ExprId) O.Option[compt
 
     val dctx: *comptime.ComptimeCtx = context.declaring_comptime_ctx(ctx, sym);
     if (dctx == nil) { ret O.none[comptime.CTValue](); }
-    val opt_nc: O.Option[comptime.NamedConst] = comptime.lookup(dctx, sym.name);
+    val opt_nc: O.Option[comptime.NamedConst] = comptime.lookup(dctx, sym.canon);
     if (O.is_none[comptime.NamedConst](opt_nc)) { ret O.none[comptime.CTValue](); }
     val named: comptime.NamedConst = O.unwrap[comptime.NamedConst](opt_nc);
     if (named.gated && ctx.scope.env.union_build) {
@@ -1387,8 +1408,8 @@ fun fold_comptime_arg(ctx: *context.LowerContext, eid: id.ExprId) O.Option[compt
 }
 
 fun expr_span_of(ctx: *context.LowerContext, eid: id.ExprId) token.Span {
-    val opt_e: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_some[*expr.Expr](opt_e)) { ret O.unwrap[*expr.Expr](opt_e).span; }
+    val opt_e: R.Result[expr.Expr, str] = context.expression(ctx, eid);
+    if (R.is_ok[expr.Expr, str](opt_e)) { ret R.unwrap_ok[expr.Expr, str](opt_e).span; }
     var s: token.Span;
     s.offset = 0;
     s.len    = 0;
@@ -1396,7 +1417,7 @@ fun expr_span_of(ctx: *context.LowerContext, eid: id.ExprId) token.Span {
 }
 
 fun report_expr(ctx: *context.LowerContext, eid: id.ExprId, message: str) R.Result[value.Value, fail.Fail] {
-    diagnostic.record_error(?ctx.s.diags, ctx.scope.a.file_id, expr_span_of(ctx, eid), message);
+    diagnostic.record_error(ctx.diags, ctx.scope.a.file_id, expr_span_of(ctx, eid), message);
     ret R.err[value.Value, fail.Fail](fail.reported());
 }
 
@@ -1474,6 +1495,9 @@ fun lower_generic_instance(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.
         ret R.err[value.Value, fail.Fail](fail.message("lower: unresolved generic call target"));
     }
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](opt_sym);
+    val acquired: R.Result[scx.DefinedSymbol, fail.Fail] = context.symbol_definition(ctx, sym);
+    if (R.is_err[scx.DefinedSymbol, fail.Fail](acquired)) { ret R.err[value.Value, fail.Fail](R.unwrap_err[scx.DefinedSymbol, fail.Fail](acquired)); }
+    val current: scx.DefinedSymbol = R.unwrap_ok[scx.DefinedSymbol, fail.Fail](acquired);
 
     val argc: u32 = e.data.call.type_args_len;
     val res_args: R.Result[*type.TypeId, fail.Fail] = collect_call_type_args(ctx, e, argc);
@@ -1488,13 +1512,13 @@ fun lower_generic_instance(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.
     }
     val link: intern.StrId = R.unwrap_ok[intern.StrId, fail.Fail](res_link);
 
-    val res_enq: R.Result[R.Void, fail.Fail] = context.enqueue_instance(ctx, sym.decl, sym.origin, args, argc, link, sym.name);
+    val res_enq: R.Result[R.Void, fail.Fail] = context.enqueue_instance(ctx, current.symbol.decl, sym.origin, args, argc, link, sym.name);
     if (R.is_err[R.Void, fail.Fail](res_enq)) {
         free_type_args(ctx, args, argc);
         ret R.err[value.Value, fail.Fail](R.unwrap_err[R.Void, fail.Fail](res_enq));
     }
 
-    val res_sig: R.Result[ir_type.IrTypeId, fail.Fail] = context.instance_ref_sig(ctx, sym.decl, sym.origin, args, argc);
+    val res_sig: R.Result[ir_type.IrTypeId, fail.Fail] = context.instance_ref_sig(ctx, current.symbol.decl, sym.origin, args, argc);
     free_type_args(ctx, args, argc);
     if (R.is_err[ir_type.IrTypeId, fail.Fail](res_sig)) { ret R.err[value.Value, fail.Fail](R.unwrap_err[ir_type.IrTypeId, fail.Fail](res_sig)); }
     ret fn_reference(ctx, link, R.unwrap_ok[ir_type.IrTypeId, fail.Fail](res_sig), false);
@@ -1507,6 +1531,9 @@ fun lower_pack_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr,
         ret R.err[value.Value, fail.Fail](fail.message("lower: unresolved pack-tailed call target"));
     }
     val sym: *resolve.Symbol = O.unwrap[*resolve.Symbol](opt_sym);
+    val acquired: R.Result[scx.DefinedSymbol, fail.Fail] = context.symbol_definition(ctx, sym);
+    if (R.is_err[scx.DefinedSymbol, fail.Fail](acquired)) { ret R.err[value.Value, fail.Fail](R.unwrap_err[scx.DefinedSymbol, fail.Fail](acquired)); }
+    val current: scx.DefinedSymbol = R.unwrap_ok[scx.DefinedSymbol, fail.Fail](acquired);
 
     val argc: u32 = e.data.call.type_args_len;
     val res_args: R.Result[*type.TypeId, fail.Fail] = collect_call_type_args(ctx, e, argc);
@@ -1564,14 +1591,14 @@ fun lower_pack_callee(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr,
     }
     val link: intern.StrId = R.unwrap_ok[intern.StrId, fail.Fail](res_link);
 
-    val res_enq: R.Result[R.Void, fail.Fail] = context.enqueue_pack_instance(ctx, sym.decl, sym.origin, args, argc, types, elem_len, link);
+    val res_enq: R.Result[R.Void, fail.Fail] = context.enqueue_pack_instance(ctx, current.symbol.decl, sym.origin, args, argc, types, elem_len, link);
     if (R.is_err[R.Void, fail.Fail](res_enq)) {
         if (owns_types && types != nil) { A.deallocate[type.TypeId](ctx.s.alloc, types, elem_len::usize); }
         free_type_args(ctx, args, argc);
         ret R.err[value.Value, fail.Fail](R.unwrap_err[R.Void, fail.Fail](res_enq));
     }
 
-    val res_sig: R.Result[ir_type.IrTypeId, fail.Fail] = context.pack_instance_ref_sig(ctx, sym.decl, sym.origin, args, argc, types, elem_len);
+    val res_sig: R.Result[ir_type.IrTypeId, fail.Fail] = context.pack_instance_ref_sig(ctx, current.symbol.decl, sym.origin, args, argc, types, elem_len);
     if (owns_types && types != nil)   { A.deallocate[type.TypeId](ctx.s.alloc, types, elem_len::usize); }
     free_type_args(ctx, args, argc);
     if (R.is_err[ir_type.IrTypeId, fail.Fail](res_sig)) { ret R.err[value.Value, fail.Fail](R.unwrap_err[ir_type.IrTypeId, fail.Fail](res_sig)); }
@@ -2251,9 +2278,10 @@ fun assign_epilogue(ctx: *context.LowerContext, e: *expr.Expr, rhs: value.Value)
     }
 
     if (ctx.debug) {
-        val opt_lhs: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, e.data.binary.lhs);
-        if (O.is_some[*expr.Expr](opt_lhs)) {
-            val lhs_e: *expr.Expr = O.unwrap[*expr.Expr](opt_lhs);
+        val opt_lhs: R.Result[expr.Expr, str] = context.expression(ctx, e.data.binary.lhs);
+        if (R.is_ok[expr.Expr, str](opt_lhs)) {
+            var lhs_e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_lhs);
+            val lhs_e: *expr.Expr = ?lhs_e_value;
             if (lhs_e.kind == expr.EXPR_KIND_IDENT) {
                 val lhs_sem: type.TypeId = context.expr_type_of(ctx, e.data.binary.lhs);
                 val res_dbg: R.Result[R.Void, fail.Fail] = context.emit_dbg_birth(ctx, lhs_e.span, rhs.ty, lhs_sem, false, rhs, O.none[value.Value]());
@@ -2267,9 +2295,10 @@ fun assign_epilogue(ctx: *context.LowerContext, e: *expr.Expr, rhs: value.Value)
 }
 
 fun lower_vector_lane_write(ctx: *context.LowerContext, lhs: id.ExprId, rhs: value.Value) R.Result[bool, fail.Fail] {
-    val opt_e: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, lhs);
-    if (O.is_none[*expr.Expr](opt_e)) { ret R.ok[bool, fail.Fail](false); }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](opt_e);
+    val opt_e: R.Result[expr.Expr, str] = context.expression(ctx, lhs);
+    if (R.is_err[expr.Expr, str](opt_e)) { ret R.ok[bool, fail.Fail](false); }
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_e);
+    val e: *expr.Expr = ?e_value;
     if (e.kind != expr.EXPR_KIND_INDEX) { ret R.ok[bool, fail.Fail](false); }
 
     val opt_lane: O.Option[R.Result[u64, fail.Fail]] = vector_lane_of(ctx, e);
@@ -2354,9 +2383,10 @@ fun lower_logical(ctx: *context.LowerContext, e: *expr.Expr) R.Result[value.Valu
 }
 
 fun address_operand_names_function(ctx: *context.LowerContext, eid: id.ExprId) bool {
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_none[*expr.Expr](e_opt)) { ret false; }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    val e_opt: R.Result[expr.Expr, str] = context.expression(ctx, eid);
+    if (R.is_err[expr.Expr, str](e_opt)) { ret false; }
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](e_opt);
+    val e: *expr.Expr = ?e_value;
     if (e.kind == expr.EXPR_KIND_GENERIC_INSTANCE) { ret true; }
     if (e.kind != expr.EXPR_KIND_IDENT && e.kind != expr.EXPR_KIND_MEMBER) { ret false; }
     val sid: resolve.SymbolId = context.expr_symbol_of(ctx, eid);
@@ -2394,9 +2424,10 @@ fun lower_unary(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Res
 }
 
 pub fun condition_value(ctx: *context.LowerContext, eid: id.ExprId, v: value.Value) R.Result[value.Value, fail.Fail] {
-    val e_opt: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_some[*expr.Expr](e_opt)) {
-        val e: *expr.Expr = O.unwrap[*expr.Expr](e_opt);
+    val e_opt: R.Result[expr.Expr, str] = context.expression(ctx, eid);
+    if (R.is_ok[expr.Expr, str](e_opt)) {
+        var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](e_opt);
+        val e: *expr.Expr = ?e_value;
         if (e.kind == expr.EXPR_KIND_BINARY
          && (is_compare_binop(e.data.binary.op)
           || e.data.binary.op == expr.BIN_AND
@@ -2764,9 +2795,10 @@ fun field_access_is_volatile(ctx: *context.LowerContext, obj_eid: id.ExprId) boo
 }
 
 fun lvalue_is_volatile_field(ctx: *context.LowerContext, eid: id.ExprId) bool {
-    val opt_e: O.Option[*expr.Expr] = ast.get_expr(ctx.scope.a, eid);
-    if (O.is_none[*expr.Expr](opt_e)) { ret false; }
-    val e: *expr.Expr = O.unwrap[*expr.Expr](opt_e);
+    val opt_e: R.Result[expr.Expr, str] = context.expression(ctx, eid);
+    if (R.is_err[expr.Expr, str](opt_e)) { ret false; }
+    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_e);
+    val e: *expr.Expr = ?e_value;
     if (e.kind == expr.EXPR_KIND_MEMBER)  { ret field_access_is_volatile(ctx, e.data.member.object); }
     if (e.kind == expr.EXPR_KIND_PROJECT) { ret field_access_is_volatile(ctx, e.data.project.object); }
     ret false;
@@ -2866,18 +2898,18 @@ pub fun field_index_in_type(ctx: *context.LowerContext, rec_ty: type.TypeId, nam
 
     val res_name: R.Result[str, str] = str_copy_slice(ctx.s.alloc, src_text, name.offset, name.len);
     if (R.is_err[str, str](res_name)) {
-        diagnostic.record_error(?ctx.s.diags, ctx.scope.a.file_id, name, "no such field on the receiver type");
+        diagnostic.record_error(ctx.diags, ctx.scope.a.file_id, name, "no such field on the receiver type");
         ret 0;
     }
     val fname: str = R.unwrap_ok[str, str](res_name);
     val res_msg: R.Result[str, str] = str_join(ctx.s.alloc, "no field '", fname, "' on the receiver type");
     str_free(ctx.s.alloc, fname);
     if (R.is_err[str, str](res_msg)) {
-        diagnostic.record_error(?ctx.s.diags, ctx.scope.a.file_id, name, "no such field on the receiver type");
+        diagnostic.record_error(ctx.diags, ctx.scope.a.file_id, name, "no such field on the receiver type");
         ret 0;
     }
     val msg: str = R.unwrap_ok[str, str](res_msg);
-    diagnostic.record_error(?ctx.s.diags, ctx.scope.a.file_id, name, msg);
+    diagnostic.record_error(ctx.diags, ctx.scope.a.file_id, name, msg);
     str_free(ctx.s.alloc, msg);
     ret 0;
 }

--- a/src/lang/me/lower/mangle.mach
+++ b/src/lang/me/lower/mangle.mach
@@ -10,16 +10,11 @@ use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
-use mach.lang.fe.ast;
 use mach.lang.fe.sema.typename;
-use mach.lang.fe.ast.decl;
-use mach.lang.fe.ast.id;
 use mach.lang.fe.comptime;
-use mach.lang.fe.token;
 use mach.lang.float;
 use mach.lang.intern;
 use mach.lang.session;
-use mach.lang.source;
 use mach.lang.type;
 use mach.lang.fail;
 
@@ -337,7 +332,7 @@ fun encoded_type_len(s: *session.Session, tid: type.TypeId, depth: usize) R.Resu
         ret modifier_len(s, 3 + decimal_len(t.data.array.count::u64), t.data.array.base, depth);
     }
     if (kind == type.TYPE_REC || kind == type.TYPE_UNI) {
-        ret R.ok[usize, fail.Fail](nominal_len(s, t.data.nominal.origin, t.data.nominal.name));
+        ret nominal_len(s, ?t.data.nominal);
     }
     if (kind == type.TYPE_INSTANCE) { ret instance_enc_len(s, t, depth); }
     if (kind == type.TYPE_FUN)      { ret fun_enc_len(s, t, depth); }
@@ -394,7 +389,7 @@ fun write_encoded_type(s: *session.Session, buf: *u8, k: usize, tid: type.TypeId
         ret write_encoded_type(s, buf, w, t.data.array.base, depth);
     }
     if (kind == type.TYPE_REC || kind == type.TYPE_UNI) {
-        ret R.ok[usize, fail.Fail](write_nominal(s, buf, k, t.data.nominal.origin, t.data.nominal.name));
+        ret write_nominal(s, buf, k, ?t.data.nominal);
     }
     if (kind == type.TYPE_INSTANCE) { ret write_instance_enc(s, buf, k, t, depth); }
     if (kind == type.TYPE_FUN)      { ret write_fun_enc(s, buf, k, t, depth); }
@@ -418,23 +413,58 @@ fun write_dollars(buf: *u8, k: usize, n: usize) usize {
     ret w;
 }
 
-fun nominal_len(s: *session.Session, origin: session.ModuleId, name: intern.StrId) usize {
-    val path: str = module_path_get(s, session.module_fqn(s, origin));
-    ret str_len(path) + 1 + str_len(interned_or_empty(s, name));
+fun nominal_path(s: *session.Session, nominal: *type.TypeNominal) R.Result[str, fail.Fail] {
+    val mid: session.ModuleId = session.module_id_for_stable(s, nominal.owner.module);
+    if (mid == session.MODULE_NIL) { ret R.err[str, fail.Fail](fail.message("mangle: nominal module is not acquired in the current operation")); }
+    val fqn: intern.StrId = session.module_fqn(s, mid);
+    val path: O.Option[str] = intern.lookup(?s.interner, fqn);
+    if (O.is_none[str](path)) { ret R.err[str, fail.Fail](fail.message("mangle: nominal module has no canonical name")); }
+    ret R.ok[str, fail.Fail](O.unwrap[str](path));
 }
 
-fun write_nominal(s: *session.Session, buf: *u8, k: usize, origin: session.ModuleId, name: intern.StrId) usize {
-    val path: str = module_path_get(s, session.module_fqn(s, origin));
-    var w: usize = write_str(buf, k, path);
+fun nominal_len(s: *session.Session, nominal: *type.TypeNominal) R.Result[usize, fail.Fail] {
+    val path: R.Result[str, fail.Fail] = nominal_path(s, nominal);
+    if (R.is_err[str, fail.Fail](path)) { ret R.err[usize, fail.Fail](R.unwrap_err[str, fail.Fail](path)); }
+    var size: usize = str_len(R.unwrap_ok[str, fail.Fail](path)) + 1 + str_len(interned_or_empty(s, nominal.name));
+    if (nominal.incarnation != 0) {
+        val recipe: O.Option[str] = intern.lookup(?s.interner, nominal.syntax);
+        if (O.is_none[str](recipe)) { ret R.err[usize, fail.Fail](fail.message("mangle: anonymous type has no canonical recipe")); }
+        size = size + 1 + str_len(O.unwrap[str](recipe));
+    }
+    ret R.ok[usize, fail.Fail](size);
+}
+
+fun write_nominal(s: *session.Session, buf: *u8, k: usize, nominal: *type.TypeNominal) R.Result[usize, fail.Fail] {
+    val path: R.Result[str, fail.Fail] = nominal_path(s, nominal);
+    if (R.is_err[str, fail.Fail](path)) { ret R.err[usize, fail.Fail](R.unwrap_err[str, fail.Fail](path)); }
+    var w: usize = write_str(buf, k, R.unwrap_ok[str, fail.Fail](path));
     buf[w] = '.'; w = w + 1;
-    ret write_str(buf, w, interned_or_empty(s, name));
+    w = write_str(buf, w, interned_or_empty(s, nominal.name));
+    if (nominal.incarnation != 0) {
+        val recipe: O.Option[str] = intern.lookup(?s.interner, nominal.syntax);
+        if (O.is_none[str](recipe)) { ret R.err[usize, fail.Fail](fail.message("mangle: anonymous type has no canonical recipe")); }
+        buf[w] = '$'; w = w + 1;
+        w = write_str(buf, w, O.unwrap[str](recipe));
+    }
+    ret R.ok[usize, fail.Fail](w);
+}
+
+fun instance_nominal(s: *session.Session, t: *type.Type) R.Result[*type.TypeNominal, fail.Fail] {
+    val found: O.Option[*type.Type] = type.get(?s.types, t.data.instance.nominal);
+    if (O.is_none[*type.Type](found)) { ret R.err[*type.TypeNominal, fail.Fail](fail.message("mangle: generic instance has no nominal type")); }
+    val nominal: *type.Type = O.unwrap[*type.Type](found);
+    if (nominal.kind != type.TYPE_REC && nominal.kind != type.TYPE_UNI) {
+        ret R.err[*type.TypeNominal, fail.Fail](fail.message("mangle: generic instance nominal has the wrong kind"));
+    }
+    ret R.ok[*type.TypeNominal, fail.Fail](?nominal.data.nominal);
 }
 
 fun instance_enc_len(s: *session.Session, t: *type.Type, depth: usize) R.Result[usize, fail.Fail] {
-    val origin: session.ModuleId = t.data.instance.target_origin;
-    val gname:  intern.StrId     = generic_decl_name(s, origin, t.data.instance.target_decl);
-
-    var total: usize = nominal_len(s, origin, gname);
+    val nominal: R.Result[*type.TypeNominal, fail.Fail] = instance_nominal(s, t);
+    if (R.is_err[*type.TypeNominal, fail.Fail](nominal)) { ret R.err[usize, fail.Fail](R.unwrap_err[*type.TypeNominal, fail.Fail](nominal)); }
+    val size: R.Result[usize, fail.Fail] = nominal_len(s, R.unwrap_ok[*type.TypeNominal, fail.Fail](nominal));
+    if (R.is_err[usize, fail.Fail](size)) { ret size; }
+    var total: usize = R.unwrap_ok[usize, fail.Fail](size);
     val astart: u32 = t.data.instance.args_start;
     val alen:   u32 = t.data.instance.args_len;
     var i: u32 = 0;
@@ -448,10 +478,11 @@ fun instance_enc_len(s: *session.Session, t: *type.Type, depth: usize) R.Result[
 }
 
 fun write_instance_enc(s: *session.Session, buf: *u8, k: usize, t: *type.Type, depth: usize) R.Result[usize, fail.Fail] {
-    val origin: session.ModuleId = t.data.instance.target_origin;
-    val gname:  intern.StrId     = generic_decl_name(s, origin, t.data.instance.target_decl);
-
-    var w: usize = write_nominal(s, buf, k, origin, gname);
+    val nominal: R.Result[*type.TypeNominal, fail.Fail] = instance_nominal(s, t);
+    if (R.is_err[*type.TypeNominal, fail.Fail](nominal)) { ret R.err[usize, fail.Fail](R.unwrap_err[*type.TypeNominal, fail.Fail](nominal)); }
+    val written: R.Result[usize, fail.Fail] = write_nominal(s, buf, k, R.unwrap_ok[*type.TypeNominal, fail.Fail](nominal));
+    if (R.is_err[usize, fail.Fail](written)) { ret written; }
+    var w: usize = R.unwrap_ok[usize, fail.Fail](written);
     val astart: u32 = t.data.instance.args_start;
     val alen:   u32 = t.data.instance.args_len;
     var i: u32 = 0;
@@ -463,29 +494,6 @@ fun write_instance_enc(s: *session.Session, buf: *u8, k: usize, t: *type.Type, d
         i = i + 1;
     }
     ret R.ok[usize, fail.Fail](w);
-}
-
-fun generic_decl_name(s: *session.Session, origin: session.ModuleId, gdecl: id.DeclId) intern.StrId {
-    val ga: *ast.Ast = session.module_ast(s, origin);
-    if (ga == nil) { ret intern.STR_NIL; }
-
-    val opt_decl: O.Option[*decl.Decl] = ast.get_decl(ga, gdecl);
-    if (O.is_none[*decl.Decl](opt_decl)) { ret intern.STR_NIL; }
-    val d: *decl.Decl = O.unwrap[*decl.Decl](opt_decl);
-
-    var nspan: token.Span;
-    if (d.kind == decl.DECL_KIND_REC) { nspan = d.data.rec_.name; }
-    or (d.kind == decl.DECL_KIND_UNI) { nspan = d.data.uni_.name; }
-    or (d.kind == decl.DECL_KIND_FUN) { nspan = d.data.fun_.name; }
-    or { ret intern.STR_NIL; }
-
-    val opt_src: O.Option[*source.SourceFile] = source.get(?s.sources, ga.file_id);
-    if (O.is_none[*source.SourceFile](opt_src)) { ret intern.STR_NIL; }
-    val text: str = O.unwrap[*source.SourceFile](opt_src).text;
-
-    val res_id: R.Result[intern.StrId, str] = intern.intern_span(?s.interner, text, nspan);
-    if (R.is_err[intern.StrId, str](res_id)) { ret intern.STR_NIL; }
-    ret R.unwrap_ok[intern.StrId, str](res_id);
 }
 
 fun fun_enc_len(s: *session.Session, t: *type.Type, depth: usize) R.Result[usize, fail.Fail] {

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -20,6 +20,7 @@ use mach.lang.fe.ast.stmt;
 use mach.lang.fe.comptime;
 use mach.lang.fe.resolve;
 use mach.lang.fe.sema;
+use scx: mach.lang.fe.sema.context;
 use mach.lang.fe.token;
 use mach.lang.intern;
 use mach.lang.me.ir;
@@ -485,7 +486,7 @@ fun lower_comptime_each(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[R.Vo
         }
         owner = context.substitute_type(ctx, raw_owner);
         if (!is_fields_record_type(ctx, owner)) {
-            diagnostic.record_error(?ctx.s.diags, ctx.scope.a.file_id, s.span,
+            diagnostic.record_error(ctx.diags, ctx.scope.a.file_id, s.span,
                 "$fields(T): type argument instantiated as a non-record type");
             ret R.err[R.Void, fail.Fail](fail.reported());
         }
@@ -497,36 +498,26 @@ fun lower_comptime_each(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[R.Vo
     }
     val fname: intern.StrId = R.unwrap_ok[intern.StrId, str](res_name);
 
-    var deps: sema.SemaDeps;
-    val res_deps: R.Result[sema.SemaDeps, str] = sema.collect_module_deps(ctx.s);
-    if (R.is_err[sema.SemaDeps, str](res_deps)) {
-        ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[sema.SemaDeps, str](res_deps)));
-    }
-    deps = R.unwrap_ok[sema.SemaDeps, str](res_deps);
-
     val n: u32 = type.field_count(?ctx.s.types, owner);
     var i: u32 = 0;
     for (i < n) {
         val mark_r: R.Result[comptime.FrameMark, str] = comptime.frame_open(ctx.scope.ctx);
         if (R.is_err[comptime.FrameMark, str](mark_r)) {
-            sema.free_module_deps(ctx.s, ?deps);
             ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[comptime.FrameMark, str](mark_r)));
         }
         val mark: comptime.FrameMark = R.unwrap_ok[comptime.FrameMark, str](mark_r);
         val res_bind: R.Result[R.Void, str] = comptime.bind(ctx.scope.ctx, fname, comptime.field_value(owner::u32, i));
         if (R.is_err[R.Void, str](res_bind)) {
             val res_close: R.Result[R.Void, str] = comptime.frame_close(ctx.scope.ctx, mark);
-            sema.free_module_deps(ctx.s, ?deps);
             if (R.is_err[R.Void, str](res_close)) { ret fail.lift[R.Void](res_close); }
             ret fail.lift[R.Void](res_bind);
         }
 
-        val res_reinfer: R.Result[R.Void, fail.Fail] = sema.reinfer_pack_each_body(ctx.s, ctx.scope.a, ctx.scope.rr, ?deps, ctx.scope.ctx,
+        val res_reinfer: R.Result[R.Void, fail.Fail] = sema.reinfer_pack_each_body(ctx.s, ctx.scope.a, ctx.scope.rr, ctx.deps, ctx.scope.ctx,
             ctx.scope.own_module, ctx.scope.sema_result, ctx.fn_ret_sem, ce.body_start, ce.body_len,
-            ctx.scope.subst, ctx.scope.subst_len, ctx.ct_insts);
+            ctx.scope.subst, ctx.scope.subst_len, ctx.ct_insts, ctx.diags);
         if (R.is_err[R.Void, fail.Fail](res_reinfer)) {
             val res_close: R.Result[R.Void, str] = comptime.frame_close(ctx.scope.ctx, mark);
-            sema.free_module_deps(ctx.s, ?deps);
             if (R.is_err[R.Void, str](res_close)) { ret fail.lift[R.Void](res_close); }
             ret res_reinfer;
         }
@@ -534,16 +525,13 @@ fun lower_comptime_each(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[R.Vo
         val res_body: R.Result[R.Void, fail.Fail] = lower_stmt_list(ctx, ce.body_start, ce.body_len);
         val res_close: R.Result[R.Void, str] = comptime.frame_close(ctx.scope.ctx, mark);
         if (R.is_err[R.Void, fail.Fail](res_body)) {
-            sema.free_module_deps(ctx.s, ?deps);
             ret res_body;
         }
         if (R.is_err[R.Void, str](res_close)) {
-            sema.free_module_deps(ctx.s, ?deps);
             ret fail.lift[R.Void](res_close);
         }
         i = i + 1;
     }
-    sema.free_module_deps(ctx.s, ?deps);
     ret R.ok_void[fail.Fail]();
 }
 
@@ -555,17 +543,10 @@ fun lower_pack_each(ctx: *context.LowerContext, ce: *stmt.StmtComptimeEach) R.Re
     }
     val fname: intern.StrId = R.unwrap_ok[intern.StrId, str](res_name);
 
-    val res_deps: R.Result[sema.SemaDeps, str] = sema.collect_module_deps(ctx.s);
-    if (R.is_err[sema.SemaDeps, str](res_deps)) {
-        ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[sema.SemaDeps, str](res_deps)));
-    }
-    var deps: sema.SemaDeps = R.unwrap_ok[sema.SemaDeps, str](res_deps);
-
     var i: u32 = 0;
     for (i < ctx.pack_len) {
         val mark_r: R.Result[comptime.FrameMark, str] = comptime.frame_open(ctx.scope.ctx);
         if (R.is_err[comptime.FrameMark, str](mark_r)) {
-            sema.free_module_deps(ctx.s, ?deps);
             ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[comptime.FrameMark, str](mark_r)));
         }
         val mark: comptime.FrameMark = R.unwrap_ok[comptime.FrameMark, str](mark_r);
@@ -573,17 +554,15 @@ fun lower_pack_each(ctx: *context.LowerContext, ce: *stmt.StmtComptimeEach) R.Re
         val res_bind: R.Result[R.Void, str] = comptime.bind(ctx.scope.ctx, fname, desc);
         if (R.is_err[R.Void, str](res_bind)) {
             val res_close: R.Result[R.Void, str] = comptime.frame_close(ctx.scope.ctx, mark);
-            sema.free_module_deps(ctx.s, ?deps);
             if (R.is_err[R.Void, str](res_close)) { ret fail.lift[R.Void](res_close); }
             ret fail.lift[R.Void](res_bind);
         }
 
-        val res_reinfer: R.Result[R.Void, fail.Fail] = sema.reinfer_pack_each_body(ctx.s, ctx.scope.a, ctx.scope.rr, ?deps, ctx.scope.ctx,
+        val res_reinfer: R.Result[R.Void, fail.Fail] = sema.reinfer_pack_each_body(ctx.s, ctx.scope.a, ctx.scope.rr, ctx.deps, ctx.scope.ctx,
             ctx.scope.own_module, ctx.scope.sema_result, ctx.pack_ret_type, ce.body_start, ce.body_len,
-            ctx.scope.subst, ctx.scope.subst_len, ctx.ct_insts);
+            ctx.scope.subst, ctx.scope.subst_len, ctx.ct_insts, ctx.diags);
         if (R.is_err[R.Void, fail.Fail](res_reinfer)) {
             val res_close: R.Result[R.Void, str] = comptime.frame_close(ctx.scope.ctx, mark);
-            sema.free_module_deps(ctx.s, ?deps);
             if (R.is_err[R.Void, str](res_close)) { ret fail.lift[R.Void](res_close); }
             ret res_reinfer;
         }
@@ -591,16 +570,13 @@ fun lower_pack_each(ctx: *context.LowerContext, ce: *stmt.StmtComptimeEach) R.Re
         val res_body: R.Result[R.Void, fail.Fail] = lower_stmt_list(ctx, ce.body_start, ce.body_len);
         val res_close: R.Result[R.Void, str] = comptime.frame_close(ctx.scope.ctx, mark);
         if (R.is_err[R.Void, fail.Fail](res_body)) {
-            sema.free_module_deps(ctx.s, ?deps);
             ret res_body;
         }
         if (R.is_err[R.Void, str](res_close)) {
-            sema.free_module_deps(ctx.s, ?deps);
             ret fail.lift[R.Void](res_close);
         }
         i = i + 1;
     }
-    sema.free_module_deps(ctx.s, ?deps);
     ret R.ok_void[fail.Fail]();
 }
 
@@ -661,21 +637,22 @@ fun lower_const_array_each_local(ctx: *context.LowerContext, ce: *stmt.StmtCompt
 
 fun lower_const_array_each_imported(ctx: *context.LowerContext, ce: *stmt.StmtComptimeEach,
                                     sym: *resolve.Symbol, elem_ty: type.TypeId, count: u32) R.Result[R.Void, fail.Fail] {
-    val sc_o: O.Option[context.ModuleScope] = context.origin_scope(ctx.s, sym.origin);
-    if (O.is_none[context.ModuleScope](sc_o)) {
-        ret R.err[R.Void, fail.Fail](fail.message("internal: `$each` imported array origin module snapshot unavailable (dependency-ordering invariant violated)"));
-    }
-    val osc: context.ModuleScope = O.unwrap[context.ModuleScope](sc_o);
+    val acquired: R.Result[context.ModuleScope, fail.Fail] = context.origin_scope(ctx, sym.origin);
+    if (R.is_err[context.ModuleScope, fail.Fail](acquired)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[context.ModuleScope, fail.Fail](acquired)); }
+    val osc: context.ModuleScope = R.unwrap_ok[context.ModuleScope, fail.Fail](acquired);
+    val selected: R.Result[scx.DefinedSymbol, fail.Fail] = context.symbol_definition(ctx, sym);
+    if (R.is_err[scx.DefinedSymbol, fail.Fail](selected)) { ret R.err[R.Void, fail.Fail](R.unwrap_err[scx.DefinedSymbol, fail.Fail](selected)); }
+    val current: scx.DefinedSymbol = R.unwrap_ok[scx.DefinedSymbol, fail.Fail](selected);
     val oa: *ast.Ast = osc.a;
     val octx: *comptime.ComptimeCtx = osc.ctx;
 
-    val od_opt: O.Option[*decl.Decl] = ast.get_decl(oa, sym.decl);
+    val od_opt: O.Option[*decl.Decl] = ast.get_decl(oa, current.symbol.decl);
     if (O.is_none[*decl.Decl](od_opt)) { ret R.err[R.Void, fail.Fail](fail.message("lower: `$each` array sequence is unresolved")); }
     if (O.unwrap[*decl.Decl](od_opt).kind != decl.DECL_KIND_VAL) {
         ret R.err[R.Void, fail.Fail](fail.message("lower: `$each` array sequence must name an immutable `val`"));
     }
 
-    val opt_info: O.Option[comptime.ArrayLitInfo] = comptime.decl_array_lit(oa, sym.decl);
+    val opt_info: O.Option[comptime.ArrayLitInfo] = comptime.decl_array_lit(oa, current.symbol.decl);
     if (O.is_none[comptime.ArrayLitInfo](opt_info)) { ret R.err[R.Void, fail.Fail](fail.message("lower: `$each` array sequence has no array-literal initializer")); }
     val info: comptime.ArrayLitInfo = O.unwrap[comptime.ArrayLitInfo](opt_info);
 
@@ -858,7 +835,7 @@ fun grow_bind_cap(cap: u32) u32 {
 }
 
 fun report_asm(ctx: *context.LowerContext, span: token.Span, message: str) R.Result[R.Void, fail.Fail] {
-    diagnostic.record_error(?ctx.s.diags, ctx.scope.a.file_id, span, message);
+    diagnostic.record_error(ctx.diags, ctx.scope.a.file_id, span, message);
     ret R.err[R.Void, fail.Fail](fail.reported());
 }
 
@@ -872,7 +849,7 @@ fun report_asm_named(ctx: *context.LowerContext, span: token.Span, prefix: str, 
     if (R.is_err[str, str](res_msg)) { ret report_asm(ctx, span, prefix); }
     val buf: str = R.unwrap_ok[str, str](res_msg);
 
-    diagnostic.record_error(?ctx.s.diags, ctx.scope.a.file_id, span, buf);
+    diagnostic.record_error(ctx.diags, ctx.scope.a.file_id, span, buf);
     A.deallocate[u8](ctx.s.alloc, buf::*u8, str_len(buf) + 1);
     ret R.err[R.Void, fail.Fail](fail.reported());
 }

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -607,6 +607,264 @@ pub fun invalidate(db: *QueryDb, kind: QueryKind, key: u64) R.Result[R.Void, str
     ret R.ok_void[str]();
 }
 
+pub rec PreparedRetirement {
+    owner: *QueryDb;
+    operation: u64;
+    revision: Revision;
+    keys: Vector[QueryKey];
+    selected: Map[QueryKey, usize];
+}
+
+rec RetireNode {
+    key: QueryKey;
+    entry: *QueryEntry;
+    first: usize;
+    dependents: usize;
+    selected: bool;
+}
+
+rec RetireEdge {
+    dependent: usize;
+    next: usize;
+}
+
+pub fun discard_retirement(prepared: *PreparedRetirement) {
+    if (prepared.owner == nil) { ret; }
+    vector.dnit[QueryKey](?prepared.keys);
+    map.dnit[QueryKey, usize](?prepared.selected);
+    prepared.owner = nil;
+}
+
+pub fun prepare_retirement(db: *QueryDb, roots: *QueryKey, count: usize) R.Result[PreparedRetirement, str] {
+    if (db == nil || db.operation_active || db.presentation_pending) {
+        ret R.err[PreparedRetirement, str]("cannot prepare query retirement during query use");
+    }
+    if (roots == nil && count != 0) { ret R.err[PreparedRetirement, str]("retirement roots are nil"); }
+    var prepared: PreparedRetirement = PreparedRetirement{
+        owner: db, operation: db.operation_sequence, revision: db.revision,
+        keys: vector.init[QueryKey](db.a), selected: map.init[QueryKey, usize](db.a, query_key_hash, query_key_equal)
+    };
+    var complete: bool = false;
+    fin { if (!complete) { discard_retirement(?prepared); } }
+    var nodes: Vector[RetireNode] = vector.init[RetireNode](db.a);
+    fin { vector.dnit[RetireNode](?nodes); }
+    var edges: Vector[RetireEdge] = vector.init[RetireEdge](db.a);
+    fin { vector.dnit[RetireEdge](?edges); }
+    var pending: Vector[usize] = vector.init[usize](db.a);
+    fin { vector.dnit[usize](?pending); }
+    var index: Map[QueryKey, usize] = map.init[QueryKey, usize](db.a, query_key_hash, query_key_equal);
+    fin { map.dnit[QueryKey, usize](?index); }
+    var kind: u32 = 0;
+    for (kind < db.kinds) {
+        val sh: *QueryShard = ?db.storage[kind];
+        if (sh.entries.editing) { ret R.err[PreparedRetirement, str]("query shard has an active editor"); }
+        var j: usize = 0;
+        for (j < sh.index.len) {
+            val indexed: QueryIndexEntry = sh.index.data[j];
+            val entry: R.Result[*QueryEntry, str] = handle.get[QueryEntry, QueryEntryDomain](?sh.entries, indexed.id);
+            if (R.is_err[*QueryEntry, str](entry)) { ret R.err[PreparedRetirement, str](R.unwrap_err[*QueryEntry, str](entry)); }
+            val key: QueryKey = QueryKey{ kind: kind::QueryKind, key: indexed.key };
+            val added: R.Result[usize, str] = vector.push[RetireNode](?nodes,
+                RetireNode{ key: key, entry: R.unwrap_ok[*QueryEntry, str](entry), first: ~(0::usize) });
+            if (R.is_err[usize, str](added)) { ret R.err[PreparedRetirement, str](R.unwrap_err[usize, str](added)); }
+            val mapped: R.Result[bool, str] = map.insert[QueryKey, usize](?index, key, nodes.len - 1);
+            if (R.is_err[bool, str](mapped)) { ret R.err[PreparedRetirement, str](R.unwrap_err[bool, str](mapped)); }
+            j = j + 1;
+        }
+        kind = kind + 1;
+    }
+    var i: usize = 0;
+    for (i < count) {
+        var key: QueryKey = roots[i];
+        if (key.kind::u32 >= db.kinds || !db.storage[key.kind::u32].registered) {
+            ret R.err[PreparedRetirement, str]("retirement root kind is not registered");
+        }
+        if (R.is_err[*usize, str](map.get[QueryKey, usize](?index, ?key))) {
+            val added: R.Result[usize, str] = vector.push[RetireNode](?nodes,
+                RetireNode{ key: key, first: ~(0::usize) });
+            if (R.is_err[usize, str](added)) { ret R.err[PreparedRetirement, str](R.unwrap_err[usize, str](added)); }
+            val mapped: R.Result[bool, str] = map.insert[QueryKey, usize](?index, key, nodes.len - 1);
+            if (R.is_err[bool, str](mapped)) { ret R.err[PreparedRetirement, str](R.unwrap_err[bool, str](mapped)); }
+        }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < nodes.len) {
+        val entry: *QueryEntry = nodes.data[i].entry;
+        if (entry == nil) { i = i + 1; cnt; }
+        var j: u32 = 0;
+        for (j < entry.dep_len) {
+            var key: QueryKey = QueryKey{ kind: entry.deps[j].kind, key: entry.deps[j].key };
+            val found: R.Result[*usize, str] = map.get[QueryKey, usize](?index, ?key);
+            if (R.is_ok[*usize, str](found)) {
+                val child: usize = @R.unwrap_ok[*usize, str](found);
+                val added: R.Result[usize, str] = vector.push[RetireEdge](?edges,
+                    RetireEdge{ dependent: i, next: nodes.data[child].first });
+                if (R.is_err[usize, str](added)) { ret R.err[PreparedRetirement, str](R.unwrap_err[usize, str](added)); }
+                nodes.data[child].first = edges.len - 1;
+            }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < count) {
+        var key: QueryKey = roots[i];
+        val found: R.Result[*usize, str] = map.get[QueryKey, usize](?index, ?key);
+        if (R.is_ok[*usize, str](found)) {
+            val n: usize = @R.unwrap_ok[*usize, str](found);
+            if (!nodes.data[n].selected) {
+                nodes.data[n].selected = true;
+                val added: R.Result[usize, str] = vector.push[usize](?pending, n);
+                if (R.is_err[usize, str](added)) { ret R.err[PreparedRetirement, str](R.unwrap_err[usize, str](added)); }
+            }
+        }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < pending.len) {
+        var edge: usize = nodes.data[pending.data[i]].first;
+        for (edge != ~(0::usize)) {
+            val n: usize = edges.data[edge].dependent;
+            if (!nodes.data[n].selected) {
+                nodes.data[n].selected = true;
+                val added: R.Result[usize, str] = vector.push[usize](?pending, n);
+                if (R.is_err[usize, str](added)) { ret R.err[PreparedRetirement, str](R.unwrap_err[usize, str](added)); }
+            }
+            edge = edges.data[edge].next;
+        }
+        i = i + 1;
+    }
+    val selected: usize = pending.len;
+    pending.len = 0;
+    i = 0;
+    for (i < nodes.len) {
+        if (nodes.data[i].selected) {
+            var edge: usize = nodes.data[i].first;
+            for (edge != ~(0::usize)) {
+                if (nodes.data[edges.data[edge].dependent].selected) {
+                    nodes.data[i].dependents = nodes.data[i].dependents + 1;
+                }
+                edge = edges.data[edge].next;
+            }
+            if (nodes.data[i].dependents == 0) {
+                val added: R.Result[usize, str] = vector.push[usize](?pending, i);
+                if (R.is_err[usize, str](added)) { ret R.err[PreparedRetirement, str](R.unwrap_err[usize, str](added)); }
+            }
+        }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < pending.len) {
+        val node: RetireNode = nodes.data[pending.data[i]];
+        val added: R.Result[usize, str] = vector.push[QueryKey](?prepared.keys, node.key);
+        if (R.is_err[usize, str](added)) { ret R.err[PreparedRetirement, str](R.unwrap_err[usize, str](added)); }
+        var j: u32 = 0;
+        for (node.entry != nil && j < node.entry.dep_len) {
+            var key: QueryKey = QueryKey{ kind: node.entry.deps[j].kind, key: node.entry.deps[j].key };
+            val found: R.Result[*usize, str] = map.get[QueryKey, usize](?index, ?key);
+            if (R.is_ok[*usize, str](found)) {
+                val child: usize = @R.unwrap_ok[*usize, str](found);
+                if (nodes.data[child].selected) {
+                    nodes.data[child].dependents = nodes.data[child].dependents - 1;
+                    if (nodes.data[child].dependents == 0) {
+                        val queued: R.Result[usize, str] = vector.push[usize](?pending, child);
+                        if (R.is_err[usize, str](queued)) { ret R.err[PreparedRetirement, str](R.unwrap_err[usize, str](queued)); }
+                    }
+                }
+            }
+            j = j + 1;
+        }
+        i = i + 1;
+    }
+    if (prepared.keys.len != selected) { ret R.err[PreparedRetirement, str]("query retirement contains a dependency cycle"); }
+    if (selected != 0 && db.revision == ~(0::Revision)) { ret R.err[PreparedRetirement, str]("query revision sequence exhausted"); }
+    kind = 0;
+    for (kind < db.kinds) {
+        val sh: *QueryShard = ?db.storage[kind];
+        var removals: usize = 0;
+        i = 0;
+        for (i < sh.index.len) {
+            val item: QueryIndexEntry = sh.index.data[i];
+            var key: QueryKey = QueryKey{ kind: kind::QueryKind, key: item.key };
+            val found: R.Result[*usize, str] = map.get[QueryKey, usize](?index, ?key);
+            if (R.is_ok[*usize, str](found) && nodes.data[@R.unwrap_ok[*usize, str](found)].selected) {
+                if (item.id.generation == ~(0::u32)) { ret R.err[PreparedRetirement, str]("query handle generation exhausted"); }
+                removals = removals + 1;
+            }
+            i = i + 1;
+        }
+        if (removals::u64 > (~(0::u64)) - sh.entries.store_epoch) { ret R.err[PreparedRetirement, str]("query shard generation exhausted"); }
+        val reserved: R.Result[usize, str] = vector.reserve[usize](?sh.entries.free_list, removals);
+        if (R.is_err[usize, str](reserved)) { ret R.err[PreparedRetirement, str](R.unwrap_err[usize, str](reserved)); }
+        kind = kind + 1;
+    }
+    i = 0;
+    for (i < nodes.len) {
+        if (!nodes.data[i].selected) {
+            var key: QueryKey = nodes.data[i].key;
+            map.remove[QueryKey, usize](?index, ?key);
+        }
+        i = i + 1;
+    }
+    map.dnit[QueryKey, usize](?prepared.selected);
+    prepared.selected = index;
+    index = map.init[QueryKey, usize](db.a, query_key_hash, query_key_equal);
+    complete = true;
+    ret R.ok[PreparedRetirement, str](prepared);
+}
+
+pub fun validate_retirement(prepared: *PreparedRetirement) R.Result[R.Void, str] {
+    val db: *QueryDb = prepared.owner;
+    if (db == nil || db.operation_active || db.presentation_pending || db.operation_sequence != prepared.operation
+        || db.revision != prepared.revision) { ret R.err[R.Void, str]("prepared query retirement is stale"); }
+    ret R.ok_void[str]();
+}
+
+pub fun commit_retirement(prepared: *PreparedRetirement) R.Result[R.Void, str] {
+    val valid: R.Result[R.Void, str] = validate_retirement(prepared);
+    if (R.is_err[R.Void, str](valid)) { ret valid; }
+    val db: *QueryDb = prepared.owner;
+    if (prepared.keys.len != 0) {
+        db.revision = db.revision + 1;
+        var i: usize = 0;
+        for (i < prepared.keys.len) {
+            val key: QueryKey = prepared.keys.data[i];
+            val sh: *QueryShard = ?db.storage[key.kind::u32];
+            val entry: *QueryEntry = entry_find(sh, key.key);
+            if (entry != nil) { entry_free(db, sh, entry); }
+            i = i + 1;
+        }
+        var kind: u32 = 0;
+        for (kind < db.kinds) {
+            val sh: *QueryShard = ?db.storage[kind];
+            var write: usize = 0;
+            i = 0;
+            for (i < sh.index.len) {
+                val item: QueryIndexEntry = sh.index.data[i];
+                var key: QueryKey = QueryKey{ kind: kind::QueryKind, key: item.key };
+                if (R.is_ok[*usize, str](map.get[QueryKey, usize](?prepared.selected, ?key))) {
+                    var editor: handle.HandleEditor[QueryEntry, QueryEntryDomain] =
+                        R.unwrap_ok[handle.HandleEditor[QueryEntry, QueryEntryDomain], str](handle.edit[QueryEntry, QueryEntryDomain](?sh.entries));
+                    R.unwrap_ok[QueryEntry, str](handle.editor_remove[QueryEntry, QueryEntryDomain](?editor, item.id));
+                    handle.editor_finish[QueryEntry, QueryEntryDomain](?editor);
+                    var removed: u64 = item.key;
+                    map.remove[u64, handle.HandleId[QueryEntryDomain]](?sh.by_key, ?removed);
+                }
+                or {
+                    sh.index.data[write] = item;
+                    write = write + 1;
+                }
+                i = i + 1;
+            }
+            sh.index.len = write;
+            kind = kind + 1;
+        }
+    }
+    discard_retirement(prepared);
+    ret R.ok_void[str]();
+}
+
 # successful end permits serial reads until the next begin, input mutation, or retirement
 pub fun get[T](rt: *QueryRuntime[T], ctx: *T, kind: QueryKind, key: u64) R.Result[QueryView, fail.Fail] {
     val acquired: R.Result[*QueryEntry, fail.Fail] = acquire_entry[T](rt, ctx, kind, key);
@@ -3346,5 +3604,72 @@ test "mach.lang.query.get:validating_a_stale_dependency_records_no_incidental_ed
     var mid_keys: Vector[QueryKey] = R.unwrap_ok[Vector[QueryKey], str](mid);
     fin { vector.dnit[QueryKey](?mid_keys); }
     if (mid_keys.len != 1 || mid_keys.data[0].kind != Q_TOKENIZE) { ret 10; }
+    ret 0;
+}
+
+var t_retire_db: *QueryDb = nil;
+var t_retire_order: u32 = 0;
+var t_retire_inputs_live: bool = true;
+
+fun t_retire_parent(value: *u8, len: u32, a: *A.Allocator) {
+    t_retire_order = t_retire_order * 10 + 1;
+    val child: R.Result[*QueryEntry, str] = peek(t_retire_db, Q_TOKENIZE, 1);
+    if (R.is_err[*QueryEntry, str](child) || R.unwrap_ok[*QueryEntry, str](child).value == nil) {
+        t_retire_inputs_live = false;
+    }
+}
+
+fun t_retire_child(value: *u8, len: u32, a: *A.Allocator) {
+    t_retire_order = t_retire_order * 10 + 2;
+    val input: R.Result[*QueryEntry, str] = peek(t_retire_db, Q_FILE_TEXT, 1);
+    if (R.is_err[*QueryEntry, str](input) || R.unwrap_ok[*QueryEntry, str](input).value == nil) {
+        t_retire_inputs_live = false;
+    }
+}
+
+test "mach.lang.query.retirement:dependents_retire_before_inputs_and_unrelated_roots_survive" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var db: QueryDb = R.unwrap_ok[QueryDb, str](init(?alloc));
+    fin { dnit(?db); t_retire_db = nil; }
+    var ctx: TestQueryContext;
+    if (!t_context_init(?ctx, ?db, T_MODE_PARSE_DEPS)) { ret 1; }
+    fin { t_context_dnit(?ctx); }
+    R.unwrap_ok[R.Void, str](register_input(?db, Q_FILE_TEXT));
+    R.unwrap_ok[R.Void, str](register_derived_owned(?db, Q_TOKENIZE, t_retire_child));
+    R.unwrap_ok[R.Void, str](register_derived_owned(?db, Q_PARSE, t_retire_parent));
+    R.unwrap_ok[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "a"::*u8, 1));
+    R.unwrap_ok[R.Void, str](set_input(?db, Q_FILE_TEXT, 2, "unrelated"::*u8, 9));
+    R.unwrap_ok[*QueryEntry, fail.Fail](t_get(?ctx, Q_PARSE, 1));
+    val unrelated: Revision = peek_revision(?db, Q_FILE_TEXT, 2);
+    t_retire_db = ?db;
+    t_retire_order = 0;
+    t_retire_inputs_live = true;
+    var root: QueryKey = QueryKey{ kind: Q_FILE_TEXT, key: 1 };
+    var prepared: PreparedRetirement = R.unwrap_ok[PreparedRetirement, str](prepare_retirement(?db, ?root, 1));
+    fin { discard_retirement(?prepared); }
+    if (t_retire_order != 0 || shard_len(?db, Q_FILE_TEXT) != 2) { ret 2; }
+    R.unwrap_ok[R.Void, str](commit_retirement(?prepared));
+    if (t_retire_order != 12 || !t_retire_inputs_live) { ret 3; }
+    if (shard_len(?db, Q_PARSE) != 0 || shard_len(?db, Q_TOKENIZE) != 0 || shard_len(?db, Q_FILE_TEXT) != 1) { ret 4; }
+    if (peek_revision(?db, Q_FILE_TEXT, 2) != unrelated || peek_revision(?db, Q_FILE_TEXT, 1) != 0) { ret 5; }
+    ret 0;
+}
+
+test "mach.lang.query.retirement:input_mutation_refuses_a_stale_preparation_without_retiring_owners" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var db: QueryDb = R.unwrap_ok[QueryDb, str](init(?alloc));
+    fin { dnit(?db); }
+    R.unwrap_ok[R.Void, str](register_input(?db, Q_FILE_TEXT));
+    R.unwrap_ok[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "a"::*u8, 1));
+    var root: QueryKey = QueryKey{ kind: Q_FILE_TEXT, key: 1 };
+    var prepared: PreparedRetirement = R.unwrap_ok[PreparedRetirement, str](prepare_retirement(?db, ?root, 1));
+    fin { discard_retirement(?prepared); }
+    R.unwrap_ok[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "b"::*u8, 1));
+    val changed: Revision = peek_revision(?db, Q_FILE_TEXT, 1);
+    if (R.is_ok[R.Void, str](commit_retirement(?prepared))) { ret 1; }
+    if (shard_len(?db, Q_FILE_TEXT) != 1 || peek_revision(?db, Q_FILE_TEXT, 1) != changed) { ret 2; }
+    if (R.unwrap_ok[*QueryEntry, str](peek(?db, Q_FILE_TEXT, 1)).value[0] != 'b'::u8) { ret 3; }
     ret 0;
 }

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -1585,6 +1585,7 @@ fun t_present(ctx: *TestQueryContext, operation: Operation, kind: QueryKind, key
     var root: QueryKey = QueryKey{ kind: kind, key: key };
     val presented: R.Result[*Presentation, str] = collect(ctx.runtime.db, operation, ?root, 1, ctx.diags.a);
     if (R.is_err[*Presentation, str](presented)) { ret R.void_of[*Presentation, str](presented); }
+    presentation_dnit(ctx.last_presentation);
     ctx.last_presentation = R.unwrap_ok[*Presentation, str](presented);
     ret diagnostic.replay_into(?ctx.diags, ?ctx.last_presentation.diags);
 }

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -903,7 +903,6 @@ fun refresh_entry[T](rt: *QueryRuntime[T], ctx: *T, sh: *QueryShard, kind: Query
 
 fun refresh_dependencies[T](rt: *QueryRuntime[T], ctx: *T, entry: *QueryEntry, evidence: *QueryEntry) R.Result[bool, fail.Fail] {
     val db: *QueryDb = rt.db;
-    var same: bool = true;
     var i: u32 = 0;
     for (i < entry.dep_len) {
         val dep: Dep = entry.deps[i];
@@ -919,17 +918,17 @@ fun refresh_dependencies[T](rt: *QueryRuntime[T], ctx: *T, entry: *QueryEntry, e
             val sampled: R.Result[MetadataRevision, fail.Fail] = sample_metadata(db, dep.kind, dep.key);
             if (R.is_err[MetadataRevision, fail.Fail](sampled)) { ret R.err[bool, fail.Fail](R.unwrap_err[MetadataRevision, fail.Fail](sampled)); }
             val current: MetadataRevision = R.unwrap_ok[MetadataRevision, fail.Fail](sampled);
-            if (current.present != dep.present || current.revision != dep.last_changed) { same = false; }
+            if (current.present != dep.present || current.revision != dep.last_changed) { ret R.ok[bool, fail.Fail](false); }
         } or {
             if (sh.role == SHARD_DERIVED) {
                 val child: R.Result[*QueryEntry, fail.Fail] = get_inner[T](rt, ctx, sh, dep.kind, dep.key);
                 if (R.is_err[*QueryEntry, fail.Fail](child)) { ret R.err[bool, fail.Fail](R.unwrap_err[*QueryEntry, fail.Fail](child)); }
             }
-            if (last_changed_get(db, dep.kind, dep.key) != dep.last_changed) { same = false; }
+            if (last_changed_get(db, dep.kind, dep.key) != dep.last_changed) { ret R.ok[bool, fail.Fail](false); }
         }
         i = i + 1;
     }
-    ret R.ok[bool, fail.Fail](same);
+    ret R.ok[bool, fail.Fail](true);
 }
 
 fun stack_push(db: *QueryDb, kind: QueryKind, key: u64, entry: *QueryEntry) R.Result[R.Void, str] {
@@ -1544,6 +1543,7 @@ val T_MODE_DEDUP:      TestComputeMode = 7;
 val T_MODE_AUTO_DEP:   TestComputeMode = 8;
 val T_MODE_OWNED_DIAG: TestComputeMode = 9;
 val T_MODE_DIRECT_TOKENIZE: TestComputeMode = 10;
+val T_MODE_BRANCH: TestComputeMode = 11;
 
 rec TestQueryContext {
     runtime: QueryRuntime[TestQueryContext];
@@ -1708,6 +1708,7 @@ fun t_owned_diag_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator, diag
 
 fun t_dispatch(ctx: *TestQueryContext, kind: QueryKind, key: u64,
                a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
+    if (ctx.mode == T_MODE_BRANCH) { ret t_branch_compute(ctx, kind, key, a, diags); }
     if (ctx.mode == T_MODE_FAIL) { ret t_always_fail(ctx, key, a, diags); }
     if (ctx.mode == T_MODE_TOKENIZE) { ret t_tok_compute(ctx, key, a, diags); }
     if (ctx.mode == T_MODE_OWNED) { ret t_owned_compute(ctx, key, a, diags); }
@@ -2989,5 +2990,55 @@ test "mach.lang.query.reusable:validates_transitive_inputs_without_computing_the
     if (!str_equals(R.unwrap_err[bool, fail.Fail](refused).message, "metadata producer refused")) { ret 14; }
     if (R.is_ok[R.Void, fail.Fail](end(?fixture.db, R.unwrap_ok[Operation, str](retry)))) { ret 15; }
     if (fixture.parent_calls != 2) { ret 16; }
+    ret 0;
+}
+
+
+fun t_branch_compute(ctx: *TestQueryContext, kind: QueryKind, key: u64,
+                     a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
+    val selected: R.Result[QueryView, fail.Fail] = get[TestQueryContext](?ctx.runtime, ctx, Q_FILE_TEXT, key);
+    if (R.is_err[QueryView, fail.Fail](selected)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[QueryView, fail.Fail](selected)); }
+    val branch: u8 = R.unwrap_ok[QueryView, fail.Fail](selected).value[0];
+    if (kind == Q_TOKENIZE && branch != 0) {
+        ret R.err[QueryOutput, fail.Fail](fail.message("the previous branch has no current definition"));
+    }
+    var byte: u8 = branch;
+    if (kind == Q_TOKENIZE) { byte = 77; }
+    or (branch == 0) {
+        val child: R.Result[QueryView, fail.Fail] = get[TestQueryContext](?ctx.runtime, ctx, Q_TOKENIZE, key);
+        if (R.is_err[QueryView, fail.Fail](child)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[QueryView, fail.Fail](child)); }
+        byte = R.unwrap_ok[QueryView, fail.Fail](child).value[0];
+    }
+    val copied: R.Result[*u8, str] = bytes_dup(a, ?byte, 1);
+    if (R.is_err[*u8, str](copied)) { ret fail.lift[QueryOutput](R.err[QueryOutput, str](R.unwrap_err[*u8, str](copied))); }
+    ret R.ok[QueryOutput, fail.Fail](QueryOutput{ bytes: R.unwrap_ok[*u8, str](copied), len: 1 });
+}
+
+test "mach.lang.query.get:changed_selector_does_not_validate_an_obsolete_branch" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    val initialized: R.Result[QueryDb, str] = init(?a);
+    if (R.is_err[QueryDb, str](initialized)) { ret 2; }
+    var db: QueryDb = R.unwrap_ok[QueryDb, str](initialized);
+    fin { dnit(?db); }
+    var ctx: TestQueryContext;
+    if (!t_context_init(?ctx, ?db, T_MODE_BRANCH)) { ret 3; }
+    fin { t_context_dnit(?ctx); }
+    if (R.is_err[R.Void, str](register_input(?db, Q_FILE_TEXT))) { ret 4; }
+    if (R.is_err[R.Void, str](register_derived(?db, Q_TOKENIZE))) { ret 5; }
+    if (R.is_err[R.Void, str](register_derived(?db, Q_PARSE))) { ret 6; }
+    var turn: u32 = 0;
+    for (turn < 4) {
+        var branch: u8 = (turn & 1)::u8;
+        if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, ?branch, 1))) { ret 7; }
+        val reusable_r: R.Result[bool, fail.Fail] = t_reusable(?ctx, Q_PARSE, 1);
+        if (R.is_err[bool, fail.Fail](reusable_r) || R.unwrap_ok[bool, fail.Fail](reusable_r)) { ret 8; }
+        val read: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_PARSE, 1);
+        if (R.is_err[*QueryEntry, fail.Fail](read)) { ret 9; }
+        var expected: u8 = 77;
+        if (branch != 0) { expected = branch; }
+        if (R.unwrap_ok[*QueryEntry, fail.Fail](read).value[0] != expected) { ret 10; }
+        turn = turn + 1;
+    }
     ret 0;
 }

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -3098,3 +3098,253 @@ test "mach.lang.query:equal_owned_candidates_preserve_identity_and_release_once"
     if (t_live != 0) { ret 8; }
     ret code;
 }
+
+rec ChainFixture {
+    db: QueryDb;
+    runtime: QueryRuntime[ChainFixture];
+    presentation: *Presentation;
+    b_calls: u32;
+    c_calls: u32;
+    t_calls: u32;
+    b_constant: bool;
+    b_fail: bool;
+    b_diag: bool;
+}
+
+fun chain_byte(alloc: *A.Allocator, byte: u8) R.Result[QueryOutput, fail.Fail] {
+    val storage: R.Result[*u8, str] = A.allocate[u8](alloc, 1);
+    if (R.is_err[*u8, str](storage)) { ret fail.lift[QueryOutput](R.err[QueryOutput, str](R.unwrap_err[*u8, str](storage))); }
+    val bytes: *u8 = R.unwrap_ok[*u8, str](storage);
+    bytes[0] = byte;
+    ret R.ok[QueryOutput, fail.Fail](QueryOutput{ bytes: bytes, len: 1 });
+}
+
+# a = Q_FILE_TEXT input, b = Q_TOKENIZE over a, c = Q_PARSE over b, t = Q_SEMA over a and the Q_TARGET input
+fun chain_compute(f: *ChainFixture, kind: QueryKind, key: u64,
+                  alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
+    if (kind == Q_TOKENIZE) {
+        f.b_calls = f.b_calls + 1;
+        val a: R.Result[QueryView, fail.Fail] = get[ChainFixture](?f.runtime, f, Q_FILE_TEXT, 1);
+        if (R.is_err[QueryView, fail.Fail](a)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[QueryView, fail.Fail](a)); }
+        if (f.b_diag) {
+            val emitted: R.Result[R.Void, str] = diagnostic.error(diags, 0, token.Span{ offset: 0, len: 1 }, "b changed");
+            if (R.is_err[R.Void, str](emitted)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](emitted))); }
+        }
+        if (f.b_fail) { ret R.err[QueryOutput, fail.Fail](fail.message("b failed")); }
+        var byte: u8 = R.unwrap_ok[QueryView, fail.Fail](a).value[0];
+        if (f.b_constant) { byte = 7; }
+        ret chain_byte(alloc, byte);
+    }
+    if (kind == Q_PARSE) {
+        f.c_calls = f.c_calls + 1;
+        val b: R.Result[QueryView, fail.Fail] = get[ChainFixture](?f.runtime, f, Q_TOKENIZE, 1);
+        if (R.is_err[QueryView, fail.Fail](b)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[QueryView, fail.Fail](b)); }
+        ret chain_byte(alloc, R.unwrap_ok[QueryView, fail.Fail](b).value[0] + 1);
+    }
+    if (kind == Q_SEMA) {
+        f.t_calls = f.t_calls + 1;
+        val a: R.Result[QueryView, fail.Fail] = get[ChainFixture](?f.runtime, f, Q_FILE_TEXT, 1);
+        if (R.is_err[QueryView, fail.Fail](a)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[QueryView, fail.Fail](a)); }
+        val target: R.Result[QueryView, fail.Fail] = get[ChainFixture](?f.runtime, f, Q_TARGET, 0);
+        if (R.is_err[QueryView, fail.Fail](target)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[QueryView, fail.Fail](target)); }
+        ret chain_byte(alloc, R.unwrap_ok[QueryView, fail.Fail](a).value[0] + R.unwrap_ok[QueryView, fail.Fail](target).value[0]);
+    }
+    if (kind == Q_LOWER) {
+        val c: R.Result[QueryView, fail.Fail] = get[ChainFixture](?f.runtime, f, Q_PARSE, 1);
+        if (R.is_err[QueryView, fail.Fail](c)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[QueryView, fail.Fail](c)); }
+        ret chain_byte(alloc, R.unwrap_ok[QueryView, fail.Fail](c).value[0]);
+    }
+    ret R.err[QueryOutput, fail.Fail](fail.message("chain fixture has no such query"));
+}
+
+fun chain_init(f: *ChainFixture, alloc: *A.Allocator) R.Result[R.Void, str] {
+    val initialized: R.Result[QueryDb, str] = init(alloc);
+    if (R.is_err[QueryDb, str](initialized)) { ret R.void_of[QueryDb, str](initialized); }
+    f.db = R.unwrap_ok[QueryDb, str](initialized);
+    f.presentation = nil;
+    f.b_calls = 0;
+    f.c_calls = 0;
+    f.t_calls = 0;
+    f.b_constant = false;
+    f.b_fail = false;
+    f.b_diag = false;
+    val configured: R.Result[QueryRuntime[ChainFixture], str] = runtime[ChainFixture](?f.db, chain_compute);
+    if (R.is_err[QueryRuntime[ChainFixture], str](configured)) { dnit(?f.db); ret R.void_of[QueryRuntime[ChainFixture], str](configured); }
+    f.runtime = R.unwrap_ok[QueryRuntime[ChainFixture], str](configured);
+    if (R.is_err[R.Void, str](register_input(?f.db, Q_FILE_TEXT)) || R.is_err[R.Void, str](register_input(?f.db, Q_TARGET))
+        || R.is_err[R.Void, str](register_derived(?f.db, Q_TOKENIZE)) || R.is_err[R.Void, str](register_derived(?f.db, Q_PARSE))
+        || R.is_err[R.Void, str](register_derived(?f.db, Q_SEMA)) || R.is_err[R.Void, str](register_derived(?f.db, Q_LOWER))) {
+        dnit(?f.db);
+        ret R.err[R.Void, str]("chain fixture registration failed");
+    }
+    ret set_input(?f.db, Q_FILE_TEXT, 1, "a"::*u8, 1);
+}
+
+fun chain_dnit(f: *ChainFixture) {
+    presentation_dnit(f.presentation);
+    f.presentation = nil;
+    dnit(?f.db);
+}
+
+# one operation: read the root, end, and keep its presentation for inspection
+fun chain_get(f: *ChainFixture, kind: QueryKind, key: u64) R.Result[QueryView, fail.Fail] {
+    presentation_dnit(f.presentation);
+    f.presentation = nil;
+    val opened: R.Result[Operation, str] = begin(?f.db);
+    if (R.is_err[Operation, str](opened)) { ret fail.lift[QueryView](R.err[QueryView, str](R.unwrap_err[Operation, str](opened))); }
+    val operation: Operation = R.unwrap_ok[Operation, str](opened);
+    val result: R.Result[QueryView, fail.Fail] = get[ChainFixture](?f.runtime, f, kind, key);
+    val closed: R.Result[R.Void, fail.Fail] = end(?f.db, operation);
+    var root: QueryKey = QueryKey{ kind: kind, key: key };
+    val presented: R.Result[*Presentation, str] = collect(?f.db, operation, ?root, 1, f.db.a);
+    if (R.is_err[*Presentation, str](presented)) { ret fail.lift[QueryView](R.err[QueryView, str](R.unwrap_err[*Presentation, str](presented))); }
+    f.presentation = R.unwrap_ok[*Presentation, str](presented);
+    if (R.is_err[QueryView, fail.Fail](result)) { ret result; }
+    if (R.is_err[R.Void, fail.Fail](closed)) { ret R.err[QueryView, fail.Fail](R.unwrap_err[R.Void, fail.Fail](closed)); }
+    ret result;
+}
+
+fun chain_reusable(f: *ChainFixture, kind: QueryKind, key: u64) R.Result[bool, fail.Fail] {
+    val opened: R.Result[Operation, str] = begin(?f.db);
+    if (R.is_err[Operation, str](opened)) { ret fail.lift[bool](R.err[bool, str](R.unwrap_err[Operation, str](opened))); }
+    val operation: Operation = R.unwrap_ok[Operation, str](opened);
+    val result: R.Result[bool, fail.Fail] = reusable[ChainFixture](?f.runtime, f, kind, key);
+    val closed: R.Result[R.Void, fail.Fail] = end(?f.db, operation);
+    val released: R.Result[R.Void, str] = discard(?f.db, operation);
+    if (R.is_err[bool, fail.Fail](result)) { ret result; }
+    if (R.is_err[R.Void, fail.Fail](closed)) { ret R.err[bool, fail.Fail](R.unwrap_err[R.Void, fail.Fail](closed)); }
+    if (R.is_err[R.Void, str](released)) { ret fail.lift[bool](R.err[bool, str](R.unwrap_err[R.Void, str](released))); }
+    ret result;
+}
+
+test "mach.lang.query.get:a_change_below_b_refreshes_c_through_b" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var f: ChainFixture;
+    if (R.is_err[R.Void, str](chain_init(?f, ?alloc))) { ret 2; }
+    fin { chain_dnit(?f); }
+    val cold: R.Result[QueryView, fail.Fail] = chain_get(?f, Q_PARSE, 1);
+    if (R.is_err[QueryView, fail.Fail](cold) || R.unwrap_ok[QueryView, fail.Fail](cold).value[0] != 'a'::u8 + 1) { ret 3; }
+    if (f.b_calls != 1 || f.c_calls != 1) { ret 4; }
+    val c_before: Revision = peek_revision(?f.db, Q_PARSE, 1);
+    val b_before: Revision = peek_revision(?f.db, Q_TOKENIZE, 1);
+    if (R.is_err[R.Void, str](set_input(?f.db, Q_FILE_TEXT, 1, "b"::*u8, 1))) { ret 5; }
+    val stale: R.Result[bool, fail.Fail] = chain_reusable(?f, Q_PARSE, 1);
+    if (R.is_err[bool, fail.Fail](stale) || R.unwrap_ok[bool, fail.Fail](stale)) { ret 6; }
+    val warm: R.Result[QueryView, fail.Fail] = chain_get(?f, Q_PARSE, 1);
+    if (R.is_err[QueryView, fail.Fail](warm) || R.unwrap_ok[QueryView, fail.Fail](warm).value[0] != 'b'::u8 + 1) { ret 7; }
+    if (f.b_calls != 2 || f.c_calls != 2) { ret 8; }
+    if (peek_revision(?f.db, Q_PARSE, 1) <= c_before || peek_revision(?f.db, Q_TOKENIZE, 1) <= b_before) { ret 9; }
+    val same: R.Result[QueryView, fail.Fail] = chain_get(?f, Q_PARSE, 1);
+    if (R.is_err[QueryView, fail.Fail](same) || f.b_calls != 2 || f.c_calls != 2) { ret 10; }
+    ret 0;
+}
+
+test "mach.lang.query.get:an_equal_recomputed_b_cuts_off_c" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var f: ChainFixture;
+    if (R.is_err[R.Void, str](chain_init(?f, ?alloc))) { ret 2; }
+    fin { chain_dnit(?f); }
+    f.b_constant = true;
+    val cold: R.Result[QueryView, fail.Fail] = chain_get(?f, Q_PARSE, 1);
+    if (R.is_err[QueryView, fail.Fail](cold) || R.unwrap_ok[QueryView, fail.Fail](cold).value[0] != 8) { ret 3; }
+    val c_before: Revision = peek_revision(?f.db, Q_PARSE, 1);
+    val b_before: Revision = peek_revision(?f.db, Q_TOKENIZE, 1);
+    if (R.is_err[R.Void, str](set_input(?f.db, Q_FILE_TEXT, 1, "b"::*u8, 1))) { ret 4; }
+    val warm: R.Result[QueryView, fail.Fail] = chain_get(?f, Q_PARSE, 1);
+    if (R.is_err[QueryView, fail.Fail](warm) || R.unwrap_ok[QueryView, fail.Fail](warm).value[0] != 8) { ret 5; }
+    if (f.b_calls != 2 || f.c_calls != 1) { ret 6; }
+    if (peek_revision(?f.db, Q_PARSE, 1) != c_before || peek_revision(?f.db, Q_TOKENIZE, 1) != b_before) { ret 7; }
+    ret 0;
+}
+
+test "mach.lang.query.get:a_failed_b_cannot_leave_a_stale_successful_c" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var f: ChainFixture;
+    if (R.is_err[R.Void, str](chain_init(?f, ?alloc))) { ret 2; }
+    fin { chain_dnit(?f); }
+    if (R.is_err[QueryView, fail.Fail](chain_get(?f, Q_PARSE, 1))) { ret 3; }
+    if (R.is_err[R.Void, str](set_input(?f.db, Q_FILE_TEXT, 1, "b"::*u8, 1))) { ret 4; }
+    f.b_fail = true;
+    val failed: R.Result[QueryView, fail.Fail] = chain_get(?f, Q_PARSE, 1);
+    if (!R.is_err[QueryView, fail.Fail](failed) || !str_contains(R.unwrap_err[QueryView, fail.Fail](failed).message, "b failed")) { ret 5; }
+    if (f.b_calls != 2 || f.c_calls != 1) { ret 6; }
+    val still: R.Result[bool, fail.Fail] = chain_reusable(?f, Q_PARSE, 1);
+    if (R.is_ok[bool, fail.Fail](still) && R.unwrap_ok[bool, fail.Fail](still)) { ret 7; }
+    val again: R.Result[QueryView, fail.Fail] = chain_get(?f, Q_PARSE, 1);
+    if (!R.is_err[QueryView, fail.Fail](again) || f.c_calls != 1) { ret 8; }
+    f.b_fail = false;
+    val recovered: R.Result[QueryView, fail.Fail] = chain_get(?f, Q_PARSE, 1);
+    if (R.is_err[QueryView, fail.Fail](recovered) || R.unwrap_ok[QueryView, fail.Fail](recovered).value[0] != 'b'::u8 + 1) { ret 9; }
+    if (f.b_calls != 5 || f.c_calls != 2) { ret 10; }
+    ret 0;
+}
+
+test "mach.lang.query.publish:changed_diagnostics_with_equal_bytes_are_observable" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var f: ChainFixture;
+    if (R.is_err[R.Void, str](chain_init(?f, ?alloc))) { ret 2; }
+    fin { chain_dnit(?f); }
+    f.b_constant = true;
+    if (R.is_err[QueryView, fail.Fail](chain_get(?f, Q_PARSE, 1))) { ret 3; }
+    if (diagnostic.len(?f.presentation.diags) != 0) { ret 4; }
+    val b_before: Revision = peek_revision(?f.db, Q_TOKENIZE, 1);
+    if (R.is_err[R.Void, str](set_input(?f.db, Q_FILE_TEXT, 1, "b"::*u8, 1))) { ret 5; }
+    f.b_diag = true;
+    val warm: R.Result[QueryView, fail.Fail] = chain_get(?f, Q_PARSE, 1);
+    if (R.is_err[QueryView, fail.Fail](warm) || R.unwrap_ok[QueryView, fail.Fail](warm).value[0] != 8) { ret 6; }
+    if (diagnostic.len(?f.presentation.diags) != 1 || !str_contains(f.presentation.diags.items.data[0].message, "b changed")) { ret 7; }
+    if (peek_revision(?f.db, Q_TOKENIZE, 1) == b_before) { ret 8; }
+    val replayed: R.Result[QueryView, fail.Fail] = chain_get(?f, Q_PARSE, 1);
+    if (R.is_err[QueryView, fail.Fail](replayed) || diagnostic.len(?f.presentation.diags) != 1) { ret 9; }
+    if (f.b_calls != 2) { ret 10; }
+    ret 0;
+}
+
+test "mach.lang.query.get:a_selected_target_change_invalidates_products_that_read_it" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var f: ChainFixture;
+    if (R.is_err[R.Void, str](chain_init(?f, ?alloc))) { ret 2; }
+    fin { chain_dnit(?f); }
+    if (R.is_err[R.Void, str](set_input(?f.db, Q_TARGET, 0, "\x01"::*u8, 1))) { ret 3; }
+    val host: R.Result[QueryView, fail.Fail] = chain_get(?f, Q_SEMA, 1);
+    if (R.is_err[QueryView, fail.Fail](host) || R.unwrap_ok[QueryView, fail.Fail](host).value[0] != 'a'::u8 + 1) { ret 4; }
+    val before: Revision = peek_revision(?f.db, Q_SEMA, 1);
+    if (R.is_err[R.Void, str](set_input(?f.db, Q_TARGET, 0, "\x02"::*u8, 1))) { ret 5; }
+    val stale: R.Result[bool, fail.Fail] = chain_reusable(?f, Q_SEMA, 1);
+    if (R.is_err[bool, fail.Fail](stale) || R.unwrap_ok[bool, fail.Fail](stale)) { ret 6; }
+    val other: R.Result[QueryView, fail.Fail] = chain_get(?f, Q_SEMA, 1);
+    if (R.is_err[QueryView, fail.Fail](other) || R.unwrap_ok[QueryView, fail.Fail](other).value[0] != 'a'::u8 + 2) { ret 7; }
+    if (f.t_calls != 2 || peek_revision(?f.db, Q_SEMA, 1) <= before) { ret 8; }
+    if (R.is_err[R.Void, str](set_input(?f.db, Q_TARGET, 0, "\x02"::*u8, 1))) { ret 9; }
+    if (R.is_err[QueryView, fail.Fail](chain_get(?f, Q_SEMA, 1)) || f.t_calls != 2) { ret 10; }
+    ret 0;
+}
+
+test "mach.lang.query.get:validating_a_stale_dependency_records_no_incidental_edge" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var f: ChainFixture;
+    if (R.is_err[R.Void, str](chain_init(?f, ?alloc))) { ret 2; }
+    fin { chain_dnit(?f); }
+    f.b_constant = true;
+    if (R.is_err[QueryView, fail.Fail](chain_get(?f, Q_PARSE, 1))) { ret 3; }
+    if (R.is_err[R.Void, str](set_input(?f.db, Q_FILE_TEXT, 1, "b"::*u8, 1))) { ret 4; }
+    if (R.is_err[QueryView, fail.Fail](chain_get(?f, Q_LOWER, 1))) { ret 5; }
+    if (f.b_calls != 2 || f.c_calls != 1) { ret 6; }
+    val root: R.Result[Vector[QueryKey], str] = cached_dependency_keys(?f.db, Q_LOWER, 1, ?alloc);
+    if (R.is_err[Vector[QueryKey], str](root)) { ret 7; }
+    var root_keys: Vector[QueryKey] = R.unwrap_ok[Vector[QueryKey], str](root);
+    fin { vector.dnit[QueryKey](?root_keys); }
+    if (root_keys.len != 1 || root_keys.data[0].kind != Q_PARSE) { ret 8; }
+    val mid: R.Result[Vector[QueryKey], str] = cached_dependency_keys(?f.db, Q_PARSE, 1, ?alloc);
+    if (R.is_err[Vector[QueryKey], str](mid)) { ret 9; }
+    var mid_keys: Vector[QueryKey] = R.unwrap_ok[Vector[QueryKey], str](mid);
+    fin { vector.dnit[QueryKey](?mid_keys); }
+    if (mid_keys.len != 1 || mid_keys.data[0].kind != Q_TOKENIZE) { ret 10; }
+    ret 0;
+}

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -5,14 +5,15 @@ use std.collections.vector;
 use std.collections.vector.Vector;
 use std.format;
 use std.memory;
+use std.text.string.str_dup;
+use std.text.string.str_free;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
-use std.types.char.char;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_contains;
-use std.types.string.str_len;
+use std.types.string.str_equals;
 
 use A: std.allocator;
 use O: std.types.option;
@@ -58,7 +59,54 @@ pub val SHARD_METADATA: ShardRole = 2;
 
 pub def FinalizeFn: fun(*u8, u32, *A.Allocator);
 
-pub def RevisionFn: fun(u64) Revision;
+pub rec MetadataRevision {
+    present: bool;
+    revision: Revision;
+}
+
+pub def RevisionFn: fun(ptr, u64) R.Result[MetadataRevision, fail.Fail];
+
+pub rec RevisionProvider {
+    context: ptr;
+    read: RevisionFn;
+}
+
+pub rec QueryKey {
+    kind: QueryKind;
+    key: u64;
+}
+
+pub rec Operation {
+    owner: ptr;
+    sequence: u64;
+}
+
+pub rec PreparedQuery {
+    operation: Operation;
+    key: QueryKey;
+}
+
+pub rec Presentation {
+    alloc: *A.Allocator;
+    diags: diagnostic.DiagnosticStore;
+    failure: O.Option[fail.Fail];
+    message: str;
+    message_alloc: *A.Allocator;
+}
+
+rec MetadataSample {
+    key: QueryKey;
+    value: MetadataRevision;
+}
+
+rec Attempt {
+    key: QueryKey;
+    prepared: *QueryEntry;
+    fresh: bool;
+    cancelled: bool;
+    failed: bool;
+    evidence: QueryEntry;
+}
 
 pub rec QueryOutput {
     bytes: *u8;
@@ -69,9 +117,18 @@ pub rec Dep {
     kind:         QueryKind;
     key:          u64;
     last_changed: Revision;
+    diagnostics_changed: Revision;
+    present: bool;
+    observed: bool;
 }
 
-pub rec QueryEntry {
+pub rec QueryView {
+    value: *u8;
+    value_len: u32;
+    last_changed: Revision;
+}
+
+rec QueryEntry {
     key:          u64;
     value:        *u8;
     value_len:    u32;
@@ -80,6 +137,8 @@ pub rec QueryEntry {
     dep_len:      u32;
     dep_cap:      u32;
     diags:        *diagnostic.DiagnosticStore;
+    diagnostics_changed: Revision;
+    ready: bool;
 }
 
 pub rec QueryEntryDomain {}
@@ -98,7 +157,7 @@ rec StackFrame {
 pub rec QueryShard {
     kind:       QueryKind;
     role:       ShardRole;
-    revisions:  RevisionFn;
+    revisions:  RevisionProvider;
     finalize:   FinalizeFn;
     registered: bool;
     entries:    handle.HandleTable[QueryEntry, QueryEntryDomain];
@@ -114,15 +173,25 @@ pub rec QueryDb {
     kinds:        u32;
     compute_depth: u32;
     stack:        Vector[StackFrame];
+    prepared_count: usize;
+    operation_sequence: u64;
+    operation_active: bool;
+    presentation_pending: bool;
+    operation_failure: O.Option[fail.Fail];
+    operation_message: str;
+    attempts: Vector[Attempt];
+    attempt_index: Map[QueryKey, usize];
+    validated: Map[QueryKey, Revision];
+    metadata: Vector[MetadataSample];
+    metadata_index: Map[QueryKey, usize];
 }
 
 pub rec QueryCapabilities[T] {
-    compute: fun(*T, QueryKind, u64, *A.Allocator) R.Result[QueryOutput, fail.Fail];
+    compute: fun(*T, QueryKind, u64, *A.Allocator, *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail];
 }
 
 pub rec QueryRuntime[T] {
     db:    *QueryDb;
-    diags: *diagnostic.DiagnosticStore;
     caps:  QueryCapabilities[T];
 }
 
@@ -139,11 +208,27 @@ pub fun init(a: *A.Allocator) R.Result[QueryDb, str] {
     db.kinds         = 0;
     db.compute_depth = 0;
     db.stack         = vector.init[StackFrame](a);
+    db.prepared_count = 0;
+    db.operation_sequence = 0;
+    db.operation_active = false;
+    db.presentation_pending = false;
+    db.operation_failure = O.none[fail.Fail]();
+    db.operation_message = nil;
+    db.attempts = vector.init[Attempt](a);
+    db.attempt_index = map.init[QueryKey, usize](a, query_key_hash, query_key_equal);
+    db.validated = map.init[QueryKey, Revision](a, query_key_hash, query_key_equal);
+    db.metadata = vector.init[MetadataSample](a);
+    db.metadata_index = map.init[QueryKey, usize](a, query_key_hash, query_key_equal);
     ret R.ok[QueryDb, str](db);
 }
 
 pub fun dnit(db: *QueryDb) {
     if (db == nil) { ret; }
+
+    attempts_clear(db);
+    if (db.operation_message != nil) { str_free(db.a, db.operation_message); db.operation_message = nil; }
+    vector.dnit[Attempt](?db.attempts);
+    map.dnit[QueryKey, usize](?db.attempt_index);
 
     if (db.storage != nil) {
         var i: u32 = 0;
@@ -157,6 +242,10 @@ pub fun dnit(db: *QueryDb) {
     }
 
     vector.dnit[StackFrame](?db.stack);
+    map.dnit[QueryKey, Revision](?db.validated);
+    vector.dnit[MetadataSample](?db.metadata);
+    map.dnit[QueryKey, usize](?db.metadata_index);
+    db.operation_active = false;
 
     db.storage     = nil;
     db.storage_cap = 0;
@@ -165,15 +254,15 @@ pub fun dnit(db: *QueryDb) {
 }
 
 pub fun register_input(db: *QueryDb, kind: QueryKind) R.Result[R.Void, str] {
-    ret register(db, kind, SHARD_INPUT, nil::RevisionFn);
+    ret register(db, kind, SHARD_INPUT, RevisionProvider{});
 }
 
 pub fun register_derived(db: *QueryDb, kind: QueryKind) R.Result[R.Void, str] {
-    ret register(db, kind, SHARD_DERIVED, nil::RevisionFn);
+    ret register(db, kind, SHARD_DERIVED, RevisionProvider{});
 }
 
 pub fun register_derived_owned(db: *QueryDb, kind: QueryKind, finalize: FinalizeFn) R.Result[R.Void, str] {
-    val res_register: R.Result[R.Void, str] = register(db, kind, SHARD_DERIVED, nil::RevisionFn);
+    val res_register: R.Result[R.Void, str] = register(db, kind, SHARD_DERIVED, RevisionProvider{});
     if (R.is_err[R.Void, str](res_register)) { ret res_register; }
 
     val sh: *QueryShard = ?db.storage[kind::u32];
@@ -181,22 +270,278 @@ pub fun register_derived_owned(db: *QueryDb, kind: QueryKind, finalize: Finalize
     ret R.ok_void[str]();
 }
 
-pub fun register_metadata(db: *QueryDb, kind: QueryKind, lookup: RevisionFn) R.Result[R.Void, str] {
-    ret register(db, kind, SHARD_METADATA, lookup);
+pub fun register_metadata(db: *QueryDb, kind: QueryKind, provider: RevisionProvider) R.Result[R.Void, str] {
+    if (provider.read == nil) { ret R.err[R.Void, str]("metadata query requires a revision provider"); }
+    ret register(db, kind, SHARD_METADATA, provider);
 }
 
-pub fun runtime[T](db: *QueryDb, diags: *diagnostic.DiagnosticStore,
-                   compute: fun(*T, QueryKind, u64, *A.Allocator) R.Result[QueryOutput, fail.Fail]) R.Result[QueryRuntime[T], str] {
+pub fun runtime[T](db: *QueryDb, compute: fun(*T, QueryKind, u64, *A.Allocator, *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail]) R.Result[QueryRuntime[T], str] {
     if (db == nil) { ret R.err[QueryRuntime[T], str]("query runtime requires a database"); }
-    if (diags == nil) { ret R.err[QueryRuntime[T], str]("query runtime requires a diagnostic store"); }
     if (compute == nil) { ret R.err[QueryRuntime[T], str]("query runtime requires a compute capability"); }
     var caps: QueryCapabilities[T];
     caps.compute = compute;
     var rt: QueryRuntime[T];
     rt.db    = db;
-    rt.diags = diags;
     rt.caps  = caps;
     ret R.ok[QueryRuntime[T], str](rt);
+}
+
+fun query_key_hash(raw: ptr) u64 {
+    val key: *QueryKey = raw::*QueryKey;
+    var mixed: u64 = key.key ^ (key.kind::u64 * 0x9e3779b97f4a7c15);
+    mixed = (mixed ^ (mixed >> 30)) * 0xbf58476d1ce4e5b9;
+    mixed = (mixed ^ (mixed >> 27)) * 0x94d049bb133111eb;
+    ret mixed ^ (mixed >> 31);
+}
+
+fun query_key_equal(left: ptr, right: ptr) bool {
+    val a: *QueryKey = left::*QueryKey;
+    val b: *QueryKey = right::*QueryKey;
+    ret a.kind == b.kind && a.key == b.key;
+}
+
+pub fun begin(db: *QueryDb) R.Result[Operation, str] {
+    if (db == nil) { ret R.err[Operation, str]("query operation requires a database"); }
+    if (db.operation_active || db.stack.len != 0) { ret R.err[Operation, str]("query operation is already active"); }
+    if (db.presentation_pending) { ret R.err[Operation, str]("collect or discard the previous query presentation first"); }
+    if (db.operation_sequence == ~(0::u64)) { ret R.err[Operation, str]("query operation sequence exhausted"); }
+    map.clear[QueryKey, Revision](?db.validated);
+    map.clear[QueryKey, usize](?db.metadata_index);
+    db.metadata.len = 0;
+    db.operation_sequence = db.operation_sequence + 1;
+    db.operation_active = true;
+    db.operation_failure = O.none[fail.Fail]();
+    ret R.ok[Operation, str](Operation{ owner: db::ptr, sequence: db.operation_sequence });
+}
+
+pub fun end(db: *QueryDb, operation: Operation) R.Result[R.Void, fail.Fail] {
+    if (db == nil || operation.owner != db::ptr || !db.operation_active || operation.sequence != db.operation_sequence) {
+        ret R.err[R.Void, fail.Fail](fail.message("query operation is stale or belongs to another database"));
+    }
+    if (db.stack.len != 0) { ret R.err[R.Void, fail.Fail](fail.message("cannot end a query operation during computation")); }
+    if (db.prepared_count != 0) { ret R.err[R.Void, fail.Fail](fail.message("cannot end a query operation with unfinished prepared products")); }
+    fin {
+        db.operation_active = false;
+        db.presentation_pending = true;
+    }
+    if (O.is_some[fail.Fail](db.operation_failure)) { ret R.err[R.Void, fail.Fail](O.unwrap[fail.Fail](db.operation_failure)); }
+    var i: usize = 0;
+    for (i < db.metadata.len) {
+        val sample: MetadataSample = db.metadata.data[i];
+        val provider: RevisionProvider = db.storage[sample.key.kind::u32].revisions;
+        val current: R.Result[MetadataRevision, fail.Fail] = provider.read(provider.context, sample.key.key);
+        if (R.is_err[MetadataRevision, fail.Fail](current)) {
+            operation_fail(db, R.unwrap_err[MetadataRevision, fail.Fail](current));
+            ret R.err[R.Void, fail.Fail](O.unwrap[fail.Fail](db.operation_failure));
+        }
+        val value: MetadataRevision = R.unwrap_ok[MetadataRevision, fail.Fail](current);
+        if (value.present != sample.value.present || value.revision != sample.value.revision) {
+            operation_fail(db, fail.message("external query metadata changed during the operation"));
+            ret R.err[R.Void, fail.Fail](O.unwrap[fail.Fail](db.operation_failure));
+        }
+        i = i + 1;
+    }
+    ret R.ok_void[fail.Fail]();
+}
+
+fun operation_fail(db: *QueryDb, failure: fail.Fail) {
+    if (O.is_some[fail.Fail](db.operation_failure)
+        && (O.unwrap[fail.Fail](db.operation_failure).kind == fail.MESSAGE || failure.kind == fail.REPORTED)) { ret; }
+    if (failure.kind == fail.REPORTED) { db.operation_failure = O.some[fail.Fail](failure); ret; }
+    val copied: R.Result[str, str] = str_dup(db.a, failure.message);
+    if (R.is_err[str, str](copied)) {
+        db.operation_failure = O.some[fail.Fail](fail.message(R.unwrap_err[str, str](copied)));
+        ret;
+    }
+    db.operation_message = R.unwrap_ok[str, str](copied);
+    db.operation_failure = O.some[fail.Fail](fail.message(db.operation_message));
+}
+
+fun attempt_prepare(db: *QueryDb, key: QueryKey) R.Result[usize, str] {
+    var lookup: QueryKey = key;
+    val prior: R.Result[*usize, str] = map.get[QueryKey, usize](?db.attempt_index, ?lookup);
+    if (R.is_ok[*usize, str](prior)) { ret R.ok[usize, str](@R.unwrap_ok[*usize, str](prior)); }
+    val index: usize = db.attempts.len;
+    val added: R.Result[usize, str] = vector.push[Attempt](?db.attempts, Attempt{ key: key });
+    if (R.is_err[usize, str](added)) { ret added; }
+    val indexed: R.Result[bool, str] = map.insert[QueryKey, usize](?db.attempt_index, key, index);
+    if (R.is_err[bool, str](indexed)) {
+        db.attempts.len = index;
+        ret R.err[usize, str](R.unwrap_err[bool, str](indexed));
+    }
+    ret R.ok[usize, str](index);
+}
+
+fun attempt_preserve(db: *QueryDb, sh: *QueryShard, index: usize, candidate: *QueryEntry) {
+    val attempt: *Attempt = ?db.attempts.data[index];
+    attempt.failed = true;
+    attempt.evidence.deps = candidate.deps;
+    attempt.evidence.dep_len = candidate.dep_len;
+    attempt.evidence.dep_cap = candidate.dep_cap;
+    attempt.evidence.diags = candidate.diags;
+    candidate.deps = nil;
+    candidate.dep_len = 0;
+    candidate.dep_cap = 0;
+    candidate.diags = nil;
+    entry_free(db, sh, candidate);
+}
+
+fun attempts_clear(db: *QueryDb) {
+    var i: usize = 0;
+    for (i < db.attempts.len) {
+        val attempt: *Attempt = ?db.attempts.data[i];
+        if (attempt.prepared != nil) {
+            entry_free(db, ?db.storage[attempt.key.kind::u32], attempt.prepared);
+            A.deallocate[QueryEntry](db.a, attempt.prepared, 1);
+        }
+        entry_free(db, ?db.storage[attempt.key.kind::u32], ?attempt.evidence);
+        i = i + 1;
+    }
+    db.attempts.len = 0;
+    db.prepared_count = 0;
+    map.clear[QueryKey, usize](?db.attempt_index);
+}
+
+pub fun discard(db: *QueryDb, operation: Operation) R.Result[R.Void, str] {
+    if (db == nil || operation.owner != db::ptr || operation.sequence != db.operation_sequence
+        || db.operation_active || !db.presentation_pending) {
+        ret R.err[R.Void, str]("query presentation is stale or not ready");
+    }
+    attempts_clear(db);
+    if (db.operation_message != nil) { str_free(db.a, db.operation_message); db.operation_message = nil; }
+    map.clear[QueryKey, Revision](?db.validated);
+    map.clear[QueryKey, usize](?db.metadata_index);
+    db.metadata.len = 0;
+    db.operation_failure = O.none[fail.Fail]();
+    db.presentation_pending = false;
+    ret R.ok_void[str]();
+}
+
+# the caller takes the optional string allocated by db.a before discarding a failed collection
+pub fun take_failure_message(db: *QueryDb, operation: Operation) R.Result[str, str] {
+    if (db == nil || operation.owner != db::ptr || operation.sequence != db.operation_sequence
+        || db.operation_active || !db.presentation_pending) {
+        ret R.err[str, str]("query failure message is stale or not ready");
+    }
+    val message: str = db.operation_message;
+    db.operation_message = nil;
+    ret R.ok[str, str](message);
+}
+
+pub fun collect(db: *QueryDb, operation: Operation, roots: *QueryKey, count: usize,
+                a: *A.Allocator) R.Result[*Presentation, str] {
+    if (db == nil || operation.owner != db::ptr || operation.sequence != db.operation_sequence
+        || db.operation_active || !db.presentation_pending) {
+        ret R.err[*Presentation, str]("query presentation is stale or not ready");
+    }
+    if (roots == nil && count != 0) { ret R.err[*Presentation, str]("query presentation roots are nil"); }
+    val allocated: R.Result[*Presentation, str] = A.allocate[Presentation](a, 1);
+    if (R.is_err[*Presentation, str](allocated)) { ret allocated; }
+    val result: *Presentation = R.unwrap_ok[*Presentation, str](allocated);
+    result.alloc = a;
+    result.diags = diagnostic.store_init(a);
+    result.failure = O.none[fail.Fail]();
+    result.message = nil;
+    result.message_alloc = db.a;
+    val store: *diagnostic.DiagnosticStore = ?result.diags;
+    var complete: bool = false;
+    fin {
+        if (!complete) {
+            presentation_dnit(result);
+        }
+    }
+    var visited: Map[QueryKey, u8] = map.init[QueryKey, u8](a, query_key_hash, query_key_equal);
+    fin { map.dnit[QueryKey, u8](?visited); }
+    var i: usize = 0;
+    for (i < count) {
+        val copied: R.Result[R.Void, str] = collect_node(db, roots[i], ?visited, store);
+        if (R.is_err[R.Void, str](copied)) { ret R.err[*Presentation, str](R.unwrap_err[R.Void, str](copied)); }
+        i = i + 1;
+    }
+    result.failure = db.operation_failure;
+    result.message = db.operation_message;
+    db.operation_message = nil;
+    val released: R.Result[R.Void, str] = discard(db, operation);
+    if (R.is_err[R.Void, str](released)) { ret R.err[*Presentation, str](R.unwrap_err[R.Void, str](released)); }
+    complete = true;
+    ret R.ok[*Presentation, str](result);
+}
+
+pub fun presentation_dnit(p: *Presentation) {
+    if (p == nil) { ret; }
+    val a: *A.Allocator = p.alloc;
+    diagnostic.store_dnit(?p.diags);
+    if (p.message != nil) { str_free(p.message_alloc, p.message); }
+    A.deallocate[Presentation](a, p, 1);
+}
+
+fun collect_node(db: *QueryDb, key: QueryKey, visited: *Map[QueryKey, u8],
+                 into: *diagnostic.DiagnosticStore) R.Result[R.Void, str] {
+    var lookup: QueryKey = key;
+    val prior: R.Result[*u8, str] = map.get[QueryKey, u8](visited, ?lookup);
+    if (R.is_ok[*u8, str](prior)) {
+        if (@R.unwrap_ok[*u8, str](prior) == 1) { ret R.err[R.Void, str]("query diagnostic provenance contains a cycle"); }
+        ret R.ok_void[str]();
+    }
+    val entered: R.Result[bool, str] = map.insert[QueryKey, u8](visited, key, 1);
+    if (R.is_err[bool, str](entered)) { ret R.void_of[bool, str](entered); }
+    var entry: *QueryEntry = nil;
+    val attempted: R.Result[*usize, str] = map.get[QueryKey, usize](?db.attempt_index, ?lookup);
+    if (R.is_ok[*usize, str](attempted)) {
+        val attempt: *Attempt = ?db.attempts.data[@R.unwrap_ok[*usize, str](attempted)];
+        if (attempt.failed) { entry = ?attempt.evidence; }
+    }
+    if (entry == nil) {
+        val current: R.Result[*Revision, str] = map.get[QueryKey, Revision](?db.validated, ?lookup);
+        if (R.is_ok[*Revision, str](current) && @R.unwrap_ok[*Revision, str](current) != 0) {
+            val sh: *QueryShard = ?db.storage[key.kind::u32];
+            entry = entry_find(sh, key.key);
+            if (entry == nil || !entry.ready || entry.last_changed != @R.unwrap_ok[*Revision, str](current)) {
+                ret R.err[R.Void, str]("query presentation owner changed after validation");
+            }
+        }
+    }
+    if (entry != nil) {
+        var i: u32 = 0;
+        for (i < entry.dep_len) {
+            val dep: Dep = entry.deps[i];
+            val copied: R.Result[R.Void, str] = collect_node(db, QueryKey{ kind: dep.kind, key: dep.key }, visited, into);
+            if (R.is_err[R.Void, str](copied)) { ret copied; }
+            i = i + 1;
+        }
+        if (entry.diags != nil) {
+            if (entry.diags.lost != 0) { ret R.err[R.Void, str]("query diagnostics contain a lost emission"); }
+            val copied: R.Result[R.Void, str] = diagnostic.replay_into(into, entry.diags);
+            if (R.is_err[R.Void, str](copied)) { ret copied; }
+        }
+    }
+    val state: R.Result[*u8, str] = map.get[QueryKey, u8](visited, ?lookup);
+    if (R.is_err[*u8, str](state)) { ret R.void_of[*u8, str](state); }
+    @R.unwrap_ok[*u8, str](state) = 2;
+    ret R.ok_void[str]();
+}
+
+fun sample_metadata(db: *QueryDb, kind: QueryKind, key: u64) R.Result[MetadataRevision, fail.Fail] {
+    if (!db.operation_active) { ret R.err[MetadataRevision, fail.Fail](fail.message("metadata read requires an active query operation")); }
+    val sr: R.Result[*QueryShard, str] = shard_get(db, kind);
+    if (R.is_err[*QueryShard, str](sr)) { ret fail.lift[MetadataRevision](R.err[MetadataRevision, str](R.unwrap_err[*QueryShard, str](sr))); }
+    val sh: *QueryShard = R.unwrap_ok[*QueryShard, str](sr);
+    if (sh.role != SHARD_METADATA) { ret R.err[MetadataRevision, fail.Fail](fail.message("metadata read requires a metadata query")); }
+    var pair: QueryKey = QueryKey{ kind: kind, key: key };
+    val prior: R.Result[*usize, str] = map.get[QueryKey, usize](?db.metadata_index, ?pair);
+    if (R.is_ok[*usize, str](prior)) { ret R.ok[MetadataRevision, fail.Fail](db.metadata.data[@R.unwrap_ok[*usize, str](prior)].value); }
+    val read: R.Result[MetadataRevision, fail.Fail] = sh.revisions.read(sh.revisions.context, key);
+    if (R.is_err[MetadataRevision, fail.Fail](read)) { ret read; }
+    val value: MetadataRevision = R.unwrap_ok[MetadataRevision, fail.Fail](read);
+    val index: usize = db.metadata.len;
+    val pushed: R.Result[usize, str] = vector.push[MetadataSample](?db.metadata, MetadataSample{ key: pair, value: value });
+    if (R.is_err[usize, str](pushed)) { ret fail.lift[MetadataRevision](R.err[MetadataRevision, str](R.unwrap_err[usize, str](pushed))); }
+    val indexed: R.Result[bool, str] = map.insert[QueryKey, usize](?db.metadata_index, pair, index);
+    if (R.is_err[bool, str](indexed)) {
+        db.metadata.len = index;
+        ret fail.lift[MetadataRevision](R.err[MetadataRevision, str](R.unwrap_err[bool, str](indexed)));
+    }
+    ret R.ok[MetadataRevision, fail.Fail](value);
 }
 
 pub fun is_registered(db: *QueryDb, kind: QueryKind) bool {
@@ -204,73 +549,272 @@ pub fun is_registered(db: *QueryDb, kind: QueryKind) bool {
     ret (?db.storage[kind::u32]).registered;
 }
 
-pub fun set_input(db: *QueryDb, kind: QueryKind, key: u64, value: *u8, value_len: u32) R.Result[R.Void, str] {
-    val res_shard: R.Result[*QueryShard, str] = shard_get(db, kind);
-    if (R.is_err[*QueryShard, str](res_shard)) {
-        ret R.err[R.Void, str](R.unwrap_err[*QueryShard, str](res_shard));
-    }
-    val sh: *QueryShard = R.unwrap_ok[*QueryShard, str](res_shard);
-
-    if (sh.role != SHARD_INPUT) {
-        ret R.err[R.Void, str]("set_input: kind is not an input query");
-    }
-
+fun next_revision(db: *QueryDb) R.Result[Revision, str] {
+    if (db.revision == ~(0::Revision)) { ret R.err[Revision, str]("query revision sequence exhausted"); }
     db.revision = db.revision + 1;
+    ret R.ok[Revision, str](db.revision);
+}
 
-    val existing: *QueryEntry = entry_find(sh, key);
-    if (existing != nil) {
-        val same: bool = existing.value_len == value_len
-            && memory.raw_equal(existing.value::ptr, value::ptr, value_len::usize);
-        if (same) { ret R.ok_void[str](); }
-
-        val res_copy: R.Result[*u8, str] = bytes_dup(db.a, value, value_len);
-        if (R.is_err[*u8, str](res_copy)) {
-            ret R.err[R.Void, str](R.unwrap_err[*u8, str](res_copy));
+pub fun set_input(db: *QueryDb, kind: QueryKind, key: u64, value: *u8, value_len: u32) R.Result[R.Void, str] {
+    if (db.operation_active || db.presentation_pending) { ret R.err[R.Void, str]("cannot change query inputs before the operation is released"); }
+    val res_shard: R.Result[*QueryShard, str] = shard_get(db, kind);
+    if (R.is_err[*QueryShard, str](res_shard)) { ret R.void_of[*QueryShard, str](res_shard); }
+    val sh: *QueryShard = R.unwrap_ok[*QueryShard, str](res_shard);
+    if (sh.role != SHARD_INPUT) { ret R.err[R.Void, str]("set_input: kind is not an input query"); }
+    if (value_len != 0 && value == nil) { ret R.err[R.Void, str]("input bytes are nil"); }
+    var entry: *QueryEntry = entry_find(sh, key);
+    if (entry != nil && entry.ready && entry.value_len == value_len
+        && memory.raw_equal(entry.value::ptr, value::ptr, value_len::usize)) { ret R.ok_void[str](); }
+    if (db.revision == ~(0::Revision)) { ret R.err[R.Void, str]("query revision sequence exhausted"); }
+    val copied: R.Result[*u8, str] = bytes_dup(db.a, value, value_len);
+    if (R.is_err[*u8, str](copied)) { ret R.void_of[*u8, str](copied); }
+    val bytes: *u8 = R.unwrap_ok[*u8, str](copied);
+    if (entry == nil) {
+        val added: R.Result[*QueryEntry, str] = entry_append(db, sh, key);
+        if (R.is_err[*QueryEntry, str](added)) {
+            if (bytes != nil && value_len != 0) { A.deallocate[u8](db.a, bytes, value_len::usize); }
+            ret R.void_of[*QueryEntry, str](added);
         }
-        if (existing.value != nil && existing.value_len > 0) {
-            A.deallocate[u8](db.a, existing.value, existing.value_len::usize);
-        }
-        existing.value        = R.unwrap_ok[*u8, str](res_copy);
-        existing.value_len    = value_len;
-        existing.last_changed = db.revision;
-        ret R.ok_void[str]();
+        entry = R.unwrap_ok[*QueryEntry, str](added);
     }
-
-    val res_copy: R.Result[*u8, str] = bytes_dup(db.a, value, value_len);
-    if (R.is_err[*u8, str](res_copy)) {
-        ret R.err[R.Void, str](R.unwrap_err[*u8, str](res_copy));
-    }
-
-    val res_entry: R.Result[*QueryEntry, str] = entry_append(db, sh, key);
-    if (R.is_err[*QueryEntry, str](res_entry)) {
-        val buf: *u8 = R.unwrap_ok[*u8, str](res_copy);
-        if (buf != nil && value_len > 0) { A.deallocate[u8](db.a, buf, value_len::usize); }
-        ret R.err[R.Void, str](R.unwrap_err[*QueryEntry, str](res_entry));
-    }
-    val entry: *QueryEntry = R.unwrap_ok[*QueryEntry, str](res_entry);
-    entry.value        = R.unwrap_ok[*u8, str](res_copy);
-    entry.value_len    = value_len;
-    entry.last_changed = db.revision;
+    if (entry.value != nil && entry.value_len != 0) { A.deallocate[u8](db.a, entry.value, entry.value_len::usize); }
+    entry.value = bytes;
+    entry.value_len = value_len;
+    entry.ready = true;
+    entry.last_changed = R.unwrap_ok[Revision, str](next_revision(db));
     ret R.ok_void[str]();
 }
 
 pub fun invalidate(db: *QueryDb, kind: QueryKind, key: u64) R.Result[R.Void, str] {
+    if (db.operation_active || db.presentation_pending) { ret R.err[R.Void, str]("cannot retire a query before the operation is released"); }
     val res_shard: R.Result[*QueryShard, str] = shard_get(db, kind);
-    if (R.is_err[*QueryShard, str](res_shard)) {
-        ret R.err[R.Void, str](R.unwrap_err[*QueryShard, str](res_shard));
-    }
-
-    db.revision = db.revision + 1;
-
-    entry_remove(db, R.unwrap_ok[*QueryShard, str](res_shard), key);
+    if (R.is_err[*QueryShard, str](res_shard)) { ret R.void_of[*QueryShard, str](res_shard); }
+    val sh: *QueryShard = R.unwrap_ok[*QueryShard, str](res_shard);
+    if (entry_find(sh, key) == nil) { ret R.ok_void[str](); }
+    val rev: R.Result[Revision, str] = next_revision(db);
+    if (R.is_err[Revision, str](rev)) { ret R.void_of[Revision, str](rev); }
+    entry_remove(db, sh, key);
     ret R.ok_void[str]();
 }
 
-pub fun get[T](rt: *QueryRuntime[T], ctx: *T, kind: QueryKind, key: u64) R.Result[*QueryEntry, fail.Fail] {
-    if (rt == nil || rt.db == nil || rt.diags == nil || rt.caps.compute == nil || ctx == nil) {
+# successful end permits serial reads until the next begin, input mutation, or retirement
+pub fun get[T](rt: *QueryRuntime[T], ctx: *T, kind: QueryKind, key: u64) R.Result[QueryView, fail.Fail] {
+    val acquired: R.Result[*QueryEntry, fail.Fail] = acquire_entry[T](rt, ctx, kind, key);
+    if (R.is_err[*QueryEntry, fail.Fail](acquired)) { ret R.err[QueryView, fail.Fail](R.unwrap_err[*QueryEntry, fail.Fail](acquired)); }
+    val entry: *QueryEntry = R.unwrap_ok[*QueryEntry, fail.Fail](acquired);
+    ret R.ok[QueryView, fail.Fail](QueryView{ value: entry.value, value_len: entry.value_len, last_changed: entry.last_changed });
+}
+
+# validation may refresh dependencies but never computes the requested product
+pub fun reusable[T](rt: *QueryRuntime[T], ctx: *T, kind: QueryKind, key: u64) R.Result[bool, fail.Fail] {
+    if (rt == nil || rt.db == nil || ctx == nil || rt.caps.compute == nil) {
+        ret R.err[bool, fail.Fail](fail.message("query reuse requires a complete runtime"));
+    }
+    val db: *QueryDb = rt.db;
+    if (!db.operation_active || db.stack.len != 0) {
+        ret R.err[bool, fail.Fail](fail.message("query reuse requires an active owner-thread operation"));
+    }
+    if (O.is_some[fail.Fail](db.operation_failure)) { ret R.err[bool, fail.Fail](O.unwrap[fail.Fail](db.operation_failure)); }
+    val result: R.Result[bool, fail.Fail] = reusable_inner[T](rt, ctx, kind, key);
+    if (R.is_err[bool, fail.Fail](result)) {
+        operation_fail(db, R.unwrap_err[bool, fail.Fail](result));
+        ret R.err[bool, fail.Fail](O.unwrap[fail.Fail](db.operation_failure));
+    }
+    ret result;
+}
+
+fun reusable_inner[T](rt: *QueryRuntime[T], ctx: *T, kind: QueryKind, key: u64) R.Result[bool, fail.Fail] {
+    val db: *QueryDb = rt.db;
+    val found: R.Result[*QueryShard, str] = shard_get(db, kind);
+    if (R.is_err[*QueryShard, str](found)) { ret fail.lift[bool](R.err[bool, str](R.unwrap_err[*QueryShard, str](found))); }
+    val sh: *QueryShard = R.unwrap_ok[*QueryShard, str](found);
+    if (sh.role != SHARD_DERIVED) { ret R.err[bool, fail.Fail](fail.message("query reuse requires a derived product")); }
+    var pair: QueryKey = QueryKey{ kind: kind, key: key };
+    val pending: R.Result[*usize, str] = map.get[QueryKey, usize](?db.attempt_index, ?pair);
+    if (R.is_ok[*usize, str](pending) && (db.attempts.data[@R.unwrap_ok[*usize, str](pending)].prepared != nil
+        || db.attempts.data[@R.unwrap_ok[*usize, str](pending)].cancelled)) {
+        ret R.err[bool, fail.Fail](fail.message("query product is awaiting owner completion"));
+    }
+    val entry: *QueryEntry = entry_find(sh, key);
+    if (entry == nil || !entry.ready) { ret R.ok[bool, fail.Fail](false); }
+    val prior: R.Result[*Revision, str] = map.get[QueryKey, Revision](?db.validated, ?pair);
+    if (R.is_ok[*Revision, str](prior) && @R.unwrap_ok[*Revision, str](prior) != 0) {
+        if (@R.unwrap_ok[*Revision, str](prior) != entry.last_changed) {
+            ret R.err[bool, fail.Fail](fail.message("validated query owner changed during reuse"));
+        }
+        ret R.ok[bool, fail.Fail](true);
+    }
+    val reserved: R.Result[bool, str] = map.insert[QueryKey, Revision](?db.validated, pair, 0);
+    if (R.is_err[bool, str](reserved)) { ret fail.lift[bool](reserved); }
+    val prepared: R.Result[usize, str] = attempt_prepare(db, pair);
+    if (R.is_err[usize, str](prepared)) { ret fail.lift[bool](R.err[bool, str](R.unwrap_err[usize, str](prepared))); }
+    val pushed: R.Result[R.Void, str] = stack_push(db, kind, key, nil);
+    if (R.is_err[R.Void, str](pushed)) { ret fail.lift[bool](R.err[bool, str](R.unwrap_err[R.Void, str](pushed))); }
+    fin { stack_pop(db); }
+    var evidence: QueryEntry = QueryEntry{};
+    val current: R.Result[bool, fail.Fail] = refresh_dependencies[T](rt, ctx, entry, ?evidence);
+    if (R.is_err[bool, fail.Fail](current)) {
+        attempt_preserve(db, sh, R.unwrap_ok[usize, str](prepared), ?evidence);
+        ret current;
+    }
+    entry_free(db, sh, ?evidence);
+    if (!R.unwrap_ok[bool, fail.Fail](current)) { ret current; }
+    val slot: R.Result[*Revision, str] = map.get[QueryKey, Revision](?db.validated, ?pair);
+    if (R.is_err[*Revision, str](slot)) { ret fail.lift[bool](R.err[bool, str](R.unwrap_err[*Revision, str](slot))); }
+    @R.unwrap_ok[*Revision, str](slot) = entry.last_changed;
+    ret current;
+}
+
+pub fun prepare[T](rt: *QueryRuntime[T], ctx: *T, kind: QueryKind, key: u64,
+                   compute: fun(*T, QueryKind, u64, *A.Allocator, *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail]) R.Result[PreparedQuery, fail.Fail] {
+    val result: R.Result[PreparedQuery, fail.Fail] = prepare_inner[T](rt, ctx, kind, key, compute);
+    if (R.is_err[PreparedQuery, fail.Fail](result) && rt != nil && rt.db != nil && rt.db.operation_active) {
+        operation_fail(rt.db, R.unwrap_err[PreparedQuery, fail.Fail](result));
+        ret R.err[PreparedQuery, fail.Fail](O.unwrap[fail.Fail](rt.db.operation_failure));
+    }
+    ret result;
+}
+
+fun prepare_inner[T](rt: *QueryRuntime[T], ctx: *T, kind: QueryKind, key: u64,
+                   compute: fun(*T, QueryKind, u64, *A.Allocator, *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail]) R.Result[PreparedQuery, fail.Fail] {
+    if (compute == nil) { ret R.err[PreparedQuery, fail.Fail](fail.message("prepared query requires a compute callback")); }
+    val current: R.Result[bool, fail.Fail] = reusable[T](rt, ctx, kind, key);
+    if (R.is_err[bool, fail.Fail](current)) { ret R.err[PreparedQuery, fail.Fail](R.unwrap_err[bool, fail.Fail](current)); }
+    if (R.unwrap_ok[bool, fail.Fail](current)) { ret R.err[PreparedQuery, fail.Fail](fail.message("cannot prepare a query owner already acquired in this operation")); }
+    val db: *QueryDb = rt.db;
+    val sh: *QueryShard = ?db.storage[kind::u32];
+    val pair: QueryKey = QueryKey{ kind: kind, key: key };
+    val reserved: R.Result[usize, str] = attempt_prepare(db, pair);
+    if (R.is_err[usize, str](reserved)) { ret fail.lift[PreparedQuery](R.err[PreparedQuery, str](R.unwrap_err[usize, str](reserved))); }
+    val index: usize = R.unwrap_ok[usize, str](reserved);
+    if (db.attempts.data[index].prepared != nil) { ret R.err[PreparedQuery, fail.Fail](fail.message("query product is already prepared")); }
+    val allocated: R.Result[*QueryEntry, str] = A.allocate[QueryEntry](db.a, 1);
+    if (R.is_err[*QueryEntry, str](allocated)) { ret fail.lift[PreparedQuery](R.err[PreparedQuery, str](R.unwrap_err[*QueryEntry, str](allocated))); }
+    val candidate: *QueryEntry = R.unwrap_ok[*QueryEntry, str](allocated);
+    @candidate = QueryEntry{ key: key };
+    val fresh: bool = entry_find(sh, key) == nil;
+    var retained: bool = false;
+    fin {
+        if (!retained) {
+            attempt_preserve(db, sh, index, candidate);
+            A.deallocate[QueryEntry](db.a, candidate, 1);
+            if (fresh) { entry_remove(db, sh, key); }
+        }
+    }
+    if (fresh) {
+        val added: R.Result[*QueryEntry, str] = entry_append(db, sh, key);
+        if (R.is_err[*QueryEntry, str](added)) { ret fail.lift[PreparedQuery](R.err[PreparedQuery, str](R.unwrap_err[*QueryEntry, str](added))); }
+    }
+    var lookup: QueryKey = pair;
+    val marked: R.Result[bool, str] = map.insert[QueryKey, Revision](?db.validated, lookup, 0);
+    if (R.is_err[bool, str](marked)) { ret fail.lift[PreparedQuery](R.err[PreparedQuery, str](R.unwrap_err[bool, str](marked))); }
+    val pushed: R.Result[R.Void, str] = stack_push(db, kind, key, nil);
+    if (R.is_err[R.Void, str](pushed)) { ret fail.lift[PreparedQuery](R.err[PreparedQuery, str](R.unwrap_err[R.Void, str](pushed))); }
+    val computed: R.Result[R.Void, fail.Fail] = candidate_compute[T](rt, ctx, sh, key, candidate, compute);
+    stack_pop(db);
+    if (R.is_err[R.Void, fail.Fail](computed)) {
+        operation_fail(db, R.unwrap_err[R.Void, fail.Fail](computed));
+        ret R.err[PreparedQuery, fail.Fail](O.unwrap[fail.Fail](db.operation_failure));
+    }
+    db.attempts.data[index].prepared = candidate;
+    db.attempts.data[index].fresh = fresh;
+    db.prepared_count = db.prepared_count + 1;
+    retained = true;
+    ret R.ok[PreparedQuery, fail.Fail](PreparedQuery{
+        operation: Operation{ owner: db::ptr, sequence: db.operation_sequence }, key: pair
+    });
+}
+
+fun prepared_attempt(db: *QueryDb, prepared: PreparedQuery) R.Result[*Attempt, str] {
+    if (db == nil || prepared.operation.owner != db::ptr || prepared.operation.sequence != db.operation_sequence
+        || !db.operation_active || db.stack.len != 0) { ret R.err[*Attempt, str]("prepared query belongs to another operation"); }
+    var key: QueryKey = prepared.key;
+    val index: R.Result[*usize, str] = map.get[QueryKey, usize](?db.attempt_index, ?key);
+    if (R.is_err[*usize, str](index)) { ret R.err[*Attempt, str]("prepared query is no longer owned"); }
+    val attempt: *Attempt = ?db.attempts.data[@R.unwrap_ok[*usize, str](index)];
+    if (attempt.prepared == nil) { ret R.err[*Attempt, str]("prepared query has already been consumed"); }
+    ret R.ok[*Attempt, str](attempt);
+}
+
+pub fun prepared_view(db: *QueryDb, prepared: PreparedQuery) R.Result[QueryView, str] {
+    val owner: R.Result[*Attempt, str] = prepared_attempt(db, prepared);
+    if (R.is_err[*Attempt, str](owner)) { ret R.err[QueryView, str](R.unwrap_err[*Attempt, str](owner)); }
+    val candidate: *QueryEntry = R.unwrap_ok[*Attempt, str](owner).prepared;
+    ret R.ok[QueryView, str](QueryView{ value: candidate.value, value_len: candidate.value_len });
+}
+
+pub fun cancel_prepared(db: *QueryDb, prepared: PreparedQuery) R.Result[R.Void, str] {
+    val owner: R.Result[*Attempt, str] = prepared_attempt(db, prepared);
+    if (R.is_err[*Attempt, str](owner)) { ret R.void_of[*Attempt, str](owner); }
+    val attempt: *Attempt = R.unwrap_ok[*Attempt, str](owner);
+    val candidate: *QueryEntry = attempt.prepared;
+    val sh: *QueryShard = ?db.storage[prepared.key.kind::u32];
+    var key: QueryKey = prepared.key;
+    val index: R.Result[*usize, str] = map.get[QueryKey, usize](?db.attempt_index, ?key);
+    if (R.is_err[*usize, str](index)) { ret R.void_of[*usize, str](index); }
+    attempt_preserve(db, sh, @R.unwrap_ok[*usize, str](index), candidate);
+    A.deallocate[QueryEntry](db.a, candidate, 1);
+    attempt.prepared = nil;
+    attempt.cancelled = true;
+    db.prepared_count = db.prepared_count - 1;
+    if (attempt.fresh) { entry_remove(db, sh, prepared.key.key); }
+    ret R.ok_void[str]();
+}
+
+pub fun complete_prepared(db: *QueryDb, prepared: PreparedQuery, result: R.Result[R.Void, fail.Fail]) R.Result[R.Void, fail.Fail] {
+    val owner: R.Result[*Attempt, str] = prepared_attempt(db, prepared);
+    if (R.is_err[*Attempt, str](owner)) { ret fail.lift[R.Void](R.void_of[*Attempt, str](owner)); }
+    if (R.is_err[R.Void, fail.Fail](result)) { operation_fail(db, R.unwrap_err[R.Void, fail.Fail](result)); }
+    if (O.is_some[fail.Fail](db.operation_failure)) {
+        val cancelled: R.Result[R.Void, str] = cancel_prepared(db, prepared);
+        if (R.is_err[R.Void, str](cancelled)) { ret fail.lift[R.Void](cancelled); }
+        ret R.err[R.Void, fail.Fail](O.unwrap[fail.Fail](db.operation_failure));
+    }
+    val attempt: *Attempt = R.unwrap_ok[*Attempt, str](owner);
+    val sh: *QueryShard = ?db.storage[prepared.key.kind::u32];
+    val entry: *QueryEntry = entry_find(sh, prepared.key.key);
+    if (entry == nil) { ret R.err[R.Void, fail.Fail](fail.message("prepared query lost its publication slot")); }
+    var key: QueryKey = prepared.key;
+    val revision: R.Result[*Revision, str] = map.get[QueryKey, Revision](?db.validated, ?key);
+    if (R.is_err[*Revision, str](revision)) { ret fail.lift[R.Void](R.void_of[*Revision, str](revision)); }
+    val published: R.Result[*QueryEntry, fail.Fail] = candidate_publish(db, sh, entry, attempt.prepared);
+    if (R.is_err[*QueryEntry, fail.Fail](published)) {
+        operation_fail(db, R.unwrap_err[*QueryEntry, fail.Fail](published));
+        val cancelled: R.Result[R.Void, str] = cancel_prepared(db, prepared);
+        if (R.is_err[R.Void, str](cancelled)) { ret fail.lift[R.Void](cancelled); }
+        ret R.err[R.Void, fail.Fail](O.unwrap[fail.Fail](db.operation_failure));
+    }
+    @R.unwrap_ok[*Revision, str](revision) = entry.last_changed;
+    A.deallocate[QueryEntry](db.a, attempt.prepared, 1);
+    attempt.prepared = nil;
+    db.prepared_count = db.prepared_count - 1;
+    ret R.ok_void[fail.Fail]();
+}
+
+fun acquire_entry[T](rt: *QueryRuntime[T], ctx: *T, kind: QueryKind, key: u64) R.Result[*QueryEntry, fail.Fail] {
+    if (rt == nil || rt.db == nil) { ret R.err[*QueryEntry, fail.Fail](fail.message("query get requires a live runtime")); }
+    if (O.is_some[fail.Fail](rt.db.operation_failure) && rt.db.operation_active) {
+        ret R.err[*QueryEntry, fail.Fail](O.unwrap[fail.Fail](rt.db.operation_failure));
+    }
+    val result: R.Result[*QueryEntry, fail.Fail] = get_acquired[T](rt, ctx, kind, key);
+    if (R.is_err[*QueryEntry, fail.Fail](result) && rt.db.operation_active) {
+        operation_fail(rt.db, R.unwrap_err[*QueryEntry, fail.Fail](result));
+        ret R.err[*QueryEntry, fail.Fail](O.unwrap[fail.Fail](rt.db.operation_failure));
+    }
+    ret result;
+}
+
+fun get_acquired[T](rt: *QueryRuntime[T], ctx: *T, kind: QueryKind, key: u64) R.Result[*QueryEntry, fail.Fail] {
+    if (rt == nil || rt.db == nil || rt.caps.compute == nil || ctx == nil) {
         ret R.err[*QueryEntry, fail.Fail](fail.message("query get requires a complete live runtime"));
     }
     val db: *QueryDb = rt.db;
+    var owner: *QueryEntry = nil;
+    if (db.stack.len != 0) { owner = db.stack.data[db.stack.len - 1].entry; }
+    if (owner != nil && !stack_contains(db, kind, key)) {
+        val edge: R.Result[R.Void, str] = dep_prepare(db, owner, kind, key);
+        if (R.is_err[R.Void, str](edge)) { ret R.err[*QueryEntry, fail.Fail](fail.message(R.unwrap_err[R.Void, str](edge))); }
+    }
     val res_shard: R.Result[*QueryShard, str] = shard_get(db, kind);
     if (R.is_err[*QueryShard, str](res_shard)) {
         ret R.err[*QueryEntry, fail.Fail](fail.message(R.unwrap_err[*QueryShard, str](res_shard)));
@@ -283,7 +827,8 @@ pub fun get[T](rt: *QueryRuntime[T], ctx: *T, kind: QueryKind, key: u64) R.Resul
 
     if (db.stack.len > 0) {
         val owner: *StackFrame = ?db.stack.data[db.stack.len - 1];
-        val dep_r: R.Result[Revision, str] = dep_upsert(db, owner.entry, kind, key);
+        if (owner.entry == nil) { ret R.ok[*QueryEntry, fail.Fail](entry); }
+        val dep_r: R.Result[Revision, str] = dep_upsert(db, owner.entry, kind, key, entry.last_changed, entry.diagnostics_changed, true);
         if (R.is_err[Revision, str](dep_r)) {
             ret R.err[*QueryEntry, fail.Fail](fail.message(R.unwrap_err[Revision, str](dep_r)));
         }
@@ -294,52 +839,97 @@ pub fun get[T](rt: *QueryRuntime[T], ctx: *T, kind: QueryKind, key: u64) R.Resul
 
 fun get_inner[T](rt: *QueryRuntime[T], ctx: *T, sh: *QueryShard, kind: QueryKind, key: u64) R.Result[*QueryEntry, fail.Fail] {
     val db: *QueryDb = rt.db;
-    if (sh.role == SHARD_METADATA) {
-        ret R.err[*QueryEntry, fail.Fail](fail.message("get: metadata kinds have no stored value"));
+    if (!db.operation_active) { ret R.err[*QueryEntry, fail.Fail](fail.message("query read requires an active operation")); }
+    var pair: QueryKey = QueryKey{ kind: kind, key: key };
+    val pending: R.Result[*usize, str] = map.get[QueryKey, usize](?db.attempt_index, ?pair);
+    if (R.is_ok[*usize, str](pending) && (db.attempts.data[@R.unwrap_ok[*usize, str](pending)].prepared != nil
+        || db.attempts.data[@R.unwrap_ok[*usize, str](pending)].cancelled)) {
+        ret R.err[*QueryEntry, fail.Fail](fail.message("query product is awaiting owner completion"));
     }
-
-    if (sh.role == SHARD_INPUT) {
+    val prior: R.Result[*Revision, str] = map.get[QueryKey, Revision](?db.validated, ?pair);
+    if (R.is_ok[*Revision, str](prior) && @R.unwrap_ok[*Revision, str](prior) != 0) {
         val entry: *QueryEntry = entry_find(sh, key);
-        if (entry == nil) {
-            ret R.err[*QueryEntry, fail.Fail](fail.message("get: input query has no value for key"));
+        if (entry == nil || !entry.ready || entry.last_changed != @R.unwrap_ok[*Revision, str](prior)) {
+            ret R.err[*QueryEntry, fail.Fail](fail.message("validated query owner changed during the operation"));
         }
         ret R.ok[*QueryEntry, fail.Fail](entry);
     }
+    if (stack_contains(db, kind, key)) { ret R.err[*QueryEntry, fail.Fail](cycle_failure(db, kind, key)); }
+    val reserved: R.Result[bool, str] = map.insert[QueryKey, Revision](?db.validated, pair, 0);
+    if (R.is_err[bool, str](reserved)) { ret fail.lift[*QueryEntry](R.err[*QueryEntry, str](R.unwrap_err[bool, str](reserved))); }
+    val prepared: R.Result[usize, str] = attempt_prepare(db, pair);
+    if (R.is_err[usize, str](prepared)) { ret fail.lift[*QueryEntry](R.err[*QueryEntry, str](R.unwrap_err[usize, str](prepared))); }
+    val refreshed: R.Result[*QueryEntry, fail.Fail] = refresh_entry[T](rt, ctx, sh, kind, key, R.unwrap_ok[usize, str](prepared));
+    if (R.is_err[*QueryEntry, fail.Fail](refreshed)) { ret refreshed; }
+    val revision: R.Result[*Revision, str] = map.get[QueryKey, Revision](?db.validated, ?pair);
+    if (R.is_err[*Revision, str](revision)) { ret fail.lift[*QueryEntry](R.err[*QueryEntry, str](R.unwrap_err[*Revision, str](revision))); }
+    @R.unwrap_ok[*Revision, str](revision) = R.unwrap_ok[*QueryEntry, fail.Fail](refreshed).last_changed;
+    ret refreshed;
+}
 
-    val existing: *QueryEntry = entry_find(sh, key);
-    if (existing != nil) {
-        if (stack_contains(db, kind, key)) {
-            ret R.err[*QueryEntry, fail.Fail](fail.message(cycle_message(db, kind, key)));
+fun refresh_entry[T](rt: *QueryRuntime[T], ctx: *T, sh: *QueryShard, kind: QueryKind, key: u64, attempt: usize) R.Result[*QueryEntry, fail.Fail] {
+    val db: *QueryDb = rt.db;
+    if (sh.role == SHARD_METADATA) { ret R.err[*QueryEntry, fail.Fail](fail.message("get: metadata kinds have no stored value")); }
+    if (sh.role == SHARD_INPUT) {
+        val entry: *QueryEntry = entry_find(sh, key);
+        if (entry == nil || !entry.ready) { ret R.err[*QueryEntry, fail.Fail](fail.message("get: input query has no value for key")); }
+        ret R.ok[*QueryEntry, fail.Fail](entry);
+    }
+    if (stack_contains(db, kind, key)) { ret R.err[*QueryEntry, fail.Fail](cycle_failure(db, kind, key)); }
+    val pushed: R.Result[R.Void, str] = stack_push(db, kind, key, nil);
+    if (R.is_err[R.Void, str](pushed)) { ret fail.lift[*QueryEntry](R.err[*QueryEntry, str](R.unwrap_err[R.Void, str](pushed))); }
+    fin { stack_pop(db); }
+    var entry: *QueryEntry = entry_find(sh, key);
+    if (entry != nil && entry.ready) {
+        var validation: QueryEntry = QueryEntry{};
+        val valid: R.Result[bool, fail.Fail] = refresh_dependencies[T](rt, ctx, entry, ?validation);
+        if (R.is_err[bool, fail.Fail](valid)) {
+            attempt_preserve(db, sh, attempt, ?validation);
+            ret R.err[*QueryEntry, fail.Fail](R.unwrap_err[bool, fail.Fail](valid));
         }
-        if (is_entry_valid(db, existing)) {
-            if (db.compute_depth == 0 && existing.diags != nil) {
-                val replay_r: R.Result[R.Void, str] = diagnostic.replay_into(rt.diags, existing.diags);
-                if (R.is_err[R.Void, str](replay_r)) { ret R.err[*QueryEntry, fail.Fail](fail.message(R.unwrap_err[R.Void, str](replay_r))); }
+        entry_free(db, sh, ?validation);
+        if (R.unwrap_ok[bool, fail.Fail](valid)) { ret R.ok[*QueryEntry, fail.Fail](entry); }
+    }
+    val fresh: bool = entry == nil;
+    if (fresh) {
+        val added: R.Result[*QueryEntry, str] = entry_append(db, sh, key);
+        if (R.is_err[*QueryEntry, str](added)) { ret fail.lift[*QueryEntry](added); }
+        entry = R.unwrap_ok[*QueryEntry, str](added);
+    }
+    val computed: R.Result[*QueryEntry, fail.Fail] = recompute[T](rt, ctx, sh, entry, key, attempt);
+    if (fresh && R.is_err[*QueryEntry, fail.Fail](computed)) { entry_remove(db, sh, key); }
+    ret computed;
+}
+
+fun refresh_dependencies[T](rt: *QueryRuntime[T], ctx: *T, entry: *QueryEntry, evidence: *QueryEntry) R.Result[bool, fail.Fail] {
+    val db: *QueryDb = rt.db;
+    var same: bool = true;
+    var i: u32 = 0;
+    for (i < entry.dep_len) {
+        val dep: Dep = entry.deps[i];
+        if (!dep.observed) { ret R.err[bool, fail.Fail](fail.message("cached query has an incomplete dependency")); }
+        if (evidence != nil) {
+            val edge: R.Result[R.Void, str] = dep_prepare(db, evidence, dep.kind, dep.key);
+            if (R.is_err[R.Void, str](edge)) { ret fail.lift[bool](R.err[bool, str](R.unwrap_err[R.Void, str](edge))); }
+        }
+        val shard: R.Result[*QueryShard, str] = shard_get(db, dep.kind);
+        if (R.is_err[*QueryShard, str](shard)) { ret fail.lift[bool](R.err[bool, str](R.unwrap_err[*QueryShard, str](shard))); }
+        val sh: *QueryShard = R.unwrap_ok[*QueryShard, str](shard);
+        if (sh.role == SHARD_METADATA) {
+            val sampled: R.Result[MetadataRevision, fail.Fail] = sample_metadata(db, dep.kind, dep.key);
+            if (R.is_err[MetadataRevision, fail.Fail](sampled)) { ret R.err[bool, fail.Fail](R.unwrap_err[MetadataRevision, fail.Fail](sampled)); }
+            val current: MetadataRevision = R.unwrap_ok[MetadataRevision, fail.Fail](sampled);
+            if (current.present != dep.present || current.revision != dep.last_changed) { same = false; }
+        } or {
+            if (sh.role == SHARD_DERIVED) {
+                val child: R.Result[*QueryEntry, fail.Fail] = get_inner[T](rt, ctx, sh, dep.kind, dep.key);
+                if (R.is_err[*QueryEntry, fail.Fail](child)) { ret R.err[bool, fail.Fail](R.unwrap_err[*QueryEntry, fail.Fail](child)); }
             }
-            ret R.ok[*QueryEntry, fail.Fail](existing);
+            if (last_changed_get(db, dep.kind, dep.key) != dep.last_changed) { same = false; }
         }
-
-        val push_r: R.Result[R.Void, str] = stack_push(db, kind, key, existing);
-        if (R.is_err[R.Void, str](push_r)) {
-            ret R.err[*QueryEntry, fail.Fail](fail.message(R.unwrap_err[R.Void, str](push_r)));
-        }
-        val result: R.Result[*QueryEntry, fail.Fail] = recompute[T](rt, ctx, sh, existing, key);
-        stack_pop(db);
-        ret result;
+        i = i + 1;
     }
-
-    val res_entry: R.Result[*QueryEntry, str] = entry_append(db, sh, key);
-    if (R.is_err[*QueryEntry, str](res_entry)) { ret fail.lift[*QueryEntry](res_entry); }
-    val entry: *QueryEntry = R.unwrap_ok[*QueryEntry, str](res_entry);
-
-    val push_r: R.Result[R.Void, str] = stack_push(db, kind, key, entry);
-    if (R.is_err[R.Void, str](push_r)) {
-        entry_remove(db, sh, key);
-        ret R.err[*QueryEntry, fail.Fail](fail.message(R.unwrap_err[R.Void, str](push_r)));
-    }
-    val result: R.Result[*QueryEntry, fail.Fail] = recompute[T](rt, ctx, sh, entry, key);
-    stack_pop(db);
-    ret result;
+    ret R.ok[bool, fail.Fail](same);
 }
 
 fun stack_push(db: *QueryDb, kind: QueryKind, key: u64, entry: *QueryEntry) R.Result[R.Void, str] {
@@ -366,88 +956,107 @@ fun stack_contains(db: *QueryDb, kind: QueryKind, key: u64) bool {
     ret false;
 }
 
-fun cycle_message(db: *QueryDb, kind: QueryKind, key: u64) str {
-    var b: textbuild.TextBuilder = textbuild.tb_init(db.a);
-    textbuild.tb_append(?b, "query cycle: ");
-
-    var fmt_failed: bool = false;
-    var i: usize = 0;
-    for (!fmt_failed && i < db.stack.len) {
-        val f: *StackFrame = ?db.stack.data[i];
-        val seg_r: R.Result[str, str] = format.sprint(db.a, "{}:{} -> ", f.kind, f.key);
-        if (R.is_err[str, str](seg_r)) {
-            fmt_failed = true;
-        } or {
-            val s: str = R.unwrap_ok[str, str](seg_r);
-            textbuild.tb_append(?b, s);
-            A.deallocate[char](db.a, s, str_len(s) + 1);
-        }
-        i = i + 1;
+fun cycle_failure(db: *QueryDb, kind: QueryKind, key: u64) fail.Fail {
+    val built: R.Result[str, str] = cycle_message(db, kind, key);
+    if (R.is_err[str, str](built)) {
+        operation_fail(db, fail.message(R.unwrap_err[str, str](built)));
+        ret O.unwrap[fail.Fail](db.operation_failure);
     }
-
-    if (!fmt_failed) {
-        val tail_r: R.Result[str, str] = format.sprint(db.a, "{}:{} (already computing)", kind, key);
-        if (R.is_err[str, str](tail_r)) {
-            fmt_failed = true;
-        } or {
-            val s: str = R.unwrap_ok[str, str](tail_r);
-            textbuild.tb_append(?b, s);
-            A.deallocate[char](db.a, s, str_len(s) + 1);
-        }
+    val text: str = R.unwrap_ok[str, str](built);
+    if (O.is_some[fail.Fail](db.operation_failure) && O.unwrap[fail.Fail](db.operation_failure).kind == fail.MESSAGE) {
+        str_free(db.a, text);
+        ret O.unwrap[fail.Fail](db.operation_failure);
     }
-
-    if (fmt_failed || textbuild.tb_failed(?b)) {
-        textbuild.tb_dnit(?b);
-        ret "query cycle detected (message construction failed)";
-    }
-
-    val fin: R.Result[str, str] = textbuild.tb_finish(?b);
-    if (R.is_err[str, str](fin)) {
-        textbuild.tb_dnit(?b);
-        ret "query cycle detected (message allocation failed)";
-    }
-    ret R.unwrap_ok[str, str](fin);
+    db.operation_message = text;
+    db.operation_failure = O.some[fail.Fail](fail.message(text));
+    ret O.unwrap[fail.Fail](db.operation_failure);
 }
 
-pub fun record_dep(db: *QueryDb, owner_kind: QueryKind, owner_key: u64, dep_kind: QueryKind, dep_key: u64) R.Result[R.Void, str] {
-    val r: R.Result[Revision, str] = record_dep_rev(db, owner_kind, owner_key, dep_kind, dep_key);
-    if (R.is_err[Revision, str](r)) { ret R.err[R.Void, str](R.unwrap_err[Revision, str](r)); }
+fun cycle_message(db: *QueryDb, kind: QueryKind, key: u64) R.Result[str, str] {
+    var b: textbuild.TextBuilder = textbuild.tb_init(db.a);
+    fin { textbuild.tb_dnit(?b); }
+    val prefix: R.Result[R.Void, str] = textbuild.tb_append(?b, "query cycle: ");
+    if (R.is_err[R.Void, str](prefix)) { ret R.err[str, str](R.unwrap_err[R.Void, str](prefix)); }
+    var i: usize = 0;
+    for (i < db.stack.len) {
+        val frame: *StackFrame = ?db.stack.data[i];
+        val segment: R.Result[str, str] = format.sprint(db.a, "{}:{} -> ", frame.kind, frame.key);
+        if (R.is_err[str, str](segment)) { ret segment; }
+        val text: str = R.unwrap_ok[str, str](segment);
+        val appended: R.Result[R.Void, str] = textbuild.tb_append(?b, text);
+        str_free(db.a, text);
+        if (R.is_err[R.Void, str](appended)) { ret R.err[str, str](R.unwrap_err[R.Void, str](appended)); }
+        i = i + 1;
+    }
+    val tail: R.Result[str, str] = format.sprint(db.a, "{}:{} (already computing)", kind, key);
+    if (R.is_err[str, str](tail)) { ret tail; }
+    val text: str = R.unwrap_ok[str, str](tail);
+    val appended: R.Result[R.Void, str] = textbuild.tb_append(?b, text);
+    str_free(db.a, text);
+    if (R.is_err[R.Void, str](appended)) { ret R.err[str, str](R.unwrap_err[R.Void, str](appended)); }
+    ret textbuild.tb_finish(?b);
+}
+
+pub fun revision[T](rt: *QueryRuntime[T], ctx: *T, kind: QueryKind, key: u64) R.Result[Revision, fail.Fail] {
+    val read: R.Result[QueryView, fail.Fail] = get[T](rt, ctx, kind, key);
+    if (R.is_err[QueryView, fail.Fail](read)) { ret R.err[Revision, fail.Fail](R.unwrap_err[QueryView, fail.Fail](read)); }
+    ret R.ok[Revision, fail.Fail](R.unwrap_ok[QueryView, fail.Fail](read).last_changed);
+}
+
+pub fun depend[T](rt: *QueryRuntime[T], ctx: *T, kind: QueryKind, key: u64) R.Result[R.Void, fail.Fail] {
+    ret R.void_of[Revision, fail.Fail](revision[T](rt, ctx, kind, key));
+}
+
+pub fun observe(db: *QueryDb, kind: QueryKind, key: u64) R.Result[MetadataRevision, fail.Fail] {
+    val result: R.Result[MetadataRevision, fail.Fail] = observe_inner(db, kind, key);
+    if (db != nil && db.operation_active && R.is_err[MetadataRevision, fail.Fail](result)) {
+        operation_fail(db, R.unwrap_err[MetadataRevision, fail.Fail](result));
+        ret R.err[MetadataRevision, fail.Fail](O.unwrap[fail.Fail](db.operation_failure));
+    }
+    ret result;
+}
+
+fun observe_inner(db: *QueryDb, kind: QueryKind, key: u64) R.Result[MetadataRevision, fail.Fail] {
+    if (db == nil || db.stack.len == 0 || db.stack.data[db.stack.len - 1].entry == nil) {
+        ret R.err[MetadataRevision, fail.Fail](fail.message("metadata dependency requires an active computation"));
+    }
+    val sampled: R.Result[MetadataRevision, fail.Fail] = sample_metadata(db, kind, key);
+    if (R.is_err[MetadataRevision, fail.Fail](sampled)) { ret sampled; }
+    val value: MetadataRevision = R.unwrap_ok[MetadataRevision, fail.Fail](sampled);
+    val recorded: R.Result[Revision, str] = dep_upsert(db, db.stack.data[db.stack.len - 1].entry,
+        kind, key, value.revision, 0, value.present);
+    if (R.is_err[Revision, str](recorded)) { ret fail.lift[MetadataRevision](R.err[MetadataRevision, str](R.unwrap_err[Revision, str](recorded))); }
+    ret sampled;
+}
+
+fun dep_prepare(db: *QueryDb, entry: *QueryEntry, kind: QueryKind, key: u64) R.Result[R.Void, str] {
+    var i: u32 = 0;
+    for (i < entry.dep_len) {
+        if (entry.deps[i].kind == kind && entry.deps[i].key == key) { ret R.ok_void[str](); }
+        i = i + 1;
+    }
+    val reserved: R.Result[R.Void, str] = deps_reserve(db, entry, 1);
+    if (R.is_err[R.Void, str](reserved)) { ret reserved; }
+    entry.deps[entry.dep_len] = Dep{ kind: kind, key: key };
+    entry.dep_len = entry.dep_len + 1;
     ret R.ok_void[str]();
 }
 
-pub fun record_dep_rev(db: *QueryDb, owner_kind: QueryKind, owner_key: u64, dep_kind: QueryKind, dep_key: u64) R.Result[Revision, str] {
-    if (owner_kind::u32 >= db.kinds) {
-        ret R.err[Revision, str]("record_dep: owner kind out of range");
-    }
-    val sh: *QueryShard = ?db.storage[owner_kind::u32];
-    if (!sh.registered) {
-        ret R.err[Revision, str]("record_dep: owner kind not registered");
-    }
-    val entry: *QueryEntry = entry_find(sh, owner_key);
-    if (entry == nil) {
-        ret R.err[Revision, str]("record_dep: owner entry not found");
-    }
-
-    if (!dep_kind_valid(db, dep_kind)) {
-        ret R.err[Revision, str]("record_dep: dependency kind is not a registered, readable query");
-    }
-
-    ret dep_upsert(db, entry, dep_kind, dep_key);
-}
-
-fun dep_kind_valid(db: *QueryDb, kind: QueryKind) bool {
-    if (kind::u32 >= db.kinds) { ret false; }
-    val sh: *QueryShard = ?db.storage[kind::u32];
-    if (!sh.registered) { ret false; }
-    if (sh.role == SHARD_METADATA && sh.revisions == nil::RevisionFn) { ret false; }
-    ret true;
-}
-
-fun dep_upsert(db: *QueryDb, entry: *QueryEntry, dep_kind: QueryKind, dep_key: u64) R.Result[Revision, str] {
+fun dep_upsert(db: *QueryDb, entry: *QueryEntry, dep_kind: QueryKind, dep_key: u64, rev: Revision, diagnostic_revision: Revision, present: bool) R.Result[Revision, str] {
     var i: u32 = 0;
     for (i < entry.dep_len) {
         val d: *Dep = ?entry.deps[i];
         if (d.kind == dep_kind && d.key == dep_key) {
+            if (!d.observed) {
+                d.last_changed = rev;
+                d.diagnostics_changed = diagnostic_revision;
+                d.present = present;
+                d.observed = true;
+                ret R.ok[Revision, str](rev);
+            }
+            if (d.last_changed != rev || d.diagnostics_changed != diagnostic_revision || d.present != present) {
+                ret R.err[Revision, str]("query dependency changed after acquisition");
+            }
             ret R.ok[Revision, str](d.last_changed);
         }
         i = i + 1;
@@ -456,20 +1065,42 @@ fun dep_upsert(db: *QueryDb, entry: *QueryEntry, dep_kind: QueryKind, dep_key: u
     val res_reserve: R.Result[R.Void, str] = deps_reserve(db, entry, 1);
     if (R.is_err[R.Void, str](res_reserve)) { ret R.err[Revision, str](R.unwrap_err[R.Void, str](res_reserve)); }
 
-    val rev: Revision = last_changed_get(db, dep_kind, dep_key);
     val dep: *Dep = ?entry.deps[entry.dep_len];
+    dep.observed     = true;
     dep.kind         = dep_kind;
     dep.key          = dep_key;
     dep.last_changed = rev;
+    dep.present = present;
+    dep.diagnostics_changed = diagnostic_revision;
     entry.dep_len = entry.dep_len + 1;
     ret R.ok[Revision, str](rev);
+}
+
+# observation copies recorded keys without validating or exposing a cached product
+pub fun cached_dependency_keys(db: *QueryDb, kind: QueryKind, key: u64,
+                               a: *A.Allocator) R.Result[Vector[QueryKey], str] {
+    val found: R.Result[*QueryEntry, str] = peek(db, kind, key);
+    if (R.is_err[*QueryEntry, str](found)) { ret R.err[Vector[QueryKey], str](R.unwrap_err[*QueryEntry, str](found)); }
+    val entry: *QueryEntry = R.unwrap_ok[*QueryEntry, str](found);
+    var keys: Vector[QueryKey] = vector.init[QueryKey](a);
+    var transferred: bool = false;
+    fin { if (!transferred) { vector.dnit[QueryKey](?keys); } }
+    var i: u32 = 0;
+    for (i < entry.dep_len) {
+        val dep: Dep = entry.deps[i];
+        val copied: R.Result[usize, str] = vector.push[QueryKey](?keys, QueryKey{ kind: dep.kind, key: dep.key });
+        if (R.is_err[usize, str](copied)) { ret R.err[Vector[QueryKey], str](R.unwrap_err[usize, str](copied)); }
+        i = i + 1;
+    }
+    transferred = true;
+    ret R.ok[Vector[QueryKey], str](keys);
 }
 
 pub fun peek_revision(db: *QueryDb, kind: QueryKind, key: u64) Revision {
     ret last_changed_get(db, kind, key);
 }
 
-pub fun peek(db: *QueryDb, kind: QueryKind, key: u64) R.Result[*QueryEntry, str] {
+fun peek(db: *QueryDb, kind: QueryKind, key: u64) R.Result[*QueryEntry, str] {
     val sh_r: R.Result[*QueryShard, str] = shard_get(db, kind);
     if (R.is_err[*QueryShard, str](sh_r)) {
         ret R.err[*QueryEntry, str](R.unwrap_err[*QueryShard, str](sh_r));
@@ -483,15 +1114,6 @@ pub fun peek(db: *QueryDb, kind: QueryKind, key: u64) R.Result[*QueryEntry, str]
     ret R.ok[*QueryEntry, str](entry);
 }
 
-pub fun peek_valid(db: *QueryDb, kind: QueryKind, key: u64) bool {
-    if (kind::u32 >= db.kinds) { ret false; }
-    val sh: *QueryShard = ?db.storage[kind::u32];
-    if (!sh.registered || sh.role == SHARD_METADATA) { ret false; }
-    val entry: *QueryEntry = entry_find(sh, key);
-    if (entry == nil) { ret false; }
-    if (sh.role == SHARD_INPUT) { ret true; }
-    ret is_entry_valid(db, entry);
-}
 
 pub fun shard_len(db: *QueryDb, kind: QueryKind) u32 {
     if (kind::u32 >= db.kinds) { ret 0; }
@@ -499,7 +1121,8 @@ pub fun shard_len(db: *QueryDb, kind: QueryKind) u32 {
     ret sh.index.len::u32;
 }
 
-fun register(db: *QueryDb, kind: QueryKind, role: ShardRole, revisions: RevisionFn) R.Result[R.Void, str] {
+fun register(db: *QueryDb, kind: QueryKind, role: ShardRole, revisions: RevisionProvider) R.Result[R.Void, str] {
+    if (db.operation_active || db.presentation_pending) { ret R.err[R.Void, str]("cannot register a query before the operation is released"); }
     val need: u32 = kind::u32 + 1;
     if (need > db.kinds) {
         val res_grow: R.Result[R.Void, str] = storage_grow(db, need);
@@ -557,7 +1180,7 @@ fun storage_grow(db: *QueryDb, need: u32) R.Result[R.Void, str] {
         val sh: *QueryShard = ?db.storage[i];
         sh.kind       = i::QueryKind;
         sh.role       = SHARD_INPUT;
-        sh.revisions  = nil::RevisionFn;
+        sh.revisions  = RevisionProvider{};
         sh.finalize   = nil::FinalizeFn;
         sh.registered = false;
 
@@ -609,6 +1232,8 @@ fun entry_append(db: *QueryDb, sh: *QueryShard, key: u64) R.Result[*QueryEntry, 
     fresh.dep_len      = 0;
     fresh.dep_cap      = 0;
     fresh.diags        = nil;
+    fresh.diagnostics_changed = 0;
+    fresh.ready = false;
 
     val ed_r: R.Result[handle.HandleEditor[QueryEntry, QueryEntryDomain], str] =
         handle.edit[QueryEntry, QueryEntryDomain](?sh.entries);
@@ -708,6 +1333,7 @@ fun entry_free(db: *QueryDb, sh: *QueryShard, entry: *QueryEntry) {
     entry.dep_len   = 0;
     entry.dep_cap   = 0;
     entry.diags     = nil;
+    entry.ready     = false;
 }
 
 fun shard_entries_free(db: *QueryDb, sh: *QueryShard) {
@@ -725,89 +1351,125 @@ fun shard_entries_free(db: *QueryDb, sh: *QueryShard) {
     map.dnit[u64, handle.HandleId[QueryEntryDomain]](?sh.by_key);
 }
 
-fun is_entry_valid(db: *QueryDb, entry: *QueryEntry) bool {
-    var i: u32 = 0;
-    for (i < entry.dep_len) {
-        val dep: *Dep = ?entry.deps[i];
-        if (last_changed_get(db, dep.kind, dep.key) != dep.last_changed) {
-            ret false;
-        }
-        i = i + 1;
-    }
-    ret true;
-}
-
 fun last_changed_get(db: *QueryDb, kind: QueryKind, key: u64) Revision {
     if (kind::u32 >= db.kinds) { ret 0; }
     val sh: *QueryShard = ?db.storage[kind::u32];
-    if (sh.role == SHARD_METADATA) {
-        if (sh.revisions == nil) { ret 0; }
-        ret sh.revisions(key);
-    }
+    if (sh.role == SHARD_METADATA) { ret 0; }
     val entry: *QueryEntry = entry_find(sh, key);
     if (entry == nil) { ret 0; }
     ret entry.last_changed;
 }
 
-fun recompute[T](rt: *QueryRuntime[T], ctx: *T, sh: *QueryShard, entry: *QueryEntry, key: u64) R.Result[*QueryEntry, fail.Fail] {
+fun diagnostics_changed_get(db: *QueryDb, kind: QueryKind, key: u64) Revision {
+    if (kind::u32 >= db.kinds) { ret 0; }
+    val sh: *QueryShard = ?db.storage[kind::u32];
+    if (sh.role != SHARD_DERIVED) { ret 0; }
+    val entry: *QueryEntry = entry_find(sh, key);
+    if (entry == nil || !entry.ready) { ret 0; }
+    ret entry.diagnostics_changed;
+}
+
+fun diagnostic_dependencies_equal(left: *QueryEntry, right: *QueryEntry) bool {
+    var i: u32 = 0;
+    var j: u32 = 0;
+    for (true) {
+        for (i < left.dep_len && left.deps[i].diagnostics_changed == 0) { i = i + 1; }
+        for (j < right.dep_len && right.deps[j].diagnostics_changed == 0) { j = j + 1; }
+        if (i == left.dep_len || j == right.dep_len) { ret i == left.dep_len && j == right.dep_len; }
+        val l: Dep = left.deps[i];
+        val r: Dep = right.deps[j];
+        if (l.kind != r.kind || l.key != r.key || l.diagnostics_changed != r.diagnostics_changed) { ret false; }
+        i = i + 1;
+        j = j + 1;
+    }
+    ret false;
+}
+
+fun has_diagnostics(entry: *QueryEntry) bool {
+    if (entry.diags != nil && diagnostic.len(entry.diags) != 0) { ret true; }
+    var i: u32 = 0;
+    for (i < entry.dep_len) {
+        if (entry.deps[i].diagnostics_changed != 0) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+fun candidate_compute[T](rt: *QueryRuntime[T], ctx: *T, sh: *QueryShard, key: u64,
+                         candidate: *QueryEntry,
+                         compute: fun(*T, QueryKind, u64, *A.Allocator, *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail]) R.Result[R.Void, fail.Fail] {
     val db: *QueryDb = rt.db;
-    entry.dep_len = 0;
-
-    val diag_mark: usize = diagnostic.len(rt.diags);
-
+    val diags_r: R.Result[*diagnostic.DiagnosticStore, str] = A.allocate[diagnostic.DiagnosticStore](db.a, 1);
+    if (R.is_err[*diagnostic.DiagnosticStore, str](diags_r)) {
+        ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[*diagnostic.DiagnosticStore, str](diags_r)));
+    }
+    candidate.diags = R.unwrap_ok[*diagnostic.DiagnosticStore, str](diags_r);
+    @candidate.diags = diagnostic.store_init(db.a);
+    val frame: usize = db.stack.len - 1;
+    db.stack.data[frame].entry = candidate;
+    fin { db.stack.data[frame].entry = nil; }
     db.compute_depth = db.compute_depth + 1;
-    val res_output: R.Result[QueryOutput, fail.Fail] = rt.caps.compute(ctx, sh.kind, key, db.a);
+    val computed: R.Result[QueryOutput, fail.Fail] = compute(ctx, sh.kind, key, db.a, candidate.diags);
     db.compute_depth = db.compute_depth - 1;
-
-    if (R.is_err[QueryOutput, fail.Fail](res_output)) {
-        entry_remove(db, sh, key);
-        ret R.err[*QueryEntry, fail.Fail](R.unwrap_err[QueryOutput, fail.Fail](res_output));
+    if (R.is_err[QueryOutput, fail.Fail](computed)) {
+        operation_fail(db, R.unwrap_err[QueryOutput, fail.Fail](computed));
+        ret R.err[R.Void, fail.Fail](O.unwrap[fail.Fail](db.operation_failure));
     }
-    val out: QueryOutput = R.unwrap_ok[QueryOutput, fail.Fail](res_output);
-
-    if (diagnostic.len(rt.diags) > diag_mark) {
-        val snap_r: R.Result[*diagnostic.DiagnosticStore, str] = diagnostic.snapshot_from(rt.diags, diag_mark, db.a);
-        if (R.is_err[*diagnostic.DiagnosticStore, str](snap_r)) {
-            if (out.bytes != nil && out.len > 0) {
-                if (sh.finalize != nil) { sh.finalize(out.bytes, out.len, db.a); }
-                A.deallocate[u8](db.a, out.bytes, out.len::usize);
-            }
-            entry_remove(db, sh, key);
-            ret R.err[*QueryEntry, fail.Fail](fail.message(R.unwrap_err[*diagnostic.DiagnosticStore, str](snap_r)));
-        }
-        if (entry.diags != nil) {
-            diagnostic.store_dnit(entry.diags);
-            A.deallocate[diagnostic.DiagnosticStore](db.a, entry.diags, 1::usize);
-        }
-        entry.diags = R.unwrap_ok[*diagnostic.DiagnosticStore, str](snap_r);
-    } or {
-        if (entry.diags != nil) {
-            diagnostic.store_dnit(entry.diags);
-            A.deallocate[diagnostic.DiagnosticStore](db.a, entry.diags, 1::usize);
-        }
-        entry.diags = nil;
+    val out: QueryOutput = R.unwrap_ok[QueryOutput, fail.Fail](computed);
+    candidate.value = out.bytes;
+    candidate.value_len = out.len;
+    if ((out.len != 0 && out.bytes == nil) || (out.len == 0 && out.bytes != nil)) {
+        ret R.err[R.Void, fail.Fail](fail.message("query output has an inconsistent byte extent"));
     }
-
-    val owned: bool = sh.finalize != nil;
-    if (!owned) {
-        val same: bool = entry.value_len == out.len
-            && memory.raw_equal(entry.value::ptr, out.bytes::ptr, out.len::usize);
-        if (same) {
-            if (out.bytes != nil && out.len > 0) {
-                A.deallocate[u8](db.a, out.bytes, out.len::usize);
-            }
-            ret R.ok[*QueryEntry, fail.Fail](entry);
-        }
+    if (O.is_some[fail.Fail](db.operation_failure)) {
+        ret R.err[R.Void, fail.Fail](O.unwrap[fail.Fail](db.operation_failure));
     }
+    ret R.ok_void[fail.Fail]();
+}
 
-    if (entry.value != nil && entry.value_len > 0) {
-        if (owned) { sh.finalize(entry.value, entry.value_len, db.a); }
-        A.deallocate[u8](db.a, entry.value, entry.value_len::usize);
+fun candidate_publish(db: *QueryDb, sh: *QueryShard, entry: *QueryEntry, candidate: *QueryEntry) R.Result[*QueryEntry, fail.Fail] {
+    candidate.ready = true;
+    val diag_equal: R.Result[bool, str] = diagnostic.content_equal(entry.diags, candidate.diags);
+    if (R.is_err[bool, str](diag_equal)) { ret R.err[*QueryEntry, fail.Fail](fail.message(R.unwrap_err[bool, str](diag_equal))); }
+    val same_diags: bool = R.unwrap_ok[bool, str](diag_equal) && diagnostic_dependencies_equal(entry, candidate);
+    val same_value: bool = entry.ready && sh.finalize == nil && entry.value_len == candidate.value_len
+        && memory.raw_equal(entry.value::ptr, candidate.value::ptr, candidate.value_len::usize);
+    var revision: Revision = entry.last_changed;
+    if (!same_value || !same_diags) {
+        val changed: R.Result[Revision, str] = next_revision(db);
+        if (R.is_err[Revision, str](changed)) { ret R.err[*QueryEntry, fail.Fail](fail.message(R.unwrap_err[Revision, str](changed))); }
+        revision = R.unwrap_ok[Revision, str](changed);
     }
-    entry.value        = out.bytes;
-    entry.value_len    = out.len;
-    entry.last_changed = db.revision;
+    candidate.last_changed = revision;
+    if (has_diagnostics(candidate)) {
+        if (same_diags) { candidate.diagnostics_changed = entry.diagnostics_changed; }
+        or { candidate.diagnostics_changed = revision; }
+    }
+    if (same_value) {
+        if (candidate.value != nil && candidate.value_len != 0) { A.deallocate[u8](db.a, candidate.value, candidate.value_len::usize); }
+        candidate.value = entry.value;
+        entry.value = nil;
+        entry.value_len = 0;
+    }
+    entry_free(db, sh, entry);
+    @entry = @candidate;
+    @candidate = QueryEntry{};
     ret R.ok[*QueryEntry, fail.Fail](entry);
+}
+
+fun recompute[T](rt: *QueryRuntime[T], ctx: *T, sh: *QueryShard, entry: *QueryEntry, key: u64, attempt: usize) R.Result[*QueryEntry, fail.Fail] {
+    val db: *QueryDb = rt.db;
+    var candidate: QueryEntry = QueryEntry{ key: key };
+    var committed: bool = false;
+    fin {
+        if (!committed) { attempt_preserve(db, sh, attempt, ?candidate); }
+        entry_free(db, sh, ?candidate);
+    }
+    val computed: R.Result[R.Void, fail.Fail] = candidate_compute[T](rt, ctx, sh, key, ?candidate, rt.caps.compute);
+    if (R.is_err[R.Void, fail.Fail](computed)) { ret R.err[*QueryEntry, fail.Fail](R.unwrap_err[R.Void, fail.Fail](computed)); }
+    val published: R.Result[*QueryEntry, fail.Fail] = candidate_publish(db, sh, entry, ?candidate);
+    if (R.is_ok[*QueryEntry, fail.Fail](published)) { committed = true; }
+    ret published;
 }
 
 fun deps_reserve(db: *QueryDb, entry: *QueryEntry, need: u32) R.Result[R.Void, str] {
@@ -887,21 +1549,25 @@ rec TestQueryContext {
     runtime: QueryRuntime[TestQueryContext];
     diags:   diagnostic.DiagnosticStore;
     mode:    TestComputeMode;
+    last_presentation: *Presentation;
+    diagnostic_refused: bool;
 }
 
-def TestComputeFn: fun(*TestQueryContext, QueryKind, u64, *A.Allocator) R.Result[QueryOutput, fail.Fail];
+def TestComputeFn: fun(*TestQueryContext, QueryKind, u64, *A.Allocator, *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail];
 
 fun t_context_init_with(ctx: *TestQueryContext, db: *QueryDb, diag_alloc: *A.Allocator,
                         mode: TestComputeMode) bool {
     ctx.diags = diagnostic.store_init(diag_alloc);
     val rt_r: R.Result[QueryRuntime[TestQueryContext], str] =
-        runtime[TestQueryContext](db, ?ctx.diags, t_dispatch);
+        runtime[TestQueryContext](db, t_dispatch);
     if (R.is_err[QueryRuntime[TestQueryContext], str](rt_r)) {
         diagnostic.store_dnit(?ctx.diags);
         ret false;
     }
     ctx.runtime = R.unwrap_ok[QueryRuntime[TestQueryContext], str](rt_r);
     ctx.mode    = mode;
+    ctx.last_presentation = nil;
+    ctx.diagnostic_refused = false;
     ret true;
 }
 
@@ -910,18 +1576,59 @@ fun t_context_init(ctx: *TestQueryContext, db: *QueryDb, mode: TestComputeMode) 
 }
 
 fun t_context_dnit(ctx: *TestQueryContext) {
+    presentation_dnit(ctx.last_presentation);
+    ctx.last_presentation = nil;
     diagnostic.store_dnit(?ctx.diags);
 }
 
-fun t_always_fail(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Result[QueryOutput, fail.Fail] {
+fun t_present(ctx: *TestQueryContext, operation: Operation, kind: QueryKind, key: u64) R.Result[R.Void, str] {
+    var root: QueryKey = QueryKey{ kind: kind, key: key };
+    val presented: R.Result[*Presentation, str] = collect(ctx.runtime.db, operation, ?root, 1, ctx.diags.a);
+    if (R.is_err[*Presentation, str](presented)) { ret R.void_of[*Presentation, str](presented); }
+    ctx.last_presentation = R.unwrap_ok[*Presentation, str](presented);
+    ret diagnostic.replay_into(?ctx.diags, ?ctx.last_presentation.diags);
+}
+
+fun t_get(ctx: *TestQueryContext, kind: QueryKind, key: u64) R.Result[*QueryEntry, fail.Fail] {
+    presentation_dnit(ctx.last_presentation);
+    ctx.last_presentation = nil;
+    if (ctx.runtime.db.presentation_pending) {
+        val released: R.Result[R.Void, str] = discard(ctx.runtime.db,
+            Operation{ owner: ctx.runtime.db::ptr, sequence: ctx.runtime.db.operation_sequence });
+        if (R.is_err[R.Void, str](released)) { ret R.err[*QueryEntry, fail.Fail](fail.message(R.unwrap_err[R.Void, str](released))); }
+    }
+    val opened: R.Result[Operation, str] = begin(ctx.runtime.db);
+    if (R.is_err[Operation, str](opened)) { ret fail.lift[*QueryEntry](R.err[*QueryEntry, str](R.unwrap_err[Operation, str](opened))); }
+    val result: R.Result[*QueryEntry, fail.Fail] = acquire_entry[TestQueryContext](?ctx.runtime, ctx, kind, key);
+    val closed: R.Result[R.Void, fail.Fail] = end(ctx.runtime.db, R.unwrap_ok[Operation, str](opened));
+    val shown: R.Result[R.Void, str] = t_present(ctx, R.unwrap_ok[Operation, str](opened), kind, key);
+    if (R.is_err[*QueryEntry, fail.Fail](result)) { ret result; }
+    if (R.is_err[R.Void, str](shown)) { ret R.err[*QueryEntry, fail.Fail](fail.message(R.unwrap_err[R.Void, str](shown))); }
+    if (R.is_err[R.Void, fail.Fail](closed)) { ret R.err[*QueryEntry, fail.Fail](R.unwrap_err[R.Void, fail.Fail](closed)); }
+    ret result;
+}
+
+fun t_reusable(ctx: *TestQueryContext, kind: QueryKind, key: u64) R.Result[bool, fail.Fail] {
+    val opened: R.Result[Operation, str] = begin(ctx.runtime.db);
+    if (R.is_err[Operation, str](opened)) { ret fail.lift[bool](R.err[bool, str](R.unwrap_err[Operation, str](opened))); }
+    val result: R.Result[bool, fail.Fail] = reusable[TestQueryContext](?ctx.runtime, ctx, kind, key);
+    val closed: R.Result[R.Void, fail.Fail] = end(ctx.runtime.db, R.unwrap_ok[Operation, str](opened));
+    if (R.is_err[bool, fail.Fail](result)) { ret result; }
+    if (R.is_err[R.Void, fail.Fail](closed)) { ret R.err[bool, fail.Fail](R.unwrap_err[R.Void, fail.Fail](closed)); }
+    val released: R.Result[R.Void, str] = discard(ctx.runtime.db, R.unwrap_ok[Operation, str](opened));
+    if (R.is_err[R.Void, str](released)) { ret R.err[bool, fail.Fail](fail.message(R.unwrap_err[R.Void, str](released))); }
+    ret result;
+}
+
+fun t_always_fail(ctx: *TestQueryContext, key: u64, a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
     ret R.err[QueryOutput, fail.Fail](fail.message("compute always fails"));
 }
 
-fun t_tok_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Result[QueryOutput, fail.Fail] {
+fun t_tok_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
     val db: *QueryDb = ctx.runtime.db;
-    val res_dep: R.Result[R.Void, str] = record_dep(db, Q_TOKENIZE, key, Q_FILE_TEXT, key);
-    if (R.is_err[R.Void, str](res_dep)) {
-        ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_dep)));
+    val res_dep: R.Result[R.Void, fail.Fail] = depend[TestQueryContext](?ctx.runtime, ctx, Q_FILE_TEXT, key);
+    if (R.is_err[R.Void, fail.Fail](res_dep)) {
+        ret R.err[QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](res_dep));
     }
     val res_buf: R.Result[*u8, str] = A.allocate[u8](a, 1);
     if (R.is_err[*u8, str](res_buf)) {
@@ -944,11 +1651,11 @@ fun t_handle_ptr(entry: *QueryEntry) ptr {
     ret slot[0];
 }
 
-fun t_owned_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Result[QueryOutput, fail.Fail] {
+fun t_owned_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
     val db: *QueryDb = ctx.runtime.db;
-    val res_dep: R.Result[R.Void, str] = record_dep(db, Q_PARSE, key, Q_FILE_TEXT, key);
-    if (R.is_err[R.Void, str](res_dep)) {
-        ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_dep)));
+    val res_dep: R.Result[R.Void, fail.Fail] = depend[TestQueryContext](?ctx.runtime, ctx, Q_FILE_TEXT, key);
+    if (R.is_err[R.Void, fail.Fail](res_dep)) {
+        ret R.err[QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](res_dep));
     }
     val res_art: R.Result[*u64, str] = A.allocate[u64](a, 1::usize);
     if (R.is_err[*u64, str](res_art)) {
@@ -984,12 +1691,13 @@ fun t_owned_finalize(value: *u8, value_len: u32, a: *A.Allocator) {
     t_live = t_live - 1;
 }
 
-fun t_owned_diag_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Result[QueryOutput, fail.Fail] {
-    val out_r: R.Result[QueryOutput, fail.Fail] = t_owned_compute(ctx, key, a);
+fun t_owned_diag_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
+    val out_r: R.Result[QueryOutput, fail.Fail] = t_owned_compute(ctx, key, a, diags);
     if (R.is_err[QueryOutput, fail.Fail](out_r)) { ret out_r; }
     val out: QueryOutput = R.unwrap_ok[QueryOutput, fail.Fail](out_r);
-    val diag_r: R.Result[R.Void, str] = t_emit_diag(ctx);
+    val diag_r: R.Result[R.Void, str] = t_emit_diag(diags);
     if (R.is_err[R.Void, str](diag_r)) {
+        ctx.diagnostic_refused = true;
         t_owned_finalize(out.bytes, out.len, a);
         if (out.bytes != nil && out.len > 0) { A.deallocate[u8](a, out.bytes, out.len::usize); }
         ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](diag_r)));
@@ -998,29 +1706,29 @@ fun t_owned_diag_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Re
 }
 
 fun t_dispatch(ctx: *TestQueryContext, kind: QueryKind, key: u64,
-               a: *A.Allocator) R.Result[QueryOutput, fail.Fail] {
-    if (ctx.mode == T_MODE_FAIL) { ret t_always_fail(ctx, key, a); }
-    if (ctx.mode == T_MODE_TOKENIZE) { ret t_tok_compute(ctx, key, a); }
-    if (ctx.mode == T_MODE_OWNED) { ret t_owned_compute(ctx, key, a); }
+               a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
+    if (ctx.mode == T_MODE_FAIL) { ret t_always_fail(ctx, key, a, diags); }
+    if (ctx.mode == T_MODE_TOKENIZE) { ret t_tok_compute(ctx, key, a, diags); }
+    if (ctx.mode == T_MODE_OWNED) { ret t_owned_compute(ctx, key, a, diags); }
     if (ctx.mode == T_MODE_DIAG) {
-        if (kind == Q_TOKENIZE) { ret t_inner_diag_compute(ctx, key, a); }
-        if (kind == Q_PARSE)    { ret t_outer_diag_compute(ctx, key, a); }
+        if (kind == Q_TOKENIZE) { ret t_inner_diag_compute(ctx, key, a, diags); }
+        if (kind == Q_PARSE)    { ret t_outer_diag_compute(ctx, key, a, diags); }
     }
-    if (ctx.mode == T_MODE_DIRECT) { ret t_direct_cycle_compute(ctx, key, a); }
-    if (ctx.mode == T_MODE_DIRECT_TOKENIZE) { ret t_direct_tokenize_recompute(ctx, key, a); }
+    if (ctx.mode == T_MODE_DIRECT) { ret t_direct_cycle_compute(ctx, key, a, diags); }
+    if (ctx.mode == T_MODE_DIRECT_TOKENIZE) { ret t_direct_tokenize_recompute(ctx, key, a, diags); }
     if (ctx.mode == T_MODE_INDIRECT) {
-        if (kind == Q_SEMA)  { ret t_cycle_a_compute(ctx, key, a); }
-        if (kind == Q_LOWER) { ret t_cycle_b_compute(ctx, key, a); }
+        if (kind == Q_SEMA)  { ret t_cycle_a_compute(ctx, key, a, diags); }
+        if (kind == Q_LOWER) { ret t_cycle_b_compute(ctx, key, a, diags); }
     }
     if (ctx.mode == T_MODE_PARSE_DEPS) {
-        if (kind == Q_TOKENIZE) { ret t_tok_compute(ctx, key, a); }
-        if (kind == Q_PARSE)    { ret t_parse_deps_on_tokenize(ctx, key, a); }
+        if (kind == Q_TOKENIZE) { ret t_tok_compute(ctx, key, a, diags); }
+        if (kind == Q_PARSE)    { ret t_parse_deps_on_tokenize(ctx, key, a, diags); }
     }
-    if (ctx.mode == T_MODE_DEDUP)      { ret t_dedup_owner_compute(ctx, key, a); }
-    if (ctx.mode == T_MODE_OWNED_DIAG) { ret t_owned_diag_compute(ctx, key, a); }
+    if (ctx.mode == T_MODE_DEDUP)      { ret t_dedup_owner_compute(ctx, key, a, diags); }
+    if (ctx.mode == T_MODE_OWNED_DIAG) { ret t_owned_diag_compute(ctx, key, a, diags); }
     if (ctx.mode == T_MODE_AUTO_DEP) {
-        if (kind == Q_TOKENIZE) { ret t_tok_compute(ctx, key, a); }
-        if (kind == Q_PARSE)    { ret t_auto_dep_outer_compute(ctx, key, a); }
+        if (kind == Q_TOKENIZE) { ret t_tok_compute(ctx, key, a, diags); }
+        if (kind == Q_PARSE)    { ret t_auto_dep_outer_compute(ctx, key, a, diags); }
     }
     ret R.err[QueryOutput, fail.Fail](fail.message("test query kind has no compute capability"));
 }
@@ -1036,8 +1744,8 @@ test "mach.lang.query.recompute:failed_not_cached_as_success" {
 
     if (R.is_err[R.Void, str](register_derived(?db, Q_TOKENIZE))) { dnit(?db); ret 1; }
 
-    if (!R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 42))) { dnit(?db); ret 1; }
-    if (!R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 42))) { dnit(?db); ret 1; }
+    if (!R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_TOKENIZE, 42))) { dnit(?db); ret 1; }
+    if (!R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_TOKENIZE, 42))) { dnit(?db); ret 1; }
 
     dnit(?db);
     t_context_dnit(?ctx);
@@ -1056,18 +1764,18 @@ test "mach.lang.query.set_input:identical_bytes_early_cutoff" {
     if (R.is_err[R.Void, str](register_input(?db, Q_PROJECT_ROOT))) { dnit(?db); ret 1; }
 
     if (R.is_err[R.Void, str](set_input(?db, Q_PROJECT_ROOT, 1, "hello"::*u8, 5))) { dnit(?db); ret 1; }
-    val res_entry_a: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ?ctx, Q_PROJECT_ROOT, 1);
+    val res_entry_a: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_PROJECT_ROOT, 1);
     if (R.is_err[*QueryEntry, fail.Fail](res_entry_a)) { dnit(?db); ret 1; }
     val lc_a: Revision = R.unwrap_ok[*QueryEntry, fail.Fail](res_entry_a).last_changed;
 
     if (R.is_err[R.Void, str](set_input(?db, Q_PROJECT_ROOT, 1, "hello"::*u8, 5))) { dnit(?db); ret 1; }
-    val res_entry_b: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ?ctx, Q_PROJECT_ROOT, 1);
+    val res_entry_b: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_PROJECT_ROOT, 1);
     if (R.is_err[*QueryEntry, fail.Fail](res_entry_b)) { dnit(?db); ret 1; }
     val lc_b: Revision = R.unwrap_ok[*QueryEntry, fail.Fail](res_entry_b).last_changed;
     if (lc_b != lc_a) { dnit(?db); ret 1; }
 
     if (R.is_err[R.Void, str](set_input(?db, Q_PROJECT_ROOT, 1, "world"::*u8, 5))) { dnit(?db); ret 1; }
-    val res_entry_c: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ?ctx, Q_PROJECT_ROOT, 1);
+    val res_entry_c: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_PROJECT_ROOT, 1);
     if (R.is_err[*QueryEntry, fail.Fail](res_entry_c)) { dnit(?db); ret 1; }
     val lc_c: Revision = R.unwrap_ok[*QueryEntry, fail.Fail](res_entry_c).last_changed;
     if (lc_c <= lc_a) { dnit(?db); ret 1; }
@@ -1090,17 +1798,17 @@ test "mach.lang.query.get:derived_dep_tracking_early_cutoff" {
     if (R.is_err[R.Void, str](register_derived(?db, Q_TOKENIZE))) { dnit(?db); ret 1; }
 
     if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 7, "v1"::*u8, 2))) { dnit(?db); ret 1; }
-    val res_warm: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 7);
+    val res_warm: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_TOKENIZE, 7);
     if (R.is_err[*QueryEntry, fail.Fail](res_warm)) { dnit(?db); ret 1; }
     val lc_warm: Revision = R.unwrap_ok[*QueryEntry, fail.Fail](res_warm).last_changed;
 
     if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 7, "v2"::*u8, 2))) { dnit(?db); ret 1; }
-    val res_v2: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 7);
+    val res_v2: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_TOKENIZE, 7);
     if (R.is_err[*QueryEntry, fail.Fail](res_v2)) { dnit(?db); ret 1; }
     val lc_v2: Revision = R.unwrap_ok[*QueryEntry, fail.Fail](res_v2).last_changed;
 
     if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 7, "v1"::*u8, 2))) { dnit(?db); ret 1; }
-    val res_v1: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 7);
+    val res_v1: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_TOKENIZE, 7);
     if (R.is_err[*QueryEntry, fail.Fail](res_v1)) { dnit(?db); ret 1; }
     val lc_v1: Revision = R.unwrap_ok[*QueryEntry, fail.Fail](res_v1).last_changed;
 
@@ -1126,25 +1834,25 @@ test "mach.lang.query.register_derived_owned:finalizer_frees_artifacts" {
     if (R.is_err[R.Void, str](register_derived_owned(?db, Q_PARSE, t_owned_finalize))) { dnit(?db); ret 1; }
 
     if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "a"::*u8, 1))) { dnit(?db); ret 1; }
-    val res_g1: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 1);
+    val res_g1: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_PARSE, 1);
     if (R.is_err[*QueryEntry, fail.Fail](res_g1)) { dnit(?db); ret 1; }
     if (t_live != 1)                        { dnit(?db); ret 1; }
     val p1: ptr = t_handle_ptr(R.unwrap_ok[*QueryEntry, fail.Fail](res_g1));
 
     if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "a"::*u8, 1))) { dnit(?db); ret 1; }
-    val res_g2: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 1);
+    val res_g2: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_PARSE, 1);
     if (R.is_err[*QueryEntry, fail.Fail](res_g2))                        { dnit(?db); ret 1; }
     if (t_live != 1)                                               { dnit(?db); ret 1; }
     if (t_handle_ptr(R.unwrap_ok[*QueryEntry, fail.Fail](res_g2)) != p1) { dnit(?db); ret 1; }
 
     if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "b"::*u8, 1))) { dnit(?db); ret 1; }
-    val res_g3: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 1);
+    val res_g3: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_PARSE, 1);
     if (R.is_err[*QueryEntry, fail.Fail](res_g3))                        { dnit(?db); ret 1; }
     if (t_live != 1)                                               { dnit(?db); ret 1; }
     if (t_handle_ptr(R.unwrap_ok[*QueryEntry, fail.Fail](res_g3)) == p1) { dnit(?db); ret 1; }
 
     if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 2, "c"::*u8, 1))) { dnit(?db); ret 1; }
-    if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 2)))                 { dnit(?db); ret 1; }
+    if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_PARSE, 2)))                 { dnit(?db); ret 1; }
     if (t_live != 2)                                                      { dnit(?db); ret 1; }
 
     dnit(?db);
@@ -1159,18 +1867,18 @@ fun t_diag_reset(ctx: *TestQueryContext) {
     ctx.diags = diagnostic.store_init(a);
 }
 
-fun t_emit_diag(ctx: *TestQueryContext) R.Result[R.Void, str] {
+fun t_emit_diag(diags: *diagnostic.DiagnosticStore) R.Result[R.Void, str] {
     var span: token.Span;
     span.offset = 0;
     span.len    = 1;
-    ret diagnostic.error(?ctx.diags, 0, span, "query diagnostic");
+    ret diagnostic.error(diags, 0, span, "query diagnostic");
 }
 
-fun t_inner_diag_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Result[QueryOutput, fail.Fail] {
+fun t_inner_diag_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
     val db: *QueryDb = ctx.runtime.db;
-    val rd: R.Result[R.Void, str] = record_dep(db, Q_TOKENIZE, key, Q_FILE_TEXT, key);
-    if (R.is_err[R.Void, str](rd)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rd))); }
-    val de: R.Result[R.Void, str] = t_emit_diag(ctx);
+    val rd: R.Result[R.Void, fail.Fail] = depend[TestQueryContext](?ctx.runtime, ctx, Q_FILE_TEXT, key);
+    if (R.is_err[R.Void, fail.Fail](rd)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rd)); }
+    val de: R.Result[R.Void, str] = t_emit_diag(diags);
     if (R.is_err[R.Void, str](de)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](de))); }
     val rb: R.Result[*u8, str] = A.allocate[u8](a, 1);
     if (R.is_err[*u8, str](rb)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[*u8, str](rb))); }
@@ -1182,13 +1890,13 @@ fun t_inner_diag_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Re
     ret R.ok[QueryOutput, fail.Fail](out);
 }
 
-fun t_outer_diag_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Result[QueryOutput, fail.Fail] {
+fun t_outer_diag_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
     val db: *QueryDb = ctx.runtime.db;
-    val rd: R.Result[R.Void, str] = record_dep(db, Q_PARSE, key, Q_FILE_TEXT, key);
-    if (R.is_err[R.Void, str](rd)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rd))); }
-    val de: R.Result[R.Void, str] = t_emit_diag(ctx);
+    val rd: R.Result[R.Void, fail.Fail] = depend[TestQueryContext](?ctx.runtime, ctx, Q_FILE_TEXT, key);
+    if (R.is_err[R.Void, fail.Fail](rd)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rd)); }
+    val de: R.Result[R.Void, str] = t_emit_diag(diags);
     if (R.is_err[R.Void, str](de)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](de))); }
-    val g: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ctx, Q_TOKENIZE, key);
+    val g: R.Result[*QueryEntry, fail.Fail] = acquire_entry[TestQueryContext](?ctx.runtime, ctx, Q_TOKENIZE, key);
     if (R.is_err[*QueryEntry, fail.Fail](g)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[*QueryEntry, fail.Fail](g)); }
     val rb: R.Result[*u8, str] = A.allocate[u8](a, 1);
     if (R.is_err[*u8, str](rb)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[*u8, str](rb))); }
@@ -1215,35 +1923,35 @@ test "mach.lang.query.get:reused_entry_replays_diagnostics" {
     if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "x"::*u8, 1)))             { dnit(?db); ret 1; }
 
     t_diag_reset(?ctx);
-    if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 1))) { dnit(?db); ret 1; }
+    if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_TOKENIZE, 1))) { dnit(?db); ret 1; }
     if (diagnostic.len(?ctx.diags) != 1)                      { dnit(?db); ret 1; }
 
     t_diag_reset(?ctx);
-    if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 1))) { dnit(?db); ret 1; }
+    if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_TOKENIZE, 1))) { dnit(?db); ret 1; }
     if (diagnostic.len(?ctx.diags) != 1)                      { dnit(?db); ret 1; }
 
     t_diag_reset(?ctx);
-    if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 1))) { dnit(?db); ret 1; }
-    if (diagnostic.len(?ctx.diags) != 1)                   { dnit(?db); ret 1; }
+    if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_PARSE, 1))) { dnit(?db); ret 1; }
+    if (diagnostic.len(?ctx.diags) != 2)                   { dnit(?db); ret 1; }
 
     t_diag_reset(?ctx);
-    if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 1))) { dnit(?db); ret 1; }
-    if (diagnostic.len(?ctx.diags) != 1)                   { dnit(?db); ret 1; }
+    if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_PARSE, 1))) { dnit(?db); ret 1; }
+    if (diagnostic.len(?ctx.diags) != 2)                   { dnit(?db); ret 1; }
 
     if (R.is_err[R.Void, str](invalidate(?db, Q_PARSE, 1))) { dnit(?db); ret 1; }
     if (shard_len(?db, Q_PARSE) != 0)                     { dnit(?db); ret 1; }
 
     t_diag_reset(?ctx);
-    if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 1))) { dnit(?db); ret 1; }
-    if (diagnostic.len(?ctx.diags) != 1)                   { dnit(?db); ret 1; }
+    if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_PARSE, 1))) { dnit(?db); ret 1; }
+    if (diagnostic.len(?ctx.diags) != 2)                   { dnit(?db); ret 1; }
 
     dnit(?db);
     t_context_dnit(?ctx);
     ret 0;
 }
 
-fun t_direct_tokenize_recompute(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Result[QueryOutput, fail.Fail] {
-    val g: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ctx, Q_TOKENIZE, key);
+fun t_direct_tokenize_recompute(ctx: *TestQueryContext, key: u64, a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
+    val g: R.Result[*QueryEntry, fail.Fail] = acquire_entry[TestQueryContext](?ctx.runtime, ctx, Q_TOKENIZE, key);
     if (R.is_err[*QueryEntry, fail.Fail](g)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[*QueryEntry, fail.Fail](g)); }
     val seen: *QueryEntry = R.unwrap_ok[*QueryEntry, fail.Fail](g);
     val res_buf: R.Result[*u8, str] = A.allocate[u8](a, 1);
@@ -1270,28 +1978,32 @@ test "mach.lang.query.get:a_stale_entry_under_recomputation_is_a_cycle_not_its_o
     if (R.is_err[R.Void, str](register_derived(?db, Q_TOKENIZE)))   { dnit(?db); ret 1; }
     if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "a"::*u8, 1))) { dnit(?db); ret 1; }
 
-    val first: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 1);
+    val first: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_TOKENIZE, 1);
     if (R.is_err[*QueryEntry, fail.Fail](first))                 { dnit(?db); ret 1; }
     val complete: *QueryEntry = R.unwrap_ok[*QueryEntry, fail.Fail](first);
     if (complete.value == nil || complete.value[0] != 42)        { dnit(?db); ret 1; }
 
     if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "b"::*u8, 1))) { dnit(?db); ret 1; }
-    if (peek_valid(?db, Q_TOKENIZE, 1))                          { dnit(?db); ret 1; }
+    val valid_1: R.Result[bool, fail.Fail] = t_reusable(?ctx, Q_TOKENIZE, 1);
+    if (R.is_err[bool, fail.Fail](valid_1)) { dnit(?db); ret 1; }
+    if (R.unwrap_ok[bool, fail.Fail](valid_1))                          { dnit(?db); ret 1; }
 
     ctx.mode = T_MODE_DIRECT_TOKENIZE;
-    val again: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 1);
+    val again: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_TOKENIZE, 1);
     if (!R.is_err[*QueryEntry, fail.Fail](again))                { dnit(?db); ret 1; }
     if (!str_contains(R.unwrap_err[*QueryEntry, fail.Fail](again).message, "query cycle")) { dnit(?db); ret 1; }
     if (db.stack.len != 0)                                       { dnit(?db); ret 1; }
-    if (peek_valid(?db, Q_TOKENIZE, 1))                          { dnit(?db); ret 1; }
+    val valid_2: R.Result[bool, fail.Fail] = t_reusable(?ctx, Q_TOKENIZE, 1);
+    if (R.is_err[bool, fail.Fail](valid_2)) { dnit(?db); ret 1; }
+    if (R.unwrap_ok[bool, fail.Fail](valid_2))                          { dnit(?db); ret 1; }
 
     dnit(?db);
     t_context_dnit(?ctx);
     ret 0;
 }
 
-fun t_direct_cycle_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Result[QueryOutput, fail.Fail] {
-    val g: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ctx, Q_SEMA, key);
+fun t_direct_cycle_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
+    val g: R.Result[*QueryEntry, fail.Fail] = acquire_entry[TestQueryContext](?ctx.runtime, ctx, Q_SEMA, key);
     if (R.is_err[*QueryEntry, fail.Fail](g)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[*QueryEntry, fail.Fail](g)); }
     var out: QueryOutput;
     out.bytes = nil;
@@ -1310,11 +2022,13 @@ test "mach.lang.query.get:direct_self_recursion_reports_a_cycle_not_an_empty_val
 
     if (R.is_err[R.Void, str](register_derived(?db, Q_SEMA))) { dnit(?db); ret 1; }
 
-    if (!R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_SEMA, 1))) { dnit(?db); ret 1; }
+    if (!R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_SEMA, 1))) { dnit(?db); ret 1; }
     if (db.stack.len != 0)                                { dnit(?db); ret 1; }
-    if (peek_valid(?db, Q_SEMA, 1))                        { dnit(?db); ret 1; }
+    val valid_3: R.Result[bool, fail.Fail] = t_reusable(?ctx, Q_SEMA, 1);
+    if (R.is_err[bool, fail.Fail](valid_3)) { dnit(?db); ret 1; }
+    if (R.unwrap_ok[bool, fail.Fail](valid_3))                        { dnit(?db); ret 1; }
 
-    if (!R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_SEMA, 1))) { dnit(?db); ret 1; }
+    if (!R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_SEMA, 1))) { dnit(?db); ret 1; }
     if (db.stack.len != 0)                                { dnit(?db); ret 1; }
 
     dnit(?db);
@@ -1322,8 +2036,8 @@ test "mach.lang.query.get:direct_self_recursion_reports_a_cycle_not_an_empty_val
     ret 0;
 }
 
-fun t_cycle_a_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Result[QueryOutput, fail.Fail] {
-    val g: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ctx, Q_LOWER, key);
+fun t_cycle_a_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
+    val g: R.Result[*QueryEntry, fail.Fail] = acquire_entry[TestQueryContext](?ctx.runtime, ctx, Q_LOWER, key);
     if (R.is_err[*QueryEntry, fail.Fail](g)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[*QueryEntry, fail.Fail](g)); }
     var out: QueryOutput;
     out.bytes = nil;
@@ -1331,8 +2045,8 @@ fun t_cycle_a_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Resul
     ret R.ok[QueryOutput, fail.Fail](out);
 }
 
-fun t_cycle_b_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Result[QueryOutput, fail.Fail] {
-    val g: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ctx, Q_SEMA, key);
+fun t_cycle_b_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
+    val g: R.Result[*QueryEntry, fail.Fail] = acquire_entry[TestQueryContext](?ctx.runtime, ctx, Q_SEMA, key);
     if (R.is_err[*QueryEntry, fail.Fail](g)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[*QueryEntry, fail.Fail](g)); }
     var out: QueryOutput;
     out.bytes = nil;
@@ -1352,10 +2066,14 @@ test "mach.lang.query.get:indirect_two_kind_cycle_reports_the_full_chain" {
     if (R.is_err[R.Void, str](register_derived(?db, Q_SEMA)))  { dnit(?db); ret 1; }
     if (R.is_err[R.Void, str](register_derived(?db, Q_LOWER))) { dnit(?db); ret 1; }
 
-    if (!R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_SEMA, 1))) { dnit(?db); ret 1; }
+    if (!R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_SEMA, 1))) { dnit(?db); ret 1; }
     if (db.stack.len != 0)                                { dnit(?db); ret 1; }
-    if (peek_valid(?db, Q_SEMA, 1))                        { dnit(?db); ret 1; }
-    if (peek_valid(?db, Q_LOWER, 1))                       { dnit(?db); ret 1; }
+    val valid_4: R.Result[bool, fail.Fail] = t_reusable(?ctx, Q_SEMA, 1);
+    if (R.is_err[bool, fail.Fail](valid_4)) { dnit(?db); ret 1; }
+    if (R.unwrap_ok[bool, fail.Fail](valid_4))                        { dnit(?db); ret 1; }
+    val valid_5: R.Result[bool, fail.Fail] = t_reusable(?ctx, Q_LOWER, 1);
+    if (R.is_err[bool, fail.Fail](valid_5)) { dnit(?db); ret 1; }
+    if (R.unwrap_ok[bool, fail.Fail](valid_5))                       { dnit(?db); ret 1; }
 
     dnit(?db);
     t_context_dnit(?ctx);
@@ -1375,11 +2093,11 @@ test "mach.lang.query.invalidate:advances_revision_so_a_dependent_cannot_see_reu
     if (R.is_err[R.Void, str](register_derived(?db, Q_TOKENIZE))) { dnit(?db); ret 1; }
 
     if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "a"::*u8, 1))) { dnit(?db); ret 1; }
-    if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 1)))              { dnit(?db); ret 1; }
+    if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_TOKENIZE, 1)))              { dnit(?db); ret 1; }
     val r1: Revision = peek_revision(?db, Q_TOKENIZE, 1);
 
     if (R.is_err[R.Void, str](invalidate(?db, Q_TOKENIZE, 1)))     { dnit(?db); ret 1; }
-    if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 1)))     { dnit(?db); ret 1; }
+    if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_TOKENIZE, 1)))     { dnit(?db); ret 1; }
     val r2: Revision = peek_revision(?db, Q_TOKENIZE, 1);
 
     if (r2 == r1) { dnit(?db); ret 1; }
@@ -1390,10 +2108,10 @@ test "mach.lang.query.invalidate:advances_revision_so_a_dependent_cannot_see_reu
     ret 0;
 }
 
-fun t_parse_deps_on_tokenize(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Result[QueryOutput, fail.Fail] {
+fun t_parse_deps_on_tokenize(ctx: *TestQueryContext, key: u64, a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
     val db: *QueryDb = ctx.runtime.db;
-    val rd: R.Result[R.Void, str] = record_dep(db, Q_PARSE, key, Q_TOKENIZE, key);
-    if (R.is_err[R.Void, str](rd)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rd))); }
+    val rd: R.Result[R.Void, fail.Fail] = depend[TestQueryContext](?ctx.runtime, ctx, Q_TOKENIZE, key);
+    if (R.is_err[R.Void, fail.Fail](rd)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rd)); }
     val res_buf: R.Result[*u8, str] = A.allocate[u8](a, 1);
     if (R.is_err[*u8, str](res_buf)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[*u8, str](res_buf))); }
     val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
@@ -1418,14 +2136,18 @@ test "mach.lang.query.get:invalidated_dependency_recomputed_first_is_seen_stale_
     if (R.is_err[R.Void, str](register_derived(?db, Q_PARSE)))    { dnit(?db); ret 1; }
 
     if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "a"::*u8, 1))) { dnit(?db); ret 1; }
-    if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 1)))              { dnit(?db); ret 1; }
-    if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 1)))                 { dnit(?db); ret 1; }
-    if (!peek_valid(?db, Q_PARSE, 1))                                     { dnit(?db); ret 1; }
+    if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_TOKENIZE, 1)))              { dnit(?db); ret 1; }
+    if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_PARSE, 1)))                 { dnit(?db); ret 1; }
+    val valid_6: R.Result[bool, fail.Fail] = t_reusable(?ctx, Q_PARSE, 1);
+    if (R.is_err[bool, fail.Fail](valid_6)) { dnit(?db); ret 1; }
+    if (!R.unwrap_ok[bool, fail.Fail](valid_6))                                     { dnit(?db); ret 1; }
 
     if (R.is_err[R.Void, str](invalidate(?db, Q_TOKENIZE, 1)))  { dnit(?db); ret 1; }
-    if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 1)))  { dnit(?db); ret 1; }
+    if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_TOKENIZE, 1)))  { dnit(?db); ret 1; }
 
-    if (peek_valid(?db, Q_PARSE, 1)) { dnit(?db); ret 1; }
+    val valid_7: R.Result[bool, fail.Fail] = t_reusable(?ctx, Q_PARSE, 1);
+    if (R.is_err[bool, fail.Fail](valid_7)) { dnit(?db); ret 1; }
+    if (R.unwrap_ok[bool, fail.Fail](valid_7)) { dnit(?db); ret 1; }
 
     dnit(?db);
     t_context_dnit(?ctx);
@@ -1448,13 +2170,13 @@ test "mach.lang.query.init:first_revision_is_never_the_absent_sentinel" {
     ret 0;
 }
 
-fun t_dedup_owner_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Result[QueryOutput, fail.Fail] {
+fun t_dedup_owner_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
     val db: *QueryDb = ctx.runtime.db;
-    val rd1: R.Result[R.Void, str] = record_dep(db, Q_PARSE, key, Q_FILE_TEXT, key);
-    if (R.is_err[R.Void, str](rd1)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rd1))); }
-    val rd2: R.Result[R.Void, str] = record_dep(db, Q_PARSE, key, Q_FILE_TEXT, key);
-    if (R.is_err[R.Void, str](rd2)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](rd2))); }
-    val g: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ctx, Q_FILE_TEXT, key);
+    val rd1: R.Result[R.Void, fail.Fail] = depend[TestQueryContext](?ctx.runtime, ctx, Q_FILE_TEXT, key);
+    if (R.is_err[R.Void, fail.Fail](rd1)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rd1)); }
+    val rd2: R.Result[R.Void, fail.Fail] = depend[TestQueryContext](?ctx.runtime, ctx, Q_FILE_TEXT, key);
+    if (R.is_err[R.Void, fail.Fail](rd2)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[R.Void, fail.Fail](rd2)); }
+    val g: R.Result[*QueryEntry, fail.Fail] = acquire_entry[TestQueryContext](?ctx.runtime, ctx, Q_FILE_TEXT, key);
     if (R.is_err[*QueryEntry, fail.Fail](g)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[*QueryEntry, fail.Fail](g)); }
     val res_buf: R.Result[*u8, str] = A.allocate[u8](a, 1);
     if (R.is_err[*u8, str](res_buf)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[*u8, str](res_buf))); }
@@ -1479,7 +2201,7 @@ test "mach.lang.query.record_dep:manual_and_automatic_edges_to_the_same_pair_ded
     if (R.is_err[R.Void, str](register_derived(?db, Q_PARSE))) { dnit(?db); ret 1; }
 
     if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "a"::*u8, 1))) { dnit(?db); ret 1; }
-    val res_g: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 1);
+    val res_g: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_PARSE, 1);
     if (R.is_err[*QueryEntry, fail.Fail](res_g)) { dnit(?db); ret 1; }
 
     if (R.unwrap_ok[*QueryEntry, fail.Fail](res_g).dep_len != 1) { dnit(?db); ret 1; }
@@ -1489,29 +2211,18 @@ test "mach.lang.query.record_dep:manual_and_automatic_edges_to_the_same_pair_ded
     ret 0;
 }
 
-test "mach.lang.query.record_dep_rev:rejects_an_unregistered_or_lookup_less_dependency_kind" {
+test "mach.lang.query.observe:requires_a_provider_and_an_active_computation" {
     var alloc: A.Allocator;
     page.make(?alloc);
-    val res_db: R.Result[QueryDb, str] = init(?alloc);
-    if (R.is_err[QueryDb, str](res_db)) { ret 1; }
-    var db: QueryDb = R.unwrap_ok[QueryDb, str](res_db);
-    var ctx: TestQueryContext;
-    if (!t_context_init(?ctx, ?db, T_MODE_TOKENIZE)) { dnit(?db); ret 1; }
-
-    if (R.is_err[R.Void, str](register_input(?db, Q_FILE_TEXT)))                 { dnit(?db); ret 1; }
-    if (R.is_err[R.Void, str](register_derived(?db, Q_TOKENIZE))) { dnit(?db); ret 1; }
-    if (R.is_err[R.Void, str](register_metadata(?db, Q_SEMA, nil::RevisionFn)))  { dnit(?db); ret 1; }
-
-    if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "a"::*u8, 1))) { dnit(?db); ret 1; }
-    if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 1)))              { dnit(?db); ret 1; }
-
-    if (!R.is_err[Revision, str](record_dep_rev(?db, Q_TOKENIZE, 1, Q_LOWER, 1))) { dnit(?db); ret 1; }
-    if (!R.is_err[Revision, str](record_dep_rev(?db, Q_TOKENIZE, 1, Q_SEMA, 1)))  { dnit(?db); ret 1; }
-
-    dnit(?db);
-    t_context_dnit(?ctx);
+    val initialized: R.Result[QueryDb, str] = init(?alloc);
+    if (R.is_err[QueryDb, str](initialized)) { ret 1; }
+    var db: QueryDb = R.unwrap_ok[QueryDb, str](initialized);
+    fin { dnit(?db); }
+    if (!R.is_err[R.Void, str](register_metadata(?db, Q_SEMA, RevisionProvider{}))) { ret 2; }
+    if (!R.is_err[MetadataRevision, fail.Fail](observe(?db, Q_SEMA, 1))) { ret 3; }
     ret 0;
 }
+
 
 fun t_probe_allocate(ctx: ptr, size: usize, align: usize) O.Option[ptr] {
     val p: *FailProbe = ctx::*FailProbe;
@@ -1562,7 +2273,7 @@ test "mach.lang.query.runtime:rejects_each_missing_required_capability" {
     var diags: diagnostic.DiagnosticStore = diagnostic.store_init(?alloc);
 
     val no_db: R.Result[QueryRuntime[TestQueryContext], str] =
-        runtime[TestQueryContext](nil, ?diags, t_dispatch);
+        runtime[TestQueryContext](nil, t_dispatch);
     if (!R.is_err[QueryRuntime[TestQueryContext], str](no_db)) {
         diagnostic.store_dnit(?diags);
         ret 1;
@@ -1572,16 +2283,8 @@ test "mach.lang.query.runtime:rejects_each_missing_required_capability" {
     if (R.is_err[QueryDb, str](db_r)) { diagnostic.store_dnit(?diags); ret 1; }
     var db: QueryDb = R.unwrap_ok[QueryDb, str](db_r);
 
-    val no_diags: R.Result[QueryRuntime[TestQueryContext], str] =
-        runtime[TestQueryContext](?db, nil, t_dispatch);
-    if (!R.is_err[QueryRuntime[TestQueryContext], str](no_diags)) {
-        dnit(?db);
-        diagnostic.store_dnit(?diags);
-        ret 1;
-    }
-
     val no_compute: R.Result[QueryRuntime[TestQueryContext], str] =
-        runtime[TestQueryContext](?db, ?diags, nil::TestComputeFn);
+        runtime[TestQueryContext](?db, nil::TestComputeFn);
     if (!R.is_err[QueryRuntime[TestQueryContext], str](no_compute)) {
         dnit(?db);
         diagnostic.store_dnit(?diags);
@@ -1621,26 +2324,37 @@ test "mach.lang.query.get:diag_capture_failure_after_a_successful_compute_is_fat
             dnit(?db); t_context_dnit(?ctx); ret 1;
         }
 
-        probe.calls   = 0;
+        val opened: R.Result[Operation, str] = begin(?db);
+        if (R.is_err[Operation, str](opened)) { dnit(?db); t_context_dnit(?ctx); ret 2; }
+        val operation: Operation = R.unwrap_ok[Operation, str](opened);
+        probe.calls = 0;
         probe.fail_at = fail_at;
         val get_r: R.Result[*QueryEntry, fail.Fail] =
-            get[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 1);
-
-        if (R.is_err[*QueryEntry, fail.Fail](get_r) && diagnostic.len(?ctx.diags) == 1) {
+            acquire_entry[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 1);
+        probe.fail_at = 0;
+        val ended: R.Result[R.Void, fail.Fail] = end(?db, operation);
+        var code: i32 = 0;
+        if (ctx.diagnostic_refused) {
             saw_capture_failure = true;
-            if (t_live != 0 || shard_len(?db, Q_PARSE) != 0) {
-                probe.fail_at = 0;
-                dnit(?db); t_context_dnit(?ctx); ret 1;
-            }
-
-            probe.fail_at = 0;
-            if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 1))) {
-                dnit(?db); t_context_dnit(?ctx); ret 1;
-            }
-            if (t_live != 1 || !peek_valid(?db, Q_PARSE, 1)) {
-                dnit(?db); t_context_dnit(?ctx); ret 1;
-            }
+            if (R.is_ok[*QueryEntry, fail.Fail](get_r) || R.is_ok[R.Void, fail.Fail](ended)) { code = 3; }
         }
+        if (R.is_err[*QueryEntry, fail.Fail](get_r)) {
+            if (R.unwrap_err[*QueryEntry, fail.Fail](get_r).kind != fail.MESSAGE
+                || R.is_ok[R.Void, fail.Fail](ended) || t_live != 0 || shard_len(?db, Q_PARSE) != 0) { code = 4; }
+        }
+        or {
+            if (R.is_err[R.Void, fail.Fail](ended) || t_live != 1) { code = 5; }
+        }
+        if (R.is_err[R.Void, str](t_present(?ctx, operation, Q_PARSE, 1))) { code = 6; }
+        if (R.is_err[*QueryEntry, fail.Fail](get_r)) {
+            val ready: R.Result[bool, fail.Fail] = t_reusable(?ctx, Q_PARSE, 1);
+            if (R.is_err[bool, fail.Fail](ready)) { code = 7; }
+            or { if (R.unwrap_ok[bool, fail.Fail](ready)) { code = 8; } }
+            t_diag_reset(?ctx);
+            if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_PARSE, 1))) { code = 9; }
+            if (t_live != 1 || diagnostic.len(?ctx.diags) != 1) { code = 10; }
+        }
+        if (code != 0) { dnit(?db); t_context_dnit(?ctx); ret code; }
 
         probe.fail_at = 0;
         dnit(?db);
@@ -1671,7 +2385,7 @@ test "mach.lang.query.get:diag_replay_failure_on_a_cache_hit_is_surfaced" {
     if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "x"::*u8, 1))) {
         dnit(?db); t_context_dnit(?ctx); ret 1;
     }
-    if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 1))) {
+    if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_TOKENIZE, 1))) {
         dnit(?db); t_context_dnit(?ctx); ret 1;
     }
 
@@ -1682,7 +2396,7 @@ test "mach.lang.query.get:diag_replay_failure_on_a_cache_hit_is_surfaced" {
     ctx.diags = diagnostic.store_init(?replay_alloc);
 
     val replay_r: R.Result[*QueryEntry, fail.Fail] =
-        get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 1);
+        t_get(?ctx, Q_TOKENIZE, 1);
     if (!R.is_err[*QueryEntry, fail.Fail](replay_r) || diagnostic.len(?ctx.diags) != 0 || probe.calls == 0) {
         probe.fail_at = 0;
         dnit(?db); t_context_dnit(?ctx); ret 1;
@@ -1690,7 +2404,7 @@ test "mach.lang.query.get:diag_replay_failure_on_a_cache_hit_is_surfaced" {
 
     probe.calls   = 0;
     probe.fail_at = 0;
-    if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 1))) {
+    if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_TOKENIZE, 1))) {
         dnit(?db); t_context_dnit(?ctx); ret 1;
     }
     if (diagnostic.len(?ctx.diags) != 1) { dnit(?db); t_context_dnit(?ctx); ret 1; }
@@ -1701,8 +2415,8 @@ test "mach.lang.query.get:diag_replay_failure_on_a_cache_hit_is_surfaced" {
     ret 0;
 }
 
-fun t_auto_dep_outer_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator) R.Result[QueryOutput, fail.Fail] {
-    val g: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ctx, Q_TOKENIZE, key);
+fun t_auto_dep_outer_compute(ctx: *TestQueryContext, key: u64, a: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
+    val g: R.Result[*QueryEntry, fail.Fail] = acquire_entry[TestQueryContext](?ctx.runtime, ctx, Q_TOKENIZE, key);
     if (R.is_err[*QueryEntry, fail.Fail](g)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[*QueryEntry, fail.Fail](g)); }
     val res_buf: R.Result[*u8, str] = A.allocate[u8](a, 1);
     if (R.is_err[*u8, str](res_buf)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[*u8, str](res_buf))); }
@@ -1733,26 +2447,47 @@ test "mach.lang.query.get:allocation_failure_during_automatic_dependency_capture
         if (R.is_err[R.Void, str](register_derived(?db, Q_PARSE)))    { dnit(?db); ret 1; }
 
         if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, "a"::*u8, 1))) { dnit(?db); ret 1; }
-        if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_TOKENIZE, 1)))              { dnit(?db); ret 1; }
+        if (R.is_err[*QueryEntry, fail.Fail](t_get(?ctx, Q_TOKENIZE, 1)))              { dnit(?db); ret 1; }
 
-        probe.calls   = 0;
+        val opened: R.Result[Operation, str] = begin(?db);
+        if (R.is_err[Operation, str](opened)) { dnit(?db); t_context_dnit(?ctx); ret 2; }
+        val operation: Operation = R.unwrap_ok[Operation, str](opened);
+        probe.calls = 0;
         probe.fail_at = fail_at;
-
-        val res_g: R.Result[*QueryEntry, fail.Fail] = get[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 1);
+        val res_g: R.Result[*QueryEntry, fail.Fail] =
+            acquire_entry[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 1);
+        probe.fail_at = 0;
+        val ended: R.Result[R.Void, fail.Fail] = end(?db, operation);
+        var code: i32 = 0;
         if (R.is_err[*QueryEntry, fail.Fail](res_g)) {
             saw_failure = true;
-
-            if (peek_valid(?db, Q_PARSE, 1)) { dnit(?db); ret 1; }
-
-            probe.fail_at = 0;
-            if (R.is_err[*QueryEntry, fail.Fail](get[TestQueryContext](?ctx.runtime, ?ctx, Q_PARSE, 1))) { dnit(?db); ret 1; }
-            if (!peek_valid(?db, Q_PARSE, 1))                     { dnit(?db); ret 1; }
-        } or {
-            if (R.unwrap_ok[*QueryEntry, fail.Fail](res_g).dep_len == 0) { saw_failure = true; dnit(?db); ret 1; }
+            if (R.unwrap_err[*QueryEntry, fail.Fail](res_g).kind != fail.MESSAGE
+                || R.is_ok[R.Void, fail.Fail](ended) || shard_len(?db, Q_PARSE) != 0) { code = 3; }
         }
+        or {
+            if (R.is_err[R.Void, fail.Fail](ended) || R.unwrap_ok[*QueryEntry, fail.Fail](res_g).dep_len != 1) { code = 4; }
+        }
+        if (R.is_err[R.Void, str](t_present(?ctx, operation, Q_PARSE, 1))) { code = 5; }
+        if (R.is_err[*QueryEntry, fail.Fail](res_g)) {
+            val ready: R.Result[bool, fail.Fail] = t_reusable(?ctx, Q_PARSE, 1);
+            if (R.is_err[bool, fail.Fail](ready)) { code = 6; }
+            or { if (R.unwrap_ok[bool, fail.Fail](ready)) { code = 7; } }
+            val retry: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_PARSE, 1);
+            if (R.is_err[*QueryEntry, fail.Fail](retry)) { code = 8; }
+            or {
+                val entry: *QueryEntry = R.unwrap_ok[*QueryEntry, fail.Fail](retry);
+                if (entry.dep_len != 1 || entry.deps[0].kind != Q_TOKENIZE || entry.deps[0].key != 1
+                    || !entry.deps[0].observed || entry.value_len != 1 || entry.value[0] != 3) { code = 9; }
+            }
+            val valid: R.Result[bool, fail.Fail] = t_reusable(?ctx, Q_PARSE, 1);
+            if (R.is_err[bool, fail.Fail](valid)) { code = 10; }
+            or { if (!R.unwrap_ok[bool, fail.Fail](valid)) { code = 11; } }
+        }
+        if (code != 0) { dnit(?db); t_context_dnit(?ctx); ret code; }
 
         dnit(?db);
         t_context_dnit(?ctx);
+        if (probe.live != 0) { ret 12; }
         fail_at = fail_at + 1;
     }
 
@@ -1853,5 +2588,405 @@ test "mach.lang.query.deps_reserve:refuses_a_grown_u32_doubling_that_wraps_witho
     if (!R.is_err[R.Void, str](res))    { ret 1; }
     if (probe.allocate_calls != 0)    { ret 1; }
     if (probe.reallocate_calls != 0)  { ret 1; }
+    ret 0;
+}
+
+rec MetadataFixture {
+    db: QueryDb;
+    diags: diagnostic.DiagnosticStore;
+    runtime: QueryRuntime[MetadataFixture];
+    stamp: MetadataRevision;
+    refuse: bool;
+    constant_parent: bool;
+    reads: u32;
+    child_calls: u32;
+    parent_calls: u32;
+}
+
+fun metadata_fixture_read(raw: ptr, key: u64) R.Result[MetadataRevision, fail.Fail] {
+    val fixture: *MetadataFixture = raw::*MetadataFixture;
+    fixture.reads = fixture.reads + 1;
+    if (fixture.refuse) { ret R.err[MetadataRevision, fail.Fail](fail.message("metadata producer refused")); }
+    ret R.ok[MetadataRevision, fail.Fail](fixture.stamp);
+}
+
+fun metadata_fixture_compute(fixture: *MetadataFixture, kind: QueryKind, key: u64,
+                             alloc: *A.Allocator, diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
+    var byte: u8 = 0;
+    if (kind == Q_TOKENIZE) {
+        fixture.child_calls = fixture.child_calls + 1;
+        val state: R.Result[MetadataRevision, fail.Fail] = observe(?fixture.db, Q_TARGET, 0);
+        if (R.is_err[MetadataRevision, fail.Fail](state)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[MetadataRevision, fail.Fail](state)); }
+        val stamp: MetadataRevision = R.unwrap_ok[MetadataRevision, fail.Fail](state);
+        if (stamp.present) { byte = (stamp.revision & 0x7f)::u8 | 0x80; }
+    } or {
+        fixture.parent_calls = fixture.parent_calls + 1;
+        val child: R.Result[*QueryEntry, fail.Fail] = acquire_entry[MetadataFixture](?fixture.runtime, fixture, Q_TOKENIZE, 0);
+        if (R.is_err[*QueryEntry, fail.Fail](child)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[*QueryEntry, fail.Fail](child)); }
+        byte = R.unwrap_ok[*QueryEntry, fail.Fail](child).value[0];
+        if (fixture.constant_parent) { byte = 9; }
+    }
+    val storage: R.Result[*u8, str] = A.allocate[u8](alloc, 1);
+    if (R.is_err[*u8, str](storage)) { ret fail.lift[QueryOutput](R.err[QueryOutput, str](R.unwrap_err[*u8, str](storage))); }
+    val bytes: *u8 = R.unwrap_ok[*u8, str](storage);
+    bytes[0] = byte;
+    ret R.ok[QueryOutput, fail.Fail](QueryOutput{ bytes: bytes, len: 1 });
+}
+
+fun metadata_fixture_init(fixture: *MetadataFixture, alloc: *A.Allocator) R.Result[R.Void, str] {
+    val database: R.Result[QueryDb, str] = init(alloc);
+    if (R.is_err[QueryDb, str](database)) { ret R.void_of[QueryDb, str](database); }
+    fixture.db = R.unwrap_ok[QueryDb, str](database);
+    fixture.diags = diagnostic.store_init(alloc);
+    fixture.stamp = MetadataRevision{ present: true, revision: 1 };
+    fixture.refuse = false;
+    fixture.constant_parent = false;
+    fixture.reads = 0;
+    fixture.child_calls = 0;
+    fixture.parent_calls = 0;
+    val runtime_r: R.Result[QueryRuntime[MetadataFixture], str] = runtime[MetadataFixture](
+        ?fixture.db, metadata_fixture_compute);
+    if (R.is_err[QueryRuntime[MetadataFixture], str](runtime_r)) {
+        dnit(?fixture.db);
+        diagnostic.store_dnit(?fixture.diags);
+        ret R.void_of[QueryRuntime[MetadataFixture], str](runtime_r);
+    }
+    fixture.runtime = R.unwrap_ok[QueryRuntime[MetadataFixture], str](runtime_r);
+    val meta: R.Result[R.Void, str] = register_metadata(?fixture.db, Q_TARGET,
+        RevisionProvider{ context: fixture::ptr, read: metadata_fixture_read });
+    val child: R.Result[R.Void, str] = register_derived(?fixture.db, Q_TOKENIZE);
+    val parent: R.Result[R.Void, str] = register_derived(?fixture.db, Q_PARSE);
+    if (R.is_err[R.Void, str](meta) || R.is_err[R.Void, str](child) || R.is_err[R.Void, str](parent)) {
+        dnit(?fixture.db);
+        diagnostic.store_dnit(?fixture.diags);
+        if (R.is_err[R.Void, str](meta)) { ret meta; }
+        if (R.is_err[R.Void, str](child)) { ret child; }
+        ret parent;
+    }
+    ret R.ok_void[str]();
+}
+
+fun metadata_fixture_dnit(fixture: *MetadataFixture) {
+    dnit(?fixture.db);
+    diagnostic.store_dnit(?fixture.diags);
+}
+
+fun metadata_fixture_get(fixture: *MetadataFixture) R.Result[*QueryEntry, fail.Fail] {
+    val opened: R.Result[Operation, str] = begin(?fixture.db);
+    if (R.is_err[Operation, str](opened)) { ret fail.lift[*QueryEntry](R.err[*QueryEntry, str](R.unwrap_err[Operation, str](opened))); }
+    val result: R.Result[*QueryEntry, fail.Fail] = acquire_entry[MetadataFixture](?fixture.runtime, fixture, Q_PARSE, 0);
+    val closed: R.Result[R.Void, fail.Fail] = end(?fixture.db, R.unwrap_ok[Operation, str](opened));
+    if (R.is_err[*QueryEntry, fail.Fail](result)) { ret result; }
+    if (R.is_err[R.Void, fail.Fail](closed)) { ret R.err[*QueryEntry, fail.Fail](R.unwrap_err[R.Void, fail.Fail](closed)); }
+    val released: R.Result[R.Void, str] = discard(?fixture.db, R.unwrap_ok[Operation, str](opened));
+    if (R.is_err[R.Void, str](released)) { ret R.err[*QueryEntry, fail.Fail](fail.message(R.unwrap_err[R.Void, str](released))); }
+    ret result;
+}
+
+test "mach.lang.query.refresh:external_change_refreshes_transitively_without_a_local_input_write" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var fixture: MetadataFixture;
+    if (R.is_err[R.Void, str](metadata_fixture_init(?fixture, ?alloc))) { ret 1; }
+    fin { metadata_fixture_dnit(?fixture); }
+    val first: R.Result[*QueryEntry, fail.Fail] = metadata_fixture_get(?fixture);
+    if (R.is_err[*QueryEntry, fail.Fail](first)) { ret 2; }
+    val before: Revision = R.unwrap_ok[*QueryEntry, fail.Fail](first).last_changed;
+    fixture.stamp.revision = 2;
+    val second: R.Result[*QueryEntry, fail.Fail] = metadata_fixture_get(?fixture);
+    if (R.is_err[*QueryEntry, fail.Fail](second)) { ret 3; }
+    val entry: *QueryEntry = R.unwrap_ok[*QueryEntry, fail.Fail](second);
+    if (entry.value[0] != 0x82 || entry.last_changed <= before) { ret 4; }
+    if (fixture.child_calls != 2 || fixture.parent_calls != 2) { ret 5; }
+    if (fixture.reads != 4) { ret 6; }
+    ret 0;
+}
+
+test "mach.lang.query.refresh:constant_parent_cuts_off_after_refreshing_its_changed_child" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var fixture: MetadataFixture;
+    if (R.is_err[R.Void, str](metadata_fixture_init(?fixture, ?alloc))) { ret 1; }
+    fin { metadata_fixture_dnit(?fixture); }
+    fixture.constant_parent = true;
+    val first: R.Result[*QueryEntry, fail.Fail] = metadata_fixture_get(?fixture);
+    if (R.is_err[*QueryEntry, fail.Fail](first)) { ret 2; }
+    val before: Revision = R.unwrap_ok[*QueryEntry, fail.Fail](first).last_changed;
+    fixture.stamp.revision = 2;
+    val second: R.Result[*QueryEntry, fail.Fail] = metadata_fixture_get(?fixture);
+    if (R.is_err[*QueryEntry, fail.Fail](second)) { ret 3; }
+    val entry: *QueryEntry = R.unwrap_ok[*QueryEntry, fail.Fail](second);
+    if (entry.value[0] != 9 || entry.last_changed != before) { ret 4; }
+    if (fixture.child_calls != 2 || fixture.parent_calls != 2) { ret 5; }
+    if (R.is_err[*QueryEntry, fail.Fail](metadata_fixture_get(?fixture))) { ret 6; }
+    if (fixture.child_calls != 2 || fixture.parent_calls != 2) { ret 7; }
+    ret 0;
+}
+
+test "mach.lang.query.operation:sampled_metadata_is_stable_and_a_changed_final_stamp_refuses_success" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var fixture: MetadataFixture;
+    if (R.is_err[R.Void, str](metadata_fixture_init(?fixture, ?alloc))) { ret 1; }
+    fin { metadata_fixture_dnit(?fixture); }
+    val opened: R.Result[Operation, str] = begin(?fixture.db);
+    if (R.is_err[Operation, str](opened)) { ret 2; }
+    val operation: Operation = R.unwrap_ok[Operation, str](opened);
+    val first: R.Result[*QueryEntry, fail.Fail] = acquire_entry[MetadataFixture](?fixture.runtime, ?fixture, Q_PARSE, 0);
+    if (R.is_err[*QueryEntry, fail.Fail](first)) { end(?fixture.db, operation); ret 3; }
+    fixture.stamp.revision = 2;
+    val second: R.Result[*QueryEntry, fail.Fail] = acquire_entry[MetadataFixture](?fixture.runtime, ?fixture, Q_PARSE, 0);
+    if (R.is_err[*QueryEntry, fail.Fail](second)) { end(?fixture.db, operation); ret 4; }
+    if (fixture.child_calls != 1 || fixture.parent_calls != 1 || fixture.reads != 1) { end(?fixture.db, operation); ret 5; }
+    val closed: R.Result[R.Void, fail.Fail] = end(?fixture.db, operation);
+    if (!R.is_err[R.Void, fail.Fail](closed) || fixture.db.operation_active) { ret 6; }
+    if (!str_contains(R.unwrap_err[R.Void, fail.Fail](closed).message, "changed during")) { ret 7; }
+    ret 0;
+}
+
+rec ProvenanceFixture {
+    db: QueryDb;
+    runtime: QueryRuntime[ProvenanceFixture];
+    presentation: diagnostic.DiagnosticStore;
+    calls: [5]u32;
+    fail_leaf: bool;
+    swallow: bool;
+}
+
+fun provenance_compute(f: *ProvenanceFixture, kind: QueryKind, key: u64, a: *A.Allocator,
+                       diags: *diagnostic.DiagnosticStore) R.Result[QueryOutput, fail.Fail] {
+    if (kind != Q_PARSE || key >= 5) { ret R.err[QueryOutput, fail.Fail](fail.message("unexpected provenance fixture key")); }
+    f.calls[key] = f.calls[key] + 1;
+    var message: str = "branch";
+    var offset: usize = 11;
+    if (key == 0) { message = "root"; offset = 0; }
+    or (key == 3) { message = "leaf"; offset = 3; }
+    or (key == 4) { message = "other"; offset = 4; }
+    val emitted: R.Result[R.Void, str] = diagnostic.error(diags, 0, token.Span{ offset: offset, len: 1 }, message);
+    if (R.is_err[R.Void, str](emitted)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[R.Void, str](emitted))); }
+    if (key == 3 && f.fail_leaf) { ret R.err[QueryOutput, fail.Fail](fail.message("provenance leaf failed")); }
+    if (key <= 2) {
+        var child: u64 = 3;
+        if (key == 0) { child = 1; }
+        val read: R.Result[*QueryEntry, fail.Fail] = acquire_entry[ProvenanceFixture](?f.runtime, f, Q_PARSE, child);
+        if (R.is_err[*QueryEntry, fail.Fail](read) && !f.swallow) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[*QueryEntry, fail.Fail](read)); }
+        if (key == 0) {
+            val second: R.Result[*QueryEntry, fail.Fail] = acquire_entry[ProvenanceFixture](?f.runtime, f, Q_PARSE, 2);
+            if (R.is_err[*QueryEntry, fail.Fail](second)) { ret R.err[QueryOutput, fail.Fail](R.unwrap_err[*QueryEntry, fail.Fail](second)); }
+        }
+    }
+    val bytes: R.Result[*u8, str] = A.allocate[u8](a, 1);
+    if (R.is_err[*u8, str](bytes)) { ret R.err[QueryOutput, fail.Fail](fail.message(R.unwrap_err[*u8, str](bytes))); }
+    val value: *u8 = R.unwrap_ok[*u8, str](bytes);
+    value[0] = key::u8;
+    ret R.ok[QueryOutput, fail.Fail](QueryOutput{ bytes: value, len: 1 });
+}
+
+fun provenance_init(f: *ProvenanceFixture, a: *A.Allocator) R.Result[R.Void, str] {
+    val initialized: R.Result[QueryDb, str] = init(a);
+    if (R.is_err[QueryDb, str](initialized)) { ret R.void_of[QueryDb, str](initialized); }
+    f.db = R.unwrap_ok[QueryDb, str](initialized);
+    f.presentation = diagnostic.store_init(a);
+    f.calls = [5]u32{ 0, 0, 0, 0, 0 };
+    f.fail_leaf = false;
+    f.swallow = false;
+    val configured: R.Result[QueryRuntime[ProvenanceFixture], str] = runtime[ProvenanceFixture](?f.db, provenance_compute);
+    if (R.is_err[QueryRuntime[ProvenanceFixture], str](configured)) {
+        dnit(?f.db);
+        diagnostic.store_dnit(?f.presentation);
+        ret R.void_of[QueryRuntime[ProvenanceFixture], str](configured);
+    }
+    f.runtime = R.unwrap_ok[QueryRuntime[ProvenanceFixture], str](configured);
+    val registered: R.Result[R.Void, str] = register_derived(?f.db, Q_PARSE);
+    if (R.is_err[R.Void, str](registered)) {
+        dnit(?f.db);
+        diagnostic.store_dnit(?f.presentation);
+    }
+    ret registered;
+}
+
+fun provenance_dnit(f: *ProvenanceFixture) {
+    dnit(?f.db);
+    diagnostic.store_dnit(?f.presentation);
+}
+
+fun provenance_collect(f: *ProvenanceFixture, roots: *QueryKey, count: usize) R.Result[*Presentation, fail.Fail] {
+    val opened: R.Result[Operation, str] = begin(?f.db);
+    if (R.is_err[Operation, str](opened)) { ret fail.lift[*Presentation](R.err[*Presentation, str](R.unwrap_err[Operation, str](opened))); }
+    val operation: Operation = R.unwrap_ok[Operation, str](opened);
+    var i: usize = 0;
+    for (i < count) {
+        val read: R.Result[*QueryEntry, fail.Fail] = acquire_entry[ProvenanceFixture](?f.runtime, f, roots[i].kind, roots[i].key);
+        if (R.is_err[*QueryEntry, fail.Fail](read)) {
+            end(?f.db, operation);
+            ret R.err[*Presentation, fail.Fail](R.unwrap_err[*QueryEntry, fail.Fail](read));
+        }
+        i = i + 1;
+    }
+    val closed: R.Result[R.Void, fail.Fail] = end(?f.db, operation);
+    if (R.is_err[R.Void, fail.Fail](closed)) {
+        ret R.err[*Presentation, fail.Fail](R.unwrap_err[R.Void, fail.Fail](closed));
+    }
+    ret fail.lift[*Presentation](collect(?f.db, operation, roots, count, f.db.a));
+}
+
+fun provenance_store_free(a: *A.Allocator, store: *Presentation) {
+    presentation_dnit(store);
+}
+
+test "mach.lang.query.collect:diamond_order_and_distinct_origins_are_cold_warm_invariant" {
+    var a: A.Allocator;
+    page.make(?a);
+    var f: ProvenanceFixture;
+    if (R.is_err[R.Void, str](provenance_init(?f, ?a))) { ret 1; }
+    fin { provenance_dnit(?f); }
+    var roots: [2]QueryKey = [2]QueryKey{ QueryKey{ kind: Q_PARSE, key: 0 }, QueryKey{ kind: Q_PARSE, key: 4 } };
+    val cold_r: R.Result[*Presentation, fail.Fail] = provenance_collect(?f, ?roots[0], 2);
+    if (R.is_err[*Presentation, fail.Fail](cold_r)) { ret 2; }
+    val cold: *Presentation = R.unwrap_ok[*Presentation, fail.Fail](cold_r);
+    fin { provenance_store_free(?a, cold); }
+    if (diagnostic.len(?cold.diags) != 5) { ret 3; }
+    if (cold.diags.items.data[0].loc.span.offset != 3 || cold.diags.items.data[1].loc.span.offset != 11
+        || cold.diags.items.data[2].loc.span.offset != 11 || cold.diags.items.data[3].loc.span.offset != 0
+        || cold.diags.items.data[4].loc.span.offset != 4) { ret 4; }
+    if (diagnostic.len(?f.presentation) != 0) { ret 5; }
+    val warm_r: R.Result[*Presentation, fail.Fail] = provenance_collect(?f, ?roots[0], 2);
+    if (R.is_err[*Presentation, fail.Fail](warm_r)) { ret 6; }
+    val warm: *Presentation = R.unwrap_ok[*Presentation, fail.Fail](warm_r);
+    fin { provenance_store_free(?a, warm); }
+    val equal: R.Result[bool, str] = diagnostic.content_equal(?cold.diags, ?warm.diags);
+    if (R.is_err[bool, str](equal) || !R.unwrap_ok[bool, str](equal)) { ret 7; }
+    var i: usize = 0;
+    for (i < 5) { if (f.calls[i] != 1) { ret 8; } i = i + 1; }
+    if (f.db.attempts.len != 0 || f.db.presentation_pending) { ret 9; }
+    ret 0;
+}
+
+test "mach.lang.query.collect:failed_child_cannot_be_swallowed_and_attempt_evidence_is_released" {
+    var a: A.Allocator;
+    page.make(?a);
+    var f: ProvenanceFixture;
+    if (R.is_err[R.Void, str](provenance_init(?f, ?a))) { ret 1; }
+    fin { provenance_dnit(?f); }
+    f.fail_leaf = true;
+    f.swallow = true;
+    val opened: R.Result[Operation, str] = begin(?f.db);
+    if (R.is_err[Operation, str](opened)) { ret 2; }
+    val operation: Operation = R.unwrap_ok[Operation, str](opened);
+    val read: R.Result[*QueryEntry, fail.Fail] = acquire_entry[ProvenanceFixture](?f.runtime, ?f, Q_PARSE, 0);
+    if (!R.is_err[*QueryEntry, fail.Fail](read)) { ret 3; }
+    val closed: R.Result[R.Void, fail.Fail] = end(?f.db, operation);
+    if (!R.is_err[R.Void, fail.Fail](closed)) { ret 4; }
+    if (shard_len(?f.db, Q_PARSE) != 0 || f.calls[2] != 0 || f.db.attempts.len != 3) { ret 5; }
+    var root: QueryKey = QueryKey{ kind: Q_PARSE, key: 0 };
+    val presented: R.Result[*Presentation, str] = collect(?f.db, operation, ?root, 1, ?a);
+    if (R.is_err[*Presentation, str](presented)) { ret 6; }
+    val store: *Presentation = R.unwrap_ok[*Presentation, str](presented);
+    fin { provenance_store_free(?a, store); }
+    if (diagnostic.len(?store.diags) != 3 || store.diags.items.data[0].loc.span.offset != 3
+        || store.diags.items.data[1].loc.span.offset != 11 || store.diags.items.data[2].loc.span.offset != 0) { ret 7; }
+    if (f.db.attempts.len != 0 || f.db.presentation_pending) { ret 8; }
+    f.fail_leaf = false;
+    f.swallow = false;
+    val retried: R.Result[*Presentation, fail.Fail] = provenance_collect(?f, ?root, 1);
+    if (R.is_err[*Presentation, fail.Fail](retried)) { ret 9; }
+    provenance_store_free(?a, R.unwrap_ok[*Presentation, fail.Fail](retried));
+    ret 0;
+}
+
+test "mach.lang.query.collect:allocation_refusal_keeps_one_retryable_presentation_owner" {
+    var a: A.Allocator;
+    page.make(?a);
+    var f: ProvenanceFixture;
+    if (R.is_err[R.Void, str](provenance_init(?f, ?a))) { ret 1; }
+    fin { provenance_dnit(?f); }
+    val opened: R.Result[Operation, str] = begin(?f.db);
+    if (R.is_err[Operation, str](opened)) { ret 2; }
+    val operation: Operation = R.unwrap_ok[Operation, str](opened);
+    if (R.is_err[*QueryEntry, fail.Fail](acquire_entry[ProvenanceFixture](?f.runtime, ?f, Q_PARSE, 0))) { ret 3; }
+    if (R.is_err[R.Void, fail.Fail](end(?f.db, operation))) { ret 4; }
+    var probe: FailProbe;
+    var refusing: A.Allocator;
+    if (!failprobe_make(?probe, ?refusing, 2)) { ret 5; }
+    var root: QueryKey = QueryKey{ kind: Q_PARSE, key: 0 };
+    val refused: R.Result[*Presentation, str] = collect(?f.db, operation, ?root, 1, ?refusing);
+    if (!R.is_err[*Presentation, str](refused) || probe.live != 0) { ret 6; }
+    if (!f.db.presentation_pending || f.db.attempts.len != 4) { ret 7; }
+    if (!R.is_err[Operation, str](begin(?f.db))) { ret 8; }
+    if (!R.is_err[R.Void, str](invalidate(?f.db, Q_PARSE, 0))) { ret 9; }
+    probe.fail_at = 0;
+    val retried: R.Result[*Presentation, str] = collect(?f.db, operation, ?root, 1, ?refusing);
+    if (R.is_err[*Presentation, str](retried)) { ret 10; }
+    val store: *Presentation = R.unwrap_ok[*Presentation, str](retried);
+    if (diagnostic.len(?store.diags) != 4) { provenance_store_free(?refusing, store); ret 11; }
+    provenance_store_free(?refusing, store);
+    if (probe.live != 0 || f.db.presentation_pending || f.db.attempts.len != 0) { ret 12; }
+    ret 0;
+}
+
+test "mach.lang.query.cycle:rich_failure_transfers_to_the_presentation_without_per_attempt_growth" {
+    var alloc: A.Allocator;
+    var probe: FailProbe;
+    if (!failprobe_make(?probe, ?alloc, 0)) { ret 1; }
+    val initialized: R.Result[QueryDb, str] = init(?alloc);
+    if (R.is_err[QueryDb, str](initialized)) { ret 2; }
+    var db: QueryDb = R.unwrap_ok[QueryDb, str](initialized);
+    var ctx: TestQueryContext;
+    if (!t_context_init(?ctx, ?db, T_MODE_INDIRECT)) { dnit(?db); ret 3; }
+    if (R.is_err[R.Void, str](register_derived(?db, Q_SEMA))
+        || R.is_err[R.Void, str](register_derived(?db, Q_LOWER))) { t_context_dnit(?ctx); dnit(?db); ret 4; }
+    var baseline: i64 = 0;
+    var i: u32 = 0;
+    for (i < 32) {
+        val result: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_SEMA, 7);
+        if (!R.is_err[*QueryEntry, fail.Fail](result)) { t_context_dnit(?ctx); dnit(?db); ret 5; }
+        val failure: fail.Fail = R.unwrap_err[*QueryEntry, fail.Fail](result);
+        if (failure.kind != fail.MESSAGE || !str_contains(failure.message, "9:7 -> 10:7 -> 9:7")) {
+            t_context_dnit(?ctx); dnit(?db); ret 6;
+        }
+        if (ctx.last_presentation == nil || db.operation_message != nil || db.attempts.len != 0) {
+            t_context_dnit(?ctx); dnit(?db); ret 7;
+        }
+        presentation_dnit(ctx.last_presentation);
+        ctx.last_presentation = nil;
+        if (i == 1) { baseline = probe.live; }
+        if (i > 1 && probe.live != baseline) { t_context_dnit(?ctx); dnit(?db); ret 8; }
+        i = i + 1;
+    }
+    t_context_dnit(?ctx);
+    dnit(?db);
+    if (probe.live != 0) { ret 9; }
+    ret 0;
+}
+
+test "mach.lang.query.reusable:validates_transitive_inputs_without_computing_the_requested_product" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var fixture: MetadataFixture;
+    if (R.is_err[R.Void, str](metadata_fixture_init(?fixture, ?alloc))) { ret 2; }
+    fin { metadata_fixture_dnit(?fixture); }
+    if (R.is_err[*QueryEntry, fail.Fail](metadata_fixture_get(?fixture))) { ret 3; }
+    fixture.stamp.revision = 2;
+    val begun: R.Result[Operation, str] = begin(?fixture.db);
+    if (R.is_err[Operation, str](begun)) { ret 4; }
+    val operation: Operation = R.unwrap_ok[Operation, str](begun);
+    val stale: R.Result[bool, fail.Fail] = reusable[MetadataFixture](?fixture.runtime, ?fixture, Q_PARSE, 0);
+    if (R.is_err[bool, fail.Fail](stale) || R.unwrap_ok[bool, fail.Fail](stale)) { ret 5; }
+    if (fixture.child_calls != 2 || fixture.parent_calls != 1) { ret 6; }
+    val current: R.Result[QueryView, fail.Fail] = get[MetadataFixture](?fixture.runtime, ?fixture, Q_PARSE, 0);
+    if (R.is_err[QueryView, fail.Fail](current) || R.unwrap_ok[QueryView, fail.Fail](current).value[0] != 0x82) { ret 7; }
+    if (fixture.child_calls != 2 || fixture.parent_calls != 2) { ret 8; }
+    val warm: R.Result[bool, fail.Fail] = reusable[MetadataFixture](?fixture.runtime, ?fixture, Q_PARSE, 0);
+    if (R.is_err[bool, fail.Fail](warm) || !R.unwrap_ok[bool, fail.Fail](warm)) { ret 9; }
+    if (R.is_err[R.Void, fail.Fail](end(?fixture.db, operation))) { ret 10; }
+    if (R.is_err[R.Void, str](discard(?fixture.db, operation))) { ret 11; }
+    fixture.refuse = true;
+    val retry: R.Result[Operation, str] = begin(?fixture.db);
+    if (R.is_err[Operation, str](retry)) { ret 12; }
+    val refused: R.Result[bool, fail.Fail] = reusable[MetadataFixture](?fixture.runtime, ?fixture, Q_PARSE, 0);
+    if (R.is_ok[bool, fail.Fail](refused)) { ret 13; }
+    if (!str_equals(R.unwrap_err[bool, fail.Fail](refused).message, "metadata producer refused")) { ret 14; }
+    if (R.is_ok[R.Void, fail.Fail](end(?fixture.db, R.unwrap_ok[Operation, str](retry)))) { ret 15; }
+    if (fixture.parent_calls != 2) { ret 16; }
     ret 0;
 }

--- a/src/lang/query.mach
+++ b/src/lang/query.mach
@@ -159,6 +159,7 @@ pub rec QueryShard {
     role:       ShardRole;
     revisions:  RevisionProvider;
     finalize:   FinalizeFn;
+    equal: fun(*u8, u32, *u8, u32) bool;
     registered: bool;
     entries:    handle.HandleTable[QueryEntry, QueryEntryDomain];
     index:      Vector[QueryIndexEntry];
@@ -267,6 +268,15 @@ pub fun register_derived_owned(db: *QueryDb, kind: QueryKind, finalize: Finalize
 
     val sh: *QueryShard = ?db.storage[kind::u32];
     sh.finalize = finalize;
+    ret R.ok_void[str]();
+}
+
+pub fun register_derived_equatable(db: *QueryDb, kind: QueryKind, finalize: FinalizeFn,
+                                  equal: fun(*u8, u32, *u8, u32) bool) R.Result[R.Void, str] {
+    if (finalize == nil || equal == nil) { ret R.err[R.Void, str]("owned query equality requires a finalizer and comparator"); }
+    val registered: R.Result[R.Void, str] = register_derived_owned(db, kind, finalize);
+    if (R.is_err[R.Void, str](registered)) { ret registered; }
+    db.storage[kind::u32].equal = equal;
     ret R.ok_void[str]();
 }
 
@@ -1181,6 +1191,7 @@ fun storage_grow(db: *QueryDb, need: u32) R.Result[R.Void, str] {
         sh.role       = SHARD_INPUT;
         sh.revisions  = RevisionProvider{};
         sh.finalize   = nil::FinalizeFn;
+        sh.equal = nil;
         sh.registered = false;
 
         val te_r: R.Result[handle.HandleTable[QueryEntry, QueryEntryDomain], str] =
@@ -1431,8 +1442,14 @@ fun candidate_publish(db: *QueryDb, sh: *QueryShard, entry: *QueryEntry, candida
     val diag_equal: R.Result[bool, str] = diagnostic.content_equal(entry.diags, candidate.diags);
     if (R.is_err[bool, str](diag_equal)) { ret R.err[*QueryEntry, fail.Fail](fail.message(R.unwrap_err[bool, str](diag_equal))); }
     val same_diags: bool = R.unwrap_ok[bool, str](diag_equal) && diagnostic_dependencies_equal(entry, candidate);
-    val same_value: bool = entry.ready && sh.finalize == nil && entry.value_len == candidate.value_len
-        && memory.raw_equal(entry.value::ptr, candidate.value::ptr, candidate.value_len::usize);
+    var same_value: bool = false;
+    if (entry.ready) {
+        if (sh.equal != nil) { same_value = sh.equal(entry.value, entry.value_len, candidate.value, candidate.value_len); }
+        or (sh.finalize == nil) {
+            same_value = entry.value_len == candidate.value_len
+                && memory.raw_equal(entry.value::ptr, candidate.value::ptr, candidate.value_len::usize);
+        }
+    }
     var revision: Revision = entry.last_changed;
     if (!same_value || !same_diags) {
         val changed: R.Result[Revision, str] = next_revision(db);
@@ -1445,8 +1462,10 @@ fun candidate_publish(db: *QueryDb, sh: *QueryShard, entry: *QueryEntry, candida
         or { candidate.diagnostics_changed = revision; }
     }
     if (same_value) {
+        if (sh.finalize != nil) { sh.finalize(candidate.value, candidate.value_len, db.a); }
         if (candidate.value != nil && candidate.value_len != 0) { A.deallocate[u8](db.a, candidate.value, candidate.value_len::usize); }
         candidate.value = entry.value;
+        candidate.value_len = entry.value_len;
         entry.value = nil;
         entry.value_len = 0;
     }
@@ -3041,4 +3060,41 @@ test "mach.lang.query.get:changed_selector_does_not_validate_an_obsolete_branch"
         turn = turn + 1;
     }
     ret 0;
+}
+
+fun t_owned_equal(a: *u8, a_len: u32, b: *u8, b_len: u32) bool {
+    if (a_len != $size_of(ptr)::u32 || b_len != a_len) { ret false; }
+    val x: *u64 = (@(a::*ptr))::*u64;
+    val y: *u64 = (@(b::*ptr))::*u64;
+    ret @x == @y;
+}
+
+test "mach.lang.query:equal_owned_candidates_preserve_identity_and_release_once" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    val initialized: R.Result[QueryDb, str] = init(?a);
+    if (R.is_err[QueryDb, str](initialized)) { ret 2; }
+    var db: QueryDb = R.unwrap_ok[QueryDb, str](initialized);
+    var ctx: TestQueryContext;
+    if (!t_context_init(?ctx, ?db, T_MODE_OWNED)) { dnit(?db); ret 3; }
+    fin { t_context_dnit(?ctx); }
+    t_live = 0;
+    if (R.is_err[R.Void, str](register_input(?db, Q_FILE_TEXT))
+        || R.is_err[R.Void, str](register_derived_equatable(?db, Q_PARSE, t_owned_finalize, t_owned_equal))) { dnit(?db); ret 4; }
+    var identity: ptr = nil;
+    var revision: Revision = 0;
+    var i: u8 = 0;
+    var code: i32 = 0;
+    for (i < 4) {
+        if (R.is_err[R.Void, str](set_input(?db, Q_FILE_TEXT, 1, ?i, 1))) { code = 5; brk; }
+        val result: R.Result[*QueryEntry, fail.Fail] = t_get(?ctx, Q_PARSE, 1);
+        if (R.is_err[*QueryEntry, fail.Fail](result)) { code = 6; brk; }
+        val entry: *QueryEntry = R.unwrap_ok[*QueryEntry, fail.Fail](result);
+        if (i == 0) { identity = t_handle_ptr(entry); revision = entry.last_changed; }
+        if (t_handle_ptr(entry) != identity || entry.last_changed != revision || t_live != 1) { code = 7; brk; }
+        i = i + 1;
+    }
+    dnit(?db);
+    if (t_live != 0) { ret 8; }
+    ret code;
 }

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -50,6 +50,7 @@ pub rec LinkPublication {
 }
 
 pub rec Session {
+    view_generation: u64;
     alloc:       *A.Allocator;
     build_alloc: *A.Allocator;
     sources:    source.SourceMap;
@@ -109,6 +110,7 @@ pub fun init(alloc: *A.Allocator) R.Result[Session, str] {
     s.alloc            = alloc;
     s.parse_sequence   = 0;
     s.build_alloc      = alloc;
+    s.view_generation = 1;
     s.sources          = source.init(alloc);
     s.diags            = diagnostic.store_init(alloc);
     s.query_presentation = nil;
@@ -263,8 +265,14 @@ pub fun dnit(s: *Session) {
     source.dnit(?s.sources);
 }
 
+# exhaustion permanently refuses new borrowed views while teardown remains infallible
+pub fun expire_views(s: *Session) {
+    if (s.view_generation != ~(0::u64)) { s.view_generation = s.view_generation + 1; }
+}
+
 pub fun reset_module_registry(s: *Session) {
     if (s == nil) { ret; }
+    expire_views(s);
 
     if (s.module_asts != nil && s.module_ast_cap > 0) {
         A.deallocate[*ast.Ast](s.alloc, s.module_asts, s.module_ast_cap::usize);
@@ -289,6 +297,7 @@ pub fun reset_module_registry(s: *Session) {
 }
 
 pub fun register_module_ast(s: *Session, mid: module.ModuleId, a: *ast.Ast) R.Result[R.Void, str] {
+    expire_views(s);
     val needed: u32 = mid::u32 + 1;
     if (needed > s.module_ast_cap) {
         var new_cap: u32 = s.module_ast_cap;
@@ -416,6 +425,7 @@ pub fun reset_type_projection(s: *Session) R.Result[R.Void, str] {
     if (s.queries.operation_active || s.queries.presentation_pending) {
         ret R.err[R.Void, str]("cannot replace type projections while query products are borrowed");
     }
+    expire_views(s);
     type.field_projection_reset(?s.types);
     map.clear[u32, u32](?s.type_aligns);
     map.clear[u32, u32](?s.type_packed);
@@ -424,10 +434,12 @@ pub fun reset_type_projection(s: *Session) R.Result[R.Void, str] {
 }
 
 pub fun register_type_align(s: *Session, tid: u32, align: u32) R.Result[R.Void, str] {
+    expire_views(s);
     ret R.void_of[bool, str](map.insert[u32, u32](?s.type_aligns, tid, align));
 }
 
 pub fun register_type_packed(s: *Session, tid: u32) R.Result[R.Void, str] {
+    expire_views(s);
     ret R.void_of[bool, str](map.insert[u32, u32](?s.type_packed, tid, 1));
 }
 
@@ -436,6 +448,7 @@ pub fun type_is_packed(s: *Session, tid: u32) bool {
 }
 
 pub fun register_type_volatile(s: *Session, tid: u32) R.Result[R.Void, str] {
+    expire_views(s);
     ret R.void_of[bool, str](map.insert[u32, u32](?s.type_volatile, tid, 1));
 }
 
@@ -603,6 +616,7 @@ pub fun reset_link_publications(s: *Session) {
 }
 
 pub fun register_module_sema(s: *Session, mid: module.ModuleId, p: ptr) R.Result[R.Void, str] {
+    expire_views(s);
     ret R.void_of[bool, str](map.insert[module.ModuleId, ptr](?s.module_sema, mid, p));
 }
 
@@ -615,6 +629,7 @@ pub fun module_sema_ptr(s: *Session, mid: module.ModuleId) ptr {
 }
 
 pub fun register_module_resolve(s: *Session, mid: module.ModuleId, p: ptr) R.Result[R.Void, str] {
+    expire_views(s);
     ret R.void_of[bool, str](map.insert[module.ModuleId, ptr](?s.module_resolve, mid, p));
 }
 
@@ -627,6 +642,7 @@ pub fun module_resolve_ptr(s: *Session, mid: module.ModuleId) ptr {
 }
 
 pub fun register_module_comptime(s: *Session, mid: module.ModuleId, p: ptr) R.Result[R.Void, str] {
+    expire_views(s);
     ret R.void_of[bool, str](map.insert[module.ModuleId, ptr](?s.module_comptime, mid, p));
 }
 
@@ -710,64 +726,100 @@ pub fun load_source(s: *Session, path: str, text: str) R.Result[source.FileId, s
     fin { source.discard_load(?prepared); }
     val input: R.Result[R.Void, str] = query.set_input(?s.queries, query.Q_FILE_TEXT, prepared.id::u64, text::*u8, str_len(text)::u32);
     if (R.is_err[R.Void, str](input)) { ret R.err[source.FileId, str](R.unwrap_err[R.Void, str](input)); }
+    if (prepared.changed) { expire_views(s); }
     ret R.ok[source.FileId, str](source.commit_load(?prepared));
 }
 
-pub fun set_overlay(s: *Session, path: str, text: str) R.Result[R.Void, str] {
-    val key_r: R.Result[str, str] = source_key(s, path);
-    if (R.is_err[str, str](key_r)) { ret R.err[R.Void, str](R.unwrap_err[str, str](key_r)); }
-    val key: str = R.unwrap_ok[str, str](key_r);
+pub rec PreparedOverlay {
+    owner: *Session;
+    key: str;
+    text: str;
+    index: u32;
+    remove: bool;
+    changed: bool;
+}
 
-    val dup_text_r: R.Result[str, str] = str_dup(s.alloc, text);
-    if (R.is_err[str, str](dup_text_r)) {
-        str_free(s.alloc, key);
-        ret R.err[R.Void, str](R.unwrap_err[str, str](dup_text_r));
-    }
-    val dup_text: str = R.unwrap_ok[str, str](dup_text_r);
-
+# the caller exclusively borrows overlay state through commit or discard
+pub fun prepare_overlay(s: *Session, path: str, text: str, remove: bool) R.Result[PreparedOverlay, str] {
+    val canonical: R.Result[str, str] = source_key(s, path);
+    if (R.is_err[str, str](canonical)) { ret R.err[PreparedOverlay, str](R.unwrap_err[str, str](canonical)); }
+    var prepared: PreparedOverlay = PreparedOverlay{
+        owner: s, key: R.unwrap_ok[str, str](canonical), index: s.overlay_len, remove: remove
+    };
+    var complete: bool = false;
+    fin { if (!complete) { discard_overlay(?prepared); } }
     var i: u32 = 0;
     for (i < s.overlay_len) {
-        if (str_equals(s.overlays[i].path, key)) {
-            str_free(s.alloc, s.overlays[i].text);
-            s.overlays[i].text = dup_text;
-            str_free(s.alloc, key);
-            ret R.ok_void[str]();
-        }
+        if (str_equals(s.overlays[i].path, prepared.key)) { prepared.index = i; brk; }
         i = i + 1;
     }
-
-    val res_grow: R.Result[R.Void, str] = overlays_reserve(s, s.overlay_len + 1);
-    if (R.is_err[R.Void, str](res_grow)) {
-        str_free(s.alloc, dup_text);
-        str_free(s.alloc, key);
-        ret res_grow;
+    if (remove) { prepared.changed = prepared.index < s.overlay_len; }
+    or {
+        prepared.changed = prepared.index == s.overlay_len || !str_equals(s.overlays[prepared.index].text, text);
+        if (prepared.changed) {
+            val copied: R.Result[str, str] = str_dup(s.alloc, text);
+            if (R.is_err[str, str](copied)) { ret R.err[PreparedOverlay, str](R.unwrap_err[str, str](copied)); }
+            prepared.text = R.unwrap_ok[str, str](copied);
+            if (prepared.index == s.overlay_len) {
+                if (s.overlay_len == ~(0::u32)) { ret R.err[PreparedOverlay, str]("overlay capacity exhausted"); }
+                val reserved: R.Result[R.Void, str] = overlays_reserve(s, s.overlay_len + 1);
+                if (R.is_err[R.Void, str](reserved)) { ret R.err[PreparedOverlay, str](R.unwrap_err[R.Void, str](reserved)); }
+            }
+        }
     }
-    s.overlays[s.overlay_len].path = key;
-    s.overlays[s.overlay_len].text = dup_text;
-    s.overlay_len = s.overlay_len + 1;
+    complete = true;
+    ret R.ok[PreparedOverlay, str](prepared);
+}
+
+pub fun discard_overlay(prepared: *PreparedOverlay) {
+    if (prepared.owner == nil) { ret; }
+    str_free(prepared.owner.alloc, prepared.key);
+    str_free(prepared.owner.alloc, prepared.text);
+    prepared.owner = nil;
+    prepared.key = nil;
+    prepared.text = nil;
+}
+
+pub fun commit_overlay(prepared: *PreparedOverlay) bool {
+    val s: *Session = prepared.owner;
+    val changed: bool = prepared.changed;
+    if (changed) {
+        expire_views(s);
+        val i: u32 = prepared.index;
+        if (prepared.remove) {
+            str_free(s.alloc, s.overlays[i].path);
+            str_free(s.alloc, s.overlays[i].text);
+            s.overlay_len = s.overlay_len - 1;
+            if (i != s.overlay_len) { s.overlays[i] = s.overlays[s.overlay_len]; }
+        }
+        or {
+            if (i == s.overlay_len) {
+                s.overlays[i].path = prepared.key;
+                prepared.key = nil;
+                s.overlay_len = s.overlay_len + 1;
+            }
+            or { str_free(s.alloc, s.overlays[i].text); }
+            s.overlays[i].text = prepared.text;
+            prepared.text = nil;
+        }
+    }
+    discard_overlay(prepared);
+    ret changed;
+}
+
+pub fun set_overlay(s: *Session, path: str, text: str) R.Result[R.Void, str] {
+    val staged: R.Result[PreparedOverlay, str] = prepare_overlay(s, path, text, false);
+    if (R.is_err[PreparedOverlay, str](staged)) { ret R.void_of[PreparedOverlay, str](staged); }
+    var prepared: PreparedOverlay = R.unwrap_ok[PreparedOverlay, str](staged);
+    commit_overlay(?prepared);
     ret R.ok_void[str]();
 }
 
-pub fun clear_overlay(s: *Session, path: str) bool {
-    val key_r: R.Result[str, str] = source_key(s, path);
-    if (R.is_err[str, str](key_r)) { ret false; }
-    val key: str = R.unwrap_ok[str, str](key_r);
-
-    var i: u32 = 0;
-    for (i < s.overlay_len) {
-        if (str_equals(s.overlays[i].path, key)) {
-            str_free(s.alloc, key);
-            str_free(s.alloc, s.overlays[i].path);
-            str_free(s.alloc, s.overlays[i].text);
-            val last: u32 = s.overlay_len - 1;
-            if (i != last) { s.overlays[i] = s.overlays[last]; }
-            s.overlay_len = last;
-            ret true;
-        }
-        i = i + 1;
-    }
-    str_free(s.alloc, key);
-    ret false;
+pub fun clear_overlay(s: *Session, path: str) R.Result[bool, str] {
+    val staged: R.Result[PreparedOverlay, str] = prepare_overlay(s, path, nil, true);
+    if (R.is_err[PreparedOverlay, str](staged)) { ret R.err[bool, str](R.unwrap_err[PreparedOverlay, str](staged)); }
+    var prepared: PreparedOverlay = R.unwrap_ok[PreparedOverlay, str](staged);
+    ret R.ok[bool, str](commit_overlay(?prepared));
 }
 
 pub fun overlay_get(s: *Session, path: str) O.Option[str] {
@@ -796,7 +848,10 @@ fun overlays_reserve(s: *Session, need: u32) R.Result[R.Void, str] {
 
     var new_cap: u32 = s.overlay_cap;
     if (new_cap == 0) { new_cap = OVERLAY_SEED_CAP; }
-    for (new_cap < need) { new_cap = new_cap * 2; }
+    for (new_cap < need) {
+        if (new_cap > (~(0::u32)) / 2) { new_cap = need; }
+        or { new_cap = new_cap * 2; }
+    }
 
     if (s.overlays == nil) {
         val res_alloc: R.Result[*Overlay, str] = A.allocate[Overlay](s.alloc, new_cap::usize);
@@ -822,7 +877,8 @@ test "mach.lang.session.overlay:set_get_replace_clear" {
     var bad: i32 = 0;
 
     if (O.is_some[str](overlay_get(?s, "/x/a.mach"))) { bad = 1; }
-    if (clear_overlay(?s, "/x/a.mach"))               { bad = 1; }
+    val absent: R.Result[bool, str] = clear_overlay(?s, "/x/a.mach");
+    if (R.is_err[bool, str](absent) || R.unwrap_ok[bool, str](absent)) { bad = 1; }
 
     if (R.is_err[R.Void, str](set_overlay(?s, "/x/a.mach", "AAA"))) { dnit(?s); ret 1; }
     if (R.is_err[R.Void, str](set_overlay(?s, "/x/b.mach", "BBB"))) { dnit(?s); ret 1; }
@@ -837,7 +893,8 @@ test "mach.lang.session.overlay:set_get_replace_clear" {
     val ga2: O.Option[str] = overlay_get(?s, "/x/a.mach");
     if (O.is_none[str](ga2) || !str_equals(O.unwrap[str](ga2), "A2")) { bad = 1; }
 
-    if (!clear_overlay(?s, "/x/a.mach"))              { bad = 1; }
+    val cleared: R.Result[bool, str] = clear_overlay(?s, "/x/a.mach");
+    if (R.is_err[bool, str](cleared) || !R.unwrap_ok[bool, str](cleared)) { bad = 1; }
     if (s.overlay_len != 1)                           { bad = 1; }
     if (O.is_some[str](overlay_get(?s, "/x/a.mach"))) { bad = 1; }
     val gb2: O.Option[str] = overlay_get(?s, "/x/b.mach");
@@ -870,7 +927,8 @@ test "mach.lang.session.overlay:one_file_is_one_entry_however_it_is_spelled" {
     if (O.is_some[str](overlay_get(?s, "/x/src/b.mach")) && bad == 0) { bad = 7; }
     if (O.is_some[str](overlay_get(?s, "/src/a.mach"))   && bad == 0) { bad = 8; }
 
-    if (!clear_overlay(?s, "/x//src/a.mach") && bad == 0) { bad = 9; }
+    val cleared: R.Result[bool, str] = clear_overlay(?s, "/x//src/a.mach");
+    if ((R.is_err[bool, str](cleared) || !R.unwrap_ok[bool, str](cleared)) && bad == 0) { bad = 9; }
     if (s.overlay_len != 0                   && bad == 0) { bad = 10; }
 
     dnit(?s);

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -11,12 +11,15 @@ use std.types.string.str_equals;
 use std.types.string.str_len;
 
 use A: std.allocator;
+use T: std.allocator.testing;
+use std.memory;
 use P: std.types.path;
 use O: std.types.option;
 use R: std.types.result;
 
 use mach.lang.diagnostic;
 use mach.lang.embed;
+use mach.lang.fail;
 use mach.lang.fe.ast;
 use mach.lang.intern;
 use mach.lang.module;
@@ -51,11 +54,13 @@ pub rec Session {
     build_alloc: *A.Allocator;
     sources:    source.SourceMap;
     diags:      diagnostic.DiagnosticStore;
-    gate_diags: diagnostic.GateDiagLedger;
     interner:   intern.Interner;
     types:      type.TypeInterner;
 
     queries: query.QueryDb;
+    query_presentation: *query.Presentation;
+    query_failure_message: str;
+    parse_sequence: u64;
 
     module_asts:      **ast.Ast;
     module_ast_count: u32;
@@ -102,10 +107,13 @@ val OVERLAY_SEED_CAP: u32 = 4;
 pub fun init(alloc: *A.Allocator) R.Result[Session, str] {
     var s: Session;
     s.alloc            = alloc;
+    s.parse_sequence   = 0;
     s.build_alloc      = alloc;
     s.sources          = source.init(alloc);
     s.diags            = diagnostic.store_init(alloc);
-    s.gate_diags       = diagnostic.ledger_init(alloc);
+    s.query_presentation = nil;
+    s.query_failure_message = nil;
+
     s.interner         = intern.init(alloc);
     s.module_asts      = nil;
     s.module_ast_count = 0;
@@ -138,7 +146,7 @@ pub fun init(alloc: *A.Allocator) R.Result[Session, str] {
     val opt_types: O.Option[str] = type.init(?s.types, alloc);
     if (O.is_some[str](opt_types)) {
         intern.dnit(?s.interner);
-        diagnostic.ledger_dnit(?s.gate_diags);
+
         diagnostic.store_dnit(?s.diags);
         source.dnit(?s.sources);
         ret R.err[Session, str](O.unwrap[str](opt_types));
@@ -148,7 +156,7 @@ pub fun init(alloc: *A.Allocator) R.Result[Session, str] {
     if (R.is_err[query.QueryDb, str](res_queries)) {
         type.dnit(?s.types);
         intern.dnit(?s.interner);
-        diagnostic.ledger_dnit(?s.gate_diags);
+
         diagnostic.store_dnit(?s.diags);
         source.dnit(?s.sources);
         ret R.err[Session, str](R.unwrap_err[query.QueryDb, str](res_queries));
@@ -160,7 +168,7 @@ pub fun init(alloc: *A.Allocator) R.Result[Session, str] {
         query.dnit(?s.queries);
         type.dnit(?s.types);
         intern.dnit(?s.interner);
-        diagnostic.ledger_dnit(?s.gate_diags);
+
         diagnostic.store_dnit(?s.diags);
         source.dnit(?s.sources);
         ret R.err[Session, str](R.unwrap_err[R.Void, str](res_catalog));
@@ -238,11 +246,19 @@ pub fun dnit(s: *Session) {
     map.dnit[intern.StrId, module.StableModuleId](?s.stable_ids);
     map.dnit[module.StableModuleId, module.ModuleId](?s.stable_to_mid);
 
+    if (s.query_presentation != nil) {
+        query.presentation_dnit(s.query_presentation);
+        s.query_presentation = nil;
+    }
+    if (s.query_failure_message != nil) {
+        str_free(s.queries.a, s.query_failure_message);
+        s.query_failure_message = nil;
+    }
     query.dnit(?s.queries);
     embed.dnit(?s.embeds);
     type.dnit(?s.types);
     intern.dnit(?s.interner);
-    diagnostic.ledger_dnit(?s.gate_diags);
+
     diagnostic.store_dnit(?s.diags);
     source.dnit(?s.sources);
 }
@@ -335,6 +351,9 @@ pub fun stable_module_id(s: *Session, fqn: intern.StrId) R.Result[module.StableM
         ret R.ok[module.StableModuleId, str](@R.unwrap_ok[*module.StableModuleId, str](res_get));
     }
 
+    if (s.stable_id_next == module.STABLE_MODULE_NIL) {
+        ret R.err[module.StableModuleId, str]("stable module identities are exhausted");
+    }
     val id: module.StableModuleId = s.stable_id_next;
     val res_insert: R.Result[bool, str] = map.insert[intern.StrId, module.StableModuleId](?s.stable_ids, fqn, id);
     if (R.is_err[bool, str](res_insert)) {
@@ -391,6 +410,17 @@ pub fun export_library(s: *Session, mid: module.ModuleId, did: u32) O.Option[int
         ret O.some[intern.StrId](@R.unwrap_ok[*intern.StrId, str](res_get));
     }
     ret O.none[intern.StrId]();
+}
+
+pub fun reset_type_projection(s: *Session) R.Result[R.Void, str] {
+    if (s.queries.operation_active || s.queries.presentation_pending) {
+        ret R.err[R.Void, str]("cannot replace type projections while query products are borrowed");
+    }
+    type.field_projection_reset(?s.types);
+    map.clear[u32, u32](?s.type_aligns);
+    map.clear[u32, u32](?s.type_packed);
+    map.clear[u32, u32](?s.type_volatile);
+    ret R.ok_void[str]();
 }
 
 pub fun register_type_align(s: *Session, tid: u32, align: u32) R.Result[R.Void, str] {
@@ -659,22 +689,28 @@ pub fun module_comptime_ptr(s: *Session, mid: module.ModuleId) ptr {
     ret nil;
 }
 
+pub fun next_parse_incarnation(s: *Session) R.Result[u64, str] {
+    if (s.parse_sequence == ~(0::u64)) { ret R.err[u64, str]("parsed source incarnations are exhausted"); }
+    s.parse_sequence = s.parse_sequence + 1;
+    ret R.ok[u64, str](s.parse_sequence);
+}
+
 pub fun load_source(s: *Session, path: str, text: str) R.Result[source.FileId, str] {
+    if (s.queries.operation_active || s.queries.presentation_pending) {
+        ret R.err[source.FileId, str]("cannot change source inputs before the operation is released");
+    }
     val key_r: R.Result[str, str] = source_key(s, path);
     if (R.is_err[str, str](key_r)) { ret R.err[source.FileId, str](R.unwrap_err[str, str](key_r)); }
     val key: str = R.unwrap_ok[str, str](key_r);
     fin { str_free(s.alloc, key); }
-    val res_fid: R.Result[source.FileId, str] = source.load(?s.sources, ?s.interner, key, text);
-    if (R.is_err[source.FileId, str](res_fid)) {
-        ret res_fid;
-    }
-    val fid: source.FileId = R.unwrap_ok[source.FileId, str](res_fid);
-
-    val res_input: R.Result[R.Void, str] = query.set_input(?s.queries, query.Q_FILE_TEXT, fid::u64, text::*u8, str_len(text)::u32);
-    if (R.is_err[R.Void, str](res_input)) {
-        ret R.err[source.FileId, str](R.unwrap_err[R.Void, str](res_input));
-    }
-    ret R.ok[source.FileId, str](fid);
+    if (str_len(text) > 0xFFFFFFFF::usize) { ret R.err[source.FileId, str]("source input exceeds the query byte extent"); }
+    val staged: R.Result[source.PreparedLoad, str] = source.prepare_load(?s.sources, ?s.interner, key, text);
+    if (R.is_err[source.PreparedLoad, str](staged)) { ret R.err[source.FileId, str](R.unwrap_err[source.PreparedLoad, str](staged)); }
+    var prepared: source.PreparedLoad = R.unwrap_ok[source.PreparedLoad, str](staged);
+    fin { source.discard_load(?prepared); }
+    val input: R.Result[R.Void, str] = query.set_input(?s.queries, query.Q_FILE_TEXT, prepared.id::u64, text::*u8, str_len(text)::u32);
+    if (R.is_err[R.Void, str](input)) { ret R.err[source.FileId, str](R.unwrap_err[R.Void, str](input)); }
+    ret R.ok[source.FileId, str](source.commit_load(?prepared));
 }
 
 pub fun set_overlay(s: *Session, path: str, text: str) R.Result[R.Void, str] {
@@ -945,5 +981,156 @@ test "mach.lang.session.load_source:source_and_overlay_keys_share_native_path_id
         val literal: R.Result[source.FileId, str] = load_source(?s, "/x/src\\a.mach", "literal");
         if (R.is_err[source.FileId, str](literal) || R.unwrap_ok[source.FileId, str](literal) == fid) { ret 9; }
     }
+    ret 0;
+}
+
+
+test "mach.lang.session.stable_module_id:registry_reorder_and_exhaustion_preserve_existing_identities" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val opened: R.Result[Session, str] = init(?alloc);
+    if (R.is_err[Session, str](opened)) { ret 2; }
+    var s: Session = R.unwrap_ok[Session, str](opened);
+    fin { dnit(?s); }
+    val a: R.Result[module.StableModuleId, str] = stable_module_id(?s, 1);
+    val b: R.Result[module.StableModuleId, str] = stable_module_id(?s, 2);
+    if (R.is_err[module.StableModuleId, str](a) || R.is_err[module.StableModuleId, str](b)) { ret 3; }
+    val aid: module.StableModuleId = R.unwrap_ok[module.StableModuleId, str](a);
+    val bid: module.StableModuleId = R.unwrap_ok[module.StableModuleId, str](b);
+    if (R.is_err[R.Void, str](register_stable_mid(?s, aid, 0))
+        || R.is_err[R.Void, str](register_stable_mid(?s, bid, 1))) { ret 4; }
+    reset_module_registry(?s);
+    if (R.is_err[R.Void, str](register_stable_mid(?s, bid, 0))
+        || R.is_err[R.Void, str](register_stable_mid(?s, aid, 1))) { ret 5; }
+    if (stable_module_id_lookup(?s, 1) != aid || module_id_for_stable(?s, aid) != 1) { ret 6; }
+    s.stable_id_next = module.STABLE_MODULE_NIL;
+    val existing: R.Result[module.StableModuleId, str] = stable_module_id(?s, 1);
+    if (R.is_err[module.StableModuleId, str](existing) || R.unwrap_ok[module.StableModuleId, str](existing) != aid) { ret 7; }
+    val refused: R.Result[module.StableModuleId, str] = stable_module_id(?s, 3);
+    if (!R.is_err[module.StableModuleId, str](refused)) { ret 8; }
+    if (stable_module_id_lookup(?s, 3) != module.STABLE_MODULE_NIL || s.stable_ids.len != 2
+        || s.stable_id_next != module.STABLE_MODULE_NIL) { ret 9; }
+    ret 0;
+}
+
+fun t_source_input_compute(s: *Session, kind: query.QueryKind, key: u64, a: *A.Allocator,
+                           diags: *diagnostic.DiagnosticStore) R.Result[query.QueryOutput, fail.Fail] {
+    ret R.err[query.QueryOutput, fail.Fail](fail.message("source input unexpectedly required a derived computation"));
+}
+
+fun t_source_input(s: *Session, id: source.FileId, expected: str, stamp: *query.Revision) i32 {
+    val runtime: R.Result[query.QueryRuntime[Session], str] = query.runtime[Session](?s.queries, t_source_input_compute);
+    if (R.is_err[query.QueryRuntime[Session], str](runtime)) { ret 30; }
+    var rt: query.QueryRuntime[Session] = R.unwrap_ok[query.QueryRuntime[Session], str](runtime);
+    val opened: R.Result[query.Operation, str] = query.begin(?s.queries);
+    if (R.is_err[query.Operation, str](opened)) { ret 31; }
+    val operation: query.Operation = R.unwrap_ok[query.Operation, str](opened);
+    val read: R.Result[query.QueryView, fail.Fail] = query.get[Session](?rt, s, query.Q_FILE_TEXT, id::u64);
+    var code: i32 = 0;
+    if (R.is_err[query.QueryView, fail.Fail](read)) { code = 32; }
+    or {
+        val view: query.QueryView = R.unwrap_ok[query.QueryView, fail.Fail](read);
+        if (view.value_len::usize != str_len(expected)
+            || !memory.raw_equal(view.value::ptr, expected::ptr, str_len(expected))) { code = 33; }
+        @stamp = view.last_changed;
+    }
+    if (R.is_err[R.Void, fail.Fail](query.end(?s.queries, operation))) { code = 34; }
+    if (R.is_err[R.Void, str](query.discard(?s.queries, operation))) { code = 35; }
+    ret code;
+}
+
+fun t_source_publication_attempt(tracker: *T.Testing, existing: bool, ordinal: usize, finished: *bool) i32 {
+    val opened: R.Result[Session, str] = init(T.allocator_of(tracker));
+    if (R.is_err[Session, str](opened)) { ret 2; }
+    var s: Session = R.unwrap_ok[Session, str](opened);
+    fin { dnit(?s); }
+    val path: str = "n4/source.mach";
+    var id: source.FileId = 1;
+    var old_text: str = nil;
+    var old_lines: *usize = nil;
+    var old_stamp: query.Revision = 0;
+    if (existing) {
+        val loaded: R.Result[source.FileId, str] = load_source(?s, path, "before\ntext");
+        if (R.is_err[source.FileId, str](loaded)) { ret 3; }
+        id = R.unwrap_ok[source.FileId, str](loaded);
+        old_text = s.sources.files[id].text;
+        old_lines = s.sources.files[id].line_starts;
+        val code: i32 = t_source_input(?s, id, "before\ntext", ?old_stamp);
+        if (code != 0) { ret code; }
+    }
+    val old_len: usize = s.sources.len;
+    val old_paths: usize = s.sources.by_path.len;
+    val old_revision: query.Revision = s.queries.revision;
+    T.fail_at_ordinal(tracker, T.attempt_count(tracker) + ordinal);
+    val attempted: R.Result[source.FileId, str] = load_source(?s, path, "after\ntwo\nlines");
+    T.clear_failure(tracker);
+    if (R.is_err[source.FileId, str](attempted)) {
+        if (s.sources.len != old_len || s.sources.by_path.len != old_paths || s.queries.revision != old_revision) { ret 4; }
+        if (existing) {
+            if (s.sources.files[id].text != old_text || s.sources.files[id].line_starts != old_lines
+                || !str_equals(s.sources.files[id].text, "before\ntext")) { ret 5; }
+            var stamp: query.Revision = 0;
+            val code: i32 = t_source_input(?s, id, "before\ntext", ?stamp);
+            if (code != 0) { ret code; }
+            if (stamp != old_stamp) { ret 6; }
+        }
+    }
+    or { @finished = true; }
+    val retry: R.Result[source.FileId, str] = load_source(?s, path, "after\ntwo\nlines");
+    if (R.is_err[source.FileId, str](retry) || R.unwrap_ok[source.FileId, str](retry) != id) { ret 7; }
+    if (s.sources.len != 2 || s.sources.by_path.len != 1 || s.queries.revision != old_revision + 1) { ret 8; }
+    val file: *source.SourceFile = ?s.sources.files[id];
+    if (!str_equals(file.text, "after\ntwo\nlines") || file.line_len != 3
+        || file.line_starts[1] != 6 || file.line_starts[2] != 10) { ret 9; }
+    var new_stamp: query.Revision = 0;
+    val code: i32 = t_source_input(?s, id, "after\ntwo\nlines", ?new_stamp);
+    if (code != 0) { ret code; }
+    if (new_stamp != old_revision + 1) { ret 10; }
+    ret 0;
+}
+
+test "mach.lang.session.load_source:allocation_refusal_preserves_text_identity_and_query_stamp" {
+    var mode: u32 = 0;
+    for (mode < 2) {
+        var ordinal: usize = 1;
+        var finished: bool = false;
+        for (ordinal <= 64 && !finished) {
+            var tracker: T.Testing;
+            if (O.is_some[str](T.make(?tracker))) { ret 1; }
+            val code: i32 = t_source_publication_attempt(?tracker, mode != 0, ordinal, ?finished);
+            val leaked: bool = T.leaked(?tracker) || T.double_free_count(?tracker) != 0 || T.tracking_exhausted(?tracker);
+            T.dnit(?tracker);
+            if (code != 0) { ret code; }
+            if (leaked) { ret 11; }
+            ordinal = ordinal + 1;
+        }
+        if (!finished || ordinal <= 2) { ret 12; }
+        mode = mode + 1;
+    }
+    ret 0;
+}
+
+test "mach.lang.session.load_source:active_and_pending_operations_refuse_before_source_mutation" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val opened: R.Result[Session, str] = init(?alloc);
+    if (R.is_err[Session, str](opened)) { ret 2; }
+    var s: Session = R.unwrap_ok[Session, str](opened);
+    fin { dnit(?s); }
+    val loaded: R.Result[source.FileId, str] = load_source(?s, "n4/source.mach", "before");
+    if (R.is_err[source.FileId, str](loaded)) { ret 3; }
+    val id: source.FileId = R.unwrap_ok[source.FileId, str](loaded);
+    val text: str = s.sources.files[id].text;
+    val revision: query.Revision = s.queries.revision;
+    val started: R.Result[query.Operation, str] = query.begin(?s.queries);
+    if (R.is_err[query.Operation, str](started)) { ret 4; }
+    val operation: query.Operation = R.unwrap_ok[query.Operation, str](started);
+    if (!R.is_err[source.FileId, str](load_source(?s, "n4/source.mach", "after"))) { ret 5; }
+    if (R.is_err[R.Void, fail.Fail](query.end(?s.queries, operation))) { ret 6; }
+    if (!R.is_err[source.FileId, str](load_source(?s, "n4/new.mach", "new"))) { ret 7; }
+    if (s.sources.len != 2 || s.sources.by_path.len != 1 || s.sources.files[id].text != text
+        || !str_equals(text, "before") || s.queries.revision != revision) { ret 8; }
+    if (R.is_err[R.Void, str](query.discard(?s.queries, operation))) { ret 9; }
+    if (R.is_err[source.FileId, str](load_source(?s, "n4/source.mach", "after"))) { ret 10; }
     ret 0;
 }

--- a/src/lang/source.mach
+++ b/src/lang/source.mach
@@ -52,6 +52,8 @@ pub rec LineSpan {
 }
 
 pub rec SourceFile {
+    present:     bool;
+    revision:    u64;
     path:        str;
     text:        str;
     line_starts: *usize;
@@ -140,6 +142,8 @@ pub fun add(m: *SourceMap, path: str, text: str) R.Result[FileId, str] {
     }
 
     var file: SourceFile;
+    file.present = true;
+    file.revision = 1;
     file.path        = path_copy;
     file.text        = text_copy;
     file.line_starts = starts;
@@ -153,11 +157,12 @@ pub fun add(m: *SourceMap, path: str, text: str) R.Result[FileId, str] {
 }
 
 pub fun update(m: *SourceMap, id: FileId, text: str) R.Result[bool, str] {
-    if (id::usize >= m.len) { ret R.ok[bool, str](false); }
+    if (id == FILE_NIL || id::usize >= m.len) { ret R.ok[bool, str](false); }
 
     val file: *SourceFile = ?m.files[id];
 
-    if (str_equals(file.text, text)) { ret R.ok[bool, str](true); }
+    if (file.present && str_equals(file.text, text)) { ret R.ok[bool, str](false); }
+    if (file.revision == ~(0::u64)) { ret R.err[bool, str]("source revision exhausted"); }
 
     var line_len: usize = 0;
     val res_starts: R.Result[*usize, str] = line_index_build(m.a, text, ?line_len);
@@ -179,6 +184,8 @@ pub fun update(m: *SourceMap, id: FileId, text: str) R.Result[bool, str] {
     file.text        = text_copy;
     file.line_starts = starts;
     file.line_len    = line_len;
+    file.present = true;
+    file.revision = file.revision + 1;
 
     ret R.ok[bool, str](true);
 }
@@ -204,8 +211,10 @@ pub fun prepare_load(m: *SourceMap, interner: *intern.Interner, path: str, text:
         val current: O.Option[*SourceFile] = get(m, prepared.id);
         if (O.is_none[*SourceFile](current)) { ret R.err[PreparedLoad, str]("source path index has no file owner"); }
         val file: *SourceFile = O.unwrap[*SourceFile](current);
-        if (str_equals(file.text, text)) { ret R.ok[PreparedLoad, str](prepared); }
+        if (file.present && str_equals(file.text, text)) { ret R.ok[PreparedLoad, str](prepared); }
+        if (file.revision == ~(0::u64)) { ret R.err[PreparedLoad, str]("source revision exhausted"); }
         prepared.file.path = file.path;
+        prepared.file.revision = file.revision + 1;
     }
     or {
         if (m.len::u64 > 0xFFFFFFFF || m.len == ~(0::usize)) { ret R.err[PreparedLoad, str]("source file identities are exhausted"); }
@@ -217,7 +226,9 @@ pub fun prepare_load(m: *SourceMap, interner: *intern.Interner, path: str, text:
         if (R.is_err[str, str](copied_path)) { ret R.err[PreparedLoad, str](R.unwrap_err[str, str](copied_path)); }
         prepared.file.path = R.unwrap_ok[str, str](copied_path);
         prepared.new_entry = true;
+        prepared.file.revision = 1;
     }
+    prepared.file.present = true;
     var transferred: bool = false;
     fin {
         if (!transferred) {
@@ -280,6 +291,25 @@ pub fun load(m: *SourceMap, interner: *intern.Interner, path: str, text: str) R.
     ret R.ok[FileId, str](commit_load(?prepared));
 }
 
+# preflight completes before query and editor owners are retired
+pub fun prepare_release(m: *SourceMap, id: FileId) R.Result[R.Void, str] {
+    if (id == FILE_NIL || id::usize >= m.len) { ret R.err[R.Void, str]("source identity is absent"); }
+    if (m.files[id].present && m.files[id].revision == ~(0::u64)) { ret R.err[R.Void, str]("source revision exhausted"); }
+    ret R.ok_void[str]();
+}
+
+pub fun release_payload(m: *SourceMap, id: FileId) {
+    val file: *SourceFile = ?m.files[id];
+    if (!file.present) { ret; }
+    str_free(m.a, file.text);
+    line_index_free(m.a, file.line_starts, file.line_len);
+    file.text = nil;
+    file.line_starts = nil;
+    file.line_len = 0;
+    file.present = false;
+    file.revision = file.revision + 1;
+}
+
 pub fun get(m: *SourceMap, id: FileId) O.Option[*SourceFile] {
     if (id == FILE_NIL || id::usize >= m.len) { ret O.none[*SourceFile](); }
     ret O.some[*SourceFile](?m.files[id]);
@@ -320,6 +350,32 @@ fun snapshot_path_index(src: *SourceMap, dst: *SourceMap) R.Result[R.Void, str] 
     ret R.ok_void[str]();
 }
 
+pub fun copy_file(file: *SourceFile, a: *A.Allocator) R.Result[SourceFile, str] {
+    var copied: SourceFile = SourceFile{ present: file.present, revision: file.revision };
+    var complete: bool = false;
+    fin { if (!complete) { dnit_file(?copied, a); } }
+    val path: R.Result[str, str] = str_dup(a, file.path);
+    if (R.is_err[str, str](path)) { ret R.err[SourceFile, str](R.unwrap_err[str, str](path)); }
+    copied.path = R.unwrap_ok[str, str](path);
+    if (file.present) {
+        val text: R.Result[str, str] = str_dup(a, file.text);
+        if (R.is_err[str, str](text)) { ret R.err[SourceFile, str](R.unwrap_err[str, str](text)); }
+        copied.text = R.unwrap_ok[str, str](text);
+        val lines: R.Result[*usize, str] = line_index_build(a, copied.text, ?copied.line_len);
+        if (R.is_err[*usize, str](lines)) { ret R.err[SourceFile, str](R.unwrap_err[*usize, str](lines)); }
+        copied.line_starts = R.unwrap_ok[*usize, str](lines);
+    }
+    complete = true;
+    ret R.ok[SourceFile, str](copied);
+}
+
+pub fun dnit_file(file: *SourceFile, a: *A.Allocator) {
+    str_free(a, file.path);
+    str_free(a, file.text);
+    line_index_free(a, file.line_starts, file.line_len);
+    @file = SourceFile{};
+}
+
 pub fun snapshot_from(src: *SourceMap, a: *A.Allocator) R.Result[*SourceMap, str] {
     if (src == nil || a == nil) { ret R.err[*SourceMap, str]("source snapshot requires a map and allocator"); }
 
@@ -347,44 +403,17 @@ pub fun snapshot_from(src: *SourceMap, a: *A.Allocator) R.Result[*SourceMap, str
     snap.cap   = src.len;
     snap.len   = 1;
 
+    snap.files[0] = SourceFile{};
     var i: usize = 1;
     for (i < src.len) {
-        val file: *SourceFile = ?src.files[i];
-
-        val path_r: R.Result[str, str] = str_dup(a, file.path);
-        if (R.is_err[str, str](path_r)) {
+        val copied: R.Result[SourceFile, str] = copy_file(?src.files[i], a);
+        if (R.is_err[SourceFile, str](copied)) {
             dnit(snap);
             A.deallocate[SourceMap](a, snap, 1);
-            ret R.err[*SourceMap, str](R.unwrap_err[str, str](path_r));
+            ret R.err[*SourceMap, str](R.unwrap_err[SourceFile, str](copied));
         }
-        val path_copy: str = R.unwrap_ok[str, str](path_r);
-
-        val text_r: R.Result[str, str] = str_dup(a, file.text);
-        if (R.is_err[str, str](text_r)) {
-            str_free(a, path_copy);
-            dnit(snap);
-            A.deallocate[SourceMap](a, snap, 1);
-            ret R.err[*SourceMap, str](R.unwrap_err[str, str](text_r));
-        }
-        val text_copy: str = R.unwrap_ok[str, str](text_r);
-
-        var line_len: usize = 0;
-        val lines_r: R.Result[*usize, str] = line_index_build(a, text_copy, ?line_len);
-        if (R.is_err[*usize, str](lines_r)) {
-            str_free(a, text_copy);
-            str_free(a, path_copy);
-            dnit(snap);
-            A.deallocate[SourceMap](a, snap, 1);
-            ret R.err[*SourceMap, str](R.unwrap_err[*usize, str](lines_r));
-        }
-
-        var copy: SourceFile;
-        copy.path        = path_copy;
-        copy.text        = text_copy;
-        copy.line_starts = R.unwrap_ok[*usize, str](lines_r);
-        copy.line_len    = line_len;
-        snap.files[i]    = copy;
-        snap.len         = i + 1;
+        snap.files[i] = R.unwrap_ok[SourceFile, str](copied);
+        snap.len = i + 1;
         i = i + 1;
     }
 
@@ -540,6 +569,10 @@ test "mach.lang.source.update:identical_text_preserves_storage" {
     val fid: FileId = R.unwrap_ok[FileId, str](res1);
     val text0: str = (?m.files[fid::usize]).text;
     val lines0: *usize = (?m.files[fid::usize]).line_starts;
+    val revision: u64 = m.files[fid].revision;
+    val identical: R.Result[bool, str] = update(?m, fid, "hello\nworld");
+    if (R.is_err[bool, str](identical) || R.unwrap_ok[bool, str](identical)) { ret 2; }
+    if (m.files[fid].revision != revision) { ret 3; }
 
     val res2: R.Result[FileId, str] = load(?m, ?ix, "p.mach", "hello\nworld");
     if (R.is_err[FileId, str](res2)) { ret 1; }

--- a/src/lang/source.mach
+++ b/src/lang/source.mach
@@ -1,4 +1,5 @@
 use std.allocator.page;
+use T: std.allocator.testing;
 use std.collections.map;
 use std.text.string.str_dup;
 use std.text.string.str_free;
@@ -100,6 +101,9 @@ pub fun dnit(m: *SourceMap) {
 }
 
 pub fun add(m: *SourceMap, path: str, text: str) R.Result[FileId, str] {
+    if (m.len::u64 > 0xFFFFFFFF || m.len == ~(0::usize)) {
+        ret R.err[FileId, str]("source file identities are exhausted");
+    }
     if (m.len == 0) {
         val res_sentinel: R.Result[R.Void, str] = files_reserve(m);
         if (R.is_err[R.Void, str](res_sentinel)) { ret R.err[FileId, str](R.unwrap_err[R.Void, str](res_sentinel)); }
@@ -179,32 +183,101 @@ pub fun update(m: *SourceMap, id: FileId, text: str) R.Result[bool, str] {
     ret R.ok[bool, str](true);
 }
 
-pub fun load(m: *SourceMap, interner: *intern.Interner, path: str, text: str) R.Result[FileId, str] {
-    val res_pid: R.Result[intern.StrId, str] = intern.intern(interner, path);
-    if (R.is_err[intern.StrId, str](res_pid)) {
-        ret R.err[FileId, str](R.unwrap_err[intern.StrId, str](res_pid));
-    }
-    val pid: intern.StrId = R.unwrap_ok[intern.StrId, str](res_pid);
+pub rec PreparedLoad {
+    owner: *SourceMap;
+    id: FileId;
+    key: intern.StrId;
+    file: SourceFile;
+    changed: bool;
+    new_entry: bool;
+}
 
-    val res_existing: R.Result[*FileId, str] = map.get[intern.StrId, FileId](?m.by_path, ?pid);
-    if (R.is_ok[*FileId, str](res_existing)) {
-        val fid: FileId = @R.unwrap_ok[*FileId, str](res_existing);
-        val changed_r: R.Result[bool, str] = update(m, fid, text);
-        if (R.is_err[bool, str](changed_r)) {
-            ret R.err[FileId, str](R.unwrap_err[bool, str](changed_r));
+# the caller exclusively borrows the map until commit or discard
+pub fun prepare_load(m: *SourceMap, interner: *intern.Interner, path: str, text: str) R.Result[PreparedLoad, str] {
+    val interned: R.Result[intern.StrId, str] = intern.intern(interner, path);
+    if (R.is_err[intern.StrId, str](interned)) { ret R.err[PreparedLoad, str](R.unwrap_err[intern.StrId, str](interned)); }
+    val key: intern.StrId = R.unwrap_ok[intern.StrId, str](interned);
+    var prepared: PreparedLoad = PreparedLoad{ owner: m, key: key };
+    val existing: R.Result[*FileId, str] = map.get[intern.StrId, FileId](?m.by_path, ?key);
+    if (R.is_ok[*FileId, str](existing)) {
+        prepared.id = @R.unwrap_ok[*FileId, str](existing);
+        val current: O.Option[*SourceFile] = get(m, prepared.id);
+        if (O.is_none[*SourceFile](current)) { ret R.err[PreparedLoad, str]("source path index has no file owner"); }
+        val file: *SourceFile = O.unwrap[*SourceFile](current);
+        if (str_equals(file.text, text)) { ret R.ok[PreparedLoad, str](prepared); }
+        prepared.file.path = file.path;
+    }
+    or {
+        if (m.len::u64 > 0xFFFFFFFF || m.len == ~(0::usize)) { ret R.err[PreparedLoad, str]("source file identities are exhausted"); }
+        prepared.id = m.len::FileId;
+        if (m.len == 0) { prepared.id = 1; }
+        val reserved: R.Result[R.Void, str] = files_reserve(m);
+        if (R.is_err[R.Void, str](reserved)) { ret R.err[PreparedLoad, str](R.unwrap_err[R.Void, str](reserved)); }
+        val copied_path: R.Result[str, str] = str_dup(m.a, path);
+        if (R.is_err[str, str](copied_path)) { ret R.err[PreparedLoad, str](R.unwrap_err[str, str](copied_path)); }
+        prepared.file.path = R.unwrap_ok[str, str](copied_path);
+        prepared.new_entry = true;
+    }
+    var transferred: bool = false;
+    fin {
+        if (!transferred) {
+            if (prepared.new_entry) { str_free(m.a, prepared.file.path); }
+            str_free(m.a, prepared.file.text);
+            line_index_free(m.a, prepared.file.line_starts, prepared.file.line_len);
         }
-        ret R.ok[FileId, str](fid);
     }
-
-    val res_add: R.Result[FileId, str] = add(m, path, text);
-    if (R.is_err[FileId, str](res_add)) { ret res_add; }
-    val fid: FileId = R.unwrap_ok[FileId, str](res_add);
-
-    val res_insert: R.Result[bool, str] = map.insert[intern.StrId, FileId](?m.by_path, pid, fid);
-    if (R.is_err[bool, str](res_insert)) {
-        ret R.err[FileId, str](R.unwrap_err[bool, str](res_insert));
+    val lines: R.Result[*usize, str] = line_index_build(m.a, text, ?prepared.file.line_len);
+    if (R.is_err[*usize, str](lines)) { ret R.err[PreparedLoad, str](R.unwrap_err[*usize, str](lines)); }
+    prepared.file.line_starts = R.unwrap_ok[*usize, str](lines);
+    val copied: R.Result[str, str] = str_dup(m.a, text);
+    if (R.is_err[str, str](copied)) { ret R.err[PreparedLoad, str](R.unwrap_err[str, str](copied)); }
+    prepared.file.text = R.unwrap_ok[str, str](copied);
+    if (prepared.new_entry) {
+        val indexed: R.Result[bool, str] = map.insert[intern.StrId, FileId](?m.by_path, key, prepared.id);
+        if (R.is_err[bool, str](indexed)) { ret R.err[PreparedLoad, str](R.unwrap_err[bool, str](indexed)); }
     }
-    ret R.ok[FileId, str](fid);
+    prepared.changed = true;
+    transferred = true;
+    ret R.ok[PreparedLoad, str](prepared);
+}
+
+pub fun discard_load(prepared: *PreparedLoad) {
+    if (prepared.owner == nil) { ret; }
+    val m: *SourceMap = prepared.owner;
+    if (prepared.changed) {
+        if (prepared.new_entry) {
+            map.remove[intern.StrId, FileId](?m.by_path, ?prepared.key);
+            str_free(m.a, prepared.file.path);
+        }
+        str_free(m.a, prepared.file.text);
+        line_index_free(m.a, prepared.file.line_starts, prepared.file.line_len);
+    }
+    prepared.owner = nil;
+    prepared.file = SourceFile{};
+}
+
+pub fun commit_load(prepared: *PreparedLoad) FileId {
+    val m: *SourceMap = prepared.owner;
+    val id: FileId = prepared.id;
+    if (prepared.changed) {
+        if (!prepared.new_entry) {
+            str_free(m.a, m.files[id].text);
+            line_index_free(m.a, m.files[id].line_starts, m.files[id].line_len);
+        }
+        if (m.len == 0) { m.files[0] = SourceFile{}; }
+        m.files[id] = prepared.file;
+        if (prepared.new_entry) { m.len = id::usize + 1; }
+    }
+    prepared.owner = nil;
+    prepared.file = SourceFile{};
+    ret id;
+}
+
+pub fun load(m: *SourceMap, interner: *intern.Interner, path: str, text: str) R.Result[FileId, str] {
+    val staged: R.Result[PreparedLoad, str] = prepare_load(m, interner, path, text);
+    if (R.is_err[PreparedLoad, str](staged)) { ret R.err[FileId, str](R.unwrap_err[PreparedLoad, str](staged)); }
+    var prepared: PreparedLoad = R.unwrap_ok[PreparedLoad, str](staged);
+    ret R.ok[FileId, str](commit_load(?prepared));
 }
 
 pub fun get(m: *SourceMap, id: FileId) O.Option[*SourceFile] {
@@ -542,4 +615,25 @@ test "mach.lang.source.srcloc:offset_roundtrips_to_line_col" {
 
     dnit(?m);
     ret 0;
+}
+
+
+test "mach.lang.source.add:identity_exhaustion_precedes_allocation_or_publication" {
+    var tracked: T.Testing;
+    if (O.is_some[str](T.make(?tracked))) { ret 1; }
+    fin { T.dnit(?tracked); }
+    var m: SourceMap = init(T.allocator_of(?tracked));
+    var limit: usize = ~(0::usize);
+    $if ($mach.build.pointer_width == 8) { limit = 0x100000000::usize; }
+    m.len = limit;
+    T.fail_at_ordinal(?tracked, 1);
+    val refused: R.Result[FileId, str] = add(?m, "full.mach", "");
+    var bad: i32 = 0;
+    if (!R.is_err[FileId, str](refused)) { bad = 2; }
+    or (!str_equals(R.unwrap_err[FileId, str](refused), "source file identities are exhausted")) { bad = 3; }
+    if (m.len != limit || T.attempt_count(?tracked) != 0) { bad = 4; }
+    m.len = 0;
+    dnit(?m);
+    if (T.leaked(?tracked) || T.double_free_count(?tracked) != 0) { bad = 5; }
+    ret bad;
 }

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -28,6 +28,7 @@ use mach.lang.handle;
 use mach.lang.intern;
 use mach.lang.layout;
 use mach.lang.module;
+use mach.lang.source;
 
 pub def TypeId:     u32;
 pub val TYPE_NIL:   TypeId = 0xFFFFFFFF;
@@ -340,27 +341,35 @@ pub rec TypeFun {
     params_start: u32;
     params_len:   u32;
     c_variadic:   bool;
+    next_in_bucket: TypeId;
+}
+
+# persistent source identity, independent of the current module registry
+pub rec TypeOwner {
+    module: module.StableModuleId;
+    file: source.FileId;
 }
 
 pub rec TypeNominal {
-    name:   intern.StrId;
-    origin: module.ModuleId;
-    decl:   id.DeclId;
+    name: intern.StrId;
+    owner: TypeOwner;
+    incarnation: u64;
+    syntax: intern.StrId;
 }
 
 pub rec TypeGenericParam {
-    name:   intern.StrId;
-    origin: module.ModuleId;
-    owner:  id.DeclId;
-    index:  u32;
+    name: intern.StrId;
+    owner: TypeOwner;
+    owner_name: intern.StrId;
+    owner_kind: TypeKind;
+    index: u32;
 }
 
 pub rec TypeInstance {
-    nominal:       TypeId;
-    target_origin: module.ModuleId;
-    target_decl:   id.DeclId;
-    args_start:    u32;
-    args_len:      u32;
+    nominal: TypeId;
+    args_start: u32;
+    args_len: u32;
+    next_in_bucket: TypeId;
 }
 
 pub rec Type {
@@ -1129,11 +1138,13 @@ pub fun intern_handle(ti: *TypeInterner, name: intern.StrId, ctor: u32, ops: *u3
     t.data.handle.ops_len   = count;
 
     val res_append: R.Result[TypeId, str] = append_type(ti, t);
-    if (R.is_err[TypeId, str](res_append)) { ret res_append; }
+    if (R.is_err[TypeId, str](res_append)) { ti.handle_ops_len = t.data.handle.ops_start; ret res_append; }
     val tid: TypeId = R.unwrap_ok[TypeId, str](res_append);
 
     val res_track: R.Result[R.Void, str] = track_handle(ti, tid);
     if (R.is_err[R.Void, str](res_track)) {
+        ti.types.len = tid::usize;
+        ti.handle_ops_len = t.data.handle.ops_start;
         ret R.err[TypeId, str](R.unwrap_err[R.Void, str](res_track));
     }
     ret R.ok[TypeId, str](tid);
@@ -1239,33 +1250,63 @@ pub fun intern_pack(ti: *TypeInterner) R.Result[TypeId, str] {
     ret intern_dedup(ti, t);
 }
 
-pub fun intern_nominal(ti: *TypeInterner, name: intern.StrId, origin: module.ModuleId, decl: id.DeclId, kind: TypeKind) R.Result[TypeId, str] {
+pub fun intern_nominal(ti: *TypeInterner, name: intern.StrId, owner: TypeOwner, kind: TypeKind) R.Result[TypeId, str] {
     var t: Type;
-    t.kind                = kind;
-    t.data.nominal.name   = name;
-    t.data.nominal.origin = origin;
-    t.data.nominal.decl   = decl;
+    t.kind = kind;
+    t.data.nominal.name = name;
+    t.data.nominal.owner = owner;
+    t.data.nominal.incarnation = 0;
+    t.data.nominal.syntax = intern.STR_NIL;
     ret intern_dedup(ti, t);
 }
 
-pub fun intern_generic_param(ti: *TypeInterner, name: intern.StrId, origin: module.ModuleId, owner: id.DeclId, index: u32) R.Result[TypeId, str] {
+# an anonymous recipe belongs to one source incarnation
+pub fun intern_anonymous(ti: *TypeInterner, name: intern.StrId, owner: TypeOwner,
+    incarnation: u64, syntax: intern.StrId, kind: TypeKind) R.Result[TypeId, str] {
+    if (incarnation == 0 || syntax == intern.STR_NIL) {
+        ret R.err[TypeId, str]("anonymous type requires its parsed incarnation and structural recipe");
+    }
     var t: Type;
-    t.kind                      = TYPE_GENERIC_PARAM;
-    t.data.generic_param.name   = name;
-    t.data.generic_param.origin = origin;
-    t.data.generic_param.owner  = owner;
-    t.data.generic_param.index  = index;
+    t.kind = kind;
+    t.data.nominal.name = name;
+    t.data.nominal.owner = owner;
+    t.data.nominal.incarnation = incarnation;
+    t.data.nominal.syntax = syntax;
+    ret intern_dedup(ti, t);
+}
+
+pub fun intern_generic_param(ti: *TypeInterner, name: intern.StrId, owner: TypeOwner,
+    owner_name: intern.StrId, owner_kind: TypeKind, index: u32) R.Result[TypeId, str] {
+    var t: Type;
+    t.kind = TYPE_GENERIC_PARAM;
+    t.data.generic_param.name = name;
+    t.data.generic_param.owner = owner;
+    t.data.generic_param.owner_name = owner_name;
+    t.data.generic_param.owner_kind = owner_kind;
+    t.data.generic_param.index = index;
     ret intern_dedup(ti, t);
 }
 
 pub fun intern_function(ti: *TypeInterner, ret_type: TypeId, params: *TypeId, count: u32, c_variadic: bool) R.Result[TypeId, str] {
+    if (count != 0 && params == nil) { ret R.err[TypeId, str]("type parameter input is nil"); }
     val h: u64 = hash_fun(ret_type, params, count, c_variadic);
+    ret intern_function_bucket(ti, ret_type, params, count, c_variadic, h);
+}
 
+fun intern_function_bucket(ti: *TypeInterner, ret_type: TypeId, params: *TypeId, count: u32, c_variadic: bool, h: u64) R.Result[TypeId, str] {
+
+    var head: TypeId = TYPE_NIL;
     val res_get: R.Result[*TypeId, str] = map.get[u64, TypeId](?ti.fun_index, ?h);
     if (R.is_ok[*TypeId, str](res_get)) {
-        val existing: TypeId = @R.unwrap_ok[*TypeId, str](res_get);
-        if (fun_matches(ti, existing, ret_type, params, count, c_variadic)) {
-            ret R.ok[TypeId, str](existing);
+        head = @R.unwrap_ok[*TypeId, str](res_get);
+        var existing: TypeId = head;
+        for (existing != TYPE_NIL) {
+            val entry: R.Result[*Type, str] = handle.chunk_get[Type](?ti.types, existing::usize);
+            if (R.is_err[*Type, str](entry)) { ret R.err[TypeId, str](R.unwrap_err[*Type, str](entry)); }
+            val candidate: *Type = R.unwrap_ok[*Type, str](entry);
+            if (candidate.kind != TYPE_FUN) { ret R.err[TypeId, str]("type interner bucket has the wrong kind"); }
+            if (fun_matches(ti, existing, ret_type, params, count, c_variadic)) { ret R.ok[TypeId, str](existing); }
+            existing = candidate.data.fn.next_in_bucket;
         }
     }
 
@@ -1282,25 +1323,29 @@ pub fun intern_function(ti: *TypeInterner, ret_type: TypeId, params: *TypeId, co
     t.data.fn.params_len   = count;
     t.data.fn.c_variadic   = c_variadic;
 
+    t.data.fn.next_in_bucket = head;
+
     val res_append: R.Result[TypeId, str] = append_type(ti, t);
     if (R.is_err[TypeId, str](res_append)) {
+        ti.params_len = start;
         ret res_append;
     }
     val tid: TypeId = R.unwrap_ok[TypeId, str](res_append);
 
     val res_insert: R.Result[bool, str] = map.insert[u64, TypeId](?ti.fun_index, h, tid);
     if (R.is_err[bool, str](res_insert)) {
+        ti.types.len = tid::usize;
+        ti.params_len = start;
         ret R.err[TypeId, str](R.unwrap_err[bool, str](res_insert));
     }
 
     ret R.ok[TypeId, str](tid);
 }
 
-fun hash_instance(target_origin: module.ModuleId, target_decl: id.DeclId, args: *TypeId, count: u32) u64 {
+fun hash_instance(nominal: TypeId, args: *TypeId, count: u32) u64 {
     var h: u64 = fnv1a.FNV_INIT;
     h = fnv1a.step_u8(h, TYPE_INSTANCE::u8);
-    h = fnv1a.step_u32(h, target_origin::u32);
-    h = fnv1a.step_u32(h, target_decl::u32);
+    h = fnv1a.step_u32(h, nominal::u32);
     h = fnv1a.step_u32(h, count);
 
     var i: u32 = 0;
@@ -1311,13 +1356,12 @@ fun hash_instance(target_origin: module.ModuleId, target_decl: id.DeclId, args: 
     ret h;
 }
 
-fun instance_matches(ti: *TypeInterner, tid: TypeId, target_origin: module.ModuleId, target_decl: id.DeclId, args: *TypeId, count: u32) bool {
+fun instance_matches(ti: *TypeInterner, tid: TypeId, nominal: TypeId, args: *TypeId, count: u32) bool {
     val r: R.Result[*Type, str] = handle.chunk_get[Type](?ti.types, tid::usize);
     if (R.is_err[*Type, str](r)) { ret false; }
     val cand: *Type = R.unwrap_ok[*Type, str](r);
     if (cand.kind != TYPE_INSTANCE)                        { ret false; }
-    if (cand.data.instance.target_origin != target_origin) { ret false; }
-    if (cand.data.instance.target_decl != target_decl)     { ret false; }
+    if (cand.data.instance.nominal != nominal) { ret false; }
     if (cand.data.instance.args_len != count)               { ret false; }
 
     var i: u32 = 0;
@@ -1328,14 +1372,26 @@ fun instance_matches(ti: *TypeInterner, tid: TypeId, target_origin: module.Modul
     ret true;
 }
 
-pub fun intern_instance(ti: *TypeInterner, nominal: TypeId, target_origin: module.ModuleId, target_decl: id.DeclId, args: *TypeId, count: u32) R.Result[TypeId, str] {
-    val h: u64 = hash_instance(target_origin, target_decl, args, count);
+pub fun intern_instance(ti: *TypeInterner, nominal: TypeId, args: *TypeId, count: u32) R.Result[TypeId, str] {
+    if (count != 0 && args == nil) { ret R.err[TypeId, str]("type parameter input is nil"); }
+    val h: u64 = hash_instance(nominal, args, count);
+    ret intern_instance_bucket(ti, nominal, args, count, h);
+}
 
+fun intern_instance_bucket(ti: *TypeInterner, nominal: TypeId, args: *TypeId, count: u32, h: u64) R.Result[TypeId, str] {
+
+    var head: TypeId = TYPE_NIL;
     val res_get: R.Result[*TypeId, str] = map.get[u64, TypeId](?ti.instance_index, ?h);
     if (R.is_ok[*TypeId, str](res_get)) {
-        val existing: TypeId = @R.unwrap_ok[*TypeId, str](res_get);
-        if (instance_matches(ti, existing, target_origin, target_decl, args, count)) {
-            ret R.ok[TypeId, str](existing);
+        head = @R.unwrap_ok[*TypeId, str](res_get);
+        var existing: TypeId = head;
+        for (existing != TYPE_NIL) {
+            val entry: R.Result[*Type, str] = handle.chunk_get[Type](?ti.types, existing::usize);
+            if (R.is_err[*Type, str](entry)) { ret R.err[TypeId, str](R.unwrap_err[*Type, str](entry)); }
+            val candidate: *Type = R.unwrap_ok[*Type, str](entry);
+            if (candidate.kind != TYPE_INSTANCE) { ret R.err[TypeId, str]("type interner bucket has the wrong kind"); }
+            if (instance_matches(ti, existing, nominal, args, count)) { ret R.ok[TypeId, str](existing); }
+            existing = candidate.data.instance.next_in_bucket;
         }
     }
 
@@ -1348,19 +1404,22 @@ pub fun intern_instance(ti: *TypeInterner, nominal: TypeId, target_origin: modul
     var t: Type;
     t.kind                        = TYPE_INSTANCE;
     t.data.instance.nominal       = nominal;
-    t.data.instance.target_origin = target_origin;
-    t.data.instance.target_decl   = target_decl;
     t.data.instance.args_start    = start;
     t.data.instance.args_len      = count;
 
+    t.data.instance.next_in_bucket = head;
+
     val res_append: R.Result[TypeId, str] = append_type(ti, t);
     if (R.is_err[TypeId, str](res_append)) {
+        ti.params_len = start;
         ret res_append;
     }
     val tid: TypeId = R.unwrap_ok[TypeId, str](res_append);
 
     val res_insert: R.Result[bool, str] = map.insert[u64, TypeId](?ti.instance_index, h, tid);
     if (R.is_err[bool, str](res_insert)) {
+        ti.types.len = tid::usize;
+        ti.params_len = start;
         ret R.err[TypeId, str](R.unwrap_err[bool, str](res_insert));
     }
 
@@ -1389,6 +1448,17 @@ pub fun type_equals_signatures(ti: *TypeInterner, a: TypeId, b: TypeId) bool {
         i = i + 1;
     }
     ret true;
+}
+
+pub fun field_projection_reset(ti: *TypeInterner) {
+    handle.chunk_dnit[FieldTable](?ti.field_tables);
+    handle.chunk_dnit[FieldEntry](?ti.field_pool);
+    ti.field_tables = handle.chunk_init[FieldTable](ti.a);
+    ti.field_pool = handle.chunk_init[FieldEntry](ti.a);
+    map.clear[TypeId, u32](?ti.field_index);
+    ti.field_epoch = 0;
+    ti.gparam_epoch = 0;
+    if (ti.gparam != nil && ti.gparam_cap != 0) { memory.zero[u8](ti.gparam, ti.gparam_cap::usize); }
 }
 
 pub fun field_epoch_bump(ti: *TypeInterner) {
@@ -1555,6 +1625,7 @@ fun intern_dedup(ti: *TypeInterner, t: Type) R.Result[TypeId, str] {
 
     val res_insert: R.Result[bool, str] = map.insert[Type, TypeId](?ti.dedup, t, tid);
     if (R.is_err[bool, str](res_insert)) {
+        ti.types.len = tid::usize;
         ret R.err[TypeId, str](R.unwrap_err[bool, str](res_insert));
     }
 
@@ -1562,7 +1633,9 @@ fun intern_dedup(ti: *TypeInterner, t: Type) R.Result[TypeId, str] {
 }
 
 fun append_type(ti: *TypeInterner, t: Type) R.Result[TypeId, str] {
-    val tid: TypeId = handle.chunk_count[Type](?ti.types)::u32;
+    val count: usize = handle.chunk_count[Type](?ti.types);
+    if (count >= TYPE_ERROR::usize) { ret R.err[TypeId, str]("type identities are exhausted"); }
+    val tid: TypeId = count::TypeId;
 
     val ce_r: R.Result[handle.ChunkEditor[Type], str] = handle.chunk_edit[Type](?ti.types);
     if (R.is_err[handle.ChunkEditor[Type], str](ce_r)) {
@@ -1617,15 +1690,30 @@ fun reserve_params(ti: *TypeInterner, need: u32) R.Result[R.Void, str] {
 
 fun params_append(ti: *TypeInterner, src: *TypeId, len: u32) R.Result[u32, str] {
     val start: u32 = ti.params_len;
+    if (len != 0 && src == nil) { ret R.err[u32, str]("type parameter input is nil"); }
+    var borrowed: bool = false;
+    var offset: usize = 0;
+    if (len != 0 && ti.params != nil && src::usize >= ti.params::usize) {
+        val delta: usize = src::usize - ti.params::usize;
+        if (delta / $size_of(TypeId) < ti.params_cap::usize) {
+            offset = delta / $size_of(TypeId);
+            if (delta % $size_of(TypeId) != 0 || offset > start::usize || len::usize > start::usize - offset) {
+                ret R.err[u32, str]("type parameter input exceeds its owned run");
+            }
+            borrowed = true;
+        }
+    }
 
     val res_reserve: R.Result[R.Void, str] = reserve_params(ti, len);
     if (R.is_err[R.Void, str](res_reserve)) {
         ret R.err[u32, str](R.unwrap_err[R.Void, str](res_reserve));
     }
 
+    var input: *TypeId = src;
+    if (borrowed) { input = ?ti.params[offset]; }
     var i: u32 = 0;
     for (i < len) {
-        ti.params[start + i] = src[i];
+        ti.params[start + i] = input[i];
         i = i + 1;
     }
     ti.params_len = start + len;
@@ -1686,12 +1774,19 @@ fun hash_type(p: ptr) u64 {
         h = fnv1a.step_u32(h, t.data.vector.lanes);
     }
     or (t.kind == TYPE_REC || t.kind == TYPE_UNI) {
-        h = fnv1a.step_u32(h, t.data.nominal.origin::u32);
-        h = fnv1a.step_u32(h, t.data.nominal.decl::u32);
+        h = fnv1a.step_u32(h, t.data.nominal.owner.module::u32);
+        h = fnv1a.step_u32(h, t.data.nominal.owner.file::u32);
+        h = fnv1a.step_u32(h, t.data.nominal.name::u32);
+        h = fnv1a.step_u32(h, t.data.nominal.incarnation::u32);
+        h = fnv1a.step_u32(h, (t.data.nominal.incarnation >> 32)::u32);
+        h = fnv1a.step_u32(h, t.data.nominal.syntax::u32);
     }
     or (t.kind == TYPE_GENERIC_PARAM) {
-        h = fnv1a.step_u32(h, t.data.generic_param.origin::u32);
-        h = fnv1a.step_u32(h, t.data.generic_param.owner::u32);
+        h = fnv1a.step_u32(h, t.data.generic_param.owner.module::u32);
+        h = fnv1a.step_u32(h, t.data.generic_param.owner.file::u32);
+        h = fnv1a.step_u32(h, t.data.generic_param.owner_name::u32);
+        h = fnv1a.step_u8(h, t.data.generic_param.owner_kind);
+        h = fnv1a.step_u32(h, t.data.generic_param.name::u32);
         h = fnv1a.step_u32(h, t.data.generic_param.index);
     }
     or (t.kind == TYPE_ABI) {
@@ -1722,12 +1817,18 @@ fun eq_type(pa: ptr, pb: ptr) bool {
             && a.data.vector.lanes == b.data.vector.lanes;
     }
     if (a.kind == TYPE_REC || a.kind == TYPE_UNI) {
-        ret a.data.nominal.origin == b.data.nominal.origin
-            && a.data.nominal.decl == b.data.nominal.decl;
+        ret a.data.nominal.owner.module == b.data.nominal.owner.module
+            && a.data.nominal.owner.file == b.data.nominal.owner.file
+            && a.data.nominal.name == b.data.nominal.name
+            && a.data.nominal.incarnation == b.data.nominal.incarnation
+            && a.data.nominal.syntax == b.data.nominal.syntax;
     }
     if (a.kind == TYPE_GENERIC_PARAM) {
-        ret a.data.generic_param.origin == b.data.generic_param.origin
-            && a.data.generic_param.owner == b.data.generic_param.owner
+        ret a.data.generic_param.owner.module == b.data.generic_param.owner.module
+            && a.data.generic_param.owner.file == b.data.generic_param.owner.file
+            && a.data.generic_param.owner_name == b.data.generic_param.owner_name
+            && a.data.generic_param.owner_kind == b.data.generic_param.owner_kind
+            && a.data.generic_param.name == b.data.generic_param.name
             && a.data.generic_param.index == b.data.generic_param.index;
     }
     if (a.kind == TYPE_ABI) {
@@ -1775,27 +1876,27 @@ test "mach.lang.type.intern_function:identical_signatures" {
     ret 0;
 }
 
-test "mach.lang.type.intern_generic_param:dedup_by_origin_owner_index" {
+test "mach.lang.type.intern_generic_param:dedup_by_persistent_owner_name_and_index" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var ti: TypeInterner;
     if (O.is_some[str](init(?ti, ?alloc))) { ret 1; }
 
-    val r1: R.Result[TypeId, str] = intern_generic_param(?ti, intern.STR_NIL, 1::module.ModuleId, 0::id.DeclId, 0);
-    val r2: R.Result[TypeId, str] = intern_generic_param(?ti, intern.STR_NIL, 1::module.ModuleId, 0::id.DeclId, 0);
+    val r1: R.Result[TypeId, str] = intern_generic_param(?ti, 7::intern.StrId, TypeOwner{ module: 1::module.StableModuleId, file: 1::source.FileId }, 0::intern.StrId, TYPE_FUN, 0);
+    val r2: R.Result[TypeId, str] = intern_generic_param(?ti, 7::intern.StrId, TypeOwner{ module: 1::module.StableModuleId, file: 1::source.FileId }, 0::intern.StrId, TYPE_FUN, 0);
     if (R.is_err[TypeId, str](r1))                                    { dnit(?ti); ret 1; }
     if (R.is_err[TypeId, str](r2))                                    { dnit(?ti); ret 1; }
     if (R.unwrap_ok[TypeId, str](r1) != R.unwrap_ok[TypeId, str](r2)) { dnit(?ti); ret 1; }
 
-    val r_other_module: R.Result[TypeId, str] = intern_generic_param(?ti, intern.STR_NIL, 2::module.ModuleId, 0::id.DeclId, 0);
+    val r_other_module: R.Result[TypeId, str] = intern_generic_param(?ti, 7::intern.StrId, TypeOwner{ module: 2::module.StableModuleId, file: 1::source.FileId }, 0::intern.StrId, TYPE_FUN, 0);
     if (R.is_err[TypeId, str](r_other_module)) { dnit(?ti); ret 1; }
     if (R.unwrap_ok[TypeId, str](r1) == R.unwrap_ok[TypeId, str](r_other_module)) { dnit(?ti); ret 1; }
 
-    val r_other_owner: R.Result[TypeId, str] = intern_generic_param(?ti, intern.STR_NIL, 1::module.ModuleId, 1::id.DeclId, 0);
+    val r_other_owner: R.Result[TypeId, str] = intern_generic_param(?ti, 7::intern.StrId, TypeOwner{ module: 1::module.StableModuleId, file: 1::source.FileId }, 1::intern.StrId, TYPE_FUN, 0);
     if (R.is_err[TypeId, str](r_other_owner)) { dnit(?ti); ret 1; }
     if (R.unwrap_ok[TypeId, str](r1) == R.unwrap_ok[TypeId, str](r_other_owner)) { dnit(?ti); ret 1; }
 
-    val r_other_index: R.Result[TypeId, str] = intern_generic_param(?ti, intern.STR_NIL, 1::module.ModuleId, 0::id.DeclId, 1);
+    val r_other_index: R.Result[TypeId, str] = intern_generic_param(?ti, 7::intern.StrId, TypeOwner{ module: 1::module.StableModuleId, file: 1::source.FileId }, 0::intern.StrId, TYPE_FUN, 1);
     if (R.is_err[TypeId, str](r_other_index)) { dnit(?ti); ret 1; }
     if (R.unwrap_ok[TypeId, str](r1) == R.unwrap_ok[TypeId, str](r_other_index)) { dnit(?ti); ret 1; }
 
@@ -1803,7 +1904,7 @@ test "mach.lang.type.intern_generic_param:dedup_by_origin_owner_index" {
     ret 0;
 }
 
-test "mach.lang.type.intern_instance:dedup_by_origin_decl_args" {
+test "mach.lang.type.intern_instance:dedup_by_nominal_and_arguments" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var ti: TypeInterner;
@@ -1812,29 +1913,29 @@ test "mach.lang.type.intern_instance:dedup_by_origin_decl_args" {
     val u32_id: TypeId = O.unwrap[TypeId](prim(?ti, TYPE_U32));
     val u8_id:  TypeId = O.unwrap[TypeId](prim(?ti, TYPE_U8));
 
-    val rn: R.Result[TypeId, str] = intern_nominal(?ti, intern.STR_NIL, 1::module.ModuleId, 0::id.DeclId, TYPE_REC);
+    val rn: R.Result[TypeId, str] = intern_nominal(?ti, 0::intern.StrId, TypeOwner{ module: 1::module.StableModuleId, file: 1::source.FileId }, TYPE_REC);
     if (R.is_err[TypeId, str](rn)) { dnit(?ti); ret 1; }
     val nom: TypeId = R.unwrap_ok[TypeId, str](rn);
 
     var a1: [1]TypeId;
     a1[0] = u32_id;
 
-    val r1: R.Result[TypeId, str] = intern_instance(?ti, nom, 1::module.ModuleId, 0::id.DeclId, ?a1[0], 1);
-    val r2: R.Result[TypeId, str] = intern_instance(?ti, nom, 1::module.ModuleId, 0::id.DeclId, ?a1[0], 1);
+    val r1: R.Result[TypeId, str] = intern_instance(?ti, nom, ?a1[0], 1);
+    val r2: R.Result[TypeId, str] = intern_instance(?ti, nom, ?a1[0], 1);
     if (R.is_err[TypeId, str](r1))                                    { dnit(?ti); ret 1; }
     if (R.is_err[TypeId, str](r2))                                    { dnit(?ti); ret 1; }
     if (R.unwrap_ok[TypeId, str](r1) != R.unwrap_ok[TypeId, str](r2)) { dnit(?ti); ret 1; }
 
     var a1u8: [1]TypeId;
     a1u8[0] = u8_id;
-    val r3: R.Result[TypeId, str] = intern_instance(?ti, nom, 1::module.ModuleId, 0::id.DeclId, ?a1u8[0], 1);
+    val r3: R.Result[TypeId, str] = intern_instance(?ti, nom, ?a1u8[0], 1);
     if (R.is_err[TypeId, str](r3))                                    { dnit(?ti); ret 1; }
     if (R.unwrap_ok[TypeId, str](r1) == R.unwrap_ok[TypeId, str](r3)) { dnit(?ti); ret 1; }
 
     var a2: [2]TypeId;
     a2[0] = u32_id;
     a2[1] = u8_id;
-    val r4: R.Result[TypeId, str] = intern_instance(?ti, nom, 1::module.ModuleId, 0::id.DeclId, ?a2[0], 2);
+    val r4: R.Result[TypeId, str] = intern_instance(?ti, nom, ?a2[0], 2);
     if (R.is_err[TypeId, str](r4))                                    { dnit(?ti); ret 1; }
     if (R.unwrap_ok[TypeId, str](r1) == R.unwrap_ok[TypeId, str](r4)) { dnit(?ti); ret 1; }
 
@@ -1852,15 +1953,15 @@ test "mach.lang.type.is_union:instance_follows_its_nominal" {
     var args: [1]TypeId;
     args[0] = u32_id;
 
-    val rr: R.Result[TypeId, str] = intern_nominal(?ti, intern.STR_NIL, 1::module.ModuleId, 0::id.DeclId, TYPE_REC);
-    val ru: R.Result[TypeId, str] = intern_nominal(?ti, intern.STR_NIL, 1::module.ModuleId, 1::id.DeclId, TYPE_UNI);
+    val rr: R.Result[TypeId, str] = intern_nominal(?ti, 0::intern.StrId, TypeOwner{ module: 1::module.StableModuleId, file: 1::source.FileId }, TYPE_REC);
+    val ru: R.Result[TypeId, str] = intern_nominal(?ti, 1::intern.StrId, TypeOwner{ module: 1::module.StableModuleId, file: 1::source.FileId }, TYPE_UNI);
     if (R.is_err[TypeId, str](rr)) { dnit(?ti); ret 1; }
     if (R.is_err[TypeId, str](ru)) { dnit(?ti); ret 1; }
     val rec_nom: TypeId = R.unwrap_ok[TypeId, str](rr);
     val uni_nom: TypeId = R.unwrap_ok[TypeId, str](ru);
 
-    val ri: R.Result[TypeId, str] = intern_instance(?ti, rec_nom, 1::module.ModuleId, 0::id.DeclId, ?args[0], 1);
-    val ui: R.Result[TypeId, str] = intern_instance(?ti, uni_nom, 1::module.ModuleId, 1::id.DeclId, ?args[0], 1);
+    val ri: R.Result[TypeId, str] = intern_instance(?ti, rec_nom, ?args[0], 1);
+    val ui: R.Result[TypeId, str] = intern_instance(?ti, uni_nom, ?args[0], 1);
     if (R.is_err[TypeId, str](ri)) { dnit(?ti); ret 1; }
     if (R.is_err[TypeId, str](ui)) { dnit(?ti); ret 1; }
     val rec_inst: TypeId = R.unwrap_ok[TypeId, str](ri);
@@ -2565,7 +2666,7 @@ fun intern_distinct_instances(ti: *TypeInterner, first: u32, count: u32) R.Resul
     var i: u32 = first;
     for (i < first + count) {
         var arg: TypeId = i::TypeId;
-        val r: R.Result[TypeId, str] = intern_instance(ti, 0::TypeId, 0::module.ModuleId, i::id.DeclId, ?arg, 1);
+        val r: R.Result[TypeId, str] = intern_instance(ti, 0::TypeId, ?arg, 1);
         if (R.is_err[TypeId, str](r)) { ret R.err[R.Void, str](R.unwrap_err[TypeId, str](r)); }
         i = i + 1;
     }
@@ -2678,4 +2779,162 @@ test "mach.lang.type.scans:allocation_failures_keep_their_reason_and_release_sca
     dnit(?ti);
     if (T.leaked(?t) || T.double_free_count(?t) != 0 || T.tracking_exhausted(?t)) { code = 9; }
     ret code;
+}
+
+
+test "mach.lang.type.intern_nominal:named_identity_survives_unrelated_declaration_insertion" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var ti: TypeInterner;
+    if (O.is_some[str](init(?ti, ?alloc))) { ret 2; }
+    fin { dnit(?ti); }
+    val owner: TypeOwner = TypeOwner{ module: 9, file: 4 };
+    val first: R.Result[TypeId, str] = intern_nominal(?ti, 7, owner, TYPE_REC);
+    if (R.is_err[TypeId, str](first)) { ret 3; }
+    if (R.is_err[TypeId, str](intern_nominal(?ti, 8, owner, TYPE_REC))) { ret 4; }
+    val warm: R.Result[TypeId, str] = intern_nominal(?ti, 7, owner, TYPE_REC);
+    if (R.is_err[TypeId, str](warm) || R.unwrap_ok[TypeId, str](first) != R.unwrap_ok[TypeId, str](warm)) { ret 5; }
+    val other_file: R.Result[TypeId, str] = intern_nominal(?ti, 7, TypeOwner{ module: 9, file: 5 }, TYPE_REC);
+    val other_module: R.Result[TypeId, str] = intern_nominal(?ti, 7, TypeOwner{ module: 10, file: 4 }, TYPE_REC);
+    val renamed: R.Result[TypeId, str] = intern_nominal(?ti, 8, owner, TYPE_REC);
+    if (R.is_err[TypeId, str](other_file) || R.is_err[TypeId, str](other_module) || R.is_err[TypeId, str](renamed)) { ret 6; }
+    val original: TypeId = R.unwrap_ok[TypeId, str](first);
+    if (original == R.unwrap_ok[TypeId, str](other_file) || original == R.unwrap_ok[TypeId, str](other_module)
+        || original == R.unwrap_ok[TypeId, str](renamed)) { ret 7; }
+    ret 0;
+}
+
+test "mach.lang.type.intern_anonymous:identical_shapes_keep_their_source_incarnation" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var ti: TypeInterner;
+    if (O.is_some[str](init(?ti, ?alloc))) { ret 2; }
+    fin { dnit(?ti); }
+    val owner: TypeOwner = TypeOwner{ module: 9, file: 4 };
+    val first: R.Result[TypeId, str] = intern_anonymous(?ti, 7, owner, 1, 2, TYPE_REC);
+    val same: R.Result[TypeId, str] = intern_anonymous(?ti, 7, owner, 1, 2, TYPE_REC);
+    val edited: R.Result[TypeId, str] = intern_anonymous(?ti, 7, owner, 2, 2, TYPE_REC);
+    val other: R.Result[TypeId, str] = intern_anonymous(?ti, 7, TypeOwner{ module: 10, file: 5 }, 1, 2, TYPE_REC);
+    if (R.is_err[TypeId, str](first) || R.is_err[TypeId, str](same) || R.is_err[TypeId, str](edited) || R.is_err[TypeId, str](other)) { ret 3; }
+    val original: TypeId = R.unwrap_ok[TypeId, str](first);
+    if (original != R.unwrap_ok[TypeId, str](same)) { ret 4; }
+    if (original == R.unwrap_ok[TypeId, str](edited) || original == R.unwrap_ok[TypeId, str](other)) { ret 5; }
+    if (!R.is_err[TypeId, str](intern_anonymous(?ti, 7, owner, 0, 2, TYPE_REC))) { ret 6; }
+    ret 0;
+}
+
+
+test "mach.lang.type.interning:hash_collisions_keep_every_canonical_signature" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var ti: TypeInterner;
+    if (O.is_some[str](init(?ti, ?alloc))) { ret 2; }
+    fin { dnit(?ti); }
+    var first: TypeId = O.unwrap[TypeId](prim(?ti, TYPE_I32));
+    var second: TypeId = O.unwrap[TypeId](prim(?ti, TYPE_U64));
+    val f1: R.Result[TypeId, str] = intern_function_bucket(?ti, first, ?first, 1, false, 7);
+    val f2: R.Result[TypeId, str] = intern_function_bucket(?ti, first, ?second, 1, false, 7);
+    val i1: R.Result[TypeId, str] = intern_instance_bucket(?ti, first, ?first, 1, 7);
+    val i2: R.Result[TypeId, str] = intern_instance_bucket(?ti, first, ?second, 1, 7);
+    if (R.is_err[TypeId, str](f1) || R.is_err[TypeId, str](f2) || R.is_err[TypeId, str](i1) || R.is_err[TypeId, str](i2)) { ret 3; }
+    if (R.unwrap_ok[TypeId, str](f1) == R.unwrap_ok[TypeId, str](f2) || R.unwrap_ok[TypeId, str](i1) == R.unwrap_ok[TypeId, str](i2)) { ret 4; }
+    val count: TypeId = type_count(?ti);
+    val params: u32 = ti.params_len;
+    var n: u32 = 0;
+    for (n < 32) {
+        val a: R.Result[TypeId, str] = intern_function_bucket(?ti, first, ?first, 1, false, 7);
+        val b: R.Result[TypeId, str] = intern_function_bucket(?ti, first, ?second, 1, false, 7);
+        val c: R.Result[TypeId, str] = intern_instance_bucket(?ti, first, ?first, 1, 7);
+        val d: R.Result[TypeId, str] = intern_instance_bucket(?ti, first, ?second, 1, 7);
+        if (R.is_err[TypeId, str](a) || R.is_err[TypeId, str](b) || R.is_err[TypeId, str](c) || R.is_err[TypeId, str](d)) { ret 5; }
+        if (R.unwrap_ok[TypeId, str](a) != R.unwrap_ok[TypeId, str](f1) || R.unwrap_ok[TypeId, str](b) != R.unwrap_ok[TypeId, str](f2)
+            || R.unwrap_ok[TypeId, str](c) != R.unwrap_ok[TypeId, str](i1) || R.unwrap_ok[TypeId, str](d) != R.unwrap_ok[TypeId, str](i2)) { ret 6; }
+        n = n + 1;
+    }
+    if (type_count(?ti) != count || ti.params_len != params) { ret 7; }
+    ret 0;
+}
+
+fun t_intern_attempt(ti: *TypeInterner, kind: u32, arg: *TypeId) R.Result[TypeId, str] {
+    val base: TypeId = O.unwrap[TypeId](prim(ti, TYPE_I32));
+    if (kind == 0) { ret intern_pointer(ti, base); }
+    if (kind == 1) { ret intern_function(ti, base, arg, 1, false); }
+    ret intern_instance(ti, base, arg, 1);
+}
+
+test "mach.lang.type.interning:refused_publication_retries_one_canonical_identity" {
+    var kind: u32 = 0;
+    for (kind < 3) {
+        var ordinal: usize = 1;
+        var finished: bool = false;
+        for (ordinal <= 16 && !finished) {
+            var t: T.Testing;
+            if (O.is_some[str](T.make(?t))) { ret 1; }
+            var ti: TypeInterner;
+            if (O.is_some[str](init(?ti, T.allocator_of(?t)))) { T.dnit(?t); ret 2; }
+            val before: TypeId = type_count(?ti);
+            val run: u32 = ti.params_len;
+            var arg: TypeId = O.unwrap[TypeId](prim(?ti, TYPE_U64));
+            T.fail_at_ordinal(?t, T.attempt_count(?t) + ordinal);
+            val attempt: R.Result[TypeId, str] = t_intern_attempt(?ti, kind, ?arg);
+            var code: i32 = 0;
+            if (R.is_err[TypeId, str](attempt)) {
+                if (!str_equals(R.unwrap_err[TypeId, str](attempt), "out of memory")) { code = 3; }
+                if (type_count(?ti) != before || ti.params_len != run) { code = 4; }
+            }
+            or { finished = true; }
+            T.clear_failure(?t);
+            val retry: R.Result[TypeId, str] = t_intern_attempt(?ti, kind, ?arg);
+            val again: R.Result[TypeId, str] = t_intern_attempt(?ti, kind, ?arg);
+            if (R.is_err[TypeId, str](retry) || R.is_err[TypeId, str](again)) { code = 5; }
+            or {
+                if (R.unwrap_ok[TypeId, str](retry) != before || R.unwrap_ok[TypeId, str](again) != before || type_count(?ti) != before + 1) { code = 6; }
+            }
+            dnit(?ti);
+            if (T.leaked(?t) || T.double_free_count(?t) != 0 || T.tracking_exhausted(?t)) { code = 7; }
+            T.dnit(?t);
+            if (code != 0) { ret code; }
+            ordinal = ordinal + 1;
+        }
+        if (!finished) { ret 8; }
+        kind = kind + 1;
+    }
+    ret 0;
+}
+
+fun t_borrowed_parameter_growth(tracker: *T.Testing) i32 {
+    var ti: TypeInterner;
+    if (O.is_some[str](init(?ti, T.allocator_of(tracker)))) { ret 2; }
+    fin { dnit(?ti); }
+    var arg: TypeId = O.unwrap[TypeId](prim(?ti, TYPE_I32));
+    for (ti.params_len < ti.params_cap) {
+        if (R.is_err[u32, str](params_append(?ti, ?arg, 1))) { ret 3; }
+    }
+    val old_len: u32 = ti.params_len;
+    val old_address: usize = ti.params::usize;
+    val appended: R.Result[u32, str] = params_append(?ti, ti.params, old_len);
+    if (R.is_err[u32, str](appended) || R.unwrap_ok[u32, str](appended) != old_len || ti.params_len != old_len * 2) { ret 4; }
+    if (ti.params::usize == old_address) { ret 7; }
+    var i: u32 = 0;
+    for (i < ti.params_len) {
+        if (ti.params[i] != arg) { ret 5; }
+        i = i + 1;
+    }
+    val saved: usize = ti.types.len;
+    ti.types.len = TYPE_ERROR::usize;
+    val exhausted: R.Result[TypeId, str] = intern_pointer(?ti, O.unwrap[TypeId](prim(?ti, TYPE_U64)));
+    ti.types.len = saved;
+    if (R.is_ok[TypeId, str](exhausted) || !str_equals(R.unwrap_err[TypeId, str](exhausted), "type identities are exhausted")) { ret 6; }
+    ret 0;
+}
+
+
+test "mach.lang.type.interning:borrowed_parameter_runs_survive_pool_growth" {
+    var tracker: T.Testing;
+    if (O.is_some[str](T.make(?tracker))) { ret 1; }
+    fin { T.dnit(?tracker); }
+    val code: i32 = t_borrowed_parameter_growth(?tracker);
+    if (code != 0) { ret code; }
+    if (T.leaked(?tracker) || T.double_free_count(?tracker) != 0 || T.tracking_exhausted(?tracker)) { ret 8; }
+    ret 0;
 }

--- a/test/census/real-bools.txt
+++ b/test/census/real-bools.txt
@@ -29,6 +29,7 @@ src/lang/driver/passes.mach:run_gate_pass
 src/lang/driver/passes.mach:run_link_pass
 src/lang/driver/passes.mach:run_one_union_tuple
 src/lang/driver/passes.mach:run_union_gate_pass
+src/lang/editor.mach:close
 src/lang/editor.mach:update
 src/lang/embed.mach:escapes_root
 src/lang/fe/comptime.mach:gate_chain_defers
@@ -96,6 +97,7 @@ src/lang/me/transform/vectorize.mach:stores_are_pure_trees
 src/lang/me/transform/vectorize.mach:vectorizable
 src/lang/me/transform/vectorize.mach:vectorize_one
 src/lang/me/transform/vectorize.mach:vectorize_reduction
+src/lang/session.mach:clear_overlay
 src/lang/source.mach:update
 src/lang/target/isa/arm64/encode.mach:mem_access_needs_no_scratch
 src/lang/target/isa/asm.mach:bind_offset

--- a/test/census/real-bools.txt
+++ b/test/census/real-bools.txt
@@ -1,3 +1,4 @@
+src/cli/cmd/dep.mach:dep_root_for
 src/cli/cmd/init.mach:recovery_backup
 src/lang/be/codegen/looprotate.mach:try_rotate_header
 src/lang/be/linker.mach:archive_image_needed
@@ -7,9 +8,13 @@ src/lang/be/linker.mach:synthesize_common_storage
 src/lang/be/linker.mach:synthesize_local_imports
 src/lang/build/plan.mach:cell_declared
 src/lang/build/plan.mach:steps_demanded
+src/lang/diagnostic.mach:content_equal
 src/lang/diagnostic.mach:gate_commit
 src/lang/diagnostic.mach:gate_error
 src/lang/diagnostic.mach:gate_error_named
+src/lang/driver.mach:resolve_query_phase
+src/lang/driver.mach:run_gate_pass
+src/lang/driver.mach:run_link_pass
 src/lang/driver/config.mach:is_target_env_key
 src/lang/driver/deps.mach:env_names_git_config
 src/lang/driver/deps.mach:git_env_prefix
@@ -71,10 +76,10 @@ src/lang/me/pass/inline.mach:peel_function
 src/lang/me/pass/inline.mach:run
 src/lang/me/pass/mem2reg.mach:promote_function
 src/lang/me/pass/mem2reg.mach:run
-src/lang/me/pass/scalarize.mach:gap_work
 src/lang/me/pass/scalarize.mach:expand_gap_ops
-src/lang/me/pass/scalarize.mach:lane_work
 src/lang/me/pass/scalarize.mach:expand_lane_ops
+src/lang/me/pass/scalarize.mach:gap_work
+src/lang/me/pass/scalarize.mach:lane_work
 src/lang/me/pass/scalarize.mach:run
 src/lang/me/pipeline.mach:run
 src/lang/me/pipeline.mach:run_impl
@@ -97,4 +102,3 @@ src/lang/target/isa/asm.mach:bind_offset
 src/lang/target/isa/asm.mach:finish
 src/lang/target/isa/asm.mach:next
 src/lang/target/isa/x64/encode.mach:x64_mov_sysreg
-src/cli/cmd/dep.mach:dep_root_for


### PR DESCRIPTION
Roadmap F2. Extracts the #3220 and #2999 implementations from the pre-language candidate (`feat/3220` at 6c0a27c5 and `feat/2999` at 7fcedc46, plus the candidate's later query corrections) onto dev, proves each acceptance bullet with a named test, and records the semantic-result extension contract in `doc/design/query-semantic-results.md`.

Full suite through the from-source compiler: 2665 passed, 0 failed, 2665 total. `git diff --check dev...HEAD` clean.

## #3220 acceptance to tests

- Mutate A and request only C; C refreshed when required; equal recomputed B permits early cutoff; a failed B cannot leave a stale successful C:
  `mach.lang.query.get:a_change_below_b_refreshes_c_through_b`, `mach.lang.query.get:an_equal_recomputed_b_cuts_off_c`, `mach.lang.query.get:a_failed_b_cannot_leave_a_stale_successful_c`, `mach.lang.query.refresh:constant_parent_cuts_off_after_refreshing_its_changed_child`, `mach.lang.query.reusable:validates_transitive_inputs_without_computing_the_requested_product`, `mach.lang.query.get:changed_selector_does_not_validate_an_obsolete_branch`; at the driver, `mach.lang.driver:incremental_sema_firewall_body_edit_equals_scratch`.
- Cycles tracked before recursive validation; validation adds no incidental edges:
  `mach.lang.query.get:direct_self_recursion_reports_a_cycle_not_an_empty_value`, `mach.lang.query.get:indirect_two_kind_cycle_reports_the_full_chain`, `mach.lang.query.get:a_stale_entry_under_recomputation_is_a_cycle_not_its_old_value`, `mach.lang.query.cycle:rich_failure_transfers_to_the_presentation_without_per_attempt_growth`, `mach.lang.query.get:validating_a_stale_dependency_records_no_incidental_edge`.
- Diagnostic changes observable with unchanged bytes; nested replay neither duplicates nor loses:
  `mach.lang.query.publish:changed_diagnostics_with_equal_bytes_are_observable`, `mach.lang.query.get:reused_entry_replays_diagnostics`, `mach.lang.query.collect:diamond_order_and_distinct_origins_are_cold_warm_invariant`, `mach.lang.query.collect:failed_child_cannot_be_swallowed_and_attempt_evidence_is_released`, `mach.lang.diagnostic.gate_error:snapshots_preserve_replay_and_truncation_identity`, `mach.lang.driver:analyze_project_resets_and_replays_cached_diagnostics`.
- External revision callbacks, target changes and overlays cannot be skipped on an unchanged database revision:
  `mach.lang.query.refresh:external_change_refreshes_transitively_without_a_local_input_write`, `mach.lang.query.operation:sampled_metadata_is_stable_and_a_changed_final_stamp_refuses_success`, `mach.lang.query.get:a_selected_target_change_invalidates_products_that_read_it`, `mach.lang.driver:analyze_project_selected_target_change_invalidates_typed_products`, `mach.lang.driver:incremental_overlay_reparses_exactly_overlaid_module`.
- Ownership valid through failed computation, replacement, retirement and public result use; tracking distinguishes leaks from premature frees:
  `mach.lang.query.register_derived_owned:finalizer_frees_artifacts`, `mach.lang.query:equal_owned_candidates_preserve_identity_and_release_once`, `mach.lang.query.collect:allocation_refusal_keeps_one_retryable_presentation_owner`, `mach.lang.query.get:allocation_failure_during_automatic_dependency_capture_fails_closed`, `mach.lang.query.retirement:dependents_retire_before_inputs_and_unrelated_roots_survive`, `mach.lang.query.retirement:input_mutation_refuses_a_stale_preparation_without_retiring_owners`, `mach.lang.fe.sema.infer:nominal_and_anonymous_field_recipe_oom_is_internal`.
- Editor consumers identify source revision and selected target; an unrelated query cannot reset a valid result's diagnostics; target changes do not reuse host-default analysis:
  `mach.lang.editor.analyze:explicit_target_changes_context_and_expires_previous_view`, `mach.lang.editor.analyze:owned_diagnostics_survive_retirement_and_raw_views_expire`, `mach.lang.editor.analyze:owned_rejection_snapshot_preserves_allocation_refusal`, `mach.lang.editor.analyze:project_phase_does_not_run_later_frontend_work`.

## #2999 acceptance to tests

- Repeated open/update/close retires overlays and analysis without invalidating unrelated FileIds or outstanding products outside their declared lifetime:
  `mach.lang.editor.close:reuses_slots_and_reopens_the_same_source_identity`, `mach.lang.editor.close:repeated_open_update_close_leaves_unrelated_products_and_identities_valid`, `mach.lang.editor.close:removes_extra_roots_and_reloads_closed_dependencies_from_disk`, `mach.lang.editor.analyze:owned_diagnostics_survive_retirement_and_raw_views_expire` (a retired buffer's owned snapshot outlives the session while raw views expire), `mach.lang.editor.close:refuses_during_an_outstanding_query_and_keeps_every_buffer`, `mach.lang.editor.lifecycle:allocation_refusal_preserves_open_buffers_and_retry`.

## Beyond the checkpoint

The checkpoint itself was red on dev (123 failures, reproduced on a throwaway build of `feat/3220`). Making it green needed the candidate's later query corrections (7a579b28, cb3844f9, 08687577, 174471c1, 0984b224, cherry-picked with `(#3220)` subjects), the sema half of b5d0fc85 so importers depend on a dependency's public surface rather than its body, three small driver fixes (lower items counted once, a serial optimize item, oblivious violations reported as rejections), two fixture repairs, and the driver harness adapted to the candidate's model in which a rejected phase returns a reported failure with its diagnostics presented.

Left out of the candidate on purpose: `mach check` (d2bbbfba, its own CLI feature), the lower-side binding-interface query and inline-body integration of b5d0fc85, deprecation notices, and the v5 manifest work.

Closes #3220
Closes #2999
