### PR TITLE
sema: settle the `name[` reading from the imported declaration's kind

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Bracket interpretation of an imported name follows the imported declaration's
+  own kind. An imported value keeps its subscript reading, and the resolver's
+  choice tracks a dependency change without rewriting the parse tree (#3121).
+
 - Name resolution reports one phase row per build. A deferred comptime gate no
   longer makes the resolver report every module again for each pass it takes,
   and each module's resolve time is accumulated across those passes (#3231).

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -52,6 +52,7 @@ use mach.lang.build.request;
 use mach.lang.diagnostic;
 use mach.lang.fe.ast;
 use mach.lang.fe.ast.decl;
+use aexpr: mach.lang.fe.ast.expr;
 use aid: mach.lang.fe.ast.id;
 use amodule: mach.lang.fe.ast.module;
 use mach.lang.fe.comptime;
@@ -8843,6 +8844,92 @@ test "mach.lang.driver:bracket_value_keeps_subscripts" {
     if (!ut_sema_rejects_with("pub fun ident[T](s: T) T { ret s; }\nfun main() i64 { ret ident[0]; }\n",
         "not indexable: a function has no elements")) { bad = 1; }
     ret bad;
+}
+
+test "mach.lang.driver:bracket_interpretation_changes_without_rewriting_reused_syntax" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val initialized: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?s); }
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { ret 3; }
+    var names: [2]str = [2]str{"main.mach", "lib.mach"};
+    var versions: [2]str = [2]str{
+        "pub def Key: i64;\npub fun item[T](v: T) T { ret v; }\n",
+        "pub val Key: u64 = 0;\nfun identity(v: i64) i64 { ret v; }\npub val item: [1]fun(i64) i64 = [1]fun(i64) i64{identity};\n"
+    };
+    var texts: [2]str = [2]str{
+        "use uniontest.lib.item;\nuse uniontest.lib.Key;\nfun main() i64 { ret item[Key](3); }\n", versions[0]
+    };
+    val scaffold: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
+    if (R.is_err[str, str](scaffold)) { ret 4; }
+    val root: str = R.unwrap_ok[str, str](scaffold);
+    fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+    val joined: R.Result[str, str] = path.join(?alloc, root, "src/lib.mach");
+    if (R.is_err[str, str](joined)) { ret 5; }
+    val filename: str = R.unwrap_ok[str, str](joined);
+    fin { str_free(?alloc, filename); }
+    var saved: *aexpr.Expr = nil;
+    var count: usize = 0;
+    fin { if (saved != nil) { A.deallocate[aexpr.Expr](?alloc, saved, count); } }
+    var owner: *ast.Ast = nil;
+    var incarnation: u64 = 0;
+    var selected: aid.ExprId = aid.EXPR_NIL;
+    var revision: query.Revision = 0;
+    var round: u32 = 0;
+    for (round < 3) {
+        val version: u32 = round % 2;
+        if (O.is_some[str](fs.write_bytes(filename, versions[version], str_len(versions[version]), 420))) { ret 6; }
+        val opened: R.Result[project.Project, outcome.Fail] = driver.build_project_union(?s, root);
+        if (R.is_err[project.Project, outcome.Fail](opened)) { ret 7; }
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](opened);
+        fin { project.dnit_project(?p); }
+        val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+        if (mid == session.MODULE_NIL) { ret 8; }
+        val parsed: *ast.Ast = p.modules[mid::u32].a;
+        if (parsed == nil) { ret 9; }
+        val current: query.Revision = query.peek_revision(?s.queries, query.Q_PARSE, p.modules[mid::u32].file_id::u64);
+        if (round == 0) {
+            owner = parsed;
+            incarnation = parsed.incarnation;
+            revision = current;
+            count = parsed.expr_len;
+            val storage: R.Result[*aexpr.Expr, str] = A.allocate[aexpr.Expr](?alloc, count);
+            if (R.is_err[*aexpr.Expr, str](storage)) { ret 10; }
+            saved = R.unwrap_ok[*aexpr.Expr, str](storage);
+            memory.copy[aexpr.Expr](saved, parsed.exprs, count);
+            var i: usize = 0;
+            for (i < count) {
+                if (saved[i].kind == aexpr.EXPR_KIND_CALL && saved[i].data.call.index_callee != aid.EXPR_NIL) {
+                    if (selected != aid.EXPR_NIL) { ret 11; }
+                    selected = i::aid.ExprId;
+                }
+                i = i + 1;
+            }
+            if (selected == aid.EXPR_NIL || revision == 0) { ret 12; }
+        }
+        if (parsed != owner || parsed.incarnation != incarnation || parsed.expr_len != count || current != revision
+            || !memory.equal[aexpr.Expr](saved, parsed.exprs, count)) { ret 13; }
+        if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p))) {
+            var di: usize = 0;
+            for (di < diagnostic.len(?s.diags)) {
+                print.eprintln(s.diags.items.data[di].message);
+                di = di + 1;
+            }
+            ret 14;
+        }
+        val interpreted: R.Result[aexpr.Expr, str] = resolve.expression(p.modules[mid::u32].resolve_result, parsed, selected);
+        if (R.is_err[aexpr.Expr, str](interpreted)) { ret 15; }
+        val node: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](interpreted);
+        if (node.kind != aexpr.EXPR_KIND_CALL || node.data.call.index_callee != aid.EXPR_NIL) { ret 16; }
+        if (version == 0 && (node.data.call.type_args_len != 1 || node.data.call.callee != saved[selected].data.call.callee)) { ret 17; }
+        if (version == 1 && (node.data.call.type_args_len != 0 || node.data.call.callee != saved[selected].data.call.index_callee)) { ret 18; }
+        if (R.is_err[R.Void, outcome.Fail](driver.run_lower_pass(?p))) { ret 19; }
+        if (!memory.equal[aexpr.Expr](saved, parsed.exprs, count)) { ret 20; }
+        round = round + 1;
+    }
+    ret 0;
 }
 
 test "mach.lang.driver:generic_instance_as_value_cross_module" {

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -1943,9 +1943,9 @@ fun callee_accepts_type_args(rc: *ResolveContext, callee: id.ExprId) bool {
     val sid: SymbolId = rc.expr_resolved[callee];
     if (sid == SYMBOL_NIL || sid >= rc.sym_len) { ret false; }
     val sym: *Symbol = ?rc.symbols[sid];
-    ret sym.kind == SYM_FUN || sym.kind == SYM_REC || sym.kind == SYM_UNI
-     || sym.kind == SYM_DEF || sym.kind == SYM_GENERIC || sym.kind == SYM_PRIM
-     || sym.kind == SYM_IMPORTED;
+    val kind: SymKind = sym.definition_kind;
+    ret kind == SYM_FUN || kind == SYM_REC || kind == SYM_UNI
+     || kind == SYM_DEF || kind == SYM_GENERIC || kind == SYM_PRIM;
 }
 
 fun bind_ident(rc: *ResolveContext, eid: id.ExprId, span: token.Span) R.Result[R.Void, str] {


### PR DESCRIPTION
Extracts the last outstanding piece of #3121 from the pre-language candidate onto `dev`.

## What landed

`dev` already carries the resolver-product refactor: bracket interpretation is published through `resolve.expression` and there is no snapshot or restore machinery left in `src/lang/fe/`. What was still missing is the reading itself.

`callee_accepts_type_args` decided whether `name[...]` accepts type arguments from the symbol's own `kind`. Every imported name reports `SYM_IMPORTED` there, so an imported name accepted type arguments no matter what it actually named, and an imported value's subscript was read as a generic instantiation. The predicate now reads `definition_kind`, which resolves through to the declaration the import names, so the bracket reading follows that declaration and tracks a change in a dependency.

Candidate commits used: `5463d473` (the fix) and `51dbfcd3` (its test). Both applied to `dev` without hand rework.

## Verification

- Full suite through the from-source compiler built at this branch: **2667 passed, 0 failed** (`dev` is 2666; the delta is the one new test).
- Mutation proof: reverting the `definition_kind` read makes `mach.lang.driver:bracket_interpretation_changes_without_rewriting_reused_syntax` fail with `not a generic: declaration takes no type parameters` (exit 14). Restored, it passes.
- `git diff --check dev...HEAD` clean.

The new test also asserts the acceptance property directly: across three builds that swap `lib.mach` between a generic function and an array value, the parse tree's expression array is byte-identical before and after both sema and lowering, while the published interpretation of the same expression changes.

Closes #3121
