### PR TITLE
sema/codegen: mixed-width literal coercion tightening and signed vector-division folding

### DIFF
--- a/.github/skills/mach/SKILL.md
+++ b/.github/skills/mach/SKILL.md
@@ -302,7 +302,10 @@ Ten 128-bit SIMD vector types are also seeded: `f32x4 f64x2`, `i8x16 i16x8
 i32x4 i64x2`, and `u8x16 u16x8 u32x4 u64x2` — a single `x`, no other shapes.
 Literals are full-arity (`f32x4{1.0, 2.0, 3.0, 4.0}`), lane access `v[i]` takes
 a comptime-constant index, and the operators apply lane-wise with a comparison
-producing a same-shape unsigned mask. See `doc/language/types.md`.
+producing a same-shape unsigned mask. Integer vector `/` follows scalar division
+per lane using the lane type's signedness. It scalarizes where packed integer
+division is unavailable, and secret dividends or divisors are rejected. Vector
+`%` and shifts remain unsupported. See `doc/language/types.md`.
 
 ```mach
 *T                  # pointer          ?x address-of, @p dereference

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   longer makes the resolver report every module again for each pass it takes,
   and each module's resolve time is accumulated across those passes (#3231).
 
+- Constant expressions evaluate nested scalar casts and preserve integer widths and
+  signedness. A failed global initializer now rejects the compilation instead of
+  publishing a zero value or a successful cached lowering product (#3122).
+
+- Integer vector `/` is supported end to end. Each lane follows scalar division,
+  signedness is preserved, secret operands are rejected, and targets without a
+  packed integer divide scalarize the operation (#3122).
+
 - Test listing stops after collecting tests. It no longer generates or links
   machine code, and it produces no test executable (#3230).
 

--- a/doc/language/operators.md
+++ b/doc/language/operators.md
@@ -109,7 +109,10 @@ Two postfix cast operators, both written `expr OP Type`:
 
 - `expr::Type` — **value conversion**. Resizes integers (sign- or zero-extend,
   truncate), converts between integer and float (a numeric `CVT`), and is the
-  identity on a same-type operand. Value-preserving where representable.
+  identity on a same-type operand. Value-preserving where representable. When
+  either type is nonnumeric, equal sizes are required and the bits are reinterpreted.
+  Constant expressions follow these rules at every nesting depth, including casts
+  through type aliases.
 - `expr:~Type` — **bit reinterpret**. Reads the operand's exact bits as the
   target type with no conversion. Legal only when `Type` has the same byte size
   as the operand's type (a size mismatch is a compile error). The `~` recalls
@@ -142,17 +145,22 @@ the two differ only in how they are realized.
 | Lane family | `+` `-` | `*` | `/` | `%` | `& \| ^ ~` | `<< >>` | `== != < > <= >=` |
 |---|---|---|---|---|---|---|---|
 | float — `f32x4`, `f64x2` | yes | yes | yes | no | — | no | → same-shape unsigned mask |
-| integer — `i8x16` `i16x8` `i32x4` `i64x2` (+ unsigned) | yes | yes | no | no | yes | no | → same-shape unsigned mask |
+| integer — `i8x16` `i16x8` `i32x4` `i64x2` (+ unsigned) | yes | yes | yes | no | yes | no | → same-shape unsigned mask |
 
 Both operands of a binary operator must be the **same** vector shape: there is no
 implicit scalar↔vector mixing and no cross-shape widening. Anything the table
 marks `no` is a compile error, not a silent fallback:
 
 - no vector `%` on any lane type;
-- no integer vector `/` — division is float lanes only;
 - bitwise `& | ^ ~` require integer lanes; the shifts `<< >>` are not in this
   increment (a per-lane variable shift is AVX2-only on x86_64, with no 8-bit
   packed form).
+
+Integer division uses each lane's signedness and scalar division behavior, including
+truncation toward zero for signed quotients and the scalar behavior for division by
+zero or signed overflow. A secret dividend or divisor is rejected because integer
+division has variable latency. x86_64 and aarch64 realize integer vector division
+as scalar lane operations, as does RISC-V without a vector unit.
 
 ### Legality is target-independent; realization is not
 

--- a/src/lang/be/codegen/vector_runtime.mach
+++ b/src/lang/be/codegen/vector_runtime.mach
@@ -566,3 +566,60 @@ test "mach.lang.be.codegen.vector_runtime.call:vector_live_across_call" {
     if (r[2] != 0x55667788 || r[3] != 0x7FEEDDCC) { ret 2; }
     ret 0;
 }
+
+#[volatile]
+rec DivisionCounter { value: u32; }
+
+#[noinline]
+fun divide_i8x16(a: i8x16, b: i8x16, counter: *DivisionCounter) i8x16 { counter.value = counter.value + 1; ret a / b; }
+
+#[noinline]
+fun divide_i16x8(a: i16x8, b: i16x8) i16x8 { ret a / b; }
+
+#[noinline]
+fun divide_i32x4(a: i32x4, b: i32x4) i32x4 { ret a / b; }
+
+#[noinline]
+fun divide_i64x2(a: i64x2, b: i64x2) i64x2 { ret a / b; }
+
+#[noinline]
+fun divide_u8x16(a: u8x16, b: u8x16) u8x16 { ret a / b; }
+
+#[noinline]
+fun divide_u16x8(a: u16x8, b: u16x8) u16x8 { ret a / b; }
+
+#[noinline]
+fun divide_u32x4(a: u32x4, b: u32x4) u32x4 { ret a / b; }
+
+#[noinline]
+fun divide_u64x2(a: u64x2, b: u64x2) u64x2 { ret a / b; }
+
+test "mach.lang.be.codegen.vector_runtime.arith:integer_division_all_lane_widths" {
+    var counter: DivisionCounter = DivisionCounter{value: 8};
+    val q1: i8x16 = divide_i8x16(i8x16{-127, 127, -127, -1, -128, 0, 27, -27, -127, 127, -127, -1, -128, 0, 27, -27}, i8x16{3, -3, -3, 2, 2, 7, 4, 4, 3, -3, -3, 2, 2, 7, 4, 4}, ?counter);
+    if (q1[0] != -42 || q1[1] != -42 || q1[2] != 42 || q1[3] != 0) { ret 1; }
+    if (q1[4] != -64 || q1[5] != 0 || q1[6] != 6 || q1[7] != -6) { ret 1; }
+    if (q1[8] != -42 || q1[9] != -42 || q1[10] != 42 || q1[11] != 0) { ret 1; }
+    if (q1[12] != -64 || q1[13] != 0 || q1[14] != 6 || q1[15] != -6) { ret 1; }
+    val q2: i16x8 = divide_i16x8(i16x8{-32767, 32767, -32767, -1, -32768, 0, 27, -27}, i16x8{3, -3, -3, 2, 2, 7, 4, 4});
+    if (q2[0] != -10922 || q2[1] != -10922 || q2[2] != 10922 || q2[3] != 0) { ret 2; }
+    if (q2[4] != -16384 || q2[5] != 0 || q2[6] != 6 || q2[7] != -6) { ret 2; }
+    val q3: i32x4 = divide_i32x4(i32x4{-2147483647, 2147483647, -2147483647, -1}, i32x4{3, -3, -3, 2});
+    if (q3[0] != -715827882 || q3[1] != -715827882 || q3[2] != 715827882 || q3[3] != 0) { ret 3; }
+    val q4: i64x2 = divide_i64x2(i64x2{-9223372036854775807, 9223372036854775807}, i64x2{3, -3});
+    if (q4[0] != -3074457345618258602 || q4[1] != -3074457345618258602) { ret 4; }
+    val q5: u8x16 = divide_u8x16(u8x16{255, 128, 254, 0, 29, 31, 33, 35, 255, 128, 254, 0, 29, 31, 33, 35}, u8x16{3, 2, 7, 1, 4, 5, 6, 7, 3, 2, 7, 1, 4, 5, 6, 7});
+    if (q5[0] != 85 || q5[1] != 64 || q5[2] != 36 || q5[3] != 0) { ret 5; }
+    if (q5[4] != 7 || q5[5] != 6 || q5[6] != 5 || q5[7] != 5) { ret 5; }
+    if (q5[8] != 85 || q5[9] != 64 || q5[10] != 36 || q5[11] != 0) { ret 5; }
+    if (q5[12] != 7 || q5[13] != 6 || q5[14] != 5 || q5[15] != 5) { ret 5; }
+    val q6: u16x8 = divide_u16x8(u16x8{65535, 32768, 65534, 0, 29, 31, 33, 35}, u16x8{3, 2, 7, 1, 4, 5, 6, 7});
+    if (q6[0] != 21845 || q6[1] != 16384 || q6[2] != 9362 || q6[3] != 0) { ret 6; }
+    if (q6[4] != 7 || q6[5] != 6 || q6[6] != 5 || q6[7] != 5) { ret 6; }
+    val q7: u32x4 = divide_u32x4(u32x4{4294967295, 2147483648, 4294967294, 0}, u32x4{3, 2, 7, 1});
+    if (q7[0] != 1431655765 || q7[1] != 1073741824 || q7[2] != 613566756 || q7[3] != 0) { ret 7; }
+    val q8: u64x2 = divide_u64x2(u64x2{18446744073709551615, 9223372036854775808}, u64x2{3, 2});
+    if (q8[0] != 6148914691236517205 || q8[1] != 4611686018427387904) { ret 8; }
+    if (counter.value != 9) { ret 9; }
+    ret 0;
+}

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -2643,6 +2643,15 @@ test "mach.lang.driver:vector_surface_typechecks" {
     ret bad;
 }
 
+test "mach.lang.driver:integer_vector_division_accepts_public_and_rejects_either_secret_operand" {
+    if (!ut_sema_clean("fun signed(a: i32x4, b: i32x4) i32x4 { ret a / b; }\nfun unsigned(a: u64x2, b: u64x2) u64x2 { ret a / b; }\nfun main() i32 { ret 0; }\n")) { ret 1; }
+    if (ut_vec_diag("#[oblivious]\nfun f(a: ^i32x4, b: i32x4) ^i32x4 { ret a / b; }\nfun main() i32 { ret 0; }\n",
+        "secret divisor or dividend leaks through timing") != 0) { ret 2; }
+    if (ut_vec_diag("#[oblivious]\nfun f(a: u64x2, b: ^u64x2) ^u64x2 { ret a / b; }\nfun main() i32 { ret 0; }\n",
+        "secret divisor or dividend leaks through timing") != 0) { ret 3; }
+    ret 0;
+}
+
 test "mach.lang.driver:vector_negative_diagnostics" {
     var bad: i32 = 0;
 
@@ -2656,8 +2665,8 @@ test "mach.lang.driver:vector_negative_diagnostics" {
         "index 4 is out of bounds for `f32x4` of length 4") != 0) { bad = 1; }
     if (ut_vec_diag("fun main() i32 { val a: i32x4 = i32x4{1, 2, 3, 4}; val b: i32x4 = i32x4{1, 2, 3, 4}; val c: i32x4 = a % b; ret 0; }\n",
         "vector `%` is not supported") != 0) { bad = 1; }
-    if (ut_vec_diag("fun main() i32 { val a: i32x4 = i32x4{1, 2, 3, 4}; val b: i32x4 = i32x4{1, 2, 3, 4}; val c: i32x4 = a / b; ret 0; }\n",
-        "integer vector `/` is not supported") != 0) { bad = 1; }
+    if (ut_vec_diag("fun f(a: i32x4, b: u32x4) i32x4 { ret a / b; }\nfun main() i32 { ret 0; }\n",
+        "incompatible operand types") != 0) { bad = 1; }
     if (ut_vec_diag("fun main() i32 { val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; val s: f32 = 1.0; val c: f32x4 = a + s; ret 0; }\n",
         "mismatch") != 0) { bad = 1; }
     if (ut_vec_diag("fun main() i32 { val a: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; val b: f32x4 = f32x4{1.0, 2.0, 3.0, 4.0}; if (a == b) { ret 1; } ret 0; }\n",
@@ -12343,6 +12352,87 @@ test "mach.lang.driver:same_module_global_folds_through_cross_module_base" {
     ret bad;
 }
 
+test "mach.lang.driver:nested_scalar_casts_fold_global_initializers" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "def Word: u64;\nval ALL: Word = ~(0::Word);\nval BYTE: u8 = ~((0::u8) | (0::u8));\nval SIGNED: i8 = (255u8:~i8);\nval HIGH: u64 = (128u8:~i8)::u64;\nval EXP: u64 = ((5.0:~u64) >> 52);\nfun main() i32 { $if ((~((0::u8) + (0::u8))) != 255u8) { $error(\"nested bitwise width\"); } $if (((5.0:~u64) >> 52) != 1025) { $error(\"nested cast gate\"); } ret 0; }\n";
+    val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { ret 2; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    fin { project.dnit_project(?p); }
+    if (ut_count_errors(?s.diags) != 0) { ret 3; }
+    val m: *ir.Module = ut_ir_of(?p, ?s, "uniontest.main");
+    if (m == nil) { ret 4; }
+    var labels: [5]str;
+    labels[0] = "uniontest.main.ALL"; labels[1] = "uniontest.main.BYTE";
+    labels[2] = "uniontest.main.SIGNED"; labels[3] = "uniontest.main.HIGH";
+    labels[4] = "uniontest.main.EXP";
+    var expected: [5]u64;
+    expected[0] = 0xFFFFFFFFFFFFFFFF; expected[1] = 255;
+    expected[2] = 0xFFFFFFFFFFFFFFFF; expected[3] = 0xFFFFFFFFFFFFFF80;
+    expected[4] = 1025;
+    var i: u32 = 0;
+    for (i < 5) {
+        val gi: i64 = ut_global_ix(?s, m, labels[i]);
+        if (gi < 0) { ret 5; }
+        val init: value.Value = m.globals[gi::u32].init;
+        if (init.kind != value.VAL_CONST_INT || init.data.int_lit != expected[i]) { ret (6 + i)::i32; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+test "mach.lang.driver:rejected_global_has_no_lower_query_product" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = "val X: u64 = Y;\nval Y: u64 = X;\nfun main() i32 { ret 0; }\n";
+    val rooted: R.Result[str, str] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](rooted)) { ret 2; }
+    val root: str = R.unwrap_ok[str, str](rooted);
+    fin { fs.remove_all(?alloc, root); }
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { ret 3; }
+    var selection: manifest.Selection = ut_target_sel("linux");
+    val built: R.Result[project.Project, outcome.Fail] = driver.build_project(?s, root, ?selection);
+    if (R.is_err[project.Project, outcome.Fail](built)) { ret 4; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](built);
+    fin { project.dnit_project(?p); }
+    if (R.is_err[R.Void, outcome.Fail](driver.run_sema_pass(?p))) { ret 5; }
+    val lowered: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
+    if (R.is_ok[R.Void, outcome.Fail](lowered)) { ret 6; }
+    if (R.unwrap_err[R.Void, outcome.Fail](lowered).kind != outcome.FAIL_REPORTED) { ret 7; }
+    if (ut_count_errors(?s.diags) != 2) { ret 8; }
+    val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+    if (mid == session.MODULE_NIL || p.modules[mid::u32].ir_module != nil) { ret 9; }
+    val stable: session.StableModuleId = ut_stable(?p, ?s, "uniontest.main");
+    val begun: R.Result[query.Operation, outcome.Fail] = project.begin_query_phase(?p);
+    if (R.is_err[query.Operation, outcome.Fail](begun)) { ret 10; }
+    val operation: query.Operation = R.unwrap_ok[query.Operation, outcome.Fail](begun);
+    val acquired: R.Result[query.QueryView, fail.Fail] = query.get[project.Project](?p.queries, ?p, query.Q_LOWER, passes.back_half_key(stable, false));
+    val ended: R.Result[R.Void, fail.Fail] = query.end(?s.queries, operation);
+    val discarded: R.Result[R.Void, str] = query.discard(?s.queries, operation);
+    if (R.is_ok[query.QueryView, fail.Fail](acquired)) { ret 11; }
+    if (R.unwrap_err[query.QueryView, fail.Fail](acquired).kind != fail.REPORTED) { ret 12; }
+    if (R.is_ok[R.Void, fail.Fail](ended)) { ret 13; }
+    if (R.unwrap_err[R.Void, fail.Fail](ended).kind != fail.REPORTED) { ret 14; }
+    if (R.is_err[R.Void, str](discarded)) { ret 15; }
+    if (p.modules[mid::u32].ir_module != nil) { ret 16; }
+    ret 0;
+}
+
 test "mach.lang.driver:same_module_forward_reference_is_refused" {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -12357,13 +12447,14 @@ test "mach.lang.driver:same_module_forward_reference_is_refused" {
     texts[1] = "pub rec P { x: u64; y: u64; }\npub val BASE: u64 = $size_of(P);\n";
 
     val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 2);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
-    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-
+    if (R.is_ok[project.Project, outcome.Fail](pr)) {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
     var bad: i32 = 0;
-    if (!ut_diag_has(?p.s.diags, "global initialiser of `B` must be a constant expression")) { bad = 1; }
+    if (R.unwrap_err[project.Project, outcome.Fail](pr).kind != outcome.FAIL_REPORTED) { bad = 2; }
+    if (!ut_diag_has(?s.diags, "global initialiser of `B` must be a constant expression")) { bad = 1; }
 
-    project.dnit_project(?p);
     session.dnit(?s);
     ret bad;
 }
@@ -12381,15 +12472,16 @@ test "mach.lang.driver:same_module_global_cycle_is_refused" {
     texts[0] = "val X: u64 = Y;\nval Y: u64 = X;\nfun main() i32 { ret 0; }\n";
 
     val pr: R.Result[project.Project, outcome.Fail] = ut_lower_n(?s, ?alloc, ?names[0], ?texts[0], 1);
-    if (R.is_err[project.Project, outcome.Fail](pr)) { session.dnit(?s); ret 1; }
-    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
-
+    if (R.is_ok[project.Project, outcome.Fail](pr)) {
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+        project.dnit_project(?p); session.dnit(?s); ret 1;
+    }
     var bad: i32 = 0;
-    if (!ut_diag_has(?p.s.diags, "global initialiser of `X` must be a constant expression")) { bad = 1; }
-    if (!ut_diag_has(?p.s.diags, "global initialiser of `Y` must be a constant expression")) { bad = 1; }
-    if (ut_count_errors(?p.s.diags) != 2) { bad = 1; }
+    if (R.unwrap_err[project.Project, outcome.Fail](pr).kind != outcome.FAIL_REPORTED) { bad = 2; }
+    if (!ut_diag_has(?s.diags, "global initialiser of `X` must be a constant expression")) { bad = 1; }
+    if (!ut_diag_has(?s.diags, "global initialiser of `Y` must be a constant expression")) { bad = 1; }
+    if (ut_count_errors(?s.diags) != 2) { bad = 1; }
 
-    project.dnit_project(?p);
     session.dnit(?s);
     ret bad;
 }
@@ -14214,7 +14306,7 @@ test "mach.lang.driver:debug_info_on_a_target_without_a_debug_model_fails_the_ar
 }
 
 fun ut_divide_program() str {
-    ret "pub var Z: i32 = 0;\npub var N: i32 = 1;\npub var M: i32 = -2147483648;\npub var Q: i32 = -1;\npub var ZL: i64 = 0;\npub var ML: i64 = -9223372036854775807 - 1;\npub var QL: i64 = -1;\n\n#[symbol(\"main\")]\nfun main(argc: i64) i64 {\n    if (argc == 1) { if (100 / N == 100) { ret 0; } ret 3; }\n    if (argc == 2) { ret (100 / Z)::i64; }\n    if (argc == 3) { ret (M / Q)::i64; }\n    if (argc == 4) { ret 100 / ZL; }\n    ret ML / QL;\n}\n\n#[symbol(\"_start\")]\npub fun start() {\n    $if ($mach.build.arch == $mach.arch.x86_64) {\n        asm x86_64 {\n            mov rdi, [rsp]\n            and rsp, -16\n            call main\n            mov rdi, rax\n            mov rax, 60\n            syscall\n        }\n    }\n    $or ($mach.build.arch == $mach.arch.aarch64) {\n        asm aarch64 {\n            ldr x0, [sp]\n            bl main\n            mov x8, 93\n            svc 0\n        }\n    }\n    $or {\n        asm riscv64 {\n            ld a0, 0(sp)\n            call main\n            li a7, 93\n            ecall\n        }\n    }\n}\n";
+    ret "pub var Z: i32 = 0;\npub var N: i32 = 1;\npub var M: i32 = -2147483648;\npub var Q: i32 = -1;\npub var ZL: i64 = 0;\npub var ML: i64 = -9223372036854775807 - 1;\npub var QL: i64 = -1;\n\n#[symbol(\"main\")]\nfun main(argc: i64) i64 {\n    if (argc == 1) { val q: i32x4 = i32x4{-10, 10, -10, 1} / i32x4{3, -3, -3, 2}; if (q[0] != -3 || q[1] != -3 || q[2] != 3 || q[3] != 0) { ret 4; } if (100 / N == 100) { ret 0; } ret 3; }\n    if (argc == 2) { ret (100 / Z)::i64; }\n    if (argc == 3) { ret (M / Q)::i64; }\n    if (argc == 4) { ret 100 / ZL; }\n    if (argc == 5) { ret ML / QL; }\n    if (argc == 6) { val q: i32x4 = i32x4{100, 200, 300, 400} / i32x4{N, Z, N, N}; ret q[0]::i64; }\n    if (argc == 7) { val q: u64x2 = u64x2{18446744073709551615, 80} / u64x2{N::u64, ZL::u64}; ret q[0]::i64; }\n    if (argc == 8) { val q: i32x4 = i32x4{N, M, N, N} / i32x4{N, Q, N, N}; ret q[0]::i64; }\n    val q: i64x2 = i64x2{N::i64, ML} / i64x2{N::i64, QL}; ret q[0];\n}\n\n#[symbol(\"_start\")]\npub fun start() {\n    $if ($mach.build.arch == $mach.arch.x86_64) {\n        asm x86_64 {\n            mov rdi, [rsp]\n            and rsp, -16\n            call main\n            mov rdi, rax\n            mov rax, 60\n            syscall\n        }\n    }\n    $or ($mach.build.arch == $mach.arch.aarch64) {\n        asm aarch64 {\n            ldr x0, [sp]\n            bl main\n            mov x8, 93\n            svc 0\n        }\n    }\n    $or {\n        asm riscv64 {\n            ld a0, 0(sp)\n            call main\n            li a7, 93\n            ecall\n        }\n    }\n}\n";
 }
 
 fun ut_divide_manifest() str {
@@ -14222,7 +14314,7 @@ fun ut_divide_manifest() str {
 }
 
 fun ut_run_with_argc(cwd: str, runner: str, program: str, argc: usize, trapped: *bool, exit_code: *i32) bool {
-    var argv: [8]*u8;
+    var argv: [12]*u8;
     var n: usize = 0;
     var launch: str = program;
     if (!str_empty(runner)) { argv[n] = runner::*u8; n = n + 1; launch = runner; }
@@ -14287,7 +14379,7 @@ fun ut_divide_trap_target(alloc: *A.Allocator, target_name: str, runner_name: st
             var code: i32 = 0;
             if (!ut_run_with_argc(root, runner, program, 1, ?trapped, ?code) || trapped || code != 0) { bad = 2; }
             var argc: usize = 2;
-            for (argc <= 5) {
+            for (argc <= 9) {
                 if (!ut_run_with_argc(root, runner, program, argc, ?trapped, ?code) || !trapped) {
                     print.print("divide-trap: no trap on "); print.print(target_name); print.printf(" for argc {} (exit {})\n", argc, code);
                     bad = 3;
@@ -20605,4 +20697,10 @@ fun ut_planned_link_images(s: *session.Session, tgt: *target.Target, images: *of
     val opened: R.Result[*publication.Destination, str] = ut_publication_open(?operation, s.alloc, out_path::str);
     if (R.is_err[*publication.Destination, str](opened)) { ret ut_publication_close(?operation, R.err[R.Void, str](R.unwrap_err[*publication.Destination, str](opened))); }
     ret ut_publication_close(?operation, linker.link_images(s, tgt, images, image_count, dynlibs, dynlib_count, R.unwrap_ok[*publication.Destination, str](opened), name, mode, pie, image_options));
+}
+
+test "mach.lang.driver:declaration_cast_gates_resolve_local_and_imported_type_aliases" {
+    ret ut_single_ok2(
+        "use Flag: uniontest.lib.Flag;\ndef Local: u8;\n$if ((1::Local) == 1u8) { fun local_selected() i32 { ret 1; } } $or { use uniontest.missing; }\n$if ((0::Flag) == 1u8) { use uniontest.missing; } $or { fun imported_selected() i32 { ret 2; } }\nfun main() i32 { ret local_selected() + imported_selected(); }\n",
+        "pub def Flag: u8;\n");
 }

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -178,6 +178,8 @@ pub rec PhaseCapabilities[T] {
     query:     fun(*T, u32, u8) R.Result[O.Option[CTValue], EvalFail];
     layout:    fun(*T, u32) R.Result[O.Option[CTValue], EvalFail];
     ident:     fun(*T, id.ExprId) bool;
+    cast:      fun(*T, id.ExprId, CTValue) R.Result[CTValue, EvalFail];
+    scalar:    fun(*T, id.ExprId, CTValue) R.Result[CTValue, EvalFail];
 }
 
 fun capabilities_empty[T](kind: PhaseCapabilityKind, diags: *diagnostic.DiagnosticStore) PhaseCapabilities[T] {
@@ -191,6 +193,8 @@ fun capabilities_empty[T](kind: PhaseCapabilityKind, diags: *diagnostic.Diagnost
     caps.query  = nil;
     caps.layout = nil;
     caps.ident  = nil;
+    caps.cast   = nil;
+    caps.scalar = nil;
     ret caps;
 }
 
@@ -214,7 +218,7 @@ pub fun no_capabilities(diags: *diagnostic.DiagnosticStore) PhaseCapabilities[No
 
 fun capabilities_complete[T](caps: PhaseCapabilities[T]) bool {
     if (caps.expression == nil) { ret false; }
-    val no_types: bool = caps.type_ == nil && caps.field == nil && caps.query == nil && caps.layout == nil;
+    val no_types: bool = caps.type_ == nil && caps.field == nil && caps.query == nil && caps.layout == nil && caps.cast == nil && caps.scalar == nil;
     if (caps.kind == PHASE_CAP_NONE) {
         ret caps.member == nil && no_types && caps.ident == nil;
     }
@@ -229,7 +233,7 @@ fun capabilities_complete[T](caps: PhaseCapabilities[T]) bool {
     }
     if (caps.kind == PHASE_CAP_SEMANTIC_TYPES || caps.kind == PHASE_CAP_LOWERING) {
         ret caps.member != nil && caps.type_ != nil && caps.field != nil
-            && caps.query != nil && caps.layout != nil && caps.ident != nil;
+            && caps.query != nil && caps.layout != nil && caps.ident != nil && caps.cast != nil && caps.scalar != nil;
     }
     ret false;
 }
@@ -274,6 +278,8 @@ pub fun semantic_type_capabilities[T](
     field:  fun(*T, u32, u32, u8) R.Result[O.Option[CTValue], EvalFail],
     query:  fun(*T, u32, u8) R.Result[O.Option[CTValue], EvalFail],
     layout: fun(*T, u32) R.Result[O.Option[CTValue], EvalFail],
+    cast:   fun(*T, id.ExprId, CTValue) R.Result[CTValue, EvalFail],
+    scalar: fun(*T, id.ExprId, CTValue) R.Result[CTValue, EvalFail],
     ident:  fun(*T, id.ExprId) bool,
     expression: fun(*T, *ast.Ast, id.ExprId) R.Result[expr.Expr, EvalFail],
     diags:  *diagnostic.DiagnosticStore
@@ -284,6 +290,8 @@ pub fun semantic_type_capabilities[T](
     caps.field  = field;
     caps.query  = query;
     caps.layout = layout;
+    caps.cast = cast;
+    caps.scalar = scalar;
     caps.ident  = ident;
     caps.expression = expression;
     ret capabilities_publish[T](caps);
@@ -295,6 +303,8 @@ pub fun lowering_capabilities[T](
     field:  fun(*T, u32, u32, u8) R.Result[O.Option[CTValue], EvalFail],
     query:  fun(*T, u32, u8) R.Result[O.Option[CTValue], EvalFail],
     layout: fun(*T, u32) R.Result[O.Option[CTValue], EvalFail],
+    cast:   fun(*T, id.ExprId, CTValue) R.Result[CTValue, EvalFail],
+    scalar: fun(*T, id.ExprId, CTValue) R.Result[CTValue, EvalFail],
     ident:  fun(*T, id.ExprId) bool,
     expression: fun(*T, *ast.Ast, id.ExprId) R.Result[expr.Expr, EvalFail],
     diags:  *diagnostic.DiagnosticStore
@@ -305,6 +315,8 @@ pub fun lowering_capabilities[T](
     caps.field  = field;
     caps.query  = query;
     caps.layout = layout;
+    caps.cast = cast;
+    caps.scalar = scalar;
     caps.ident  = ident;
     caps.expression = expression;
     ret capabilities_publish[T](caps);
@@ -1035,7 +1047,7 @@ pub fun evaluate_at_float_width[T](
     if (k == expr.EXPR_KIND_LIT_STR)   { ret eval_lit_str(source, node.span, interner); }
     if (k == expr.EXPR_KIND_LIT_NIL)   { ret reject("nil is not comptime-evaluable"); }
 
-    if (k == expr.EXPR_KIND_BINARY) { ret eval_binary[T](c, cap_ctx, caps, a, source, ?node.data.binary, interner, fw); }
+    if (k == expr.EXPR_KIND_BINARY) { ret eval_binary[T](c, cap_ctx, caps, a, source, e, ?node.data.binary, interner, fw); }
     if (k == expr.EXPR_KIND_UNARY)  { ret eval_unary[T](c, cap_ctx, caps, a, source, ?node.data.unary, interner, fw); }
 
     if (k == expr.EXPR_KIND_IDENT) {
@@ -1069,7 +1081,14 @@ pub fun evaluate_at_float_width[T](
         ret reject("function calls are not comptime-evaluable");
     }
     if (k == expr.EXPR_KIND_INDEX)      { ret reject("index expressions are not comptime-evaluable"); }
-    if (k == expr.EXPR_KIND_CAST)       { ret reject("type casts are not comptime-evaluable"); }
+    if (k == expr.EXPR_KIND_CAST) {
+        if (!capabilities_have_types[T](cap_ctx, caps)) {
+            ret awaiting(EVAL_FAIL_NEEDS_TYPES, "a comptime cast requires its resolved source and destination types");
+        }
+        val operand: R.Result[CTValue, EvalFail] = evaluate[T](c, cap_ctx, caps, a, source, node.data.cast.value, interner);
+        if (R.is_err[CTValue, EvalFail](operand)) { ret operand; }
+        ret caps.cast(cap_ctx, e, R.unwrap_ok[CTValue, EvalFail](operand));
+    }
     if (k == expr.EXPR_KIND_ARRAY_LIT)  { ret reject("array literals are not comptime-evaluable"); }
     if (k == expr.EXPR_KIND_STRUCT_LIT) { ret reject("struct literals are not comptime-evaluable"); }
     if (k == expr.EXPR_KIND_VECTOR_LIT) { ret reject("vector literals are not comptime-evaluable"); }
@@ -1522,6 +1541,7 @@ fun eval_binary[T](
     caps:     PhaseCapabilities[T],
     a:        *ast.Ast,
     source:   str,
+    eid:      id.ExprId,
     bin:      *expr.ExprBinary,
     interner: *intern.Interner,
     fw:       float.FloatWidth
@@ -1569,7 +1589,13 @@ fun eval_binary[T](
      || bin.op == expr.BIN_GT || bin.op == expr.BIN_GEQ) {
         ret apply_compare(bin.op, lhs, rhs);
     }
-    ret apply_arith(bin.op, lhs, rhs);
+    val result: R.Result[CTValue, EvalFail] = apply_arith(bin.op, lhs, rhs);
+    if (R.is_err[CTValue, EvalFail](result)) { ret result; }
+    if ((bin.op == expr.BIN_BIT_AND || bin.op == expr.BIN_BIT_OR || bin.op == expr.BIN_BIT_XOR)
+        && capabilities_have_types[T](cap_ctx, caps)) {
+        ret caps.scalar(cap_ctx, eid, R.unwrap_ok[CTValue, EvalFail](result));
+    }
+    ret result;
 }
 
 fun eval_unary[T](
@@ -1588,7 +1614,12 @@ fun eval_unary[T](
 
     val r: R.Result[CTValue, EvalFail] = evaluate_at_float_width[T](c, cap_ctx, caps, a, source, un.operand, interner, fw);
     if (R.is_err[CTValue, EvalFail](r)) { ret r; }
-    val v: CTValue = R.unwrap_ok[CTValue, EvalFail](r);
+    var v: CTValue = R.unwrap_ok[CTValue, EvalFail](r);
+    if (un.op == expr.UN_BIT_NOT && capabilities_have_types[T](cap_ctx, caps)) {
+        val typed: R.Result[CTValue, EvalFail] = caps.scalar(cap_ctx, un.operand, v);
+        if (R.is_err[CTValue, EvalFail](typed)) { ret typed; }
+        v = R.unwrap_ok[CTValue, EvalFail](typed);
+    }
 
     if (un.op == expr.UN_NEG) {
         if (v.kind == CT_KIND_INT)   { ret ct_negate(v); }
@@ -1605,9 +1636,91 @@ fun eval_unary[T](
     }
     if (un.op == expr.UN_BIT_NOT) {
         if (v.kind != CT_KIND_INT) { ret reject("unary ~ requires an integer operand"); }
-        ret make_int_value(~v.data.i, v.int_unsigned);
+        if (v.int_width == 0) { ret make_int_value(~v.data.i, v.int_unsigned); }
+        ret cast_int(~v.data.i, v.int_width::u32, !v.int_unsigned);
     }
     ret reject("unsupported unary operator");
+}
+
+fun cast_int(bits: i64, width: u32, signed: bool) R.Result[CTValue, EvalFail] {
+    if (width == 0 || width > 64) { ret internal_failure("comptime scalar cast has an invalid integer width"); }
+    var value: i64 = bits;
+    if (width < 64) {
+        val shift: u64 = (64 - width)::u64;
+        val masked: u64 = (bits:~u64 << shift) >> shift;
+        value = masked:~i64;
+        if (signed) { value = (value << shift) >> shift; }
+    }
+    var out: CTValue;
+    out.kind = CT_KIND_INT;
+    out.int_unsigned = !signed;
+    out.int_width = width::u8;
+    out.data.i = value;
+    ret R.ok[CTValue, EvalFail](out);
+}
+
+fun cast_desc(types: *type.TypeInterner, tid: type.TypeId, pointer_width: u32) R.Result[type.PrimDesc, EvalFail] {
+    val found: O.Option[*type.Type] = type.get(types, type.strip_secret(types, tid));
+    if (O.is_none[*type.Type](found)) {
+        ret R.err[type.PrimDesc, EvalFail](eval_error(EVAL_FAIL_NEEDS_TYPES, "comptime cast type is not resolved"));
+    }
+    val kind: type.TypeKind = O.unwrap[*type.Type](found).kind;
+    var desc: type.PrimDesc = type.prim_desc(kind);
+    if (kind == type.TYPE_PTR || kind == type.TYPE_POINTER || kind == type.TYPE_FUN) {
+        desc.class = type.PRIM_CLASS_PTR;
+        desc.bits = pointer_width * 8;
+        desc.signed = false;
+    }
+    if (desc.class == type.PRIM_CLASS_NONE) {
+        ret R.err[type.PrimDesc, EvalFail](eval_error(EVAL_FAIL_REJECTED, "comptime casts require scalar types"));
+    }
+    ret R.ok[type.PrimDesc, EvalFail](desc);
+}
+
+pub fun cast_scalar(types: *type.TypeInterner, pointer_width: u32, value: CTValue,
+                    from_ty: type.TypeId, to_ty: type.TypeId, reinterpret: bool) R.Result[CTValue, EvalFail] {
+    val from_r: R.Result[type.PrimDesc, EvalFail] = cast_desc(types, from_ty, pointer_width);
+    if (R.is_err[type.PrimDesc, EvalFail](from_r)) { ret R.err[CTValue, EvalFail](R.unwrap_err[type.PrimDesc, EvalFail](from_r)); }
+    val to_r: R.Result[type.PrimDesc, EvalFail] = cast_desc(types, to_ty, pointer_width);
+    if (R.is_err[type.PrimDesc, EvalFail](to_r)) { ret R.err[CTValue, EvalFail](R.unwrap_err[type.PrimDesc, EvalFail](to_r)); }
+    val from: type.PrimDesc = R.unwrap_ok[type.PrimDesc, EvalFail](from_r);
+    val to: type.PrimDesc = R.unwrap_ok[type.PrimDesc, EvalFail](to_r);
+    val representation: bool = reinterpret || from.class == type.PRIM_CLASS_PTR || to.class == type.PRIM_CLASS_PTR;
+    if (representation && from.bits != to.bits) { ret reject("comptime bit reinterpret requires equal source and destination sizes"); }
+    if (value.kind == CT_KIND_STR && from.class == type.PRIM_CLASS_PTR && to.class == type.PRIM_CLASS_PTR) {
+        ret R.ok[CTValue, EvalFail](value);
+    }
+    val from_float: bool = from.class == type.PRIM_CLASS_FLOAT;
+    val to_float: bool = to.class == type.PRIM_CLASS_FLOAT;
+    if ((from_float && value.kind != CT_KIND_FLOAT) || (!from_float && value.kind != CT_KIND_INT)) {
+        ret reject("comptime cast operand is not a scalar value of its source type");
+    }
+    var fw: float.FloatWidth = float.FLOAT_W_64;
+    if (to.bits == 32) { fw = float.FLOAT_W_32; }
+    if (from_float) {
+        var source_fw: float.FloatWidth = float.FLOAT_W_64;
+        if (from.bits == 32) { source_fw = float.FLOAT_W_32; }
+        val source_r: R.Result[CTValue, EvalFail] = float_value(value.data.f, source_fw);
+        if (R.is_err[CTValue, EvalFail](source_r)) { ret source_r; }
+        val source_value: f64 = R.unwrap_ok[CTValue, EvalFail](source_r).data.f;
+        if (to_float) { ret float_value(source_value, fw); }
+        if (representation) {
+            if (from.bits == 32) { ret cast_int(((source_value::f32):~u32)::i64, to.bits, to.signed); }
+            ret cast_int(source_value:~i64, to.bits, to.signed);
+        }
+        if (to.signed) { ret cast_int(source_value::i64, to.bits, true); }
+        ret cast_int((source_value::u64):~i64, to.bits, false);
+    }
+    val source_r: R.Result[CTValue, EvalFail] = cast_int(value.data.i, from.bits, from.signed);
+    if (R.is_err[CTValue, EvalFail](source_r)) { ret source_r; }
+    val source_value: i64 = R.unwrap_ok[CTValue, EvalFail](source_r).data.i;
+    if (!to_float) { ret cast_int(source_value, to.bits, to.signed); }
+    if (representation) {
+        if (to.bits == 32) { ret float_value(((source_value:~u64)::u32):~f32::f64, fw); }
+        ret float_value(source_value:~f64, fw);
+    }
+    if (from.signed) { ret float_value(source_value::f64, fw); }
+    ret float_value((source_value:~u64)::f64, fw);
 }
 
 fun eval_logical[T](
@@ -2621,12 +2734,20 @@ fun apply_float_arith(op: expr.BinOp, lhs: CTValue, rhs: CTValue) R.Result[CTVal
     ret reject("unsupported float operator");
 }
 
+fun bitwise_value(bits: i64, lhs: CTValue, rhs: CTValue) R.Result[CTValue, EvalFail] {
+    val unsigned: bool = lhs.int_unsigned || rhs.int_unsigned;
+    if (lhs.int_width != 0 && lhs.int_width == rhs.int_width) {
+        ret cast_int(bits, lhs.int_width::u32, !unsigned);
+    }
+    ret make_int_value(bits, unsigned);
+}
+
 fun apply_int_arith(op: expr.BinOp, lhs: CTValue, rhs: CTValue) R.Result[CTValue, EvalFail] {
     val res_uns: bool = lhs.int_unsigned || rhs.int_unsigned;
 
-    if (op == expr.BIN_BIT_AND)                   { ret make_int_value(lhs.data.i & rhs.data.i, res_uns); }
-    if (op == expr.BIN_BIT_OR)                    { ret make_int_value(lhs.data.i | rhs.data.i, res_uns); }
-    if (op == expr.BIN_BIT_XOR)                   { ret make_int_value(lhs.data.i ^ rhs.data.i, res_uns); }
+    if (op == expr.BIN_BIT_AND) { ret bitwise_value(lhs.data.i & rhs.data.i, lhs, rhs); }
+    if (op == expr.BIN_BIT_OR) { ret bitwise_value(lhs.data.i | rhs.data.i, lhs, rhs); }
+    if (op == expr.BIN_BIT_XOR) { ret bitwise_value(lhs.data.i ^ rhs.data.i, lhs, rhs); }
     if (op == expr.BIN_SHL || op == expr.BIN_SHR) { ret apply_int_shift(op, lhs, rhs); }
 
     if (!res_uns) { ret apply_signed_arith(op, lhs.data.i, rhs.data.i); }
@@ -3567,6 +3688,49 @@ fun t_capability_nested(state: *TCapabilityNested, eid: id.ExprId) R.Result[O.Op
         ret R.err[O.Option[CTValue], EvalFail](R.unwrap_err[CTValue, EvalFail](r));
     }
     ret R.ok[O.Option[CTValue], EvalFail](O.some[CTValue](R.unwrap_ok[CTValue, EvalFail](r)));
+}
+
+test "mach.lang.fe.comptime.cast_scalar:width_signedness_and_reinterpretation" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    var types: type.TypeInterner;
+    if (O.is_some[str](type.init(?types, ?a))) { ret 1; }
+    fin { type.dnit(?types); }
+    val u8t: type.TypeId = O.unwrap[type.TypeId](type.prim(?types, type.TYPE_U8));
+    val i8t: type.TypeId = O.unwrap[type.TypeId](type.prim(?types, type.TYPE_I8));
+    val u64t: type.TypeId = O.unwrap[type.TypeId](type.prim(?types, type.TYPE_U64));
+    val i64t: type.TypeId = O.unwrap[type.TypeId](type.prim(?types, type.TYPE_I64));
+    val f64t: type.TypeId = O.unwrap[type.TypeId](type.prim(?types, type.TYPE_F64));
+    val raw: CTValue = R.unwrap_ok[CTValue, EvalFail](make_int_value(255, true));
+    val signed_r: R.Result[CTValue, EvalFail] = cast_scalar(?types, 8, raw, u8t, i8t, true);
+    if (R.is_err[CTValue, EvalFail](signed_r)) { ret 2; }
+    val signed: CTValue = R.unwrap_ok[CTValue, EvalFail](signed_r);
+    if (signed.data.i != -1 || signed.int_unsigned || signed.int_width != 8) { ret 3; }
+    val wide_r: R.Result[CTValue, EvalFail] = cast_scalar(?types, 8, signed, i8t, u64t, false);
+    if (R.is_err[CTValue, EvalFail](wide_r)) { ret 4; }
+    val wide: CTValue = R.unwrap_ok[CTValue, EvalFail](wide_r);
+    if (wide.data.i != -1 || !wide.int_unsigned || wide.int_width != 64) { ret 5; }
+    val narrow_r: R.Result[CTValue, EvalFail] = cast_scalar(?types, 8,
+        R.unwrap_ok[CTValue, EvalFail](int_value(300)), i64t, u8t, false);
+    if (R.is_err[CTValue, EvalFail](narrow_r)) { ret 6; }
+    val narrow: CTValue = R.unwrap_ok[CTValue, EvalFail](narrow_r);
+    if (narrow.data.i != 44 || !narrow.int_unsigned || narrow.int_width != 8) { ret 7; }
+    val negative_zero: CTValue = ct_float(float.f64_neg(0.0), float.FLOAT_W_64);
+    val bits_r: R.Result[CTValue, EvalFail] = cast_scalar(?types, 8, negative_zero, f64t, u64t, true);
+    if (R.is_err[CTValue, EvalFail](bits_r)) { ret 8; }
+    val bits: CTValue = R.unwrap_ok[CTValue, EvalFail](bits_r);
+    if (bits.data.i:~u64 != 0x8000000000000000 || !bits.int_unsigned) { ret 9; }
+    val back_r: R.Result[CTValue, EvalFail] = cast_scalar(?types, 8, bits, u64t, f64t, true);
+    if (R.is_err[CTValue, EvalFail](back_r)) { ret 10; }
+    if (R.unwrap_ok[CTValue, EvalFail](back_r).data.f:~u64 != 0x8000000000000000) { ret 11; }
+    if (!R.is_err[CTValue, EvalFail](cast_scalar(?types, 8, raw, u8t, u64t, true))) { ret 12; }
+    val ptrt: type.TypeId = O.unwrap[type.TypeId](type.prim(?types, type.TYPE_PTR));
+    val pointer: CTValue = R.unwrap_ok[CTValue, EvalFail](make_int_value(0x3FF0000000000000, true));
+    val float_r: R.Result[CTValue, EvalFail] = cast_scalar(?types, 8, pointer, ptrt, f64t, false);
+    if (R.is_err[CTValue, EvalFail](float_r) || R.unwrap_ok[CTValue, EvalFail](float_r).data.f != 1.0) { ret 13; }
+    val pointer_r: R.Result[CTValue, EvalFail] = cast_scalar(?types, 8, ct_float(1.0, float.FLOAT_W_64), f64t, ptrt, false);
+    if (R.is_err[CTValue, EvalFail](pointer_r) || R.unwrap_ok[CTValue, EvalFail](pointer_r).data.i != pointer.data.i) { ret 14; }
+    ret 0;
 }
 
 test "mach.lang.fe.comptime.capabilities:mismatched_phase_does_not_dispatch" {

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -74,8 +74,29 @@ fun semantic_type_caps(diags: *diagnostic.DiagnosticStore) R.Result[comptime.Pha
         context.resolve_field_member,
         infer.resolve_type_query,
         infer.resolve_layout_intrinsic,
+        resolve_scalar_cast, resolve_scalar_value,
         context.comptime_ident_is_runtime, context.comptime_expression, diags
     );
+}
+
+fun resolve_scalar_value(sc: *context.SemaContext, eid: id.ExprId, value: comptime.CTValue) R.Result[comptime.CTValue, comptime.EvalFail] {
+    if (sc.expr_type == nil || eid::usize >= sc.a.expr_len) {
+        ret R.err[comptime.CTValue, comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_NEEDS_TYPES, "comptime scalar expression type is not resolved"));
+    }
+    val ty: type.TypeId = context.apply_subst(sc, sc.expr_type[eid]);
+    ret comptime.cast_scalar(?sc.s.types, sc.ctx.env.pointer_width, value, ty, ty, false);
+}
+
+fun resolve_scalar_cast(sc: *context.SemaContext, eid: id.ExprId, value: comptime.CTValue) R.Result[comptime.CTValue, comptime.EvalFail] {
+    val expression_r: R.Result[expr.Expr, str] = context.expression(sc, eid);
+    if (R.is_err[expr.Expr, str](expression_r)) { ret R.err[comptime.CTValue, comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_INTERNAL, R.unwrap_err[expr.Expr, str](expression_r))); }
+    val node: expr.Expr = R.unwrap_ok[expr.Expr, str](expression_r);
+    if (node.kind != expr.EXPR_KIND_CAST) { ret R.err[comptime.CTValue, comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_INTERNAL, "semantic cast capability requires a cast expression")); }
+    if (sc.expr_type == nil || node.data.cast.value::usize >= sc.a.expr_len) {
+        ret R.err[comptime.CTValue, comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_NEEDS_TYPES, "comptime cast operand type is not resolved"));
+    }
+    ret comptime.cast_scalar(?sc.s.types, sc.ctx.env.pointer_width, value,
+        context.apply_subst(sc, sc.expr_type[node.data.cast.value]), context.resolved_type_of(sc, node.data.cast.ty), node.data.cast.reinterpret);
 }
 
 pub fun sema(
@@ -919,12 +940,37 @@ fun decl_gate_is_active(sc: *context.SemaContext, cond: id.ExprId) R.Result[bool
     ret R.ok[bool, str](v.outcome == comptime.GATE_ACTIVE);
 }
 
+fun decl_gate_layout(sc: *context.SemaContext, eid: u32) R.Result[O.Option[comptime.CTValue], comptime.EvalFail] {
+    ret R.err[O.Option[comptime.CTValue], comptime.EvalFail](comptime.eval_error(
+        comptime.EVAL_FAIL_NEEDS_LAYOUT, comptime.COMPTIME_LAYOUT_NO_RESOLVER_MSG));
+}
+
 fun decide_decl_gate(sc: *context.SemaContext, cond: id.ExprId) R.Result[R.Void, str] {
     val vr: R.Result[comptime.GateVerdict, str] = decl_gate_verdict(sc, cond);
     if (R.is_err[comptime.GateVerdict, str](vr)) {
         ret R.err[R.Void, str](R.unwrap_err[comptime.GateVerdict, str](vr));
     }
-    val v: comptime.GateVerdict = R.unwrap_ok[comptime.GateVerdict, str](vr);
+    var v: comptime.GateVerdict = R.unwrap_ok[comptime.GateVerdict, str](vr);
+    if (v.outcome == comptime.GATE_AWAITING_PHASE && v.fail == comptime.EVAL_FAIL_NEEDS_TYPES) {
+        val saved_gate: bool = sc.in_comptime_gate;
+        sc.in_comptime_gate = true;
+        fin { sc.in_comptime_gate = saved_gate; }
+        val gate_ty: type.TypeId = infer.infer_expr(sc, cond);
+        if (type.is_u8(?sc.s.types, gate_ty)) {
+            val caps_r: R.Result[comptime.PhaseCapabilities[context.SemaContext], str] = semantic_type_caps(sc.diags);
+            if (R.is_err[comptime.PhaseCapabilities[context.SemaContext], str](caps_r)) {
+                ret R.err[R.Void, str](R.unwrap_err[comptime.PhaseCapabilities[context.SemaContext], str](caps_r));
+            }
+            var caps: comptime.PhaseCapabilities[context.SemaContext] = R.unwrap_ok[comptime.PhaseCapabilities[context.SemaContext], str](caps_r);
+            caps.layout = decl_gate_layout;
+            val typed: R.Result[comptime.GateVerdict, str] = comptime.evaluate_gate[context.SemaContext](
+                sc.ctx, sc, caps, sc.a, sc.source, cond, ?sc.s.interner, comptime.GATE_SCOPE_DECL, true, true);
+            if (R.is_err[comptime.GateVerdict, str](typed)) {
+                ret R.err[R.Void, str](R.unwrap_err[comptime.GateVerdict, str](typed));
+            }
+            v = R.unwrap_ok[comptime.GateVerdict, str](typed);
+        }
+    }
 
     if (v.outcome == comptime.GATE_ACTIVE || v.outcome == comptime.GATE_INACTIVE) {
         ret R.ok_void[str]();

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -1169,10 +1169,7 @@ fun infer_vector_binary(sc: *context.SemaContext, op: expr.BinOp, lt: type.TypeI
     }
 
     if (op == expr.BIN_DIV) {
-        if (!float_lane) {
-            context.report(sc, span, "integer vector `/` is not supported");
-            ret type.TYPE_ERROR;
-        }
+        if (int_lane) { gate_ct_always(sc, ct.CT_OP_INT_DIVMOD, either_secret, span); }
         ret join_secret(sc, lbase, either_secret);
     }
 

--- a/src/lang/me/ir/opdesc.mach
+++ b/src/lang/me/ir/opdesc.mach
@@ -190,7 +190,7 @@ val IR_OP_DESCRIPTORS: [IR_OP_DESCRIPTOR_COUNT]IrOpDescriptor = [IR_OP_DESCRIPTO
         roles: [OP_MAX_FIXED_OPERANDS]OperandRole{ ROLE_VALUE, ROLE_VALUE, ROLE_NONE },
         tail_role: ROLE_NONE, tail_role_alt: ROLE_NONE,
         result: RESULT_DECLARED,
-        vec_op: IVEC_DIV, vec_class: VCLASS_DISALLOWED,
+        vec_op: IVEC_DIV, vec_class: VCLASS_BINARY,
         ct_class: CTC_NONE, lower_route: LOWER_DIV,
     },
     IrOpDescriptor{

--- a/src/lang/me/lower.mach
+++ b/src/lang/me/lower.mach
@@ -79,11 +79,21 @@ pub fun lower_module(req: *context.LowerRequest) R.Result[ir.Module, fail.Fail] 
         val did: id.DeclId = a.decl_ids[pool_ix];
         val res_decl: R.Result[R.Void, fail.Fail] = decl.lower_decl(?lc, did);
         if (R.is_err[R.Void, fail.Fail](res_decl)) {
-            ret lower_module_fail(?lc, ?m, R.unwrap_err[R.Void, fail.Fail](res_decl));
+            val failure: fail.Fail = R.unwrap_err[R.Void, fail.Fail](res_decl);
+            val declaration: O.Option[*adecl.Decl] = ast.get_decl(a, did);
+            if (failure.kind != fail.REPORTED || O.is_none[*adecl.Decl](declaration)) {
+                ret lower_module_fail(?lc, ?m, failure);
+            }
+            val kind: adecl.DeclKind = O.unwrap[*adecl.Decl](declaration).kind;
+            if (kind != adecl.DECL_KIND_VAL && kind != adecl.DECL_KIND_VAR) {
+                ret lower_module_fail(?lc, ?m, failure);
+            }
+            if (lc.status.kind == fail.ACCEPTED) { fail.reject(?lc.status); }
         }
         i = i + 1;
     }
 
+    if (lc.status.kind != fail.ACCEPTED) { ret lower_module_fail(?lc, ?m, fail.phase_failure(lc.status)); }
     val res_drain_types: R.Result[R.Void, fail.Fail] = drain_instances(?lc, s);
     if (R.is_err[R.Void, fail.Fail](res_drain_types)) {
         ret lower_module_fail(?lc, ?m, R.unwrap_err[R.Void, fail.Fail](res_drain_types));

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -345,6 +345,7 @@ pub fun init_context(lc: *LowerContext, req: *LowerRequest, m: *ir.Module) R.Res
         resolve_field_member,
         resolve_type_query,
         resolve_layout_intrinsic,
+        resolve_scalar_cast, resolve_scalar_value,
         comptime_ident_is_runtime, comptime_expression, req.diags
     );
     if (R.is_err[comptime.PhaseCapabilities[LowerContext], str](caps_r)) {
@@ -644,6 +645,20 @@ pub fun comptime_ident_is_runtime(lc: *LowerContext, eid: id.ExprId) bool {
     val sid: resolve.SymbolId = rr.expr_resolved[eid];
     if (sid == resolve.SYMBOL_NIL || sid::u32 >= rr.symbol_count) { ret false; }
     ret resolve.symbol_is_runtime(?rr.symbols[sid]);
+}
+
+fun resolve_scalar_value(lc: *LowerContext, eid: id.ExprId, value: comptime.CTValue) R.Result[comptime.CTValue, comptime.EvalFail] {
+    val ty: type.TypeId = expr_type_of(lc, eid);
+    ret comptime.cast_scalar(?lc.s.types, lc.tgt.isa.pointer_width, value, ty, ty, false);
+}
+
+fun resolve_scalar_cast(lc: *LowerContext, eid: id.ExprId, value: comptime.CTValue) R.Result[comptime.CTValue, comptime.EvalFail] {
+    val expression_r: R.Result[aexpr.Expr, str] = expression(lc, eid);
+    if (R.is_err[aexpr.Expr, str](expression_r)) { ret R.err[comptime.CTValue, comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_INTERNAL, R.unwrap_err[aexpr.Expr, str](expression_r))); }
+    val node: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](expression_r);
+    if (node.kind != aexpr.EXPR_KIND_CAST) { ret R.err[comptime.CTValue, comptime.EvalFail](comptime.eval_error(comptime.EVAL_FAIL_INTERNAL, "lowering cast capability requires a cast expression")); }
+    ret comptime.cast_scalar(?lc.s.types, lc.tgt.isa.pointer_width, value,
+        expr_type_of(lc, node.data.cast.value), type_resolved_of(lc, node.data.cast.ty), node.data.cast.reinterpret);
 }
 
 pub fun resolve_type_comparison_operand(lc: *LowerContext, eid: id.ExprId) R.Result[O.Option[u32], comptime.EvalFail] {

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -245,22 +245,9 @@ pub fun lower_global(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, 
     or (d.data.bind.init != id.EXPR_NIL) {
         val res_fold: R.Result[value.Value, fail.Fail] = fold_global_init(ctx, d.data.bind.init, gty, bare);
         if (R.is_err[value.Value, fail.Fail](res_fold)) {
-            val fold_err: str = R.unwrap_err[value.Value, fail.Fail](res_fold).message;
-            if (is_internal_err(fold_err)) {
-                val res_diag: R.Result[R.Void, fail.Fail] = diag_named(ctx, d.data.bind.name, bare,
-                    "global initialiser of `", "` must be a constant expression",
-                    "a global initialiser must be a constant expression");
-                if (R.is_err[R.Void, fail.Fail](res_diag)) { ret res_diag; }
-            }
-            or {
-                val res_diag2: R.Result[R.Void, str] =
-                    diagnostic.error(ctx.diags, ctx.scope.a.file_id, d.data.bind.name, fold_err);
-                if (R.is_err[R.Void, str](res_diag2)) { ret fail.lift[R.Void](res_diag2); }
-            }
+            ret R.err[R.Void, fail.Fail](R.unwrap_err[value.Value, fail.Fail](res_fold));
         }
-        or {
-            init_val = R.unwrap_ok[value.Value, fail.Fail](res_fold);
-        }
+        init_val = R.unwrap_ok[value.Value, fail.Fail](res_fold);
     }
 
     val res_align: R.Result[u32, fail.Fail] = global_align_of(ctx, d);
@@ -487,19 +474,8 @@ fun free_pack_param_bufs(ctx: *context.LowerContext, params: *value.Value, total
     if (slots != nil && type_len > 0) { A.deallocate[value.Value](ctx.s.alloc, slots, type_len::usize); }
 }
 
-fun is_internal_err(msg: str) bool {
-    val p: str = "lower:";
-    val n: usize = str_len(p);
-    if (str_len(msg) < n) { ret false; }
-    var i: usize = 0;
-    for (i < n) {
-        if (msg[i] != p[i]) { ret false; }
-        i = i + 1;
-    }
-    ret true;
-}
-
 fun diag_named(ctx: *context.LowerContext, span: token.Span, name_id: intern.StrId, prefix: str, suffix: str, fallback: str) R.Result[R.Void, fail.Fail] {
+    fail.reject(?ctx.status);
     val opt_name: O.Option[str] = intern.lookup(?ctx.s.interner, name_id);
     if (O.is_none[str](opt_name)) {
         ret fail.lift[R.Void](diagnostic.error(ctx.diags, ctx.scope.a.file_id, span, fallback));
@@ -508,7 +484,7 @@ fun diag_named(ctx: *context.LowerContext, span: token.Span, name_id: intern.Str
 
     val res_msg: R.Result[str, str] = str_join(ctx.s.alloc, prefix, name, suffix);
     if (R.is_err[str, str](res_msg)) {
-        ret fail.lift[R.Void](diagnostic.error(ctx.diags, ctx.scope.a.file_id, span, fallback));
+        ret R.err[R.Void, fail.Fail](fail.message(R.unwrap_err[str, str](res_msg)));
     }
     val buf: str = R.unwrap_ok[str, str](res_msg);
 
@@ -747,6 +723,17 @@ fun terminate_orphan_blocks(ctx: *context.LowerContext) R.Result[R.Void, fail.Fa
 }
 
 fun fold_global_init(ctx: *context.LowerContext, eid: id.ExprId, gty: ir_type.IrTypeId, name: intern.StrId) R.Result[value.Value, fail.Fail] {
+    val folded: R.Result[value.Value, fail.Fail] = fold_global_value(ctx, eid, gty, name);
+    if (ctx.status.kind == fail.INTERNAL) { ret R.err[value.Value, fail.Fail](fail.phase_failure(ctx.status)); }
+    if (R.is_err[value.Value, fail.Fail](folded)) {
+        val failure: fail.Fail = R.unwrap_err[value.Value, fail.Fail](folded);
+        if (failure.kind == fail.REPORTED) { if (ctx.status.kind == fail.ACCEPTED) { fail.reject(?ctx.status); } }
+        or { fail.internal(?ctx.status, failure.message); }
+    }
+    ret folded;
+}
+
+fun fold_global_value(ctx: *context.LowerContext, eid: id.ExprId, gty: ir_type.IrTypeId, name: intern.StrId) R.Result[value.Value, fail.Fail] {
     if (is_null_init(ctx, eid)) { ret R.ok[value.Value, fail.Fail](value.const_null(gty)); }
 
     val res_agg: R.Result[O.Option[value.Value], fail.Fail] = constagg.try_const_aggregate(ctx, eid, gty);
@@ -754,30 +741,46 @@ fun fold_global_init(ctx: *context.LowerContext, eid: id.ExprId, gty: ir_type.Ir
     val opt_agg: O.Option[value.Value] = R.unwrap_ok[O.Option[value.Value], fail.Fail](res_agg);
     if (O.is_some[value.Value](opt_agg)) { ret R.ok[value.Value, fail.Fail](O.unwrap[value.Value](opt_agg)); }
 
-    val opt_ct: O.Option[comptime.CTValue] = try_comptime(ctx, eid);
-    if (O.is_some[comptime.CTValue](opt_ct)) {
-        val cv: comptime.CTValue = O.unwrap[comptime.CTValue](opt_ct);
+    val evaluated: R.Result[comptime.CTValue, comptime.EvalFail] = try_comptime(ctx, eid);
+    if (R.is_ok[comptime.CTValue, comptime.EvalFail](evaluated)) {
+        val cv: comptime.CTValue = R.unwrap_ok[comptime.CTValue, comptime.EvalFail](evaluated);
+        val converted: R.Result[value.Value, fail.Fail] = expr.const_value_of_init(ctx, eid, cv);
+        if (R.is_err[value.Value, fail.Fail](converted)) { ret converted; }
         if (name != intern.STR_NIL && O.is_none[comptime.NamedConst](comptime.lookup(ctx.scope.ctx, name))) {
             val res_bind: R.Result[R.Void, str] = comptime.bind(ctx.scope.ctx, name, cv);
             if (R.is_err[R.Void, str](res_bind)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_bind))); }
         }
-        ret expr.const_value_of_init(ctx, eid, cv);
+        ret converted;
+    }
+
+    val eval_failure: comptime.EvalFail = R.unwrap_err[comptime.CTValue, comptime.EvalFail](evaluated);
+    if (eval_failure.kind == comptime.EVAL_FAIL_INTERNAL) {
+        ret R.err[value.Value, fail.Fail](fail.message(eval_failure.message));
     }
 
     val opt_init: R.Result[aexpr.Expr, str] = context.expression(ctx, eid);
-    if (R.is_err[aexpr.Expr, str](opt_init)) { ret R.err[value.Value, fail.Fail](fail.message("lower: global initialiser expression out of range")); }
+    if (R.is_err[aexpr.Expr, str](opt_init)) { ret R.err[value.Value, fail.Fail](fail.message(R.unwrap_err[aexpr.Expr, str](opt_init))); }
     var ie_value: aexpr.Expr = R.unwrap_ok[aexpr.Expr, str](opt_init);
     val ie: *aexpr.Expr = ?ie_value;
-
-    val opt_cast: O.Option[R.Result[value.Value, fail.Fail]] = expr.try_lower_comptime_cast(ctx, eid, ie);
-    if (O.is_some[R.Result[value.Value, fail.Fail]](opt_cast)) { ret O.unwrap[R.Result[value.Value, fail.Fail]](opt_cast); }
 
     if (ie.kind == aexpr.EXPR_KIND_CALL) {
         val opt_intr: O.Option[R.Result[value.Value, fail.Fail]] = expr.try_lower_comptime_intrinsic(ctx, eid, ie);
         if (O.is_some[R.Result[value.Value, fail.Fail]](opt_intr)) { ret O.unwrap[R.Result[value.Value, fail.Fail]](opt_intr); }
     }
 
-    ret R.err[value.Value, fail.Fail](fail.message("lower: a global initialiser must be a constant expression"));
+    if (eval_failure.kind == comptime.EVAL_FAIL_REJECTED) {
+        fail.reject(?ctx.status);
+        val reported: R.Result[R.Void, str] = diagnostic.error(ctx.diags, ctx.scope.a.file_id, ie.span, eval_failure.message);
+        if (R.is_err[R.Void, str](reported)) { ret fail.lift[value.Value](R.err[value.Value, str](R.unwrap_err[R.Void, str](reported))); }
+    }
+    or (eval_failure.kind == comptime.EVAL_FAIL_UNBOUND || eval_failure.kind == comptime.EVAL_FAIL_NEEDS_MEMBER
+        || eval_failure.kind == comptime.EVAL_FAIL_NEEDS_TYPES || eval_failure.kind == comptime.EVAL_FAIL_NEEDS_LAYOUT) {
+        val reported: R.Result[R.Void, fail.Fail] = diag_named(ctx, ie.span, name,
+            "global initialiser of `", "` must be a constant expression", "a global initialiser must be a constant expression");
+        if (R.is_err[R.Void, fail.Fail](reported)) { ret R.err[value.Value, fail.Fail](R.unwrap_err[R.Void, fail.Fail](reported)); }
+    }
+    or { ret R.err[value.Value, fail.Fail](fail.message("lower: invalid comptime evaluation failure kind")); }
+    ret R.err[value.Value, fail.Fail](fail.reported());
 }
 
 fun is_null_init(ctx: *context.LowerContext, eid: id.ExprId) bool {
@@ -1074,28 +1077,27 @@ fun global_align_of(ctx: *context.LowerContext, d: *decl.Decl) R.Result[u32, fai
     val u64t: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](res_u64);
 
     val res_fold: R.Result[value.Value, fail.Fail] = fold_global_init(ctx, arg, u64t, intern.STR_NIL);
-    if (R.is_err[value.Value, fail.Fail](res_fold)) {
-        val res_diag: R.Result[R.Void, str] = diagnostic.error(ctx.diags, ctx.scope.a.file_id, d.data.bind.name, "`align` decorator requires a compile-time constant argument");
-        if (R.is_err[R.Void, str](res_diag)) { ret R.err[u32, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_diag))); }
-        ret R.ok[u32, fail.Fail](0);
-    }
+    if (R.is_err[value.Value, fail.Fail](res_fold)) { ret R.err[u32, fail.Fail](R.unwrap_err[value.Value, fail.Fail](res_fold)); }
     val v: value.Value = R.unwrap_ok[value.Value, fail.Fail](res_fold);
     if (v.kind != value.VAL_CONST_INT) {
+        fail.reject(?ctx.status);
         val res_diag: R.Result[R.Void, str] = diagnostic.error(ctx.diags, ctx.scope.a.file_id, d.data.bind.name, "`align` decorator requires an integer argument");
         if (R.is_err[R.Void, str](res_diag)) { ret R.err[u32, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_diag))); }
-        ret R.ok[u32, fail.Fail](0);
+        ret R.err[u32, fail.Fail](fail.reported());
     }
 
     val n: u64 = v.data.int_lit;
     if (n == 0 || (n & (n - 1)) != 0) {
+        fail.reject(?ctx.status);
         val res_diag: R.Result[R.Void, str] = diagnostic.error(ctx.diags, ctx.scope.a.file_id, d.data.bind.name, "`align` value must be a non-zero power of two");
         if (R.is_err[R.Void, str](res_diag)) { ret R.err[u32, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_diag))); }
-        ret R.ok[u32, fail.Fail](0);
+        ret R.err[u32, fail.Fail](fail.reported());
     }
     if (n > 0xFFFFFFFF) {
+        fail.reject(?ctx.status);
         val res_diag: R.Result[R.Void, str] = diagnostic.error(ctx.diags, ctx.scope.a.file_id, d.data.bind.name, "`align` value exceeds the maximum alignment");
         if (R.is_err[R.Void, str](res_diag)) { ret R.err[u32, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_diag))); }
-        ret R.ok[u32, fail.Fail](0);
+        ret R.err[u32, fail.Fail](fail.reported());
     }
     ret R.ok[u32, fail.Fail](n::u32);
 }
@@ -1150,15 +1152,9 @@ fun param_symbol(ctx: *context.LowerContext, fun_did: id.DeclId, index: u32) res
     ret resolve.param_symbol(ctx.scope.rr, fun_did, index);
 }
 
-fun try_comptime(ctx: *context.LowerContext, eid: id.ExprId) O.Option[comptime.CTValue] {
-    val res_eval: R.Result[comptime.CTValue, comptime.EvalFail] =
-        comptime.evaluate_at_float_width[context.LowerContext](ctx.scope.ctx, ctx, ctx.caps, ctx.scope.a, context.module_source(ctx), eid, ?ctx.s.interner,
-                                     context.expr_float_width(ctx, eid));
-    context.record_eval_result(ctx, res_eval);
-    if (R.is_ok[comptime.CTValue, comptime.EvalFail](res_eval)) {
-        ret O.some[comptime.CTValue](R.unwrap_ok[comptime.CTValue, comptime.EvalFail](res_eval));
-    }
-    ret O.none[comptime.CTValue]();
+fun try_comptime(ctx: *context.LowerContext, eid: id.ExprId) R.Result[comptime.CTValue, comptime.EvalFail] {
+    ret comptime.evaluate_at_float_width[context.LowerContext](ctx.scope.ctx, ctx, ctx.caps, ctx.scope.a,
+        context.module_source(ctx), eid, ?ctx.s.interner, context.expr_float_width(ctx, eid));
 }
 
 fun fun_export_of(ctx: *context.LowerContext, did: id.DeclId) O.Option[intern.StrId] {

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -999,7 +999,7 @@ pub fun try_lower_comptime_intrinsic(ctx: *context.LowerContext, eid: id.ExprId,
             if (d.signed) { max = (1::u64 << (d.bits - 1)::usize) - 1; }
             or            { max = ~(0::u64) >> (64 - d.bits)::usize; }
             if (n::u64 > max) {
-                ret O.some[R.Result[value.Value, fail.Fail]](R.err[value.Value, fail.Fail](fail.message("a layout measurement does not fit the type it is assigned to; widen the binding or cast the measurement")));
+                ret O.some[R.Result[value.Value, fail.Fail]](R.err[value.Value, fail.Fail](context.report_gate(ctx, e.span, "a layout measurement does not fit the type it is assigned to; widen the binding or cast the measurement")));
             }
         }
     }
@@ -1019,108 +1019,15 @@ pub fun try_lower_comptime_cast(ctx: *context.LowerContext, eid: id.ExprId, e: *
 }
 
 fun fold_const_scalar(ctx: *context.LowerContext, eid: id.ExprId) O.Option[R.Result[comptime.CTValue, comptime.EvalFail]] {
-    val opt_e: R.Result[expr.Expr, str] = context.expression(ctx, eid);
-    if (R.is_err[expr.Expr, str](opt_e)) { ret O.none[R.Result[comptime.CTValue, comptime.EvalFail]](); }
-    var e_value: expr.Expr = R.unwrap_ok[expr.Expr, str](opt_e);
-    val e: *expr.Expr = ?e_value;
-
-    if (e.kind != expr.EXPR_KIND_CAST) {
-        val res_eval: R.Result[comptime.CTValue, comptime.EvalFail] =
-            comptime.evaluate_at_float_width[context.LowerContext](ctx.scope.ctx, ctx, ctx.caps, ctx.scope.a, context.module_source(ctx), eid, ?ctx.s.interner,
-                                         context.expr_float_width(ctx, eid));
-        context.record_eval_result(ctx, res_eval);
-        if (R.is_err[comptime.CTValue, comptime.EvalFail](res_eval)) { ret O.none[R.Result[comptime.CTValue, comptime.EvalFail]](); }
-        ret O.some[R.Result[comptime.CTValue, comptime.EvalFail]](R.ok[comptime.CTValue, comptime.EvalFail](R.unwrap_ok[comptime.CTValue, comptime.EvalFail](res_eval)));
+    val evaluated: R.Result[comptime.CTValue, comptime.EvalFail] =
+        comptime.evaluate_at_float_width[context.LowerContext](ctx.scope.ctx, ctx, ctx.caps, ctx.scope.a, context.module_source(ctx), eid, ?ctx.s.interner,
+            context.expr_float_width(ctx, eid));
+    context.record_eval_result(ctx, evaluated);
+    if (R.is_err[comptime.CTValue, comptime.EvalFail](evaluated)
+        && R.unwrap_err[comptime.CTValue, comptime.EvalFail](evaluated).kind != comptime.EVAL_FAIL_INTERNAL) {
+        ret O.none[R.Result[comptime.CTValue, comptime.EvalFail]]();
     }
-
-    val opt_op: O.Option[R.Result[comptime.CTValue, comptime.EvalFail]] = fold_const_scalar(ctx, e.data.cast.value);
-    if (O.is_none[R.Result[comptime.CTValue, comptime.EvalFail]](opt_op)) { ret O.none[R.Result[comptime.CTValue, comptime.EvalFail]](); }
-    val res_op: R.Result[comptime.CTValue, comptime.EvalFail] = O.unwrap[R.Result[comptime.CTValue, comptime.EvalFail]](opt_op);
-    if (R.is_err[comptime.CTValue, comptime.EvalFail](res_op)) { ret O.some[R.Result[comptime.CTValue, comptime.EvalFail]](res_op); }
-    val opv: comptime.CTValue = R.unwrap_ok[comptime.CTValue, comptime.EvalFail](res_op);
-
-    val from_ty: type.TypeId = context.expr_type_of(ctx, e.data.cast.value);
-    val to_ty:   type.TypeId = context.type_resolved_of(ctx, e.data.cast.ty);
-    ret O.some[R.Result[comptime.CTValue, comptime.EvalFail]](convert_const_scalar(ctx, opv, from_ty, to_ty, e.data.cast.reinterpret));
-}
-
-fun convert_const_scalar(
-    ctx:         *context.LowerContext,
-    v:           comptime.CTValue,
-    from_ty:     type.TypeId,
-    to_ty:       type.TypeId,
-    reinterpret: bool
-) R.Result[comptime.CTValue, comptime.EvalFail] {
-    val from_float: bool = is_float_type(ctx, from_ty);
-    val to_float:   bool = is_float_type(ctx, to_ty);
-    val to_signed:  bool = is_signed_type(ctx, to_ty);
-    val to_bits:    u32  = scalar_bits(ctx, to_ty);
-
-    if (reinterpret) { ret reinterpret_const_scalar(ctx, v, from_ty, from_float, to_bits, to_signed, to_float); }
-
-    val to_fw: float.FloatWidth = context.float_width_of_type(ctx, to_ty);
-
-    if (from_float && to_float) { ret float_ct(v.data.f, to_fw); }
-    if (from_float && !to_float) {
-        if (to_signed) { ret int_ct(rerepresent_int(v.data.f::i64, to_bits, to_signed), !to_signed); }
-        ret int_ct(rerepresent_int((v.data.f::u64):~i64, to_bits, to_signed), !to_signed);
-    }
-    if (!from_float && to_float) {
-        if (is_signed_type(ctx, from_ty)) { ret float_ct(v.data.i::f64, to_fw); }
-        ret float_ct((v.data.i:~u64)::f64, to_fw);
-    }
-
-    ret int_ct(rerepresent_int(v.data.i, to_bits, to_signed), !to_signed);
-}
-
-fun reinterpret_const_scalar(
-    ctx:        *context.LowerContext,
-    v:          comptime.CTValue,
-    from_ty:    type.TypeId,
-    from_float: bool,
-    to_bits:    u32,
-    to_signed:  bool,
-    to_float:   bool
-) R.Result[comptime.CTValue, comptime.EvalFail] {
-    if (from_float == to_float) { ret R.ok[comptime.CTValue, comptime.EvalFail](v); }
-
-    val from_bits: u32 = scalar_bits(ctx, from_ty);
-
-    if (from_float && !to_float) {
-        if (from_bits <= 32) {
-            val bits32: u32 = (v.data.f::f32):~u32;
-            ret int_ct(rerepresent_int(bits32::i64, to_bits, to_signed), !to_signed);
-        }
-        ret int_ct(rerepresent_int(v.data.f:~i64, to_bits, to_signed), !to_signed);
-    }
-
-    if (to_bits <= 32) {
-        val bits32: u32 = (v.data.i:~u64)::u32;
-        val f32v:   f32 = bits32:~f32;
-        ret float_ct(f32v::f64, float.FLOAT_W_32);
-    }
-    ret float_ct(v.data.i:~f64, float.FLOAT_W_64);
-}
-
-fun rerepresent_int(x: i64, to_bits: u32, to_signed: bool) i64 {
-    if (to_bits == 0 || to_bits >= 64) { ret x; }
-    val shift:  u64 = (64 - to_bits)::u64;
-    val masked: u64 = (x::u64 << shift) >> shift;
-    if (!to_signed) { ret masked::i64; }
-    ret (masked::i64 << shift) >> shift;
-}
-
-fun int_ct(i: i64, unsigned: bool) R.Result[comptime.CTValue, comptime.EvalFail] {
-    var v: comptime.CTValue;
-    v.kind         = comptime.CT_KIND_INT;
-    v.int_unsigned = unsigned;
-    v.int_width    = 0;
-    v.data.i       = i;
-    ret R.ok[comptime.CTValue, comptime.EvalFail](v);
-}
-
-fun float_ct(f: f64, w: float.FloatWidth) R.Result[comptime.CTValue, comptime.EvalFail] {
-    ret R.ok[comptime.CTValue, comptime.EvalFail](comptime.ct_float(f, w));
+    ret O.some[R.Result[comptime.CTValue, comptime.EvalFail]](evaluated);
 }
 
 fun lower_call(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Result[value.Value, fail.Fail] {
@@ -1663,7 +1570,10 @@ fun lower_vector_binary(ctx: *context.LowerContext, op: expr.BinOp, lhs: value.V
     if (op == expr.BIN_ADD)     { ret fail.lift[value.Value](builder.emit_add(?ctx.builder, lhs, rhs)); }
     if (op == expr.BIN_SUB)     { ret fail.lift[value.Value](builder.emit_sub(?ctx.builder, lhs, rhs)); }
     if (op == expr.BIN_MUL)     { ret fail.lift[value.Value](builder.emit_mul(?ctx.builder, lhs, rhs)); }
-    if (op == expr.BIN_DIV)     { ret fail.lift[value.Value](builder.emit_div_u(?ctx.builder, lhs, rhs)); }
+    if (op == expr.BIN_DIV) {
+        if (vector_lane_signed(ctx, lty)) { ret fail.lift[value.Value](builder.emit_div_s(?ctx.builder, lhs, rhs)); }
+        ret fail.lift[value.Value](builder.emit_div_u(?ctx.builder, lhs, rhs));
+    }
     if (op == expr.BIN_BIT_AND) { ret fail.lift[value.Value](builder.emit_and(?ctx.builder, lhs, rhs)); }
     if (op == expr.BIN_BIT_OR)  { ret fail.lift[value.Value](builder.emit_or(?ctx.builder, lhs, rhs)); }
     if (op == expr.BIN_BIT_XOR) { ret fail.lift[value.Value](builder.emit_xor(?ctx.builder, lhs, rhs)); }
@@ -2451,7 +2361,9 @@ fun lower_cast(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Resu
     if (R.is_err[ir_type.IrTypeId, fail.Fail](res_dst)) { ret R.err[value.Value, fail.Fail](R.unwrap_err[ir_type.IrTypeId, fail.Fail](res_dst)); }
     val dst: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, fail.Fail](res_dst);
 
-    if (e.data.cast.reinterpret) { ret lower_reinterpret(ctx, v, from_ty, dst); }
+    if (e.data.cast.reinterpret || !type.is_numeric(?ctx.s.types, from_ty) || !type.is_numeric(?ctx.s.types, to_ty)) {
+        ret lower_reinterpret(ctx, v, from_ty, dst);
+    }
 
     val from_float:  bool = is_float_type(ctx, from_ty);
     val to_float:    bool = is_float_type(ctx, to_ty);
@@ -3085,26 +2997,6 @@ test "mach.lang.me.lower.expr.struct_lit:union_literal_static_and_runtime_agree"
     ret bad;
 }
 
-test "mach.lang.me.lower.expr.int_ct:records_destination_signedness" {
-    var bad: i32 = 0;
-
-    val u: comptime.CTValue = R.unwrap_ok[comptime.CTValue, comptime.EvalFail](int_ct(-1, true));
-    if (!u.int_unsigned)                        { bad = bad + 1; }
-    if (u.kind != comptime.CT_KIND_INT)         { bad = bad + 2; }
-
-    val s: comptime.CTValue = R.unwrap_ok[comptime.CTValue, comptime.EvalFail](int_ct(-1, false));
-    if (s.int_unsigned)                         { bad = bad + 4; }
-
-    if (u.data.i != s.data.i)                   { bad = bad + 8; }
-
-    if (rerepresent_int(300, 8, false) != 44)   { bad = bad + 16; }
-    if (rerepresent_int(300, 8, true) != 44)    { bad = bad + 32; }
-    if (rerepresent_int(-1, 8, false) != 255)   { bad = bad + 64; }
-    if (rerepresent_int(-1, 8, true) != -1)     { bad = bad + 128; }
-
-    ret bad;
-}
-
 val convert_const_probe_u64:        u64 = 18446744073709551615;
 val convert_const_probe_u64_as_f64: f64 = convert_const_probe_u64::f64;
 
@@ -3129,6 +3021,16 @@ test "mach.lang.me.lower.expr.convert_const_scalar:unsigned_conversions_agree_wi
     if (convert_const_probe_f64_as_u64 != 9223372036854775808)                                                   { bad = bad + 8; }
 
     ret bad;
+}
+
+fun t_pointer_float(value: ptr) f64 { ret value::f64; }
+fun t_float_pointer(value: f64) ptr { ret value::ptr; }
+
+test "mach.lang.me.lower.expr.convert_const_scalar:nonnumeric_casts_preserve_bits" {
+    val bits: u64 = 0x3FF0000000000000;
+    if (t_pointer_float(bits::ptr) != 1.0) { ret 1; }
+    if (t_float_pointer(1.0)::u64 != bits) { ret 2; }
+    ret 0;
 }
 
 val reinterpret_probe_f64:      f64 = 5.0;

--- a/src/lang/me/pass/scalarize.mach
+++ b/src/lang/me/pass/scalarize.mach
@@ -131,7 +131,7 @@ pub fun detect(m: *ir.Module, tgt: *target.Target, first: *ScalarizeSite) u32 {
     var fi: u32 = 0;
     for (fi < m.function_len) {
         val fn: *ir.Function = ?m.functions[fi];
-        if ((fn.flags & ir.FN_FLAG_EXTERN) == 0 && !effect.function_has_volatile(fn)) {
+        if ((fn.flags & ir.FN_FLAG_EXTERN) == 0) {
             var bi: u32 = 0;
             for (bi < fn.block_count) {
                 val blk: *ir.Block = ?fn.blocks[bi];
@@ -221,18 +221,21 @@ fun lane_ptr(c: *Ctx, blk: *ir.Block, base: value.Value, arr_ty: ir_type.IrTypeI
     ret push(c, blk, instruction.OP_GEP, c.ptr_ty, arr_ty, ?ops[0], 3, loc);
 }
 
-fun emit_load(c: *Ctx, blk: *ir.Block, ptr: value.Value, elem_ty: ir_type.IrTypeId, loc: source.SrcLoc) R.Result[value.Value, str] {
+fun emit_load(c: *Ctx, blk: *ir.Block, ptr: value.Value, elem_ty: ir_type.IrTypeId, loc: source.SrcLoc, flags: u16) R.Result[value.Value, str] {
     var ops: [1]value.Value;
     ops[0] = ptr;
-    ret push(c, blk, instruction.OP_LOAD, elem_ty, ir_type.IRT_NIL, ?ops[0], 1, loc);
+    val r: R.Result[value.Value, str] = push(c, blk, instruction.OP_LOAD, elem_ty, ir_type.IRT_NIL, ?ops[0], 1, loc);
+    if (R.is_ok[value.Value, str](r)) { c.fn.instrs[R.unwrap_ok[value.Value, str](r).data.instr::u32].flags = flags; }
+    ret r;
 }
 
-fun emit_store(c: *Ctx, blk: *ir.Block, v: value.Value, ptr: value.Value, loc: source.SrcLoc) R.Result[R.Void, str] {
+fun emit_store(c: *Ctx, blk: *ir.Block, v: value.Value, ptr: value.Value, loc: source.SrcLoc, flags: u16) R.Result[R.Void, str] {
     var ops: [2]value.Value;
     ops[0] = v;
     ops[1] = ptr;
     val r: R.Result[value.Value, str] = push(c, blk, instruction.OP_STORE, c.void_ty, ir_type.IRT_NIL, ?ops[0], 2, loc);
     if (R.is_err[value.Value, str](r)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](r)); }
+    c.fn.instrs[R.unwrap_ok[value.Value, str](r).data.instr::u32].flags = flags;
     ret R.ok_void[str]();
 }
 
@@ -288,12 +291,12 @@ fun expand_binary(c: *Ctx, blk: *ir.Block, kind: instruction.InstrKind, dst: val
     for (k < vi.lanes) {
         val pa: R.Result[value.Value, str] = lane_ptr(c, blk, a, arr, k, loc);
         if (R.is_err[value.Value, str](pa)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](pa)); }
-        val va: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pa), vi.elem, loc);
+        val va: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pa), vi.elem, loc, 0);
         if (R.is_err[value.Value, str](va)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](va)); }
 
         val pb: R.Result[value.Value, str] = lane_ptr(c, blk, b, arr, k, loc);
         if (R.is_err[value.Value, str](pb)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](pb)); }
-        val vb: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pb), vi.elem, loc);
+        val vb: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pb), vi.elem, loc, 0);
         if (R.is_err[value.Value, str](vb)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](vb)); }
 
         val va_v: value.Value = lane_secret(c, R.unwrap_ok[value.Value, str](va), a_secret);
@@ -303,7 +306,7 @@ fun expand_binary(c: *Ctx, blk: *ir.Block, kind: instruction.InstrKind, dst: val
 
         val pr: R.Result[value.Value, str] = lane_ptr(c, blk, dst, arr, k, loc);
         if (R.is_err[value.Value, str](pr)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](pr)); }
-        val rs: R.Result[R.Void, str] = emit_store(c, blk, R.unwrap_ok[value.Value, str](vr), R.unwrap_ok[value.Value, str](pr), loc);
+        val rs: R.Result[R.Void, str] = emit_store(c, blk, R.unwrap_ok[value.Value, str](vr), R.unwrap_ok[value.Value, str](pr), loc, 0);
         if (R.is_err[R.Void, str](rs)) { ret rs; }
         k = k + 1;
     }
@@ -319,7 +322,7 @@ fun expand_unary(c: *Ctx, blk: *ir.Block, kind: instruction.InstrKind, dst: valu
     for (k < vi.lanes) {
         val pa: R.Result[value.Value, str] = lane_ptr(c, blk, a, arr, k, loc);
         if (R.is_err[value.Value, str](pa)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](pa)); }
-        val va: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pa), vi.elem, loc);
+        val va: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pa), vi.elem, loc, 0);
         if (R.is_err[value.Value, str](va)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](va)); }
 
         val va_v: value.Value = lane_secret(c, R.unwrap_ok[value.Value, str](va), a_secret);
@@ -328,7 +331,7 @@ fun expand_unary(c: *Ctx, blk: *ir.Block, kind: instruction.InstrKind, dst: valu
 
         val pr: R.Result[value.Value, str] = lane_ptr(c, blk, dst, arr, k, loc);
         if (R.is_err[value.Value, str](pr)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](pr)); }
-        val rs: R.Result[R.Void, str] = emit_store(c, blk, R.unwrap_ok[value.Value, str](vr), R.unwrap_ok[value.Value, str](pr), loc);
+        val rs: R.Result[R.Void, str] = emit_store(c, blk, R.unwrap_ok[value.Value, str](vr), R.unwrap_ok[value.Value, str](pr), loc, 0);
         if (R.is_err[R.Void, str](rs)) { ret rs; }
         k = k + 1;
     }
@@ -356,12 +359,12 @@ fun expand_compare(c: *Ctx, blk: *ir.Block, kind: instruction.InstrKind, dst: va
     for (k < op.lanes) {
         val pa: R.Result[value.Value, str] = lane_ptr(c, blk, a, arr_op, k, loc);
         if (R.is_err[value.Value, str](pa)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](pa)); }
-        val va: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pa), op.elem, loc);
+        val va: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pa), op.elem, loc, 0);
         if (R.is_err[value.Value, str](va)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](va)); }
 
         val pb: R.Result[value.Value, str] = lane_ptr(c, blk, b, arr_op, k, loc);
         if (R.is_err[value.Value, str](pb)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](pb)); }
-        val vb: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pb), op.elem, loc);
+        val vb: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](pb), op.elem, loc, 0);
         if (R.is_err[value.Value, str](vb)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](vb)); }
 
         var la: value.Value = R.unwrap_ok[value.Value, str](va);
@@ -390,14 +393,14 @@ fun expand_compare(c: *Ctx, blk: *ir.Block, kind: instruction.InstrKind, dst: va
 
         val pr: R.Result[value.Value, str] = lane_ptr(c, blk, dst, arr_mask, k, loc);
         if (R.is_err[value.Value, str](pr)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](pr)); }
-        val rs: R.Result[R.Void, str] = emit_store(c, blk, R.unwrap_ok[value.Value, str](neg), R.unwrap_ok[value.Value, str](pr), loc);
+        val rs: R.Result[R.Void, str] = emit_store(c, blk, R.unwrap_ok[value.Value, str](neg), R.unwrap_ok[value.Value, str](pr), loc, 0);
         if (R.is_err[R.Void, str](rs)) { ret rs; }
         k = k + 1;
     }
     ret R.ok_void[str]();
 }
 
-fun copy_vector(c: *Ctx, blk: *ir.Block, dst: value.Value, src: value.Value, vi: VInfo, loc: source.SrcLoc) R.Result[R.Void, str] {
+fun copy_vector(c: *Ctx, blk: *ir.Block, dst: value.Value, src: value.Value, vi: VInfo, loc: source.SrcLoc, read_flags: u16, write_flags: u16) R.Result[R.Void, str] {
     val ra: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?c.m.types, vi.elem, vi.lanes);
     if (R.is_err[ir_type.IrTypeId, str](ra)) { ret R.err[R.Void, str](R.unwrap_err[ir_type.IrTypeId, str](ra)); }
     val arr: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](ra);
@@ -406,12 +409,12 @@ fun copy_vector(c: *Ctx, blk: *ir.Block, dst: value.Value, src: value.Value, vi:
     for (k < vi.lanes) {
         val ps: R.Result[value.Value, str] = lane_ptr(c, blk, src, arr, k, loc);
         if (R.is_err[value.Value, str](ps)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](ps)); }
-        val v: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](ps), vi.elem, loc);
+        val v: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](ps), vi.elem, loc, read_flags);
         if (R.is_err[value.Value, str](v)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](v)); }
 
         val pd: R.Result[value.Value, str] = lane_ptr(c, blk, dst, arr, k, loc);
         if (R.is_err[value.Value, str](pd)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](pd)); }
-        val rs: R.Result[R.Void, str] = emit_store(c, blk, R.unwrap_ok[value.Value, str](v), R.unwrap_ok[value.Value, str](pd), loc);
+        val rs: R.Result[R.Void, str] = emit_store(c, blk, R.unwrap_ok[value.Value, str](v), R.unwrap_ok[value.Value, str](pd), loc, write_flags);
         if (R.is_err[R.Void, str](rs)) { ret rs; }
         k = k + 1;
     }
@@ -464,7 +467,7 @@ fun scalarize_function(c: *Ctx, i8_ty: ir_type.IrTypeId) R.Result[R.Void, str] {
         val inst: *instruction.Instruction = ?fn.instrs[iid];
         if (mem_image(c, inst.ty) && is_disallowed_op(inst.kind)) {
             slots_free(c, slots);
-            ret R.err[R.Void, str]("scalarize: vector operator is not in the increment-1 table (shift / integer div-rem / negate)");
+            ret R.err[R.Void, str]("scalarize: vector operator is not in the increment-1 table (shift / remainder / negate)");
         }
         if (inst.kind == instruction.OP_BITCAST && inst.operand_count >= 1
             && mem_image(c, inst.ty)
@@ -577,7 +580,7 @@ fun expand_lane_read_scalarized(c: *Ctx, blk: *ir.Block, cur: id.InstructionId) 
 
     val rp: R.Result[value.Value, str] = lane_ptr(c, blk, base, R.unwrap_ok[ir_type.IrTypeId, str](ra), k, loc);
     if (R.is_err[value.Value, str](rp)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](rp)); }
-    val rl: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](rp), elem, loc);
+    val rl: R.Result[value.Value, str] = emit_load(c, blk, R.unwrap_ok[value.Value, str](rp), elem, loc, 0);
     if (R.is_err[value.Value, str](rl)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](rl)); }
 
     c.pval[cur::u32]     = lane_secret(c, R.unwrap_ok[value.Value, str](rl), secret);
@@ -601,14 +604,14 @@ fun expand_lane_write_scalarized(c: *Ctx, blk: *ir.Block, cur: id.InstructionId)
     var vi: VInfo;
     val rv: R.Result[R.Void, str] = vec_info(c.m, vty, ?vi);
     if (R.is_err[R.Void, str](rv)) { ret rv; }
-    val rc: R.Result[R.Void, str] = copy_vector(c, blk, dst, src, vi, loc);
+    val rc: R.Result[R.Void, str] = copy_vector(c, blk, dst, src, vi, loc, 0, 0);
     if (R.is_err[R.Void, str](rc)) { ret rc; }
 
     val ra: R.Result[ir_type.IrTypeId, str] = ir_type.intern_array(?c.m.types, vi.elem, vi.lanes);
     if (R.is_err[ir_type.IrTypeId, str](ra)) { ret R.err[R.Void, str](R.unwrap_err[ir_type.IrTypeId, str](ra)); }
     val rp: R.Result[value.Value, str] = lane_ptr(c, blk, dst, R.unwrap_ok[ir_type.IrTypeId, str](ra), k, loc);
     if (R.is_err[value.Value, str](rp)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](rp)); }
-    ret emit_store(c, blk, lane_val, R.unwrap_ok[value.Value, str](rp), loc);
+    ret emit_store(c, blk, lane_val, R.unwrap_ok[value.Value, str](rp), loc, 0);
 }
 
 fun fill_one(c: *Ctx, blk: *ir.Block, cur: id.InstructionId, i8_ty: ir_type.IrTypeId) R.Result[R.Void, str] {
@@ -640,7 +643,7 @@ fun fill_one(c: *Ctx, blk: *ir.Block, cur: id.InstructionId, i8_ty: ir_type.IrTy
         if (R.is_err[R.Void, str](rv)) { ret rv; }
         if (kind == instruction.OP_LOAD) {
             val src: value.Value = resolve(c, ip.operands[0]);
-            ret copy_vector(c, blk, dst, src, vi, loc);
+            ret copy_vector(c, blk, dst, src, vi, loc, ip.flags & instruction.INSTR_FLAG_VOLATILE, 0);
         }
         if (is_unary_op(kind) || kind == instruction.OP_DECLASSIFY) {
             val a: value.Value = resolve(c, ip.operands[0]);
@@ -665,7 +668,7 @@ fun fill_one(c: *Ctx, blk: *ir.Block, cur: id.InstructionId, i8_ty: ir_type.IrTy
         var vi: VInfo;
         val rv: R.Result[R.Void, str] = vec_info(c.m, vty, ?vi);
         if (R.is_err[R.Void, str](rv)) { ret rv; }
-        ret copy_vector(c, blk, dstp, srcv, vi, loc);
+        ret copy_vector(c, blk, dstp, srcv, vi, loc, 0, ip.flags & instruction.INSTR_FLAG_VOLATILE);
     }
 
     rewrite_ops(c, ?fn.instrs[cur::u32]);
@@ -774,7 +777,7 @@ fun expand_lane_read(lc: *LaneCtx, blk: *ir.Block, cur: id.InstructionId) R.Resu
         R.unwrap_ok[ir_type.IrTypeId, str](ra), k, loc);
     if (R.is_err[value.Value, str](rp)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](rp)); }
 
-    val rl: R.Result[value.Value, str] = emit_load(?lc.c, blk, R.unwrap_ok[value.Value, str](rp), elem, loc);
+    val rl: R.Result[value.Value, str] = emit_load(?lc.c, blk, R.unwrap_ok[value.Value, str](rp), elem, loc, 0);
     if (R.is_err[value.Value, str](rl)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](rl)); }
 
     lc.c.pval[cur::u32]     = lane_secret(?lc.c, R.unwrap_ok[value.Value, str](rl), src.secret);
@@ -803,16 +806,16 @@ fun expand_lane_write(lc: *LaneCtx, blk: *ir.Block, cur: id.InstructionId) R.Res
 
     val slot: value.Value = lc.slot[cur::u32];
 
-    val rs: R.Result[R.Void, str] = emit_store(?lc.c, blk, src, slot, loc);
+    val rs: R.Result[R.Void, str] = emit_store(?lc.c, blk, src, slot, loc, 0);
     if (R.is_err[R.Void, str](rs)) { ret rs; }
 
     val rp: R.Result[value.Value, str] = lane_ptr(?lc.c, blk, slot, arr, k, loc);
     if (R.is_err[value.Value, str](rp)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](rp)); }
 
-    val rs2: R.Result[R.Void, str] = emit_store(?lc.c, blk, lane_val, R.unwrap_ok[value.Value, str](rp), loc);
+    val rs2: R.Result[R.Void, str] = emit_store(?lc.c, blk, lane_val, R.unwrap_ok[value.Value, str](rp), loc, 0);
     if (R.is_err[R.Void, str](rs2)) { ret rs2; }
 
-    val rl: R.Result[value.Value, str] = emit_load(?lc.c, blk, slot, vty, loc);
+    val rl: R.Result[value.Value, str] = emit_load(?lc.c, blk, slot, vty, loc, 0);
     if (R.is_err[value.Value, str](rl)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](rl)); }
 
     lc.c.pval[cur::u32]     = R.unwrap_ok[value.Value, str](rl);
@@ -865,7 +868,7 @@ fun expand_lane_block(lc: *LaneCtx, blk: *ir.Block, is_entry: bool) R.Result[R.V
         for (p < lc.pn) {
             if (lc.pslot_set[p]) {
                 val rsp: R.Result[R.Void, str] = emit_store(?lc.c, blk,
-                    value.param(p, fn.params[p].ty), lc.pslot[p], source.loc(source.FILE_NIL, 0));
+                    value.param(p, fn.params[p].ty), lc.pslot[p], source.loc(source.FILE_NIL, 0), 0);
                 if (R.is_err[R.Void, str](rsp)) { body_free(?lc.c, old, old_len); ret rsp; }
             }
             p = p + 1;
@@ -879,7 +882,7 @@ fun expand_lane_block(lc: *LaneCtx, blk: *ir.Block, is_entry: bool) R.Result[R.V
             val rap: R.Result[R.Void, str] = ir.block_append_instr(lc.c.m, blk, lc.slot_alloca[pid]);
             if (R.is_err[R.Void, str](rap)) { body_free(?lc.c, old, old_len); ret rap; }
             val rsp: R.Result[R.Void, str] = emit_store(?lc.c, blk,
-                value.instr(pid::id.InstructionId, fn.instrs[pid].ty), lc.slot[pid], fn.instrs[pid].loc);
+                value.instr(pid::id.InstructionId, fn.instrs[pid].ty), lc.slot[pid], fn.instrs[pid].loc, 0);
             if (R.is_err[R.Void, str](rsp)) { body_free(?lc.c, old, old_len); ret rsp; }
         }
         ph = ph + 1;
@@ -903,7 +906,7 @@ fun expand_lane_block(lc: *LaneCtx, blk: *ir.Block, is_entry: bool) R.Result[R.V
                 rr = ir.block_append_instr(lc.c.m, blk, lc.slot_alloca[cur::u32]);
                 if (!R.is_err[R.Void, str](rr)) {
                     rr = emit_store(?lc.c, blk,
-                        value.instr(cur, fn.instrs[cur::u32].ty), lc.slot[cur::u32], fn.instrs[cur::u32].loc);
+                        value.instr(cur, fn.instrs[cur::u32].ty), lc.slot[cur::u32], fn.instrs[cur::u32].loc, 0);
                 }
             }
         }
@@ -1024,8 +1027,7 @@ pub fun expand_lane_ops(m: *ir.Module, tgt: *target.Target) R.Result[bool, str] 
     var fi: u32 = 0;
     for (fi < m.function_len) {
         val fn: *ir.Function = ?m.functions[fi];
-        if ((fn.flags & ir.FN_FLAG_EXTERN) == 0 && fn.instr_len > 0
-            && !effect.function_has_volatile(fn)) {
+        if ((fn.flags & ir.FN_FLAG_EXTERN) == 0 && fn.instr_len > 0) {
             var work: FunctionWork = FunctionWork{module: m, body: fn, target: tgt,
                 void_ty: void_ty, ptr_ty: ptr_ty, idx_ty: idx_ty, i8_ty: ir_type.IRT_NIL};
             val changed_r: R.Result[bool, str] = scratch.run[FunctionWork, bool](?workspace, m.alloc, ?work, lane_work);
@@ -1346,8 +1348,7 @@ pub fun expand_gap_ops(m: *ir.Module, tgt: *target.Target) R.Result[bool, str] {
     var fi: u32 = 0;
     for (fi < m.function_len) {
         val fn: *ir.Function = ?m.functions[fi];
-        if ((fn.flags & ir.FN_FLAG_EXTERN) == 0 && fn.instr_len > 0
-            && !effect.function_has_volatile(fn)) {
+        if ((fn.flags & ir.FN_FLAG_EXTERN) == 0 && fn.instr_len > 0) {
             var work: FunctionWork = FunctionWork{module: m, body: fn, target: tgt,
                 void_ty: void_ty, ptr_ty: ptr_ty, idx_ty: idx_ty, i8_ty: ir_type.IRT_NIL};
             val changed_r: R.Result[bool, str] = scratch.run[FunctionWork, bool](?workspace, m.alloc, ?work, gap_work);
@@ -1384,8 +1385,7 @@ fun has_mem_image_value(m: *ir.Module, tgt: *target.Target) bool {
     var fi: u32 = 0;
     for (fi < m.function_len) {
         val fn: *ir.Function = ?m.functions[fi];
-        if ((fn.flags & ir.FN_FLAG_EXTERN) == 0 && fn.instr_len > 0
-            && !effect.function_has_volatile(fn)) {
+        if ((fn.flags & ir.FN_FLAG_EXTERN) == 0 && fn.instr_len > 0) {
             if (function_has_mem_image(m, fn, tgt)) { ret true; }
         }
         fi = fi + 1;
@@ -1424,7 +1424,7 @@ pub fun run(m: *ir.Module, tgt: *target.Target) R.Result[bool, str] {
     for (fi < m.function_len) {
         val fn: *ir.Function = ?m.functions[fi];
         if ((fn.flags & ir.FN_FLAG_EXTERN) == 0 && fn.instr_len > 0
-            && !effect.function_has_volatile(fn) && function_has_mem_image(m, fn, tgt)) {
+            && function_has_mem_image(m, fn, tgt)) {
             var work: FunctionWork = FunctionWork{module: m, body: fn, target: tgt,
                 void_ty: void_ty, ptr_ty: ptr_ty, idx_ty: idx_ty, i8_ty: i8_ty};
             val expanded: R.Result[R.Void, str] = scratch.run[FunctionWork, R.Void](?workspace, m.alloc, ?work, scalarize_work);
@@ -1581,6 +1581,12 @@ fun vec_binop_module(alloc: *A.Allocator, kind: instruction.InstrKind, elem_bits
         if (R.is_err[value.Value, str](builder.emit_mul(?bld, pv0, pv1))) { ret false; }
         ret true;
     }
+    if (kind == instruction.OP_DIV_S) {
+        ret R.is_ok[value.Value, str](builder.emit_div_s(?bld, pv0, pv1));
+    }
+    if (kind == instruction.OP_DIV_U) {
+        ret R.is_ok[value.Value, str](builder.emit_div_u(?bld, pv0, pv1));
+    }
     if (R.is_err[value.Value, str](builder.emit_add(?bld, pv0, pv1))) { ret false; }
     ret true;
 }
@@ -1617,6 +1623,16 @@ test "mach.lang.me.pass.scalarize:require_and_expansion_read_one_authority" {
     if (gap_agreement(?alloc, ?reg, "x86_64", instruction.OP_ADD, 32, 4) != 0)  { ret 10; }
     if (gap_agreement(?alloc, ?reg, "aarch64", instruction.OP_ADD, 32, 4) != 0) { ret 11; }
 
+    var bits: u32 = 8;
+    for (bits <= 64) {
+        if (gap_agreement(?alloc, ?reg, "x86_64", instruction.OP_DIV_S, bits, 128 / bits) != 1) { ret 12; }
+        if (gap_agreement(?alloc, ?reg, "x86_64", instruction.OP_DIV_U, bits, 128 / bits) != 1) { ret 13; }
+        if (gap_agreement(?alloc, ?reg, "aarch64", instruction.OP_DIV_S, bits, 128 / bits) != 1) { ret 14; }
+        if (gap_agreement(?alloc, ?reg, "aarch64", instruction.OP_DIV_U, bits, 128 / bits) != 1) { ret 15; }
+        if (gap_agreement(?alloc, ?reg, "riscv64", instruction.OP_DIV_S, bits, 128 / bits) != 1) { ret 16; }
+        if (gap_agreement(?alloc, ?reg, "riscv64", instruction.OP_DIV_U, bits, 128 / bits) != 1) { ret 17; }
+        bits = bits * 2;
+    }
     ret 0;
 }
 
@@ -1872,4 +1888,129 @@ test "mach.lang.me.pass.scalarize:failed_instruction_releases_untransferred_oper
     if (tracking.live != live || tracking.double_frees != 0) { ret 3; }
     if (tracking.attempts != tracking.fail_at || fn.instr_len != 0) { ret 4; }
     ret 0;
+}
+
+fun test_external_parameter(fn: *ir.Function, v: value.Value) u32 {
+    var current: value.Value = v;
+    var left: u32 = fn.instr_len;
+    for (left > 0 && current.kind == value.VAL_INSTR) {
+        val ix: u32 = current.data.instr::u32;
+        if (ix >= fn.instr_len || fn.instrs[ix].kind != instruction.OP_GEP) { ret 0; }
+        current = fn.instrs[ix].operands[0];
+        left = left - 1;
+    }
+    if (current.kind == value.VAL_PARAM) { ret current.data.param_ix + 1; }
+    ret 0;
+}
+
+fun test_volatile_division(alloc: *A.Allocator, reg: *target.TargetRegistry, arch: str) i32 {
+    var tgt: target.Target;
+    if (!test_target(reg, arch, ?tgt)) { ret 1; }
+    val mr: R.Result[ir.Module, str] = ir.init(alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](mr)) { ret 2; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](mr);
+    fin { ir.dnit(?m); }
+    val pr: R.Result[ir_type.IrTypeId, str] = ir_type.intern_ptr(?m.types);
+    val er: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(?m.types, 32);
+    val vr: R.Result[ir_type.IrTypeId, str] = ir_type.intern_void(?m.types);
+    if (R.is_err[ir_type.IrTypeId, str](pr) || R.is_err[ir_type.IrTypeId, str](er)
+        || R.is_err[ir_type.IrTypeId, str](vr)) { ret 3; }
+    val pt: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](pr);
+    val elem: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](er);
+    val vty: R.Result[ir_type.IrTypeId, str] = ir_type.intern_vector(?m.types, elem, 4);
+    if (R.is_err[ir_type.IrTypeId, str](vty)) { ret 4; }
+    val vec: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](vty);
+    val fr: R.Result[u32, str] = ir.function_add(?m, intern.STR_NIL, ir_type.IRT_NIL, 0);
+    if (R.is_err[u32, str](fr)) { ret 5; }
+    val fn: *ir.Function = ?m.functions[R.unwrap_ok[u32, str](fr)];
+    val args: R.Result[*value.Value, str] = A.allocate[value.Value](alloc, 4);
+    if (R.is_err[*value.Value, str](args)) { ret 6; }
+    fn.params = R.unwrap_ok[*value.Value, str](args);
+    fn.param_count = 4;
+    var i: u32 = 0;
+    for (i < 4) { fn.params[i] = value.param(i, pt); i = i + 1; }
+    var b: builder.Builder = builder.init(?m);
+    builder.set_function(?b, fn);
+    val br: R.Result[id.BlockId, str] = builder.new_block(?b);
+    if (R.is_err[id.BlockId, str](br)) { ret 7; }
+    val bid: id.BlockId = R.unwrap_ok[id.BlockId, str](br);
+    builder.set_block(?b, bid);
+    val blk: *ir.Block = ?fn.blocks[bid::u32];
+    var c: Ctx = Ctx{alloc: alloc, m: ?m, fn: fn, ptr_ty: pt,
+        void_ty: R.unwrap_ok[ir_type.IrTypeId, str](vr)};
+    val loc: source.SrcLoc = source.loc(source.FILE_NIL, 0);
+    val scalar: R.Result[value.Value, str] = emit_load(?c, blk, value.param(3, pt), elem, loc, instruction.INSTR_FLAG_VOLATILE);
+    val lhs: R.Result[value.Value, str] = emit_load(?c, blk, value.param(0, pt), vec, loc, instruction.INSTR_FLAG_VOLATILE);
+    val rhs: R.Result[value.Value, str] = emit_load(?c, blk, value.param(1, pt), vec, loc, instruction.INSTR_FLAG_VOLATILE);
+    if (R.is_err[value.Value, str](scalar) || R.is_err[value.Value, str](lhs) || R.is_err[value.Value, str](rhs)) { ret 8; }
+    val q: R.Result[value.Value, str] = emit_binop(?c, blk, instruction.OP_DIV_S, vec,
+        R.unwrap_ok[value.Value, str](lhs), R.unwrap_ok[value.Value, str](rhs), loc);
+    if (R.is_err[value.Value, str](q)) { ret 9; }
+    if (R.is_err[R.Void, str](emit_store(?c, blk, R.unwrap_ok[value.Value, str](q), value.param(2, pt), loc, instruction.INSTR_FLAG_VOLATILE))) { ret 10; }
+    if (R.is_err[R.Void, str](emit_store(?c, blk, R.unwrap_ok[value.Value, str](scalar), value.param(3, pt), loc, instruction.INSTR_FLAG_VOLATILE))) { ret 11; }
+    if (R.is_err[R.Void, str](builder.emit_ret_void(?b))) { ret 12; }
+    var site: ScalarizeSite;
+    if (detect(?m, ?tgt, ?site) != 1 || site.op != instruction.OP_DIV_S) { ret 13; }
+    if (R.is_err[bool, str](run(?m, ?tgt)) || R.is_err[bool, str](expand_gap_ops(?m, ?tgt))
+        || R.is_err[bool, str](expand_lane_ops(?m, ?tgt))) { ret 14; }
+    val body: *ir.Function = ?m.functions[0];
+    val block: *ir.Block = ?body.blocks[bid::u32];
+    var counts: [4]u32 = [4]u32{0, 0, 0, 0};
+    var divisions: u32 = 0;
+    var phase: u32 = 0;
+    var accesses: u32 = 1;
+    if (!tgt.model.has_v128) { accesses = 4; }
+    i = 0;
+    for (i < block.instr_count) {
+        val inst: *instruction.Instruction = ?body.instrs[block.instructions[i]::u32];
+        if (inst.kind == instruction.OP_DIV_S || inst.kind == instruction.OP_DIV_U) {
+            if (inst.kind != instruction.OP_DIV_S || inst.ty != elem || inst.operands[0].ty != elem
+                || inst.operands[1].ty != elem || counts[0] != accesses || counts[1] != accesses || counts[2] != 0) { ret 15; }
+            divisions = divisions + 1;
+        }
+        if (inst.kind == instruction.OP_LOAD || inst.kind == instruction.OP_STORE) {
+            var pointer: value.Value = inst.operands[0];
+            var memory_type: ir_type.IrTypeId = inst.ty;
+            if (inst.kind == instruction.OP_STORE) { pointer = inst.operands[1]; memory_type = inst.operands[0].ty; }
+            val owner: u32 = test_external_parameter(body, pointer);
+            if (owner == 0) {
+                if (effect.is_volatile(inst)) { ret 16; }
+            }
+            or {
+                if (owner > 4 || !effect.is_volatile(inst)) { ret 17; }
+                counts[owner - 1] = counts[owner - 1] + 1;
+                if (owner == 4) {
+                    if (memory_type != elem) { ret 18; }
+                    if (counts[3] == 1 && (phase != 0 || inst.kind != instruction.OP_LOAD)) { ret 19; }
+                    if (counts[3] == 2 && (phase != 3 || inst.kind != instruction.OP_STORE)) { ret 20; }
+                }
+                or {
+                    if (counts[3] != 1 || owner < phase) { ret 21; }
+                    phase = owner;
+                    val want_store: bool = owner == 3;
+                    if ((inst.kind == instruction.OP_STORE) != want_store) { ret 22; }
+                    if (want_store && divisions != 4) { ret 23; }
+                    if (accesses == 1 && memory_type != vec) { ret 24; }
+                    if (accesses == 4 && memory_type != elem) { ret 25; }
+                }
+            }
+        }
+        i = i + 1;
+    }
+    if (divisions != 4 || counts[0] != accesses || counts[1] != accesses
+        || counts[2] != accesses || counts[3] != 2) { ret 26; }
+    ret 0;
+}
+
+test "mach.lang.me.pass.scalarize:division_preserves_external_volatile_accesses" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var reg: target.TargetRegistry = target.registry_init();
+    fin { target.registry_dnit(?reg); }
+    if (R.is_err[R.Void, str](target.register_all(?reg, target_testing.debug_descriptor))) { ret 2; }
+    val x64: i32 = test_volatile_division(?alloc, ?reg, "x86_64");
+    if (x64 != 0) { ret x64; }
+    val arm: i32 = test_volatile_division(?alloc, ?reg, "aarch64");
+    if (arm != 0) { ret arm; }
+    ret test_volatile_division(?alloc, ?reg, "riscv64");
 }

--- a/src/lang/target/isa/arm64/register.mach
+++ b/src/lang/target/isa/arm64/register.mach
@@ -79,7 +79,7 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[R.Void, str] {
     var arm64_classes: [3]isa.RegClass;
     var arm64_model: isa.MachineModel;
     var arm64_reserved_regs: [3]isa.Register;
-    var arm64_packed_gaps: [1]isa.PackedGap;
+    var arm64_packed_gaps: [5]isa.PackedGap;
     var arm64_reload_scratch_regs: [3]isa.Register;
 
     arm64_classes[0].name      = "gpr";
@@ -148,8 +148,12 @@ pub fun register_arm64(reg: *isa.IsaRegistry) R.Result[R.Void, str] {
     arm64_model.vec_mem_widths  = isa.VEC_MEM_ALL_128;
     arm64_model.xbank_widths    = isa.XBANK_4_8;
     arm64_packed_gaps[0].op = isa.VEC_OP_MUL; arm64_packed_gaps[0].is_float = false; arm64_packed_gaps[0].lane_bits = 64;
+    arm64_packed_gaps[1].op = isa.VEC_OP_DIV; arm64_packed_gaps[1].is_float = false; arm64_packed_gaps[1].lane_bits = 8;
+    arm64_packed_gaps[2].op = isa.VEC_OP_DIV; arm64_packed_gaps[2].is_float = false; arm64_packed_gaps[2].lane_bits = 16;
+    arm64_packed_gaps[3].op = isa.VEC_OP_DIV; arm64_packed_gaps[3].is_float = false; arm64_packed_gaps[3].lane_bits = 32;
+    arm64_packed_gaps[4].op = isa.VEC_OP_DIV; arm64_packed_gaps[4].is_float = false; arm64_packed_gaps[4].lane_bits = 64;
     arm64_model.packed_gaps     = ?arm64_packed_gaps[0];
-    arm64_model.packed_gap_len  = 1;
+    arm64_model.packed_gap_len  = 5;
     arm64_model.vector_compute_generic = false;
     arm64_model.has_lane_ops    = true;
     arm64_model.ct_trust_mul  = false;

--- a/src/lang/target/isa/x64/register.mach
+++ b/src/lang/target/isa/x64/register.mach
@@ -111,7 +111,7 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[R.Void, str] {
     var x64_classes: [3]isa.RegClass;
     var x64_model: isa.MachineModel;
     var x64_reserved_regs: [2]isa.Register;
-    var x64_packed_gaps: [3]isa.PackedGap;
+    var x64_packed_gaps: [7]isa.PackedGap;
     var x64_reload_scratch_regs: [3]isa.Register;
 
     x64_classes[0].name      = "gpr";
@@ -181,8 +181,12 @@ pub fun register_x64(reg: *isa.IsaRegistry) R.Result[R.Void, str] {
     x64_packed_gaps[0].op = isa.VEC_OP_MUL; x64_packed_gaps[0].is_float = false; x64_packed_gaps[0].lane_bits = 8;
     x64_packed_gaps[1].op = isa.VEC_OP_MUL; x64_packed_gaps[1].is_float = false; x64_packed_gaps[1].lane_bits = 32;
     x64_packed_gaps[2].op = isa.VEC_OP_MUL; x64_packed_gaps[2].is_float = false; x64_packed_gaps[2].lane_bits = 64;
+    x64_packed_gaps[3].op = isa.VEC_OP_DIV; x64_packed_gaps[3].is_float = false; x64_packed_gaps[3].lane_bits = 8;
+    x64_packed_gaps[4].op = isa.VEC_OP_DIV; x64_packed_gaps[4].is_float = false; x64_packed_gaps[4].lane_bits = 16;
+    x64_packed_gaps[5].op = isa.VEC_OP_DIV; x64_packed_gaps[5].is_float = false; x64_packed_gaps[5].lane_bits = 32;
+    x64_packed_gaps[6].op = isa.VEC_OP_DIV; x64_packed_gaps[6].is_float = false; x64_packed_gaps[6].lane_bits = 64;
     x64_model.packed_gaps     = ?x64_packed_gaps[0];
-    x64_model.packed_gap_len  = 3;
+    x64_model.packed_gap_len  = 7;
     x64_model.vector_compute_generic = true;
     x64_model.ct_trust_mul    = false;
     x64_model.has_var_shift = true;


### PR DESCRIPTION
Closes #3122

## What landed

**Comptime casts compose at any depth.** Constant evaluation rejected `EXPR_KIND_CAST` outright, and lowering carried its own private scalar-conversion table that dropped integer widths. `comptime.cast_scalar` is now the single conversion rule, published from `comptime.mach` and reached through two new phase capabilities (`cast`, `scalar`) that sema and lowering both implement. Casts nest, casts through type aliases resolve, and a comptime result agrees with the runtime on width and signedness.

**Width-carrying bitwise results.** `& | ^` and unary `~` previously produced a width-less value, so a nested cast or a declaration gate saw a different number from the one the runtime computes. They now carry the operand's width when the operands agree on one. A declaration gate whose condition needs types is re-evaluated once types are available, which is what makes a gate on `(1::Local) == 1u8` decide correctly.

**Integer vector `/` end to end.** This settles the second half of the issue: rather than removing an unreachable fold, division is implemented. Sema accepts integer vector `/`, gating it as a non-constant-time operation so a secret dividend or divisor is refused. Lowering expands per lane using the lane type's signedness. x86_64 and aarch64 declare a packed gap for integer `VEC_OP_DIV` at every lane width, so the operation scalarizes on both. Required vector lowering now also runs in functions holding volatile accesses and carries each access's volatile flag through the expansion, which it previously skipped.

**Failed global initializers reject the compilation.** This is a consequence of routing casts through comptime rather than separate work: `try_comptime` now returns a typed `EvalFail` instead of an `Option`, so lowering can tell "needs types" from "rejected" and report at the right span. Lowering marks its own status, the `"lower:"`-prefix string test is gone, and a rejected global publishes no `Q_LOWER` product instead of a zero value plus a successful cached lowering product.

## On the interrupted WIP commit

The branch carried a second, unverified commit reverting `~` to a width-less value. It is dropped. Applied on top of this change it fails `mach.lang.driver:nested_scalar_casts_fold_global_initializers` with exit 2, because `~(0::u8)` then folds to `0xFFFFFFFFFFFFFFFF` rather than `255`. That contradicts the acceptance this change exists to establish, so the branch is the single verified commit.

## Verification

All run through a from-source compiler built from this branch, not the installed seed.

| Check | Result |
|---|---|
| `mach test . --jobs 8` | 2674 passed, 0 failed |
| dev baseline | 2666 |
| tests added by this commit | 8 |
| corpus layers A+B, x86_64-linux and aarch64-linux | 728 cells pass, 0 fail, 0 skip |
| debug cells per target | 91 supported, 0 unsupported, 0 failed, 0 declared skip |
| `git diff --check dev...HEAD` | clean |

No golden disassembly changed. Layer B passed against the checked-in goldens as they stand, and the working tree is clean after the run, so nothing was blessed.

The eight added tests: comptime `cast_scalar` width, signedness and reinterpretation; nested scalar casts folding global initializers; declaration cast gates resolving local and imported type aliases; a rejected global publishing no `Q_LOWER` product; nonnumeric casts preserving bits in `convert_const_scalar`; integer vector division accepted for public operands and refused for either secret operand; integer division across all eight lane widths at run time; and scalarized division preserving external volatile accesses.
