### PR TITLE
ci: raise the targets job limit for the #3247 build-cost regression (#2299)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -331,7 +331,9 @@ jobs:
     name: targets on ${{ matrix.runner }}
     needs: test-legs
     runs-on: ${{ matrix.runner }}
-    timeout-minutes: 30
+    # the query and cache work landed by PR #3247 roughly doubled per-build cost (#2299);
+    # the fixes on feat/3218 (digest memo, surface decode) follow in their own PR
+    timeout-minutes: 50
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
Since PR #3247 landed the candidate's query and cache work on dev, the targets job's corpus step takes about 620 seconds against 342 before (runs 34505224774 vs 34508081913), and the whole job now finishes within seconds of its 30-minute limit. PR #3250 was cancelled mid link suite with zero failures for that reason. This raises the limit to 50 minutes, matching feat/3218. The attributed causes and the two fixes already on feat/3218 (executable digest once per process, forwarded surfaces decoded once per operation, see doc/design/build-overhead-3218.md there) follow in their own dev PR under #2299.
