### PR TITLE
perf: acquire each definition once per computation and verify field graphs once per projection (#2299)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,11 +60,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   refreshes them. Dependency commands preserve the project's Git history.
 - Query products validate their inputs transitively before reuse, own their diagnostics and release replaced or failed candidates through their finalizers. Equal recomputed dependencies keep their revision, changed diagnostics with equal bytes stay observable, external revisions and the selected target invalidate what read them, and a failed dependency never leaves a stale successful product. Importers depend on a dependency's public surface, so a body-only edit reuses their typed results (#3220).
 - A build decodes each origin module's typed surface once per surface it builds,
-  however many public symbols forward from that origin, and remaps a resolve result
-  once per operation instead of on every definition read. A one-file build reaching
-  42 std modules drops from 677 ms to 488 ms in the debug compiler (sema 209 ms to
-  88 ms), and the 91-case x86_64-linux layer A corpus from 266 s to 196 s; the log
-  is `doc/design/build-overhead-3218.md` (#2299).
+  remaps a resolve result once per operation, acquires each origin's current
+  definition once per sema or lower computation, and verifies a field graph once
+  per type projection. On one 43-module artifact with the debug compiler, sema
+  drops from 212 ms to 75 ms and lower from 261 ms to 117 ms (37 ms and 82 ms
+  before the query work of #3247); the log is `doc/design/build-overhead-3218.md`
+  (#2299).
 - Editor analysis returns an owned diagnostic/source snapshot with explicit phase and target selection. Raw products have checked serial-view lifetimes. Closing a buffer retires its overlay, source payload and cached dependents while retaining its FileId. Buffer slots are reused, and checked editor teardown preserves owners on preparation failure (#2999).
 
 ## [4.30.0] - 2026-09-07

--- a/doc/design/build-overhead-3218.md
+++ b/doc/design/build-overhead-3218.md
@@ -12,16 +12,54 @@ products and transitive validation but not 60570613's object-image cache: the CI
 targets job's corpus step went from 342 to 620 seconds. Fixes A and B apply to dev
 unchanged and were cherry-picked from 60c2c479. Fix C has no target on dev, since
 dev never hashes the running compiler (there is no `src/lang/build/cache/`); it
-stays on feat/3218 to land with the object cache. Finding 1 below (the
-per-invocation digest) therefore does not apply to dev today, and finding 2 is the
-remainder handed to F4/R2. On dev (debug compilers built by the 4.30.0 seed,
-load average 7 to 12 from peer workers, 3 alternating repetitions): the 91-case
-x86_64-linux layer A corpus as one `test/run.sh` process went from 245/282/266 s
-(median 266) to 196/228/191 s (median 196); a one-file build reaching 42 std
-modules from 677/694/676 ms to 518/488/472 ms, sema 209 to 88 ms and lower 253 to
-176 ms. The mutation control is both memos disabled (`false &&` on the
-`remap_result` early return and on the `origin_surface` lookup): 739/673/679 ms,
-sema 231/210/213 ms, which is the baseline cost back.
+lands with the object cache under F4 (#3221). Finding 1 below (the per-invocation
+digest) therefore does not apply to dev today.
+
+On dev the regression is per-artifact compile time in the sema and lower phases,
+not per-process overhead. `-v` on one o2 corpus artifact (43 modules, 40 of them
+std), debug compilers built by the 4.30.0 seed, median of 3, ms:
+
+| compiler | resolve | sema | lower | optimize | codegen | wall |
+|---|---|---|---|---|---|---|
+| pre-#3247 dev (44d1df47) | 22 | 37 | 82 | 271 | 113 | 615 |
+| dev (853d4c17) | 27 | 212 | 261 | 274 | 122 | 986 |
+| dev + A + B | 26 | 86 | 180 | 274 | 115 | 781 |
+| dev + A + B + E + F | 28 | 75 | 117 | 275 | 115 | 706 |
+
+Optimize and codegen do not move on dev. A + B recovered 72% of the sema delta and
+45% of the lower delta, so the remainder was profiled (`perf record` on the single
+build, stacks diffed against the pre-#3247 compiler). The lower phase's serial
+main-thread work (`lower_raw`) had grown from 421 to 921 samples, and 346 of the
+new samples were `read_definition` reached from `lower_callee`: every imported
+call site acquired the callee's current definition through the query layer again,
+and each acquisition re-ran `fields.install` (223 samples) to verify the origin's
+field graph against the already published tables, plus a Q_SEMA lookup with its
+dependency edge (101) and the parsed-definition lookup (48). The optimize pipeline
+inclusive of verification is identical in both compilers (5873 vs 5930 samples); it
+only shifts between the phase timers because the lower workers overlap it.
+
+Fix E: the definition reader remembers each origin it has acquired for the life of
+the reader (one sema or lower computation), serving later requests at the same or a
+lower phase from the entry and upgrading it when a higher phase is asked for. The
+first acquisition still records the dependency edge. Fix F: a field graph records
+the projection generation it was installed under; published tables only change
+through a projection reset, which bumps the generation, so a second install under
+the same projection returns at once. Both carry a unit test that fails with the
+memo disabled and nothing else changes (2676 tests either way, one failure each).
+
+Fix D (the `definition_index` map replacing the linear scan in `acquire_symbol`,
+fe56b9ad) was retried on top of E + F: lower 113/130/115/113/115 ms without it
+against 114/109/110/109/114 with it, five alternating repetitions. About 5 ms
+inside the spread, the same verdict as step 4; not taken.
+
+What remains over the pre-#3247 compiler, sema +38 ms and lower +35 ms, is the
+accepted contract: the owned typed-surface copy decoded per consumer in
+`build_sema_deps_query` (about 80 samples in each phase), the by-value expression
+view through `interpretation.get` (#3121, about 40 per phase), the per-consumer
+`constant_decode`, and the generic-instance queueing in sema. Those are finding 2,
+handed to F4/R2.
+
+The corpus wall numbers for this landing are in the pull request.
 
 ## Step 1: shape
 

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -376,7 +376,7 @@ fun sema_handle_decode(e: query.QueryView) *sema.SemaResult {
 
 fun build_sema_deps_query(p: *project.Project, m: *project.ModuleEntry) R.Result[sema.SemaDeps, fail.Fail] {
     var deps: sema.SemaDeps = sema.SemaDeps{};
-    deps.definitions = scx.DefinitionReader{ ctx: p::ptr, read: read_definition };
+    deps.definitions = scx.reader_init(p::ptr, read_definition, p.s.alloc);
     val closure: R.Result[LowerClosure, str] = collect_lower_closure(p, m);
     if (R.is_err[LowerClosure, str](closure)) { ret R.err[sema.SemaDeps, fail.Fail](fail.message(R.unwrap_err[LowerClosure, str](closure))); }
     var imports: LowerClosure = R.unwrap_ok[LowerClosure, str](closure);
@@ -407,6 +407,7 @@ fun build_sema_deps_query(p: *project.Project, m: *project.ModuleEntry) R.Result
 }
 
 fun free_sema_deps_query(alloc: *A.Allocator, deps: *sema.SemaDeps) {
+    scx.reader_dnit(?deps.definitions);
     var i: u32 = 0;
     for (i < deps.count) { scx.module_sema_dnit(?deps.entries[i]); i = i + 1; }
     if (deps.entries != nil) { A.deallocate[sema.ModuleSema](alloc, deps.entries, deps.count::usize); }
@@ -794,7 +795,7 @@ fun run_union_gate_pass(p: *project.Project) R.Result[bool, str] {
 
 fun build_gate_deps(p: *project.Project, m: *project.ModuleEntry) R.Result[sema.SemaDeps, str] {
     var deps: sema.SemaDeps;
-    deps.definitions = scx.DefinitionReader{ ctx: p::ptr, read: read_definition };
+    deps.definitions = scx.reader_init(p::ptr, read_definition, p.s.alloc);
     deps.entries = nil;
     deps.count = 0;
     val rr: R.Result[resolve.ResolveDeps, str] = build_resolve_deps_owned(p, m);

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -746,7 +746,8 @@ fun analyze_buffer(es: *EditorSession, fid: source.FileId) R.Result[*context.Sem
     }
 
     var deps: context.SemaDeps = context.SemaDeps{};
-    deps.definitions = context.DefinitionReader{ ctx: es::ptr, read: buffer_definition };
+    deps.definitions = context.reader_init(es::ptr, buffer_definition, es.alloc);
+    fin { context.reader_dnit(?deps.definitions); }
     deps.entries = nil;
     deps.count   = 0;
 
@@ -1552,7 +1553,8 @@ fun t_run_sema(es: *EditorSession, fid: source.FileId, pw: u32) R.Result[*diagno
     diags_reset(es);
 
     var deps: context.SemaDeps = context.SemaDeps{};
-    deps.definitions = context.DefinitionReader{ ctx: es::ptr, read: buffer_definition };
+    deps.definitions = context.reader_init(es::ptr, buffer_definition, es.alloc);
+    fin { context.reader_dnit(?deps.definitions); }
     deps.entries = nil;
     deps.count   = 0;
 

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -92,9 +92,26 @@ pub rec Definition {
     ctx: *comptime.ComptimeCtx;
 }
 
+pub rec AcquiredDefinition {
+    phase: DefinitionPhase;
+    definition: Definition;
+}
+
 pub rec DefinitionReader {
     ctx: ptr;
     read: fun(ptr, session.ModuleId, DefinitionPhase) R.Result[Definition, fail.Fail];
+    acquired: vector.Vector[AcquiredDefinition];
+}
+
+# a reader lives for one computation, which acquires the same current definition once per origin
+pub fun reader_init(ctx: ptr, read: fun(ptr, session.ModuleId, DefinitionPhase) R.Result[Definition, fail.Fail],
+                    a: *A.Allocator) DefinitionReader {
+    ret DefinitionReader{ ctx: ctx, read: read, acquired: vector.init[AcquiredDefinition](a) };
+}
+
+pub fun reader_dnit(reader: *DefinitionReader) {
+    if (reader == nil) { ret; }
+    vector.dnit[AcquiredDefinition](?reader.acquired);
 }
 
 pub rec DefinedSymbol {
@@ -106,6 +123,17 @@ pub fun acquire_definition(reader: *DefinitionReader, origin: session.ModuleId,
                            phase: DefinitionPhase) R.Result[Definition, fail.Fail] {
     if (reader == nil || reader.ctx == nil || reader.read == nil || phase > DEFINITION_TYPED) {
         ret R.err[Definition, fail.Fail](fail.message("current definition acquisition requires an active phase capability"));
+    }
+    var slot: usize = reader.acquired.len;
+    var ai: usize = 0;
+    for (ai < reader.acquired.len) {
+        val entry: *AcquiredDefinition = ?reader.acquired.data[ai];
+        if (entry.definition.origin == origin) {
+            if (entry.phase >= phase) { ret R.ok[Definition, fail.Fail](entry.definition); }
+            slot = ai;
+            brk;
+        }
+        ai = ai + 1;
     }
     val acquired: R.Result[Definition, fail.Fail] = reader.read(reader.ctx, origin, phase);
     if (R.is_err[Definition, fail.Fail](acquired)) { ret acquired; }
@@ -126,6 +154,12 @@ pub fun acquire_definition(reader: *DefinitionReader, origin: session.ModuleId,
     }
     if (phase == DEFINITION_TYPED && current.sr.status.kind != fail.ACCEPTED) {
         ret R.err[Definition, fail.Fail](fail.phase_failure(current.sr.status));
+    }
+    val entry: AcquiredDefinition = AcquiredDefinition{ phase: phase, definition: current };
+    if (slot < reader.acquired.len) { reader.acquired.data[slot] = entry; }
+    or {
+        val added: R.Result[usize, str] = vector.push[AcquiredDefinition](?reader.acquired, entry);
+        if (R.is_err[usize, str](added)) { ret R.err[Definition, fail.Fail](fail.message(R.unwrap_err[usize, str](added))); }
     }
     ret acquired;
 }
@@ -1376,4 +1410,67 @@ pub fun record_eval_result(sc: *SemaContext, r: R.Result[comptime.CTValue, compt
     if (!R.is_err[comptime.CTValue, comptime.EvalFail](r)) { ret; }
     val f: comptime.EvalFail = R.unwrap_err[comptime.CTValue, comptime.EvalFail](r);
     if (f.kind == comptime.EVAL_FAIL_INTERNAL) { fail.internal(?sc.status, f.message); }
+}
+
+rec CountingDefinition {
+    current: Definition;
+    reads: u32;
+}
+
+fun t_counting_definition(raw: ptr, origin: session.ModuleId, phase: DefinitionPhase) R.Result[Definition, fail.Fail] {
+    val probe: *CountingDefinition = raw::*CountingDefinition;
+    probe.reads = probe.reads + 1;
+    if (probe.current.origin != origin) { ret R.err[Definition, fail.Fail](fail.message("counting definition owner differs")); }
+    ret R.ok[Definition, fail.Fail](probe.current);
+}
+
+test "mach.lang.fe.sema.context.acquire_definition:reads_each_origin_once_per_reader_and_upgrades_the_phase" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
+
+    var a1: ast.Ast;
+    var sm1: SemaResult = SemaResult{};
+    var rr1: resolve.ResolveResult;
+    var cc1: comptime.ComptimeCtx;
+    a1.incarnation = 1;
+    rr1.status = fail.accepted();
+    sm1.status = fail.accepted();
+    val mid: session.ModuleId = 0::session.ModuleId;
+    if (R.is_err[R.Void, str](session.register_module_identity(?s, mid, ?a1, 7::intern.StrId, 5))) { ret 1; }
+
+    var probe: CountingDefinition = CountingDefinition{
+        current: Definition{
+            parsed: resolve.ParsedDefinition{ a: ?a1, owner: resolve.type_owner(?s, mid, a1.file_id), incarnation: a1.incarnation },
+            origin: mid, rr: ?rr1, sr: ?sm1, ctx: ?cc1
+        },
+        reads: 0
+    };
+    var reader: DefinitionReader = reader_init((?probe)::ptr, t_counting_definition, ?alloc);
+    fin { reader_dnit(?reader); }
+
+    val first: R.Result[Definition, fail.Fail] = acquire_definition(?reader, mid, DEFINITION_RESOLVED);
+    val second: R.Result[Definition, fail.Fail] = acquire_definition(?reader, mid, DEFINITION_RESOLVED);
+    if (R.is_err[Definition, fail.Fail](first) || R.is_err[Definition, fail.Fail](second)) { ret 2; }
+    if (probe.reads != 1) { ret 3; }
+    if (R.unwrap_ok[Definition, fail.Fail](second).rr != ?rr1) { ret 4; }
+
+    # a typed request outranks the resolved entry and replaces it
+    val typed: R.Result[Definition, fail.Fail] = acquire_definition(?reader, mid, DEFINITION_TYPED);
+    if (R.is_err[Definition, fail.Fail](typed) || probe.reads != 2) { ret 5; }
+    if (R.unwrap_ok[Definition, fail.Fail](typed).sr != ?sm1) { ret 6; }
+    val resolved_again: R.Result[Definition, fail.Fail] = acquire_definition(?reader, mid, DEFINITION_RESOLVED);
+    val typed_again: R.Result[Definition, fail.Fail] = acquire_definition(?reader, mid, DEFINITION_TYPED);
+    if (R.is_err[Definition, fail.Fail](resolved_again) || R.is_err[Definition, fail.Fail](typed_again)) { ret 7; }
+    if (probe.reads != 2 || reader.acquired.len != 1) { ret 8; }
+
+    # a failed read is not remembered, and another origin is its own entry
+    val other: R.Result[Definition, fail.Fail] = acquire_definition(?reader, 1::session.ModuleId, DEFINITION_RESOLVED);
+    if (R.is_ok[Definition, fail.Fail](other) || probe.reads != 3 || reader.acquired.len != 1) { ret 9; }
+    val other_again: R.Result[Definition, fail.Fail] = acquire_definition(?reader, 1::session.ModuleId, DEFINITION_RESOLVED);
+    if (R.is_ok[Definition, fail.Fail](other_again) || probe.reads != 4) { ret 10; }
+    ret 0;
 }

--- a/src/lang/fe/sema/fields.mach
+++ b/src/lang/fe/sema/fields.mach
@@ -39,10 +39,12 @@ pub val MATERIALIZED: CaptureMode = 1;
 
 pub rec Graph {
     nodes: vector.Vector[Node];
+    installed: bool;
+    installed_generation: u64;
 }
 
 pub fun init(a: *A.Allocator) Graph {
-    ret Graph{ nodes: vector.init[Node](a) };
+    ret Graph{ nodes: vector.init[Node](a), installed: false, installed_generation: 0 };
 }
 
 pub fun dnit(graph: *Graph) {
@@ -235,6 +237,10 @@ fun same_fields(s: *session.Session, table: *type.FieldTable, node: *Node) bool 
 }
 
 pub fun install(s: *session.Session, graph: *Graph) R.Result[R.Void, str] {
+    # published tables only change through a projection reset, so a graph installed
+    # under this projection verifies identically on every later acquisition
+    val generation: u64 = s.types.projection_generation;
+    if (graph.installed && graph.installed_generation == generation) { ret R.ok_void[str](); }
     var i: usize = 0;
     for (i < graph.nodes.len) {
         val node: *Node = ?graph.nodes.data[i];
@@ -273,6 +279,8 @@ pub fun install(s: *session.Session, graph: *Graph) R.Result[R.Void, str] {
         if (R.is_err[R.Void, str](published)) { ret published; }
         i = i + 1;
     }
+    graph.installed = true;
+    graph.installed_generation = generation;
     ret R.ok_void[str]();
 }
 
@@ -350,6 +358,62 @@ test "mach.lang.fe.sema.fields:circular_graph_owns_fields_and_remaps_rebuilt_pro
     session.dnit(?s);
     session_live = false;
     if (T.live_count(?tracker) != 0 || T.double_free_count(?tracker) != 0) { ret 18; }
+    ret 0;
+}
+
+test "mach.lang.fe.sema.fields:install_verifies_once_per_projection" {
+    var tracker: T.Testing;
+    if (O.is_some[str](T.make(?tracker))) { ret 1; }
+    fin { T.dnit(?tracker); }
+    val allocated: *A.Allocator = T.allocator_of(?tracker);
+    val initialized: R.Result[session.Session, str] = session.init(allocated);
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    fin { session.dnit(?s); }
+    val first_r: R.Result[type.TypeId, str] = type.intern_nominal(?s.types, 1::intern.StrId, type.TypeOwner{ module: 0, file: 0 }, type.TYPE_REC);
+    val second_r: R.Result[type.TypeId, str] = type.intern_nominal(?s.types, 2::intern.StrId, type.TypeOwner{ module: 0, file: 0 }, type.TYPE_REC);
+    if (R.is_err[type.TypeId, str](first_r) || R.is_err[type.TypeId, str](second_r)) { ret 3; }
+    val first: type.TypeId = R.unwrap_ok[type.TypeId, str](first_r);
+    val second: type.TypeId = R.unwrap_ok[type.TypeId, str](second_r);
+    val to_first_r: R.Result[type.TypeId, str] = type.intern_pointer(?s.types, first);
+    val to_second_r: R.Result[type.TypeId, str] = type.intern_pointer(?s.types, second);
+    if (R.is_err[type.TypeId, str](to_first_r) || R.is_err[type.TypeId, str](to_second_r)) { ret 4; }
+    val to_first: type.TypeId = R.unwrap_ok[type.TypeId, str](to_first_r);
+    val to_second: type.TypeId = R.unwrap_ok[type.TypeId, str](to_second_r);
+    if (R.is_err[R.Void, str](t_one_field(?s, second, to_first))
+        || R.is_err[R.Void, str](t_one_field(?s, first, to_second))) { ret 5; }
+    var root: type.TypeId = first;
+    var roots: Roots = Roots{ data: ?root, len: 1 };
+    val captured: R.Result[Graph, fail.Fail] = capture[session.Session](?s, allocated, ?roots, 1, MATERIALIZED, nil, ?s, t_prepared);
+    if (R.is_err[Graph, fail.Fail](captured)) { ret 6; }
+    var graph: Graph = R.unwrap_ok[Graph, fail.Fail](captured);
+    fin { dnit(?graph); }
+    if (graph.nodes.len != 2 || graph.nodes.data[0].ty != first || graph.nodes.data[0].entries.len != 1) { ret 7; }
+
+    if (R.is_err[R.Void, str](session.reset_type_projection(?s))) { ret 8; }
+    if (R.is_err[R.Void, str](install(?s, ?graph))) { ret 9; }
+
+    # a graph installed under this projection is not compared with the tables again,
+    # so a disagreement introduced afterwards goes unseen until the projection resets
+    graph.nodes.data[0].entries.data[0].ty = to_first;
+    if (R.is_err[R.Void, str](install(?s, ?graph))) { ret 10; }
+    val kept: O.Option[*type.FieldEntry] = type.field_at(?s.types, first, 0);
+    if (O.is_none[*type.FieldEntry](kept) || O.unwrap[*type.FieldEntry](kept).ty != to_second) { ret 11; }
+
+    if (R.is_err[R.Void, str](session.reset_type_projection(?s))) { ret 12; }
+    if (R.is_err[R.Void, str](install(?s, ?graph))) { ret 13; }
+    val republished: O.Option[*type.FieldEntry] = type.field_at(?s.types, first, 0);
+    if (O.is_none[*type.FieldEntry](republished) || O.unwrap[*type.FieldEntry](republished).ty != to_first) { ret 14; }
+
+    # the same projection with a foreign table that disagrees is still refused on first install
+    var again: Graph = init(allocated);
+    fin { dnit(?again); }
+    val recaptured: R.Result[Graph, fail.Fail] = capture[session.Session](?s, allocated, ?roots, 1, MATERIALIZED, nil, ?s, t_prepared);
+    if (R.is_err[Graph, fail.Fail](recaptured)) { ret 15; }
+    dnit(?again);
+    again = R.unwrap_ok[Graph, fail.Fail](recaptured);
+    again.nodes.data[0].entries.data[0].ty = to_second;
+    if (R.is_ok[R.Void, str](install(?s, ?again))) { ret 16; }
     ret 0;
 }
 

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1858,8 +1858,9 @@ test "mach.lang.me.lower.context.module_scope:refuses_a_piece_that_belongs_to_an
         origin: mid, rr: ?rr1, sr: ?sm1, ctx: ?cc1
     };
     var deps: sema.SemaDeps = sema.SemaDeps{
-        definitions: scx.DefinitionReader{ ctx: (?current)::ptr, read: fixture_definition }
+        definitions: scx.reader_init((?current)::ptr, fixture_definition, ?alloc)
     };
+    fin { scx.reader_dnit(?deps.definitions); }
 
     var code: i32 = 0;
 
@@ -1918,8 +1919,9 @@ test "mach.lang.me.lower.context.request:refuses_a_module_product_that_does_not_
         origin: mid, rr: ?rr1, sr: ?sm1, ctx: ?cc1
     };
     var deps: sema.SemaDeps = sema.SemaDeps{
-        definitions: scx.DefinitionReader{ ctx: (?current)::ptr, read: fixture_definition }
+        definitions: scx.reader_init((?current)::ptr, fixture_definition, ?alloc)
     };
+    fin { scx.reader_dnit(?deps.definitions); }
 
     var code: i32 = 0;
 

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -434,6 +434,8 @@ pub rec TypeInterner {
     field_pool: handle.StableChunks[FieldEntry];
 
     field_epoch: u32;
+    # bumped by every projection reset; published tables never change otherwise
+    projection_generation: u64;
 
     visits:     *VisitSet;
     visits_len: u32;
@@ -505,6 +507,7 @@ pub fun init(ti: *TypeInterner, a: *A.Allocator) O.Option[str] {
     ti.field_pool   = handle.chunk_init[FieldEntry](a);
 
     ti.field_epoch = 0;
+    ti.projection_generation = 0;
 
     ti.visits     = nil;
     ti.visits_len = 0;
@@ -622,6 +625,7 @@ pub fun dnit(ti: *TypeInterner) {
     ti.handle_ops_cap = 0;
 
     ti.field_epoch = 0;
+    ti.projection_generation = 0;
 
     ti.visits     = nil;
     ti.visits_len = 0;
@@ -1458,6 +1462,7 @@ pub fun field_projection_reset(ti: *TypeInterner) {
     map.clear[TypeId, u32](?ti.field_index);
     ti.field_epoch = 0;
     ti.gparam_epoch = 0;
+    ti.projection_generation = ti.projection_generation + 1;
     if (ti.gparam != nil && ti.gparam_cap != 0) { memory.zero[u8](ti.gparam, ti.gparam_cap::usize); }
 }
 


### PR DESCRIPTION
Second F5 landing on dev (Track B, #2299), following #3252.

On dev the regression from #3247 is per-artifact compile time in sema and lower. #3252 (fixes A and B from the log) recovered 72% of the sema delta and 45% of the lower delta against the pre-#3247 compiler, so the remainder was profiled. The lower phase's serial main-thread work had more than doubled, and most of the new samples were `read_definition` reached from `lower_callee`: every imported call site acquired the callee's current definition through the query layer again, and each acquisition re-verified the origin's whole field graph against the already published tables, plus a Q_SEMA lookup with its dependency edge and the parsed-definition lookup. The same repeat happens for foreign symbols during sema.

Two fixes, same contract:

- **E, per-computation definition memo.** The definition reader remembers each origin it has acquired for its own life (one sema or lower computation), serving later requests at the same or a lower phase and upgrading the entry when a higher phase is asked for. The first acquisition records the dependency edge exactly as before.
- **F, once-per-projection field-graph install.** A field graph records the projection generation it was installed under. Published tables only change through a projection reset, which now bumps that generation, so a second install under the same projection returns at once.

Fix D from the log (the `definition_index` map) was retried on top: about 5 ms inside a 109 to 130 ms spread over five alternating repetitions, so not taken. The remainder over the pre-#3247 compiler (sema +38 ms, lower +35 ms on the artifact below) is the accepted contract: the owned typed-surface copy per consumer, the by-value expression view from #3121, per-consumer constant decode and generic-instance queueing. Handed to F4/R2 in the log.

## Numbers

One o2 corpus artifact (`hosted_bin__call__call_chain`, 43 modules, 40 of them std), debug compilers built by the 4.30.0 seed, `-v` phase times, median of 3, ms:

| compiler | resolve | sema | lower | optimize | codegen | wall |
|---|---|---|---|---|---|---|
| pre-#3247 dev (44d1df47) | 22 | 37 | 82 | 271 | 113 | 615 |
| dev (853d4c17) | 27 | 212 | 261 | 274 | 122 | 986 |
| dev + #3252 (A+B) | 26 | 86 | 180 | 274 | 115 | 781 |
| this branch (A+B+E+F) | 28 | 75 | 117 | 275 | 115 | 706 |

Optimize and codegen do not regress on dev in these measurements. Sema recovers 78% and lower 80% of the #3247 delta.

91-case corpus, `test/run.sh --target x86_64-linux --layer a`, one driver process, dev (853d4c17) vs this branch, alternating (273 cells pass on both): load average 3 to 6:

| compiler | run1 | run2 | run3 | median |
|---|---|---|---|---|
| dev 853d4c17 | 225.1 s | 230.6 s | 227.2 s | 227.2 s (spread 2%) |
| this branch | 152.9 s | 152.1 s | 151.4 s | 152.1 s (spread 1%) |

Under the heavier load of the #3252 measurement (average 7 to 12) dev measured 265.5 s and A+B alone 196.0 s, so the two landings together take the single-process layer A corpus from about 266 s to about 152 s.

## Verification

- `./out/audit/mach test . --jobs 8`: 2676 passed, 0 failed, 2676 total (dev has 2674; the two added tests are the mutation controls)
- Mutation controls: with the reader memo disabled, exactly `context.acquire_definition:reads_each_origin_once_per_reader_and_upgrades_the_phase` fails (2675/2676); with the install memo disabled, exactly `fields:install_verifies_once_per_projection` fails (2675/2676)
- `sh test/census.sh` ok, `git diff --check origin/dev...HEAD` clean
- CHANGELOG line under Unreleased updated, references #2299
