### PR TITLE
feat(cli): check projects through the shared frontend with mach check (#3224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `mach check <path>` runs load, resolve and sema over the source reachable from
+  the artifacts `mach build` would select, through the same driver, queries and
+  phase outcomes, and exits with the frontend's own classification: 0 accepted,
+  1 rejected or user error, 2 internal, 3 environment. No step runs, nothing is
+  lowered, generated, linked or written, and a generated or embedded input that
+  does not exist yet is reported as missing rather than produced (#3224).
+
 - `mach build <path> --plan` prints the effective build through the normal
   planner and exits: per cell the project, target, profile, artifact, entry,
   output paths, the dependency and project prerequisite steps in execution

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- `mach build <path> --plan` prints the effective build through the normal
+  planner and exits: per cell the project, target, profile, artifact, entry,
+  output paths, the dependency and project prerequisite steps in execution
+  order, the artifact requirements, and the manifest, dependency-export and
+  command-line link requirements. The plan is configured against the realized
+  dependency closure the way a build is, so an unrealized dependency, an invalid
+  dependency manifest or a dependency cycle is reported with the build's own
+  diagnostic; nothing is fetched, generated, compiled, linked or written, and a
+  cell with prerequisites says its generated inputs are unresolved. It replaces
+  `--explain` (#3223).
+
 - `{artifact.suffix}` in an artifact `out` expands to the conventional filename
   suffix for the artifact's kind on the selected target (`.exe`/`.lib`/`.dll` on
   Windows, `.a`/`.so` on Linux, `.a`/`.dylib` on Darwin, `.spv` for a SPIR-V

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -5,8 +5,8 @@ mach <command> [options]
 ```
 
 The compiler dispatches on `argv[1]`. With no command, or an unknown one, it
-prints usage and exits `1`. The project commands — `build`, `run`, `test`,
-`clean`, and `doc` — take the project as a **required** positional: a directory
+prints usage and exits `1`. The project commands — `build`, `check`, `run`,
+`test`, `clean`, and `doc` — take the project as a **required** positional: a directory
 containing `mach.toml`, or the path of a `mach.toml` itself. Nothing is
 searched for: `mach build src` inside a project is `error: no mach.toml in the
 project directory`, and a bare invocation with no path is a user error.
@@ -41,6 +41,7 @@ argument forwarding.
 | Command | Summary |
 |---------|---------|
 | `build` | compile the project to objects and (for a `bin` artifact) a linked binary |
+| `check` | run the frontend over the source the selected artifacts reach, and stop |
 | `run`   | execute the already-built binary (a post-`build` convenience, not a rebuild) |
 | `test`  | build the test binary and run the collected tests |
 | `clean` | remove the project's build output directory trees |
@@ -52,8 +53,10 @@ argument forwarding.
 
 ## Global flags
 
-Read by `build` and `test`, which share one schema. `run` accepts only the
-selection subset (`--target`, `--profile`, `--bin`, `-o`) and `doc` only
+Read by `build` and `test`, which share one schema. `check` accepts the
+selection subset without `-o` (`--target`, `--profile`, `--bin`, `--lib`) and
+the readout flags, `run` only the selection subset (`--target`, `--profile`,
+`--bin`, `-o`) and `doc` only
 `--target`, `--bin`, `--lib`, `--out`, and `--quiet`; every other option is
 unknown to them by name (`unknown flag '--emit-ir' for 'mach doc'`,
 `unknown flag '--lib' for 'mach run'`), exactly as a misspelled one is. A
@@ -85,6 +88,36 @@ unknown flag).
 
 > `mach dep`, `mach init`, and `mach clean` do not use the shared config
 > parser; they read only their own flags listed below.
+
+## `mach check`
+
+```
+mach check <path> [--target <name>] [--profile <name>] [--bin <name> | --lib <name>] [-v | -vv | --quiet]
+```
+
+Runs the frontend over the source a build would compile and stops there.
+Selection is `mach build`'s: every artifact declared for the resolved target,
+or the one `--bin`/`--lib` names, on the selected profile, and the source
+checked is what those artifacts reach from their entries through `use`,
+including dependency modules. That is the selected-artifact graph, not the
+whole `src` tree: a file nothing selected imports is not read, and a `--bin`
+that reaches less checks less.
+
+Each cell runs load, resolve and sema through the same driver, queries and
+phase outcomes `mach build` and the editor use, so what check accepts, rejects
+or fails on is what the same build's frontend would, with the same diagnostics
+at the same locations and the same classification. The exit status is that
+classification: 0 accepted, 1 rejected (or a user error such as a bad manifest
+or selection), 2 an internal failure, 3 an environment failure. It is never
+derived from counting or matching diagnostic text.
+
+Nothing else runs. No build step or dependency step executes, nothing is
+lowered, generated, linked, published or written, and `out/` is not created.
+A generated source module or an embedded input that a step or a required
+artifact would produce is reported as the missing input it is, naming it; run
+the build that produces it first. A clean check is a statement about the
+frontend only: it does not establish that lowering, code generation, the ABI or
+the link would succeed.
 
 ## `mach build`
 

--- a/doc/cli.md
+++ b/doc/cli.md
@@ -145,8 +145,22 @@ adjustment, including differences between absolute and image-relative symbols.
 The optimisation pipeline comes from the selected profile's `opt` — the profile
 is how a build picks its optimisation level.
 
-`--explain` resolves the full build plan — the (target, artifact) matrix and each
-unit's inputs — prints it, and exits without compiling or linking.
+`--plan` resolves the effective build — the (target, artifact) matrix and, per
+unit, the selected project, target, profile, artifact, entry, output paths, the
+prerequisite steps in execution order (each dependency's exported steps first,
+then the project's own), the artifact requirements, the manifest, dependency
+export and command-line link requirements, and the phase order — prints it, and
+exits. Nothing is executed: no generator or build step runs, no dependency is
+fetched, no compiler or linker runs, and no output is written or published.
+
+The plan is resolved through the same planner and the same dependency
+configuration a build uses, so an invalid manifest, a dependency that is not
+realized, and a dependency cycle are reported here exactly as a build reports
+them, with the same classification. What planning cannot know it says instead of
+guessing: a unit with prerequisites prints that its generated input bytes are
+unresolved until those prerequisites run. A printed plan is a statement about
+selection, not a claim that those bytes are valid or that the link will
+succeed.
 
 | Flag           | Value          | Effect |
 |----------------|----------------|--------|
@@ -159,7 +173,7 @@ unit's inputs — prints it, and exits without compiling or linking.
 | `--subsystem <k>` | `console`\|`gui` | the environment a windows executable declares it runs under, overriding the artifact's `subsystem` key (see below) |
 | `-L <dir>`     | dir            | add a search directory for `-l`-resolved inputs; repeatable |
 | `-l <name>`    | name           | link a named object, archive, or target-format shared library, resolved through the `-L` dirs (see below); repeatable |
-| `--explain`    | —              | print the resolved build plan and exit without building |
+| `--plan`       | —              | print the effective build plan and exit without building |
 | *(positional)* | input path     | a bare argument that contains `/`, ends in `.o` / `.obj` / `.a` / `.lib`, or names a `.so`, `.dylib`, or `.dll` is linked explicitly |
 
 Plus the global flags above.

--- a/src/cli/args.mach
+++ b/src/cli/args.mach
@@ -49,7 +49,7 @@ pub val SEL_N: usize = 5;
 # `--target` through visibility masks, and both still parse the hidden rows
 pub val SEL: [SEL_N]FlagSpec = [SEL_N]FlagSpec{
     FlagSpec{ name: "--target",  value: "name", doc: "select a [target.<name>] entry", default: "", repeatable: false, conflicts: "", implies: "", alias_of: "" },
-    FlagSpec{ name: "--profile", value: "name", doc: "select a profile", default: "sole or default profile, otherwise built-in debug", repeatable: false, conflicts: "", implies: "", alias_of: "" },
+    FlagSpec{ name: "--profile", value: "name", doc: "select a profile", default: "the sole or default profile", repeatable: false, conflicts: "", implies: "", alias_of: "" },
     FlagSpec{ name: "-o",        value: "path", doc: "override the linked-binary path", default: "", repeatable: false, conflicts: "", implies: "", alias_of: "" },
     FlagSpec{ name: "--bin",     value: "name", doc: "narrow the build to one binary artifact", default: "", repeatable: false, conflicts: "", implies: "", alias_of: "" },
     FlagSpec{ name: "--lib",     value: "name", doc: "narrow the build to one static or shared library artifact", default: "", repeatable: false, conflicts: "", implies: "", alias_of: "" },
@@ -264,8 +264,10 @@ pub val CMD_DOC:   CommandId = 6;
 pub val CMD_INFO:  CommandId = 7;
 # `mach help`
 pub val CMD_HELP:  CommandId = 8;
+# `mach check`
+pub val CMD_CHECK: CommandId = 9;
 # number of commands, the length of COMMANDS
-pub val CMD_N:     usize = 9;
+pub val CMD_N:     usize = 10;
 # no command recognized; the value of ParsedInvocation.command when has_command is false
 pub val CMD_NONE:  CommandId = 255;
 
@@ -313,6 +315,17 @@ pub val BUILD_SCHEMA: [BUILD_SCHEMA_N]TableRef = [BUILD_SCHEMA_N]TableRef{
     TableRef{ table: ?JOBS[0],      n: JOBS_N,      accepted: nil },
     TableRef{ table: ?LINKIN[0],    n: LINKIN_N,    accepted: nil },
     TableRef{ table: ?BUILD_OWN[0], n: BUILD_OWN_N, accepted: nil },
+};
+
+# SEL rows check accepts: every row but `-o`, since nothing is written
+pub val CHECK_SEL_ACCEPTED: [SEL_N]bool = [SEL_N]bool{ true, true, false, true, true };
+
+# length of CHECK_SCHEMA
+pub val CHECK_SCHEMA_N: usize = 2;
+# the option tables mach check accepts: SEL masked by CHECK_SEL_ACCEPTED, and RDO
+pub val CHECK_SCHEMA: [CHECK_SCHEMA_N]TableRef = [CHECK_SCHEMA_N]TableRef{
+    TableRef{ table: ?SEL[0], n: SEL_N, accepted: ?CHECK_SEL_ACCEPTED[0] },
+    TableRef{ table: ?RDO[0], n: RDO_N, accepted: nil },
 };
 
 # SEL rows run accepts: every row but `--lib`
@@ -522,10 +535,11 @@ pub rec CommandSpec {
     example_n:        usize;
 }
 
-# the nine command records in help order: build, run, test, clean, dep, init,
-# doc, info, help. Indexed by search, not by CommandId
+# the ten command records in help order: build, check, run, test, clean, dep,
+# init, doc, info, help. Indexed by search, not by CommandId
 pub val COMMANDS: [CMD_N]CommandSpec = [CMD_N]CommandSpec{
     CommandSpec{ name: "build", aliases: nil, alias_n: 0, id: CMD_BUILD, grammar: " <path> [options] [inputs...]", summary: "compile a project", effect: "compile selected project artifacts and produce the requested object or linked outputs", exits: "0 success, 1 user error, 2 internal error", terminator: "", tables: ?BUILD_SCHEMA[0], table_n: BUILD_SCHEMA_N, constraints: ?BUILD_CONSTRAINT[0], constraint_n: BUILD_CONSTRAINT_N, pos_start: 2, truncate_at_sep: false, has_action: false, examples: nil, example_n: 0 },
+    CommandSpec{ name: "check", aliases: nil, alias_n: 0, id: CMD_CHECK, grammar: " <path> [options]", summary: "check project source without building", effect: "parse, resolve and type-check the source reachable from the selected artifacts through the frontend; no build step runs and nothing is generated, compiled, linked or written", exits: "0 accepted, 1 rejected or user error, 2 internal failure, 3 environment failure", terminator: "", tables: ?CHECK_SCHEMA[0], table_n: CHECK_SCHEMA_N, constraints: ?TEST_CONSTRAINT[0], constraint_n: TEST_CONSTRAINT_N, pos_start: 2, truncate_at_sep: false, has_action: false, examples: nil, example_n: 0 },
     CommandSpec{ name: "run", aliases: nil, alias_n: 0, id: CMD_RUN, grammar: " <path> [options] [-- args...]", summary: "execute a built project artifact", effect: "resolve an existing built executable and run it without rebuilding", exits: "the program exit code, 1 user error, 2 internal error, 3 the run exceeded --timeout_seconds", terminator: "arguments after -- are forwarded to the program", tables: ?RUN_SCHEMA[0], table_n: RUN_SCHEMA_N, constraints: nil, constraint_n: 0, pos_start: 2, truncate_at_sep: true, has_action: false, examples: nil, example_n: 0 },
     CommandSpec{ name: "test", aliases: nil, alias_n: 0, id: CMD_TEST, grammar: " <path> [options]", summary: "build and run project tests", effect: "build one test dispatcher and run each selected test in its own process", exits: "0 all passed, 1 failed or user error, 2 internal error", terminator: "", tables: ?TEST_SCHEMA[0], table_n: TEST_SCHEMA_N, constraints: ?TEST_CONSTRAINT[0], constraint_n: TEST_CONSTRAINT_N, pos_start: 2, truncate_at_sep: false, has_action: false, examples: nil, example_n: 0 },
     CommandSpec{ name: "clean", aliases: nil, alias_n: 0, id: CMD_CLEAN, grammar: " <path>", summary: "remove project build output", effect: "remove the output, object, IR, and assembly trees declared by the manifest", exits: "0 success, 1 user error, 2 I/O or internal error", terminator: "", tables: nil, table_n: 0, constraints: nil, constraint_n: 0, pos_start: 2, truncate_at_sep: false, has_action: false, examples: nil, example_n: 0 },

--- a/src/cli/args.mach
+++ b/src/cli/args.mach
@@ -117,9 +117,9 @@ pub val LINKIN: [LINKIN_N]FlagSpec = [LINKIN_N]FlagSpec{
 
 # row count of BUILD_OWN
 pub val BUILD_OWN_N: usize = 1;
-# the `--explain` option, build only
+# the `--plan` option, build only
 pub val BUILD_OWN: [BUILD_OWN_N]FlagSpec = [BUILD_OWN_N]FlagSpec{
-    FlagSpec{ name: "--explain", value: "", doc: "print the resolved build plan and exit without building", default: "", repeatable: false, conflicts: "", implies: "", alias_of: "" },
+    FlagSpec{ name: "--plan", value: "", doc: "print the effective build plan and exit without building", default: "", repeatable: false, conflicts: "", implies: "", alias_of: "" },
 };
 
 # row count of RUN_OWN
@@ -461,7 +461,7 @@ pub val BUILD_CONSTRAINT_N: usize = 3;
 pub val BUILD_CONSTRAINT: [BUILD_CONSTRAINT_N]str = [BUILD_CONSTRAINT_N]str{
     "-v and -vv cannot be combined with --quiet or -q",
     "--bin and --lib cannot be combined",
-    "--explain cannot be combined with --quiet or -q",
+    "--plan cannot be combined with --quiet or -q",
 };
 
 # length of TEST_CONSTRAINT

--- a/src/cli/cmd.mach
+++ b/src/cli/cmd.mach
@@ -92,6 +92,7 @@ pub fun dispatch(argc: usize, argv: **u8) i64 {
     if (inv.command == args.CMD_INFO)  { rc = info.run_typed(argv, ?inv);    }
     or (inv.command == args.CMD_CLEAN) { rc = clean.run_typed(argv, ?inv);   }
     or (inv.command == args.CMD_BUILD) { rc = build.run_typed(argv, ?inv);   }
+    or (inv.command == args.CMD_CHECK) { rc = build.check_typed(argv, ?inv); }
     or (inv.command == args.CMD_RUN)   { rc = run.run_typed(argv, ?inv);    }
     or (inv.command == args.CMD_TEST)  { rc = testing.run_typed(argv, ?inv); }
     or (inv.command == args.CMD_DEP)   { rc = dep.run_typed(argv, ?inv);    }

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -36,6 +36,8 @@ use mach.lang.driver;
 use mach.lang.manifest;
 use mach.lang.readout;
 use mach.lang.session;
+use mach.lang.diagnostic;
+use mach.lang.source;
 
 # initialise a session, load the manifest, and plan a build for parsed CLI arguments
 # ---
@@ -120,9 +122,29 @@ fun plan_failure(a: *A.Allocator, ps: *session.Session, failure: outcome.Fail) R
 # inv: the parsed invocation for this command
 # ret: 0 success, 1 user error, 2 internal failure, 3 environment failure
 pub fun run_typed(argv: **u8, inv: *args.ParsedInvocation) i64 {
-    val cmd: args.CommandId = args.CMD_BUILD;
+    ret run_invocation(argv, inv, args.CMD_BUILD, request.GOAL_EXECUTE);
+}
 
-    var goal: request.BuildGoal = request.GOAL_EXECUTE;
+# `mach check`: plan the same cells `mach build` would and run each through the
+# frontend only, load, resolve and sema, reporting the same diagnostics with the
+# same classification. no build step runs, nothing is generated, compiled, linked
+# or written, and a generated or embedded input that does not exist yet is an
+# error naming it rather than a reason to run the step
+# ---
+# argv: the full process arguments
+# inv: the parsed invocation for this command
+# ret: 0 accepted, 1 rejected or user error, 2 internal failure, 3 environment failure
+pub fun check_typed(argv: **u8, inv: *args.ParsedInvocation) i64 {
+    if (inv.positional_count != 1) {
+        val f: outcome.Fail = outcome.user("mach check expects one project path");
+        ret cli_diag.render_fail(?f);
+    }
+    ret run_invocation(argv, inv, args.CMD_CHECK, request.GOAL_CHECK);
+}
+
+fun run_invocation(argv: **u8, inv: *args.ParsedInvocation, cmd: args.CommandId,
+                   requested_goal: request.BuildGoal) i64 {
+    var goal: request.BuildGoal = requested_goal;
     val opt_emit: O.Option[*u8] = args.invocation_value(cmd, inv, argv, "--emit");
     if (O.is_some[*u8](opt_emit)) {
         val kind: str = O.unwrap[*u8](opt_emit)::str;
@@ -156,7 +178,9 @@ pub fun run_typed(argv: **u8, inv: *args.ParsedInvocation) i64 {
         val f: outcome.Fail = outcome.user("`--plan` and `--quiet`/`-q` cannot be combined");
         ret cli_diag.render_fail(?f);
     }
-    if (args.reject_unknown_from_invocation(inv, argv, "mach build")) { ret 1; }
+    var command_name: str = "mach build";
+    if (cmd == args.CMD_CHECK) { command_name = "mach check"; }
+    if (args.reject_unknown_from_invocation(inv, argv, command_name)) { ret 1; }
 
     var arg: *u8 = nil;
     if (inv.has_positional) { arg = argv[inv.positional_idx]; }
@@ -627,5 +651,179 @@ test "mach.cli.cmd.build.run_typed:plan_prints_every_cell_and_writes_nothing" {
         if (!str_equals(entry, ".") && !str_equals(entry, "..") && !str_equals(entry, "mach.toml") && !str_equals(entry, "src")) { ret 6; }
         i = i + 1;
     }
+    ret 0;
+}
+
+fun t_check(argc: usize, argv: **u8) i64 {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 2; }
+    val parsed: R.Result[args.ParsedInvocation, str] = args.parse_invocation(?a, argc, argv);
+    if (R.is_err[args.ParsedInvocation, str](parsed)) { ret 2; }
+    var inv: args.ParsedInvocation = R.unwrap_ok[args.ParsedInvocation, str](parsed);
+    ret check_typed(argv, ?inv);
+}
+
+fun t_root_holds_only_sources(a: *A.Allocator, root: str) bool {
+    val listed: R.Result[Vector[str], str] = fs.read_dir(a, root);
+    if (R.is_err[Vector[str], str](listed)) { ret false; }
+    var names: Vector[str] = R.unwrap_ok[Vector[str], str](listed);
+    var i: usize = 0;
+    for (i < names.len) {
+        val entry: str = names.data[i];
+        if (!str_equals(entry, ".") && !str_equals(entry, "..") && !str_equals(entry, "mach.toml")
+            && !str_equals(entry, "src") && !str_equals(entry, "dep")) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+val T_CHECK_MAIN_OK: str = "use planfx.support;\n\n#[symbol(\"_start\")]\nfun start() {\n    val t: u64 = support.tint(1);\n    asm x86_64 {\n        mov rax, 60\n        mov rdi, {t}\n        syscall\n    }\n}\n";
+
+test "mach.cli.cmd.build.check_typed:checks_the_selected_graph_and_runs_no_step" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    var root: str = "";
+    if (!t_plan_scaffold(?a, T_PLAN_MANIFEST, ?root)) { ret 2; }
+    fin { fs.remove_all(?a, root); }
+    val src: str = t_req_join(?a, root, "src");
+    if (!t_req_write(?a, src, "main.mach", T_CHECK_MAIN_OK)) { ret 3; }
+    if (!t_req_write(?a, src, "unselected.mach", "this file is never imported and is deliberately not Mach\n")) { ret 4; }
+
+    var argv: [5]*u8;
+    argv[0] = "mach"::*u8; argv[1] = "check"::*u8; argv[2] = root::*u8;
+    argv[3] = "--target"::*u8; argv[4] = "host"::*u8;
+
+    # accepted: both artifacts on the target, the reachable graph only; the two
+    # steps app needs never ran and nothing was written
+    if (t_check(5, ?argv[0]) != 0) { ret 5; }
+    if (fs.exists(t_req_join(?a, root, "out")) || !t_root_holds_only_sources(?a, root)) { ret 6; }
+
+    # rejected by sema: a name that does not resolve in the selected entry
+    if (!t_req_write(?a, src, "main.mach", "use planfx.support;\nfun start() u64 { ret support.absent(1); }\n")) { ret 7; }
+    if (t_check(5, ?argv[0]) != 1) { ret 8; }
+    if (fs.exists(t_req_join(?a, root, "out"))) { ret 9; }
+
+    # rejected by the parser
+    if (!t_req_write(?a, src, "main.mach", "fun start( {\n")) { ret 10; }
+    if (t_check(5, ?argv[0]) != 1) { ret 11; }
+
+    # rejected by resolution: an import of a module that does not exist
+    if (!t_req_write(?a, src, "main.mach", "use planfx.generated;\nfun start() u64 { ret 0; }\n")) { ret 12; }
+    if (t_check(5, ?argv[0]) != 1) { ret 13; }
+
+    # narrowing to the library artifact leaves the broken binary entry unread
+    var narrowed: [7]*u8;
+    narrowed[0] = "mach"::*u8; narrowed[1] = "check"::*u8; narrowed[2] = root::*u8;
+    narrowed[3] = "--target"::*u8; narrowed[4] = "host"::*u8; narrowed[5] = "--lib"::*u8; narrowed[6] = "support"::*u8;
+    if (t_check(7, ?narrowed[0]) != 0) { ret 14; }
+    narrowed[5] = "--bin"::*u8; narrowed[6] = "app"::*u8;
+    if (t_check(7, ?narrowed[0]) != 1) { ret 15; }
+
+    # a malformed manifest is a user error before any source is read
+    if (!t_req_write(?a, root, "mach.toml", "[project]\nid = \"planfx\"\n")) { ret 16; }
+    if (t_check(5, ?argv[0]) != 1) { ret 17; }
+    if (fs.exists(t_req_join(?a, root, "out"))) { ret 18; }
+    ret 0;
+}
+
+test "mach.cli.cmd.build.check_typed:a_missing_generated_input_is_reported_not_produced" {
+    $if ($mach.build.os != $mach.os.linux)      { ret 0; }
+    $if ($mach.build.arch != $mach.arch.x86_64) { ret 0; }
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    val created: R.Result[fs.TempFile, str] = fs.temp_create(?a, "mach_check_generated");
+    if (R.is_err[fs.TempFile, str](created)) { ret 2; }
+    var temporary: fs.TempFile = R.unwrap_ok[fs.TempFile, str](created);
+    val root: str = fs.temp_path(?temporary);
+    fs.temp_close_and_remove(?temporary);
+    fin { fs.remove_all(?a, root); }
+    val src: str = t_req_join(?a, root, "src");
+    if (!t_req_write(?a, root, "mach.toml", T_REQ_MANIFEST)
+        || !t_req_write(?a, src, "shader.mach", T_REQ_SHADER)
+        || !t_req_write(?a, src, "main.mach", T_REQ_MAIN)) { ret 3; }
+
+    # main embeds the output of the required artifact shader-a, which only a build produces
+    var argv: [5]*u8;
+    argv[0] = "mach"::*u8; argv[1] = "check"::*u8; argv[2] = root::*u8;
+    argv[3] = "--target"::*u8; argv[4] = "host"::*u8;
+    if (t_check(5, ?argv[0]) != 1) { ret 4; }
+    if (fs.exists(t_req_join(?a, root, "out"))) { ret 5; }
+
+    # the build produces it, and the same check then accepts the same source
+    var build_argv: [5]*u8;
+    build_argv[0] = "mach"::*u8; build_argv[1] = "build"::*u8; build_argv[2] = root::*u8;
+    build_argv[3] = "--target"::*u8; build_argv[4] = "host"::*u8;
+    if (t_build(5, ?build_argv[0]) != 0) { ret 6; }
+    if (!fs.is_file(t_req_join(?a, root, "out/alt/debug/lib/shader-a.a"))) { ret 7; }
+    if (t_check(5, ?argv[0]) != 0) { ret 8; }
+    ret 0;
+}
+
+test "mach.cli.cmd.build.check_typed:requires_one_path_and_refuses_output_options" {
+    var argv: [5]*u8;
+    argv[0] = "mach"::*u8; argv[1] = "check"::*u8; argv[2] = "."::*u8;
+    argv[3] = "-o"::*u8; argv[4] = "bin/unexpected"::*u8;
+    if (t_check(2, ?argv[0]) != 1) { ret 1; }
+    if (t_check(5, ?argv[0]) != 1) { ret 2; }
+    argv[3] = "--emit-ir"::*u8;
+    if (t_check(4, ?argv[0]) != 1) { ret 3; }
+    argv[3] = "second-project"::*u8;
+    if (t_check(4, ?argv[0]) != 1) { ret 4; }
+    ret 0;
+}
+
+test "mach.cli.cmd.build.check:the_outcome_carries_located_diagnostics_and_a_typed_classification" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    var root: str = "";
+    if (!t_plan_scaffold(?a, T_PLAN_MANIFEST, ?root)) { ret 2; }
+    fin { fs.remove_all(?a, root); }
+    val src: str = t_req_join(?a, root, "src");
+    if (!t_req_write(?a, src, "main.mach", "use planfx.support;\nfun start() u64 { ret support.absent(1); }\n")) { ret 3; }
+
+    var cli: args.CliArgs = t_plan_cli("host", "app", false);
+    var ps: session.Session;
+    val planned: R.Result[plan.BuildPlan, outcome.Fail] = plan_invocation(?a, root, ?cli, request.GOAL_CHECK, false, ?ps);
+    if (R.is_err[plan.BuildPlan, outcome.Fail](planned)) { ret 4; }
+    var bp: plan.BuildPlan = R.unwrap_ok[plan.BuildPlan, outcome.Fail](planned);
+    fin { session.dnit(?ps); }
+    # the selected binary and the artifact it requires are both checked, neither built
+    if (bp.units.len != 2) { ret 5; }
+    var ui: usize = 0;
+    for (ui < bp.units.len) {
+        val unit: *plan.BuildUnit = ?bp.units.data[ui];
+        if (unit.goal != request.GOAL_CHECK) { ret 6; }
+        if (unit.phases.len != 2 || unit.phases.data[0] != plan.PH_LOAD || unit.phases.data[1] != plan.PH_SEMA) { ret 6; }
+        if (!str_empty(unit.out_path)) { ret 7; }
+        ui = ui + 1;
+    }
+
+    var oa: A.Allocator;
+    if (O.is_some[str](page.make(?oa))) { ret 8; }
+    val executed: R.Result[outcome.BuildOutcome, outcome.Fail] = engine.execute(?bp, ?a, ?oa, nil);
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](executed)) { ret 9; }
+    var bo: outcome.BuildOutcome = R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](executed);
+    fin { outcome.outcome_dnit(?bo); }
+    if (bo.severity != outcome.BUILD_USER) { ret 10; }
+    if (cli_diag.outcome_code(?bo) != 1) { ret 11; }
+    if (bo.artifacts.len != 0) { ret 12; }
+
+    var located: bool = false;
+    var i: usize = 0;
+    for (i < bo.events.len) {
+        val ev: *outcome.BuildEvent = ?bo.events.data[i];
+        if (ev.kind == outcome.BUILD_EVENT_DIAGNOSTICS) {
+            val diags: *diagnostic.DiagnosticStore = ev.data.diagnostics.diags;
+            var j: usize = 0;
+            for (j < diagnostic.len(diags)) {
+                val d: *diagnostic.Diagnostic = ?diags.items.data[j];
+                if (d.severity == diagnostic.SEVERITY_ERROR && d.loc.file_id != source.FILE_NIL && d.loc.span.len > 0) { located = true; }
+                j = j + 1;
+            }
+        }
+        i = i + 1;
+    }
+    if (!located) { ret 13; }
+    if (fs.exists(t_req_join(?a, root, "out"))) { ret 14; }
     ret 0;
 }

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -8,8 +8,17 @@ use std.types.path;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
+use std.types.string.str_empty;
+use std.types.string.str_index_of;
+use std.io.writer;
+use std.types.string.str_contains;
+use std.types.string.str_equals;
+use std.text.string.str_dup;
+use std.text.string.str_free;
 
 use A: std.allocator;
+use std.collections.vector;
+use std.collections.vector.Vector;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -34,12 +43,17 @@ use mach.lang.session;
 # root: the project root directory
 # cli: the parsed arguments
 # goal: what to produce, objects or an executable
+# configure_deps: also resolve every cell against the realized dependency closure,
+#  filling in its exported dependency steps and export link requirements. a build
+#  that goes on to execute resolves each cell as it runs it, so only a caller that
+#  reports the plan instead of running it asks for this
 # ps: out; the session the plan refers to, initialised here; on an error it has already been
-#  torn down
-# ret: the plan, or a Fail: internal for session or registry setup, user for manifest,
-#  selection, and request errors, and whatever plan.plan returns
+#  torn down and the returned failure message is owned by `a`
+# ret: the plan, configured against the realized dependency closure, or a Fail:
+#  internal for session or registry setup, user for manifest, selection, request
+#  and dependency-configuration errors, and whatever plan.plan returns
 pub fun plan_invocation(a: *A.Allocator, root: str, cli: *args.CliArgs, goal: request.BuildGoal,
-                        ps: *session.Session) R.Result[plan.BuildPlan, outcome.Fail] {
+                        configure_deps: bool, ps: *session.Session) R.Result[plan.BuildPlan, outcome.Fail] {
     val res_session: R.Result[session.Session, str] = session.init(a);
     if (R.is_err[session.Session, str](res_session)) {
         ret R.err[plan.BuildPlan, outcome.Fail](outcome.internal("failed to initialise compiler session"));
@@ -48,44 +62,59 @@ pub fun plan_invocation(a: *A.Allocator, root: str, cli: *args.CliArgs, goal: re
 
     val res_register: R.Result[R.Void, str] = driver.setup_registry(?ps.registry);
     if (R.is_err[R.Void, str](res_register)) {
-        session.dnit(ps);
-        ret R.err[plan.BuildPlan, outcome.Fail](outcome.internal(R.unwrap_err[R.Void, str](res_register)));
+        ret plan_failure(a, ps, outcome.internal(R.unwrap_err[R.Void, str](res_register)));
     }
 
     val res_manifest: R.Result[manifest.Manifest, str] = driver.load_manifest(ps, root);
     if (R.is_err[manifest.Manifest, str](res_manifest)) {
-        val f: outcome.Fail = outcome.user(R.unwrap_err[manifest.Manifest, str](res_manifest));
-        session.dnit(ps);
-        ret R.err[plan.BuildPlan, outcome.Fail](f);
+        ret plan_failure(a, ps, outcome.user(R.unwrap_err[manifest.Manifest, str](res_manifest)));
     }
     var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](res_manifest);
 
     var pick: manifest.Selection;
     val sr: R.Result[R.Void, str] = args.selection_from_config(cli, ?pick);
     if (R.is_err[R.Void, str](sr)) {
-        val f: outcome.Fail = outcome.user(R.unwrap_err[R.Void, str](sr));
-        session.dnit(ps);
-        ret R.err[plan.BuildPlan, outcome.Fail](f);
+        ret plan_failure(a, ps, outcome.user(R.unwrap_err[R.Void, str](sr)));
     }
 
     val res_req: R.Result[request.BuildRequest, outcome.Fail] = request.compose(a, ?ps.interner, ?m, cli, root, goal, ?pick);
     if (R.is_err[request.BuildRequest, outcome.Fail](res_req)) {
-        val f: outcome.Fail = R.unwrap_err[request.BuildRequest, outcome.Fail](res_req);
-        session.dnit(ps);
-        ret R.err[plan.BuildPlan, outcome.Fail](f);
+        ret plan_failure(a, ps, R.unwrap_err[request.BuildRequest, outcome.Fail](res_req));
     }
 
     val plan_r: R.Result[plan.BuildPlan, outcome.Fail] = plan.plan(ps.alloc, ?ps.interner, ?ps.registry, ?m,
         R.unwrap_ok[request.BuildRequest, outcome.Fail](res_req));
     if (R.is_err[plan.BuildPlan, outcome.Fail](plan_r)) {
-        session.dnit(ps);
+        ret plan_failure(a, ps, R.unwrap_err[plan.BuildPlan, outcome.Fail](plan_r));
     }
-    ret plan_r;
+    var bp: plan.BuildPlan = R.unwrap_ok[plan.BuildPlan, outcome.Fail](plan_r);
+
+    if (configure_deps) {
+        val configured: R.Result[R.Void, outcome.Fail] = plan.configure(ps, ?m, ?bp);
+        if (R.is_err[R.Void, outcome.Fail](configured)) {
+            ret plan_failure(a, ps, R.unwrap_err[R.Void, outcome.Fail](configured));
+        }
+    }
+    ret R.ok[plan.BuildPlan, outcome.Fail](bp);
+}
+
+# tear the session down and return a failure whose message outlives it: a message
+# the session allocated dies with `session.dnit`, and every caller renders it after
+fun plan_failure(a: *A.Allocator, ps: *session.Session, failure: outcome.Fail) R.Result[plan.BuildPlan, outcome.Fail] {
+    var stable: outcome.Fail = failure;
+    if (failure.message != nil) {
+        val copied: R.Result[str, str] = str_dup(a, failure.message);
+        if (R.is_err[str, str](copied)) { stable = outcome.internal("failed to retain the build planning error"); }
+        or { stable.message = R.unwrap_ok[str, str](copied); }
+    }
+    session.dnit(ps);
+    ret R.err[plan.BuildPlan, outcome.Fail](stable);
 }
 
 # `mach build`: plan and execute a build of the project operand, rendering diagnostics and
-# the outcome to stderr. `-O1` is refused before parsing; `--explain` prints the plan and
-# stops; `-v` and `-vv` render the phase readout after the build
+# the outcome to stderr. `-O1` is refused before parsing; `--plan` prints the effective
+# plan and stops without running a generator, a compiler or a linker; `-v` and `-vv`
+# render the phase readout after the build
 # ---
 # argv: the full process arguments
 # inv: the parsed invocation for this command
@@ -122,9 +151,9 @@ pub fun run_typed(argv: **u8, inv: *args.ParsedInvocation) i64 {
         ret cli_diag.render_fail(?f);
     }
 
-    val explain_only: bool = args.invocation_flag(cmd, inv, "--explain");
-    if (quiet_explain_conflict(config.quiet, explain_only)) {
-        val f: outcome.Fail = outcome.user("`--explain` and `--quiet`/`-q` cannot be combined");
+    val plan_only: bool = args.invocation_flag(cmd, inv, "--plan");
+    if (quiet_plan_conflict(config.quiet, plan_only)) {
+        val f: outcome.Fail = outcome.user("`--plan` and `--quiet`/`-q` cannot be combined");
         ret cli_diag.render_fail(?f);
     }
     if (args.reject_unknown_from_invocation(inv, argv, "mach build")) { ret 1; }
@@ -159,7 +188,7 @@ pub fun run_typed(argv: **u8, inv: *args.ParsedInvocation) i64 {
     }
 
     var ps: session.Session;
-    val plan_r: R.Result[plan.BuildPlan, outcome.Fail] = plan_invocation(?menu_alloc, root, ?config, goal, ?ps);
+    val plan_r: R.Result[plan.BuildPlan, outcome.Fail] = plan_invocation(?menu_alloc, root, ?config, goal, plan_only, ?ps);
     if (R.is_err[plan.BuildPlan, outcome.Fail](plan_r)) {
         var f: outcome.Fail = R.unwrap_err[plan.BuildPlan, outcome.Fail](plan_r);
         val c: i64 = cli_diag.render_fail(?f);
@@ -168,7 +197,7 @@ pub fun run_typed(argv: **u8, inv: *args.ParsedInvocation) i64 {
     }
     val bp: plan.BuildPlan = R.unwrap_ok[plan.BuildPlan, outcome.Fail](plan_r);
 
-    if (explain_only) {
+    if (plan_only) {
         plan.explain(?bp, ?ps.interner);
         session.dnit(?ps);
         arena.dnit(?menu_ar);
@@ -205,8 +234,8 @@ pub fun run_typed(argv: **u8, inv: *args.ParsedInvocation) i64 {
     ret code;
 }
 
-fun quiet_explain_conflict(quiet: bool, explain_only: bool) bool {
-    ret quiet && explain_only;
+fun quiet_plan_conflict(quiet: bool, plan_only: bool) bool {
+    ret quiet && plan_only;
 }
 
 fun t_build(argc: usize, argv: **u8) i64 {
@@ -218,21 +247,21 @@ fun t_build(argc: usize, argv: **u8) i64 {
     ret run_typed(argv, ?inv);
 }
 
-test "mach.cli.cmd.build.quiet_explain_conflict:only_the_combination_conflicts" {
-    if (!quiet_explain_conflict(true, true))  { ret 1; }
-    if (quiet_explain_conflict(true, false))  { ret 2; }
-    if (quiet_explain_conflict(false, true))  { ret 3; }
-    if (quiet_explain_conflict(false, false)) { ret 4; }
+test "mach.cli.cmd.build.quiet_plan_conflict:only_the_combination_conflicts" {
+    if (!quiet_plan_conflict(true, true))  { ret 1; }
+    if (quiet_plan_conflict(true, false))  { ret 2; }
+    if (quiet_plan_conflict(false, true))  { ret 3; }
+    if (quiet_plan_conflict(false, false)) { ret 4; }
     ret 0;
 }
 
-test "mach.cli.cmd.build.run_typed:rejects_quiet_combined_with_explain" {
+test "mach.cli.cmd.build.run_typed:rejects_quiet_combined_with_plan" {
     var argv: [4]*u8;
-    argv[0] = "mach"; argv[1] = "build"; argv[2] = "--quiet"; argv[3] = "--explain";
+    argv[0] = "mach"; argv[1] = "build"; argv[2] = "--quiet"; argv[3] = "--plan";
     if (t_build(4, ?argv[0]) != 1) { ret 1; }
 
     var alias: [4]*u8;
-    alias[0] = "mach"; alias[1] = "build"; alias[2] = "-q"; alias[3] = "--explain";
+    alias[0] = "mach"; alias[1] = "build"; alias[2] = "-q"; alias[3] = "--plan";
     if (t_build(4, ?alias[0]) != 1) { ret 2; }
 
     ret 0;
@@ -375,4 +404,228 @@ test "mach.cli.cmd.build.run_typed:rejects_o1_before_any_side_effect_o0_and_o2_s
 
     fs.remove_all(?a, root);
     ret bad;
+}
+
+fun str_index(s: str, sub: str) usize {
+    val at: O.Option[usize] = str_index_of(s, sub);
+    if (O.is_none[usize](at)) { ret str_len(s); }
+    ret O.unwrap[usize](at);
+}
+
+fun t_plan_cli(target: str, artifact: str, all_targets: bool) args.CliArgs {
+    var cli: args.CliArgs;
+    cli.target      = target;
+    cli.bin         = artifact::*u8;
+    if (str_empty(artifact)) { cli.bin = nil; }
+    cli.all_targets = all_targets;
+    ret cli;
+}
+
+fun t_text_sink_write(ctx: ptr, buf: *u8, len: usize) R.Result[usize, str] {
+    val sink: *Vector[u8] = ctx::*Vector[u8];
+    var i: usize = 0;
+    for (i < len) {
+        val pushed: R.Result[usize, str] = vector.push[u8](sink, buf[i]);
+        if (R.is_err[usize, str](pushed)) { ret R.err[usize, str](R.unwrap_err[usize, str](pushed)); }
+        i = i + 1;
+    }
+    ret R.ok[usize, str](len);
+}
+
+fun t_plan_text(a: *A.Allocator, root: str, cli: *args.CliArgs, configure_deps: bool,
+                out_text: *str) R.Result[R.Void, outcome.Fail] {
+    var ps: session.Session;
+    val planned: R.Result[plan.BuildPlan, outcome.Fail] = plan_invocation(a, root, cli,
+        request.GOAL_EXECUTE, configure_deps, ?ps);
+    if (R.is_err[plan.BuildPlan, outcome.Fail](planned)) {
+        ret R.err[R.Void, outcome.Fail](R.unwrap_err[plan.BuildPlan, outcome.Fail](planned));
+    }
+    var bp: plan.BuildPlan = R.unwrap_ok[plan.BuildPlan, outcome.Fail](planned);
+
+    var sink: Vector[u8] = vector.init[u8](a);
+    var w: writer.Writer;
+    w.ctx     = (?sink)::ptr;
+    w.f_write = t_text_sink_write;
+    plan.render(?w, ?bp, ?ps.interner);
+    session.dnit(?ps);
+
+    val terminated: R.Result[usize, str] = vector.push[u8](?sink, 0);
+    if (R.is_err[usize, str](terminated)) { ret R.err[R.Void, outcome.Fail](outcome.internal("out of memory")); }
+    @out_text = sink.data::str;
+    ret R.ok_void[outcome.Fail]();
+}
+
+val T_PLAN_MANIFEST: str = "[project]\nid = \"planfx\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.host]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.win]\nisa = \"x86_64\"\nos = \"windows\"\nabi = \"win64\"\n\n[artifact.support]\nkind = \"static\"\nentry = \"support.mach\"\nout = \"lib/libsupport{artifact.suffix}\"\ntargets = [\"*\"]\nlink = []\nneed = []\n\n[artifact.app]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/app{artifact.suffix}\"\ntargets = [\"*\"]\nlink = []\nneed = [\"artifact.support\", \"step.generate\"]\n\n[step.generate]\nargv = [\"sh\", \"-c\", \"printf generated > {project.out}/generated.txt\"]\nin = []\nout = [\"{project.out}/generated.txt\"]\nneed = [\"step.prepare\"]\n\n[step.prepare]\nargv = [\"sh\", \"-c\", \"printf prepared > {project.out}/prepared.txt\"]\nin = []\nout = [\"{project.out}/prepared.txt\"]\nneed = []\n\n[profile.debug]\ndefault = true\nopt = 0\ndebug = false\nsimd = \"scalarize\"\nvectorize = true\nfloat_reassoc = false\n";
+
+val T_PLAN_SUPPORT: str = "pub fun tint(x: u64) u64 { ret x + 3; }\n";
+
+val T_PLAN_MAIN: str = "#[symbol(\"_start\")]\nfun start() {\n    asm x86_64 {\n        mov rax, 60\n        mov rdi, 0\n        syscall\n    }\n}\n";
+
+fun t_plan_scaffold(a: *A.Allocator, manifest_text: str, out_root: *str) bool {
+    val created: R.Result[fs.TempFile, str] = fs.temp_create(a, "mach_plan_case");
+    if (R.is_err[fs.TempFile, str](created)) { ret false; }
+    var temporary: fs.TempFile = R.unwrap_ok[fs.TempFile, str](created);
+    val root: str = fs.temp_path(?temporary);
+    fs.temp_close_and_remove(?temporary);
+    if (O.is_some[str](fs.create_dir_all(a, root, 0o755))) { ret false; }
+    @out_root = root;
+    if (!t_req_write(a, root, "mach.toml", manifest_text)) { ret false; }
+    val src: str = t_req_join(a, root, "src");
+    if (!t_req_write(a, src, "support.mach", T_PLAN_SUPPORT)) { ret false; }
+    ret t_req_write(a, src, "main.mach", T_PLAN_MAIN);
+}
+
+test "mach.cli.cmd.build.plan:displays_the_selection_the_build_produces_and_executes_nothing" {
+    $if ($mach.build.os != $mach.os.linux)      { ret 0; }
+    $if ($mach.build.arch != $mach.arch.x86_64) { ret 0; }
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    var root: str = "";
+    if (!t_plan_scaffold(?a, T_PLAN_MANIFEST, ?root)) { ret 2; }
+    fin { fs.remove_all(?a, root); }
+
+    var cli: args.CliArgs = t_plan_cli("", "", true);
+    var text: str = "";
+    val rendered: R.Result[R.Void, outcome.Fail] = t_plan_text(?a, root, ?cli, true, ?text);
+    if (R.is_err[R.Void, outcome.Fail](rendered)) { ret 3; }
+
+    # every declared cell, its entry, its derived suffix and its prerequisite order
+    if (!str_contains(text, "project: planfx")) { ret 4; }
+    if (!str_contains(text, "units:   4"))      { ret 5; }
+    if (!str_contains(text, "  entry   main.mach"))    { ret 6; }
+    if (!str_contains(text, "  entry   support.mach")) { ret 7; }
+    if (!str_contains(text, "/out/host/debug/bin/app\n"))     { ret 8; }
+    if (!str_contains(text, "/out/win/debug/bin/app.exe\n"))  { ret 9; }
+    if (!str_contains(text, "/out/host/debug/lib/libsupport.a\n"))   { ret 10; }
+    if (!str_contains(text, "/out/win/debug/lib/libsupport.lib\n")) { ret 11; }
+    if (!str_contains(text, "  need    artifact support"))   { ret 12; }
+    if (!str_contains(text, "  step    project prepare"))    { ret 13; }
+    if (!str_contains(text, "  step    project generate"))   { ret 14; }
+    if (str_index(text, "  step    project prepare") > str_index(text, "  step    project generate")) { ret 15; }
+    if (!str_contains(text, "generated bytes are unresolved")) { ret 16; }
+    if (!str_contains(text, "it does not claim the link succeeds")) { ret 17; }
+    if (str_contains(text, "not configured against the dependency closure")) { ret 18; }
+
+    # nothing ran: no step output, no object, IR or assembly tree, no artifact
+    if (fs.exists(t_req_join(?a, root, "out"))) { ret 19; }
+
+    # the build that follows produces exactly the paths the plan named
+    var argv: [5]*u8;
+    argv[0] = "mach"::*u8; argv[1] = "build"::*u8; argv[2] = root::*u8;
+    argv[3] = "--target"::*u8; argv[4] = "host"::*u8;
+    if (t_build(5, ?argv[0]) != 0) { ret 20; }
+    if (!fs.is_file(t_req_join(?a, root, "out/host/debug/bin/app")))          { ret 21; }
+    if (!fs.is_file(t_req_join(?a, root, "out/host/debug/lib/libsupport.a"))) { ret 22; }
+    if (!fs.is_file(t_req_join(?a, root, "out/host/debug/generated.txt")))    { ret 23; }
+    if (!fs.is_file(t_req_join(?a, root, "out/host/debug/prepared.txt")))     { ret 24; }
+    ret 0;
+}
+
+test "mach.cli.cmd.build.plan:an_unconfigured_plan_does_not_claim_an_empty_dependency_closure" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    var root: str = "";
+    if (!t_plan_scaffold(?a, T_PLAN_MANIFEST, ?root)) { ret 2; }
+    fin { fs.remove_all(?a, root); }
+    var cli: args.CliArgs = t_plan_cli("host", "app", false);
+    var text: str = "";
+    if (R.is_err[R.Void, outcome.Fail](t_plan_text(?a, root, ?cli, false, ?text))) { ret 3; }
+    if (!str_contains(text, "not configured against the dependency closure")) { ret 4; }
+    if (fs.exists(t_req_join(?a, root, "out"))) { ret 5; }
+    ret 0;
+}
+
+test "mach.cli.cmd.build.plan:dependency_prerequisites_missing_realizations_and_cycles_use_the_shared_service" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    var root: str = "";
+    val with_dep: str = plan.join_msg(?a, T_PLAN_MANIFEST, "\n[dep.vendor]\npath = \"../source-must-not-be-read\"\n");
+    if (!t_plan_scaffold(?a, with_dep, ?root)) { ret 2; }
+    fin { fs.remove_all(?a, root); }
+    var cli: args.CliArgs = t_plan_cli("host", "app", false);
+    var text: str = "";
+
+    # a dependency that is not realized fails planning exactly as a build fails it
+    val missing: R.Result[R.Void, outcome.Fail] = t_plan_text(?a, root, ?cli, true, ?text);
+    if (R.is_ok[R.Void, outcome.Fail](missing)) { ret 3; }
+    var failure: outcome.Fail = R.unwrap_err[R.Void, outcome.Fail](missing);
+    if (failure.kind != outcome.FAIL_USER) { ret 4; }
+    if (!str_contains(failure.message, "is not resolved (missing")) { ret 5; }
+    if (fs.exists(t_req_join(?a, root, "dep/vendor")) || fs.exists(t_req_join(?a, root, "out"))) { ret 6; }
+
+    # the same realized dependency's exported steps and link requirements, in order
+    val dep_root: str = t_req_join(?a, root, "dep/vendor");
+    val dep_manifest: str = "[project]\nid = \"vendor\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out\"\n[profile.debug]\ndefault = true\nopt = 0\ndebug = false\nsimd = \"scalarize\"\nvectorize = false\nfloat_reassoc = false\n[artifact.vendor]\nkind = \"static\"\ndefault = true\nentry = \"public.mach\"\nout = \"lib/vendor.a\"\ntargets = [\"*\"]\nlink = []\nneed = []\n[link.generated]\nsource = \"local\"\npath = \"{project.out}/vendor.o\"\nos = [\"*\"]\nisa = [\"*\"]\nabi = [\"*\"]\nexport = true\n[step.first]\nargv = [\"sh\", \"-c\", \"printf ran > {project.out}/dep-first.txt\"]\nin = []\nout = [\"{project.out}/dep-first.txt\"]\nneed = []\n[step.object]\nargv = [\"sh\", \"-c\", \"printf ran > {project.out}/vendor.o\"]\nin = []\nout = [\"{project.out}/vendor.o\"]\nneed = [\"step.first\"]\n";
+    if (!t_req_write(?a, dep_root, "mach.toml", dep_manifest)) { ret 7; }
+    if (!t_req_write(?a, t_req_join(?a, dep_root, "src"), "public.mach", "this is deliberately not Mach source\n")) { ret 8; }
+
+    if (R.is_err[R.Void, outcome.Fail](t_plan_text(?a, root, ?cli, true, ?text))) { ret 9; }
+    if (!str_contains(text, "  step    dependency vendor.first"))  { ret 10; }
+    if (!str_contains(text, "  step    dependency vendor.object")) { ret 11; }
+    if (str_index(text, "vendor.first") > str_index(text, "vendor.object")) { ret 12; }
+    if (!str_contains(text, "  link    dependency export "))       { ret 13; }
+    if (!str_contains(text, "vendor.o"))                           { ret 14; }
+    # the dependency's exported steps precede the project's own
+    if (str_index(text, "  step    dependency vendor.object") > str_index(text, "  step    project prepare")) { ret 15; }
+    # neither the dependency's steps nor the project's ran, and its source was never read
+    if (fs.exists(t_req_join(?a, root, "out")) || fs.exists(t_req_join(?a, dep_root, "out"))) { ret 16; }
+
+    # a dependency cycle is the shared service's diagnostic, not a planner-local one
+    val cyclic: str = plan.join_msg(?a, dep_manifest, "\n[dep.planfx]\npath = \"../..\"\n");
+    if (!t_req_write(?a, dep_root, "mach.toml", cyclic)) { ret 17; }
+    val cycle: R.Result[R.Void, outcome.Fail] = t_plan_text(?a, root, ?cli, true, ?text);
+    if (R.is_ok[R.Void, outcome.Fail](cycle)) { ret 18; }
+    failure = R.unwrap_err[R.Void, outcome.Fail](cycle);
+    if (failure.kind != outcome.FAIL_USER) { ret 19; }
+    if (fs.exists(t_req_join(?a, root, "out"))) { ret 20; }
+
+    # an invalid root manifest is the manifest diagnostic, reported before any cell
+    if (!t_req_write(?a, root, "mach.toml", "[project]\nid = \"planfx\"\n")) { ret 21; }
+    val invalid: R.Result[R.Void, outcome.Fail] = t_plan_text(?a, root, ?cli, true, ?text);
+    if (R.is_ok[R.Void, outcome.Fail](invalid)) { ret 22; }
+    failure = R.unwrap_err[R.Void, outcome.Fail](invalid);
+    if (failure.kind != outcome.FAIL_USER || !str_contains(failure.message, "mach.toml:")) { ret 23; }
+    ret 0;
+}
+
+test "mach.cli.cmd.build.plan_failure:the_message_outlives_the_session_it_came_from" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    val initialized: R.Result[session.Session, str] = session.init(?a);
+    if (R.is_err[session.Session, str](initialized)) { ret 2; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](initialized);
+    val copied: R.Result[str, str] = str_dup(s.alloc, "owned planning failure");
+    if (R.is_err[str, str](copied)) { session.dnit(?s); ret 3; }
+    val session_owned: str = R.unwrap_ok[str, str](copied);
+    val result: R.Result[plan.BuildPlan, outcome.Fail] = plan_failure(?a, ?s, outcome.user(session_owned));
+    if (R.is_ok[plan.BuildPlan, outcome.Fail](result)) { ret 4; }
+    val failure: outcome.Fail = R.unwrap_err[plan.BuildPlan, outcome.Fail](result);
+    if (failure.message == session_owned || failure.kind != outcome.FAIL_USER) { ret 5; }
+    val intact: bool = str_equals(failure.message, "owned planning failure");
+    str_free(?a, failure.message);
+    if (!intact) { ret 6; }
+    ret 0;
+}
+
+test "mach.cli.cmd.build.run_typed:plan_prints_every_cell_and_writes_nothing" {
+    var a: A.Allocator;
+    if (O.is_some[str](page.make(?a))) { ret 1; }
+    var root: str = "";
+    if (!t_plan_scaffold(?a, T_PLAN_MANIFEST, ?root)) { ret 2; }
+    fin { fs.remove_all(?a, root); }
+    var argv: [5]*u8;
+    argv[0] = "mach"::*u8; argv[1] = "build"::*u8; argv[2] = root::*u8;
+    argv[3] = "--all-targets"::*u8; argv[4] = "--plan"::*u8;
+    if (t_build(5, ?argv[0]) != 0) { ret 3; }
+    if (fs.exists(t_req_join(?a, root, "out"))) { ret 4; }
+    val listed: R.Result[Vector[str], str] = fs.read_dir(?a, root);
+    if (R.is_err[Vector[str], str](listed)) { ret 5; }
+    var names: Vector[str] = R.unwrap_ok[Vector[str], str](listed);
+    var i: usize = 0;
+    for (i < names.len) {
+        val entry: str = names.data[i];
+        if (!str_equals(entry, ".") && !str_equals(entry, "..") && !str_equals(entry, "mach.toml") && !str_equals(entry, "src")) { ret 6; }
+        i = i + 1;
+    }
+    ret 0;
 }

--- a/src/cli/cmd/help.mach
+++ b/src/cli/cmd/help.mach
@@ -704,7 +704,7 @@ test "mach.cli.cmd.help.render:overview_and_pages_come_from_schema_order" {
     val build: str = sink_text(?out_sink);
     if (!str_contains(build, "usage: mach build <path> [options] [inputs...]")) { ret 6; }
     if (!str_contains(build, "--profile <name>")) { ret 7; }
-    if (!str_contains(build, "default: sole or default profile")) { ret 8; }
+    if (!str_contains(build, "default: the sole or default profile")) { ret 8; }
     if (!str_contains(build, "--bin <name>")) { ret 9; }
     if (!str_contains(build, "--bin and --lib cannot be combined")) { ret 10; }
     if (!str_contains(build, "-L <dir>")) { ret 11; }

--- a/src/cli/cmd/testing.mach
+++ b/src/cli/cmd/testing.mach
@@ -171,7 +171,7 @@ pub fun run_typed(argv: **u8, inv: *args.ParsedInvocation) i64 {
     if (list) { goal = request.GOAL_TEST_LIST; }
 
     var ps: session.Session;
-    val plan_r: R.Result[plan.BuildPlan, outcome.Fail] = build.plan_invocation(?a, root, ?config, goal, ?ps);
+    val plan_r: R.Result[plan.BuildPlan, outcome.Fail] = build.plan_invocation(?a, root, ?config, goal, false, ?ps);
     if (R.is_err[plan.BuildPlan, outcome.Fail](plan_r)) {
         var pf: outcome.Fail = R.unwrap_err[plan.BuildPlan, outcome.Fail](plan_r);
         val pc: i64 = cli_diag.render_fail(?pf);

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -367,7 +367,7 @@ pub fun execute_warm(bp: *plan.BuildPlan, unit_index: usize, s: *session.Session
         outcome.fold_fail(?bo, ?cleanup);
         if (R.is_ok[R.Void, outcome.Fail](result)) { result = R.err[R.Void, outcome.Fail](cleanup); }
     }
-    if (R.is_ok[R.Void, outcome.Fail](result) && ev != nil) {
+    if (R.is_ok[R.Void, outcome.Fail](result) && ev != nil && req.goal != request.GOAL_CHECK) {
         emit_unit_summary(?p, ?st, ev);
     }
 

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -34,9 +34,14 @@ use mach.lang.target.of.bin;
 use mach.lang.target.of.coff;
 use mach.lang.target.of.elf;
 use mach.lang.target.of.macho;
+use std.io.writer;
+
 use mach.lang.build.outcome;
 use mach.lang.build.request;
+use mach.lang.driver;
+use dcfg: mach.lang.driver.config;
 use mach.lang.driver.project;
+use mach.lang.session;
 use mach.lang.intern;
 use mach.lang.manifest;
 use mach.lang.me.pipeline;
@@ -78,6 +83,16 @@ pub rec LinkInput {
     include_referenced: bool;
 }
 
+# one planned cell: an artifact on a target for a profile, with every decision
+# the engine executes. `plan` fills everything the root manifest decides; `configure`
+# adds what the realized dependency closure decides
+# ---
+# steps: the root manifest's prerequisite steps in execution order, by name
+# dep_steps: exported dependency steps in execution order as `<dep id>.<step>`;
+#  empty until `configure`
+# export_links: the dependency closure's exported link requirements for this
+#  cell, in link order; empty until `configure`
+# configured: `configure` ran, so `dep_steps` and `export_links` are effective
 pub rec BuildUnit {
     target_entry: *project.TargetEntry;
     profile:      str;
@@ -90,6 +105,10 @@ pub rec BuildUnit {
     asm_dir:      str;
     link_inputs:  Vector[LinkInput];
     phases:       Vector[PhaseKind];
+    steps:        Vector[str];
+    dep_steps:    Vector[str];
+    export_links: Vector[manifest.LinkRequirement];
+    configured:   bool;
 
     sel_target:   str;
     sel_artifact: str;
@@ -102,8 +121,10 @@ pub rec BuildUnit {
 
 pub def BuildRequest: request.BuildRequest;
 
+# project: the root manifest's `[project].id`
 pub rec BuildPlan {
     request: BuildRequest;
+    project: str;
     units:   Vector[BuildUnit];
 }
 
@@ -112,6 +133,7 @@ pub fun plan(a: *A.Allocator, itn: *intern.Interner, reg: *target.TargetRegistry
     var bp: BuildPlan;
     bp.request = owned_req;
     bp.units   = vector.init[BuildUnit](a);
+    bp.project = entry_name(itn, m.id);
     val req: *request.BuildRequest = ?bp.request;
 
     if (request.test_goal(req.goal)) {
@@ -200,6 +222,80 @@ pub fun plan(a: *A.Allocator, itn: *intern.Interner, reg: *target.TargetRegistry
         ret R.err[BuildPlan, outcome.Fail](outcome.user(out_conflict_msg(a, ?bp)));
     }
     ret R.ok[BuildPlan, outcome.Fail](bp);
+}
+
+# resolve every planned cell against the realized dependency closure, filling in
+# the exported dependency steps and export link requirements each cell consumes.
+# it configures projects through the same `driver.begin_build` a build runs, so a
+# missing realization, an invalid dependency manifest or a dependency cycle is
+# reported here exactly as the build would report it. nothing is fetched, no step
+# runs and no output is written
+# ---
+# s: the session the plan was made in
+# m: the root manifest
+# bp: the plan, mutated in place; each unit becomes `configured`
+# ret: ok; the configuration failure of the first cell that has one
+pub fun configure(s: *session.Session, m: *manifest.Manifest, bp: *BuildPlan) R.Result[R.Void, outcome.Fail] {
+    var i: usize = 0;
+    for (i < bp.units.len) {
+        val u: *BuildUnit = ?bp.units.data[i];
+        var req: request.BuildRequest = request.for_cell(?bp.request, u.sel_target,
+            u.sel_artifact, u.want_lib, u.subsystem, u.goal);
+        val begun: R.Result[project.Project, outcome.Fail] = driver.begin_build(s, m, ?req, nil);
+        if (R.is_err[project.Project, outcome.Fail](begun)) {
+            ret R.err[R.Void, outcome.Fail](R.unwrap_err[project.Project, outcome.Fail](begun));
+        }
+        var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](begun);
+        val collected: R.Result[R.Void, outcome.Fail] = collect_dependency_plan(?p, u);
+        project.dnit_project(?p);
+        if (R.is_err[R.Void, outcome.Fail](collected)) { ret collected; }
+        u.configured = true;
+        i = i + 1;
+    }
+    ret R.ok_void[outcome.Fail]();
+}
+
+fun collect_dependency_plan(p: *project.Project, u: *BuildUnit) R.Result[R.Void, outcome.Fail] {
+    val itn: *intern.Interner = ?p.s.interner;
+    val planned: R.Result[Vector[dcfg.DependencyStep], str] = dcfg.plan_dep_steps(p,
+        entry_name(itn, u.target_entry.isa_name), entry_name(itn, u.target_entry.os_name),
+        entry_name(itn, u.target_entry.abi_name));
+    if (R.is_err[Vector[dcfg.DependencyStep], str](planned)) {
+        ret R.err[R.Void, outcome.Fail](outcome.user(R.unwrap_err[Vector[dcfg.DependencyStep], str](planned)));
+    }
+    var steps: Vector[dcfg.DependencyStep] = R.unwrap_ok[Vector[dcfg.DependencyStep], str](planned);
+    fin { vector.dnit[dcfg.DependencyStep](?steps); }
+
+    var i: usize = 0;
+    for (i < steps.len) {
+        val selected: dcfg.DependencyStep = steps.data[i];
+        val dm: *manifest.Manifest = ?p.config.deps[selected.dependency].manifest;
+        val labelled: R.Result[str, str] = format.sprint(u.dep_steps.a, "{}.{}",
+            entry_name(itn, dm.id), entry_name(itn, dm.steps[selected.step].name));
+        if (R.is_err[str, str](labelled)) {
+            ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[str, str](labelled)));
+        }
+        val pushed: R.Result[usize, str] = vector.push[str](?u.dep_steps, R.unwrap_ok[str, str](labelled));
+        if (R.is_err[usize, str](pushed)) {
+            ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[usize, str](pushed)));
+        }
+        i = i + 1;
+    }
+
+    # the claimed-symbol array belongs to the project config and dies with it; the
+    # plan keeps only the interned identity it displays
+    var li: u32 = 0;
+    for (li < p.config.cascade_lib_count) {
+        var retained: manifest.LinkRequirement = p.config.cascade_libs[li];
+        retained.symbols      = nil;
+        retained.symbol_count = 0;
+        val pushed: R.Result[usize, str] = vector.push[manifest.LinkRequirement](?u.export_links, retained);
+        if (R.is_err[usize, str](pushed)) {
+            ret R.err[R.Void, outcome.Fail](outcome.internal(R.unwrap_err[usize, str](pushed)));
+        }
+        li = li + 1;
+    }
+    ret R.ok_void[outcome.Fail]();
 }
 
 fun selected_unit_count(bp: *BuildPlan) usize {
@@ -361,6 +457,12 @@ fun unit_decisions_equal(a: *BuildUnit, b: *BuildUnit) bool {
         if (!str_equals(a.requires.data[ri], b.requires.data[ri])) { ret false; }
         ri = ri + 1;
     }
+    if (a.steps.len != b.steps.len) { ret false; }
+    var si: usize = 0;
+    for (si < a.steps.len) {
+        if (!str_equals(a.steps.data[si], b.steps.data[si])) { ret false; }
+        si = si + 1;
+    }
     if (!str_equals(a.out_path, b.out_path)) { ret false; }
     if (!str_equals(a.obj_dir, b.obj_dir))   { ret false; }
     if (!str_equals(a.ir_dir, b.ir_dir))     { ret false; }
@@ -488,7 +590,10 @@ fun plan_unit(a: *A.Allocator, itn: *intern.Interner, reg: *target.TargetRegistr
     if (R.is_err[str, outcome.Fail](op_r)) { ret R.err[BuildUnit, outcome.Fail](R.unwrap_err[str, outcome.Fail](op_r)); }
     u.out_path = R.unwrap_ok[str, outcome.Fail](op_r);
 
-    u.link_inputs = vector.init[LinkInput](a);
+    u.link_inputs  = vector.init[LinkInput](a);
+    u.dep_steps    = vector.init[str](a);
+    u.export_links = vector.init[manifest.LinkRequirement](a);
+    u.configured   = false;
     var ti: usize = 0;
     for (ti < req.link_tokens.len) {
         val token: str = req.link_tokens.data[ti].text;
@@ -622,8 +727,9 @@ fun derive_phases(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
                   req: *request.BuildRequest, bu: *manifest.BuildUnit,
                   tgt: *target.Target, u: *BuildUnit) R.Result[R.Void, outcome.Fail] {
     u.phases = vector.init[PhaseKind](a);
+    u.steps  = vector.init[str](a);
 
-    val demanded_r: R.Result[bool, outcome.Fail] = steps_demanded(a, itn, m, req, bu);
+    val demanded_r: R.Result[bool, outcome.Fail] = steps_demanded(a, itn, m, req, bu, ?u.steps);
     if (R.is_err[bool, outcome.Fail](demanded_r)) { ret R.void_of[bool, outcome.Fail](demanded_r); }
     if (m.dep_count > 0) {
         val r1: R.Result[R.Void, outcome.Fail] = push_phase(u, PH_DEP_STEPS);
@@ -666,8 +772,12 @@ fun push_phase(u: *BuildUnit, k: PhaseKind) R.Result[R.Void, outcome.Fail] {
     ret R.ok_void[outcome.Fail]();
 }
 
+# the root manifest's prerequisite steps this cell demands, appended to `steps`
+# in execution order. the same `manifest.plan_steps` the driver runs, so the
+# displayed order is the executed order
 fun steps_demanded(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
-                   req: *request.BuildRequest, bu: *manifest.BuildUnit) R.Result[bool, outcome.Fail] {
+                   req: *request.BuildRequest, bu: *manifest.BuildUnit,
+                   steps: *Vector[str]) R.Result[bool, outcome.Fail] {
     if (m.step_count == 0) { ret R.ok[bool, outcome.Fail](false); }
 
     val pn_opt: O.Option[str] = intern.lookup(itn, bu.profile_name);
@@ -706,7 +816,15 @@ fun steps_demanded(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest
     if (R.is_err[R.Void, str](r)) {
         ret R.err[bool, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](r)));
     }
-    if (order != nil && count > 0) { A.deallocate[u32](a, order, count::usize); }
+    fin { if (order != nil && count > 0) { A.deallocate[u32](a, order, count::usize); } }
+    var i: u32 = 0;
+    for (i < count) {
+        val named: O.Option[str] = intern.lookup(itn, m.steps[order[i]].name);
+        if (O.is_none[str](named)) { ret R.err[bool, outcome.Fail](outcome.internal("planned step name is not interned")); }
+        val pushed: R.Result[usize, str] = vector.push[str](steps, O.unwrap[str](named));
+        if (R.is_err[usize, str](pushed)) { ret R.err[bool, outcome.Fail](outcome.internal("out of memory")); }
+        i = i + 1;
+    }
     ret R.ok[bool, outcome.Fail](count > 0);
 }
 
@@ -1375,49 +1493,103 @@ fun write_named_versioned(dir: *u8, name: *u8, v: u32, buf: *u8, cap: usize) boo
     ret true;
 }
 
-pub fun explain(p: *BuildPlan, itn: *intern.Interner) {
-    print.printf("plan: {}\n", p.request.project_root);
-    print.printf("units: {}\n", p.units.len::i64);
+# render the effective plan: one block per selected cell, naming the project,
+# target, profile, artifact, entry, output paths, ordered prerequisite steps and
+# link requirements. a plan the caller never configured says so instead of
+# claiming an empty dependency closure
+# ---
+# w: the sink; `explain` passes stdout
+# p: the plan
+# itn: resolves interned names
+pub fun render(w: *writer.Writer, p: *BuildPlan, itn: *intern.Interner) {
+    format.format(w, "plan:    {}\n", p.request.project_root);
+    format.format(w, "project: {}\n", p.project);
+    format.format(w, "units:   {}\n", p.units.len::i64);
 
     var i: usize = 0;
     for (i < p.units.len) {
         val u: *BuildUnit = ?p.units.data[i];
-        print.print("\n");
-        print.printf("unit {}: {} ({})  target {}  profile {}\n",
+        format.write_str(w, "\n");
+        format.format(w, "unit {}: {} ({})  target {}  profile {}\n",
             (i + 1)::i64, unit_artifact_label(u), unit_kind_label(u),
             entry_name(itn, u.target_entry.name), u.profile);
-        print.printf("  goal    {}\n", request.goal_name(u.goal));
-        print.printf("  tuple   {}-{}-{}\n",
+        format.format(w, "  goal    {}\n", request.goal_name(u.goal));
+        format.format(w, "  tuple   {}-{}-{}\n",
             entry_name(itn, u.target_entry.isa_name),
             entry_name(itn, u.target_entry.os_name),
             entry_name(itn, u.target_entry.abi_name));
-        print.printf("  opt     {}\n", opt_name(u.opt_level));
-        if (!str_empty(u.out_path)) { print.printf("  out     {}\n", u.out_path); }
-        print.printf("  obj     {}\n", u.obj_dir);
-        if (!str_empty(u.ir_dir))  { print.printf("  ir      {}\n", u.ir_dir); }
-        if (!str_empty(u.asm_dir)) { print.printf("  asm     {}\n", u.asm_dir); }
+        format.format(w, "  opt     {}\n", opt_name(u.opt_level));
+        format.format(w, "  entry   {}\n", entry_name(itn, u.target_entry.entrypoint));
+        if (!str_empty(u.out_path)) { format.format(w, "  out     {}\n", u.out_path); }
+        format.format(w, "  obj     {}\n", u.obj_dir);
+        if (!str_empty(u.ir_dir))  { format.format(w, "  ir      {}\n", u.ir_dir); }
+        if (!str_empty(u.asm_dir)) { format.format(w, "  asm     {}\n", u.asm_dir); }
 
+        var ri: usize = 0;
+        for (ri < u.requires.len) {
+            format.format(w, "  need    artifact {}\n", u.requires.data[ri]);
+            ri = ri + 1;
+        }
+        var di: usize = 0;
+        for (di < u.dep_steps.len) {
+            format.format(w, "  step    dependency {}\n", u.dep_steps.data[di]);
+            di = di + 1;
+        }
+        var si: usize = 0;
+        for (si < u.steps.len) {
+            format.format(w, "  step    project {}\n", u.steps.data[si]);
+            si = si + 1;
+        }
+
+        var mi: u32 = 0;
+        for (mi < u.target_entry.lib_count) {
+            format.format(w, "  link    manifest {}\n", link_requirement_label(itn, ?u.target_entry.libs[mi]));
+            mi = mi + 1;
+        }
+        var ei: usize = 0;
+        for (ei < u.export_links.len) {
+            format.format(w, "  link    dependency export {}\n", link_requirement_label(itn, ?u.export_links.data[ei]));
+            ei = ei + 1;
+        }
         var li: usize = 0;
         for (li < u.link_inputs.len) {
             val inp: *LinkInput = ?u.link_inputs.data[li];
-            if (inp.kind == LINK_STATIC) { print.printf("  link    static  {}\n", inp.text); }
+            if (inp.kind == LINK_STATIC) { format.format(w, "  link    static  {}\n", inp.text); }
             or {
-                print.printf("  link    dynamic {}\n", inp.text);
-                if (!str_empty(inp.rpath)) { print.printf("  rpath   {}\n", inp.rpath); }
+                format.format(w, "  link    dynamic {}\n", inp.text);
+                if (!str_empty(inp.rpath)) { format.format(w, "  rpath   {}\n", inp.rpath); }
             }
             li = li + 1;
         }
 
-        print.print("  phases  ");
+        format.write_str(w, "  phases  ");
         var pi: usize = 0;
         for (pi < u.phases.len) {
-            if (pi > 0) { print.print(" -> "); }
-            print.print(phase_name(u.phases.data[pi]));
+            if (pi > 0) { format.write_str(w, " -> "); }
+            format.write_str(w, phase_name(u.phases.data[pi]));
             pi = pi + 1;
         }
-        print.print("\n");
+        format.write_str(w, "\n");
+
+        if (!u.configured) {
+            format.write_str(w, "  deps    not resolved: this plan was not configured against the dependency closure\n");
+        }
+        if (u.dep_steps.len != 0 || u.steps.len != 0 || u.requires.len != 0) {
+            format.write_str(w, "  inputs  generated bytes are unresolved until the prerequisites above run\n");
+        }
         i = i + 1;
     }
+    format.write_str(w, "\nthis plan reports the selected build. it does not read generated bytes, and it does not claim the link succeeds\n");
+}
+
+pub fun explain(p: *BuildPlan, itn: *intern.Interner) {
+    var w: writer.Writer = fs.writer(fs.STDOUT);
+    render(?w, p, itn);
+}
+
+fun link_requirement_label(itn: *intern.Interner, l: *manifest.LinkRequirement) str {
+    if (l.source == manifest.LINK_LOCAL) { ret entry_name(itn, l.text); }
+    ret entry_name(itn, l.library);
 }
 
 fun unit_artifact_label(u: *BuildUnit) str {

--- a/src/lang/build/plan.mach
+++ b/src/lang/build/plan.mach
@@ -324,7 +324,7 @@ fun plan_cell(a: *A.Allocator, itn: *intern.Interner, reg: *target.TargetRegistr
               tname: str, aname: str, want_lib: bool, has_artifact: bool,
               is_required: bool) R.Result[R.Void, outcome.Fail] {
     var cell_req: request.BuildRequest = @req;
-    if (is_required) { cell_req.goal = request.GOAL_EXECUTE; }
+    if (is_required && req.goal != request.GOAL_CHECK) { cell_req.goal = request.GOAL_EXECUTE; }
     val ur: R.Result[BuildUnit, outcome.Fail] = plan_unit(a, itn, reg, m, ?cell_req,
         tname, aname, want_lib, has_artifact, is_required);
     if (R.is_err[BuildUnit, outcome.Fail](ur)) {
@@ -675,6 +675,7 @@ pub fun finished_modules(tgt: *target.Target) bool {
 fun unit_out_path(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
                   req: *request.BuildRequest, bu: *manifest.BuildUnit,
                   tgt: *target.Target, obj_dir: str, is_required: bool) R.Result[str, outcome.Fail] {
+    if (req.goal == request.GOAL_CHECK)     { ret R.ok[str, outcome.Fail](""); }
     if (req.goal == request.GOAL_OBJECTS)   { ret R.ok[str, outcome.Fail](obj_dir); }
     if (req.goal == request.GOAL_TEST_LIST) { ret R.ok[str, outcome.Fail](""); }
     if (req.goal == request.GOAL_EXECUTE && finished_modules(tgt)) {
@@ -728,6 +729,11 @@ fun derive_phases(a: *A.Allocator, itn: *intern.Interner, m: *manifest.Manifest,
                   tgt: *target.Target, u: *BuildUnit) R.Result[R.Void, outcome.Fail] {
     u.phases = vector.init[PhaseKind](a);
     u.steps  = vector.init[str](a);
+    if (req.goal == request.GOAL_CHECK) {
+        val loaded: R.Result[R.Void, outcome.Fail] = push_phase(u, PH_LOAD);
+        if (R.is_err[R.Void, outcome.Fail](loaded)) { ret loaded; }
+        ret push_phase(u, PH_SEMA);
+    }
 
     val demanded_r: R.Result[bool, outcome.Fail] = steps_demanded(a, itn, m, req, bu, ?u.steps);
     if (R.is_err[bool, outcome.Fail](demanded_r)) { ret R.void_of[bool, outcome.Fail](demanded_r); }

--- a/src/lang/build/request.mach
+++ b/src/lang/build/request.mach
@@ -127,6 +127,10 @@ pub val GOAL_TESTS:     BuildGoal = 2;
 
 pub val GOAL_TEST_LIST: BuildGoal = 3;
 
+# `mach check`: load, resolve and check the selected artifacts' reachable source
+# through the frontend and stop; no step runs and no product is written
+pub val GOAL_CHECK: BuildGoal = 4;
+
 rec BuildGoalSpec {
     goal:        BuildGoal;
     display:     str;
@@ -136,12 +140,13 @@ rec BuildGoalSpec {
 
 val BUILD_GOAL_CATALOG_VERSION: u8 = 1;
 
-val BUILD_GOAL_N: usize = 4;
+val BUILD_GOAL_N: usize = 5;
 val BUILD_GOALS: [BUILD_GOAL_N]BuildGoalSpec = [BUILD_GOAL_N]BuildGoalSpec{
     BuildGoalSpec{ goal: GOAL_EXECUTE,   display: "executable", emit_name: "exe", fingerprint_tag: 1 },
     BuildGoalSpec{ goal: GOAL_OBJECTS,   display: "objects",    emit_name: "obj", fingerprint_tag: 2 },
     BuildGoalSpec{ goal: GOAL_TESTS,     display: "tests",      emit_name: "",    fingerprint_tag: 3 },
     BuildGoalSpec{ goal: GOAL_TEST_LIST, display: "test list",  emit_name: "",    fingerprint_tag: 4 },
+    BuildGoalSpec{ goal: GOAL_CHECK,     display: "check",      emit_name: "",    fingerprint_tag: 5 },
 };
 
 pub val EMIT_HELP: str = "obj | exe (default exe; obj stops at the objects)";
@@ -495,7 +500,7 @@ test "mach.lang.build.request.for_cell:swaps_selection_only" {
 
 test "mach.lang.build.request.build_goal_catalog:complete_unique_ordered_roundtrip" {
     if (BUILD_GOAL_CATALOG_VERSION != 1)               { ret 1; }
-    if (BUILD_GOAL_N != GOAL_TEST_LIST::usize + 1)     { ret 1; }
+    if (BUILD_GOAL_N != GOAL_CHECK::usize + 1)         { ret 1; }
 
     var seen: [BUILD_GOAL_N]bool;
     var i: usize = 0;

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -2652,62 +2652,92 @@ pub fun dep_out_home(alloc: *A.Allocator, project_root: str, root_out: str) R.Re
     ret out_r;
 }
 
-pub fun execute_dep_steps(p: *project.Project, isa: str, os: str, abi: str) R.Result[R.Void, str] {
+# one exported dependency step selected for a cell, by position in the closure
+# ---
+# dependency: index into `p.config.deps`
+# step: index into that dependency manifest's `steps`
+pub rec DependencyStep {
+    dependency: u32;
+    step:       u32;
+}
+
+# the exported dependency steps a cell runs, in execution order: each realized
+# dependency's export step plan for the cell target, dependencies in closure
+# order. shared by `execute_dep_steps` and the build plan display
+# ---
+# p: the configured project
+# isa, os, abi: the cell target tuple
+# ret: the ordered steps, owned by the caller; err from the export plan
+pub fun plan_dep_steps(p: *project.Project, isa: str, os: str, abi: str) R.Result[Vector[DependencyStep], str] {
+    var steps: Vector[DependencyStep] = vector.init[DependencyStep](p.alloc);
+    var retained: bool = false;
+    fin { if (!retained) { vector.dnit[DependencyStep](?steps); } }
     val n: u32 = p.config.dep_count;
-    if (n == 0) { ret R.ok_void[str](); }
+    if (n == 0) { retained = true; ret R.ok[Vector[DependencyStep], str](steps); }
 
     var tgt: manifest.TargetDef;
     val ri: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, isa);
-    if (R.is_err[intern.StrId, str](ri)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](ri)); }
+    if (R.is_err[intern.StrId, str](ri)) { ret R.err[Vector[DependencyStep], str](R.unwrap_err[intern.StrId, str](ri)); }
     tgt.isa = R.unwrap_ok[intern.StrId, str](ri);
     val ro: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, os);
-    if (R.is_err[intern.StrId, str](ro)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](ro)); }
+    if (R.is_err[intern.StrId, str](ro)) { ret R.err[Vector[DependencyStep], str](R.unwrap_err[intern.StrId, str](ro)); }
     tgt.os = R.unwrap_ok[intern.StrId, str](ro);
     val ra: R.Result[intern.StrId, str] = intern.intern(?p.s.interner, abi);
-    if (R.is_err[intern.StrId, str](ra)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](ra)); }
+    if (R.is_err[intern.StrId, str](ra)) { ret R.err[Vector[DependencyStep], str](R.unwrap_err[intern.StrId, str](ra)); }
     tgt.abi = R.unwrap_ok[intern.StrId, str](ra);
 
     val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
-    val root_project: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_root));
     var cv: manifest.TmplVars = ddep.cell_tmpl_vars(p);
-
     var i: u32 = 0;
     for (i < n) {
-        val vr_opt: O.Option[str] = intern.lookup(?p.s.interner, p.config.deps[i].vendor_root);
-        if (O.is_none[str](vr_opt)) { ret R.err[R.Void, str]("internal: dep metadata not interned"); }
-        val dep_vr: str = O.unwrap[str](vr_opt);
-
         val mfd: *manifest.Manifest = ?p.config.deps[i].manifest;
-        val dep_owner_opt: O.Option[str] = intern.lookup(?p.s.interner, mfd.id);
-        if (O.is_none[str](dep_owner_opt)) { ret R.err[R.Void, str]("internal: dependency manifest id not interned"); }
-        val dep_owner: str = O.unwrap[str](dep_owner_opt);
-
-        var dep_order: *u32 = nil;
-        var dep_count: u32  = 0;
-        val dpr: R.Result[R.Void, str] = manifest.plan_export_steps(p.alloc, ?p.s.interner, mfd, ?tgt, root_out, ?cv, ?dep_order, ?dep_count);
-        if (R.is_err[R.Void, str](dpr)) { ret dpr; }
-
-        if (dep_count > 0) {
-            val hr: R.Result[str, str] = dep_out_home(p.alloc, root_project, root_out);
-            if (R.is_err[str, str](hr)) { A.deallocate[u32](p.alloc, dep_order, dep_count::usize); ret R.err[R.Void, str](R.unwrap_err[str, str](hr)); }
-            val dep_home: str = R.unwrap_ok[str, str](hr);
-            val dep_abs_r: R.Result[str, str] = absolute_execution_root(p.alloc, dep_vr);
-            if (R.is_err[str, str](dep_abs_r)) {
-                str_free(p.alloc, dep_home);
-                A.deallocate[u32](p.alloc, dep_order, dep_count::usize);
-                ret R.err[R.Void, str](R.unwrap_err[str, str](dep_abs_r));
+        var order: *u32 = nil;
+        var count: u32  = 0;
+        val planned: R.Result[R.Void, str] = manifest.plan_export_steps(p.alloc, ?p.s.interner, mfd, ?tgt, root_out, ?cv, ?order, ?count);
+        if (R.is_err[R.Void, str](planned)) { ret R.err[Vector[DependencyStep], str](R.unwrap_err[R.Void, str](planned)); }
+        var si: u32 = 0;
+        for (si < count) {
+            val pushed: R.Result[usize, str] = vector.push[DependencyStep](?steps, DependencyStep{dependency: i, step: order[si]});
+            if (R.is_err[usize, str](pushed)) {
+                A.deallocate[u32](p.alloc, order, count::usize);
+                ret R.err[Vector[DependencyStep], str](R.unwrap_err[usize, str](pushed));
             }
-            val dep_abs: str = R.unwrap_ok[str, str](dep_abs_r);
-            var si: u32 = 0;
-            for (si < dep_count) {
-                val rs: R.Result[R.Void, str] = run_one_step(p.alloc, p, ?mfd.steps[dep_order[si]], dep_abs, dep_home, dep_owner);
-                if (R.is_err[R.Void, str](rs)) { str_free(p.alloc, dep_abs); str_free(p.alloc, dep_home); A.deallocate[u32](p.alloc, dep_order, dep_count::usize); ret rs; }
-                si = si + 1;
-            }
-            str_free(p.alloc, dep_abs);
-            str_free(p.alloc, dep_home);
-            A.deallocate[u32](p.alloc, dep_order, dep_count::usize);
+            si = si + 1;
         }
+        if (order != nil && count > 0) { A.deallocate[u32](p.alloc, order, count::usize); }
+        i = i + 1;
+    }
+    retained = true;
+    ret R.ok[Vector[DependencyStep], str](steps);
+}
+
+pub fun execute_dep_steps(p: *project.Project, isa: str, os: str, abi: str) R.Result[R.Void, str] {
+    val planned: R.Result[Vector[DependencyStep], str] = plan_dep_steps(p, isa, os, abi);
+    if (R.is_err[Vector[DependencyStep], str](planned)) { ret R.err[R.Void, str](R.unwrap_err[Vector[DependencyStep], str](planned)); }
+    var steps: Vector[DependencyStep] = R.unwrap_ok[Vector[DependencyStep], str](planned);
+    fin { vector.dnit[DependencyStep](?steps); }
+    if (steps.len == 0) { ret R.ok_void[str](); }
+
+    val root_out: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_out));
+    val root_project: str = O.unwrap[str](intern.lookup(?p.s.interner, p.config.project_root));
+    val hr: R.Result[str, str] = dep_out_home(p.alloc, root_project, root_out);
+    if (R.is_err[str, str](hr)) { ret R.err[R.Void, str](R.unwrap_err[str, str](hr)); }
+    val dep_home: str = R.unwrap_ok[str, str](hr);
+    fin { str_free(p.alloc, dep_home); }
+
+    var i: usize = 0;
+    for (i < steps.len) {
+        val selected: DependencyStep = steps.data[i];
+        val mfd: *manifest.Manifest = ?p.config.deps[selected.dependency].manifest;
+        val vr_opt: O.Option[str] = intern.lookup(?p.s.interner, p.config.deps[selected.dependency].vendor_root);
+        val dep_owner_opt: O.Option[str] = intern.lookup(?p.s.interner, mfd.id);
+        if (O.is_none[str](vr_opt) || O.is_none[str](dep_owner_opt)) { ret R.err[R.Void, str]("internal: dep metadata not interned"); }
+        val dep_abs_r: R.Result[str, str] = absolute_execution_root(p.alloc, O.unwrap[str](vr_opt));
+        if (R.is_err[str, str](dep_abs_r)) { ret R.err[R.Void, str](R.unwrap_err[str, str](dep_abs_r)); }
+        val dep_abs: str = R.unwrap_ok[str, str](dep_abs_r);
+        val rs: R.Result[R.Void, str] = run_one_step(p.alloc, p, ?mfd.steps[selected.step], dep_abs, dep_home, O.unwrap[str](dep_owner_opt));
+        str_free(p.alloc, dep_abs);
+        if (R.is_err[R.Void, str](rs)) { ret rs; }
         i = i + 1;
     }
     ret R.ok_void[str]();


### PR DESCRIPTION
`mach check <path>` runs load, resolve and sema over the source the selected artifacts reach, through the same driver, queries and phase outcomes as `mach build`, and executes nothing else. Based on `feat/3223` (PR #3255, itself on `feat/3222`, PR #3253); neither is merged yet, so the first five commits here are those PRs and this issue is the last commit.

**Scope decision** (the issue asks it to be specified): check covers the selected-artifact graph, not the whole `src` tree. Every artifact declared for the resolved target, or the one `--bin`/`--lib` names, is checked from its entry through `use`, dependency modules included; a file nothing selected imports is not read. A required artifact is checked, not built. Documented in `doc/cli.md`.

## Acceptance mapping

**Syntax, resolution, type and comptime rejection agree with the same selected frontend build; exit status is not a diagnostic heuristic**

- `mach.cli.cmd.build.check_typed:checks_the_selected_graph_and_runs_no_step` — accepted on valid source with an unimported invalid file present; rejected (exit 1) by sema (unresolved member), by the parser, and by resolution (import of a missing module); `--lib support` accepts while `--bin app` on the same tree rejects, so the selection decides what is read; a malformed manifest is a user error before any source is read.
- `mach.cli.cmd.build.check:the_outcome_carries_located_diagnostics_and_a_typed_classification` — the plan for a check cell has exactly the phases load and sema and no output path, the outcome's severity is `BUILD_USER` folded from the typed `Fail` kind, and `cli_diag.outcome_code` maps it to 1. The same code path `mach build` exits through; nothing counts or matches diagnostic text.

**No code generation or linking; missing generated-source prerequisites reported, not silently produced**

- `checks_the_selected_graph_and_runs_no_step` — the fixture's two steps write files if run; `out/` is never created and the project root holds only `mach.toml`, `src` and `dep` afterwards. Deleting the GOAL_CHECK phase gate in `derive_phases` fails this test and the outcome test (mutation checked).
- `mach.cli.cmd.build.check_typed:a_missing_generated_input_is_reported_not_produced` — `main.mach` embeds `{artifact.shader-a.out}`, which only a build produces: check exits 1 and creates nothing; after `mach build` produces it, the same check accepts the same source. Also the existing `mach.lang.build.plan.plan:phases_follow_goal` family for the other goals.

**Shared diagnostics expose source locations and stable classifications; no backend/ABI/link claim**

- The outcome test asserts an error diagnostic with a real file id and a non-empty span in the recorded batch. The CLI doc and the command's help say a clean check establishes nothing about lowering, codegen, ABI or the link, and the command's effect text says so in `mach help check`.

**Native CLI controls and malformed-project cases show selected work, not an empty success**

- `mach.cli.cmd.build.check_typed:requires_one_path_and_refuses_output_options` — no path, two paths, `-o` and `--emit-ir` are all refused as user errors; the schema masks `-o` out of the selection table and carries no emit, opt, jobs or link-input tables.
- Incremental reuse: check runs through `engine.execute`, so it takes the same warm/cold path and query ownership as a build (#3220/#3221); nothing separate was added.

## Left out of the candidate and why

- d2bbbfba's shape (GOAL_CHECK through the engine) is kept. Its check test drove the `T_REQ` fixture through an embed that needs a built artifact; that case is now its own test with the build-then-check half added, and the selection test uses a fixture whose steps leave observable files.
- ee4f7285 / cb46794d (diagnostic location fixes on the feat/3112 line) were not needed: the outcome test passes on dev's diagnostics.

## Also in this PR

- The shared `--profile` help text said "otherwise built-in debug", which #3222 removed for a root; it now says "the sole or default profile" (help golden updated).

## Verification

- `mach build . -o out/audit/mach` with the 4.30.0 seed, then `./out/audit/mach test . --jobs 8`: 2689 passed, 0 failed (feat/3223: 2685; four new tests).
- Manual: `mach check .` on an init scaffold exits 0 with `-v` showing load/resolve/sema over 41 modules and nothing else; `mach help check` renders the command.
- `git diff --check dev...HEAD` clean.

Closes #3224
