### PR TITLE
ci(bootstrap): remove the v5 transition stage (#3112)

### DIFF
--- a/.github/actions/setup-mach/bootstrap.py
+++ b/.github/actions/setup-mach/bootstrap.py
@@ -11,13 +11,9 @@ import tempfile
 census = runpy.run_path(str(Path(__file__).with_name('census.py')))['census']
 # (name, compiler source, std pin, mode). 'single' stages are one-way bridges built
 # once by the previous compiler. 'fixpoint' stages build A, B and C and require B == C.
-# the transition bridge is f2569491's source with the pre-suffix manifest of 52a53af8:
-# it parses under 4.30, implements the v5 manifest, and cannot rebuild itself against
-# a published std, so it is one-way. it lives on branch bootstrap/v5-transition.
 STAGES = [
     ('bridge', '878a8f66a90127360dc23de4480241934fc1bf0d', '3ee8e709a8ed7baff6e93780ce9b3582a907a91f', 'single'),
     ('audited', 'b65afb9704218e89998af5f71050ca315e7709a9', '168a9f760d7c0f7a182f3b0685081e62f1a4f682', 'fixpoint'),
-    ('transition', 'cd283ceeae8deb1ffbe760980f2d1db3ef22a7ac', '168a9f760d7c0f7a182f3b0685081e62f1a4f682', 'single'),
 ]
 
 
@@ -38,15 +34,6 @@ def run(label, command, source, evidence):
         raise RuntimeError(label + ' failed with exit ' + str(result.returncode))
 
 
-def required_stage():
-    # the source tree names the chain stage that compiles it; absent means the audited compiler
-    marker = Path('.mach-bootstrap')
-    name = marker.read_text(encoding='utf-8').strip() if marker.exists() else 'audited'
-    if name not in [stage[0] for stage in STAGES] or name == 'bridge':
-        raise ValueError('.mach-bootstrap names an unknown stage: ' + name)
-    return name
-
-
 def main():
     destination = Path('.mach-toolchain').resolve()
     evidence = destination / 'evidence'
@@ -59,14 +46,11 @@ def main():
         raise ValueError('bootstrap requires the published v4.26.5 seed')
     for name in ['release.json', 'SHA256SUMS', 'provenance.json']:
         shutil.copy2(seed_dir / name, evidence / ('seed-' + name))
-    last = required_stage()
-    provenance = dict(seed=seed, seed_sha256=digest(compiler), profile='debug', required=last, stages=[], fixpoint=False)
+    provenance = dict(seed=seed, seed_sha256=digest(compiler), profile='debug', stages=[], fixpoint=False)
     record = evidence / 'provenance.json'
     record.write_text(json.dumps(provenance, indent=2), encoding='utf-8')
     with tempfile.TemporaryDirectory(prefix='mach-bootstrap-', dir=os.environ.get('RUNNER_TEMP')) as scratch:
         for name, source_ref, std_ref, mode in STAGES:
-            if STAGES.index((name, source_ref, std_ref, mode)) > [stage[0] for stage in STAGES].index(last):
-                break
             source = Path(scratch) / name
             subprocess.run(['git', 'clone', '--quiet', 'https://github.com/briar-systems/mach', str(source)], check=True)
             subprocess.run(['git', 'checkout', '--detach', source_ref], cwd=source, check=True)

--- a/doc/design/release-shape.md
+++ b/doc/design/release-shape.md
@@ -21,7 +21,7 @@ main commit `b65afb9704218e89998af5f71050ca315e7709a9` with std **1.0.1**
 reachable from main. The bridge contains the same compiler source and manifest
 as the earlier audit bridge. No retired proof branch is required.
 
-There are four builds: one bridge build followed by audited A, B and C.
+There are four builds: one bridge build followed by audited A, B and C. The
 bootstrap uses the debug profile, with optimization and compiler debug symbols
 disabled. Both repositories install audited B only after B and C match byte for
 byte. Ordinary CI then runs its existing debug and release checks with that

--- a/doc/design/release-shape.md
+++ b/doc/design/release-shape.md
@@ -21,7 +21,7 @@ main commit `b65afb9704218e89998af5f71050ca315e7709a9` with std **1.0.1**
 reachable from main. The bridge contains the same compiler source and manifest
 as the earlier audit bridge. No retired proof branch is required.
 
-A one-way transition stage follows: audited B builds `cd283ceeae8deb1ffbe760980f2d1db3ef22a7ac` (f2569491's source with the pre-suffix manifest of 52a53af8, branch `bootstrap/v5-transition`) once, and that compiler builds the development source, whose manifest and std pin the audited compiler cannot parse. There are five builds: one bridge build, audited A, B and C, and one transition build. A root `.mach-bootstrap` file names the stage a source tree requires (absent means `audited`), so `dev` keeps building with the audited compiler while the integration branch names `transition`. The
+There are four builds: one bridge build followed by audited A, B and C.
 bootstrap uses the debug profile, with optimization and compiler debug symbols
 disabled. Both repositories install audited B only after B and C match byte for
 byte. Ordinary CI then runs its existing debug and release checks with that

--- a/doc/tooling/bootstrap.md
+++ b/doc/tooling/bootstrap.md
@@ -29,21 +29,10 @@ git -C bootstrap-main submodule update --init --recursive
 cmp bootstrap-main/mB bootstrap-main/mC
 ./bootstrap-main/mB info --version
 
-git clone --no-checkout https://github.com/briar-systems/mach bootstrap-transition
-git -C bootstrap-transition checkout --detach cd283ceeae8deb1ffbe760980f2d1db3ef22a7ac
-git -C bootstrap-transition submodule update --init --recursive
-(cd bootstrap-transition && ../bootstrap-main/mB build . --profile debug -o mT)
 ```
 
-The version command must print `4.30.0`. The transition stage is one-way: the
-audited compiler builds `bootstrap-transition/mT` once. That source is f2569491
-with the pre-suffix manifest of 52a53af8, kept on branch `bootstrap/v5-transition`.
-It parses under 4.30 and implements the v5 manifest, but it cannot rebuild
-itself against a published std, so it is never asked to. A source tree names the
-stage that compiles it in a root `.mach-bootstrap` file containing `audited` or
-`transition`; an absent file means `audited`. `dev` builds with the audited
-compiler. The v5 integration branch names `transition`. Use the compiler that
-your checkout names, after initializing that checkout's submodules
+The final command must print `4.30.0`. Use `bootstrap-main/mB` as the compiler
+for your development checkout, after initializing that checkout's submodules
 with `git submodule update --init --recursive`. The bridge pins std
 `3ee8e709a8ed7baff6e93780ce9b3582a907a91f`. The audited source pins std
 `168a9f760d7c0f7a182f3b0685081e62f1a4f682` (1.0.1).


### PR DESCRIPTION
Owner ruling 2026-09-11. The integration branch was rebuilt language-only and builds from the audited 4.30 compiler with a converging fixpoint, so the one-way transition stage added in PR #3240 and its `.mach-bootstrap` selector have no consumer. This restores the two-hop chain the release-shape and bootstrap docs describe. The archived candidate head (`archive/3218-candidate-era`) still needs the stage but is not built by CI; the stage's source stays on `bootstrap/v5-transition`.