### PR TITLE
test: de-pinned compiler memory harness recovered from the #2299 archive (#2299)

### DIFF
--- a/.github/workflows/compiler-memory.yml
+++ b/.github/workflows/compiler-memory.yml
@@ -1,0 +1,94 @@
+name: compiler memory
+
+# Peak-memory and wall-time curves for the compiler at the dispatched ref
+# (#2299), optionally alternated against a control ref on the same runner.
+# Manual only: it is a measurement, not a gate, and it belongs on a runner
+# nothing else is using.
+
+on:
+  workflow_dispatch:
+    inputs:
+      control:
+        description: git ref whose compiler is the control; empty measures the checkout alone
+        required: false
+        default: ''
+      repetitions:
+        description: measurements per cell and variant
+        required: false
+        default: '3'
+      expect-identical:
+        description: fail when the two compilers produce different images for one cell (lifetime-only change)
+        type: boolean
+        required: false
+        default: false
+      runner:
+        description: runner to measure on
+        type: choice
+        required: false
+        default: ubuntu-latest
+        options:
+          - ubuntu-latest
+          - ubuntu-24.04-arm
+
+permissions:
+  contents: read
+
+jobs:
+  memory:
+    name: measure ${{ inputs.runner }}
+    runs-on: ${{ inputs.runner }}
+    timeout-minutes: 180
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: bootstrap audited mach
+        uses: ./.github/actions/setup-mach
+
+      - name: build the compiler under test
+        run: |
+          set -euo pipefail
+          mach dep pull .
+          mach build . -o a
+          ./a build . -o b
+          mkdir -p .memory
+          cp b .memory/compiler
+
+      - name: build the control compiler
+        if: inputs.control != ''
+        env:
+          CONTROL: ${{ inputs.control }}
+        run: |
+          set -euo pipefail
+          git worktree add --detach .wt/control "$CONTROL"
+          cd .wt/control
+          mach dep pull .
+          mach build . -o a
+          ./a build . -o b
+          cp b ../../.memory/control
+
+      - name: measure
+        env:
+          CONTROL: ${{ inputs.control }}
+          REPETITIONS: ${{ inputs.repetitions }}
+          EXPECT_IDENTICAL: ${{ inputs.expect-identical }}
+        run: |
+          set -euo pipefail
+          args=(--compiler .memory/compiler --repetitions "$REPETITIONS")
+          if [ -n "$CONTROL" ]; then args+=(--control .memory/control); fi
+          if [ "$EXPECT_IDENTICAL" = "true" ]; then args+=(--expect-identical); fi
+          python3 test/memory.py "${args[@]}"
+
+      - name: retain measurements
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: compiler-memory-${{ inputs.runner }}
+          path: |
+            test/out/memory/provenance.json
+            test/out/memory/results.json
+            test/out/memory/summary.json
+            test/out/memory/*.log
+            test/out/memory/*-census.json
+          if-no-files-found: error

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   into the object's `Tag_RISCV_arch`; an unknown extension, another version, a
   noncanonical string or the E base is refused rather than rounded up to the
   default machine (#3127).
+- `test/memory.py` measures a compiler's peak resident memory and wall time over
+  a cold self-build and three synthetic workload families (many modules, one
+  dense module, a large by-value aggregate) at both profiles and two worker
+  counts, checking every generated executable's output and the worker-count
+  image identity; with a control compiler the two alternate over identical
+  inputs. The `compiler memory` workflow runs it on demand, never on the PR
+  lane. The 2026-09-06 archive measurements it replaces are preserved in
+  `doc/design/2299-archive-inventory.md` (#2299).
 
 ### Fixed
 

--- a/doc/design/2299-archive-inventory.md
+++ b/doc/design/2299-archive-inventory.md
@@ -1,0 +1,156 @@
+# Archive inventory for #2299 scratch ownership (F5 remainder, O1)
+
+Inventory of the 43 commits from 2026-09-05 and 2026-09-06 on the fourteen
+`fix/2299*` branches that survive only in the workspace archive bundle. They were
+written against dev of 2026-09-05 (archive base `3a962411`, std `c2e2340`, later
+`3ee8e709`), before the F2 query landing (#3247), the F5 decode fixes (#3252,
+#3254) and the `sel` to `pick` rename. Every branch, its unique commits and the
+verdict are recorded here so the bundle can be discarded.
+
+Roadmap rows: F5 is the #2299 measurement remainder, O1 is #3123 allocating
+transform ownership.
+
+## Verdicts
+
+| group | commits | on dev as | applies to dev | row | verdict |
+|---|---|---|---|---|---|
+| (a) per-function optimizer scratch, typed transform results | 8 | `98102529` (2026-09-06), diff empty on `src/lang/me/` | 4 conflict on already-present hunks, 4 empty | O1 | superseded |
+| (b) module scratch release after object retention | 1 | `bb0a9deb` (2026-09-06), `codegen.mach` byte-identical | CHANGELOG conflict only | F5 | superseded |
+| (c) scalarization ownership | 2 | `98102529`, then #3123 fail-at-N cleanup `bd3ffad8`, `1311df15` | conflict on already-present hunks | O1 | superseded |
+| (d) memory measurement harness and CI workflows | 15 | nothing on dev | new files apply, but every script pins archive SHAs, std `3ee8e709` and seed `v4.26.5`, and every workflow triggers on a deleted branch | F5 | extract, de-pinned (see below) |
+| (e) native proof and mutation CI drivers | 10 | the in-tree guards they exercise landed with (a) to (c) | new files apply, pinned the same way | O1 | superseded, mutation controls re-run against dev instead |
+| (f) fixture and phase-outcome fixes | 4 | `e1885b82` (2026-09-06), a superset | 22, 3 and 1 conflicts on already-present hunks, one empty | neither | superseded |
+| merge commits | 3 | n/a | n/a | n/a | discard |
+
+Nothing in (a), (b), (c) or (f) is unlanded: the coordinator squashed the three
+source branches onto dev on 2026-09-06 as `e1885b82`, `bb0a9deb` and `98102529`
+before the archive was taken. `src/lang/me/scratch.mach` exists on dev with the
+bounded workspace, and the four proof tests below are in the tree.
+
+## The branches
+
+| branch | tip | unique commits | contents |
+|---|---|---|---|
+| fix/2299 | `5932eca2` | 7 | (b) `fb4f28f4` and (f) `885ffee5`, `032c1a49`, `9b97449f`, `f7792877`, two merges |
+| fix/2299-proof | `b2a2770f` | 6 | (e) `96bc615e`, `129962c2`, `b2a2770f` over fix/2299 |
+| fix/2299-memory-baseline | `31be33ea` | 8 | (d) `db681836`, `ca012deb`, `200acdcb`, `49ddc059`, `17b4ed7a`, `6769cce9`, `dbd7b3fe`, `31be33ea` off `feef0bc5` |
+| fix/2299-memory-after | `a018751b` | 7 | (d) `a018751b` over fix/2299 |
+| fix/2299-memory-control | `ba8f1000` | 8 | (d) `ba8f1000`, a revert of (b) used as the matched control |
+| fix/2299-memory-matched | `25ab8ffc` | 8 | (d) `25ab8ffc` over fix/2299 |
+| fix/2299-optimizer | `298b0ac5` | 13 | (a) `e8bd94fa`, `aca8a9ab`, `82e5ea21`, `9af91635`, `a7b49168`, `298b0ac5` |
+| fix/2299-optimizer-proof | `7f0b0f11` | 12 | (e) `c2a488b7`, `ebe15e2c`, `882fa40c`, `7f0b0f11` |
+| fix/2299-optimizer-matched | `b577205b` | 12 | (d) `a2278ebd`, `46bb0657`, `b577205b` |
+| fix/2299-transforms | `bfdf7890` | 16 | (a) `9ecef8ab`, `bfdf7890`, one merge |
+| fix/2299-transforms-proof | `0d0c3f50` | 15 | (e) `02d6e973`, `0d0c3f50` |
+| fix/2299-transforms-matched | `24046fb0` | 13 | (d) `24046fb0` |
+| fix/2299-scalarize | `5109e34e` | 19 | (c) `e3115052`, `5109e34e` |
+| fix/2299-scalarize-proof | `12588405` | 18 | (e) `12588405` |
+
+## Group (a), (b), (c): landed
+
+The dev landings are byte-identical to the archive tips on every file the archive
+commits touch. `git diff 5109e34e 98102529 -- src/lang/me` is empty, and so is
+`git diff fb4f28f4 bb0a9deb -- src/lang/be/codegen.mach`. The (c) fail-at-N
+ownership the archive sketched in `e3115052` was then taken further under #3123
+by `bd3ffad8` and `1311df15`.
+
+The archive's (a) commit messages record the design that dev now carries: one
+bounded 64 KiB workspace chunk reused between functions, verifier scratch separate
+from algebraic scratch, promoted debug operands retained with the IR, typed
+transform change results, and LICM and SROA analysis reclaimed per function.
+
+## Group (f): landed
+
+`e1885b82` carries the explicit phase outcomes (`src/lang/fail.mach`,
+`doc/design/failure-kind.md`, the driver and sema consumers) plus diagnostic
+ownership on top. The two follow-up fixes are present in their final form: the
+typed reinference check in `lower/decl.mach` and the scaffold failure checks in
+`sema/tests.mach`, and the editor buffer initialization the archive patched in
+three places is one struct literal on dev.
+
+## Group (e): the guards are in-tree, the drivers are one-shot
+
+Each driver built A from the seed and B from A at a pinned archive SHA, ran the
+middle-end suite in both profiles, then mutated one release site and asserted
+that exactly one named test fails with a specific exit. The guards, their anchors
+and the expected failure, all present on dev today:
+
+| guard | mutation | expected |
+|---|---|---|
+| `mach.lang.be.codegen.scratch:module_images_survive_reclaimed_working_storage` | `fin { arena.dnit(?scratch); }` to `fin { }` in `be/codegen.mach` | exit 3 |
+| `mach.lang.me.pipeline:simple_passes_do_not_retain_function_work_in_ir` | `verify_work` passes `m.alloc` instead of `alloc` | exit 10 |
+| `mach.lang.me.pass.scalarize:rejected_work_does_not_retain_maps_in_ir` | `scalarize_work` allocates from `m.alloc` instead of `alloc` | exit 4 |
+| `mach.lang.me.pass.scalarize:failed_instruction_releases_untransferred_operands` | delete the `A.deallocate[value.Value](m.alloc, owned, ...)` in the refused path | exit 3 |
+
+The native runs that established these, all green: codegen 34005798043, optimizer
+34008225851, transforms 34009898175, scalarize 34010965307 (ubuntu and windows
+each). The drivers are not extracted: each pins `baseline` to an archive SHA and
+triggers on a branch that no longer exists, and the mutation is a four-line recipe
+the PR for this inventory re-ran against dev (results in the PR).
+
+## Group (d): the measurements, preserved
+
+The harness generated three synthetic families (`modules` at 10, 50, 150 modules
+of 16 functions, `dense` with the same functions in one module, `aggregate` with a
+4096, 16384 and 65536 byte record copied by value), built each in debug and release
+at jobs 1 and 4 with output removed before every process, verified the executable's
+printed checksum, ELF objects and jobs-1 versus jobs-4 image identity, and recorded
+GNU time peak RSS plus a 20 ms `/proc` sampler on the child. Matched runs built two
+compilers from two refs with the same seed and alternated them for three
+repetitions over the same generated inputs. Seed `v4.26.5` throughout, ubuntu-latest,
+one compiler process at a time with a process census before each.
+
+Peak RSS in MiB and wall seconds, medians of three where n is three. Artifacts
+expire 2026-12-05.
+
+Self-build of the compiler source, debug profile unless stated:
+
+| step | before | after | run |
+|---|---|---|---|
+| (b) codegen scratch, `ba8f1000` vs `5932eca2` | 2973.1 / 17.10 | 1419.5 / 17.25 | 34006203230 |
+| (a) optimizer scratch, `5932eca2` vs `9af91635` | 1423.4 / 17.32 | 1185.1 / 17.29 | 34007743132 |
+| (a) optimizer scratch, release | 3973.6 / 54.37 | 2555.3 / 54.17 | 34008565946 |
+| (a) LICM and SROA, `298b0ac5` vs `bfdf7890` | 1182.8 / 17.46 | 1182.2 / 17.46 | 34010537722 |
+| (a) LICM and SROA, release | 2559.8 / 54.78 | 2179.3 / 54.68 | 34010537722 |
+
+Single-cell baselines, pre-scratch `feef0bc5` (run 34004956086) and after (b)
+`1750f256` (run 34005747560), debug jobs 1 unless stated:
+
+| workload | pre-scratch | after (b) |
+|---|---|---|
+| modules-150 | 87.2 / 0.31 | 58.3 / 0.47 |
+| modules-150 jobs 4 | 87.3 / 0.21 | 58.3 / 0.31 |
+| dense-150 | 87.9 / 0.92 | 82.9 / 1.07 |
+| aggregate-65536 | 67.2 / 0.12 | 68.8 / 0.15 |
+| seed to A | 3198.2 / 7.52 | 3216.6 / 9.26 |
+| A to B | 2951.5 / 12.27 | 1420.2 / 17.12 |
+
+Matched synthetic cells after (a), `5932eca2` vs `9af91635`, run 34007743132:
+
+| workload | before | after |
+|---|---|---|
+| modules-150 debug jobs 1 | 58.1 / 0.48 | 52.1 / 0.49 |
+| modules-150 release jobs 1 | 63.2 / 0.53 | 51.4 / 0.57 |
+| dense-150 debug jobs 1 | 85.6 / 1.09 | 77.8 / 1.10 |
+| dense-150 release jobs 1 | 86.3 / 0.48 | 75.2 / 0.48 |
+| aggregate-65536 debug jobs 1 | 69.2 / 0.15 | 65.9 / 0.15 |
+
+The many-module and self-build workloads moved. The large aggregate did not, which
+is the #3109 bulk lowering item, tracked separately. All cells passed the checksum
+and the jobs identity, and every self-build pair was byte-identical.
+
+Three further scripts on fix/2299-memory-baseline (`compiler-memory-isolate.py`,
+`compiler-memory-piece-compare.py`, `compiler-memory-matched-combined.py`, runs
+34039970329, 34042979096, 34071499020) were a stage-by-stage bootstrap slowdown
+investigation pinned to feat/3218 workloads `49fbbc48` and `2152b51d`. They belong
+to the #3218 overhead log, not to scratch ownership, and are discarded here.
+
+## What is extracted
+
+The generator and runner from (d), de-pinned, as `test/memory.py`: the compiler
+under test is an argument, an optional control compiler enables the alternating
+matched mode, the checkout under test is the self-build workload, and provenance
+records compiler digests, the checkout and std heads and the host. A
+`workflow_dispatch` workflow builds the compilers from the seed and runs it. It is
+not on the PR lane. The reproducible curves #2299 asks for come from running it
+against the current compiler, not from these preserved numbers.

--- a/test/memory.py
+++ b/test/memory.py
@@ -1,0 +1,519 @@
+#!/usr/bin/env python3
+"""Peak-memory and wall-time curves for a mach compiler (#2299).
+
+usage: memory.py --compiler <path> [--control <path>] [options]
+
+Measures one compiler, or alternates two, over the same workloads: a cold
+self-build of this checkout and three synthetic families whose size is the
+axis the compiler's resident memory is expected to scale along.
+
+  modules    N modules of 16 small functions, one call chain through them all
+  dense      the same functions in one module
+  aggregate  one record of N bytes copied by value through a call
+
+Every cell is a fresh compiler process with the project's outputs removed
+first: the self-build rebuilds this checkout and clears its out/<target>/<profile>
+cells for that profile, so stage the compiler under test outside them. The kernel's peak RSS for the child (wait4 rusage) is the headline
+number; a /proc sampler records VmRSS, RssAnon and RssFile at 20 ms and kills
+the child if it crosses the resident budget. Every synthetic executable is run
+and its printed checksum compared with the generator's expectation, every
+retained object is checked to be an ELF64 object, and the jobs-1 and jobs-4
+images of one compiler must be byte-identical. With --control the two
+compilers alternate order each repetition and the images they produce per
+cell are compared; --expect-identical makes a difference fatal, which is the
+bar for a lifetime-only change.
+
+Outputs, under --out (default test/out/memory, project-relative):
+
+  provenance.json  compiler digests and banners, checkout and std heads, host
+  results.json     one record per measured process, appended as it runs
+  summary.json     medians per cell and variant
+  <name>.log       the process's combined output
+  <name>-census.json  compiler processes found on the host before the run
+
+Linux only: it reads /proc and generates a freestanding entry for the host
+ISA (x86_64 or aarch64). A compiler process that belongs to someone else
+(`mach build` or `mach test` already running) aborts the run unless
+--tolerate-busy is given, in which case it is recorded on the cell.
+"""
+
+import argparse
+import hashlib
+import json
+import os
+import pathlib
+import platform
+import re
+import shutil
+import signal
+import statistics
+import struct
+import subprocess
+import sys
+import threading
+import time
+
+CHECKOUT = pathlib.Path(__file__).resolve().parents[1]
+
+HOSTS = {
+    'x86_64': ('x86_64', 'sysv64'),
+    'aarch64': ('aarch64', 'aapcs64'),
+}
+
+MANIFEST = '''[project]
+id = "bench"
+version = "0.0.0"
+src = "src"
+out = "out/{{target.name}}/{{profile.name}}"
+
+[target.linux]
+isa = "{isa}"
+os = "linux"
+abi = "{abi}"
+
+[profile.debug]
+opt = 0
+debug = true
+simd = "scalarize"
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+
+[artifact.bench]
+kind = "bin"
+entry = "main.mach"
+out = "bin/bench"
+targets = ["linux"]
+link = []
+need = []
+'''
+
+# the entry reads argc, calls bench_main(argc) and writes the returned i64
+# to stdout as eight little-endian bytes, then exits 0
+ENTRY = {
+    'x86_64': '''
+#[naked]
+#[symbol("_start")]
+pub fun start() {
+    asm x86_64 {
+        mov rdi, [rsp]
+        and rsp, -16
+        call bench_main
+        sub rsp, 16
+        mov [rsp], rax
+        mov rax, 1
+        mov rdi, 1
+        mov rsi, rsp
+        mov rdx, 8
+        syscall
+        mov rax, 231
+        mov rdi, 0
+        syscall
+    }
+}
+''',
+    'aarch64': '''
+#[symbol("_start")]
+pub fun start() {
+    asm aarch64 {
+        mov x9, sp
+        ldr x0, [x9]
+        bl bench_main
+        sub sp, sp, 16
+        str x0, [sp]
+        mov x8, 64
+        mov x0, 1
+        mov x1, sp
+        mov x2, 8
+        svc 0
+        mov x8, 94
+        mov x0, 0
+        svc 0
+    }
+}
+''',
+}
+
+CENSUS = re.compile(rb'(mach[-_.0-9A-Za-z]*|m[0-9A-Za-z]*|A|B|C|D)')
+
+
+def sha256(path):
+    return hashlib.sha256(pathlib.Path(path).read_bytes()).hexdigest()
+
+
+def git(*args, cwd=CHECKOUT):
+    return subprocess.run(['git', *args], cwd=cwd, check=True, capture_output=True, text=True).stdout.strip()
+
+
+def meminfo(field):
+    text = pathlib.Path('/proc/meminfo').read_text()
+    return int(re.search(field + r':\s+(\d+)', text)[1]) * 1024
+
+
+# the compiler is spawned by a minimal interpreter, not by this process: at exec
+# the kernel folds the forking image's high-water mark into the child's rusage,
+# so a fork from here would floor every cell at this process's own RSS. the
+# spawner's floor is measured on /bin/true and recorded in provenance.
+SPAWNER = """
+import json, os, sys
+fd = int(sys.argv[1])
+pid = os.fork()
+if pid == 0:
+    os.execv(sys.argv[2], sys.argv[2:])
+_, status, ru = os.wait4(pid, 0)
+os.write(fd, json.dumps({'peak_rss_kib': ru.ru_maxrss, 'user_s': ru.ru_utime, 'system_s': ru.ru_stime}).encode())
+sys.exit(os.waitstatus_to_exitcode(status))
+"""
+
+
+class Runner:
+    def __init__(self, out, budget, tolerate_busy):
+        self.out = out
+        self.budget = budget
+        self.tolerate_busy = tolerate_busy
+        self.results = []
+        self.killed = None
+
+    def census(self, name):
+        found = []
+        me = os.getpid()
+        for entry in pathlib.Path('/proc').iterdir():
+            if not entry.name.isdigit() or int(entry.name) == me:
+                continue
+            try:
+                args = (entry / 'cmdline').read_bytes().split(b'\0')
+            except OSError:
+                continue
+            if len(args) > 1 and CENSUS.fullmatch(args[0].split(b'/')[-1]) and args[1] in (b'build', b'test'):
+                found.append({'pid': int(entry.name), 'argv': [x.decode(errors='replace') for x in args if x]})
+        (self.out / (name + '-census.json')).write_text(json.dumps(found, indent=2) + '\n')
+        if found and not self.tolerate_busy:
+            raise SystemExit(f'{name}: another compiler is running on this host ({len(found)} found); '
+                             'wait for it or pass --tolerate-busy')
+        return found
+
+    def spawn(self, command, cwd, sink, timeout, on_sample=None):
+        """Run command under the spawner; returns (exit code, rusage dict, wall seconds)."""
+        read_end, write_end = os.pipe()
+        process = subprocess.Popen([sys.executable, '-I', '-S', '-c', SPAWNER, str(write_end), *map(str, command)],
+                                   cwd=cwd, stdout=sink, stderr=subprocess.STDOUT, pass_fds=[write_end],
+                                   start_new_session=True)
+        os.close(write_end)
+        started = time.monotonic()
+        done = threading.Event()
+
+        def sample():
+            children = pathlib.Path('/proc', str(process.pid), 'task', str(process.pid), 'children')
+            while not done.wait(0.02):
+                try:
+                    for pid in children.read_text().split():
+                        text = pathlib.Path('/proc', pid, 'status').read_text()
+                        if on_sample is not None and on_sample(text):
+                            self.kill(process, 'resident budget exceeded')
+                            return
+                except OSError:
+                    continue
+                if meminfo('MemAvailable') < 2 * 1024 ** 3:
+                    self.kill(process, 'host memory below 2 GiB available')
+                    return
+
+        sampler = threading.Thread(target=sample)
+        sampler.start()
+        try:
+            process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            self.kill(process, f'timed out after {timeout} s')
+            process.wait()
+        finally:
+            done.set()
+            sampler.join()
+        wall = time.monotonic() - started
+        report = os.read(read_end, 4096)
+        os.close(read_end)
+        return process.returncode, (json.loads(report) if report else {}), wall
+
+    def kill(self, process, why):
+        self.killed = why
+        try:
+            os.killpg(process.pid, signal.SIGKILL)
+        except ProcessLookupError:
+            pass
+
+    def floor(self):
+        """The spawner's own contribution to a child's peak, measured on true."""
+        with open(os.devnull, 'wb') as sink:
+            code, usage, _ = self.spawn([shutil.which('true')], self.out, sink, 30)
+        if code != 0 or 'peak_rss_kib' not in usage:
+            raise SystemExit('spawner floor measurement failed')
+        return usage['peak_rss_kib']
+
+    def timed(self, name, command, cwd, timeout):
+        busy = self.census(name)
+        sampled = {'VmRSS_kib': 0, 'RssAnon_kib': 0, 'RssFile_kib': 0, 'samples': 0}
+        self.killed = None
+
+        def on_sample(text):
+            for field in ('VmRSS', 'RssAnon', 'RssFile'):
+                match = re.search(r'^' + field + r':\s+(\d+)', text, re.M)
+                if match:
+                    sampled[field + '_kib'] = max(sampled[field + '_kib'], int(match[1]))
+            sampled['samples'] += 1
+            return sampled['VmRSS_kib'] * 1024 > self.budget
+
+        log = self.out / (name + '.log')
+        with log.open('wb') as sink:
+            code, usage, wall = self.spawn(command, cwd, sink, timeout, on_sample)
+        record = {
+            'name': name, 'command': [str(c) for c in command], 'exit': code,
+            'wall_s': round(wall, 3), 'user_s': round(usage.get('user_s', 0.0), 3), 'system_s': round(usage.get('system_s', 0.0), 3),
+            'peak_rss_kib': usage.get('peak_rss_kib'), 'sampled': sampled, 'busy_host': bool(busy),
+            'resident_budget_bytes': self.budget, 'killed': self.killed,
+        }
+        self.results.append(record)
+        (self.out / 'results.json').write_text(json.dumps(self.results, indent=2) + '\n')
+        print(json.dumps(record), flush=True)
+        if code or self.killed:
+            raise SystemExit(f'{name}: exit {code}{", " + self.killed if self.killed else ""}, see {log}')
+        return record
+
+
+def function(index):
+    return f'#[noinline]\npub fun f{index}(x: i64) i64 {{ ret (x * 3 + {index + 1}) ^ {index % 29}; }}\n'
+
+
+def generate(project, family, size, isa):
+    """Write one synthetic project; returns (expected checksum, metadata)."""
+    shutil.rmtree(project, ignore_errors=True)
+    (project / 'src').mkdir(parents=True)
+    (project / 'mach.toml').write_text(MANIFEST.format(isa=isa, abi=HOSTS[isa][1]))
+    entry = ENTRY[isa]
+    if family in ('modules', 'dense'):
+        count = size * 16
+        expected = sum((3 + i + 1) ^ (i % 29) for i in range(count))
+        imports, bodies, calls = [], [], []
+        for group in range(size):
+            functions = ''.join(function(i) for i in range(group * 16, (group + 1) * 16))
+            lines = '\n'.join(f'    total = total + f{i}(x);' for i in range(group * 16, (group + 1) * 16))
+            module = functions + f'#[noinline]\npub fun group{group}(x: i64) i64 {{\n    var total: i64 = 0;\n{lines}\n    ret total;\n}}\n'
+            if family == 'modules':
+                (project / 'src' / f'm{group}.mach').write_text(module)
+                imports.append(f'use bench.m{group};')
+                calls.append(f'    total = total + m{group}.group{group}(x);')
+            else:
+                bodies.append(module)
+                calls.append(f'    total = total + group{group}(x);')
+        main = ('\n'.join(imports + bodies) + '\n#[symbol("bench_main")]\npub fun bench_main(x: i64) i64 {\n'
+                '    var total: i64 = 0;\n' + '\n'.join(calls) + '\n    ret total;\n}\n' + entry)
+        metadata = {'functions': count + size + 2, 'modules': size + 1 if family == 'modules' else 1}
+    elif family == 'aggregate':
+        main = f'''rec Big {{ data: [{size}]u8; }}
+#[noinline]
+fun change(v: Big) Big {{
+    v.data[0] = v.data[0] + 1;
+    v.data[{size - 1}] = v.data[{size - 1}] + 2;
+    ret v;
+}}
+#[symbol("bench_main")]
+pub fun bench_main(x: i64) i64 {{
+    var v: Big;
+    v.data[0] = x::u8;
+    v.data[{size // 2}] = 31;
+    v.data[{size - 1}] = 17;
+    val changed: Big = change(v);
+    ret changed.data[0]::i64 + changed.data[{size // 2}]::i64 * 3 + changed.data[{size - 1}]::i64 * 5
+        + v.data[0]::i64 * 7 + v.data[{size // 2}]::i64 * 11 + v.data[{size - 1}]::i64 * 13;
+}}
+''' + entry
+        expected = 2 + 31 * 3 + 19 * 5 + 1 * 7 + 31 * 11 + 17 * 13
+        metadata = {'aggregate_bytes': size, 'functions': 3, 'modules': 1}
+    else:
+        raise SystemExit('unknown family ' + family)
+    (project / 'src' / 'main.mach').write_text(main)
+    return expected, metadata
+
+
+def check_synthetic(project, profile, expected):
+    binary = project / 'out' / 'linux' / profile / 'bin' / 'bench'
+    run = subprocess.run([str(binary)], capture_output=True, timeout=30)
+    if run.returncode != 0 or run.stderr or run.stdout != struct.pack('<q', expected):
+        observed = struct.unpack('<q', run.stdout)[0] if len(run.stdout) == 8 else run.stdout
+        raise SystemExit(f'{binary}: exit {run.returncode}, printed {observed!r}, expected {expected}')
+    objects = sorted((project / 'out').rglob('*.o'))
+    if not objects:
+        raise SystemExit(f'{project}: no retained objects')
+    for obj in objects:
+        if obj.read_bytes()[:5] != b'\x7fELF\x02':
+            raise SystemExit(f'{obj}: not an ELF64 object')
+    return binary, objects
+
+
+def clear_self(profile):
+    """Cold self-build: remove this checkout's build cells for the profile."""
+    for cell in (CHECKOUT / 'out').glob(f'*/{profile}'):
+        shutil.rmtree(cell)
+
+
+def summarize(results):
+    cells = {}
+    for r in results:
+        if 'cell' not in r:
+            continue
+        cells.setdefault(r['cell'], {}).setdefault(r['variant'], []).append(r)
+    summary = []
+    for cell, variants in cells.items():
+        row = {'cell': cell}
+        for variant, records in variants.items():
+            row[variant] = {
+                'n': len(records),
+                'peak_rss_mib': round(statistics.median(r['peak_rss_kib'] for r in records) / 1024, 1),
+                'wall_s': round(statistics.median(r['wall_s'] for r in records), 3),
+                'images': sorted({r['image_sha256'] for r in records}),
+            }
+        row['identical_across_variants'] = len({tuple(v['images']) for k, v in row.items() if k != 'cell'}) == 1
+        summary.append(row)
+    return summary
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument('--compiler', required=True, type=pathlib.Path, help='compiler under test')
+    parser.add_argument('--control', type=pathlib.Path, help='second compiler; the two alternate every repetition')
+    parser.add_argument('--repetitions', type=int, default=1, help='measurements per cell and variant (default 1)')
+    parser.add_argument('--families', default='modules,dense,aggregate')
+    parser.add_argument('--sizes', default='modules=10,50,150;dense=10,50,150;aggregate=4096,16384,65536',
+                        help='per-family size lists')
+    parser.add_argument('--profiles', default='debug,release')
+    parser.add_argument('--jobs', default='1,4', help='codegen worker counts to compare')
+    parser.add_argument('--no-self', action='store_true', help='skip the self-build workload')
+    parser.add_argument('--self-profiles', default='debug', help='profiles for the self-build workload')
+    parser.add_argument('--out', type=pathlib.Path, default=CHECKOUT / 'test' / 'out' / 'memory')
+    parser.add_argument('--budget-mib', type=int, default=0,
+                        help='resident budget per process (default min(8 GiB, 60%% of MemTotal))')
+    parser.add_argument('--timeout', type=int, default=900, help='seconds per process')
+    parser.add_argument('--tolerate-busy', action='store_true', help='record, rather than refuse, other compilers on the host')
+    parser.add_argument('--expect-identical', action='store_true',
+                        help='fail when the compilers produce different images for one cell')
+    args = parser.parse_args()
+
+    if sys.platform != 'linux' or platform.machine() not in HOSTS:
+        raise SystemExit(f'unsupported host {sys.platform}/{platform.machine()}: linux x86_64 or aarch64 only')
+    isa = platform.machine()
+    budget = args.budget_mib * 1024 ** 2 if args.budget_mib else min(8 * 1024 ** 3, meminfo('MemTotal') * 3 // 5)
+    out = args.out.resolve()
+    shutil.rmtree(out, ignore_errors=True)
+    out.mkdir(parents=True)
+    runner = Runner(out, budget, args.tolerate_busy)
+
+    variants = {'compiler': args.compiler}
+    if args.control:
+        variants = {'control': args.control, 'compiler': args.compiler}
+    compilers = {}
+    for variant, path in variants.items():
+        if not os.access(path, os.X_OK):
+            raise SystemExit(f'{variant}: {path} is not an executable')
+        staged = out / 'compilers' / ('mach-' + variant)
+        staged.parent.mkdir(exist_ok=True)
+        shutil.copy2(path, staged)
+        compilers[variant] = staged
+    order = list(variants)
+
+    provenance = {
+        'checkout': git('rev-parse', 'HEAD'),
+        'checkout_dirty': bool(git('status', '--porcelain', '--', 'src', 'mach.toml', 'dep/std')),
+        'std': git('rev-parse', 'HEAD:dep/std'),
+        'compilers': {variant: {'path': str(path), 'sha256': sha256(path), 'bytes': path.stat().st_size,
+                                'banner': subprocess.run([str(compilers[variant])], capture_output=True, text=True).stdout.splitlines()[0]}
+                      for variant, path in variants.items()},
+        'host': {'uname': platform.uname()._asdict(), 'cpus': os.cpu_count(), 'mem_total_bytes': meminfo('MemTotal'),
+                 'cpu_model': next((line.split(':', 1)[1].strip() for line in pathlib.Path('/proc/cpuinfo').read_text().splitlines()
+                                    if line.startswith('model name')), None)},
+        'resident_budget_bytes': budget,
+        'spawner_floor_kib': runner.floor(),
+        'repetitions': args.repetitions,
+        'method': 'Cold: project outputs removed before each compiler process, OS file cache not flushed. '
+                  'peak_rss_kib is the kernel ru_maxrss of the compiler process as seen by a minimal spawner whose own '
+                  'floor is spawner_floor_kib; sampled is a 20 ms /proc reader. With a control, variants alternate order '
+                  'every repetition over identical generated inputs.',
+        'generator_sha256': sha256(__file__),
+    }
+    (out / 'provenance.json').write_text(json.dumps(provenance, indent=2) + '\n')
+    print(json.dumps({'compilers': provenance['compilers'], 'spawner_floor_kib': provenance['spawner_floor_kib']}, indent=2), flush=True)
+
+    mismatches = []
+
+    def measure(cell, project, profile, jobs, repetition, variant, expected):
+        if expected is None:
+            clear_self(profile)
+        else:
+            shutil.rmtree(project / 'out', ignore_errors=True)
+        name = f'{cell}-{repetition}-{variant}'
+        record = runner.timed(name, [compilers[variant], 'build', '.', '--profile', profile, '--jobs', str(jobs)], project, args.timeout)
+        if expected is None:
+            images = sorted((project / 'out').glob(f'*/{profile}/bin/mach'))
+            if len(images) != 1:
+                raise SystemExit(f'{name}: expected one host image, found {images}')
+            binary = images[0]
+            objects = sorted((project / 'out').rglob('*.o'))
+        else:
+            binary, objects = check_synthetic(project, profile, expected)
+        record.update(cell=cell, variant=variant, repetition=repetition, profile=profile, jobs=jobs,
+                      image_sha256=sha256(binary), image_bytes=binary.stat().st_size,
+                      object_count=len(objects), object_bytes=sum(p.stat().st_size for p in objects))
+        (out / 'results.json').write_text(json.dumps(runner.results, indent=2) + '\n')
+        return record
+
+    def compare(cell, records):
+        images = {r['variant']: r['image_sha256'] for r in records}
+        if len(set(images.values())) > 1:
+            mismatches.append({'cell': cell, 'images': images})
+            print(f'{cell}: images differ across variants {images}', flush=True)
+
+    if not args.no_self:
+        for profile in args.self_profiles.split(','):
+            cell = f'self-{profile}'
+            for repetition in range(args.repetitions):
+                sequence = order if repetition % 2 == 0 else order[::-1]
+                records = [measure(cell, CHECKOUT, profile, os.cpu_count() or 1, repetition, variant, None) for variant in sequence]
+                compare(cell, records)
+
+    sizes = {}
+    for item in args.sizes.split(';'):
+        family, values = item.split('=')
+        sizes[family.strip()] = [int(v) for v in values.split(',')]
+    projects = out / 'projects'
+    for family in args.families.split(','):
+        for size in sizes[family]:
+            project = projects / f'{family}-{size}'
+            expected, metadata = generate(project, family, size, isa)
+            for profile in args.profiles.split(','):
+                per_jobs = {}
+                for jobs in [int(j) for j in args.jobs.split(',')]:
+                    cell = f'{family}-{size}-{profile}-jobs{jobs}'
+                    for repetition in range(args.repetitions):
+                        sequence = order if repetition % 2 == 0 else order[::-1]
+                        records = [measure(cell, project, profile, jobs, repetition, variant, expected) for variant in sequence]
+                        for r in records:
+                            r.update(family=family, size=size, expected=expected, **metadata)
+                            per_jobs.setdefault(r['variant'], {}).setdefault(jobs, set()).add(r['image_sha256'])
+                        compare(cell, records)
+                for variant, by_jobs in per_jobs.items():
+                    images = set().union(*by_jobs.values())
+                    if len(images) != 1:
+                        raise SystemExit(f'{family}-{size}-{profile}: worker count changed the image for {variant}: {by_jobs}')
+            shutil.rmtree(project / 'out', ignore_errors=True)
+
+    summary = summarize(runner.results)
+    (out / 'summary.json').write_text(json.dumps({'cells': summary, 'mismatches': mismatches}, indent=2) + '\n')
+    print(f'\n{"cell":36} ' + ' '.join(f'{v:>26}' for v in order))
+    for row in summary:
+        print(f'{row["cell"]:36} ' + ' '.join(f'{row[v]["peak_rss_mib"]:>14.1f} MiB {row[v]["wall_s"]:>6.2f}s' for v in order if v in row)
+              + ('' if row['identical_across_variants'] else '  images differ'))
+    print(f'\n{len(runner.results)} processes, results in {out}')
+    if mismatches and args.expect_identical:
+        raise SystemExit(f'{len(mismatches)} cells produced different images across variants')
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
Recovers what was still unlanded from the fourteen archived `fix/2299*` branches (43 commits, 2026-09-05/06, reachable from no live ref) and records the rest. Part of #2299 (F5 remainder) and #3123 (O1); neither closes here.

## Inventory verdicts (`doc/design/2299-archive-inventory.md`)

| group | commits | on dev as | verdict |
|---|---|---|---|
| (a) per-function optimizer scratch, typed transform results | 8 | `98102529`, diff empty on `src/lang/me/` | superseded (O1) |
| (b) module scratch release after object retention | 1 | `bb0a9deb`, `codegen.mach` byte-identical | superseded (F5) |
| (c) scalarization ownership | 2 | `98102529` then #3123's `bd3ffad8`, `1311df15` | superseded (O1) |
| (d) memory measurement harness and CI workflows | 15 | nothing on dev | extracted, de-pinned |
| (e) native proof and mutation CI drivers | 10 | the in-tree guards landed with (a) to (c) | superseded; controls re-run below |
| (f) fixture and phase-outcome fixes | 4 | `e1885b82`, a superset | superseded |
| merges | 3 | | discard |

The three source groups were squashed onto dev by the previous coordinator on 2026-09-06 before the archive was taken. The (d) scripts pinned archive SHAs, std `3ee8e709` and seed `v4.26.5`, and their workflows triggered on branches that no longer exist; their CI runs all succeeded and the artifacts expire 2026-12-05, so the inventory preserves the measured curves (self-build debug 2973 to 1420 to 1185 MiB, release 3974 to 2555 to 2179 MiB, every pair byte-identical) with run ids.

## What lands

- `test/memory.py`: the (d) generator and runner, de-pinned. The compiler under test is an argument, `--control` alternates a second compiler over identical inputs every repetition, the self-build is this checkout, and provenance records compiler digests, checkout and std heads and the host. Peak RSS is the kernel `ru_maxrss` read by a minimal spawner whose own floor (about 7 MiB) is measured on `true` and recorded, because a fork from the harness itself folds its RSS into every child's peak. Synthetic executables are run and checked, objects are checked to be ELF64, jobs-1 and jobs-4 images must match, and `--expect-identical` makes a cross-variant image difference fatal (the lifetime-only bar).
- `.github/workflows/compiler-memory.yml`: `workflow_dispatch` only, with a control ref, repetitions, expect-identical and runner (x86_64 or arm) inputs. **It is not on the PR lane and nothing here runs in CI on push.**

## Acceptance to test

| #2299 acceptance | where |
|---|---|
| reproducible baseline/final RSS and time curves, serial/parallel, with exact provenance | `test/memory.py` cells x jobs 1/4 x profiles, `provenance.json`; historical curves in the inventory with run ids |
| measured release point, not source inspection | matched mode (`--control`) alternating over identical inputs |
| byte-identical objects for lifetime-only changes | `--expect-identical` and the jobs identity assertion |
| ownership controls that detect premature reclamation | the four in-tree guards, mutation-verified below |

## Verification

- `./out/audit/mach test . --jobs 8`: 2700 passed, 0 failed, 2700 total. Compiler source is unchanged from dev, so the delta is 0 and no test is added.
- `sh test/census.sh`: ok.
- Corpus layer B, `--target x86_64-linux --target aarch64-linux`: 182 pass, 0 fail, 0 skip, goldens untouched.
- Mutation controls against dev's landed guards, each intact 1/0/1 and mutated 0/1/1 with the expected exit: `codegen.scratch:module_images_survive_reclaimed_working_storage` (release removed, exit 3), `pipeline:simple_passes_do_not_retain_function_work_in_ir` (verifier work allocated from the IR owner, exit 10), `scalarize:rejected_work_does_not_retain_maps_in_ir` (function work allocated from the IR owner, exit 4), `scalarize:failed_instruction_releases_untransferred_operands` (refused-path release removed, exit 3).
- Harness run locally on this host (busy, wall not comparable): dev-HEAD compiler vs the 4.30.0 seed, 28 processes, every checksum and jobs identity passed; self-build debug peak 1626 and 1889 MiB (HEAD) against 1534 and 1516 MiB (seed). Indicative only, recorded for F5.
- `git diff --check`: clean. CHANGELOG line under Unreleased references #2299.
