### PR TITLE
fix(abi): classify padding-only SysV eightbytes as no register and carry aggregate secrecy through transport (#3263)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The System V x86-64 classifier spent a register on an eightbyte that holds
+  only padding: a 16-byte aggregate with data in its first eightbyte alone (an
+  over-aligned `#[align(16)] rec { a: u8; }`) rode rdi and rsi and returned
+  through rax and rdx, where gcc and clang classify the empty eightbyte
+  NO_CLASS and use rdi and rax alone. A C callee read its next argument from
+  the wrong register and a returned object copied rdx's leftovers into its
+  tail padding. Padding-only eightbytes now consume no register, the
+  classifier emits one piece per populated eightbyte, and the store side zeroes
+  every logical byte no piece delivers (#3263).
 - The names of tables marked `default = true` collected while parsing
   `[target.*]` and `[profile.*]` were never released (#3222).
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tail padding. Padding-only eightbytes now consume no register, the
   classifier emits one piece per populated eightbyte, and the store side zeroes
   every logical byte no piece delivers (#3263).
+- Secrecy provenance of a by-value aggregate was attached to its home instead
+  of its bytes: an aggregate's MIR vreg is the address of its home, and seeding
+  it secret for an outer-secret parameter or call result made every field read
+  of a by-value `^Rec` inside an `#[oblivious]` function a secret-dependent
+  address, while a public record with a `^` field reached the argument
+  registers straight from memory with public provenance. Call arguments,
+  returned values and parameters now carry the union of the object's secret
+  byte ranges, aggregate homes are never seeded secret, transport runs with the
+  object's secrecy so every carrier and caller copy is secret, and the release
+  profile's scalar replacement taints each field slot from the typed accesses
+  to that field rather than from the whole object, so a public field of a
+  record with a secret field stays public in both profiles (#3263).
 - The names of tables marked `default = true` collected while parsing
   `[target.*]` and `[profile.*]` were never released (#3222).
 

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -132,7 +132,7 @@ fun collect_leaves(ctx: *context.LowerCtx, ty: type.IrTypeId, base_off: u64, str
     ret count + 1;
 }
 
-fun aggregate_sse_mask(ctx: *context.LowerCtx, ty: type.IrTypeId) u8 {
+fun aggregate_eightbyte_mask(ctx: *context.LowerCtx, ty: type.IrTypeId) u8 {
     if (!context.value_is_aggregate(ctx, ty)) { ret 0; }
     val size: u64 = type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
     if (size == 0 || size > 16) { ret 0; }
@@ -149,8 +149,10 @@ fun aggregate_sse_mask(ctx: *context.LowerCtx, ty: type.IrTypeId) u8 {
         i = i + 1;
     }
     var mask: u8 = 0;
-    if (classes[0] == EB_SSE) { mask = mask | 1; }
-    if (classes[1] == EB_SSE) { mask = mask | 2; }
+    if (classes[0] == EB_SSE)      { mask = mask | abi.EB_SSE_LO; }
+    if (classes[1] == EB_SSE)      { mask = mask | abi.EB_SSE_HI; }
+    if (classes[0] == EB_NO_CLASS) { mask = mask | abi.EB_EMPTY_LO; }
+    if (size > 8 && classes[1] == EB_NO_CLASS) { mask = mask | abi.EB_EMPTY_HI; }
     ret mask;
 }
 
@@ -334,7 +336,7 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
     val ret_float: bool = context.value_is_float(ctx, ret_type);
     val ret_aggr:  bool = context.value_is_aggregate(ctx, ret_type);
     val ret_vec:   bool = context.value_is_vector(ctx, ret_type);
-    val ret_eb:    u8   = aggregate_sse_mask(ctx, ret_type);
+    val ret_eb:    u8   = aggregate_eightbyte_mask(ctx, ret_type);
     var ret_hm:    u8   = 0;
     var ret_he:    u8   = 0;
     hfa_info(ctx, ret_type, ?ret_hm, ?ret_he);
@@ -382,7 +384,7 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
         val pal:  u64  = type.byte_align_for_machine(ctx.types, pty, ctx.layout)::u64;
         val pfl:  bool = context.value_is_float(ctx, pty);
         val pag:  bool = context.value_is_aggregate(ctx, pty);
-        val peb:  u8   = aggregate_sse_mask(ctx, pty);
+        val peb:  u8   = aggregate_eightbyte_mask(ctx, pty);
         var phm:  u8   = 0;
         var phe:  u8   = 0;
         hfa_info(ctx, pty, ?phm, ?phe);
@@ -768,6 +770,41 @@ fun load_piece_carrier(ctx: *context.LowerCtx, mb: *mir.MirBlock, registers: *mi
     ret emit_call_reg(ctx, mb, registers, reg, mir.op_mem_slot(key, 0), carrier_width);
 }
 
+fun zero_range(ctx: *context.LowerCtx, mb: *mir.MirBlock, plan: PiecePlan, from: u64, to: u64) R.Result[R.Void, str] {
+    var off: u64 = from;
+    for (off < to) {
+        val width: u8 = context.copy_chunk_width(ctx.tgt, to - off);
+        var mem: mir.MirOperand = mir.op_mem_value(plan.mem_base, off::i64);
+        if (plan.mem_slot) { mem = mir.op_mem_slot(plan.mem_base, off::i64); }
+        val zero: R.Result[R.Void, str] = context.push_store_chunk(ctx, mb, mem, mir.op_imm(0), width);
+        if (R.is_err[R.Void, str](zero)) { ret zero; }
+        off = off + width::u64;
+    }
+    ret R.ok_void[str]();
+}
+
+# a convention may deliver nothing for a padding-only eightbyte; the logical object still owns those bytes,
+# so the store side zeroes every logical byte no piece delivers before the pieces land
+fun zero_undelivered_bytes(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: *abi.ParamSlot, plan: PiecePlan) R.Result[R.Void, str] {
+    var cursor: u64 = 0;
+    var i: u32 = 0;
+    for (i < slot.piece_count) {
+        val p: *abi.ParamPiece = ?slot.pieces[i];
+        val wr: R.Result[u8, str] = abi.piece_memory_width(slot, p);
+        if (R.is_err[u8, str](wr)) { ret R.err[R.Void, str](R.unwrap_err[u8, str](wr)); }
+        val start: u64 = p.src_off::u64;
+        if (start > cursor) {
+            val zr: R.Result[R.Void, str] = zero_range(ctx, mb, plan, cursor, start);
+            if (R.is_err[R.Void, str](zr)) { ret zr; }
+        }
+        val end: u64 = start + R.unwrap_ok[u8, str](wr)::u64;
+        if (end > cursor) { cursor = end; }
+        i = i + 1;
+    }
+    if (cursor < slot.size) { ret zero_range(ctx, mb, plan, cursor, slot.size); }
+    ret R.ok_void[str]();
+}
+
 fun materialize_pieces(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, plan: PiecePlan) R.Result[R.Void, str] {
     val er: R.Result[u64, str] = abi.carrier_storage_extent(?slot);
     if (R.is_err[u64, str](er)) { ret R.err[R.Void, str](R.unwrap_err[u64, str](er)); }
@@ -782,6 +819,10 @@ fun materialize_pieces(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.Para
     if (copies == nil) { copies = ?pending_copies; }
     var registers: *mir.MirBlock = plan.registers;
     if (!plan.store && registers == mb) { registers = ?pending; }
+    if (plan.store) {
+        val zr: R.Result[R.Void, str] = zero_undelivered_bytes(ctx, mb, ?slot, plan);
+        if (R.is_err[R.Void, str](zr)) { ret zr; }
+    }
     var i: u32 = 0;
     for (i < slot.piece_count) {
         val p: abi.ParamPiece = slot.pieces[i];
@@ -2205,4 +2246,332 @@ test "mach.lang.be.codegen.mir.abi:call_result_owns_carrier_alignment_without_ch
     val nine: i32 = t_result_carrier_alignment(8, 9);
     if (nine != 0) { ret nine; }
     ret t_result_carrier_alignment(32, 3);
+}
+
+# record shapes for the transport inventory (#3263); each is a record IR type built the way lower_rec builds it
+val REC_P1:    u32 = 0;
+val REC_T3:    u32 = 1;
+val REC_S8:    u32 = 2;
+val REC_T9:    u32 = 3;
+val REC_T16:   u32 = 4;
+val REC_O24:   u32 = 5;
+val REC_NEST:  u32 = 6;
+val REC_AL16:  u32 = 7;
+val REC_TF16:  u32 = 8;
+val REC_TF8:   u32 = 9;
+val REC_TFM:   u32 = 10;
+val REC_SHAPE_COUNT: u32 = 11;
+
+fun t_rec_shape(types: *type.IrTypeTable, which: u32) R.Result[type.IrTypeId, str] {
+    val u8r: R.Result[type.IrTypeId, str] = type.intern_int(types, 8);
+    val u32r: R.Result[type.IrTypeId, str] = type.intern_int(types, 32);
+    val i64r: R.Result[type.IrTypeId, str] = type.intern_int(types, 64);
+    val f32r: R.Result[type.IrTypeId, str] = type.intern_float(types, 32);
+    val f64r: R.Result[type.IrTypeId, str] = type.intern_float(types, 64);
+    if (R.is_err[type.IrTypeId, str](u8r) || R.is_err[type.IrTypeId, str](u32r)
+        || R.is_err[type.IrTypeId, str](i64r) || R.is_err[type.IrTypeId, str](f32r) || R.is_err[type.IrTypeId, str](f64r)) {
+        ret R.err[type.IrTypeId, str]("leaf");
+    }
+    val u8t:  type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](u8r);
+    val u32t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](u32r);
+    val i64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](i64r);
+    val f32t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](f32r);
+    val f64t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](f64r);
+    var fields: [2]type.IrTypeId;
+    fields[0] = u8t;
+    var count: u32 = 2;
+    var align: u32 = 0;
+    if (which == REC_P1)  { count = 1; }
+    or (which == REC_T3)  { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, u8t, 2); if (R.is_err[type.IrTypeId, str](a)) { ret a; } fields[1] = R.unwrap_ok[type.IrTypeId, str](a); }
+    or (which == REC_S8)  { fields[1] = u32t; }
+    or (which == REC_T9)  { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, u8t, 8); if (R.is_err[type.IrTypeId, str](a)) { ret a; } fields[1] = R.unwrap_ok[type.IrTypeId, str](a); }
+    or (which == REC_T16) { fields[1] = i64t; }
+    or (which == REC_O24) { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, i64t, 2); if (R.is_err[type.IrTypeId, str](a)) { ret a; } fields[1] = R.unwrap_ok[type.IrTypeId, str](a); }
+    or (which == REC_NEST) { val inner: R.Result[type.IrTypeId, str] = t_rec_shape(types, REC_S8); if (R.is_err[type.IrTypeId, str](inner)) { ret inner; } fields[1] = R.unwrap_ok[type.IrTypeId, str](inner); }
+    or (which == REC_AL16) { fields[1] = u8t; align = 16; }
+    or (which == REC_TF16) { fields[1] = f64t; }
+    or (which == REC_TF8) { fields[1] = f32t; }
+    or (which == REC_TFM) { fields[0] = f64t; fields[1] = i64t; }
+    or { ret R.err[type.IrTypeId, str]("shape"); }
+    ret type.intern_struct(types, ?fields[0], count, align, false);
+}
+
+rec RecTransport {
+    size:       u64;
+    align:      u32;
+    hfa:        u8;
+    eightbytes: u8;
+    arg:        abi.ParamSlot;
+    ret:        abi.ParamSlot;
+}
+
+# classifies `fun(T)` and `fun() T` for one convention through the real type derivation and the real vtable
+fun t_rec_transport(alloc: *A.Allocator, isa_name: str, os_name: str, abi_name: str, which: u32, out: *RecTransport) i32 {
+    val mr: R.Result[ir.Module, str] = ir.init(alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](mr);
+    fin { ir.dnit(?m); }
+    var reg: treg.TargetRegistry = treg.registry_init();
+    fin { treg.registry_dnit(?reg); }
+    if (R.is_err[R.Void, str](treg.register_all(?reg, target_testing.debug_descriptor))) { ret 2; }
+    val tr: R.Result[target.Target, str] = treg.select(?reg, isa_name, os_name, abi_name);
+    if (R.is_err[target.Target, str](tr)) { ret 3; }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+    val sr: R.Result[type.IrTypeId, str] = t_rec_shape(?m.types, which);
+    if (R.is_err[type.IrTypeId, str](sr)) { ret 4; }
+    var rec_t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](sr);
+    val vr: R.Result[type.IrTypeId, str] = type.intern_void(?m.types);
+    if (R.is_err[type.IrTypeId, str](vr)) { ret 5; }
+    val void_t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](vr);
+    # the argument is classified on `fun(T)` and the return on `fun() T`, so a hidden result pointer never shifts the argument
+    val ar: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, void_t, ?rec_t, 1, false);
+    val rr: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, rec_t, nil, 0, false);
+    if (R.is_err[type.IrTypeId, str](ar) || R.is_err[type.IrTypeId, str](rr)) { ret 5; }
+    var ctx: context.LowerCtx;
+    ctx.alloc  = alloc;
+    ctx.tgt    = ?tgt;
+    ctx.layout = target.layout_machine(?tgt);
+    ctx.m      = ?m;
+    ctx.types  = ?m.types;
+    var layout: abi.SigLayout;
+    if (R.is_err[R.Void, str](classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](ar), void_t, ?layout))) { ret 6; }
+    if (layout.param_count != 1) { sig_layout_free(?ctx, ?layout); ret 7; }
+    out.arg = layout.params[0];
+    sig_layout_free(?ctx, ?layout);
+    var rlayout: abi.SigLayout;
+    if (R.is_err[R.Void, str](classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](rr), rec_t, ?rlayout))) { ret 8; }
+    out.ret = rlayout.ret_slot;
+    sig_layout_free(?ctx, ?rlayout);
+    out.size  = type.byte_size_for_machine(?m.types, rec_t, ctx.layout)::u64;
+    out.align = type.byte_align_for_machine(?m.types, rec_t, ctx.layout);
+    var he: u8 = 0;
+    hfa_info(?ctx, rec_t, ?out.hfa, ?he);
+    out.eightbytes = aggregate_eightbyte_mask(?ctx, rec_t);
+    ret 0;
+}
+
+# one register piece: class, register, transport width; the logical bytes it moves come from piece_memory_width
+fun t_piece_is(slot: *abi.ParamSlot, i: u32, kind: abi.PieceKind, reg: i32, width: u8, logical: u8) bool {
+    if (i >= slot.piece_count) { ret false; }
+    val p: *abi.ParamPiece = ?slot.pieces[i];
+    if (p.kind != kind || p.reg != reg || p.width != width) { ret false; }
+    val lw: R.Result[u8, str] = abi.piece_memory_width(slot, p);
+    if (R.is_err[u8, str](lw)) { ret false; }
+    ret R.unwrap_ok[u8, str](lw) == logical;
+}
+
+fun t_one_gp(slot: *abi.ParamSlot, reg: i32, width: u8, logical: u8) bool {
+    ret slot.class == abi.CLASS_GP && slot.piece_count == 1 && t_piece_is(slot, 0, abi.PIECE_GP, reg, width, logical);
+}
+
+fun t_gp_pair(slot: *abi.ParamSlot, r0: i32, r1: i32, width: u8, logical1: u8) bool {
+    ret slot.class == abi.CLASS_GP && slot.piece_count == 2
+        && t_piece_is(slot, 0, abi.PIECE_GP, r0, width, width)
+        && t_piece_is(slot, 1, abi.PIECE_GP, r1, width, logical1);
+}
+
+# a two-leaf split: one general and one float register, each carrying its own leaf at its own offset
+fun t_leaf_split(slot: *abi.ParamSlot, kind0: abi.PieceKind, r0: i32, w0: u8, kind1: abi.PieceKind, r1: i32, off1: u8, w1: u8) bool {
+    ret slot.piece_count == 2
+        && t_piece_is(slot, 0, kind0, r0, w0, w0)
+        && t_piece_is(slot, 1, kind1, r1, w1, w1)
+        && slot.pieces[0].src_off == 0 && slot.pieces[1].src_off == off1::i64;
+}
+
+fun t_byref(slot: *abi.ParamSlot, reg: i32) bool {
+    ret slot.class == abi.CLASS_BYREF && slot.reg == reg;
+}
+
+fun t_sret(slot: *abi.ParamSlot, reg: i32) bool {
+    ret slot.class == abi.CLASS_SRET && slot.reg == reg;
+}
+
+val SYSV_RDI: i32 = 7;
+val SYSV_RSI: i32 = 6;
+val SYSV_RAX: i32 = 0;
+val SYSV_RDX: i32 = 2;
+val WIN_RCX:  i32 = 1;
+val AAPCS_X8: i32 = 8;
+val RV_A0:    i32 = 10;
+val RV_A1:    i32 = 11;
+
+fun t_xmm(i: i32) i32 { ret isa.regid_make(isa.REG_CLASS_ID_XMM, i); }
+fun t_fa(i: i32) i32 { ret isa.regid_make(isa.REG_CLASS_ID_XMM, RV_A0 + i); }
+
+# the SysV cells: an integer leaf makes its eightbyte INTEGER, a float-only eightbyte is SSE, and an eightbyte
+# holding only padding consumes no register at all
+fun t_sysv_cells(alloc: *A.Allocator) i32 {
+    var t: RecTransport;
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_P1, ?t) != 0) { ret 1; }
+    if (t.size != 1 || !t_one_gp(?t.arg, SYSV_RDI, 8, 1) || !t_one_gp(?t.ret, SYSV_RAX, 8, 1)) { ret 2; }
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_T3, ?t) != 0) { ret 3; }
+    if (t.size != 3 || !t_one_gp(?t.arg, SYSV_RDI, 8, 3) || !t_one_gp(?t.ret, SYSV_RAX, 8, 3)) { ret 4; }
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_S8, ?t) != 0) { ret 5; }
+    if (t.size != 8 || !t_one_gp(?t.arg, SYSV_RDI, 8, 8) || !t_one_gp(?t.ret, SYSV_RAX, 8, 8)) { ret 6; }
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_T9, ?t) != 0) { ret 7; }
+    if (t.size != 9 || !t_gp_pair(?t.arg, SYSV_RDI, SYSV_RSI, 8, 1) || !t_gp_pair(?t.ret, SYSV_RAX, SYSV_RDX, 8, 1)) { ret 8; }
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_T16, ?t) != 0) { ret 9; }
+    if (t.size != 16 || !t_gp_pair(?t.arg, SYSV_RDI, SYSV_RSI, 8, 8) || !t_gp_pair(?t.ret, SYSV_RAX, SYSV_RDX, 8, 8)) { ret 10; }
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_O24, ?t) != 0) { ret 11; }
+    if (t.size != 24 || t.arg.class != abi.CLASS_STACK || t.arg.size != 24 || !t_sret(?t.ret, SYSV_RAX)) { ret 12; }
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_NEST, ?t) != 0) { ret 13; }
+    if (t.size != 12 || !t_gp_pair(?t.arg, SYSV_RDI, SYSV_RSI, 8, 4) || !t_gp_pair(?t.ret, SYSV_RAX, SYSV_RDX, 8, 4)) { ret 14; }
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_AL16, ?t) != 0) { ret 15; }
+    if (t.size != 16 || t.align != 16 || t.eightbytes != abi.EB_EMPTY_HI) { ret 16; }
+    if (!t_one_gp(?t.arg, SYSV_RDI, 8, 8) || !t_one_gp(?t.ret, SYSV_RAX, 8, 8)) { ret 17; }
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_TF16, ?t) != 0) { ret 18; }
+    if (t.size != 16 || t.eightbytes != abi.EB_SSE_HI || t.arg.class != abi.CLASS_GP || t.arg.piece_count != 2) { ret 19; }
+    if (!t_piece_is(?t.arg, 0, abi.PIECE_GP, SYSV_RDI, 8, 8) || !t_piece_is(?t.arg, 1, abi.PIECE_FP, t_xmm(0), 8, 8)) { ret 20; }
+    if (!t_piece_is(?t.ret, 0, abi.PIECE_GP, SYSV_RAX, 8, 8) || !t_piece_is(?t.ret, 1, abi.PIECE_FP, t_xmm(0), 8, 8)) { ret 21; }
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_TF8, ?t) != 0) { ret 22; }
+    if (t.size != 8 || t.eightbytes != 0 || !t_one_gp(?t.arg, SYSV_RDI, 8, 8) || !t_one_gp(?t.ret, SYSV_RAX, 8, 8)) { ret 23; }
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_TFM, ?t) != 0) { ret 24; }
+    if (t.size != 16 || t.eightbytes != abi.EB_SSE_LO || t.arg.piece_count != 2) { ret 25; }
+    if (!t_piece_is(?t.arg, 0, abi.PIECE_FP, t_xmm(0), 8, 8) || !t_piece_is(?t.arg, 1, abi.PIECE_GP, SYSV_RDI, 8, 8)) { ret 26; }
+    if (!t_piece_is(?t.ret, 0, abi.PIECE_FP, t_xmm(0), 8, 8) || !t_piece_is(?t.ret, 1, abi.PIECE_GP, SYSV_RAX, 8, 8)) { ret 27; }
+    ret 0;
+}
+
+# the Win64 cells: only 1, 2, 4 and 8 byte records ride a register; everything else is the address of a caller copy
+fun t_win64_cells(alloc: *A.Allocator) i32 {
+    var t: RecTransport;
+    if (t_rec_transport(alloc, "x86_64", "windows", "win64", REC_P1, ?t) != 0) { ret 1; }
+    if (!t_one_gp(?t.arg, WIN_RCX, 8, 1) || !t_one_gp(?t.ret, SYSV_RAX, 8, 1)) { ret 2; }
+    if (t_rec_transport(alloc, "x86_64", "windows", "win64", REC_T3, ?t) != 0) { ret 3; }
+    if (!t_byref(?t.arg, WIN_RCX) || !t_sret(?t.ret, SYSV_RAX)) { ret 4; }
+    if (t_rec_transport(alloc, "x86_64", "windows", "win64", REC_S8, ?t) != 0) { ret 5; }
+    if (!t_one_gp(?t.arg, WIN_RCX, 8, 8) || !t_one_gp(?t.ret, SYSV_RAX, 8, 8)) { ret 6; }
+    var which: u32 = REC_T9;
+    for (which < REC_SHAPE_COUNT) {
+        if (which != REC_TF8) {
+            if (t_rec_transport(alloc, "x86_64", "windows", "win64", which, ?t) != 0) { ret 7; }
+            if (!t_byref(?t.arg, WIN_RCX) || !t_sret(?t.ret, SYSV_RAX)) { ret 8; }
+        }
+        which = which + 1;
+    }
+    if (t_rec_transport(alloc, "x86_64", "windows", "win64", REC_TF8, ?t) != 0) { ret 9; }
+    if (!t_one_gp(?t.arg, WIN_RCX, 8, 8) || !t_one_gp(?t.ret, SYSV_RAX, 8, 8)) { ret 10; }
+    ret 0;
+}
+
+# the AAPCS64 cells: none of these records is an HFA (each has an integer leaf), so every one rides the
+# general registers; up to 16 bytes ride x0/x1, larger goes by reference with x8 for returns
+fun t_aapcs64_cells(alloc: *A.Allocator) i32 {
+    var t: RecTransport;
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_P1, ?t) != 0) { ret 1; }
+    if (!t_one_gp(?t.arg, 0, 8, 1) || !t_one_gp(?t.ret, 0, 8, 1)) { ret 2; }
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_T3, ?t) != 0) { ret 3; }
+    if (!t_one_gp(?t.arg, 0, 8, 3) || !t_one_gp(?t.ret, 0, 8, 3)) { ret 4; }
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_S8, ?t) != 0) { ret 5; }
+    if (!t_one_gp(?t.arg, 0, 8, 8) || !t_one_gp(?t.ret, 0, 8, 8)) { ret 6; }
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_T9, ?t) != 0) { ret 7; }
+    if (!t_gp_pair(?t.arg, 0, 1, 8, 1) || !t_gp_pair(?t.ret, 0, 1, 8, 1)) { ret 8; }
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_T16, ?t) != 0) { ret 9; }
+    if (!t_gp_pair(?t.arg, 0, 1, 8, 8) || !t_gp_pair(?t.ret, 0, 1, 8, 8)) { ret 10; }
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_O24, ?t) != 0) { ret 11; }
+    if (!t_byref(?t.arg, 0) || !t_sret(?t.ret, AAPCS_X8)) { ret 12; }
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_NEST, ?t) != 0) { ret 13; }
+    if (!t_gp_pair(?t.arg, 0, 1, 8, 4) || !t_gp_pair(?t.ret, 0, 1, 8, 4)) { ret 14; }
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_AL16, ?t) != 0) { ret 15; }
+    if (t.align != 16 || !t_gp_pair(?t.arg, 0, 1, 8, 8) || !t_gp_pair(?t.ret, 0, 1, 8, 8)) { ret 16; }
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_TF16, ?t) != 0) { ret 17; }
+    if (t.hfa != 0 || !t_gp_pair(?t.arg, 0, 1, 8, 8) || !t_gp_pair(?t.ret, 0, 1, 8, 8)) { ret 18; }
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_TF8, ?t) != 0) { ret 19; }
+    if (t.hfa != 0 || !t_one_gp(?t.arg, 0, 8, 8) || !t_one_gp(?t.ret, 0, 8, 8)) { ret 20; }
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_TFM, ?t) != 0) { ret 21; }
+    if (t.hfa != 0 || !t_gp_pair(?t.arg, 0, 1, 8, 8) || !t_gp_pair(?t.ret, 0, 1, 8, 8)) { ret 22; }
+    ret 0;
+}
+
+# the RV64 cells: integer-only records ride a0/a1 or go by reference above two words; a record of exactly one
+# float and one integer leaf splits into a float and an integer register under lp64d and rides a0/a1 under lp64
+fun t_rv64_cells(alloc: *A.Allocator, abi_name: str, hard_float: bool) i32 {
+    var t: RecTransport;
+    if (t_rec_transport(alloc, "riscv64", "linux", abi_name, REC_P1, ?t) != 0) { ret 1; }
+    if (!t_one_gp(?t.arg, RV_A0, 8, 1) || !t_one_gp(?t.ret, RV_A0, 8, 1)) { ret 2; }
+    if (t_rec_transport(alloc, "riscv64", "linux", abi_name, REC_T3, ?t) != 0) { ret 3; }
+    if (!t_one_gp(?t.arg, RV_A0, 8, 3) || !t_one_gp(?t.ret, RV_A0, 8, 3)) { ret 4; }
+    if (t_rec_transport(alloc, "riscv64", "linux", abi_name, REC_S8, ?t) != 0) { ret 5; }
+    if (!t_one_gp(?t.arg, RV_A0, 8, 8) || !t_one_gp(?t.ret, RV_A0, 8, 8)) { ret 6; }
+    if (t_rec_transport(alloc, "riscv64", "linux", abi_name, REC_T9, ?t) != 0) { ret 7; }
+    if (!t_gp_pair(?t.arg, RV_A0, RV_A1, 8, 1) || !t_gp_pair(?t.ret, RV_A0, RV_A1, 8, 1)) { ret 8; }
+    if (t_rec_transport(alloc, "riscv64", "linux", abi_name, REC_T16, ?t) != 0) { ret 9; }
+    if (!t_gp_pair(?t.arg, RV_A0, RV_A1, 8, 8) || !t_gp_pair(?t.ret, RV_A0, RV_A1, 8, 8)) { ret 10; }
+    if (t_rec_transport(alloc, "riscv64", "linux", abi_name, REC_O24, ?t) != 0) { ret 11; }
+    if (!t_byref(?t.arg, RV_A0) || !t_sret(?t.ret, RV_A0)) { ret 12; }
+    if (t_rec_transport(alloc, "riscv64", "linux", abi_name, REC_NEST, ?t) != 0) { ret 13; }
+    if (!t_gp_pair(?t.arg, RV_A0, RV_A1, 8, 4) || !t_gp_pair(?t.ret, RV_A0, RV_A1, 8, 4)) { ret 14; }
+    if (t_rec_transport(alloc, "riscv64", "linux", abi_name, REC_AL16, ?t) != 0) { ret 15; }
+    if (!t_gp_pair(?t.arg, RV_A0, RV_A1, 8, 8) || !t_gp_pair(?t.ret, RV_A0, RV_A1, 8, 8)) { ret 16; }
+    if (t_rec_transport(alloc, "riscv64", "linux", abi_name, REC_TF16, ?t) != 0) { ret 17; }
+    if (hard_float) {
+        if (!t_leaf_split(?t.arg, abi.PIECE_GP, RV_A0, 1, abi.PIECE_FP, t_fa(0), 8, 8)) { ret 18; }
+        if (!t_leaf_split(?t.ret, abi.PIECE_GP, RV_A0, 1, abi.PIECE_FP, t_fa(0), 8, 8)) { ret 19; }
+    } or {
+        if (!t_gp_pair(?t.arg, RV_A0, RV_A1, 8, 8) || !t_gp_pair(?t.ret, RV_A0, RV_A1, 8, 8)) { ret 20; }
+    }
+    if (t_rec_transport(alloc, "riscv64", "linux", abi_name, REC_TF8, ?t) != 0) { ret 21; }
+    if (hard_float) {
+        if (!t_leaf_split(?t.arg, abi.PIECE_GP, RV_A0, 1, abi.PIECE_FP, t_fa(0), 4, 4)) { ret 22; }
+        if (!t_leaf_split(?t.ret, abi.PIECE_GP, RV_A0, 1, abi.PIECE_FP, t_fa(0), 4, 4)) { ret 23; }
+    } or {
+        if (!t_one_gp(?t.arg, RV_A0, 8, 8) || !t_one_gp(?t.ret, RV_A0, 8, 8)) { ret 24; }
+    }
+    if (t_rec_transport(alloc, "riscv64", "linux", abi_name, REC_TFM, ?t) != 0) { ret 25; }
+    if (hard_float) {
+        if (!t_leaf_split(?t.arg, abi.PIECE_FP, t_fa(0), 8, abi.PIECE_GP, RV_A0, 8, 8)) { ret 26; }
+        if (!t_leaf_split(?t.ret, abi.PIECE_FP, t_fa(0), 8, abi.PIECE_GP, RV_A0, 8, 8)) { ret 27; }
+    } or {
+        if (!t_gp_pair(?t.arg, RV_A0, RV_A1, 8, 8) || !t_gp_pair(?t.ret, RV_A0, RV_A1, 8, 8)) { ret 28; }
+    }
+    ret 0;
+}
+
+# the RV32 cells: the word is four bytes, so an 8-byte record already needs the a0/a1 pair and anything above
+# eight bytes goes by reference; the one-float-one-integer split still applies under ilp32d
+fun t_rv32_cells(alloc: *A.Allocator, isa_name: str, abi_name: str, hard_float: bool) i32 {
+    var t: RecTransport;
+    if (t_rec_transport(alloc, isa_name, "freestanding", abi_name, REC_P1, ?t) != 0) { ret 1; }
+    if (!t_one_gp(?t.arg, RV_A0, 4, 1) || !t_one_gp(?t.ret, RV_A0, 4, 1)) { ret 2; }
+    if (t_rec_transport(alloc, isa_name, "freestanding", abi_name, REC_T3, ?t) != 0) { ret 3; }
+    if (!t_one_gp(?t.arg, RV_A0, 4, 3) || !t_one_gp(?t.ret, RV_A0, 4, 3)) { ret 4; }
+    if (t_rec_transport(alloc, isa_name, "freestanding", abi_name, REC_S8, ?t) != 0) { ret 5; }
+    if (!t_gp_pair(?t.arg, RV_A0, RV_A1, 4, 4) || !t_gp_pair(?t.ret, RV_A0, RV_A1, 4, 4)) { ret 6; }
+    if (t_rec_transport(alloc, isa_name, "freestanding", abi_name, REC_TF8, ?t) != 0) { ret 7; }
+    if (hard_float) {
+        if (!t_leaf_split(?t.arg, abi.PIECE_GP, RV_A0, 1, abi.PIECE_FP, t_fa(0), 4, 4)) { ret 8; }
+        if (!t_leaf_split(?t.ret, abi.PIECE_GP, RV_A0, 1, abi.PIECE_FP, t_fa(0), 4, 4)) { ret 9; }
+    } or {
+        if (!t_gp_pair(?t.arg, RV_A0, RV_A1, 4, 4) || !t_gp_pair(?t.ret, RV_A0, RV_A1, 4, 4)) { ret 10; }
+    }
+    var which: u32 = REC_T9;
+    for (which < REC_SHAPE_COUNT) {
+        if (which != REC_TF8) {
+            if (t_rec_transport(alloc, isa_name, "freestanding", abi_name, which, ?t) != 0) { ret 11; }
+            if (!t_byref(?t.arg, RV_A0) || !t_sret(?t.ret, RV_A0)) { ret 12; }
+        }
+        which = which + 1;
+    }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.mir.abi:record_transport_classifies_by_layout_on_every_convention" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    # exit codes: convention block of thirty plus the failing cell
+    val sysv: i32 = t_sysv_cells(?alloc);
+    if (sysv != 0) { ret 30 + sysv; }
+    val win: i32 = t_win64_cells(?alloc);
+    if (win != 0) { ret 60 + win; }
+    val arm: i32 = t_aapcs64_cells(?alloc);
+    if (arm != 0) { ret 90 + arm; }
+    val rv64d: i32 = t_rv64_cells(?alloc, "lp64d", true);
+    if (rv64d != 0) { ret 120 + rv64d; }
+    val rv64: i32 = t_rv64_cells(?alloc, "lp64", false);
+    if (rv64 != 0) { ret 150 + rv64; }
+    val rv32d: i32 = t_rv32_cells(?alloc, "rv32imafdc", "ilp32d", true);
+    if (rv32d != 0) { ret 180 + rv32d; }
+    val rv32: i32 = t_rv32_cells(?alloc, "rv32imc", "ilp32", false);
+    if (rv32 != 0) { ret 210 + rv32; }
+    ret 0;
 }

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -579,8 +579,11 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         }
         val argop: mir.MirOperand = R.unwrap_ok[mir.MirOperand, str](aor);
 
+        # the carriers, the caller's copy and every temporary between them are secret when any byte of the object is
+        ctx.cur_writes_secret = av.secret;
         val er: R.Result[R.Void, str] = emit_arg_slot(ctx, mb, registers, slot, argop, soff, aag, av.ty,
                                                     natural_stack_slot(ctx.tgt, pidx >= layout.param_count));
+        ctx.cur_writes_secret = false;
         if (R.is_err[R.Void, str](er)) {
             sig_layout_free(ctx, ?layout);
             ret er;
@@ -651,7 +654,9 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
 
     val dst: u32 = context.instr_vreg(ctx, iid);
     if (dst != mir.MIR_VREG_NIL && rslot.class != abi.CLASS_SRET) {
+        ctx.cur_writes_secret = inst.secret;
         val rr: R.Result[R.Void, str] = emit_ret_slot_to_vreg(ctx, mb, rslot, dst, ret_aggr, ret_type, ret_storage_align);
+        ctx.cur_writes_secret = false;
         if (R.is_err[R.Void, str](rr)) { ret rr; }
     }
     if (ret_sret_register && dst != mir.MIR_VREG_NIL) {
@@ -1099,7 +1104,9 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[R.Void,
         val slot: abi.ParamSlot = layout.params[i];
 
         if (pag || param_has_use(ctx.fn, i)) {
+            ctx.cur_writes_secret = ctx.fn.params[i].secret;
             val er: R.Result[R.Void, str] = emit_param_slot(ctx, mb, ?copies, slot, pv, pty, slot.offset, pag);
+            ctx.cur_writes_secret = false;
             if (R.is_err[R.Void, str](er)) {
                 sig_layout_free(ctx, ?layout);
                 ret er;
@@ -1246,6 +1253,8 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
     val rvr: R.Result[mir.MirOperand, str] = lower_value_addr(ctx, mb, rv);
     if (R.is_err[mir.MirOperand, str](rvr)) { ret R.err[R.Void, str](R.unwrap_err[mir.MirOperand, str](rvr)); }
     val rvop: mir.MirOperand = R.unwrap_ok[mir.MirOperand, str](rvr);
+    ctx.cur_writes_secret = rv.secret;
+    fin { ctx.cur_writes_secret = false; }
 
     if (slot.class == abi.CLASS_AGG) {
         val lr: R.Result[R.Void, str] = context.emit_agg_load(ctx, mb, slot.reg::u32, rvop);

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -91,7 +91,7 @@ pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) R.Resul
         val pv: u32 = R.unwrap_ok[u32, str](res_vreg);
         ctx.param_vregs[i] = pv;
         ctx.f.vregs[pv].ty = fn.params[i].ty::u32;
-        if (fn.params[i].secret) { ctx.f.vregs[pv].secret = true; }
+        if (fn.params[i].secret && !value_is_aggregate(ctx, fn.params[i].ty)) { ctx.f.vregs[pv].secret = true; }
         i = i + 1;
     }
 
@@ -106,7 +106,8 @@ pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) R.Resul
             val rv: u32 = R.unwrap_ok[u32, str](res_vreg);
             ctx.instr_vregs[i] = rv;
             ctx.f.vregs[rv].ty = inst.ty::u32;
-            if (inst.secret && (inst.kind == instruction.OP_LOAD || inst.kind == instruction.OP_CALL)) {
+            if (inst.secret && (inst.kind == instruction.OP_LOAD || inst.kind == instruction.OP_CALL)
+                && !value_is_aggregate(ctx, inst.ty)) {
                 ctx.f.vregs[rv].secret = true;
             }
         }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -14451,6 +14451,94 @@ test "mach.lang.driver:exceptional_division_traps_identically_on_every_native_ba
     ret 0;
 }
 
+fun ut_native_start_stub() str {
+    ret "\n#[symbol(\"_start\")]\npub fun start() {\n    $if ($mach.build.arch == $mach.arch.x86_64) {\n        asm x86_64 {\n            mov rdi, [rsp]\n            and rsp, -16\n            call main\n            mov rdi, rax\n            mov rax, 60\n            syscall\n        }\n    }\n    $or ($mach.build.arch == $mach.arch.aarch64) {\n        asm aarch64 {\n            ldr x0, [sp]\n            bl main\n            mov x8, 93\n            svc 0\n        }\n    }\n    $or {\n        asm riscv64 {\n            ld a0, 0(sp)\n            call main\n            li a7, 93\n            ecall\n        }\n    }\n}\n";
+}
+
+# builds a freestanding fixture for one target and profile and runs it; the fixture exits 0 when every check holds
+fun ut_native_fixture_case(alloc: *A.Allocator, target_name: str, runner_name: str, release: bool, program: str, label: str) i32 {
+    var runner: str = "";
+    if (!str_empty(runner_name)) {
+        val rr: R.Result[str, str] = exec.resolve(alloc, runner_name);
+        if (R.is_err[str, str](rr)) { print.print("native-fixture: runner absent, arm skipped: "); print.print(runner_name); print.print("\n"); ret 0; }
+        runner = R.unwrap_ok[str, str](rr);
+    }
+    val sr: R.Result[session.Session, str] = session.init(alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { session.dnit(?s); ret 1; }
+
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str; texts[0] = ut_cc3(alloc, program, "\n", ut_native_start_stub());
+    val root_r: R.Result[str, str] = ut_scaffold_m(alloc, ut_divide_manifest(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { session.dnit(?s); ret 1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+
+    var bad: i32 = 0;
+    val mr: R.Result[manifest.Manifest, str] = driver.load_manifest(?s, root);
+    if (R.is_err[manifest.Manifest, str](mr)) { fs.remove_all(alloc, root); session.dnit(?s); ret 1; }
+    var m: manifest.Manifest = R.unwrap_ok[manifest.Manifest, str](mr);
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = root;
+    rq.target = target_name;
+    if (release) { rq.profile = "release"; rq.opt = pipeline.OPT_RELEASE; }
+    val pr: R.Result[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, ?s.registry, ?m, rq);
+    if (R.is_err[bplan.BuildPlan, outcome.Fail](pr)) { fs.remove_all(alloc, root); session.dnit(?s); ret 1; }
+    var bp: bplan.BuildPlan = R.unwrap_ok[bplan.BuildPlan, outcome.Fail](pr);
+    val br: R.Result[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, alloc, nil);
+    if (R.is_err[outcome.BuildOutcome, outcome.Fail](br)) {
+        print.print("native-fixture: build failed for "); print.print(label); print.print(" on "); print.print(target_name); print.print("\n");
+        bad = 2;
+    } or {
+        val bo: outcome.BuildOutcome = R.unwrap_ok[outcome.BuildOutcome, outcome.Fail](br);
+        if (bo.severity != outcome.BUILD_OK || bo.artifacts.len != 1) { bad = 3; }
+        or {
+            var trapped: bool = false;
+            var code: i32 = 0;
+            if (!ut_run_with_argc(root, runner, bo.artifacts.data[0].path, 1, ?trapped, ?code)) { bad = 4; }
+            or (trapped || code != 0) {
+                print.print("native-fixture: "); print.print(label); print.print(" on "); print.print(target_name);
+                var profile_name: str = "debug";
+                if (release) { profile_name = "release"; }
+                print.print(" "); print.print(profile_name);
+                print.printf(" (trapped {}, exit {})\n", trapped::u8, code);
+                bad = 5;
+            }
+        }
+    }
+    if (O.is_some[str](fs.remove_all(alloc, root))) { bad = 6; }
+    session.dnit(?s);
+    ret bad;
+}
+
+# runs one fixture on the three native linux targets in both profiles
+fun ut_native_fixture_all(alloc: *A.Allocator, program: str, label: str) i32 {
+    var release: bool = false;
+    var pass: u32 = 0;
+    for (pass < 2) {
+        if (ut_native_fixture_case(alloc, "linux-x86_64", "", release, program, label) != 0)              { ret 1; }
+        if (ut_native_fixture_case(alloc, "linux-arm64", "qemu-aarch64", release, program, label) != 0)  { ret 2; }
+        if (ut_native_fixture_case(alloc, "linux-riscv64", "qemu-riscv64", release, program, label) != 0) { ret 3; }
+        release = true;
+        pass = pass + 1;
+    }
+    ret 0;
+}
+
+# record transport extents (#3263): every carrier class on a poisoned stack, the callee never reads carrier padding
+# as payload, a returned carrier never writes beyond the logical object, and padding, including the eightbyte no
+# register delivered, is zero after the round trip
+fun ut_record_extents_program() str {
+    ret "rec P1 { a: u8; }\nrec T3 { a: u8; b: [2]u8; }\nrec T9 { a: u8; b: [8]u8; }\nrec S4 { a: u8; b: u16; }\nrec Nest { a: u8; b: S4; }\n#[packed]\nrec PK9 { a: u8; b: u64; }\n#[align(16)]\nrec AL16 { a: u8; b: u8; }\nrec TF { a: u8; b: f64; }\nrec TFM { b: f64; c: i64; }\nrec Mid { a: u8; b: [3]u8; c: [10]u8; }\n#[packed]\nrec Cell { lo: u8; t: T3; hi: u8; }\nrec Row { lo: u8; t: T9; hi: u8; }\n\n#[noinline] fun byte_at(p: *u8, i: u64) u8 { ret p[i]; }\n#[noinline] fun sink(p: *u8) u8 { ret p[0]; }\n# dirties the stack region a following callee's frame and its carrier homes will occupy\n#[noinline] fun dirty() u8 { var junk: [2048]u8; var i: u64 = 0; for (i < 2048) { junk[i] = 0xAA; i = i + 1; } ret sink(?junk[0]); }\n#[noinline] fun zeros_from(p: *u8, from: u64, to: u64) u8 { var i: u64 = from; for (i < to) { if (p[i] != 0) { ret 0; } i = i + 1; } ret 1; }\n\n#[noinline] fun mk_p1(x: u8) P1 { var r: P1; r.a = x; ret r; }\n#[noinline] fun mk_t3(x: u8) T3 { var r: T3; r.a = 1; r.b[0] = x; r.b[1] = x + 1; ret r; }\n#[noinline] fun mk_t9(x: u8) T9 { var r: T9; r.a = 1; r.b[0] = x; r.b[7] = x + 1; ret r; }\n#[noinline] fun mk_s4(x: u16) S4 { var r: S4; r.a = 1; r.b = x; ret r; }\n#[noinline] fun mk_nest(x: u16) Nest { var r: Nest; r.a = 1; r.b = mk_s4(x); ret r; }\n#[noinline] fun mk_pk9(x: u64) PK9 { var r: PK9; r.a = 1; r.b = x; ret r; }\n#[noinline] fun mk_al16(x: u8) AL16 { var r: AL16; r.a = 1; r.b = x; ret r; }\n#[noinline] fun mk_tf(x: f64) TF { var r: TF; r.a = 1; r.b = x; ret r; }\n#[noinline] fun mk_tfm(x: i64) TFM { var r: TFM; r.b = 2.5; r.c = x; ret r; }\n#[noinline] fun mk_mid(x: u8) Mid { var r: Mid; r.a = 1; r.b[0] = x; r.b[2] = x + 2; ret r; }\n\n# callee-side checks: the carrier's padding never becomes payload, and a copy of the parameter keeps its zero suffix\n#[noinline] fun t_p1(v: P1) u8 { ret v.a; }\n#[noinline] fun t_t3(v: T3) u8 { val c: T3 = v; if (c.a != 1) { ret 0xFF; } ret c.b[0] + c.b[1]; }\n#[noinline] fun t_t9(v: T9) u8 { val c: T9 = v; val p: *u8 = (?c)::*u8; if (byte_at(p, 0) != 1) { ret 0xFE; } ret c.b[0] + c.b[7]; }\n#[noinline] fun t_s4(v: S4) u16 { val p: *u8 = (?v)::*u8; if (byte_at(p, 1) != 0) { ret 0xFFFE; } if (v.a != 1) { ret 0xFFFF; } ret v.b; }\n#[noinline] fun t_nest(v: Nest) u16 { val p: *u8 = (?v)::*u8; if (byte_at(p, 1) != 0 || byte_at(p, 3) != 0) { ret 0xFFFE; } if (v.a != 1) { ret 0xFFFF; } ret t_s4(v.b); }\n#[noinline] fun t_pk9(v: PK9) u64 { val c: PK9 = v; if (c.a != 1) { ret 0; } ret c.b; }\n#[noinline] fun t_al16(v: AL16) u8 { val p: *u8 = (?v)::*u8; if (zeros_from(p, 2, 16) == 0) { ret 0xFE; } val c: AL16 = v; val q: *u8 = (?c)::*u8; if (zeros_from(q, 2, 16) == 0) { ret 0xFD; } if (c.a != 1) { ret 0xFF; } ret c.b; }\n#[noinline] fun t_tf(v: TF) f64 { val p: *u8 = (?v)::*u8; if (zeros_from(p, 1, 8) == 0) { ret -2.0; } if (v.a != 1) { ret -1.0; } ret v.b; }\n#[noinline] fun t_tfm(v: TFM) i64 { if (v.b != 2.5) { ret -1; } ret v.c; }\n#[noinline] fun t_mid(v: Mid) u8 { val p: *u8 = (?v)::*u8; if (zeros_from(p, 4, 14) == 0) { ret 0xFE; } if (v.a != 1) { ret 0xFF; } ret v.b[0] + v.b[2]; }\n#[noinline] fun many9(a: T9, b: T9, c: T9, d: T9, e: T9, f: T9, g: T9, h: T9, i: T9) u64 { ret t_t9(a)::u64 + t_t9(b)::u64 + t_t9(c)::u64 + t_t9(d)::u64 + t_t9(e)::u64 + t_t9(f)::u64 + t_t9(g)::u64 + t_t9(h)::u64 + t_t9(i)::u64; }\n#[noinline] fun many_al(a: AL16, b: AL16, c: AL16, d: AL16, e: AL16, f: AL16, g: AL16, h: AL16, i: AL16) u64 { ret t_al16(a)::u64 + t_al16(b)::u64 + t_al16(c)::u64 + t_al16(d)::u64 + t_al16(e)::u64 + t_al16(f)::u64 + t_al16(g)::u64 + t_al16(h)::u64 + t_al16(i)::u64; }\n#[noinline] fun after_al(a: AL16, next: i64) i64 { if (a.a != 1) { ret -1; } ret a.b::i64 + next; }\n#[noinline] fun al_after(first: i64, a: AL16, next: i64) i64 { if (a.a != 1) { ret -1; } ret a.b::i64 + next + first; }\n\n#[symbol(\"main\")]\nfun main(argc: i64) i64 {\n    if ($size_of(T3) != 3 || $size_of(T9) != 9 || $size_of(S4) != 4 || $size_of(Nest) != 6 || $size_of(PK9) != 9 || $size_of(AL16) != 16 || $align_of(AL16) != 16 || $size_of(TF) != 16 || $size_of(Mid) != 14) { ret 100; }\n    # round trips through carriers wider than the object, on a poisoned stack\n    dirty();\n    if (t_p1(mk_p1(0)) != 0 || t_p1(mk_p1(1)) != 1) { ret 1; }\n    dirty();\n    if (t_t3(mk_t3(3)) != 7) { ret 2; }\n    dirty();\n    if (t_t9(mk_t9(4)) != 9) { ret 3; }\n    dirty();\n    if (t_s4(mk_s4(0x1234)) != 0x1234) { ret 4; }\n    dirty();\n    if (t_nest(mk_nest(0x0506)) != 0x0506) { ret 5; }\n    dirty();\n    if (t_pk9(mk_pk9(0x1122334455667788)) != 0x1122334455667788) { ret 6; }\n    dirty();\n    if (t_al16(mk_al16(9)) != 9) { ret 7; }\n    dirty();\n    if (t_tf(mk_tf(2.5)) != 2.5) { ret 8; }\n    dirty();\n    if (t_tfm(mk_tfm(-77)) != -77) { ret 9; }\n    dirty();\n    if (t_mid(mk_mid(1)) != 4) { ret 10; }\n    dirty();\n    if (many9(mk_t9(1), mk_t9(2), mk_t9(3), mk_t9(4), mk_t9(5), mk_t9(6), mk_t9(7), mk_t9(8), mk_t9(9)) != 99) { ret 11; }\n    dirty();\n    if (many_al(mk_al16(1), mk_al16(2), mk_al16(3), mk_al16(4), mk_al16(5), mk_al16(6), mk_al16(7), mk_al16(8), mk_al16(9)) != 45) { ret 12; }\n    # the argument after an over-aligned record lands where the convention puts it\n    if (after_al(mk_al16(3), 40) != 43 || al_after(100, mk_al16(3), 40) != 143) { ret 13; }\n    # storing a returned carrier never writes beyond the logical object\n    var cell: Cell;\n    cell.lo = 0x5A; cell.hi = 0xA5;\n    dirty();\n    cell.t = mk_t3(1);\n    if (cell.lo != 0x5A || cell.hi != 0xA5 || t_t3(cell.t) != 3) { ret 20; }\n    var row: Row;\n    row.lo = 0x5A; row.hi = 0xA5;\n    dirty();\n    row.t = mk_t9(1);\n    if (row.lo != 0x5A || row.hi != 0xA5 || t_t9(row.t) != 3) { ret 21; }\n    var arr: [3]T9;\n    val pa: *u8 = (?arr)::*u8;\n    var i: u64 = 0;\n    for (i < 27) { pa[i] = 0xCC; i = i + 1; }\n    dirty();\n    arr[1] = mk_t9(2);\n    if (byte_at(pa, 8) != 0xCC || byte_at(pa, 18) != 0xCC || byte_at(pa, 9) != 1 || t_t9(arr[1]) != 5) { ret 22; }\n    var cells: [3]T3;\n    val pc: *u8 = (?cells)::*u8;\n    i = 0;\n    for (i < 9) { pc[i] = 0xCC; i = i + 1; }\n    dirty();\n    cells[1] = mk_t3(2);\n    if (byte_at(pc, 2) != 0xCC || byte_at(pc, 6) != 0xCC || byte_at(pc, 3) != 1 || byte_at(pc, 4) != 2 || byte_at(pc, 5) != 3) { ret 23; }\n    # the padding of a returned object is zero after the round trip, including the eightbyte no register delivered\n    dirty();\n    var s: S4 = mk_s4(7);\n    val ps: *u8 = (?s)::*u8;\n    if (byte_at(ps, 1) != 0) { ret 30; }\n    dirty();\n    var n: Nest = mk_nest(8);\n    val pn: *u8 = (?n)::*u8;\n    if (byte_at(pn, 1) != 0 || byte_at(pn, 3) != 0) { ret 31; }\n    dirty();\n    var al: AL16 = mk_al16(1);\n    if (zeros_from((?al)::*u8, 2, 16) == 0) { ret 32; }\n    dirty();\n    var tf: TF = mk_tf(1.0);\n    if (zeros_from((?tf)::*u8, 1, 8) == 0) { ret 33; }\n    dirty();\n    var m: Mid = mk_mid(0);\n    if (zeros_from((?m)::*u8, 4, 14) == 0) { ret 34; }\n    ret 0;\n}\n";
+}
+
+test "mach.lang.driver:record_transport_preserves_logical_extents_through_wider_carriers_on_every_native_backend" {
+    $if ($mach.build.os != $mach.os.linux || $mach.build.arch != $mach.arch.x86_64) { ret 0; }
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    ret ut_native_fixture_all(?alloc, ut_record_extents_program(), "transport extents");
+}
+
 fun ut_spirv_env_manifest(alloc: *A.Allocator, env_line: str) str {
     ret ut_cc3(alloc, "[project]\nid = \"envtest\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.gpu]\nisa = \"spirv\"\nos = \"freestanding\"\nabi = \"spirv\"\n", env_line, "\n[artifact.k]\nkind = \"bin\"\nentry = \"k.mach\"\nout = \"k.spv\"\ntargets = [\"*\"]\nlink = []\nneed = []\n[profile.debug]\ndefault = true\nopt = 0\ndebug = true\nsimd = \"scalarize\"\nvectorize = false\nfloat_reassoc = false\n[profile.release]\nopt = 2\ndebug = false\nsimd = \"scalarize\"\nvectorize = true\nfloat_reassoc = false\n");
 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -2076,6 +2076,30 @@ fun ut_vec_lower(s: *session.Session, alloc: *A.Allocator, src: str, target_name
     ret R.ok[project.Project, outcome.Fail](p);
 }
 
+# the same through a chosen optimization level, so the release pipeline's SROA and mem2reg run before inspection
+fun ut_vec_lower_opt(s: *session.Session, alloc: *A.Allocator, src: str, target_name: str, opt: pipeline.OptLevel) R.Result[project.Project, outcome.Fail] {
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = src;
+    val root_r: R.Result[str, str] = ut_scaffold_m(alloc, ut_manifest_spirv(), ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { ret R.err[project.Project, outcome.Fail](outcome.user(R.unwrap_err[str, str](root_r))); }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    val rr: R.Result[R.Void, str] = driver.setup_registry(?s.registry);
+    if (R.is_err[R.Void, str](rr)) { fs.remove_all(alloc, root); ret R.err[project.Project, outcome.Fail](outcome.user(R.unwrap_err[R.Void, str](rr))); }
+    var tsel: manifest.Selection = ut_target_sel(target_name);
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project(s, root, ?tsel);
+    fs.remove_all(alloc, root);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    p.req.opt = opt;
+    val se: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
+    if (R.is_err[R.Void, outcome.Fail](se)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](se)); }
+    val le: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
+    if (R.is_err[R.Void, outcome.Fail](le)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](le)); }
+    ret R.ok[project.Project, outcome.Fail](p);
+}
+
 fun ut_count_geps_into_vector(p: *project.Project, total: *u32, into_vec: *u32, lane_ops: *u32) {
     @total    = 0;
     @into_vec = 0;
@@ -7964,6 +7988,20 @@ fun ut_back_half(s: *session.Session, root: str) R.Result[project.Project, outco
     val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_union(s, root);
     if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
     var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    val rs: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
+    if (R.is_err[R.Void, outcome.Fail](rs)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](rs)); }
+    val rl: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
+    if (R.is_err[R.Void, outcome.Fail](rl)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](rl)); }
+    val rc: R.Result[R.Void, outcome.Fail] = driver.run_codegen_pass(?p);
+    if (R.is_err[R.Void, outcome.Fail](rc)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](rc)); }
+    ret R.ok[project.Project, outcome.Fail](p);
+}
+
+fun ut_back_half_opt(s: *session.Session, root: str, opt: pipeline.OptLevel) R.Result[project.Project, outcome.Fail] {
+    val pr: R.Result[project.Project, outcome.Fail] = driver.build_project_union(s, root);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { ret pr; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    p.req.opt = opt;
     val rs: R.Result[R.Void, outcome.Fail] = driver.run_sema_pass(?p);
     if (R.is_err[R.Void, outcome.Fail](rs)) { project.dnit_project(?p); ret R.err[project.Project, outcome.Fail](R.unwrap_err[R.Void, outcome.Fail](rs)); }
     val rl: R.Result[R.Void, outcome.Fail] = driver.run_lower_pass(?p);
@@ -14537,6 +14575,188 @@ test "mach.lang.driver:record_transport_preserves_logical_extents_through_wider_
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
     ret ut_native_fixture_all(?alloc, ut_record_extents_program(), "transport extents");
+}
+
+# the pipeline's verdict on one program: 0 accepted, 1 rejected (a reported diagnostic, or the constant-time
+# validator's refusal, which the backend still surfaces as an internal failure naming the oblivious function), -1 apparatus
+fun ut_pipeline_verdict(alloc: *A.Allocator, text: str, opt: pipeline.OptLevel) i32 {
+    val sr: R.Result[session.Session, str] = session.init(alloc);
+    if (R.is_err[session.Session, str](sr)) { ret -1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
+    if (R.is_err[R.Void, str](driver.setup_registry(?s.registry))) { ret -1; }
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str; texts[0] = text;
+    val root_r: R.Result[str, str] = ut_scaffold(alloc, ?names[0], ?texts[0], 1);
+    if (R.is_err[str, str](root_r)) { ret -1; }
+    val root: str = R.unwrap_ok[str, str](root_r);
+    fin { fs.remove_all(alloc, root); }
+    val pr: R.Result[project.Project, outcome.Fail] = ut_back_half_opt(?s, root, opt);
+    if (R.is_err[project.Project, outcome.Fail](pr)) {
+        val f: outcome.Fail = R.unwrap_err[project.Project, outcome.Fail](pr);
+        if (f.kind == outcome.FAIL_REPORTED) { ret 1; }
+        if (f.kind == outcome.FAIL_INTERNAL && f.message != nil && ut_str_contains(f.message, "#[oblivious]")) { ret 1; }
+        ret -1;
+    }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    project.dnit_project(?p);
+    ret 0;
+}
+
+# secret content in an aggregate is a property of its bytes, not of the home that holds them (#3263)
+test "mach.lang.driver:record_secret_content_transport_keeps_content_secrecy_and_public_fields_public" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val head: str = "rec Rec { a: u64; b: u64; } rec S { d: u64; p: ^u64; } rec P { d: u64; p: u64; } ";
+    var bodies: [9]str = [9]str{
+        "#[oblivious] fun f(v: ^Rec) u64 { ret (v.a):>u64; }",
+        "#[oblivious] #[noinline] fun c(v: ^Rec) ^Rec { val u: ^Rec = v; ret u; }",
+        "#[oblivious] #[noinline] fun mk() ^Rec { var r: ^Rec; ret r; } #[oblivious] fun use() u64 { val r: ^Rec = mk(); ret (r.a):>u64; }",
+        "#[oblivious] fun g(v: S) u64 { ret (v.p):>u64; }",
+        "#[oblivious] #[noinline] fun k(v: S) S { ret v; } #[oblivious] fun m() u64 { var t: S; t.d = 1; t.p = 5; val u: S = k(t); ret (u.p):>u64; }",
+        "#[oblivious] fun q(v: P) u64 { if (v.p > 3) { ret 1; } ret 0; }",
+        "#[oblivious] fun d(v: S) u64 { if (v.d > 3) { ret 1; } ret 0; }",
+        "#[oblivious] fun h(v: S) u64 { if (v.p > 3) { ret 1; } ret 0; }",
+        "#[oblivious] fun x(v: S, p: *u8) u8 { ret p[v.p]; }" };
+    var want: [9]i32 = [9]i32{ 0, 0, 0, 0, 0, 0, 0, 1, 1 };
+    var i: usize = 0;
+    for (i < 9) {
+        val text: str = ut_cc3(?alloc, head, " ", bodies[i]);
+        val debug_v:   i32 = ut_pipeline_verdict(?alloc, text, pipeline.OPT_DEBUG);
+        val release_v: i32 = ut_pipeline_verdict(?alloc, text, pipeline.OPT_RELEASE);
+        str_free(?alloc, text);
+        if (debug_v != want[i])   { print.printf("record-secrecy: debug verdict {} for fixture {}\n", debug_v, i); ret 2; }
+        if (release_v != want[i]) { print.printf("record-secrecy: release verdict {} for fixture {}\n", release_v, i); ret 3; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+fun ut_record_secrecy_program() str {
+    ret "rec S { d: u64; p: ^u64; }\nrec P { d: u64; p: u64; }\n#[noinline] fun take_s(v: S) u64 { if (v.d == 1) { ret (v.p):>u64; } ret 0; }\n#[noinline] fun take_p(v: P) u64 { if (v.d == 1) { ret v.p; } ret 0; }\n#[noinline] fun give_s(x: ^u64) S { var r: S; r.d = 1; r.p = x; ret r; }\n#[noinline] fun give_p(x: u64) P { var r: P; r.d = 1; r.p = x; ret r; }\nfun call_s(x: ^u64) u64 { ret take_s(give_s(x)); }\nfun call_p(x: u64) u64 { ret take_p(give_p(x)); }\n";
+}
+
+fun ut_str_ends_with(hay: str, needle: str) bool {
+    val hn: usize = str_len(hay);
+    val nn: usize = str_len(needle);
+    if (nn > hn) { ret false; }
+    var k: usize = 0;
+    for (k < nn) { if (hay[hn - nn + k] != needle[k]) { ret false; } k = k + 1; }
+    ret true;
+}
+
+# counts the argument moves of a vreg into a physical register (those ahead of a block's last call) in the function
+# whose name ends with `suffix`, and how many of those vregs are secret; also whether any conditional branch in it
+# reads a secret vreg. a function without a call has only return moves, which count as its argument moves here
+fun ut_transport_moves(s: *session.Session, mm: *mir.MirModule, suffix: str, moves: *u32, secret: *u32, branch_secret: *bool) bool {
+    var vregs: u32 = 0;
+    ret ut_transport_moves_v(s, mm, suffix, moves, secret, branch_secret, ?vregs);
+}
+
+# the same, also counting the function's secret vregs of any role
+fun ut_transport_moves_v(s: *session.Session, mm: *mir.MirModule, suffix: str, moves: *u32, secret: *u32, branch_secret: *bool, secret_vregs: *u32) bool {
+    @moves = 0;
+    @secret = 0;
+    @branch_secret = false;
+    @secret_vregs = 0;
+    var fi: u32 = 0;
+    for (fi < mm.function_len) {
+        val mf: *mir.MirFunction = ?mm.functions[fi];
+        val name: O.Option[str] = intern.lookup(?s.interner, mf.name);
+        if (O.is_none[str](name)) { fi = fi + 1; cnt; }
+        if (!ut_str_ends_with(O.unwrap[str](name), suffix)) { fi = fi + 1; cnt; }
+        var vi: u32 = 0;
+        for (vi < mf.vreg_count) { if (mf.vregs[vi].secret) { @secret_vregs = @secret_vregs + 1; } vi = vi + 1; }
+        var bi: u32 = 0;
+        for (bi < mf.block_count) {
+            val blk: *mir.MirBlock = ?mf.blocks[bi];
+            var last_call: u32 = 0;
+            var has_call: bool = false;
+            var ci: u32 = 0;
+            for (ci < blk.instr_count) { if (blk.instrs[ci].opcode == mir.MIR_CALL) { last_call = ci; has_call = true; } ci = ci + 1; }
+            var ii: u32 = 0;
+            for (ii < blk.instr_count) {
+                val mi: *mir.MirInstr = ?blk.instrs[ii];
+                if (mi.opcode == mir.MIR_MOV && mi.operand_count >= 2
+                    && mi.operands[0].kind == mir.MIR_OP_PREG && mi.operands[1].kind == mir.MIR_OP_VREG
+                    && (!has_call || ii < last_call)) {
+                    @moves = @moves + 1;
+                    if (mf.vregs[mi.operands[1].vreg].secret) { @secret = @secret + 1; }
+                }
+                if (mi.opcode == mir.MIR_CBR || mir.is_fused_cbr(mi.opcode)) {
+                    var k: u32 = 0;
+                    for (k < mi.operand_count) {
+                        if (mi.operands[k].kind == mir.MIR_OP_VREG && mf.vregs[mi.operands[k].vreg].secret) { @branch_secret = true; }
+                        k = k + 1;
+                    }
+                }
+                ii = ii + 1;
+            }
+            bi = bi + 1;
+        }
+        ret true;
+    }
+    ret false;
+}
+
+fun ut_record_secrecy_carriers(alloc: *A.Allocator, target_name: str, opt: pipeline.OptLevel) i32 {
+    val sr: R.Result[session.Session, str] = session.init(alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
+    val pr: R.Result[project.Project, outcome.Fail] = ut_vec_lower_opt(?s, alloc, ut_record_secrecy_program(), target_name, opt);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { ret 2; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    fin { project.dnit_project(?p); }
+    var bad: i32 = 0;
+    var mi: u32 = 0;
+    for (mi < p.module_len) {
+        val me: *project.ModuleEntry = ?p.modules[mi];
+        if (me.ir_module == nil) { mi = mi + 1; cnt; }
+        val mr: R.Result[mir.MirModule, str] = mirlower.lower_ir(?p.target, me.ir_module, alloc, ?s.interner, ?s.sources);
+        if (R.is_err[mir.MirModule, str](mr)) { ret 3; }
+        var mm: mir.MirModule = R.unwrap_ok[mir.MirModule, str](mr);
+        var moves: u32 = 0;
+        var secret: u32 = 0;
+        var branch: bool = false;
+        # the secret argument and both carrier pieces of the secret-content record are secret at the call
+        if (!ut_transport_moves(?s, ?mm, ".call_s", ?moves, ?secret, ?branch)) { ret 4; }
+        if (moves < 3 || secret != moves) { print.printf("record-secrecy: call_s moved {} vregs, {} secret\n", moves, secret); bad = 5; }
+        # the public record's carriers and the public argument stay public
+        if (!ut_transport_moves(?s, ?mm, ".call_p", ?moves, ?secret, ?branch)) { ret 6; }
+        if (secret != 0) { print.printf("record-secrecy: call_p moved {} vregs, {} secret\n", moves, secret); bad = 7; }
+        # the returned carriers of a secret-content record are secret; a public record's are not
+        if (!ut_transport_moves(?s, ?mm, ".give_s", ?moves, ?secret, ?branch)) { ret 8; }
+        if (moves < 2 || secret != moves) { print.printf("record-secrecy: give_s moved {} vregs, {} secret\n", moves, secret); bad = 9; }
+        if (!ut_transport_moves(?s, ?mm, ".give_p", ?moves, ?secret, ?branch)) { ret 10; }
+        if (secret != 0) { bad = 11; }
+        # reading the public field keeps its public provenance: the test on it never branches on a secret, while the
+        # secret field's value still reaches the function as a secret vreg after the profile's own passes ran over
+        # the by-value copy (release splits it into per-field slots and promotes them)
+        var vregs: u32 = 0;
+        if (!ut_transport_moves_v(?s, ?mm, ".take_s", ?moves, ?secret, ?branch, ?vregs)) { ret 12; }
+        if (branch) { bad = 13; }
+        if (vregs == 0) { print.print("record-secrecy: take_s holds no secret vreg\n"); bad = 16; }
+        if (!ut_transport_moves_v(?s, ?mm, ".take_p", ?moves, ?secret, ?branch, ?vregs)) { ret 14; }
+        if (branch || vregs != 0) { bad = 15; }
+        mir.dnit_module(?mm);
+        mi = mi + 1;
+    }
+    ret bad;
+}
+
+test "mach.lang.driver:record_secret_content_carriers_are_secret_and_the_public_field_test_is_public_on_x86_64_and_aarch64" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val x86: i32 = ut_record_secrecy_carriers(?alloc, "linux", pipeline.OPT_DEBUG);
+    if (x86 != 0) { ret 20 + x86; }
+    val arm: i32 = ut_record_secrecy_carriers(?alloc, "linux-arm64", pipeline.OPT_DEBUG);
+    if (arm != 0) { ret 40 + arm; }
+    val x86r: i32 = ut_record_secrecy_carriers(?alloc, "linux", pipeline.OPT_RELEASE);
+    if (x86r != 0) { ret 60 + x86r; }
+    val armr: i32 = ut_record_secrecy_carriers(?alloc, "linux-arm64", pipeline.OPT_RELEASE);
+    if (armr != 0) { ret 80 + armr; }
+    ret 0;
 }
 
 fun ut_spirv_env_manifest(alloc: *A.Allocator, env_line: str) str {

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -1359,6 +1359,11 @@ pub fun type_is_secret(lc: *LowerContext, tid: type.TypeId) bool {
     ret type.is_secret(?lc.s.types, substitute_type(lc, tid));
 }
 
+pub fun type_contains_secret(lc: *LowerContext, tid: type.TypeId) bool {
+    if (tid == type.TYPE_NIL || tid == type.TYPE_ERROR) { ret false; }
+    ret type.contains_secret(?lc.s.types, substitute_type(lc, tid));
+}
+
 pub fun type_carries_secret(lc: *LowerContext, tid: type.TypeId) bool {
     if (tid == type.TYPE_NIL) { ret false; }
     ret type.carries_secret(?lc.s.types, substitute_type(lc, tid));

--- a/src/lang/me/lower/decl.mach
+++ b/src/lang/me/lower/decl.mach
@@ -455,7 +455,7 @@ fun emit_pack_param(ctx: *context.LowerContext, params: *value.Value, w: u32, p_
     val p_ir: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, fail.Fail](res_p_ir);
 
     var pval: value.Value = value.param(w, p_ir);
-    if (context.type_is_secret(ctx, p_sem)) { pval.secret = true; }
+    if (context.type_contains_secret(ctx, p_sem)) { pval.secret = true; }
 
     val res_slot: R.Result[value.Value, str] = builder.emit_alloca(?ctx.builder, p_ir, value.const_int(1, xty));
     if (R.is_err[value.Value, str](res_slot)) { ret fail.lift[value.Value](res_slot); }
@@ -606,7 +606,7 @@ fun lower_params(ctx: *context.LowerContext, did: id.DeclId, d: *decl.Decl, fn_i
             p_ir = R.unwrap_ok[ir_type.IrTypeId, fail.Fail](res_p_ir);
         }
         var pval: value.Value = value.param(w, p_ir);
-        if (context.type_is_secret(ctx, p_sem)) { pval.secret = true; }
+        if (context.type_contains_secret(ctx, p_sem)) { pval.secret = true; }
         params[w] = pval;
 
         val res_slot: R.Result[value.Value, str] = builder.emit_alloca(?ctx.builder, p_ir, value.const_int(1, xty));

--- a/src/lang/me/lower/expr.mach
+++ b/src/lang/me/lower/expr.mach
@@ -1093,6 +1093,8 @@ fun lower_call(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Resu
                 ret res_arg;
             }
             args[dst] = R.unwrap_ok[value.Value, fail.Fail](res_arg);
+            # an aggregate argument whose bytes may hold a secret rides secret carriers, whatever its outer secrecy
+            if (context.type_contains_secret(ctx, context.expr_type_of(ctx, arg_eid))) { args[dst].secret = true; }
             dst = dst + 1;
             i   = i + 1;
         }
@@ -1106,7 +1108,13 @@ fun lower_call(ctx: *context.LowerContext, eid: id.ExprId, e: *expr.Expr) R.Resu
 
     val res_call: R.Result[value.Value, str] = builder.emit_call(?ctx.builder, callee, args, rtc, rt);
     if (args != nil) { A.deallocate[value.Value](ctx.s.alloc, args, rtc::usize); }
-    ret fail.lift[value.Value](res_call);
+    if (R.is_err[value.Value, str](res_call)) { ret fail.lift[value.Value](res_call); }
+    var out: value.Value = R.unwrap_ok[value.Value, str](res_call);
+    if (!out.secret && context.type_contains_secret(ctx, context.expr_type_of(ctx, eid))) {
+        out.secret = true;
+        instruction.mark_result_secret(ctx.builder.fn.instrs, ctx.builder.fn.instr_len, out);
+    }
+    ret R.ok[value.Value, fail.Fail](out);
 }
 
 fun runtime_arg_count(ctx: *context.LowerContext, a: *ast.Ast, f: *decl.DeclFun, argc: u32) u32 {

--- a/src/lang/me/lower/stmt.mach
+++ b/src/lang/me/lower/stmt.mach
@@ -237,7 +237,8 @@ fun lower_ret(ctx: *context.LowerContext, s: *stmt.Stmt) R.Result[R.Void, fail.F
         if (R.is_err[value.Value, fail.Fail](res_value)) {
             ret R.err[R.Void, fail.Fail](R.unwrap_err[value.Value, fail.Fail](res_value));
         }
-        val v: value.Value = R.unwrap_ok[value.Value, fail.Fail](res_value);
+        var v: value.Value = R.unwrap_ok[value.Value, fail.Fail](res_value);
+        if (context.type_contains_secret(ctx, context.expr_type_of(ctx, s.data.ret_.value))) { v.secret = true; }
 
         val res_fins: R.Result[R.Void, fail.Fail] = replay_fins_from(ctx, 0);
         if (R.is_err[R.Void, fail.Fail](res_fins)) { ret res_fins; }

--- a/src/lang/me/transform/sroa.mach
+++ b/src/lang/me/transform/sroa.mach
@@ -60,7 +60,10 @@ rec State {
     cand_nf:     *u32;
     cand_root:   *u32;
     cand_out:    *bool;
-    cand_secret: *bool;
+    # one flag per candidate and field: a field's slot is secret when a typed access to that field is, or when the
+    # candidate's home itself is. an aggregate-level secret operation (a store, copy or zeroing of the whole object)
+    # says only that some byte of the object is secret and taints no field by itself; the typed field accesses say which
+    field_secret: *bool;
     cand_home:   *id.BlockId;
     cand_local:  *bool;
     cand_slot:   *u32;
@@ -166,7 +169,7 @@ fun state_init(st: *State, m: *ir.Module, fn: *ir.Function, tgt: *target.Target,
     st.cand_nf     = nil;
     st.cand_root   = nil;
     st.cand_out    = nil;
-    st.cand_secret = nil;
+    st.field_secret = nil;
     st.cand_home   = nil;
     st.cand_local  = nil;
     st.cand_slot   = nil;
@@ -269,9 +272,11 @@ fun state_alloc(st: *State) R.Result[R.Void, str] {
     if (R.is_err[*bool, str](r_cx)) { ret R.err[R.Void, str](R.unwrap_err[*bool, str](r_cx)); }
     st.cand_out = R.unwrap_ok[*bool, str](r_cx);
 
-    val r_cs: R.Result[*bool, str] = A.allocate[bool](st.alloc, n::usize);
+    val r_cs: R.Result[*bool, str] = A.allocate[bool](st.alloc, (n * MAX_FIELDS)::usize);
     if (R.is_err[*bool, str](r_cs)) { ret R.err[R.Void, str](R.unwrap_err[*bool, str](r_cs)); }
-    st.cand_secret = R.unwrap_ok[*bool, str](r_cs);
+    st.field_secret = R.unwrap_ok[*bool, str](r_cs);
+    var fs: u32 = 0;
+    for (fs < n * MAX_FIELDS) { st.field_secret[fs] = false; fs = fs + 1; }
 
     val r_ch: R.Result[*id.BlockId, str] = A.allocate[id.BlockId](st.alloc, n::usize);
     if (R.is_err[*id.BlockId, str](r_ch)) { ret R.err[R.Void, str](R.unwrap_err[*id.BlockId, str](r_ch)); }
@@ -315,7 +320,7 @@ fun state_dnit(st: *State) {
     if (st.cand_nf != nil)     { A.deallocate[u32](st.alloc, st.cand_nf, c::usize); }
     if (st.cand_root != nil)   { A.deallocate[u32](st.alloc, st.cand_root, c::usize); }
     if (st.cand_out != nil)    { A.deallocate[bool](st.alloc, st.cand_out, c::usize); }
-    if (st.cand_secret != nil) { A.deallocate[bool](st.alloc, st.cand_secret, c::usize); }
+    if (st.field_secret != nil) { A.deallocate[bool](st.alloc, st.field_secret, (c * MAX_FIELDS)::usize); }
     if (st.cand_home != nil)   { A.deallocate[id.BlockId](st.alloc, st.cand_home, c::usize); }
     if (st.cand_local != nil)  { A.deallocate[bool](st.alloc, st.cand_local, c::usize); }
     if (st.cand_slot != nil)   { A.deallocate[u32](st.alloc, st.cand_slot, c::usize); }
@@ -478,7 +483,7 @@ fun collect_candidates(st: *State) {
             st.cand_nf[c]     = agg_field_count(st, ty);
             st.cand_root[c]   = c;
             st.cand_out[c]    = false;
-            st.cand_secret[c] = inst.secret;
+            taint_all(st, c, inst.secret);
             st.cand_home[c]   = st.instr_block[i];
             st.cand_local[c]  = true;
             st.cand_slot[c]   = NONE_U32;
@@ -533,8 +538,15 @@ fun is_address_value(v: value.Value) bool {
     ret v.kind == value.VAL_INSTR || v.kind == value.VAL_PARAM || v.kind == value.VAL_GLOBAL;
 }
 
-fun taint(st: *State, c: u32, s: bool) {
-    if (s) { st.cand_secret[c] = true; }
+fun taint_field(st: *State, c: u32, k: u32, s: bool) {
+    if (s && k < MAX_FIELDS) { st.field_secret[c * MAX_FIELDS + k] = true; }
+}
+
+# a secret home (a secret alloca, or its address used as a secret value) is secret in every field
+fun taint_all(st: *State, c: u32, s: bool) {
+    if (!s) { ret; }
+    var k: u32 = 0;
+    for (k < MAX_FIELDS) { st.field_secret[c * MAX_FIELDS + k] = true; k = k + 1; }
 }
 
 fun note_home(st: *State, c: u32, b: id.BlockId) {
@@ -560,8 +572,7 @@ fun classify_references(st: *State) {
             if (op.kind == value.VAL_INSTR && op.data.instr::u32 < st.pool_len) {
                 val c: u32 = st.cand_of[op.data.instr::u32];
                 if (c != NONE_U32) {
-                    taint(st, c, op.secret);
-                    taint(st, c, inst.secret);
+                    taint_all(st, c, op.secret);
                     if (inst.kind != instruction.OP_PHI) { note_home(st, c, st.instr_block[i]); }
                     if (!classify_one(st, c, i::id.InstructionId, inst, o)) { st.cand_out[c] = true; }
                 }
@@ -673,8 +684,7 @@ fun classify_gep_uses(st: *State) {
             if (op.kind == value.VAL_INSTR && op.data.instr::u32 < st.pool_len) {
                 val g: u32 = st.gep_of[op.data.instr::u32];
                 if (g != NONE_U32) {
-                    taint(st, g, op.secret);
-                    taint(st, g, inst.secret);
+                    taint_field(st, g, st.gep_field[op.data.instr::u32], op.secret || inst.secret);
                     note_home(st, g, st.instr_block[i]);
                     if (!gep_use_ok(st, g, op.data.instr, i::id.InstructionId, inst, o)) { st.cand_out[g] = true; }
                 }
@@ -1073,7 +1083,7 @@ fun emit_field_slots(st: *State) R.Result[R.Void, str] {
         var k: u32 = 0;
         for (k < st.cand_nf[c]) {
             val ft: ir_type.IrTypeId = slot_ty(st, st.cand_ty[c], k);
-            val r: R.Result[value.Value, str] = emit_slot(st, ?cur, ft, partition_secret(st, c));
+            val r: R.Result[value.Value, str] = emit_slot(st, ?cur, ft, partition_field_secret(st, c, k));
             if (R.is_err[value.Value, str](r)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](r)); }
             st.slots[st.cand_slot[c] + k] = R.unwrap_ok[value.Value, str](r);
             k = k + 1;
@@ -1084,11 +1094,12 @@ fun emit_field_slots(st: *State) R.Result[R.Void, str] {
     ret rotate_to_front(st, 0::id.BlockId, before);
 }
 
-fun partition_secret(st: *State, c: u32) bool {
+fun partition_field_secret(st: *State, c: u32, k: u32) bool {
+    if (k >= MAX_FIELDS) { ret true; }
     val root: u32 = find_root(st, c);
     var d: u32 = 0;
     for (d < st.cand_count) {
-        if (st.cand_secret[d] && find_root(st, d) == root) { ret true; }
+        if (st.field_secret[d * MAX_FIELDS + k] && find_root(st, d) == root) { ret true; }
         d = d + 1;
     }
     ret false;
@@ -1212,7 +1223,7 @@ fun rewrite_instr(st: *State, rw: *mutate.Rewrite, bid: id.BlockId, iid: id.Inst
         val c: u32 = candidate_at(st, inst.operands[0]);
         if (c != NONE_U32 && st.cand_out[c] == false) {
             st.erase[iid::u32] = true;
-            ret expand_memzero(st, ?cur, c, inst.secret);
+            ret expand_memzero(st, ?cur, c);
         }
         ret R.ok_void[str]();
     }
@@ -1221,7 +1232,7 @@ fun rewrite_instr(st: *State, rw: *mutate.Rewrite, bid: id.BlockId, iid: id.Inst
         val dc: u32 = candidate_at(st, inst.operands[1]);
         if (dc != NONE_U32 && st.cand_out[dc] == false) {
             st.erase[iid::u32] = true;
-            ret expand_copy(st, ?cur, dc, inst.operands[0], inst.secret);
+            ret expand_copy(st, ?cur, dc, inst.operands[0]);
         }
     }
     ret R.ok_void[str]();
@@ -1244,7 +1255,7 @@ fun reinterpret_load(st: *State, rw: *mutate.Rewrite, cur: *Cursor, iid: id.Inst
     if (inst.ty == sty) { ret R.ok_void[str](); }
 
     val slot: value.Value = st.slots[st.cand_slot[c] + st.gep_field[gid]];
-    val tainted: bool = inst.secret || st.cand_secret[c];
+    val tainted: bool = inst.secret || partition_field_secret(st, c, st.gep_field[gid]);
     val inst_ty: ir_type.IrTypeId = inst.ty;
     val r_load: R.Result[value.Value, str] = emit_load(st, cur, slot, sty, tainted);
     if (R.is_err[value.Value, str](r_load)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](r_load)); }
@@ -1276,7 +1287,7 @@ fun reinterpret_store(st: *State, cur: *Cursor, iid: id.InstructionId,
     if (v.ty == sty) { ret R.ok_void[str](); }
 
     val slot: value.Value = st.slots[st.cand_slot[c] + st.gep_field[gid]];
-    val tainted: bool = inst.secret || v.secret || st.cand_secret[c];
+    val tainted: bool = inst.secret || v.secret || partition_field_secret(st, c, st.gep_field[gid]);
     val acc: u32 = ir_type.byte_size_for_machine(?st.m.types, v.ty, resolved.layout_machine(st.tgt));
     val cell: u32 = ir_type.byte_size_for_machine(?st.m.types, sty, resolved.layout_machine(st.tgt));
 
@@ -1346,12 +1357,13 @@ fun retarget_gep(st: *State, rw: *mutate.Rewrite, gid: id.InstructionId, c: u32)
     ret R.ok_void[str]();
 }
 
-fun expand_memzero(st: *State, cur: *Cursor, c: u32, secret: bool) R.Result[R.Void, str] {
-    val tainted: bool = secret || st.cand_secret[c];
+# zeroing writes a public constant, so each field's store carries the field's own secrecy and not the object's
+fun expand_memzero(st: *State, cur: *Cursor, c: u32) R.Result[R.Void, str] {
     var k: u32 = 0;
     for (k < st.cand_nf[c]) {
         val ft: ir_type.IrTypeId = slot_ty(st, st.cand_ty[c], k);
         val slot: value.Value = st.slots[st.cand_slot[c] + k];
+        val tainted: bool = partition_field_secret(st, c, k);
         if (ir_type.is_aggregate(?st.m.types, ft)) {
             val r: R.Result[R.Void, str] = emit_memzero(st, cur, slot, ft, tainted);
             if (R.is_err[R.Void, str](r)) { ret r; }
@@ -1364,14 +1376,17 @@ fun expand_memzero(st: *State, cur: *Cursor, c: u32, secret: bool) R.Result[R.Vo
     ret R.ok_void[str]();
 }
 
-fun expand_copy(st: *State, cur: *Cursor, dst: u32, src: value.Value, secret: bool) R.Result[R.Void, str] {
-    val tainted: bool = secret || src.secret || st.cand_secret[dst];
+# a whole-object copy is secret only in the fields whose typed accesses are: the object's own flag is the union
+# over its fields and would make every public field secret
+fun expand_copy(st: *State, cur: *Cursor, dst: u32, src: value.Value) R.Result[R.Void, str] {
     val sc: u32 = candidate_at(st, src);
     var k: u32 = 0;
     for (k < st.cand_nf[dst]) {
+        var tainted: bool = partition_field_secret(st, dst, k);
         var from: value.Value;
         if (sc != NONE_U32 && st.cand_out[sc] == false) {
             from = st.slots[st.cand_slot[sc] + k];
+            if (partition_field_secret(st, sc, k)) { tainted = true; }
         } or {
             val r: R.Result[value.Value, str] = emit_field_gep(st, cur, src, st.cand_ty[dst], k, tainted);
             if (R.is_err[value.Value, str](r)) { ret R.err[R.Void, str](R.unwrap_err[value.Value, str](r)); }
@@ -1779,7 +1794,8 @@ test "mach.lang.me.transform.sroa.run:preserves_a_secret_field" {
         if (fn.instrs[i].kind == instruction.OP_ALLOCA && fn.instrs[i].secret) { tainted_slots = tainted_slots + 1; }
         i = i + 1;
     }
-    if (tainted_slots == 0) { code = 1; }
+    # the field the secret was stored to is secret; the untouched public field beside it is not
+    if (tainted_slots != 1) { code = 1; }
 
     if (R.is_err[bool, str](mem2reg.run(?m))) { code = 1; }
     if (R.is_err[bool, str](dce.run(?m)))     { code = 1; }

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -133,6 +133,13 @@ pub rec ParamSlot {
     piece_count:    u32;
 }
 
+# eightbyte class mask handed to a classifier: bit 0 and bit 1 mark eightbyte 0 and 1 as SSE, bit 2 and
+# bit 3 mark them as holding no leaf at all (padding only), and an unmarked eightbyte inside the object is INTEGER
+pub val EB_SSE_LO:   u8 = 1;
+pub val EB_SSE_HI:   u8 = 2;
+pub val EB_EMPTY_LO: u8 = 4;
+pub val EB_EMPTY_HI: u8 = 8;
+
 pub def ClassifyFn: fun(u64, u64, bool, u8, bool, i32, i32, u8, u8) ParamSlot;
 
 pub def ArgPassingFn: fun(i32, u64, u64, bool, u8, bool, bool, i32, i32, u8, u8, AggLayout) ParamSlot;

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -73,7 +73,7 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
     }
 
     if (is_aggregate) {
-        val eb0_sse: bool = (fp_eightbytes & 1) != 0;
+        val eb0_sse: bool = (fp_eightbytes & abi.EB_SSE_LO) != 0;
         if (size <= 8) {
             if (eb0_sse) {
                 if (fp_used < FP_PARAM_COUNT) {
@@ -87,20 +87,23 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
             ret abi.make_slot(abi.CLASS_STACK, -1, 0, size, 0);
         }
 
-        val eb1_sse: bool = (fp_eightbytes & 2) != 0;
+        val eb1_sse: bool = (fp_eightbytes & abi.EB_SSE_HI) != 0;
+        val eb0_used: bool = (fp_eightbytes & abi.EB_EMPTY_LO) == 0;
+        val eb1_used: bool = (fp_eightbytes & abi.EB_EMPTY_HI) == 0;
         var gp_need: i32 = 0;
         var fp_need: i32 = 0;
-        if (eb0_sse) { fp_need = fp_need + 1; } or { gp_need = gp_need + 1; }
-        if (eb1_sse) { fp_need = fp_need + 1; } or { gp_need = gp_need + 1; }
+        if (eb0_used) { if (eb0_sse) { fp_need = fp_need + 1; } or { gp_need = gp_need + 1; } }
+        if (eb1_used) { if (eb1_sse) { fp_need = fp_need + 1; } or { gp_need = gp_need + 1; } }
+        if (!eb0_used && !eb1_used) { gp_need = 1; }
 
         if (gp_used + gp_need <= GP_PARAM_COUNT && fp_used + fp_need <= FP_PARAM_COUNT) {
             var gi: i32 = gp_used;
             var fi: i32 = fp_used;
-            var r0: i32 = 0;
-            var r1: i32 = 0;
-            if (eb0_sse) { r0 = fp_param_reg(fi); fi = fi + 1; } or { r0 = gp_param_reg(gi); gi = gi + 1; }
-            if (eb1_sse) { r1 = fp_param_reg(fi); fi = fi + 1; } or { r1 = gp_param_reg(gi); gi = gi + 1; }
-            ret abi.make_slot_pair(abi.CLASS_GP, r0, r1, 0, size, EIGHTBYTE);
+            var r0: i32 = -1;
+            var r1: i32 = -1;
+            if (eb0_used || !eb1_used) { if (eb0_sse) { r0 = fp_param_reg(fi); fi = fi + 1; } or { r0 = gp_param_reg(gi); gi = gi + 1; } }
+            if (eb1_used) { if (eb1_sse) { r1 = fp_param_reg(fi); fi = fi + 1; } or { r1 = gp_param_reg(gi); gi = gi + 1; } }
+            ret eightbyte_slot(r0, r1, size);
         }
         ret abi.make_slot(abi.CLASS_STACK, -1, 0, size, 0);
     }
@@ -144,20 +147,22 @@ pub fun classify_return(size: u64, align: u64,
     }
 
     if (is_aggregate) {
-        val eb0_sse: bool = (fp_eightbytes & 1) != 0;
+        val eb0_sse: bool = (fp_eightbytes & abi.EB_SSE_LO) != 0;
         if (size <= 8) {
             if (eb0_sse) { ret abi.make_slot(abi.CLASS_GP, REG_XMM0, 0, size, 8); }
             ret abi.make_slot(abi.CLASS_GP, REG_RAX, 0, size, 8);
         }
 
-        val eb1_sse: bool = (fp_eightbytes & 2) != 0;
+        val eb1_sse: bool = (fp_eightbytes & abi.EB_SSE_HI) != 0;
+        val eb0_used: bool = (fp_eightbytes & abi.EB_EMPTY_LO) == 0;
+        val eb1_used: bool = (fp_eightbytes & abi.EB_EMPTY_HI) == 0;
         var ni: i32 = 0;
         var ns: i32 = 0;
-        var r0: i32 = 0;
-        var r1: i32 = 0;
-        if (eb0_sse) { r0 = ret_sse_reg(ns); ns = ns + 1; } or { r0 = ret_int_reg(ni); ni = ni + 1; }
-        if (eb1_sse) { r1 = ret_sse_reg(ns); ns = ns + 1; } or { r1 = ret_int_reg(ni); ni = ni + 1; }
-        ret abi.make_slot_pair(abi.CLASS_GP, r0, r1, 0, size, EIGHTBYTE);
+        var r0: i32 = -1;
+        var r1: i32 = -1;
+        if (eb0_used || !eb1_used) { if (eb0_sse) { r0 = ret_sse_reg(ns); ns = ns + 1; } or { r0 = ret_int_reg(ni); ni = ni + 1; } }
+        if (eb1_used) { if (eb1_sse) { r1 = ret_sse_reg(ns); ns = ns + 1; } or { r1 = ret_int_reg(ni); ni = ni + 1; } }
+        ret eightbyte_slot(r0, r1, size);
     }
 
     if (is_vector && size > VEC_REG_BYTES) {
@@ -173,6 +178,15 @@ pub fun classify_return(size: u64, align: u64,
     }
 
     ret abi.make_slot(abi.CLASS_GP, REG_RAX, 0, size, 8);
+}
+
+# one piece per classified eightbyte; a padding-only eightbyte (register -1) is delivered by nobody
+fun eightbyte_slot(r0: i32, r1: i32, size: u64) abi.ParamSlot {
+    if (r0 >= 0 && r1 >= 0) { ret abi.make_slot_pair(abi.CLASS_GP, r0, r1, 0, size, EIGHTBYTE); }
+    if (r0 >= 0) { ret abi.make_slot(abi.CLASS_GP, r0, 0, size, EIGHTBYTE::u8); }
+    var piece: abi.ParamPiece = abi.make_piece(abi.PIECE_GP, r1, EIGHTBYTE::i64, 0, EIGHTBYTE::u8);
+    if (isa.regid_class(r1) == isa.REG_CLASS_ID_XMM) { piece.kind = abi.PIECE_FP; }
+    ret abi.make_slot_pieces(abi.CLASS_GP, ?piece, 1, size);
 }
 
 fun ret_int_reg(index: i32) i32 {
@@ -329,5 +343,34 @@ test "mach.lang.target.abi.sysv.classify_arg:large_aggregate_memory_class_by_val
     if (s2.class != abi.CLASS_STACK) { ret 1; }
     if (s2.reg   != -1)              { ret 1; }
     if (s2.size  != 17)              { ret 1; }
+    ret 0;
+}
+
+test "mach.lang.target.abi.sysv.classify_arg:padding_only_eightbyte_consumes_no_register" {
+    val s: abi.ParamSlot = classify_arg(0, 16, 16, false, abi.EB_EMPTY_HI, true, false, 0, 0, 0, 0, abi.agg_none());
+    if (s.class != abi.CLASS_GP || s.piece_count != 1) { ret 1; }
+    if (s.pieces[0].reg != REG_RDI || s.pieces[0].width != 8 || s.pieces[0].src_off != 0) { ret 2; }
+    if (s.size != 16) { ret 3; }
+    val next: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, false, 1, 0, 0, 0, abi.agg_none());
+    if (next.reg != REG_RSI) { ret 4; }
+    val lo: abi.ParamSlot = classify_arg(0, 16, 16, false, abi.EB_EMPTY_LO, true, false, 0, 0, 0, 0, abi.agg_none());
+    if (lo.class != abi.CLASS_GP || lo.piece_count != 1) { ret 5; }
+    if (lo.pieces[0].reg != REG_RDI || lo.pieces[0].src_off != 8 || lo.pieces[0].width != 8) { ret 6; }
+    val sse_hi: abi.ParamSlot = classify_arg(0, 16, 16, false, abi.EB_EMPTY_LO | abi.EB_SSE_HI, true, false, 0, 0, 0, 0, abi.agg_none());
+    if (sse_hi.piece_count != 1 || sse_hi.pieces[0].kind != abi.PIECE_FP || sse_hi.pieces[0].reg != fp_param_reg(0)) { ret 7; }
+    val spilled: abi.ParamSlot = classify_arg(0, 16, 16, false, abi.EB_EMPTY_HI, true, false, 6, 0, 0, 0, abi.agg_none());
+    if (spilled.class != abi.CLASS_STACK) { ret 8; }
+    val fits: abi.ParamSlot = classify_arg(0, 16, 16, false, abi.EB_EMPTY_HI, true, false, 5, 0, 0, 0, abi.agg_none());
+    if (fits.class != abi.CLASS_GP || fits.pieces[0].reg != REG_R9) { ret 9; }
+    ret 0;
+}
+
+test "mach.lang.target.abi.sysv.classify_return:padding_only_eightbyte_returns_in_rax_alone" {
+    val s: abi.ParamSlot = classify_return(16, 16, false, abi.EB_EMPTY_HI, true, false, 0, 0, abi.agg_none());
+    if (s.class != abi.CLASS_GP || s.piece_count != 1 || s.pieces[0].reg != REG_RAX || s.size != 16) { ret 1; }
+    val full: abi.ParamSlot = classify_return(16, 8, false, 0, true, false, 0, 0, abi.agg_none());
+    if (full.piece_count != 2 || full.pieces[1].reg != REG_RDX) { ret 2; }
+    val hi: abi.ParamSlot = classify_return(16, 16, false, abi.EB_EMPTY_LO, true, false, 0, 0, abi.agg_none());
+    if (hi.piece_count != 1 || hi.pieces[0].reg != REG_RAX || hi.pieces[0].src_off != 8) { ret 3; }
     ret 0;
 }

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -783,6 +783,25 @@ pub fun carries_secret(ti: *TypeInterner, tid: TypeId) bool {
     ret false;
 }
 
+# true when any byte of a value of this type may be secret: the type itself, an element, a field or a case
+# payload; a pointer's pointee is not the object's storage and does not count
+pub fun contains_secret(ti: *TypeInterner, tid: TypeId) bool {
+    val opt_type: O.Option[*Type] = get(ti, tid);
+    if (O.is_none[*Type](opt_type)) { ret false; }
+    val t: *Type = O.unwrap[*Type](opt_type);
+    if (t.kind == TYPE_SECRET) { ret true; }
+    if (t.kind == TYPE_ARRAY)  { ret contains_secret(ti, t.data.array.base); }
+    if (t.kind != TYPE_REC && t.kind != TYPE_UNI && t.kind != TYPE_INSTANCE) { ret false; }
+    val n: u32 = field_count(ti, tid);
+    var i: u32 = 0;
+    for (i < n) {
+        val fe: O.Option[*FieldEntry] = field_at(ti, tid, i);
+        if (O.is_some[*FieldEntry](fe) && contains_secret(ti, O.unwrap[*FieldEntry](fe).ty)) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
 rec VisitSet {
     stamp: *u32;
     cap:   u32;

--- a/test/link/cases/3263-record-abi-c-callee/case.conf
+++ b/test/link/cases/3263-record-abi-c-callee/case.conf
@@ -1,0 +1,22 @@
+# By-value records across an `ext` boundary against a C callee and a C caller the
+# RUNNER'S own toolchain built (mach #3263). Eleven shapes cover a 1-byte record,
+# a 3-byte record in an 8-byte register, a 9-byte record in two registers with one
+# logical byte in the second, a 16-byte record, a 24-byte record in memory, a nested
+# record, an over-aligned record, and float, float32 and mixed float/integer
+# fields.
+#
+# WHAT ONLY A FOREIGN TOOLCHAIN CAN SAY. mach's own caller and callee agree with each
+# other by construction, so a classification that is wrong on both sides is invisible
+# to every mach-only fixture. The over-aligned 16-byte record is the shape that found
+# one: its second eightbyte holds only padding, System V assigns it no register, and
+# mach used to spend rsi on it, so `c_al16(v, next)` read `next` from the wrong
+# register and a returned `al16` copied rdx's leftovers into the tail padding. The
+# `next` argument after every record is there for that reason: it lands where the
+# convention says only if the record consumed exactly the registers the convention
+# says. Against the unpatched compiler this case reports `al16=3006 al16_after=3015`
+# on x86_64-linux.
+#
+# Both directions run: mach calls C with each shape and reads each shape back from C,
+# then C calls mach with the same shapes and reads what mach returns. -O0 keeps every
+# C field read in place.
+run: exec

--- a/test/link/cases/3263-record-abi-c-callee/expect.txt
+++ b/test/link/cases/3263-record-abi-c-callee/expect.txt
@@ -1,0 +1,5 @@
+mach->c p1=107 t3=1154 s8=2000109 t9=2165 t16=3000097 o24=5198
+mach->c nest=4000116 al16=3106 al16_after=3115 tf=4107 tf8=1102 tfm=2691
+c->mach p1=1 t3=1405 s8=16909060 t9=1708 t16=-11 o24=11213
+c->mach nest=124 al16=115 al16_tail=1 tf2=33 tf8x2=5 tfm=483
+c drives mach: 0

--- a/test/link/cases/3263-record-abi-c-callee/mach.toml
+++ b/test/link/cases/3263-record-abi-c-callee/mach.toml
@@ -1,0 +1,77 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.x86_64-linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.aarch64-linux]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.riscv64-linux]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64d"
+
+[target.x86_64-windows]
+isa = "x86_64"
+os  = "windows"
+abi = "win64"
+
+[target.aarch64-darwin]
+isa = "aarch64"
+os  = "darwin"
+abi = "aapcs64"
+
+[target.x86_64-darwin]
+isa = "x86_64"
+os  = "darwin"
+abi = "sysv64"
+
+[profile.debug]
+default = true
+opt = 0
+debug = false
+simd = "scalarize"
+vectorize = true
+float_reassoc = false
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+vectorize = true
+float_reassoc = false
+
+[step.probe]
+argv = ["sh", "../../lib/cc.sh", "-c", "-O0", "-fno-stack-protector", "probe.c", "-o", "{project.out}/obj/probe.o"]
+env = { MACH_TARGET_ISA = "{target.isa}", MACH_TARGET_OS = "{target.os}", MACH_TARGET_ABI = "{target.abi}" }
+in = ["probe.c"]
+out = ["{project.out}/obj/probe.o"]
+need = []
+
+[link.probe]
+source = "local"
+path = "{project.out}/obj/probe.o"
+os = ["*"]
+isa = ["*"]
+abi = ["*"]
+export = false
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = ["probe"]
+need = []
+
+[dep.std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/test/link/cases/3263-record-abi-c-callee/probe.c
+++ b/test/link/cases/3263-record-abi-c-callee/probe.c
@@ -1,0 +1,85 @@
+/* C half of the record transport controls (mach #3263). Each struct is the C spelling
+ * of a mach record of matching layout. Compiled at -O0 so every field read really
+ * happens. */
+/* the MSVC-target compiler marks floating-point use with this symbol; nothing links a C runtime here */
+#ifdef _WIN32
+int _fltused = 0;
+#endif
+
+struct p1 { unsigned char d; };
+struct t3 { unsigned char d; unsigned char p[2]; };
+struct s8 { unsigned char d; unsigned int p; };
+struct t9 { unsigned char d; unsigned char p[8]; };
+struct t16 { unsigned char d; long long p; };
+struct o24 { unsigned char d; long long p[2]; };
+struct nest { unsigned char d; struct s8 p; };
+struct al16 { unsigned char d; unsigned char p; } __attribute__((aligned(16)));
+struct tf { unsigned char d; double p; };
+struct tf8 { unsigned char d; float p; };
+struct tfm { double p; long long q; };
+
+long long c_p1(struct p1 v, long long next) { return v.d * 100 + next; }
+long long c_t3(struct t3 v, long long next) { return v.d * 100 + v.p[0] + v.p[1] * 10 + next * 1000; }
+long long c_s8(struct s8 v, long long next) { return v.d * 100 + (long long)v.p + next * 1000000; }
+long long c_t9(struct t9 v, long long next) { return v.d * 100 + v.p[0] + v.p[7] * 10 + next * 1000; }
+long long c_t16(struct t16 v, long long next) { return v.d * 100 + v.p + next * 1000000; }
+long long c_o24(struct o24 v, long long next) { return v.d * 100 + v.p[0] + v.p[1] * 10 + next * 1000; }
+long long c_nest(struct nest v, long long next) { return v.d * 100 + v.p.d * 10 + (long long)v.p.p + next * 1000000; }
+long long c_al16(struct al16 v, long long next) { return v.d * 100 + v.p + next * 1000; }
+long long c_al16_after(long long first, struct al16 v, long long next) { return first + v.d * 100 + v.p + next * 1000; }
+long long c_tf(struct tf v, long long next) { return v.d * 100 + (long long)v.p + next * 1000; }
+long long c_tf8(struct tf8 v, long long next) { return v.d * 100 + (long long)v.p + next * 1000; }
+long long c_tfm(struct tfm v, long long next) { return (long long)v.p * 100 + v.q + next * 1000; }
+
+struct p1 c_mk_p1(unsigned char d) { struct p1 r; r.d = d; return r; }
+struct t3 c_mk_t3(unsigned char x) { struct t3 r; r.d = 1; r.p[0] = x; r.p[1] = x + 1; return r; }
+struct s8 c_mk_s8(unsigned int x) { struct s8 r; r.d = 1; r.p = x; return r; }
+struct t9 c_mk_t9(unsigned char x) { struct t9 r; r.d = 1; r.p[0] = x; r.p[7] = x + 1; return r; }
+struct t16 c_mk_t16(long long x) { struct t16 r; r.d = 1; r.p = x; return r; }
+struct o24 c_mk_o24(long long x) { struct o24 r; r.d = 1; r.p[0] = x; r.p[1] = x + 1; return r; }
+struct nest c_mk_nest(unsigned int x) { struct nest r; r.d = 1; r.p.d = 1; r.p.p = x; return r; }
+struct al16 c_mk_al16(unsigned char x) { struct al16 r; r.d = 1; r.p = x; return r; }
+struct tf c_mk_tf(double x) { struct tf r; r.d = 1; r.p = x; return r; }
+struct tf8 c_mk_tf8(float x) { struct tf8 r; r.d = 1; r.p = x; return r; }
+struct tfm c_mk_tfm(long long x) { struct tfm r; r.p = 2.5; r.q = x; return r; }
+
+/* the reverse direction: C calls mach with the same shapes */
+long long m_t3(struct t3 v, long long next);
+long long m_t9(struct t9 v, long long next);
+long long m_al16(struct al16 v, long long next);
+long long m_al16_after(long long first, struct al16 v, long long next);
+long long m_tf(struct tf v, long long next);
+long long m_tfm(struct tfm v, long long next);
+long long m_o24(struct o24 v, long long next);
+struct t9 m_mk_t9(unsigned char x);
+struct al16 m_mk_al16(unsigned char x);
+struct tf m_mk_tf(double x);
+struct tfm m_mk_tfm(long long x);
+struct t3 m_mk_t3(unsigned char x);
+
+long long c_drives_mach(void) {
+    struct t3 a = c_mk_t3(4);
+    struct t9 b = c_mk_t9(5);
+    struct al16 c = c_mk_al16(6);
+    struct tf d = c_mk_tf(7.5);
+    struct o24 e = c_mk_o24(8);
+    struct tfm f = c_mk_tfm(-9);
+    if (m_t3(a, 1) != 100 + 4 + 50 + 1000) return 1;
+    if (m_t9(b, 2) != 100 + 5 + 60 + 2000) return 2;
+    if (m_al16(c, 3) != 100 + 6 + 3000) return 3;
+    if (m_al16_after(9, c, 3) != 9 + 100 + 6 + 3000) return 4;
+    if (m_tf(d, 4) != 100 + 7 + 4000) return 5;
+    if (m_o24(e, 5) != 100 + 8 + 90 + 5000) return 6;
+    if (m_tfm(f, 6) != 200 - 9 + 6000) return 7;
+    struct t9 rb = m_mk_t9(11);
+    if (rb.d != 1 || rb.p[0] != 11 || rb.p[7] != 12) return 8;
+    struct al16 rc = m_mk_al16(13);
+    if (rc.d != 1 || rc.p != 13) return 9;
+    struct tf rd = m_mk_tf(14.5);
+    if (rd.d != 1 || rd.p != 14.5) return 10;
+    struct tfm rf = m_mk_tfm(-15);
+    if (rf.p != 2.5 || rf.q != -15) return 11;
+    struct t3 ra = m_mk_t3(15);
+    if (ra.d != 1 || ra.p[0] != 15 || ra.p[1] != 16) return 12;
+    return 0;
+}

--- a/test/link/cases/3263-record-abi-c-callee/src/main.mach
+++ b/test/link/cases/3263-record-abi-c-callee/src/main.mach
@@ -1,0 +1,94 @@
+# by-value record transport against a C callee and a C caller (mach #3263)
+#
+# Every function below is paired with one in probe.c of matching layout; see case.conf
+# for what the pairing proves. The observable is the value each side computed from the
+# fields and the argument after the record, printed by mach.
+
+use std.runtime;
+use std.types.size.usize;
+use p: std.print;
+
+rec P1 { d: u8; }
+rec T3 { d: u8; p: [2]u8; }
+rec S8 { d: u8; p: u32; }
+rec T9 { d: u8; p: [8]u8; }
+rec T16 { d: u8; p: i64; }
+rec O24 { d: u8; p: [2]i64; }
+rec Nest { d: u8; p: S8; }
+#[align(16)]
+rec AL16 { d: u8; p: u8; }
+rec TF { d: u8; p: f64; }
+rec TF8 { d: u8; p: f32; }
+rec TFM { p: f64; q: i64; }
+
+ext fun c_p1(v: P1, next: i64) i64;
+ext fun c_t3(v: T3, next: i64) i64;
+ext fun c_s8(v: S8, next: i64) i64;
+ext fun c_t9(v: T9, next: i64) i64;
+ext fun c_t16(v: T16, next: i64) i64;
+ext fun c_o24(v: O24, next: i64) i64;
+ext fun c_nest(v: Nest, next: i64) i64;
+ext fun c_al16(v: AL16, next: i64) i64;
+ext fun c_al16_after(first: i64, v: AL16, next: i64) i64;
+ext fun c_tf(v: TF, next: i64) i64;
+ext fun c_tf8(v: TF8, next: i64) i64;
+ext fun c_tfm(v: TFM, next: i64) i64;
+ext fun c_mk_p1(d: u8) P1;
+ext fun c_mk_t3(x: u8) T3;
+ext fun c_mk_s8(x: u32) S8;
+ext fun c_mk_t9(x: u8) T9;
+ext fun c_mk_t16(x: i64) T16;
+ext fun c_mk_o24(x: i64) O24;
+ext fun c_mk_nest(x: u32) Nest;
+ext fun c_mk_al16(x: u8) AL16;
+ext fun c_mk_tf(x: f64) TF;
+ext fun c_mk_tf8(x: f32) TF8;
+ext fun c_mk_tfm(x: i64) TFM;
+ext fun c_drives_mach() i64;
+
+#[symbol("m_t3")] pub fun m_t3(v: T3, next: i64) i64 { ret v.d::i64 * 100 + v.p[0]::i64 + v.p[1]::i64 * 10 + next * 1000; }
+#[symbol("m_t9")] pub fun m_t9(v: T9, next: i64) i64 { ret v.d::i64 * 100 + v.p[0]::i64 + v.p[7]::i64 * 10 + next * 1000; }
+#[symbol("m_al16")] pub fun m_al16(v: AL16, next: i64) i64 { ret v.d::i64 * 100 + v.p::i64 + next * 1000; }
+#[symbol("m_al16_after")] pub fun m_al16_after(first: i64, v: AL16, next: i64) i64 { ret first + v.d::i64 * 100 + v.p::i64 + next * 1000; }
+#[symbol("m_tf")] pub fun m_tf(v: TF, next: i64) i64 { ret v.d::i64 * 100 + v.p::i64 + next * 1000; }
+#[symbol("m_tfm")] pub fun m_tfm(v: TFM, next: i64) i64 { ret v.p::i64 * 100 + v.q + next * 1000; }
+#[symbol("m_o24")] pub fun m_o24(v: O24, next: i64) i64 { ret v.d::i64 * 100 + v.p[0] + v.p[1] * 10 + next * 1000; }
+#[symbol("m_mk_t9")] pub fun m_mk_t9(x: u8) T9 { var a: [8]u8; a[0] = x; a[7] = x + 1; ret T9{d: 1, p: a}; }
+#[symbol("m_mk_al16")] pub fun m_mk_al16(x: u8) AL16 { ret AL16{d: 1, p: x}; }
+#[symbol("m_mk_tf")] pub fun m_mk_tf(x: f64) TF { ret TF{d: 1, p: x}; }
+#[symbol("m_mk_tfm")] pub fun m_mk_tfm(x: i64) TFM { ret TFM{p: 2.5, q: x}; }
+#[symbol("m_mk_t3")] pub fun m_mk_t3(x: u8) T3 { var a: [2]u8; a[0] = x; a[1] = x + 1; ret T3{d: 1, p: a}; }
+
+fun code(v: u8) i64 { ret v::i64; }
+
+# the undelivered eightbyte of a returned over-aligned record is zero, whatever the convention's
+# spare register held; the delivered eightbyte's own padding is the C callee's to fill
+#[noinline] fun zeros_from(q: *u8, from: u64, to: u64) i64 { var i: u64 = from; for (i < to) { if (q[i] != 0) { ret 0; } i = i + 1; } ret 1; }
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var a3: [2]u8; a3[0] = 4; a3[1] = 5;
+    var a9: [8]u8; a9[0] = 5; a9[7] = 6;
+    var a24: [2]i64; a24[0] = 8; a24[1] = 9;
+    p.printlnf("mach->c p1={} t3={} s8={} t9={} t16={} o24={}",
+        c_p1(P1{d: 1}, 7), c_t3(T3{d: 1, p: a3}, 1), c_s8(S8{d: 1, p: 9}, 2), c_t9(T9{d: 1, p: a9}, 2), c_t16(T16{d: 1, p: -3}, 3), c_o24(O24{d: 1, p: a24}, 5));
+    p.printlnf("mach->c nest={} al16={} al16_after={} tf={} tf8={} tfm={}",
+        c_nest(Nest{d: 1, p: S8{d: 1, p: 6}}, 4), c_al16(AL16{d: 1, p: 6}, 3), c_al16_after(9, AL16{d: 1, p: 6}, 3), c_tf(TF{d: 1, p: 7.5}, 4), c_tf8(TF8{d: 1, p: 2.5}, 1), c_tfm(TFM{p: 7.5, q: -9}, 2));
+    val r1: P1 = c_mk_p1(1);
+    val r3: T3 = c_mk_t3(4);
+    val r8: S8 = c_mk_s8(0x01020304);
+    val r9: T9 = c_mk_t9(7);
+    val r16: T16 = c_mk_t16(-11);
+    val r24: O24 = c_mk_o24(12);
+    p.printlnf("c->mach p1={} t3={} s8={} t9={} t16={} o24={}",
+        r1.d::i64, code(r3.d) * 1000 + code(r3.p[0]) * 100 + code(r3.p[1]), r8.p::i64, code(r9.d) * 1000 + code(r9.p[0]) * 100 + code(r9.p[7]), r16.p, r24.d::i64 * 10000 + r24.p[0] * 100 + r24.p[1]);
+    val rn: Nest = c_mk_nest(14);
+    val ral: AL16 = c_mk_al16(15);
+    val rtf: TF = c_mk_tf(16.5);
+    val rtf8: TF8 = c_mk_tf8(2.5);
+    val rtfm: TFM = c_mk_tfm(-17);
+    p.printlnf("c->mach nest={} al16={} al16_tail={} tf2={} tf8x2={} tfm={}",
+        rn.d::i64 * 100 + rn.p.d::i64 * 10 + rn.p.p::i64, ral.d::i64 * 100 + ral.p::i64, zeros_from((?ral)::*u8, 8, 16), (rtf.p * 2.0)::i64, (rtf8.p * 2.0)::i64, (rtfm.p * 2.0)::i64 * 100 + rtfm.q);
+    p.printlnf("c drives mach: {}", c_drives_mach());
+    ret 0;
+}


### PR DESCRIPTION
Two convention-level ABI fixes extracted from feat/3218 onto dev with record-level tests, one commit each.

## SysV padding-only eightbyte

A 16-byte aggregate whose second eightbyte holds only padding (`#[align(16)] rec { a: u8; }`) classifies that eightbyte NO_CLASS; gcc and clang pass it in rdi alone and return it in rax alone. mach spent rsi and rdx on it, so a C callee read its next argument from the wrong register and a returned object copied rdx's leftovers into its tail padding. The eightbyte mask now reports padding-only eightbytes (`EB_EMPTY_LO`/`EB_EMPTY_HI`), `sysv.classify_arg`/`classify_return` build one piece per populated eightbyte, and the store side of `materialize_pieces` zeroes every logical byte no piece delivers.

Reproduced on dev first with the new link case `test/link/cases/3263-record-abi-c-callee` against a clang-built callee and caller: `al16=106 al16_after=115 al16_tail=0`, `c drives mach: 3`.

Tests: `sysv.classify_arg:padding_only_eightbyte_consumes_no_register`, `sysv.classify_return:padding_only_eightbyte_returns_in_rax_alone`, `mir.abi:record_transport_classifies_by_layout_on_every_convention` (eleven record shapes through SysV64, Win64, AAPCS64, lp64d, lp64, ilp32d, ilp32 via the real type derivation and vtable), `driver:record_transport_preserves_logical_extents_through_wider_carriers_on_every_native_backend` (poisoned-stack round trips on x86_64, aarch64 and riscv64 in both profiles), and the C link case.

## Aggregate secrecy provenance

An aggregate's MIR vreg is the address of its home; seeding it secret for an outer-secret parameter or call result made every field read of a by-value `^Rec` in an `#[oblivious]` function a secret-dependent address, while a record with a `^u64` field reached the argument registers with public provenance. `type.contains_secret` (union of secret byte ranges) is carried by call arguments, returned values and parameters; homes are never seeded secret; argument, return and parameter transport run with the object's secrecy.

Extracting this onto records surfaced one more piece the tag branch never hit: the release profile's SROA tainted a whole partition from any secret operation on it, so with the union flag on the parameter copy a branch on the *public* field of a record with a secret field was refused in release (accepted on dev today). Each field slot now takes its secrecy from the typed accesses to that field; a whole-object store, copy or zeroing taints no field by itself. `sroa.run:preserves_a_secret_field` now asserts the public neighbour stays public.

Tests: `driver:record_secret_content_transport_keeps_content_secrecy_and_public_fields_public` (nine verdict fixtures, both profiles), `driver:record_secret_content_carriers_are_secret_and_the_public_field_test_is_public_on_x86_64_and_aarch64` (MIR inspection, both profiles).

## Verification

- Full suite through the from-source compiler: 2721 passed, 0 failed (dev baseline in a throwaway worktree: 2715; net +6, the six added tests).
- `sh test/census.sh` ok; `git diff --check dev...HEAD` clean.
- Corpus layer B on x86_64-linux, aarch64-linux, riscv64-linux: 273 cells pass, 0 fail, no golden moved.
- Link leg x86_64-linux: 138 pass / 0 fail, including the new C case in both profiles.
- Mutation controls, each reverted after: SysV eightbyte counted again → 2 sysv tests, the record sweep and the link case fail; undelivered-byte zeroing removed → the extents fixture fails (exit 12, poisoned nine-argument call); argument transport public → carriers test fails on `call_s`; return transport public → carriers test fails on `give_s`; SROA per-field taint reverted → release verdict fixture 6 fails.

## Out of scope, found while building the control

A `#[packed]` record with an unaligned field (`#[packed] rec { d: u8; p: u64; }`, 9 bytes) is MEMORY class under System V ("unaligned fields"); clang passes it on the stack and returns it via sret, while mach rides rdi/rsi and rax/rdx. Against a C callee the argument reads garbage and the return segfaults. The packed shape is therefore excluded from the C control here (feat/3218's control excluded it too). This needs its own issue.

Closes #3263
