### PR TITLE
fix(abi): classify packed records with unaligned fields as SysV MEMORY class (#3266)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -77,6 +77,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   tail padding. Padding-only eightbytes now consume no register, the
   classifier emits one piece per populated eightbyte, and the store side zeroes
   every logical byte no piece delivers (#3263).
+- A `#[packed]` record with a field at an offset that is not a multiple of the
+  field's own alignment (`#[packed] rec { a: u8; b: u32; }`) was classified by
+  its eightbytes under System V x86-64 and rode rdi and rsi, where the ABI's
+  unaligned-field rule makes the whole aggregate MEMORY class: gcc and clang
+  pass it on the stack and return it through a hidden pointer, so a C callee
+  read the argument as garbage and a C caller's return faulted. The eightbyte
+  walk now flags any struct member or array element at an unaligned offset and
+  the classifier takes the flag as MEMORY; a packed record whose fields happen
+  to sit aligned keeps its registers, and Win64 (non-power-of-two sizes were
+  already by reference) and AAPCS64 (records classify by size alone) are
+  unchanged (#3266).
 - Secrecy provenance of a by-value aggregate was attached to its home instead
   of its bytes: an aggregate's MIR vreg is the address of its home, and seeding
   it secret for an outer-secret parameter or call result made every field read

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -132,10 +132,45 @@ fun collect_leaves(ctx: *context.LowerCtx, ty: type.IrTypeId, base_off: u64, str
     ret count + 1;
 }
 
+# the System V unaligned-field rule: a member whose offset is not a multiple of its own type's alignment
+# makes the whole aggregate MEMORY class. every struct member is checked against its type's alignment at
+# every nesting level and every array element is visited at its own offset, so a packed element whose
+# fields sit aligned in element 0 and unaligned in element 1 is caught, exactly as clang walks it
+fun has_unaligned_field(ctx: *context.LowerCtx, ty: type.IrTypeId, base_off: u64) bool {
+    val it: O.Option[*type.IrType] = type.get(ctx.types, ty);
+    if (!O.is_some[*type.IrType](it)) { ret false; }
+    val t: *type.IrType = O.unwrap[*type.IrType](it);
+    if (t.kind == type.IRT_STRUCT || t.kind == type.IRT_UNION) {
+        var i: u32 = 0;
+        for (i < t.data.struct_.field_count) {
+            val fty: type.IrTypeId = t.data.struct_.fields[i];
+            var fo: u64 = 0;
+            if (t.kind == type.IRT_STRUCT) { fo = type.byte_offset_for_machine(ctx.types, ty, i, ctx.layout)::u64; }
+            val fal: u64 = type.byte_align_for_machine(ctx.types, fty, ctx.layout)::u64;
+            if (fal != 0 && (base_off + fo) % fal != 0) { ret true; }
+            if (has_unaligned_field(ctx, fty, base_off + fo)) { ret true; }
+            i = i + 1;
+        }
+        ret false;
+    }
+    if (t.kind == type.IRT_ARRAY) {
+        val elem: type.IrTypeId = t.data.array_.element;
+        val es:   u64 = type.byte_size_for_machine(ctx.types, elem, ctx.layout)::u64;
+        val n:    u32 = type.array_count(ctx.types, ty);
+        var i: u32 = 0;
+        for (i < n) {
+            if (has_unaligned_field(ctx, elem, base_off + i::u64 * es)) { ret true; }
+            i = i + 1;
+        }
+    }
+    ret false;
+}
+
 fun aggregate_eightbyte_mask(ctx: *context.LowerCtx, ty: type.IrTypeId) u8 {
     if (!context.value_is_aggregate(ctx, ty)) { ret 0; }
     val size: u64 = type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
     if (size == 0 || size > 16) { ret 0; }
+    if (has_unaligned_field(ctx, ty, 0)) { ret abi.EB_UNALIGNED; }
     var leaves: [16]abi.AggField;
     val n: u32 = collect_leaves(ctx, ty, 0, false, ?leaves[0], AGG_LEAF_CAP, 0);
     var classes: [2]u8;
@@ -2271,6 +2306,14 @@ val REC_TF8:   u32 = 9;
 val REC_TFM:   u32 = 10;
 val REC_SHAPE_COUNT: u32 = 11;
 
+# packed shapes (#3266), outside the sweep because their cells differ per convention: an unaligned u32, an
+# unaligned i64, a packed record whose fields happen to sit aligned, and an array whose packed element is
+# aligned in element 0 and unaligned in element 1
+val REC_PK5:   u32 = 11;
+val REC_PK9:   u32 = 12;
+val REC_PKA:   u32 = 13;
+val REC_PKARR: u32 = 14;
+
 fun t_rec_shape(types: *type.IrTypeTable, which: u32) R.Result[type.IrTypeId, str] {
     val u8r: R.Result[type.IrTypeId, str] = type.intern_int(types, 8);
     val u32r: R.Result[type.IrTypeId, str] = type.intern_int(types, 32);
@@ -2290,6 +2333,7 @@ fun t_rec_shape(types: *type.IrTypeTable, which: u32) R.Result[type.IrTypeId, st
     fields[0] = u8t;
     var count: u32 = 2;
     var align: u32 = 0;
+    var packed: bool = false;
     if (which == REC_P1)  { count = 1; }
     or (which == REC_T3)  { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, u8t, 2); if (R.is_err[type.IrTypeId, str](a)) { ret a; } fields[1] = R.unwrap_ok[type.IrTypeId, str](a); }
     or (which == REC_S8)  { fields[1] = u32t; }
@@ -2301,8 +2345,22 @@ fun t_rec_shape(types: *type.IrTypeTable, which: u32) R.Result[type.IrTypeId, st
     or (which == REC_TF16) { fields[1] = f64t; }
     or (which == REC_TF8) { fields[1] = f32t; }
     or (which == REC_TFM) { fields[0] = f64t; fields[1] = i64t; }
+    or (which == REC_PK5) { fields[1] = u32t; packed = true; }
+    or (which == REC_PK9) { fields[1] = i64t; packed = true; }
+    or (which == REC_PKA) { fields[0] = i64t; fields[1] = u32t; packed = true; }
+    or (which == REC_PKARR) {
+        var ef: [2]type.IrTypeId;
+        ef[0] = u32t;
+        ef[1] = u8t;
+        val inner: R.Result[type.IrTypeId, str] = type.intern_struct(types, ?ef[0], 2, 0, true);
+        if (R.is_err[type.IrTypeId, str](inner)) { ret inner; }
+        val a: R.Result[type.IrTypeId, str] = type.intern_array(types, R.unwrap_ok[type.IrTypeId, str](inner), 2);
+        if (R.is_err[type.IrTypeId, str](a)) { ret a; }
+        fields[0] = R.unwrap_ok[type.IrTypeId, str](a);
+        count = 1;
+    }
     or { ret R.err[type.IrTypeId, str]("shape"); }
-    ret type.intern_struct(types, ?fields[0], count, align, false);
+    ret type.intern_struct(types, ?fields[0], count, align, packed);
 }
 
 rec RecTransport {
@@ -2561,6 +2619,57 @@ fun t_rv32_cells(alloc: *A.Allocator, isa_name: str, abi_name: str, hard_float: 
         }
         which = which + 1;
     }
+    ret 0;
+}
+
+# the packed cells (#3266): System V makes any record with an unaligned field MEMORY class (stack argument,
+# hidden-pointer return) while a packed record whose fields sit aligned keeps its eightbyte classification;
+# Win64 already takes every non-power-of-two size by reference and AAPCS64 and lp64d classify by size alone
+fun t_packed_cells(alloc: *A.Allocator) i32 {
+    var t: RecTransport;
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_PK5, ?t) != 0) { ret 1; }
+    if (t.size != 5 || t.align != 1 || t.eightbytes != abi.EB_UNALIGNED) { ret 2; }
+    if (t.arg.class != abi.CLASS_STACK || t.arg.size != 5 || !t_sret(?t.ret, SYSV_RAX)) { ret 3; }
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_PK9, ?t) != 0) { ret 4; }
+    if (t.size != 9 || t.eightbytes != abi.EB_UNALIGNED) { ret 5; }
+    if (t.arg.class != abi.CLASS_STACK || t.arg.size != 9 || !t_sret(?t.ret, SYSV_RAX)) { ret 6; }
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_PKA, ?t) != 0) { ret 7; }
+    if (t.size != 12 || t.align != 1 || t.eightbytes != 0) { ret 8; }
+    if (!t_gp_pair(?t.arg, SYSV_RDI, SYSV_RSI, 8, 4) || !t_gp_pair(?t.ret, SYSV_RAX, SYSV_RDX, 8, 4)) { ret 9; }
+    if (t_rec_transport(alloc, "x86_64", "linux", "sysv64", REC_PKARR, ?t) != 0) { ret 10; }
+    if (t.size != 10 || t.eightbytes != abi.EB_UNALIGNED) { ret 11; }
+    if (t.arg.class != abi.CLASS_STACK || t.arg.size != 10 || !t_sret(?t.ret, SYSV_RAX)) { ret 12; }
+
+    var which: u32 = REC_PK5;
+    for (which <= REC_PKARR) {
+        if (t_rec_transport(alloc, "x86_64", "windows", "win64", which, ?t) != 0) { ret 13; }
+        if (!t_byref(?t.arg, WIN_RCX) || !t_sret(?t.ret, SYSV_RAX)) { ret 14; }
+        which = which + 1;
+    }
+
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_PK5, ?t) != 0) { ret 15; }
+    if (!t_one_gp(?t.arg, 0, 8, 5) || !t_one_gp(?t.ret, 0, 8, 5)) { ret 16; }
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_PK9, ?t) != 0) { ret 17; }
+    if (!t_gp_pair(?t.arg, 0, 1, 8, 1) || !t_gp_pair(?t.ret, 0, 1, 8, 1)) { ret 18; }
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_PKA, ?t) != 0) { ret 19; }
+    if (!t_gp_pair(?t.arg, 0, 1, 8, 4) || !t_gp_pair(?t.ret, 0, 1, 8, 4)) { ret 20; }
+    if (t_rec_transport(alloc, "aarch64", "linux", "aapcs64", REC_PKARR, ?t) != 0) { ret 21; }
+    if (!t_gp_pair(?t.arg, 0, 1, 8, 2) || !t_gp_pair(?t.ret, 0, 1, 8, 2)) { ret 22; }
+
+    if (t_rec_transport(alloc, "riscv64", "linux", "lp64d", REC_PK5, ?t) != 0) { ret 23; }
+    if (!t_one_gp(?t.arg, RV_A0, 8, 5) || !t_one_gp(?t.ret, RV_A0, 8, 5)) { ret 24; }
+    if (t_rec_transport(alloc, "riscv64", "linux", "lp64d", REC_PK9, ?t) != 0) { ret 25; }
+    if (!t_gp_pair(?t.arg, RV_A0, RV_A1, 8, 1) || !t_gp_pair(?t.ret, RV_A0, RV_A1, 8, 1)) { ret 26; }
+    if (t_rec_transport(alloc, "riscv64", "linux", "lp64d", REC_PKA, ?t) != 0) { ret 27; }
+    if (!t_gp_pair(?t.arg, RV_A0, RV_A1, 8, 4) || !t_gp_pair(?t.ret, RV_A0, RV_A1, 8, 4)) { ret 28; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.mir.abi:packed_record_with_unaligned_field_is_sysv_memory_class" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val r: i32 = t_packed_cells(?alloc);
+    if (r != 0) { ret 30 + r; }
     ret 0;
 }
 

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -134,11 +134,14 @@ pub rec ParamSlot {
 }
 
 # eightbyte class mask handed to a classifier: bit 0 and bit 1 mark eightbyte 0 and 1 as SSE, bit 2 and
-# bit 3 mark them as holding no leaf at all (padding only), and an unmarked eightbyte inside the object is INTEGER
-pub val EB_SSE_LO:   u8 = 1;
-pub val EB_SSE_HI:   u8 = 2;
-pub val EB_EMPTY_LO: u8 = 4;
-pub val EB_EMPTY_HI: u8 = 8;
+# bit 3 mark them as holding no leaf at all (padding only), and an unmarked eightbyte inside the object is INTEGER;
+# bit 4 marks an aggregate holding a field at an offset that is not a multiple of the field's own alignment
+# (a packed record), which System V classifies as MEMORY regardless of what its eightbytes hold
+pub val EB_SSE_LO:    u8 = 1;
+pub val EB_SSE_HI:    u8 = 2;
+pub val EB_EMPTY_LO:  u8 = 4;
+pub val EB_EMPTY_HI:  u8 = 8;
+pub val EB_UNALIGNED: u8 = 16;
 
 pub def ClassifyFn: fun(u64, u64, bool, u8, bool, i32, i32, u8, u8) ParamSlot;
 

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -68,7 +68,7 @@ pub fun classify_arg(index: i32, size: u64, align: u64,
                      is_float: bool, fp_eightbytes: u8, is_aggregate: bool, is_vector: bool,
                      gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8,
                      agg: abi.AggLayout) abi.ParamSlot {
-    if (is_aggregate && size > MAX_REG_RET) {
+    if (is_aggregate && memory_class(size, fp_eightbytes)) {
         ret abi.make_slot(abi.CLASS_STACK, -1, 0, size, 0);
     }
 
@@ -142,7 +142,7 @@ pub fun classify_return(size: u64, align: u64,
         ret abi.make_slot(abi.CLASS_GP, -1, 0, 0, 0);
     }
 
-    if (is_aggregate && size > MAX_REG_RET) {
+    if (is_aggregate && memory_class(size, fp_eightbytes)) {
         ret abi.make_slot(abi.CLASS_SRET, REG_RAX, 0, 8, 8);
     }
 
@@ -178,6 +178,12 @@ pub fun classify_return(size: u64, align: u64,
     }
 
     ret abi.make_slot(abi.CLASS_GP, REG_RAX, 0, size, 8);
+}
+
+# 3.2.3 rule 1: an aggregate larger than two eightbytes, or one holding an unaligned field, is MEMORY class
+fun memory_class(size: u64, fp_eightbytes: u8) bool {
+    if (size > MAX_REG_RET) { ret true; }
+    ret (fp_eightbytes & abi.EB_UNALIGNED) != 0;
 }
 
 # one piece per classified eightbyte; a padding-only eightbyte (register -1) is delivered by nobody
@@ -372,5 +378,30 @@ test "mach.lang.target.abi.sysv.classify_return:padding_only_eightbyte_returns_i
     if (full.piece_count != 2 || full.pieces[1].reg != REG_RDX) { ret 2; }
     val hi: abi.ParamSlot = classify_return(16, 16, false, abi.EB_EMPTY_LO, true, false, 0, 0, abi.agg_none());
     if (hi.piece_count != 1 || hi.pieces[0].reg != REG_RAX || hi.pieces[0].src_off != 8) { ret 3; }
+    ret 0;
+}
+
+test "mach.lang.target.abi.sysv.classify_arg:unaligned_field_is_memory_class" {
+    val s: abi.ParamSlot = classify_arg(0, 5, 1, false, abi.EB_UNALIGNED, true, false, 0, 0, 0, 0, abi.agg_none());
+    if (s.class != abi.CLASS_STACK || s.reg != -1 || s.size != 5) { ret 1; }
+    val two: abi.ParamSlot = classify_arg(0, 9, 1, false, abi.EB_UNALIGNED, true, false, 0, 0, 0, 0, abi.agg_none());
+    if (two.class != abi.CLASS_STACK || two.size != 9) { ret 2; }
+    val sse: abi.ParamSlot = classify_arg(0, 16, 1, false, abi.EB_UNALIGNED | abi.EB_SSE_LO | abi.EB_SSE_HI, true, false, 0, 0, 0, 0, abi.agg_none());
+    if (sse.class != abi.CLASS_STACK) { ret 3; }
+    val aligned: abi.ParamSlot = classify_arg(0, 12, 1, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
+    if (aligned.class != abi.CLASS_GP || aligned.piece_count != 2) { ret 4; }
+    if (aligned.pieces[0].reg != REG_RDI || aligned.pieces[1].reg != REG_RSI) { ret 5; }
+    val next: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
+    if (next.reg != REG_RDI) { ret 6; }
+    ret 0;
+}
+
+test "mach.lang.target.abi.sysv.classify_return:unaligned_field_returns_through_hidden_pointer" {
+    val s: abi.ParamSlot = classify_return(5, 1, false, abi.EB_UNALIGNED, true, false, 0, 0, abi.agg_none());
+    if (s.class != abi.CLASS_SRET || s.reg != REG_RAX) { ret 1; }
+    val two: abi.ParamSlot = classify_return(9, 1, false, abi.EB_UNALIGNED, true, false, 0, 0, abi.agg_none());
+    if (two.class != abi.CLASS_SRET) { ret 2; }
+    val aligned: abi.ParamSlot = classify_return(12, 1, false, 0, true, false, 0, 0, abi.agg_none());
+    if (aligned.class != abi.CLASS_GP || aligned.piece_count != 2 || aligned.pieces[1].reg != REG_RDX) { ret 3; }
     ret 0;
 }

--- a/test/link/cases/3263-record-abi-c-callee/case.conf
+++ b/test/link/cases/3263-record-abi-c-callee/case.conf
@@ -3,7 +3,7 @@
 # a 3-byte record in an 8-byte register, a 9-byte record in two registers with one
 # logical byte in the second, a 16-byte record, a 24-byte record in memory, a nested
 # record, an over-aligned record, and float, float32 and mixed float/integer
-# fields.
+# fields; three more cover packed records (mach #3266, below).
 #
 # WHAT ONLY A FOREIGN TOOLCHAIN CAN SAY. mach's own caller and callee agree with each
 # other by construction, so a classification that is wrong on both sides is invisible
@@ -15,6 +15,25 @@
 # convention says only if the record consumed exactly the registers the convention
 # says. Against the unpatched compiler this case reports `al16=3006 al16_after=3015`
 # on x86_64-linux.
+#
+# PACKED RECORDS (mach #3266). System V makes any aggregate holding a field at an
+# offset that is not a multiple of the field's own alignment MEMORY class: it goes on
+# the stack as an argument and comes back through a hidden pointer. mach used to
+# classify a packed record by its eightbytes alone, so `c_pk5(v, next)` read `v`
+# from rdi and `next` from rsi while C had put `v` on the stack and `next` in rdi,
+# and a returned `pk5` had C writing through rdi as a pointer while mach had put a
+# value there: garbage one way, a fault the other. Against the unpatched compiler this
+# case reports `pk5=17920001022701` and then dies on signal 11. `pka` is the control
+# the other way: packed, but every field happens to sit aligned, so it keeps its two
+# registers and must not move.
+#
+# One packed shape is deliberately NOT here: a record holding an array of packed
+# elements whose fields sit aligned in element 0 and unaligned in element 1
+# (`struct pkc { u32; u8 } e[2]`, a u32 at offset 5). The ABI text says MEMORY and
+# clang says MEMORY, but gcc classifies an array by its first element alone and
+# passes it in registers. The two toolchains this suite resolves to disagree, so
+# the shape cannot be a control; mach follows the ABI text and the compiler's own
+# transport inventory (mir/abi.mach, REC_PKARR) pins that.
 #
 # Both directions run: mach calls C with each shape and reads each shape back from C,
 # then C calls mach with the same shapes and reads what mach returns. -O0 keeps every

--- a/test/link/cases/3263-record-abi-c-callee/expect.txt
+++ b/test/link/cases/3263-record-abi-c-callee/expect.txt
@@ -2,4 +2,6 @@ mach->c p1=107 t3=1154 s8=2000109 t9=2165 t16=3000097 o24=5198
 mach->c nest=4000116 al16=3106 al16_after=3115 tf=4107 tf8=1102 tfm=2691
 c->mach p1=1 t3=1405 s8=16909060 t9=1708 t16=-11 o24=11213
 c->mach nest=124 al16=115 al16_tail=1 tf2=33 tf8x2=5 tfm=483
+mach->c pk5=7070100 pk9=-4991999900 pka=9000221
+c->mach pk5=1080000 pk9=4000000000 pka=222
 c drives mach: 0

--- a/test/link/cases/3263-record-abi-c-callee/probe.c
+++ b/test/link/cases/3263-record-abi-c-callee/probe.c
@@ -17,6 +17,13 @@ struct al16 { unsigned char d; unsigned char p; } __attribute__((aligned(16)));
 struct tf { unsigned char d; double p; };
 struct tf8 { unsigned char d; float p; };
 struct tfm { double p; long long q; };
+/* packed shapes (mach #3266): pk5 and pk9 hold a field at an offset its type does not align to, and pka
+ * packs fields that happen to sit aligned anyway */
+#pragma pack(push, 1)
+struct pk5 { unsigned char d; unsigned int p; };
+struct pk9 { unsigned char d; long long p; };
+struct pka { long long d; unsigned int p; };
+#pragma pack(pop)
 
 long long c_p1(struct p1 v, long long next) { return v.d * 100 + next; }
 long long c_t3(struct t3 v, long long next) { return v.d * 100 + v.p[0] + v.p[1] * 10 + next * 1000; }
@@ -30,6 +37,9 @@ long long c_al16_after(long long first, struct al16 v, long long next) { return 
 long long c_tf(struct tf v, long long next) { return v.d * 100 + (long long)v.p + next * 1000; }
 long long c_tf8(struct tf8 v, long long next) { return v.d * 100 + (long long)v.p + next * 1000; }
 long long c_tfm(struct tfm v, long long next) { return (long long)v.p * 100 + v.q + next * 1000; }
+long long c_pk5(struct pk5 v, long long next) { return v.d * 100 + (long long)v.p + next * 1000000; }
+long long c_pk9(struct pk9 v, long long next) { return v.d * 100 + v.p + next * 1000000; }
+long long c_pka(struct pka v, long long next) { return v.d * 100 + (long long)v.p + next * 1000000; }
 
 struct p1 c_mk_p1(unsigned char d) { struct p1 r; r.d = d; return r; }
 struct t3 c_mk_t3(unsigned char x) { struct t3 r; r.d = 1; r.p[0] = x; r.p[1] = x + 1; return r; }
@@ -42,6 +52,9 @@ struct al16 c_mk_al16(unsigned char x) { struct al16 r; r.d = 1; r.p = x; return
 struct tf c_mk_tf(double x) { struct tf r; r.d = 1; r.p = x; return r; }
 struct tf8 c_mk_tf8(float x) { struct tf8 r; r.d = 1; r.p = x; return r; }
 struct tfm c_mk_tfm(long long x) { struct tfm r; r.p = 2.5; r.q = x; return r; }
+struct pk5 c_mk_pk5(unsigned int x) { struct pk5 r; r.d = 1; r.p = x; return r; }
+struct pk9 c_mk_pk9(long long x) { struct pk9 r; r.d = 1; r.p = x; return r; }
+struct pka c_mk_pka(unsigned int x) { struct pka r; r.d = 2; r.p = x; return r; }
 
 /* the reverse direction: C calls mach with the same shapes */
 long long m_t3(struct t3 v, long long next);
@@ -56,6 +69,12 @@ struct al16 m_mk_al16(unsigned char x);
 struct tf m_mk_tf(double x);
 struct tfm m_mk_tfm(long long x);
 struct t3 m_mk_t3(unsigned char x);
+long long m_pk5(struct pk5 v, long long next);
+long long m_pk9(struct pk9 v, long long next);
+long long m_pka(struct pka v, long long next);
+struct pk5 m_mk_pk5(unsigned int x);
+struct pk9 m_mk_pk9(long long x);
+struct pka m_mk_pka(unsigned int x);
 
 long long c_drives_mach(void) {
     struct t3 a = c_mk_t3(4);
@@ -81,5 +100,17 @@ long long c_drives_mach(void) {
     if (rf.p != 2.5 || rf.q != -15) return 11;
     struct t3 ra = m_mk_t3(15);
     if (ra.d != 1 || ra.p[0] != 15 || ra.p[1] != 16) return 12;
+    struct pk5 g = c_mk_pk5(70000);
+    struct pk9 h = c_mk_pk9(-5000000000LL);
+    struct pka i = c_mk_pka(21);
+    if (m_pk5(g, 7) != 100 + 70000 + 7000000) return 13;
+    if (m_pk9(h, 8) != 100 - 5000000000LL + 8000000) return 14;
+    if (m_pka(i, 9) != 200 + 21 + 9000000) return 15;
+    struct pk5 rg = m_mk_pk5(80000);
+    if (rg.d != 1 || rg.p != 80000) return 16;
+    struct pk9 rh = m_mk_pk9(-6000000000LL);
+    if (rh.d != 1 || rh.p != -6000000000LL) return 17;
+    struct pka ri = m_mk_pka(22);
+    if (ri.d != 2 || ri.p != 22) return 18;
     return 0;
 }

--- a/test/link/cases/3263-record-abi-c-callee/src/main.mach
+++ b/test/link/cases/3263-record-abi-c-callee/src/main.mach
@@ -20,6 +20,12 @@ rec AL16 { d: u8; p: u8; }
 rec TF { d: u8; p: f64; }
 rec TF8 { d: u8; p: f32; }
 rec TFM { p: f64; q: i64; }
+#[packed]
+rec PK5 { d: u8; p: u32; }
+#[packed]
+rec PK9 { d: u8; p: i64; }
+#[packed]
+rec PKA { d: i64; p: u32; }
 
 ext fun c_p1(v: P1, next: i64) i64;
 ext fun c_t3(v: T3, next: i64) i64;
@@ -44,6 +50,12 @@ ext fun c_mk_al16(x: u8) AL16;
 ext fun c_mk_tf(x: f64) TF;
 ext fun c_mk_tf8(x: f32) TF8;
 ext fun c_mk_tfm(x: i64) TFM;
+ext fun c_pk5(v: PK5, next: i64) i64;
+ext fun c_pk9(v: PK9, next: i64) i64;
+ext fun c_pka(v: PKA, next: i64) i64;
+ext fun c_mk_pk5(x: u32) PK5;
+ext fun c_mk_pk9(x: i64) PK9;
+ext fun c_mk_pka(x: u32) PKA;
 ext fun c_drives_mach() i64;
 
 #[symbol("m_t3")] pub fun m_t3(v: T3, next: i64) i64 { ret v.d::i64 * 100 + v.p[0]::i64 + v.p[1]::i64 * 10 + next * 1000; }
@@ -58,6 +70,12 @@ ext fun c_drives_mach() i64;
 #[symbol("m_mk_tf")] pub fun m_mk_tf(x: f64) TF { ret TF{d: 1, p: x}; }
 #[symbol("m_mk_tfm")] pub fun m_mk_tfm(x: i64) TFM { ret TFM{p: 2.5, q: x}; }
 #[symbol("m_mk_t3")] pub fun m_mk_t3(x: u8) T3 { var a: [2]u8; a[0] = x; a[1] = x + 1; ret T3{d: 1, p: a}; }
+#[symbol("m_pk5")] pub fun m_pk5(v: PK5, next: i64) i64 { ret v.d::i64 * 100 + v.p::i64 + next * 1000000; }
+#[symbol("m_pk9")] pub fun m_pk9(v: PK9, next: i64) i64 { ret v.d::i64 * 100 + v.p + next * 1000000; }
+#[symbol("m_pka")] pub fun m_pka(v: PKA, next: i64) i64 { ret v.d * 100 + v.p::i64 + next * 1000000; }
+#[symbol("m_mk_pk5")] pub fun m_mk_pk5(x: u32) PK5 { ret PK5{d: 1, p: x}; }
+#[symbol("m_mk_pk9")] pub fun m_mk_pk9(x: i64) PK9 { ret PK9{d: 1, p: x}; }
+#[symbol("m_mk_pka")] pub fun m_mk_pka(x: u32) PKA { ret PKA{d: 2, p: x}; }
 
 fun code(v: u8) i64 { ret v::i64; }
 
@@ -89,6 +107,13 @@ fun main(argc: usize, argv: **u8) i64 {
     val rtfm: TFM = c_mk_tfm(-17);
     p.printlnf("c->mach nest={} al16={} al16_tail={} tf2={} tf8x2={} tfm={}",
         rn.d::i64 * 100 + rn.p.d::i64 * 10 + rn.p.p::i64, ral.d::i64 * 100 + ral.p::i64, zeros_from((?ral)::*u8, 8, 16), (rtf.p * 2.0)::i64, (rtf8.p * 2.0)::i64, (rtfm.p * 2.0)::i64 * 100 + rtfm.q);
+    p.printlnf("mach->c pk5={} pk9={} pka={}",
+        c_pk5(PK5{d: 1, p: 70000}, 7), c_pk9(PK9{d: 1, p: -5000000000}, 8), c_pka(PKA{d: 2, p: 21}, 9));
+    val rpk5: PK5 = c_mk_pk5(80000);
+    val rpk9: PK9 = c_mk_pk9(-6000000000);
+    val rpka: PKA = c_mk_pka(22);
+    p.printlnf("c->mach pk5={} pk9={} pka={}",
+        rpk5.d::i64 * 1000000 + rpk5.p::i64, rpk9.d::i64 * 10000000000 + rpk9.p, rpka.d * 100 + rpka.p::i64);
     p.printlnf("c drives mach: {}", c_drives_mach());
     ret 0;
 }


### PR DESCRIPTION
A `#[packed]` record with a field at an offset that is not a multiple of the field's own alignment is MEMORY class under System V x86-64 (3.2.3 rule 1), but mach classified it by its eightbytes and passed it in rdi/rsi and returned it in rax/rdx. Against clang or gcc the argument read garbage one way and the return faulted the other.

## Fix

- `mir/abi.mach`: the eightbyte walk sets a new `abi.EB_UNALIGNED` flag when any struct member or array element sits at an offset not aligned to its type (the field type's alignment at every nesting level, every array element at its own offset, the walk clang does).
- `sysv.mach`: `classify_arg` and `classify_return` take the flag as MEMORY through one `memory_class` predicate shared with the size rule: stack argument, hidden-pointer return. A packed record whose fields happen to sit aligned keeps its eightbyte classification.
- Win64 and AAPCS64 need no change: Win64 already takes every non-power-of-two size by reference and AAPCS64 classifies by size alone. The transport inventory (`t_packed_cells`) pins both, plus lp64d.

## Control

The #3263 C control gains `pk5` (`u8; u32`), `pk9` (`u8; i64`) and `pka` (`i64; u32`, packed but aligned, must keep its registers) in both directions. Against the unpatched compiler it reports `pk5=17920001022701` and dies on signal 11; patched it prints the hand-computed values and the C-driven direction returns 0.

One shape is deliberately inventory-only: a record holding `[2]` of a packed `{u32; u8}` element, aligned in element 0 and unaligned in element 1. The ABI text and clang say MEMORY, gcc classifies an array by its first element alone and passes it in registers, so the two toolchains the suite resolves to disagree and it cannot be a foreign-toolchain control. mach follows the ABI text; `case.conf` records the divergence.

## Verification

- full suite through the from-source compiler: 2729 -> 2732, the three new tests exactly
- `sh test/census.sh` ok
- corpus layer B on x86_64-linux, aarch64-linux, riscv64-linux: 273 pass, 0 fail, no golden moved (no corpus case has a packed by-value record)
- link leg x86_64-linux: 138 pass / 0 fail with the extended control
- the extended control cross-built for x86_64-windows runs identically under wine; for aarch64-linux under qemu the packed lines match and the only diff is the pre-existing `al16_tail` byte, which is x1's leftover under AAPCS64 and settles only on native silicon
- mutation control: with the flag dropped from `memory_class` the three new unit tests fail (exit 33, 1, 1) and the C control fails with the original signature
- `git diff --check dev...HEAD` clean

Closes #3266