### PR TITLE
spirv: accept the value-oriented module ABI and legal pointer-to-record parameters (#2963, #2940)

### DIFF
--- a/doc/design/spirv-abi-2963.md
+++ b/doc/design/spirv-abi-2963.md
@@ -57,7 +57,9 @@ sites on `dev`, every one of which the acceptance below removes:
   nominal positions) and `mir/context.mach:586-594` their constructors.
 - `mir/abi.mach:33 MAX_GP_ARG_REGS = 16` and `:45 abi_gp_arg_reg` filling a fixed
   `[16]isa.Register` from the convention's bank (the shared overrun hazard #2962
-  guards), reachable for SPIR-V only because the bank exists.
+  guards), reachable for SPIR-V only because the bank exists. It stays for the
+  carriers conventions and is unreachable from a values convention, which
+  publishes no bank.
 
 ### 1.2 What the candidate era adds that `dev` lacks
 
@@ -146,7 +148,8 @@ hand-written module under `spv1.0`, `spv1.3`, `spv1.4`, `spv1.6`, `vulkan1.0`,
 | pointer result (`fun f(p: *Rec) *Rec`) | refused, located | a `Function`-storage pointer result needs VariablePointers-class capabilities outside the declared environments |
 | pointer held in a record or array, pointer-valued local | refused, located | a pointer in memory is a variable pointer |
 | recursive reference type (`rec Node { next: *Node; }`) by pointer | refused at lowering, located | the pointee type itself contains a pointer |
-| function value parameter | refused, located | no function pointers in logical addressing |
+| function value parameter | refused, located, "unsupported parameter N of type `fun(...) ...`: logical addressing has no function pointers" | no function pointers in logical addressing |
+| raw union parameter | refused, located, "unsupported parameter N of type `uni{...}`: SPIR-V has no untyped union" | no untyped union type |
 | pointer arithmetic (`mem/ptr_arith`) | refused | unchanged target limitation |
 
 Debug: the v5 release contract says SPIR-V "explicitly refuses debug requests".
@@ -155,9 +158,55 @@ registers no debug model. The driver test pins it on a SPIR-V target selection.
 
 ## 4. Acceptance map
 
-Filled in as the tests land; see the PR body for the final mapping.
+Every class in section 1 is demonstrated by a test that runs `spirv-val` on the
+module (the driver tests evaluate the module as well) or by a corpus cell whose
+layer A cell is `spirv-val` and whose layer B golden is `spirv-dis` text.
 
-## 5. The interface L6 will call
+| class | demonstration | evidence |
+|---|---|---|
+| scalar, vector, composite by value, pointer to record, more than 16 arguments, composite return | `mach.lang.driver:logical_value_abi_preserves_mixed_arguments_and_references_on_spirv` (21 parameters: 17 `u32`, `f32`, `Pair`, `*Pair`, `u32x4`; returns `Pair`; evaluates the module and finds the 25-word `OpFunctionCall`) | `src/lang/driver/tests.mach` |
+| more than 16 arguments in the corpus (#2923) | `call/call_mixed` layer A (o0, o2) and layer B; `mixed` has 20 `OpFunctionParameter` | `test/golden/spirv/call/call_mixed.dis` |
+| pointer to record, whole object (#2940 repro) | builds and validates at `-O0` and `-O2`: `%7 = OpTypePointer Function %Pair`, `fill` takes `%9 = OpFunctionParameter %7`, each field write is `OpAccessChain %12 %9 ...` + `OpStore`, the caller passes `%26 = OpVariable %7 Function` directly: `%33 = OpFunctionCall %4 %1 %26 %32` | this document, section 4 |
+| pointer to record, forwarded parameter | the driver test above (`forwarded(p, 8)` re-passes an `OpFunctionParameter`) | |
+| pointer to record in the corpus | `mem/rec_layout` layer B golden blessed; layer A o2 passes; o0 declared a target limitation (subobject argument) | `test/golden/spirv/mem/rec_layout.dis`, `test/golden/spirv/SKIPS` |
+| pointer to scalar | `mem/ptr_arith`'s `bump(p: *u64)` parameter is accepted; the refusal moved to the `MIR_GEP` that indexes off it | `SKIPS` entry quotes the new message |
+| illegal pointer classes still refused, located | `mach.lang.driver:logical_shader_reference_capabilities_refuse_returns_subobjects_and_cycles` (pointer result, subobject argument, recursive reference type), each with `main.mach:` in the diagnostic | |
+| function reference refused, located, naming the parameter and type | `mach.lang.driver:logical_shader_refuses_a_function_value_parameter_with_its_type`; corpus `call/call_indirect` quotes "unsupported parameter 1 of type `fun(i64, i64) i64` ..." | |
+| union refused naming the type | corpus `mem/uni_layout` quotes "unsupported parameter 2 of type `uni{f32, i32, i32, [4]i8}` ..." | |
+| readonly storage binding reached through a reference argument | `mach.lang.driver:spirv_refuses_an_escaping_readonly_storage_address` (a reference argument of a value call is a potential write to its origin) | |
+| `-g` refused by policy | `mach.lang.driver:spirv_debug_request_is_refused_by_the_declared_target_policy`; the corpus reports 83 `debug unsupported` cells for spirv | |
+| limit refusals are typed | `types.instruction_operands_fit` bounds `OpTypeFunction`, `OpFunctionCall` and mapped instructions by the 16-bit word count; `mach.lang.target.isa.spirv.types:logical_signature_has_no_synthetic_parameter_bank` interns a 256-parameter signature | `src/lang/target/isa/spirv/types.mach` |
+| no bank anywhere | `abi/spirv.mach` publishes no `gp_arg_regs`; `register.mach` publishes no register class; `emit.mach` has no `Regs`, no `MIR_OP_PREG` arm; `mach.lang.target.abi_vtable:granularity_matches_its_classifier` checks the values convention publishes nothing a bank would need | |
+| machine targets unchanged | corpus layer B on `x86_64-linux`: 91 pass, 0 fail, before and after; `tuple_capability` refuses a values convention on a register machine (`TUPLE_ABI_TRANSPORT`) | |
+
+Two rules landed beside the port because the first green run exposed them:
+
+- `MIR_RET` is `MIRF_NO_SHAPE`. On a values target the return carries its value
+  operand, and `instr_defines_shape` would otherwise type that operand as a fresh
+  definition of the machine word (an `f32` return became `f64`, a `u8` counter
+  `i64`). Machine targets emit `MIR_RET` with no operands, so the flag is inert
+  there.
+- A reference argument of `MIR_VALUE_CALL` is a potential write to its origin.
+  The candidate marked every argument read-only, which let a `*f32x4` argument
+  rooted in a `readonly` storage binding pass the readonly check and fail later
+  with an unrelated message.
+- An `OpFunctionCall` result id is allocated after its operands are read, so the
+  constants a call materializes precede the result. Twenty layer B goldens are
+  renumbered by exactly that; for each the id-stripped text, the opcode multiset
+  and the line count are unchanged (checked mechanically before blessing).
+
+## 5. Verification record
+
+| bar | result |
+|---|---|
+| full suite, from-source compiler | 2738 passed, 0 failed (baseline on `dev` 2633d5ba4: 2732); the six new tests are the two logical-ABI driver tests, the function-value refusal, the debug refusal, the 256-parameter signature and the typed-reference identity test |
+| `sh test/census.sh` | ok |
+| corpus spirv layers A and B | 248 pass, 0 fail, 100 skip (83 debug-unsupported cells, 17 declared); 22 goldens blessed: 2 new, 20 renumbered |
+| corpus x86_64-linux layer B | 91 pass, 0 fail |
+| `spirv-val` probe of the subobject-argument rule | rejected under spv1.0, spv1.3, spv1.4, spv1.6, vulkan1.0 through vulkan1.3 |
+| mutation controls | each refusal deleted in turn, its test fails: debug refusal in `passes.mach debug_info_of` (exit 4); subobject argument check in `read_value` (exit 14); pointer-result check in `emit_function` (exit 4); recursive-reference guard in `lower/context.mach` (segfault: unbounded `lower_type` recursion); parameter-type refusal in `emit_function` (exit 5). The `MIR_RET` shape flag and the reference-argument write rule were each seen failing four and one existing tests before they landed |
+
+## 6. The interface L6 will call
 
 L6 carries a tag (declared discriminator plus payload composite) through SPIR-V
 storage, composites, calls and returns. The surface it uses, and what may not

--- a/doc/design/spirv-abi-2963.md
+++ b/doc/design/spirv-abi-2963.md
@@ -1,0 +1,192 @@
+# SPIR-V value-oriented module ABI (#2963, #2940, roadmap N4)
+
+This document records what the SPIR-V calling convention on `dev` does today for
+every parameter and return class, where the synthetic register bank the N1 census
+counted still leaks into the emitter, what the candidate-era work adds, the
+contract this lane lands, and the interface L6 (tag transport through SPIR-V) will
+call. Sources: `gh issue view 2963`, `gh issue view 2940`,
+`doc/design/backend-census-2212.md` section 5 and section 11 (N4),
+`doc/design/v5-release-contract.md` (SPIR-V boundary), the archived integration
+head `archive/3218-candidate-era` (commit `2c463ae7` and the value-ABI hunks folded
+into `c2fbd635`), and the tree at `dev` `2633d5ba4`.
+
+## 1. Inventory: the convention on `dev` today
+
+`abi/spirv.mach` satisfies the register-machine `AbiVTable` with an identity
+convention: argument `i` is classified into nominal general register `i`
+(`classify_arg` returns `CLASS_GP` with `reg = index`, or `CLASS_AGG` with
+`reg = index` for an aggregate), the return is classified into nominal register 0,
+and `arg_regs` publishes a bank of `ARG_REG_COUNT = 16` eight-byte registers.
+`register.mach` declares two 16-wide register classes (`gpr`, `fpr`) for a machine
+that has none. Shared MIR lowering then pre-colours every argument into a `PREG`
+and the emitter (`spirv/emit.mach`) keeps a 16-slot shadow file `rec Regs`
+(`val_id`, `imm`, `is_imm`, `is_bool`) per structured node that maps those nominal
+registers back to SSA ids.
+
+| class | how it crosses on `dev` | site | verdict |
+|---|---|---|---|
+| scalar (int, float, bool) | `MIR_MOV vreg -> PREG i` at the call, `PREG i -> vreg` at entry; the emitter reads `Regs.val_id[i]` (or an immediate) and widens a bool to the parameter type | `abi/spirv.mach:14-21`, `emit.mach:2686 emit_call`, `:3193 emit_mov`, `:3224 reg_value` | accepted (works, but through the bank) |
+| vector (`u32x4`, `f32x4`, ...) | as scalar: one nominal register per vector, typed by `ir_value_spv_type` | same | accepted (through the bank) |
+| composite record by value | `CLASS_AGG`: `MIR_AGG_LOAD PREG i <- mem` at the call, `MIR_AGG_STORE mem <- PREG i` at entry; the emitter loads the whole `OpTypeStruct` and parks it in `Regs.val_id[i]` | `mir/context.mach:586-594`, `mir/abi.mach:967,1206`, `emit.mach:2529-2610` | accepted (through the bank) |
+| array by value | as composite (`OpTypeArray` is a whole value) | same | accepted (through the bank) |
+| pointer to record | `spv_type_of` has no `IRT_PTR` arm and returns 0; `emit_function` refuses "unsupported parameter type in the SPIR-V target" with no source location, parameter name or type | `emit.mach:2164`, `:1500-1503` | gap (#2940) |
+| pointer to scalar | same refusal; `mem/ptr_arith` indexes off it, which logical addressing cannot express | same, `test/golden/spirv/SKIPS` | refused-by-policy (pointer arithmetic); the whole-object pointer itself is a gap |
+| function reference (`call/call_indirect`) | same refusal; logical addressing has no function pointer | same | refused-by-policy |
+| return (scalar, vector, composite) | callee: `MIR_AGG_LOAD PREG 0` / `MIR_MOV PREG 0` then bare `MIR_RET`; `emit_terminator` reads `Regs.val_id[0]` for `OpReturnValue`; caller: `MIR_CALL_RES` then `MIR_MOV vreg <- PREG 0` / `MIR_AGG_STORE mem <- PREG 0` | `mir/abi.mach:1294`, `emit.mach:1748-1755`, `:2780-2786` | accepted (through the bank, result position 0) |
+| more than 16 arguments (`call/call_mixed`, #2923) | refused "more than 16 parameters is not supported by the SPIR-V target" at `emit_function` and `emit_call`; `types.type_fn` silently returns 0 past `MAX_FN_PARAMS` | `emit.mach:1494,2718`, `types.mach:53,451` | gap (#2963) |
+| `-g` on a SPIR-V target | `of/spv.mach:117` registers no debug model (`default_debug = ""`); `passes.mach:969 debug_info_of` refuses "debug info was requested, but this target registers no debug model"; the corpus driver maps that exact text to a `DEBUG_UNSUPPORTED` skip cell (`test/lib/driver.py:24-26,518-526`) | | refused-by-policy (v5 contract: "Debug requests are explicitly refused") |
+
+### 1.1 Where the synthetic bank leaks into the emitter
+
+The N1 census counted one synthetic 16-register bank. It is load-bearing at these
+sites on `dev`, every one of which the acceptance below removes:
+
+- `abi/spirv.mach:11 ARG_REG_COUNT = 16` and `:40 arg_regs` (the identity bank).
+- `spirv/register.mach:25-32` two 16-wide `RegClass` rows and `reg_class_len = 2`.
+- `spirv/types.mach:53 MAX_FN_PARAMS = 16`, `:451 type_fn` returning 0 past it, and
+  the `[18]u32` operand buffer at `:463`.
+- `spirv/emit.mach:76 rec Regs` and every `preg_val: *Regs` parameter threaded
+  through `emit_node`, `emit_terminator`, `read_condition`, `read_operand`,
+  `emit_mov`, `emit_call`, `emit_spirv_op`, `emit_agg_load`, `emit_agg_store`,
+  `reg_value`, `operand_is_bool`; the `[16]u32` `ptypes`/`param_ids`/`argty` and
+  `[19]u32` call operand buffers; the `MIR_OP_PREG` arms in `read_operand`,
+  `emit_mov`, `is_reg_copy`; the twelve-parameter cap in `emit_spirv_op`.
+- `spirv/emit.mach:1863-1935 build_vmaps` reconstructing a vreg's type by pairing
+  `MIR_CALL`/`MIR_CALL_RES` with the following `MIR_MOV vreg <- PREG`.
+- `mir.mach:168-170 MIR_AGG_LOAD`/`MIR_AGG_STORE` (whole objects in and out of
+  nominal positions) and `mir/context.mach:586-594` their constructors.
+- `mir/abi.mach:33 MAX_GP_ARG_REGS = 16` and `:45 abi_gp_arg_reg` filling a fixed
+  `[16]isa.Register` from the convention's bank (the shared overrun hazard #2962
+  guards), reachable for SPIR-V only because the bank exists.
+
+### 1.2 What the candidate era adds that `dev` lacks
+
+- `2c463ae7 test(abi): census the value-based convention constructor`: adds
+  `value_abi_vtable` in `src/lang/target/abi.mach` to the `isa/tests.mach`
+  construction census allow-list. Test-only; it presumes the constructor.
+- The value-ABI hunks of `c2fbd635` (an omnibus "local validation candidate"
+  commit, never landed): `abi.CLASS_VALUE` replacing `CLASS_AGG`;
+  `abi.PassingModel` (`PASSING_CARRIERS`, `PASSING_VALUES`) on `AbiVTable`;
+  `abi.value_abi_vtable` and `abi.make_slot_value`; `descriptor_valid` and
+  `register` splitting their checks by passing model; `mir.MIR_VALUE_CALL` and
+  `mir.MIR_VALUE_PARAM` replacing `MIR_AGG_LOAD`/`MIR_AGG_STORE`;
+  `mir.REG_CLASS_VALUE`; `mir/abi.mach lower_value_call`/`lower_value_params` and
+  the `PASSING_VALUES` forks in `lower_call`/`lower_params`/`lower_ret`;
+  `mir/context.mach` selecting `REG_CLASS_VALUE` for every vreg of a value target;
+  `target.mach TUPLE_ABI_TRANSPORT` and the passing model in the fingerprint;
+  `abi/spirv.mach` reduced to two `make_slot_value` classifiers; `spirv/emit.mach`
+  with `Regs` deleted, `read_value`/`write_value`/`emit_param` over logical
+  operands, an `IRT_PTR` arm in `spv_type_of`, per-parameter located refusals, and
+  heap-sized operand buffers bounded by the 65535-word instruction encoding;
+  `spirv/types.mach pointer_shape` and `instruction_operands_fit`;
+  `spirv/register.mach` publishing no register classes; the driver test
+  `logical_value_abi_preserves_mixed_arguments_and_references_on_spirv`
+  (21 arguments: 17 `u32`, one `f32`, one `Pair` by value, one `*Pair`, one
+  `u32x4`, returning `Pair`, checked by evaluating the module and by finding a
+  25-word `OpFunctionCall`) and
+  `logical_shader_reference_capabilities_refuse_returns_subobjects_and_cycles`.
+- The candidate also rewrote unrelated things in the same files (security
+  provenance on `MirInstr`, RISC-V feature selection, ELF attribute validation,
+  the removal of the MOS 6502 convention, and a reversal of `dev`'s later
+  `46b3214bc` defs-count refactor). None of that is N4 and none of it is ported.
+
+## 2. The contract this lane lands
+
+The four open questions in #2963 are settled as follows.
+
+1. **`CLASS_VALUE` subsumes `CLASS_AGG`.** Both meant "the whole object crosses as
+   itself"; the only difference was that `CLASS_AGG` named a nominal register. A
+   value slot names no register (`reg = -1`), no pieces, no offset and no indirect
+   extent, and `abi.make_slot_value(size)` is its only constructor. Register
+   machines never produce it: their aggregates keep classifying into carriers
+   (`CLASS_GP`/`CLASS_FP` pieces, `CLASS_BYREF`, `CLASS_SRET`, ...) exactly as
+   before, so no machine ABI changes behaviour.
+2. **The axis is declared on the convention, not derived from the machine.**
+   `AbiVTable.passing` is `PASSING_CARRIERS` (every register ABI, built by
+   `abi_vtable`) or `PASSING_VALUES` (built by `value_abi_vtable`, which takes
+   only the two classifiers and refuses a bank, a callee-saved set, a variadic
+   model, a slot granularity, a stack alignment, a red zone, shadow space or an
+   indirect-result register). `target.tuple_capability` pairs the two models with
+   the instruction-set family: a values convention needs a whole-module emitter
+   and a carriers convention needs a machine, else `TUPLE_ABI_TRANSPORT`. The
+   model is part of the target fingerprint.
+3. **MIR carries value calls directly.** `MIR_VALUE_CALL callee, result, args...`
+   and `MIR_VALUE_PARAM dest, index` are the only call-boundary instructions a
+   values target lowers to (`SEL_CLASS_SPIRV_ONLY`, no shape). An aggregate
+   operand is its owned home (`op_mem_value`), a scalar is its vreg. Every vreg of
+   a values function is `REG_CLASS_VALUE`, so no register allocator, spill or
+   pre-colouring pass can apply. `MIR_RET value` returns the value operand itself.
+4. **Returns take the same treatment.** The callee's `MIR_RET` names the value;
+   `emit_terminator` reads it with `read_value`, and the caller's `MIR_VALUE_CALL`
+   result operand is written with `write_value` (an SSA id for a scalar or vector,
+   an `OpStore` into the owned home for a composite). Nominal position 0 is gone.
+
+The emitter side: `OpFunctionParameter` per logical parameter typed by
+`ir_value_spv_type`; `OpTypeFunction` and `OpFunctionCall` sized by the encoding
+(`types.instruction_operands_fit`), so the only parameter-count bound left is the
+SPIR-V word-count field; a pointer parameter is `OpTypePointer Function T` and the
+argument is the `OpVariable` (or forwarded `OpFunctionParameter`) itself.
+
+## 3. Environment policy for limits and refusals
+
+SPIR-V's 255 parameters is a minimum every consumer supports, not a maximum
+(Khronos universal limits). The compiler therefore imposes no count of its own:
+`emit_function` and `emit_call` refuse only when the instruction would not fit its
+16-bit word count, and that refusal is a located `unsupported` diagnostic.
+
+Pointer classes, checked against `spirv-val` 2026.3 on this host with a
+hand-written module under `spv1.0`, `spv1.3`, `spv1.4`, `spv1.6`, `vulkan1.0`,
+`vulkan1.1`, `vulkan1.2` and `vulkan1.3`:
+
+| class | outcome | why |
+|---|---|---|
+| `*Rec` parameter, argument is a local `var` (memory object declaration) | accepted | logical addressing permits a `Function`-storage pointer parameter whose argument is an `OpVariable` |
+| `*Rec` parameter forwarded from a `*Rec` parameter | accepted | an `OpFunctionParameter` is a memory object declaration |
+| `*Rec` argument that is a subobject access chain (`?outer.pair`, `?n.w.m`) | refused, located | `spirv-val` rejects `OpFunctionCall` with an access-chain pointer operand in every declared environment: "Pointer operand must be a memory object declaration". Not lifted by any capability inside the declared ceilings. This is why `mem/rec_layout` stays in `SKIPS`, reclassified from MACH DEFECT to TARGET LIMITATION |
+| pointer result (`fun f(p: *Rec) *Rec`) | refused, located | a `Function`-storage pointer result needs VariablePointers-class capabilities outside the declared environments |
+| pointer held in a record or array, pointer-valued local | refused, located | a pointer in memory is a variable pointer |
+| recursive reference type (`rec Node { next: *Node; }`) by pointer | refused at lowering, located | the pointee type itself contains a pointer |
+| function value parameter | refused, located | no function pointers in logical addressing |
+| pointer arithmetic (`mem/ptr_arith`) | refused | unchanged target limitation |
+
+Debug: the v5 release contract says SPIR-V "explicitly refuses debug requests".
+The refusal site is `passes.mach debug_info_of` because the `spv` object format
+registers no debug model. The driver test pins it on a SPIR-V target selection.
+
+## 4. Acceptance map
+
+Filled in as the tests land; see the PR body for the final mapping.
+
+## 5. The interface L6 will call
+
+L6 carries a tag (declared discriminator plus payload composite) through SPIR-V
+storage, composites, calls and returns. The surface it uses, and what may not
+change:
+
+- `abi.value_abi_vtable(id, name, arch_id, arg_passing, ret_passing)` and
+  `abi.make_slot_value(size)`: a values convention classifies every argument and
+  return, tag included, as one `CLASS_VALUE` slot sized by the object's extent.
+  May not change: a value slot never names a register, piece or indirect extent.
+- `abi.AbiVTable.passing` with `abi.PASSING_VALUES`: the one predicate lowering
+  and the target layer consult. May not change: nothing derives it from the machine.
+- `mir.MIR_VALUE_CALL` (`callee, result, args...`) and `mir.MIR_VALUE_PARAM`
+  (`dest, index`): a tag argument or result is its owned home (`op_mem_value`).
+  May not change: operand order, and that an aggregate crosses as its home.
+- `mir.REG_CLASS_VALUE`: every vreg of a values function. May not change: it is
+  never a bank index.
+- `spirv/emit.mach spv_type_of`: a tag's IR struct (discriminator field then the
+  payload) maps to `OpTypeStruct` with the same member order; `IRT_PTR` maps to
+  `OpTypePointer Function`. May not change: member order is the IR field order.
+- `spirv/emit.mach read_value`/`write_value`: the only two paths a logical value
+  takes into an `OpFunctionCall` operand or `OpReturnValue`, and out of a result
+  into a vreg or an `OpStore` into its home. May not change: a composite argument
+  is an `OpLoad` of the whole object and a composite result is an `OpStore` of the
+  whole object, never a per-field copy.
+- `spirv/emit.mach emit_access_chain` over `MIR_GEP`: a discriminator or payload
+  field of a tag in `Function` storage is reached by `OpAccessChain` with constant
+  member ordinals. May not change: member ordinals are constant.
+- `spirv/types.mach pointer_shape(tt, id, &storage)` and
+  `instruction_operands_fit(fixed, variable)`: the pointer predicate and the only
+  size bound. May not change: their signatures.
+- `isa.TargetDefs`/`isa.Environment`/`environment_profile` (frozen by N1 section
+  11): the environment ceilings a tag payload's scalar types are checked against.

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -165,9 +165,11 @@ pub val MIR_MEMZERO: MirOpcode = 0x111C;
 # copies the exact byte extent as a snapshot, including overlapping ranges
 pub val MIR_MEMCPY: MirOpcode = 0x111D;
 
-pub val MIR_AGG_LOAD: MirOpcode = 0x111E;
+# callee, explicit result destination, then ordered logical arguments
+pub val MIR_VALUE_CALL: MirOpcode = 0x111E;
 
-pub val MIR_AGG_STORE: MirOpcode = 0x111F;
+# destination and logical parameter index, without physical carriers
+pub val MIR_VALUE_PARAM: MirOpcode = 0x111F;
 
 pub val MIR_OP_NONE: MirOpcode = 0xFFFF;
 
@@ -399,7 +401,7 @@ val SELECTION_CATALOG: [SELECTION_CATALOG_COUNT]MirOpDescriptor = [SELECTION_CAT
                      ct_class: MCT_NONE, reg_operands: 0x0, fused_cbr: MIR_OP_NONE },
     MirOpDescriptor{ op: MIR_RET, name: "MIR_RET", class: SEL_CLASS_REACHABLE,
                      operand_banks: "a*",
-                     flags: MIRF_TERMINATOR,
+                     flags: MIRF_TERMINATOR | MIRF_NO_SHAPE,
                      ct_class: MCT_NONE, reg_operands: 0x0, fused_cbr: MIR_OP_NONE },
     MirOpDescriptor{ op: MIR_UNREACHABLE, name: "MIR_UNREACHABLE", class: SEL_CLASS_REACHABLE,
                      operand_banks: "n*",
@@ -557,13 +559,13 @@ val SELECTION_CATALOG: [SELECTION_CATALOG_COUNT]MirOpDescriptor = [SELECTION_CAT
                      operand_banks: "g*",
                      flags: MIRF_MEMORY | MIRF_ADDRESSED,
                      ct_class: MCT_NONE, reg_operands: 0x0, fused_cbr: MIR_OP_NONE },
-    MirOpDescriptor{ op: MIR_AGG_LOAD, name: "MIR_AGG_LOAD", class: SEL_CLASS_SPIRV_ONLY,
+    MirOpDescriptor{ op: MIR_VALUE_CALL, name: "MIR_VALUE_CALL", class: SEL_CLASS_SPIRV_ONLY,
                      operand_banks: "a*",
-                     flags: MIRF_NONE,
+                     flags: MIRF_NO_SHAPE,
                      ct_class: MCT_NONE, reg_operands: 0x0, fused_cbr: MIR_OP_NONE },
-    MirOpDescriptor{ op: MIR_AGG_STORE, name: "MIR_AGG_STORE", class: SEL_CLASS_SPIRV_ONLY,
+    MirOpDescriptor{ op: MIR_VALUE_PARAM, name: "MIR_VALUE_PARAM", class: SEL_CLASS_SPIRV_ONLY,
                      operand_banks: "a*",
-                     flags: MIRF_NONE,
+                     flags: MIRF_NO_SHAPE,
                      ct_class: MCT_NONE, reg_operands: 0x0, fused_cbr: MIR_OP_NONE },
     MirOpDescriptor{ op: MIR_SEL_CBR_EQ, name: "MIR_SEL_CBR_EQ", class: SEL_CLASS_FUSED,
                      operand_banks: "ggnn",
@@ -748,6 +750,8 @@ pub val FCC_GE: u8 = 5;
 pub val MIR_VREG_NIL: u32 = 0xFFFFFFFF;
 
 pub val REG_CLASS_GP: u32 = 0;
+# every vreg of a values convention: never a bank index
+pub val REG_CLASS_VALUE: u32 = 0xFFFFFFFF;
 
 pub val ALU_MIN_WIDTH: u8 = 4;
 
@@ -1149,7 +1153,7 @@ pub fun op_block(block: u32) MirOperand {
 
 pub fun vreg_is_fp(fn: *MirFunction, vreg: u32) bool {
     if (vreg >= fn.vreg_count) { ret false; }
-    ret fn.vregs[vreg].class != REG_CLASS_GP;
+    ret fn.vregs[vreg].class != REG_CLASS_GP && fn.vregs[vreg].class != REG_CLASS_VALUE;
 }
 
 pub fun push_function(mm: *MirModule, mf: MirFunction) R.Result[R.Void, str] {
@@ -1403,7 +1407,7 @@ test "mach.lang.be.codegen.mir.opcode_name:total_and_distinct" {
     ops[81] = MIR_FCMP;        ops[82] = MIR_FNEG;
     ops[83] = MIR_VEC_BUILD;   ops[84] = MIR_MUL_HI_U;
     ops[85] = MIR_MEMZERO;     ops[86] = MIR_MEMCPY;
-    ops[87] = MIR_AGG_LOAD;    ops[88] = MIR_AGG_STORE;
+    ops[87] = MIR_VALUE_CALL;  ops[88] = MIR_VALUE_PARAM;
 
     var i: usize = 0;
     for (i < 89) {

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -271,10 +271,7 @@ fun agg_layout(ctx: *context.LowerCtx, ty: type.IrTypeId, is_aggr: bool) abi.Agg
 }
 
 fun advance_arg_cursors(slot: *abi.ParamSlot, gp_used: *i32, fp_used: *i32) {
-    if (slot.class == abi.CLASS_AGG) {
-        @gp_used = @gp_used + 1;
-        ret;
-    }
+
     var i: u32 = 0;
     for (i < slot.piece_count) {
         val k: abi.PieceKind = slot.pieces[i].kind;
@@ -472,6 +469,93 @@ fun call_ret_type(ctx: *context.LowerCtx, sig: type.IrTypeId, fallback: type.IrT
     ret fallback;
 }
 
+fun value_slot_valid(slot: *abi.ParamSlot, extent: u64) bool {
+    ret slot.class == abi.CLASS_VALUE && slot.size == extent && slot.reg == -1
+        && slot.piece_count == 0 && slot.offset == 0 && slot.indirect_size == 0 && slot.indirect_align == 0;
+}
+
+fun value_operand(ctx: *context.LowerCtx, v: value.Value) mir.MirOperand {
+    var op: mir.MirOperand = context.lower_value(ctx, v);
+    if (context.value_is_aggregate(ctx, v.ty) && op.kind == mir.MIR_OP_VREG) {
+        op = mir.op_mem_value(op.vreg, 0);
+    }
+    ret op;
+}
+
+fun push_value_instr(ctx: *context.LowerCtx, mb: *mir.MirBlock, opcode: mir.MirOpcode,
+                     ops: *mir.MirOperand, count: u32) R.Result[R.Void, str] {
+    val pushed: R.Result[R.Void, str] = context.push_instr(ctx, mb, mir.instr(opcode, ops, count, 0, 0));
+    if (R.is_err[R.Void, str](pushed)) { A.deallocate[mir.MirOperand](ctx.alloc, ops, count::usize); }
+    ret pushed;
+}
+
+fun lower_value_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.Instruction,
+                     iid: id.InstructionId, ret_type: type.IrTypeId, slots: *abi.SigLayout) R.Result[R.Void, str] {
+    val sig: O.Option[*type.IrType] = type.get(ctx.types, inst.aux_ty);
+    if (O.is_none[*type.IrType](sig)) { ret R.err[R.Void, str]("mir.abi: logical call requires a typed signature"); }
+    val fn_ty: *type.IrType = O.unwrap[*type.IrType](sig);
+    if (fn_ty.kind != type.IRT_FN || fn_ty.data.fn.variadic || inst.operand_count - 1 != slots.param_count) {
+        ret R.err[R.Void, str]("mir.abi: logical call requires exact nonvariadic arguments");
+    }
+    if (!value_slot_valid(?slots.ret_slot, type.byte_size_for_machine(ctx.types, ret_type, ctx.layout)::u64)) {
+        ret R.err[R.Void, str]("mir.abi: invalid logical result slot");
+    }
+    var i: u32 = 0;
+    for (i < slots.param_count) {
+        if (!value_slot_valid(?slots.params[i], type.byte_size_for_machine(ctx.types, fn_ty.data.fn.params[i], ctx.layout)::u64)) {
+            ret R.err[R.Void, str]("mir.abi: invalid logical argument slot");
+        }
+        i = i + 1;
+    }
+    val dst: u32 = context.instr_vreg(ctx, iid);
+    var result: mir.MirOperand = mir.op_vreg(dst);
+    if (context.value_is_aggregate(ctx, ret_type)) {
+        if (dst == mir.MIR_VREG_NIL) { ret R.err[R.Void, str]("mir.abi: logical composite call has no result owner"); }
+        val home: R.Result[R.Void, str] = context.alloc_object_storage(ctx, mb, dst, ret_type);
+        if (R.is_err[R.Void, str](home)) { ret home; }
+        result = mir.op_mem_value(dst, 0);
+    }
+    if (inst.operand_count == 0xFFFFFFFF) { ret R.err[R.Void, str]("mir.abi: logical call operand extent overflow"); }
+    val count: u32 = inst.operand_count + 1;
+    val ar: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, count::usize);
+    if (R.is_err[*mir.MirOperand, str](ar)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](ar)); }
+    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ar);
+    ops[0] = context.lower_value(ctx, inst.operands[0]);
+    ops[1] = result;
+    i = 0;
+    for (i < slots.param_count) { ops[i + 2] = value_operand(ctx, inst.operands[i + 1]); i = i + 1; }
+    ret push_value_instr(ctx, mb, mir.MIR_VALUE_CALL, ops, count);
+}
+
+fun lower_value_params(ctx: *context.LowerCtx, mb: *mir.MirBlock, slots: *abi.SigLayout) R.Result[R.Void, str] {
+    if (slots.param_count != ctx.param_count || slots.param_count != ctx.fn.param_count) {
+        ret R.err[R.Void, str]("mir.abi: logical parameter signature does not match its bindings");
+    }
+    var i: u32 = 0;
+    for (i < slots.param_count) {
+        val ty: type.IrTypeId = ctx.fn.params[i].ty;
+        if (!value_slot_valid(?slots.params[i], type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64)) {
+            ret R.err[R.Void, str]("mir.abi: invalid logical parameter slot");
+        }
+        val dst: u32 = ctx.param_vregs[i];
+        var dest: mir.MirOperand = mir.op_vreg(dst);
+        if (context.value_is_aggregate(ctx, ty)) {
+            val home: R.Result[R.Void, str] = context.alloc_object_storage(ctx, mb, dst, ty);
+            if (R.is_err[R.Void, str](home)) { ret home; }
+            dest = mir.op_mem_value(dst, 0);
+        }
+        val ar: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+        if (R.is_err[*mir.MirOperand, str](ar)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](ar)); }
+        val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ar);
+        ops[0] = dest;
+        ops[1] = mir.op_imm(i::i64);
+        val pushed: R.Result[R.Void, str] = push_value_instr(ctx, mb, mir.MIR_VALUE_PARAM, ops, 2);
+        if (R.is_err[R.Void, str](pushed)) { ret pushed; }
+        i = i + 1;
+    }
+    ret R.ok_void[str]();
+}
+
 pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
     if (inst.operand_count == 0) {
         ret R.err[R.Void, str]("mir.lower_ir: call with no callee operand");
@@ -491,6 +575,12 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     var layout: abi.SigLayout;
     val cls: R.Result[R.Void, str] = classify_signature(ctx, sig, ret_type, ?layout);
     if (R.is_err[R.Void, str](cls)) { ret cls; }
+
+    if (context.values_convention(ctx)) {
+        val vr: R.Result[R.Void, str] = lower_value_call(ctx, mb, inst, iid, ret_type, ?layout);
+        sig_layout_free(ctx, ?layout);
+        ret vr;
+    }
 
     val rslot: abi.ParamSlot = layout.ret_slot;
 
@@ -519,28 +609,24 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     var sret_ptr: u32 = mir.MIR_VREG_NIL;
     if (ret_mem && res_dst != mir.MIR_VREG_NIL) {
         var ra: R.Result[R.Void, str] = R.ok_void[str]();
-        if (rslot.class == abi.CLASS_AGG) {
-            ra = context.alloc_object_storage(ctx, mb, res_dst, ret_type);
-        } or {
-            var owned_size: u64 = ret_size;
-            if (rslot.class != abi.CLASS_SRET) {
-                val extent: R.Result[u64, str] = abi.carrier_storage_extent(?rslot);
-                if (R.is_err[u64, str](extent)) {
-                    sig_layout_free(ctx, ?layout);
-                    ret R.err[R.Void, str](R.unwrap_err[u64, str](extent));
-                }
-                owned_size = R.unwrap_ok[u64, str](extent);
-                val alignment: R.Result[u32, str] = abi.carrier_storage_alignment(?rslot);
-                if (R.is_err[u32, str](alignment)) {
-                    sig_layout_free(ctx, ?layout);
-                    ret R.err[R.Void, str](R.unwrap_err[u32, str](alignment));
-                }
-                if (R.unwrap_ok[u32, str](alignment) > ret_storage_align) {
-                    ret_storage_align = R.unwrap_ok[u32, str](alignment);
-                }
+        var owned_size: u64 = ret_size;
+        if (rslot.class != abi.CLASS_SRET) {
+            val extent: R.Result[u64, str] = abi.carrier_storage_extent(?rslot);
+            if (R.is_err[u64, str](extent)) {
+                sig_layout_free(ctx, ?layout);
+                ret R.err[R.Void, str](R.unwrap_err[u64, str](extent));
             }
-            ra = context.alloc_result_storage(ctx, mb, res_dst, owned_size, ret_storage_align);
+            owned_size = R.unwrap_ok[u64, str](extent);
+            val alignment: R.Result[u32, str] = abi.carrier_storage_alignment(?rslot);
+            if (R.is_err[u32, str](alignment)) {
+                sig_layout_free(ctx, ?layout);
+                ret R.err[R.Void, str](R.unwrap_err[u32, str](alignment));
+            }
+            if (R.unwrap_ok[u32, str](alignment) > ret_storage_align) {
+                ret_storage_align = R.unwrap_ok[u32, str](alignment);
+            }
         }
+        ra = context.alloc_result_storage(ctx, mb, res_dst, owned_size, ret_storage_align);
         if (R.is_err[R.Void, str](ra)) {
             sig_layout_free(ctx, ?layout);
             ret ra;
@@ -964,9 +1050,7 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, registers: *mir.Mir
         if (R.is_err[R.Void, str](ar)) { ret ar; }
         ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg::u32), mir.op_vreg(base), ptr_move_width(ctx));
     }
-    if (slot.class == abi.CLASS_AGG) {
-        ret context.emit_agg_load(ctx, registers, slot.reg::u32, argop);
-    }
+
     if (is_aggr) {
         var base: u32 = mir.MIR_VREG_NIL;
         val ar: R.Result[R.Void, str] = context.addr_to_vreg(ctx, mb, argop, ?base);
@@ -1083,9 +1167,7 @@ fun record_outgoing_size(ctx: *context.LowerCtx, bytes: i64) {
 }
 
 fun emit_ret_slot_to_vreg(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, dst: u32, is_aggr: bool, ty: type.IrTypeId, owned_align: u32) R.Result[R.Void, str] {
-    if (slot.class == abi.CLASS_AGG) {
-        ret context.emit_agg_store(ctx, mb, mir.op_mem_value(dst, 0), slot.reg::u32);
-    }
+
     if (is_aggr) {
         val extent: R.Result[u64, str] = abi.carrier_storage_extent(?slot);
         if (R.is_err[u64, str](extent)) { ret R.err[R.Void, str](R.unwrap_err[u64, str](extent)); }
@@ -1111,6 +1193,12 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[R.Void,
     var layout: abi.SigLayout;
     val cls: R.Result[R.Void, str] = classify_signature(ctx, ctx.fn.sig, ret_type, ?layout);
     if (R.is_err[R.Void, str](cls)) { ret cls; }
+
+    if (context.values_convention(ctx)) {
+        val vr: R.Result[R.Void, str] = lower_value_params(ctx, mb, ?layout);
+        sig_layout_free(ctx, ?layout);
+        ret vr;
+    }
 
     if (layout.ret_slot.class == abi.CLASS_SRET) {
         val sret_reg: i32 = ctx.tgt.abi.indirect_result_reg;
@@ -1203,11 +1291,7 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, copies: *mir.MirB
     if (slot.class == abi.CLASS_BYREF) {
         ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), mir.op_preg(slot.reg::u32), ptr_move_width(ctx));
     }
-    if (slot.class == abi.CLASS_AGG) {
-        val ar: R.Result[R.Void, str] = context.alloc_object_storage(ctx, mb, pv, ty);
-        if (R.is_err[R.Void, str](ar)) { ret ar; }
-        ret context.emit_agg_store(ctx, mb, mir.op_mem_value(pv, 0), slot.reg::u32);
-    }
+
     if (is_aggr) {
         val extent: R.Result[u64, str] = abi.carrier_storage_extent(?slot);
         if (R.is_err[u64, str](extent)) { ret R.err[R.Void, str](R.unwrap_err[u64, str](extent)); }
@@ -1291,10 +1375,14 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
     ctx.cur_writes_secret = rv.secret;
     fin { ctx.cur_writes_secret = false; }
 
-    if (slot.class == abi.CLASS_AGG) {
-        val lr: R.Result[R.Void, str] = context.emit_agg_load(ctx, mb, slot.reg::u32, rvop);
-        if (R.is_err[R.Void, str](lr)) { ret lr; }
-        ret emit_bare_ret(ctx, mb);
+
+    if (context.values_convention(ctx)) {
+        if (!value_slot_valid(?slot, rsz)) { ret R.err[R.Void, str]("mir.abi: invalid logical result slot"); }
+        val ar: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 1::usize);
+        if (R.is_err[*mir.MirOperand, str](ar)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](ar)); }
+        val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ar);
+        ops[0] = value_operand(ctx, rv);
+        ret push_value_instr(ctx, mb, mir.MIR_RET, ops, 1);
     }
     if (slot.class == abi.CLASS_SRET) {
         if (ctx.sret_vreg == mir.MIR_VREG_NIL) {

--- a/src/lang/be/codegen/mir/bulk.mach
+++ b/src/lang/be/codegen/mir/bulk.mach
@@ -5,6 +5,8 @@ use mach.lang.be.codegen.ctvalidate;
 use mach.lang.target.isa;
 use O: std.types.option;
 use mach.lang.target.resolved;
+use mach.lang.target.abi;
+use target_testing: mach.lang.target.testing;
 use R: std.types.result;
 use std.types.bool.bool;
 use std.types.bool.true;
@@ -599,6 +601,8 @@ fun t_case_model(size: u64, src: u64, dst: u64, copy: bool, pointer_width: u32, 
     fin { mir.dnit_function(?alloc, ?f); }
     var ctx: context.LowerCtx;
     ctx.alloc = ?alloc;
+    var convention: abi.AbiVTable = target_testing.carriers_convention();
+    tgt.abi = ?convention;
     ctx.tgt = ?tgt;
     ctx.f = ?f;
     if (R.is_err[R.Void, str](t_setup(?ctx, size, copy))) { ret 2; }
@@ -660,7 +664,9 @@ test "mach.lang.be.codegen.mir.bulk:bounded_shape_secrecy_and_debug_ownership" {
         fin { mir.dnit_function(?alloc, ?f); }
         var ctx: context.LowerCtx;
         ctx.alloc = ?alloc;
-        ctx.tgt = ?tgt;
+        var convention: abi.AbiVTable = target_testing.carriers_convention();
+    tgt.abi = ?convention;
+    ctx.tgt = ?tgt;
         ctx.f = ?f;
         if (R.is_err[R.Void, str](t_setup(?ctx, sizes[si], true))) { ret 2; }
         if (R.is_err[R.Void, str](expand(?ctx))) { ret 3; }
@@ -772,7 +778,9 @@ test "mach.lang.be.codegen.mir.bulk:every_allocation_failure_releases_owned_stor
         var f: mir.MirFunction;
         var ctx: context.LowerCtx;
         ctx.alloc = ?alloc;
-        ctx.tgt = ?tgt;
+        var convention: abi.AbiVTable = target_testing.carriers_convention();
+    tgt.abi = ?convention;
+    ctx.tgt = ?tgt;
         ctx.f = ?f;
         if (R.is_err[R.Void, str](t_setup(?ctx, 257, true))) { mir.dnit_function(?alloc, ?f); ret 2; }
         val before: u32 = probe.calls;
@@ -812,6 +820,8 @@ test "mach.lang.be.codegen.mir.bulk:secret_payload_accepts_public_addresses_and_
     f.oblivious = true;
     var ctx: context.LowerCtx;
     ctx.alloc = ?alloc;
+    var convention: abi.AbiVTable = target_testing.carriers_convention();
+    tgt.abi = ?convention;
     ctx.tgt = ?tgt;
     ctx.f = ?f;
     if (R.is_err[R.Void, str](t_setup(?ctx, 257, true))) { ret 2; }
@@ -873,7 +883,9 @@ test "mach.lang.be.codegen.mir.bulk:common_copies_bound_live_pieces_and_large_co
             fin { mir.dnit_function(?alloc, ?f); }
             var ctx: context.LowerCtx;
             ctx.alloc = ?alloc;
-            ctx.tgt = ?tgt;
+            var convention: abi.AbiVTable = target_testing.carriers_convention();
+    tgt.abi = ?convention;
+    ctx.tgt = ?tgt;
             ctx.f = ?f;
             if (R.is_err[R.Void, str](t_setup(?ctx, sizes[si], mode == 1))) { ret 2; }
             f.blocks[0].instrs[0].memory_flags = 0;

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -24,7 +24,9 @@ use ir_type: mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.source;
 use mach.lang.target.isa;
+use mach.lang.target.abi;
 use target:  mach.lang.target.resolved;
+use target_testing: mach.lang.target.testing;
 
 pub rec LowerCtx {
     alloc:       *A.Allocator;
@@ -169,6 +171,11 @@ pub fun drain_pending_dbg(ctx: *LowerCtx, mi: *mir.MirInstr) R.Result[R.Void, st
     ret R.ok_void[str]();
 }
 
+# the convention declares how values cross a call: a values convention has no banks, so every vreg is a value
+pub fun values_convention(ctx: *LowerCtx) bool {
+    ret ctx.tgt.abi.passing == abi.PASSING_VALUES;
+}
+
 pub fun new_vreg(ctx: *LowerCtx, reg_class: u32) R.Result[u32, str] {
     val f: *mir.MirFunction = ctx.f;
     if (f.vreg_count >= f.vreg_cap) {
@@ -179,7 +186,9 @@ pub fun new_vreg(ctx: *LowerCtx, reg_class: u32) R.Result[u32, str] {
         f.vreg_cap = new_cap;
     }
     val vid: u32 = f.vreg_count;
-    f.vregs[vid] = mir.vreg(vid, reg_class, false, false);
+    var selected_class: u32 = reg_class;
+    if (values_convention(ctx)) { selected_class = mir.REG_CLASS_VALUE; }
+    f.vregs[vid] = mir.vreg(vid, selected_class, false, false);
     f.vreg_count = f.vreg_count + 1;
     ret R.ok[u32, str](vid);
 }
@@ -583,16 +592,6 @@ pub fun copy_aggregate(ctx: *LowerCtx, mb: *mir.MirBlock, dst_mem: mir.MirOperan
               ctx.tgt.model.pointer_width::u8, ctx.tgt.model.pointer_width::u8);
 }
 
-pub fun emit_agg_load(ctx: *LowerCtx, mb: *mir.MirBlock, pos: u32, src_mem: mir.MirOperand) R.Result[R.Void, str] {
-    ret inst2(ctx, mb, mir.MIR_AGG_LOAD, mir.op_preg(pos), src_mem,
-              ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
-}
-
-pub fun emit_agg_store(ctx: *LowerCtx, mb: *mir.MirBlock, dst_mem: mir.MirOperand, pos: u32) R.Result[R.Void, str] {
-    ret inst2(ctx, mb, mir.MIR_AGG_STORE, dst_mem, mir.op_preg(pos),
-              ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
-}
-
 pub fun alloc_object_storage(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, ty: ir_type.IrTypeId) R.Result[R.Void, str] {
     val res_key: R.Result[u32, str] = new_vreg(ctx, mir.REG_CLASS_GP);
     if (R.is_err[u32, str](res_key)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_key)); }
@@ -656,6 +655,7 @@ fun param_vreg(ctx: *LowerCtx, ix: u32) u32 {
 }
 
 fun reg_class_of(ctx: *LowerCtx, tgt: *target.Target, ty: ir_type.IrTypeId) u32 {
+    if (values_convention(ctx)) { ret mir.REG_CLASS_VALUE; }
     val opt_type: O.Option[*ir_type.IrType] = ir_type.get(ctx.types, ty);
     if (O.is_some[*ir_type.IrType](opt_type)) {
         val t: *ir_type.IrType = O.unwrap[*ir_type.IrType](opt_type);
@@ -840,6 +840,8 @@ test "mach.lang.be.codegen.mir.context.vector_scaffolding" {
     var ctx: LowerCtx;
     ctx.alloc = ?alloc;
     ctx.types = ?types;
+    var convention: abi.AbiVTable = target_testing.carriers_convention();
+    tgt.abi   = ?convention;
     ctx.tgt   = ?tgt;
     ctx.layout = target.layout_machine(?tgt);
 
@@ -907,6 +909,8 @@ test "mach.lang.be.codegen.mir.context.op_width_is_a_fact_about_the_value" {
     tgt.model.reg_class_len = 1;
     var ctx: LowerCtx;
     ctx.types = ?types;
+    var convention: abi.AbiVTable = target_testing.carriers_convention();
+    tgt.abi   = ?convention;
     ctx.tgt   = ?tgt;
     ctx.layout = target.layout_machine(?tgt);
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -17880,6 +17880,7 @@ val UT_AGG_TY_SCALAR: u8 = 1;
 val UT_AGG_TY_SEQ:    u8 = 2;
 val UT_AGG_TY_STRUCT: u8 = 3;
 val UT_AGG_TY_PTR:    u8 = 4;
+val UT_AGG_TY_VOID:   u8 = 5;
 
 rec UtAggEval {
     ty_kind:  [1024]u8;
@@ -17965,7 +17966,8 @@ fun ut_agg_prepare(st: *UtAggEval, w: *u32, n: u32) bool {
         if (op == spirv.OP_TYPE_VOID || op == spirv.OP_TYPE_BOOL) {
             val r: u32 = w[i + 1];
             if (r >= UT_AGG_IDS) { ret false; }
-            st.ty_kind[r] = UT_AGG_TY_SCALAR; st.ty_words[r] = 1; st.ty_bits[r] = 32;
+            if (op == spirv.OP_TYPE_VOID) { st.ty_kind[r] = UT_AGG_TY_VOID; }
+            or { st.ty_kind[r] = UT_AGG_TY_SCALAR; st.ty_words[r] = 1; st.ty_bits[r] = 32; }
         }
         or (op == spirv.OP_TYPE_INT || op == spirv.OP_TYPE_FLOAT) {
             val r: u32 = w[i + 1];
@@ -18110,7 +18112,15 @@ fun ut_agg_bind_params(st: *UtAggEval, w: *u32, n: u32, fn: u32, arg_first: u32,
         val pid: u32 = w[i + 2];
         val aid: u32 = w[arg_first + k];
         if (pty >= UT_AGG_IDS || pid >= UT_AGG_IDS || aid >= UT_AGG_IDS) { ret false; }
-        if (!ut_agg_copy(st, pid, 0, aid, 0, st.ty_words[pty])) { ret false; }
+        if (st.ty_kind[pty] == UT_AGG_TY_PTR) {
+            if (!st.is_ptr[aid] || st.ptr_ty[aid] != st.ty_elem[pty]) { ret false; }
+            st.is_ptr[pid] = true;
+            st.ptr_blk[pid] = st.ptr_blk[aid];
+            st.ptr_off[pid] = st.ptr_off[aid];
+            st.ptr_ty[pid] = st.ptr_ty[aid];
+        } or {
+            if (!ut_agg_copy(st, pid, 0, aid, 0, st.ty_words[pty])) { ret false; }
+        }
         st.val_ty[pid] = pty;
         k = k + 1;
         i = i + (w[i] >> 16);
@@ -18194,7 +18204,7 @@ fun ut_agg_exec(st: *UtAggEval, w: *u32, n: u32, entry: u32) bool {
             i = i + len; cnt;
         }
 
-        if (op == spirv.OP_U_CONVERT) {
+        if (op == spirv.OP_U_CONVERT || op == spirv.OP_BITCAST) {
             val ty:  u32 = w[i + 1];
             val res: u32 = w[i + 2];
             val src: u32 = w[i + 3];
@@ -18279,9 +18289,12 @@ fun ut_agg_exec(st: *UtAggEval, w: *u32, n: u32, entry: u32) bool {
 
         if (op == spirv.OP_RETURN) {
             if (sp == 0) { ret true; }
-            ret false;
+            sp = sp - 1;
+            if (r_ty[sp] >= UT_AGG_IDS || st.ty_kind[r_ty[sp]] != UT_AGG_TY_VOID) { ret false; }
+            i = r_ix[sp]; cnt;
         }
 
+        print.eprintlnf("SPIR-V fixture cannot interpret opcode {} at word {}", op, i);
         ret false;
     }
     ret false;
@@ -18364,8 +18377,8 @@ fun ut_agg_ops_and_loads(mm: *mir.MirModule, out_loads: *u32) u32 {
             val blk: *mir.MirBlock = ?mf.blocks[bi];
             var ii: u32 = 0;
             for (ii < blk.instr_count) {
-                if (blk.instrs[ii].opcode == mir.MIR_AGG_LOAD)  { ac = ac + 1; }
-                if (blk.instrs[ii].opcode == mir.MIR_AGG_STORE) { ac = ac + 1; }
+                if (blk.instrs[ii].opcode == mir.MIR_VALUE_CALL)  { ac = ac + 1; }
+                if (blk.instrs[ii].opcode == mir.MIR_VALUE_PARAM) { ac = ac + 1; }
                 if (blk.instrs[ii].opcode == mir.MIR_LOAD)      { ld = ld + 1; }
                 ii = ii + 1;
             }
@@ -18448,7 +18461,7 @@ test "mach.lang.driver:a_spirv_backend_refusal_is_located" {
     var bad: i32 = 0;
     if (ut_spv_codegen(?p, ?s, "spvcase.main", ?img, ?err)) { bad = 1; }
     or {
-        if (!ut_str_contains(err, "MIR_CALL")) { bad = 1; }
+        if (!ut_str_contains(err, "MIR_VALUE_CALL")) { bad = 1; }
         if (!ut_str_contains(err, " in vs,"))  { bad = 1; }
         if (!ut_str_contains(err, "main.mach:")) { bad = 1; }
         if (ut_str_contains(err, "no source location on this instruction")) { bad = 1; }
@@ -19043,8 +19056,8 @@ fun ut_symaddr_and_agg(mm: *mir.MirModule, flat: bool, out_agg: *u32) u32 {
                     && mi.operands[1].kind == mir.MIR_OP_SYM) { lea = lea + 1; }
                 if (flat && mi.opcode == mir.MIR_STORE && mi.operand_count == 2
                     && mi.operands[0].kind == mir.MIR_OP_SYM) { lea = lea + 1; }
-                if (mi.opcode == mir.MIR_AGG_LOAD)  { ac = ac + 1; }
-                if (mi.opcode == mir.MIR_AGG_STORE) { ac = ac + 1; }
+                if (mi.opcode == mir.MIR_VALUE_CALL)  { ac = ac + 1; }
+                if (mi.opcode == mir.MIR_VALUE_PARAM) { ac = ac + 1; }
                 if (mi.opcode == mir.MIR_MEMCPY || mi.opcode == mir.MIR_MEMZERO) { ac = ac + 1; }
                 ii = ii + 1;
             }
@@ -21094,4 +21107,116 @@ test "mach.lang.driver:declaration_cast_gates_resolve_local_and_imported_type_al
     ret ut_single_ok2(
         "use Flag: uniontest.lib.Flag;\ndef Local: u8;\n$if ((1::Local) == 1u8) { fun local_selected() i32 { ret 1; } } $or { use uniontest.missing; }\n$if ((0::Flag) == 1u8) { use uniontest.missing; } $or { fun imported_selected() i32 { ret 2; } }\nfun main() i32 { ret local_selected() + imported_selected(); }\n",
         "pub def Flag: u8;\n");
+}
+
+test "mach.lang.driver:logical_value_abi_preserves_mixed_arguments_and_references_on_spirv" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
+    var names: [1]str = [1]str{"main.mach"};
+    var texts: [1]str;
+    texts[0] = "rec Pair { a: u32; b: u32; }\n#[noinline] fun fill(p: *Pair, v: u32) { p.a = v; p.b = v + 1; }\n#[noinline] fun forwarded(p: *Pair, v: u32) { fill(p, v); }\n#[noinline] fun many(i0: u32, i1: u32, i2: u32, i3: u32, i4: u32, i5: u32, i6: u32, i7: u32, i8: u32, i9: u32, i10: u32, i11: u32, i12: u32, i13: u32, i14: u32, i15: u32, i16: u32, f: f32, q: Pair, p: *Pair, v: u32x4) Pair {\n    forwarded(p, 8);\n    ret Pair{a: i0 + i1 + i2 + i3 + i4 + i5 + i6 + i7 + i8 + i9 + i10 + i11 + i12 + i13 + i14 + i15 + i16 + (f:~u32) + q.a + q.b + p.a + p.b + v[0] + v[3], b: i16};\n}\n#[output(0)] var output_value: u32;\n#[output(1)] var output_tail: u32;\n#[output(2)] var output_reference: u32;\n#[stage(\"vertex\")] fun vs() {\n    var q: Pair = Pair{a: 7, b: 8};\n    val r: Pair = many(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 1.0, q, ?q, u32x4{2, 3, 4, 5});\n    output_value = r.a;\n    output_tail = r.b;\n    output_reference = q.a + q.b;\n}\nfun main() i32 { ret 0; }\n";
+    val pr: R.Result[project.Project, outcome.Fail] = ut_spv_lower(?s, ?alloc,
+        ?names[0], ?texts[0], 1, "", nil, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](pr)) { ret 2; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    fin { project.dnit_project(?p); }
+    var image: of.ObjectImage;
+    var error: str = nil;
+    if (!ut_spv_codegen(?p, ?s, "spvcase.main", ?image, ?error)) {
+        print.eprintlnf("{}", error);
+        ret 3;
+    }
+    fin { obj.dnit(?image); }
+    val actual_value: u64 = ut_spv_read_location(?alloc, ?image, 0);
+    if (actual_value != 1065353408) { print.eprintlnf("logical value checksum: got {}, expected 1065353408", actual_value); ret 4; }
+    val actual_tail: u64 = ut_spv_read_location(?alloc, ?image, 1);
+    if (actual_tail != 17) { print.eprintlnf("logical tail: got {}, expected 17", actual_tail); ret 5; }
+    val actual_reference: u64 = ut_spv_read_location(?alloc, ?image, 2);
+    if (actual_reference != 17) { print.eprintlnf("logical reference: got {}, expected 17", actual_reference); ret 6; }
+    var count: u32 = 0;
+    val words: *u32 = ut_spv_words(?image, ?count);
+    if (words == nil || count == 0) { ret 7; }
+    var at: u32 = 0;
+    var found: bool = false;
+    for (at < count) {
+        val width: u32 = words[at] >> 16;
+        if (width == 0 || width > count - at) { ret 7; }
+        if ((words[at] & 0xFFFF) == spirv.OP_FUNCTION_CALL && width == 25) { found = true; }
+        at = at + width;
+    }
+    if (!found) { ret 8; }
+    ret 0;
+}
+
+fun ut_spv_reference_refusal(text: str, needle: str, during_lower: bool) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
+    var names: [1]str = [1]str{"main.mach"};
+    var texts: [1]str = [1]str{text};
+    val pr: R.Result[project.Project, outcome.Fail] = ut_spv_lower(?s, ?alloc,
+        ?names[0], ?texts[0], 1, "", nil, nil, 0);
+    if (R.is_err[project.Project, outcome.Fail](pr)) {
+        if (!during_lower || R.unwrap_err[project.Project, outcome.Fail](pr).kind != outcome.FAIL_REPORTED
+            || !ut_diag_has(?s.diags, needle)) { ret 2; }
+        ret 0;
+    }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](pr);
+    fin { project.dnit_project(?p); }
+    if (during_lower) { ret 3; }
+    var image: of.ObjectImage;
+    var error: str = nil;
+    if (ut_spv_codegen(?p, ?s, "spvcase.main", ?image, ?error)) { obj.dnit(?image); ret 4; }
+    if (!ut_str_contains(error, needle) || !ut_str_contains(error, "main.mach:")
+        || ut_str_contains(error, "no source location")) { print.eprintlnf("{}", error); ret 5; }
+    ret 0;
+}
+
+test "mach.lang.driver:logical_shader_reference_capabilities_refuse_returns_subobjects_and_cycles" {
+    val returned: i32 = ut_spv_reference_refusal(
+        "rec Pair { a: u32; b: u32; }\n#[noinline] fun identity(p: *Pair) *Pair { ret p; }\n#[output(0)] var o: u32;\n#[stage(\"vertex\")] fun vs() { var q: Pair = Pair{a: 1, b: 2}; val p: *Pair = identity(?q); o = p.a; }\nfun main() i32 { ret 0; }\n",
+        "does not support Function-storage reference results", false);
+    if (returned != 0) { ret returned; }
+    val subobject: i32 = ut_spv_reference_refusal(
+        "rec Pair { a: u32; b: u32; }\nrec Outer { lead: u32; pair: Pair; }\n#[noinline] fun read(p: *Pair) u32 { ret p.a; }\n#[output(0)] var o: u32;\n#[stage(\"vertex\")] fun vs() { var q: Outer = Outer{lead: 0, pair: Pair{a: 1, b: 2}}; o = read(?q.pair); }\nfun main() i32 { ret 0; }\n",
+        "not a subobject access chain", false);
+    if (subobject != 0) { ret 10 + subobject; }
+    val recursive: i32 = ut_spv_reference_refusal(
+        "rec Node { next: *Node; value: u32; }\n#[noinline] fun read(p: *Node) u32 { ret p.value; }\n#[output(0)] var o: u32;\n#[stage(\"vertex\")] fun vs() { var n: Node; o = read(?n); }\nfun main() i32 { ret 0; }\n",
+        "recursive reference types require pointer capabilities", true);
+    if (recursive != 0) { ret 20 + recursive; }
+    ret 0;
+}
+
+
+test "mach.lang.driver:spirv_debug_request_is_refused_by_the_declared_target_policy" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val sr: R.Result[session.Session, str] = session.init(?alloc);
+    if (R.is_err[session.Session, str](sr)) { ret 1; }
+    var s: session.Session = R.unwrap_ok[session.Session, str](sr);
+    fin { session.dnit(?s); }
+    val ps: R.Result[project.Project, outcome.Fail] = ut_ct_edge_project(?s, ?alloc, "fun main() i32 { ret 0; }\n", "spv");
+    if (R.is_err[project.Project, outcome.Fail](ps)) { ret 2; }
+    var p: project.Project = R.unwrap_ok[project.Project, outcome.Fail](ps);
+    fin { project.dnit_project(?p); }
+    if (p.target.debug != nil) { ret 3; }
+    p.req.debug = true;
+    if (ut_run_codegen_err(?p, "registers no debug model") != 0) { ret 4; }
+    p.req.debug = false;
+    if (ut_run_codegen_ok(?p) != 0) { ret 5; }
+    ret 0;
+}
+
+test "mach.lang.driver:logical_shader_refuses_a_function_value_parameter_with_its_type" {
+    ret ut_spv_reference_refusal(
+        "fun add1(v: u32) u32 { ret v + 1; }\n#[noinline] fun apply(f: fun(u32) u32, v: u32) u32 { ret f(v); }\n#[output(0)] var o: u32;\n#[stage(\"vertex\")] fun vs() { o = apply(add1, 4); }\nfun main() i32 { ret 0; }\n",
+        "logical addressing has no function pointers", false);
 }

--- a/src/lang/me/ir/printer.mach
+++ b/src/lang/me/ir/printer.mach
@@ -942,7 +942,13 @@ pub fun print_type(out: *writer.Writer, m: *ir.Module, tid: type.IrTypeId) R.Res
         if (R.is_err[R.Void, str](res_tag)) { ret res_tag; }
         ret emit_u64(out, t.data.bits::u64);
     }
-    if (t.kind == type.IRT_PTR) { ret emit_str(out, "ptr"); }
+    if (t.kind == type.IRT_PTR) {
+        val prefix: R.Result[R.Void, str] = emit_str(out, "ptr");
+        if (R.is_err[R.Void, str](prefix) || t.data.pointee == type.IRT_NIL) { ret prefix; }
+        val space: R.Result[R.Void, str] = emit_str(out, " ");
+        if (R.is_err[R.Void, str](space)) { ret space; }
+        ret print_type_ref(out, t.data.pointee);
+    }
     if (t.kind == type.IRT_ARRAY) {
         val res_open: R.Result[R.Void, str] = emit_str(out, "[");
         if (R.is_err[R.Void, str](res_open)) { ret res_open; }

--- a/src/lang/me/ir/type.mach
+++ b/src/lang/me/ir/type.mach
@@ -66,6 +66,7 @@ pub rec IrType {
     kind: IrTypeKind;
     data: uni {
         bits:    u32;
+        pointee: IrTypeId;
         array_:  IrTypeArray;
         vector_: IrTypeVector;
         handle_: IrTypeHandle;
@@ -126,6 +127,13 @@ pub fun dnit(t: *IrTypeTable) {
 pub fun get(t: *IrTypeTable, id: IrTypeId) O.Option[*IrType] {
     if (id >= t.len) { ret O.none[*IrType](); }
     ret O.some[*IrType](?t.types[id]);
+}
+
+pub fun reference_valid(t: *IrTypeTable, id: IrTypeId) bool {
+    if (id >= t.len) { ret false; }
+    val ty: *IrType = ?t.types[id];
+    if (ty.kind != IRT_PTR || ty.data.pointee == IRT_NIL) { ret true; }
+    ret ty.data.pointee < id && t.types[ty.data.pointee].kind != IRT_VOID;
 }
 
 pub fun array_count(t: *IrTypeTable, id: IrTypeId) u32 {
@@ -208,8 +216,18 @@ pub fun intern_float(t: *IrTypeTable, bits: u32) R.Result[IrTypeId, str] {
 
 pub fun intern_ptr(t: *IrTypeTable) R.Result[IrTypeId, str] {
     var ir: IrType;
-    ir.kind      = IRT_PTR;
-    ir.data.bits = 0;
+    ir.kind         = IRT_PTR;
+    ir.data.pointee = IRT_NIL;
+    ret intern_inline(t, ir);
+}
+
+pub fun intern_reference(t: *IrTypeTable, pointee: IrTypeId) R.Result[IrTypeId, str] {
+    if (pointee >= t.len || t.types[pointee].kind == IRT_VOID) {
+        ret R.err[IrTypeId, str]("ir.type: reference requires a defined object type");
+    }
+    var ir: IrType;
+    ir.kind = IRT_PTR;
+    ir.data.pointee = pointee;
     ret intern_inline(t, ir);
 }
 
@@ -454,6 +472,7 @@ fun hash_ir_type(p: ptr) u64 {
         h = fnv1a.step_u32(h, ir.data.bits);
         ret h;
     }
+    if (ir.kind == IRT_PTR) { ret fnv1a.step_u32(h, ir.data.pointee); }
     if (ir.kind == IRT_ARRAY) {
         h = fnv1a.step_u32(h, ir.data.array_.element);
         h = fnv1a.step_u32(h, ir.data.array_.count);
@@ -510,6 +529,7 @@ fun eq_ir_type(pa: ptr, pb: ptr) bool {
     if (a.kind == IRT_INT || a.kind == IRT_FLOAT) {
         ret a.data.bits == b.data.bits;
     }
+    if (a.kind == IRT_PTR) { ret a.data.pointee == b.data.pointee; }
     if (a.kind == IRT_ARRAY) {
         ret a.data.array_.element == b.data.array_.element
             && a.data.array_.count == b.data.array_.count;
@@ -684,5 +704,29 @@ test "mach.lang.me.ir.type.intern_vector:dedup_size_align" {
     if (byte_align_for_machine(?types, vecty, machine) != 4)  { dnit(?types); ret 1; }
 
     dnit(?types);
+    ret 0;
+}
+
+test "mach.lang.me.ir.type:logical_references_preserve_pointee_identity" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var tt: IrTypeTable;
+    if (O.is_some[str](init(?tt, ?alloc))) { ret 1; }
+    fin { dnit(?tt); }
+    val i32r: R.Result[IrTypeId, str] = intern_int(?tt, 32);
+    val i64r: R.Result[IrTypeId, str] = intern_int(?tt, 64);
+    val opaque: R.Result[IrTypeId, str] = intern_ptr(?tt);
+    if (R.is_err[IrTypeId, str](i32r) || R.is_err[IrTypeId, str](i64r) || R.is_err[IrTypeId, str](opaque)) { ret 2; }
+    val p32: R.Result[IrTypeId, str] = intern_reference(?tt, R.unwrap_ok[IrTypeId, str](i32r));
+    val p64: R.Result[IrTypeId, str] = intern_reference(?tt, R.unwrap_ok[IrTypeId, str](i64r));
+    if (R.is_err[IrTypeId, str](p32) || R.is_err[IrTypeId, str](p64)) { ret 3; }
+    val a: IrTypeId = R.unwrap_ok[IrTypeId, str](p32);
+    val b: IrTypeId = R.unwrap_ok[IrTypeId, str](p64);
+    if (a == b || a == R.unwrap_ok[IrTypeId, str](opaque) || b == R.unwrap_ok[IrTypeId, str](opaque)) { ret 4; }
+    val again: R.Result[IrTypeId, str] = intern_reference(?tt, R.unwrap_ok[IrTypeId, str](i32r));
+    if (R.is_err[IrTypeId, str](again) || R.unwrap_ok[IrTypeId, str](again) != a) { ret 5; }
+    if (byte_size_for_machine(?tt, a, layout.machine(4, 0)) != 4
+        || byte_align_for_machine(?tt, a, layout.machine(8, 0)) != 8) { ret 6; }
+    if (R.is_ok[IrTypeId, str](intern_reference(?tt, IRT_NIL))) { ret 7; }
     ret 0;
 }

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -502,7 +502,7 @@ fun check_one_instr(m: *ir.Module, fn: *ir.Function, iid: id.InstructionId, fi: 
         if (o.repr) {
             if (op.ty != type.IRT_NIL) {
                 val ot: O.Option[*type.IrType] = type.get(?m.types, op.ty);
-                if (!O.is_some[*type.IrType](ot)) {
+                if (!O.is_some[*type.IrType](ot) || !type.reference_valid(?m.types, op.ty)) {
                     val rr: R.Result[R.Void, str] = push(r, fi, bid, iid, VC_TYPE_RESOLVE);
                     if (R.is_err[R.Void, str](rr)) { ret rr; }
                 }
@@ -567,7 +567,7 @@ fun check_aux_resolve(m: *ir.Module, ins: *instruction.Instruction, fi: u32, bid
     val ty: type.IrTypeId = ins.aux_ty;
 
     val at: O.Option[*type.IrType] = type.get(?m.types, ty);
-    if (!O.is_some[*type.IrType](at)) {
+    if (!O.is_some[*type.IrType](at) || !type.reference_valid(?m.types, ty)) {
         ret push(r, fi, bid, iid, VC_TYPE_RESOLVE);
     }
     ret R.ok_void[str]();
@@ -736,7 +736,7 @@ fun vector_build_ok(m: *ir.Module, ins: *instruction.Instruction) bool {
 
 fun type_has_kind(m: *ir.Module, ty: type.IrTypeId, k: type.IrTypeKind) bool {
     val ot: O.Option[*type.IrType] = type.get(?m.types, ty);
-    if (!O.is_some[*type.IrType](ot)) { ret false; }
+    if (!O.is_some[*type.IrType](ot) || !type.reference_valid(?m.types, ty)) { ret false; }
     ret O.unwrap[*type.IrType](ot).kind == k;
 }
 

--- a/src/lang/me/lower/context.mach
+++ b/src/lang/me/lower/context.mach
@@ -125,7 +125,13 @@ pub rec LowerRequest {
     debug:     bool;
 }
 
+rec LogicalTypePath {
+    ty: type.TypeId;
+    previous: *LogicalTypePath;
+}
+
 pub rec LowerContext {
+    logical_type_path: *LogicalTypePath;
     deps: *sema.SemaDeps;
     diags: *diagnostic.DiagnosticStore;
     status: fail.PhaseStatus;
@@ -324,6 +330,7 @@ pub fun init_context(lc: *LowerContext, req: *LowerRequest, m: *ir.Module) R.Res
     if (req == nil) { ret R.err[R.Void, fail.Fail](fail.message("lower: init_context requires a lowering request")); }
     val s: *session.Session = req.s;
     lc.status      = fail.accepted();
+    lc.logical_type_path = nil;
     lc.s           = s;
     lc.deps        = req.deps;
     lc.diags       = req.diags;
@@ -1125,6 +1132,26 @@ pub fun lower_type(lc: *LowerContext, tid: type.TypeId) R.Result[ir_type.IrTypeI
         rtid = recover_type(lc, generics.substitute(lc.s, tid, lc.scope.subst, lc.scope.subst_len));
     }
 
+    val previous: *LogicalTypePath = lc.logical_type_path;
+    var path: LogicalTypePath;
+    if (!lc.tgt.model.flat_addressing) {
+        var active: *LogicalTypePath = previous;
+        for (active != nil) {
+            if (active.ty == rtid) {
+                var span: token.Span;
+                span.offset = lc.builder.loc.offset;
+                span.len = 0;
+                ret R.err[ir_type.IrTypeId, fail.Fail](report_gate(lc, span,
+                    "recursive reference types require pointer capabilities absent from the Logical Shader environment"));
+            }
+            active = active.previous;
+        }
+        path.ty = rtid;
+        path.previous = previous;
+        lc.logical_type_path = ?path;
+    }
+    fin { lc.logical_type_path = previous; }
+
     val fields: R.Result[R.Void, str] = generics.ensure_fields(lc.s, rtid);
     if (R.is_err[R.Void, str](fields)) { ret fail.lift[ir_type.IrTypeId](R.err[ir_type.IrTypeId, str](R.unwrap_err[R.Void, str](fields))); }
     if (lc.status.kind == fail.INTERNAL) { ret R.err[ir_type.IrTypeId, fail.Fail](fail.phase_failure(lc.status)); }
@@ -1142,7 +1169,12 @@ pub fun lower_type(lc: *LowerContext, tid: type.TypeId) R.Result[ir_type.IrTypeI
     if (d.class == type.PRIM_CLASS_INT)   { ret fail.lift[ir_type.IrTypeId](ir_type.intern_int(?lc.m.types, d.bits)); }
     if (d.class == type.PRIM_CLASS_FLOAT) { ret fail.lift[ir_type.IrTypeId](ir_type.intern_float(?lc.m.types, d.bits)); }
     if (d.class == type.PRIM_CLASS_PTR)   { ret fail.lift[ir_type.IrTypeId](ir_type.intern_ptr(?lc.m.types)); }
-    if (k == type.TYPE_POINTER)           { ret fail.lift[ir_type.IrTypeId](ir_type.intern_ptr(?lc.m.types)); }
+    if (k == type.TYPE_POINTER) {
+        if (lc.tgt.model.flat_addressing) { ret fail.lift[ir_type.IrTypeId](ir_type.intern_ptr(?lc.m.types)); }
+        val base: R.Result[ir_type.IrTypeId, fail.Fail] = lower_type(lc, t.data.pointer.base);
+        if (R.is_err[ir_type.IrTypeId, fail.Fail](base)) { ret base; }
+        ret fail.lift[ir_type.IrTypeId](ir_type.intern_reference(?lc.m.types, R.unwrap_ok[ir_type.IrTypeId, fail.Fail](base)));
+    }
 
     if (k == type.TYPE_ARRAY) {
         val res_base: R.Result[ir_type.IrTypeId, fail.Fail] = lower_type(lc, t.data.array.base);

--- a/src/lang/me/vecform.mach
+++ b/src/lang/me/vecform.mach
@@ -171,9 +171,9 @@ test "mach.lang.me.vecform.vec_op_of:is_total_over_the_descriptor_vector_tags" {
     types[0].data.bits = 9;
     if (decide(?m, ?tgt, ?inst) != isa.FORM_UNDECLARED) { ret 10; }
     if (realizes_packed(?m, ?tgt, ?inst) || holds_in_register(?m, ?tgt, 1)) { ret 5; }
-    types[0].data.bits = 16; types[0].kind = ir_type.IRT_PTR;
+    types[0].data.pointee = ir_type.IRT_NIL; types[0].kind = ir_type.IRT_PTR;
     if (realizes_packed(?m, ?tgt, ?inst) || holds_in_register(?m, ?tgt, 1)) { ret 6; }
-    types[0].kind = ir_type.IRT_INT; types[1].data.vector_.lanes = 0;
+    types[0].kind = ir_type.IRT_INT; types[0].data.bits = 16; types[1].data.vector_.lanes = 0;
     if (realizes_packed(?m, ?tgt, ?inst) || holds_in_register(?m, ?tgt, 1)) { ret 7; }
     ret 0;
 }

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -515,6 +515,7 @@ pub fun fingerprint(t: *resolved.Target, e: *binary.Encoder) bool {
 
     ok = ok && fp.write_domain_u8(e, fp.DOMAIN_ABI, abi.ABI_CATALOG_VERSION, abi.abi_fingerprint_tag(t.abi_id));
     ok = ok && fp.write_domain_str(e, fp.DOMAIN_ABI, TARGET_FINGERPRINT_VERSION, t.abi.name);
+    ok = ok && fp.write_domain_u8(e, fp.DOMAIN_ABI, TARGET_FINGERPRINT_VERSION, t.abi.passing);
 
     ok = ok && fp.write_domain_u8(e, fp.DOMAIN_OS, os.OS_CATALOG_VERSION, os.os_fingerprint_tag(t.os_id));
     ok = ok && fp.write_domain_str(e, fp.DOMAIN_OS, TARGET_FINGERPRINT_VERSION, t.os.name);
@@ -678,13 +679,14 @@ pub val TUPLE_OF_SHAPE:     u32 = 5;
 pub val TUPLE_OS_NO_ISA:    u32 = 6;
 pub val TUPLE_ABI_NEEDS_FLOAT: u32 = 7;
 pub val TUPLE_TARGET_UNAVAILABLE: u32 = 8;
+pub val TUPLE_ABI_TRANSPORT: u32 = 9;
 
 rec TupleCapabilitySpec {
     code:  u32;
     label: str;
 }
 
-val TUPLE_CAPABILITY_N: usize = 9;
+val TUPLE_CAPABILITY_N: usize = 10;
 val TUPLE_CAPABILITIES: [TUPLE_CAPABILITY_N]TupleCapabilitySpec = [TUPLE_CAPABILITY_N]TupleCapabilitySpec{
     TupleCapabilitySpec{ code: TUPLE_OK,             label: "ok" },
     TupleCapabilitySpec{ code: TUPLE_NO_CODEGEN,      label: "no_codegen" },
@@ -695,12 +697,18 @@ val TUPLE_CAPABILITIES: [TUPLE_CAPABILITY_N]TupleCapabilitySpec = [TUPLE_CAPABIL
     TupleCapabilitySpec{ code: TUPLE_OS_NO_ISA,       label: "os_no_isa" },
     TupleCapabilitySpec{ code: TUPLE_ABI_NEEDS_FLOAT, label: "abi_needs_float" },
     TupleCapabilitySpec{ code: TUPLE_TARGET_UNAVAILABLE, label: "target_unavailable" },
+    TupleCapabilitySpec{ code: TUPLE_ABI_TRANSPORT,   label: "abi_transport" },
 };
 
 pub fun tuple_capability(os_vt: *os.OsVTable, isa_vt: *isa.IsaVTable, abi_vt: *abi.AbiVTable, of_vt: *of.OfVTable) u32 {
     if (isa_vt.id == isa.ARCH_MOS6502)       { ret TUPLE_TARGET_UNAVAILABLE; }
     if (!isa.has_codegen(isa_vt))            { ret TUPLE_NO_CODEGEN; }
     if (!abi.covers_isa(abi_vt, isa_vt.id))  { ret TUPLE_ABI_MISMATCH; }
+    if (abi_vt.passing == abi.PASSING_VALUES) {
+        if (!isa.emits_whole_module(isa_vt)) { ret TUPLE_ABI_TRANSPORT; }
+    } or (abi_vt.passing == abi.PASSING_CARRIERS) {
+        if (isa_vt.machine == nil) { ret TUPLE_ABI_TRANSPORT; }
+    } or { ret TUPLE_ABI_TRANSPORT; }
     if (abi_vt.float_arg_bits > isa_vt.model.flen_bits) { ret TUPLE_ABI_NEEDS_FLOAT; }
     if (!os.supports_isa(os_vt, isa_vt.id))  { ret TUPLE_OS_NO_ISA; }
     if (!os.supports_of(os_vt, of_vt.name))  { ret TUPLE_OS_NO_OF; }
@@ -710,6 +718,10 @@ pub fun tuple_capability(os_vt: *os.OsVTable, isa_vt: *isa.IsaVTable, abi_vt: *a
 }
 
 fun tuple_capability_message(code: u32, os_vt: *os.OsVTable, isa_vt: *isa.IsaVTable, abi_vt: *abi.AbiVTable, of_vt: *of.OfVTable) str {
+    if (code == TUPLE_ABI_TRANSPORT) {
+        if (abi_vt.passing == abi.PASSING_VALUES) { ret "calling convention passes logical values, which only a whole-module emitter can carry"; }
+        ret "calling convention passes physical carriers, which only a register machine can carry";
+    }
     var alloc: A.Allocator;
     val alloc_failed: bool = O.is_some[str](page.make(?alloc));
 
@@ -881,6 +893,7 @@ test "mach.lang.target.tuple_capability_catalog:complete_unique_ordered" {
     if (TUPLE_CAPABILITIES[6].code != TUPLE_OS_NO_ISA)       { ret 1; }
     if (TUPLE_CAPABILITIES[7].code != TUPLE_ABI_NEEDS_FLOAT) { ret 1; }
     if (TUPLE_CAPABILITIES[8].code != TUPLE_TARGET_UNAVAILABLE) { ret 1; }
+    if (TUPLE_CAPABILITIES[9].code != TUPLE_ABI_TRANSPORT) { ret 1; }
 
     var i: usize = 0;
     for (i < TUPLE_CAPABILITY_N) {
@@ -2061,6 +2074,15 @@ test "mach.lang.target.abi_vtable:granularity_matches_its_classifier" {
     var i: u32 = 0;
     for (i < reg.abi.count) {
         val vt: *abi.AbiVTable = ?reg.abi.entries[i];
+        if (vt.passing == abi.PASSING_VALUES) {
+            if (vt.arg_slot_granularity != 0 || vt.gp_arg_regs != nil
+                || vt.callee_saved != nil || vt.va_model != nil || vt.arg_passing == nil) { ret 2; }
+            val classify: abi.ArgPassingFn = vt.arg_passing;
+            val logical: abi.ParamSlot = classify(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
+            if (logical.class != abi.CLASS_VALUE || logical.piece_count != 0 || logical.size != 16 || logical.reg != -1) { ret 3; }
+            i = i + 1;
+            cnt;
+        }
         if (vt.arg_slot_granularity == 0) { ret 1; }
         if (vt.arg_passing == nil)        { i = i + 1; cnt; }
 
@@ -2171,6 +2193,15 @@ test "mach.lang.target.fingerprint:sensitive_to_arch_abi_os_of_debug_backend_and
     var tbase: resolved.Target = R.unwrap_ok[resolved.Target, str](base);
     var ebase: binary.Encoder = binary.encoder(?alloc, binary.LITTLE);
     if (!fingerprint(?tbase, ?ebase)) { ret 1; }
+
+    var value_abi: abi.AbiVTable = @tbase.abi;
+    value_abi.passing = abi.PASSING_VALUES;
+    var value_target: resolved.Target = tbase;
+    value_target.abi = ?value_abi;
+    var e_value: binary.Encoder = binary.encoder(?alloc, binary.LITTLE);
+    fin { binary.encoder_dnit(?e_value); }
+    if (!fingerprint(?value_target, ?e_value) || fp_bytes_equal(?ebase, ?e_value)) { ret 2; }
+    if (tuple_capability(tbase.os, tbase.isa, ?value_abi, tbase.of) != TUPLE_ABI_TRANSPORT) { ret 3; }
 
     var td_page: resolved.Target = tbase;
     td_page.page_size = tbase.page_size * 2;

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -100,7 +100,7 @@ pub val CLASS_BYREF:       ParamClass = 4;
 pub val CLASS_STACK_BYREF: ParamClass = 5;
 pub val CLASS_VEC_BYREF: ParamClass = 6;
 pub val CLASS_VEC_STACK_BYREF: ParamClass = 7;
-pub val CLASS_AGG: ParamClass = 8;
+pub val CLASS_VALUE: ParamClass = 8;
 
 pub def PieceKind: u8;
 pub val PIECE_GP:    PieceKind = 0;
@@ -153,7 +153,12 @@ pub def RegFileFn: isa.RegFileFn;
 
 pub def VaModelFn: fun() VaModel;
 
+pub def PassingModel: u8;
+pub val PASSING_CARRIERS: PassingModel = 0;
+pub val PASSING_VALUES: PassingModel = 1;
+
 pub rec AbiVTable {
+    passing:                     PassingModel;
     id:                          u32;
     name:                        str;
     arch_id:                     u32;
@@ -183,6 +188,7 @@ pub fun abi_vtable(id: u32, name: str, arch_id: u32,
                    float_arg_bits: u32, arg_slot_granularity: u32,
                    va_model: VaModelFn) AbiVTable {
     var v: AbiVTable;
+    v.passing                     = PASSING_CARRIERS;
     v.id                          = id;
     v.name                        = name;
     v.arch_id                     = arch_id;
@@ -201,6 +207,19 @@ pub fun abi_vtable(id: u32, name: str, arch_id: u32,
     v.float_arg_bits              = float_arg_bits;
     v.arg_slot_granularity        = arg_slot_granularity;
     v.va_model                    = va_model;
+    ret v;
+}
+
+pub fun value_abi_vtable(id: u32, name: str, arch_id: u32,
+                         arg_passing: ArgPassingFn, ret_passing: RetPassingFn) AbiVTable {
+    var v: AbiVTable;
+    v.passing = PASSING_VALUES;
+    v.id = id;
+    v.name = name;
+    v.arch_id = arch_id;
+    v.arg_passing = arg_passing;
+    v.ret_passing = ret_passing;
+    v.indirect_result_reg = -1;
     ret v;
 }
 
@@ -378,9 +397,15 @@ fun dup_id(reg: *AbiRegistry, id: u32) bool {
 }
 
 fun descriptor_valid(vt: *AbiVTable) bool {
-    ret vt != nil && str_len(vt.name) > 0 && vt.arch_id != isa.ARCH_UNKNOWN
-        && vt.arg_passing != nil && vt.ret_passing != nil
-        && vt.gp_arg_regs != nil && vt.callee_saved != nil
+    if (vt == nil || str_len(vt.name) == 0 || vt.arch_id == isa.ARCH_UNKNOWN
+        || vt.arg_passing == nil || vt.ret_passing == nil) { ret false; }
+    if (vt.passing == PASSING_VALUES) {
+        ret vt.gp_arg_regs == nil && vt.callee_saved == nil && vt.va_model == nil
+            && vt.arg_slot_granularity == 0 && vt.stack_align == 0
+            && vt.red_zone == 0 && vt.shadow_space == 0 && vt.indirect_result_reg == -1
+            && !vt.indirect_result_in_argfile && !vt.consumes_agg_layout;
+    }
+    ret vt.passing == PASSING_CARRIERS && vt.gp_arg_regs != nil && vt.callee_saved != nil
         && vt.va_model != nil && vt.arg_slot_granularity > 0;
 }
 
@@ -443,17 +468,21 @@ pub fun register(reg: *AbiRegistry, vt: *AbiVTable) R.Result[R.Void, str] {
         ret R.err[R.Void, str](errf("mach.lang.target.abi: a calling convention must declare argument and return classification",
             "mach.lang.target.abi: calling convention '{}' is missing `arg_passing` or `ret_passing`", vt.name));
     }
-    if (vt.gp_arg_regs == nil || vt.callee_saved == nil) {
+    if (vt.passing == PASSING_CARRIERS && (vt.gp_arg_regs == nil || vt.callee_saved == nil)) {
         ret R.err[R.Void, str](errf("mach.lang.target.abi: a calling convention must declare its register files",
             "mach.lang.target.abi: calling convention '{}' is missing `gp_arg_regs` or `callee_saved`", vt.name));
     }
-    if (vt.va_model == nil) {
+    if (vt.passing == PASSING_CARRIERS && vt.va_model == nil) {
         ret R.err[R.Void, str](errf("mach.lang.target.abi: a calling convention must declare its variadic model",
             "mach.lang.target.abi: calling convention '{}' is missing `va_model`", vt.name));
     }
-    if (vt.arg_slot_granularity == 0) {
+    if (vt.passing == PASSING_CARRIERS && vt.arg_slot_granularity == 0) {
         ret R.err[R.Void, str](errf("mach.lang.target.abi: a calling convention must declare a nonzero argument slot granularity",
             "mach.lang.target.abi: calling convention '{}' declares an `arg_slot_granularity` of 0", vt.name));
+    }
+
+    if (!descriptor_valid(vt)) {
+        ret R.err[R.Void, str]("mach.lang.target.abi: invalid calling convention transport contract");
     }
 
     val name_r: R.Result[str, str] = str_copy(?reg.alloc, vt.name);
@@ -554,15 +583,11 @@ pub fun make_slot_indirect(class: ParamClass, reg: i32, offset: i64, size: u64,
     ret s;
 }
 
-pub fun make_slot_whole(reg: i32, size: u64) ParamSlot {
+pub fun make_slot_value(size: u64) ParamSlot {
     var s: ParamSlot;
-    s.class          = CLASS_AGG;
-    s.reg            = reg;
-    s.offset         = 0;
-    s.size           = size;
-    s.indirect_size  = 0;
-    s.indirect_align = 0;
-    s.piece_count    = 0;
+    s.class = CLASS_VALUE;
+    s.reg = -1;
+    s.size = size;
     ret s;
 }
 

--- a/src/lang/target/abi/spirv.mach
+++ b/src/lang/target/abi/spirv.mach
@@ -1,6 +1,4 @@
 use std.types.bool.bool;
-use std.types.bool.false;
-use std.types.bool.true;
 use std.types.string.str;
 
 use R: std.types.result;
@@ -8,69 +6,20 @@ use R: std.types.result;
 use mach.lang.target.abi;
 use mach.lang.target.isa;
 
-val ARG_REG_COUNT: i32 = 16;
-
 fun classify_arg(index: i32, size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
-                 is_aggregate: bool, is_vector: bool,
-                 gp_used: i32, fp_used: i32,
+                 is_aggregate: bool, is_vector: bool, gp_used: i32, fp_used: i32,
                  hfa_members: u8, hfa_elem: u8, agg: abi.AggLayout) abi.ParamSlot {
-    if (is_aggregate) { ret abi.make_slot_whole(index, size); }
-    var sz: u64 = size;
-    if (sz > 8) { sz = 8; }
-    ret abi.make_slot(abi.CLASS_GP, index, 0, sz, 8);
+    ret abi.make_slot_value(size);
 }
 
 fun classify_return(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
                     is_aggregate: bool, is_vector: bool, hfa_members: u8, hfa_elem: u8,
                     agg: abi.AggLayout) abi.ParamSlot {
-    if (is_aggregate) { ret abi.make_slot_whole(0, size); }
-    var sz: u64 = size;
-    if (sz > 8) { sz = 8; }
-    ret abi.make_slot(abi.CLASS_GP, 0, 0, sz, 8);
+    ret abi.make_slot_value(size);
 }
-
-fun classify_value(size: u64, align: u64, is_float: bool, fp_eightbytes: u8,
-                   is_aggregate: bool, gp_used: i32, fp_used: i32, hfa_members: u8, hfa_elem: u8) abi.ParamSlot {
-    if (is_aggregate) { ret abi.make_slot_whole(gp_used, size); }
-    var sz: u64 = size;
-    if (sz > 8) { sz = 8; }
-    ret abi.make_slot(abi.CLASS_GP, gp_used, 0, sz, 8);
-}
-
-fun arg_regs(out: *isa.Register) i32 {
-    var i: i32 = 0;
-    for (i < ARG_REG_COUNT) {
-        out[i].id   = i;
-        out[i].size = 8;
-        i = i + 1;
-    }
-    ret ARG_REG_COUNT;
-}
-
-fun callee_saved(out: *isa.Register) i32 {
-    ret 0;
-}
-
-fun va_model() abi.VaModel {
-    ret abi.va_model_make(abi.VA_MODEL_REG_SAVE, false, -1, 0);
-}
-
-pub val WORD: u32 = 4;
 
 pub fun register(reg: *abi.AbiRegistry) R.Result[R.Void, str] {
-    val float_arg_bits: u32 = 0;
-
-    var spirv_abi_vtable: abi.AbiVTable = abi.abi_vtable(
-        abi.ABI_SPIRV, "spirv", isa.ARCH_SPIRV,
-        classify_arg, classify_return,
-        arg_regs, callee_saved,
-        0, 0, 0,
-        0, false,
-        false, true,
-        float_arg_bits, WORD,
-        va_model
-    );
-    abi.with_legacy_classifier(?spirv_abi_vtable, classify_value);
-
-    ret abi.register(reg, ?spirv_abi_vtable);
+    var v: abi.AbiVTable = abi.value_abi_vtable(abi.ABI_SPIRV, "spirv", isa.ARCH_SPIRV,
+                                               classify_arg, classify_return);
+    ret abi.register(reg, ?v);
 }

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -68,16 +68,10 @@ rec VMaps {
     chain_id: *u32;
     chain_ty: *u32;
     chain_sc: *u32;
+    chain_object: *bool;
     opq_var: *u32;
     opq_ssa: *u32;
     n:       u32;
-}
-
-rec Regs {
-    val_id:  [16]u32;
-    imm:     [16]i64;
-    is_imm:  [16]bool;
-    is_bool: [16]bool;
 }
 
 rec FnEnt {
@@ -364,7 +358,7 @@ fun callee_count(e: *Emit, ix: u32) u32 {
         val blk: *mir.MirBlock = ?mf.blocks[bi];
         var ii: u32 = 0;
         for (ii < blk.instr_count) {
-            if (blk.instrs[ii].opcode == mir.MIR_CALL) { n = n + 1; }
+            if (blk.instrs[ii].opcode == mir.MIR_VALUE_CALL) { n = n + 1; }
             ii = ii + 1;
         }
         bi = bi + 1;
@@ -382,7 +376,7 @@ fun callee_at(e: *Emit, ix: u32, k: u32) u32 {
         var ii: u32 = 0;
         for (ii < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[ii];
-            if (mi.opcode == mir.MIR_CALL) {
+            if (mi.opcode == mir.MIR_VALUE_CALL) {
                 if (n == k) {
                     if (mi.operand_count < 1 || mi.operands[0].kind != mir.MIR_OP_SYM) { ret FN_NONE; }
                     ret fn_lookup(e, mi.operands[0].sym);
@@ -542,7 +536,7 @@ fun scan_fn_writes(e: *Emit, fx: u32, mf: *mir.MirFunction) R.Result[R.Void, str
             for (oi < mi.operand_count) {
                 val g: u32 = operand_origin(e, origin, n, ?mi.operands[oi]);
                 if (g == GL_NONE) { oi = oi + 1; cnt; }
-                if (operand_only_reads(mi.opcode, oi)) { oi = oi + 1; cnt; }
+                if (operand_only_reads(mi, oi)) { oi = oi + 1; cnt; }
                 val rm: R.Result[R.Void, str] = mark_written(e, fx, mi, g);
                 if (R.is_err[R.Void, str](rm)) {
                     if (origin != nil) { A.deallocate[u32](e.alloc, origin, n::usize); }
@@ -558,11 +552,14 @@ fun scan_fn_writes(e: *Emit, fx: u32, mf: *mir.MirFunction) R.Result[R.Void, str
     ret R.ok_void[str]();
 }
 
-fun operand_only_reads(op: mir.MirOpcode, oi: u32) bool {
+fun operand_only_reads(mi: *mir.MirInstr, oi: u32) bool {
+    val op: mir.MirOpcode = mi.opcode;
     if (op == mir.MIR_LOAD)      { ret oi == 1; }
     if (op == mir.MIR_GEP)       { ret oi < 2; }
     if (op == mir.MIR_MEMCPY)    { ret oi == 1; }
-    if (op == mir.MIR_AGG_LOAD)  { ret oi == 1; }
+    # a by-value argument is loaded from its object; a reference argument may be written through by the callee
+    if (op == mir.MIR_VALUE_CALL) { ret oi >= 2 && mi.operands[oi].kind == mir.MIR_OP_MEM; }
+    if (op == mir.MIR_RET) { ret oi == 0; }
     ret false;
 }
 
@@ -1476,6 +1473,107 @@ fun emit_cap(e: *Emit, cap: u32) {
     spirv.inst(e.b, ?e.b.caps, spirv.OP_CAPABILITY, ?o[0], 1);
 }
 
+rec TypeText {
+    buf: [TYPE_TEXT_CAP]u8;
+    len: usize;
+}
+
+val TYPE_TEXT_CAP: usize = 160;
+
+val TYPE_TEXT_DEPTH: u32 = 6;
+
+fun text_put(out: *TypeText, s: str) {
+    val n: usize = str_len(s);
+    var i: usize = 0;
+    for (i < n) {
+        if (out.len + 1 < TYPE_TEXT_CAP) { out.buf[out.len] = s[i]; out.len = out.len + 1; }
+        i = i + 1;
+    }
+}
+
+fun text_put_u32(out: *TypeText, n: u32) {
+    var digits: [12]u8;
+    var k: u32 = 0;
+    var v: u32 = n;
+    if (v == 0) { digits[0] = 48; k = 1; }
+    for (v > 0) { digits[k] = (48 + v % 10)::u8; v = v / 10; k = k + 1; }
+    for (k > 0) {
+        k = k - 1;
+        if (out.len + 1 < TYPE_TEXT_CAP) { out.buf[out.len] = digits[k]; out.len = out.len + 1; }
+    }
+}
+
+fun spell_members(e: *Emit, tys: *type.IrTypeTable, out: *TypeText, members: *type.IrTypeId, count: u32, depth: u32) {
+    var i: u32 = 0;
+    for (i < count) {
+        if (i > 0) { text_put(out, ", "); }
+        spell_type(e, tys, out, members[i], depth + 1);
+        i = i + 1;
+    }
+}
+
+# a source-shaped spelling of an IR type for a diagnostic, bounded in depth and length
+fun spell_type(e: *Emit, tys: *type.IrTypeTable, out: *TypeText, id: type.IrTypeId, depth: u32) {
+    if (depth > TYPE_TEXT_DEPTH) { text_put(out, "..."); ret; }
+    val opt: O.Option[*type.IrType] = type.get(tys, id);
+    if (O.is_none[*type.IrType](opt)) { text_put(out, "?"); ret; }
+    val t: *type.IrType = O.unwrap[*type.IrType](opt);
+    if (t.kind == type.IRT_VOID)   { text_put(out, "void"); ret; }
+    if (t.kind == type.IRT_INT)    { text_put(out, "i"); text_put_u32(out, t.data.bits); ret; }
+    if (t.kind == type.IRT_FLOAT)  { text_put(out, "f"); text_put_u32(out, t.data.bits); ret; }
+    if (t.kind == type.IRT_HANDLE) { text_put(out, "handle"); ret; }
+    if (t.kind == type.IRT_VECTOR) {
+        spell_type(e, tys, out, t.data.vector_.element, depth + 1);
+        text_put(out, "x"); text_put_u32(out, t.data.vector_.lanes);
+        ret;
+    }
+    if (t.kind == type.IRT_ARRAY) {
+        text_put(out, "["); text_put_u32(out, t.data.array_.count); text_put(out, "]");
+        spell_type(e, tys, out, t.data.array_.element, depth + 1);
+        ret;
+    }
+    if (t.kind == type.IRT_PTR) {
+        text_put(out, "*");
+        if (t.data.pointee != type.IRT_NIL) { spell_type(e, tys, out, t.data.pointee, depth + 1); }
+        ret;
+    }
+    if (t.kind == type.IRT_FN) {
+        text_put(out, "fun(");
+        spell_members(e, tys, out, t.data.fn.params, t.data.fn.param_count, depth);
+        if (t.data.fn.variadic) { text_put(out, ", ..."); }
+        text_put(out, ")");
+        val rt: O.Option[*type.IrType] = type.get(tys, t.data.fn.ret_type);
+        if (O.is_some[*type.IrType](rt) && O.unwrap[*type.IrType](rt).kind != type.IRT_VOID) {
+            text_put(out, " ");
+            spell_type(e, tys, out, t.data.fn.ret_type, depth + 1);
+        }
+        ret;
+    }
+    if (t.kind == type.IRT_STRUCT) { text_put(out, "rec{"); }
+    or (t.kind == type.IRT_UNION)  { text_put(out, "uni{"); }
+    or { text_put(out, "?"); ret; }
+    spell_members(e, tys, out, t.data.struct_.fields, t.data.struct_.field_count, depth);
+    text_put(out, "}");
+}
+
+fun type_text(e: *Emit, out: *TypeText, id: type.IrTypeId) str {
+    out.len = 0;
+    spell_type(e, ?e.ir.types, out, id, 0);
+    out.buf[out.len] = 0;
+    ret ?out.buf[0];
+}
+
+fun type_refusal_reason(e: *Emit, id: type.IrTypeId) str {
+    val opt: O.Option[*type.IrType] = type.get(?e.ir.types, id);
+    if (O.is_none[*type.IrType](opt)) { ret "the type is not defined in this module"; }
+    val k: type.IrTypeKind = O.unwrap[*type.IrType](opt).kind;
+    if (k == type.IRT_FN)    { ret "logical addressing has no function pointers, so a function value cannot cross a call"; }
+    if (k == type.IRT_UNION) { ret "SPIR-V has no untyped union, so a raw union has no type to declare"; }
+    if (k == type.IRT_PTR)   { ret "a logical reference must name a Function-storage object whose type SPIR-V can declare, and may not itself contain a reference"; }
+    if (k == type.IRT_STRUCT || k == type.IRT_ARRAY) { ret "a member of this composite has no SPIR-V type"; }
+    ret "this type has no SPIR-V form";
+}
+
 fun emit_function(e: *Emit, fx: u32) R.Result[R.Void, str] {
     val mf: *mir.MirFunction = fn_mir(e, fx);
     if (mf == nil) { ret R.err[R.Void, str]("spirv.emit: an emitted function has no lowered body"); }
@@ -1485,20 +1583,52 @@ fun emit_function(e: *Emit, fx: u32) R.Result[R.Void, str] {
     e.ir = fn_mod(e, fx);
     val irfn: *ir.Function = fn_ir(e, fx);
 
+    var bi: u32 = 0;
+    for (bi < mf.block_count && e.cur_instr == nil) {
+        var ii: u32 = 0;
+        for (ii < mf.blocks[bi].instr_count && e.cur_instr == nil) {
+            if (mf.blocks[bi].instrs[ii].loc.file != source.FILE_NIL) { e.cur_instr = ?mf.blocks[bi].instrs[ii]; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+
     var returns_void: bool = false;
     val ret_ty: u32 = ir_return_spv_type(e, irfn, ?returns_void);
     if (ret_ty == 0) {
         ret unsupported(e, "unsupported return type in the SPIR-V target");
     }
-    var ptypes: [16]u32;
-    if (irfn.param_count > types.MAX_FN_PARAMS) {
-        ret unsupported(e, "more than 16 parameters is not supported by the SPIR-V target");
+    var return_storage: u32 = 0;
+    if (types.pointer_shape(e.tt, ret_ty, ?return_storage) != 0) {
+        ret unsupported(e, "the current SPIR-V Logical Shader environment does not support Function-storage reference results");
     }
+    if (!types.instruction_operands_fit(2, irfn.param_count)) {
+        ret unsupported(e, "SPIR-V OpTypeFunction parameter count exceeds its 65535-word instruction encoding");
+    }
+    val pr: R.Result[*u32, str] = A.allocate[u32](e.alloc, (irfn.param_count + 1)::usize);
+    if (R.is_err[*u32, str](pr)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](pr)); }
+    val ptypes: *u32 = R.unwrap_ok[*u32, str](pr);
+    fin { A.deallocate[u32](e.alloc, ptypes, (irfn.param_count + 1)::usize); }
+    val pir: R.Result[*u32, str] = A.allocate[u32](e.alloc, (irfn.param_count + 1)::usize);
+    if (R.is_err[*u32, str](pir)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](pir)); }
+    val param_ids: *u32 = R.unwrap_ok[*u32, str](pir);
+    fin { A.deallocate[u32](e.alloc, param_ids, (irfn.param_count + 1)::usize); }
     var pi: u32 = 0;
     for (pi < irfn.param_count) {
         val pt: u32 = ir_value_spv_type(e, irfn.params[pi].ty);
         if (pt == 0) {
-            ret unsupported(e, "unsupported parameter type in the SPIR-V target");
+            var shown: TypeText;
+            val message: R.Result[str, str] = format.sprint(e.alloc,
+                "unsupported parameter {} of type `{}` in the SPIR-V Logical Shader environment: {}",
+                pi + 1, type_text(e, ?shown, irfn.params[pi].ty), type_refusal_reason(e, irfn.params[pi].ty));
+            if (R.is_err[str, str](message)) { ret R.err[R.Void, str](R.unwrap_err[str, str](message)); }
+            val text: str = R.unwrap_ok[str, str](message);
+            fin { A.deallocate[u8](e.alloc, text, str_len(text) + 1); }
+            val saved: R.Result[intern.StrId, str] = intern.intern(e.interner, text);
+            if (R.is_err[intern.StrId, str](saved)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](saved)); }
+            val held: O.Option[str] = intern.lookup(e.interner, R.unwrap_ok[intern.StrId, str](saved));
+            if (O.is_none[str](held)) { ret R.err[R.Void, str]("spirv.emit: parameter diagnostic is absent from its interner"); }
+            ret unsupported(e, O.unwrap[str](held));
         }
         ptypes[pi] = pt;
         pi = pi + 1;
@@ -1533,7 +1663,6 @@ fun emit_function(e: *Emit, fx: u32) R.Result[R.Void, str] {
     fop[0] = ret_ty; fop[1] = fn_id; fop[2] = spirv.FUNCTION_CONTROL_NONE; fop[3] = fnty;
     spirv.inst(e.b, ?e.b.functions, spirv.OP_FUNCTION, ?fop[0], 4);
 
-    var param_ids: [16]u32;
     pi = 0;
     for (pi < irfn.param_count) {
         val pid: u32 = spirv.alloc_id(e.b);
@@ -1560,6 +1689,7 @@ fun emit_function(e: *Emit, fx: u32) R.Result[R.Void, str] {
     var vm: VMaps;
     val mr: R.Result[R.Void, str] = build_vmaps(e, mf, irfn, ?vm);
     if (R.is_err[R.Void, str](mr)) {
+        vmaps_dnit(e, ?vm);
         A.deallocate[u32](e.alloc, labels, st.count::usize);
         cfg.dnit(?st);
         ret mr;
@@ -1665,27 +1795,17 @@ fun emit_node(e: *Emit, mf: *mir.MirFunction, st: *cfg.Structure, ix: u32, is_en
         ret R.ok_void[str]();
     }
 
-    var rg: Regs;
-    var i: u32 = 0;
-    for (i < types.MAX_FN_PARAMS) { rg.val_id[i] = 0; rg.imm[i] = 0; rg.is_imm[i] = false; rg.is_bool[i] = false; i = i + 1; }
-
-    if (param_count > types.MAX_FN_PARAMS) {
-        ret R.err[R.Void, str]("spirv.emit: a function reached body emission with more parameters than the register file holds");
-    }
-    i = 0;
-    for (i < param_count) { rg.val_id[i] = param_ids[i]; i = i + 1; }
-
     val blk: *mir.MirBlock = ?mf.blocks[st.nodes[ix].block];
     if (role == cfg.ROLE_REAL) {
         var ii: u32 = 0;
         for (ii + 1 < blk.instr_count) {
-            val r: R.Result[R.Void, str] = emit_instr(e, mf, vm, ?rg, ?blk.instrs[ii]);
+            val r: R.Result[R.Void, str] = emit_instr(e, mf, vm, ?blk.instrs[ii], param_ids, param_count);
             if (R.is_err[R.Void, str](r)) { ret r; }
             ii = ii + 1;
         }
     }
 
-    ret emit_terminator(e, mf, st, ix, labels, vm, ?rg, returns_void, ret_ty);
+    ret emit_terminator(e, mf, st, ix, labels, vm, returns_void, ret_ty);
 }
 
 fun emit_merge(e: *Emit, st: *cfg.Structure, ix: u32, labels: *u32) {
@@ -1712,7 +1832,7 @@ fun emit_branch(e: *Emit, label: u32) {
 }
 
 fun emit_terminator(e: *Emit, mf: *mir.MirFunction, st: *cfg.Structure, ix: u32, labels: *u32,
-                    vm: *VMaps, preg_val: *Regs, returns_void: bool, ret_ty: u32) R.Result[R.Void, str] {
+                    vm: *VMaps, returns_void: bool, ret_ty: u32) R.Result[R.Void, str] {
     if (st.nodes[ix].split != cfg.NO_BLOCK) {
         emit_merge(e, st, ix, labels);
         emit_branch(e, labels[st.nodes[ix].split]);
@@ -1729,7 +1849,7 @@ fun emit_terminator(e: *Emit, mf: *mir.MirFunction, st: *cfg.Structure, ix: u32,
         ret R.ok_void[str]();
     }
     if (term.opcode == mir.MIR_CBR) {
-        val cond: u32 = read_condition(e, vm, preg_val, ?term.operands[0]);
+        val cond: u32 = read_condition(e, vm, ?term.operands[0]);
         if (cond == 0) { ret emit_fail(e, "spirv.emit: unreadable branch condition"); }
         emit_merge(e, st, ix, labels);
         var bc: [3]u32;
@@ -1745,11 +1865,14 @@ fun emit_terminator(e: *Emit, mf: *mir.MirFunction, st: *cfg.Structure, ix: u32,
     }
     if (term.opcode == mir.MIR_RET) {
         if (returns_void) {
+            if (term.operand_count != 0) { ret emit_fail(e, "spirv.emit: void return carries a value"); }
             spirv.inst(e.b, ?e.b.functions, spirv.OP_RETURN, nil, 0);
             ret R.ok_void[str]();
         }
-        val rid: u32 = reg_value(e, preg_val, 0, ret_ty);
-        if (rid == 0) { ret emit_fail(e, "spirv.emit: value return with no pre-colored result"); }
+        if (term.operand_count != 1) { ret emit_fail(e, "spirv.emit: logical return requires one value"); }
+        val rr: R.Result[u32, str] = read_value(e, mf, vm, ?term.operands[0], ret_ty, term.memory_flags);
+        if (R.is_err[u32, str](rr)) { ret emit_fail(e, R.unwrap_err[u32, str](rr)); }
+        val rid: u32 = R.unwrap_ok[u32, str](rr);
         var rv: [1]u32;
         rv[0] = rid;
         spirv.inst(e.b, ?e.b.functions, spirv.OP_RETURN_VALUE, ?rv[0], 1);
@@ -1758,12 +1881,12 @@ fun emit_terminator(e: *Emit, mf: *mir.MirFunction, st: *cfg.Structure, ix: u32,
     ret unsupported(e, "instruction is not yet supported by the SPIR-V target");
 }
 
-fun read_condition(e: *Emit, vm: *VMaps, preg_val: *Regs, op: *mir.MirOperand) u32 {
+fun read_condition(e: *Emit, vm: *VMaps, op: *mir.MirOperand) u32 {
     if (op.kind != mir.MIR_OP_VREG) { e.b.err = true; ret 0; }
     val v: u32 = op.vreg;
     if (v >= vm.n) { e.b.err = true; ret 0; }
     val ty: u32 = vm.type_id[v];
-    val raw: u32 = read_operand(e, vm, preg_val, op, ty);
+    val raw: u32 = read_operand(e, vm, op, ty);
     if (e.b.err || raw == 0) { ret 0; }
     if (vm.is_bool[v]) { ret raw; }
 
@@ -1863,6 +1986,7 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
     out.chain_id = nil;
     out.chain_ty = nil;
     out.chain_sc = nil;
+    out.chain_object = nil;
     out.opq_var = nil;
     out.opq_ssa = nil;
     if (n == 0) { ret R.ok_void[str](); }
@@ -1885,6 +2009,9 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
     val rcs: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
     if (R.is_err[*u32, str](rcs)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](rcs)); }
     out.chain_sc = R.unwrap_ok[*u32, str](rcs);
+    val rco: R.Result[*bool, str] = A.allocate[bool](e.alloc, n::usize);
+    if (R.is_err[*bool, str](rco)) { ret R.err[R.Void, str](R.unwrap_err[*bool, str](rco)); }
+    out.chain_object = R.unwrap_ok[*bool, str](rco);
     val rov: R.Result[*u32, str] = A.allocate[u32](e.alloc, n::usize);
     if (R.is_err[*u32, str](rov)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](rov)); }
     out.opq_var = R.unwrap_ok[*u32, str](rov);
@@ -1893,40 +2020,34 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
     out.opq_ssa = R.unwrap_ok[*u32, str](ros);
 
     var i: u32 = 0;
-    for (i < n) { out.type_id[i] = 0; out.var_id[i] = 0; out.is_bool[i] = false; out.chain_id[i] = 0; out.chain_ty[i] = 0; out.chain_sc[i] = 0; out.opq_var[i] = 0; out.opq_ssa[i] = 0; i = i + 1; }
+    for (i < n) { out.type_id[i] = 0; out.var_id[i] = 0; out.is_bool[i] = false; out.chain_id[i] = 0; out.chain_ty[i] = 0; out.chain_sc[i] = 0; out.chain_object[i] = false; out.opq_var[i] = 0; out.opq_ssa[i] = 0; i = i + 1; }
 
     var pb: u32 = 0;
     for (pb < mf.block_count) {
         val blk: *mir.MirBlock = ?mf.blocks[pb];
         var ei: u32 = 0;
-        var callee: intern.StrId = intern.STR_NIL;
         for (ei < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[ei];
-            if (mi.opcode == mir.MIR_CALL && mi.operand_count >= 1 && mi.operands[0].kind == mir.MIR_OP_SYM) {
-                callee = mi.operands[0].sym;
+            var dest: *mir.MirOperand = nil;
+            var ty: u32 = 0;
+            if (mi.opcode == mir.MIR_VALUE_PARAM) {
+                if (mi.operand_count != 2 || mi.operands[1].kind != mir.MIR_OP_IMM
+                    || mi.operands[1].imm < 0 || mi.operands[1].imm >= irfn.param_count::i64) {
+                    ret emit_fail(e, "spirv.emit: malformed logical parameter binding");
+                }
+                dest = ?mi.operands[0];
+                ty = ir_value_spv_type(e, irfn.params[mi.operands[1].imm::u32].ty);
             }
-            or (mi.opcode == mir.MIR_CALL_RES) { callee = intern.STR_NIL; }
-            or (mi.opcode == mir.MIR_MOV && mi.operand_count == 2 &&
-                mi.operands[0].kind == mir.MIR_OP_VREG && mi.operands[1].kind == mir.MIR_OP_PREG) {
-                val k: u32 = mi.operands[1].preg;
-                val v: u32 = mi.operands[0].vreg;
-                var t: u32 = 0;
-                if (callee != intern.STR_NIL) {
-                    val cfn: *ir.Function = ir_function_record(e.ir, callee);
-                    if (cfn != nil) {
-                        var cvoid: bool = false;
-                        t = ir_return_spv_type(e, cfn, ?cvoid);
-                        if (cvoid) { t = 0; }
-                    }
-                    callee = intern.STR_NIL;
+            or (mi.opcode == mir.MIR_VALUE_CALL) {
+                if (mi.operand_count < 2) { ret emit_fail(e, "spirv.emit: malformed logical call"); }
+                dest = ?mi.operands[1];
+                if (dest.kind == mir.MIR_OP_VREG && dest.vreg < n) {
+                    ty = ir_value_spv_type(e, mf.vregs[dest.vreg].ty);
                 }
-                or (k < irfn.param_count) {
-                    t = ir_value_spv_type(e, irfn.params[k].ty);
-                }
-                if (t != 0 && v < n && out.type_id[v] == 0) {
-                    out.type_id[v] = t;
-                    out.is_bool[v] = types.type_is_bool(e.tt, t);
-                }
+            }
+            if (dest != nil && dest.kind == mir.MIR_OP_VREG && dest.vreg < n && ty != 0) {
+                out.type_id[dest.vreg] = ty;
+                out.is_bool[dest.vreg] = types.type_is_bool(e.tt, ty);
             }
             ei = ei + 1;
         }
@@ -1946,7 +2067,9 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
 
     i = 0;
     for (i < n) {
-        if (out.type_id[i] != 0 && !types.type_is_opaque(e.tt, out.type_id[i])) {
+        var storage: u32 = 0;
+        if (out.type_id[i] != 0 && !types.type_is_opaque(e.tt, out.type_id[i])
+            && types.pointer_shape(e.tt, out.type_id[i], ?storage) == 0) {
             val ptr_ty: u32 = types.type_ptr(e.tt, spirv.STORAGE_FUNCTION, out.type_id[i]);
             val var_id: u32 = spirv.alloc_id(e.b);
             var vop: [3]u32;
@@ -1983,6 +2106,10 @@ fun declare_allocas(e: *Emit, mf: *mir.MirFunction, out: *VMaps) R.Result[R.Void
                 ret unsupported(e, "a multi-element local allocation is not supported by the SPIR-V target: it is an array of whole objects reached by pointer arithmetic, which the logical addressing model has no form for");
             }
 
+            var storage: u32 = 0;
+            if (types.pointer_shape(e.tt, ty, ?storage) != 0) {
+                ret unsupported(e, "SPIR-V Logical Shader pointer-valued local storage requires VariablePointers capability");
+            }
             val ptr_ty: u32 = types.type_ptr(e.tt, spirv.STORAGE_FUNCTION, ty);
             val var_id: u32 = spirv.alloc_id(e.b);
             var vop: [3]u32;
@@ -1991,6 +2118,7 @@ fun declare_allocas(e: *Emit, mf: *mir.MirFunction, out: *VMaps) R.Result[R.Void
             out.chain_id[dst] = var_id;
             out.chain_ty[dst] = ty;
             out.chain_sc[dst] = spirv.STORAGE_FUNCTION;
+            out.chain_object[dst] = true;
             ii = ii + 1;
         }
         bi = bi + 1;
@@ -2054,7 +2182,7 @@ fun type_computed_defs(e: *Emit, mf: *mir.MirFunction, out: *VMaps, skip_copies:
 fun is_reg_copy(mi: *mir.MirInstr) bool {
     if (mi.opcode != mir.MIR_MOV && mi.opcode != mir.MIR_DECLASSIFY) { ret false; }
     if (mi.operand_count != 2) { ret false; }
-    ret mi.operands[1].kind == mir.MIR_OP_VREG || mi.operands[1].kind == mir.MIR_OP_PREG
+    ret mi.operands[1].kind == mir.MIR_OP_VREG
      || mi.operands[1].kind == mir.MIR_OP_IMM;
 }
 
@@ -2118,8 +2246,9 @@ fun vmaps_dnit(e: *Emit, vm: *VMaps) {
     if (vm.chain_id != nil) { A.deallocate[u32](e.alloc, vm.chain_id, vm.n::usize); }
     if (vm.chain_ty != nil) { A.deallocate[u32](e.alloc, vm.chain_ty, vm.n::usize); }
     if (vm.chain_sc != nil) { A.deallocate[u32](e.alloc, vm.chain_sc, vm.n::usize); }
+    if (vm.chain_object != nil) { A.deallocate[bool](e.alloc, vm.chain_object, vm.n::usize); }
     vm.type_id = nil; vm.var_id = nil; vm.is_bool = nil;
-    vm.chain_id = nil; vm.chain_ty = nil; vm.chain_sc = nil; vm.n = 0;
+    vm.chain_id = nil; vm.chain_ty = nil; vm.chain_sc = nil; vm.chain_object = nil; vm.n = 0;
 }
 
 fun lane_type_of(e: *Emit, lane: u32) u32 {
@@ -2153,7 +2282,15 @@ fun value_type_for(e: *Emit, mf: *mir.MirFunction, mi: *mir.MirInstr, vreg: u32,
     var bytes: u32 = width::u32;
     if (bytes == 0) { bytes = e.tgt.model.gpr_width; }
     val bits: u32 = bytes * 8;
-    if (mir.vreg_is_fp(mf, vreg)) {
+    var floating: bool = mi.opcode == mir.MIR_FADD || mi.opcode == mir.MIR_FSUB
+        || mi.opcode == mir.MIR_FMUL || mi.opcode == mir.MIR_FDIV || mi.opcode == mir.MIR_FNEG
+        || mi.opcode == mir.MIR_FP_TRUNC || mi.opcode == mir.MIR_FP_EXT
+        || mi.opcode == mir.MIR_SI_TO_FP || mi.opcode == mir.MIR_UI_TO_FP;
+    if (vreg < mf.vreg_count && mf.vregs[vreg].ty != mir.VREG_TY_NIL) {
+        val declared: O.Option[*type.IrType] = type.get(?e.ir.types, mf.vregs[vreg].ty);
+        if (O.is_some[*type.IrType](declared)) { floating = O.unwrap[*type.IrType](declared).kind == type.IRT_FLOAT; }
+    }
+    if (floating) {
         if (bits == 32 || bits == 64) { ret types.type_float(e.tt, bits); }
         ret 0;
     }
@@ -2165,6 +2302,12 @@ fun spv_type_of(e: *Emit, tys: *type.IrTypeTable, id: type.IrTypeId) u32 {
     val opt: O.Option[*type.IrType] = type.get(tys, id);
     if (O.is_none[*type.IrType](opt)) { ret 0; }
     val t: *type.IrType = O.unwrap[*type.IrType](opt);
+    if (t.kind == type.IRT_PTR) {
+        if (t.data.pointee == type.IRT_NIL) { ret 0; }
+        val pointee: u32 = spv_type_of(e, tys, t.data.pointee);
+        if (pointee == 0) { ret 0; }
+        ret types.type_ptr(e.tt, spirv.STORAGE_FUNCTION, pointee);
+    }
     if (t.kind == type.IRT_INT)   { ret types.type_int(e.tt, t.data.bits); }
     if (t.kind == type.IRT_FLOAT) { ret types.type_float(e.tt, t.data.bits); }
     if (t.kind == type.IRT_VECTOR) {
@@ -2175,6 +2318,8 @@ fun spv_type_of(e: *Emit, tys: *type.IrTypeTable, id: type.IrTypeId) u32 {
     if (t.kind == type.IRT_ARRAY) {
         val elem: u32 = spv_type_of(e, tys, t.data.array_.element);
         if (elem == 0) { ret 0; }
+        var storage: u32 = 0;
+        if (types.pointer_shape(e.tt, elem, ?storage) != 0) { ret 0; }
         ret types.type_array(e.tt, elem, t.data.array_.count, false);
     }
     if (t.kind == type.IRT_HANDLE) { ret handle_spv_type(e, tys, t); }
@@ -2185,7 +2330,8 @@ fun spv_type_of(e: *Emit, tys: *type.IrTypeTable, id: type.IrTypeId) u32 {
         var i: u32 = 0;
         for (i < n) {
             val mt: u32 = spv_type_of(e, tys, t.data.struct_.fields[i]);
-            if (mt == 0) { ret 0; }
+            var storage: u32 = 0;
+            if (mt == 0 || types.pointer_shape(e.tt, mt, ?storage) != 0) { ret 0; }
             members[i] = mt;
             i = i + 1;
         }
@@ -2308,7 +2454,7 @@ fun memory_store(e: *Emit, ptr: u32, value: u32, flags: u8) {
     spirv.inst(e.b, ?e.b.functions, spirv.OP_STORE, ?ops[0], count);
 }
 
-fun emit_global_load(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[R.Void, str] {
+fun emit_global_load(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr) R.Result[R.Void, str] {
     if (mi.operand_count != 2 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0]));
     }
@@ -2335,7 +2481,7 @@ fun emit_global_load(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs
     ret store_vreg(e, vm, dst, result);
 }
 
-fun emit_global_store(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[R.Void, str] {
+fun emit_global_store(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr) R.Result[R.Void, str] {
     if (mi.operand_count != 2) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0])); }
     var chain_ty: u32 = 0;
     var var_id: u32 = chain_target(vm, ?mi.operands[0], ?chain_ty);
@@ -2345,7 +2491,7 @@ fun emit_global_store(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Reg
         value_ty = interface_value_type(e, ?mi.operands[0]);
     }
     if (var_id == 0) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0])); }
-    val value: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], value_ty);
+    val value: u32 = read_operand(e, vm, ?mi.operands[1], value_ty);
     if (e.b.err || value == 0) { ret emit_fail(e, "spirv.emit: unreadable value in an interface store"); }
     memory_store(e, var_id, value, mi.memory_flags);
     ret R.ok_void[str]();
@@ -2380,7 +2526,7 @@ fun whole_value_as(e: *Emit, value: u32, from_ty: u32, to_ty: u32) u32 {
     ret res;
 }
 
-fun emit_access_chain(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs,
+fun emit_access_chain(e: *Emit, mf: *mir.MirFunction, vm: *VMaps,
                       mi: *mir.MirInstr) R.Result[R.Void, str] {
     if (mi.operand_count < 3 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1]));
@@ -2438,7 +2584,7 @@ fun emit_access_chain(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Reg
             if (elem == 0 || types.vector_shape(e.tt, cur, ?lanes) != 0) {
                 ret unsupported(e, "a runtime index into a record or vector is not supported by the SPIR-V target: SPIR-V takes a struct member and a vector lane by a constant ordinal, since the type reached depends on which one it is");
             }
-            idx[k] = read_operand(e, vm, preg_val, opnd, types.type_int(e.tt, 32));
+            idx[k] = read_operand(e, vm, opnd, types.type_int(e.tt, 32));
             cur = elem;
         }
         if (cur == 0 || idx[k] == 0) {
@@ -2526,64 +2672,79 @@ fun emit_memcpy(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr) R
     ret R.ok_void[str]();
 }
 
-fun emit_agg_load(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[R.Void, str] {
-    if (mi.operand_count != 2 || mi.operands[0].kind != mir.MIR_OP_PREG) {
-        ret emit_fail(e, "spirv.emit: malformed whole-object load");
+
+fun read_value(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, op: *mir.MirOperand,
+               want_ty: u32, flags: u8) R.Result[u32, str] {
+    var storage: u32 = 0;
+    val pointee: u32 = types.pointer_shape(e.tt, want_ty, ?storage);
+    if (pointee != 0) {
+        var actual: u32 = 0;
+        val reference: u32 = chain_target(vm, op, ?actual);
+        if (reference == 0 || actual != pointee || chain_storage(vm, op) != storage) {
+            ret R.err[u32, str]("SPIR-V Logical Shader reference arguments require a matching Function-storage object");
+        }
+        if (op.vreg >= vm.n || !vm.chain_object[op.vreg]) {
+            ret R.err[u32, str]("SPIR-V Logical Shader Function-storage reference arguments must name a memory object declaration, not a subobject access chain");
+        }
+        ret R.ok[u32, str](reference);
     }
-    val pos: u32 = mi.operands[0].preg;
-    if (pos >= 16) { ret emit_fail(e, "spirv.emit: whole-object load into a position out of range"); }
-
-    var src_ty: u32 = 0;
-    var pos_ty: u32 = 0;
-    var src: u32 = chain_target(vm, ?mi.operands[1], ?src_ty);
-    pos_ty = src_ty;
-    if (src == 0) {
-        src = interface_target(e, ?mi.operands[1]);
-        src_ty = interface_value_type(e, ?mi.operands[1]);
-        pos_ty = interface_position_type(e, ?mi.operands[1]);
+    if (op.kind == mir.MIR_OP_MEM || op.kind == mir.MIR_OP_SYM) {
+        var ty: u32 = 0;
+        var src: u32 = chain_target(vm, op, ?ty);
+        if (src == 0) { src = interface_target(e, op); ty = interface_value_type(e, op); }
+        if (src == 0 || ty == 0) { ret R.err[u32, str](addressed_memory_refusal(e, mf, op)); }
+        val loaded: u32 = spirv.alloc_id(e.b);
+        memory_load(e, ty, loaded, src, flags);
+        val converted: u32 = whole_value_as(e, loaded, ty, want_ty);
+        if (converted == 0) { ret R.err[u32, str]("spirv.emit: logical argument object does not match its declared type"); }
+        ret R.ok[u32, str](converted);
     }
-    if (src == 0 || src_ty == 0) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1])); }
-
-    val loaded: u32 = spirv.alloc_id(e.b);
-    memory_load(e, src_ty, loaded, src, mi.memory_flags);
-
-    val value: u32 = whole_value_as(e, loaded, src_ty, pos_ty);
-    if (value == 0) {
-        ret unsupported(e, "this object cannot be handed to a call or a return by value in the SPIR-V target: the type it is stored at and the type its position takes describe different objects, so no whole value crosses between them");
-    }
-
-    preg_val.val_id[pos]  = value;
-    preg_val.is_imm[pos]  = false;
-    preg_val.is_bool[pos] = false;
-    ret R.ok_void[str]();
+    if (!operand_matches_type(vm, op, want_ty)) { ret R.err[u32, str]("spirv.emit: logical argument type mismatch"); }
+    val result: u32 = read_operand(e, vm, op, want_ty);
+    if (result == 0 || e.b.err) { ret R.err[u32, str]("spirv.emit: unreadable logical value"); }
+    ret R.ok[u32, str](result);
 }
 
-fun emit_agg_store(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[R.Void, str] {
-    if (mi.operand_count != 2 || mi.operands[1].kind != mir.MIR_OP_PREG) {
-        ret emit_fail(e, "spirv.emit: malformed whole-object store");
+fun write_value(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, op: *mir.MirOperand,
+                held: u32, held_ty: u32, flags: u8) R.Result[R.Void, str] {
+    var storage: u32 = 0;
+    val pointee: u32 = types.pointer_shape(e.tt, held_ty, ?storage);
+    if (pointee != 0) {
+        if (op.kind != mir.MIR_OP_VREG || op.vreg >= vm.n || vm.type_id[op.vreg] != held_ty) {
+            ret emit_fail(e, "spirv.emit: logical reference binding type mismatch");
+        }
+        vm.chain_id[op.vreg] = held;
+        vm.chain_ty[op.vreg] = pointee;
+        vm.chain_sc[op.vreg] = storage;
+        vm.chain_object[op.vreg] = true;
+        ret R.ok_void[str]();
     }
-
-    var dst_ty: u32 = 0;
-    var pos_ty: u32 = 0;
-    var dst: u32 = chain_target(vm, ?mi.operands[0], ?dst_ty);
-    pos_ty = dst_ty;
-    if (dst == 0) {
-        dst = interface_target(e, ?mi.operands[0]);
-        dst_ty = interface_value_type(e, ?mi.operands[0]);
-        pos_ty = interface_position_type(e, ?mi.operands[0]);
+    if (op.kind == mir.MIR_OP_MEM) {
+        var ty: u32 = 0;
+        val dst: u32 = chain_target(vm, op, ?ty);
+        if (dst == 0 || ty == 0) { ret unsupported(e, addressed_memory_refusal(e, mf, op)); }
+        val converted: u32 = whole_value_as(e, held, held_ty, ty);
+        if (converted == 0) { ret emit_fail(e, "spirv.emit: logical result object does not match its owned home"); }
+        memory_store(e, dst, converted, flags);
+        ret R.ok_void[str]();
     }
-    if (dst == 0 || dst_ty == 0) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0])); }
-
-    val held: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], pos_ty);
-    if (e.b.err || held == 0) { ret emit_fail(e, "spirv.emit: whole-object store with no value in its position"); }
-
-    val value: u32 = whole_value_as(e, held, pos_ty, dst_ty);
-    if (value == 0) {
-        ret unsupported(e, "this object cannot be written from a call or a return position in the SPIR-V target: the type its position takes and the type it is stored at describe different objects, so no whole value crosses between them");
+    if (op.kind != mir.MIR_OP_VREG || op.vreg >= vm.n || vm.type_id[op.vreg] != held_ty) {
+        ret emit_fail(e, "spirv.emit: logical result type mismatch");
     }
+    ret store_vreg(e, vm, op.vreg, held);
+}
 
-    memory_store(e, dst, value, mi.memory_flags);
-    ret R.ok_void[str]();
+fun emit_param(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr,
+               params: *u32, count: u32) R.Result[R.Void, str] {
+    if (mi.operand_count != 2 || mi.operands[1].kind != mir.MIR_OP_IMM
+        || mi.operands[1].imm < 0 || mi.operands[1].imm >= count::i64) {
+        ret emit_fail(e, "spirv.emit: malformed logical parameter binding");
+    }
+    val index: u32 = mi.operands[1].imm::u32;
+    val fn: *ir.Function = ir_function_record(e.ir, mf.name);
+    if (fn == nil || index >= fn.param_count) { ret emit_fail(e, "spirv.emit: logical parameter has no signature"); }
+    ret write_value(e, mf, vm, ?mi.operands[0], params[index],
+                    ir_value_spv_type(e, fn.params[index].ty), mi.memory_flags);
 }
 
 fun by_class(lane_float: bool, int_op: u32, float_op: u32) u32 {
@@ -2609,145 +2770,123 @@ fun refusal_fn_name(e: *Emit) str {
     ret "<unresolved function name>";
 }
 
-fun emit_instr(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[R.Void, str] {
+fun emit_instr(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr, params: *u32, param_count: u32) R.Result[R.Void, str] {
     e.cur_instr = mi;
     val op: mir.MirOpcode = mi.opcode;
 
     val lf: bool = mir.vec_lane_is_vector(mi.vec_lane)
                 && mir.vec_lane_kind(mi.vec_lane) == mir.VEC_LANE_FLOAT;
 
-    if (op == mir.MIR_ADD)   { ret emit_binary(e, vm, preg_val, mi, by_class(lf, spirv.OP_I_ADD, spirv.OP_F_ADD)); }
-    if (op == mir.MIR_SUB)   { ret emit_binary(e, vm, preg_val, mi, by_class(lf, spirv.OP_I_SUB, spirv.OP_F_SUB)); }
-    if (op == mir.MIR_MUL)   { ret emit_binary(e, vm, preg_val, mi, by_class(lf, spirv.OP_I_MUL, spirv.OP_F_MUL)); }
-    if (op == mir.MIR_DIV_S) { ret emit_binary(e, vm, preg_val, mi, by_class(lf, spirv.OP_S_DIV, spirv.OP_F_DIV)); }
-    if (op == mir.MIR_DIV_U) { ret emit_binary(e, vm, preg_val, mi, by_class(lf, spirv.OP_U_DIV, spirv.OP_F_DIV)); }
-    if (op == mir.MIR_REM_S) { ret emit_binary(e, vm, preg_val, mi, by_class(lf, spirv.OP_S_REM, spirv.OP_F_REM)); }
-    if (op == mir.MIR_REM_U) { ret emit_binary(e, vm, preg_val, mi, by_class(lf, spirv.OP_U_MOD, spirv.OP_F_REM)); }
-    if (op == mir.MIR_AND)   { ret emit_binary(e, vm, preg_val, mi, spirv.OP_BITWISE_AND); }
-    if (op == mir.MIR_OR)    { ret emit_binary(e, vm, preg_val, mi, spirv.OP_BITWISE_OR); }
-    if (op == mir.MIR_XOR)   { ret emit_binary(e, vm, preg_val, mi, spirv.OP_BITWISE_XOR); }
-    if (op == mir.MIR_SHL)   { ret emit_binary(e, vm, preg_val, mi, spirv.OP_SHIFT_LEFT_LOGICAL); }
-    if (op == mir.MIR_SHR_U) { ret emit_binary(e, vm, preg_val, mi, spirv.OP_SHIFT_RIGHT_LOGICAL); }
-    if (op == mir.MIR_SHR_S) { ret emit_binary(e, vm, preg_val, mi, spirv.OP_SHIFT_RIGHT_ARITHMETIC); }
+    if (op == mir.MIR_ADD)   { ret emit_binary(e, vm, mi, by_class(lf, spirv.OP_I_ADD, spirv.OP_F_ADD)); }
+    if (op == mir.MIR_SUB)   { ret emit_binary(e, vm, mi, by_class(lf, spirv.OP_I_SUB, spirv.OP_F_SUB)); }
+    if (op == mir.MIR_MUL)   { ret emit_binary(e, vm, mi, by_class(lf, spirv.OP_I_MUL, spirv.OP_F_MUL)); }
+    if (op == mir.MIR_DIV_S) { ret emit_binary(e, vm, mi, by_class(lf, spirv.OP_S_DIV, spirv.OP_F_DIV)); }
+    if (op == mir.MIR_DIV_U) { ret emit_binary(e, vm, mi, by_class(lf, spirv.OP_U_DIV, spirv.OP_F_DIV)); }
+    if (op == mir.MIR_REM_S) { ret emit_binary(e, vm, mi, by_class(lf, spirv.OP_S_REM, spirv.OP_F_REM)); }
+    if (op == mir.MIR_REM_U) { ret emit_binary(e, vm, mi, by_class(lf, spirv.OP_U_MOD, spirv.OP_F_REM)); }
+    if (op == mir.MIR_AND)   { ret emit_binary(e, vm, mi, spirv.OP_BITWISE_AND); }
+    if (op == mir.MIR_OR)    { ret emit_binary(e, vm, mi, spirv.OP_BITWISE_OR); }
+    if (op == mir.MIR_XOR)   { ret emit_binary(e, vm, mi, spirv.OP_BITWISE_XOR); }
+    if (op == mir.MIR_SHL)   { ret emit_binary(e, vm, mi, spirv.OP_SHIFT_LEFT_LOGICAL); }
+    if (op == mir.MIR_SHR_U) { ret emit_binary(e, vm, mi, spirv.OP_SHIFT_RIGHT_LOGICAL); }
+    if (op == mir.MIR_SHR_S) { ret emit_binary(e, vm, mi, spirv.OP_SHIFT_RIGHT_ARITHMETIC); }
 
-    if (op == mir.MIR_FADD) { ret emit_binary(e, vm, preg_val, mi, spirv.OP_F_ADD); }
-    if (op == mir.MIR_FSUB) { ret emit_binary(e, vm, preg_val, mi, spirv.OP_F_SUB); }
-    if (op == mir.MIR_FMUL) { ret emit_binary(e, vm, preg_val, mi, spirv.OP_F_MUL); }
-    if (op == mir.MIR_FDIV) { ret emit_binary(e, vm, preg_val, mi, spirv.OP_F_DIV); }
+    if (op == mir.MIR_FADD) { ret emit_binary(e, vm, mi, spirv.OP_F_ADD); }
+    if (op == mir.MIR_FSUB) { ret emit_binary(e, vm, mi, spirv.OP_F_SUB); }
+    if (op == mir.MIR_FMUL) { ret emit_binary(e, vm, mi, spirv.OP_F_MUL); }
+    if (op == mir.MIR_FDIV) { ret emit_binary(e, vm, mi, spirv.OP_F_DIV); }
 
-    if (op == mir.MIR_NEG)  { ret emit_unary(e, vm, preg_val, mi, by_class(lf, spirv.OP_S_NEGATE, spirv.OP_F_NEGATE)); }
-    if (op == mir.MIR_NOT)  { ret emit_unary(e, vm, preg_val, mi, spirv.OP_NOT); }
-    if (op == mir.MIR_FNEG) { ret emit_unary(e, vm, preg_val, mi, spirv.OP_F_NEGATE); }
+    if (op == mir.MIR_NEG)  { ret emit_unary(e, vm, mi, by_class(lf, spirv.OP_S_NEGATE, spirv.OP_F_NEGATE)); }
+    if (op == mir.MIR_NOT)  { ret emit_unary(e, vm, mi, spirv.OP_NOT); }
+    if (op == mir.MIR_FNEG) { ret emit_unary(e, vm, mi, spirv.OP_F_NEGATE); }
 
-    if (op == mir.MIR_CMP_EQ)   { ret emit_compare(e, vm, preg_val, mi, by_class(lf, spirv.OP_I_EQUAL, spirv.OP_F_ORD_EQUAL)); }
-    if (op == mir.MIR_CMP_NE)   { ret emit_compare(e, vm, preg_val, mi, by_class(lf, spirv.OP_I_NOT_EQUAL, spirv.OP_F_UNORD_NOT_EQUAL)); }
-    if (op == mir.MIR_CMP_LT_S) { ret emit_compare(e, vm, preg_val, mi, by_class(lf, spirv.OP_S_LESS_THAN, spirv.OP_F_ORD_LESS_THAN)); }
-    if (op == mir.MIR_CMP_LT_U) { ret emit_compare(e, vm, preg_val, mi, by_class(lf, spirv.OP_U_LESS_THAN, spirv.OP_F_ORD_LESS_THAN)); }
-    if (op == mir.MIR_CMP_LE_S) { ret emit_compare(e, vm, preg_val, mi, by_class(lf, spirv.OP_S_LESS_THAN_EQUAL, spirv.OP_F_ORD_LESS_THAN_EQUAL)); }
-    if (op == mir.MIR_CMP_LE_U) { ret emit_compare(e, vm, preg_val, mi, by_class(lf, spirv.OP_U_LESS_THAN_EQUAL, spirv.OP_F_ORD_LESS_THAN_EQUAL)); }
+    if (op == mir.MIR_CMP_EQ)   { ret emit_compare(e, vm, mi, by_class(lf, spirv.OP_I_EQUAL, spirv.OP_F_ORD_EQUAL)); }
+    if (op == mir.MIR_CMP_NE)   { ret emit_compare(e, vm, mi, by_class(lf, spirv.OP_I_NOT_EQUAL, spirv.OP_F_UNORD_NOT_EQUAL)); }
+    if (op == mir.MIR_CMP_LT_S) { ret emit_compare(e, vm, mi, by_class(lf, spirv.OP_S_LESS_THAN, spirv.OP_F_ORD_LESS_THAN)); }
+    if (op == mir.MIR_CMP_LT_U) { ret emit_compare(e, vm, mi, by_class(lf, spirv.OP_U_LESS_THAN, spirv.OP_F_ORD_LESS_THAN)); }
+    if (op == mir.MIR_CMP_LE_S) { ret emit_compare(e, vm, mi, by_class(lf, spirv.OP_S_LESS_THAN_EQUAL, spirv.OP_F_ORD_LESS_THAN_EQUAL)); }
+    if (op == mir.MIR_CMP_LE_U) { ret emit_compare(e, vm, mi, by_class(lf, spirv.OP_U_LESS_THAN_EQUAL, spirv.OP_F_ORD_LESS_THAN_EQUAL)); }
 
-    if (op == mir.MIR_FCMP) { ret emit_float_compare(e, vm, preg_val, mi); }
+    if (op == mir.MIR_FCMP) { ret emit_float_compare(e, vm, mi); }
 
-    if (op == mir.MIR_VEC_EXTRACT) { ret emit_vec_extract(e, vm, preg_val, mi); }
-    if (op == mir.MIR_VEC_INSERT)  { ret emit_vec_insert(e, vm, preg_val, mi); }
-    if (op == mir.MIR_VEC_BUILD)   { ret emit_vec_build(e, vm, preg_val, mi); }
+    if (op == mir.MIR_VEC_EXTRACT) { ret emit_vec_extract(e, vm, mi); }
+    if (op == mir.MIR_VEC_INSERT)  { ret emit_vec_insert(e, vm, mi); }
+    if (op == mir.MIR_VEC_BUILD)   { ret emit_vec_build(e, vm, mi); }
 
-    if (op == mir.MIR_TRUNC) { ret emit_convert(e, vm, preg_val, mi, spirv.OP_U_CONVERT, false); }
-    if (op == mir.MIR_ZEXT)  { ret emit_convert(e, vm, preg_val, mi, spirv.OP_U_CONVERT, false); }
-    if (op == mir.MIR_SEXT)  { ret emit_convert(e, vm, preg_val, mi, spirv.OP_S_CONVERT, false); }
+    if (op == mir.MIR_TRUNC) { ret emit_convert(e, vm, mi, spirv.OP_U_CONVERT, false); }
+    if (op == mir.MIR_ZEXT)  { ret emit_convert(e, vm, mi, spirv.OP_U_CONVERT, false); }
+    if (op == mir.MIR_SEXT)  { ret emit_convert(e, vm, mi, spirv.OP_S_CONVERT, false); }
 
-    if (op == mir.MIR_FP_TRUNC) { ret emit_convert(e, vm, preg_val, mi, spirv.OP_F_CONVERT, true); }
-    if (op == mir.MIR_FP_EXT)   { ret emit_convert(e, vm, preg_val, mi, spirv.OP_F_CONVERT, true); }
-    if (op == mir.MIR_FP_TO_SI) { ret emit_convert(e, vm, preg_val, mi, spirv.OP_CONVERT_F_TO_S, true); }
-    if (op == mir.MIR_FP_TO_UI) { ret emit_convert(e, vm, preg_val, mi, spirv.OP_CONVERT_F_TO_U, true); }
-    if (op == mir.MIR_SI_TO_FP) { ret emit_convert(e, vm, preg_val, mi, spirv.OP_CONVERT_S_TO_F, false); }
-    if (op == mir.MIR_UI_TO_FP) { ret emit_convert(e, vm, preg_val, mi, spirv.OP_CONVERT_U_TO_F, false); }
+    if (op == mir.MIR_FP_TRUNC) { ret emit_convert(e, vm, mi, spirv.OP_F_CONVERT, true); }
+    if (op == mir.MIR_FP_EXT)   { ret emit_convert(e, vm, mi, spirv.OP_F_CONVERT, true); }
+    if (op == mir.MIR_FP_TO_SI) { ret emit_convert(e, vm, mi, spirv.OP_CONVERT_F_TO_S, true); }
+    if (op == mir.MIR_FP_TO_UI) { ret emit_convert(e, vm, mi, spirv.OP_CONVERT_F_TO_U, true); }
+    if (op == mir.MIR_SI_TO_FP) { ret emit_convert(e, vm, mi, spirv.OP_CONVERT_S_TO_F, false); }
+    if (op == mir.MIR_UI_TO_FP) { ret emit_convert(e, vm, mi, spirv.OP_CONVERT_U_TO_F, false); }
 
-    if (op == mir.MIR_BITCAST) { ret emit_convert(e, vm, preg_val, mi, spirv.OP_BITCAST, false); }
+    if (op == mir.MIR_BITCAST) { ret emit_convert(e, vm, mi, spirv.OP_BITCAST, false); }
 
-    if (op == mir.MIR_MOV) { ret emit_mov(e, vm, preg_val, mi); }
-    if (op == mir.MIR_DECLASSIFY) { ret emit_mov(e, vm, preg_val, mi); }
+    if (op == mir.MIR_MOV) { ret emit_mov(e, vm, mi); }
+    if (op == mir.MIR_DECLASSIFY) { ret emit_mov(e, vm, mi); }
 
-    if (op == mir.MIR_CALL) { ret emit_call(e, preg_val, mi); }
-    if (op == mir.MIR_CALL_RES) { ret R.ok_void[str](); }
+    if (op == mir.MIR_VALUE_CALL) { ret emit_call(e, mf, vm, mi); }
+    if (op == mir.MIR_VALUE_PARAM) { ret emit_param(e, mf, vm, mi, params, param_count); }
 
-    if (op == mir.MIR_LOAD)  { ret emit_global_load(e, mf, vm, preg_val, mi); }
-    if (op == mir.MIR_STORE) { ret emit_global_store(e, mf, vm, preg_val, mi); }
-    if (op == mir.MIR_GEP) { ret emit_access_chain(e, mf, vm, preg_val, mi); }
+    if (op == mir.MIR_LOAD)  { ret emit_global_load(e, mf, vm, mi); }
+    if (op == mir.MIR_STORE) { ret emit_global_store(e, mf, vm, mi); }
+    if (op == mir.MIR_GEP) { ret emit_access_chain(e, mf, vm, mi); }
     if (op == mir.MIR_ALLOCA) { ret R.ok_void[str](); }
     if (op == mir.MIR_MEMZERO) { ret emit_memzero(e, mf, vm, mi); }
     if (op == mir.MIR_MEMCPY) { ret emit_memcpy(e, mf, vm, mi); }
-    if (op == mir.MIR_AGG_LOAD)  { ret emit_agg_load(e, mf, vm, preg_val, mi); }
-    if (op == mir.MIR_AGG_STORE) { ret emit_agg_store(e, mf, vm, preg_val, mi); }
 
     ret unsupported(e, "instruction is not yet supported by the SPIR-V target");
 }
 
-fun emit_call(e: *Emit, preg_val: *Regs, mi: *mir.MirInstr) R.Result[R.Void, str] {
-    if (mi.operand_count < 1) { ret emit_fail(e, "spirv.emit: call with no callee operand"); }
+fun emit_call(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr) R.Result[R.Void, str] {
+    if (mi.operand_count < 2) { ret emit_fail(e, "spirv.emit: logical call requires callee and result operands"); }
     val callee: *mir.MirOperand = ?mi.operands[0];
     if (callee.kind != mir.MIR_OP_SYM) {
-        ret unsupported(e, "a call through a function pointer is not yet supported by the SPIR-V target");
+        ret unsupported(e, "SPIR-V logical shader calls require a statically named function");
     }
-
     val xfn: *ir.Function = ir_function_record(e.ir, callee.sym);
-    if (xfn != nil && xfn.op_set != defs.SPV_SET_NONE) {
-        ret emit_spirv_op(e, preg_val, xfn);
-    }
-    if (xfn != nil && xfn.is_import) {
-        ret unsupported(e, foreign_call_refusal(e, xfn));
-    }
-
+    if (xfn != nil && xfn.op_set != defs.SPV_SET_NONE) { ret emit_spirv_op(e, mf, vm, mi, xfn); }
+    if (xfn != nil && xfn.is_import) { ret unsupported(e, foreign_call_refusal(e, xfn)); }
     val fx: u32 = fn_lookup(e, callee.sym);
-    if (fx == FN_NONE || e.fns[fx].id == 0) {
-        ret unsupported(e, unresolved_call_refusal(e, callee.sym, fx));
-    }
-
+    if (fx == FN_NONE || e.fns[fx].id == 0) { ret unsupported(e, unresolved_call_refusal(e, callee.sym, fx)); }
+    val irfn: *ir.Function = fn_ir(e, fx);
+    val count: u32 = irfn.param_count;
+    if (count != mi.operand_count - 2) { ret emit_fail(e, "spirv.emit: logical call arity mismatch"); }
+    if (!types.instruction_operands_fit(3, count)) { ret unsupported(e, "SPIR-V OpFunctionCall arguments exceed its 65535-word instruction encoding"); }
+    val ar: R.Result[*u32, str] = A.allocate[u32](e.alloc, (count + 3)::usize);
+    if (R.is_err[*u32, str](ar)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](ar)); }
+    val ops: *u32 = R.unwrap_ok[*u32, str](ar);
+    fin { A.deallocate[u32](e.alloc, ops, (count + 3)::usize); }
     val saved_ir: *ir.Module = e.ir;
     val saved_mi: u32 = e.cur_mi;
     e.ir = fn_mod(e, fx);
     e.cur_mi = e.fns[fx].mi;
-    val irfn: *ir.Function = fn_ir(e, fx);
-
     var returns_void: bool = false;
     val ret_ty: u32 = ir_return_spv_type(e, irfn, ?returns_void);
-    if (ret_ty == 0) {
-        e.ir = saved_ir; e.cur_mi = saved_mi;
-        ret unsupported(e, "unsupported return type in the SPIR-V target");
-    }
-    if (irfn.param_count > types.MAX_FN_PARAMS) {
-        e.ir = saved_ir; e.cur_mi = saved_mi;
-        ret unsupported(e, "more than 16 parameters is not supported by the SPIR-V target");
-    }
-
-    var argty: [16]u32;
     var i: u32 = 0;
-    for (i < irfn.param_count) {
-        argty[i] = ir_value_spv_type(e, irfn.params[i].ty);
-        i = i + 1;
-    }
-    val param_count: u32 = irfn.param_count;
+    for (i < count) { ops[i + 3] = ir_value_spv_type(e, irfn.params[i].ty); i = i + 1; }
     e.ir = saved_ir;
     e.cur_mi = saved_mi;
-
-    val total: u32 = 3 + param_count;
-    var ops: [19]u32;
+    if (ret_ty == 0) { ret unsupported(e, "unsupported logical result type in SPIR-V"); }
     ops[0] = ret_ty;
-    val result: u32 = spirv.alloc_id(e.b);
-    ops[1] = result;
     ops[2] = e.fns[fx].id;
     i = 0;
-    for (i < param_count) {
-        val aid: u32 = reg_value(e, preg_val, i, argty[i]);
-        if (aid == 0) { ret emit_fail(e, "spirv.emit: call argument with no pre-colored value"); }
-        ops[3 + i] = aid;
+    for (i < count) {
+        if (ops[i + 3] == 0) { ret unsupported(e, "unsupported logical argument type in SPIR-V"); }
+        val value: R.Result[u32, str] = read_value(e, mf, vm, ?mi.operands[i + 2], ops[i + 3], mi.memory_flags);
+        if (R.is_err[u32, str](value)) { ret emit_fail(e, R.unwrap_err[u32, str](value)); }
+        ops[i + 3] = R.unwrap_ok[u32, str](value);
         i = i + 1;
     }
-    spirv.inst(e.b, ?e.b.functions, spirv.OP_FUNCTION_CALL, ?ops[0], total);
-    if (!returns_void) {
-        preg_val.val_id[0]  = result;
-        preg_val.is_imm[0]  = false;
-        preg_val.is_bool[0] = types.type_is_bool(e.tt, ret_ty);
+    ops[1] = spirv.alloc_id(e.b);
+    spirv.inst(e.b, ?e.b.functions, spirv.OP_FUNCTION_CALL, ops, count + 3);
+    if (!returns_void) { ret write_value(e, mf, vm, ?mi.operands[1], ops[1], ret_ty, mi.memory_flags); }
+    if (mi.operands[1].kind != mir.MIR_OP_VREG || mi.operands[1].vreg != mir.MIR_VREG_NIL) {
+        ret emit_fail(e, "spirv.emit: void logical call names a result");
     }
     ret R.ok_void[str]();
 }
@@ -2788,7 +2927,7 @@ fun unresolved_call_refusal(e: *Emit, name: intern.StrId, fx: u32) str {
     ret R.unwrap_ok[str, str](r);
 }
 
-fun emit_spirv_op(e: *Emit, preg_val: *Regs, fn: *ir.Function) R.Result[R.Void, str] {
+fun emit_spirv_op(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr, fn: *ir.Function) R.Result[R.Void, str] {
     val sig_opt: O.Option[*type.IrType] = type.get(?e.ir.types, fn.sig);
     if (O.is_none[*type.IrType](sig_opt)) {
         ret emit_fail(e, "spirv.emit: a `spirv_op` callee has no signature type");
@@ -2798,9 +2937,8 @@ fun emit_spirv_op(e: *Emit, preg_val: *Regs, fn: *ir.Function) R.Result[R.Void, 
         ret emit_fail(e, "spirv.emit: a `spirv_op` callee's signature is not a function type");
     }
     val argc: u32 = sig.data.fn.param_count;
-    if (argc > 12) {
-        ret unsupported(e, "a `spirv_op` function takes at most 12 parameters on the SPIR-V target");
-    }
+    if (argc != mi.operand_count - 2) { ret emit_fail(e, "spirv.emit: mapped logical call arity mismatch"); }
+    if (!types.instruction_operands_fit(4, argc)) { ret unsupported(e, "SPIR-V mapped instruction arguments exceed its 65535-word encoding"); }
 
     var returns_void: bool = false;
     val ret_ty: u32 = ir_return_spv_type(e, fn, ?returns_void);
@@ -2809,11 +2947,12 @@ fun emit_spirv_op(e: *Emit, preg_val: *Regs, fn: *ir.Function) R.Result[R.Void, 
         ret unsupported(e, "a `spirv_op` function must return a value; a SPIR-V instruction has a result id");
     }
 
-    var ops: [16]u32;
+    val ar: R.Result[*u32, str] = A.allocate[u32](e.alloc, (argc + 4)::usize);
+    if (R.is_err[*u32, str](ar)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](ar)); }
+    val ops: *u32 = R.unwrap_ok[*u32, str](ar);
+    fin { A.deallocate[u32](e.alloc, ops, (argc + 4)::usize); }
     var base: u32 = 2;
     ops[0] = ret_ty;
-    val result: u32 = spirv.alloc_id(e.b);
-    ops[1] = result;
     if (fn.op_set != defs.SPV_SET_CORE) {
         val set_id: u32 = ext_set_id(e, fn.op_set);
         if (set_id == 0) {
@@ -2826,20 +2965,20 @@ fun emit_spirv_op(e: *Emit, preg_val: *Regs, fn: *ir.Function) R.Result[R.Void, 
 
     var i: u32 = 0;
     for (i < argc) {
-        val aid: u32 = reg_value(e, preg_val, i, ir_value_spv_type(e, sig.data.fn.params[i]));
-        if (aid == 0) { ret emit_fail(e, "spirv.emit: `spirv_op` argument with no pre-colored value"); }
-        ops[base + i] = aid;
+        val value: R.Result[u32, str] = read_value(e, mf, vm, ?mi.operands[i + 2],
+            ir_value_spv_type(e, sig.data.fn.params[i]), mi.memory_flags);
+        if (R.is_err[u32, str](value)) { ret emit_fail(e, R.unwrap_err[u32, str](value)); }
+        ops[base + i] = R.unwrap_ok[u32, str](value);
         i = i + 1;
     }
+    val result: u32 = spirv.alloc_id(e.b);
+    ops[1] = result;
 
     var opcode: u32 = spirv.OP_EXT_INST;
     if (fn.op_set == defs.SPV_SET_CORE) { opcode = fn.op_code; }
     spirv.inst(e.b, ?e.b.functions, opcode, ?ops[0], base + argc);
 
-    preg_val.val_id[0]  = result;
-    preg_val.is_imm[0]  = false;
-    preg_val.is_bool[0] = types.type_is_bool(e.tt, ret_ty);
-    ret R.ok_void[str]();
+    ret write_value(e, mf, vm, ?mi.operands[1], result, ret_ty, mi.memory_flags);
 }
 
 fun ext_set_id(e: *Emit, set: u32) u32 {
@@ -2861,7 +3000,7 @@ fun ir_function_record(irmod: *ir.Module, name: intern.StrId) *ir.Function {
     ret nil;
 }
 
-fun read_operand(e: *Emit, vm: *VMaps, preg_val: *Regs, op: *mir.MirOperand, want_ty: u32) u32 {
+fun read_operand(e: *Emit, vm: *VMaps, op: *mir.MirOperand, want_ty: u32) u32 {
     if (op.kind == mir.MIR_OP_VREG) {
         val v: u32 = op.vreg;
         if (v < vm.n && vm.opq_var[v] != 0) {
@@ -2885,10 +3024,7 @@ fun read_operand(e: *Emit, vm: *VMaps, preg_val: *Regs, op: *mir.MirOperand, wan
     if (op.kind == mir.MIR_OP_IMM) {
         ret immediate(e, want_ty, op.imm);
     }
-    if (op.kind == mir.MIR_OP_PREG) {
-        if (op.preg >= 16) { e.b.err = true; ret 0; }
-        ret reg_value(e, preg_val, op.preg, want_ty);
-    }
+
     e.b.err = true;
     ret 0;
 }
@@ -2937,7 +3073,7 @@ fun store_vreg(e: *Emit, vm: *VMaps, vreg: u32, value: u32) R.Result[R.Void, str
     ret R.ok_void[str]();
 }
 
-fun emit_binary(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr, op_code: u32) R.Result[R.Void, str] {
+fun emit_binary(e: *Emit, vm: *VMaps, mi: *mir.MirInstr, op_code: u32) R.Result[R.Void, str] {
     if (mi.operand_count != 3 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret emit_fail(e, "spirv.emit: malformed binary instruction");
     }
@@ -2948,8 +3084,8 @@ fun emit_binary(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr, op_cod
      || !operand_matches_type(vm, ?mi.operands[2], ty)) {
         ret emit_fail(e, "spirv.emit: binary instruction mixes operand types");
     }
-    val a: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], ty);
-    val b: u32 = read_operand(e, vm, preg_val, ?mi.operands[2], ty);
+    val a: u32 = read_operand(e, vm, ?mi.operands[1], ty);
+    val b: u32 = read_operand(e, vm, ?mi.operands[2], ty);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in binary instruction"); }
     val result: u32 = spirv.alloc_id(e.b);
     var ops: [4]u32;
@@ -2958,13 +3094,13 @@ fun emit_binary(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr, op_cod
     ret store_vreg(e, vm, dst, result);
 }
 
-fun emit_unary(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr, op_code: u32) R.Result[R.Void, str] {
+fun emit_unary(e: *Emit, vm: *VMaps, mi: *mir.MirInstr, op_code: u32) R.Result[R.Void, str] {
     if (mi.operand_count != 2 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret emit_fail(e, "spirv.emit: malformed unary instruction");
     }
     val dst: u32 = mi.operands[0].vreg;
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: unary result vreg out of range"); }
-    val a: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], vm.type_id[dst]);
+    val a: u32 = read_operand(e, vm, ?mi.operands[1], vm.type_id[dst]);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in unary instruction"); }
     val result: u32 = spirv.alloc_id(e.b);
     var ops: [3]u32;
@@ -2973,9 +3109,9 @@ fun emit_unary(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr, op_code
     ret store_vreg(e, vm, dst, result);
 }
 
-fun emit_compare(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr, op_code: u32) R.Result[R.Void, str] {
+fun emit_compare(e: *Emit, vm: *VMaps, mi: *mir.MirInstr, op_code: u32) R.Result[R.Void, str] {
     if (mir.vec_lane_is_vector(mi.vec_lane)) {
-        ret emit_vector_compare(e, vm, preg_val, mi, op_code);
+        ret emit_vector_compare(e, vm, mi, op_code);
     }
     var cbits: u32 = mi.width::u32 * 8;
     if (cbits == 0) { cbits = e.tgt.model.gpr_width * 8; }
@@ -2983,10 +3119,10 @@ fun emit_compare(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr, op_co
     if (cmp_ty == 0) {
         ret unsupported(e, "unsupported comparison width in the SPIR-V target");
     }
-    ret emit_compare_typed(e, vm, preg_val, mi, op_code, cmp_ty);
+    ret emit_compare_typed(e, vm, mi, op_code, cmp_ty);
 }
 
-fun emit_vector_compare(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr, op_code: u32) R.Result[R.Void, str] {
+fun emit_vector_compare(e: *Emit, vm: *VMaps, mi: *mir.MirInstr, op_code: u32) R.Result[R.Void, str] {
     if (mi.operand_count != 3 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret emit_fail(e, "spirv.emit: malformed vector comparison instruction");
     }
@@ -3001,8 +3137,8 @@ fun emit_vector_compare(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr
         ret unsupported(e, unsupported_value_type(e, mi));
     }
 
-    val a: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], operand_ty);
-    val b: u32 = read_operand(e, vm, preg_val, ?mi.operands[2], operand_ty);
+    val a: u32 = read_operand(e, vm, ?mi.operands[1], operand_ty);
+    val b: u32 = read_operand(e, vm, ?mi.operands[2], operand_ty);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in vector comparison"); }
 
     val bvec: u32 = spirv.alloc_id(e.b);
@@ -3034,7 +3170,7 @@ fun mask_splat(e: *Emit, vec_ty: u32, lanes: u32, lo: u32, hi: u32) u32 {
     ret types.const_composite(e.tt, vec_ty, ?parts[0], count);
 }
 
-fun emit_vec_extract(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[R.Void, str] {
+fun emit_vec_extract(e: *Emit, vm: *VMaps, mi: *mir.MirInstr) R.Result[R.Void, str] {
     if (mi.operand_count != 3 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret emit_fail(e, "spirv.emit: malformed vector extract instruction");
     }
@@ -3045,7 +3181,7 @@ fun emit_vec_extract(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: vector extract result vreg out of range"); }
     val vec_ty: u32 = operand_vector_type(e, vm, mi, ?mi.operands[1]);
     if (vec_ty == 0) { ret unsupported(e, unsupported_value_type(e, mi)); }
-    val src: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], vec_ty);
+    val src: u32 = read_operand(e, vm, ?mi.operands[1], vec_ty);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in vector extract"); }
 
     val result: u32 = spirv.alloc_id(e.b);
@@ -3055,7 +3191,7 @@ fun emit_vec_extract(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R
     ret store_vreg(e, vm, dst, result);
 }
 
-fun emit_vec_insert(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[R.Void, str] {
+fun emit_vec_insert(e: *Emit, vm: *VMaps, mi: *mir.MirInstr) R.Result[R.Void, str] {
     if (mi.operand_count != 4 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret emit_fail(e, "spirv.emit: malformed vector insert instruction");
     }
@@ -3070,8 +3206,8 @@ fun emit_vec_insert(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.
     val lane_ty: u32 = types.vector_value_shape(e.tt, vec_ty, ?lanes);
     if (lane_ty == 0) { ret unsupported(e, unsupported_value_type(e, mi)); }
 
-    val src: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], vec_ty);
-    val lane: u32 = read_operand(e, vm, preg_val, ?mi.operands[3], lane_ty);
+    val src: u32 = read_operand(e, vm, ?mi.operands[1], vec_ty);
+    val lane: u32 = read_operand(e, vm, ?mi.operands[3], lane_ty);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in vector insert"); }
 
     val result: u32 = spirv.alloc_id(e.b);
@@ -3081,7 +3217,7 @@ fun emit_vec_insert(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.
     ret store_vreg(e, vm, dst, result);
 }
 
-fun emit_vec_build(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[R.Void, str] {
+fun emit_vec_build(e: *Emit, vm: *VMaps, mi: *mir.MirInstr) R.Result[R.Void, str] {
     if (mi.operand_count < 2 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret emit_fail(e, "spirv.emit: malformed vector build instruction");
     }
@@ -3105,7 +3241,7 @@ fun emit_vec_build(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.R
     ops[1] = result;
     var i: u32 = 0;
     for (i < given) {
-        ops[2 + i] = read_operand(e, vm, preg_val, ?mi.operands[1 + i], lane_ty);
+        ops[2 + i] = read_operand(e, vm, ?mi.operands[1 + i], lane_ty);
         i = i + 1;
     }
     if (e.b.err) {
@@ -3126,7 +3262,7 @@ fun operand_vector_type(e: *Emit, vm: *VMaps, mi: *mir.MirInstr, op: *mir.MirOpe
     ret vector_type_of(e, mi.vec_lane, false);
 }
 
-fun emit_float_compare(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[R.Void, str] {
+fun emit_float_compare(e: *Emit, vm: *VMaps, mi: *mir.MirInstr) R.Result[R.Void, str] {
     var fbits: u32 = mi.width::u32 * 8;
     if (fbits != 32 && fbits != 64) {
         ret unsupported(e, "unsupported float comparison width in the SPIR-V target");
@@ -3139,10 +3275,10 @@ fun emit_float_compare(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr)
     or (cc == mir.FCC_LE)      { op_code = spirv.OP_F_ORD_LESS_THAN_EQUAL; }
     or (cc == mir.FCC_GT)      { op_code = spirv.OP_F_ORD_GREATER_THAN; }
     or (cc != mir.FCC_GE)      { ret unsupported(e, "unknown float comparison condition in the SPIR-V target"); }
-    ret emit_compare_typed(e, vm, preg_val, mi, op_code, types.type_float(e.tt, fbits));
+    ret emit_compare_typed(e, vm, mi, op_code, types.type_float(e.tt, fbits));
 }
 
-fun emit_compare_typed(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr,
+fun emit_compare_typed(e: *Emit, vm: *VMaps, mi: *mir.MirInstr,
                        op_code: u32, operand_ty: u32) R.Result[R.Void, str] {
     if (mi.operand_count != 3 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret emit_fail(e, "spirv.emit: malformed comparison instruction");
@@ -3153,8 +3289,8 @@ fun emit_compare_typed(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr,
      || !operand_matches_type(vm, ?mi.operands[2], operand_ty)) {
         ret emit_fail(e, "spirv.emit: comparison mixes operand types");
     }
-    val a: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], operand_ty);
-    val b: u32 = read_operand(e, vm, preg_val, ?mi.operands[2], operand_ty);
+    val a: u32 = read_operand(e, vm, ?mi.operands[1], operand_ty);
+    val b: u32 = read_operand(e, vm, ?mi.operands[2], operand_ty);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in comparison"); }
     val bool_ty: u32 = types.type_bool(e.tt);
     val result: u32 = spirv.alloc_id(e.b);
@@ -3164,7 +3300,7 @@ fun emit_compare_typed(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr,
     ret store_vreg(e, vm, dst, result);
 }
 
-fun emit_convert(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr,
+fun emit_convert(e: *Emit, vm: *VMaps, mi: *mir.MirInstr,
                  op_code: u32, src_is_float: bool) R.Result[R.Void, str] {
     if (mi.operand_count != 2 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret emit_fail(e, "spirv.emit: malformed conversion instruction");
@@ -3181,7 +3317,7 @@ fun emit_convert(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr,
             ret unsupported(e, "unsupported conversion source width in the SPIR-V target");
         }
     }
-    val a: u32 = read_operand(e, vm, preg_val, ?mi.operands[1], src_ty);
+    val a: u32 = read_operand(e, vm, ?mi.operands[1], src_ty);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in conversion"); }
     val result: u32 = spirv.alloc_id(e.b);
     var ops: [3]u32;
@@ -3190,48 +3326,31 @@ fun emit_convert(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr,
     ret store_vreg(e, vm, dst, result);
 }
 
-fun emit_mov(e: *Emit, vm: *VMaps, preg_val: *Regs, mi: *mir.MirInstr) R.Result[R.Void, str] {
+fun emit_mov(e: *Emit, vm: *VMaps, mi: *mir.MirInstr) R.Result[R.Void, str] {
     if (mi.operand_count != 2) { ret emit_fail(e, "spirv.emit: malformed move instruction"); }
     val dst: *mir.MirOperand = ?mi.operands[0];
     val src: *mir.MirOperand = ?mi.operands[1];
 
     if (dst.kind == mir.MIR_OP_VREG) {
         if (dst.vreg >= vm.n) { ret emit_fail(e, "spirv.emit: move destination vreg out of range"); }
-        val val_id: u32 = read_operand(e, vm, preg_val, src, vm.type_id[dst.vreg]);
-        if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable move source"); }
-        ret store_vreg(e, vm, dst.vreg, val_id);
-    }
-    if (dst.kind == mir.MIR_OP_PREG) {
-        if (dst.preg >= 16) { ret emit_fail(e, "spirv.emit: move destination register out of range"); }
-        if (src.kind == mir.MIR_OP_IMM) {
-            preg_val.val_id[dst.preg]  = 0;
-            preg_val.imm[dst.preg]     = src.imm;
-            preg_val.is_imm[dst.preg]  = true;
-            preg_val.is_bool[dst.preg] = false;
+        var pointee: u32 = 0;
+        val reference: u32 = chain_target(vm, src, ?pointee);
+        if (reference != 0) {
+            vm.chain_id[dst.vreg] = reference;
+            vm.chain_ty[dst.vreg] = pointee;
+            vm.chain_sc[dst.vreg] = chain_storage(vm, src);
+            vm.chain_object[dst.vreg] = src.vreg < vm.n && vm.chain_object[src.vreg];
             ret R.ok_void[str]();
         }
-        val boolean: bool = operand_is_bool(vm, preg_val, src);
-        val val_id: u32 = read_operand(e, vm, preg_val, src, 0);
+        val val_id: u32 = read_operand(e, vm, src, vm.type_id[dst.vreg]);
         if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable move source"); }
-        preg_val.val_id[dst.preg]  = val_id;
-        preg_val.is_imm[dst.preg]  = false;
-        preg_val.is_bool[dst.preg] = boolean;
-        ret R.ok_void[str]();
+        ret store_vreg(e, vm, dst.vreg, val_id);
     }
     ret unsupported(e, "memory-destination move is not yet supported by the SPIR-V target");
 }
 
-fun reg_value(e: *Emit, rg: *Regs, k: u32, want_ty: u32) u32 {
-    if (rg.is_imm[k]) { ret immediate(e, want_ty, rg.imm[k]); }
-    if (rg.is_bool[k] && rg.val_id[k] != 0 && want_ty != 0 && !types.type_is_bool(e.tt, want_ty)) {
-        ret widen_bool(e, rg.val_id[k], want_ty);
-    }
-    ret rg.val_id[k];
-}
-
-fun operand_is_bool(vm: *VMaps, rg: *Regs, op: *mir.MirOperand) bool {
+fun operand_is_bool(vm: *VMaps, op: *mir.MirOperand) bool {
     if (op.kind == mir.MIR_OP_VREG) { ret op.vreg < vm.n && vm.is_bool[op.vreg]; }
-    if (op.kind == mir.MIR_OP_PREG) { ret op.preg < 16 && rg.is_bool[op.preg]; }
     ret false;
 }
 
@@ -3406,18 +3525,17 @@ test "mach.lang.target.isa.spirv.emit:volatile_opaque_load_is_evaluated_once_at_
     vm.type_id = ?tys[0];
     vm.opq_ssa = ?held[0];
     vm.opq_var = ?deferred[0];
-    var regs: Regs;
     var mf: mir.MirFunction;
     var ops: [2]mir.MirOperand;
     ops[0] = mir.op_vreg(0);
     ops[1] = mir.op_sym(1, 0);
     var mi: mir.MirInstr = mir.instr(mir.MIR_LOAD, ?ops[0], 2, 8, 8);
     mi.memory_flags = mir.MEMORY_VOLATILE;
-    if (R.is_err[R.Void, str](emit_global_load(?e, ?mf, ?vm, ?regs, ?mi))) { ret 2; }
+    if (R.is_err[R.Void, str](emit_global_load(?e, ?mf, ?vm, ?mi))) { ret 2; }
     if (b.functions.len != 5 || b.functions.words[4] != 1) { ret 3; }
     if (held[0] == 0 || deferred[0] != 0) { ret 4; }
-    val first: u32 = read_operand(?e, ?vm, ?regs, ?ops[0], ty);
-    val second: u32 = read_operand(?e, ?vm, ?regs, ?ops[0], ty);
+    val first: u32 = read_operand(?e, ?vm, ?ops[0], ty);
+    val second: u32 = read_operand(?e, ?vm, ?ops[0], ty);
     if (first != held[0] || second != held[0]) { ret 5; }
     if (b.functions.len != 5 || b.err) { ret 6; }
     ret 0;

--- a/src/lang/target/isa/spirv/register.mach
+++ b/src/lang/target/isa/spirv/register.mach
@@ -13,7 +13,6 @@ use mach.lang.target.isa.spirv.defs;
 
 pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[R.Void, str] {
     var spirv_model:   isa.MachineModel;
-    var spirv_classes: [2]isa.RegClass;
     var def_storage: defs.DefStorage;
 
     spirv_model.pointer_width = 8;
@@ -22,14 +21,8 @@ pub fun register_spirv(reg: *isa.IsaRegistry) R.Result[R.Void, str] {
     spirv_model.spill_width   = 8;
     spirv_model.alu_min_width = 1;
     spirv_model.endianness    = isa.ENDIAN_LITTLE;
-    spirv_classes[0].name      = "gpr";
-    spirv_classes[0].kind      = isa.RC_GENERAL;
-    spirv_classes[0].len       = 16;
-    spirv_classes[1].name      = "fpr";
-    spirv_classes[1].kind      = isa.RC_FLOAT;
-    spirv_classes[1].len       = 16;
-    spirv_model.reg_classes   = ?spirv_classes[0];
-    spirv_model.reg_class_len = 2;
+    spirv_model.reg_classes   = nil;
+    spirv_model.reg_class_len = 0;
     spirv_model.frame_ptr_reg = -1;
     spirv_model.stack_ptr_reg = -1;
     spirv_model.reserved_regs = nil;

--- a/src/lang/target/isa/spirv/types.mach
+++ b/src/lang/target/isa/spirv/types.mach
@@ -50,7 +50,7 @@ pub val MAX_VECTOR_COMPONENTS: u32 = 4;
 
 pub val MAX_STRUCT_MEMBERS: u32 = 16;
 
-pub val MAX_FN_PARAMS: u32 = 16;
+
 
 rec CompositeKey {
     type_id:    u32;
@@ -446,9 +446,23 @@ pub fun type_ptr(tt: *TypeTable, storage: u32, pointee: u32) u32 {
     ret id;
 }
 
+pub fun pointer_shape(tt: *TypeTable, id: u32, storage: *u32) u32 {
+    var i: usize = 0;
+    for (i < tt.scalars.len) {
+        val k: *ScalarKey = ?tt.scalars.data[i];
+        if (k.id == id && k.tag == TAG_PTR) { @storage = k.a; ret k.b; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+pub fun instruction_operands_fit(fixed: u32, variable: u32) bool {
+    ret fixed <= 65534 && variable <= 65534 - fixed;
+}
+
 pub fun type_fn(tt: *TypeTable, ret_id: u32, params: *u32, n: u32) u32 {
     if (tt.b.err) { ret 0; }
-    if (n > MAX_FN_PARAMS) { ret 0; }
+    if (!instruction_operands_fit(2, n)) { ret 0; }
 
     var i: usize = 0;
     for (i < tt.fns.len) {
@@ -460,7 +474,10 @@ pub fun type_fn(tt: *TypeTable, ret_id: u32, params: *u32, n: u32) u32 {
     }
 
     val id: u32 = spirv.alloc_id(tt.b);
-    var ops: [18]u32;
+    val ar: R.Result[*u32, str] = A.allocate[u32](tt.b.alloc, (n + 2)::usize);
+    if (R.is_err[*u32, str](ar)) { tt.b.err = true; ret 0; }
+    val ops: *u32 = R.unwrap_ok[*u32, str](ar);
+    fin { A.deallocate[u32](tt.b.alloc, ops, (n + 2)::usize); }
     ops[0] = id; ops[1] = ret_id;
     var pi: u32 = 0;
     for (pi < n) { ops[2 + pi] = params[pi]; pi = pi + 1; }
@@ -971,7 +988,7 @@ test "mach.lang.target.isa.spirv.types.type_array:shape_cache_insert_failure_rol
 
 test "mach.lang.target.isa.spirv.types.type_fn:cache_insert_failure_marks_err_frees_the_copy_and_caches_nothing" {
     var probe: TypesFailProbe;
-    var alloc: A.Allocator = types_fail_probe_make(?probe, 4);
+    var alloc: A.Allocator = types_fail_probe_make(?probe, 5);
     var b: spirv.Builder = spirv.builder_init(?alloc);
     var tt: TypeTable = types_init(?b);
     val ret_id: u32 = type_void(?tt);
@@ -983,9 +1000,9 @@ test "mach.lang.target.isa.spirv.types.type_fn:cache_insert_failure_marks_err_fr
     var bad: i32 = 0;
     if (id != 0)             { bad = 1; }
     if (!b.err)              { bad = 2; }
-    if (probe.allocate_calls != 4) { bad = 3; }
-    if (probe.allocate_ok != 3) { bad = 4; }
-    if (probe.deallocate_calls != 1) { bad = 5; }
+    if (probe.allocate_calls != 5) { bad = 3; }
+    if (probe.allocate_ok != 4) { bad = 4; }
+    if (probe.deallocate_calls != 2) { bad = 5; }
     if (tt.fns.len != 0)     { bad = 6; }
 
     types_dnit(?tt);
@@ -1079,4 +1096,25 @@ test "mach.lang.target.isa.spirv.types.type_int:instruction_emission_failure_mid
     types_dnit(?tt);
     spirv.builder_dnit(?b);
     ret bad;
+}
+
+test "mach.lang.target.isa.spirv.types:logical_signature_has_no_synthetic_parameter_bank" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var b: spirv.Builder = spirv.builder_init(?alloc);
+    fin { spirv.builder_dnit(?b); }
+    var tt: TypeTable = types_init(?b);
+    fin { types_dnit(?tt); }
+    val elem: u32 = type_int(?tt, 32);
+    var params: [256]u32;
+    var i: u32 = 0;
+    for (i < 256) { params[i] = elem; i = i + 1; }
+    val result: u32 = type_fn(?tt, elem, ?params[0], 256);
+    if (result == 0 || b.err || tt.fns.len != 1) { ret 2; }
+    if (tt.fns.data[0].param_count != 256 || tt.fns.data[0].params[255] != elem) { ret 3; }
+    if (type_fn(?tt, elem, ?params[0], 256) != result || tt.fns.len != 1) { ret 4; }
+    if (!instruction_operands_fit(2, 65532) || instruction_operands_fit(2, 65533)) { ret 5; }
+    if (!instruction_operands_fit(3, 65531) || instruction_operands_fit(3, 65532)) { ret 6; }
+    if (instruction_operands_fit(65535, 0)) { ret 7; }
+    ret 0;
 }

--- a/src/lang/target/isa/tests.mach
+++ b/src/lang/target/isa/tests.mach
@@ -29,7 +29,7 @@ val CENSUS_HARNESS:     i32 = 1;
 val CENSUS_UNPERMITTED: i32 = 2;
 val CENSUS_COUNT:       i32 = 3;
 
-val ALLOWED_LEN: usize = 12;
+val ALLOWED_LEN: usize = 13;
 
 fun allowed_fun(i: usize) str {
     if (i == 0)  { ret "operand_blank"; }
@@ -43,6 +43,7 @@ fun allowed_fun(i: usize) str {
     if (i == 8)  { ret "instr"; }
     if (i == 9)  { ret "abi_vtable"; }
     if (i == 10) { ret "vreg"; }
+    if (i == 12) { ret "value_abi_vtable"; }
     ret "asm_bind";
 }
 
@@ -56,7 +57,7 @@ fun allowed_file(i: usize) str {
     if (i == 6)  { ret "src/lang/target/isa/arm64/printer.mach"; }
     if (i == 7)  { ret "src/lang/target/isa/asm.mach"; }
     if (i == 8)  { ret "src/lang/be/codegen/mir.mach"; }
-    if (i == 9)  { ret "src/lang/target/abi.mach"; }
+    if (i == 9 || i == 12) { ret "src/lang/target/abi.mach"; }
     ret "src/lang/be/codegen/mir.mach";
 }
 

--- a/src/lang/target/testing.mach
+++ b/src/lang/target/testing.mach
@@ -1,9 +1,11 @@
 use std.types.bool.bool;
+use std.types.bool.false;
 use std.types.string.str;
 
 use R: std.types.result;
 
 use mach.lang.be.codegen.debug_input;
+use mach.lang.target.abi;
 use mach.lang.target.of;
 
 fun produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
@@ -21,4 +23,9 @@ pub fun debug_descriptor() R.Result[of.DebugVTable, str] {
     descriptor.produce = produce;
     descriptor.supports = supports;
     ret R.ok[of.DebugVTable, str](descriptor);
+}
+
+# a register-machine scaffold convention: carriers, no banks, no hooks; only for tests that never classify
+pub fun carriers_convention() abi.AbiVTable {
+    ret abi.abi_vtable(0, "", 0, nil, nil, nil, nil, 16, 0, 0, -1, false, false, false, 0, 8, nil);
 }

--- a/test/cases/call/call_float_regs.mach
+++ b/test/cases/call/call_float_regs.mach
@@ -3,8 +3,7 @@
 # riscv, and a second sixteen, all f32, put that tail in stack slots wider than the
 # value. every operand is a multiple of 1/64 with a small exponent, so every sum and
 # product below is exact in both f32 and f64 and the case measures argument
-# placement rather than rounding. sixteen is also the most parameters the SPIR-V
-# target accepts, which is why the tail stops there rather than running longer.
+# placement rather than rounding.
 
 use corpus.lib.fold;
 

--- a/test/cases/call/call_int_regs.mach
+++ b/test/cases/call/call_int_regs.mach
@@ -3,8 +3,7 @@
 # second sixteen, all narrower than a stack slot, put that tail in slots wider than
 # the values. every argument is folded in parameter order, so a swapped pair, a slot
 # written at the wrong width, or a narrow argument extended the wrong way changes
-# the checksum. sixteen is also the most parameters the SPIR-V target accepts, which
-# is why the tail stops there rather than running longer.
+# the checksum.
 
 use corpus.lib.fold;
 

--- a/test/golden/spirv/SKIPS
+++ b/test/golden/spirv/SKIPS
@@ -26,21 +26,24 @@
 # would record broken output as the code we meant to generate, which is worse than
 # having no golden at all.
 #
-# 78 of the 91 cases build and validate for spirv and carry the column. the 13 below
-# do not.
+# 82 of the 91 cases build and validate for spirv at every profile and carry the
+# column. mem/rec_layout carries layer B and the o2 half of layer A. the 8 cases
+# below cannot be expressed by the target.
 
 # ---- TARGET LIMITATION ----
 
 call/call_recursive  ab  a SPIR-V execution model has no call stack, so a function may not be reachable from itself: "this call graph is a cycle and the SPIR-V target cannot express it: descend -> descend". recursion at four shapes is what the case is, so there is nothing to narrow.
 call/call_chain      ab  same refusal, "chain -> chain". the case holds values live across a self-recursive chain by construction.
-call/call_indirect   ab  "unsupported parameter type in the SPIR-V target (in apply)". the parameter is a function value and logical addressing has no function pointer, so the target cannot take the case's whole subject.
+call/call_indirect   ab  "unsupported parameter 1 of type `fun(i64, i64) i64` in the SPIR-V Logical Shader environment: logical addressing has no function pointers, so a function value cannot cross a call". the parameter is a function value, so the target cannot take the case's whole subject.
 cmp/short_circuit    ab  "a plain module-scope variable is not reachable from the SPIR-V target: a shader has no general global storage, so a module-scope `val` / `var` reaches a stage only by carrying an interface role". the case proves non-evaluation through side-effect counters, which have to be module-scope state.
 mem/global_data      ab  same refusal. module-scope initialized storage is the case.
 mem/global_zero      ab  same refusal. module-scope zero-initialized storage is the case.
-mem/ptr_arith        ab  "unsupported parameter type in the SPIR-V target (in bump)". bump indexes off a pointer to a scalar, which is pointer arithmetic, and logical addressing reaches an object only through an access chain rooted in that object. pointer arithmetic is the case.
-mem/uni_layout       ab  a uni has no SPIR-V type: passed by value it is "unsupported parameter type in the SPIR-V target", and held locally it is "unsupported local allocation type in the SPIR-V target". a raw union read back through a second member is the case.
+mem/ptr_arith        ab  "pointer arithmetic across whole objects is not supported by the SPIR-V target: a logical pointer names one object, so a getelementptr's leading index may only be 0". the pointer-to-scalar parameter itself is accepted (#2940); bump then indexes off it, and pointer arithmetic is the case.
+mem/uni_layout       ab  "unsupported parameter 2 of type `uni{f32, i32, i32, [4]i8}` in the SPIR-V Logical Shader environment: SPIR-V has no untyped union, so a raw union has no type to declare". a raw union read back through a second member is the case.
+mem/rec_layout       a:o0  fill_mid(?n.w.m, ...) passes a subobject of a local record: "SPIR-V Logical Shader Function-storage reference arguments must name a memory object declaration, not a subobject access chain". spirv-val rejects an OpAccessChain result as an OpFunctionCall pointer operand in every declared environment (checked against spv1.0 through spv1.6 and vulkan1.0 through vulkan1.3), so this is a target bound, not #2940, which is closed for a whole-object or forwarded pointer-to-record argument. at o2 the call is inlined, the subobject reference disappears, and the case builds, validates and carries its layer B golden.
 
 # ---- MACH DEFECT ----
 
-mem/rec_layout     ab  #2940 fill_mid takes *Mid and the parameter is refused, "unsupported parameter type in the SPIR-V target (in fill_mid)". logical addressing expresses a Function-storage pointer parameter reached by access chain, so this is a missing lowering rather than a target bound.
-call/call_mixed    ab  #2923 "more than 16 parameters is not supported by the SPIR-V target (in mixed)". SPIR-V allows 255 and types.mach says the sixteen is the emitter's own fixed operand buffer. the case exists to exhaust the integer and float banks in one signature, which needs eighteen, so it cannot be shortened without giving up what it tests.
+# none. #2923 (more than sixteen parameters) and #2940 (a pointer to a record as a
+# parameter) closed with the value-oriented module ABI (#2963); call/call_mixed
+# carries the column and mem/rec_layout carries layer B.

--- a/test/golden/spirv/call/call_mixed.dis
+++ b/test/golden/spirv/call/call_mixed.dis
@@ -1,0 +1,2190 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Khronos; 0
+; Bound: 1583
+; Schema: 0
+OpCapability Shader
+OpCapability Linkage
+OpCapability Int8
+OpCapability Int16
+OpCapability Int64
+OpCapability Float64
+OpMemoryModel Logical GLSL450
+OpDecorate %1 LinkageAttributes "corpus.cases.call.call_mixed.gen" Export
+OpDecorate %2 LinkageAttributes "corpus.cases.call.call_mixed.as_f32" Export
+OpDecorate %3 LinkageAttributes "corpus.cases.call.call_mixed.as_f64" Export
+OpDecorate %4 LinkageAttributes "corpus.cases.call.call_mixed.mixed" Export
+OpDecorate %5 LinkageAttributes "corpus.cases.call.call_mixed.checksum" Export
+%ulong = OpTypeInt 64 0
+%16 = OpTypeFunction %ulong %ulong %ulong
+%_ptr_Function_ulong = OpTypePointer Function %ulong
+%ulong_6364136223846793005 = OpConstant %ulong 6364136223846793005
+%ulong_1442695040888963407 = OpConstant %ulong 1442695040888963407
+%float = OpTypeFloat 32
+%37 = OpTypeFunction %float %ulong
+%_ptr_Function_float = OpTypePointer Function %float
+%ulong_4095 = OpConstant %ulong 4095
+%float_2048 = OpConstant %float 2048
+%float_8 = OpConstant %float 8
+%double = OpTypeFloat 64
+%59 = OpTypeFunction %double %ulong
+%_ptr_Function_double = OpTypePointer Function %double
+%ulong_1048575 = OpConstant %ulong 1048575
+%double_524288 = OpConstant %double 524288
+%double_64 = OpConstant %double 64
+%uint = OpTypeInt 32 0
+%v3float = OpTypeVector %float 3
+%ushort = OpTypeInt 16 0
+%v4float = OpTypeVector %float 4
+%uchar = OpTypeInt 8 0
+%v2float = OpTypeVector %float 2
+%86 = OpTypeFunction %ulong %ulong %float %uint %double %v3float %ulong %float %ushort %v4float %double %ulong %float %uchar %double %v2float %ulong %float %uint %double %ulong
+%_ptr_Function_uint = OpTypePointer Function %uint
+%_ptr_Function_v3float = OpTypePointer Function %v3float
+%_ptr_Function_ushort = OpTypePointer Function %ushort
+%_ptr_Function_v4float = OpTypePointer Function %v4float
+%_ptr_Function_uchar = OpTypePointer Function %uchar
+%_ptr_Function_v2float = OpTypePointer Function %v2float
+%346 = OpTypeFunction %ulong %ulong
+%bool = OpTypeBool
+%uint_24 = OpConstant %uint 24
+%_arr_ulong_uint_24 = OpTypeArray %ulong %uint_24
+%_ptr_Function__arr_ulong_uint_24 = OpTypePointer Function %_arr_ulong_uint_24
+%_ptr_Function_bool = OpTypePointer Function %bool
+%655 = OpConstantNull %_arr_ulong_uint_24
+%ulong_0 = OpConstant %ulong 0
+%ulong_24 = OpConstant %ulong 24
+%ulong_3 = OpConstant %ulong 3
+%uint_2 = OpConstant %uint 2
+%uint_3 = OpConstant %uint 3
+%uint_4 = OpConstant %uint 4
+%uint_5 = OpConstant %uint 5
+%uint_6 = OpConstant %uint 6
+%uint_7 = OpConstant %uint 7
+%uint_8 = OpConstant %uint 8
+%uint_9 = OpConstant %uint 9
+%uint_0 = OpConstant %uint 0
+%uint_1 = OpConstant %uint 1
+%uint_10 = OpConstant %uint 10
+%uint_11 = OpConstant %uint 11
+%uint_12 = OpConstant %uint 12
+%uint_13 = OpConstant %uint 13
+%uint_14 = OpConstant %uint 14
+%uint_15 = OpConstant %uint 15
+%uint_17 = OpConstant %uint 17
+%uint_19 = OpConstant %uint 19
+%uint_21 = OpConstant %uint 21
+%uint_23 = OpConstant %uint 23
+%ulong_11 = OpConstant %ulong 11
+%uint_16 = OpConstant %uint 16
+%uint_18 = OpConstant %uint 18
+%uint_20 = OpConstant %uint 20
+%uint_22 = OpConstant %uint 22
+%ulong_1 = OpConstant %ulong 1
+%1225 = OpTypeFunction %ulong
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%1270 = OpTypeFunction %ulong %ulong %uchar
+%1315 = OpTypeFunction %ulong %ulong %ushort
+%1360 = OpTypeFunction %ulong %ulong %uint
+%1490 = OpTypeFunction %ulong %ulong %float
+%1538 = OpTypeFunction %ulong %ulong %double
+%1 = OpFunction %ulong None %16
+%17 = OpFunctionParameter %ulong
+%18 = OpFunctionParameter %ulong
+%19 = OpLabel
+%21 = OpVariable %_ptr_Function_ulong Function
+%22 = OpVariable %_ptr_Function_ulong Function
+%23 = OpVariable %_ptr_Function_ulong Function
+%24 = OpVariable %_ptr_Function_ulong Function
+%25 = OpVariable %_ptr_Function_ulong Function
+OpStore %21 %17
+OpStore %22 %18
+%26 = OpLoad %ulong %22
+%28 = OpIMul %ulong %26 %ulong_6364136223846793005
+OpStore %23 %28
+%29 = OpLoad %ulong %23
+%31 = OpIAdd %ulong %29 %ulong_1442695040888963407
+OpStore %24 %31
+%32 = OpLoad %ulong %24
+%33 = OpLoad %ulong %21
+%34 = OpIAdd %ulong %32 %33
+OpStore %25 %34
+%35 = OpLoad %ulong %25
+OpReturnValue %35
+OpFunctionEnd
+%2 = OpFunction %float None %37
+%38 = OpFunctionParameter %ulong
+%39 = OpLabel
+%40 = OpVariable %_ptr_Function_ulong Function
+%41 = OpVariable %_ptr_Function_ulong Function
+%43 = OpVariable %_ptr_Function_float Function
+%44 = OpVariable %_ptr_Function_float Function
+%45 = OpVariable %_ptr_Function_float Function
+OpStore %40 %38
+%46 = OpLoad %ulong %40
+%48 = OpBitwiseAnd %ulong %46 %ulong_4095
+OpStore %41 %48
+%49 = OpLoad %ulong %41
+%50 = OpConvertUToF %float %49
+OpStore %43 %50
+%51 = OpLoad %float %43
+%53 = OpFSub %float %51 %float_2048
+OpStore %44 %53
+%54 = OpLoad %float %44
+%56 = OpFDiv %float %54 %float_8
+OpStore %45 %56
+%57 = OpLoad %float %45
+OpReturnValue %57
+OpFunctionEnd
+%3 = OpFunction %double None %59
+%60 = OpFunctionParameter %ulong
+%61 = OpLabel
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%65 = OpVariable %_ptr_Function_double Function
+%66 = OpVariable %_ptr_Function_double Function
+%67 = OpVariable %_ptr_Function_double Function
+OpStore %62 %60
+%68 = OpLoad %ulong %62
+%70 = OpBitwiseAnd %ulong %68 %ulong_1048575
+OpStore %63 %70
+%71 = OpLoad %ulong %63
+%72 = OpConvertUToF %double %71
+OpStore %65 %72
+%73 = OpLoad %double %65
+%75 = OpFSub %double %73 %double_524288
+OpStore %66 %75
+%76 = OpLoad %double %66
+%78 = OpFDiv %double %76 %double_64
+OpStore %67 %78
+%79 = OpLoad %double %67
+OpReturnValue %79
+OpFunctionEnd
+%4 = OpFunction %ulong None %86
+%87 = OpFunctionParameter %ulong
+%88 = OpFunctionParameter %float
+%89 = OpFunctionParameter %uint
+%90 = OpFunctionParameter %double
+%91 = OpFunctionParameter %v3float
+%92 = OpFunctionParameter %ulong
+%93 = OpFunctionParameter %float
+%94 = OpFunctionParameter %ushort
+%95 = OpFunctionParameter %v4float
+%96 = OpFunctionParameter %double
+%97 = OpFunctionParameter %ulong
+%98 = OpFunctionParameter %float
+%99 = OpFunctionParameter %uchar
+%100 = OpFunctionParameter %double
+%101 = OpFunctionParameter %v2float
+%102 = OpFunctionParameter %ulong
+%103 = OpFunctionParameter %float
+%104 = OpFunctionParameter %uint
+%105 = OpFunctionParameter %double
+%106 = OpFunctionParameter %ulong
+%107 = OpLabel
+%108 = OpVariable %_ptr_Function_ulong Function
+%109 = OpVariable %_ptr_Function_float Function
+%111 = OpVariable %_ptr_Function_uint Function
+%112 = OpVariable %_ptr_Function_double Function
+%114 = OpVariable %_ptr_Function_v3float Function
+%115 = OpVariable %_ptr_Function_ulong Function
+%116 = OpVariable %_ptr_Function_float Function
+%118 = OpVariable %_ptr_Function_ushort Function
+%120 = OpVariable %_ptr_Function_v4float Function
+%121 = OpVariable %_ptr_Function_double Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_float Function
+%125 = OpVariable %_ptr_Function_uchar Function
+%126 = OpVariable %_ptr_Function_double Function
+%128 = OpVariable %_ptr_Function_v2float Function
+%129 = OpVariable %_ptr_Function_ulong Function
+%130 = OpVariable %_ptr_Function_float Function
+%131 = OpVariable %_ptr_Function_uint Function
+%132 = OpVariable %_ptr_Function_double Function
+%133 = OpVariable %_ptr_Function_ulong Function
+%134 = OpVariable %_ptr_Function_ulong Function
+%135 = OpVariable %_ptr_Function_ulong Function
+%136 = OpVariable %_ptr_Function_ulong Function
+%137 = OpVariable %_ptr_Function_ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_float Function
+%140 = OpVariable %_ptr_Function_ulong Function
+%141 = OpVariable %_ptr_Function_float Function
+%142 = OpVariable %_ptr_Function_ulong Function
+%143 = OpVariable %_ptr_Function_float Function
+%144 = OpVariable %_ptr_Function_ulong Function
+%145 = OpVariable %_ptr_Function_ulong Function
+%146 = OpVariable %_ptr_Function_ulong Function
+%147 = OpVariable %_ptr_Function_ulong Function
+%148 = OpVariable %_ptr_Function_float Function
+%149 = OpVariable %_ptr_Function_ulong Function
+%150 = OpVariable %_ptr_Function_float Function
+%151 = OpVariable %_ptr_Function_ulong Function
+%152 = OpVariable %_ptr_Function_float Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_float Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_ulong Function
+%158 = OpVariable %_ptr_Function_ulong Function
+%159 = OpVariable %_ptr_Function_ulong Function
+%160 = OpVariable %_ptr_Function_ulong Function
+%161 = OpVariable %_ptr_Function_float Function
+%162 = OpVariable %_ptr_Function_ulong Function
+%163 = OpVariable %_ptr_Function_float Function
+%164 = OpVariable %_ptr_Function_ulong Function
+%165 = OpVariable %_ptr_Function_ulong Function
+%166 = OpVariable %_ptr_Function_ulong Function
+%167 = OpVariable %_ptr_Function_ulong Function
+%168 = OpVariable %_ptr_Function_ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_float Function
+%175 = OpVariable %_ptr_Function_float Function
+%176 = OpVariable %_ptr_Function_float Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_double Function
+%179 = OpVariable %_ptr_Function_double Function
+%180 = OpVariable %_ptr_Function_double Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_v3float Function
+%183 = OpVariable %_ptr_Function_v3float Function
+%184 = OpVariable %_ptr_Function_float Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_float Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_float Function
+%189 = OpVariable %_ptr_Function_ulong Function
+OpStore %108 %87
+OpStore %109 %88
+OpStore %111 %89
+OpStore %112 %90
+OpStore %114 %91
+OpStore %115 %92
+OpStore %116 %93
+OpStore %118 %94
+OpStore %120 %95
+OpStore %121 %96
+OpStore %122 %97
+OpStore %123 %98
+OpStore %125 %99
+OpStore %126 %100
+OpStore %128 %101
+OpStore %129 %102
+OpStore %130 %103
+OpStore %131 %104
+OpStore %132 %105
+OpStore %133 %106
+%190 = OpFunctionCall %ulong %6
+OpStore %134 %190
+%191 = OpLoad %ulong %134
+%192 = OpLoad %ulong %108
+%193 = OpFunctionCall %ulong %7 %191 %192
+OpStore %135 %193
+%194 = OpLoad %ulong %135
+%195 = OpLoad %float %109
+%196 = OpFunctionCall %ulong %13 %194 %195
+OpStore %136 %196
+%197 = OpLoad %ulong %136
+%198 = OpLoad %uint %111
+%199 = OpFunctionCall %ulong %10 %197 %198
+OpStore %137 %199
+%200 = OpLoad %ulong %137
+%201 = OpLoad %double %112
+%202 = OpFunctionCall %ulong %14 %200 %201
+OpStore %138 %202
+%203 = OpLoad %v3float %114
+%204 = OpCompositeExtract %float %203 0
+OpStore %139 %204
+%205 = OpLoad %ulong %138
+%206 = OpLoad %float %139
+%207 = OpFunctionCall %ulong %13 %205 %206
+OpStore %140 %207
+%208 = OpLoad %v3float %114
+%209 = OpCompositeExtract %float %208 1
+OpStore %141 %209
+%210 = OpLoad %ulong %140
+%211 = OpLoad %float %141
+%212 = OpFunctionCall %ulong %13 %210 %211
+OpStore %142 %212
+%213 = OpLoad %v3float %114
+%214 = OpCompositeExtract %float %213 2
+OpStore %143 %214
+%215 = OpLoad %ulong %142
+%216 = OpLoad %float %143
+%217 = OpFunctionCall %ulong %13 %215 %216
+OpStore %144 %217
+%218 = OpLoad %ulong %144
+%219 = OpLoad %ulong %115
+%220 = OpFunctionCall %ulong %12 %218 %219
+OpStore %145 %220
+%221 = OpLoad %ulong %145
+%222 = OpLoad %float %116
+%223 = OpFunctionCall %ulong %13 %221 %222
+OpStore %146 %223
+%224 = OpLoad %ulong %146
+%225 = OpLoad %ushort %118
+%226 = OpFunctionCall %ulong %9 %224 %225
+OpStore %147 %226
+%227 = OpLoad %v4float %120
+%228 = OpCompositeExtract %float %227 0
+OpStore %148 %228
+%229 = OpLoad %ulong %147
+%230 = OpLoad %float %148
+%231 = OpFunctionCall %ulong %13 %229 %230
+OpStore %149 %231
+%232 = OpLoad %v4float %120
+%233 = OpCompositeExtract %float %232 1
+OpStore %150 %233
+%234 = OpLoad %ulong %149
+%235 = OpLoad %float %150
+%236 = OpFunctionCall %ulong %13 %234 %235
+OpStore %151 %236
+%237 = OpLoad %v4float %120
+%238 = OpCompositeExtract %float %237 2
+OpStore %152 %238
+%239 = OpLoad %ulong %151
+%240 = OpLoad %float %152
+%241 = OpFunctionCall %ulong %13 %239 %240
+OpStore %153 %241
+%242 = OpLoad %v4float %120
+%243 = OpCompositeExtract %float %242 3
+OpStore %154 %243
+%244 = OpLoad %ulong %153
+%245 = OpLoad %float %154
+%246 = OpFunctionCall %ulong %13 %244 %245
+OpStore %155 %246
+%247 = OpLoad %ulong %155
+%248 = OpLoad %double %121
+%249 = OpFunctionCall %ulong %14 %247 %248
+OpStore %156 %249
+%250 = OpLoad %ulong %156
+%251 = OpLoad %ulong %122
+%252 = OpFunctionCall %ulong %7 %250 %251
+OpStore %157 %252
+%253 = OpLoad %ulong %157
+%254 = OpLoad %float %123
+%255 = OpFunctionCall %ulong %13 %253 %254
+OpStore %158 %255
+%256 = OpLoad %ulong %158
+%257 = OpLoad %uchar %125
+%258 = OpFunctionCall %ulong %8 %256 %257
+OpStore %159 %258
+%259 = OpLoad %ulong %159
+%260 = OpLoad %double %126
+%261 = OpFunctionCall %ulong %14 %259 %260
+OpStore %160 %261
+%262 = OpLoad %v2float %128
+%263 = OpCompositeExtract %float %262 0
+OpStore %161 %263
+%264 = OpLoad %ulong %160
+%265 = OpLoad %float %161
+%266 = OpFunctionCall %ulong %13 %264 %265
+OpStore %162 %266
+%267 = OpLoad %v2float %128
+%268 = OpCompositeExtract %float %267 1
+OpStore %163 %268
+%269 = OpLoad %ulong %162
+%270 = OpLoad %float %163
+%271 = OpFunctionCall %ulong %13 %269 %270
+OpStore %164 %271
+%272 = OpLoad %ulong %164
+%273 = OpLoad %ulong %129
+%274 = OpFunctionCall %ulong %7 %272 %273
+OpStore %165 %274
+%275 = OpLoad %ulong %165
+%276 = OpLoad %float %130
+%277 = OpFunctionCall %ulong %13 %275 %276
+OpStore %166 %277
+%278 = OpLoad %ulong %166
+%279 = OpLoad %uint %131
+%280 = OpFunctionCall %ulong %11 %278 %279
+OpStore %167 %280
+%281 = OpLoad %ulong %167
+%282 = OpLoad %double %132
+%283 = OpFunctionCall %ulong %14 %281 %282
+OpStore %168 %283
+%284 = OpLoad %ulong %168
+%285 = OpLoad %ulong %133
+%286 = OpFunctionCall %ulong %7 %284 %285
+OpStore %169 %286
+%287 = OpLoad %ulong %122
+%288 = OpLoad %ulong %129
+%289 = OpIMul %ulong %287 %288
+OpStore %170 %289
+%290 = OpLoad %ulong %108
+%291 = OpLoad %ulong %170
+%292 = OpIAdd %ulong %290 %291
+OpStore %171 %292
+%293 = OpLoad %ulong %171
+%294 = OpLoad %ulong %133
+%295 = OpISub %ulong %293 %294
+OpStore %172 %295
+%296 = OpLoad %ulong %169
+%297 = OpLoad %ulong %172
+%298 = OpFunctionCall %ulong %7 %296 %297
+OpStore %173 %298
+%299 = OpLoad %float %116
+%300 = OpLoad %float %123
+%301 = OpFMul %float %299 %300
+OpStore %174 %301
+%302 = OpLoad %float %109
+%303 = OpLoad %float %174
+%304 = OpFAdd %float %302 %303
+OpStore %175 %304
+%305 = OpLoad %float %175
+%306 = OpLoad %float %130
+%307 = OpFSub %float %305 %306
+OpStore %176 %307
+%308 = OpLoad %ulong %173
+%309 = OpLoad %float %176
+%310 = OpFunctionCall %ulong %13 %308 %309
+OpStore %177 %310
+%311 = OpLoad %double %121
+%312 = OpLoad %double %126
+%313 = OpFMul %double %311 %312
+OpStore %178 %313
+%314 = OpLoad %double %112
+%315 = OpLoad %double %178
+%316 = OpFAdd %double %314 %315
+OpStore %179 %316
+%317 = OpLoad %double %179
+%318 = OpLoad %double %132
+%319 = OpFSub %double %317 %318
+OpStore %180 %319
+%320 = OpLoad %ulong %177
+%321 = OpLoad %double %180
+%322 = OpFunctionCall %ulong %14 %320 %321
+OpStore %181 %322
+%324 = OpLoad %float %148
+%325 = OpLoad %float %150
+%326 = OpLoad %float %161
+%323 = OpCompositeConstruct %v3float %324 %325 %326
+OpStore %182 %323
+%327 = OpLoad %v3float %114
+%328 = OpLoad %v3float %182
+%329 = OpFAdd %v3float %327 %328
+OpStore %183 %329
+%330 = OpLoad %v3float %183
+%331 = OpCompositeExtract %float %330 0
+OpStore %184 %331
+%332 = OpLoad %ulong %181
+%333 = OpLoad %float %184
+%334 = OpFunctionCall %ulong %13 %332 %333
+OpStore %185 %334
+%335 = OpLoad %v3float %183
+%336 = OpCompositeExtract %float %335 1
+OpStore %186 %336
+%337 = OpLoad %ulong %185
+%338 = OpLoad %float %186
+%339 = OpFunctionCall %ulong %13 %337 %338
+OpStore %187 %339
+%340 = OpLoad %v3float %183
+%341 = OpCompositeExtract %float %340 2
+OpStore %188 %341
+%342 = OpLoad %ulong %187
+%343 = OpLoad %float %188
+%344 = OpFunctionCall %ulong %13 %342 %343
+OpStore %189 %344
+%345 = OpLoad %ulong %189
+OpReturnValue %345
+OpFunctionEnd
+%5 = OpFunction %ulong None %346
+%347 = OpFunctionParameter %ulong
+%348 = OpLabel
+%419 = OpVariable %_ptr_Function__arr_ulong_uint_24 Function
+%420 = OpVariable %_ptr_Function_ulong Function
+%421 = OpVariable %_ptr_Function_ulong Function
+%423 = OpVariable %_ptr_Function_bool Function
+%424 = OpVariable %_ptr_Function_ulong Function
+%425 = OpVariable %_ptr_Function_bool Function
+%426 = OpVariable %_ptr_Function_ulong Function
+%427 = OpVariable %_ptr_Function_ulong Function
+%428 = OpVariable %_ptr_Function_ulong Function
+%429 = OpVariable %_ptr_Function_ulong Function
+%430 = OpVariable %_ptr_Function_ulong Function
+%431 = OpVariable %_ptr_Function_v3float Function
+%432 = OpVariable %_ptr_Function_ulong Function
+%433 = OpVariable %_ptr_Function_ulong Function
+%434 = OpVariable %_ptr_Function_ulong Function
+%435 = OpVariable %_ptr_Function_ulong Function
+%436 = OpVariable %_ptr_Function_v4float Function
+%437 = OpVariable %_ptr_Function_ulong Function
+%438 = OpVariable %_ptr_Function_ulong Function
+%439 = OpVariable %_ptr_Function_ulong Function
+%440 = OpVariable %_ptr_Function_float Function
+%441 = OpVariable %_ptr_Function_v2float Function
+%442 = OpVariable %_ptr_Function_ulong Function
+%443 = OpVariable %_ptr_Function_ulong Function
+%444 = OpVariable %_ptr_Function_ulong Function
+%445 = OpVariable %_ptr_Function_float Function
+%446 = OpVariable %_ptr_Function_ulong Function
+%447 = OpVariable %_ptr_Function_uint Function
+%448 = OpVariable %_ptr_Function_ulong Function
+%449 = OpVariable %_ptr_Function_ulong Function
+%450 = OpVariable %_ptr_Function_ulong Function
+%451 = OpVariable %_ptr_Function_float Function
+%452 = OpVariable %_ptr_Function_ulong Function
+%453 = OpVariable %_ptr_Function_ushort Function
+%454 = OpVariable %_ptr_Function_ulong Function
+%455 = OpVariable %_ptr_Function_ulong Function
+%456 = OpVariable %_ptr_Function_ulong Function
+%457 = OpVariable %_ptr_Function_float Function
+%458 = OpVariable %_ptr_Function_ulong Function
+%459 = OpVariable %_ptr_Function_uchar Function
+%460 = OpVariable %_ptr_Function_ulong Function
+%461 = OpVariable %_ptr_Function_ulong Function
+%462 = OpVariable %_ptr_Function_ulong Function
+%463 = OpVariable %_ptr_Function_float Function
+%464 = OpVariable %_ptr_Function_ulong Function
+%465 = OpVariable %_ptr_Function_uint Function
+%466 = OpVariable %_ptr_Function_ulong Function
+%467 = OpVariable %_ptr_Function_ulong Function
+%468 = OpVariable %_ptr_Function_ulong Function
+%469 = OpVariable %_ptr_Function_ulong Function
+%470 = OpVariable %_ptr_Function_ulong Function
+%471 = OpVariable %_ptr_Function_ulong Function
+%472 = OpVariable %_ptr_Function_ulong Function
+%473 = OpVariable %_ptr_Function_ulong Function
+%474 = OpVariable %_ptr_Function_v3float Function
+%475 = OpVariable %_ptr_Function_ulong Function
+%476 = OpVariable %_ptr_Function_ulong Function
+%477 = OpVariable %_ptr_Function_ulong Function
+%478 = OpVariable %_ptr_Function_ulong Function
+%479 = OpVariable %_ptr_Function_v4float Function
+%480 = OpVariable %_ptr_Function_ulong Function
+%481 = OpVariable %_ptr_Function_ulong Function
+%482 = OpVariable %_ptr_Function_float Function
+%483 = OpVariable %_ptr_Function_v2float Function
+%484 = OpVariable %_ptr_Function_ulong Function
+%485 = OpVariable %_ptr_Function_ulong Function
+%486 = OpVariable %_ptr_Function_float Function
+%487 = OpVariable %_ptr_Function_ulong Function
+%488 = OpVariable %_ptr_Function_uint Function
+%489 = OpVariable %_ptr_Function_ulong Function
+%490 = OpVariable %_ptr_Function_ulong Function
+%491 = OpVariable %_ptr_Function_ulong Function
+%492 = OpVariable %_ptr_Function_float Function
+%493 = OpVariable %_ptr_Function_ulong Function
+%494 = OpVariable %_ptr_Function_ushort Function
+%495 = OpVariable %_ptr_Function_ulong Function
+%496 = OpVariable %_ptr_Function_ulong Function
+%497 = OpVariable %_ptr_Function_ulong Function
+%498 = OpVariable %_ptr_Function_float Function
+%499 = OpVariable %_ptr_Function_ulong Function
+%500 = OpVariable %_ptr_Function_uchar Function
+%501 = OpVariable %_ptr_Function_ulong Function
+%502 = OpVariable %_ptr_Function_ulong Function
+%503 = OpVariable %_ptr_Function_ulong Function
+%504 = OpVariable %_ptr_Function_float Function
+%505 = OpVariable %_ptr_Function_ulong Function
+%506 = OpVariable %_ptr_Function_uint Function
+%507 = OpVariable %_ptr_Function_ulong Function
+%508 = OpVariable %_ptr_Function_ulong Function
+%509 = OpVariable %_ptr_Function_ulong Function
+%510 = OpVariable %_ptr_Function_ulong Function
+%511 = OpVariable %_ptr_Function_float Function
+%512 = OpVariable %_ptr_Function_ulong Function
+%513 = OpVariable %_ptr_Function_uint Function
+%514 = OpVariable %_ptr_Function_ulong Function
+%515 = OpVariable %_ptr_Function_ulong Function
+%516 = OpVariable %_ptr_Function_ulong Function
+%517 = OpVariable %_ptr_Function_float Function
+%518 = OpVariable %_ptr_Function_ulong Function
+%519 = OpVariable %_ptr_Function_ushort Function
+%520 = OpVariable %_ptr_Function_ulong Function
+%521 = OpVariable %_ptr_Function_ulong Function
+%522 = OpVariable %_ptr_Function_ulong Function
+%523 = OpVariable %_ptr_Function_float Function
+%524 = OpVariable %_ptr_Function_ulong Function
+%525 = OpVariable %_ptr_Function_uchar Function
+%526 = OpVariable %_ptr_Function_ulong Function
+%527 = OpVariable %_ptr_Function_ulong Function
+%528 = OpVariable %_ptr_Function_ulong Function
+%529 = OpVariable %_ptr_Function_float Function
+%530 = OpVariable %_ptr_Function_ulong Function
+%531 = OpVariable %_ptr_Function_uint Function
+%532 = OpVariable %_ptr_Function_ulong Function
+%533 = OpVariable %_ptr_Function_ulong Function
+%534 = OpVariable %_ptr_Function_ulong Function
+%535 = OpVariable %_ptr_Function_ulong Function
+%536 = OpVariable %_ptr_Function_ulong Function
+%537 = OpVariable %_ptr_Function_ulong Function
+%538 = OpVariable %_ptr_Function_ulong Function
+%539 = OpVariable %_ptr_Function_ulong Function
+%540 = OpVariable %_ptr_Function_ulong Function
+%541 = OpVariable %_ptr_Function_ulong Function
+%542 = OpVariable %_ptr_Function_ulong Function
+%543 = OpVariable %_ptr_Function_float Function
+%544 = OpVariable %_ptr_Function_float Function
+%545 = OpVariable %_ptr_Function_float Function
+%546 = OpVariable %_ptr_Function_ulong Function
+%547 = OpVariable %_ptr_Function_float Function
+%548 = OpVariable %_ptr_Function_float Function
+%549 = OpVariable %_ptr_Function_float Function
+%550 = OpVariable %_ptr_Function_ulong Function
+%551 = OpVariable %_ptr_Function_float Function
+%552 = OpVariable %_ptr_Function_float Function
+%553 = OpVariable %_ptr_Function_float Function
+%554 = OpVariable %_ptr_Function_ulong Function
+%555 = OpVariable %_ptr_Function_float Function
+%556 = OpVariable %_ptr_Function_float Function
+%557 = OpVariable %_ptr_Function_float Function
+%558 = OpVariable %_ptr_Function_ulong Function
+%559 = OpVariable %_ptr_Function_float Function
+%560 = OpVariable %_ptr_Function_float Function
+%561 = OpVariable %_ptr_Function_float Function
+%562 = OpVariable %_ptr_Function_ulong Function
+%563 = OpVariable %_ptr_Function_float Function
+%564 = OpVariable %_ptr_Function_float Function
+%565 = OpVariable %_ptr_Function_float Function
+%566 = OpVariable %_ptr_Function_ulong Function
+%567 = OpVariable %_ptr_Function_float Function
+%568 = OpVariable %_ptr_Function_float Function
+%569 = OpVariable %_ptr_Function_float Function
+%570 = OpVariable %_ptr_Function_ulong Function
+%571 = OpVariable %_ptr_Function_float Function
+%572 = OpVariable %_ptr_Function_float Function
+%573 = OpVariable %_ptr_Function_float Function
+%574 = OpVariable %_ptr_Function_ulong Function
+%575 = OpVariable %_ptr_Function_float Function
+%576 = OpVariable %_ptr_Function_float Function
+%577 = OpVariable %_ptr_Function_float Function
+%578 = OpVariable %_ptr_Function_ulong Function
+%579 = OpVariable %_ptr_Function_float Function
+%580 = OpVariable %_ptr_Function_float Function
+%581 = OpVariable %_ptr_Function_float Function
+%582 = OpVariable %_ptr_Function_ulong Function
+%583 = OpVariable %_ptr_Function_float Function
+%584 = OpVariable %_ptr_Function_float Function
+%585 = OpVariable %_ptr_Function_float Function
+%586 = OpVariable %_ptr_Function_ulong Function
+%587 = OpVariable %_ptr_Function_float Function
+%588 = OpVariable %_ptr_Function_float Function
+%589 = OpVariable %_ptr_Function_float Function
+%590 = OpVariable %_ptr_Function_ulong Function
+%591 = OpVariable %_ptr_Function_float Function
+%592 = OpVariable %_ptr_Function_float Function
+%593 = OpVariable %_ptr_Function_float Function
+%594 = OpVariable %_ptr_Function_ulong Function
+%595 = OpVariable %_ptr_Function_float Function
+%596 = OpVariable %_ptr_Function_float Function
+%597 = OpVariable %_ptr_Function_float Function
+%598 = OpVariable %_ptr_Function_ulong Function
+%599 = OpVariable %_ptr_Function_float Function
+%600 = OpVariable %_ptr_Function_float Function
+%601 = OpVariable %_ptr_Function_float Function
+%602 = OpVariable %_ptr_Function_ulong Function
+%603 = OpVariable %_ptr_Function_float Function
+%604 = OpVariable %_ptr_Function_float Function
+%605 = OpVariable %_ptr_Function_float Function
+%606 = OpVariable %_ptr_Function_ulong Function
+%607 = OpVariable %_ptr_Function_double Function
+%608 = OpVariable %_ptr_Function_double Function
+%609 = OpVariable %_ptr_Function_double Function
+%610 = OpVariable %_ptr_Function_ulong Function
+%611 = OpVariable %_ptr_Function_double Function
+%612 = OpVariable %_ptr_Function_double Function
+%613 = OpVariable %_ptr_Function_double Function
+%614 = OpVariable %_ptr_Function_ulong Function
+%615 = OpVariable %_ptr_Function_double Function
+%616 = OpVariable %_ptr_Function_double Function
+%617 = OpVariable %_ptr_Function_double Function
+%618 = OpVariable %_ptr_Function_ulong Function
+%619 = OpVariable %_ptr_Function_double Function
+%620 = OpVariable %_ptr_Function_double Function
+%621 = OpVariable %_ptr_Function_double Function
+%622 = OpVariable %_ptr_Function_ulong Function
+%623 = OpVariable %_ptr_Function_double Function
+%624 = OpVariable %_ptr_Function_double Function
+%625 = OpVariable %_ptr_Function_double Function
+%626 = OpVariable %_ptr_Function_ulong Function
+%627 = OpVariable %_ptr_Function_double Function
+%628 = OpVariable %_ptr_Function_double Function
+%629 = OpVariable %_ptr_Function_double Function
+%630 = OpVariable %_ptr_Function_ulong Function
+%631 = OpVariable %_ptr_Function_double Function
+%632 = OpVariable %_ptr_Function_double Function
+%633 = OpVariable %_ptr_Function_double Function
+%634 = OpVariable %_ptr_Function_ulong Function
+%635 = OpVariable %_ptr_Function_double Function
+%636 = OpVariable %_ptr_Function_double Function
+%637 = OpVariable %_ptr_Function_double Function
+%638 = OpVariable %_ptr_Function_ulong Function
+%639 = OpVariable %_ptr_Function_double Function
+%640 = OpVariable %_ptr_Function_double Function
+%641 = OpVariable %_ptr_Function_double Function
+%642 = OpVariable %_ptr_Function_ulong Function
+%643 = OpVariable %_ptr_Function_double Function
+%644 = OpVariable %_ptr_Function_double Function
+%645 = OpVariable %_ptr_Function_double Function
+%646 = OpVariable %_ptr_Function_ulong Function
+%647 = OpVariable %_ptr_Function_double Function
+%648 = OpVariable %_ptr_Function_double Function
+%649 = OpVariable %_ptr_Function_double Function
+%650 = OpVariable %_ptr_Function_ulong Function
+%651 = OpVariable %_ptr_Function_double Function
+%652 = OpVariable %_ptr_Function_double Function
+%653 = OpVariable %_ptr_Function_double Function
+OpStore %420 %347
+%654 = OpFunctionCall %ulong %6
+OpStore %421 %654
+OpStore %419 %655
+OpStore %536 %ulong_0
+OpBranch %349
+%349 = OpLabel
+%657 = OpLoad %ulong %536
+%659 = OpULessThan %bool %657 %ulong_24
+OpStore %423 %659
+%660 = OpLoad %bool %423
+OpLoopMerge %351 %414 None
+OpBranchConditional %660 %350 %351
+%351 = OpLabel
+%661 = OpLoad %ulong %421
+OpStore %535 %661
+OpStore %537 %ulong_0
+OpStore %538 %ulong_0
+OpBranch %352
+%352 = OpLabel
+%662 = OpLoad %ulong %538
+%664 = OpULessThan %bool %662 %ulong_3
+OpStore %425 %664
+%665 = OpLoad %bool %425
+OpLoopMerge %354 %413 None
+OpBranchConditional %665 %353 %354
+%354 = OpLabel
+OpBranch %359
+%359 = OpLabel
+%666 = OpLoad %ulong %537
+%667 = OpBitwiseAnd %ulong %666 %ulong_4095
+OpStore %546 %667
+%668 = OpLoad %ulong %546
+%669 = OpConvertUToF %float %668
+OpStore %547 %669
+%670 = OpLoad %float %547
+%671 = OpFSub %float %670 %float_2048
+OpStore %548 %671
+%672 = OpLoad %float %548
+%673 = OpFDiv %float %672 %float_8
+OpStore %549 %673
+OpBranch %360
+%360 = OpLabel
+%675 = OpAccessChain %_ptr_Function_ulong %419 %uint_2
+%676 = OpLoad %ulong %675
+OpStore %472 %676
+OpBranch %363
+%363 = OpLabel
+%677 = OpLoad %ulong %472
+%678 = OpBitwiseAnd %ulong %677 %ulong_4095
+OpStore %554 %678
+%679 = OpLoad %ulong %554
+%680 = OpConvertUToF %float %679
+OpStore %555 %680
+%681 = OpLoad %float %555
+%682 = OpFSub %float %681 %float_2048
+OpStore %556 %682
+%683 = OpLoad %float %556
+%684 = OpFDiv %float %683 %float_8
+OpStore %557 %684
+OpBranch %364
+%364 = OpLabel
+%686 = OpAccessChain %_ptr_Function_ulong %419 %uint_3
+%687 = OpLoad %ulong %686
+OpStore %473 %687
+OpBranch %367
+%367 = OpLabel
+%688 = OpLoad %ulong %473
+%689 = OpBitwiseAnd %ulong %688 %ulong_4095
+OpStore %562 %689
+%690 = OpLoad %ulong %562
+%691 = OpConvertUToF %float %690
+OpStore %563 %691
+%692 = OpLoad %float %563
+%693 = OpFSub %float %692 %float_2048
+OpStore %564 %693
+%694 = OpLoad %float %564
+%695 = OpFDiv %float %694 %float_8
+OpStore %565 %695
+OpBranch %368
+%368 = OpLabel
+%697 = OpLoad %float %549
+%698 = OpLoad %float %557
+%699 = OpLoad %float %565
+%696 = OpCompositeConstruct %v3float %697 %698 %699
+OpStore %474 %696
+%701 = OpAccessChain %_ptr_Function_ulong %419 %uint_4
+%702 = OpLoad %ulong %701
+OpStore %475 %702
+OpBranch %371
+%371 = OpLabel
+%703 = OpLoad %ulong %475
+%704 = OpBitwiseAnd %ulong %703 %ulong_4095
+OpStore %570 %704
+%705 = OpLoad %ulong %570
+%706 = OpConvertUToF %float %705
+OpStore %571 %706
+%707 = OpLoad %float %571
+%708 = OpFSub %float %707 %float_2048
+OpStore %572 %708
+%709 = OpLoad %float %572
+%710 = OpFDiv %float %709 %float_8
+OpStore %573 %710
+OpBranch %372
+%372 = OpLabel
+%712 = OpAccessChain %_ptr_Function_ulong %419 %uint_5
+%713 = OpLoad %ulong %712
+OpStore %476 %713
+OpBranch %375
+%375 = OpLabel
+%714 = OpLoad %ulong %476
+%715 = OpBitwiseAnd %ulong %714 %ulong_4095
+OpStore %578 %715
+%716 = OpLoad %ulong %578
+%717 = OpConvertUToF %float %716
+OpStore %579 %717
+%718 = OpLoad %float %579
+%719 = OpFSub %float %718 %float_2048
+OpStore %580 %719
+%720 = OpLoad %float %580
+%721 = OpFDiv %float %720 %float_8
+OpStore %581 %721
+OpBranch %376
+%376 = OpLabel
+%723 = OpAccessChain %_ptr_Function_ulong %419 %uint_6
+%724 = OpLoad %ulong %723
+OpStore %477 %724
+OpBranch %379
+%379 = OpLabel
+%725 = OpLoad %ulong %477
+%726 = OpBitwiseAnd %ulong %725 %ulong_4095
+OpStore %586 %726
+%727 = OpLoad %ulong %586
+%728 = OpConvertUToF %float %727
+OpStore %587 %728
+%729 = OpLoad %float %587
+%730 = OpFSub %float %729 %float_2048
+OpStore %588 %730
+%731 = OpLoad %float %588
+%732 = OpFDiv %float %731 %float_8
+OpStore %589 %732
+OpBranch %380
+%380 = OpLabel
+%734 = OpAccessChain %_ptr_Function_ulong %419 %uint_7
+%735 = OpLoad %ulong %734
+OpStore %478 %735
+OpBranch %383
+%383 = OpLabel
+%736 = OpLoad %ulong %478
+%737 = OpBitwiseAnd %ulong %736 %ulong_4095
+OpStore %594 %737
+%738 = OpLoad %ulong %594
+%739 = OpConvertUToF %float %738
+OpStore %595 %739
+%740 = OpLoad %float %595
+%741 = OpFSub %float %740 %float_2048
+OpStore %596 %741
+%742 = OpLoad %float %596
+%743 = OpFDiv %float %742 %float_8
+OpStore %597 %743
+OpBranch %384
+%384 = OpLabel
+%745 = OpLoad %float %573
+%746 = OpLoad %float %581
+%747 = OpLoad %float %589
+%748 = OpLoad %float %597
+%744 = OpCompositeConstruct %v4float %745 %746 %747 %748
+OpStore %479 %744
+%750 = OpAccessChain %_ptr_Function_ulong %419 %uint_8
+%751 = OpLoad %ulong %750
+OpStore %480 %751
+OpBranch %387
+%387 = OpLabel
+%752 = OpLoad %ulong %480
+%753 = OpBitwiseAnd %ulong %752 %ulong_4095
+OpStore %602 %753
+%754 = OpLoad %ulong %602
+%755 = OpConvertUToF %float %754
+OpStore %603 %755
+%756 = OpLoad %float %603
+%757 = OpFSub %float %756 %float_2048
+OpStore %604 %757
+%758 = OpLoad %float %604
+%759 = OpFDiv %float %758 %float_8
+OpStore %605 %759
+OpBranch %388
+%388 = OpLabel
+%761 = OpAccessChain %_ptr_Function_ulong %419 %uint_9
+%762 = OpLoad %ulong %761
+OpStore %481 %762
+%763 = OpLoad %ulong %481
+%764 = OpFunctionCall %float %2 %763
+OpStore %482 %764
+%766 = OpLoad %float %605
+%767 = OpLoad %float %482
+%765 = OpCompositeConstruct %v2float %766 %767
+OpStore %483 %765
+%769 = OpAccessChain %_ptr_Function_ulong %419 %uint_0
+%770 = OpLoad %ulong %769
+OpStore %484 %770
+%772 = OpAccessChain %_ptr_Function_ulong %419 %uint_1
+%773 = OpLoad %ulong %772
+OpStore %485 %773
+%774 = OpLoad %ulong %485
+%775 = OpFunctionCall %float %2 %774
+OpStore %486 %775
+%776 = OpAccessChain %_ptr_Function_ulong %419 %uint_2
+%777 = OpLoad %ulong %776
+OpStore %487 %777
+%778 = OpLoad %ulong %487
+%779 = OpUConvert %uint %778
+OpStore %488 %779
+%780 = OpAccessChain %_ptr_Function_ulong %419 %uint_3
+%781 = OpLoad %ulong %780
+OpStore %489 %781
+OpBranch %391
+%391 = OpLabel
+%782 = OpLoad %ulong %489
+%783 = OpBitwiseAnd %ulong %782 %ulong_1048575
+OpStore %610 %783
+%784 = OpLoad %ulong %610
+%785 = OpConvertUToF %double %784
+OpStore %611 %785
+%786 = OpLoad %double %611
+%787 = OpFSub %double %786 %double_524288
+OpStore %612 %787
+%788 = OpLoad %double %612
+%789 = OpFDiv %double %788 %double_64
+OpStore %613 %789
+OpBranch %392
+%392 = OpLabel
+%790 = OpAccessChain %_ptr_Function_ulong %419 %uint_4
+%791 = OpLoad %ulong %790
+OpStore %490 %791
+%792 = OpAccessChain %_ptr_Function_ulong %419 %uint_5
+%793 = OpLoad %ulong %792
+OpStore %491 %793
+%794 = OpLoad %ulong %491
+%795 = OpFunctionCall %float %2 %794
+OpStore %492 %795
+%796 = OpAccessChain %_ptr_Function_ulong %419 %uint_6
+%797 = OpLoad %ulong %796
+OpStore %493 %797
+%798 = OpLoad %ulong %493
+%799 = OpUConvert %ushort %798
+OpStore %494 %799
+%800 = OpAccessChain %_ptr_Function_ulong %419 %uint_7
+%801 = OpLoad %ulong %800
+OpStore %495 %801
+OpBranch %395
+%395 = OpLabel
+%802 = OpLoad %ulong %495
+%803 = OpBitwiseAnd %ulong %802 %ulong_1048575
+OpStore %618 %803
+%804 = OpLoad %ulong %618
+%805 = OpConvertUToF %double %804
+OpStore %619 %805
+%806 = OpLoad %double %619
+%807 = OpFSub %double %806 %double_524288
+OpStore %620 %807
+%808 = OpLoad %double %620
+%809 = OpFDiv %double %808 %double_64
+OpStore %621 %809
+OpBranch %396
+%396 = OpLabel
+%810 = OpAccessChain %_ptr_Function_ulong %419 %uint_8
+%811 = OpLoad %ulong %810
+OpStore %496 %811
+%812 = OpAccessChain %_ptr_Function_ulong %419 %uint_9
+%813 = OpLoad %ulong %812
+OpStore %497 %813
+%814 = OpLoad %ulong %497
+%815 = OpFunctionCall %float %2 %814
+OpStore %498 %815
+%817 = OpAccessChain %_ptr_Function_ulong %419 %uint_10
+%818 = OpLoad %ulong %817
+OpStore %499 %818
+%819 = OpLoad %ulong %499
+%820 = OpUConvert %uchar %819
+OpStore %500 %820
+%822 = OpAccessChain %_ptr_Function_ulong %419 %uint_11
+%823 = OpLoad %ulong %822
+OpStore %501 %823
+OpBranch %399
+%399 = OpLabel
+%824 = OpLoad %ulong %501
+%825 = OpBitwiseAnd %ulong %824 %ulong_1048575
+OpStore %626 %825
+%826 = OpLoad %ulong %626
+%827 = OpConvertUToF %double %826
+OpStore %627 %827
+%828 = OpLoad %double %627
+%829 = OpFSub %double %828 %double_524288
+OpStore %628 %829
+%830 = OpLoad %double %628
+%831 = OpFDiv %double %830 %double_64
+OpStore %629 %831
+OpBranch %400
+%400 = OpLabel
+%833 = OpAccessChain %_ptr_Function_ulong %419 %uint_12
+%834 = OpLoad %ulong %833
+OpStore %502 %834
+%836 = OpAccessChain %_ptr_Function_ulong %419 %uint_13
+%837 = OpLoad %ulong %836
+OpStore %503 %837
+%838 = OpLoad %ulong %503
+%839 = OpFunctionCall %float %2 %838
+OpStore %504 %839
+%841 = OpAccessChain %_ptr_Function_ulong %419 %uint_14
+%842 = OpLoad %ulong %841
+OpStore %505 %842
+%843 = OpLoad %ulong %505
+%844 = OpUConvert %uint %843
+OpStore %506 %844
+%846 = OpAccessChain %_ptr_Function_ulong %419 %uint_15
+%847 = OpLoad %ulong %846
+OpStore %507 %847
+OpBranch %403
+%403 = OpLabel
+%848 = OpLoad %ulong %507
+%849 = OpBitwiseAnd %ulong %848 %ulong_1048575
+OpStore %634 %849
+%850 = OpLoad %ulong %634
+%851 = OpConvertUToF %double %850
+OpStore %635 %851
+%852 = OpLoad %double %635
+%853 = OpFSub %double %852 %double_524288
+OpStore %636 %853
+%854 = OpLoad %double %636
+%855 = OpFDiv %double %854 %double_64
+OpStore %637 %855
+OpBranch %404
+%404 = OpLabel
+%856 = OpAccessChain %_ptr_Function_ulong %419 %uint_1
+%857 = OpLoad %ulong %856
+OpStore %508 %857
+%858 = OpLoad %ulong %484
+%859 = OpLoad %float %486
+%860 = OpLoad %uint %488
+%861 = OpLoad %double %613
+%862 = OpLoad %v3float %474
+%863 = OpLoad %ulong %490
+%864 = OpLoad %float %492
+%865 = OpLoad %ushort %494
+%866 = OpLoad %v4float %479
+%867 = OpLoad %double %621
+%868 = OpLoad %ulong %496
+%869 = OpLoad %float %498
+%870 = OpLoad %uchar %500
+%871 = OpLoad %double %629
+%872 = OpLoad %v2float %483
+%873 = OpLoad %ulong %502
+%874 = OpLoad %float %504
+%875 = OpLoad %uint %506
+%876 = OpLoad %double %637
+%877 = OpLoad %ulong %508
+%878 = OpFunctionCall %ulong %4 %858 %859 %860 %861 %862 %863 %864 %865 %866 %867 %868 %869 %870 %871 %872 %873 %874 %875 %876 %877
+OpStore %509 %878
+%879 = OpAccessChain %_ptr_Function_ulong %419 %uint_3
+%880 = OpLoad %ulong %879
+OpStore %510 %880
+%881 = OpLoad %ulong %510
+%882 = OpFunctionCall %float %2 %881
+OpStore %511 %882
+%883 = OpAccessChain %_ptr_Function_ulong %419 %uint_5
+%884 = OpLoad %ulong %883
+OpStore %512 %884
+%885 = OpLoad %ulong %512
+%886 = OpUConvert %uint %885
+OpStore %513 %886
+%887 = OpAccessChain %_ptr_Function_ulong %419 %uint_7
+%888 = OpLoad %ulong %887
+OpStore %514 %888
+OpBranch %405
+%405 = OpLabel
+%889 = OpLoad %ulong %514
+%890 = OpBitwiseAnd %ulong %889 %ulong_1048575
+OpStore %638 %890
+%891 = OpLoad %ulong %638
+%892 = OpConvertUToF %double %891
+OpStore %639 %892
+%893 = OpLoad %double %639
+%894 = OpFSub %double %893 %double_524288
+OpStore %640 %894
+%895 = OpLoad %double %640
+%896 = OpFDiv %double %895 %double_64
+OpStore %641 %896
+OpBranch %406
+%406 = OpLabel
+%897 = OpAccessChain %_ptr_Function_ulong %419 %uint_9
+%898 = OpLoad %ulong %897
+OpStore %515 %898
+%899 = OpAccessChain %_ptr_Function_ulong %419 %uint_11
+%900 = OpLoad %ulong %899
+OpStore %516 %900
+%901 = OpLoad %ulong %516
+%902 = OpFunctionCall %float %2 %901
+OpStore %517 %902
+%903 = OpAccessChain %_ptr_Function_ulong %419 %uint_13
+%904 = OpLoad %ulong %903
+OpStore %518 %904
+%905 = OpLoad %ulong %518
+%906 = OpUConvert %ushort %905
+OpStore %519 %906
+%907 = OpAccessChain %_ptr_Function_ulong %419 %uint_15
+%908 = OpLoad %ulong %907
+OpStore %520 %908
+OpBranch %407
+%407 = OpLabel
+%909 = OpLoad %ulong %520
+%910 = OpBitwiseAnd %ulong %909 %ulong_1048575
+OpStore %642 %910
+%911 = OpLoad %ulong %642
+%912 = OpConvertUToF %double %911
+OpStore %643 %912
+%913 = OpLoad %double %643
+%914 = OpFSub %double %913 %double_524288
+OpStore %644 %914
+%915 = OpLoad %double %644
+%916 = OpFDiv %double %915 %double_64
+OpStore %645 %916
+OpBranch %408
+%408 = OpLabel
+%918 = OpAccessChain %_ptr_Function_ulong %419 %uint_17
+%919 = OpLoad %ulong %918
+OpStore %521 %919
+%921 = OpAccessChain %_ptr_Function_ulong %419 %uint_19
+%922 = OpLoad %ulong %921
+OpStore %522 %922
+%923 = OpLoad %ulong %522
+%924 = OpFunctionCall %float %2 %923
+OpStore %523 %924
+%926 = OpAccessChain %_ptr_Function_ulong %419 %uint_21
+%927 = OpLoad %ulong %926
+OpStore %524 %927
+%928 = OpLoad %ulong %524
+%929 = OpUConvert %uchar %928
+OpStore %525 %929
+%931 = OpAccessChain %_ptr_Function_ulong %419 %uint_23
+%932 = OpLoad %ulong %931
+OpStore %526 %932
+OpBranch %409
+%409 = OpLabel
+%933 = OpLoad %ulong %526
+%934 = OpBitwiseAnd %ulong %933 %ulong_1048575
+OpStore %646 %934
+%935 = OpLoad %ulong %646
+%936 = OpConvertUToF %double %935
+OpStore %647 %936
+%937 = OpLoad %double %647
+%938 = OpFSub %double %937 %double_524288
+OpStore %648 %938
+%939 = OpLoad %double %648
+%940 = OpFDiv %double %939 %double_64
+OpStore %649 %940
+OpBranch %410
+%410 = OpLabel
+%941 = OpAccessChain %_ptr_Function_ulong %419 %uint_2
+%942 = OpLoad %ulong %941
+OpStore %527 %942
+%943 = OpAccessChain %_ptr_Function_ulong %419 %uint_4
+%944 = OpLoad %ulong %943
+OpStore %528 %944
+%945 = OpLoad %ulong %528
+%946 = OpFunctionCall %float %2 %945
+OpStore %529 %946
+%947 = OpAccessChain %_ptr_Function_ulong %419 %uint_6
+%948 = OpLoad %ulong %947
+OpStore %530 %948
+%949 = OpLoad %ulong %530
+%950 = OpUConvert %uint %949
+OpStore %531 %950
+%951 = OpAccessChain %_ptr_Function_ulong %419 %uint_8
+%952 = OpLoad %ulong %951
+OpStore %532 %952
+OpBranch %411
+%411 = OpLabel
+%953 = OpLoad %ulong %532
+%954 = OpBitwiseAnd %ulong %953 %ulong_1048575
+OpStore %650 %954
+%955 = OpLoad %ulong %650
+%956 = OpConvertUToF %double %955
+OpStore %651 %956
+%957 = OpLoad %double %651
+%958 = OpFSub %double %957 %double_524288
+OpStore %652 %958
+%959 = OpLoad %double %652
+%960 = OpFDiv %double %959 %double_64
+OpStore %653 %960
+OpBranch %412
+%412 = OpLabel
+%961 = OpLoad %ulong %509
+%962 = OpLoad %float %511
+%963 = OpLoad %uint %513
+%964 = OpLoad %double %641
+%965 = OpLoad %v3float %474
+%966 = OpLoad %ulong %515
+%967 = OpLoad %float %517
+%968 = OpLoad %ushort %519
+%969 = OpLoad %v4float %479
+%970 = OpLoad %double %645
+%971 = OpLoad %ulong %521
+%972 = OpLoad %float %523
+%973 = OpLoad %uchar %525
+%974 = OpLoad %double %649
+%975 = OpLoad %v2float %483
+%976 = OpLoad %ulong %527
+%977 = OpLoad %float %529
+%978 = OpLoad %uint %531
+%979 = OpLoad %double %653
+%980 = OpLoad %ulong %537
+%981 = OpFunctionCall %ulong %4 %961 %962 %963 %964 %965 %966 %967 %968 %969 %970 %971 %972 %973 %974 %975 %976 %977 %978 %979 %980
+OpStore %533 %981
+%982 = OpLoad %ulong %535
+%983 = OpLoad %ulong %533
+%984 = OpFunctionCall %ulong %7 %982 %983
+OpStore %534 %984
+%985 = OpLoad %ulong %534
+OpReturnValue %985
+%353 = OpLabel
+%986 = OpLoad %ulong %538
+%988 = OpIMul %ulong %986 %ulong_11
+OpStore %426 %988
+%989 = OpLoad %ulong %426
+%990 = OpLoad %ulong %420
+%991 = OpIAdd %ulong %989 %990
+OpStore %427 %991
+%993 = OpAccessChain %_ptr_Function_ulong %419 %uint_16
+%994 = OpLoad %ulong %993
+OpStore %428 %994
+OpBranch %357
+%357 = OpLabel
+%995 = OpLoad %ulong %428
+%996 = OpBitwiseAnd %ulong %995 %ulong_4095
+OpStore %542 %996
+%997 = OpLoad %ulong %542
+%998 = OpConvertUToF %float %997
+OpStore %543 %998
+%999 = OpLoad %float %543
+%1000 = OpFSub %float %999 %float_2048
+OpStore %544 %1000
+%1001 = OpLoad %float %544
+%1002 = OpFDiv %float %1001 %float_8
+OpStore %545 %1002
+OpBranch %358
+%358 = OpLabel
+%1003 = OpAccessChain %_ptr_Function_ulong %419 %uint_17
+%1004 = OpLoad %ulong %1003
+OpStore %429 %1004
+OpBranch %361
+%361 = OpLabel
+%1005 = OpLoad %ulong %429
+%1006 = OpBitwiseAnd %ulong %1005 %ulong_4095
+OpStore %550 %1006
+%1007 = OpLoad %ulong %550
+%1008 = OpConvertUToF %float %1007
+OpStore %551 %1008
+%1009 = OpLoad %float %551
+%1010 = OpFSub %float %1009 %float_2048
+OpStore %552 %1010
+%1011 = OpLoad %float %552
+%1012 = OpFDiv %float %1011 %float_8
+OpStore %553 %1012
+OpBranch %362
+%362 = OpLabel
+%1014 = OpAccessChain %_ptr_Function_ulong %419 %uint_18
+%1015 = OpLoad %ulong %1014
+OpStore %430 %1015
+OpBranch %365
+%365 = OpLabel
+%1016 = OpLoad %ulong %430
+%1017 = OpBitwiseAnd %ulong %1016 %ulong_4095
+OpStore %558 %1017
+%1018 = OpLoad %ulong %558
+%1019 = OpConvertUToF %float %1018
+OpStore %559 %1019
+%1020 = OpLoad %float %559
+%1021 = OpFSub %float %1020 %float_2048
+OpStore %560 %1021
+%1022 = OpLoad %float %560
+%1023 = OpFDiv %float %1022 %float_8
+OpStore %561 %1023
+OpBranch %366
+%366 = OpLabel
+%1025 = OpLoad %float %545
+%1026 = OpLoad %float %553
+%1027 = OpLoad %float %561
+%1024 = OpCompositeConstruct %v3float %1025 %1026 %1027
+OpStore %431 %1024
+%1028 = OpAccessChain %_ptr_Function_ulong %419 %uint_19
+%1029 = OpLoad %ulong %1028
+OpStore %432 %1029
+OpBranch %369
+%369 = OpLabel
+%1030 = OpLoad %ulong %432
+%1031 = OpBitwiseAnd %ulong %1030 %ulong_4095
+OpStore %566 %1031
+%1032 = OpLoad %ulong %566
+%1033 = OpConvertUToF %float %1032
+OpStore %567 %1033
+%1034 = OpLoad %float %567
+%1035 = OpFSub %float %1034 %float_2048
+OpStore %568 %1035
+%1036 = OpLoad %float %568
+%1037 = OpFDiv %float %1036 %float_8
+OpStore %569 %1037
+OpBranch %370
+%370 = OpLabel
+%1039 = OpAccessChain %_ptr_Function_ulong %419 %uint_20
+%1040 = OpLoad %ulong %1039
+OpStore %433 %1040
+OpBranch %373
+%373 = OpLabel
+%1041 = OpLoad %ulong %433
+%1042 = OpBitwiseAnd %ulong %1041 %ulong_4095
+OpStore %574 %1042
+%1043 = OpLoad %ulong %574
+%1044 = OpConvertUToF %float %1043
+OpStore %575 %1044
+%1045 = OpLoad %float %575
+%1046 = OpFSub %float %1045 %float_2048
+OpStore %576 %1046
+%1047 = OpLoad %float %576
+%1048 = OpFDiv %float %1047 %float_8
+OpStore %577 %1048
+OpBranch %374
+%374 = OpLabel
+%1049 = OpAccessChain %_ptr_Function_ulong %419 %uint_21
+%1050 = OpLoad %ulong %1049
+OpStore %434 %1050
+OpBranch %377
+%377 = OpLabel
+%1051 = OpLoad %ulong %434
+%1052 = OpBitwiseAnd %ulong %1051 %ulong_4095
+OpStore %582 %1052
+%1053 = OpLoad %ulong %582
+%1054 = OpConvertUToF %float %1053
+OpStore %583 %1054
+%1055 = OpLoad %float %583
+%1056 = OpFSub %float %1055 %float_2048
+OpStore %584 %1056
+%1057 = OpLoad %float %584
+%1058 = OpFDiv %float %1057 %float_8
+OpStore %585 %1058
+OpBranch %378
+%378 = OpLabel
+%1060 = OpAccessChain %_ptr_Function_ulong %419 %uint_22
+%1061 = OpLoad %ulong %1060
+OpStore %435 %1061
+OpBranch %381
+%381 = OpLabel
+%1062 = OpLoad %ulong %435
+%1063 = OpBitwiseAnd %ulong %1062 %ulong_4095
+OpStore %590 %1063
+%1064 = OpLoad %ulong %590
+%1065 = OpConvertUToF %float %1064
+OpStore %591 %1065
+%1066 = OpLoad %float %591
+%1067 = OpFSub %float %1066 %float_2048
+OpStore %592 %1067
+%1068 = OpLoad %float %592
+%1069 = OpFDiv %float %1068 %float_8
+OpStore %593 %1069
+OpBranch %382
+%382 = OpLabel
+%1071 = OpLoad %float %569
+%1072 = OpLoad %float %577
+%1073 = OpLoad %float %585
+%1074 = OpLoad %float %593
+%1070 = OpCompositeConstruct %v4float %1071 %1072 %1073 %1074
+OpStore %436 %1070
+%1075 = OpAccessChain %_ptr_Function_ulong %419 %uint_23
+%1076 = OpLoad %ulong %1075
+OpStore %437 %1076
+OpBranch %385
+%385 = OpLabel
+%1077 = OpLoad %ulong %437
+%1078 = OpBitwiseAnd %ulong %1077 %ulong_4095
+OpStore %598 %1078
+%1079 = OpLoad %ulong %598
+%1080 = OpConvertUToF %float %1079
+OpStore %599 %1080
+%1081 = OpLoad %float %599
+%1082 = OpFSub %float %1081 %float_2048
+OpStore %600 %1082
+%1083 = OpLoad %float %600
+%1084 = OpFDiv %float %1083 %float_8
+OpStore %601 %1084
+OpBranch %386
+%386 = OpLabel
+%1085 = OpAccessChain %_ptr_Function_ulong %419 %uint_0
+%1086 = OpLoad %ulong %1085
+OpStore %438 %1086
+%1087 = OpLoad %ulong %438
+%1088 = OpLoad %ulong %427
+%1089 = OpIAdd %ulong %1087 %1088
+OpStore %439 %1089
+%1090 = OpLoad %ulong %439
+%1091 = OpFunctionCall %float %2 %1090
+OpStore %440 %1091
+%1093 = OpLoad %float %601
+%1094 = OpLoad %float %440
+%1092 = OpCompositeConstruct %v2float %1093 %1094
+OpStore %441 %1092
+%1095 = OpLoad %ulong %1085
+OpStore %442 %1095
+%1096 = OpLoad %ulong %442
+%1097 = OpLoad %ulong %427
+%1098 = OpIAdd %ulong %1096 %1097
+OpStore %443 %1098
+%1099 = OpAccessChain %_ptr_Function_ulong %419 %uint_1
+%1100 = OpLoad %ulong %1099
+OpStore %444 %1100
+%1101 = OpLoad %ulong %444
+%1102 = OpFunctionCall %float %2 %1101
+OpStore %445 %1102
+%1103 = OpAccessChain %_ptr_Function_ulong %419 %uint_2
+%1104 = OpLoad %ulong %1103
+OpStore %446 %1104
+%1105 = OpLoad %ulong %446
+%1106 = OpUConvert %uint %1105
+OpStore %447 %1106
+%1107 = OpAccessChain %_ptr_Function_ulong %419 %uint_3
+%1108 = OpLoad %ulong %1107
+OpStore %448 %1108
+OpBranch %389
+%389 = OpLabel
+%1109 = OpLoad %ulong %448
+%1110 = OpBitwiseAnd %ulong %1109 %ulong_1048575
+OpStore %606 %1110
+%1111 = OpLoad %ulong %606
+%1112 = OpConvertUToF %double %1111
+OpStore %607 %1112
+%1113 = OpLoad %double %607
+%1114 = OpFSub %double %1113 %double_524288
+OpStore %608 %1114
+%1115 = OpLoad %double %608
+%1116 = OpFDiv %double %1115 %double_64
+OpStore %609 %1116
+OpBranch %390
+%390 = OpLabel
+%1117 = OpAccessChain %_ptr_Function_ulong %419 %uint_4
+%1118 = OpLoad %ulong %1117
+OpStore %449 %1118
+%1119 = OpAccessChain %_ptr_Function_ulong %419 %uint_5
+%1120 = OpLoad %ulong %1119
+OpStore %450 %1120
+%1121 = OpLoad %ulong %450
+%1122 = OpFunctionCall %float %2 %1121
+OpStore %451 %1122
+%1123 = OpAccessChain %_ptr_Function_ulong %419 %uint_6
+%1124 = OpLoad %ulong %1123
+OpStore %452 %1124
+%1125 = OpLoad %ulong %452
+%1126 = OpUConvert %ushort %1125
+OpStore %453 %1126
+%1127 = OpAccessChain %_ptr_Function_ulong %419 %uint_7
+%1128 = OpLoad %ulong %1127
+OpStore %454 %1128
+OpBranch %393
+%393 = OpLabel
+%1129 = OpLoad %ulong %454
+%1130 = OpBitwiseAnd %ulong %1129 %ulong_1048575
+OpStore %614 %1130
+%1131 = OpLoad %ulong %614
+%1132 = OpConvertUToF %double %1131
+OpStore %615 %1132
+%1133 = OpLoad %double %615
+%1134 = OpFSub %double %1133 %double_524288
+OpStore %616 %1134
+%1135 = OpLoad %double %616
+%1136 = OpFDiv %double %1135 %double_64
+OpStore %617 %1136
+OpBranch %394
+%394 = OpLabel
+%1137 = OpAccessChain %_ptr_Function_ulong %419 %uint_8
+%1138 = OpLoad %ulong %1137
+OpStore %455 %1138
+%1139 = OpAccessChain %_ptr_Function_ulong %419 %uint_9
+%1140 = OpLoad %ulong %1139
+OpStore %456 %1140
+%1141 = OpLoad %ulong %456
+%1142 = OpFunctionCall %float %2 %1141
+OpStore %457 %1142
+%1143 = OpAccessChain %_ptr_Function_ulong %419 %uint_10
+%1144 = OpLoad %ulong %1143
+OpStore %458 %1144
+%1145 = OpLoad %ulong %458
+%1146 = OpUConvert %uchar %1145
+OpStore %459 %1146
+%1147 = OpAccessChain %_ptr_Function_ulong %419 %uint_11
+%1148 = OpLoad %ulong %1147
+OpStore %460 %1148
+OpBranch %397
+%397 = OpLabel
+%1149 = OpLoad %ulong %460
+%1150 = OpBitwiseAnd %ulong %1149 %ulong_1048575
+OpStore %622 %1150
+%1151 = OpLoad %ulong %622
+%1152 = OpConvertUToF %double %1151
+OpStore %623 %1152
+%1153 = OpLoad %double %623
+%1154 = OpFSub %double %1153 %double_524288
+OpStore %624 %1154
+%1155 = OpLoad %double %624
+%1156 = OpFDiv %double %1155 %double_64
+OpStore %625 %1156
+OpBranch %398
+%398 = OpLabel
+%1157 = OpAccessChain %_ptr_Function_ulong %419 %uint_12
+%1158 = OpLoad %ulong %1157
+OpStore %461 %1158
+%1159 = OpAccessChain %_ptr_Function_ulong %419 %uint_13
+%1160 = OpLoad %ulong %1159
+OpStore %462 %1160
+%1161 = OpLoad %ulong %462
+%1162 = OpFunctionCall %float %2 %1161
+OpStore %463 %1162
+%1163 = OpAccessChain %_ptr_Function_ulong %419 %uint_14
+%1164 = OpLoad %ulong %1163
+OpStore %464 %1164
+%1165 = OpLoad %ulong %464
+%1166 = OpUConvert %uint %1165
+OpStore %465 %1166
+%1167 = OpAccessChain %_ptr_Function_ulong %419 %uint_15
+%1168 = OpLoad %ulong %1167
+OpStore %466 %1168
+OpBranch %401
+%401 = OpLabel
+%1169 = OpLoad %ulong %466
+%1170 = OpBitwiseAnd %ulong %1169 %ulong_1048575
+OpStore %630 %1170
+%1171 = OpLoad %ulong %630
+%1172 = OpConvertUToF %double %1171
+OpStore %631 %1172
+%1173 = OpLoad %double %631
+%1174 = OpFSub %double %1173 %double_524288
+OpStore %632 %1174
+%1175 = OpLoad %double %632
+%1176 = OpFDiv %double %1175 %double_64
+OpStore %633 %1176
+OpBranch %402
+%402 = OpLabel
+%1177 = OpAccessChain %_ptr_Function_ulong %419 %uint_1
+%1178 = OpLoad %ulong %1177
+OpStore %467 %1178
+%1179 = OpLoad %ulong %467
+%1180 = OpLoad %ulong %427
+%1181 = OpIAdd %ulong %1179 %1180
+OpStore %468 %1181
+%1182 = OpLoad %ulong %443
+%1183 = OpLoad %float %445
+%1184 = OpLoad %uint %447
+%1185 = OpLoad %double %609
+%1186 = OpLoad %v3float %431
+%1187 = OpLoad %ulong %449
+%1188 = OpLoad %float %451
+%1189 = OpLoad %ushort %453
+%1190 = OpLoad %v4float %436
+%1191 = OpLoad %double %617
+%1192 = OpLoad %ulong %455
+%1193 = OpLoad %float %457
+%1194 = OpLoad %uchar %459
+%1195 = OpLoad %double %625
+%1196 = OpLoad %v2float %441
+%1197 = OpLoad %ulong %461
+%1198 = OpLoad %float %463
+%1199 = OpLoad %uint %465
+%1200 = OpLoad %double %633
+%1201 = OpLoad %ulong %468
+%1202 = OpFunctionCall %ulong %4 %1182 %1183 %1184 %1185 %1186 %1187 %1188 %1189 %1190 %1191 %1192 %1193 %1194 %1195 %1196 %1197 %1198 %1199 %1200 %1201
+OpStore %469 %1202
+%1203 = OpLoad %ulong %535
+%1204 = OpLoad %ulong %469
+%1205 = OpFunctionCall %ulong %7 %1203 %1204
+OpStore %470 %1205
+%1206 = OpLoad %ulong %538
+%1208 = OpIAdd %ulong %1206 %ulong_1
+OpStore %471 %1208
+%1209 = OpLoad %ulong %470
+OpStore %535 %1209
+%1210 = OpLoad %ulong %469
+OpStore %537 %1210
+%1211 = OpLoad %ulong %471
+OpStore %538 %1211
+OpBranch %413
+%350 = OpLabel
+OpBranch %355
+%355 = OpLabel
+%1212 = OpLoad %ulong %536
+%1213 = OpIMul %ulong %1212 %ulong_6364136223846793005
+OpStore %539 %1213
+%1214 = OpLoad %ulong %539
+%1215 = OpIAdd %ulong %1214 %ulong_1442695040888963407
+OpStore %540 %1215
+%1216 = OpLoad %ulong %540
+%1217 = OpLoad %ulong %420
+%1218 = OpIAdd %ulong %1216 %1217
+OpStore %541 %1218
+OpBranch %356
+%356 = OpLabel
+%1219 = OpLoad %ulong %536
+%1220 = OpAccessChain %_ptr_Function_ulong %419 %1219
+%1221 = OpLoad %ulong %541
+OpStore %1220 %1221
+%1222 = OpLoad %ulong %536
+%1223 = OpIAdd %ulong %1222 %ulong_1
+OpStore %424 %1223
+%1224 = OpLoad %ulong %424
+OpStore %536 %1224
+OpBranch %414
+%413 = OpLabel
+OpBranch %352
+%414 = OpLabel
+OpBranch %349
+OpFunctionEnd
+%6 = OpFunction %ulong None %1225
+%1226 = OpLabel
+OpReturnValue %ulong_14695981039346656037
+OpFunctionEnd
+%7 = OpFunction %ulong None %16
+%1228 = OpFunctionParameter %ulong
+%1229 = OpFunctionParameter %ulong
+%1230 = OpLabel
+%1235 = OpVariable %_ptr_Function_ulong Function
+%1236 = OpVariable %_ptr_Function_ulong Function
+%1237 = OpVariable %_ptr_Function_bool Function
+%1238 = OpVariable %_ptr_Function_ulong Function
+%1239 = OpVariable %_ptr_Function_ulong Function
+%1240 = OpVariable %_ptr_Function_ulong Function
+%1241 = OpVariable %_ptr_Function_ulong Function
+%1242 = OpVariable %_ptr_Function_ulong Function
+%1243 = OpVariable %_ptr_Function_ulong Function
+%1244 = OpVariable %_ptr_Function_ulong Function
+%1245 = OpVariable %_ptr_Function_ulong Function
+OpStore %1235 %1228
+OpStore %1236 %1229
+%1246 = OpLoad %ulong %1235
+OpStore %1244 %1246
+OpStore %1245 %ulong_0
+OpBranch %1231
+%1231 = OpLabel
+%1247 = OpLoad %ulong %1245
+%1249 = OpULessThan %bool %1247 %ulong_8
+OpStore %1237 %1249
+%1250 = OpLoad %bool %1237
+OpLoopMerge %1233 %1234 None
+OpBranchConditional %1250 %1232 %1233
+%1233 = OpLabel
+%1251 = OpLoad %ulong %1244
+OpReturnValue %1251
+%1232 = OpLabel
+%1252 = OpLoad %ulong %1245
+%1253 = OpIMul %ulong %1252 %ulong_8
+OpStore %1238 %1253
+%1254 = OpLoad %ulong %1236
+%1255 = OpLoad %ulong %1238
+%1256 = OpShiftRightLogical %ulong %1254 %1255
+OpStore %1239 %1256
+%1257 = OpLoad %ulong %1239
+%1259 = OpBitwiseAnd %ulong %1257 %ulong_255
+OpStore %1240 %1259
+%1260 = OpLoad %ulong %1244
+%1261 = OpLoad %ulong %1240
+%1262 = OpBitwiseXor %ulong %1260 %1261
+OpStore %1241 %1262
+%1263 = OpLoad %ulong %1241
+%1265 = OpIMul %ulong %1263 %ulong_1099511628211
+OpStore %1242 %1265
+%1266 = OpLoad %ulong %1245
+%1267 = OpIAdd %ulong %1266 %ulong_1
+OpStore %1243 %1267
+%1268 = OpLoad %ulong %1242
+OpStore %1244 %1268
+%1269 = OpLoad %ulong %1243
+OpStore %1245 %1269
+OpBranch %1234
+%1234 = OpLabel
+OpBranch %1231
+OpFunctionEnd
+%8 = OpFunction %ulong None %1270
+%1271 = OpFunctionParameter %ulong
+%1272 = OpFunctionParameter %uchar
+%1273 = OpLabel
+%1280 = OpVariable %_ptr_Function_ulong Function
+%1281 = OpVariable %_ptr_Function_uchar Function
+%1282 = OpVariable %_ptr_Function_ulong Function
+%1283 = OpVariable %_ptr_Function_bool Function
+%1284 = OpVariable %_ptr_Function_ulong Function
+%1285 = OpVariable %_ptr_Function_ulong Function
+%1286 = OpVariable %_ptr_Function_ulong Function
+%1287 = OpVariable %_ptr_Function_ulong Function
+%1288 = OpVariable %_ptr_Function_ulong Function
+%1289 = OpVariable %_ptr_Function_ulong Function
+%1290 = OpVariable %_ptr_Function_ulong Function
+%1291 = OpVariable %_ptr_Function_ulong Function
+OpStore %1280 %1271
+OpStore %1281 %1272
+%1292 = OpLoad %uchar %1281
+%1293 = OpUConvert %ulong %1292
+OpStore %1282 %1293
+OpBranch %1274
+%1274 = OpLabel
+%1294 = OpLoad %ulong %1280
+OpStore %1290 %1294
+OpStore %1291 %ulong_0
+OpBranch %1275
+%1275 = OpLabel
+%1295 = OpLoad %ulong %1291
+%1296 = OpULessThan %bool %1295 %ulong_8
+OpStore %1283 %1296
+%1297 = OpLoad %bool %1283
+OpLoopMerge %1277 %1279 None
+OpBranchConditional %1297 %1276 %1277
+%1277 = OpLabel
+OpBranch %1278
+%1278 = OpLabel
+%1298 = OpLoad %ulong %1290
+OpReturnValue %1298
+%1276 = OpLabel
+%1299 = OpLoad %ulong %1291
+%1300 = OpIMul %ulong %1299 %ulong_8
+OpStore %1284 %1300
+%1301 = OpLoad %ulong %1282
+%1302 = OpLoad %ulong %1284
+%1303 = OpShiftRightLogical %ulong %1301 %1302
+OpStore %1285 %1303
+%1304 = OpLoad %ulong %1285
+%1305 = OpBitwiseAnd %ulong %1304 %ulong_255
+OpStore %1286 %1305
+%1306 = OpLoad %ulong %1290
+%1307 = OpLoad %ulong %1286
+%1308 = OpBitwiseXor %ulong %1306 %1307
+OpStore %1287 %1308
+%1309 = OpLoad %ulong %1287
+%1310 = OpIMul %ulong %1309 %ulong_1099511628211
+OpStore %1288 %1310
+%1311 = OpLoad %ulong %1291
+%1312 = OpIAdd %ulong %1311 %ulong_1
+OpStore %1289 %1312
+%1313 = OpLoad %ulong %1288
+OpStore %1290 %1313
+%1314 = OpLoad %ulong %1289
+OpStore %1291 %1314
+OpBranch %1279
+%1279 = OpLabel
+OpBranch %1275
+OpFunctionEnd
+%9 = OpFunction %ulong None %1315
+%1316 = OpFunctionParameter %ulong
+%1317 = OpFunctionParameter %ushort
+%1318 = OpLabel
+%1325 = OpVariable %_ptr_Function_ulong Function
+%1326 = OpVariable %_ptr_Function_ushort Function
+%1327 = OpVariable %_ptr_Function_ulong Function
+%1328 = OpVariable %_ptr_Function_bool Function
+%1329 = OpVariable %_ptr_Function_ulong Function
+%1330 = OpVariable %_ptr_Function_ulong Function
+%1331 = OpVariable %_ptr_Function_ulong Function
+%1332 = OpVariable %_ptr_Function_ulong Function
+%1333 = OpVariable %_ptr_Function_ulong Function
+%1334 = OpVariable %_ptr_Function_ulong Function
+%1335 = OpVariable %_ptr_Function_ulong Function
+%1336 = OpVariable %_ptr_Function_ulong Function
+OpStore %1325 %1316
+OpStore %1326 %1317
+%1337 = OpLoad %ushort %1326
+%1338 = OpUConvert %ulong %1337
+OpStore %1327 %1338
+OpBranch %1319
+%1319 = OpLabel
+%1339 = OpLoad %ulong %1325
+OpStore %1335 %1339
+OpStore %1336 %ulong_0
+OpBranch %1320
+%1320 = OpLabel
+%1340 = OpLoad %ulong %1336
+%1341 = OpULessThan %bool %1340 %ulong_8
+OpStore %1328 %1341
+%1342 = OpLoad %bool %1328
+OpLoopMerge %1322 %1324 None
+OpBranchConditional %1342 %1321 %1322
+%1322 = OpLabel
+OpBranch %1323
+%1323 = OpLabel
+%1343 = OpLoad %ulong %1335
+OpReturnValue %1343
+%1321 = OpLabel
+%1344 = OpLoad %ulong %1336
+%1345 = OpIMul %ulong %1344 %ulong_8
+OpStore %1329 %1345
+%1346 = OpLoad %ulong %1327
+%1347 = OpLoad %ulong %1329
+%1348 = OpShiftRightLogical %ulong %1346 %1347
+OpStore %1330 %1348
+%1349 = OpLoad %ulong %1330
+%1350 = OpBitwiseAnd %ulong %1349 %ulong_255
+OpStore %1331 %1350
+%1351 = OpLoad %ulong %1335
+%1352 = OpLoad %ulong %1331
+%1353 = OpBitwiseXor %ulong %1351 %1352
+OpStore %1332 %1353
+%1354 = OpLoad %ulong %1332
+%1355 = OpIMul %ulong %1354 %ulong_1099511628211
+OpStore %1333 %1355
+%1356 = OpLoad %ulong %1336
+%1357 = OpIAdd %ulong %1356 %ulong_1
+OpStore %1334 %1357
+%1358 = OpLoad %ulong %1333
+OpStore %1335 %1358
+%1359 = OpLoad %ulong %1334
+OpStore %1336 %1359
+OpBranch %1324
+%1324 = OpLabel
+OpBranch %1320
+OpFunctionEnd
+%10 = OpFunction %ulong None %1360
+%1361 = OpFunctionParameter %ulong
+%1362 = OpFunctionParameter %uint
+%1363 = OpLabel
+%1370 = OpVariable %_ptr_Function_ulong Function
+%1371 = OpVariable %_ptr_Function_uint Function
+%1372 = OpVariable %_ptr_Function_ulong Function
+%1373 = OpVariable %_ptr_Function_bool Function
+%1374 = OpVariable %_ptr_Function_ulong Function
+%1375 = OpVariable %_ptr_Function_ulong Function
+%1376 = OpVariable %_ptr_Function_ulong Function
+%1377 = OpVariable %_ptr_Function_ulong Function
+%1378 = OpVariable %_ptr_Function_ulong Function
+%1379 = OpVariable %_ptr_Function_ulong Function
+%1380 = OpVariable %_ptr_Function_ulong Function
+%1381 = OpVariable %_ptr_Function_ulong Function
+OpStore %1370 %1361
+OpStore %1371 %1362
+%1382 = OpLoad %uint %1371
+%1383 = OpUConvert %ulong %1382
+OpStore %1372 %1383
+OpBranch %1364
+%1364 = OpLabel
+%1384 = OpLoad %ulong %1370
+OpStore %1380 %1384
+OpStore %1381 %ulong_0
+OpBranch %1365
+%1365 = OpLabel
+%1385 = OpLoad %ulong %1381
+%1386 = OpULessThan %bool %1385 %ulong_8
+OpStore %1373 %1386
+%1387 = OpLoad %bool %1373
+OpLoopMerge %1367 %1369 None
+OpBranchConditional %1387 %1366 %1367
+%1367 = OpLabel
+OpBranch %1368
+%1368 = OpLabel
+%1388 = OpLoad %ulong %1380
+OpReturnValue %1388
+%1366 = OpLabel
+%1389 = OpLoad %ulong %1381
+%1390 = OpIMul %ulong %1389 %ulong_8
+OpStore %1374 %1390
+%1391 = OpLoad %ulong %1372
+%1392 = OpLoad %ulong %1374
+%1393 = OpShiftRightLogical %ulong %1391 %1392
+OpStore %1375 %1393
+%1394 = OpLoad %ulong %1375
+%1395 = OpBitwiseAnd %ulong %1394 %ulong_255
+OpStore %1376 %1395
+%1396 = OpLoad %ulong %1380
+%1397 = OpLoad %ulong %1376
+%1398 = OpBitwiseXor %ulong %1396 %1397
+OpStore %1377 %1398
+%1399 = OpLoad %ulong %1377
+%1400 = OpIMul %ulong %1399 %ulong_1099511628211
+OpStore %1378 %1400
+%1401 = OpLoad %ulong %1381
+%1402 = OpIAdd %ulong %1401 %ulong_1
+OpStore %1379 %1402
+%1403 = OpLoad %ulong %1378
+OpStore %1380 %1403
+%1404 = OpLoad %ulong %1379
+OpStore %1381 %1404
+OpBranch %1369
+%1369 = OpLabel
+OpBranch %1365
+OpFunctionEnd
+%11 = OpFunction %ulong None %1360
+%1405 = OpFunctionParameter %ulong
+%1406 = OpFunctionParameter %uint
+%1407 = OpLabel
+%1414 = OpVariable %_ptr_Function_ulong Function
+%1415 = OpVariable %_ptr_Function_uint Function
+%1416 = OpVariable %_ptr_Function_ulong Function
+%1417 = OpVariable %_ptr_Function_bool Function
+%1418 = OpVariable %_ptr_Function_ulong Function
+%1419 = OpVariable %_ptr_Function_ulong Function
+%1420 = OpVariable %_ptr_Function_ulong Function
+%1421 = OpVariable %_ptr_Function_ulong Function
+%1422 = OpVariable %_ptr_Function_ulong Function
+%1423 = OpVariable %_ptr_Function_ulong Function
+%1424 = OpVariable %_ptr_Function_ulong Function
+%1425 = OpVariable %_ptr_Function_ulong Function
+OpStore %1414 %1405
+OpStore %1415 %1406
+%1426 = OpLoad %uint %1415
+%1427 = OpSConvert %ulong %1426
+OpStore %1416 %1427
+OpBranch %1408
+%1408 = OpLabel
+%1428 = OpLoad %ulong %1414
+OpStore %1424 %1428
+OpStore %1425 %ulong_0
+OpBranch %1409
+%1409 = OpLabel
+%1429 = OpLoad %ulong %1425
+%1430 = OpULessThan %bool %1429 %ulong_8
+OpStore %1417 %1430
+%1431 = OpLoad %bool %1417
+OpLoopMerge %1411 %1413 None
+OpBranchConditional %1431 %1410 %1411
+%1411 = OpLabel
+OpBranch %1412
+%1412 = OpLabel
+%1432 = OpLoad %ulong %1424
+OpReturnValue %1432
+%1410 = OpLabel
+%1433 = OpLoad %ulong %1425
+%1434 = OpIMul %ulong %1433 %ulong_8
+OpStore %1418 %1434
+%1435 = OpLoad %ulong %1416
+%1436 = OpLoad %ulong %1418
+%1437 = OpShiftRightLogical %ulong %1435 %1436
+OpStore %1419 %1437
+%1438 = OpLoad %ulong %1419
+%1439 = OpBitwiseAnd %ulong %1438 %ulong_255
+OpStore %1420 %1439
+%1440 = OpLoad %ulong %1424
+%1441 = OpLoad %ulong %1420
+%1442 = OpBitwiseXor %ulong %1440 %1441
+OpStore %1421 %1442
+%1443 = OpLoad %ulong %1421
+%1444 = OpIMul %ulong %1443 %ulong_1099511628211
+OpStore %1422 %1444
+%1445 = OpLoad %ulong %1425
+%1446 = OpIAdd %ulong %1445 %ulong_1
+OpStore %1423 %1446
+%1447 = OpLoad %ulong %1422
+OpStore %1424 %1447
+%1448 = OpLoad %ulong %1423
+OpStore %1425 %1448
+OpBranch %1413
+%1413 = OpLabel
+OpBranch %1409
+OpFunctionEnd
+%12 = OpFunction %ulong None %16
+%1449 = OpFunctionParameter %ulong
+%1450 = OpFunctionParameter %ulong
+%1451 = OpLabel
+%1458 = OpVariable %_ptr_Function_ulong Function
+%1459 = OpVariable %_ptr_Function_ulong Function
+%1460 = OpVariable %_ptr_Function_bool Function
+%1461 = OpVariable %_ptr_Function_ulong Function
+%1462 = OpVariable %_ptr_Function_ulong Function
+%1463 = OpVariable %_ptr_Function_ulong Function
+%1464 = OpVariable %_ptr_Function_ulong Function
+%1465 = OpVariable %_ptr_Function_ulong Function
+%1466 = OpVariable %_ptr_Function_ulong Function
+%1467 = OpVariable %_ptr_Function_ulong Function
+%1468 = OpVariable %_ptr_Function_ulong Function
+OpStore %1458 %1449
+OpStore %1459 %1450
+OpBranch %1452
+%1452 = OpLabel
+%1469 = OpLoad %ulong %1458
+OpStore %1467 %1469
+OpStore %1468 %ulong_0
+OpBranch %1453
+%1453 = OpLabel
+%1470 = OpLoad %ulong %1468
+%1471 = OpULessThan %bool %1470 %ulong_8
+OpStore %1460 %1471
+%1472 = OpLoad %bool %1460
+OpLoopMerge %1455 %1457 None
+OpBranchConditional %1472 %1454 %1455
+%1455 = OpLabel
+OpBranch %1456
+%1456 = OpLabel
+%1473 = OpLoad %ulong %1467
+OpReturnValue %1473
+%1454 = OpLabel
+%1474 = OpLoad %ulong %1468
+%1475 = OpIMul %ulong %1474 %ulong_8
+OpStore %1461 %1475
+%1476 = OpLoad %ulong %1459
+%1477 = OpLoad %ulong %1461
+%1478 = OpShiftRightLogical %ulong %1476 %1477
+OpStore %1462 %1478
+%1479 = OpLoad %ulong %1462
+%1480 = OpBitwiseAnd %ulong %1479 %ulong_255
+OpStore %1463 %1480
+%1481 = OpLoad %ulong %1467
+%1482 = OpLoad %ulong %1463
+%1483 = OpBitwiseXor %ulong %1481 %1482
+OpStore %1464 %1483
+%1484 = OpLoad %ulong %1464
+%1485 = OpIMul %ulong %1484 %ulong_1099511628211
+OpStore %1465 %1485
+%1486 = OpLoad %ulong %1468
+%1487 = OpIAdd %ulong %1486 %ulong_1
+OpStore %1466 %1487
+%1488 = OpLoad %ulong %1465
+OpStore %1467 %1488
+%1489 = OpLoad %ulong %1466
+OpStore %1468 %1489
+OpBranch %1457
+%1457 = OpLabel
+OpBranch %1453
+OpFunctionEnd
+%13 = OpFunction %ulong None %1490
+%1491 = OpFunctionParameter %ulong
+%1492 = OpFunctionParameter %float
+%1493 = OpLabel
+%1500 = OpVariable %_ptr_Function_ulong Function
+%1501 = OpVariable %_ptr_Function_float Function
+%1502 = OpVariable %_ptr_Function_uint Function
+%1503 = OpVariable %_ptr_Function_ulong Function
+%1504 = OpVariable %_ptr_Function_bool Function
+%1505 = OpVariable %_ptr_Function_ulong Function
+%1506 = OpVariable %_ptr_Function_ulong Function
+%1507 = OpVariable %_ptr_Function_ulong Function
+%1508 = OpVariable %_ptr_Function_ulong Function
+%1509 = OpVariable %_ptr_Function_ulong Function
+%1510 = OpVariable %_ptr_Function_ulong Function
+%1511 = OpVariable %_ptr_Function_ulong Function
+%1512 = OpVariable %_ptr_Function_ulong Function
+OpStore %1500 %1491
+OpStore %1501 %1492
+%1513 = OpLoad %float %1501
+%1514 = OpBitcast %uint %1513
+OpStore %1502 %1514
+%1515 = OpLoad %uint %1502
+%1516 = OpUConvert %ulong %1515
+OpStore %1503 %1516
+OpBranch %1494
+%1494 = OpLabel
+%1517 = OpLoad %ulong %1500
+OpStore %1511 %1517
+OpStore %1512 %ulong_0
+OpBranch %1495
+%1495 = OpLabel
+%1518 = OpLoad %ulong %1512
+%1519 = OpULessThan %bool %1518 %ulong_8
+OpStore %1504 %1519
+%1520 = OpLoad %bool %1504
+OpLoopMerge %1497 %1499 None
+OpBranchConditional %1520 %1496 %1497
+%1497 = OpLabel
+OpBranch %1498
+%1498 = OpLabel
+%1521 = OpLoad %ulong %1511
+OpReturnValue %1521
+%1496 = OpLabel
+%1522 = OpLoad %ulong %1512
+%1523 = OpIMul %ulong %1522 %ulong_8
+OpStore %1505 %1523
+%1524 = OpLoad %ulong %1503
+%1525 = OpLoad %ulong %1505
+%1526 = OpShiftRightLogical %ulong %1524 %1525
+OpStore %1506 %1526
+%1527 = OpLoad %ulong %1506
+%1528 = OpBitwiseAnd %ulong %1527 %ulong_255
+OpStore %1507 %1528
+%1529 = OpLoad %ulong %1511
+%1530 = OpLoad %ulong %1507
+%1531 = OpBitwiseXor %ulong %1529 %1530
+OpStore %1508 %1531
+%1532 = OpLoad %ulong %1508
+%1533 = OpIMul %ulong %1532 %ulong_1099511628211
+OpStore %1509 %1533
+%1534 = OpLoad %ulong %1512
+%1535 = OpIAdd %ulong %1534 %ulong_1
+OpStore %1510 %1535
+%1536 = OpLoad %ulong %1509
+OpStore %1511 %1536
+%1537 = OpLoad %ulong %1510
+OpStore %1512 %1537
+OpBranch %1499
+%1499 = OpLabel
+OpBranch %1495
+OpFunctionEnd
+%14 = OpFunction %ulong None %1538
+%1539 = OpFunctionParameter %ulong
+%1540 = OpFunctionParameter %double
+%1541 = OpLabel
+%1548 = OpVariable %_ptr_Function_ulong Function
+%1549 = OpVariable %_ptr_Function_double Function
+%1550 = OpVariable %_ptr_Function_ulong Function
+%1551 = OpVariable %_ptr_Function_bool Function
+%1552 = OpVariable %_ptr_Function_ulong Function
+%1553 = OpVariable %_ptr_Function_ulong Function
+%1554 = OpVariable %_ptr_Function_ulong Function
+%1555 = OpVariable %_ptr_Function_ulong Function
+%1556 = OpVariable %_ptr_Function_ulong Function
+%1557 = OpVariable %_ptr_Function_ulong Function
+%1558 = OpVariable %_ptr_Function_ulong Function
+%1559 = OpVariable %_ptr_Function_ulong Function
+OpStore %1548 %1539
+OpStore %1549 %1540
+%1560 = OpLoad %double %1549
+%1561 = OpBitcast %ulong %1560
+OpStore %1550 %1561
+OpBranch %1542
+%1542 = OpLabel
+%1562 = OpLoad %ulong %1548
+OpStore %1558 %1562
+OpStore %1559 %ulong_0
+OpBranch %1543
+%1543 = OpLabel
+%1563 = OpLoad %ulong %1559
+%1564 = OpULessThan %bool %1563 %ulong_8
+OpStore %1551 %1564
+%1565 = OpLoad %bool %1551
+OpLoopMerge %1545 %1547 None
+OpBranchConditional %1565 %1544 %1545
+%1545 = OpLabel
+OpBranch %1546
+%1546 = OpLabel
+%1566 = OpLoad %ulong %1558
+OpReturnValue %1566
+%1544 = OpLabel
+%1567 = OpLoad %ulong %1559
+%1568 = OpIMul %ulong %1567 %ulong_8
+OpStore %1552 %1568
+%1569 = OpLoad %ulong %1550
+%1570 = OpLoad %ulong %1552
+%1571 = OpShiftRightLogical %ulong %1569 %1570
+OpStore %1553 %1571
+%1572 = OpLoad %ulong %1553
+%1573 = OpBitwiseAnd %ulong %1572 %ulong_255
+OpStore %1554 %1573
+%1574 = OpLoad %ulong %1558
+%1575 = OpLoad %ulong %1554
+%1576 = OpBitwiseXor %ulong %1574 %1575
+OpStore %1555 %1576
+%1577 = OpLoad %ulong %1555
+%1578 = OpIMul %ulong %1577 %ulong_1099511628211
+OpStore %1556 %1578
+%1579 = OpLoad %ulong %1559
+%1580 = OpIAdd %ulong %1579 %ulong_1
+OpStore %1557 %1580
+%1581 = OpLoad %ulong %1556
+OpStore %1558 %1581
+%1582 = OpLoad %ulong %1557
+OpStore %1559 %1582
+OpBranch %1547
+%1547 = OpLabel
+OpBranch %1543
+OpFunctionEnd

--- a/test/golden/spirv/call/call_rec_edge.dis
+++ b/test/golden/spirv/call/call_rec_edge.dis
@@ -412,11 +412,11 @@ OpFunctionEnd
 %271 = OpVariable %_ptr_Function_ulong Function
 OpStore %253 %251
 %272 = OpLoad %ulong %253
-%273 = OpFunctionCall %ulong %18 %272 %ulong_9
-OpStore %254 %273
+%274 = OpFunctionCall %ulong %18 %272 %ulong_9
+OpStore %254 %274
 %275 = OpLoad %ulong %254
-%276 = OpFunctionCall %ulong %18 %275 %ulong_12
-OpStore %255 %276
+%277 = OpFunctionCall %ulong %18 %275 %ulong_12
+OpStore %255 %277
 %278 = OpLoad %ulong %255
 %279 = OpFunctionCall %ulong %18 %278 %ulong_16
 OpStore %256 %279
@@ -427,14 +427,14 @@ OpStore %257 %281
 %283 = OpFunctionCall %ulong %18 %282 %ulong_16
 OpStore %258 %283
 %284 = OpLoad %ulong %258
-%285 = OpFunctionCall %ulong %18 %284 %ulong_17
-OpStore %259 %285
+%286 = OpFunctionCall %ulong %18 %284 %ulong_17
+OpStore %259 %286
 %287 = OpLoad %ulong %259
 %288 = OpFunctionCall %ulong %18 %287 %ulong_1
 OpStore %260 %288
 %289 = OpLoad %ulong %260
-%290 = OpFunctionCall %ulong %18 %289 %ulong_4
-OpStore %261 %290
+%291 = OpFunctionCall %ulong %18 %289 %ulong_4
+OpStore %261 %291
 %292 = OpLoad %ulong %261
 %293 = OpFunctionCall %ulong %18 %292 %ulong_8
 OpStore %262 %293

--- a/test/golden/spirv/call/call_rec_large.dis
+++ b/test/golden/spirv/call/call_rec_large.dis
@@ -532,8 +532,8 @@ OpFunctionEnd
 %360 = OpVariable %_ptr_Function_ulong Function
 OpStore %343 %341
 %361 = OpLoad %ulong %343
-%362 = OpFunctionCall %ulong %20 %361 %ulong_24
-OpStore %344 %362
+%363 = OpFunctionCall %ulong %20 %361 %ulong_24
+OpStore %344 %363
 %364 = OpLoad %ulong %344
 %365 = OpFunctionCall %ulong %20 %364 %ulong_24
 OpStore %345 %365
@@ -541,20 +541,20 @@ OpStore %345 %365
 %367 = OpFunctionCall %ulong %20 %366 %ulong_24
 OpStore %346 %367
 %368 = OpLoad %ulong %346
-%369 = OpFunctionCall %ulong %20 %368 %ulong_32
-OpStore %347 %369
+%370 = OpFunctionCall %ulong %20 %368 %ulong_32
+OpStore %347 %370
 %371 = OpLoad %ulong %347
 %372 = OpFunctionCall %ulong %20 %371 %ulong_32
 OpStore %348 %372
 %373 = OpLoad %ulong %348
-%374 = OpFunctionCall %ulong %20 %373 %ulong_48
-OpStore %349 %374
+%375 = OpFunctionCall %ulong %20 %373 %ulong_48
+OpStore %349 %375
 %376 = OpLoad %ulong %349
 %377 = OpFunctionCall %ulong %20 %376 %ulong_48
 OpStore %350 %377
 %378 = OpLoad %ulong %350
-%379 = OpFunctionCall %ulong %20 %378 %ulong_8
-OpStore %351 %379
+%380 = OpFunctionCall %ulong %20 %378 %ulong_8
+OpStore %351 %380
 %381 = OpLoad %ulong %351
 %382 = OpFunctionCall %ulong %20 %381 %ulong_8
 OpStore %352 %382
@@ -562,20 +562,20 @@ OpStore %352 %382
 %384 = OpFunctionCall %ulong %20 %383 %ulong_8
 OpStore %353 %384
 %385 = OpLoad %ulong %353
-%386 = OpFunctionCall %ulong %20 %385 %ulong_16
-OpStore %354 %386
+%387 = OpFunctionCall %ulong %20 %385 %ulong_16
+OpStore %354 %387
 %388 = OpLoad %ulong %354
 %389 = OpFunctionCall %ulong %20 %388 %ulong_16
 OpStore %355 %389
 %390 = OpLoad %ulong %355
-%391 = OpFunctionCall %ulong %20 %390 %ulong_20
-OpStore %356 %391
+%392 = OpFunctionCall %ulong %20 %390 %ulong_20
+OpStore %356 %392
 %393 = OpLoad %ulong %356
 %394 = OpFunctionCall %ulong %20 %393 %ulong_16
 OpStore %357 %394
 %395 = OpLoad %ulong %357
-%396 = OpFunctionCall %ulong %20 %395 %ulong_40
-OpStore %358 %396
+%397 = OpFunctionCall %ulong %20 %395 %ulong_40
+OpStore %358 %397
 %398 = OpLoad %ulong %358
 %399 = OpFunctionCall %ulong %20 %398 %ulong_24
 OpStore %359 %399

--- a/test/golden/spirv/call/call_rec_small.dis
+++ b/test/golden/spirv/call/call_rec_small.dis
@@ -265,17 +265,17 @@ OpFunctionEnd
 %165 = OpVariable %_ptr_Function_ulong Function
 OpStore %152 %150
 %166 = OpLoad %ulong %152
-%167 = OpFunctionCall %ulong %14 %166 %ulong_1
-OpStore %153 %167
+%168 = OpFunctionCall %ulong %14 %166 %ulong_1
+OpStore %153 %168
 %169 = OpLoad %ulong %153
-%170 = OpFunctionCall %ulong %14 %169 %ulong_2
-OpStore %154 %170
+%171 = OpFunctionCall %ulong %14 %169 %ulong_2
+OpStore %154 %171
 %172 = OpLoad %ulong %154
-%173 = OpFunctionCall %ulong %14 %172 %ulong_4
-OpStore %155 %173
+%174 = OpFunctionCall %ulong %14 %172 %ulong_4
+OpStore %155 %174
 %175 = OpLoad %ulong %155
-%176 = OpFunctionCall %ulong %14 %175 %ulong_8
-OpStore %156 %176
+%177 = OpFunctionCall %ulong %14 %175 %ulong_8
+OpStore %156 %177
 %178 = OpLoad %ulong %156
 %179 = OpFunctionCall %ulong %14 %178 %ulong_1
 OpStore %157 %179
@@ -301,8 +301,8 @@ OpStore %163 %191
 %193 = OpFunctionCall %ulong %14 %192 %ulong_4
 OpStore %164 %193
 %194 = OpLoad %ulong %164
-%195 = OpFunctionCall %ulong %14 %194 %ulong_6
-OpStore %165 %195
+%196 = OpFunctionCall %ulong %14 %194 %ulong_6
+OpStore %165 %196
 %197 = OpLoad %ulong %165
 OpReturnValue %197
 OpFunctionEnd

--- a/test/golden/spirv/call/call_ret_large.dis
+++ b/test/golden/spirv/call/call_ret_large.dis
@@ -546,29 +546,29 @@ OpFunctionEnd
 %370 = OpVariable %_ptr_Function_ulong Function
 OpStore %361 %359
 %371 = OpLoad %ulong %361
-%372 = OpFunctionCall %ulong %24 %371 %ulong_20
-OpStore %362 %372
+%373 = OpFunctionCall %ulong %24 %371 %ulong_20
+OpStore %362 %373
 %374 = OpLoad %ulong %362
-%375 = OpFunctionCall %ulong %24 %374 %ulong_24
-OpStore %363 %375
+%376 = OpFunctionCall %ulong %24 %374 %ulong_24
+OpStore %363 %376
 %377 = OpLoad %ulong %363
 %378 = OpFunctionCall %ulong %24 %377 %ulong_24
 OpStore %364 %378
 %379 = OpLoad %ulong %364
-%380 = OpFunctionCall %ulong %24 %379 %ulong_32
-OpStore %365 %380
+%381 = OpFunctionCall %ulong %24 %379 %ulong_32
+OpStore %365 %381
 %382 = OpLoad %ulong %365
-%383 = OpFunctionCall %ulong %24 %382 %ulong_40
-OpStore %366 %383
+%384 = OpFunctionCall %ulong %24 %382 %ulong_40
+OpStore %366 %384
 %385 = OpLoad %ulong %366
-%386 = OpFunctionCall %ulong %24 %385 %ulong_48
-OpStore %367 %386
+%387 = OpFunctionCall %ulong %24 %385 %ulong_48
+OpStore %367 %387
 %388 = OpLoad %ulong %367
 %389 = OpFunctionCall %ulong %24 %388 %ulong_48
 OpStore %368 %389
 %390 = OpLoad %ulong %368
-%391 = OpFunctionCall %ulong %24 %390 %ulong_8
-OpStore %369 %391
+%392 = OpFunctionCall %ulong %24 %390 %ulong_8
+OpStore %369 %392
 %393 = OpLoad %ulong %369
 %394 = OpFunctionCall %ulong %24 %393 %ulong_32
 OpStore %370 %394

--- a/test/golden/spirv/call/call_ret_small.dis
+++ b/test/golden/spirv/call/call_ret_small.dis
@@ -663,20 +663,20 @@ OpStore %452 %450
 %464 = OpFunctionCall %ulong %23 %463 %ulong_1
 OpStore %453 %464
 %465 = OpLoad %ulong %453
-%466 = OpFunctionCall %ulong %23 %465 %ulong_2
-OpStore %454 %466
+%467 = OpFunctionCall %ulong %23 %465 %ulong_2
+OpStore %454 %467
 %468 = OpLoad %ulong %454
-%469 = OpFunctionCall %ulong %23 %468 %ulong_4
-OpStore %455 %469
+%470 = OpFunctionCall %ulong %23 %468 %ulong_4
+OpStore %455 %470
 %471 = OpLoad %ulong %455
-%472 = OpFunctionCall %ulong %23 %471 %ulong_8
-OpStore %456 %472
+%473 = OpFunctionCall %ulong %23 %471 %ulong_8
+OpStore %456 %473
 %474 = OpLoad %ulong %456
 %475 = OpFunctionCall %ulong %23 %474 %ulong_8
 OpStore %457 %475
 %476 = OpLoad %ulong %457
-%477 = OpFunctionCall %ulong %23 %476 %ulong_12
-OpStore %458 %477
+%478 = OpFunctionCall %ulong %23 %476 %ulong_12
+OpStore %458 %478
 %479 = OpLoad %ulong %458
 %480 = OpFunctionCall %ulong %23 %479 %ulong_16
 OpStore %459 %480

--- a/test/golden/spirv/call/call_variadic.dis
+++ b/test/golden/spirv/call/call_variadic.dis
@@ -508,8 +508,8 @@ OpStore %197 %422
 %425 = OpFunctionCall %ulong %22 %423 %424
 OpStore %198 %425
 %426 = OpLoad %ulong %198
-%427 = OpFunctionCall %ulong %22 %426 %ulong_8
-OpStore %199 %427
+%428 = OpFunctionCall %ulong %22 %426 %ulong_8
+OpStore %199 %428
 OpBranch %60
 %60 = OpLabel
 %430 = OpAccessChain %_ptr_Function_ulong %116 %uint_0
@@ -666,8 +666,8 @@ OpStore %225 %541
 %544 = OpFunctionCall %ulong %22 %542 %543
 OpStore %226 %544
 %545 = OpLoad %ulong %226
-%546 = OpFunctionCall %ulong %22 %545 %ulong_6
-OpStore %227 %546
+%547 = OpFunctionCall %ulong %22 %545 %ulong_6
+OpStore %227 %547
 OpBranch %74
 %74 = OpLabel
 %548 = OpLoad %ulong %124
@@ -924,8 +924,8 @@ OpBranch %101
 %694 = OpFunctionCall %ulong %22 %692 %693
 OpStore %282 %694
 %695 = OpLoad %ulong %282
-%696 = OpFunctionCall %ulong %22 %695 %ulong_1
-OpStore %283 %696
+%697 = OpFunctionCall %ulong %22 %695 %ulong_1
+OpStore %283 %697
 OpBranch %102
 %102 = OpLabel
 OpBranch %103

--- a/test/golden/spirv/cmp/cmp_i32.dis
+++ b/test/golden/spirv/cmp/cmp_i32.dis
@@ -140,56 +140,56 @@ OpStore %30 %90
 %92 = OpLoad %uint %30
 %93 = OpIEqual %bool %91 %92
 OpStore %31 %93
-%94 = OpLoad %ulong %44
-%95 = OpLoad %bool %31
-%100 = OpSelect %uchar %95 %uchar_1 %uchar_0
-%97 = OpFunctionCall %ulong %3 %94 %100
-OpStore %32 %97
+%95 = OpLoad %ulong %44
+%96 = OpLoad %bool %31
+%99 = OpSelect %uchar %96 %uchar_1 %uchar_0
+%100 = OpFunctionCall %ulong %3 %95 %99
+OpStore %32 %100
 %101 = OpLoad %uint %29
 %102 = OpLoad %uint %30
 %103 = OpINotEqual %bool %101 %102
 OpStore %33 %103
 %104 = OpLoad %ulong %32
 %105 = OpLoad %bool %33
-%107 = OpSelect %uchar %105 %uchar_1 %uchar_0
-%106 = OpFunctionCall %ulong %3 %104 %107
-OpStore %34 %106
+%106 = OpSelect %uchar %105 %uchar_1 %uchar_0
+%107 = OpFunctionCall %ulong %3 %104 %106
+OpStore %34 %107
 %108 = OpLoad %uint %29
 %109 = OpLoad %uint %30
 %110 = OpSLessThan %bool %108 %109
 OpStore %35 %110
 %111 = OpLoad %ulong %34
 %112 = OpLoad %bool %35
-%114 = OpSelect %uchar %112 %uchar_1 %uchar_0
-%113 = OpFunctionCall %ulong %3 %111 %114
-OpStore %36 %113
+%113 = OpSelect %uchar %112 %uchar_1 %uchar_0
+%114 = OpFunctionCall %ulong %3 %111 %113
+OpStore %36 %114
 %115 = OpLoad %uint %30
 %116 = OpLoad %uint %29
 %117 = OpSLessThan %bool %115 %116
 OpStore %37 %117
 %118 = OpLoad %ulong %36
 %119 = OpLoad %bool %37
-%121 = OpSelect %uchar %119 %uchar_1 %uchar_0
-%120 = OpFunctionCall %ulong %3 %118 %121
-OpStore %38 %120
+%120 = OpSelect %uchar %119 %uchar_1 %uchar_0
+%121 = OpFunctionCall %ulong %3 %118 %120
+OpStore %38 %121
 %122 = OpLoad %uint %29
 %123 = OpLoad %uint %30
 %124 = OpSLessThanEqual %bool %122 %123
 OpStore %39 %124
 %125 = OpLoad %ulong %38
 %126 = OpLoad %bool %39
-%128 = OpSelect %uchar %126 %uchar_1 %uchar_0
-%127 = OpFunctionCall %ulong %3 %125 %128
-OpStore %40 %127
+%127 = OpSelect %uchar %126 %uchar_1 %uchar_0
+%128 = OpFunctionCall %ulong %3 %125 %127
+OpStore %40 %128
 %129 = OpLoad %uint %30
 %130 = OpLoad %uint %29
 %131 = OpSLessThanEqual %bool %129 %130
 OpStore %41 %131
 %132 = OpLoad %ulong %40
 %133 = OpLoad %bool %41
-%135 = OpSelect %uchar %133 %uchar_1 %uchar_0
-%134 = OpFunctionCall %ulong %3 %132 %135
-OpStore %42 %134
+%134 = OpSelect %uchar %133 %uchar_1 %uchar_0
+%135 = OpFunctionCall %ulong %3 %132 %134
+OpStore %42 %135
 %136 = OpLoad %ulong %45
 %138 = OpIAdd %ulong %136 %ulong_1
 OpStore %43 %138

--- a/test/golden/spirv/cmp/cmp_i64.dis
+++ b/test/golden/spirv/cmp/cmp_i64.dis
@@ -135,56 +135,56 @@ OpStore %28 %86
 %88 = OpLoad %ulong %28
 %89 = OpIEqual %bool %87 %88
 OpStore %29 %89
-%90 = OpLoad %ulong %42
-%91 = OpLoad %bool %29
-%96 = OpSelect %uchar %91 %uchar_1 %uchar_0
-%93 = OpFunctionCall %ulong %3 %90 %96
-OpStore %30 %93
+%91 = OpLoad %ulong %42
+%92 = OpLoad %bool %29
+%95 = OpSelect %uchar %92 %uchar_1 %uchar_0
+%96 = OpFunctionCall %ulong %3 %91 %95
+OpStore %30 %96
 %97 = OpLoad %ulong %27
 %98 = OpLoad %ulong %28
 %99 = OpINotEqual %bool %97 %98
 OpStore %31 %99
 %100 = OpLoad %ulong %30
 %101 = OpLoad %bool %31
-%103 = OpSelect %uchar %101 %uchar_1 %uchar_0
-%102 = OpFunctionCall %ulong %3 %100 %103
-OpStore %32 %102
+%102 = OpSelect %uchar %101 %uchar_1 %uchar_0
+%103 = OpFunctionCall %ulong %3 %100 %102
+OpStore %32 %103
 %104 = OpLoad %ulong %27
 %105 = OpLoad %ulong %28
 %106 = OpSLessThan %bool %104 %105
 OpStore %33 %106
 %107 = OpLoad %ulong %32
 %108 = OpLoad %bool %33
-%110 = OpSelect %uchar %108 %uchar_1 %uchar_0
-%109 = OpFunctionCall %ulong %3 %107 %110
-OpStore %34 %109
+%109 = OpSelect %uchar %108 %uchar_1 %uchar_0
+%110 = OpFunctionCall %ulong %3 %107 %109
+OpStore %34 %110
 %111 = OpLoad %ulong %28
 %112 = OpLoad %ulong %27
 %113 = OpSLessThan %bool %111 %112
 OpStore %35 %113
 %114 = OpLoad %ulong %34
 %115 = OpLoad %bool %35
-%117 = OpSelect %uchar %115 %uchar_1 %uchar_0
-%116 = OpFunctionCall %ulong %3 %114 %117
-OpStore %36 %116
+%116 = OpSelect %uchar %115 %uchar_1 %uchar_0
+%117 = OpFunctionCall %ulong %3 %114 %116
+OpStore %36 %117
 %118 = OpLoad %ulong %27
 %119 = OpLoad %ulong %28
 %120 = OpSLessThanEqual %bool %118 %119
 OpStore %37 %120
 %121 = OpLoad %ulong %36
 %122 = OpLoad %bool %37
-%124 = OpSelect %uchar %122 %uchar_1 %uchar_0
-%123 = OpFunctionCall %ulong %3 %121 %124
-OpStore %38 %123
+%123 = OpSelect %uchar %122 %uchar_1 %uchar_0
+%124 = OpFunctionCall %ulong %3 %121 %123
+OpStore %38 %124
 %125 = OpLoad %ulong %28
 %126 = OpLoad %ulong %27
 %127 = OpSLessThanEqual %bool %125 %126
 OpStore %39 %127
 %128 = OpLoad %ulong %38
 %129 = OpLoad %bool %39
-%131 = OpSelect %uchar %129 %uchar_1 %uchar_0
-%130 = OpFunctionCall %ulong %3 %128 %131
-OpStore %40 %130
+%130 = OpSelect %uchar %129 %uchar_1 %uchar_0
+%131 = OpFunctionCall %ulong %3 %128 %130
+OpStore %40 %131
 %132 = OpLoad %ulong %43
 %134 = OpIAdd %ulong %132 %ulong_1
 OpStore %41 %134

--- a/test/golden/spirv/cmp/cmp_u32.dis
+++ b/test/golden/spirv/cmp/cmp_u32.dis
@@ -140,56 +140,56 @@ OpStore %30 %90
 %92 = OpLoad %uint %30
 %93 = OpIEqual %bool %91 %92
 OpStore %31 %93
-%94 = OpLoad %ulong %44
-%95 = OpLoad %bool %31
-%100 = OpSelect %uchar %95 %uchar_1 %uchar_0
-%97 = OpFunctionCall %ulong %3 %94 %100
-OpStore %32 %97
+%95 = OpLoad %ulong %44
+%96 = OpLoad %bool %31
+%99 = OpSelect %uchar %96 %uchar_1 %uchar_0
+%100 = OpFunctionCall %ulong %3 %95 %99
+OpStore %32 %100
 %101 = OpLoad %uint %29
 %102 = OpLoad %uint %30
 %103 = OpINotEqual %bool %101 %102
 OpStore %33 %103
 %104 = OpLoad %ulong %32
 %105 = OpLoad %bool %33
-%107 = OpSelect %uchar %105 %uchar_1 %uchar_0
-%106 = OpFunctionCall %ulong %3 %104 %107
-OpStore %34 %106
+%106 = OpSelect %uchar %105 %uchar_1 %uchar_0
+%107 = OpFunctionCall %ulong %3 %104 %106
+OpStore %34 %107
 %108 = OpLoad %uint %29
 %109 = OpLoad %uint %30
 %110 = OpULessThan %bool %108 %109
 OpStore %35 %110
 %111 = OpLoad %ulong %34
 %112 = OpLoad %bool %35
-%114 = OpSelect %uchar %112 %uchar_1 %uchar_0
-%113 = OpFunctionCall %ulong %3 %111 %114
-OpStore %36 %113
+%113 = OpSelect %uchar %112 %uchar_1 %uchar_0
+%114 = OpFunctionCall %ulong %3 %111 %113
+OpStore %36 %114
 %115 = OpLoad %uint %30
 %116 = OpLoad %uint %29
 %117 = OpULessThan %bool %115 %116
 OpStore %37 %117
 %118 = OpLoad %ulong %36
 %119 = OpLoad %bool %37
-%121 = OpSelect %uchar %119 %uchar_1 %uchar_0
-%120 = OpFunctionCall %ulong %3 %118 %121
-OpStore %38 %120
+%120 = OpSelect %uchar %119 %uchar_1 %uchar_0
+%121 = OpFunctionCall %ulong %3 %118 %120
+OpStore %38 %121
 %122 = OpLoad %uint %29
 %123 = OpLoad %uint %30
 %124 = OpULessThanEqual %bool %122 %123
 OpStore %39 %124
 %125 = OpLoad %ulong %38
 %126 = OpLoad %bool %39
-%128 = OpSelect %uchar %126 %uchar_1 %uchar_0
-%127 = OpFunctionCall %ulong %3 %125 %128
-OpStore %40 %127
+%127 = OpSelect %uchar %126 %uchar_1 %uchar_0
+%128 = OpFunctionCall %ulong %3 %125 %127
+OpStore %40 %128
 %129 = OpLoad %uint %30
 %130 = OpLoad %uint %29
 %131 = OpULessThanEqual %bool %129 %130
 OpStore %41 %131
 %132 = OpLoad %ulong %40
 %133 = OpLoad %bool %41
-%135 = OpSelect %uchar %133 %uchar_1 %uchar_0
-%134 = OpFunctionCall %ulong %3 %132 %135
-OpStore %42 %134
+%134 = OpSelect %uchar %133 %uchar_1 %uchar_0
+%135 = OpFunctionCall %ulong %3 %132 %134
+OpStore %42 %135
 %136 = OpLoad %ulong %45
 %138 = OpIAdd %ulong %136 %ulong_1
 OpStore %43 %138

--- a/test/golden/spirv/cmp/cmp_u64.dis
+++ b/test/golden/spirv/cmp/cmp_u64.dis
@@ -135,56 +135,56 @@ OpStore %28 %86
 %88 = OpLoad %ulong %28
 %89 = OpIEqual %bool %87 %88
 OpStore %29 %89
-%90 = OpLoad %ulong %42
-%91 = OpLoad %bool %29
-%96 = OpSelect %uchar %91 %uchar_1 %uchar_0
-%93 = OpFunctionCall %ulong %3 %90 %96
-OpStore %30 %93
+%91 = OpLoad %ulong %42
+%92 = OpLoad %bool %29
+%95 = OpSelect %uchar %92 %uchar_1 %uchar_0
+%96 = OpFunctionCall %ulong %3 %91 %95
+OpStore %30 %96
 %97 = OpLoad %ulong %27
 %98 = OpLoad %ulong %28
 %99 = OpINotEqual %bool %97 %98
 OpStore %31 %99
 %100 = OpLoad %ulong %30
 %101 = OpLoad %bool %31
-%103 = OpSelect %uchar %101 %uchar_1 %uchar_0
-%102 = OpFunctionCall %ulong %3 %100 %103
-OpStore %32 %102
+%102 = OpSelect %uchar %101 %uchar_1 %uchar_0
+%103 = OpFunctionCall %ulong %3 %100 %102
+OpStore %32 %103
 %104 = OpLoad %ulong %27
 %105 = OpLoad %ulong %28
 %106 = OpULessThan %bool %104 %105
 OpStore %33 %106
 %107 = OpLoad %ulong %32
 %108 = OpLoad %bool %33
-%110 = OpSelect %uchar %108 %uchar_1 %uchar_0
-%109 = OpFunctionCall %ulong %3 %107 %110
-OpStore %34 %109
+%109 = OpSelect %uchar %108 %uchar_1 %uchar_0
+%110 = OpFunctionCall %ulong %3 %107 %109
+OpStore %34 %110
 %111 = OpLoad %ulong %28
 %112 = OpLoad %ulong %27
 %113 = OpULessThan %bool %111 %112
 OpStore %35 %113
 %114 = OpLoad %ulong %34
 %115 = OpLoad %bool %35
-%117 = OpSelect %uchar %115 %uchar_1 %uchar_0
-%116 = OpFunctionCall %ulong %3 %114 %117
-OpStore %36 %116
+%116 = OpSelect %uchar %115 %uchar_1 %uchar_0
+%117 = OpFunctionCall %ulong %3 %114 %116
+OpStore %36 %117
 %118 = OpLoad %ulong %27
 %119 = OpLoad %ulong %28
 %120 = OpULessThanEqual %bool %118 %119
 OpStore %37 %120
 %121 = OpLoad %ulong %36
 %122 = OpLoad %bool %37
-%124 = OpSelect %uchar %122 %uchar_1 %uchar_0
-%123 = OpFunctionCall %ulong %3 %121 %124
-OpStore %38 %123
+%123 = OpSelect %uchar %122 %uchar_1 %uchar_0
+%124 = OpFunctionCall %ulong %3 %121 %123
+OpStore %38 %124
 %125 = OpLoad %ulong %28
 %126 = OpLoad %ulong %27
 %127 = OpULessThanEqual %bool %125 %126
 OpStore %39 %127
 %128 = OpLoad %ulong %38
 %129 = OpLoad %bool %39
-%131 = OpSelect %uchar %129 %uchar_1 %uchar_0
-%130 = OpFunctionCall %ulong %3 %128 %131
-OpStore %40 %130
+%130 = OpSelect %uchar %129 %uchar_1 %uchar_0
+%131 = OpFunctionCall %ulong %3 %128 %130
+OpStore %40 %131
 %132 = OpLoad %ulong %43
 %134 = OpIAdd %ulong %132 %ulong_1
 OpStore %41 %134

--- a/test/golden/spirv/comptime/ct_runtime_agree.dis
+++ b/test/golden/spirv/comptime/ct_runtime_agree.dis
@@ -383,50 +383,50 @@ OpStore %145 %327
 %330 = OpFunctionCall %ulong %6 %328 %329
 OpStore %146 %330
 %331 = OpLoad %ulong %146
-%332 = OpFunctionCall %ulong %6 %331 %ulong_916259695
-OpStore %147 %332
+%333 = OpFunctionCall %ulong %6 %331 %ulong_916259695
+OpStore %147 %333
 %334 = OpLoad %ulong %147
 %335 = OpLoad %ulong %136
 %336 = OpFunctionCall %ulong %6 %334 %335
 OpStore %148 %336
 %337 = OpLoad %ulong %148
-%338 = OpFunctionCall %ulong %6 %337 %ulong_7544905068303
-OpStore %149 %338
+%339 = OpFunctionCall %ulong %6 %337 %ulong_7544905068303
+OpStore %149 %339
 %340 = OpLoad %ulong %149
 %341 = OpLoad %ulong %138
 %342 = OpFunctionCall %ulong %6 %340 %341
 OpStore %150 %342
 %343 = OpLoad %ulong %150
-%344 = OpFunctionCall %ulong %6 %343 %ulong_7495090973393
-OpStore %151 %344
+%345 = OpFunctionCall %ulong %6 %343 %ulong_7495090973393
+OpStore %151 %345
 %346 = OpLoad %ulong %151
 %347 = OpLoad %ulong %140
 %348 = OpFunctionCall %ulong %6 %346 %347
 OpStore %152 %348
 %349 = OpLoad %ulong %152
-%350 = OpFunctionCall %ulong %6 %349 %ulong_373041873
-OpStore %153 %350
+%351 = OpFunctionCall %ulong %6 %349 %ulong_373041873
+OpStore %153 %351
 %352 = OpLoad %ulong %153
 %353 = OpLoad %ulong %141
 %354 = OpFunctionCall %ulong %6 %352 %353
 OpStore %154 %354
 %355 = OpLoad %ulong %154
-%356 = OpFunctionCall %ulong %6 %355 %ulong_990215688041620353
-OpStore %155 %356
+%357 = OpFunctionCall %ulong %6 %355 %ulong_990215688041620353
+OpStore %155 %357
 %358 = OpLoad %ulong %155
 %359 = OpLoad %ulong %142
 %360 = OpFunctionCall %ulong %6 %358 %359
 OpStore %156 %360
 %361 = OpLoad %ulong %156
-%362 = OpFunctionCall %ulong %6 %361 %ulong_7554746155102
-OpStore %157 %362
+%363 = OpFunctionCall %ulong %6 %361 %ulong_7554746155102
+OpStore %157 %363
 %364 = OpLoad %ulong %157
 %365 = OpLoad %ulong %143
 %366 = OpFunctionCall %ulong %6 %364 %365
 OpStore %158 %366
 %367 = OpLoad %ulong %158
-%368 = OpFunctionCall %ulong %6 %367 %ulong_7555119196975
-OpStore %159 %368
+%369 = OpFunctionCall %ulong %6 %367 %ulong_7555119196975
+OpStore %159 %369
 %370 = OpLoad %ulong %159
 %371 = OpLoad %ulong %144
 %372 = OpFunctionCall %ulong %6 %370 %371
@@ -458,29 +458,29 @@ OpStore %168 %392
 %395 = OpFAdd %double %393 %394
 OpStore %169 %395
 %396 = OpLoad %ulong %160
-%397 = OpFunctionCall %ulong %8 %396 %double_0_33333333333333331
-OpStore %170 %397
+%398 = OpFunctionCall %ulong %8 %396 %double_0_33333333333333331
+OpStore %170 %398
 %399 = OpLoad %ulong %170
 %400 = OpLoad %double %164
 %401 = OpFunctionCall %ulong %8 %399 %400
 OpStore %171 %401
 %402 = OpLoad %ulong %171
-%403 = OpFunctionCall %ulong %8 %402 %double_0_33333333333333304
-OpStore %172 %403
+%404 = OpFunctionCall %ulong %8 %402 %double_0_33333333333333304
+OpStore %172 %404
 %405 = OpLoad %ulong %172
 %406 = OpLoad %double %166
 %407 = OpFunctionCall %ulong %8 %405 %406
 OpStore %173 %407
 %408 = OpLoad %ulong %173
-%409 = OpFunctionCall %ulong %8 %408 %double_0_30303030303030276
-OpStore %174 %409
+%410 = OpFunctionCall %ulong %8 %408 %double_0_30303030303030276
+OpStore %174 %410
 %411 = OpLoad %ulong %174
 %412 = OpLoad %double %167
 %413 = OpFunctionCall %ulong %8 %411 %412
 OpStore %175 %413
 %414 = OpLoad %ulong %175
-%415 = OpFunctionCall %ulong %8 %414 %double_0_42516069788797045
-OpStore %176 %415
+%416 = OpFunctionCall %ulong %8 %414 %double_0_42516069788797045
+OpStore %176 %416
 %417 = OpLoad %ulong %176
 %418 = OpLoad %double %169
 %419 = OpFunctionCall %ulong %8 %417 %418
@@ -512,29 +512,29 @@ OpStore %185 %439
 %442 = OpFAdd %float %440 %441
 OpStore %186 %442
 %443 = OpLoad %ulong %177
-%444 = OpFunctionCall %ulong %7 %443 %float_0_333333343
-OpStore %187 %444
+%445 = OpFunctionCall %ulong %7 %443 %float_0_333333343
+OpStore %187 %445
 %446 = OpLoad %ulong %187
 %447 = OpLoad %float %181
 %448 = OpFunctionCall %ulong %7 %446 %447
 OpStore %188 %448
 %449 = OpLoad %ulong %188
-%450 = OpFunctionCall %ulong %7 %449 %float_0_333333492
-OpStore %189 %450
+%451 = OpFunctionCall %ulong %7 %449 %float_0_333333492
+OpStore %189 %451
 %452 = OpLoad %ulong %189
 %453 = OpLoad %float %183
 %454 = OpFunctionCall %ulong %7 %452 %453
 OpStore %190 %454
 %455 = OpLoad %ulong %190
-%456 = OpFunctionCall %ulong %7 %455 %float_0_303030431
-OpStore %191 %456
+%457 = OpFunctionCall %ulong %7 %455 %float_0_303030431
+OpStore %191 %457
 %458 = OpLoad %ulong %191
 %459 = OpLoad %float %184
 %460 = OpFunctionCall %ulong %7 %458 %459
 OpStore %192 %460
 %461 = OpLoad %ulong %192
-%462 = OpFunctionCall %ulong %7 %461 %float_0_425160795
-OpStore %193 %462
+%463 = OpFunctionCall %ulong %7 %461 %float_0_425160795
+OpStore %193 %463
 %464 = OpLoad %ulong %193
 %465 = OpLoad %float %186
 %466 = OpFunctionCall %ulong %7 %464 %465
@@ -543,20 +543,20 @@ OpStore %194 %466
 %468 = OpFunctionCall %ulong %6 %467 %ulong_2654435761
 OpStore %195 %468
 %469 = OpLoad %ulong %195
-%470 = OpFunctionCall %ulong %6 %469 %ulong_5445325986
-OpStore %196 %470
+%471 = OpFunctionCall %ulong %6 %469 %ulong_5445325986
+OpStore %196 %471
 %472 = OpLoad %ulong %196
-%473 = OpFunctionCall %ulong %6 %472 %ulong_21862106997
-OpStore %197 %473
+%474 = OpFunctionCall %ulong %6 %472 %ulong_21862106997
+OpStore %197 %474
 %475 = OpLoad %ulong %197
-%476 = OpFunctionCall %ulong %6 %475 %ulong_52920935978
-OpStore %198 %476
+%477 = OpFunctionCall %ulong %6 %475 %ulong_52920935978
+OpStore %198 %477
 %478 = OpLoad %ulong %198
-%479 = OpFunctionCall %ulong %6 %478 %ulong_135205673541
-OpStore %199 %479
+%480 = OpFunctionCall %ulong %6 %478 %ulong_135205673541
+OpStore %199 %480
 %481 = OpLoad %ulong %199
-%482 = OpFunctionCall %ulong %6 %481 %ulong_247317407946
-OpStore %200 %482
+%483 = OpFunctionCall %ulong %6 %481 %ulong_247317407946
+OpStore %200 %483
 OpStore %131 %484
 %486 = OpLoad %ulong %132
 %487 = OpIAdd %ulong %ulong_1 %486
@@ -608,8 +608,8 @@ OpLoopMerge %77 %124 None
 OpBranchConditional %523 %76 %77
 %77 = OpLabel
 %524 = OpLoad %ulong %233
-%525 = OpFunctionCall %ulong %6 %524 %ulong_11
-OpStore %213 %525
+%526 = OpFunctionCall %ulong %6 %524 %ulong_11
+OpStore %213 %526
 %527 = OpLoad %ulong %144
 %528 = OpLoad %ulong %142
 %529 = OpULessThan %bool %527 %528
@@ -619,8 +619,8 @@ OpSelectionMerge %80 None
 OpBranchConditional %530 %78 %79
 %79 = OpLabel
 %531 = OpLoad %ulong %213
-%532 = OpFunctionCall %ulong %6 %531 %ulong_22
-OpStore %216 %532
+%533 = OpFunctionCall %ulong %6 %531 %ulong_22
+OpStore %216 %533
 %534 = OpLoad %ulong %216
 OpStore %232 %534
 OpBranch %80
@@ -633,8 +633,8 @@ OpStore %232 %537
 OpBranch %80
 %80 = OpLabel
 %538 = OpLoad %ulong %232
-%539 = OpFunctionCall %ulong %6 %538 %ulong_33
-OpStore %217 %539
+%540 = OpFunctionCall %ulong %6 %538 %ulong_33
+OpStore %217 %540
 %542 = OpLoad %ulong %141
 %543 = OpULessThan %bool %ulong_65535 %542
 OpStore %218 %543
@@ -643,8 +643,8 @@ OpSelectionMerge %83 None
 OpBranchConditional %544 %81 %82
 %82 = OpLabel
 %545 = OpLoad %ulong %217
-%546 = OpFunctionCall %ulong %6 %545 %ulong_44
-OpStore %220 %546
+%547 = OpFunctionCall %ulong %6 %545 %ulong_44
+OpStore %220 %547
 %548 = OpLoad %ulong %220
 OpStore %231 %548
 OpBranch %83

--- a/test/golden/spirv/float/arith_f32.dis
+++ b/test/golden/spirv/float/arith_f32.dis
@@ -98,8 +98,8 @@ OpStore %41 %48
 OpReturnValue %49
 %30 = OpLabel
 %50 = OpLoad %ulong %36
-%51 = OpFunctionCall %ulong %5 %50 %uint_4294967295
-OpStore %40 %51
+%52 = OpFunctionCall %ulong %5 %50 %uint_4294967295
+OpStore %40 %52
 %53 = OpLoad %ulong %40
 OpReturnValue %53
 %33 = OpLabel

--- a/test/golden/spirv/float/arith_f64.dis
+++ b/test/golden/spirv/float/arith_f64.dis
@@ -95,8 +95,8 @@ OpStore %39 %46
 OpReturnValue %47
 %29 = OpLabel
 %48 = OpLoad %ulong %34
-%49 = OpFunctionCall %ulong %5 %48 %ulong_18446744073709551615
-OpStore %38 %49
+%50 = OpFunctionCall %ulong %5 %48 %ulong_18446744073709551615
+OpStore %38 %50
 %51 = OpLoad %ulong %38
 OpReturnValue %51
 %32 = OpLabel

--- a/test/golden/spirv/float/cmp_f32.dis
+++ b/test/golden/spirv/float/cmp_f32.dis
@@ -93,9 +93,9 @@ OpStore %25 %32
 %33 = OpLoad %ulong %25
 OpReturnValue %33
 %13 = OpLabel
-%34 = OpLoad %ulong %19
-%36 = OpFunctionCall %ulong %5 %34 %uint_4294967295
-OpStore %24 %36
+%35 = OpLoad %ulong %19
+%37 = OpFunctionCall %ulong %5 %35 %uint_4294967295
+OpStore %24 %37
 %38 = OpLoad %ulong %24
 OpReturnValue %38
 %16 = OpLabel
@@ -648,54 +648,54 @@ OpStore %143 %492
 OpStore %144 %495
 %496 = OpLoad %ulong %220
 %497 = OpLoad %bool %144
-%499 = OpSelect %uchar %497 %uchar_1 %uchar_0
-%498 = OpFunctionCall %ulong %4 %496 %499
-OpStore %145 %498
+%498 = OpSelect %uchar %497 %uchar_1 %uchar_0
+%499 = OpFunctionCall %ulong %4 %496 %498
+OpStore %145 %499
 %500 = OpLoad %float %142
 %501 = OpLoad %float %143
 %502 = OpFUnordNotEqual %bool %500 %501
 OpStore %146 %502
 %503 = OpLoad %ulong %145
 %504 = OpLoad %bool %146
-%506 = OpSelect %uchar %504 %uchar_1 %uchar_0
-%505 = OpFunctionCall %ulong %4 %503 %506
-OpStore %147 %505
+%505 = OpSelect %uchar %504 %uchar_1 %uchar_0
+%506 = OpFunctionCall %ulong %4 %503 %505
+OpStore %147 %506
 %507 = OpLoad %float %142
 %508 = OpLoad %float %143
 %509 = OpFOrdLessThan %bool %507 %508
 OpStore %148 %509
 %510 = OpLoad %ulong %147
 %511 = OpLoad %bool %148
-%513 = OpSelect %uchar %511 %uchar_1 %uchar_0
-%512 = OpFunctionCall %ulong %4 %510 %513
-OpStore %149 %512
+%512 = OpSelect %uchar %511 %uchar_1 %uchar_0
+%513 = OpFunctionCall %ulong %4 %510 %512
+OpStore %149 %513
 %514 = OpLoad %float %142
 %515 = OpLoad %float %143
 %516 = OpFOrdLessThanEqual %bool %514 %515
 OpStore %150 %516
 %517 = OpLoad %ulong %149
 %518 = OpLoad %bool %150
-%520 = OpSelect %uchar %518 %uchar_1 %uchar_0
-%519 = OpFunctionCall %ulong %4 %517 %520
-OpStore %151 %519
+%519 = OpSelect %uchar %518 %uchar_1 %uchar_0
+%520 = OpFunctionCall %ulong %4 %517 %519
+OpStore %151 %520
 %521 = OpLoad %float %143
 %522 = OpLoad %float %142
 %523 = OpFOrdLessThan %bool %521 %522
 OpStore %152 %523
 %524 = OpLoad %ulong %151
 %525 = OpLoad %bool %152
-%527 = OpSelect %uchar %525 %uchar_1 %uchar_0
-%526 = OpFunctionCall %ulong %4 %524 %527
-OpStore %153 %526
+%526 = OpSelect %uchar %525 %uchar_1 %uchar_0
+%527 = OpFunctionCall %ulong %4 %524 %526
+OpStore %153 %527
 %528 = OpLoad %float %143
 %529 = OpLoad %float %142
 %530 = OpFOrdLessThanEqual %bool %528 %529
 OpStore %154 %530
 %531 = OpLoad %ulong %153
 %532 = OpLoad %bool %154
-%534 = OpSelect %uchar %532 %uchar_1 %uchar_0
-%533 = OpFunctionCall %ulong %4 %531 %534
-OpStore %155 %533
+%533 = OpSelect %uchar %532 %uchar_1 %uchar_0
+%534 = OpFunctionCall %ulong %4 %531 %533
+OpStore %155 %534
 %535 = OpLoad %bool %148
 OpSelectionMerge %50 None
 OpBranchConditional %535 %48 %49
@@ -827,9 +827,9 @@ OpBranch %67
 %67 = OpLabel
 %593 = OpLoad %ulong %167
 %594 = OpLoad %bool %230
-%596 = OpSelect %uchar %594 %uchar_1 %uchar_0
-%595 = OpFunctionCall %ulong %4 %593 %596
-OpStore %170 %595
+%595 = OpSelect %uchar %594 %uchar_1 %uchar_0
+%596 = OpFunctionCall %ulong %4 %593 %595
+OpStore %170 %596
 %597 = OpLoad %float %142
 %598 = OpLoad %float %143
 %599 = OpFOrdLessThan %bool %597 %598
@@ -852,9 +852,9 @@ OpBranch %69
 %69 = OpLabel
 %606 = OpLoad %ulong %170
 %607 = OpLoad %bool %231
-%609 = OpSelect %uchar %607 %uchar_1 %uchar_0
-%608 = OpFunctionCall %ulong %4 %606 %609
-OpStore %173 %608
+%608 = OpSelect %uchar %607 %uchar_1 %uchar_0
+%609 = OpFunctionCall %ulong %4 %606 %608
+OpStore %173 %609
 %610 = OpLoad %float %142
 %611 = OpLoad %float %143
 %612 = OpFOrdLessThan %bool %610 %611
@@ -865,9 +865,9 @@ OpStore %174 %612
 OpStore %175 %615
 %616 = OpLoad %ulong %173
 %617 = OpLoad %bool %175
-%619 = OpSelect %uchar %617 %uchar_1 %uchar_0
-%618 = OpFunctionCall %ulong %4 %616 %619
-OpStore %176 %618
+%618 = OpSelect %uchar %617 %uchar_1 %uchar_0
+%619 = OpFunctionCall %ulong %4 %616 %618
+OpStore %176 %619
 %620 = OpLoad %float %142
 %621 = OpLoad %float %142
 %622 = OpFOrdEqual %bool %620 %621
@@ -890,9 +890,9 @@ OpBranch %71
 %71 = OpLabel
 %629 = OpLoad %ulong %176
 %630 = OpLoad %bool %232
-%632 = OpSelect %uchar %630 %uchar_1 %uchar_0
-%631 = OpFunctionCall %ulong %4 %629 %632
-OpStore %179 %631
+%631 = OpSelect %uchar %630 %uchar_1 %uchar_0
+%632 = OpFunctionCall %ulong %4 %629 %631
+OpStore %179 %632
 %633 = OpLoad %float %142
 %634 = OpLoad %float %142
 %635 = OpFUnordNotEqual %bool %633 %634
@@ -915,9 +915,9 @@ OpBranch %73
 %73 = OpLabel
 %642 = OpLoad %ulong %179
 %643 = OpLoad %bool %233
-%645 = OpSelect %uchar %643 %uchar_1 %uchar_0
-%644 = OpFunctionCall %ulong %4 %642 %645
-OpStore %182 %644
+%644 = OpSelect %uchar %643 %uchar_1 %uchar_0
+%645 = OpFunctionCall %ulong %4 %642 %644
+OpStore %182 %645
 %646 = OpLoad %uint %223
 %647 = OpIAdd %uint %646 %uint_1
 OpStore %183 %647

--- a/test/golden/spirv/float/cmp_f64.dis
+++ b/test/golden/spirv/float/cmp_f64.dis
@@ -108,8 +108,8 @@ OpStore %26 %33
 OpReturnValue %34
 %14 = OpLabel
 %35 = OpLoad %ulong %20
-%36 = OpFunctionCall %ulong %4 %35 %ulong_18446744073709551615
-OpStore %25 %36
+%37 = OpFunctionCall %ulong %4 %35 %ulong_18446744073709551615
+OpStore %25 %37
 %38 = OpLoad %ulong %25
 OpReturnValue %38
 %17 = OpLabel
@@ -786,54 +786,54 @@ OpStore %219 %607
 OpStore %220 %610
 %611 = OpLoad %ulong %269
 %612 = OpLoad %bool %220
-%614 = OpSelect %uchar %612 %uchar_1 %uchar_0
-%613 = OpFunctionCall %ulong %5 %611 %614
-OpStore %221 %613
+%613 = OpSelect %uchar %612 %uchar_1 %uchar_0
+%614 = OpFunctionCall %ulong %5 %611 %613
+OpStore %221 %614
 %615 = OpLoad %double %217
 %616 = OpLoad %double %219
 %617 = OpFUnordNotEqual %bool %615 %616
 OpStore %222 %617
 %618 = OpLoad %ulong %221
 %619 = OpLoad %bool %222
-%621 = OpSelect %uchar %619 %uchar_1 %uchar_0
-%620 = OpFunctionCall %ulong %5 %618 %621
-OpStore %223 %620
+%620 = OpSelect %uchar %619 %uchar_1 %uchar_0
+%621 = OpFunctionCall %ulong %5 %618 %620
+OpStore %223 %621
 %622 = OpLoad %double %217
 %623 = OpLoad %double %219
 %624 = OpFOrdLessThan %bool %622 %623
 OpStore %224 %624
 %625 = OpLoad %ulong %223
 %626 = OpLoad %bool %224
-%628 = OpSelect %uchar %626 %uchar_1 %uchar_0
-%627 = OpFunctionCall %ulong %5 %625 %628
-OpStore %225 %627
+%627 = OpSelect %uchar %626 %uchar_1 %uchar_0
+%628 = OpFunctionCall %ulong %5 %625 %627
+OpStore %225 %628
 %629 = OpLoad %double %217
 %630 = OpLoad %double %219
 %631 = OpFOrdLessThanEqual %bool %629 %630
 OpStore %226 %631
 %632 = OpLoad %ulong %225
 %633 = OpLoad %bool %226
-%635 = OpSelect %uchar %633 %uchar_1 %uchar_0
-%634 = OpFunctionCall %ulong %5 %632 %635
-OpStore %227 %634
+%634 = OpSelect %uchar %633 %uchar_1 %uchar_0
+%635 = OpFunctionCall %ulong %5 %632 %634
+OpStore %227 %635
 %636 = OpLoad %double %219
 %637 = OpLoad %double %217
 %638 = OpFOrdLessThan %bool %636 %637
 OpStore %228 %638
 %639 = OpLoad %ulong %227
 %640 = OpLoad %bool %228
-%642 = OpSelect %uchar %640 %uchar_1 %uchar_0
-%641 = OpFunctionCall %ulong %5 %639 %642
-OpStore %229 %641
+%641 = OpSelect %uchar %640 %uchar_1 %uchar_0
+%642 = OpFunctionCall %ulong %5 %639 %641
+OpStore %229 %642
 %643 = OpLoad %double %219
 %644 = OpLoad %double %217
 %645 = OpFOrdLessThanEqual %bool %643 %644
 OpStore %230 %645
 %646 = OpLoad %ulong %229
 %647 = OpLoad %bool %230
-%649 = OpSelect %uchar %647 %uchar_1 %uchar_0
-%648 = OpFunctionCall %ulong %5 %646 %649
-OpStore %231 %648
+%648 = OpSelect %uchar %647 %uchar_1 %uchar_0
+%649 = OpFunctionCall %ulong %5 %646 %648
+OpStore %231 %649
 %650 = OpLoad %ulong %286
 %651 = OpIAdd %ulong %650 %ulong_1
 OpStore %232 %651
@@ -878,54 +878,54 @@ OpStore %157 %667
 OpStore %158 %670
 %671 = OpLoad %ulong %271
 %672 = OpLoad %bool %158
-%674 = OpSelect %uchar %672 %uchar_1 %uchar_0
-%673 = OpFunctionCall %ulong %5 %671 %674
-OpStore %159 %673
+%673 = OpSelect %uchar %672 %uchar_1 %uchar_0
+%674 = OpFunctionCall %ulong %5 %671 %673
+OpStore %159 %674
 %675 = OpLoad %double %156
 %676 = OpLoad %double %157
 %677 = OpFUnordNotEqual %bool %675 %676
 OpStore %160 %677
 %678 = OpLoad %ulong %159
 %679 = OpLoad %bool %160
-%681 = OpSelect %uchar %679 %uchar_1 %uchar_0
-%680 = OpFunctionCall %ulong %5 %678 %681
-OpStore %161 %680
+%680 = OpSelect %uchar %679 %uchar_1 %uchar_0
+%681 = OpFunctionCall %ulong %5 %678 %680
+OpStore %161 %681
 %682 = OpLoad %double %156
 %683 = OpLoad %double %157
 %684 = OpFOrdLessThan %bool %682 %683
 OpStore %162 %684
 %685 = OpLoad %ulong %161
 %686 = OpLoad %bool %162
-%688 = OpSelect %uchar %686 %uchar_1 %uchar_0
-%687 = OpFunctionCall %ulong %5 %685 %688
-OpStore %163 %687
+%687 = OpSelect %uchar %686 %uchar_1 %uchar_0
+%688 = OpFunctionCall %ulong %5 %685 %687
+OpStore %163 %688
 %689 = OpLoad %double %156
 %690 = OpLoad %double %157
 %691 = OpFOrdLessThanEqual %bool %689 %690
 OpStore %164 %691
 %692 = OpLoad %ulong %163
 %693 = OpLoad %bool %164
-%695 = OpSelect %uchar %693 %uchar_1 %uchar_0
-%694 = OpFunctionCall %ulong %5 %692 %695
-OpStore %165 %694
+%694 = OpSelect %uchar %693 %uchar_1 %uchar_0
+%695 = OpFunctionCall %ulong %5 %692 %694
+OpStore %165 %695
 %696 = OpLoad %double %157
 %697 = OpLoad %double %156
 %698 = OpFOrdLessThan %bool %696 %697
 OpStore %166 %698
 %699 = OpLoad %ulong %165
 %700 = OpLoad %bool %166
-%702 = OpSelect %uchar %700 %uchar_1 %uchar_0
-%701 = OpFunctionCall %ulong %5 %699 %702
-OpStore %167 %701
+%701 = OpSelect %uchar %700 %uchar_1 %uchar_0
+%702 = OpFunctionCall %ulong %5 %699 %701
+OpStore %167 %702
 %703 = OpLoad %double %157
 %704 = OpLoad %double %156
 %705 = OpFOrdLessThanEqual %bool %703 %704
 OpStore %168 %705
 %706 = OpLoad %ulong %167
 %707 = OpLoad %bool %168
-%709 = OpSelect %uchar %707 %uchar_1 %uchar_0
-%708 = OpFunctionCall %ulong %5 %706 %709
-OpStore %169 %708
+%708 = OpSelect %uchar %707 %uchar_1 %uchar_0
+%709 = OpFunctionCall %ulong %5 %706 %708
+OpStore %169 %709
 %710 = OpLoad %bool %162
 OpSelectionMerge %50 None
 OpBranchConditional %710 %48 %49
@@ -1057,9 +1057,9 @@ OpBranch %67
 %67 = OpLabel
 %768 = OpLoad %ulong %181
 %769 = OpLoad %bool %281
-%771 = OpSelect %uchar %769 %uchar_1 %uchar_0
-%770 = OpFunctionCall %ulong %5 %768 %771
-OpStore %184 %770
+%770 = OpSelect %uchar %769 %uchar_1 %uchar_0
+%771 = OpFunctionCall %ulong %5 %768 %770
+OpStore %184 %771
 %772 = OpLoad %double %156
 %773 = OpLoad %double %157
 %774 = OpFOrdLessThan %bool %772 %773
@@ -1082,9 +1082,9 @@ OpBranch %69
 %69 = OpLabel
 %781 = OpLoad %ulong %184
 %782 = OpLoad %bool %282
-%784 = OpSelect %uchar %782 %uchar_1 %uchar_0
-%783 = OpFunctionCall %ulong %5 %781 %784
-OpStore %187 %783
+%783 = OpSelect %uchar %782 %uchar_1 %uchar_0
+%784 = OpFunctionCall %ulong %5 %781 %783
+OpStore %187 %784
 %785 = OpLoad %double %156
 %786 = OpLoad %double %157
 %787 = OpFOrdLessThan %bool %785 %786
@@ -1095,9 +1095,9 @@ OpStore %188 %787
 OpStore %189 %790
 %791 = OpLoad %ulong %187
 %792 = OpLoad %bool %189
-%794 = OpSelect %uchar %792 %uchar_1 %uchar_0
-%793 = OpFunctionCall %ulong %5 %791 %794
-OpStore %190 %793
+%793 = OpSelect %uchar %792 %uchar_1 %uchar_0
+%794 = OpFunctionCall %ulong %5 %791 %793
+OpStore %190 %794
 %795 = OpLoad %double %156
 %796 = OpLoad %double %156
 %797 = OpFOrdEqual %bool %795 %796
@@ -1120,9 +1120,9 @@ OpBranch %71
 %71 = OpLabel
 %804 = OpLoad %ulong %190
 %805 = OpLoad %bool %283
-%807 = OpSelect %uchar %805 %uchar_1 %uchar_0
-%806 = OpFunctionCall %ulong %5 %804 %807
-OpStore %193 %806
+%806 = OpSelect %uchar %805 %uchar_1 %uchar_0
+%807 = OpFunctionCall %ulong %5 %804 %806
+OpStore %193 %807
 %808 = OpLoad %double %156
 %809 = OpLoad %double %156
 %810 = OpFUnordNotEqual %bool %808 %809
@@ -1145,9 +1145,9 @@ OpBranch %73
 %73 = OpLabel
 %817 = OpLoad %ulong %193
 %818 = OpLoad %bool %284
-%820 = OpSelect %uchar %818 %uchar_1 %uchar_0
-%819 = OpFunctionCall %ulong %5 %817 %820
-OpStore %196 %819
+%819 = OpSelect %uchar %818 %uchar_1 %uchar_0
+%820 = OpFunctionCall %ulong %5 %817 %819
+OpStore %196 %820
 %821 = OpLoad %ulong %274
 %822 = OpIAdd %ulong %821 %ulong_1
 OpStore %197 %822

--- a/test/golden/spirv/float/special_f32.dis
+++ b/test/golden/spirv/float/special_f32.dis
@@ -120,8 +120,8 @@ OpStore %44 %51
 OpReturnValue %52
 %33 = OpLabel
 %53 = OpLoad %ulong %39
-%54 = OpFunctionCall %ulong %6 %53 %uint_4294967295
-OpStore %43 %54
+%55 = OpFunctionCall %ulong %6 %53 %uint_4294967295
+OpStore %43 %55
 %56 = OpLoad %ulong %43
 OpReturnValue %56
 %36 = OpLabel
@@ -888,29 +888,29 @@ OpStore %210 %706
 %708 = OpLoad %float %401
 %709 = OpFOrdEqual %bool %707 %708
 OpStore %211 %709
-%710 = OpLoad %ulong %210
-%711 = OpLoad %bool %211
-%716 = OpSelect %uchar %711 %uchar_1 %uchar_0
-%713 = OpFunctionCall %ulong %5 %710 %716
-OpStore %212 %713
+%711 = OpLoad %ulong %210
+%712 = OpLoad %bool %211
+%715 = OpSelect %uchar %712 %uchar_1 %uchar_0
+%716 = OpFunctionCall %ulong %5 %711 %715
+OpStore %212 %716
 %717 = OpLoad %float %395
 %718 = OpLoad %float %401
 %719 = OpFOrdLessThan %bool %717 %718
 OpStore %213 %719
 %720 = OpLoad %ulong %212
 %721 = OpLoad %bool %213
-%723 = OpSelect %uchar %721 %uchar_1 %uchar_0
-%722 = OpFunctionCall %ulong %5 %720 %723
-OpStore %214 %722
+%722 = OpSelect %uchar %721 %uchar_1 %uchar_0
+%723 = OpFunctionCall %ulong %5 %720 %722
+OpStore %214 %723
 %724 = OpLoad %float %401
 %725 = OpLoad %float %395
 %726 = OpFOrdLessThan %bool %724 %725
 OpStore %215 %726
 %727 = OpLoad %ulong %214
 %728 = OpLoad %bool %215
-%730 = OpSelect %uchar %728 %uchar_1 %uchar_0
-%729 = OpFunctionCall %ulong %5 %727 %730
-OpStore %216 %729
+%729 = OpSelect %uchar %728 %uchar_1 %uchar_0
+%730 = OpFunctionCall %ulong %5 %727 %729
+OpStore %216 %730
 %731 = OpLoad %ulong %216
 %732 = OpLoad %float %407
 %733 = OpFunctionCall %ulong %2 %731 %732
@@ -1052,9 +1052,9 @@ OpStore %250 %831
 OpStore %251 %834
 %835 = OpLoad %ulong %250
 %836 = OpLoad %bool %251
-%838 = OpSelect %uchar %836 %uchar_1 %uchar_0
-%837 = OpFunctionCall %ulong %5 %835 %838
-OpStore %252 %837
+%837 = OpSelect %uchar %836 %uchar_1 %uchar_0
+%838 = OpFunctionCall %ulong %5 %835 %837
+OpStore %252 %838
 %840 = OpLoad %float %425
 %841 = OpFSub %float %float_0 %840
 OpStore %253 %841
@@ -1064,9 +1064,9 @@ OpStore %253 %841
 OpStore %254 %844
 %845 = OpLoad %ulong %252
 %846 = OpLoad %bool %254
-%848 = OpSelect %uchar %846 %uchar_1 %uchar_0
-%847 = OpFunctionCall %ulong %5 %845 %848
-OpStore %255 %847
+%847 = OpSelect %uchar %846 %uchar_1 %uchar_0
+%848 = OpFunctionCall %ulong %5 %845 %847
+OpStore %255 %848
 %849 = OpLoad %float %407
 %850 = OpLoad %float %407
 %851 = OpFSub %float %849 %850
@@ -1136,36 +1136,36 @@ OpStore %271 %895
 OpStore %272 %898
 %899 = OpLoad %ulong %271
 %900 = OpLoad %bool %272
-%902 = OpSelect %uchar %900 %uchar_1 %uchar_0
-%901 = OpFunctionCall %ulong %5 %899 %902
-OpStore %273 %901
+%901 = OpSelect %uchar %900 %uchar_1 %uchar_0
+%902 = OpFunctionCall %ulong %5 %899 %901
+OpStore %273 %902
 %903 = OpLoad %float %419
 %904 = OpLoad %float %419
 %905 = OpFOrdEqual %bool %903 %904
 OpStore %274 %905
 %906 = OpLoad %ulong %273
 %907 = OpLoad %bool %274
-%909 = OpSelect %uchar %907 %uchar_1 %uchar_0
-%908 = OpFunctionCall %ulong %5 %906 %909
-OpStore %275 %908
+%908 = OpSelect %uchar %907 %uchar_1 %uchar_0
+%909 = OpFunctionCall %ulong %5 %906 %908
+OpStore %275 %909
 %910 = OpLoad %float %419
 %911 = OpLoad %float %419
 %912 = OpFOrdLessThan %bool %910 %911
 OpStore %276 %912
 %913 = OpLoad %ulong %275
 %914 = OpLoad %bool %276
-%916 = OpSelect %uchar %914 %uchar_1 %uchar_0
-%915 = OpFunctionCall %ulong %5 %913 %916
-OpStore %277 %915
+%915 = OpSelect %uchar %914 %uchar_1 %uchar_0
+%916 = OpFunctionCall %ulong %5 %913 %915
+OpStore %277 %916
 %917 = OpLoad %float %419
 %918 = OpLoad %float %419
 %919 = OpFOrdLessThanEqual %bool %917 %918
 OpStore %278 %919
 %920 = OpLoad %ulong %277
 %921 = OpLoad %bool %278
-%923 = OpSelect %uchar %921 %uchar_1 %uchar_0
-%922 = OpFunctionCall %ulong %5 %920 %923
-OpStore %279 %922
+%922 = OpSelect %uchar %921 %uchar_1 %uchar_0
+%923 = OpFunctionCall %ulong %5 %920 %922
+OpStore %279 %923
 %924 = OpLoad %float %419
 %925 = OpFNegate %float %924
 OpStore %280 %925
@@ -1312,18 +1312,18 @@ OpStore %316 %1029
 OpStore %317 %1032
 %1033 = OpLoad %ulong %316
 %1034 = OpLoad %bool %317
-%1036 = OpSelect %uchar %1034 %uchar_1 %uchar_0
-%1035 = OpFunctionCall %ulong %5 %1033 %1036
-OpStore %318 %1035
+%1035 = OpSelect %uchar %1034 %uchar_1 %uchar_0
+%1036 = OpFunctionCall %ulong %5 %1033 %1035
+OpStore %318 %1036
 %1037 = OpLoad %float %431
 %1038 = OpLoad %float %395
 %1039 = OpFOrdEqual %bool %1037 %1038
 OpStore %319 %1039
 %1040 = OpLoad %ulong %318
 %1041 = OpLoad %bool %319
-%1043 = OpSelect %uchar %1041 %uchar_1 %uchar_0
-%1042 = OpFunctionCall %ulong %5 %1040 %1043
-OpStore %320 %1042
+%1042 = OpSelect %uchar %1041 %uchar_1 %uchar_0
+%1043 = OpFunctionCall %ulong %5 %1040 %1042
+OpStore %320 %1043
 %1044 = OpLoad %float %431
 %1045 = OpFSub %float %float_0 %1044
 OpStore %321 %1045
@@ -1333,9 +1333,9 @@ OpStore %321 %1045
 OpStore %322 %1048
 %1049 = OpLoad %ulong %320
 %1050 = OpLoad %bool %322
-%1052 = OpSelect %uchar %1050 %uchar_1 %uchar_0
-%1051 = OpFunctionCall %ulong %5 %1049 %1052
-OpStore %323 %1051
+%1051 = OpSelect %uchar %1050 %uchar_1 %uchar_0
+%1052 = OpFunctionCall %ulong %5 %1049 %1051
+OpStore %323 %1052
 %1053 = OpLoad %ulong %323
 OpStore %375 %1053
 %1054 = OpLoad %float %427

--- a/test/golden/spirv/float/special_f64.dis
+++ b/test/golden/spirv/float/special_f64.dis
@@ -127,8 +127,8 @@ OpStore %44 %51
 OpReturnValue %52
 %34 = OpLabel
 %53 = OpLoad %ulong %39
-%54 = OpFunctionCall %ulong %5 %53 %ulong_18446744073709551615
-OpStore %43 %54
+%55 = OpFunctionCall %ulong %5 %53 %ulong_18446744073709551615
+OpStore %43 %55
 %56 = OpLoad %ulong %43
 OpReturnValue %56
 %37 = OpLabel
@@ -847,29 +847,29 @@ OpStore %220 %714
 %716 = OpLoad %double %423
 %717 = OpFOrdEqual %bool %715 %716
 OpStore %221 %717
-%718 = OpLoad %ulong %220
-%719 = OpLoad %bool %221
-%724 = OpSelect %uchar %719 %uchar_1 %uchar_0
-%721 = OpFunctionCall %ulong %6 %718 %724
-OpStore %222 %721
+%719 = OpLoad %ulong %220
+%720 = OpLoad %bool %221
+%723 = OpSelect %uchar %720 %uchar_1 %uchar_0
+%724 = OpFunctionCall %ulong %6 %719 %723
+OpStore %222 %724
 %725 = OpLoad %double %419
 %726 = OpLoad %double %423
 %727 = OpFOrdLessThan %bool %725 %726
 OpStore %223 %727
 %728 = OpLoad %ulong %222
 %729 = OpLoad %bool %223
-%731 = OpSelect %uchar %729 %uchar_1 %uchar_0
-%730 = OpFunctionCall %ulong %6 %728 %731
-OpStore %224 %730
+%730 = OpSelect %uchar %729 %uchar_1 %uchar_0
+%731 = OpFunctionCall %ulong %6 %728 %730
+OpStore %224 %731
 %732 = OpLoad %double %423
 %733 = OpLoad %double %419
 %734 = OpFOrdLessThan %bool %732 %733
 OpStore %225 %734
 %735 = OpLoad %ulong %224
 %736 = OpLoad %bool %225
-%738 = OpSelect %uchar %736 %uchar_1 %uchar_0
-%737 = OpFunctionCall %ulong %6 %735 %738
-OpStore %226 %737
+%737 = OpSelect %uchar %736 %uchar_1 %uchar_0
+%738 = OpFunctionCall %ulong %6 %735 %737
+OpStore %226 %738
 %739 = OpLoad %ulong %226
 %740 = OpLoad %double %429
 %741 = OpFunctionCall %ulong %2 %739 %740
@@ -1011,9 +1011,9 @@ OpStore %260 %839
 OpStore %261 %842
 %843 = OpLoad %ulong %260
 %844 = OpLoad %bool %261
-%846 = OpSelect %uchar %844 %uchar_1 %uchar_0
-%845 = OpFunctionCall %ulong %6 %843 %846
-OpStore %262 %845
+%845 = OpSelect %uchar %844 %uchar_1 %uchar_0
+%846 = OpFunctionCall %ulong %6 %843 %845
+OpStore %262 %846
 %848 = OpLoad %double %447
 %849 = OpFSub %double %double_0 %848
 OpStore %263 %849
@@ -1023,9 +1023,9 @@ OpStore %263 %849
 OpStore %264 %852
 %853 = OpLoad %ulong %262
 %854 = OpLoad %bool %264
-%856 = OpSelect %uchar %854 %uchar_1 %uchar_0
-%855 = OpFunctionCall %ulong %6 %853 %856
-OpStore %265 %855
+%855 = OpSelect %uchar %854 %uchar_1 %uchar_0
+%856 = OpFunctionCall %ulong %6 %853 %855
+OpStore %265 %856
 %857 = OpLoad %double %429
 %858 = OpLoad %double %429
 %859 = OpFSub %double %857 %858
@@ -1095,36 +1095,36 @@ OpStore %281 %903
 OpStore %282 %906
 %907 = OpLoad %ulong %281
 %908 = OpLoad %bool %282
-%910 = OpSelect %uchar %908 %uchar_1 %uchar_0
-%909 = OpFunctionCall %ulong %6 %907 %910
-OpStore %283 %909
+%909 = OpSelect %uchar %908 %uchar_1 %uchar_0
+%910 = OpFunctionCall %ulong %6 %907 %909
+OpStore %283 %910
 %911 = OpLoad %double %441
 %912 = OpLoad %double %441
 %913 = OpFOrdEqual %bool %911 %912
 OpStore %284 %913
 %914 = OpLoad %ulong %283
 %915 = OpLoad %bool %284
-%917 = OpSelect %uchar %915 %uchar_1 %uchar_0
-%916 = OpFunctionCall %ulong %6 %914 %917
-OpStore %285 %916
+%916 = OpSelect %uchar %915 %uchar_1 %uchar_0
+%917 = OpFunctionCall %ulong %6 %914 %916
+OpStore %285 %917
 %918 = OpLoad %double %441
 %919 = OpLoad %double %441
 %920 = OpFOrdLessThan %bool %918 %919
 OpStore %286 %920
 %921 = OpLoad %ulong %285
 %922 = OpLoad %bool %286
-%924 = OpSelect %uchar %922 %uchar_1 %uchar_0
-%923 = OpFunctionCall %ulong %6 %921 %924
-OpStore %287 %923
+%923 = OpSelect %uchar %922 %uchar_1 %uchar_0
+%924 = OpFunctionCall %ulong %6 %921 %923
+OpStore %287 %924
 %925 = OpLoad %double %441
 %926 = OpLoad %double %441
 %927 = OpFOrdLessThanEqual %bool %925 %926
 OpStore %288 %927
 %928 = OpLoad %ulong %287
 %929 = OpLoad %bool %288
-%931 = OpSelect %uchar %929 %uchar_1 %uchar_0
-%930 = OpFunctionCall %ulong %6 %928 %931
-OpStore %289 %930
+%930 = OpSelect %uchar %929 %uchar_1 %uchar_0
+%931 = OpFunctionCall %ulong %6 %928 %930
+OpStore %289 %931
 %932 = OpLoad %double %441
 %933 = OpFNegate %double %932
 OpStore %290 %933
@@ -1271,18 +1271,18 @@ OpStore %326 %1037
 OpStore %327 %1040
 %1041 = OpLoad %ulong %326
 %1042 = OpLoad %bool %327
-%1044 = OpSelect %uchar %1042 %uchar_1 %uchar_0
-%1043 = OpFunctionCall %ulong %6 %1041 %1044
-OpStore %328 %1043
+%1043 = OpSelect %uchar %1042 %uchar_1 %uchar_0
+%1044 = OpFunctionCall %ulong %6 %1041 %1043
+OpStore %328 %1044
 %1045 = OpLoad %double %465
 %1046 = OpLoad %double %419
 %1047 = OpFOrdEqual %bool %1045 %1046
 OpStore %329 %1047
 %1048 = OpLoad %ulong %328
 %1049 = OpLoad %bool %329
-%1051 = OpSelect %uchar %1049 %uchar_1 %uchar_0
-%1050 = OpFunctionCall %ulong %6 %1048 %1051
-OpStore %330 %1050
+%1050 = OpSelect %uchar %1049 %uchar_1 %uchar_0
+%1051 = OpFunctionCall %ulong %6 %1048 %1050
+OpStore %330 %1051
 %1052 = OpLoad %double %465
 %1053 = OpFSub %double %double_0 %1052
 OpStore %331 %1053
@@ -1292,9 +1292,9 @@ OpStore %331 %1053
 OpStore %332 %1056
 %1057 = OpLoad %ulong %330
 %1058 = OpLoad %bool %332
-%1060 = OpSelect %uchar %1058 %uchar_1 %uchar_0
-%1059 = OpFunctionCall %ulong %6 %1057 %1060
-OpStore %333 %1059
+%1059 = OpSelect %uchar %1058 %uchar_1 %uchar_0
+%1060 = OpFunctionCall %ulong %6 %1057 %1059
+OpStore %333 %1060
 %1061 = OpLoad %ulong %333
 OpStore %403 %1061
 %1062 = OpLoad %double %453

--- a/test/golden/spirv/frame/frame_align.dis
+++ b/test/golden/spirv/frame/frame_align.dis
@@ -1277,8 +1277,8 @@ OpBranchConditional %955 %206 %207
 %958 = OpFunctionCall %ulong %8 %956 %957
 OpStore %337 %958
 %959 = OpLoad %ulong %337
-%960 = OpFunctionCall %ulong %8 %959 %uchar_0
-OpStore %338 %960
+%961 = OpFunctionCall %ulong %8 %959 %uchar_0
+OpStore %338 %961
 %962 = OpLoad %ulong %338
 %963 = OpLoad %uchar %287
 %964 = OpFunctionCall %ulong %8 %962 %963

--- a/test/golden/spirv/mem/addr_modes.dis
+++ b/test/golden/spirv/mem/addr_modes.dis
@@ -502,17 +502,17 @@ OpStore %230 %405
 %408 = OpFunctionCall %ulong %5 %406 %407
 OpStore %231 %408
 %409 = OpLoad %ulong %231
-%410 = OpFunctionCall %ulong %3 %409 %ulong_8200
-OpStore %232 %410
+%411 = OpFunctionCall %ulong %3 %409 %ulong_8200
+OpStore %232 %411
 %412 = OpLoad %ulong %232
-%413 = OpFunctionCall %ulong %3 %412 %ulong_8204
-OpStore %233 %413
+%414 = OpFunctionCall %ulong %3 %412 %ulong_8204
+OpStore %233 %414
 %415 = OpLoad %ulong %233
-%416 = OpFunctionCall %ulong %3 %415 %ulong_10252
-OpStore %234 %416
+%417 = OpFunctionCall %ulong %3 %415 %ulong_10252
+OpStore %234 %417
 %418 = OpLoad %ulong %234
-%419 = OpFunctionCall %ulong %3 %418 %ulong_10256
-OpStore %235 %419
+%420 = OpFunctionCall %ulong %3 %418 %ulong_10256
+OpStore %235 %420
 OpStore %254 %ulong_0
 OpStore %264 %ulong_0
 OpBranch %35

--- a/test/golden/spirv/mem/array_index.dis
+++ b/test/golden/spirv/mem/array_index.dis
@@ -621,8 +621,8 @@ OpStore %270 %524
 %527 = OpFunctionCall %ulong %6 %525 %526
 OpStore %271 %527
 %528 = OpLoad %ulong %271
-%529 = OpFunctionCall %ulong %4 %528 %ulong_16
-OpStore %272 %529
+%530 = OpFunctionCall %ulong %4 %528 %ulong_16
+OpStore %272 %530
 OpStore %139 %531
 %532 = OpLoad %ulong %160
 %533 = OpUConvert %uint %532
@@ -638,8 +638,8 @@ OpLoopMerge %107 %116 None
 OpBranchConditional %537 %106 %107
 %107 = OpLabel
 %538 = OpLoad %ulong %272
-%539 = OpFunctionCall %ulong %5 %538 %uchar_17
-OpStore %279 %539
+%540 = OpFunctionCall %ulong %5 %538 %uchar_17
+OpStore %279 %540
 %541 = OpLoad %ulong %279
 OpStore %295 %541
 OpStore %323 %ulong_0
@@ -653,8 +653,8 @@ OpLoopMerge %110 %115 None
 OpBranchConditional %544 %109 %110
 %110 = OpLabel
 %545 = OpLoad %ulong %295
-%546 = OpFunctionCall %ulong %6 %545 %ushort_4660
-OpStore %287 %546
+%547 = OpFunctionCall %ulong %6 %545 %ushort_4660
+OpStore %287 %547
 %548 = OpLoad %ulong %287
 %549 = OpFunctionCall %ulong %4 %548 %ulong_4
 OpStore %288 %549

--- a/test/golden/spirv/mem/rec_layout.dis
+++ b/test/golden/spirv/mem/rec_layout.dis
@@ -1,0 +1,1144 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Khronos; 0
+; Bound: 827
+; Schema: 0
+OpCapability Shader
+OpCapability Linkage
+OpCapability Int8
+OpCapability Int16
+OpCapability Int64
+OpMemoryModel Logical GLSL450
+OpDecorate %1 LinkageAttributes "corpus.cases.mem.rec_layout.fold_tiny" Export
+OpDecorate %2 LinkageAttributes "corpus.cases.mem.rec_layout.fold_mid" Export
+OpDecorate %3 LinkageAttributes "corpus.cases.mem.rec_layout.fold_wide" Export
+OpDecorate %4 LinkageAttributes "corpus.cases.mem.rec_layout.fold_nest" Export
+OpDecorate %5 LinkageAttributes "corpus.cases.mem.rec_layout.fill_mid" Export
+OpDecorate %6 LinkageAttributes "corpus.cases.mem.rec_layout.checksum" Export
+%ulong = OpTypeInt 64 0
+%uchar = OpTypeInt 8 0
+%uint = OpTypeInt 32 0
+%_struct_15 = OpTypeStruct %uchar %uint %uchar
+%16 = OpTypeFunction %ulong %ulong %_struct_15
+%_ptr_Function__struct_15 = OpTypePointer Function %_struct_15
+%_ptr_Function_ulong = OpTypePointer Function %ulong
+%_ptr_Function_uchar = OpTypePointer Function %uchar
+%_ptr_Function_uint = OpTypePointer Function %uint
+%uint_0 = OpConstant %uint 0
+%uint_1 = OpConstant %uint 1
+%uint_2 = OpConstant %uint 2
+%ushort = OpTypeInt 16 0
+%_struct_52 = OpTypeStruct %ushort %_struct_15 %uchar
+%53 = OpTypeFunction %ulong %ulong %_struct_52
+%_ptr_Function__struct_52 = OpTypePointer Function %_struct_52
+%_ptr_Function_ushort = OpTypePointer Function %ushort
+%uint_3 = OpConstant %uint 3
+%_arr_ushort_uint_3 = OpTypeArray %ushort %uint_3
+%_struct_102 = OpTypeStruct %_struct_52 %ulong %_arr_ushort_uint_3 %uchar
+%103 = OpTypeFunction %ulong %ulong %_struct_102
+%_ptr_Function__struct_102 = OpTypePointer Function %_struct_102
+%_ptr_Function__arr_ushort_uint_3 = OpTypePointer Function %_arr_ushort_uint_3
+%_arr__struct_52_uint_2 = OpTypeArray %_struct_52 %uint_2
+%_struct_158 = OpTypeStruct %_struct_102 %_arr__struct_52_uint_2 %uint
+%159 = OpTypeFunction %ulong %ulong %_struct_158
+%_ptr_Function__struct_158 = OpTypePointer Function %_struct_158
+%_ptr_Function__arr__struct_52_uint_2 = OpTypePointer Function %_arr__struct_52_uint_2
+%void = OpTypeVoid
+%243 = OpTypeFunction %void %_ptr_Function__struct_52 %uint
+%uint_4 = OpConstant %uint 4
+%284 = OpTypeFunction %ulong %ulong
+%ulong_12 = OpConstant %ulong 12
+%ulong_20 = OpConstant %ulong 20
+%ulong_40 = OpConstant %ulong 40
+%ulong_88 = OpConstant %ulong 88
+%ulong_4 = OpConstant %ulong 4
+%ulong_8 = OpConstant %ulong 8
+%ulong_16 = OpConstant %ulong 16
+%ulong_24 = OpConstant %ulong 24
+%ulong_32 = OpConstant %ulong 32
+%ulong_38 = OpConstant %ulong 38
+%ulong_80 = OpConstant %ulong 80
+%430 = OpConstantNull %_struct_158
+%uint_10 = OpConstant %uint 10
+%ulong_18364758544493064720 = OpConstant %ulong 18364758544493064720
+%uint_20 = OpConstant %uint 20
+%uint_21 = OpConstant %uint 21
+%uint_22 = OpConstant %uint 22
+%uint_23 = OpConstant %uint 23
+%uint_30 = OpConstant %uint 30
+%uint_40 = OpConstant %uint 40
+%uint_50 = OpConstant %uint 50
+%uint_4042322160 = OpConstant %uint 4042322160
+%uchar_7 = OpConstant %uchar 7
+%ulong_3 = OpConstant %ulong 3
+%643 = OpTypeFunction %ulong
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%646 = OpTypeFunction %ulong %ulong %ulong
+%bool = OpTypeBool
+%_ptr_Function_bool = OpTypePointer Function %bool
+%ulong_0 = OpConstant %ulong 0
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%ulong_1 = OpConstant %ulong 1
+%692 = OpTypeFunction %ulong %ulong %uchar
+%737 = OpTypeFunction %ulong %ulong %ushort
+%782 = OpTypeFunction %ulong %ulong %uint
+%1 = OpFunction %ulong None %16
+%17 = OpFunctionParameter %ulong
+%18 = OpFunctionParameter %_struct_15
+%19 = OpLabel
+%21 = OpVariable %_ptr_Function__struct_15 Function
+%23 = OpVariable %_ptr_Function_ulong Function
+%24 = OpVariable %_ptr_Function_ulong Function
+%25 = OpVariable %_ptr_Function_ulong Function
+%26 = OpVariable %_ptr_Function_ulong Function
+%28 = OpVariable %_ptr_Function_uchar Function
+%30 = OpVariable %_ptr_Function_uint Function
+%31 = OpVariable %_ptr_Function_uchar Function
+OpStore %23 %17
+OpStore %21 %18
+%33 = OpAccessChain %_ptr_Function_uchar %21 %uint_0
+%34 = OpLoad %uchar %33
+OpStore %28 %34
+%36 = OpAccessChain %_ptr_Function_uint %21 %uint_1
+%37 = OpLoad %uint %36
+OpStore %30 %37
+%39 = OpAccessChain %_ptr_Function_uchar %21 %uint_2
+%40 = OpLoad %uchar %39
+OpStore %31 %40
+%41 = OpLoad %ulong %23
+%42 = OpLoad %uchar %28
+%43 = OpFunctionCall %ulong %9 %41 %42
+OpStore %24 %43
+%44 = OpLoad %ulong %24
+%45 = OpLoad %uint %30
+%46 = OpFunctionCall %ulong %11 %44 %45
+OpStore %25 %46
+%47 = OpLoad %ulong %25
+%48 = OpLoad %uchar %31
+%49 = OpFunctionCall %ulong %9 %47 %48
+OpStore %26 %49
+%50 = OpLoad %ulong %26
+OpReturnValue %50
+OpFunctionEnd
+%2 = OpFunction %ulong None %53
+%54 = OpFunctionParameter %ulong
+%55 = OpFunctionParameter %_struct_52
+%56 = OpLabel
+%60 = OpVariable %_ptr_Function__struct_52 Function
+%61 = OpVariable %_ptr_Function_ulong Function
+%62 = OpVariable %_ptr_Function_ulong Function
+%63 = OpVariable %_ptr_Function_ulong Function
+%64 = OpVariable %_ptr_Function_ulong Function
+%65 = OpVariable %_ptr_Function_ulong Function
+%66 = OpVariable %_ptr_Function_ulong Function
+%68 = OpVariable %_ptr_Function_ushort Function
+%69 = OpVariable %_ptr_Function_uchar Function
+%70 = OpVariable %_ptr_Function_uchar Function
+%71 = OpVariable %_ptr_Function_uint Function
+%72 = OpVariable %_ptr_Function_uchar Function
+OpStore %61 %54
+OpStore %60 %55
+%73 = OpAccessChain %_ptr_Function_ushort %60 %uint_0
+%74 = OpLoad %ushort %73
+OpStore %68 %74
+%75 = OpAccessChain %_ptr_Function__struct_15 %60 %uint_1
+%76 = OpAccessChain %_ptr_Function_uchar %75 %uint_0
+%77 = OpLoad %uchar %76
+OpStore %70 %77
+%78 = OpAccessChain %_ptr_Function_uint %75 %uint_1
+%79 = OpLoad %uint %78
+OpStore %71 %79
+%80 = OpAccessChain %_ptr_Function_uchar %75 %uint_2
+%81 = OpLoad %uchar %80
+OpStore %72 %81
+%82 = OpAccessChain %_ptr_Function_uchar %60 %uint_2
+%83 = OpLoad %uchar %82
+OpStore %69 %83
+%84 = OpLoad %ulong %61
+%85 = OpLoad %ushort %68
+%86 = OpFunctionCall %ulong %10 %84 %85
+OpStore %62 %86
+OpBranch %57
+%57 = OpLabel
+%87 = OpLoad %ulong %62
+%88 = OpLoad %uchar %70
+%89 = OpFunctionCall %ulong %9 %87 %88
+OpStore %64 %89
+%90 = OpLoad %ulong %64
+%91 = OpLoad %uint %71
+%92 = OpFunctionCall %ulong %11 %90 %91
+OpStore %65 %92
+%93 = OpLoad %ulong %65
+%94 = OpLoad %uchar %72
+%95 = OpFunctionCall %ulong %9 %93 %94
+OpStore %66 %95
+OpBranch %58
+%58 = OpLabel
+%96 = OpLoad %ulong %66
+%97 = OpLoad %uchar %69
+%98 = OpFunctionCall %ulong %9 %96 %97
+OpStore %63 %98
+%99 = OpLoad %ulong %63
+OpReturnValue %99
+OpFunctionEnd
+%3 = OpFunction %ulong None %103
+%104 = OpFunctionParameter %ulong
+%105 = OpFunctionParameter %_struct_102
+%106 = OpLabel
+%108 = OpVariable %_ptr_Function__struct_102 Function
+%109 = OpVariable %_ptr_Function__struct_102 Function
+%110 = OpVariable %_ptr_Function__struct_52 Function
+%111 = OpVariable %_ptr_Function_ulong Function
+%112 = OpVariable %_ptr_Function_ulong Function
+%113 = OpVariable %_ptr_Function_ulong Function
+%114 = OpVariable %_ptr_Function_ulong Function
+%115 = OpVariable %_ptr_Function_ushort Function
+%116 = OpVariable %_ptr_Function_ulong Function
+%117 = OpVariable %_ptr_Function_ushort Function
+%118 = OpVariable %_ptr_Function_ulong Function
+%119 = OpVariable %_ptr_Function_ushort Function
+%120 = OpVariable %_ptr_Function_ulong Function
+%121 = OpVariable %_ptr_Function_uchar Function
+%122 = OpVariable %_ptr_Function_ulong Function
+OpStore %111 %104
+OpStore %108 %105
+%123 = OpLoad %_struct_102 %108
+OpStore %109 %123
+%124 = OpAccessChain %_ptr_Function__struct_52 %109 %uint_0
+%125 = OpLoad %_struct_52 %124
+OpStore %110 %125
+%126 = OpLoad %ulong %111
+%127 = OpLoad %_struct_52 %110
+%128 = OpFunctionCall %ulong %2 %126 %127
+OpStore %112 %128
+%129 = OpAccessChain %_ptr_Function_ulong %109 %uint_1
+%130 = OpLoad %ulong %129
+OpStore %113 %130
+%131 = OpLoad %ulong %112
+%132 = OpLoad %ulong %113
+%133 = OpFunctionCall %ulong %8 %131 %132
+OpStore %114 %133
+%135 = OpAccessChain %_ptr_Function__arr_ushort_uint_3 %109 %uint_2
+%136 = OpAccessChain %_ptr_Function_ushort %135 %uint_0
+%137 = OpLoad %ushort %136
+OpStore %115 %137
+%138 = OpLoad %ulong %114
+%139 = OpLoad %ushort %115
+%140 = OpFunctionCall %ulong %10 %138 %139
+OpStore %116 %140
+%141 = OpAccessChain %_ptr_Function_ushort %135 %uint_1
+%142 = OpLoad %ushort %141
+OpStore %117 %142
+%143 = OpLoad %ulong %116
+%144 = OpLoad %ushort %117
+%145 = OpFunctionCall %ulong %10 %143 %144
+OpStore %118 %145
+%146 = OpAccessChain %_ptr_Function_ushort %135 %uint_2
+%147 = OpLoad %ushort %146
+OpStore %119 %147
+%148 = OpLoad %ulong %118
+%149 = OpLoad %ushort %119
+%150 = OpFunctionCall %ulong %10 %148 %149
+OpStore %120 %150
+%151 = OpAccessChain %_ptr_Function_uchar %109 %uint_3
+%152 = OpLoad %uchar %151
+OpStore %121 %152
+%153 = OpLoad %ulong %120
+%154 = OpLoad %uchar %121
+%155 = OpFunctionCall %ulong %9 %153 %154
+OpStore %122 %155
+%156 = OpLoad %ulong %122
+OpReturnValue %156
+OpFunctionEnd
+%4 = OpFunction %ulong None %159
+%160 = OpFunctionParameter %ulong
+%161 = OpFunctionParameter %_struct_158
+%162 = OpLabel
+%166 = OpVariable %_ptr_Function__struct_158 Function
+%167 = OpVariable %_ptr_Function__struct_158 Function
+%168 = OpVariable %_ptr_Function__struct_102 Function
+%169 = OpVariable %_ptr_Function__struct_102 Function
+%170 = OpVariable %_ptr_Function__struct_52 Function
+%171 = OpVariable %_ptr_Function__struct_52 Function
+%172 = OpVariable %_ptr_Function__struct_52 Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_uint Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_ushort Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ushort Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ushort Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_uchar Function
+%188 = OpVariable %_ptr_Function_ulong Function
+OpStore %173 %160
+OpStore %166 %161
+%189 = OpLoad %_struct_158 %166
+OpStore %167 %189
+%190 = OpAccessChain %_ptr_Function__struct_102 %167 %uint_0
+%191 = OpLoad %_struct_102 %190
+OpStore %168 %191
+OpBranch %163
+%163 = OpLabel
+%192 = OpLoad %_struct_102 %168
+OpStore %169 %192
+%193 = OpAccessChain %_ptr_Function__struct_52 %169 %uint_0
+%194 = OpLoad %_struct_52 %193
+OpStore %170 %194
+%195 = OpLoad %ulong %173
+%196 = OpLoad %_struct_52 %170
+%197 = OpFunctionCall %ulong %2 %195 %196
+OpStore %178 %197
+%198 = OpAccessChain %_ptr_Function_ulong %169 %uint_1
+%199 = OpLoad %ulong %198
+OpStore %179 %199
+%200 = OpLoad %ulong %178
+%201 = OpLoad %ulong %179
+%202 = OpFunctionCall %ulong %8 %200 %201
+OpStore %180 %202
+%203 = OpAccessChain %_ptr_Function__arr_ushort_uint_3 %169 %uint_2
+%204 = OpAccessChain %_ptr_Function_ushort %203 %uint_0
+%205 = OpLoad %ushort %204
+OpStore %181 %205
+%206 = OpLoad %ulong %180
+%207 = OpLoad %ushort %181
+%208 = OpFunctionCall %ulong %10 %206 %207
+OpStore %182 %208
+%209 = OpAccessChain %_ptr_Function_ushort %203 %uint_1
+%210 = OpLoad %ushort %209
+OpStore %183 %210
+%211 = OpLoad %ulong %182
+%212 = OpLoad %ushort %183
+%213 = OpFunctionCall %ulong %10 %211 %212
+OpStore %184 %213
+%214 = OpAccessChain %_ptr_Function_ushort %203 %uint_2
+%215 = OpLoad %ushort %214
+OpStore %185 %215
+%216 = OpLoad %ulong %184
+%217 = OpLoad %ushort %185
+%218 = OpFunctionCall %ulong %10 %216 %217
+OpStore %186 %218
+%219 = OpAccessChain %_ptr_Function_uchar %169 %uint_3
+%220 = OpLoad %uchar %219
+OpStore %187 %220
+%221 = OpLoad %ulong %186
+%222 = OpLoad %uchar %187
+%223 = OpFunctionCall %ulong %9 %221 %222
+OpStore %188 %223
+OpBranch %164
+%164 = OpLabel
+%225 = OpAccessChain %_ptr_Function__arr__struct_52_uint_2 %167 %uint_1
+%226 = OpAccessChain %_ptr_Function__struct_52 %225 %uint_0
+%227 = OpLoad %_struct_52 %226
+OpStore %171 %227
+%228 = OpLoad %ulong %188
+%229 = OpLoad %_struct_52 %171
+%230 = OpFunctionCall %ulong %2 %228 %229
+OpStore %174 %230
+%231 = OpAccessChain %_ptr_Function__struct_52 %225 %uint_1
+%232 = OpLoad %_struct_52 %231
+OpStore %172 %232
+%233 = OpLoad %ulong %174
+%234 = OpLoad %_struct_52 %172
+%235 = OpFunctionCall %ulong %2 %233 %234
+OpStore %175 %235
+%236 = OpAccessChain %_ptr_Function_uint %167 %uint_2
+%237 = OpLoad %uint %236
+OpStore %176 %237
+%238 = OpLoad %ulong %175
+%239 = OpLoad %uint %176
+%240 = OpFunctionCall %ulong %11 %238 %239
+OpStore %177 %240
+%241 = OpLoad %ulong %177
+OpReturnValue %241
+OpFunctionEnd
+%5 = OpFunction %void None %243
+%244 = OpFunctionParameter %_ptr_Function__struct_52
+%245 = OpFunctionParameter %uint
+%246 = OpLabel
+%247 = OpVariable %_ptr_Function_uint Function
+%248 = OpVariable %_ptr_Function_ushort Function
+%249 = OpVariable %_ptr_Function_uint Function
+%250 = OpVariable %_ptr_Function_uchar Function
+%251 = OpVariable %_ptr_Function_uint Function
+%252 = OpVariable %_ptr_Function_uint Function
+%253 = OpVariable %_ptr_Function_uchar Function
+%254 = OpVariable %_ptr_Function_uint Function
+%255 = OpVariable %_ptr_Function_uchar Function
+OpStore %247 %245
+%256 = OpLoad %uint %247
+%257 = OpUConvert %ushort %256
+OpStore %248 %257
+%258 = OpAccessChain %_ptr_Function_ushort %244 %uint_0
+%259 = OpLoad %ushort %248
+OpStore %258 %259
+%260 = OpLoad %uint %247
+%261 = OpIAdd %uint %260 %uint_1
+OpStore %249 %261
+%262 = OpLoad %uint %249
+%263 = OpUConvert %uchar %262
+OpStore %250 %263
+%264 = OpAccessChain %_ptr_Function__struct_15 %244 %uint_1
+%265 = OpAccessChain %_ptr_Function_uchar %264 %uint_0
+%266 = OpLoad %uchar %250
+OpStore %265 %266
+%267 = OpLoad %uint %247
+%268 = OpIAdd %uint %267 %uint_2
+OpStore %251 %268
+%269 = OpAccessChain %_ptr_Function_uint %264 %uint_1
+%270 = OpLoad %uint %251
+OpStore %269 %270
+%271 = OpLoad %uint %247
+%272 = OpIAdd %uint %271 %uint_3
+OpStore %252 %272
+%273 = OpLoad %uint %252
+%274 = OpUConvert %uchar %273
+OpStore %253 %274
+%275 = OpAccessChain %_ptr_Function_uchar %264 %uint_2
+%276 = OpLoad %uchar %253
+OpStore %275 %276
+%277 = OpLoad %uint %247
+%279 = OpIAdd %uint %277 %uint_4
+OpStore %254 %279
+%280 = OpLoad %uint %254
+%281 = OpUConvert %uchar %280
+OpStore %255 %281
+%282 = OpAccessChain %_ptr_Function_uchar %244 %uint_2
+%283 = OpLoad %uchar %255
+OpStore %282 %283
+OpReturn
+OpFunctionEnd
+%6 = OpFunction %ulong None %284
+%285 = OpFunctionParameter %ulong
+%286 = OpLabel
+%293 = OpVariable %_ptr_Function__struct_158 Function
+%294 = OpVariable %_ptr_Function__struct_158 Function
+%295 = OpVariable %_ptr_Function__struct_158 Function
+%296 = OpVariable %_ptr_Function__struct_158 Function
+%297 = OpVariable %_ptr_Function__struct_158 Function
+%298 = OpVariable %_ptr_Function__struct_158 Function
+%299 = OpVariable %_ptr_Function__struct_158 Function
+%300 = OpVariable %_ptr_Function__struct_52 Function
+%301 = OpVariable %_ptr_Function__struct_52 Function
+%302 = OpVariable %_ptr_Function__struct_52 Function
+%303 = OpVariable %_ptr_Function__struct_52 Function
+%304 = OpVariable %_ptr_Function__struct_52 Function
+%305 = OpVariable %_ptr_Function__struct_158 Function
+%306 = OpVariable %_ptr_Function_ulong Function
+%307 = OpVariable %_ptr_Function_ulong Function
+%308 = OpVariable %_ptr_Function_uint Function
+%309 = OpVariable %_ptr_Function_ulong Function
+%310 = OpVariable %_ptr_Function_ulong Function
+%311 = OpVariable %_ptr_Function_ulong Function
+%312 = OpVariable %_ptr_Function_ulong Function
+%313 = OpVariable %_ptr_Function_ulong Function
+%314 = OpVariable %_ptr_Function_ulong Function
+%315 = OpVariable %_ptr_Function_ulong Function
+%316 = OpVariable %_ptr_Function_ulong Function
+%317 = OpVariable %_ptr_Function_ulong Function
+%318 = OpVariable %_ptr_Function_ulong Function
+%319 = OpVariable %_ptr_Function_ulong Function
+%320 = OpVariable %_ptr_Function_ulong Function
+%321 = OpVariable %_ptr_Function_ulong Function
+%322 = OpVariable %_ptr_Function_ulong Function
+%323 = OpVariable %_ptr_Function_ulong Function
+%324 = OpVariable %_ptr_Function_ulong Function
+%325 = OpVariable %_ptr_Function_ulong Function
+%326 = OpVariable %_ptr_Function_ulong Function
+%327 = OpVariable %_ptr_Function_uint Function
+%328 = OpVariable %_ptr_Function_ulong Function
+%329 = OpVariable %_ptr_Function_uint Function
+%330 = OpVariable %_ptr_Function_ushort Function
+%331 = OpVariable %_ptr_Function_uint Function
+%332 = OpVariable %_ptr_Function_ushort Function
+%333 = OpVariable %_ptr_Function_uint Function
+%334 = OpVariable %_ptr_Function_ushort Function
+%335 = OpVariable %_ptr_Function_uint Function
+%336 = OpVariable %_ptr_Function_uchar Function
+%337 = OpVariable %_ptr_Function_uint Function
+%338 = OpVariable %_ptr_Function_uint Function
+%339 = OpVariable %_ptr_Function_uint Function
+%340 = OpVariable %_ptr_Function_ulong Function
+%341 = OpVariable %_ptr_Function_uint Function
+%342 = OpVariable %_ptr_Function_uint Function
+%343 = OpVariable %_ptr_Function_ulong Function
+%344 = OpVariable %_ptr_Function_uchar Function
+%345 = OpVariable %_ptr_Function_uchar Function
+%346 = OpVariable %_ptr_Function_ulong Function
+%347 = OpVariable %_ptr_Function_ulong Function
+%348 = OpVariable %_ptr_Function_ulong Function
+%349 = OpVariable %_ptr_Function_ulong Function
+%350 = OpVariable %_ptr_Function_uint Function
+%351 = OpVariable %_ptr_Function_uint Function
+%352 = OpVariable %_ptr_Function_ulong Function
+%353 = OpVariable %_ptr_Function_uint Function
+%354 = OpVariable %_ptr_Function_uint Function
+%355 = OpVariable %_ptr_Function_ulong Function
+%356 = OpVariable %_ptr_Function_ulong Function
+%357 = OpVariable %_ptr_Function_ulong Function
+%358 = OpVariable %_ptr_Function_ushort Function
+%359 = OpVariable %_ptr_Function_uint Function
+%360 = OpVariable %_ptr_Function_uchar Function
+%361 = OpVariable %_ptr_Function_uint Function
+%362 = OpVariable %_ptr_Function_uint Function
+%363 = OpVariable %_ptr_Function_uchar Function
+%364 = OpVariable %_ptr_Function_uint Function
+%365 = OpVariable %_ptr_Function_uchar Function
+%366 = OpVariable %_ptr_Function_ushort Function
+%367 = OpVariable %_ptr_Function_uint Function
+%368 = OpVariable %_ptr_Function_uchar Function
+%369 = OpVariable %_ptr_Function_uint Function
+%370 = OpVariable %_ptr_Function_uint Function
+%371 = OpVariable %_ptr_Function_uchar Function
+%372 = OpVariable %_ptr_Function_uint Function
+%373 = OpVariable %_ptr_Function_uchar Function
+%374 = OpVariable %_ptr_Function_ushort Function
+%375 = OpVariable %_ptr_Function_uint Function
+%376 = OpVariable %_ptr_Function_uchar Function
+%377 = OpVariable %_ptr_Function_uint Function
+%378 = OpVariable %_ptr_Function_uint Function
+%379 = OpVariable %_ptr_Function_uchar Function
+%380 = OpVariable %_ptr_Function_uint Function
+%381 = OpVariable %_ptr_Function_uchar Function
+OpStore %306 %285
+%382 = OpFunctionCall %ulong %7
+OpStore %307 %382
+%383 = OpLoad %ulong %306
+%384 = OpUConvert %uint %383
+OpStore %308 %384
+%385 = OpLoad %ulong %307
+%387 = OpFunctionCall %ulong %8 %385 %ulong_12
+OpStore %309 %387
+%388 = OpLoad %ulong %309
+%390 = OpFunctionCall %ulong %8 %388 %ulong_20
+OpStore %310 %390
+%391 = OpLoad %ulong %310
+%393 = OpFunctionCall %ulong %8 %391 %ulong_40
+OpStore %311 %393
+%394 = OpLoad %ulong %311
+%396 = OpFunctionCall %ulong %8 %394 %ulong_88
+OpStore %312 %396
+%397 = OpLoad %ulong %312
+%399 = OpFunctionCall %ulong %8 %397 %ulong_4
+OpStore %313 %399
+%400 = OpLoad %ulong %313
+%401 = OpFunctionCall %ulong %8 %400 %ulong_4
+OpStore %314 %401
+%402 = OpLoad %ulong %314
+%404 = OpFunctionCall %ulong %8 %402 %ulong_8
+OpStore %315 %404
+%405 = OpLoad %ulong %315
+%406 = OpFunctionCall %ulong %8 %405 %ulong_8
+OpStore %316 %406
+%407 = OpLoad %ulong %316
+%408 = OpFunctionCall %ulong %8 %407 %ulong_4
+OpStore %317 %408
+%409 = OpLoad %ulong %317
+%410 = OpFunctionCall %ulong %8 %409 %ulong_8
+OpStore %318 %410
+%411 = OpLoad %ulong %318
+%412 = OpFunctionCall %ulong %8 %411 %ulong_4
+OpStore %319 %412
+%413 = OpLoad %ulong %319
+%415 = OpFunctionCall %ulong %8 %413 %ulong_16
+OpStore %320 %415
+%416 = OpLoad %ulong %320
+%418 = OpFunctionCall %ulong %8 %416 %ulong_24
+OpStore %321 %418
+%419 = OpLoad %ulong %321
+%421 = OpFunctionCall %ulong %8 %419 %ulong_32
+OpStore %322 %421
+%422 = OpLoad %ulong %322
+%424 = OpFunctionCall %ulong %8 %422 %ulong_38
+OpStore %323 %424
+%425 = OpLoad %ulong %323
+%426 = OpFunctionCall %ulong %8 %425 %ulong_40
+OpStore %324 %426
+%427 = OpLoad %ulong %324
+%429 = OpFunctionCall %ulong %8 %427 %ulong_80
+OpStore %325 %429
+OpStore %293 %430
+%431 = OpLoad %_struct_158 %293
+OpStore %294 %431
+%432 = OpLoad %ulong %325
+%433 = OpLoad %_struct_158 %294
+%434 = OpFunctionCall %ulong %4 %432 %433
+OpStore %326 %434
+%435 = OpAccessChain %_ptr_Function__struct_102 %293 %uint_0
+%436 = OpAccessChain %_ptr_Function__struct_52 %435 %uint_0
+%438 = OpLoad %uint %308
+%439 = OpIAdd %uint %uint_10 %438
+OpStore %327 %439
+OpBranch %287
+%287 = OpLabel
+%440 = OpLoad %uint %327
+%441 = OpUConvert %ushort %440
+OpStore %358 %441
+%442 = OpAccessChain %_ptr_Function_ushort %436 %uint_0
+%443 = OpLoad %ushort %358
+OpStore %442 %443
+%444 = OpLoad %uint %327
+%445 = OpIAdd %uint %444 %uint_1
+OpStore %359 %445
+%446 = OpLoad %uint %359
+%447 = OpUConvert %uchar %446
+OpStore %360 %447
+%448 = OpAccessChain %_ptr_Function__struct_15 %436 %uint_1
+%449 = OpAccessChain %_ptr_Function_uchar %448 %uint_0
+%450 = OpLoad %uchar %360
+OpStore %449 %450
+%451 = OpLoad %uint %327
+%452 = OpIAdd %uint %451 %uint_2
+OpStore %361 %452
+%453 = OpAccessChain %_ptr_Function_uint %448 %uint_1
+%454 = OpLoad %uint %361
+OpStore %453 %454
+%455 = OpLoad %uint %327
+%456 = OpIAdd %uint %455 %uint_3
+OpStore %362 %456
+%457 = OpLoad %uint %362
+%458 = OpUConvert %uchar %457
+OpStore %363 %458
+%459 = OpAccessChain %_ptr_Function_uchar %448 %uint_2
+%460 = OpLoad %uchar %363
+OpStore %459 %460
+%461 = OpLoad %uint %327
+%462 = OpIAdd %uint %461 %uint_4
+OpStore %364 %462
+%463 = OpLoad %uint %364
+%464 = OpUConvert %uchar %463
+OpStore %365 %464
+%465 = OpAccessChain %_ptr_Function_uchar %436 %uint_2
+%466 = OpLoad %uchar %365
+OpStore %465 %466
+OpBranch %288
+%288 = OpLabel
+%468 = OpLoad %ulong %306
+%469 = OpIAdd %ulong %ulong_18364758544493064720 %468
+OpStore %328 %469
+%470 = OpAccessChain %_ptr_Function__struct_102 %293 %uint_0
+%471 = OpAccessChain %_ptr_Function_ulong %470 %uint_1
+%472 = OpLoad %ulong %328
+OpStore %471 %472
+%474 = OpLoad %uint %308
+%475 = OpIAdd %uint %uint_20 %474
+OpStore %329 %475
+%476 = OpLoad %uint %329
+%477 = OpUConvert %ushort %476
+OpStore %330 %477
+%478 = OpAccessChain %_ptr_Function__arr_ushort_uint_3 %470 %uint_2
+%479 = OpAccessChain %_ptr_Function_ushort %478 %uint_0
+%480 = OpLoad %ushort %330
+OpStore %479 %480
+%482 = OpLoad %uint %308
+%483 = OpIAdd %uint %uint_21 %482
+OpStore %331 %483
+%484 = OpLoad %uint %331
+%485 = OpUConvert %ushort %484
+OpStore %332 %485
+%486 = OpAccessChain %_ptr_Function_ushort %478 %uint_1
+%487 = OpLoad %ushort %332
+OpStore %486 %487
+%489 = OpLoad %uint %308
+%490 = OpIAdd %uint %uint_22 %489
+OpStore %333 %490
+%491 = OpLoad %uint %333
+%492 = OpUConvert %ushort %491
+OpStore %334 %492
+%493 = OpAccessChain %_ptr_Function_ushort %478 %uint_2
+%494 = OpLoad %ushort %334
+OpStore %493 %494
+%496 = OpLoad %uint %308
+%497 = OpIAdd %uint %uint_23 %496
+OpStore %335 %497
+%498 = OpLoad %uint %335
+%499 = OpUConvert %uchar %498
+OpStore %336 %499
+%500 = OpAccessChain %_ptr_Function_uchar %470 %uint_3
+%501 = OpLoad %uchar %336
+OpStore %500 %501
+%502 = OpAccessChain %_ptr_Function__arr__struct_52_uint_2 %293 %uint_1
+%503 = OpAccessChain %_ptr_Function__struct_52 %502 %uint_0
+%505 = OpLoad %uint %308
+%506 = OpIAdd %uint %uint_30 %505
+OpStore %337 %506
+OpBranch %289
+%289 = OpLabel
+%507 = OpLoad %uint %337
+%508 = OpUConvert %ushort %507
+OpStore %366 %508
+%509 = OpAccessChain %_ptr_Function_ushort %503 %uint_0
+%510 = OpLoad %ushort %366
+OpStore %509 %510
+%511 = OpLoad %uint %337
+%512 = OpIAdd %uint %511 %uint_1
+OpStore %367 %512
+%513 = OpLoad %uint %367
+%514 = OpUConvert %uchar %513
+OpStore %368 %514
+%515 = OpAccessChain %_ptr_Function__struct_15 %503 %uint_1
+%516 = OpAccessChain %_ptr_Function_uchar %515 %uint_0
+%517 = OpLoad %uchar %368
+OpStore %516 %517
+%518 = OpLoad %uint %337
+%519 = OpIAdd %uint %518 %uint_2
+OpStore %369 %519
+%520 = OpAccessChain %_ptr_Function_uint %515 %uint_1
+%521 = OpLoad %uint %369
+OpStore %520 %521
+%522 = OpLoad %uint %337
+%523 = OpIAdd %uint %522 %uint_3
+OpStore %370 %523
+%524 = OpLoad %uint %370
+%525 = OpUConvert %uchar %524
+OpStore %371 %525
+%526 = OpAccessChain %_ptr_Function_uchar %515 %uint_2
+%527 = OpLoad %uchar %371
+OpStore %526 %527
+%528 = OpLoad %uint %337
+%529 = OpIAdd %uint %528 %uint_4
+OpStore %372 %529
+%530 = OpLoad %uint %372
+%531 = OpUConvert %uchar %530
+OpStore %373 %531
+%532 = OpAccessChain %_ptr_Function_uchar %503 %uint_2
+%533 = OpLoad %uchar %373
+OpStore %532 %533
+OpBranch %290
+%290 = OpLabel
+%534 = OpAccessChain %_ptr_Function__arr__struct_52_uint_2 %293 %uint_1
+%535 = OpAccessChain %_ptr_Function__struct_52 %534 %uint_1
+%537 = OpLoad %uint %308
+%538 = OpIAdd %uint %uint_40 %537
+OpStore %338 %538
+OpBranch %291
+%291 = OpLabel
+%539 = OpLoad %uint %338
+%540 = OpUConvert %ushort %539
+OpStore %374 %540
+%541 = OpAccessChain %_ptr_Function_ushort %535 %uint_0
+%542 = OpLoad %ushort %374
+OpStore %541 %542
+%543 = OpLoad %uint %338
+%544 = OpIAdd %uint %543 %uint_1
+OpStore %375 %544
+%545 = OpLoad %uint %375
+%546 = OpUConvert %uchar %545
+OpStore %376 %546
+%547 = OpAccessChain %_ptr_Function__struct_15 %535 %uint_1
+%548 = OpAccessChain %_ptr_Function_uchar %547 %uint_0
+%549 = OpLoad %uchar %376
+OpStore %548 %549
+%550 = OpLoad %uint %338
+%551 = OpIAdd %uint %550 %uint_2
+OpStore %377 %551
+%552 = OpAccessChain %_ptr_Function_uint %547 %uint_1
+%553 = OpLoad %uint %377
+OpStore %552 %553
+%554 = OpLoad %uint %338
+%555 = OpIAdd %uint %554 %uint_3
+OpStore %378 %555
+%556 = OpLoad %uint %378
+%557 = OpUConvert %uchar %556
+OpStore %379 %557
+%558 = OpAccessChain %_ptr_Function_uchar %547 %uint_2
+%559 = OpLoad %uchar %379
+OpStore %558 %559
+%560 = OpLoad %uint %338
+%561 = OpIAdd %uint %560 %uint_4
+OpStore %380 %561
+%562 = OpLoad %uint %380
+%563 = OpUConvert %uchar %562
+OpStore %381 %563
+%564 = OpAccessChain %_ptr_Function_uchar %535 %uint_2
+%565 = OpLoad %uchar %381
+OpStore %564 %565
+OpBranch %292
+%292 = OpLabel
+%567 = OpLoad %uint %308
+%568 = OpIAdd %uint %uint_50 %567
+OpStore %339 %568
+%569 = OpAccessChain %_ptr_Function_uint %293 %uint_2
+%570 = OpLoad %uint %339
+OpStore %569 %570
+%571 = OpLoad %_struct_158 %293
+OpStore %295 %571
+%572 = OpLoad %ulong %326
+%573 = OpLoad %_struct_158 %295
+%574 = OpFunctionCall %ulong %4 %572 %573
+OpStore %340 %574
+%575 = OpAccessChain %_ptr_Function__struct_102 %293 %uint_0
+%576 = OpAccessChain %_ptr_Function__struct_52 %575 %uint_0
+%577 = OpAccessChain %_ptr_Function__struct_15 %576 %uint_1
+%578 = OpAccessChain %_ptr_Function_uint %577 %uint_1
+%579 = OpLoad %uint %578
+OpStore %341 %579
+%580 = OpLoad %uint %341
+%582 = OpBitwiseXor %uint %580 %uint_4042322160
+OpStore %342 %582
+%583 = OpLoad %uint %342
+OpStore %578 %583
+%584 = OpLoad %_struct_158 %293
+OpStore %296 %584
+%585 = OpLoad %ulong %340
+%586 = OpLoad %_struct_158 %296
+%587 = OpFunctionCall %ulong %4 %585 %586
+OpStore %343 %587
+%588 = OpAccessChain %_ptr_Function__arr__struct_52_uint_2 %293 %uint_1
+%589 = OpAccessChain %_ptr_Function__struct_52 %588 %uint_1
+%590 = OpAccessChain %_ptr_Function__struct_15 %589 %uint_1
+%591 = OpAccessChain %_ptr_Function_uchar %590 %uint_2
+%592 = OpLoad %uchar %591
+OpStore %344 %592
+%593 = OpLoad %uchar %344
+%595 = OpIAdd %uchar %593 %uchar_7
+OpStore %345 %595
+%596 = OpLoad %uchar %345
+OpStore %591 %596
+%597 = OpLoad %_struct_158 %293
+OpStore %297 %597
+%598 = OpLoad %ulong %343
+%599 = OpLoad %_struct_158 %297
+%600 = OpFunctionCall %ulong %4 %598 %599
+OpStore %346 %600
+%601 = OpAccessChain %_ptr_Function_ulong %575 %uint_1
+%602 = OpLoad %ulong %601
+OpStore %347 %602
+%603 = OpLoad %ulong %347
+%605 = OpShiftRightLogical %ulong %603 %ulong_3
+OpStore %348 %605
+%606 = OpLoad %ulong %348
+OpStore %601 %606
+%607 = OpLoad %_struct_158 %293
+OpStore %298 %607
+%608 = OpLoad %ulong %346
+%609 = OpLoad %_struct_158 %298
+%610 = OpFunctionCall %ulong %4 %608 %609
+OpStore %349 %610
+%611 = OpLoad %uint %569
+OpStore %350 %611
+%612 = OpLoad %uint %350
+%613 = OpIMul %uint %612 %uint_3
+OpStore %351 %613
+%614 = OpLoad %uint %351
+OpStore %569 %614
+%615 = OpLoad %_struct_158 %293
+OpStore %299 %615
+%616 = OpLoad %ulong %349
+%617 = OpLoad %_struct_158 %299
+%618 = OpFunctionCall %ulong %4 %616 %617
+OpStore %352 %618
+%619 = OpAccessChain %_ptr_Function__struct_52 %588 %uint_0
+%620 = OpLoad %_struct_52 %619
+OpStore %301 %620
+%621 = OpLoad %_struct_52 %301
+OpStore %300 %621
+%622 = OpAccessChain %_ptr_Function__struct_15 %300 %uint_1
+%623 = OpAccessChain %_ptr_Function_uint %622 %uint_1
+%624 = OpLoad %uint %623
+OpStore %353 %624
+%625 = OpLoad %uint %353
+%626 = OpIAdd %uint %625 %uint_1
+OpStore %354 %626
+%627 = OpLoad %uint %354
+OpStore %623 %627
+%628 = OpLoad %_struct_52 %300
+OpStore %302 %628
+%629 = OpLoad %ulong %352
+%630 = OpLoad %_struct_52 %302
+%631 = OpFunctionCall %ulong %2 %629 %630
+OpStore %355 %631
+%632 = OpLoad %_struct_52 %619
+OpStore %303 %632
+%633 = OpLoad %ulong %355
+%634 = OpLoad %_struct_52 %303
+%635 = OpFunctionCall %ulong %2 %633 %634
+OpStore %356 %635
+%636 = OpLoad %_struct_52 %300
+OpStore %304 %636
+%637 = OpLoad %_struct_52 %304
+OpStore %619 %637
+%638 = OpLoad %_struct_158 %293
+OpStore %305 %638
+%639 = OpLoad %ulong %356
+%640 = OpLoad %_struct_158 %305
+%641 = OpFunctionCall %ulong %4 %639 %640
+OpStore %357 %641
+%642 = OpLoad %ulong %357
+OpReturnValue %642
+OpFunctionEnd
+%7 = OpFunction %ulong None %643
+%644 = OpLabel
+OpReturnValue %ulong_14695981039346656037
+OpFunctionEnd
+%8 = OpFunction %ulong None %646
+%647 = OpFunctionParameter %ulong
+%648 = OpFunctionParameter %ulong
+%649 = OpLabel
+%655 = OpVariable %_ptr_Function_ulong Function
+%656 = OpVariable %_ptr_Function_ulong Function
+%658 = OpVariable %_ptr_Function_bool Function
+%659 = OpVariable %_ptr_Function_ulong Function
+%660 = OpVariable %_ptr_Function_ulong Function
+%661 = OpVariable %_ptr_Function_ulong Function
+%662 = OpVariable %_ptr_Function_ulong Function
+%663 = OpVariable %_ptr_Function_ulong Function
+%664 = OpVariable %_ptr_Function_ulong Function
+%665 = OpVariable %_ptr_Function_ulong Function
+%666 = OpVariable %_ptr_Function_ulong Function
+OpStore %655 %647
+OpStore %656 %648
+%667 = OpLoad %ulong %655
+OpStore %665 %667
+OpStore %666 %ulong_0
+OpBranch %650
+%650 = OpLabel
+%669 = OpLoad %ulong %666
+%670 = OpULessThan %bool %669 %ulong_8
+OpStore %658 %670
+%671 = OpLoad %bool %658
+OpLoopMerge %652 %653 None
+OpBranchConditional %671 %651 %652
+%652 = OpLabel
+%672 = OpLoad %ulong %665
+OpReturnValue %672
+%651 = OpLabel
+%673 = OpLoad %ulong %666
+%674 = OpIMul %ulong %673 %ulong_8
+OpStore %659 %674
+%675 = OpLoad %ulong %656
+%676 = OpLoad %ulong %659
+%677 = OpShiftRightLogical %ulong %675 %676
+OpStore %660 %677
+%678 = OpLoad %ulong %660
+%680 = OpBitwiseAnd %ulong %678 %ulong_255
+OpStore %661 %680
+%681 = OpLoad %ulong %665
+%682 = OpLoad %ulong %661
+%683 = OpBitwiseXor %ulong %681 %682
+OpStore %662 %683
+%684 = OpLoad %ulong %662
+%686 = OpIMul %ulong %684 %ulong_1099511628211
+OpStore %663 %686
+%687 = OpLoad %ulong %666
+%689 = OpIAdd %ulong %687 %ulong_1
+OpStore %664 %689
+%690 = OpLoad %ulong %663
+OpStore %665 %690
+%691 = OpLoad %ulong %664
+OpStore %666 %691
+OpBranch %653
+%653 = OpLabel
+OpBranch %650
+OpFunctionEnd
+%9 = OpFunction %ulong None %692
+%693 = OpFunctionParameter %ulong
+%694 = OpFunctionParameter %uchar
+%695 = OpLabel
+%702 = OpVariable %_ptr_Function_ulong Function
+%703 = OpVariable %_ptr_Function_uchar Function
+%704 = OpVariable %_ptr_Function_ulong Function
+%705 = OpVariable %_ptr_Function_bool Function
+%706 = OpVariable %_ptr_Function_ulong Function
+%707 = OpVariable %_ptr_Function_ulong Function
+%708 = OpVariable %_ptr_Function_ulong Function
+%709 = OpVariable %_ptr_Function_ulong Function
+%710 = OpVariable %_ptr_Function_ulong Function
+%711 = OpVariable %_ptr_Function_ulong Function
+%712 = OpVariable %_ptr_Function_ulong Function
+%713 = OpVariable %_ptr_Function_ulong Function
+OpStore %702 %693
+OpStore %703 %694
+%714 = OpLoad %uchar %703
+%715 = OpUConvert %ulong %714
+OpStore %704 %715
+OpBranch %696
+%696 = OpLabel
+%716 = OpLoad %ulong %702
+OpStore %712 %716
+OpStore %713 %ulong_0
+OpBranch %697
+%697 = OpLabel
+%717 = OpLoad %ulong %713
+%718 = OpULessThan %bool %717 %ulong_8
+OpStore %705 %718
+%719 = OpLoad %bool %705
+OpLoopMerge %699 %701 None
+OpBranchConditional %719 %698 %699
+%699 = OpLabel
+OpBranch %700
+%700 = OpLabel
+%720 = OpLoad %ulong %712
+OpReturnValue %720
+%698 = OpLabel
+%721 = OpLoad %ulong %713
+%722 = OpIMul %ulong %721 %ulong_8
+OpStore %706 %722
+%723 = OpLoad %ulong %704
+%724 = OpLoad %ulong %706
+%725 = OpShiftRightLogical %ulong %723 %724
+OpStore %707 %725
+%726 = OpLoad %ulong %707
+%727 = OpBitwiseAnd %ulong %726 %ulong_255
+OpStore %708 %727
+%728 = OpLoad %ulong %712
+%729 = OpLoad %ulong %708
+%730 = OpBitwiseXor %ulong %728 %729
+OpStore %709 %730
+%731 = OpLoad %ulong %709
+%732 = OpIMul %ulong %731 %ulong_1099511628211
+OpStore %710 %732
+%733 = OpLoad %ulong %713
+%734 = OpIAdd %ulong %733 %ulong_1
+OpStore %711 %734
+%735 = OpLoad %ulong %710
+OpStore %712 %735
+%736 = OpLoad %ulong %711
+OpStore %713 %736
+OpBranch %701
+%701 = OpLabel
+OpBranch %697
+OpFunctionEnd
+%10 = OpFunction %ulong None %737
+%738 = OpFunctionParameter %ulong
+%739 = OpFunctionParameter %ushort
+%740 = OpLabel
+%747 = OpVariable %_ptr_Function_ulong Function
+%748 = OpVariable %_ptr_Function_ushort Function
+%749 = OpVariable %_ptr_Function_ulong Function
+%750 = OpVariable %_ptr_Function_bool Function
+%751 = OpVariable %_ptr_Function_ulong Function
+%752 = OpVariable %_ptr_Function_ulong Function
+%753 = OpVariable %_ptr_Function_ulong Function
+%754 = OpVariable %_ptr_Function_ulong Function
+%755 = OpVariable %_ptr_Function_ulong Function
+%756 = OpVariable %_ptr_Function_ulong Function
+%757 = OpVariable %_ptr_Function_ulong Function
+%758 = OpVariable %_ptr_Function_ulong Function
+OpStore %747 %738
+OpStore %748 %739
+%759 = OpLoad %ushort %748
+%760 = OpUConvert %ulong %759
+OpStore %749 %760
+OpBranch %741
+%741 = OpLabel
+%761 = OpLoad %ulong %747
+OpStore %757 %761
+OpStore %758 %ulong_0
+OpBranch %742
+%742 = OpLabel
+%762 = OpLoad %ulong %758
+%763 = OpULessThan %bool %762 %ulong_8
+OpStore %750 %763
+%764 = OpLoad %bool %750
+OpLoopMerge %744 %746 None
+OpBranchConditional %764 %743 %744
+%744 = OpLabel
+OpBranch %745
+%745 = OpLabel
+%765 = OpLoad %ulong %757
+OpReturnValue %765
+%743 = OpLabel
+%766 = OpLoad %ulong %758
+%767 = OpIMul %ulong %766 %ulong_8
+OpStore %751 %767
+%768 = OpLoad %ulong %749
+%769 = OpLoad %ulong %751
+%770 = OpShiftRightLogical %ulong %768 %769
+OpStore %752 %770
+%771 = OpLoad %ulong %752
+%772 = OpBitwiseAnd %ulong %771 %ulong_255
+OpStore %753 %772
+%773 = OpLoad %ulong %757
+%774 = OpLoad %ulong %753
+%775 = OpBitwiseXor %ulong %773 %774
+OpStore %754 %775
+%776 = OpLoad %ulong %754
+%777 = OpIMul %ulong %776 %ulong_1099511628211
+OpStore %755 %777
+%778 = OpLoad %ulong %758
+%779 = OpIAdd %ulong %778 %ulong_1
+OpStore %756 %779
+%780 = OpLoad %ulong %755
+OpStore %757 %780
+%781 = OpLoad %ulong %756
+OpStore %758 %781
+OpBranch %746
+%746 = OpLabel
+OpBranch %742
+OpFunctionEnd
+%11 = OpFunction %ulong None %782
+%783 = OpFunctionParameter %ulong
+%784 = OpFunctionParameter %uint
+%785 = OpLabel
+%792 = OpVariable %_ptr_Function_ulong Function
+%793 = OpVariable %_ptr_Function_uint Function
+%794 = OpVariable %_ptr_Function_ulong Function
+%795 = OpVariable %_ptr_Function_bool Function
+%796 = OpVariable %_ptr_Function_ulong Function
+%797 = OpVariable %_ptr_Function_ulong Function
+%798 = OpVariable %_ptr_Function_ulong Function
+%799 = OpVariable %_ptr_Function_ulong Function
+%800 = OpVariable %_ptr_Function_ulong Function
+%801 = OpVariable %_ptr_Function_ulong Function
+%802 = OpVariable %_ptr_Function_ulong Function
+%803 = OpVariable %_ptr_Function_ulong Function
+OpStore %792 %783
+OpStore %793 %784
+%804 = OpLoad %uint %793
+%805 = OpUConvert %ulong %804
+OpStore %794 %805
+OpBranch %786
+%786 = OpLabel
+%806 = OpLoad %ulong %792
+OpStore %802 %806
+OpStore %803 %ulong_0
+OpBranch %787
+%787 = OpLabel
+%807 = OpLoad %ulong %803
+%808 = OpULessThan %bool %807 %ulong_8
+OpStore %795 %808
+%809 = OpLoad %bool %795
+OpLoopMerge %789 %791 None
+OpBranchConditional %809 %788 %789
+%789 = OpLabel
+OpBranch %790
+%790 = OpLabel
+%810 = OpLoad %ulong %802
+OpReturnValue %810
+%788 = OpLabel
+%811 = OpLoad %ulong %803
+%812 = OpIMul %ulong %811 %ulong_8
+OpStore %796 %812
+%813 = OpLoad %ulong %794
+%814 = OpLoad %ulong %796
+%815 = OpShiftRightLogical %ulong %813 %814
+OpStore %797 %815
+%816 = OpLoad %ulong %797
+%817 = OpBitwiseAnd %ulong %816 %ulong_255
+OpStore %798 %817
+%818 = OpLoad %ulong %802
+%819 = OpLoad %ulong %798
+%820 = OpBitwiseXor %ulong %818 %819
+OpStore %799 %820
+%821 = OpLoad %ulong %799
+%822 = OpIMul %ulong %821 %ulong_1099511628211
+OpStore %800 %822
+%823 = OpLoad %ulong %803
+%824 = OpIAdd %ulong %823 %ulong_1
+OpStore %801 %824
+%825 = OpLoad %ulong %800
+OpStore %802 %825
+%826 = OpLoad %ulong %801
+OpStore %803 %826
+OpBranch %791
+%791 = OpLabel
+OpBranch %787
+OpFunctionEnd


### PR DESCRIPTION
Roadmap N4. Lands the value-oriented ABI contract for module emitters and the legal pointer-to-record parameter on SPIR-V. Design, inventory and the L6 interface are in `doc/design/spirv-abi-2963.md`.

## What changed

- `abi.AbiVTable.passing` declares how values cross a call: `PASSING_CARRIERS` (every register ABI, unchanged) or `PASSING_VALUES` (`abi.value_abi_vtable`, two classifiers, no bank, no callee-saved set, no variadic model). `CLASS_VALUE` subsumes `CLASS_AGG` and names no register. `target.tuple_capability` pairs the model with the instruction-set family (`TUPLE_ABI_TRANSPORT`) and the model is in the target fingerprint.
- A values target lowers calls to `MIR_VALUE_CALL callee, result, args...` and parameters to `MIR_VALUE_PARAM dest, index`; every vreg is `REG_CLASS_VALUE`; `MIR_RET` carries the value and is `MIRF_NO_SHAPE`.
- The SPIR-V emitter has no `Regs` shadow file, no identity bank, no `MAX_FN_PARAMS`, no fixed operand buffers and no `MIR_OP_PREG` arm. The only count bound is the 16-bit instruction word count (`types.instruction_operands_fit`). An `OpFunctionCall` result id is allocated after its operands.
- IR carries a typed reference (`type.intern_reference`) on a logical-addressing target only; machine targets keep the opaque pointer. A recursive reference type is refused at lowering with a location.
- A pointer parameter is `OpTypePointer Function T`; the argument is the `OpVariable` or forwarded `OpFunctionParameter`. A parameter the environment cannot take is refused with its index, a source-shaped type spelling and the reason, at a source location.
- A reference argument of a value call counts as a potential write to its origin, so a `readonly` storage binding still refuses.

## Acceptance

| bullet | demonstrated by |
|---|---|
| scalar, vector, composite by value, pointer to record (whole object and forwarded), 21 parameters, composite return, `spirv-val` clean and evaluated | `mach.lang.driver:logical_value_abi_preserves_mixed_arguments_and_references_on_spirv` |
| the historical >16-parameter case (#2923) | corpus `call/call_mixed` layers A (o0, o2) and B: `mixed` has 20 `OpFunctionParameter`; golden blessed |
| #2940 repro accepted at `-O0` and `-O2` | `fill` takes `%9 = OpFunctionParameter %_ptr_Function_Pair`, field writes are `OpAccessChain` + `OpStore`, the caller passes the `OpVariable` directly (`%33 = OpFunctionCall %4 %1 %26 %32`); `mem/rec_layout` layer B golden blessed, layer A o2 passes |
| illegal pointer classes still refused with a located diagnostic | `mach.lang.driver:logical_shader_reference_capabilities_refuse_returns_subobjects_and_cycles` (pointer result, subobject argument, recursive reference); `mach.lang.driver:logical_shader_refuses_a_function_value_parameter_with_its_type` |
| `-g` on a SPIR-V target refused per the v5 SPIR-V boundary | `mach.lang.driver:spirv_debug_request_is_refused_by_the_declared_target_policy`; corpus reports 83 debug-unsupported cells |
| limit refusals are typed, not internal errors | `instruction_operands_fit` at `OpTypeFunction`, `OpFunctionCall` and mapped instructions; `mach.lang.target.isa.spirv.types:logical_signature_has_no_synthetic_parameter_bank` interns 256 parameters |
| no synthetic bank remains | `mach.lang.target.abi_vtable:granularity_matches_its_classifier` checks the values convention publishes nothing a bank needs; `register.mach` publishes no register class |
| machine targets unchanged | corpus `x86_64-linux` layer B 91/91 pass before and after |
| readonly storage through a reference argument | `mach.lang.driver:spirv_refuses_an_escaping_readonly_storage_address` |

`mem/rec_layout` at o0 passes `?n.w.m` (a subobject access chain) as a pointer argument. `spirv-val` 2026.3 rejects an access-chain pointer operand of `OpFunctionCall` under spv1.0 through spv1.6 and vulkan1.0 through vulkan1.3, so that one cell is declared a target limitation in `SKIPS` (`a:o0`), not a defect; the whole-object and forwarded forms the issue asks for are accepted.

## Verification

- Full suite through the from-source compiler: 2738 passed, 0 failed (dev baseline 2732; +6: the four driver tests, the 256-parameter signature test, the typed-reference identity test).
- `sh test/census.sh`: ok.
- Corpus spirv layers A and B: 248 pass, 0 fail, 100 skip. 22 goldens blessed: 2 new, 20 renumbered by the result-id order change; for each of the 20 the id-stripped text, opcode multiset and line count are unchanged (checked mechanically).
- Corpus x86_64-linux layer B: 91 pass, 0 fail.
- Mutation controls, one per refusal: debug refusal deleted (test exit 4), subobject check deleted (exit 14), pointer-result check deleted (exit 4), recursive-reference guard deleted (segfault from unbounded recursion), parameter-type refusal deleted (exit 5).

Closes #2963
Closes #2940
