### PR TITLE
codegen(x64): realize 64-bit vector ordering compares as a packed SSE2 sequence (#3120)

### DIFF
--- a/src/lang/be/codegen/vector_runtime.mach
+++ b/src/lang/be/codegen/vector_runtime.mach
@@ -325,39 +325,119 @@ test "mach.lang.be.codegen.vector_runtime.compare:u8x16" {
     ret 0;
 }
 
+# every ordering predicate at 64-bit lanes against the mask the two facts imply:
+# which lanes are greater and which are equal. the code names the predicate that
+# disagreed.
+fun t_ord_i64x2(a: i64x2, b: i64x2, want_gt: u64x2, want_eq: u64x2) i32 {
+    var want_ge: u64x2 = want_gt | want_eq;
+    var want_lt: u64x2 = ~want_ge;
+    var want_le: u64x2 = ~want_gt;
+    var lt: u64x2 = a < b;
+    if (lt[0] != want_lt[0] || lt[1] != want_lt[1]) { ret 1; }
+    var le: u64x2 = a <= b;
+    if (le[0] != want_le[0] || le[1] != want_le[1]) { ret 2; }
+    var gt: u64x2 = a > b;
+    if (gt[0] != want_gt[0] || gt[1] != want_gt[1]) { ret 3; }
+    var ge: u64x2 = a >= b;
+    if (ge[0] != want_ge[0] || ge[1] != want_ge[1]) { ret 4; }
+    var eq: u64x2 = a == b;
+    if (eq[0] != want_eq[0] || eq[1] != want_eq[1]) { ret 5; }
+    var ne: u64x2 = a != b;
+    if (ne[0] != ~want_eq[0] || ne[1] != ~want_eq[1]) { ret 6; }
+    ret 0;
+}
+
+fun t_ord_u64x2(a: u64x2, b: u64x2, want_gt: u64x2, want_eq: u64x2) i32 {
+    var want_ge: u64x2 = want_gt | want_eq;
+    var want_lt: u64x2 = ~want_ge;
+    var want_le: u64x2 = ~want_gt;
+    var lt: u64x2 = a < b;
+    if (lt[0] != want_lt[0] || lt[1] != want_lt[1]) { ret 1; }
+    var le: u64x2 = a <= b;
+    if (le[0] != want_le[0] || le[1] != want_le[1]) { ret 2; }
+    var gt: u64x2 = a > b;
+    if (gt[0] != want_gt[0] || gt[1] != want_gt[1]) { ret 3; }
+    var ge: u64x2 = a >= b;
+    if (ge[0] != want_ge[0] || ge[1] != want_ge[1]) { ret 4; }
+    var eq: u64x2 = a == b;
+    if (eq[0] != want_eq[0] || eq[1] != want_eq[1]) { ret 5; }
+    var ne: u64x2 = a != b;
+    if (ne[0] != ~want_eq[0] || ne[1] != ~want_eq[1]) { ret 6; }
+    ret 0;
+}
+
 test "mach.lang.be.codegen.vector_runtime.compare:i64x2" {
     var a: i64x2 = i64x2{ 266, -1 };
     var b: i64x2 = i64x2{ 10, 0 };
-    var eq: u64x2 = a == b;
-    if (eq[0] != 0 || eq[1] != 0) { ret 1; }
-    var ne: u64x2 = a != b;
-    if (ne[0] != M64 || ne[1] != M64) { ret 2; }
-    var lt: u64x2 = a < b;
-    if (lt[0] != 0 || lt[1] != M64) { ret 3; }
-    var le: u64x2 = a <= b;
-    if (le[0] != 0 || le[1] != M64) { ret 4; }
-    var gt: u64x2 = a > b;
-    if (gt[0] != M64 || gt[1] != 0) { ret 5; }
-    var ge: u64x2 = a >= b;
-    if (ge[0] != M64 || ge[1] != 0) { ret 6; }
+    val r: i32 = t_ord_i64x2(a, b, u64x2{ M64, 0 }, u64x2{ 0, 0 });
+    if (r != 0) { ret r; }
+    ret 0;
+}
+
+# a 64-bit lane ordered through 32-bit halves has to read a tied high half's low
+# half as unsigned: 0x1_FFFFFFFF against 0x1_00000001 in both directions, and the
+# same tie under a negative high half. a signed low-half compare inverts these.
+test "mach.lang.be.codegen.vector_runtime.compare:i64x2_low_half_tie" {
+    var a: i64x2 = i64x2{ 8589934591, 4294967297 };
+    var b: i64x2 = i64x2{ 4294967297, 8589934591 };
+    val r: i32 = t_ord_i64x2(a, b, u64x2{ M64, 0 }, u64x2{ 0, 0 });
+    if (r != 0) { ret r; }
+    var c: i64x2 = i64x2{ -1, -4294967296 };
+    var d: i64x2 = i64x2{ -4294967296, -1 };
+    val r2: i32 = t_ord_i64x2(c, d, u64x2{ M64, 0 }, u64x2{ 0, 0 });
+    if (r2 != 0) { ret 10 + r2; }
+    ret 0;
+}
+
+# the high half decides as signed: INT64_MIN below INT64_MAX and below -1 in both
+# lane orders, a high half that differs by one against a low half arguing the
+# other way, and an equal pair.
+test "mach.lang.be.codegen.vector_runtime.compare:i64x2_sign_boundary" {
+    val imin: i64 = 9223372036854775808:~i64;
+    val imax: i64 = 9223372036854775807;
+    var a: i64x2 = i64x2{ imin, imax };
+    var b: i64x2 = i64x2{ imax, imin };
+    val r: i32 = t_ord_i64x2(a, b, u64x2{ 0, M64 }, u64x2{ 0, 0 });
+    if (r != 0) { ret r; }
+    var c: i64x2 = i64x2{ imin, 0x123456789ABCDEF0 };
+    var d: i64x2 = i64x2{ -1, 0x123456789ABCDEF0 };
+    val r2: i32 = t_ord_i64x2(c, d, u64x2{ 0, 0 }, u64x2{ 0, M64 });
+    if (r2 != 0) { ret 10 + r2; }
+    var e: i64x2 = i64x2{ 8589934592, 0 };
+    var f: i64x2 = i64x2{ 8589934591, -1 };
+    val r3: i32 = t_ord_i64x2(e, f, u64x2{ M64, M64 }, u64x2{ 0, 0 });
+    if (r3 != 0) { ret 20 + r3; }
     ret 0;
 }
 
 test "mach.lang.be.codegen.vector_runtime.compare:u64x2" {
     var a: u64x2 = u64x2{ 266, 18446744073709551615 };
     var b: u64x2 = u64x2{ 10, 0 };
-    var lt: u64x2 = a < b;
-    if (lt[0] != 0 || lt[1] != 0) { ret 1; }
-    var gt: u64x2 = a > b;
-    if (gt[0] != M64 || gt[1] != M64) { ret 2; }
-    var eq: u64x2 = a == b;
-    if (eq[0] != 0 || eq[1] != 0) { ret 3; }
-    var ne: u64x2 = a != b;
-    if (ne[0] != M64 || ne[1] != M64) { ret 4; }
-    var le: u64x2 = a <= b;
-    if (le[0] != 0 || le[1] != 0) { ret 5; }
-    var ge: u64x2 = a >= b;
-    if (ge[0] != M64 || ge[1] != M64) { ret 6; }
+    val r: i32 = t_ord_u64x2(a, b, u64x2{ M64, M64 }, u64x2{ 0, 0 });
+    if (r != 0) { ret r; }
+    ret 0;
+}
+
+# the unsigned reading: a set top bit orders above a clear one in both lane orders,
+# a tied high half breaks on the unsigned low half in both directions, all-ones
+# above zero, and an equal pair beside a high half that differs by one.
+test "mach.lang.be.codegen.vector_runtime.compare:u64x2_top_bit_and_low_half_tie" {
+    var a: u64x2 = u64x2{ 0x8000000000000000, 0x7FFFFFFFFFFFFFFF };
+    var b: u64x2 = u64x2{ 0x7FFFFFFFFFFFFFFF, 0x8000000000000000 };
+    val r: i32 = t_ord_u64x2(a, b, u64x2{ M64, 0 }, u64x2{ 0, 0 });
+    if (r != 0) { ret r; }
+    var c: u64x2 = u64x2{ 8589934591, 4294967297 };
+    var d: u64x2 = u64x2{ 4294967297, 8589934591 };
+    val r2: i32 = t_ord_u64x2(c, d, u64x2{ M64, 0 }, u64x2{ 0, 0 });
+    if (r2 != 0) { ret 10 + r2; }
+    var e: u64x2 = u64x2{ M64, 0 };
+    var f: u64x2 = u64x2{ 0, M64 };
+    val r3: i32 = t_ord_u64x2(e, f, u64x2{ M64, 0 }, u64x2{ 0, 0 });
+    if (r3 != 0) { ret 20 + r3; }
+    var g: u64x2 = u64x2{ 0x8000000080000000, 0xFFFFFFFF00000000 };
+    var k: u64x2 = u64x2{ 0x8000000080000000, 0xFFFFFFFEFFFFFFFF };
+    val r4: i32 = t_ord_u64x2(g, k, u64x2{ 0, M64 }, u64x2{ M64, 0 });
+    if (r4 != 0) { ret 30 + r4; }
     ret 0;
 }
 

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -3516,68 +3516,65 @@ fun emit_vcmp_eq_s0(lhs: isa.Operand, rhs: isa.Operand, w: u8, buf: *enc.ByteBuf
     ret emit_packed_op(pcmpeq_op(w), float_scratch0(), rhs, buf);
 }
 
-fun i64_ordering_setcc(op: mir.MirOpcode) u16 {
-    if (op == mir.MIR_SEL_CMP_LT_S) { ret x64.SETL; }
-    if (op == mir.MIR_SEL_CMP_LE_S) { ret x64.SETLE; }
-    if (op == mir.MIR_SEL_CMP_LT_U) { ret x64.SETB; }
-    ret x64.SETBE;
-}
+fun emit_vcmp_gt64_s0(x: isa.Operand, y: isa.Operand, signed: bool, buf: *enc.ByteBuf) R.Result[R.Void, str] {
+    # x > y per 64-bit lane as an all-ones mask in scratch0, from dword compares only:
+    # the high dwords decide unless they tie, and a tie is broken by the low dwords read
+    # as unsigned. an unsigned dword gt is the signed one xored with "the signs differ",
+    # which keeps the sequence inside the two scratch registers with no constant to hold;
+    # pshufd 0xF5 spreads a lane's high dword over both dwords and 0xA0 its low dword.
+    # this is the one seam an x86-64 level replaces with pcmpgtq (#3269).
+    val s0: i32 = float_scratch0();
+    val s1: i32 = float_scratch1();
 
-fun emit_vcmp_i64_lane_mask(setcc: u16, dst_gp: i32, cmp_gp: i32, buf: *enc.ByteBuf) {
-    emit_gp_inst(x64.CMP, isa.make_reg(dst_gp, 8), isa.make_reg(cmp_gp, 8), 8, x64.FLAG_REX_W, buf);
-    var setb: isa.Inst = isa.inst_blank();
-    setb.opcode   = setcc;
-    setb.dst      = isa.make_reg(dst_gp, 1);
-    setb.dst.size = 1;
-    setb.size     = 1;
-    encode_inst(?setb, buf);
-    var mz: isa.Inst = isa.inst_blank();
-    mz.opcode    = x64.MOVZX;
-    mz.dst       = isa.make_reg(dst_gp, 8);
-    mz.dst.size  = DEFAULT_OPERAND_SIZE;
-    mz.src1      = isa.make_reg(dst_gp, 1);
-    mz.src1.size = 1;
-    mz.size      = DEFAULT_OPERAND_SIZE;
-    mz.flags     = x64.FLAG_REX_W;
-    encode_inst(?mz, buf);
-    emit_gp_inst(x64.NEG, isa.make_reg(dst_gp, 8), isa.make_reg(dst_gp, 8), 8, x64.FLAG_REX_W, buf);
+    val ld0: R.Result[R.Void, str] = emit_vec_load(x, s1, buf);
+    if (R.is_err[R.Void, str](ld0)) { ret ld0; }
+    val rx: R.Result[R.Void, str] = emit_packed_op(x64.PXOR, s1, y, buf);
+    if (R.is_err[R.Void, str](rx)) { ret rx; }
+    val rz: R.Result[R.Void, str] = emit_vec_zero(s0, buf);
+    if (R.is_err[R.Void, str](rz)) { ret rz; }
+    val rs: R.Result[R.Void, str] = emit_packed_op(x64.PCMPGTD, s0, vec_reg(s1), buf);
+    if (R.is_err[R.Void, str](rs)) { ret rs; }
+
+    val ld1: R.Result[R.Void, str] = emit_vec_load(x, s1, buf);
+    if (R.is_err[R.Void, str](ld1)) { ret ld1; }
+    val rg: R.Result[R.Void, str] = emit_packed_op(x64.PCMPGTD, s1, y, buf);
+    if (R.is_err[R.Void, str](rg)) { ret rg; }
+    val ru: R.Result[R.Void, str] = emit_packed_op(x64.PXOR, s0, vec_reg(s1), buf);
+    if (R.is_err[R.Void, str](ru)) { ret ru; }
+
+    val ld2: R.Result[R.Void, str] = emit_vec_load(x, s1, buf);
+    if (R.is_err[R.Void, str](ld2)) { ret ld2; }
+    val re: R.Result[R.Void, str] = emit_packed_op(x64.PCMPEQD, s1, y, buf);
+    if (R.is_err[R.Void, str](re)) { ret re; }
+    emit_packed_rri(x64.PSHUFD, s1, s1, 0xF5, buf);
+    val ra: R.Result[R.Void, str] = emit_packed_op(x64.PAND, s1, vec_reg(s0), buf);
+    if (R.is_err[R.Void, str](ra)) { ret ra; }
+    emit_packed_rri(x64.PSHUFD, s1, s1, 0xA0, buf);
+
+    if (signed) {
+        val ld3: R.Result[R.Void, str] = emit_vec_load(x, s0, buf);
+        if (R.is_err[R.Void, str](ld3)) { ret ld3; }
+        val rh: R.Result[R.Void, str] = emit_packed_op(x64.PCMPGTD, s0, y, buf);
+        if (R.is_err[R.Void, str](rh)) { ret rh; }
+    }
+    emit_packed_rri(x64.PSHUFD, s0, s0, 0xF5, buf);
+    ret emit_packed_op(x64.POR, s0, vec_reg(s1), buf);
 }
 
 fun encode_vcmp_i64_ordering(dst: isa.Operand, lhs: isa.Operand, rhs: isa.Operand, op: mir.MirOpcode, buf: *enc.ByteBuf) R.Result[R.Void, str] {
-    val setcc: u16 = i64_ordering_setcc(op);
-
-    val l0: R.Result[R.Void, str] = emit_vec_load(lhs, float_scratch0(), buf);
-    if (R.is_err[R.Void, str](l0)) { ret l0; }
-    val l1: R.Result[R.Void, str] = emit_vec_load(rhs, float_scratch1(), buf);
-    if (R.is_err[R.Void, str](l1)) { ret l1; }
-
-    emit_gp_inst(x64.MOVQ, isa.make_reg(x64.R10, 8), vec_reg(float_scratch0()), 8, 0, buf);
-    emit_gp_inst(x64.MOVQ, isa.make_reg(x64.R11, 8), vec_reg(float_scratch1()), 8, 0, buf);
-    emit_vcmp_i64_lane_mask(setcc, x64.R10, x64.R11, buf);
-
-    emit_packed_rri(x64.PSHUFD, float_scratch0(), float_scratch0(), 0x4E, buf);
-    emit_packed_rri(x64.PSHUFD, float_scratch1(), float_scratch1(), 0x4E, buf);
-    emit_gp_inst(x64.MOVQ, isa.make_reg(x64.R8, 8), vec_reg(float_scratch0()), 8, 0, buf);
-    emit_gp_inst(x64.MOVQ, isa.make_reg(x64.R11, 8), vec_reg(float_scratch1()), 8, 0, buf);
-    emit_vcmp_i64_lane_mask(setcc, x64.R8, x64.R11, buf);
-
-    emit_gp_inst(x64.MOVQ, vec_reg(float_scratch0()), isa.make_reg(x64.R10, 8), 8, 0, buf);
-    emit_gp_inst(x64.MOVQ, vec_reg(float_scratch1()), isa.make_reg(x64.R8, 8), 8, 0, buf);
-    emit_packed_rri(x64.PSHUFD, float_scratch1(), float_scratch1(), 0x4E, buf);
-    val por: R.Result[R.Void, str] = emit_packed_op(x64.POR, float_scratch0(), vec_reg(float_scratch1()), buf);
-    if (R.is_err[R.Void, str](por)) { ret por; }
-
+    val signed: bool = op == mir.MIR_SEL_CMP_LT_S || op == mir.MIR_SEL_CMP_LE_S;
+    if (op == mir.MIR_SEL_CMP_LT_S || op == mir.MIR_SEL_CMP_LT_U) {
+        val rg: R.Result[R.Void, str] = emit_vcmp_gt64_s0(rhs, lhs, signed, buf);
+        if (R.is_err[R.Void, str](rg)) { ret rg; }
+        ret emit_vec_store(dst, float_scratch0(), buf);
+    }
+    val rg: R.Result[R.Void, str] = emit_vcmp_gt64_s0(lhs, rhs, signed, buf);
+    if (R.is_err[R.Void, str](rg)) { ret rg; }
+    val ra: R.Result[R.Void, str] = emit_vec_all_ones(float_scratch1(), buf);
+    if (R.is_err[R.Void, str](ra)) { ret ra; }
+    val rx: R.Result[R.Void, str] = emit_packed_op(x64.PXOR, float_scratch0(), vec_reg(float_scratch1()), buf);
+    if (R.is_err[R.Void, str](rx)) { ret rx; }
     ret emit_vec_store(dst, float_scratch0(), buf);
-}
-
-fun emit_gp_inst(opcode: u16, dst: isa.Operand, src: isa.Operand, size: u8, flags: u16, buf: *enc.ByteBuf) {
-    var mi: isa.Inst = isa.inst_blank();
-    mi.opcode = opcode;
-    mi.dst    = dst;
-    mi.src1   = src;
-    mi.size   = size;
-    mi.flags  = flags;
-    encode_inst(?mi, buf);
 }
 
 fun encode_vector_compare(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) R.Result[R.Void, str] {

--- a/test/cases/vec/vec_cmp_i64.mach
+++ b/test/cases/vec/vec_cmp_i64.mach
@@ -1,0 +1,94 @@
+# ordering at 64-bit integer lanes, every predicate, signed and unsigned. an ISA
+# without a 64-bit packed compare orders a lane through its two 32-bit halves, so
+# the pairs tie on the high half and differ on the low half in both directions,
+# with the low half's top bit set on one side: a low half read as signed inverts
+# those lanes. the sign boundaries (INT64_MIN against INT64_MAX and against -1, a
+# set top bit against a clear one) settle the high half's reading, a high half
+# that differs by one sits beside a low half arguing the other way, and an equal
+# pair holds the equality predicates. a mask is all-ones or all-zeros, and the
+# select built on it folds both operands through it.
+
+use corpus.lib.fold;
+
+fun fold_u64x2(h: u64, v: u64x2) u64 {
+    var a: u64 = fold.mix_u64(h, v[0]);
+    a = fold.mix_u64(a, v[1]);
+    ret a;
+}
+
+fun fold_i64x2(h: u64, v: i64x2) u64 {
+    var a: u64 = fold.mix_i64(h, v[0]);
+    a = fold.mix_i64(a, v[1]);
+    ret a;
+}
+
+pub fun checksum(seed: u64) u64 {
+    var h: u64 = fold.init();
+    val s: i64 = seed:~i64;
+    val imin: i64 = 9223372036854775808:~i64;
+    val imax: i64 = 9223372036854775807;
+
+    var av: [6]i64x2;
+    var bv: [6]i64x2;
+    av[0] = i64x2{8589934591, 4294967297};
+    bv[0] = i64x2{4294967297, 8589934591};
+    av[1] = i64x2{-1, -4294967296};
+    bv[1] = i64x2{-4294967296, -1};
+    av[2] = i64x2{imin, imax};
+    bv[2] = i64x2{imax, imin};
+    av[3] = i64x2{imin, 0x123456789ABCDEF0};
+    bv[3] = i64x2{-1, 0x123456789ABCDEF0};
+    av[4] = i64x2{8589934592, 0};
+    bv[4] = i64x2{8589934591, -1};
+    av[5] = i64x2{266, -1};
+    bv[5] = i64x2{10, 0};
+
+    var k: u64 = 0;
+    for (k < 6) {
+        var a: i64x2 = av[k];
+        var b: i64x2 = bv[k];
+        a[0] = a[0] + s;
+        b[1] = b[1] + s;
+        h = fold_u64x2(h, a < b);
+        h = fold_u64x2(h, a <= b);
+        h = fold_u64x2(h, a > b);
+        h = fold_u64x2(h, a >= b);
+        h = fold_u64x2(h, a == b);
+        h = fold_u64x2(h, a != b);
+        val m: u64x2 = a < b;
+        val lo: i64x2 = ((m & (a:~u64x2)) | (~m & (b:~u64x2))):~i64x2;
+        h = fold_i64x2(h, lo);
+        k = k + 1;
+    }
+
+    var cv: [5]u64x2;
+    var dv: [5]u64x2;
+    cv[0] = u64x2{9223372036854775808, 9223372036854775807};
+    dv[0] = u64x2{9223372036854775807, 9223372036854775808};
+    cv[1] = u64x2{8589934591, 4294967297};
+    dv[1] = u64x2{4294967297, 8589934591};
+    cv[2] = u64x2{18446744073709551615, 0};
+    dv[2] = u64x2{0, 18446744073709551615};
+    cv[3] = u64x2{9223372039002259456, 18446744069414584320};
+    dv[3] = u64x2{9223372039002259456, 18446744069414584319};
+    cv[4] = u64x2{266, 18446744073709551615};
+    dv[4] = u64x2{10, 0};
+
+    var j: u64 = 0;
+    for (j < 5) {
+        var c: u64x2 = cv[j];
+        var d: u64x2 = dv[j];
+        c[0] = c[0] + seed;
+        d[1] = d[1] + seed;
+        h = fold_u64x2(h, c < d);
+        h = fold_u64x2(h, c <= d);
+        h = fold_u64x2(h, c > d);
+        h = fold_u64x2(h, c >= d);
+        h = fold_u64x2(h, c == d);
+        h = fold_u64x2(h, c != d);
+        val m: u64x2 = c < d;
+        h = fold_u64x2(h, (m & c) | (~m & d));
+        j = j + 1;
+    }
+    ret h;
+}

--- a/test/golden/aarch64-darwin/vec/vec_cmp_i64.dis
+++ b/test/golden/aarch64-darwin/vec/vec_cmp_i64.dis
@@ -1,0 +1,941 @@
+vec/vec_cmp_i64.o:
+
+Disassembly of section __TEXT,__text:
+
+<corpus.cases.vec.vec_cmp_i64.fold_u64x2>:
+               	stp	x29, x30, [sp, #-0x10]!
+               	mov	x29, sp
+               	sub	sp, sp, #0x10
+               	mov	x1, x0
+               	stur	q0, [x29, #-0x10]
+               	ldur	q31, [x29, #-0x10]
+               	mov.d	x2, v31[0]
+               	mov	x0, x1
+               	mov	x1, x2
+<L0>:
+               	bl	 <L0>
+               	mov	x1, x0
+               	ldur	q31, [x29, #-0x10]
+               	mov.d	x2, v31[1]
+               	mov	x0, x1
+               	mov	x1, x2
+<L1>:
+               	bl	 <L1>
+               	mov	sp, x29
+               	ldp	x29, x30, [sp], #0x10
+               	ret
+
+<corpus.cases.vec.vec_cmp_i64.fold_i64x2>:
+               	stp	x29, x30, [sp, #-0x10]!
+               	mov	x29, sp
+               	sub	sp, sp, #0x10
+               	mov	x1, x0
+               	stur	q0, [x29, #-0x10]
+               	ldur	q31, [x29, #-0x10]
+               	mov.d	x2, v31[0]
+               	mov	x0, x1
+               	mov	x1, x2
+<L0>:
+               	bl	 <L0>
+               	mov	x1, x0
+               	ldur	q31, [x29, #-0x10]
+               	mov.d	x2, v31[1]
+               	mov	x0, x1
+               	mov	x1, x2
+<L1>:
+               	bl	 <L1>
+               	mov	sp, x29
+               	ldp	x29, x30, [sp], #0x10
+               	ret
+
+<corpus.cases.vec.vec_cmp_i64.checksum>:
+               	stp	x29, x30, [sp, #-0x10]!
+               	mov	x29, sp
+               	sub	sp, sp, #0x410
+               	sub	x16, x29, #0x3f0
+               	stp	x19, x20, [x16]
+               	stp	x21, x22, [x16, #-0x10]
+               	stur	x23, [x16, #-0x18]
+               	mov	x19, x0
+<L0>:
+               	bl	 <L0>
+               	sub	x20, x29, #0x60
+               	add	x1, x20, #0x0
+               	add	x2, x1, #0x0
+               	mov	x1, #0x60               ; =96
+<L1>:
+               	str	xzr, [x2]
+               	add	x2, x2, #0x8
+               	sub	x1, x1, #0x8
+               	cmp	x1, #0x0
+               	b.ne	 <L1>
+               	sub	x21, x29, #0xc0
+               	add	x1, x21, #0x0
+               	add	x2, x1, #0x0
+               	mov	x1, #0x60               ; =96
+<L2>:
+               	str	xzr, [x2]
+               	add	x2, x2, #0x8
+               	sub	x1, x1, #0x8
+               	cmp	x1, #0x0
+               	b.ne	 <L2>
+               	sub	x1, x29, #0xd0
+               	add	x2, x1, #0x0
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0x1               ; =1
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x20, #0x0
+               	str	q0, [x1]
+               	sub	x1, x29, #0xe0
+               	add	x2, x1, #0x0
+               	mov	x17, #0x1               ; =1
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x0
+               	str	q0, [x1]
+               	sub	x1, x29, #0xf0
+               	add	x2, x1, #0x0
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xffff00000000    ; =281470681743360
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x20, #0x10
+               	str	q0, [x1]
+               	sub	x1, x29, #0x100
+               	add	x2, x1, #0x0
+               	mov	x17, #0xffff00000000    ; =281470681743360
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
+               	sub	x1, x29, #0x110
+               	add	x2, x1, #0x0
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x20, #0x20
+               	str	q0, [x1]
+               	sub	x1, x29, #0x120
+               	add	x2, x1, #0x0
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x20
+               	str	q0, [x1]
+               	sub	x1, x29, #0x130
+               	add	x2, x1, #0x0
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xdef0            ; =57072
+               	movk	x17, #0x9abc, lsl #16
+               	movk	x17, #0x5678, lsl #32
+               	movk	x17, #0x1234, lsl #48
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x20, #0x30
+               	str	q0, [x1]
+               	sub	x1, x29, #0x140
+               	add	x2, x1, #0x0
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xdef0            ; =57072
+               	movk	x17, #0x9abc, lsl #16
+               	movk	x17, #0x5678, lsl #32
+               	movk	x17, #0x1234, lsl #48
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x30
+               	str	q0, [x1]
+               	sub	x1, x29, #0x150
+               	add	x2, x1, #0x0
+               	mov	x17, #0x200000000       ; =8589934592
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	str	xzr, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x20, #0x40
+               	str	q0, [x1]
+               	sub	x1, x29, #0x160
+               	add	x2, x1, #0x0
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x40
+               	str	q0, [x1]
+               	sub	x1, x29, #0x170
+               	add	x2, x1, #0x0
+               	mov	x17, #0x10a             ; =266
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x20, #0x50
+               	str	q0, [x1]
+               	sub	x1, x29, #0x180
+               	add	x2, x1, #0x0
+               	mov	x17, #0xa               ; =10
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	str	xzr, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x50
+               	str	q0, [x1]
+               	mov	x22, x0
+               	mov	x23, #0x0               ; =0
+               	cmp	x23, #0x6
+               	b.lo	 <L3>
+               	b	 <L18>
+<L3>:
+               	mov	x16, #0x10              ; =16
+               	mul	x0, x23, x16
+               	add	x1, x20, x0
+               	ldr	q0, [x1]
+               	mov	x16, #0x10              ; =16
+               	mul	x0, x23, x16
+               	add	x1, x21, x0
+               	ldr	q1, [x1]
+               	mov.d	x0, v0[0]
+               	add	x1, x0, x19
+               	mov.16b	v30, v0
+               	mov.d	v30[0], x1
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q30, [x29, x16]
+               	mov.d	x0, v1[1]
+               	add	x1, x0, x19
+               	mov.16b	v30, v1
+               	mov.d	v30[1], x1
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q30, [x29, x16]
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmgt.2d	v31, v31, v30
+               	mov	x16, #0xfd10            ; =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfd10            ; =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+               	mov	x0, x22
+<L4>:
+               	bl	 <L4>
+               	mov	x16, #0xfd10            ; =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L5>:
+               	bl	 <L5>
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmge.2d	v31, v31, v30
+               	mov	x16, #0xfd00            ; =64768
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfd00            ; =64768
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+<L6>:
+               	bl	 <L6>
+               	mov	x16, #0xfd00            ; =64768
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L7>:
+               	bl	 <L7>
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmgt.2d	v31, v31, v30
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+<L8>:
+               	bl	 <L8>
+               	mov	x16, #0xfcf0            ; =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L9>:
+               	bl	 <L9>
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmge.2d	v31, v31, v30
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+<L10>:
+               	bl	 <L10>
+               	mov	x16, #0xfce0            ; =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L11>:
+               	bl	 <L11>
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq.2d	v31, v31, v30
+               	mov	x16, #0xfcd0            ; =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfcd0            ; =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+<L12>:
+               	bl	 <L12>
+               	mov	x16, #0xfcd0            ; =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L13>:
+               	bl	 <L13>
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq.2d	v31, v31, v30
+               	mvn.16b	v31, v31
+               	mov	x16, #0xfcc0            ; =64704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfcc0            ; =64704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+<L14>:
+               	bl	 <L14>
+               	mov	x16, #0xfcc0            ; =64704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L15>:
+               	bl	 <L15>
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmgt.2d	v0, v31, v30
+               	mov	x16, #0xfd30            ; =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v1, v0, v30
+               	mvn.16b	v2, v0
+               	mov	x16, #0xfd20            ; =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v0, v2, v30
+               	orr.16b	v31, v1, v0
+               	mov	x16, #0xfcb0            ; =64688
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfcb0            ; =64688
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+<L16>:
+               	bl	 <L16>
+               	mov	x16, #0xfcb0            ; =64688
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L17>:
+               	bl	 <L17>
+               	add	x23, x23, #0x1
+               	mov	x22, x0
+               	cmp	x23, #0x6
+               	b.lo	 <L3>
+<L18>:
+               	sub	x20, x29, #0x1d0
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x50               ; =80
+<L19>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L19>
+               	sub	x21, x29, #0x220
+               	add	x0, x21, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x50               ; =80
+<L20>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L20>
+               	sub	x0, x29, #0x230
+               	add	x1, x0, #0x0
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x0
+               	str	q0, [x0]
+               	sub	x0, x29, #0x240
+               	add	x1, x0, #0x0
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #-0x8000000000000000 ; =-9223372036854775808
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x0
+               	str	q0, [x0]
+               	sub	x0, x29, #0x250
+               	add	x1, x0, #0x0
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #0x1               ; =1
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x10
+               	str	q0, [x0]
+               	sub	x0, x29, #0x260
+               	add	x1, x0, #0x0
+               	mov	x17, #0x1               ; =1
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x10
+               	str	q0, [x0]
+               	sub	x0, x29, #0x270
+               	add	x1, x0, #0x0
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	str	xzr, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x20
+               	str	q0, [x0]
+               	sub	x0, x29, #0x280
+               	add	x1, x0, #0x0
+               	str	xzr, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x20
+               	str	q0, [x0]
+               	sub	x0, x29, #0x290
+               	add	x1, x0, #0x0
+               	mov	x17, #0x80000000        ; =2147483648
+               	movk	x17, #0x8000, lsl #48
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #0xffff00000000    ; =281470681743360
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x30
+               	str	q0, [x0]
+               	sub	x0, x29, #0x2a0
+               	add	x1, x0, #0x0
+               	mov	x17, #0x80000000        ; =2147483648
+               	movk	x17, #0x8000, lsl #48
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xfffe, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x30
+               	str	q0, [x0]
+               	sub	x0, x29, #0x2b0
+               	add	x1, x0, #0x0
+               	mov	x17, #0x10a             ; =266
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #0xffff            ; =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x40
+               	str	q0, [x0]
+               	sub	x0, x29, #0x2c0
+               	add	x1, x0, #0x0
+               	mov	x17, #0xa               ; =10
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	str	xzr, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x40
+               	str	q0, [x0]
+               	mov	x23, #0x0               ; =0
+               	cmp	x23, #0x5
+               	b.lo	 <L21>
+               	b	 <L36>
+<L21>:
+               	mov	x16, #0x10              ; =16
+               	mul	x0, x23, x16
+               	add	x1, x20, x0
+               	ldr	q0, [x1]
+               	mov	x16, #0x10              ; =16
+               	mul	x0, x23, x16
+               	add	x1, x21, x0
+               	ldr	q1, [x1]
+               	mov.d	x0, v0[0]
+               	add	x1, x0, x19
+               	mov.16b	v30, v0
+               	mov.d	v30[0], x1
+               	mov	x16, #0xfca0            ; =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q30, [x29, x16]
+               	mov.d	x0, v1[1]
+               	add	x1, x0, x19
+               	mov.16b	v30, v1
+               	mov.d	v30[1], x1
+               	mov	x16, #0xfc90            ; =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q30, [x29, x16]
+               	mov	x16, #0xfc90            ; =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfca0            ; =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhi.2d	v31, v31, v30
+               	mov	x16, #0xfc80            ; =64640
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfc80            ; =64640
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+               	mov	x0, x22
+<L22>:
+               	bl	 <L22>
+               	mov	x16, #0xfc80            ; =64640
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L23>:
+               	bl	 <L23>
+               	mov	x16, #0xfc90            ; =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfca0            ; =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhs.2d	v31, v31, v30
+               	mov	x16, #0xfc70            ; =64624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfc70            ; =64624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+<L24>:
+               	bl	 <L24>
+               	mov	x16, #0xfc70            ; =64624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L25>:
+               	bl	 <L25>
+               	mov	x16, #0xfca0            ; =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfc90            ; =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhi.2d	v31, v31, v30
+               	mov	x16, #0xfc60            ; =64608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfc60            ; =64608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+<L26>:
+               	bl	 <L26>
+               	mov	x16, #0xfc60            ; =64608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L27>:
+               	bl	 <L27>
+               	mov	x16, #0xfca0            ; =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfc90            ; =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhs.2d	v31, v31, v30
+               	mov	x16, #0xfc50            ; =64592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfc50            ; =64592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+<L28>:
+               	bl	 <L28>
+               	mov	x16, #0xfc50            ; =64592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L29>:
+               	bl	 <L29>
+               	mov	x16, #0xfca0            ; =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfc90            ; =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq.2d	v31, v31, v30
+               	mov	x16, #0xfc40            ; =64576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfc40            ; =64576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+<L30>:
+               	bl	 <L30>
+               	mov	x16, #0xfc40            ; =64576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L31>:
+               	bl	 <L31>
+               	mov	x16, #0xfca0            ; =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfc90            ; =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq.2d	v31, v31, v30
+               	mvn.16b	v31, v31
+               	mov	x16, #0xfc30            ; =64560
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfc30            ; =64560
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+<L32>:
+               	bl	 <L32>
+               	mov	x16, #0xfc30            ; =64560
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L33>:
+               	bl	 <L33>
+               	mov	x16, #0xfc90            ; =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfca0            ; =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhi.2d	v0, v31, v30
+               	mov	x16, #0xfca0            ; =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v1, v0, v30
+               	mvn.16b	v2, v0
+               	mov	x16, #0xfc90            ; =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and.16b	v0, v2, v30
+               	orr.16b	v31, v1, v0
+               	mov	x16, #0xfc20            ; =64544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfc20            ; =64544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[0]
+<L34>:
+               	bl	 <L34>
+               	mov	x16, #0xfc20            ; =64544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov.d	x1, v31[1]
+<L35>:
+               	bl	 <L35>
+               	add	x23, x23, #0x1
+               	mov	x22, x0
+               	cmp	x23, #0x5
+               	b.lo	 <L21>
+<L36>:
+               	mov	x0, x22
+               	sub	x16, x29, #0x3f0
+               	ldp	x19, x20, [x16]
+               	ldp	x21, x22, [x16, #-0x10]
+               	ldur	x23, [x16, #-0x18]
+               	mov	sp, x29
+               	ldp	x29, x30, [sp], #0x10
+               	ret

--- a/test/golden/aarch64-linux/vec/vec_cmp_i64.dis
+++ b/test/golden/aarch64-linux/vec/vec_cmp_i64.dis
@@ -1,0 +1,941 @@
+vec/vec_cmp_i64.o:
+
+Disassembly of section .text:
+
+<corpus.cases.vec.vec_cmp_i64.fold_u64x2>:
+               	stp	x29, x30, [sp, #-0x10]!
+               	mov	x29, sp
+               	sub	sp, sp, #0x10
+               	mov	x1, x0
+               	stur	q0, [x29, #-0x10]
+               	ldur	q31, [x29, #-0x10]
+               	mov	x2, v31.d[0]
+               	mov	x0, x1
+               	mov	x1, x2
+<L0>:
+               	bl	 <L0>
+               	mov	x1, x0
+               	ldur	q31, [x29, #-0x10]
+               	mov	x2, v31.d[1]
+               	mov	x0, x1
+               	mov	x1, x2
+<L1>:
+               	bl	 <L1>
+               	mov	sp, x29
+               	ldp	x29, x30, [sp], #0x10
+               	ret
+
+<corpus.cases.vec.vec_cmp_i64.fold_i64x2>:
+               	stp	x29, x30, [sp, #-0x10]!
+               	mov	x29, sp
+               	sub	sp, sp, #0x10
+               	mov	x1, x0
+               	stur	q0, [x29, #-0x10]
+               	ldur	q31, [x29, #-0x10]
+               	mov	x2, v31.d[0]
+               	mov	x0, x1
+               	mov	x1, x2
+<L0>:
+               	bl	 <L0>
+               	mov	x1, x0
+               	ldur	q31, [x29, #-0x10]
+               	mov	x2, v31.d[1]
+               	mov	x0, x1
+               	mov	x1, x2
+<L1>:
+               	bl	 <L1>
+               	mov	sp, x29
+               	ldp	x29, x30, [sp], #0x10
+               	ret
+
+<corpus.cases.vec.vec_cmp_i64.checksum>:
+               	stp	x29, x30, [sp, #-0x10]!
+               	mov	x29, sp
+               	sub	sp, sp, #0x410
+               	sub	x16, x29, #0x3f0
+               	stp	x19, x20, [x16]
+               	stp	x21, x22, [x16, #-0x10]
+               	stur	x23, [x16, #-0x18]
+               	mov	x19, x0
+<L0>:
+               	bl	 <L0>
+               	sub	x20, x29, #0x60
+               	add	x1, x20, #0x0
+               	add	x2, x1, #0x0
+               	mov	x1, #0x60               // =96
+<L1>:
+               	str	xzr, [x2]
+               	add	x2, x2, #0x8
+               	sub	x1, x1, #0x8
+               	cmp	x1, #0x0
+               	b.ne	 <L1>
+               	sub	x21, x29, #0xc0
+               	add	x1, x21, #0x0
+               	add	x2, x1, #0x0
+               	mov	x1, #0x60               // =96
+<L2>:
+               	str	xzr, [x2]
+               	add	x2, x2, #0x8
+               	sub	x1, x1, #0x8
+               	cmp	x1, #0x0
+               	b.ne	 <L2>
+               	sub	x1, x29, #0xd0
+               	add	x2, x1, #0x0
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0x1               // =1
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x20, #0x0
+               	str	q0, [x1]
+               	sub	x1, x29, #0xe0
+               	add	x2, x1, #0x0
+               	mov	x17, #0x1               // =1
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x0
+               	str	q0, [x1]
+               	sub	x1, x29, #0xf0
+               	add	x2, x1, #0x0
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xffff00000000    // =281470681743360
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x20, #0x10
+               	str	q0, [x1]
+               	sub	x1, x29, #0x100
+               	add	x2, x1, #0x0
+               	mov	x17, #0xffff00000000    // =281470681743360
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x10
+               	str	q0, [x1]
+               	sub	x1, x29, #0x110
+               	add	x2, x1, #0x0
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x20, #0x20
+               	str	q0, [x1]
+               	sub	x1, x29, #0x120
+               	add	x2, x1, #0x0
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x20
+               	str	q0, [x1]
+               	sub	x1, x29, #0x130
+               	add	x2, x1, #0x0
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xdef0            // =57072
+               	movk	x17, #0x9abc, lsl #16
+               	movk	x17, #0x5678, lsl #32
+               	movk	x17, #0x1234, lsl #48
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x20, #0x30
+               	str	q0, [x1]
+               	sub	x1, x29, #0x140
+               	add	x2, x1, #0x0
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xdef0            // =57072
+               	movk	x17, #0x9abc, lsl #16
+               	movk	x17, #0x5678, lsl #32
+               	movk	x17, #0x1234, lsl #48
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x30
+               	str	q0, [x1]
+               	sub	x1, x29, #0x150
+               	add	x2, x1, #0x0
+               	mov	x17, #0x200000000       // =8589934592
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	str	xzr, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x20, #0x40
+               	str	q0, [x1]
+               	sub	x1, x29, #0x160
+               	add	x2, x1, #0x0
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x40
+               	str	q0, [x1]
+               	sub	x1, x29, #0x170
+               	add	x2, x1, #0x0
+               	mov	x17, #0x10a             // =266
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x20, #0x50
+               	str	q0, [x1]
+               	sub	x1, x29, #0x180
+               	add	x2, x1, #0x0
+               	mov	x17, #0xa               // =10
+               	str	x17, [x2]
+               	add	x2, x1, #0x8
+               	str	xzr, [x2]
+               	ldr	q0, [x1]
+               	add	x1, x21, #0x50
+               	str	q0, [x1]
+               	mov	x22, x0
+               	mov	x23, #0x0               // =0
+               	cmp	x23, #0x6
+               	b.lo	 <L3>
+               	b	 <L18>
+<L3>:
+               	mov	x16, #0x10              // =16
+               	mul	x0, x23, x16
+               	add	x1, x20, x0
+               	ldr	q0, [x1]
+               	mov	x16, #0x10              // =16
+               	mul	x0, x23, x16
+               	add	x1, x21, x0
+               	ldr	q1, [x1]
+               	mov	x0, v0.d[0]
+               	add	x1, x0, x19
+               	mov	v30.16b, v0.16b
+               	mov	v30.d[0], x1
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q30, [x29, x16]
+               	mov	x0, v1.d[1]
+               	add	x1, x0, x19
+               	mov	v30.16b, v1.16b
+               	mov	v30.d[1], x1
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q30, [x29, x16]
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmgt	v31.2d, v31.2d, v30.2d
+               	mov	x16, #0xfd10            // =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfd10            // =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+               	mov	x0, x22
+<L4>:
+               	bl	 <L4>
+               	mov	x16, #0xfd10            // =64784
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L5>:
+               	bl	 <L5>
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmge	v31.2d, v31.2d, v30.2d
+               	mov	x16, #0xfd00            // =64768
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfd00            // =64768
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+<L6>:
+               	bl	 <L6>
+               	mov	x16, #0xfd00            // =64768
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L7>:
+               	bl	 <L7>
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmgt	v31.2d, v31.2d, v30.2d
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+<L8>:
+               	bl	 <L8>
+               	mov	x16, #0xfcf0            // =64752
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L9>:
+               	bl	 <L9>
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmge	v31.2d, v31.2d, v30.2d
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+<L10>:
+               	bl	 <L10>
+               	mov	x16, #0xfce0            // =64736
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L11>:
+               	bl	 <L11>
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq	v31.2d, v31.2d, v30.2d
+               	mov	x16, #0xfcd0            // =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfcd0            // =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+<L12>:
+               	bl	 <L12>
+               	mov	x16, #0xfcd0            // =64720
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L13>:
+               	bl	 <L13>
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq	v31.2d, v31.2d, v30.2d
+               	mvn	v31.16b, v31.16b
+               	mov	x16, #0xfcc0            // =64704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfcc0            // =64704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+<L14>:
+               	bl	 <L14>
+               	mov	x16, #0xfcc0            // =64704
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L15>:
+               	bl	 <L15>
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmgt	v0.2d, v31.2d, v30.2d
+               	mov	x16, #0xfd30            // =64816
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v1.16b, v0.16b, v30.16b
+               	mvn	v2.16b, v0.16b
+               	mov	x16, #0xfd20            // =64800
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v0.16b, v2.16b, v30.16b
+               	orr	v31.16b, v1.16b, v0.16b
+               	mov	x16, #0xfcb0            // =64688
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfcb0            // =64688
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+<L16>:
+               	bl	 <L16>
+               	mov	x16, #0xfcb0            // =64688
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L17>:
+               	bl	 <L17>
+               	add	x23, x23, #0x1
+               	mov	x22, x0
+               	cmp	x23, #0x6
+               	b.lo	 <L3>
+<L18>:
+               	sub	x20, x29, #0x1d0
+               	add	x0, x20, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x50               // =80
+<L19>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L19>
+               	sub	x21, x29, #0x220
+               	add	x0, x21, #0x0
+               	add	x1, x0, #0x0
+               	mov	x0, #0x50               // =80
+<L20>:
+               	str	xzr, [x1]
+               	add	x1, x1, #0x8
+               	sub	x0, x0, #0x8
+               	cmp	x0, #0x0
+               	b.ne	 <L20>
+               	sub	x0, x29, #0x230
+               	add	x1, x0, #0x0
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x0
+               	str	q0, [x0]
+               	sub	x0, x29, #0x240
+               	add	x1, x0, #0x0
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0x7fff, lsl #48
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #-0x8000000000000000 // =-9223372036854775808
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x0
+               	str	q0, [x0]
+               	sub	x0, x29, #0x250
+               	add	x1, x0, #0x0
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #0x1               // =1
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x10
+               	str	q0, [x0]
+               	sub	x0, x29, #0x260
+               	add	x1, x0, #0x0
+               	mov	x17, #0x1               // =1
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0x1, lsl #32
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x10
+               	str	q0, [x0]
+               	sub	x0, x29, #0x270
+               	add	x1, x0, #0x0
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	str	xzr, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x20
+               	str	q0, [x0]
+               	sub	x0, x29, #0x280
+               	add	x1, x0, #0x0
+               	str	xzr, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x20
+               	str	q0, [x0]
+               	sub	x0, x29, #0x290
+               	add	x1, x0, #0x0
+               	mov	x17, #0x80000000        // =2147483648
+               	movk	x17, #0x8000, lsl #48
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #0xffff00000000    // =281470681743360
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x30
+               	str	q0, [x0]
+               	sub	x0, x29, #0x2a0
+               	add	x1, x0, #0x0
+               	mov	x17, #0x80000000        // =2147483648
+               	movk	x17, #0x8000, lsl #48
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xfffe, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x30
+               	str	q0, [x0]
+               	sub	x0, x29, #0x2b0
+               	add	x1, x0, #0x0
+               	mov	x17, #0x10a             // =266
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	mov	x17, #0xffff            // =65535
+               	movk	x17, #0xffff, lsl #16
+               	movk	x17, #0xffff, lsl #32
+               	movk	x17, #0xffff, lsl #48
+               	str	x17, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x20, #0x40
+               	str	q0, [x0]
+               	sub	x0, x29, #0x2c0
+               	add	x1, x0, #0x0
+               	mov	x17, #0xa               // =10
+               	str	x17, [x1]
+               	add	x1, x0, #0x8
+               	str	xzr, [x1]
+               	ldr	q0, [x0]
+               	add	x0, x21, #0x40
+               	str	q0, [x0]
+               	mov	x23, #0x0               // =0
+               	cmp	x23, #0x5
+               	b.lo	 <L21>
+               	b	 <L36>
+<L21>:
+               	mov	x16, #0x10              // =16
+               	mul	x0, x23, x16
+               	add	x1, x20, x0
+               	ldr	q0, [x1]
+               	mov	x16, #0x10              // =16
+               	mul	x0, x23, x16
+               	add	x1, x21, x0
+               	ldr	q1, [x1]
+               	mov	x0, v0.d[0]
+               	add	x1, x0, x19
+               	mov	v30.16b, v0.16b
+               	mov	v30.d[0], x1
+               	mov	x16, #0xfca0            // =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q30, [x29, x16]
+               	mov	x0, v1.d[1]
+               	add	x1, x0, x19
+               	mov	v30.16b, v1.16b
+               	mov	v30.d[1], x1
+               	mov	x16, #0xfc90            // =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q30, [x29, x16]
+               	mov	x16, #0xfc90            // =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfca0            // =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhi	v31.2d, v31.2d, v30.2d
+               	mov	x16, #0xfc80            // =64640
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfc80            // =64640
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+               	mov	x0, x22
+<L22>:
+               	bl	 <L22>
+               	mov	x16, #0xfc80            // =64640
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L23>:
+               	bl	 <L23>
+               	mov	x16, #0xfc90            // =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfca0            // =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhs	v31.2d, v31.2d, v30.2d
+               	mov	x16, #0xfc70            // =64624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfc70            // =64624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+<L24>:
+               	bl	 <L24>
+               	mov	x16, #0xfc70            // =64624
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L25>:
+               	bl	 <L25>
+               	mov	x16, #0xfca0            // =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfc90            // =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhi	v31.2d, v31.2d, v30.2d
+               	mov	x16, #0xfc60            // =64608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfc60            // =64608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+<L26>:
+               	bl	 <L26>
+               	mov	x16, #0xfc60            // =64608
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L27>:
+               	bl	 <L27>
+               	mov	x16, #0xfca0            // =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfc90            // =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhs	v31.2d, v31.2d, v30.2d
+               	mov	x16, #0xfc50            // =64592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfc50            // =64592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+<L28>:
+               	bl	 <L28>
+               	mov	x16, #0xfc50            // =64592
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L29>:
+               	bl	 <L29>
+               	mov	x16, #0xfca0            // =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfc90            // =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq	v31.2d, v31.2d, v30.2d
+               	mov	x16, #0xfc40            // =64576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfc40            // =64576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+<L30>:
+               	bl	 <L30>
+               	mov	x16, #0xfc40            // =64576
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L31>:
+               	bl	 <L31>
+               	mov	x16, #0xfca0            // =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfc90            // =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmeq	v31.2d, v31.2d, v30.2d
+               	mvn	v31.16b, v31.16b
+               	mov	x16, #0xfc30            // =64560
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfc30            // =64560
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+<L32>:
+               	bl	 <L32>
+               	mov	x16, #0xfc30            // =64560
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L33>:
+               	bl	 <L33>
+               	mov	x16, #0xfc90            // =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x16, #0xfca0            // =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	cmhi	v0.2d, v31.2d, v30.2d
+               	mov	x16, #0xfca0            // =64672
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v1.16b, v0.16b, v30.16b
+               	mvn	v2.16b, v0.16b
+               	mov	x16, #0xfc90            // =64656
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q30, [x29, x16]
+               	and	v0.16b, v2.16b, v30.16b
+               	orr	v31.16b, v1.16b, v0.16b
+               	mov	x16, #0xfc20            // =64544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	str	q31, [x29, x16]
+               	mov	x16, #0xfc20            // =64544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[0]
+<L34>:
+               	bl	 <L34>
+               	mov	x16, #0xfc20            // =64544
+               	movk	x16, #0xffff, lsl #16
+               	movk	x16, #0xffff, lsl #32
+               	movk	x16, #0xffff, lsl #48
+               	ldr	q31, [x29, x16]
+               	mov	x1, v31.d[1]
+<L35>:
+               	bl	 <L35>
+               	add	x23, x23, #0x1
+               	mov	x22, x0
+               	cmp	x23, #0x5
+               	b.lo	 <L21>
+<L36>:
+               	mov	x0, x22
+               	sub	x16, x29, #0x3f0
+               	ldp	x19, x20, [x16]
+               	ldp	x21, x22, [x16, #-0x10]
+               	ldur	x23, [x16, #-0x18]
+               	mov	sp, x29
+               	ldp	x29, x30, [sp], #0x10
+               	ret

--- a/test/golden/riscv64-linux/vec/vec_cmp_i64.dis
+++ b/test/golden/riscv64-linux/vec/vec_cmp_i64.dis
@@ -1,0 +1,3020 @@
+vec/vec_cmp_i64.o:
+
+Disassembly of section .text:
+
+<corpus.cases.vec.vec_cmp_i64.fold_u64x2>:
+               	addi	sp, sp, -0x40
+               	sd	ra, 0x38(sp)
+               	sd	s0, 0x30(sp)
+               	addi	s0, sp, 0x40
+               	sd	s1, 0x28(sp)
+               	mv	a2, a0
+               	mv	s1, a1
+               	addi	a1, s0, -0x28
+               	addi	a1, s0, -0x38
+               	mv	a1, s1
+               	ld	a3, 0x0(a1)
+               	mv	a0, a2
+               	mv	a1, a3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.fold_u64x2+0x34>
+               	mv	a1, a0
+               	addi	a2, s1, 0x8
+               	ld	a3, 0x0(a2)
+               	mv	a0, a1
+               	mv	a1, a3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.fold_u64x2+0x50>
+               	ld	s1, 0x28(sp)
+               	ld	ra, 0x38(sp)
+               	ld	s0, 0x30(sp)
+               	addi	sp, sp, 0x40
+               	ret
+
+<corpus.cases.vec.vec_cmp_i64.fold_i64x2>:
+               	addi	sp, sp, -0x40
+               	sd	ra, 0x38(sp)
+               	sd	s0, 0x30(sp)
+               	addi	s0, sp, 0x40
+               	sd	s1, 0x28(sp)
+               	mv	a2, a0
+               	mv	s1, a1
+               	addi	a1, s0, -0x28
+               	addi	a1, s0, -0x38
+               	mv	a1, s1
+               	ld	a3, 0x0(a1)
+               	mv	a0, a2
+               	mv	a1, a3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.fold_i64x2+0x34>
+               	mv	a1, a0
+               	addi	a2, s1, 0x8
+               	ld	a3, 0x0(a2)
+               	mv	a0, a1
+               	mv	a1, a3
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.fold_i64x2+0x50>
+               	ld	s1, 0x28(sp)
+               	ld	ra, 0x38(sp)
+               	ld	s0, 0x30(sp)
+               	addi	sp, sp, 0x40
+               	ret
+
+<corpus.cases.vec.vec_cmp_i64.checksum>:
+               	lui	t0, 0x1
+               	addiw	t0, t0, -0x330
+               	sub	sp, sp, t0
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x338
+               	add	t1, sp, t1
+               	sd	ra, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x340
+               	add	t1, sp, t1
+               	sd	s0, 0x0(t1)
+               	lui	t0, 0x1
+               	addiw	t0, t0, -0x330
+               	add	s0, sp, t0
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x348
+               	add	t1, sp, t1
+               	sd	s1, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x350
+               	add	t1, sp, t1
+               	sd	s2, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x358
+               	add	t1, sp, t1
+               	sd	s3, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x360
+               	add	t1, sp, t1
+               	sd	s4, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x368
+               	add	t1, sp, t1
+               	sd	s5, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x370
+               	add	t1, sp, t1
+               	sd	s6, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x378
+               	add	t1, sp, t1
+               	sd	s7, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x380
+               	add	t1, sp, t1
+               	sd	s8, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x388
+               	add	t1, sp, t1
+               	sd	s9, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x390
+               	add	t1, sp, t1
+               	sd	s10, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x398
+               	add	t1, sp, t1
+               	sd	s11, 0x0(t1)
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x500
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	s2, s0, -0x78
+               	addi	s3, s0, -0x88
+               	addi	s4, s0, -0x98
+               	addi	s5, s0, -0xa8
+               	addi	s6, s0, -0xb8
+               	addi	s7, s0, -0xc8
+               	addi	s8, s0, -0xd8
+               	addi	s9, s0, -0xe8
+               	addi	s10, s0, -0xf8
+               	addi	s11, s0, -0x108
+               	addi	t2, s0, -0x118
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x378
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x128
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x138
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3d0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x148
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x368
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a5, s0, -0x158
+               	addi	a5, s0, -0x168
+               	addi	t2, s0, -0x178
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a6, s0, -0x188
+               	addi	a6, s0, -0x198
+               	addi	t2, s0, -0x1a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x1b8
+               	addi	a7, s0, -0x1c8
+               	addi	t2, s0, -0x1d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t5, s0, -0x1e8
+               	addi	t5, s0, -0x1f8
+               	addi	t2, s0, -0x208
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t6, s0, -0x218
+               	addi	t6, s0, -0x228
+               	addi	t2, s0, -0x238
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	s1, s0, -0x248
+               	addi	s1, s0, -0x258
+               	addi	t2, s0, -0x268
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x278
+               	addi	a7, s0, -0x288
+               	addi	t2, s0, -0x298
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t5, s0, -0x2a8
+               	addi	t5, s0, -0x2b8
+               	addi	t2, s0, -0x2c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t6, s0, -0x2d8
+               	addi	t6, s0, -0x2e8
+               	addi	t2, s0, -0x2f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x350
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	s1, s0, -0x308
+               	addi	s1, s0, -0x318
+               	addi	t2, s0, -0x328
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x338
+               	addi	t2, s0, -0x348
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t5, s0, -0x358
+               	addi	t2, s0, -0x368
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x460
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x378
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x458
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x388
+               	addi	t2, s0, -0x398
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x450
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x3a8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x3b8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x3c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x3d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x3e8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x498
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x3f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x490
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x408
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x488
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x418
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x480
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x428
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x478
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x438
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x470
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x448
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x468
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t5, s0, -0x458
+               	addi	t5, s0, -0x468
+               	addi	t2, s0, -0x478
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	s1, s0, -0x488
+               	addi	s1, s0, -0x498
+               	addi	s1, s0, -0x4a8
+               	addi	a7, s0, -0x4b8
+               	addi	a7, s0, -0x4c8
+               	addi	t2, s0, -0x4d8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x448
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x4e8
+               	addi	a7, s0, -0x4f8
+               	addi	t2, s0, -0x508
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x440
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x518
+               	addi	a7, s0, -0x528
+               	addi	t2, s0, -0x538
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x438
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x548
+               	addi	a7, s0, -0x558
+               	addi	t2, s0, -0x568
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x430
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x578
+               	addi	a7, s0, -0x588
+               	addi	t2, s0, -0x598
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x428
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x5a8
+               	addi	a7, s0, -0x5b8
+               	addi	t2, s0, -0x5c8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x420
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x5d8
+               	addi	a7, s0, -0x5e8
+               	addi	t2, s0, -0x5f8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x418
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x608
+               	addi	a7, s0, -0x618
+               	addi	t2, s0, -0x628
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x410
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x638
+               	addi	t2, s0, -0x648
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x408
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x658
+               	addi	t2, s0, -0x668
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x400
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	t2, s0, -0x678
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3f8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a7, s0, -0x688
+               	addi	a7, s0, -0x698
+               	addi	a7, s0, -0x6a8
+               	addi	a7, s0, -0x6b8
+               	addi	a7, s0, -0x6c8
+               	addi	a7, s0, -0x6d8
+               	addi	a7, s0, -0x6e8
+               	addi	a7, s0, -0x6f8
+               	addi	a7, s0, -0x708
+               	addi	a7, s0, -0x718
+               	addi	a7, s0, -0x728
+               	addi	a7, s0, -0x738
+               	addi	a7, s0, -0x748
+               	addi	a7, s0, -0x758
+               	addi	a7, s0, -0x768
+               	addi	a7, s0, -0x778
+               	addi	a7, s0, -0x788
+               	addi	a7, s0, -0x798
+               	addi	a7, s0, -0x7a8
+               	addi	a7, s0, -0x7b8
+               	addi	a7, s0, -0x7c8
+               	addi	a7, s0, -0x7d8
+               	addi	a7, s0, -0x7e8
+               	addi	a7, s0, -0x7f8
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x7f8
+               	add	a7, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x7e8
+               	add	a7, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x7d8
+               	add	a7, s0, t0
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x7c8
+               	add	a7, s0, t0
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x5a0>
+               	mv	t2, a0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3f0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x768
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x340
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x340
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	mv	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3e8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x7
+               	and	a0, t2, t0
+               	bnez	a0, 0x770 <corpus.cases.vec.vec_cmp_i64.checksum+0x698>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3e8
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	mv	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3e0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	li	a0, 0x60
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sd	zero, 0x0(t2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	t2, t2, 0x8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3e0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, a0, -0x8
+               	li	t0, 0x0
+               	bne	a0, t0, 0x728 <corpus.cases.vec.vec_cmp_i64.checksum+0x650>
+               	j	0x7dc <corpus.cases.vec.vec_cmp_i64.checksum+0x704>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3e8
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	mv	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3d8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	li	a0, 0x60
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sb	zero, 0x0(t2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	t2, t2, 0x1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3d8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, a0, -0x1
+               	li	t0, 0x0
+               	bne	a0, t0, 0x798 <corpus.cases.vec.vec_cmp_i64.checksum+0x6c0>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x708
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x338
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x338
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	mv	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	li	t0, 0x7
+               	and	a0, t2, t0
+               	bnez	a0, 0x8a8 <corpus.cases.vec.vec_cmp_i64.checksum+0x7d0>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c8
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	mv	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	li	a0, 0x60
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sd	zero, 0x0(t2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	t2, t2, 0x8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, a0, -0x8
+               	li	t0, 0x0
+               	bne	a0, t0, 0x860 <corpus.cases.vec.vec_cmp_i64.checksum+0x788>
+               	j	0x914 <corpus.cases.vec.vec_cmp_i64.checksum+0x83c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3c8
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	mv	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	li	a0, 0x60
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sb	zero, 0x0(t2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	t2, t2, 0x1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, a0, -0x1
+               	li	t0, 0x0
+               	bne	a0, t0, 0x8d0 <corpus.cases.vec.vec_cmp_i64.checksum+0x7f8>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6f8
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	lui	t0, 0x200
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	lui	t0, 0x100
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1
+               	sd	t0, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a8
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	a0, s2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sd	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a0
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	addi	a0, s2, 0x8
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sd	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x340
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	mv	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x398
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	a0, s2
+               	ld	t2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x390
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x398
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x390
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	sd	t2, 0x0(a0)
+               	addi	a0, s2, 0x8
+               	ld	s2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x398
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	s2, 0x0(a0)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6e8
+               	add	t2, s0, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x388
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x388
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	s2, t2
+               	lui	t0, 0x100
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1
+               	sd	t0, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x388
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	s2, t2, 0x8
+               	lui	t0, 0x200
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x388
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	s2, t2
+               	ld	a0, 0x0(s2)
+               	mv	s2, s3
+               	sd	a0, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x388
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	s2, 0x0(a0)
+               	addi	a0, s3, 0x8
+               	sd	s2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x338
+               	add	t1, s0, t1
+               	ld	t3, 0x0(t1)
+               	mv	t2, t3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x380
+               	add	t1, s0, t1
+               	sd	t2, 0x0(t1)
+               	mv	s2, s3
+               	ld	a0, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x380
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	s2, t2
+               	sd	a0, 0x0(s2)
+               	addi	a0, s3, 0x8
+               	ld	s2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x380
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	s2, 0x0(a0)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6d8
+               	add	a0, s0, t0
+               	mv	s2, a0
+               	li	t0, -0x1
+               	sd	t0, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	lui	t0, 0xfff00
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(s2)
+               	mv	s2, a0
+               	ld	s3, 0x0(s2)
+               	mv	s2, s4
+               	sd	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	ld	a0, 0x0(s2)
+               	addi	s2, s4, 0x8
+               	sd	a0, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x10
+               	mv	s2, s4
+               	ld	s3, 0x0(s2)
+               	mv	s2, a0
+               	sd	s3, 0x0(s2)
+               	addi	s2, s4, 0x8
+               	ld	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	sd	s3, 0x0(s2)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6c8
+               	add	a0, s0, t0
+               	mv	s2, a0
+               	lui	t0, 0xfff00
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	li	t0, -0x1
+               	sd	t0, 0x0(s2)
+               	mv	s2, a0
+               	ld	s3, 0x0(s2)
+               	mv	s2, s5
+               	sd	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	ld	a0, 0x0(s2)
+               	addi	s2, s5, 0x8
+               	sd	a0, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x338
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x10
+               	mv	s2, s5
+               	ld	s3, 0x0(s2)
+               	mv	s2, a0
+               	sd	s3, 0x0(s2)
+               	addi	s2, s5, 0x8
+               	ld	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	sd	s3, 0x0(s2)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6b8
+               	add	a0, s0, t0
+               	mv	s2, a0
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(s2)
+               	mv	s2, a0
+               	ld	s3, 0x0(s2)
+               	mv	s2, s6
+               	sd	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	ld	a0, 0x0(s2)
+               	addi	s2, s6, 0x8
+               	sd	a0, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x20
+               	mv	s2, s6
+               	ld	s3, 0x0(s2)
+               	mv	s2, a0
+               	sd	s3, 0x0(s2)
+               	addi	s2, s6, 0x8
+               	ld	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	sd	s3, 0x0(s2)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x6a8
+               	add	a0, s0, t0
+               	mv	s2, a0
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(s2)
+               	mv	s2, a0
+               	ld	s3, 0x0(s2)
+               	mv	s2, s7
+               	sd	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	ld	a0, 0x0(s2)
+               	addi	s2, s7, 0x8
+               	sd	a0, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x338
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x20
+               	mv	s2, s7
+               	ld	s3, 0x0(s2)
+               	mv	s2, a0
+               	sd	s3, 0x0(s2)
+               	addi	s2, s7, 0x8
+               	ld	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	sd	s3, 0x0(s2)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x698
+               	add	a0, s0, t0
+               	mv	s2, a0
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	lui	t0, 0x1234
+               	addiw	t0, t0, 0x568
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x765
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x432
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x110
+               	sd	t0, 0x0(s2)
+               	mv	s2, a0
+               	ld	s3, 0x0(s2)
+               	mv	s2, s8
+               	sd	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	ld	a0, 0x0(s2)
+               	addi	s2, s8, 0x8
+               	sd	a0, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x30
+               	mv	s2, s8
+               	ld	s3, 0x0(s2)
+               	mv	s2, a0
+               	sd	s3, 0x0(s2)
+               	addi	s2, s8, 0x8
+               	ld	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	sd	s3, 0x0(s2)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x688
+               	add	a0, s0, t0
+               	mv	s2, a0
+               	li	t0, -0x1
+               	sd	t0, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	lui	t0, 0x1234
+               	addiw	t0, t0, 0x568
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x765
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x432
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x110
+               	sd	t0, 0x0(s2)
+               	mv	s2, a0
+               	ld	s3, 0x0(s2)
+               	mv	s2, s9
+               	sd	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	ld	a0, 0x0(s2)
+               	addi	s2, s9, 0x8
+               	sd	a0, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x338
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x30
+               	mv	s2, s9
+               	ld	s3, 0x0(s2)
+               	mv	s2, a0
+               	sd	s3, 0x0(s2)
+               	addi	s2, s9, 0x8
+               	ld	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	sd	s3, 0x0(s2)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x678
+               	add	a0, s0, t0
+               	mv	s2, a0
+               	lui	t0, 0x200
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	sd	zero, 0x0(s2)
+               	mv	s2, a0
+               	ld	s3, 0x0(s2)
+               	mv	s2, s10
+               	sd	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	ld	a0, 0x0(s2)
+               	addi	s2, s10, 0x8
+               	sd	a0, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x40
+               	mv	s2, s10
+               	ld	s3, 0x0(s2)
+               	mv	s2, a0
+               	sd	s3, 0x0(s2)
+               	addi	s2, s10, 0x8
+               	ld	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	sd	s3, 0x0(s2)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x668
+               	add	a0, s0, t0
+               	mv	s2, a0
+               	lui	t0, 0x200
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	li	t0, -0x1
+               	sd	t0, 0x0(s2)
+               	mv	s2, a0
+               	ld	s3, 0x0(s2)
+               	mv	s2, s11
+               	sd	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	ld	a0, 0x0(s2)
+               	addi	s2, s11, 0x8
+               	sd	a0, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x338
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x40
+               	mv	s2, s11
+               	ld	s3, 0x0(s2)
+               	mv	s2, a0
+               	sd	s3, 0x0(s2)
+               	addi	s2, s11, 0x8
+               	ld	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	sd	s3, 0x0(s2)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x658
+               	add	a0, s0, t0
+               	mv	s2, a0
+               	li	t0, 0x10a
+               	sd	t0, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	li	t0, -0x1
+               	sd	t0, 0x0(s2)
+               	mv	s2, a0
+               	ld	s3, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x378
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	s2, t2
+               	sd	s3, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	ld	a0, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x378
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	s2, t2, 0x8
+               	sd	a0, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x50
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x378
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	s2, t2
+               	ld	s3, 0x0(s2)
+               	mv	s2, a0
+               	sd	s3, 0x0(s2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x378
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	s2, t2, 0x8
+               	ld	a1, 0x0(s2)
+               	addi	s2, a0, 0x8
+               	sd	a1, 0x0(s2)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x648
+               	add	a0, s0, t0
+               	mv	a1, a0
+               	li	t0, 0xa
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	zero, 0x0(a1)
+               	mv	a1, a0
+               	ld	s2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	s2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x338
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x50
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	s2, 0x0(a1)
+               	mv	a1, a0
+               	sd	s2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x370
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	s2, t2
+               	li	s3, 0x0
+               	li	t0, 0x6
+               	bltu	s3, t0, 0x1160 <corpus.cases.vec.vec_cmp_i64.checksum+0x1088>
+               	j	0x1c88 <corpus.cases.vec.vec_cmp_i64.checksum+0x1bb0>
+               	li	t0, 0x10
+               	mul	a0, s3, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x340
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	add	a1, t2, a0
+               	mv	a0, a1
+               	ld	a2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	sd	a2, 0x0(a0)
+               	addi	a0, a1, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	li	t0, 0x10
+               	mul	a0, s3, t0
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x338
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	add	a1, t2, a0
+               	mv	a0, a1
+               	ld	a2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x368
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	sd	a2, 0x0(a0)
+               	addi	a0, a1, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x368
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x500
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	add	a0, a1, t2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x368
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x500
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	add	a0, a1, t2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x368
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x368
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	a2, 0x0(a0)
+               	slt	a0, a1, a2
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	sub	a0, t1, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a2, 0x0(a0)
+               	slt	a0, a1, a2
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	sub	a0, t1, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	a1, 0x0(a0)
+               	mv	a0, s2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1354>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1378>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	s4, 0x0(a1)
+               	slt	a1, s4, a2
+               	xori	a1, a1, 0x1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	s4, 0x0(a1)
+               	slt	a1, s4, a2
+               	xori	a1, a1, 0x1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1454>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4f0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1478>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	s4, 0x0(a1)
+               	slt	a1, a2, s4
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	s4, 0x0(a1)
+               	slt	a1, a2, s4
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x154c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1570>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	s4, 0x0(a1)
+               	slt	a1, s4, a2
+               	xori	a1, a1, 0x1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	s4, 0x0(a1)
+               	slt	a1, s4, a2
+               	xori	a1, a1, 0x1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x164c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4e0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1670>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	s4, 0x0(a1)
+               	xor	a1, a2, s4
+               	seqz	a1, a1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	s4, 0x0(a1)
+               	xor	a1, a2, s4
+               	seqz	a1, a1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x174c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1770>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	s4, 0x0(a1)
+               	xor	a1, a2, s4
+               	snez	a1, a1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	s4, 0x0(a1)
+               	xor	a1, a2, s4
+               	snez	a1, a1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x184c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4d0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1870>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	s4, 0x0(a1)
+               	slt	a1, a2, s4
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x350
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	s4, 0x0(a1)
+               	slt	a1, a2, s4
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x350
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x350
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	s4, 0x0(a1)
+               	and	a1, a2, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x350
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x360
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	s4, 0x0(a1)
+               	and	a1, a2, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x350
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	not	a1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x350
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	not	a1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	s4, 0x0(a1)
+               	and	a1, a2, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x460
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x358
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	s4, 0x0(a1)
+               	and	a1, a2, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x460
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x460
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	s4, 0x0(a1)
+               	or	a1, a2, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x458
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4c8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x460
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	s4, 0x0(a1)
+               	or	a1, a2, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x458
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x458
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1b74>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x458
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x1b98>
+               	addi	s3, s3, 0x1
+               	mv	s2, a0
+               	li	t0, 0x6
+               	bltu	s3, t0, 0x1160 <corpus.cases.vec.vec_cmp_i64.checksum+0x1088>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x5f8
+               	add	s3, s0, t0
+               	mv	a0, s3
+               	li	t0, 0x7
+               	and	a1, a0, t0
+               	bnez	a1, 0x1cc4 <corpus.cases.vec.vec_cmp_i64.checksum+0x1bec>
+               	mv	a1, a0
+               	li	a2, 0x50
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
+               	li	t0, 0x0
+               	bne	a2, t0, 0x1cac <corpus.cases.vec.vec_cmp_i64.checksum+0x1bd4>
+               	j	0x1ce0 <corpus.cases.vec.vec_cmp_i64.checksum+0x1c08>
+               	mv	a1, a0
+               	li	a0, 0x50
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
+               	li	t0, 0x0
+               	bne	a0, t0, 0x1ccc <corpus.cases.vec.vec_cmp_i64.checksum+0x1bf4>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x5a8
+               	add	s4, s0, t0
+               	mv	a0, s4
+               	li	t0, 0x7
+               	and	a1, a0, t0
+               	bnez	a1, 0x1d1c <corpus.cases.vec.vec_cmp_i64.checksum+0x1c44>
+               	mv	a1, a0
+               	li	a2, 0x50
+               	sd	zero, 0x0(a1)
+               	addi	a1, a1, 0x8
+               	addi	a2, a2, -0x8
+               	li	t0, 0x0
+               	bne	a2, t0, 0x1d04 <corpus.cases.vec.vec_cmp_i64.checksum+0x1c2c>
+               	j	0x1d38 <corpus.cases.vec.vec_cmp_i64.checksum+0x1c60>
+               	mv	a1, a0
+               	li	a0, 0x50
+               	sb	zero, 0x0(a1)
+               	addi	a1, a1, 0x1
+               	addi	a0, a0, -0x1
+               	li	t0, 0x0
+               	bne	a0, t0, 0x1d24 <corpus.cases.vec.vec_cmp_i64.checksum+0x1c4c>
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x598
+               	add	a0, s0, t0
+               	mv	a1, a0
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(a1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x450
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x450
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	mv	a0, s3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x450
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x450
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x588
+               	add	a0, s0, t0
+               	mv	a1, a0
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(a1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	mv	a0, s4
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x578
+               	add	a0, s0, t0
+               	mv	a1, a0
+               	lui	t0, 0x200
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	lui	t0, 0x100
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1
+               	sd	t0, 0x0(a1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s3, 0x10
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4b0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x568
+               	add	a0, s0, t0
+               	mv	a1, a0
+               	lui	t0, 0x100
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x1
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	lui	t0, 0x200
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(a1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s4, 0x10
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x558
+               	add	a0, s0, t0
+               	mv	a1, a0
+               	li	t0, -0x1
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	zero, 0x0(a1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s3, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x4a0
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x548
+               	add	a0, s0, t0
+               	mv	a1, a0
+               	sd	zero, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	li	t0, -0x1
+               	sd	t0, 0x0(a1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x498
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x498
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s4, 0x20
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x498
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x498
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x538
+               	add	a0, s0, t0
+               	mv	a1, a0
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x80
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	lui	t0, 0xfff00
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(a1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x490
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x490
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s3, 0x30
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x490
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x490
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x528
+               	add	a0, s0, t0
+               	mv	a1, a0
+               	lui	t0, 0xf8000
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, 0x80
+               	slli	t0, t0, 0xc
+               	slli	t0, t0, 0xc
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	lui	t0, 0xfff00
+               	slli	t0, t0, 0xc
+               	addi	t0, t0, -0x1
+               	sd	t0, 0x0(a1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x488
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x488
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s4, 0x30
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x488
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x488
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x518
+               	add	a0, s0, t0
+               	mv	a1, a0
+               	li	t0, 0x10a
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	li	t0, -0x1
+               	sd	t0, 0x0(a1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x480
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x480
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s3, 0x40
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x480
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x480
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t0, 0xfffff
+               	addiw	t0, t0, 0x508
+               	add	a0, s0, t0
+               	mv	a1, a0
+               	li	t0, 0xa
+               	sd	t0, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	zero, 0x0(a1)
+               	mv	a1, a0
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x478
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	ld	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x478
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	addi	a0, s4, 0x40
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x478
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a0
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x478
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, a0, 0x8
+               	sd	a2, 0x0(a1)
+               	li	s5, 0x0
+               	li	t0, 0x5
+               	bltu	s5, t0, 0x2450 <corpus.cases.vec.vec_cmp_i64.checksum+0x2378>
+               	j	0x2e28 <corpus.cases.vec.vec_cmp_i64.checksum+0x2d50>
+               	li	t0, 0x10
+               	mul	a0, s5, t0
+               	add	a1, s3, a0
+               	mv	a0, a1
+               	ld	a2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x470
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	sd	a2, 0x0(a0)
+               	addi	a0, a1, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x470
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	li	t0, 0x10
+               	mul	a0, s5, t0
+               	add	a1, s4, a0
+               	mv	a0, a1
+               	ld	a2, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x468
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	sd	a2, 0x0(a0)
+               	addi	a0, a1, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x468
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	sd	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x470
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x500
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	add	a0, a1, t2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x470
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x470
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x468
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x500
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	add	a0, a1, t2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x468
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, s1
+               	sd	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x468
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	sd	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	a1, 0x0(a0)
+               	mv	a0, s1
+               	ld	a2, 0x0(a0)
+               	sltu	a0, a1, a2
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	sub	a0, t1, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x448
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a0, t2, 0x8
+               	ld	a1, 0x0(a0)
+               	addi	a0, s1, 0x8
+               	ld	a2, 0x0(a0)
+               	sltu	a0, a1, a2
+               	zext.b	a1, a0
+               	li	t1, 0x0
+               	sub	a0, t1, a1
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x448
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	sd	a0, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x448
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a0, t2
+               	ld	a1, 0x0(a0)
+               	mv	a0, s2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x25d4>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x448
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x25f8>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, s1
+               	ld	a3, 0x0(a1)
+               	sltu	a1, a3, a2
+               	xori	a1, a1, 0x1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x440
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	ld	a3, 0x0(a1)
+               	sltu	a1, a3, a2
+               	xori	a1, a1, 0x1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x440
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x440
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x26b4>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x440
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x26d8>
+               	mv	a1, s1
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a3, 0x0(a1)
+               	sltu	a1, a2, a3
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x438
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s1, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a3, 0x0(a1)
+               	sltu	a1, a2, a3
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x438
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x438
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x278c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x438
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x27b0>
+               	mv	a1, s1
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a3, 0x0(a1)
+               	sltu	a1, a3, a2
+               	xori	a1, a1, 0x1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x430
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	addi	a1, s1, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a3, 0x0(a1)
+               	sltu	a1, a3, a2
+               	xori	a1, a1, 0x1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x430
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x430
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x286c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x430
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2890>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, s1
+               	ld	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	seqz	a1, a1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x428
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	ld	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	seqz	a1, a1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x428
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x428
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x294c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x428
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2970>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, s1
+               	ld	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	snez	a1, a1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x420
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	ld	a3, 0x0(a1)
+               	xor	a1, a2, a3
+               	snez	a1, a1
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x420
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x420
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2a2c>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x420
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2a50>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, s1
+               	ld	a3, 0x0(a1)
+               	sltu	a1, a2, a3
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x418
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	ld	a3, 0x0(a1)
+               	sltu	a1, a2, a3
+               	zext.b	a2, a1
+               	li	t1, 0x0
+               	sub	a1, t1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x418
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x418
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x410
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x418
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x348
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x410
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x418
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	not	a1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x408
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x418
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	not	a1, a2
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x408
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x408
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, s1
+               	ld	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x400
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x408
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	addi	a1, s1, 0x8
+               	ld	a3, 0x0(a1)
+               	and	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x400
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x410
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x400
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a2, t2
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x410
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x400
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a3, 0x0(a1)
+               	or	a1, a2, a3
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a2, t2, 0x8
+               	sd	a1, 0x0(a2)
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	mv	a1, t2
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2d14>
+               	lui	t1, 0xfffff
+               	addiw	t1, t1, 0x3f8
+               	add	t1, s0, t1
+               	ld	t2, 0x0(t1)
+               	addi	a1, t2, 0x8
+               	ld	a2, 0x0(a1)
+               	mv	a1, a2
+               	auipc	ra, 0x0
+               	jalr	ra <corpus.cases.vec.vec_cmp_i64.checksum+0x2d38>
+               	addi	s5, s5, 0x1
+               	mv	s2, a0
+               	li	t0, 0x5
+               	bltu	s5, t0, 0x2450 <corpus.cases.vec.vec_cmp_i64.checksum+0x2378>
+               	mv	a0, s2
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x348
+               	add	t1, sp, t1
+               	ld	s1, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x350
+               	add	t1, sp, t1
+               	ld	s2, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x358
+               	add	t1, sp, t1
+               	ld	s3, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x360
+               	add	t1, sp, t1
+               	ld	s4, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x368
+               	add	t1, sp, t1
+               	ld	s5, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x370
+               	add	t1, sp, t1
+               	ld	s6, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x378
+               	add	t1, sp, t1
+               	ld	s7, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x380
+               	add	t1, sp, t1
+               	ld	s8, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x388
+               	add	t1, sp, t1
+               	ld	s9, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x390
+               	add	t1, sp, t1
+               	ld	s10, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x398
+               	add	t1, sp, t1
+               	ld	s11, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x338
+               	add	t1, sp, t1
+               	ld	ra, 0x0(t1)
+               	lui	t1, 0x1
+               	addiw	t1, t1, -0x340
+               	add	t1, sp, t1
+               	ld	s0, 0x0(t1)
+               	lui	t0, 0x1
+               	addiw	t0, t0, -0x330
+               	add	sp, sp, t0
+               	ret

--- a/test/golden/spirv/vec/vec_cmp_i64.dis
+++ b/test/golden/spirv/vec/vec_cmp_i64.dis
@@ -1,0 +1,956 @@
+; SPIR-V
+; Version: 1.6
+; Generator: Khronos; 0
+; Bound: 689
+; Schema: 0
+OpCapability Shader
+OpCapability Linkage
+OpCapability Int64
+OpMemoryModel Logical GLSL450
+OpDecorate %1 LinkageAttributes "corpus.cases.vec.vec_cmp_i64.fold_u64x2" Export
+OpDecorate %2 LinkageAttributes "corpus.cases.vec.vec_cmp_i64.fold_i64x2" Export
+OpDecorate %3 LinkageAttributes "corpus.cases.vec.vec_cmp_i64.checksum" Export
+%ulong = OpTypeInt 64 0
+%v2ulong = OpTypeVector %ulong 2
+%9 = OpTypeFunction %ulong %ulong %v2ulong
+%_ptr_Function_ulong = OpTypePointer Function %ulong
+%_ptr_Function_v2ulong = OpTypePointer Function %v2ulong
+%52 = OpTypeFunction %ulong %ulong
+%bool = OpTypeBool
+%uint = OpTypeInt 32 0
+%uint_6 = OpConstant %uint 6
+%_arr_v2ulong_uint_6 = OpTypeArray %v2ulong %uint_6
+%_ptr_Function__arr_v2ulong_uint_6 = OpTypePointer Function %_arr_v2ulong_uint_6
+%uint_5 = OpConstant %uint 5
+%_arr_v2ulong_uint_5 = OpTypeArray %v2ulong %uint_5
+%_ptr_Function__arr_v2ulong_uint_5 = OpTypePointer Function %_arr_v2ulong_uint_5
+%_ptr_Function_bool = OpTypePointer Function %bool
+%231 = OpConstantNull %_arr_v2ulong_uint_6
+%ulong_8589934591 = OpConstant %ulong 8589934591
+%ulong_4294967297 = OpConstant %ulong 4294967297
+%uint_0 = OpConstant %uint 0
+%ulong_18446744073709551615 = OpConstant %ulong 18446744073709551615
+%ulong_18446744069414584320 = OpConstant %ulong 18446744069414584320
+%uint_1 = OpConstant %uint 1
+%ulong_9223372036854775808 = OpConstant %ulong 9223372036854775808
+%ulong_9223372036854775807 = OpConstant %ulong 9223372036854775807
+%uint_2 = OpConstant %uint 2
+%ulong_1311768467463790320 = OpConstant %ulong 1311768467463790320
+%uint_3 = OpConstant %uint 3
+%ulong_8589934592 = OpConstant %ulong 8589934592
+%ulong_0 = OpConstant %ulong 0
+%uint_4 = OpConstant %uint 4
+%ulong_266 = OpConstant %ulong 266
+%ulong_10 = OpConstant %ulong 10
+%ulong_6 = OpConstant %ulong 6
+%289 = OpConstantNull %_arr_v2ulong_uint_5
+%ulong_9223372039002259456 = OpConstant %ulong 9223372039002259456
+%ulong_18446744069414584319 = OpConstant %ulong 18446744069414584319
+%ulong_5 = OpConstant %ulong 5
+%v2bool = OpTypeVector %bool 2
+%354 = OpConstantComposite %v2ulong %ulong_18446744073709551615 %ulong_18446744073709551615
+%355 = OpConstantComposite %v2ulong %ulong_0 %ulong_0
+%ulong_1 = OpConstant %ulong 1
+%602 = OpTypeFunction %ulong
+%ulong_14695981039346656037 = OpConstant %ulong 14695981039346656037
+%605 = OpTypeFunction %ulong %ulong %ulong
+%ulong_8 = OpConstant %ulong 8
+%ulong_255 = OpConstant %ulong 255
+%ulong_1099511628211 = OpConstant %ulong 1099511628211
+%1 = OpFunction %ulong None %9
+%10 = OpFunctionParameter %ulong
+%11 = OpFunctionParameter %v2ulong
+%12 = OpLabel
+%14 = OpVariable %_ptr_Function_ulong Function
+%16 = OpVariable %_ptr_Function_v2ulong Function
+%17 = OpVariable %_ptr_Function_ulong Function
+%18 = OpVariable %_ptr_Function_ulong Function
+%19 = OpVariable %_ptr_Function_ulong Function
+%20 = OpVariable %_ptr_Function_ulong Function
+OpStore %14 %10
+OpStore %16 %11
+%21 = OpLoad %v2ulong %16
+%22 = OpCompositeExtract %ulong %21 0
+OpStore %17 %22
+%23 = OpLoad %ulong %14
+%24 = OpLoad %ulong %17
+%25 = OpFunctionCall %ulong %5 %23 %24
+OpStore %18 %25
+%26 = OpLoad %v2ulong %16
+%27 = OpCompositeExtract %ulong %26 1
+OpStore %19 %27
+%28 = OpLoad %ulong %18
+%29 = OpLoad %ulong %19
+%30 = OpFunctionCall %ulong %5 %28 %29
+OpStore %20 %30
+%31 = OpLoad %ulong %20
+OpReturnValue %31
+OpFunctionEnd
+%2 = OpFunction %ulong None %9
+%32 = OpFunctionParameter %ulong
+%33 = OpFunctionParameter %v2ulong
+%34 = OpLabel
+%35 = OpVariable %_ptr_Function_ulong Function
+%36 = OpVariable %_ptr_Function_v2ulong Function
+%37 = OpVariable %_ptr_Function_ulong Function
+%38 = OpVariable %_ptr_Function_ulong Function
+%39 = OpVariable %_ptr_Function_ulong Function
+%40 = OpVariable %_ptr_Function_ulong Function
+OpStore %35 %32
+OpStore %36 %33
+%41 = OpLoad %v2ulong %36
+%42 = OpCompositeExtract %ulong %41 0
+OpStore %37 %42
+%43 = OpLoad %ulong %35
+%44 = OpLoad %ulong %37
+%45 = OpFunctionCall %ulong %6 %43 %44
+OpStore %38 %45
+%46 = OpLoad %v2ulong %36
+%47 = OpCompositeExtract %ulong %46 1
+OpStore %39 %47
+%48 = OpLoad %ulong %38
+%49 = OpLoad %ulong %39
+%50 = OpFunctionCall %ulong %6 %48 %49
+OpStore %40 %50
+%51 = OpLoad %ulong %40
+OpReturnValue %51
+OpFunctionEnd
+%3 = OpFunction %ulong None %52
+%53 = OpFunctionParameter %ulong
+%54 = OpLabel
+%96 = OpVariable %_ptr_Function__arr_v2ulong_uint_6 Function
+%97 = OpVariable %_ptr_Function__arr_v2ulong_uint_6 Function
+%101 = OpVariable %_ptr_Function__arr_v2ulong_uint_5 Function
+%102 = OpVariable %_ptr_Function__arr_v2ulong_uint_5 Function
+%103 = OpVariable %_ptr_Function_ulong Function
+%104 = OpVariable %_ptr_Function_ulong Function
+%105 = OpVariable %_ptr_Function_v2ulong Function
+%106 = OpVariable %_ptr_Function_v2ulong Function
+%107 = OpVariable %_ptr_Function_v2ulong Function
+%108 = OpVariable %_ptr_Function_v2ulong Function
+%109 = OpVariable %_ptr_Function_v2ulong Function
+%110 = OpVariable %_ptr_Function_v2ulong Function
+%111 = OpVariable %_ptr_Function_v2ulong Function
+%112 = OpVariable %_ptr_Function_v2ulong Function
+%113 = OpVariable %_ptr_Function_v2ulong Function
+%114 = OpVariable %_ptr_Function_v2ulong Function
+%115 = OpVariable %_ptr_Function_v2ulong Function
+%116 = OpVariable %_ptr_Function_v2ulong Function
+%118 = OpVariable %_ptr_Function_bool Function
+%119 = OpVariable %_ptr_Function_v2ulong Function
+%120 = OpVariable %_ptr_Function_v2ulong Function
+%121 = OpVariable %_ptr_Function_ulong Function
+%122 = OpVariable %_ptr_Function_ulong Function
+%123 = OpVariable %_ptr_Function_v2ulong Function
+%124 = OpVariable %_ptr_Function_ulong Function
+%125 = OpVariable %_ptr_Function_ulong Function
+%126 = OpVariable %_ptr_Function_v2ulong Function
+%127 = OpVariable %_ptr_Function_v2ulong Function
+%128 = OpVariable %_ptr_Function_v2ulong Function
+%129 = OpVariable %_ptr_Function_v2ulong Function
+%130 = OpVariable %_ptr_Function_v2ulong Function
+%131 = OpVariable %_ptr_Function_v2ulong Function
+%132 = OpVariable %_ptr_Function_v2ulong Function
+%133 = OpVariable %_ptr_Function_v2ulong Function
+%134 = OpVariable %_ptr_Function_v2ulong Function
+%135 = OpVariable %_ptr_Function_v2ulong Function
+%136 = OpVariable %_ptr_Function_v2ulong Function
+%137 = OpVariable %_ptr_Function_v2ulong Function
+%138 = OpVariable %_ptr_Function_ulong Function
+%139 = OpVariable %_ptr_Function_v2ulong Function
+%140 = OpVariable %_ptr_Function_v2ulong Function
+%141 = OpVariable %_ptr_Function_v2ulong Function
+%142 = OpVariable %_ptr_Function_v2ulong Function
+%143 = OpVariable %_ptr_Function_v2ulong Function
+%144 = OpVariable %_ptr_Function_v2ulong Function
+%145 = OpVariable %_ptr_Function_v2ulong Function
+%146 = OpVariable %_ptr_Function_v2ulong Function
+%147 = OpVariable %_ptr_Function_v2ulong Function
+%148 = OpVariable %_ptr_Function_v2ulong Function
+%149 = OpVariable %_ptr_Function_bool Function
+%150 = OpVariable %_ptr_Function_v2ulong Function
+%151 = OpVariable %_ptr_Function_v2ulong Function
+%152 = OpVariable %_ptr_Function_ulong Function
+%153 = OpVariable %_ptr_Function_ulong Function
+%154 = OpVariable %_ptr_Function_v2ulong Function
+%155 = OpVariable %_ptr_Function_ulong Function
+%156 = OpVariable %_ptr_Function_ulong Function
+%157 = OpVariable %_ptr_Function_v2ulong Function
+%158 = OpVariable %_ptr_Function_v2ulong Function
+%159 = OpVariable %_ptr_Function_v2ulong Function
+%160 = OpVariable %_ptr_Function_v2ulong Function
+%161 = OpVariable %_ptr_Function_v2ulong Function
+%162 = OpVariable %_ptr_Function_v2ulong Function
+%163 = OpVariable %_ptr_Function_v2ulong Function
+%164 = OpVariable %_ptr_Function_v2ulong Function
+%165 = OpVariable %_ptr_Function_v2ulong Function
+%166 = OpVariable %_ptr_Function_v2ulong Function
+%167 = OpVariable %_ptr_Function_v2ulong Function
+%168 = OpVariable %_ptr_Function_v2ulong Function
+%169 = OpVariable %_ptr_Function_ulong Function
+%170 = OpVariable %_ptr_Function_ulong Function
+%171 = OpVariable %_ptr_Function_ulong Function
+%172 = OpVariable %_ptr_Function_ulong Function
+%173 = OpVariable %_ptr_Function_ulong Function
+%174 = OpVariable %_ptr_Function_ulong Function
+%175 = OpVariable %_ptr_Function_ulong Function
+%176 = OpVariable %_ptr_Function_ulong Function
+%177 = OpVariable %_ptr_Function_ulong Function
+%178 = OpVariable %_ptr_Function_ulong Function
+%179 = OpVariable %_ptr_Function_ulong Function
+%180 = OpVariable %_ptr_Function_ulong Function
+%181 = OpVariable %_ptr_Function_ulong Function
+%182 = OpVariable %_ptr_Function_ulong Function
+%183 = OpVariable %_ptr_Function_ulong Function
+%184 = OpVariable %_ptr_Function_ulong Function
+%185 = OpVariable %_ptr_Function_ulong Function
+%186 = OpVariable %_ptr_Function_ulong Function
+%187 = OpVariable %_ptr_Function_ulong Function
+%188 = OpVariable %_ptr_Function_ulong Function
+%189 = OpVariable %_ptr_Function_ulong Function
+%190 = OpVariable %_ptr_Function_ulong Function
+%191 = OpVariable %_ptr_Function_ulong Function
+%192 = OpVariable %_ptr_Function_ulong Function
+%193 = OpVariable %_ptr_Function_ulong Function
+%194 = OpVariable %_ptr_Function_ulong Function
+%195 = OpVariable %_ptr_Function_ulong Function
+%196 = OpVariable %_ptr_Function_ulong Function
+%197 = OpVariable %_ptr_Function_ulong Function
+%198 = OpVariable %_ptr_Function_ulong Function
+%199 = OpVariable %_ptr_Function_ulong Function
+%200 = OpVariable %_ptr_Function_ulong Function
+%201 = OpVariable %_ptr_Function_ulong Function
+%202 = OpVariable %_ptr_Function_ulong Function
+%203 = OpVariable %_ptr_Function_ulong Function
+%204 = OpVariable %_ptr_Function_ulong Function
+%205 = OpVariable %_ptr_Function_ulong Function
+%206 = OpVariable %_ptr_Function_ulong Function
+%207 = OpVariable %_ptr_Function_ulong Function
+%208 = OpVariable %_ptr_Function_ulong Function
+%209 = OpVariable %_ptr_Function_ulong Function
+%210 = OpVariable %_ptr_Function_ulong Function
+%211 = OpVariable %_ptr_Function_ulong Function
+%212 = OpVariable %_ptr_Function_ulong Function
+%213 = OpVariable %_ptr_Function_ulong Function
+%214 = OpVariable %_ptr_Function_ulong Function
+%215 = OpVariable %_ptr_Function_ulong Function
+%216 = OpVariable %_ptr_Function_ulong Function
+%217 = OpVariable %_ptr_Function_ulong Function
+%218 = OpVariable %_ptr_Function_ulong Function
+%219 = OpVariable %_ptr_Function_ulong Function
+%220 = OpVariable %_ptr_Function_ulong Function
+%221 = OpVariable %_ptr_Function_ulong Function
+%222 = OpVariable %_ptr_Function_ulong Function
+%223 = OpVariable %_ptr_Function_ulong Function
+%224 = OpVariable %_ptr_Function_ulong Function
+%225 = OpVariable %_ptr_Function_ulong Function
+%226 = OpVariable %_ptr_Function_ulong Function
+%227 = OpVariable %_ptr_Function_ulong Function
+%228 = OpVariable %_ptr_Function_ulong Function
+%229 = OpVariable %_ptr_Function_ulong Function
+OpStore %103 %53
+%230 = OpFunctionCall %ulong %4
+OpStore %104 %230
+OpStore %96 %231
+OpStore %97 %231
+%232 = OpCompositeConstruct %v2ulong %ulong_8589934591 %ulong_4294967297
+OpStore %105 %232
+%236 = OpAccessChain %_ptr_Function_v2ulong %96 %uint_0
+%237 = OpLoad %v2ulong %105
+OpStore %236 %237
+%238 = OpCompositeConstruct %v2ulong %ulong_4294967297 %ulong_8589934591
+OpStore %106 %238
+%239 = OpAccessChain %_ptr_Function_v2ulong %97 %uint_0
+%240 = OpLoad %v2ulong %106
+OpStore %239 %240
+%241 = OpCompositeConstruct %v2ulong %ulong_18446744073709551615 %ulong_18446744069414584320
+OpStore %107 %241
+%245 = OpAccessChain %_ptr_Function_v2ulong %96 %uint_1
+%246 = OpLoad %v2ulong %107
+OpStore %245 %246
+%247 = OpCompositeConstruct %v2ulong %ulong_18446744069414584320 %ulong_18446744073709551615
+OpStore %108 %247
+%248 = OpAccessChain %_ptr_Function_v2ulong %97 %uint_1
+%249 = OpLoad %v2ulong %108
+OpStore %248 %249
+%250 = OpCompositeConstruct %v2ulong %ulong_9223372036854775808 %ulong_9223372036854775807
+OpStore %109 %250
+%254 = OpAccessChain %_ptr_Function_v2ulong %96 %uint_2
+%255 = OpLoad %v2ulong %109
+OpStore %254 %255
+%256 = OpCompositeConstruct %v2ulong %ulong_9223372036854775807 %ulong_9223372036854775808
+OpStore %110 %256
+%257 = OpAccessChain %_ptr_Function_v2ulong %97 %uint_2
+%258 = OpLoad %v2ulong %110
+OpStore %257 %258
+%259 = OpCompositeConstruct %v2ulong %ulong_9223372036854775808 %ulong_1311768467463790320
+OpStore %111 %259
+%262 = OpAccessChain %_ptr_Function_v2ulong %96 %uint_3
+%263 = OpLoad %v2ulong %111
+OpStore %262 %263
+%264 = OpCompositeConstruct %v2ulong %ulong_18446744073709551615 %ulong_1311768467463790320
+OpStore %112 %264
+%265 = OpAccessChain %_ptr_Function_v2ulong %97 %uint_3
+%266 = OpLoad %v2ulong %112
+OpStore %265 %266
+%267 = OpCompositeConstruct %v2ulong %ulong_8589934592 %ulong_0
+OpStore %113 %267
+%271 = OpAccessChain %_ptr_Function_v2ulong %96 %uint_4
+%272 = OpLoad %v2ulong %113
+OpStore %271 %272
+%273 = OpCompositeConstruct %v2ulong %ulong_8589934591 %ulong_18446744073709551615
+OpStore %114 %273
+%274 = OpAccessChain %_ptr_Function_v2ulong %97 %uint_4
+%275 = OpLoad %v2ulong %114
+OpStore %274 %275
+%276 = OpCompositeConstruct %v2ulong %ulong_266 %ulong_18446744073709551615
+OpStore %115 %276
+%278 = OpAccessChain %_ptr_Function_v2ulong %96 %uint_5
+%279 = OpLoad %v2ulong %115
+OpStore %278 %279
+%280 = OpCompositeConstruct %v2ulong %ulong_10 %ulong_0
+OpStore %116 %280
+%282 = OpAccessChain %_ptr_Function_v2ulong %97 %uint_5
+%283 = OpLoad %v2ulong %116
+OpStore %282 %283
+%284 = OpLoad %ulong %104
+OpStore %171 %284
+OpStore %172 %ulong_0
+OpBranch %55
+%55 = OpLabel
+%285 = OpLoad %ulong %172
+%287 = OpULessThan %bool %285 %ulong_6
+OpStore %118 %287
+%288 = OpLoad %bool %118
+OpLoopMerge %57 %90 None
+OpBranchConditional %288 %56 %57
+%57 = OpLabel
+OpStore %101 %289
+OpStore %102 %289
+%290 = OpCompositeConstruct %v2ulong %ulong_9223372036854775808 %ulong_9223372036854775807
+OpStore %139 %290
+%291 = OpAccessChain %_ptr_Function_v2ulong %101 %uint_0
+%292 = OpLoad %v2ulong %139
+OpStore %291 %292
+%293 = OpCompositeConstruct %v2ulong %ulong_9223372036854775807 %ulong_9223372036854775808
+OpStore %140 %293
+%294 = OpAccessChain %_ptr_Function_v2ulong %102 %uint_0
+%295 = OpLoad %v2ulong %140
+OpStore %294 %295
+%296 = OpCompositeConstruct %v2ulong %ulong_8589934591 %ulong_4294967297
+OpStore %141 %296
+%297 = OpAccessChain %_ptr_Function_v2ulong %101 %uint_1
+%298 = OpLoad %v2ulong %141
+OpStore %297 %298
+%299 = OpCompositeConstruct %v2ulong %ulong_4294967297 %ulong_8589934591
+OpStore %142 %299
+%300 = OpAccessChain %_ptr_Function_v2ulong %102 %uint_1
+%301 = OpLoad %v2ulong %142
+OpStore %300 %301
+%302 = OpCompositeConstruct %v2ulong %ulong_18446744073709551615 %ulong_0
+OpStore %143 %302
+%303 = OpAccessChain %_ptr_Function_v2ulong %101 %uint_2
+%304 = OpLoad %v2ulong %143
+OpStore %303 %304
+%305 = OpCompositeConstruct %v2ulong %ulong_0 %ulong_18446744073709551615
+OpStore %144 %305
+%306 = OpAccessChain %_ptr_Function_v2ulong %102 %uint_2
+%307 = OpLoad %v2ulong %144
+OpStore %306 %307
+%308 = OpCompositeConstruct %v2ulong %ulong_9223372039002259456 %ulong_18446744069414584320
+OpStore %145 %308
+%310 = OpAccessChain %_ptr_Function_v2ulong %101 %uint_3
+%311 = OpLoad %v2ulong %145
+OpStore %310 %311
+%312 = OpCompositeConstruct %v2ulong %ulong_9223372039002259456 %ulong_18446744069414584319
+OpStore %146 %312
+%314 = OpAccessChain %_ptr_Function_v2ulong %102 %uint_3
+%315 = OpLoad %v2ulong %146
+OpStore %314 %315
+%316 = OpCompositeConstruct %v2ulong %ulong_266 %ulong_18446744073709551615
+OpStore %147 %316
+%317 = OpAccessChain %_ptr_Function_v2ulong %101 %uint_4
+%318 = OpLoad %v2ulong %147
+OpStore %317 %318
+%319 = OpCompositeConstruct %v2ulong %ulong_10 %ulong_0
+OpStore %148 %319
+%320 = OpAccessChain %_ptr_Function_v2ulong %102 %uint_4
+%321 = OpLoad %v2ulong %148
+OpStore %320 %321
+%322 = OpLoad %ulong %171
+OpStore %170 %322
+OpStore %173 %ulong_0
+OpBranch %58
+%58 = OpLabel
+%323 = OpLoad %ulong %173
+%325 = OpULessThan %bool %323 %ulong_5
+OpStore %149 %325
+%326 = OpLoad %bool %149
+OpLoopMerge %60 %89 None
+OpBranchConditional %326 %59 %60
+%60 = OpLabel
+%327 = OpLoad %ulong %170
+OpReturnValue %327
+%59 = OpLabel
+%328 = OpLoad %ulong %173
+%329 = OpAccessChain %_ptr_Function_v2ulong %101 %328
+%330 = OpLoad %v2ulong %329
+OpStore %150 %330
+%331 = OpLoad %ulong %173
+%332 = OpAccessChain %_ptr_Function_v2ulong %102 %331
+%333 = OpLoad %v2ulong %332
+OpStore %151 %333
+%334 = OpLoad %v2ulong %150
+%335 = OpCompositeExtract %ulong %334 0
+OpStore %152 %335
+%336 = OpLoad %ulong %152
+%337 = OpLoad %ulong %103
+%338 = OpIAdd %ulong %336 %337
+OpStore %153 %338
+%339 = OpLoad %v2ulong %150
+%340 = OpLoad %ulong %153
+%341 = OpCompositeInsert %v2ulong %340 %339 0
+OpStore %154 %341
+%342 = OpLoad %v2ulong %151
+%343 = OpCompositeExtract %ulong %342 1
+OpStore %155 %343
+%344 = OpLoad %ulong %155
+%345 = OpLoad %ulong %103
+%346 = OpIAdd %ulong %344 %345
+OpStore %156 %346
+%347 = OpLoad %v2ulong %151
+%348 = OpLoad %ulong %156
+%349 = OpCompositeInsert %v2ulong %348 %347 1
+OpStore %157 %349
+%351 = OpLoad %v2ulong %154
+%352 = OpLoad %v2ulong %157
+%353 = OpULessThan %v2bool %351 %352
+%356 = OpSelect %v2ulong %353 %354 %355
+OpStore %158 %356
+OpBranch %63
+%63 = OpLabel
+%357 = OpLoad %v2ulong %158
+%358 = OpCompositeExtract %ulong %357 0
+OpStore %178 %358
+%359 = OpLoad %ulong %170
+%360 = OpLoad %ulong %178
+%361 = OpFunctionCall %ulong %5 %359 %360
+OpStore %179 %361
+%362 = OpLoad %v2ulong %158
+%363 = OpCompositeExtract %ulong %362 1
+OpStore %180 %363
+%364 = OpLoad %ulong %179
+%365 = OpLoad %ulong %180
+%366 = OpFunctionCall %ulong %5 %364 %365
+OpStore %181 %366
+OpBranch %64
+%64 = OpLabel
+%367 = OpLoad %v2ulong %154
+%368 = OpLoad %v2ulong %157
+%369 = OpULessThanEqual %v2bool %367 %368
+%370 = OpSelect %v2ulong %369 %354 %355
+OpStore %159 %370
+OpBranch %67
+%67 = OpLabel
+%371 = OpLoad %v2ulong %159
+%372 = OpCompositeExtract %ulong %371 0
+OpStore %186 %372
+%373 = OpLoad %ulong %181
+%374 = OpLoad %ulong %186
+%375 = OpFunctionCall %ulong %5 %373 %374
+OpStore %187 %375
+%376 = OpLoad %v2ulong %159
+%377 = OpCompositeExtract %ulong %376 1
+OpStore %188 %377
+%378 = OpLoad %ulong %187
+%379 = OpLoad %ulong %188
+%380 = OpFunctionCall %ulong %5 %378 %379
+OpStore %189 %380
+OpBranch %68
+%68 = OpLabel
+%381 = OpLoad %v2ulong %157
+%382 = OpLoad %v2ulong %154
+%383 = OpULessThan %v2bool %381 %382
+%384 = OpSelect %v2ulong %383 %354 %355
+OpStore %160 %384
+OpBranch %71
+%71 = OpLabel
+%385 = OpLoad %v2ulong %160
+%386 = OpCompositeExtract %ulong %385 0
+OpStore %194 %386
+%387 = OpLoad %ulong %189
+%388 = OpLoad %ulong %194
+%389 = OpFunctionCall %ulong %5 %387 %388
+OpStore %195 %389
+%390 = OpLoad %v2ulong %160
+%391 = OpCompositeExtract %ulong %390 1
+OpStore %196 %391
+%392 = OpLoad %ulong %195
+%393 = OpLoad %ulong %196
+%394 = OpFunctionCall %ulong %5 %392 %393
+OpStore %197 %394
+OpBranch %72
+%72 = OpLabel
+%395 = OpLoad %v2ulong %157
+%396 = OpLoad %v2ulong %154
+%397 = OpULessThanEqual %v2bool %395 %396
+%398 = OpSelect %v2ulong %397 %354 %355
+OpStore %161 %398
+OpBranch %75
+%75 = OpLabel
+%399 = OpLoad %v2ulong %161
+%400 = OpCompositeExtract %ulong %399 0
+OpStore %202 %400
+%401 = OpLoad %ulong %197
+%402 = OpLoad %ulong %202
+%403 = OpFunctionCall %ulong %5 %401 %402
+OpStore %203 %403
+%404 = OpLoad %v2ulong %161
+%405 = OpCompositeExtract %ulong %404 1
+OpStore %204 %405
+%406 = OpLoad %ulong %203
+%407 = OpLoad %ulong %204
+%408 = OpFunctionCall %ulong %5 %406 %407
+OpStore %205 %408
+OpBranch %76
+%76 = OpLabel
+%409 = OpLoad %v2ulong %154
+%410 = OpLoad %v2ulong %157
+%411 = OpIEqual %v2bool %409 %410
+%412 = OpSelect %v2ulong %411 %354 %355
+OpStore %162 %412
+OpBranch %79
+%79 = OpLabel
+%413 = OpLoad %v2ulong %162
+%414 = OpCompositeExtract %ulong %413 0
+OpStore %210 %414
+%415 = OpLoad %ulong %205
+%416 = OpLoad %ulong %210
+%417 = OpFunctionCall %ulong %5 %415 %416
+OpStore %211 %417
+%418 = OpLoad %v2ulong %162
+%419 = OpCompositeExtract %ulong %418 1
+OpStore %212 %419
+%420 = OpLoad %ulong %211
+%421 = OpLoad %ulong %212
+%422 = OpFunctionCall %ulong %5 %420 %421
+OpStore %213 %422
+OpBranch %80
+%80 = OpLabel
+%423 = OpLoad %v2ulong %154
+%424 = OpLoad %v2ulong %157
+%425 = OpINotEqual %v2bool %423 %424
+%426 = OpSelect %v2ulong %425 %354 %355
+OpStore %163 %426
+OpBranch %83
+%83 = OpLabel
+%427 = OpLoad %v2ulong %163
+%428 = OpCompositeExtract %ulong %427 0
+OpStore %218 %428
+%429 = OpLoad %ulong %213
+%430 = OpLoad %ulong %218
+%431 = OpFunctionCall %ulong %5 %429 %430
+OpStore %219 %431
+%432 = OpLoad %v2ulong %163
+%433 = OpCompositeExtract %ulong %432 1
+OpStore %220 %433
+%434 = OpLoad %ulong %219
+%435 = OpLoad %ulong %220
+%436 = OpFunctionCall %ulong %5 %434 %435
+OpStore %221 %436
+OpBranch %84
+%84 = OpLabel
+%437 = OpLoad %v2ulong %154
+%438 = OpLoad %v2ulong %157
+%439 = OpULessThan %v2bool %437 %438
+%440 = OpSelect %v2ulong %439 %354 %355
+OpStore %164 %440
+%441 = OpLoad %v2ulong %164
+%442 = OpLoad %v2ulong %154
+%443 = OpBitwiseAnd %v2ulong %441 %442
+OpStore %165 %443
+%444 = OpLoad %v2ulong %164
+%445 = OpNot %v2ulong %444
+OpStore %166 %445
+%446 = OpLoad %v2ulong %166
+%447 = OpLoad %v2ulong %157
+%448 = OpBitwiseAnd %v2ulong %446 %447
+OpStore %167 %448
+%449 = OpLoad %v2ulong %165
+%450 = OpLoad %v2ulong %167
+%451 = OpBitwiseOr %v2ulong %449 %450
+OpStore %168 %451
+OpBranch %87
+%87 = OpLabel
+%452 = OpLoad %v2ulong %168
+%453 = OpCompositeExtract %ulong %452 0
+OpStore %226 %453
+%454 = OpLoad %ulong %221
+%455 = OpLoad %ulong %226
+%456 = OpFunctionCall %ulong %5 %454 %455
+OpStore %227 %456
+%457 = OpLoad %v2ulong %168
+%458 = OpCompositeExtract %ulong %457 1
+OpStore %228 %458
+%459 = OpLoad %ulong %227
+%460 = OpLoad %ulong %228
+%461 = OpFunctionCall %ulong %5 %459 %460
+OpStore %229 %461
+OpBranch %88
+%88 = OpLabel
+%462 = OpLoad %ulong %173
+%464 = OpIAdd %ulong %462 %ulong_1
+OpStore %169 %464
+%465 = OpLoad %ulong %229
+OpStore %170 %465
+%466 = OpLoad %ulong %169
+OpStore %173 %466
+OpBranch %89
+%56 = OpLabel
+%467 = OpLoad %ulong %172
+%468 = OpAccessChain %_ptr_Function_v2ulong %96 %467
+%469 = OpLoad %v2ulong %468
+OpStore %119 %469
+%470 = OpLoad %ulong %172
+%471 = OpAccessChain %_ptr_Function_v2ulong %97 %470
+%472 = OpLoad %v2ulong %471
+OpStore %120 %472
+%473 = OpLoad %v2ulong %119
+%474 = OpCompositeExtract %ulong %473 0
+OpStore %121 %474
+%475 = OpLoad %ulong %121
+%476 = OpLoad %ulong %103
+%477 = OpIAdd %ulong %475 %476
+OpStore %122 %477
+%478 = OpLoad %v2ulong %119
+%479 = OpLoad %ulong %122
+%480 = OpCompositeInsert %v2ulong %479 %478 0
+OpStore %123 %480
+%481 = OpLoad %v2ulong %120
+%482 = OpCompositeExtract %ulong %481 1
+OpStore %124 %482
+%483 = OpLoad %ulong %124
+%484 = OpLoad %ulong %103
+%485 = OpIAdd %ulong %483 %484
+OpStore %125 %485
+%486 = OpLoad %v2ulong %120
+%487 = OpLoad %ulong %125
+%488 = OpCompositeInsert %v2ulong %487 %486 1
+OpStore %126 %488
+%489 = OpLoad %v2ulong %123
+%490 = OpLoad %v2ulong %126
+%491 = OpSLessThan %v2bool %489 %490
+%492 = OpSelect %v2ulong %491 %354 %355
+OpStore %127 %492
+OpBranch %61
+%61 = OpLabel
+%493 = OpLoad %v2ulong %127
+%494 = OpCompositeExtract %ulong %493 0
+OpStore %174 %494
+%495 = OpLoad %ulong %171
+%496 = OpLoad %ulong %174
+%497 = OpFunctionCall %ulong %5 %495 %496
+OpStore %175 %497
+%498 = OpLoad %v2ulong %127
+%499 = OpCompositeExtract %ulong %498 1
+OpStore %176 %499
+%500 = OpLoad %ulong %175
+%501 = OpLoad %ulong %176
+%502 = OpFunctionCall %ulong %5 %500 %501
+OpStore %177 %502
+OpBranch %62
+%62 = OpLabel
+%503 = OpLoad %v2ulong %123
+%504 = OpLoad %v2ulong %126
+%505 = OpSLessThanEqual %v2bool %503 %504
+%506 = OpSelect %v2ulong %505 %354 %355
+OpStore %128 %506
+OpBranch %65
+%65 = OpLabel
+%507 = OpLoad %v2ulong %128
+%508 = OpCompositeExtract %ulong %507 0
+OpStore %182 %508
+%509 = OpLoad %ulong %177
+%510 = OpLoad %ulong %182
+%511 = OpFunctionCall %ulong %5 %509 %510
+OpStore %183 %511
+%512 = OpLoad %v2ulong %128
+%513 = OpCompositeExtract %ulong %512 1
+OpStore %184 %513
+%514 = OpLoad %ulong %183
+%515 = OpLoad %ulong %184
+%516 = OpFunctionCall %ulong %5 %514 %515
+OpStore %185 %516
+OpBranch %66
+%66 = OpLabel
+%517 = OpLoad %v2ulong %126
+%518 = OpLoad %v2ulong %123
+%519 = OpSLessThan %v2bool %517 %518
+%520 = OpSelect %v2ulong %519 %354 %355
+OpStore %129 %520
+OpBranch %69
+%69 = OpLabel
+%521 = OpLoad %v2ulong %129
+%522 = OpCompositeExtract %ulong %521 0
+OpStore %190 %522
+%523 = OpLoad %ulong %185
+%524 = OpLoad %ulong %190
+%525 = OpFunctionCall %ulong %5 %523 %524
+OpStore %191 %525
+%526 = OpLoad %v2ulong %129
+%527 = OpCompositeExtract %ulong %526 1
+OpStore %192 %527
+%528 = OpLoad %ulong %191
+%529 = OpLoad %ulong %192
+%530 = OpFunctionCall %ulong %5 %528 %529
+OpStore %193 %530
+OpBranch %70
+%70 = OpLabel
+%531 = OpLoad %v2ulong %126
+%532 = OpLoad %v2ulong %123
+%533 = OpSLessThanEqual %v2bool %531 %532
+%534 = OpSelect %v2ulong %533 %354 %355
+OpStore %130 %534
+OpBranch %73
+%73 = OpLabel
+%535 = OpLoad %v2ulong %130
+%536 = OpCompositeExtract %ulong %535 0
+OpStore %198 %536
+%537 = OpLoad %ulong %193
+%538 = OpLoad %ulong %198
+%539 = OpFunctionCall %ulong %5 %537 %538
+OpStore %199 %539
+%540 = OpLoad %v2ulong %130
+%541 = OpCompositeExtract %ulong %540 1
+OpStore %200 %541
+%542 = OpLoad %ulong %199
+%543 = OpLoad %ulong %200
+%544 = OpFunctionCall %ulong %5 %542 %543
+OpStore %201 %544
+OpBranch %74
+%74 = OpLabel
+%545 = OpLoad %v2ulong %123
+%546 = OpLoad %v2ulong %126
+%547 = OpIEqual %v2bool %545 %546
+%548 = OpSelect %v2ulong %547 %354 %355
+OpStore %131 %548
+OpBranch %77
+%77 = OpLabel
+%549 = OpLoad %v2ulong %131
+%550 = OpCompositeExtract %ulong %549 0
+OpStore %206 %550
+%551 = OpLoad %ulong %201
+%552 = OpLoad %ulong %206
+%553 = OpFunctionCall %ulong %5 %551 %552
+OpStore %207 %553
+%554 = OpLoad %v2ulong %131
+%555 = OpCompositeExtract %ulong %554 1
+OpStore %208 %555
+%556 = OpLoad %ulong %207
+%557 = OpLoad %ulong %208
+%558 = OpFunctionCall %ulong %5 %556 %557
+OpStore %209 %558
+OpBranch %78
+%78 = OpLabel
+%559 = OpLoad %v2ulong %123
+%560 = OpLoad %v2ulong %126
+%561 = OpINotEqual %v2bool %559 %560
+%562 = OpSelect %v2ulong %561 %354 %355
+OpStore %132 %562
+OpBranch %81
+%81 = OpLabel
+%563 = OpLoad %v2ulong %132
+%564 = OpCompositeExtract %ulong %563 0
+OpStore %214 %564
+%565 = OpLoad %ulong %209
+%566 = OpLoad %ulong %214
+%567 = OpFunctionCall %ulong %5 %565 %566
+OpStore %215 %567
+%568 = OpLoad %v2ulong %132
+%569 = OpCompositeExtract %ulong %568 1
+OpStore %216 %569
+%570 = OpLoad %ulong %215
+%571 = OpLoad %ulong %216
+%572 = OpFunctionCall %ulong %5 %570 %571
+OpStore %217 %572
+OpBranch %82
+%82 = OpLabel
+%573 = OpLoad %v2ulong %123
+%574 = OpLoad %v2ulong %126
+%575 = OpSLessThan %v2bool %573 %574
+%576 = OpSelect %v2ulong %575 %354 %355
+OpStore %133 %576
+%577 = OpLoad %v2ulong %133
+%578 = OpLoad %v2ulong %123
+%579 = OpBitwiseAnd %v2ulong %577 %578
+OpStore %134 %579
+%580 = OpLoad %v2ulong %133
+%581 = OpNot %v2ulong %580
+OpStore %135 %581
+%582 = OpLoad %v2ulong %135
+%583 = OpLoad %v2ulong %126
+%584 = OpBitwiseAnd %v2ulong %582 %583
+OpStore %136 %584
+%585 = OpLoad %v2ulong %134
+%586 = OpLoad %v2ulong %136
+%587 = OpBitwiseOr %v2ulong %585 %586
+OpStore %137 %587
+OpBranch %85
+%85 = OpLabel
+%588 = OpLoad %v2ulong %137
+%589 = OpCompositeExtract %ulong %588 0
+OpStore %222 %589
+%590 = OpLoad %ulong %217
+%591 = OpLoad %ulong %222
+%592 = OpFunctionCall %ulong %6 %590 %591
+OpStore %223 %592
+%593 = OpLoad %v2ulong %137
+%594 = OpCompositeExtract %ulong %593 1
+OpStore %224 %594
+%595 = OpLoad %ulong %223
+%596 = OpLoad %ulong %224
+%597 = OpFunctionCall %ulong %6 %595 %596
+OpStore %225 %597
+OpBranch %86
+%86 = OpLabel
+%598 = OpLoad %ulong %172
+%599 = OpIAdd %ulong %598 %ulong_1
+OpStore %138 %599
+%600 = OpLoad %ulong %225
+OpStore %171 %600
+%601 = OpLoad %ulong %138
+OpStore %172 %601
+OpBranch %90
+%89 = OpLabel
+OpBranch %58
+%90 = OpLabel
+OpBranch %55
+OpFunctionEnd
+%4 = OpFunction %ulong None %602
+%603 = OpLabel
+OpReturnValue %ulong_14695981039346656037
+OpFunctionEnd
+%5 = OpFunction %ulong None %605
+%606 = OpFunctionParameter %ulong
+%607 = OpFunctionParameter %ulong
+%608 = OpLabel
+%613 = OpVariable %_ptr_Function_ulong Function
+%614 = OpVariable %_ptr_Function_ulong Function
+%615 = OpVariable %_ptr_Function_bool Function
+%616 = OpVariable %_ptr_Function_ulong Function
+%617 = OpVariable %_ptr_Function_ulong Function
+%618 = OpVariable %_ptr_Function_ulong Function
+%619 = OpVariable %_ptr_Function_ulong Function
+%620 = OpVariable %_ptr_Function_ulong Function
+%621 = OpVariable %_ptr_Function_ulong Function
+%622 = OpVariable %_ptr_Function_ulong Function
+%623 = OpVariable %_ptr_Function_ulong Function
+OpStore %613 %606
+OpStore %614 %607
+%624 = OpLoad %ulong %613
+OpStore %622 %624
+OpStore %623 %ulong_0
+OpBranch %609
+%609 = OpLabel
+%625 = OpLoad %ulong %623
+%627 = OpULessThan %bool %625 %ulong_8
+OpStore %615 %627
+%628 = OpLoad %bool %615
+OpLoopMerge %611 %612 None
+OpBranchConditional %628 %610 %611
+%611 = OpLabel
+%629 = OpLoad %ulong %622
+OpReturnValue %629
+%610 = OpLabel
+%630 = OpLoad %ulong %623
+%631 = OpIMul %ulong %630 %ulong_8
+OpStore %616 %631
+%632 = OpLoad %ulong %614
+%633 = OpLoad %ulong %616
+%634 = OpShiftRightLogical %ulong %632 %633
+OpStore %617 %634
+%635 = OpLoad %ulong %617
+%637 = OpBitwiseAnd %ulong %635 %ulong_255
+OpStore %618 %637
+%638 = OpLoad %ulong %622
+%639 = OpLoad %ulong %618
+%640 = OpBitwiseXor %ulong %638 %639
+OpStore %619 %640
+%641 = OpLoad %ulong %619
+%643 = OpIMul %ulong %641 %ulong_1099511628211
+OpStore %620 %643
+%644 = OpLoad %ulong %623
+%645 = OpIAdd %ulong %644 %ulong_1
+OpStore %621 %645
+%646 = OpLoad %ulong %620
+OpStore %622 %646
+%647 = OpLoad %ulong %621
+OpStore %623 %647
+OpBranch %612
+%612 = OpLabel
+OpBranch %609
+OpFunctionEnd
+%6 = OpFunction %ulong None %605
+%648 = OpFunctionParameter %ulong
+%649 = OpFunctionParameter %ulong
+%650 = OpLabel
+%657 = OpVariable %_ptr_Function_ulong Function
+%658 = OpVariable %_ptr_Function_ulong Function
+%659 = OpVariable %_ptr_Function_bool Function
+%660 = OpVariable %_ptr_Function_ulong Function
+%661 = OpVariable %_ptr_Function_ulong Function
+%662 = OpVariable %_ptr_Function_ulong Function
+%663 = OpVariable %_ptr_Function_ulong Function
+%664 = OpVariable %_ptr_Function_ulong Function
+%665 = OpVariable %_ptr_Function_ulong Function
+%666 = OpVariable %_ptr_Function_ulong Function
+%667 = OpVariable %_ptr_Function_ulong Function
+OpStore %657 %648
+OpStore %658 %649
+OpBranch %651
+%651 = OpLabel
+%668 = OpLoad %ulong %657
+OpStore %666 %668
+OpStore %667 %ulong_0
+OpBranch %652
+%652 = OpLabel
+%669 = OpLoad %ulong %667
+%670 = OpULessThan %bool %669 %ulong_8
+OpStore %659 %670
+%671 = OpLoad %bool %659
+OpLoopMerge %654 %656 None
+OpBranchConditional %671 %653 %654
+%654 = OpLabel
+OpBranch %655
+%655 = OpLabel
+%672 = OpLoad %ulong %666
+OpReturnValue %672
+%653 = OpLabel
+%673 = OpLoad %ulong %667
+%674 = OpIMul %ulong %673 %ulong_8
+OpStore %660 %674
+%675 = OpLoad %ulong %658
+%676 = OpLoad %ulong %660
+%677 = OpShiftRightLogical %ulong %675 %676
+OpStore %661 %677
+%678 = OpLoad %ulong %661
+%679 = OpBitwiseAnd %ulong %678 %ulong_255
+OpStore %662 %679
+%680 = OpLoad %ulong %666
+%681 = OpLoad %ulong %662
+%682 = OpBitwiseXor %ulong %680 %681
+OpStore %663 %682
+%683 = OpLoad %ulong %663
+%684 = OpIMul %ulong %683 %ulong_1099511628211
+OpStore %664 %684
+%685 = OpLoad %ulong %667
+%686 = OpIAdd %ulong %685 %ulong_1
+OpStore %665 %686
+%687 = OpLoad %ulong %664
+OpStore %666 %687
+%688 = OpLoad %ulong %665
+OpStore %667 %688
+OpBranch %656
+%656 = OpLabel
+OpBranch %652
+OpFunctionEnd

--- a/test/golden/x86_64-darwin/vec/vec_cmp_i64.dis
+++ b/test/golden/x86_64-darwin/vec/vec_cmp_i64.dis
@@ -1,0 +1,833 @@
+vec/vec_cmp_i64.o:
+
+Disassembly of section __TEXT,__text:
+
+<corpus.cases.vec.vec_cmp_i64.fold_u64x2>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	leaq	-0x10(%rbp), %rbx
+               	movups	%xmm0, (%rbx)
+               	leaq	(%rbx), %rcx
+               	movq	(%rcx), %rsi
+               	callq	 <L0>
+<L0>:
+               	movq	%rax, %rdi
+               	leaq	0x8(%rbx), %rcx
+               	movq	(%rcx), %rsi
+               	callq	 <L1>
+<L1>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.vec.vec_cmp_i64.fold_i64x2>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	leaq	-0x10(%rbp), %rbx
+               	movups	%xmm0, (%rbx)
+               	leaq	(%rbx), %rcx
+               	movq	(%rcx), %rsi
+               	callq	 <L0>
+<L0>:
+               	movq	%rax, %rdi
+               	leaq	0x8(%rbx), %rcx
+               	movq	(%rcx), %rsi
+               	callq	 <L1>
+<L1>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.vec.vec_cmp_i64.checksum>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x510, %rsp            ## imm = 0x510
+               	movq	%rbx, -0x4e8(%rbp)
+               	movq	%r12, -0x4f0(%rbp)
+               	movq	%r13, -0x4f8(%rbp)
+               	movq	%r14, -0x500(%rbp)
+               	movq	%r15, -0x508(%rbp)
+               	movq	%rdi, %rbx
+               	callq	 <L0>
+<L0>:
+               	leaq	-0x60(%rbp), %r12
+               	leaq	(%r12), %rcx
+               	addq	$0x0, %rcx
+               	movq	$0x60, %rdx
+<L1>:
+               	movq	$0x0, (%rcx)
+               	addq	$0x8, %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L1>
+               	leaq	-0xc0(%rbp), %r13
+               	leaq	(%r13), %rcx
+               	addq	$0x0, %rcx
+               	movq	$0x60, %rdx
+<L2>:
+               	movq	$0x0, (%rcx)
+               	addq	$0x8, %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L2>
+               	leaq	-0xd0(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x1ffffffff, %r11      ## imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x100000001, %r11      ## imm = 0x100000001
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	(%r12), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0xe0(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x100000001, %r11      ## imm = 0x100000001
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x1ffffffff, %r11      ## imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	(%r13), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0xf0(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$-0x100000000, %r11     ## imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x10(%r12), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x100(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$-0x100000000, %r11     ## imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x10(%r13), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x110(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x20(%r12), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x120(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x20(%r13), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x130(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x123456789abcdef0, %r11 ## imm = 0x123456789ABCDEF0
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x30(%r12), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x140(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x123456789abcdef0, %r11 ## imm = 0x123456789ABCDEF0
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x30(%r13), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x150(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x200000000, %r11      ## imm = 0x200000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movq	$0x0, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x40(%r12), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x160(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x1ffffffff, %r11      ## imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x40(%r13), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x170(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movq	$0x10a, (%rdx)          ## imm = 0x10A
+               	leaq	0x8(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x50(%r12), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x180(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movq	$0xa, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movq	$0x0, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x50(%r13), %rcx
+               	movups	%xmm0, (%rcx)
+               	movq	%rax, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x6, %r15
+               	jb	 <L3>
+               	jmp	 <L18>
+<L3>:
+               	movq	%r15, %rax
+               	imulq	$0x10, %rax, %rax
+               	leaq	(%r12,%rax), %rcx
+               	movups	(%rcx), %xmm0
+               	leaq	-0x190(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	movq	%r15, %rcx
+               	imulq	$0x10, %rcx, %rcx
+               	leaq	(%r13,%rcx), %rdx
+               	movups	(%rdx), %xmm1
+               	leaq	-0x1a0(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rax
+               	addq	%rbx, %rax
+               	leaq	-0x1b0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movq	%rax, (%rsi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x440(%rbp)
+               	leaq	0x8(%rcx), %rax
+               	movq	(%rax), %rcx
+               	addq	%rbx, %rcx
+               	leaq	-0x1c0(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	0x8(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movups	(%rax), %xmm14
+               	movups	%xmm14, -0x450(%rbp)
+               	movaps	-0x450(%rbp), %xmm15
+               	pxor	-0x440(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x450(%rbp), %xmm15
+               	pcmpgtd	-0x440(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x450(%rbp), %xmm15
+               	pcmpeqd	-0x440(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x450(%rbp), %xmm14
+               	pcmpgtd	-0x440(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x1d0(%rbp), %r8
+               	movq	%r8, -0x428(%rbp)
+               	movq	-0x428(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x428(%rbp), %r8
+               	leaq	(%r8), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%r14, %rdi
+               	callq	 <L4>
+<L4>:
+               	movq	%rax, %rdi
+               	movq	-0x428(%rbp), %r8
+               	leaq	0x8(%r8), %rcx
+               	movq	(%rcx), %rsi
+               	callq	 <L5>
+<L5>:
+               	movaps	-0x440(%rbp), %xmm15
+               	pxor	-0x450(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x440(%rbp), %xmm15
+               	pcmpgtd	-0x450(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x440(%rbp), %xmm15
+               	pcmpeqd	-0x450(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x440(%rbp), %xmm14
+               	pcmpgtd	-0x450(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x370(%rbp), %r8
+               	movq	%r8, -0x458(%rbp)
+               	movq	-0x458(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x458(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L6>
+<L6>:
+               	movq	-0x458(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L7>
+<L7>:
+               	movaps	-0x440(%rbp), %xmm15
+               	pxor	-0x450(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x440(%rbp), %xmm15
+               	pcmpgtd	-0x450(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x440(%rbp), %xmm15
+               	pcmpeqd	-0x450(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x440(%rbp), %xmm14
+               	pcmpgtd	-0x450(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x390(%rbp), %r8
+               	movq	%r8, -0x460(%rbp)
+               	movq	-0x460(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x460(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L8>
+<L8>:
+               	movq	-0x460(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L9>
+<L9>:
+               	movaps	-0x450(%rbp), %xmm15
+               	pxor	-0x440(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x450(%rbp), %xmm15
+               	pcmpgtd	-0x440(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x450(%rbp), %xmm15
+               	pcmpeqd	-0x440(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x450(%rbp), %xmm14
+               	pcmpgtd	-0x440(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x3b0(%rbp), %r8
+               	movq	%r8, -0x468(%rbp)
+               	movq	-0x468(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x468(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L10>
+<L10>:
+               	movq	-0x468(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L11>
+<L11>:
+               	movaps	-0x440(%rbp), %xmm14
+               	pcmpeqd	-0x450(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   ## xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x3d0(%rbp), %r8
+               	movq	%r8, -0x470(%rbp)
+               	movq	-0x470(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x470(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L12>
+<L12>:
+               	movq	-0x470(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L13>
+<L13>:
+               	movaps	-0x440(%rbp), %xmm14
+               	pcmpeqd	-0x450(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   ## xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x3f0(%rbp), %r8
+               	movq	%r8, -0x478(%rbp)
+               	movq	-0x478(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x478(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L14>
+<L14>:
+               	movq	-0x478(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L15>
+<L15>:
+               	movaps	-0x450(%rbp), %xmm15
+               	pxor	-0x440(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x450(%rbp), %xmm15
+               	pcmpgtd	-0x440(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x450(%rbp), %xmm15
+               	pcmpeqd	-0x440(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x450(%rbp), %xmm14
+               	pcmpgtd	-0x440(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm2, %xmm14
+               	pand	-0x440(%rbp), %xmm14
+               	movaps	%xmm14, %xmm3
+               	movaps	%xmm2, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm0, %xmm14
+               	pand	-0x450(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm3, %xmm14
+               	por	%xmm0, %xmm14
+               	movaps	%xmm14, %xmm3
+               	leaq	-0x410(%rbp), %r8
+               	movq	%r8, -0x480(%rbp)
+               	movq	-0x480(%rbp), %r8
+               	movups	%xmm3, (%r8)
+               	movq	-0x480(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L16>
+<L16>:
+               	movq	-0x480(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L17>
+<L17>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r14
+               	cmpq	$0x6, %r15
+               	jb	 <L3>
+<L18>:
+               	leaq	-0x220(%rbp), %r12
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
+               	movq	$0x50, %rcx
+<L19>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rcx
+               	cmpq	$0x0, %rcx
+               	jne	 <L19>
+               	leaq	-0x270(%rbp), %r13
+               	leaq	(%r13), %rax
+               	addq	$0x0, %rax
+               	movq	$0x50, %rcx
+<L20>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rcx
+               	cmpq	$0x0, %rcx
+               	jne	 <L20>
+               	leaq	-0x280(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x290(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$0x7fffffffffffffff, %r11 ## imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$-0x8000000000000000, %r11 ## imm = 0x8000000000000000
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2a0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$0x1ffffffff, %r11      ## imm = 0x1FFFFFFFF
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$0x100000001, %r11      ## imm = 0x100000001
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x10(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2b0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$0x100000001, %r11      ## imm = 0x100000001
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$0x1ffffffff, %r11      ## imm = 0x1FFFFFFFF
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x10(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2c0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	$-0x1, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movq	$0x0, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x20(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2d0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	$0x0, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movq	$-0x1, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x20(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2e0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$-0x7fffffff80000000, %r11 ## imm = 0x8000000080000000
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$-0x100000000, %r11     ## imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x30(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2f0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$-0x7fffffff80000000, %r11 ## imm = 0x8000000080000000
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$-0x100000001, %r11     ## imm = 0xFFFFFFFEFFFFFFFF
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x30(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x300(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	$0x10a, (%rcx)          ## imm = 0x10A
+               	leaq	0x8(%rax), %rcx
+               	movq	$-0x1, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x40(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x310(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	$0xa, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movq	$0x0, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x40(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	movq	$0x0, %r15
+               	cmpq	$0x5, %r15
+               	jb	 <L21>
+               	jmp	 <L36>
+<L21>:
+               	movq	%r15, %rax
+               	imulq	$0x10, %rax, %rax
+               	leaq	(%r12,%rax), %rcx
+               	movups	(%rcx), %xmm0
+               	leaq	-0x320(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	movq	%r15, %rcx
+               	imulq	$0x10, %rcx, %rcx
+               	leaq	(%r13,%rcx), %rdx
+               	movups	(%rdx), %xmm1
+               	leaq	-0x330(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rax
+               	addq	%rbx, %rax
+               	leaq	-0x340(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movq	%rax, (%rsi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x4a0(%rbp)
+               	leaq	0x8(%rcx), %rax
+               	movq	(%rax), %rcx
+               	addq	%rbx, %rcx
+               	leaq	-0x350(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	0x8(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movups	(%rax), %xmm14
+               	movups	%xmm14, -0x4b0(%rbp)
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pxor	-0x4a0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pcmpgtd	-0x4a0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pcmpeqd	-0x4a0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x360(%rbp), %r8
+               	movq	%r8, -0x488(%rbp)
+               	movq	-0x488(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x488(%rbp), %r8
+               	leaq	(%r8), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%r14, %rdi
+               	callq	 <L22>
+<L22>:
+               	movq	%rax, %rdi
+               	movq	-0x488(%rbp), %r8
+               	leaq	0x8(%r8), %rcx
+               	movq	(%rcx), %rsi
+               	callq	 <L23>
+<L23>:
+               	movaps	-0x4a0(%rbp), %xmm15
+               	pxor	-0x4b0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x4a0(%rbp), %xmm15
+               	pcmpgtd	-0x4b0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x4a0(%rbp), %xmm15
+               	pcmpeqd	-0x4b0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x380(%rbp), %r8
+               	movq	%r8, -0x4b8(%rbp)
+               	movq	-0x4b8(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x4b8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L24>
+<L24>:
+               	movq	-0x4b8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L25>
+<L25>:
+               	movaps	-0x4a0(%rbp), %xmm15
+               	pxor	-0x4b0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x4a0(%rbp), %xmm15
+               	pcmpgtd	-0x4b0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x4a0(%rbp), %xmm15
+               	pcmpeqd	-0x4b0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x3a0(%rbp), %r8
+               	movq	%r8, -0x4c0(%rbp)
+               	movq	-0x4c0(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x4c0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L26>
+<L26>:
+               	movq	-0x4c0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L27>
+<L27>:
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pxor	-0x4a0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pcmpgtd	-0x4a0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pcmpeqd	-0x4a0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x3c0(%rbp), %r8
+               	movq	%r8, -0x4c8(%rbp)
+               	movq	-0x4c8(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x4c8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
+               	movq	-0x4c8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L29>
+<L29>:
+               	movaps	-0x4a0(%rbp), %xmm14
+               	pcmpeqd	-0x4b0(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   ## xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x3e0(%rbp), %r8
+               	movq	%r8, -0x4d0(%rbp)
+               	movq	-0x4d0(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x4d0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L30>
+<L30>:
+               	movq	-0x4d0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L31>
+<L31>:
+               	movaps	-0x4a0(%rbp), %xmm14
+               	pcmpeqd	-0x4b0(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   ## xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x400(%rbp), %r8
+               	movq	%r8, -0x4d8(%rbp)
+               	movq	-0x4d8(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x4d8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L32>
+<L32>:
+               	movq	-0x4d8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L33>
+<L33>:
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pxor	-0x4a0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pcmpgtd	-0x4a0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pcmpeqd	-0x4a0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   ## xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   ## xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   ## xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm2, %xmm14
+               	pand	-0x4a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm3
+               	movaps	%xmm2, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm0, %xmm14
+               	pand	-0x4b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm3, %xmm14
+               	por	%xmm0, %xmm14
+               	movaps	%xmm14, %xmm3
+               	leaq	-0x420(%rbp), %r8
+               	movq	%r8, -0x4e0(%rbp)
+               	movq	-0x4e0(%rbp), %r8
+               	movups	%xmm3, (%r8)
+               	movq	-0x4e0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L34>
+<L34>:
+               	movq	-0x4e0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L35>
+<L35>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r14
+               	cmpq	$0x5, %r15
+               	jb	 <L21>
+<L36>:
+               	movq	%r14, %rax
+               	movq	-0x4e8(%rbp), %rbx
+               	movq	-0x4f0(%rbp), %r12
+               	movq	-0x4f8(%rbp), %r13
+               	movq	-0x500(%rbp), %r14
+               	movq	-0x508(%rbp), %r15
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq

--- a/test/golden/x86_64-linux/vec/vec_cmp_i64.dis
+++ b/test/golden/x86_64-linux/vec/vec_cmp_i64.dis
@@ -1,0 +1,833 @@
+vec/vec_cmp_i64.o:
+
+Disassembly of section .text:
+
+<corpus.cases.vec.vec_cmp_i64.fold_u64x2>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	leaq	-0x10(%rbp), %rbx
+               	movups	%xmm0, (%rbx)
+               	leaq	(%rbx), %rcx
+               	movq	(%rcx), %rsi
+               	callq	 <L0>
+<L0>:
+               	movq	%rax, %rdi
+               	leaq	0x8(%rbx), %rcx
+               	movq	(%rcx), %rsi
+               	callq	 <L1>
+<L1>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.vec.vec_cmp_i64.fold_i64x2>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x20, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	leaq	-0x10(%rbp), %rbx
+               	movups	%xmm0, (%rbx)
+               	leaq	(%rbx), %rcx
+               	movq	(%rcx), %rsi
+               	callq	 <L0>
+<L0>:
+               	movq	%rax, %rdi
+               	leaq	0x8(%rbx), %rcx
+               	movq	(%rcx), %rsi
+               	callq	 <L1>
+<L1>:
+               	movq	-0x18(%rbp), %rbx
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.vec.vec_cmp_i64.checksum>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x510, %rsp            # imm = 0x510
+               	movq	%rbx, -0x4e8(%rbp)
+               	movq	%r12, -0x4f0(%rbp)
+               	movq	%r13, -0x4f8(%rbp)
+               	movq	%r14, -0x500(%rbp)
+               	movq	%r15, -0x508(%rbp)
+               	movq	%rdi, %rbx
+               	callq	 <L0>
+<L0>:
+               	leaq	-0x60(%rbp), %r12
+               	leaq	(%r12), %rcx
+               	addq	$0x0, %rcx
+               	movq	$0x60, %rdx
+<L1>:
+               	movq	$0x0, (%rcx)
+               	addq	$0x8, %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L1>
+               	leaq	-0xc0(%rbp), %r13
+               	leaq	(%r13), %rcx
+               	addq	$0x0, %rcx
+               	movq	$0x60, %rdx
+<L2>:
+               	movq	$0x0, (%rcx)
+               	addq	$0x8, %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L2>
+               	leaq	-0xd0(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x100000001, %r11      # imm = 0x100000001
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	(%r12), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0xe0(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x100000001, %r11      # imm = 0x100000001
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	(%r13), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0xf0(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x10(%r12), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x100(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x10(%r13), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x110(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x20(%r12), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x120(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x20(%r13), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x130(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x123456789abcdef0, %r11 # imm = 0x123456789ABCDEF0
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x30(%r12), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x140(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x123456789abcdef0, %r11 # imm = 0x123456789ABCDEF0
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x30(%r13), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x150(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x200000000, %r11      # imm = 0x200000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movq	$0x0, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x40(%r12), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x160(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x40(%r13), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x170(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movq	$0x10a, (%rdx)          # imm = 0x10A
+               	leaq	0x8(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x50(%r12), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x180(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movq	$0xa, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movq	$0x0, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x50(%r13), %rcx
+               	movups	%xmm0, (%rcx)
+               	movq	%rax, %r14
+               	movq	$0x0, %r15
+               	cmpq	$0x6, %r15
+               	jb	 <L3>
+               	jmp	 <L18>
+<L3>:
+               	movq	%r15, %rax
+               	imulq	$0x10, %rax, %rax
+               	leaq	(%r12,%rax), %rcx
+               	movups	(%rcx), %xmm0
+               	leaq	-0x190(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	movq	%r15, %rcx
+               	imulq	$0x10, %rcx, %rcx
+               	leaq	(%r13,%rcx), %rdx
+               	movups	(%rdx), %xmm1
+               	leaq	-0x1a0(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rax
+               	addq	%rbx, %rax
+               	leaq	-0x1b0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movq	%rax, (%rsi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x440(%rbp)
+               	leaq	0x8(%rcx), %rax
+               	movq	(%rax), %rcx
+               	addq	%rbx, %rcx
+               	leaq	-0x1c0(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	0x8(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movups	(%rax), %xmm14
+               	movups	%xmm14, -0x450(%rbp)
+               	movaps	-0x450(%rbp), %xmm15
+               	pxor	-0x440(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x450(%rbp), %xmm15
+               	pcmpgtd	-0x440(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x450(%rbp), %xmm15
+               	pcmpeqd	-0x440(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x450(%rbp), %xmm14
+               	pcmpgtd	-0x440(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x1d0(%rbp), %r8
+               	movq	%r8, -0x428(%rbp)
+               	movq	-0x428(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x428(%rbp), %r8
+               	leaq	(%r8), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%r14, %rdi
+               	callq	 <L4>
+<L4>:
+               	movq	%rax, %rdi
+               	movq	-0x428(%rbp), %r8
+               	leaq	0x8(%r8), %rcx
+               	movq	(%rcx), %rsi
+               	callq	 <L5>
+<L5>:
+               	movaps	-0x440(%rbp), %xmm15
+               	pxor	-0x450(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x440(%rbp), %xmm15
+               	pcmpgtd	-0x450(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x440(%rbp), %xmm15
+               	pcmpeqd	-0x450(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x440(%rbp), %xmm14
+               	pcmpgtd	-0x450(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x370(%rbp), %r8
+               	movq	%r8, -0x458(%rbp)
+               	movq	-0x458(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x458(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L6>
+<L6>:
+               	movq	-0x458(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L7>
+<L7>:
+               	movaps	-0x440(%rbp), %xmm15
+               	pxor	-0x450(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x440(%rbp), %xmm15
+               	pcmpgtd	-0x450(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x440(%rbp), %xmm15
+               	pcmpeqd	-0x450(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x440(%rbp), %xmm14
+               	pcmpgtd	-0x450(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x390(%rbp), %r8
+               	movq	%r8, -0x460(%rbp)
+               	movq	-0x460(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x460(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L8>
+<L8>:
+               	movq	-0x460(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L9>
+<L9>:
+               	movaps	-0x450(%rbp), %xmm15
+               	pxor	-0x440(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x450(%rbp), %xmm15
+               	pcmpgtd	-0x440(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x450(%rbp), %xmm15
+               	pcmpeqd	-0x440(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x450(%rbp), %xmm14
+               	pcmpgtd	-0x440(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x3b0(%rbp), %r8
+               	movq	%r8, -0x468(%rbp)
+               	movq	-0x468(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x468(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L10>
+<L10>:
+               	movq	-0x468(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L11>
+<L11>:
+               	movaps	-0x440(%rbp), %xmm14
+               	pcmpeqd	-0x450(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x3d0(%rbp), %r8
+               	movq	%r8, -0x470(%rbp)
+               	movq	-0x470(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x470(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L12>
+<L12>:
+               	movq	-0x470(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L13>
+<L13>:
+               	movaps	-0x440(%rbp), %xmm14
+               	pcmpeqd	-0x450(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x3f0(%rbp), %r8
+               	movq	%r8, -0x478(%rbp)
+               	movq	-0x478(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x478(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L14>
+<L14>:
+               	movq	-0x478(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L15>
+<L15>:
+               	movaps	-0x450(%rbp), %xmm15
+               	pxor	-0x440(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x450(%rbp), %xmm15
+               	pcmpgtd	-0x440(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x450(%rbp), %xmm15
+               	pcmpeqd	-0x440(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	-0x450(%rbp), %xmm14
+               	pcmpgtd	-0x440(%rbp), %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm2, %xmm14
+               	pand	-0x440(%rbp), %xmm14
+               	movaps	%xmm14, %xmm3
+               	movaps	%xmm2, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm0, %xmm14
+               	pand	-0x450(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm3, %xmm14
+               	por	%xmm0, %xmm14
+               	movaps	%xmm14, %xmm3
+               	leaq	-0x410(%rbp), %r8
+               	movq	%r8, -0x480(%rbp)
+               	movq	-0x480(%rbp), %r8
+               	movups	%xmm3, (%r8)
+               	movq	-0x480(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L16>
+<L16>:
+               	movq	-0x480(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L17>
+<L17>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r14
+               	cmpq	$0x6, %r15
+               	jb	 <L3>
+<L18>:
+               	leaq	-0x220(%rbp), %r12
+               	leaq	(%r12), %rax
+               	addq	$0x0, %rax
+               	movq	$0x50, %rcx
+<L19>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rcx
+               	cmpq	$0x0, %rcx
+               	jne	 <L19>
+               	leaq	-0x270(%rbp), %r13
+               	leaq	(%r13), %rax
+               	addq	$0x0, %rax
+               	movq	$0x50, %rcx
+<L20>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rcx
+               	cmpq	$0x0, %rcx
+               	jne	 <L20>
+               	leaq	-0x280(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x290(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2a0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$0x100000001, %r11      # imm = 0x100000001
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x10(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2b0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$0x100000001, %r11      # imm = 0x100000001
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x10(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2c0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	$-0x1, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movq	$0x0, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x20(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2d0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	$0x0, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movq	$-0x1, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x20(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2e0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$-0x7fffffff80000000, %r11 # imm = 0x8000000080000000
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x30(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2f0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$-0x7fffffff80000000, %r11 # imm = 0x8000000080000000
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x30(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x300(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	$0x10a, (%rcx)          # imm = 0x10A
+               	leaq	0x8(%rax), %rcx
+               	movq	$-0x1, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x40(%r12), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x310(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	$0xa, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movq	$0x0, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x40(%r13), %rax
+               	movups	%xmm0, (%rax)
+               	movq	$0x0, %r15
+               	cmpq	$0x5, %r15
+               	jb	 <L21>
+               	jmp	 <L36>
+<L21>:
+               	movq	%r15, %rax
+               	imulq	$0x10, %rax, %rax
+               	leaq	(%r12,%rax), %rcx
+               	movups	(%rcx), %xmm0
+               	leaq	-0x320(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	movq	%r15, %rcx
+               	imulq	$0x10, %rcx, %rcx
+               	leaq	(%r13,%rcx), %rdx
+               	movups	(%rdx), %xmm1
+               	leaq	-0x330(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rax
+               	addq	%rbx, %rax
+               	leaq	-0x340(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %rsi
+               	movq	%rax, (%rsi)
+               	movups	(%rdx), %xmm14
+               	movups	%xmm14, -0x4a0(%rbp)
+               	leaq	0x8(%rcx), %rax
+               	movq	(%rax), %rcx
+               	addq	%rbx, %rcx
+               	leaq	-0x350(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	0x8(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movups	(%rax), %xmm14
+               	movups	%xmm14, -0x4b0(%rbp)
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pxor	-0x4a0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pcmpgtd	-0x4a0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pcmpeqd	-0x4a0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x360(%rbp), %r8
+               	movq	%r8, -0x488(%rbp)
+               	movq	-0x488(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x488(%rbp), %r8
+               	leaq	(%r8), %rcx
+               	movq	(%rcx), %rsi
+               	movq	%r14, %rdi
+               	callq	 <L22>
+<L22>:
+               	movq	%rax, %rdi
+               	movq	-0x488(%rbp), %r8
+               	leaq	0x8(%r8), %rcx
+               	movq	(%rcx), %rsi
+               	callq	 <L23>
+<L23>:
+               	movaps	-0x4a0(%rbp), %xmm15
+               	pxor	-0x4b0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x4a0(%rbp), %xmm15
+               	pcmpgtd	-0x4b0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x4a0(%rbp), %xmm15
+               	pcmpeqd	-0x4b0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x380(%rbp), %r8
+               	movq	%r8, -0x4b8(%rbp)
+               	movq	-0x4b8(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x4b8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L24>
+<L24>:
+               	movq	-0x4b8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L25>
+<L25>:
+               	movaps	-0x4a0(%rbp), %xmm15
+               	pxor	-0x4b0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x4a0(%rbp), %xmm15
+               	pcmpgtd	-0x4b0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x4a0(%rbp), %xmm15
+               	pcmpeqd	-0x4b0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x3a0(%rbp), %r8
+               	movq	%r8, -0x4c0(%rbp)
+               	movq	-0x4c0(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x4c0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L26>
+<L26>:
+               	movq	-0x4c0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L27>
+<L27>:
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pxor	-0x4a0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pcmpgtd	-0x4a0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pcmpeqd	-0x4a0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x3c0(%rbp), %r8
+               	movq	%r8, -0x4c8(%rbp)
+               	movq	-0x4c8(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x4c8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L28>
+<L28>:
+               	movq	-0x4c8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L29>
+<L29>:
+               	movaps	-0x4a0(%rbp), %xmm14
+               	pcmpeqd	-0x4b0(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x3e0(%rbp), %r8
+               	movq	%r8, -0x4d0(%rbp)
+               	movq	-0x4d0(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x4d0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L30>
+<L30>:
+               	movq	-0x4d0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L31>
+<L31>:
+               	movaps	-0x4a0(%rbp), %xmm14
+               	pcmpeqd	-0x4b0(%rbp), %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	leaq	-0x400(%rbp), %r8
+               	movq	%r8, -0x4d8(%rbp)
+               	movq	-0x4d8(%rbp), %r8
+               	movups	%xmm2, (%r8)
+               	movq	-0x4d8(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L32>
+<L32>:
+               	movq	-0x4d8(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L33>
+<L33>:
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pxor	-0x4a0(%rbp), %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pcmpgtd	-0x4a0(%rbp), %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	-0x4b0(%rbp), %xmm15
+               	pcmpeqd	-0x4a0(%rbp), %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm2, %xmm14
+               	pand	-0x4a0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm3
+               	movaps	%xmm2, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm0, %xmm14
+               	pand	-0x4b0(%rbp), %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm3, %xmm14
+               	por	%xmm0, %xmm14
+               	movaps	%xmm14, %xmm3
+               	leaq	-0x420(%rbp), %r8
+               	movq	%r8, -0x4e0(%rbp)
+               	movq	-0x4e0(%rbp), %r8
+               	movups	%xmm3, (%r8)
+               	movq	-0x4e0(%rbp), %r8
+               	leaq	(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L34>
+<L34>:
+               	movq	-0x4e0(%rbp), %r8
+               	leaq	0x8(%r8), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rax, %rdi
+               	callq	 <L35>
+<L35>:
+               	addq	$0x1, %r15
+               	movq	%rax, %r14
+               	cmpq	$0x5, %r15
+               	jb	 <L21>
+<L36>:
+               	movq	%r14, %rax
+               	movq	-0x4e8(%rbp), %rbx
+               	movq	-0x4f0(%rbp), %r12
+               	movq	-0x4f8(%rbp), %r13
+               	movq	-0x500(%rbp), %r14
+               	movq	-0x508(%rbp), %r15
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq

--- a/test/golden/x86_64-windows/vec/vec_cmp_i64.dis
+++ b/test/golden/x86_64-windows/vec/vec_cmp_i64.dis
@@ -1,0 +1,801 @@
+vec/vec_cmp_i64.o:
+
+Disassembly of section .text:
+
+<corpus.cases.vec.vec_cmp_i64.fold_u64x2>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x60, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x10(%rbp), %rbx
+               	movups	%xmm0, (%rbx)
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rsi, %rdx
+               	callq	 <L0>
+<L0>:
+               	movq	%rax, %rcx
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %rbx
+               	movq	%rbx, %rdx
+               	callq	 <L1>
+<L1>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rsi
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.vec.vec_cmp_i64.fold_i64x2>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x60, %rsp
+               	movq	%rbx, -0x18(%rbp)
+               	movq	%rsi, -0x20(%rbp)
+               	movaps	%xmm14, -0x30(%rbp)
+               	movaps	%xmm15, -0x40(%rbp)
+               	movups	(%rdx), %xmm0
+               	leaq	-0x10(%rbp), %rbx
+               	movups	%xmm0, (%rbx)
+               	leaq	(%rbx), %rdx
+               	movq	(%rdx), %rsi
+               	movq	%rsi, %rdx
+               	callq	 <L0>
+<L0>:
+               	movq	%rax, %rcx
+               	leaq	0x8(%rbx), %rdx
+               	movq	(%rdx), %rbx
+               	movq	%rbx, %rdx
+               	callq	 <L1>
+<L1>:
+               	movaps	-0x30(%rbp), %xmm14
+               	movaps	-0x40(%rbp), %xmm15
+               	movq	-0x18(%rbp), %rbx
+               	movq	-0x20(%rbp), %rsi
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq
+
+<corpus.cases.vec.vec_cmp_i64.checksum>:
+               	pushq	%rbp
+               	movq	%rsp, %rbp
+               	subq	$0x4b0, %rsp            # imm = 0x4B0
+               	movq	%rbx, -0x428(%rbp)
+               	movq	%rdi, -0x430(%rbp)
+               	movq	%rsi, -0x438(%rbp)
+               	movq	%r12, -0x440(%rbp)
+               	movq	%r13, -0x448(%rbp)
+               	movq	%r14, -0x450(%rbp)
+               	movaps	%xmm6, -0x460(%rbp)
+               	movaps	%xmm7, -0x470(%rbp)
+               	movaps	%xmm14, -0x480(%rbp)
+               	movaps	%xmm15, -0x490(%rbp)
+               	movq	%rcx, %rbx
+               	callq	 <L0>
+<L0>:
+               	leaq	-0x60(%rbp), %rsi
+               	leaq	(%rsi), %rcx
+               	addq	$0x0, %rcx
+               	movq	$0x60, %rdx
+<L1>:
+               	movq	$0x0, (%rcx)
+               	addq	$0x8, %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L1>
+               	leaq	-0xc0(%rbp), %rdi
+               	leaq	(%rdi), %rcx
+               	addq	$0x0, %rcx
+               	movq	$0x60, %rdx
+<L2>:
+               	movq	$0x0, (%rcx)
+               	addq	$0x8, %rcx
+               	subq	$0x8, %rdx
+               	cmpq	$0x0, %rdx
+               	jne	 <L2>
+               	leaq	-0xd0(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x100000001, %r11      # imm = 0x100000001
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	(%rsi), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0xe0(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x100000001, %r11      # imm = 0x100000001
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	(%rdi), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0xf0(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x10(%rsi), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x100(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x10(%rdi), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x110(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x20(%rsi), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x120(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x20(%rdi), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x130(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x123456789abcdef0, %r11 # imm = 0x123456789ABCDEF0
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x30(%rsi), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x140(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movabsq	$0x123456789abcdef0, %r11 # imm = 0x123456789ABCDEF0
+               	movq	%r11, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x30(%rdi), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x150(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x200000000, %r11      # imm = 0x200000000
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movq	$0x0, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x40(%rsi), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x160(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
+               	movq	%r11, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x40(%rdi), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x170(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movq	$0x10a, (%rdx)          # imm = 0x10A
+               	leaq	0x8(%rcx), %rdx
+               	movq	$-0x1, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x50(%rsi), %rcx
+               	movups	%xmm0, (%rcx)
+               	leaq	-0x180(%rbp), %rcx
+               	leaq	(%rcx), %rdx
+               	movq	$0xa, (%rdx)
+               	leaq	0x8(%rcx), %rdx
+               	movq	$0x0, (%rdx)
+               	movups	(%rcx), %xmm0
+               	leaq	0x50(%rdi), %rcx
+               	movups	%xmm0, (%rcx)
+               	movq	%rax, %r12
+               	movq	$0x0, %r13
+               	cmpq	$0x6, %r13
+               	jb	 <L3>
+               	jmp	 <L18>
+<L3>:
+               	movq	%r13, %rax
+               	imulq	$0x10, %rax, %rax
+               	leaq	(%rsi,%rax), %rcx
+               	movups	(%rcx), %xmm0
+               	leaq	-0x190(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	movq	%r13, %rcx
+               	imulq	$0x10, %rcx, %rcx
+               	leaq	(%rdi,%rcx), %rdx
+               	movups	(%rdx), %xmm1
+               	leaq	-0x1a0(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rax
+               	addq	%rbx, %rax
+               	leaq	-0x1b0(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %r14
+               	movq	%rax, (%r14)
+               	movups	(%rdx), %xmm6
+               	leaq	0x8(%rcx), %rax
+               	movq	(%rax), %rcx
+               	addq	%rbx, %rcx
+               	leaq	-0x1c0(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	0x8(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movups	(%rax), %xmm7
+               	movaps	%xmm7, %xmm15
+               	pxor	%xmm6, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm7, %xmm15
+               	pcmpgtd	%xmm6, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm7, %xmm15
+               	pcmpeqd	%xmm6, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	%xmm7, %xmm14
+               	pcmpgtd	%xmm6, %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x1d0(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %rax
+               	movq	(%rax), %rdx
+               	movq	%r12, %rcx
+               	callq	 <L4>
+<L4>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L5>
+<L5>:
+               	movaps	%xmm6, %xmm15
+               	pxor	%xmm7, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpgtd	%xmm7, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpeqd	%xmm7, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	%xmm6, %xmm14
+               	pcmpgtd	%xmm7, %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x370(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L6>
+<L6>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L7>
+<L7>:
+               	movaps	%xmm6, %xmm15
+               	pxor	%xmm7, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpgtd	%xmm7, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpeqd	%xmm7, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	%xmm6, %xmm14
+               	pcmpgtd	%xmm7, %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x390(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L8>
+<L8>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L9>
+<L9>:
+               	movaps	%xmm7, %xmm15
+               	pxor	%xmm6, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm7, %xmm15
+               	pcmpgtd	%xmm6, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm7, %xmm15
+               	pcmpeqd	%xmm6, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	%xmm7, %xmm14
+               	pcmpgtd	%xmm6, %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x3b0(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L10>
+<L10>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L11>
+<L11>:
+               	movaps	%xmm6, %xmm14
+               	pcmpeqd	%xmm7, %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x3d0(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L12>
+<L12>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L13>
+<L13>:
+               	movaps	%xmm6, %xmm14
+               	pcmpeqd	%xmm7, %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x3f0(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L14>
+<L14>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L15>
+<L15>:
+               	movaps	%xmm7, %xmm15
+               	pxor	%xmm6, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm7, %xmm15
+               	pcmpgtd	%xmm6, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm7, %xmm15
+               	pcmpeqd	%xmm6, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	movaps	%xmm7, %xmm14
+               	pcmpgtd	%xmm6, %xmm14
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm0, %xmm14
+               	pand	%xmm6, %xmm14
+               	movaps	%xmm14, %xmm1
+               	movaps	%xmm0, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm2, %xmm14
+               	pand	%xmm7, %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm1, %xmm14
+               	por	%xmm2, %xmm14
+               	movaps	%xmm14, %xmm1
+               	leaq	-0x410(%rbp), %r14
+               	movups	%xmm1, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L16>
+<L16>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L17>
+<L17>:
+               	addq	$0x1, %r13
+               	movq	%rax, %r12
+               	cmpq	$0x6, %r13
+               	jb	 <L3>
+<L18>:
+               	leaq	-0x220(%rbp), %rsi
+               	leaq	(%rsi), %rax
+               	addq	$0x0, %rax
+               	movq	$0x50, %rcx
+<L19>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rcx
+               	cmpq	$0x0, %rcx
+               	jne	 <L19>
+               	leaq	-0x270(%rbp), %rdi
+               	leaq	(%rdi), %rax
+               	addq	$0x0, %rax
+               	movq	$0x50, %rcx
+<L20>:
+               	movq	$0x0, (%rax)
+               	addq	$0x8, %rax
+               	subq	$0x8, %rcx
+               	cmpq	$0x0, %rcx
+               	jne	 <L20>
+               	leaq	-0x280(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	(%rsi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x290(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$0x7fffffffffffffff, %r11 # imm = 0x7FFFFFFFFFFFFFFF
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$-0x8000000000000000, %r11 # imm = 0x8000000000000000
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	(%rdi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2a0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$0x100000001, %r11      # imm = 0x100000001
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x10(%rsi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2b0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$0x100000001, %r11      # imm = 0x100000001
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$0x1ffffffff, %r11      # imm = 0x1FFFFFFFF
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x10(%rdi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2c0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	$-0x1, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movq	$0x0, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x20(%rsi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2d0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	$0x0, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movq	$-0x1, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x20(%rdi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2e0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$-0x7fffffff80000000, %r11 # imm = 0x8000000080000000
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$-0x100000000, %r11     # imm = 0xFFFFFFFF00000000
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x30(%rsi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x2f0(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movabsq	$-0x7fffffff80000000, %r11 # imm = 0x8000000080000000
+               	movq	%r11, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movabsq	$-0x100000001, %r11     # imm = 0xFFFFFFFEFFFFFFFF
+               	movq	%r11, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x30(%rdi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x300(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	$0x10a, (%rcx)          # imm = 0x10A
+               	leaq	0x8(%rax), %rcx
+               	movq	$-0x1, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x40(%rsi), %rax
+               	movups	%xmm0, (%rax)
+               	leaq	-0x310(%rbp), %rax
+               	leaq	(%rax), %rcx
+               	movq	$0xa, (%rcx)
+               	leaq	0x8(%rax), %rcx
+               	movq	$0x0, (%rcx)
+               	movups	(%rax), %xmm0
+               	leaq	0x40(%rdi), %rax
+               	movups	%xmm0, (%rax)
+               	movq	$0x0, %r13
+               	cmpq	$0x5, %r13
+               	jb	 <L21>
+               	jmp	 <L36>
+<L21>:
+               	movq	%r13, %rax
+               	imulq	$0x10, %rax, %rax
+               	leaq	(%rsi,%rax), %rcx
+               	movups	(%rcx), %xmm0
+               	leaq	-0x320(%rbp), %rax
+               	movups	%xmm0, (%rax)
+               	movq	%r13, %rcx
+               	imulq	$0x10, %rcx, %rcx
+               	leaq	(%rdi,%rcx), %rdx
+               	movups	(%rdx), %xmm1
+               	leaq	-0x330(%rbp), %rcx
+               	movups	%xmm1, (%rcx)
+               	leaq	(%rax), %rdx
+               	movq	(%rdx), %rax
+               	addq	%rbx, %rax
+               	leaq	-0x340(%rbp), %rdx
+               	movups	%xmm0, (%rdx)
+               	leaq	(%rdx), %r14
+               	movq	%rax, (%r14)
+               	movups	(%rdx), %xmm6
+               	leaq	0x8(%rcx), %rax
+               	movq	(%rax), %rcx
+               	addq	%rbx, %rcx
+               	leaq	-0x350(%rbp), %rax
+               	movups	%xmm1, (%rax)
+               	leaq	0x8(%rax), %rdx
+               	movq	%rcx, (%rdx)
+               	movups	(%rax), %xmm7
+               	movaps	%xmm7, %xmm15
+               	pxor	%xmm6, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm7, %xmm15
+               	pcmpgtd	%xmm6, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm7, %xmm15
+               	pcmpeqd	%xmm6, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x360(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %rax
+               	movq	(%rax), %rdx
+               	movq	%r12, %rcx
+               	callq	 <L22>
+<L22>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L23>
+<L23>:
+               	movaps	%xmm6, %xmm15
+               	pxor	%xmm7, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpgtd	%xmm7, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpeqd	%xmm7, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x380(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L24>
+<L24>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L25>
+<L25>:
+               	movaps	%xmm6, %xmm15
+               	pxor	%xmm7, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpgtd	%xmm7, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm6, %xmm15
+               	pcmpeqd	%xmm7, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x3a0(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L26>
+<L26>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L27>
+<L27>:
+               	movaps	%xmm7, %xmm15
+               	pxor	%xmm6, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm7, %xmm15
+               	pcmpgtd	%xmm6, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm7, %xmm15
+               	pcmpeqd	%xmm6, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x3c0(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L28>
+<L28>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L29>
+<L29>:
+               	movaps	%xmm6, %xmm14
+               	pcmpeqd	%xmm7, %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x3e0(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L30>
+<L30>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L31>
+<L31>:
+               	movaps	%xmm6, %xmm14
+               	pcmpeqd	%xmm7, %xmm14
+               	pshufd	$0xb1, %xmm14, %xmm15   # xmm15 = xmm14[1,0,3,2]
+               	pand	%xmm15, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	leaq	-0x400(%rbp), %r14
+               	movups	%xmm0, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L32>
+<L32>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L33>
+<L33>:
+               	movaps	%xmm7, %xmm15
+               	pxor	%xmm6, %xmm15
+               	pxor	%xmm14, %xmm14
+               	pcmpgtd	%xmm15, %xmm14
+               	movaps	%xmm7, %xmm15
+               	pcmpgtd	%xmm6, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm7, %xmm15
+               	pcmpeqd	%xmm6, %xmm15
+               	pshufd	$0xf5, %xmm15, %xmm15   # xmm15 = xmm15[1,1,3,3]
+               	pand	%xmm14, %xmm15
+               	pshufd	$0xa0, %xmm15, %xmm15   # xmm15 = xmm15[0,0,2,2]
+               	pshufd	$0xf5, %xmm14, %xmm14   # xmm14 = xmm14[1,1,3,3]
+               	por	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm0
+               	movaps	%xmm0, %xmm14
+               	pand	%xmm6, %xmm14
+               	movaps	%xmm14, %xmm1
+               	movaps	%xmm0, %xmm14
+               	pcmpeqd	%xmm15, %xmm15
+               	pxor	%xmm15, %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm2, %xmm14
+               	pand	%xmm7, %xmm14
+               	movaps	%xmm14, %xmm2
+               	movaps	%xmm1, %xmm14
+               	por	%xmm2, %xmm14
+               	movaps	%xmm14, %xmm1
+               	leaq	-0x420(%rbp), %r14
+               	movups	%xmm1, (%r14)
+               	leaq	(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L34>
+<L34>:
+               	leaq	0x8(%r14), %rcx
+               	movq	(%rcx), %rdx
+               	movq	%rax, %rcx
+               	callq	 <L35>
+<L35>:
+               	addq	$0x1, %r13
+               	movq	%rax, %r12
+               	cmpq	$0x5, %r13
+               	jb	 <L21>
+<L36>:
+               	movq	%r12, %rax
+               	movaps	-0x460(%rbp), %xmm6
+               	movaps	-0x470(%rbp), %xmm7
+               	movaps	-0x480(%rbp), %xmm14
+               	movaps	-0x490(%rbp), %xmm15
+               	movq	-0x428(%rbp), %rbx
+               	movq	-0x430(%rbp), %rdi
+               	movq	-0x438(%rbp), %rsi
+               	movq	-0x440(%rbp), %r12
+               	movq	-0x448(%rbp), %r13
+               	movq	-0x450(%rbp), %r14
+               	movq	%rbp, %rsp
+               	popq	%rbp
+               	retq

--- a/test/ref/vec/vec_cmp_i64.c
+++ b/test/ref/vec/vec_cmp_i64.c
@@ -1,0 +1,101 @@
+#include "corpus.h"
+
+/* mach's i64x2 and u64x2 are 2 lanes x 8 bytes, size 16, and fill the vector
+ * register so $align_of is 16. a comparison yields an unsigned mask of the lane
+ * width, all-ones for true and all-zeros for false, built explicitly here. every
+ * lane is held as uint64_t: the signed pairs are written as their two's-complement
+ * patterns and the signed orderings go through the sign-bit-flip identity, so no
+ * signed type is involved and nothing here is UB. */
+typedef struct { _Alignas(16) uint64_t l[2]; } u64x2;
+
+#define M64(c) ((uint64_t)((c) ? UINT64_C(0xFFFFFFFFFFFFFFFF) : UINT64_C(0)))
+#define S64(x) ((uint64_t)((x) ^ UINT64_C(0x8000000000000000)))
+
+static uint64_t fold_u64x2(uint64_t h, u64x2 v) {
+    for (unsigned i = 0; i < 2u; i++) { h = mix_u64(h, v.l[i]); }
+    return h;
+}
+
+static u64x2 lt_s(u64x2 a, u64x2 b) { u64x2 r; for (unsigned i = 0; i < 2u; i++) { r.l[i] = M64(S64(a.l[i]) <  S64(b.l[i])); } return r; }
+static u64x2 le_s(u64x2 a, u64x2 b) { u64x2 r; for (unsigned i = 0; i < 2u; i++) { r.l[i] = M64(S64(a.l[i]) <= S64(b.l[i])); } return r; }
+static u64x2 gt_s(u64x2 a, u64x2 b) { u64x2 r; for (unsigned i = 0; i < 2u; i++) { r.l[i] = M64(S64(a.l[i]) >  S64(b.l[i])); } return r; }
+static u64x2 ge_s(u64x2 a, u64x2 b) { u64x2 r; for (unsigned i = 0; i < 2u; i++) { r.l[i] = M64(S64(a.l[i]) >= S64(b.l[i])); } return r; }
+static u64x2 lt_u(u64x2 a, u64x2 b) { u64x2 r; for (unsigned i = 0; i < 2u; i++) { r.l[i] = M64(a.l[i] <  b.l[i]); } return r; }
+static u64x2 le_u(u64x2 a, u64x2 b) { u64x2 r; for (unsigned i = 0; i < 2u; i++) { r.l[i] = M64(a.l[i] <= b.l[i]); } return r; }
+static u64x2 gt_u(u64x2 a, u64x2 b) { u64x2 r; for (unsigned i = 0; i < 2u; i++) { r.l[i] = M64(a.l[i] >  b.l[i]); } return r; }
+static u64x2 ge_u(u64x2 a, u64x2 b) { u64x2 r; for (unsigned i = 0; i < 2u; i++) { r.l[i] = M64(a.l[i] >= b.l[i]); } return r; }
+static u64x2 eq_v(u64x2 a, u64x2 b) { u64x2 r; for (unsigned i = 0; i < 2u; i++) { r.l[i] = M64(a.l[i] == b.l[i]); } return r; }
+static u64x2 ne_v(u64x2 a, u64x2 b) { u64x2 r; for (unsigned i = 0; i < 2u; i++) { r.l[i] = M64(a.l[i] != b.l[i]); } return r; }
+
+static u64x2 select(u64x2 m, u64x2 a, u64x2 b) {
+    u64x2 r;
+    for (unsigned i = 0; i < 2u; i++) { r.l[i] = (uint64_t)((m.l[i] & a.l[i]) | (~m.l[i] & b.l[i])); }
+    return r;
+}
+
+uint64_t checksum(uint64_t seed) {
+    uint64_t h = fold_init();
+    const uint64_t imin = UINT64_C(0x8000000000000000);
+    const uint64_t imax = UINT64_C(0x7FFFFFFFFFFFFFFF);
+    const uint64_t neg1 = UINT64_C(0xFFFFFFFFFFFFFFFF);
+    const uint64_t neg_2p32 = UINT64_C(0xFFFFFFFF00000000);
+
+    u64x2 av[6];
+    u64x2 bv[6];
+    av[0].l[0] = UINT64_C(8589934591); av[0].l[1] = UINT64_C(4294967297);
+    bv[0].l[0] = UINT64_C(4294967297); bv[0].l[1] = UINT64_C(8589934591);
+    av[1].l[0] = neg1;                 av[1].l[1] = neg_2p32;
+    bv[1].l[0] = neg_2p32;             bv[1].l[1] = neg1;
+    av[2].l[0] = imin;                 av[2].l[1] = imax;
+    bv[2].l[0] = imax;                 bv[2].l[1] = imin;
+    av[3].l[0] = imin;                 av[3].l[1] = UINT64_C(0x123456789ABCDEF0);
+    bv[3].l[0] = neg1;                 bv[3].l[1] = UINT64_C(0x123456789ABCDEF0);
+    av[4].l[0] = UINT64_C(8589934592); av[4].l[1] = UINT64_C(0);
+    bv[4].l[0] = UINT64_C(8589934591); bv[4].l[1] = neg1;
+    av[5].l[0] = UINT64_C(266);        av[5].l[1] = neg1;
+    bv[5].l[0] = UINT64_C(10);         bv[5].l[1] = UINT64_C(0);
+
+    for (uint64_t k = 0; k < UINT64_C(6); k = (uint64_t)(k + UINT64_C(1))) {
+        u64x2 a = av[k];
+        u64x2 b = bv[k];
+        a.l[0] = (uint64_t)(a.l[0] + seed);
+        b.l[1] = (uint64_t)(b.l[1] + seed);
+        h = fold_u64x2(h, lt_s(a, b));
+        h = fold_u64x2(h, le_s(a, b));
+        h = fold_u64x2(h, gt_s(a, b));
+        h = fold_u64x2(h, ge_s(a, b));
+        h = fold_u64x2(h, eq_v(a, b));
+        h = fold_u64x2(h, ne_v(a, b));
+        const u64x2 m = lt_s(a, b);
+        h = fold_u64x2(h, select(m, a, b));
+    }
+
+    u64x2 cv[5];
+    u64x2 dv[5];
+    cv[0].l[0] = UINT64_C(9223372036854775808); cv[0].l[1] = UINT64_C(9223372036854775807);
+    dv[0].l[0] = UINT64_C(9223372036854775807); dv[0].l[1] = UINT64_C(9223372036854775808);
+    cv[1].l[0] = UINT64_C(8589934591);          cv[1].l[1] = UINT64_C(4294967297);
+    dv[1].l[0] = UINT64_C(4294967297);          dv[1].l[1] = UINT64_C(8589934591);
+    cv[2].l[0] = UINT64_C(18446744073709551615); cv[2].l[1] = UINT64_C(0);
+    dv[2].l[0] = UINT64_C(0);                    dv[2].l[1] = UINT64_C(18446744073709551615);
+    cv[3].l[0] = UINT64_C(9223372039002259456); cv[3].l[1] = UINT64_C(18446744069414584320);
+    dv[3].l[0] = UINT64_C(9223372039002259456); dv[3].l[1] = UINT64_C(18446744069414584319);
+    cv[4].l[0] = UINT64_C(266);                 cv[4].l[1] = UINT64_C(18446744073709551615);
+    dv[4].l[0] = UINT64_C(10);                  dv[4].l[1] = UINT64_C(0);
+
+    for (uint64_t j = 0; j < UINT64_C(5); j = (uint64_t)(j + UINT64_C(1))) {
+        u64x2 c = cv[j];
+        u64x2 d = dv[j];
+        c.l[0] = (uint64_t)(c.l[0] + seed);
+        d.l[1] = (uint64_t)(d.l[1] + seed);
+        h = fold_u64x2(h, lt_u(c, d));
+        h = fold_u64x2(h, le_u(c, d));
+        h = fold_u64x2(h, gt_u(c, d));
+        h = fold_u64x2(h, ge_u(c, d));
+        h = fold_u64x2(h, eq_v(c, d));
+        h = fold_u64x2(h, ne_v(c, d));
+        const u64x2 m = lt_u(c, d);
+        h = fold_u64x2(h, select(m, c, d));
+    }
+    return h;
+}

--- a/test/vecrows/EXCEPTIONS
+++ b/test/vecrows/EXCEPTIONS
@@ -7,11 +7,3 @@
 # apart from passes, and fails the run if the entry matches nothing, so a fix that
 # lands deletes its line.
 #
-# x86_64 declares (compare, int, 64) packed. the equality predicates are packed
-# (pcmpeqd folded across the two halves), but the SSE2 baseline has no pcmpgtq and the
-# encoder realizes every ordering predicate as a per-lane general-register compare
-# (cmpq, setcc, negq) reassembled with pshufd and por. the row is packed for `==`
-# and `!=` and a lane-wise expansion for `<`, `<=`, `>` and `>=`, which the catalog's
-# per-operation granularity cannot say. surfaced by this suite under #3120.
-x86_64-linux   vecrow_cmp_lt_i64   ordering compare at 64-bit lanes is a per-lane general-register sequence on the SSE2 baseline (#3120)
-x86_64-linux   vecrow_cmp_lt_u64   ordering compare at 64-bit lanes is a per-lane general-register sequence on the SSE2 baseline (#3120)

--- a/test/vecrows/rows.conf
+++ b/test/vecrows/rows.conf
@@ -63,7 +63,7 @@ x86_64-linux      not  int    64   packed  ^pxor\b
 x86_64-linux      cmp  int    8    packed  ^pcmp(gt|eq)b\b
 x86_64-linux      cmp  int    16   packed  ^pcmp(gt|eq)w\b
 x86_64-linux      cmp  int    32   packed  ^pcmp(gt|eq)d\b
-x86_64-linux      cmp  int    64   packed  ^pcmp(gtq|eqq|eqd)\b
+x86_64-linux      cmp  int    64   packed  ^pcmp(gtq|eqq|gtd|eqd)\b
 x86_64-linux      add  float  32   packed  ^addps\b
 x86_64-linux      sub  float  32   packed  ^subps\b
 x86_64-linux      mul  float  32   packed  ^mulps\b


### PR DESCRIPTION
Closes #3120. Refs #3269.

## The cell

x86_64 declares `(compare, int, 64)` packed. Equality was packed (`pcmpeqd` folded across the halves) but the SSE2 baseline has no `pcmpgtq`, so the encoder realized every ordering predicate (`<`, `<=`, `>`, `>=`, signed and unsigned) as a per-lane general-register sequence (`movq`, `cmpq`, `setcc`, `movzbq`, `negq`) reassembled with `pshufd` and `por`. `test/vecrows/EXCEPTIONS` carried the two declared gaps. Owner ruling 2026-09-11: make the declaration true on the baseline.

## The realization

`x64/encode.mach`: the general-register path (`i64_ordering_setcc`, `emit_vcmp_i64_lane_mask`, `emit_gp_inst`) is deleted, not kept as a fallback. `emit_vcmp_gt64_s0(x, y, signed)` is the one site for the whole family: `<` is `>` with the operands swapped, `<=` and `>=` are the negation through the existing all-ones `pxor`. Per 64-bit lane, `x > y` from dword compares only:

```
movaps  x, s1 ; pxor y, s1 ; pxor s0, s0 ; pcmpgtd s1, s0      signs differ, per dword
movaps  x, s1 ; pcmpgtd y, s1 ; pxor s1, s0                    signed gt xor signs-differ = unsigned gt
movaps  x, s1 ; pcmpeqd y, s1 ; pshufd $0xf5 ; pand s0, s1 ; pshufd $0xa0     high halves tie and low half is greater (unsigned)
[signed: movaps x, s0 ; pcmpgtd y, s0]  pshufd $0xf5, s0 ; por s1, s0        high halves decide
```

The encoder has two scratch XMM registers (`XMM14`/`XMM15`, the allocator class is 14 wide). The sign-bit-flip form of the low-half unsigned compare needs the constant, a flipped `x` and a flipped `y` live at once, a third register; the signs-differ identity (`gtu = gts ^ ((x ^ y) < 0)`) is the same predicate with no constant to hold, so the sequence fits the two scratches and re-reads `x`/`y` from their operands. No general-register instruction, no constant pool, no new opcode. Under the level axis of #3269, `emit_vcmp_gt64_s0` is the single seam that becomes `pcmpgtq` (signed) or top-bit-flip plus `pcmpgtq` (unsigned); nothing else knows the sequence.

## Tests

- `vector_runtime.compare:i64x2`, `:i64x2_low_half_tie`, `:i64x2_sign_boundary`, `:u64x2`, `:u64x2_top_bit_and_low_half_tie`: every ordering predicate plus `==`/`!=` against the mask the "greater" and "equal" facts imply, on tied high halves with the low half crossing its top bit in both directions (`0x1_FFFFFFFF` against `0x1_00000001`, and under a negative high half), `INT64_MIN` against `INT64_MAX` and `-1` in both lane orders, a set top bit against a clear one both ways for `u64`, a high half one apart with the low half arguing the other way, and an equal pair. The two tests that existed pass under the old sequence too (checked with a compiler built from `origin/dev`), so the fixtures are valid; the new ones are what the old sequence's semantics were never asked.
- Mutation control: dropping the low halves' unsigned correction (`pxor s1, s0` after the signed `pcmpgtd`) fails 4 of the 13 `vector_runtime.compare` tests (`i64x2` exit 2, `i64x2_low_half_tie` exit 1, `u64x2` exit 1, `u64x2_top_bit_and_low_half_tie` exit 1); restored and rebuilt, 13/13.
- `test/vecrows`: both EXCEPTIONS lines deleted (the driver fails on an entry that matches nothing, so this is the acceptance of the row); the x86_64 row's witness pattern names `pcmpgtd` beside the `pcmpgtq` a level will emit. `vecrows/run.sh --target x86_64-linux`: 184 probe cells ok, 0 declared exceptions. Decoded `vecrow_cmp_lt_i64` at o2 is 16 packed instructions between the two `movaps` and `retq`, no general-register instruction. No other target has an EXCEPTIONS entry.
- Corpus: no existing golden on any target carried a 64-bit integer vector ordering compare (`vec_cmp_select` orders 32-bit and narrower integer lanes and the floats only; grep of every x86_64-linux golden for `set*`/`neg*` beside `pshufd` finds none), so no golden moved. `vec/vec_cmp_i64` (case + C reference) is the new golden for the row: goldens blessed for all eight targets; x86_64-linux instruction multiset `pcmpgtd 25, pcmpeqd 22, pshufd 34, pand 18, por 12, pxor 38, set*/neg* 0` (the 8 `cmpq` are the two loop bounds). Layer C agrees with the C reference at o0 and o2 on x86_64-linux (native) and riscv64-linux (qemu). Layer B on aarch64-linux: 92 pass, unchanged (the cross-ISA control). Layer A+B on x86_64-linux: 368 pass, 0 fail, 0 skip, no golden moved.

## Bars

- `mach test` through the from-source compiler: 2741 passed, 0 failed (dev: 2738; +3 is exactly the 2 compare tests replaced by 5).
- `sh test/census.sh`: all ok.

## Remaining #3120 cells

The N3 phase 2 report (PR #3264) left the issue open on this cell only: every retained cell is declared per ISA, undeclared shapes are refused, and the 552 probe cells run in CI. EXCEPTIONS is now empty for every target, so nothing on #3120 remains after this PR.
