### PR TITLE
test(link): zero the C-side al16 so the tail probe reads delivered bytes on every convention (#3263)

### DIFF
--- a/test/link/cases/3263-record-abi-c-callee/case.conf
+++ b/test/link/cases/3263-record-abi-c-callee/case.conf
@@ -10,7 +10,12 @@
 # to every mach-only fixture. The over-aligned 16-byte record is the shape that found
 # one: its second eightbyte holds only padding, System V assigns it no register, and
 # mach used to spend rsi on it, so `c_al16(v, next)` read `next` from the wrong
-# register and a returned `al16` copied rdx's leftovers into the tail padding. The
+# register and a returned `al16` copied rdx's leftovers into the tail padding. `al16_tail`
+# reads that tail; C zeroes the struct it returns because the other three conventions
+# deliver all sixteen bytes, so an indeterminate tail would print C's stack contents
+# there (it did: the first CI run of this case failed on aarch64, riscv64 and windows
+# with `al16_tail=0`). The undelivered-eightbyte zeroing itself is pinned by the
+# compiler's transport tests in mir/abi.mach. The
 # `next` argument after every record is there for that reason: it lands where the
 # convention says only if the record consumed exactly the registers the convention
 # says. Against the unpatched compiler this case reports `al16=3006 al16_after=3015`

--- a/test/link/cases/3263-record-abi-c-callee/probe.c
+++ b/test/link/cases/3263-record-abi-c-callee/probe.c
@@ -48,7 +48,10 @@ struct t9 c_mk_t9(unsigned char x) { struct t9 r; r.d = 1; r.p[0] = x; r.p[7] = 
 struct t16 c_mk_t16(long long x) { struct t16 r; r.d = 1; r.p = x; return r; }
 struct o24 c_mk_o24(long long x) { struct o24 r; r.d = 1; r.p[0] = x; r.p[1] = x + 1; return r; }
 struct nest c_mk_nest(unsigned int x) { struct nest r; r.d = 1; r.p.d = 1; r.p.p = x; return r; }
-struct al16 c_mk_al16(unsigned char x) { struct al16 r; r.d = 1; r.p = x; return r; }
+/* zeroed on purpose: the tail padding is delivered whole on aapcs64, lp64d and win64, so an
+   indeterminate tail would be C's stack garbage there and only System V's undelivered eightbyte
+   makes it a compiler property; the compiler's own transport tests pin that zeroing */
+struct al16 c_mk_al16(unsigned char x) { struct al16 r = {0}; r.d = 1; r.p = x; return r; }
 struct tf c_mk_tf(double x) { struct tf r; r.d = 1; r.p = x; return r; }
 struct tf8 c_mk_tf8(float x) { struct tf8 r; r.d = 1; r.p = x; return r; }
 struct tfm c_mk_tfm(long long x) { struct tfm r; r.p = 2.5; r.q = x; return r; }


### PR DESCRIPTION
The 3263-record-abi-c-callee case asserts that the tail padding of a returned over-aligned record is zero. That is a compiler property only on System V, where the second eightbyte is undelivered and mach zeroes it. On aapcs64, lp64d and win64 all sixteen bytes are delivered, so the probe was reading C's indeterminate stack bytes and dev CI has been red on the three non-x86_64 targets since PR #3265 merged. The C constructor now zero-initializes its struct, which makes the probe convention-independent; the undelivered-eightbyte zeroing stays pinned by the compiler's transport tests in mir/abi.mach. x86_64-linux cells verified locally; the other legs need CI's runners. References #3263.