### PR TITLE
codegen: validate secrecy against final machine effects, phase 1 (#3126)

### DIFF
--- a/doc/design/secrecy-final-effects-3126.md
+++ b/doc/design/secrecy-final-effects-3126.md
@@ -1,0 +1,492 @@
+# Secrecy against final machine effects (#3126), phase 1: inventory
+
+Roadmap item N5. This document inventories every backend stage that runs after
+the early constant-time walk (`ctvalidate.run`), states what dev validates at
+each stage today and with which test, names the concrete late expansions that
+can introduce a secret-dependent branch, address or variable-latency use on
+x86_64, aarch64 and riscv64, states the supported guarantee for the whole-module
+emitter, records what the candidate commit `702bdfb2` adds, and specifies
+phase 2 (the post-expansion validator) precisely enough to build.
+
+Line numbers cite dev at `2b44f81c6` unless a function name is given instead.
+
+## 1. Leakage model and target assumptions
+
+The model has three observation channels, taken from `doc/language/secrecy.md`
+and implemented identically by the three static checkers (sema gates, the MIR
+walk in `ctvalidate.mach`, the asm walk in `asm.mach:ct_scan`):
+
+1. **control-flow trace**: the sequence of taken branches and indirect targets.
+   A secret may not decide a conditional branch, a conditional select that the
+   target implements as a branch, or an indirect branch or call target.
+2. **memory-address trace**: the sequence of effective addresses. A secret may
+   not be a base or index of any load or store. Secret *contents* at a public
+   address are fine.
+3. **operand-dependent latency**: the retirement time of one instruction as a
+   function of its operands. Integer divide and remainder and every
+   floating-point operation are variable-latency on every target
+   (`ct.CT_CAP_ALWAYS`). Integer multiply is variable-latency unless the target
+   declares `MachineModel.ct_trust_mul`; a register-count shift is
+   variable-latency unless it declares `ct_trust_var_shift`
+   (`ct.target_provides`). Today all three ISAs declare `ct_trust_mul = false`
+   and `ct_trust_var_shift = true` (`x64/register.mach`, `arm64/register.mach`,
+   `riscv/register.mach`).
+
+Taint is a two-point lattice per value (public, secret). A value is secret if
+it was declared so at the boundary (a `^` parameter, a load from secret
+storage, a secret call result) or computed from a secret operand. The only
+downgrade is the explicit `:>T` cast, lowered to `MIR_DECLASSIFY`. Unknowns
+fail closed: an opcode without a catalog row, an operand outside the operand
+catalog, a register outside the declared range, an inline-asm mnemonic the
+grammar has not classified, and an inline-asm data directive are all refused,
+never treated as public or constant-time.
+
+Target assumptions the model makes, which no static check can discharge:
+
+- The ISA's documented data-independent timing for the instructions the
+  catalog classes `MCT_NONE` (moves, adds, logic, immediate shifts, compares,
+  conditional selects without branches, loads and stores at a public address)
+  holds on the silicon the program runs on. `ct_trust_*` are declarations, not
+  measurements.
+- Cache, branch-predictor and prefetcher state are the only microarchitectural
+  channels modelled, and only through the address and control traces above.
+  Port contention, frequency scaling, and speculative execution are out of
+  model.
+- A register's secrecy is a property of the register id, not of a width. All
+  three ISAs address sub-registers (`al`/`ax`/`eax`/`rax`, `w0`/`x0`) through
+  one `regid_make(class, index)` id with a separate width, so an alias write
+  taints the whole id. This is sound (an over-approximation) and free.
+- Flags are a fourth taint domain on x86_64 and aarch64 (riscv64 has none).
+  The generated code never lets flags live across the boundary between two MIR
+  instructions (the encoder emits every `cmp`/`test` and its consuming
+  `jcc`/`setcc`/`csinc`/`b.cond` from one `MirInstr`), so at MIR level flags
+  are invisible; inline asm is the only place flags cross instruction
+  boundaries and the asm walk models them. Phase 2 must verify the first
+  clause on the emitted stream rather than assume it.
+- Memory is one taint domain in inline asm (one monotone bit), but in
+  generated code every spill slot is a disjoint, frame-relative extent keyed by
+  the vreg it holds (`add_spill_slot(ctx, v, size)`), so slot-granular memory
+  taint is sound there. Stores through a data-register base are public-address
+  stores of possibly-secret contents; the contents are not tracked through
+  memory and a later load from the same address is trusted to carry the
+  secrecy the IR gave it (`writes_secret` on the load, `MirVReg.secret` on
+  the result).
+- `#[oblivious]` is a per-function contract; a call out is a boundary, not a
+  hole. ABI inputs are trusted to carry the declared secrecy in the declared
+  carriers (this is what `MirAbiInput` records).
+
+## 2. Pipeline position of the early walk
+
+`codegen.mach:codegen_scratch`: `lower.lower_ir` (includes `bulk.expand`
+memcpy/memzero loops and phi lowering) → `looprotate.run` → **`ctvalidate.run`**
+→ `legalize.run` → `isel.run` → `regalloc.run` → `compute_emission_order_module`
+→ `frame.run` → `encode.run`. The whole-module path (`whole_module_image`,
+`codegen.mach:237`) runs `ctvalidate.run` on every unit module before
+`emit_module`, which is where the SPIR-V refusal fires.
+
+What the early walk establishes, and its tests (`ctvalidate.mach`):
+
+| property | mechanism | test |
+|---|---|---|
+| taint re-derived as a monotone fixpoint over vregs and pregs | `apply_instr` | `ctvalidate.rederive:phi_join_branch`, `rederive:inlined_return_address`, `rederive:rotated_loop_backedge` |
+| secret `MIR_CBR` condition, secret `MIR_CALL` target, secret fused-CBR operand refused | `check_instr` | `control:secret_indirect_call`, `rederive:*` |
+| secret memory base or index refused, including a preg base | `mem_base_secret`, `mem_index_secret` | `failclosed:secret_memory_base_preg` |
+| variable-latency class gated on the target's trust | `mir.ct_op` + `ct.target_provides` | `varlat:secret_multiply_capability`, `varlat:secret_shift_count_only`, `varlat:secret_divide_and_precolor` |
+| `MIR_DECLASSIFY` is the only barrier; `MIR_CALL` clears preg taint | `apply_instr` | `barrier:declassify_stops_taint` |
+| unknown opcode, out-of-range register, unknown operand kind refused | `validate_operand_ranges`, `ct_op` error | `failclosed:unknown_opcode_rejected`, `failclosed:out_of_range_registers_rejected`, `failclosed:operand_kind_outside_the_catalog_rejected` |
+| inline asm scanned through the grammar's closed table, refused without one | `check_asm` → `tgt.arch.assembly.ct_scan` | `opaque:inline_asm_forbidden`; per-ISA `*.encode.asm_ct_scan:*` |
+| whole-module emitter refused | `run` | `scope:whole_module_backend_refused`; end to end `mach.lang.driver:oblivious_spirv_refused` |
+| end-to-end oracle | driver | `mach.lang.driver:codegen_terminal_oracle_rejects_mutations` (`CODEGEN_CASE_SECRET_MUL`), `integer_vector_division_accepts_public_and_rejects_either_secret_operand` |
+
+Everything in sections 3 to 9 runs on MIR the walk never re-inspects.
+
+## 3. Legalization (`legalize.mach`)
+
+Fires only for `width > max_alu_width` (i128 on all three ISAs), `!has_mul`
+(riscv without M), `!has_var_shift` (none of the three), and wide int↔float
+conversion (refused on every 8-byte-lane ISA at `conv_prepare`).
+
+Every expansion is straight-line masked arithmetic: no `MIR_CBR`/`MIR_BR` is
+emitted anywhere in the file, memory pieces re-displace the original base
+(`addr_displaced`), and variable-count shifts become a barrel of immediate
+shifts selected by masks (`emit_shift_barrel`). The one variable-latency
+instruction legalization introduces is `emit_divmod_zero_fixup`, which emits
+`MIR_DIV_U probe, #1, divisor` as a divide-by-zero trap probe for a wide
+divide; it derives from the denominator of a `MIR_DIV_*`/`REM_*` that the
+early walk already refused on any secret operand, so it fires only on public
+data.
+
+Two real defects, both fixed in this lane:
+
+- `new_vreg` created every temporary with `secret = false` and `alloc_lanes`
+  copied `class` but not `secret` from the wide vreg, so the lanes of a secret
+  i128 became public vregs after the walk. No leak today (nothing after
+  legalization branches or addresses on those lanes), but the seed set the
+  register allocator's coalescing guard (`try_coalesce`, `dv.secret !=
+  sv.secret`) and any later re-derivation consume was wrong: the fail-open
+  shape. Fix: `alloc_lanes` copies the wide vreg's `secret`. Test:
+  `legalize:lanes_of_a_secret_wide_value_stay_secret`.
+- `expand_mov` erased a wide `MIR_DECLASSIFY` into `MIR_MOV` lanes, so the
+  barrier did not survive legalization. Fix: the pieces keep the source opcode
+  (every ISA already selects `MIR_DECLASSIFY` at any width). Test:
+  `legalize:a_wide_declassify_keeps_its_barrier_per_lane`.
+
+Verdict: **validated by construction, not by test**, on all three ISAs. The
+constructive argument (no branch opcode, no new base register, one divide
+probe behind an already-refused class) is checked by the existing
+`legalize:expands_runtime_shift_as_a_masked_barrel` and `expands_a_wide_divide`
+tests only incidentally (they assert no `MIR_BR`/`MIR_CBR` in the pieces).
+Phase 2 validates it directly by reaching the emitted stream.
+
+## 4. Instruction selection (`rules.mach`, `<isa>/rules.mach`)
+
+All three packs are retag-only plus a small number of `RULE_EXPAND` rules that
+copy the source operands verbatim (`x64` `expand_neg`/`expand_not`, aarch64
+vector compare operand swap). No vregs are created. `combine_cbr`/`fuse_pair`
+fuses `MIR_CMP_cc v, a, b ; MIR_CBR v` into `MIR_SEL_CBR_cc a, b, T, E`; the
+walk already checks the fused forms. There is no `MIR_SELECT` opcode and no
+jump-table lowering, so selection never turns a value into a branch.
+
+**The catalog cannot be consulted after selection.** ISA opcode constants
+(`x64.Opcode` 0..134, `arm64.Opcode` 0..16 and `0x100..`, `riscv.Opcode`
+0..17) are numerically aliased onto generic MIR rows, and `SELECTION_CATALOG`
+has no ISA rows, so `mir.ct_op`/`mir.has` on a post-isel instruction return the
+aliased generic row: `x64.LEA(2)` reads as `MIR_MUL` (INT_MUL), `x64.IDIV(8)`
+as `MIR_AND` (NONE); `arm64.MUL(4)`/`riscv.MUL(4)` as `MIR_DIV_U`;
+`arm64.LSL(8)`/`riscv.SLL(8)` as `MIR_AND` (NONE); `riscv.MULHU(17)` as
+`MIR_CMP_LT_S`. Today only regalloc consults the catalog post-isel
+(`MIRF_SEL_DIVIDE`, `SEL_SHIFT`, `TWO_ADDRESS`, `FLOAT_UNIT`; none set on the
+aliased rows), so the hazard is latent. It rules out "run `ctvalidate` again
+after selection" as any part of phase 2: the final validator must key on the
+emitted `isa.Inst` in the ISA's own opcode space. The namespace collision
+itself is #2212 item 10.2 and is not touched here.
+
+Verdict: **validated** (no new value-dependent branch, address or latency
+class is introduced) on all three ISAs; **gap** in that the effect table is
+unreadable after this stage.
+
+## 5. Register allocation, physical aliases, spill and reload (`regalloc.mach`)
+
+- Rewrite: every vreg operand becomes its assigned preg (`rewrite_instr`);
+  `verify_rewritten_operands` refuses a surviving vreg, a preg outside every
+  class, a bank violation, and a non-GP memory base or index.
+- Coalescing: `try_coalesce` refuses to merge webs whose seed secrecy differs.
+  This guard had no test; `regalloc.coalesce_copies:refuses_to_merge_a_secret_with_a_public_web`
+  is added in this lane.
+- Spill: `emit_reload` emits `MIR_MOV preg(tmp), op_mem_slot(v, 0)` and
+  `emit_store` the reverse, width `spill_width`. `tmp` is drawn from the ISA's
+  reload scratch list (x86_64 `r8/r9/r10`, aarch64 `x9/x10/x11`, riscv64
+  `t2/t3/t4`) and is GP-only (the emitters refuse an FP scratch:
+  `regalloc.rewrite_instr:spilled_update_reloads_previous_value_once`).
+  FP-bank spills stay as `op_mem_slot` operands folded by the encoder through
+  `xmm14`/`v31,v30`/`f31,f30`.
+- Slot addressing: a slot operand resolves at encode to `rbp`/`x29`/`s0` (or
+  `rsp`/`sp` when `frame.realign != 0`) plus a constant (`slot_base_reg`,
+  `frame_slot_offset`), never to a data register. The slot key is the spilled
+  vreg's own id, so memory taint per slot is derivable from `MirVReg.secret`.
+- What a physical validator must model that the vreg walk did not: the reload
+  scratch is a physical alias of the spilled value for the length of one
+  instruction; a spilled secret reloaded into `r10` and then used as a base
+  would be a secret address the vreg walk cannot see because the MEM operand
+  named the vreg. Today this cannot arise (the vreg walk refused the secret
+  base before allocation), but nothing after allocation checks it. Test added
+  in this lane pinning the facts phase 2 seeds from:
+  `regalloc.rewrite_instr:a_spilled_secret_keeps_its_slot_key_through_the_scratch`.
+
+Verdict per ISA: **gap** (timing-preserving by argument, unvalidated by any
+post-allocation check) on x86_64, aarch64, riscv64.
+
+## 6. Flags
+
+Generated code never lets flags cross a `MirInstr` boundary: x86_64
+`encode_compare` emits `cmp; setcc; movzx` and `encode_fused_cbr` emits
+`[mov r11, imm]; cmp; jcc; [jmp]`; aarch64 `emit_flag_cmp` + `csinc` / `b.cond`;
+riscv64 has no flags (`slt`/`sltu`/`xor`+`sltiu`, `beq`…`bgeu`). The vreg walk
+therefore sees a compare as a value producer and a fused branch as an operand
+consumer, which is exact for generated code. Inline asm is the only place a
+`cmp` and its `jcc` are separate instructions, and there the asm walk keeps a
+flags-taint bit with a measured definer table (`x64.probe`).
+
+Verdict: **validated by construction** on all three ISAs for generated code;
+**validated** for inline asm (`x64.encode.asm_ct_scan:*`,
+`arm64.encode.asm_ct_scan:*`, `riscv.encode.asm_ct_scan:*`). Phase 2 must
+check the construction on the emitted stream (a flags-taint bit across
+`isa.Inst` notifications) instead of trusting it.
+
+## 7. Frame insertion (`frame.mach`)
+
+Layout only: slot placement, `frame.omit`, frame distances, reserve check. It
+emits no instructions. Prologue and epilogue are emitted by each encoder
+(section 9). Verdict: **validated** (nothing to validate) on all three ISAs.
+
+## 8. Relaxation
+
+- x86_64 and aarch64: none. `patch_branch_arm64` patches in place and errors
+  when a `b` exceeds ±128 MiB or a `b.cond`/`cbnz` exceeds ±1 MiB.
+- riscv64: `relax_function_bounded` inserts text (`encode.insert_text`) for a
+  B-type fixup out of ±4 KiB (`write_inverted_guard` + `jal x0, target`, both
+  re-notified by `renote_relaxed_branch`) and for a J-type out of ±1 MiB
+  (`auipc t0; jalr x0, t0`, re-notified by `renote_trampoline`). Condition
+  registers are unchanged and targets are fixed labels; the trampoline clobbers
+  `t0`, which is a reserved scratch, never a value carrier. `check_accounted`
+  runs after relaxation, so every inserted word is claimed.
+
+Verdict: **validated by construction** (no new value dependence) on riscv64;
+not applicable on x86_64/aarch64. Phase 2 reaches the inserted instructions
+through their notifications like any other.
+
+## 9. Encoding expansion
+
+Per ISA, every site that turns one `MirInstr` into a sequence containing a
+value-dependent branch, a data-register address, or a variable-latency
+instruction. All operands are pregs or slots by now (`mir_to_operand` refuses
+a vreg).
+
+### 9.1 x86_64 (`x64/encode.mach`)
+
+| class | site | trigger | sequence |
+|---|---|---|---|
+| branch introduced late | `emit_u64_to_fp` | `MIR_UI_TO_FP`, `src_width >= 8` | `test r11,r11; jl; cvtsi2sd; jmp; shr/and/or; cvtsi2sd; addsd` (branches on the operand's sign bit) |
+| branch introduced late | `emit_fp_to_u64` | `MIR_FP_TO_UI`, `width >= 8` | `ucomisd xmm,[rip+2^63]; jb; subsd; cvttsd2si; mov r10,imm64; add; jmp; cvttsd2si` |
+| branch (constant trip) | `emit_stack_probe` | prologue when `stack_probe && base_dist > page_size` | `mov r11,total; L: sub rsp,page; mov [rsp],r11; sub r11,page; cmp; ja L` |
+| branch (validated operand) | `encode_cbr`, `encode_fused_cbr`, `encode_call` reg form | `MIR_SEL_CBR*`, `MIR_CALL` | `test; jne; [jmp]`, `cmp; jcc; [jmp]`, `call reg` |
+| variable latency | `encode_divide` | `MIR_SEL_DIV_S/REM_S`, `DIV_U/REM_U` | `cwd/cdq/cqo; idiv r/m`, `xor edx,edx; div r/m` (no INT_MIN/-1 or zero check) |
+| variable latency | `encode_imul` | `MIR_SEL_MUL` | `imul dst, r/m` or `imul dst,dst,imm`, `movabs r11,imm64; imul dst,r11` |
+| variable latency (trusted) | `encode_shift` | `MIR_SEL_SHL/SHR_*` | `shl/shr/sar dst, cl` |
+| variable latency | `encode_float_*`, `encode_float_conv` | `MIR_F*`, `*_TO_FP`, `FP_TO_*` | SSE scalar and packed arithmetic, `ucomiss/sd; setcc; setp`, `cvt*` |
+| address | callee saves, probe, constant pool | prologue/epilogue, float constants | `[rbp±k]`, `[rsp]`, `[rip+disp32]` only |
+| memory-to-memory staging | `encode_inst`, `encode_mov` | any mem→mem | value staged through `r11` (or `r10`), addresses unchanged |
+
+Not emitted anywhere by codegen: `cmov`, `bsf/bsr`, `popcnt`, `rep stos`, `rep
+movs` (the `FLAG_REP` form exists only for the printer test), jump tables.
+
+The two late branches sit behind `MCT_FLOAT` opcodes, which the early walk
+refuses on any secret operand. The divide has no guard on x86_64 (the trap is
+hardware `#DE`).
+
+### 9.2 aarch64 (`arm64/encode.mach`)
+
+| class | site | trigger | sequence |
+|---|---|---|---|
+| branch introduced late | `encode_divide` | `MIR_SEL_DIV_*`, `REM_*` | `cbnz rm,+2; brk` then signed `adds xzr,rm,#1; b.ne; movz x17,#0x8000,lsl 48; subs xzr,rn,x17; b.ne; brk` then `sdiv/udiv`, `msub` for rem (branches on divisor and dividend) |
+| branch (validated operand) | `encode_cbr`, `encode_fused_cbr`, `encode_call` reg form | `MIR_SEL_CBR*`, `MIR_CALL` | `cbnz; [b]`, `subs; b.cond; [b]`, `blr` |
+| variable latency | `encode_alu3(MUL)` | `arm64.MUL` | `mul` (immediates first materialized into `x16/x17`) |
+| variable latency (trusted) | `encode_shift` | `arm64.LSL/LSR/ASR` reg count | `lslv/lsrv/asrv` |
+| variable latency | `encode_fp_*`, `encode_fp_conv`, NEON | `MIR_F*`, conversions, `VEC_*` | `fadd…fdiv`, `fcmp; csinc`, `scvtf/ucvtf/fcvtz*`, `fmul/fdiv Vd` |
+| large immediate | `emit_movewide_seq` | any imm operand | up to four `movz/movk` into `x16`/`x17` |
+| large stack offset | `emit_mem_access`, `emit_fp_mem`, `emit_add_imm` | offset outside the immediate form | `movz/movk x16,#off; ldr/str rt,[base,x16]` (register-offset form with a constant in `x16`) |
+| literal pool | `emit_fp_const` | float constant | `adrp x16; ldr Vd,[x16,:lo12:]` |
+
+No relaxation, no stack probe, no loop in the prologue, no `csel` (masked
+selects come from legalize/lowering; `csinc` only materializes a compare).
+
+### 9.3 riscv64 (`riscv/encode.mach`)
+
+| class | site | trigger | sequence |
+|---|---|---|---|
+| branch introduced late | `emit_divide_guard` | `MIR_SEL_DIV_*`, `REM_*` with register divisor | `[addiw t0,rs2,0]; bne rs2|t0,x0,+8; ebreak` then signed `addi t0,rs2,1; bne t0,x0,+skip; emit_min_check(... bne; ebreak)` (branches on divisor and dividend) |
+| branch (validated operand) | `encode_cbr`, `encode_fused_cbr`, `encode_call` reg form | `MIR_SEL_CBR*`, `MIR_CALL` | `bne cond,x0; [jal]`, `beq/bne/blt/bltu/bge/bgeu; [jal]`, `jalr ra,rs` |
+| branch (relaxation) | `relax_function_bounded` | out-of-range fixup | inverted guard + `jal`, or `auipc t0; jalr x0,t0` |
+| variable latency | `encode_alu3` | `riscv.MUL`, `riscv.MULHU` | `mul/mulw`, `mulhu` |
+| variable latency | `encode_divide` | `MIR_SEL_DIV_*` | `div/divu/rem/remu[w]` (M extension checked at encode, no software fallback) |
+| variable latency (trusted) | `encode_shift` | `riscv.SLL/SRL/SRA` reg count | `sll/srl/sra[w]` |
+| variable latency | `encode_fp_*` | `MIR_F*`, conversions | `fadd…fdiv`, `feq/flt/fle`, `fcvt.*` |
+| large immediate | `emit_li` | any imm operand | `addi`/`lui+addiw`/`lui…slli…addi` chain into `t0`/`t1` |
+| large stack offset | `emit_mem_access`, `emit_fp_mem` | offset outside ±2047 | `li t1,off; add t1,base,t1; ld/sd rt,0(t1)` |
+| atomics | none on the MIR path | `lr/sc/amo*` reachable only from inline asm | classified `CT_OP_NONE` by `asm_ct_class`; a retry loop is caught through its branch |
+
+No stack probe, no loop in the prologue.
+
+### 9.4 Verdict for encoding expansion
+
+Every late branch on all three ISAs (`emit_u64_to_fp`, `emit_fp_to_u64`,
+aarch64 `encode_divide`, riscv64 `emit_divide_guard`) is reachable only from an
+opcode class (`MCT_FLOAT`, `MCT_INT_DIVMOD`) that the early walk refuses on any
+secret operand, and every late address is frame-relative, pc-relative, or a
+constant materialized into a reserved scratch. So the physical stream is
+timing-preserving **by policy** (the walk refused the originating class) and
+**by construction** (no expansion creates a value dependence from nothing).
+Neither is a validation. Verdict per ISA: **gap** (x86_64, aarch64, riscv64):
+no test reaches the emitted instruction stream and re-derives the three
+channels over physical registers.
+
+## 10. Inline assembly
+
+Validated through the closed per-instruction effect description
+(`asm.Grammar.ct_class` → `ct.AsmClass`; `Mnemonic.writes`/`implicit`/
+`implicit_mem`) with register, flags and memory taint domains and fail-closed
+unknowns (`asm.mach:ct_check_item`). Tests: `*.encode.asm_ct_scan:*` on each
+ISA, including `a_spill_does_not_launder_a_secret` and
+`register_indirect_transfer_on_secret_refused`. The x86_64 flags definer table
+is measured on the host (`x64.probe`). An asm block in an oblivious function
+on an ISA without an assembly grammar is refused (`ctvalidate.check_asm`).
+
+Coverage limit worth stating: the x86_64 and aarch64 grammars carry no
+divide, multiply or float mnemonic, so on those ISAs the latency check inside
+asm reaches only register-count shifts; riscv64's grammar admits the whole M
+extension. Any mnemonic outside the table is refused when a secret reaches it.
+
+Verdict: **validated** on all three ISAs (asm), and this is the effect
+description phase 2 reuses for generated code.
+
+## 11. The notification stream today
+
+`encode.sink_claim`/`note_push`/`note_insert_after`/`check_accounted` tie every
+emitted byte to exactly one instruction notification, including bytes inserted
+by riscv64 relaxation. Two facts phase 2 depends on:
+
+- **The sink exists only under `--emit-asm`.** `encode_driver_asm` attaches an
+  `AsmSink` only when `asm_out != nil`; on the binary path `buf.asm == nil`,
+  `sink_active` is false, and every encoder skips its `note_*` calls. There is
+  no instruction stream to validate on an ordinary build today.
+- **The notification payload differs per ISA.** riscv64 pushes an `AsmNote`
+  carrying a full `isa.Inst` for every word (`emit_r/i/s/b/u/j` → `note`).
+  x86_64 (before `702bdfb2`) and aarch64 only `sink_claim` a byte range after
+  rendering; x86_64's `note_inst` has the `isa.Inst` in hand but does not
+  record it, and aarch64's printer works on a private `arm64/printer.mach:Inst`
+  form record, never an `isa.Inst`. Both printers render through
+  `buf.asm.out` and would dereference a nil writer.
+
+## 12. Whole-module emitter (SPIR-V): the supported guarantee
+
+Mach does not emit the instructions that execute; the downstream compiler and
+the device's timing are outside the leakage model. The supported guarantee is
+**refusal**: a `#[oblivious]` function compiled for a whole-module emitter is a
+compile error naming the function and the target (`ctvalidate.run`,
+`unverifiable_msg`), reached from `whole_module_image` for every unit module.
+Non-oblivious functions carrying secrets compile (the sema gates still hold on
+the source). No physical analysis is claimed or pretended.
+
+Tests: `ctvalidate.scope:whole_module_backend_refused`,
+`mach.lang.driver:oblivious_spirv_refused`. Verdict: **refused-by-policy**,
+validated.
+
+## 13. Verdict matrix
+
+| stage | x86_64 | aarch64 | riscv64 | spirv |
+|---|---|---|---|---|
+| early walk (`ctvalidate`) | validated | validated | validated | refused-by-policy |
+| legalization | construction (fixed: lane seeds, declassify barrier) | same | same | n/a |
+| selection | validated; catalog unreadable post-isel | same | same | n/a |
+| allocation, aliases, spill/reload | gap | gap | gap | n/a |
+| flags | construction (generated), validated (asm) | same | none | n/a |
+| frame insertion | validated (inert) | validated | validated | n/a |
+| relaxation | n/a | n/a | construction | n/a |
+| encoding expansion | gap (u64↔fp branches behind FLOAT) | gap (divide guard behind DIVMOD) | gap (divide guard behind DIVMOD) | n/a |
+| inline asm | validated | validated | validated | refused |
+
+"construction" means timing-preserving by an argument over the code, with no
+test that reaches the output. "gap" means the same argument holds and phase 2
+must replace it with a check.
+
+## 14. What `702bdfb2` adds, and how it was ported
+
+The candidate is the only prior work. It was cherry-picked onto dev and
+resolved against #3263 (aggregate secrecy carried through carriers):
+
+- `encode.AsmNote` gains `byte_len`, `loc` and `inline_site`; `note_push`
+  computes the extent from the accounted mark and stamps provenance from the
+  sink's current `MirInstr` (`sink_set_mir`, now called around
+  `encode_mir_instr` on all three ISAs; dev had it only on x86_64).
+  riscv64's relaxation re-notes inherit the guard's provenance. This is what
+  gives a phase 2 diagnostic a source location for an instruction the MIR never
+  contained.
+- The x86_64 printer pushes `ASM_NOTE_FUNC`/`BLOCK`/`INST` notes with the
+  `isa.Inst`, so x86_64's stream now carries the instruction like riscv64's.
+- `mir.MirAbiInput` and `MirFunction.abi_inputs`: for every `#[oblivious]`
+  function, `abi.record_abi_inputs` records each incoming carrier (register or
+  argument-area offset, transport width and logical width, secrecy, and for
+  indirect carriers the pointee's content class and size, plus the hidden
+  result pointer). This is the seed set of a physical dataflow: which pregs and
+  which stack bytes are secret at entry.
+- Resolution against #3263: the candidate hedged non-secret aggregate
+  parameters as `known = false` because nested `^` qualifiers were erased at
+  the boundary. On dev `value.param(...).secret` is `type.contains_secret`
+  (deep) for aggregates, so that case no longer exists; the `known` field was
+  removed and `secret` is the deep answer. `ABI_CONTENT_UNKNOWN` is kept for
+  pointer parameters, whose pointee secrecy is genuinely invisible at the IR
+  boundary. Tests: `abi:incoming_security_facts_preserve_carriers_and_indirect_contents`,
+  `abi:incoming_copies_follow_all_parameter_captures`.
+
+Nothing consumes `abi_inputs` yet; the candidate's own message says the
+checker is unfinished, and the inventory agrees.
+
+## 15. Phase 2: the post-expansion validator
+
+Sized against sections 5, 9 and 11, the validator is larger than one lane. It
+has five parts; each is a drop-in against a frozen interface.
+
+1. **Notification stream on every build.** Split "notify" from "render":
+   `AsmSink` with a nil writer records `AsmNote`s and claims bytes without
+   rendering; `encode_driver_asm` attaches a sink whenever the module contains
+   an oblivious function, not only under `--emit-asm`. The x86_64 and aarch64
+   `note_inst` become notify-then-render, with rendering gated on
+   `buf.asm.out != nil`. aarch64's printer form record must either be
+   translated to an `isa.Inst` at notification (opcode in aarch64's own
+   `Opcode` space, registers as regids, memory as base/index/disp) or the
+   effect table in part 3 must accept the form record. `check_accounted` and
+   `sink.refused` already fail the build if a byte escapes.
+
+2. **Seeds.** `MirAbiInput` (this lane) for entry pregs and argument-area
+   bytes; `MirVReg.secret` through `MirVReg.assigned` and `spill_slot` for
+   every seeded vreg; `writes_secret` loads mark their destination preg at the
+   notification that encodes them; `MIR_DECLASSIFY` (kept as an opcode through
+   legalization by this lane) is the barrier. The rewrite keeps no vreg id on
+   a `PREG` operand; either `rewrite_instr` retains the origin vreg in
+   `MirOperand.vreg` as provenance (`verify_rewritten_operands` only checks
+   `kind`) or the seeds are taken at the `MirInstr` the sink names.
+
+3. **Effect description per emitted instruction.** Reuse
+   `asm.Grammar.ct_class` (`asm_ct_class(code, flags)`) plus
+   `Mnemonic.writes`/`implicit`/`implicit_mem` for every notified `isa.Inst`:
+   this is the same closed table inline asm uses (acceptance bullet). Rows are
+   extended, not paralleled: x86_64 and aarch64 need rows for `imul/idiv/div`,
+   `mul/sdiv/udiv/msub`, the SSE scalar and packed set, `cvt*`, `ucomis*`,
+   `setcc`, `movabs`, `cbnz/tbz`, `csinc`, `movz/movk`, `adrp`; riscv64 needs
+   `mulh*`, the F/D set and `fcvt.*`. Every emitted opcode without a row is a
+   build failure in an oblivious function (unknown effects are non-public and
+   non-constant-time). `isa.Inst.clobbers` stays unpopulated; implicit writes
+   come from `Mnemonic.implicit` (item 10.3 rules).
+
+4. **The walk.** Per function, in emission order over the notification list:
+   register taint keyed by regid (aliases free), a flags bit (x86_64,
+   aarch64), slot-granular memory taint for `[fp/sp + const]` extents and the
+   asm walk's monotone bit for everything else, `MIR_CALL` clears
+   caller-saved taint and re-seeds returns. Refusals with a located diagnostic
+   (`AsmNote.loc`, `inline_site`, the rendered instruction): a `cond_flags`
+   branch under flags taint, a `cond_reg` branch or indirect target on a
+   tainted register, a memory operand with a tainted base or index, a
+   variable-latency class on a tainted operand the target does not trust, and
+   any unknown row reached by taint. `ctvalidate.run` stays as the early
+   diagnostic (its messages name the source construct; the physical walk names
+   the instruction).
+
+5. **Mutation controls, one per introduced-late class per ISA**, each proving
+   the walk rejects a program the vreg walk accepts: (a) a late branch, by
+   seeding the divisor preg of a `MIR_SEL_DIV_U` (aarch64, riscv64) or the
+   source of `MIR_FP_TO_UI` (x86_64) secret at the notification level, which
+   the vreg walk never sees because the MIR operand is a public vreg
+   (`new_vreg`) or the seed is injected after allocation; (b) a late address,
+   by spilling a seeded secret vreg and hand-rewriting the reload scratch into
+   a memory base (regalloc fixture) and, on riscv64, by relaxing a branch whose
+   trampoline `auipc t0` is preceded by a tainted `t0` write; (c) a late
+   variable-latency use, by selecting `imul`/`mul`/`mulhu` whose operand
+   preg is seeded secret with `ct_trust_mul = false`. Each control has a
+   sibling that passes when the seed is public, and one that passes when the
+   validator is moved back before allocation (the issue's own control).
+
+The corpus bar for phase 2 is byte-identity: a validator must not move a
+golden.
+
+## 16. Acceptance bullets of #3126 mapped to this lane
+
+| bullet | status |
+|---|---|
+| legalization, selection, allocation, spill/reload, flags, frame effects in final validation | inventory (sections 3 to 9); phase 2 parts 1 to 4 |
+| whole-module emitter guarantee defined | section 12, validated |
+| encoding and relaxation reach every emitted instruction | section 11 (stream exists under `--emit-asm` only); phase 2 part 1 |
+| late secret-dependent branches, addresses, variable-latency uses rejected by mutation controls | phase 2 part 5; classes and sites named in section 9 |
+| inline asm uses the same closed effect descriptions | section 10, validated; phase 2 part 3 reuses the table |
+| unknown effects are not public or constant-time by default | early walk and asm walk, validated (`failclosed:*`, `ct_check_item`); phase 2 part 3 |
+| leakage model and target assumptions documented | section 1 |
+| secret-safe boundary tests with mach-std#550 | `MirAbiInput` recorded (section 14); consumer is phase 2 part 2 |

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -115,6 +115,9 @@ pub val ASM_NOTE_BYTES_WIDTH: usize = 4;
 pub rec AsmNote {
     kind:  u8;
     off:   u32;
+    byte_len: u32;
+    loc: source.SrcLoc;
+    inline_site: u32;
     inst:  isa.Inst;
     name:  intern.StrId;
     id:    u32;
@@ -142,6 +145,9 @@ pub fun sink_init(out: *writer.Writer, interner: *intern.Interner) AsmSink {
 
 pub fun note_blank() AsmNote {
     var n: AsmNote;
+    n.byte_len = 0;
+    n.loc = source.loc_nil();
+    n.inline_site = 0;
     n.kind = ASM_NOTE_INST;
     n.off  = 0;
     n.inst = isa.inst_blank();
@@ -158,6 +164,16 @@ pub fun note_push(buf: *ByteBuf, n: *AsmNote) R.Result[R.Void, str] {
         if (R.is_err[R.Void, str](res_grow)) { ret res_grow; }
     }
     s.notes[s.note_count] = @n;
+    if (s.mi != nil) {
+        s.notes[s.note_count].loc = s.mi.loc;
+        s.notes[s.note_count].inline_site = s.mi.inline_site;
+    }
+    if (n.kind == ASM_NOTE_INST || n.kind == ASM_NOTE_BYTES) {
+        if (buf.len < n.off::usize || buf.len - n.off::usize > 0xFFFFFFFF::usize) {
+            ret R.err[R.Void, str]("encode: instruction notification extent is outside the text range");
+        }
+        s.notes[s.note_count].byte_len = (buf.len - n.off::usize)::u32;
+    }
     s.note_count = s.note_count + 1;
     if (n.kind == ASM_NOTE_INST || n.kind == ASM_NOTE_BYTES) {
         s.note_insts = s.note_insts + 1;
@@ -186,6 +202,7 @@ pub fun note_insert_after(buf: *ByteBuf, idx: u32, n: *AsmNote, nbytes: u32) R.R
         i = i - 1;
     }
     s.notes[at] = @n;
+    if (n.kind == ASM_NOTE_INST) { s.notes[at].byte_len = nbytes; }
     s.note_count = s.note_count + 1;
     if (n.kind == ASM_NOTE_INST) {
         s.note_insts = s.note_insts + 1;

--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -211,6 +211,8 @@ fun alloc_lanes(alloc: *A.Allocator, f: *mir.MirFunction, wide: u32, nlanes: u32
         val res_v: R.Result[u32, str] = new_vreg(alloc, f, cls);
         if (R.is_err[u32, str](res_v)) { ret res_v; }
         val vid: u32 = R.unwrap_ok[u32, str](res_v);
+        # a lane is the wide value: the seed the validator and the allocator read must follow it
+        f.vregs[vid].secret = f.vregs[wide].secret;
         if (i == 0) { base = vid; }
         i = i + 1;
     }
@@ -626,12 +628,15 @@ fun expand_mov(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
         ret R.err[R.Void, str](unsupported_message(alloc, mi.opcode, mi.width));
     }
     val lw: u8  = plan.lane_width;
+    # a declassify is the taint barrier; its lanes must stay one or the barrier is gone
+    var piece_op: mir.MirOpcode = mir.MIR_MOV;
+    if (mi.opcode == mir.MIR_DECLASSIFY) { piece_op = mir.MIR_DECLASSIFY; }
     var i: u32 = 0;
     for (i < nl) {
         var ops: [2]mir.MirOperand;
         ops[0] = lane_operand(plan, ?mi.operands[0], i);
         ops[1] = lane_operand(plan, ?mi.operands[1], i);
-        val r: R.Result[R.Void, str] = emit_piece(alloc, dst, cursor, mi, mir.MIR_MOV, ?ops[0], 2, lw);
+        val r: R.Result[R.Void, str] = emit_piece(alloc, dst, cursor, mi, piece_op, ?ops[0], 2, lw);
         if (R.is_err[R.Void, str](r)) { ret r; }
         i = i + 1;
     }
@@ -2910,6 +2915,98 @@ test "mach.lang.be.codegen.legalize:expands_wide_preg_move_onto_consecutive_regs
     if (b.instr_count != 2)     { ret 1; }
     if (b.instrs[0].operands[0].vreg != 1 || b.instrs[0].operands[1].preg != 4) { ret 1; }
     if (b.instrs[1].operands[0].vreg != 2 || b.instrs[1].operands[1].preg != 5) { ret 1; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.legalize:lanes_of_a_secret_wide_value_stay_secret" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var f: mir.MirFunction;
+    t_vregs(?alloc, ?f, 2);
+    f.vregs[0].secret = true;
+    f.vregs[1].secret = false;
+    var b: mir.MirBlock;
+    t_block(?alloc, ?b, 2);
+    var seed: [2]mir.MirOperand;
+    seed[0] = mir.op_vreg(0); seed[1] = mir.op_imm(0x0102);
+    t_instr(?alloc, ?b, 0, mir.MIR_MOV, ?seed[0], 2, 2);
+    var mv: [2]mir.MirOperand;
+    mv[0] = mir.op_vreg(1); mv[1] = mir.op_vreg(0);
+    t_instr(?alloc, ?b, 1, mir.MIR_MOV, ?mv[0], 2, 2);
+    f.blocks = ?b; f.block_count = 1;
+
+    var mach: Machine = t_mach(1, 2);
+    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+    if (b.instr_count != 4 || f.vreg_count != 6) { ret 2; }
+    var i: u32 = 2;
+    for (i < 4) {
+        val dst: u32 = b.instrs[i].operands[0].vreg;
+        val src: u32 = b.instrs[i].operands[1].vreg;
+        if (dst < 2 || src < 2)     { ret 3; }
+        if (!f.vregs[src].secret)   { ret 4; }
+        if (f.vregs[dst].secret)    { ret 5; }
+        i = i + 1;
+    }
+
+    # control: a public wide value legalizes into public lanes
+    var g: mir.MirFunction;
+    t_vregs(?alloc, ?g, 2);
+    g.vregs[0].secret = false;
+    g.vregs[1].secret = false;
+    var gb: mir.MirBlock;
+    t_block(?alloc, ?gb, 2);
+    t_instr(?alloc, ?gb, 0, mir.MIR_MOV, ?seed[0], 2, 2);
+    t_instr(?alloc, ?gb, 1, mir.MIR_MOV, ?mv[0], 2, 2);
+    g.blocks = ?gb; g.block_count = 1;
+    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?g))) { ret 6; }
+    i = 0;
+    for (i < g.vreg_count) {
+        if (g.vregs[i].secret) { ret 7; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.legalize:a_wide_declassify_keeps_its_barrier_per_lane" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    var f: mir.MirFunction;
+    t_vregs(?alloc, ?f, 2);
+    f.vregs[0].secret = true;
+    f.vregs[1].secret = false;
+    var b: mir.MirBlock;
+    t_block(?alloc, ?b, 2);
+    var seed: [2]mir.MirOperand;
+    seed[0] = mir.op_vreg(0); seed[1] = mir.op_imm(0x0102);
+    t_instr(?alloc, ?b, 0, mir.MIR_MOV, ?seed[0], 2, 2);
+    var dc: [2]mir.MirOperand;
+    dc[0] = mir.op_vreg(1); dc[1] = mir.op_vreg(0);
+    t_instr(?alloc, ?b, 1, mir.MIR_DECLASSIFY, ?dc[0], 2, 2);
+    f.blocks = ?b; f.block_count = 1;
+
+    var mach: Machine = t_mach(1, 2);
+    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+    if (b.instr_count != 4) { ret 2; }
+    if (b.instrs[0].opcode != mir.MIR_MOV || b.instrs[1].opcode != mir.MIR_MOV) { ret 7; }
+    var i: u32 = 2;
+    for (i < 4) {
+        if (b.instrs[i].opcode != mir.MIR_DECLASSIFY) { ret 3; }
+        if (b.instrs[i].width != 1)                   { ret 4; }
+        i = i + 1;
+    }
+
+    # control: a plain wide move stays a move
+    var g: mir.MirFunction;
+    t_vregs(?alloc, ?g, 2);
+    var gb: mir.MirBlock;
+    t_block(?alloc, ?gb, 2);
+    t_instr(?alloc, ?gb, 0, mir.MIR_MOV, ?seed[0], 2, 2);
+    t_instr(?alloc, ?gb, 1, mir.MIR_MOV, ?dc[0], 2, 2);
+    g.blocks = ?gb; g.block_count = 1;
+    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?g))) { ret 5; }
+    if (gb.instrs[2].opcode != mir.MIR_MOV || gb.instrs[3].opcode != mir.MIR_MOV) { ret 6; }
     ret 0;
 }
 

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -942,6 +942,31 @@ pub rec MirFrame {
     omit:          bool;
 }
 
+pub val ABI_INPUT_REGISTER: u8 = 0;
+pub val ABI_INPUT_ARG_STACK: u8 = 1;
+pub val ABI_INPUT_SRET: u32 = 0xFFFFFFFF;
+
+pub val ABI_CONTENT_NONE: u8 = 0;
+pub val ABI_CONTENT_UNKNOWN: u8 = 1;
+pub val ABI_CONTENT_PUBLIC: u8 = 2;
+pub val ABI_CONTENT_SECRET: u8 = 3;
+pub val ABI_CONTENT_OUTPUT: u8 = 4;
+
+pub rec MirAbiInput {
+    argument: u32;
+    location: u8;
+    reg: u32;
+    # relative to the abi argument area, not entry sp or established fp
+    offset: i64;
+    width: u64;
+    # only these low bytes have the declared carrier secrecy, excluding padding
+    logical_width: u64;
+    # any secret byte of the object makes every carrier secret (#3263)
+    secret: bool;
+    content: u8;
+    content_size: u64;
+}
+
 pub rec MirFunction {
     name:        intern.StrId;
 
@@ -953,6 +978,10 @@ pub rec MirFunction {
     vregs:       *MirVReg;
     vreg_count:  u32;
     vreg_cap:    u32;
+
+    abi_inputs: *MirAbiInput;
+    abi_input_count: usize;
+    abi_input_cap: usize;
 
     frame:          MirFrame;
     callee_mask:    u32;
@@ -1242,6 +1271,9 @@ pub fun dnit_function(a: *A.Allocator, mf: *MirFunction) {
     if (mf.vregs != nil && mf.vreg_cap > 0) {
         A.deallocate[MirVReg](a, mf.vregs, mf.vreg_cap::usize);
     }
+    if (mf.abi_inputs != nil && mf.abi_input_cap > 0) {
+        A.deallocate[MirAbiInput](a, mf.abi_inputs, mf.abi_input_cap);
+    }
     if (mf.frame.slots != nil && mf.frame.slot_cap > 0) {
         A.deallocate[MirSlot](a, mf.frame.slots, mf.frame.slot_cap::usize);
     }
@@ -1253,6 +1285,9 @@ pub fun dnit_function(a: *A.Allocator, mf: *MirFunction) {
     mf.vregs         = nil;
     mf.vreg_count    = 0;
     mf.vreg_cap      = 0;
+    mf.abi_inputs = nil;
+    mf.abi_input_count = 0;
+    mf.abi_input_cap = 0;
 }
 
 pub fun dnit_block(a: *A.Allocator, mb: *MirBlock) {

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -8,6 +8,7 @@ use std.types.string.str;
 use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
+use V: std.collections.vector;
 
 use mach.lang.intern;
 use mach.lang.be.codegen.mir;
@@ -1186,6 +1187,140 @@ fun emit_ret_slot_to_vreg(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.P
     ret capture_slot_reg(ctx, mb, dst, slot, ty);
 }
 
+fun append_abi_input(inputs: *V.Vector[mir.MirAbiInput], input: mir.MirAbiInput) R.Result[R.Void, str] {
+    if (input.width == 0 || input.logical_width > input.width) {
+        ret R.err[R.Void, str]("mir.abi: invalid incoming carrier extent");
+    }
+    if (input.location == mir.ABI_INPUT_REGISTER) {
+        if (input.reg == mir.MIR_VREG_NIL) {
+            ret R.err[R.Void, str]("mir.abi: incoming carrier has no physical register");
+        }
+    } or (input.location != mir.ABI_INPUT_ARG_STACK || input.offset < 0) {
+        ret R.err[R.Void, str]("mir.abi: invalid incoming argument-area location");
+    }
+    val pushed: R.Result[usize, str] = V.push[mir.MirAbiInput](inputs, input);
+    if (R.is_err[usize, str](pushed)) { ret R.err[R.Void, str](R.unwrap_err[usize, str](pushed)); }
+    ret R.ok_void[str]();
+}
+
+fun record_param_input(ctx: *context.LowerCtx, inputs: *V.Vector[mir.MirAbiInput],
+                       index: u32, slot: abi.ParamSlot) R.Result[R.Void, str] {
+    val param: value.Value = ctx.fn.params[index];
+    val ty: O.Option[*type.IrType] = type.get(ctx.types, param.ty);
+    if (O.is_none[*type.IrType](ty)) { ret R.err[R.Void, str]("mir.abi: incoming parameter type is absent"); }
+    val size: u64 = type.byte_size_for_machine(ctx.types, param.ty, ctx.layout)::u64;
+    if (size == 0) { ret R.ok_void[str](); }
+    val aggregate: bool = context.value_is_aggregate(ctx, param.ty);
+    val indirect: bool = slot.class == abi.CLASS_BYREF || slot.class == abi.CLASS_STACK_BYREF
+        || slot.class == abi.CLASS_VEC_BYREF || slot.class == abi.CLASS_VEC_STACK_BYREF;
+    var input: mir.MirAbiInput;
+    input.argument = index;
+    input.reg = mir.MIR_VREG_NIL;
+    input.secret = param.secret;
+    input.content = mir.ABI_CONTENT_NONE;
+    input.content_size = 0;
+    # a pointee's secrecy is not visible at the ir boundary, so it is unknown rather than public
+    if (O.unwrap[*type.IrType](ty).kind == type.IRT_PTR) { input.content = mir.ABI_CONTENT_UNKNOWN; }
+    if (indirect) {
+        input.width = ctx.tgt.model.pointer_width::u64;
+        input.logical_width = input.width;
+        input.content_size = size;
+        input.content = mir.ABI_CONTENT_PUBLIC;
+        if (input.secret) { input.content = mir.ABI_CONTENT_SECRET; }
+        input.secret = false;
+        if (slot.class == abi.CLASS_STACK_BYREF || slot.class == abi.CLASS_VEC_STACK_BYREF) {
+            input.location = mir.ABI_INPUT_ARG_STACK;
+            input.offset = slot.offset;
+        } or {
+            if (slot.reg < 0) { ret R.err[R.Void, str]("mir.abi: indirect input has no physical register"); }
+            input.reg = slot.reg::u32;
+        }
+        ret append_abi_input(inputs, input);
+    }
+    if (slot.class == abi.CLASS_STACK) {
+        input.location = mir.ABI_INPUT_ARG_STACK;
+        input.offset = slot.offset;
+        input.width = size;
+        if (!aggregate) {
+            input.width = scalar_mem_move_width(ctx.tgt.model.gpr_width, size,
+                natural_stack_slot(ctx.tgt, false))::u64;
+        }
+        input.logical_width = size;
+        ret append_abi_input(inputs, input);
+    }
+    if (slot.class != abi.CLASS_GP && slot.class != abi.CLASS_FP) {
+        ret R.err[R.Void, str]("mir.abi: incoming parameter has no native carrier class");
+    }
+    if (slot.piece_count == 0 || slot.piece_count > abi.PARAM_MAX_PIECES) {
+        ret R.err[R.Void, str]("mir.abi: incoming parameter has invalid carrier pieces");
+    }
+    var i: u32 = 0;
+    for (i < slot.piece_count) {
+        val piece: abi.ParamPiece = slot.pieces[i];
+        val wr: R.Result[u8, str] = abi.piece_memory_width(?slot, ?slot.pieces[i]);
+        if (R.is_err[u8, str](wr)) { ret R.err[R.Void, str](R.unwrap_err[u8, str](wr)); }
+        input.logical_width = R.unwrap_ok[u8, str](wr)::u64;
+        input.width = piece.width::u64;
+        input.location = mir.ABI_INPUT_REGISTER;
+        input.offset = 0;
+        if (piece.kind == abi.PIECE_STACK) {
+            if (piece.stk_off < 0 || slot.offset < 0 || slot.offset > 0x7FFFFFFFFFFFFFFF - piece.stk_off) {
+                ret R.err[R.Void, str]("mir.abi: incoming stack piece offset overflow");
+            }
+            input.location = mir.ABI_INPUT_ARG_STACK;
+            input.reg = mir.MIR_VREG_NIL;
+            input.offset = slot.offset + piece.stk_off;
+            input.width = input.logical_width;
+        } or {
+            if (piece.reg < 0) { ret R.err[R.Void, str]("mir.abi: incoming piece has no physical register"); }
+            input.reg = piece.reg::u32;
+        }
+        if (input.logical_width != 0) {
+            val added: R.Result[R.Void, str] = append_abi_input(inputs, input);
+            if (R.is_err[R.Void, str](added)) { ret added; }
+        }
+        i = i + 1;
+    }
+    ret R.ok_void[str]();
+}
+
+fun record_abi_inputs(ctx: *context.LowerCtx, slots: *abi.SigLayout) R.Result[R.Void, str] {
+    if (slots.param_count != ctx.param_count || ctx.param_count != ctx.fn.param_count) {
+        ret R.err[R.Void, str]("mir.abi: incoming signature does not match declared parameters");
+    }
+    if (ctx.f.abi_inputs != nil || ctx.f.abi_input_count != 0 || ctx.f.abi_input_cap != 0) {
+        ret R.err[R.Void, str]("mir.abi: incoming carrier facts were already recorded");
+    }
+    var inputs: V.Vector[mir.MirAbiInput] = V.init[mir.MirAbiInput](ctx.alloc);
+    fin { V.dnit[mir.MirAbiInput](?inputs); }
+    if (slots.ret_slot.class == abi.CLASS_SRET) {
+        if (ctx.tgt.abi.indirect_result_reg < 0) { ret R.err[R.Void, str]("mir.abi: indirect result has no physical register"); }
+        var result: mir.MirAbiInput;
+        result.argument = mir.ABI_INPUT_SRET;
+        result.reg = ctx.tgt.abi.indirect_result_reg::u32;
+        result.width = ctx.tgt.model.pointer_width::u64;
+        result.logical_width = result.width;
+        result.secret = false;
+        result.content = mir.ABI_CONTENT_OUTPUT;
+        result.content_size = type.byte_size_for_machine(ctx.types, context.fn_return_type(ctx), ctx.layout)::u64;
+        val added: R.Result[R.Void, str] = append_abi_input(?inputs, result);
+        if (R.is_err[R.Void, str](added)) { ret added; }
+    }
+    var i: u32 = 0;
+    for (i < slots.param_count) {
+        val added: R.Result[R.Void, str] = record_param_input(ctx, ?inputs, i, slots.params[i]);
+        if (R.is_err[R.Void, str](added)) { ret added; }
+        i = i + 1;
+    }
+    ctx.f.abi_inputs = inputs.data;
+    ctx.f.abi_input_count = inputs.len;
+    ctx.f.abi_input_cap = inputs.cap;
+    inputs.data = nil;
+    inputs.len = 0;
+    inputs.cap = 0;
+    ret R.ok_void[str]();
+}
+
 pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[R.Void, str] {
     var copies: mir.MirBlock;
     fin { mir.dnit_block(ctx.alloc, ?copies); }
@@ -1198,6 +1333,14 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[R.Void,
         val vr: R.Result[R.Void, str] = lower_value_params(ctx, mb, ?layout);
         sig_layout_free(ctx, ?layout);
         ret vr;
+    }
+
+    if (ctx.f.oblivious) {
+        val inputs: R.Result[R.Void, str] = record_abi_inputs(ctx, ?layout);
+        if (R.is_err[R.Void, str](inputs)) {
+            sig_layout_free(ctx, ?layout);
+            ret inputs;
+        }
     }
 
     if (layout.ret_slot.class == abi.CLASS_SRET) {
@@ -1800,6 +1943,94 @@ test "mach.lang.be.codegen.mir.abi.classify_signature:odd_vector_sret_shifts_mix
     ret 0;
 }
 
+test "mach.lang.be.codegen.mir.abi:incoming_security_facts_preserve_carriers_and_indirect_contents" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val mr: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
+    if (R.is_err[ir.Module, str](mr)) { ret 1; }
+    var m: ir.Module = R.unwrap_ok[ir.Module, str](mr);
+    fin { ir.dnit(?m); }
+    var reg: treg.TargetRegistry = treg.registry_init();
+    fin { treg.registry_dnit(?reg); }
+    if (R.is_err[R.Void, str](treg.register_all(?reg, target_testing.debug_descriptor))) { ret 1; }
+    val tr: R.Result[target.Target, str] = treg.select(?reg, "x86_64", "windows", "win64");
+    if (R.is_err[target.Target, str](tr)) { ret 1; }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
+    val br: R.Result[type.IrTypeId, str] = type.intern_int(?m.types, 8);
+    val fr: R.Result[type.IrTypeId, str] = type.intern_float(?m.types, 64);
+    val pr: R.Result[type.IrTypeId, str] = type.intern_ptr(?m.types);
+    if (R.is_err[type.IrTypeId, str](br) || R.is_err[type.IrTypeId, str](fr)
+        || R.is_err[type.IrTypeId, str](pr)) { ret 1; }
+    val ar: R.Result[type.IrTypeId, str] = type.intern_array(?m.types, R.unwrap_ok[type.IrTypeId, str](br), 24);
+    val vr: R.Result[type.IrTypeId, str] = type.intern_vector(?m.types, R.unwrap_ok[type.IrTypeId, str](br), 16);
+    if (R.is_err[type.IrTypeId, str](ar) || R.is_err[type.IrTypeId, str](vr)) { ret 1; }
+    val array: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](ar);
+    val ptr: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](pr);
+    var types: [7]type.IrTypeId = [7]type.IrTypeId{R.unwrap_ok[type.IrTypeId, str](br),
+        R.unwrap_ok[type.IrTypeId, str](fr), ptr, ptr, array, array, R.unwrap_ok[type.IrTypeId, str](vr)};
+    val sr: R.Result[type.IrTypeId, str] = type.intern_fn(?m.types, array, ?types[0], 7, false);
+    if (R.is_err[type.IrTypeId, str](sr)) { ret 1; }
+    var params: [7]value.Value;
+    var i: u32 = 0;
+    for (i < 7) { params[i] = value.param(i, types[i]); i = i + 1; }
+    params[0].secret = true;
+    params[3].secret = true;
+    params[4].secret = true;
+    var fn: ir.Function;
+    fn.sig = R.unwrap_ok[type.IrTypeId, str](sr);
+    fn.params = ?params[0];
+    fn.param_count = 7;
+    var f: mir.MirFunction;
+    fin { mir.dnit_function(?alloc, ?f); }
+    var ctx: context.LowerCtx;
+    ctx.alloc = ?alloc;
+    ctx.tgt = ?tgt;
+    ctx.layout = target.layout_machine(?tgt);
+    ctx.types = ?m.types;
+    ctx.fn = ?fn;
+    ctx.f = ?f;
+    ctx.param_count = 7;
+    var slots: abi.SigLayout;
+    if (R.is_err[R.Void, str](classify_signature(?ctx, fn.sig, array, ?slots))) { ret 2; }
+    fin { sig_layout_free(?ctx, ?slots); }
+    if (R.is_err[R.Void, str](record_abi_inputs(?ctx, ?slots))) { ret 3; }
+    if (f.abi_input_count != 8) { ret 4; }
+    val inputs: *mir.MirAbiInput = f.abi_inputs;
+    if (inputs[0].argument != mir.ABI_INPUT_SRET || inputs[0].reg != 1
+        || inputs[0].secret || inputs[0].content != mir.ABI_CONTENT_OUTPUT
+        || inputs[0].content_size != 24) { ret 5; }
+    i = 1;
+    for (i < 8) {
+        var logical: u64 = 8;
+        if (i == 1) { logical = 1; }
+        if (inputs[i].argument != i - 1 || inputs[i].width != 8 || inputs[i].logical_width != logical
+            || param_has_use(?fn, i - 1)) { ret 6; }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < 4) {
+        if (inputs[i].location != mir.ABI_INPUT_REGISTER) { ret 7; }
+        i = i + 1;
+    }
+    if (inputs[1].reg != 2 || !inputs[1].secret || inputs[1].content != mir.ABI_CONTENT_NONE
+        || inputs[2].reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 2)::u32 || inputs[2].secret
+        || inputs[3].reg != 9 || inputs[3].secret || inputs[3].content != mir.ABI_CONTENT_UNKNOWN) { ret 7; }
+    i = 4;
+    for (i < 8) {
+        if (inputs[i].location != mir.ABI_INPUT_ARG_STACK || inputs[i].offset != 32 + (i - 4)::i64 * 8) { ret 8; }
+        i = i + 1;
+    }
+    if (!inputs[4].secret || inputs[4].content != mir.ABI_CONTENT_UNKNOWN
+        || inputs[5].secret || inputs[5].content != mir.ABI_CONTENT_SECRET || inputs[5].content_size != 24
+        || inputs[6].secret || inputs[6].content != mir.ABI_CONTENT_PUBLIC || inputs[6].content_size != 24
+        || inputs[7].secret || inputs[7].content != mir.ABI_CONTENT_PUBLIC || inputs[7].content_size != 16) { ret 9; }
+    params[0].secret = false;
+    if (!inputs[1].secret || !R.is_err[R.Void, str](record_abi_inputs(?ctx, ?slots))) { ret 10; }
+    mir.dnit_function(?alloc, ?f);
+    if (f.abi_inputs != nil || f.abi_input_count != 0 || f.abi_input_cap != 0) { ret 11; }
+    ret 0;
+}
+
 fun t_call_preparation(indirect: bool, sret: bool) i32 {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret 1; }
@@ -2257,6 +2488,7 @@ test "mach.lang.be.codegen.mir.abi:incoming_copies_follow_all_parameter_captures
     fn.params = ?params[0];
     fn.param_count = 3;
     var f: mir.MirFunction;
+    f.oblivious = true;
     fin { mir.dnit_function(?alloc, ?f); }
     val regs: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](?alloc, mir.INITIAL_VREG_CAP::usize);
     if (R.is_err[*mir.MirVReg, str](regs)) { ret 1; }
@@ -2279,6 +2511,13 @@ test "mach.lang.be.codegen.mir.abi:incoming_copies_follow_all_parameter_captures
     var mb: mir.MirBlock;
     fin { mir.dnit_block(?alloc, ?mb); }
     if (R.is_err[R.Void, str](lower_params(?ctx, ?mb))) { ret 2; }
+    if (f.abi_input_count != 5 || f.abi_inputs[0].secret || f.abi_inputs[1].secret
+        || f.abi_inputs[2].secret || f.abi_inputs[3].secret || f.abi_inputs[4].secret) { ret 4; }
+    if (f.abi_inputs[0].width != 4 || f.abi_inputs[1].width != 8
+        || f.abi_inputs[1].reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)::u32
+        || f.abi_inputs[2].location != mir.ABI_INPUT_ARG_STACK || f.abi_inputs[2].width != 4
+        || f.abi_inputs[2].argument != 0 || f.abi_inputs[3].argument != 1
+        || f.abi_inputs[4].argument != 2 || f.abi_inputs[4].width != 16) { ret 4; }
     var bytes: CarrierBytes;
     bytes.strict_alignment = true;
     bytes.copy_clobbers_registers = true;

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -80,6 +80,9 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, alloc: 
     mf.vregs               = nil;
     mf.vreg_count          = 0;
     mf.vreg_cap            = 0;
+    mf.abi_inputs          = nil;
+    mf.abi_input_count     = 0;
+    mf.abi_input_cap       = 0;
     mf.frame.slots         = nil;
     mf.frame.slot_count    = 0;
     mf.frame.slot_cap      = 0;

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -3316,6 +3316,56 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:single_assignment_web_is_mer
     ret 0;
 }
 
+test "mach.lang.be.codegen.regalloc.coalesce_copies:refuses_to_merge_a_secret_with_a_public_web" {
+    var reg: target.TargetRegistry;
+    fin { target.registry_dnit(?reg); }
+    var t: target.Target;
+    if (!t_target(?reg, ?t)) { ret 1; }
+    var alloc: A.Allocator;
+    page.make(?alloc);
+
+    # the same single-assignment web single_assignment_web_is_merged merges, seeded secret on one side
+    var f: mir.MirFunction;
+    t_vregs(?alloc, ?f, 2);
+    f.vregs[0].secret = true;
+    var b: mir.MirBlock;
+    t_block(?alloc, ?b, 3);
+    t_mov(?alloc, ?b, 0, mir.op_vreg(0), mir.op_preg(3));
+    t_mov(?alloc, ?b, 1, mir.op_vreg(1), mir.op_vreg(0));
+    t_mov(?alloc, ?b, 2, mir.op_preg(4), mir.op_vreg(1));
+    f.blocks      = ?b;
+    f.block_count = 1;
+    f.block_cap   = 1;
+    var slots: [2]bool;
+    slots[0] = false; slots[1] = false;
+    var ctx: AllocCtx;
+    t_ctx(?ctx, ?alloc, ?f, ?slots[0]);
+    if (R.is_err[R.Void, str](coalesce_copies(?t, ?ctx))) { ret 1; }
+    if (b.instr_count != 3) { ret 2; }
+    if (b.instrs[1].operands[0].vreg != 1 || b.instrs[1].operands[1].vreg != 0) { ret 3; }
+
+    # control: the same web with both sides secret merges
+    var f2: mir.MirFunction;
+    t_vregs(?alloc, ?f2, 2);
+    f2.vregs[0].secret = true;
+    f2.vregs[1].secret = true;
+    var b2: mir.MirBlock;
+    t_block(?alloc, ?b2, 3);
+    t_mov(?alloc, ?b2, 0, mir.op_vreg(0), mir.op_preg(3));
+    t_mov(?alloc, ?b2, 1, mir.op_vreg(1), mir.op_vreg(0));
+    t_mov(?alloc, ?b2, 2, mir.op_preg(4), mir.op_vreg(1));
+    f2.blocks      = ?b2;
+    f2.block_count = 1;
+    f2.block_cap   = 1;
+    var slots2: [2]bool;
+    slots2[0] = false; slots2[1] = false;
+    var ctx2: AllocCtx;
+    t_ctx(?ctx2, ?alloc, ?f2, ?slots2[0]);
+    if (R.is_err[R.Void, str](coalesce_copies(?t, ?ctx2))) { ret 4; }
+    if (b2.instr_count != 2) { ret 5; }
+    ret 0;
+}
+
 fun t_selected_copy(t: *target.Target, opcode: u32, copied: bool) bool {
     var alloc: A.Allocator;
     if (O.is_some[str](page.make(?alloc))) { ret false; }
@@ -3930,6 +3980,64 @@ fun t_spilled_update(mode: u32) i32 {
     } or {
         if (loads != 1 || written != 3) { ret 8; }
     }
+    ret 0;
+}
+
+# a spilled secret travels through a reload scratch and a slot keyed by its own vreg id; these are the
+# physical facts a post-allocation validator seeds from (#3126)
+test "mach.lang.be.codegen.regalloc.rewrite_instr:a_spilled_secret_keeps_its_slot_key_through_the_scratch" {
+    var backing: A.Allocator;
+    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    var scratch_arena: arena.Arena;
+    if (O.is_some[str](arena.init(?scratch_arena, ?backing, 65536))) { ret 1; }
+    fin { arena.dnit(?scratch_arena); }
+    var alloc: A.Allocator;
+    if (O.is_some[str](arena.make(?alloc, ?scratch_arena))) { ret 1; }
+    var vregs: [2]mir.MirVReg;
+    vregs[0] = mir.vreg(0, REG_CLASS_GP, false, true);
+    vregs[0].spill_slot = 0;
+    vregs[1] = mir.vreg(1, REG_CLASS_GP, false, false);
+    vregs[1].assigned = 7;
+    var f: mir.MirFunction;
+    f.vregs = ?vregs[0];
+    f.vreg_count = 2;
+    var scratch: [1]isa.Register;
+    scratch[0].id = 9;
+    var ctx: AllocCtx;
+    ctx.alloc = ?alloc;
+    ctx.f = ?f;
+    ctx.spill_width = 8;
+    ctx.reload_scratch = ?scratch[0];
+    ctx.reload_scratch_count = 1;
+    var tgt: target.Target;
+    val ar: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](?alloc, 3::usize);
+    if (R.is_err[*mir.MirOperand, str](ar)) { ret 1; }
+    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ar);
+    ops[0] = mir.op_vreg(1);
+    ops[1] = mir.op_vreg(1);
+    ops[2] = mir.op_vreg(0);
+    var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ops, 3, 8, 8);
+    if (R.is_err[R.Void, str](rules.capture_operand_banks(?f, ?mi))) { ret 2; }
+    var dst: [4]mir.MirInstr;
+    var written: u32 = 0;
+    fin {
+        var i: u32 = 0;
+        for (i < written) { free_ops(?ctx, dst[i].operands, dst[i].operand_count); i = i + 1; }
+    }
+    if (R.is_err[R.Void, str](rewrite_instr(?tgt, ?ctx, ?mi, ?dst[0], ?written, false, 0))) { ret 3; }
+    if (written != 2) { ret 4; }
+
+    # the reload: the scratch is a physical alias of the secret for one instruction
+    val reload: *mir.MirInstr = ?dst[0];
+    if (reload.opcode != mir.MIR_MOV || reload.operand_count != 2) { ret 5; }
+    if (reload.operands[0].kind != mir.MIR_OP_PREG || reload.operands[0].preg != 9) { ret 6; }
+    if (reload.operands[1].kind != mir.MIR_OP_MEM || reload.operands[1].vreg != 0) { ret 7; }
+    if (!f.vregs[reload.operands[1].vreg].secret) { ret 8; }
+
+    # the use reads the scratch, and the vreg seed survives rewriting untouched
+    val use: *mir.MirInstr = ?dst[1];
+    if (use.opcode != mir.MIR_ADD || use.operands[2].kind != mir.MIR_OP_PREG || use.operands[2].preg != 9) { ret 9; }
+    if (!f.vregs[0].secret || f.vregs[1].secret) { ret 10; }
     ret 0;
 }
 

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -2829,7 +2829,9 @@ fun encode_function_arm64(st: *encode.EncodeState, f: *mir.MirFunction) R.Result
             if (mi.opcode::u16 == arm64.RET::u16 && !naked) {
                 emit_epilogue(st, f, subsize);
             }
+            encode.sink_set_mir(?st.buf, mi);
             val ei: R.Result[R.Void, str] = encode_mir_instr(st, f, fn_base, mi);
+            encode.sink_set_mir(?st.buf, nil);
             if (R.is_err[R.Void, str](ei)) { ret ei; }
             val ra: R.Result[R.Void, str] = check_accounted(st, mi.opcode::u16);
             if (R.is_err[R.Void, str](ra)) { ret ra; }

--- a/src/lang/target/isa/riscv/encode.mach
+++ b/src/lang/target/isa/riscv/encode.mach
@@ -2180,6 +2180,8 @@ fun renote_relaxed_branch(st: *encode.EncodeState, guard_pos: u32, jal_pos: u32,
     }
 
     var jump: encode.AsmNote = encode.note_blank();
+    jump.loc = guard.loc;
+    jump.inline_site = guard.inline_site;
     jump.off  = jal_pos;
     jump.inst = build_inst(inst.JAL, RZERO, 0, 0, 0);
     jump.inst.src1 = isa.make_block_label(target_block);
@@ -2204,6 +2206,8 @@ fun renote_trampoline(st: *encode.EncodeState, auipc_pos: u32, jalr_pos: u32, ta
     hi.inst.src1.sym_mod = isa.SYM_MOD_PCREL_HI;
 
     var lo: encode.AsmNote = encode.note_blank();
+    lo.loc = hi.loc;
+    lo.inline_site = hi.inline_site;
     lo.off  = jalr_pos;
     lo.inst = build_inst(inst.JALR, RZERO, SCRATCH, 0, 0);
     lo.inst.src1.sym_mod = isa.SYM_MOD_PCREL_LO;
@@ -2423,7 +2427,9 @@ fun encode_function_body(st: *encode.EncodeState, f: *mir.MirFunction) R.Result[
             if (mi.opcode::u16 == riscv.RET::u16 && !naked) {
                 emit_epilogue(st, f, total);
             }
+            encode.sink_set_mir(?st.buf, mi);
             val ei: R.Result[R.Void, str] = encode_mir_instr(st, f, fn_base, mi);
+            encode.sink_set_mir(?st.buf, nil);
             if (R.is_err[R.Void, str](ei)) { ret ei; }
             if (mi.opcode != mir.MIR_ASM) {
                 val ar: R.Result[R.Void, str] = check_generated_extensions(st, generated_start);

--- a/src/lang/target/isa/x64/printer.mach
+++ b/src/lang/target/isa/x64/printer.mach
@@ -25,6 +25,12 @@ pub fun emit_header(out: *writer.Writer) R.Result[R.Void, str] {
 }
 
 pub fun note_function(buf: *enc.ByteBuf, interner: *intern.Interner, f: *mir.MirFunction) R.Result[R.Void, str] {
+    var note: enc.AsmNote = enc.note_blank();
+    note.kind = enc.ASM_NOTE_FUNC;
+    note.off = buf.len::u32;
+    note.name = f.name;
+    val kept: R.Result[R.Void, str] = enc.note_push(buf, ?note);
+    if (R.is_err[R.Void, str](kept)) { ret kept; }
     val out: *writer.Writer = buf.asm.out;
     val res_nl: R.Result[R.Void, str] = emit_str(out, "\n# ");
     if (R.is_err[R.Void, str](res_nl)) { ret res_nl; }
@@ -34,6 +40,12 @@ pub fun note_function(buf: *enc.ByteBuf, interner: *intern.Interner, f: *mir.Mir
 }
 
 pub fun note_block(buf: *enc.ByteBuf, id: u32) R.Result[R.Void, str] {
+    var note: enc.AsmNote = enc.note_blank();
+    note.kind = enc.ASM_NOTE_BLOCK;
+    note.off = buf.len::u32;
+    note.id = id;
+    val kept: R.Result[R.Void, str] = enc.note_push(buf, ?note);
+    if (R.is_err[R.Void, str](kept)) { ret kept; }
     val out: *writer.Writer = buf.asm.out;
     val res_dot: R.Result[R.Void, str] = emit_str(out, ".");
     if (R.is_err[R.Void, str](res_dot)) { ret res_dot; }
@@ -48,7 +60,11 @@ pub fun note_inst(buf: *enc.ByteBuf, mi: *isa.Inst, start: usize) {
         enc.sink_fail(buf, R.unwrap_err[R.Void, str](res));
         ret;
     }
-    enc.sink_claim(buf, start);
+    var note: enc.AsmNote = enc.note_blank();
+    note.off = start::u32;
+    note.inst = @mi;
+    val kept: R.Result[R.Void, str] = enc.note_push(buf, ?note);
+    if (R.is_err[R.Void, str](kept)) { enc.sink_fail(buf, R.unwrap_err[R.Void, str](kept)); }
 }
 
 fun render_inst(buf: *enc.ByteBuf, mi: *isa.Inst) R.Result[R.Void, str] {


### PR DESCRIPTION
Refs #3126. Roadmap N5, phase 1: inventory and extraction. Not `Closes`: the post-expansion validator is phase 2 and is specified, not built.

## What is here

- `doc/design/secrecy-final-effects-3126.md`: per-stage, per-ISA inventory of everything after the early `ctvalidate` walk (legalization, selection, allocation and aliases, spill/reload, flags, frame insertion, relaxation, encoding expansion, inline asm), what dev validates today and with which test, the concrete late expansions on x86_64/aarch64/riscv64, the SPIR-V guarantee, the leakage model and target assumptions, and the phase 2 design.
- `702bdfb2` ported and resolved against #3263: `AsmNote` byte extent and provenance (`loc`, `inline_site`, `sink_set_mir` on all three ISAs), x86_64 instruction notes carrying the `isa.Inst`, and `MirFunction.abi_inputs` recording every incoming ABI carrier of an `#[oblivious]` function. The candidate's `known` hedge was dropped because on dev an aggregate parameter's secrecy is already the deep `contains_secret` answer; pointer pointees stay `ABI_CONTENT_UNKNOWN`.
- Two defects the inventory found, fixed with mutation-checked tests: `legalize.alloc_lanes` dropped the secret seed of a wide vreg (its lanes became public after the walk), and `expand_mov` erased a wide `MIR_DECLASSIFY` into `MIR_MOV` lanes (the barrier did not survive legalization).
- Two regalloc tests: the secret/public coalescing guard (previously untested; fails with the guard removed) and the spill-transport facts a physical validator seeds from.

## #3126 acceptance bullets

| bullet | status |
|---|---|
| legalization, selection, allocation, spill/reload, flags, frame effects in final validation | inventory doc sections 3 to 9 with per-stage verdicts; phase 2: notification stream on every build, seeds from `abi_inputs` and vreg seeds, the physical walk (doc section 15 parts 1, 2, 4) |
| whole-module emitters define the supported guarantee | refusal, validated: `ctvalidate.scope:whole_module_backend_refused`, `mach.lang.driver:oblivious_spirv_refused` (doc section 12) |
| encoding and relaxation connected to every emitted instruction | `sink_claim`/`check_accounted` already tie every byte to one notification, including riscv64 relaxation inserts; this PR adds extent and provenance to every note. Phase 2: the sink exists only under `--emit-asm` today and aarch64's note carries no `isa.Inst` (doc section 11, phase 2 part 1) |
| late secret-dependent branches, addresses, variable-latency uses rejected by independent mutation controls | sites named per ISA (doc section 9: x86_64 `emit_u64_to_fp`/`emit_fp_to_u64`, aarch64 `encode_divide`, riscv64 `emit_divide_guard`, spill scratch aliases, riscv64 trampoline); phase 2 part 5 specifies one control per class per ISA |
| inline asm uses the same closed effect descriptions | validated today (`*.encode.asm_ct_scan:*`); phase 2 part 3 reuses `asm_ct_class` for generated code and extends rows (mul/div/float) rather than adding a table |
| unknown effects do not become public or constant-time | validated at the early walk (`ctvalidate.failclosed:*`) and in asm (`ct_check_item`); phase 2 part 3 refuses any emitted opcode without a row |
| leakage model and target assumptions documented | doc section 1 |
| secret-safe boundary tests with mach-std#550 | `abi_inputs` recorded (`abi:incoming_security_facts_preserve_carriers_and_indirect_contents`); the consumer is phase 2 part 2 |

Also found and recorded, not fixed here: ISA opcode numbers alias generic `SELECTION_CATALOG` rows after selection, so `mir.ct_op` cannot be consulted post-isel (doc section 4; the namespace collision is #2212 item 10.2).

## Verification

- `mach test` through the from-source compiler: 2780 passed, 0 failed (baseline 2775; +5: `abi:incoming_security_facts_preserve_carriers_and_indirect_contents`, `legalize:lanes_of_a_secret_wide_value_stay_secret`, `legalize:a_wide_declassify_keeps_its_barrier_per_lane`, `regalloc.coalesce_copies:refuses_to_merge_a_secret_with_a_public_web`, `regalloc.rewrite_instr:a_spilled_secret_keeps_its_slot_key_through_the_scratch`).
- Mutation controls: the two legalize tests fail (exit 4, exit 3) with the respective guard line removed; the coalescing test fails (exit 2) with `dv.secret != sv.secret` removed.
- `sh test/census.sh`: all ok.
- Corpus layer B: x86_64-linux, aarch64-linux, riscv64-linux, 92 pass / 0 fail each; no golden moved.
- Link leg x86_64-linux: 138 pass / 0 fail.
