### PR TITLE
fix(cache): declare darwin's O_NONBLOCK locally, the pinned std does not export it (#3221)

### DIFF
--- a/src/lang/build/cache/store.mach
+++ b/src/lang/build/cache/store.mach
@@ -30,7 +30,9 @@ val HEADER_BYTES: usize = 76;
 val MAGIC: u32 = 0x5348434D;
 val HEX: str = "0123456789abcdef";
 val DIRENT_BUFFER: usize = 8192;
+# the pinned std exports O_NONBLOCK from neither os module, so the two values live here
 $if ($mach.build.os == $mach.os.linux) { val O_NONBLOCK: i32 = 0o4000; }
+$or ($mach.build.os == $mach.os.darwin) { val O_NONBLOCK: i32 = 0x0004; }
 
 pub rec Error {
     message: str;
@@ -171,7 +173,7 @@ fun read_entry(a: *Access, key: *[32]u8, result: *Lookup) {
     leaf(key, ?name);
     var flags: i32 = os.O_RDONLY;
     $if ($mach.build.os == $mach.os.linux) { flags = flags | native.O_NOFOLLOW | O_NONBLOCK; }
-    $or ($mach.build.os == $mach.os.darwin) { flags = flags | native.O_NOFOLLOW | native.O_NONBLOCK; }
+    $or ($mach.build.os == $mach.os.darwin) { flags = flags | native.O_NOFOLLOW | O_NONBLOCK; }
     # windows descriptor-relative open rejects reparse points before returning a handle
     val opened: i64 = os.open(txn.root_fd(?a.root), ?name[0], flags, 0);
     if (opened == os.ENOENT) { ret; }


### PR DESCRIPTION
The object store opened entries with `native.O_NONBLOCK` on darwin, but `std.system.os.darwin` at the pinned std (168a9f76) forwards `O_NOFOLLOW` and not `O_NONBLOCK`, so the compiler did not build for either darwin target since PR #3273. mach's darwin lane runs only at the release gate; mach-std's PR lane bootstraps the v5 compiler on darwin and caught it (std PR #623). The linux value already lived in store.mach for the same reason; the darwin value (0x0004) now sits beside it. Cross-builds of the compiler for darwin-aarch64, darwin-x86_64 and windows-x86_64 succeed from the fix and the darwin-aarch64 cross-build fails on the base. References #3221.