### PR TITLE
compiler: remove the seeded canonical res, opt and err so std declares them (#3226, #617)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,9 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   answer from the checked layout. Representation-changing casts that contain a
   tag are refused. Tags are carried by value through every native convention,
   through SPIR-V as a per-case composite, and by the editor's type, resolve
-  and recovery products. The canonical `res`, `opt` and `err` are std tags;
-  the compiler seeds them at this integration state until std 2.0.0 declares
-  them. The corpus gains a `tag` group of nine cases with C references.
+  and recovery products. The canonical `res`, `opt` and `err` are std tags
+  declared by std 2.0.0; the compiler has no knowledge of their names, and a
+  module may declare its own (#3226, mach-std#617). The corpus gains a `tag`
+  group of nine cases with C references.
 - `#[deprecated]` and `#[deprecated("msg")]` on `fun`, `ext fun`, `rec`,
   `uni`, `tag`, `def`, `val`, `var`, `use`, `fwd` and on a tag case: every use
   from another source module warns once with the message; the declaring

--- a/doc/language/tag.md
+++ b/doc/language/tag.md
@@ -131,10 +131,11 @@ payload. The case names `ok`, `err`, `some` and `none` are members of their
 tags, not keywords.
 
 Their layouts and closed case sets are part of std's SemVer contract; they ship
-in std 2.0.0 paired with Mach 5.0.0. Until that std lands, the compiler at the
-v5 integration state still seeds the three names itself so they resolve without
-an import; the std migration (S1, mach-std#617) removes that seeding, and a
-module declaring its own `res`, `opt` or `err` is refused until then.
+in std 2.0.0 paired with Mach 5.0.0. They are std declarations like any other:
+the compiler has no knowledge of the three names, they resolve only through an
+import or a declaration in scope, and a module may declare its own `res`, `opt`
+or `err` as a tag or as anything else. Declaring one twice in a module is the
+ordinary duplicate definition.
 
 ## Case tests
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -15673,7 +15673,7 @@ test "mach.lang.driver:record_secret_content_carriers_are_secret_and_the_public_
 }
 
 fun ut_tag_guard_program() str {
-    ret "tag Reply: u8 { empty; value: i64; }\n\npub var SEED: i64 = 42;\n\n#[noinline]\nfun make(v: i64) Reply { ret Reply.value{v}; }\n\n#[symbol(\"main\")]\nfun main(argc: i64) i64 {\n    var r: Reply = make(SEED);\n    if (argc == 1) { if (sel r.value) { ret r.value; } ret 1; }\n    if (argc == 2) { val g: res[i64, u8] = res[i64, u8].err{7}; if (sel g.err) { ret g.err::i64; } ret 1; }\n    if (argc == 3) {\n        var t: i64 = 0;\n        var i: i64 = 0;\n        for (i < 3) { i = i + 1; val item: opt[i64] = opt[i64].some{i}; if (!sel item.some) { cnt; } t = t + item.some; }\n        ret t;\n    }\n    if (sel r.value) {\n        val code: *u8 = (?r)::*u8;\n        @code = 0;\n        ret r.value;\n    }\n    ret 1;\n}\n\n#[symbol(\"_start\")]\npub fun start() {\n    $if ($mach.build.arch == $mach.arch.x86_64) {\n        asm x86_64 {\n            mov rdi, [rsp]\n            and rsp, -16\n            call main\n            mov rdi, rax\n            mov rax, 60\n            syscall\n        }\n    }\n    $or ($mach.build.arch == $mach.arch.aarch64) {\n        asm aarch64 {\n            ldr x0, [sp]\n            bl main\n            mov x8, 93\n            svc 0\n        }\n    }\n    $or {\n        asm riscv64 {\n            ld a0, 0(sp)\n            call main\n            li a7, 93\n            ecall\n        }\n    }\n}\n";
+    ret "tag res[T, E]: u8 { err: E; ok: T; } tag opt[T]: u8 { none; some: T; } tag err[E]: u8 { err: E; ok; }\ntag Reply: u8 { empty; value: i64; }\n\npub var SEED: i64 = 42;\n\n#[noinline]\nfun make(v: i64) Reply { ret Reply.value{v}; }\n\n#[symbol(\"main\")]\nfun main(argc: i64) i64 {\n    var r: Reply = make(SEED);\n    if (argc == 1) { if (sel r.value) { ret r.value; } ret 1; }\n    if (argc == 2) { val g: res[i64, u8] = res[i64, u8].err{7}; if (sel g.err) { ret g.err::i64; } ret 1; }\n    if (argc == 3) {\n        var t: i64 = 0;\n        var i: i64 = 0;\n        for (i < 3) { i = i + 1; val item: opt[i64] = opt[i64].some{i}; if (!sel item.some) { cnt; } t = t + item.some; }\n        ret t;\n    }\n    if (sel r.value) {\n        val code: *u8 = (?r)::*u8;\n        @code = 0;\n        ret r.value;\n    }\n    ret 1;\n}\n\n#[symbol(\"_start\")]\npub fun start() {\n    $if ($mach.build.arch == $mach.arch.x86_64) {\n        asm x86_64 {\n            mov rdi, [rsp]\n            and rsp, -16\n            call main\n            mov rdi, rax\n            mov rax, 60\n            syscall\n        }\n    }\n    $or ($mach.build.arch == $mach.arch.aarch64) {\n        asm aarch64 {\n            ldr x0, [sp]\n            bl main\n            mov x8, 93\n            svc 0\n        }\n    }\n    $or {\n        asm riscv64 {\n            ld a0, 0(sp)\n            call main\n            li a7, 93\n            ecall\n        }\n    }\n}\n";
 }
 
 # builds the guard program for one target and runs it: argc 1..3 read guarded payloads, argc 4 switches
@@ -16082,9 +16082,9 @@ fun ut_l4_agreement_program() str {
     ret "tag Reply: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nrec Pair { a: u32; b: u64; }\ntag Multi: u16 { a; b: u8; c: Pair; d: Reply; }\n\nval g_reply: Reply = Reply.value{42};\nval g_empty: Reply = Reply.empty{};\nval g_box: Box[u32] = Box[u32].some{7};\nval g_boxp: Box[Pair] = Box[Pair].some{Pair{a: 1, b: 2}};\nval g_multi_c: Multi = Multi.c{Pair{a: 3, b: 4}};\nval g_multi_d: Multi = Multi.d{Reply.value{5}};\nval g_multi_b: Multi = Multi.b{9};\n\n#[noinline] fun same(a: *u8, b: *u8, n: u64) u8 { var i: u64 = 0; for (i < n) { if (a[i] != b[i]) { ret 0; } i = i + 1; } ret 1; }\n#[noinline] fun mk_reply(v: i64) Reply { ret Reply.value{v}; }\n#[noinline] fun build[T](x: T) Box[T] { $each c in $cases(Box[T]) { $if (c.has_payload) { ret Box[T].[c]{x}; } } ret Box[T].none{}; }\n#[noinline] fun build_named[T](x: T) Box[T] { ret Box[T].some{x}; }\n#[noinline] fun code_of[T](v: T) u64 { $each c in $cases(T) { if (sel v.[c]) { ret c.code; } } ret 99; }\n\n#[symbol(\"main\")]\nfun main(argc: i64) i64 {\n    # a comptime-constructed global and a runtime construction of the same value are byte-identical\n    var r: Reply = mk_reply(42);\n    if (same((?g_reply)::*u8, (?r)::*u8, $size_of(Reply)) == 0) { ret 1; }\n    var e: Reply = Reply.empty{};\n    if (same((?g_empty)::*u8, (?e)::*u8, $size_of(Reply)) == 0) { ret 2; }\n    # inside a generic instantiation, through a descriptor and through the named case\n    var b: Box[u32] = build[u32](7);\n    if (same((?g_box)::*u8, (?b)::*u8, $size_of(Box[u32])) == 0) { ret 3; }\n    var b2: Box[u32] = build_named[u32](7);\n    if (same((?g_box)::*u8, (?b2)::*u8, $size_of(Box[u32])) == 0) { ret 4; }\n    var bp: Box[Pair] = build[Pair](Pair{a: 1, b: 2});\n    if (same((?g_boxp)::*u8, (?bp)::*u8, $size_of(Box[Pair])) == 0) { ret 5; }\n    # a u16 discriminator, a record payload and a nested tag payload\n    var mc: Multi = Multi.c{Pair{a: 3, b: 4}};\n    if (same((?g_multi_c)::*u8, (?mc)::*u8, $size_of(Multi)) == 0) { ret 6; }\n    var md: Multi = Multi.d{mk_reply(5)};\n    if (same((?g_multi_d)::*u8, (?md)::*u8, $size_of(Multi)) == 0) { ret 7; }\n    var mb: Multi = Multi.b{9};\n    if (same((?g_multi_b)::*u8, (?mb)::*u8, $size_of(Multi)) == 0) { ret 8; }\n    # the descriptor code is the stored discriminator on every case\n    if (code_of[Multi](g_multi_c) != 2 || code_of[Multi](g_multi_d) != 3 || code_of[Multi](g_multi_b) != 1) { ret 9; }\n    if (code_of[Reply](g_reply) != 1 || code_of[Reply](g_empty) != 0) { ret 10; }\n    if (code_of[Box[Pair]](g_boxp) != 1) { ret 11; }\n    val pm: *u8 = (?g_multi_d)::*u8;\n    if (pm[0] != 3 || pm[1] != 0) { ret 12; }\n    # `$cases` over a generic instantiation names the specialized payload type and its real offset\n    $each c in $cases(Box[Pair]) {\n        $if (c.has_payload) {\n            $if (c.type == Pair) {} $or { ret 13; }\n            if (c.offset != $offset_of(Box[Pair], some)) { ret 14; }\n            if (sel g_boxp.[c] && g_boxp.[c].b != 2) { ret 15; }\n        }\n    }\n    $each c in $cases(Box[u32]) { $if (c.has_payload) { $if (c.type == u32) {} $or { ret 16; } } }\n    ret 0;\n}\n";
 }
 
-# res/opt/err rewritten as ordinary tag declarations, every reflection item run over them and over the seeded canonical shapes
+# res/opt/err rewritten as ordinary tag declarations, every reflection item run over them and over the std spellings declared the same way
 fun ut_l4_failure_tags_program() str {
-    ret "# the canonical failure types as ordinary tag declarations, with the contract's exact shapes\ntag Res[T, E]: u8 { err: E; ok: T; }\ntag Opt[T]: u8 { none; some: T; }\ntag Err[E]: u8 { err: E; ok; }\ntag ParseError: u8 { invalid; overflow; }\n\n#[noinline] fun strlen(p: *u8) u64 { var n: u64 = 0; for (p[n] != 0) { n = n + 1; } ret n; }\n\n# every reflection item over a user-declared shape; nothing here is compiler-known\n#[noinline]\nfun probe_res(r: Res[i64, ParseError]) i64 {\n    $each c in $cases(Res[i64, ParseError]) {\n        $if (c.has_payload) {\n            $if (c.type == i64) {\n                if (c.code != 1 || strlen(c.name) != 2 || c.offset != $offset_of(Res[i64, ParseError], ok)) { ret -100; }\n                if (sel r.[c]) { ret r.[c]; }\n            }\n            $or {\n                if (c.code != 0 || c.offset != $offset_of(Res[i64, ParseError], err)) { ret -101; }\n                if (sel r.[c]) { if (sel r.[c].overflow) { ret -2; } ret -1; }\n            }\n        }\n        $or { ret -102; }\n    }\n    ret -3;\n}\n\n#[noinline]\nfun probe_opt(o: Opt[u8]) i64 {\n    $each c in $cases(Opt[u8]) {\n        $if (c.has_payload) { if (sel o.[c]) { ret o.[c]::i64; } }\n        $or { if (sel o.[c]) { if (c.code != 0) { ret -100; } ret -1; } }\n    }\n    ret -3;\n}\n\n#[noinline]\nfun probe_err(e: Err[u32]) i64 {\n    $each c in $cases(Err[u32]) {\n        $if (c.has_payload) { if (sel e.[c]) { ret e.[c]::i64; } }\n        $or { if (sel e.[c]) { if (c.code != 1) { ret -100; } ret -1; } }\n    }\n    ret -3;\n}\n\n#[noinline] fun mk_ok[T, E](v: T) Res[T, E] { $each c in $cases(Res[T, E]) { $if (c.has_payload) { $if (c.type == T) { ret Res[T, E].[c]{v}; } } } var z: Res[T, E]; ret z; }\n#[noinline] fun mk_none[T]() Opt[T] { $each c in $cases(Opt[T]) { $if (c.has_payload) {} $or { ret Opt[T].[c]{}; } } var z: Opt[T]; ret z; }\n\n# the same walk over the seeded canonical declarations\n#[noinline]\nfun probe_canon(r: res[i64, u32], o: opt[u8], e: err[u32]) i64 {\n    $each c in $cases(res[i64, u32]) { $if (c.has_payload) { $if (c.type == i64) { if (c.code != 1) { ret -100; } if (sel r.[c] && r.[c] != 7) { ret -1; } } } }\n    $each c in $cases(opt[u8]) { $if (c.has_payload) { if (sel o.[c]) { o.[c] = 5; } } }\n    if (sel o.some && o.some != 5) { ret -2; }\n    $each c in $cases(err[u32]) { $if (c.has_payload) {} $or { if (!sel e.[c] || c.code != 1) { ret -3; } } }\n    $each c in $cases(opt[u8]) { $if (c.has_payload) { o = opt[u8].[c]{6}; } }\n    if (sel o.some && o.some != 6) { ret -4; }\n    if ($offset_of(opt[u8], some) != 1 || $offset_of(res[i64, u32], ok) != 8 || $offset_of(err[u32], err) != 4) { ret -5; }\n    ret 0;\n}\n\n#[symbol(\"main\")]\nfun main(argc: i64) i64 {\n    if ($size_of(Res[i64, ParseError]) != 16 || $align_of(Res[i64, ParseError]) != 8) { ret 1; }\n    if ($size_of(Opt[u8]) != 2 || $size_of(Err[u32]) != 8) { ret 2; }\n    var r: Res[i64, ParseError];\n    if (probe_res(r) != -1) { ret 3; }\n    r = Res[i64, ParseError].err{ParseError.overflow{}};\n    if (probe_res(r) != -2) { ret 4; }\n    r = mk_ok[i64, ParseError](40);\n    if (probe_res(r) != 40) { ret 5; }\n    var o: Opt[u8];\n    if (probe_opt(o) != -1) { ret 6; }\n    o = Opt[u8].some{9};\n    if (probe_opt(o) != 9) { ret 7; }\n    o = mk_none[u8]();\n    if (probe_opt(o) != -1) { ret 8; }\n    var e: Err[u32];\n    if (probe_err(e) != 0) { ret 9; }\n    e = Err[u32].ok{};\n    if (probe_err(e) != -1) { ret 10; }\n    e = Err[u32].err{3};\n    if (probe_err(e) != 3) { ret 11; }\n    var cr: res[i64, u32] = res[i64, u32].ok{7};\n    var co: opt[u8] = opt[u8].some{1};\n    var ce: err[u32] = err[u32].ok{};\n    if (probe_canon(cr, co, ce) != 0) { ret 12; }\n    ret 0;\n}\n";
+    ret "# the canonical failure types as ordinary tag declarations, with the contract's exact shapes\ntag Res[T, E]: u8 { err: E; ok: T; }\ntag Opt[T]: u8 { none; some: T; }\ntag Err[E]: u8 { err: E; ok; }\ntag ParseError: u8 { invalid; overflow; }\n\n#[noinline] fun strlen(p: *u8) u64 { var n: u64 = 0; for (p[n] != 0) { n = n + 1; } ret n; }\n\n# every reflection item over a user-declared shape; nothing here is compiler-known\n#[noinline]\nfun probe_res(r: Res[i64, ParseError]) i64 {\n    $each c in $cases(Res[i64, ParseError]) {\n        $if (c.has_payload) {\n            $if (c.type == i64) {\n                if (c.code != 1 || strlen(c.name) != 2 || c.offset != $offset_of(Res[i64, ParseError], ok)) { ret -100; }\n                if (sel r.[c]) { ret r.[c]; }\n            }\n            $or {\n                if (c.code != 0 || c.offset != $offset_of(Res[i64, ParseError], err)) { ret -101; }\n                if (sel r.[c]) { if (sel r.[c].overflow) { ret -2; } ret -1; }\n            }\n        }\n        $or { ret -102; }\n    }\n    ret -3;\n}\n\n#[noinline]\nfun probe_opt(o: Opt[u8]) i64 {\n    $each c in $cases(Opt[u8]) {\n        $if (c.has_payload) { if (sel o.[c]) { ret o.[c]::i64; } }\n        $or { if (sel o.[c]) { if (c.code != 0) { ret -100; } ret -1; } }\n    }\n    ret -3;\n}\n\n#[noinline]\nfun probe_err(e: Err[u32]) i64 {\n    $each c in $cases(Err[u32]) {\n        $if (c.has_payload) { if (sel e.[c]) { ret e.[c]::i64; } }\n        $or { if (sel e.[c]) { if (c.code != 1) { ret -100; } ret -1; } }\n    }\n    ret -3;\n}\n\n#[noinline] fun mk_ok[T, E](v: T) Res[T, E] { $each c in $cases(Res[T, E]) { $if (c.has_payload) { $if (c.type == T) { ret Res[T, E].[c]{v}; } } } var z: Res[T, E]; ret z; }\n#[noinline] fun mk_none[T]() Opt[T] { $each c in $cases(Opt[T]) { $if (c.has_payload) {} $or { ret Opt[T].[c]{}; } } var z: Opt[T]; ret z; }\n\n# the same walk over the lowercase std spellings, declared here exactly as std declares them\ntag res[T, E]: u8 { err: E; ok: T; } tag opt[T]: u8 { none; some: T; } tag err[E]: u8 { err: E; ok; }\n#[noinline]\nfun probe_canon(r: res[i64, u32], o: opt[u8], e: err[u32]) i64 {\n    $each c in $cases(res[i64, u32]) { $if (c.has_payload) { $if (c.type == i64) { if (c.code != 1) { ret -100; } if (sel r.[c] && r.[c] != 7) { ret -1; } } } }\n    $each c in $cases(opt[u8]) { $if (c.has_payload) { if (sel o.[c]) { o.[c] = 5; } } }\n    if (sel o.some && o.some != 5) { ret -2; }\n    $each c in $cases(err[u32]) { $if (c.has_payload) {} $or { if (!sel e.[c] || c.code != 1) { ret -3; } } }\n    $each c in $cases(opt[u8]) { $if (c.has_payload) { o = opt[u8].[c]{6}; } }\n    if (sel o.some && o.some != 6) { ret -4; }\n    if ($offset_of(opt[u8], some) != 1 || $offset_of(res[i64, u32], ok) != 8 || $offset_of(err[u32], err) != 4) { ret -5; }\n    ret 0;\n}\n\n#[symbol(\"main\")]\nfun main(argc: i64) i64 {\n    if ($size_of(Res[i64, ParseError]) != 16 || $align_of(Res[i64, ParseError]) != 8) { ret 1; }\n    if ($size_of(Opt[u8]) != 2 || $size_of(Err[u32]) != 8) { ret 2; }\n    var r: Res[i64, ParseError];\n    if (probe_res(r) != -1) { ret 3; }\n    r = Res[i64, ParseError].err{ParseError.overflow{}};\n    if (probe_res(r) != -2) { ret 4; }\n    r = mk_ok[i64, ParseError](40);\n    if (probe_res(r) != 40) { ret 5; }\n    var o: Opt[u8];\n    if (probe_opt(o) != -1) { ret 6; }\n    o = Opt[u8].some{9};\n    if (probe_opt(o) != 9) { ret 7; }\n    o = mk_none[u8]();\n    if (probe_opt(o) != -1) { ret 8; }\n    var e: Err[u32];\n    if (probe_err(e) != 0) { ret 9; }\n    e = Err[u32].ok{};\n    if (probe_err(e) != -1) { ret 10; }\n    e = Err[u32].err{3};\n    if (probe_err(e) != 3) { ret 11; }\n    var cr: res[i64, u32] = res[i64, u32].ok{7};\n    var co: opt[u8] = opt[u8].some{1};\n    var ce: err[u32] = err[u32].ok{};\n    if (probe_canon(cr, co, ce) != 0) { ret 12; }\n    ret 0;\n}\n";
 }
 
 test "mach.lang.driver:comptime_tag_values_agree_with_runtime_representation_on_every_native_backend" {
@@ -16118,8 +16118,12 @@ test "mach.lang.driver:tag_fixture_corpus_accepts_and_rejects_identically_across
         val f: TagFixture = TAG_CORPUS[i];
         var want: i32 = 1;
         if (f.accept) { want = 0; }
-        val debug_v:   i32 = ut_pipeline_verdict(?alloc, f.text, pipeline.OPT_DEBUG);
-        val release_v: i32 = ut_pipeline_verdict(?alloc, f.text, pipeline.OPT_RELEASE);
+        val text_opt: O.Option[str] = ut_std_tags(?alloc, f.text);
+        if (O.is_none[str](text_opt)) { ret 5; }
+        val text: str = O.unwrap[str](text_opt);
+        val debug_v:   i32 = ut_pipeline_verdict(?alloc, text, pipeline.OPT_DEBUG);
+        val release_v: i32 = ut_pipeline_verdict(?alloc, text, pipeline.OPT_RELEASE);
+        ut_std_tags_free(?alloc, text);
         if (debug_v != want)   { print.printf("tag-corpus: debug verdict {} for fixture {} (want {})\n", debug_v, i, want); ret 2; }
         if (release_v != want) { print.printf("tag-corpus: release verdict {} for fixture {} (want {})\n", release_v, i, want); ret 3; }
         checked = checked + 1;
@@ -22715,8 +22719,23 @@ test "mach.lang.driver:declaration_cast_gates_resolve_local_and_imported_type_al
         "pub def Flag: u8;\n");
 }
 
+# the std failure tags exactly as std declares them: the compiler knows nothing about these
+# names, so a fixture that uses `res`, `opt` or `err` declares them beneath this prelude
+val TAG_STD_PRELUDE: str = "tag res[T, E]: u8 { err: E; ok: T; } tag opt[T]: u8 { none; some: T; } tag err[E]: u8 { err: E; ok; }\n";
+
+# `text` beneath the std tag prelude; released with ut_std_tags_free
+fun ut_std_tags(alloc: *A.Allocator, text: str) O.Option[str] {
+    val r: R.Result[str, str] = format.sprint(alloc, "{}{}", TAG_STD_PRELUDE, text);
+    if (R.is_err[str, str](r)) { ret O.none[str](); }
+    ret O.some[str](R.unwrap_ok[str, str](r));
+}
+
+fun ut_std_tags_free(alloc: *A.Allocator, text: str) {
+    A.deallocate[char](alloc, text::*char, str_len(text) + 1);
+}
+
 # every plain single-module tag fixture the sema tests carry, in one spelling: the per-topic tests
-# index it by range and the profile-agreement test builds every row through the whole back half
+# index it by range and the profile-agreement test builds every row beneath the std tag prelude
 rec TagFixture {
     text:   str;
     needle: str;
@@ -22791,7 +22810,7 @@ val TAG_CORPUS: [187]TagFixture = [187]TagFixture{
     TagFixture{text: "$if ($is_tag(^err[u32])) { $error(\"secret shape\"); }", needle: "", accept: true, code: 7},
     TagFixture{text: "$if ($size_of(opt[u64]) == 16) {} $or { $error(\"unexpected size\"); }", needle: "", accept: true, code: 8},
     TagFixture{text: "$if ($align_of(opt[u64]) == 8) {} $or { $error(\"unexpected align\"); }", needle: "", accept: true, code: 9},
-    TagFixture{text: "val err: i64 = 10; val r: res[i64, u32] = res[i64, u32].ok{err};", needle: "", accept: true, code: 1},
+    TagFixture{text: "fun f() res[i64, u32] { val err: i64 = 10; ret res[i64, u32].ok{err}; }", needle: "", accept: true, code: 1},
     TagFixture{text: "val ok: u32 = 5; val r: res[i64, u32] = res[i64, u32].err{ok};", needle: "", accept: true, code: 2},
     TagFixture{text: "val none: i64 = 7; val o: opt[i64] = opt[i64].some{none};", needle: "", accept: true, code: 3},
     TagFixture{text: "val some: i32 = 0; val o: opt[i64] = opt[i64].none{};", needle: "", accept: true, code: 4},
@@ -22917,12 +22936,20 @@ val TAG_CORPUS: [187]TagFixture = [187]TagFixture{
 };
 
 fun ut_tag_corpus_range(first: usize, count: usize) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret -1; }
     var i: usize = 0;
     for (i < count) {
         val f: TagFixture = TAG_CORPUS[first + i];
-        if (f.accept) { if (!ut_sema_clean(f.text)) { ret f.code; } }
-        or (str_len(f.needle) == 0) { if (!ut_sema_rejects(f.text)) { ret f.code; } }
-        or { if (!ut_sema_rejects_with(f.text, f.needle)) { ret f.code; } }
+        val text_opt: O.Option[str] = ut_std_tags(?alloc, f.text);
+        if (O.is_none[str](text_opt)) { ret -1; }
+        val text: str = O.unwrap[str](text_opt);
+        var ok: bool = true;
+        if (f.accept) { ok = ut_sema_clean(text); }
+        or (str_len(f.needle) == 0) { ok = ut_sema_rejects(text); }
+        or { ok = ut_sema_rejects_with(text, f.needle); }
+        ut_std_tags_free(?alloc, text);
+        if (!ok) { ret f.code; }
         i = i + 1;
     }
     ret 0;
@@ -22946,7 +22973,7 @@ test "mach.lang.fe.sema:tag_discriminator_is_declared_and_checked" {
     if (ut_sema_extent_is("#[packed] tag Reply: u32 { empty; value: u64; }", "Reply", 12, 1) != 0) { ret 4; }
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; } fun f() $discriminant_of(Reply) { ret 1u8; }")) { ret 5; }
     if (!ut_sema_clean("tag Reply: u32 { empty; value: i64; } fun f() $discriminant_of(Reply) { ret 1u32; }")) { ret 6; }
-    if (!ut_sema_clean("fun f() $discriminant_of(opt[i64]) { ret 1u8; }")) { ret 7; }
+    if (!ut_sema_clean("tag res[T, E]: u8 { err: E; ok: T; } tag opt[T]: u8 { none; some: T; } tag err[E]: u8 { err: E; ok; }\nfun f() $discriminant_of(opt[i64]) { ret 1u8; }")) { ret 7; }
     if (!ut_sema_rejects_with("tag Reply: u32 { empty; } fun f() u8 { ret 1u8::$discriminant_of(Reply); }", "type mismatch")) { ret 8; }
     ret 0;
 }
@@ -22989,7 +23016,7 @@ test "mach.lang.fe.sema:tag_construction_through_qualified_and_aliased_heads" {
     if (!ut_sema_clean2("use uniontest.lib.Reply; fun f() Reply { ret Reply.value{42}; }",
         "pub tag Reply: u8 { empty; value: i64; }")) { ret 4; }
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; } def A: Reply; fun f(v: i64) A { ret A.value{v}; }")) { ret 5; }
-    if (!ut_sema_clean("fun f[E](e: E) res[i64, E] { ret res[i64, E].err{e}; } fun g() res[i64, u32] { ret f[u32](1u32); }")) { ret 6; }
+    if (!ut_sema_clean("tag res[T, E]: u8 { err: E; ok: T; } tag opt[T]: u8 { none; some: T; } tag err[E]: u8 { err: E; ok; }\nfun f[E](e: E) res[i64, E] { ret res[i64, E].err{e}; } fun g() res[i64, u32] { ret f[u32](1u32); }")) { ret 6; }
     if (!ut_sema_rejects_with("rec Point { x: i64; } fun f() Point { ret Point.x{1}; }", "is not a tag")) { ret 7; }
     ret 0;
 }
@@ -22998,7 +23025,7 @@ test "mach.lang.me.lower:tag_values_lower_and_codegen" {
     if (ut_codegen_target_ok("tag Reply: u8 { empty; value: i64; } fun main() i32 { val a: Reply = Reply.value{42}; val b: Reply = Reply.empty{}; if (sel a.value && sel b.empty) { ret 0; } ret 1; }", "linux") != 0) { ret 1; }
     if (ut_codegen_target_ok("tag Reply: u8 { empty; value: i64; } val g: Reply = Reply.value{42}; fun main() i32 { if (sel g.value) { ret 0; } ret 1; }", "linux") != 0) { ret 2; }
     if (ut_codegen_target_ok("tag Wide: u32 { a; b: i64; c: i64; } fun main() i32 { val w: Wide = Wide.c{9}; if (sel w.c) { ret 0; } ret 1; }", "linux") != 0) { ret 3; }
-    if (ut_codegen_target_ok("fun main() i32 { val r: res[i64, u32] = res[i64, u32].ok{5}; if (sel r.ok) { ret 0; } ret 1; }", "linux") != 0) { ret 4; }
+    if (ut_codegen_target_ok("tag res[T, E]: u8 { err: E; ok: T; } tag opt[T]: u8 { none; some: T; } tag err[E]: u8 { err: E; ok; }\nfun main() i32 { val r: res[i64, u32] = res[i64, u32].ok{5}; if (sel r.ok) { ret 0; } ret 1; }", "linux") != 0) { ret 4; }
     if (ut_codegen_target_ok("tag Reply: u8 { empty; value: i64; } rec Box { r: Reply; } fun main() i32 { var b: Box; if (sel b.r.empty) { ret 0; } ret 1; }", "linux") != 0) { ret 5; }
     if (ut_codegen_target_ok("tag Reply: u8 { empty; value: i64; } fun main() i32 { var a: [2]Reply; a[0] = Reply.value{1}; if (sel a[0].value) { ret 0; } ret 1; }", "linux") != 0) { ret 6; }
     val cross: str = "tag Reply: u8 { empty; value: i64; } val g: Reply = Reply.value{42}; fun main() i32 { val a: Reply = Reply.empty{}; if (sel a.empty && sel g.value) { ret 0; } ret 1; }";
@@ -23045,9 +23072,9 @@ test "mach.lang.fe.sema:cases_enumerates_owner_qualified_case_descriptors" {
     if (!ut_sema_rejects_with("tag Reply: u8 { empty; value: i64; }\nfun take[T](v: T) u64 { ret 1; }\nfun f(v: Reply) u64 { $each c in $cases(Reply) { if (sel v.[c]) { ret take[c.type](0); } } ret 0; }", "this case has no payload, so it has no `.type` or `.offset`")) { ret 18; }
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nfun count[T]() u64 { var n: u64 = 0; $each c in $cases(T) { n = n + 1; } ret n; }\nfun g() u64 { ret count[Reply]() + count[Box[u8]](); }")) { ret 11; }
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nrec Holder { r: Reply; n: u8; }\nfun f(h: Holder) i64 { $each f in $fields(Holder) { $if ($is_tag(f.type)) { $each c in $cases(f.type) { $if (c.has_payload) { if (sel h.[f].[c]) { ret h.[f].[c]; } } } } } ret -1; }")) { ret 12; }
-    if (!ut_sema_clean("fun f() u64 { $each c in $cases(res[i64, u32]) { $if (c.has_payload) { $if (c.type == i64) { $if (c.code == 1) {} $or { $error(\"ok code\"); } } } } ret 0; }")) { ret 13; }
-    if (!ut_sema_clean("fun f() u64 { $each c in $cases(opt[u8]) { $if (c.has_payload) {} $or { $if (c.code == 0) {} $or { $error(\"none code\"); } } } ret 0; }")) { ret 14; }
-    if (!ut_sema_clean("fun f() u64 { $each c in $cases(err[u32]) { $if (c.has_payload) { $if (c.type == u32) {} $or { $error(\"err type\"); } } } ret 0; }")) { ret 15; }
+    if (!ut_sema_clean("tag res[T, E]: u8 { err: E; ok: T; } tag opt[T]: u8 { none; some: T; } tag err[E]: u8 { err: E; ok; }\nfun f() u64 { $each c in $cases(res[i64, u32]) { $if (c.has_payload) { $if (c.type == i64) { $if (c.code == 1) {} $or { $error(\"ok code\"); } } } } ret 0; }")) { ret 13; }
+    if (!ut_sema_clean("tag res[T, E]: u8 { err: E; ok: T; } tag opt[T]: u8 { none; some: T; } tag err[E]: u8 { err: E; ok; }\nfun f() u64 { $each c in $cases(opt[u8]) { $if (c.has_payload) {} $or { $if (c.code == 0) {} $or { $error(\"none code\"); } } } ret 0; }")) { ret 14; }
+    if (!ut_sema_clean("tag res[T, E]: u8 { err: E; ok: T; } tag opt[T]: u8 { none; some: T; } tag err[E]: u8 { err: E; ok; }\nfun f() u64 { $each c in $cases(err[u32]) { $if (c.has_payload) { $if (c.type == u32) {} $or { $error(\"err type\"); } } } ret 0; }")) { ret 15; }
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\n$if ($is_tag(Reply)) {} $or { $error(\"tag\"); }\n$if ($is_tag(^Reply)) { $error(\"secret shape\"); }")) { ret 16; }
     if (!ut_sema_rejects_with("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nfun f() u64 { var n: u64 = 0; $each c in $cases(^Reply) { n = n + 1; } ret n; }", "`$cases` refuses `^Reply`")) { ret 17; }
     if (!ut_sema_rejects_with("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nrec P { a: u8; }\nfun f() u64 { var n: u64 = 0; $each c in $cases(P) { n = n + 1; } ret n; }", "`$cases` requires a tag type")) { ret 18; }
@@ -23071,7 +23098,7 @@ test "mach.lang.fe.sema:descriptor_projection_obeys_the_named_case_guard_rules" 
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\ntag Outer: u8 { none; inner: Reply; }\nfun f(o: Outer) i64 { $each c in $cases(Outer) { $if (c.has_payload) { if (sel o.[c]) { if (sel o.[c].value) { ret o.[c].value; } } } } ret -1; }")) { ret 6; }
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nfun f(v: Reply) i64 { $each c in $cases(Reply) { $if (c.has_payload) { if (sel v.[c]) { if (sel v.value) { ret v.value + v.[c]; } } } } ret -1; }")) { ret 7; }
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nfun f(v: Box[u32]) u32 { $each c in $cases(Box[u32]) { $if (c.has_payload) { if (sel v.[c]) { ret v.[c]; } } } ret 0; }")) { ret 8; }
-    if (!ut_sema_clean("fun f(r: res[i64, u32]) i64 { $each c in $cases(res[i64, u32]) { $if (c.has_payload) { $if (c.type == i64) { if (sel r.[c]) { ret r.[c]; } } } } ret -1; }")) { ret 9; }
+    if (!ut_sema_clean("tag res[T, E]: u8 { err: E; ok: T; } tag opt[T]: u8 { none; some: T; } tag err[E]: u8 { err: E; ok; }\nfun f(r: res[i64, u32]) i64 { $each c in $cases(res[i64, u32]) { $if (c.has_payload) { $if (c.type == i64) { if (sel r.[c]) { ret r.[c]; } } } } ret -1; }")) { ret 9; }
     if (!ut_sema_rejects_with("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nfun f(v: Reply) i64 { $each c in $cases(Reply) { $if (c.has_payload) { ret v.[c]; } } ret 0; }", "a tag payload requires a `sel` guard for its case")) { ret 10; }
     if (!ut_sema_rejects_with("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nfun f(v: Reply) i64 { $each c in $cases(Reply) { if (sel v.[c]) { ret v.[c]; } } ret 0; }", "this tag case takes no payload")) { ret 11; }
     if (!ut_sema_rejects_with("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nfun f(v: Reply) i64 { $each c in $cases(Reply) { $if (c.has_payload) { if (sel v.[c] && v.[c] > 3) { ret v.[c]; } } } ret 0; }", "a tag payload requires a `sel` guard for its case")) { ret 12; }
@@ -23089,7 +23116,7 @@ test "mach.lang.fe.sema:descriptor_construction_and_foreign_descriptors" {
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nfun f() Reply { $each c in $cases(Reply) { $if (c.has_payload) {} $or { ret Reply.[c]{}; } } ret Reply.empty{}; }")) { ret 2; }
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nfun build[T](x: T) Box[T] { $each c in $cases(Box[T]) { $if (c.has_payload) { ret Box[T].[c]{x}; } } ret Box[T].none{}; }\nfun g() Box[u32] { ret build[u32](7); }")) { ret 3; }
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\ndef R: Box[u32];\nfun f() R { $each c in $cases(R) { $if (c.has_payload) { ret R.[c]{7}; } } ret R.none{}; }")) { ret 4; }
-    if (!ut_sema_clean("fun f() opt[u8] { $each c in $cases(opt[u8]) { $if (c.has_payload) { ret opt[u8].[c]{4}; } } ret opt[u8].none{}; }")) { ret 5; }
+    if (!ut_sema_clean("tag res[T, E]: u8 { err: E; ok: T; } tag opt[T]: u8 { none; some: T; } tag err[E]: u8 { err: E; ok; }\nfun f() opt[u8] { $each c in $cases(opt[u8]) { $if (c.has_payload) { ret opt[u8].[c]{4}; } } ret opt[u8].none{}; }")) { ret 5; }
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nval g: Reply = Reply.value{42};\nfun f() i64 { $each c in $cases(Reply) { $if (c.has_payload) { if (sel g.[c]) { ret g.[c]; } } } ret 0; }")) { ret 6; }
     if (!ut_sema_rejects_with("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nfun f() Reply { $each c in $cases(Reply) { ret Reply.[c]{1}; } ret Reply.empty{}; }", "this tag case takes no payload")) { ret 7; }
     if (!ut_sema_rejects_with("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nfun f() Reply { $each c in $cases(Reply) { $if (c.has_payload) { ret Reply.[c]{}; } } ret Reply.empty{}; }", "this tag case requires a payload")) { ret 8; }
@@ -23115,7 +23142,7 @@ test "mach.lang.fe.sema:offset_of_answers_from_the_checked_layout_during_type_ch
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nfun f() u64 { $if ($offset_of(Reply, value) == 8) { ret 1; } ret 0; }")) { ret 5; }
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nrec Holder { buf: [$offset_of(Reply, value)]u8; }\n$if ($size_of(Holder) == 8) {} $or { $error(\"type position\"); }")) { ret 6; }
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\n$if ($size_of(Reply) == 16) {} $or { $error(\"size\"); }\n$if ($align_of(Reply) == 8) {} $or { $error(\"align\"); }\n$if ($size_of(^Reply) == 16) {} $or { $error(\"secret size\"); }")) { ret 7; }
-    if (!ut_sema_clean("$if ($offset_of(res[i64, u32], ok) == 8) {} $or { $error(\"res\"); }\n$if ($offset_of(opt[u8], some) == 1) {} $or { $error(\"opt\"); }")) { ret 8; }
+    if (!ut_sema_clean("tag res[T, E]: u8 { err: E; ok: T; } tag opt[T]: u8 { none; some: T; } tag err[E]: u8 { err: E; ok; }\n$if ($offset_of(res[i64, u32], ok) == 8) {} $or { $error(\"res\"); }\n$if ($offset_of(opt[u8], some) == 1) {} $or { $error(\"opt\"); }")) { ret 8; }
     if (!ut_sema_clean("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nfun of[T]() u64 { ret $offset_of(Box[T], some); }\nfun g() u64 { ret of[u64](); }")) { ret 9; }
     if (!ut_sema_rejects_with("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\nfun f() u64 { ret $offset_of(Reply, empty); }", "has no payload, so it has no offset")) { ret 10; }
     if (!ut_sema_rejects_with("tag Reply: u8 { empty; value: i64; }\ntag Other: u8 { empty; value: i64; }\ntag Box[T]: u8 { none; some: T; }\n$if ($offset_of(Reply, empty) == 0) {}", "has no payload, so it has no offset")) { ret 11; }
@@ -23154,11 +23181,35 @@ test "mach.lang.fe.sema:canonical_tags_casts_and_contextual_names" {
 }
 
 test "mach.lang.fe.sema:canonical_tags_specialize_across_modules" {
-    if (!ut_sema_clean2("use uniontest.lib; fun f() res[i64, u32] { val a: opt[i64] = lib.wrap[i64](42); val b: opt[i64] = lib.wrap[i64](7); ret lib.result[i64, u32](42); }", "pub fun wrap[T](v: T) opt[T] { ret opt[T].some{v}; } pub fun result[T, E](v: T) res[T, E] { ret res[T, E].ok{v}; }")) { ret 1; }
-    if (!ut_sema_clean("fun wrap[T](v: T) opt[T] { ret opt[T].some{v}; } fun f() opt[err[u32]] { ret wrap[err[u32]](err[u32].ok{}); }")) { ret 2; }
-    if (!ut_sema_rejects_with("tag opt[T]: u8 { none; some: T; }", "canonical tag name")) { ret 3; }
-    if (!ut_sema_rejects_with("rec res { field: i64; }", "canonical tag name")) { ret 4; }
-    if (!ut_sema_rejects_with("def err: u32;", "canonical tag name")) { ret 5; }
+    if (!ut_sema_clean2("use uniontest.lib; use uniontest.lib.res; use uniontest.lib.opt; fun f() res[i64, u32] { val a: opt[i64] = lib.wrap[i64](42); val b: opt[i64] = lib.wrap[i64](7); ret lib.result[i64, u32](42); }", "pub tag res[T, E]: u8 { err: E; ok: T; } pub tag opt[T]: u8 { none; some: T; } pub fun wrap[T](v: T) opt[T] { ret opt[T].some{v}; } pub fun result[T, E](v: T) res[T, E] { ret res[T, E].ok{v}; }")) { ret 1; }
+    if (!ut_sema_clean("tag res[T, E]: u8 { err: E; ok: T; } tag opt[T]: u8 { none; some: T; } tag err[E]: u8 { err: E; ok; }\nfun wrap[T](v: T) opt[T] { ret opt[T].some{v}; } fun f() opt[err[u32]] { ret wrap[err[u32]](err[u32].ok{}); }")) { ret 2; }
+    ret 0;
+}
+
+test "mach.lang.fe.sema:a_module_may_declare_res_opt_and_err" {
+    # the compiler knows nothing about these names: a module declares them as std does, or as anything else
+    if (!ut_sema_clean("tag res[T, E]: u8 { err: E; ok: T; } val a: res[i64, u32] = res[i64, u32].ok{1};")) { ret 1; }
+    if (!ut_sema_clean("tag opt[T]: u8 { none; some: T; }")) { ret 2; }
+    if (!ut_sema_clean("rec res { field: i64; }")) { ret 3; }
+    if (!ut_sema_clean("def err: u32;")) { ret 4; }
+    if (!ut_sema_clean("fun opt() i64 { ret 1; }")) { ret 5; }
+    # declaring one twice in a module is the ordinary duplicate definition
+    if (!ut_sema_rejects_with("tag res[T, E]: u8 { err: E; ok: T; } tag res[T, E]: u8 { err: E; ok: T; }", "duplicate definition: `res` is already bound in this scope")) { ret 6; }
+    if (!ut_sema_rejects_with("tag opt[T]: u8 { none; some: T; } rec opt { a: u8; }", "duplicate definition: `opt` is already bound in this scope")) { ret 7; }
+    ret 0;
+}
+
+# a generic instantiated over a user-declared res reaches the mangler with a real owner module
+fun ut_generic_over_user_res_program() str {
+    ret "tag res[T, E]: u8 { err: E; ok: T; }\nrec Vector[T] { items: [4]T; len: u64; }\n#[noinline] fun push[T](v: *Vector[T], x: T) { (@v).items[(@v).len] = x; (@v).len = (@v).len + 1; }\n#[noinline] fun at[T](v: *Vector[T], i: u64) T { ret (@v).items[i]; }\n#[noinline] fun sum(v: *Vector[res[i32, u8]]) i64 { var t: i64 = 0; var i: u64 = 0; for (i < (@v).len) { val e: res[i32, u8] = at[res[i32, u8]](v, i); if (sel e.ok) { t = t + e.ok::i64; } or (sel e.err) { t = t - e.err::i64; } i = i + 1; } ret t; }\n#[symbol(\"main\")]\nfun main(argc: i64) i64 {\n    var v: Vector[res[i32, u8]];\n    push[res[i32, u8]](?v, res[i32, u8].ok{7});\n    push[res[i32, u8]](?v, res[i32, u8].err{3});\n    if (v.len != 2 || $size_of(Vector[res[i32, u8]]) != 40) { ret 1; }\n    val a: res[i32, u8] = at[res[i32, u8]](?v, 0);\n    if (sel a.ok) { if (a.ok != 7) { ret 2; } } or { ret 2; }\n    val b: res[i32, u8] = at[res[i32, u8]](?v, 1);\n    if (sel b.err) { if (b.err != 3) { ret 3; } } or { ret 3; }\n    if (sum(?v) != 4) { ret 4; }\n    ret 0;\n}\n";
+}
+
+test "mach.lang.driver:a_generic_instantiated_over_a_user_declared_res_builds_and_runs" {
+    $if ($mach.build.os != $mach.os.linux || $mach.build.arch != $mach.arch.x86_64) { ret 0; }
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    if (ut_tag_native_case(?alloc, "linux-x86_64", "", false, ut_generic_over_user_res_program(), "generic over a user res") != 0) { ret 2; }
+    if (ut_tag_native_case(?alloc, "linux-x86_64", "", true, ut_generic_over_user_res_program(), "generic over a user res") != 0) { ret 3; }
     ret 0;
 }
 

--- a/src/lang/fe/resolve.mach
+++ b/src/lang/fe/resolve.mach
@@ -196,9 +196,6 @@ rec ResolveContext {
     prim_names: [11]intern.StrId;
     prim_syms:  [11]SymbolId;
 
-    canon_tag_names: [type.CANON_TAG_COUNT]intern.StrId;
-    canon_tag_syms:  [type.CANON_TAG_COUNT]SymbolId;
-
     vec_cache: map.Map[intern.StrId, SymbolId];
 
     imported_cache: map.Map[ImportedKey, SymbolId];
@@ -339,12 +336,6 @@ pub fun resolve(
         ret R.err[ResolveResult, fail.Fail](fail.message(R.unwrap_err[R.Void, str](sp_r)));
     }
 
-    val sct_r: R.Result[R.Void, str] = seed_canonical_tags(?rc);
-    if (R.is_err[R.Void, str](sct_r)) {
-        dnit_context(?rc);
-        ret R.err[ResolveResult, fail.Fail](fail.message(R.unwrap_err[R.Void, str](sct_r)));
-    }
-
     val m_opt: O.Option[*module.Module] = ast.get_module(a, a.root_module);
     if (O.is_none[*module.Module](m_opt)) {
         dnit_context(?rc);
@@ -459,13 +450,6 @@ fun init_context(
         rc.prim_names[pi] = intern.STR_NIL;
         rc.prim_syms[pi]  = SYMBOL_NIL;
         pi = pi + 1;
-    }
-
-    var ci: u32 = 0;
-    for (ci < type.CANON_TAG_COUNT) {
-        rc.canon_tag_names[ci] = intern.STR_NIL;
-        rc.canon_tag_syms[ci]  = SYMBOL_NIL;
-        ci = ci + 1;
     }
 
     rc.imported_cache = map.init[ImportedKey, SymbolId](s.alloc, imported_hash, imported_equal);
@@ -625,13 +609,6 @@ fun scope_lookup_chain(rc: *ResolveContext, scope: ScopeId, name: intern.StrId) 
         val found: SymbolId = scope_lookup_local(rc, cur, name);
         if (found != SYMBOL_NIL) { ret found; }
         cur = rc.scopes[cur].parent;
-    }
-    var j: u32 = 0;
-    for (j < type.CANON_TAG_COUNT) {
-        if (rc.canon_tag_names[j] == name) {
-            ret rc.canon_tag_syms[j];
-        }
-        j = j + 1;
     }
     ret SYMBOL_NIL;
 }
@@ -827,33 +804,6 @@ fun seed_one_primitive(rc: *ResolveContext, index: u32, name: str, kind_ordinal:
     ret R.ok_void[str]();
 }
 
-fun seed_canonical_tags(rc: *ResolveContext) R.Result[R.Void, str] {
-    var k: u32 = 0;
-    for (k < type.CANON_TAG_COUNT) {
-        val family: type.CanonTagFamily = k::type.CanonTagFamily;
-        val r: R.Result[R.Void, str] = seed_one_canonical_tag(rc, family, type.canon_tag_name(family));
-        if (R.is_err[R.Void, str](r)) { ret r; }
-        k = k + 1;
-    }
-    ret R.ok_void[str]();
-}
-
-fun seed_one_canonical_tag(rc: *ResolveContext, family: type.CanonTagFamily, name: str) R.Result[R.Void, str] {
-    val r_id: R.Result[intern.StrId, str] = intern.intern(?rc.s.interner, name);
-    if (R.is_err[intern.StrId, str](r_id)) { fail.internal(?rc.status, R.unwrap_err[intern.StrId, str](r_id)); ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](r_id)); }
-    val name_id: intern.StrId = R.unwrap_ok[intern.StrId, str](r_id);
-
-    val r_sym: R.Result[SymbolId, str] = add_symbol(rc, SYM_TAG, 0, name_id, name_id, id.DECL_NIL, family::u32, session.MODULE_NIL);
-    if (R.is_err[SymbolId, str](r_sym)) { fail.internal(?rc.status, R.unwrap_err[SymbolId, str](r_sym)); ret R.err[R.Void, str](R.unwrap_err[SymbolId, str](r_sym)); }
-    val sid: SymbolId = R.unwrap_ok[SymbolId, str](r_sym);
-    rc.symbols[sid].generic_arity = type.canon_tag_arity(family);
-    rc.symbols[sid].definition_file = src.FILE_NIL;
-
-    rc.canon_tag_names[family] = name_id;
-    rc.canon_tag_syms[family]  = sid;
-    ret R.ok_void[str]();
-}
-
 pub def TypeSpellStatus: u8;
 
 pub val TYPE_SPELL_NONE:        TypeSpellStatus = 0;
@@ -879,16 +829,6 @@ fun type_spelling(rc: *ResolveContext, name: intern.StrId) R.Result[TypeSpelling
             ret R.ok[TypeSpelling, str](out);
         }
         i = i + 1;
-    }
-
-    var j: u32 = 0;
-    for (j < type.CANON_TAG_COUNT) {
-        if (rc.canon_tag_names[j] == name) {
-            out.status = TYPE_SPELL_FOUND;
-            out.sym    = rc.canon_tag_syms[j];
-            ret R.ok[TypeSpelling, str](out);
-        }
-        j = j + 1;
     }
 
     val cached: R.Result[*SymbolId, str] = map.get[intern.StrId, SymbolId](?rc.vec_cache, ?name);
@@ -1015,7 +955,7 @@ fun collect_one_decl(rc: *ResolveContext, decl_id: id.DeclId, scope: ScopeId, at
 }
 
 fun declare_decl(rc: *ResolveContext, kind: SymKind, flags: u8, name_span: token.Span, decl_id: id.DeclId, scope: ScopeId) R.Result[R.Void, str] {
-    val rn: R.Result[R.Void, str] = reject_builtin_named_type(rc, kind, name_span);
+    val rn: R.Result[R.Void, str] = reject_vector_spelled_type(rc, kind, name_span);
     if (R.is_err[R.Void, str](rn)) { ret rn; }
 
     val r: R.Result[SymbolId, str] = declare(rc, kind, flags, name_span, decl_id, 0, rc.own_module, scope);
@@ -1026,7 +966,7 @@ fun declare_decl(rc: *ResolveContext, kind: SymKind, flags: u8, name_span: token
     ret R.ok_void[str]();
 }
 
-fun reject_builtin_named_type(rc: *ResolveContext, kind: SymKind, name_span: token.Span) R.Result[R.Void, str] {
+fun reject_vector_spelled_type(rc: *ResolveContext, kind: SymKind, name_span: token.Span) R.Result[R.Void, str] {
     if (kind != SYM_REC && kind != SYM_UNI && kind != SYM_TAG && kind != SYM_DEF) { ret R.ok_void[str](); }
     if (name_span.len == 0) { ret R.ok_void[str](); }
 
@@ -1038,9 +978,6 @@ fun reject_builtin_named_type(rc: *ResolveContext, kind: SymKind, name_span: tok
     if (O.is_none[str](no)) { ret R.ok_void[str](); }
     val spelling: str = O.unwrap[str](no);
 
-    if (O.is_some[type.CanonTagFamily](type.canon_tag_family_from_name(spelling))) {
-        ret report(rc, name_span, "a canonical tag name cannot also name a declared type");
-    }
     if (!type.is_vector_spelling(spelling)) { ret R.ok_void[str](); }
 
     val rm: R.Result[str, str] = format.sprint(rc.s.alloc,

--- a/src/lang/fe/sema/generics.mach
+++ b/src/lang/fe/sema/generics.mach
@@ -957,18 +957,6 @@ fun generic_nominal_of_inner(sc: *sema.SemaContext, sym: *resolve.Symbol) type.T
     if (sym.definition_kind == resolve.SYM_UNI) { kind = type.TYPE_UNI; }
     if (sym.definition_kind == resolve.SYM_TAG) { kind = type.TYPE_TAG; }
     if (sym.definition_file == source.FILE_NIL) {
-        if (sym.definition_kind == resolve.SYM_TAG) {
-            val name_opt: O.Option[str] = intern.lookup(?sc.s.interner, sym.name);
-            if (O.is_some[str](name_opt)) {
-                val fam_opt: O.Option[type.CanonTagFamily] = type.canon_tag_family_from_name(O.unwrap[str](name_opt));
-                if (O.is_some[type.CanonTagFamily](fam_opt)) {
-                    val fam: type.CanonTagFamily = O.unwrap[type.CanonTagFamily](fam_opt);
-                    val r: R.Result[type.TypeId, str] = type.ensure_canon_tag(?sc.s.types, fam, ?sc.s.interner);
-                    if (R.is_err[type.TypeId, str](r)) { fail.internal(?sc.status, R.unwrap_err[type.TypeId, str](r)); ret type.TYPE_ERROR; }
-                    ret R.unwrap_ok[type.TypeId, str](r);
-                }
-            }
-        }
         fail.internal(?sc.status, "generic nominal has no defining source identity");
         ret type.TYPE_ERROR;
     }
@@ -985,13 +973,7 @@ fun build_instance_table(g: *GenericOp, instance: type.TypeId, gnom: type.TypeId
         if (O.unwrap[*type.FieldTable](opt_instance_table).epoch == type.field_epoch(?s.types)) { ret; }
     }
 
-    var opt_generic_table: O.Option[*type.FieldTable] = type.field_table_for(?s.types, gnom);
-    if (O.is_none[*type.FieldTable](opt_generic_table) && type.is_canonical_tag(?s.types, gnom)) {
-        val fam: type.CanonTagFamily = O.unwrap[type.CanonTagFamily](type.canonical_tag_family(?s.types, gnom));
-        val ensured: R.Result[type.TypeId, str] = type.ensure_canon_tag(?s.types, fam, ?s.interner);
-        if (R.is_err[type.TypeId, str](ensured)) { fail.internal(g.status, R.unwrap_err[type.TypeId, str](ensured)); ret; }
-        opt_generic_table = type.field_table_for(?s.types, gnom);
-    }
+    val opt_generic_table: O.Option[*type.FieldTable] = type.field_table_for(?s.types, gnom);
     if (O.is_none[*type.FieldTable](opt_generic_table)) { ret; }
     val fields_len: u32 = O.unwrap[*type.FieldTable](opt_generic_table).fields_len;
 

--- a/src/lang/fe/sema/infer.mach
+++ b/src/lang/fe/sema/infer.mach
@@ -3176,18 +3176,6 @@ fun type_for_symbol(sc: *context.SemaContext, sym: *resolve.Symbol, span: token.
         if (sym.kind == resolve.SYM_UNI) { kind = type.TYPE_UNI; }
         if (sym.kind == resolve.SYM_TAG) { kind = type.TYPE_TAG; }
         if (sym.definition_file == source.FILE_NIL) {
-            if (sym.kind == resolve.SYM_TAG) {
-                val name_opt: O.Option[str] = intern.lookup(?sc.s.interner, sym.name);
-                if (O.is_some[str](name_opt)) {
-                    val fam_opt: O.Option[type.CanonTagFamily] = type.canon_tag_family_from_name(O.unwrap[str](name_opt));
-                    if (O.is_some[type.CanonTagFamily](fam_opt)) {
-                        val fam: type.CanonTagFamily = O.unwrap[type.CanonTagFamily](fam_opt);
-                        val r: R.Result[type.TypeId, str] = type.ensure_canon_tag(?sc.s.types, fam, ?sc.s.interner);
-                        if (R.is_err[type.TypeId, str](r)) { fail.internal(?sc.status, R.unwrap_err[type.TypeId, str](r)); ret type.TYPE_ERROR; }
-                        ret R.unwrap_ok[type.TypeId, str](r);
-                    }
-                }
-            }
             fail.internal(?sc.status, "nominal symbol has no defining source identity");
             ret type.TYPE_ERROR;
         }

--- a/src/lang/fe/sema/recipe.mach
+++ b/src/lang/fe/sema/recipe.mach
@@ -68,10 +68,6 @@ fun nested_recipe(out: *Encoder, value: intern.StrId) {
 
 fun owner(out: *Encoder, value: type.TypeOwner) {
     if (O.is_some[str](out.failure)) { ret; }
-    if (value.module == session.STABLE_MODULE_NIL && value.file == source.FILE_NIL) {
-        byte(out, 'c');
-        ret;
-    }
     if (value.module != session.STABLE_MODULE_NIL) {
         val mid: session.ModuleId = session.module_id_for_stable(out.s, value.module);
         if (mid == session.MODULE_NIL) { out.failure = O.some[str]("canonical type owner is not acquired"); ret; }

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -176,17 +176,6 @@ pub fun init(alloc: *A.Allocator) R.Result[Session, str] {
         ret R.err[Session, str](R.unwrap_err[R.Void, str](res_catalog));
     }
 
-    val res_canon: R.Result[R.Void, str] = type.ensure_all_canonical_tags(?s.types, ?s.interner);
-    if (R.is_err[R.Void, str](res_canon)) {
-        query.dnit(?s.queries);
-        type.dnit(?s.types);
-        intern.dnit(?s.interner);
-
-        diagnostic.store_dnit(?s.diags);
-        source.dnit(?s.sources);
-        ret R.err[Session, str](R.unwrap_err[R.Void, str](res_canon));
-    }
-
     ret R.ok[Session, str](s);
 }
 
@@ -441,8 +430,6 @@ pub fun reset_type_projection(s: *Session) R.Result[R.Void, str] {
     map.clear[u32, u32](?s.type_aligns);
     map.clear[u32, u32](?s.type_packed);
     map.clear[u32, u32](?s.type_volatile);
-    val res_canon: R.Result[R.Void, str] = type.ensure_all_canonical_tags(?s.types, ?s.interner);
-    if (R.is_err[R.Void, str](res_canon)) { ret res_canon; }
     ret R.ok_void[str]();
 }
 

--- a/src/lang/type.mach
+++ b/src/lang/type.mach
@@ -355,39 +355,6 @@ pub rec TypeOwner {
     file: source.FileId;
 }
 
-pub def CanonTagFamily: u8;
-
-pub val CANON_TAG_RES:   CanonTagFamily = 0;
-pub val CANON_TAG_OPT:   CanonTagFamily = 1;
-pub val CANON_TAG_ERR:   CanonTagFamily = 2;
-pub val CANON_TAG_COUNT: u32            = 3;
-
-pub fun canon_tag_arity(family: CanonTagFamily) u32 {
-    if (family == CANON_TAG_RES) { ret 2; }
-    ret 1;
-}
-
-pub fun canon_tag_name(family: CanonTagFamily) str {
-    if (family == CANON_TAG_RES) { ret "res"; }
-    if (family == CANON_TAG_OPT) { ret "opt"; }
-    if (family == CANON_TAG_ERR) { ret "err"; }
-    ret "";
-}
-
-pub fun canon_tag_family_from_name(name: str) O.Option[CanonTagFamily] {
-    if (str_equals(name, "res")) { ret O.some[CanonTagFamily](CANON_TAG_RES); }
-    if (str_equals(name, "opt")) { ret O.some[CanonTagFamily](CANON_TAG_OPT); }
-    if (str_equals(name, "err")) { ret O.some[CanonTagFamily](CANON_TAG_ERR); }
-    ret O.none[CanonTagFamily]();
-}
-
-pub fun canon_tag_owner() TypeOwner {
-    var o: TypeOwner;
-    o.module = module.STABLE_MODULE_NIL;
-    o.file   = source.FILE_NIL;
-    ret o;
-}
-
 pub rec TypeNominal {
     name: intern.StrId;
     owner: TypeOwner;
@@ -473,8 +440,6 @@ pub rec TypeInterner {
     prims: [PRIM_COUNT]TypeId;
 
     vecs: [VEC_COUNT]TypeId;
-
-    canon_tags: [CANON_TAG_COUNT]TypeId;
 
     field_tables: handle.StableChunks[FieldTable];
 
@@ -620,12 +585,6 @@ pub fun init(ti: *TypeInterner, a: *A.Allocator) O.Option[str] {
         }
         ti.vecs[vi] = R.unwrap_ok[TypeId, str](res_vec);
         vi = vi + 1;
-    }
-
-    var ci: u32 = 0;
-    for (ci < CANON_TAG_COUNT) {
-        ti.canon_tags[ci] = TYPE_NIL;
-        ci = ci + 1;
     }
 
     ret O.none[str]();
@@ -1729,28 +1688,6 @@ pub fun is_valid_discriminator_kind(k: TypeKind) bool {
     ret k == TYPE_U8 || k == TYPE_U16 || k == TYPE_U32 || k == TYPE_U64;
 }
 
-pub fun canonical_tag_id(ti: *TypeInterner, family: CanonTagFamily) TypeId {
-    if (family::u32 >= CANON_TAG_COUNT) { ret TYPE_NIL; }
-    ret ti.canon_tags[family];
-}
-
-pub fun canonical_tag_family(ti: *TypeInterner, tid: TypeId) O.Option[CanonTagFamily] {
-    val nom: TypeId = aggregate_nominal(ti, tid);
-    if (nom == TYPE_ERROR || nom == TYPE_NIL) { ret O.none[CanonTagFamily](); }
-    var i: u32 = 0;
-    for (i < CANON_TAG_COUNT) {
-        if (ti.canon_tags[i] != TYPE_NIL && ti.canon_tags[i] == nom) {
-            ret O.some[CanonTagFamily](i::CanonTagFamily);
-        }
-        i = i + 1;
-    }
-    ret O.none[CanonTagFamily]();
-}
-
-pub fun is_canonical_tag(ti: *TypeInterner, tid: TypeId) bool {
-    ret O.is_some[CanonTagFamily](canonical_tag_family(ti, tid));
-}
-
 pub fun is_union(ti: *TypeInterner, tid: TypeId) bool {
     ret nominal_kind_is(ti, tid, TYPE_UNI);
 }
@@ -1804,137 +1741,6 @@ pub fun field_entry_at(ti: *TypeInterner, ft: *FieldTable, ix: u32) *FieldEntry 
     val entry_r: R.Result[*FieldEntry, str] = handle.chunk_get[FieldEntry](?ti.field_pool, (ft.fields_start + ix)::usize);
     if (R.is_err[*FieldEntry, str](entry_r)) { ret nil; }
     ret R.unwrap_ok[*FieldEntry, str](entry_r);
-}
-
-pub fun ensure_canon_tag(ti: *TypeInterner, family: CanonTagFamily, interner: *intern.Interner) R.Result[TypeId, str] {
-    if (family::u32 >= CANON_TAG_COUNT) {
-        ret R.err[TypeId, str]("invalid canonical tag family");
-    }
-    val fam_name: str = canon_tag_name(family);
-    val r_name: R.Result[intern.StrId, str] = intern.intern(interner, fam_name);
-    if (R.is_err[intern.StrId, str](r_name)) { ret r_name; }
-    val name: intern.StrId = R.unwrap_ok[intern.StrId, str](r_name);
-
-    var nom: TypeId = ti.canon_tags[family];
-    if (nom == TYPE_NIL) {
-        val r_nom: R.Result[TypeId, str] = intern_nominal(ti, name, canon_tag_owner(), TYPE_TAG);
-        if (R.is_err[TypeId, str](r_nom)) { ret r_nom; }
-        nom = R.unwrap_ok[TypeId, str](r_nom);
-        ti.canon_tags[family] = nom;
-    }
-
-    val opt_u8: O.Option[TypeId] = prim(ti, TYPE_U8);
-    if (O.is_none[TypeId](opt_u8)) { ret R.err[TypeId, str]("canonical tag discriminator type is unavailable"); }
-    val disc_set: R.Result[R.Void, str] = set_tag_discriminator(ti, nom, O.unwrap[TypeId](opt_u8));
-    if (R.is_err[R.Void, str](disc_set)) { ret R.err[TypeId, str](R.unwrap_err[R.Void, str](disc_set)); }
-
-    val opt_table: O.Option[*FieldTable] = field_table_for(ti, nom);
-    if (O.is_some[*FieldTable](opt_table)) {
-        ret R.ok[TypeId, str](nom);
-    }
-
-    if (family == CANON_TAG_RES) {
-        val r_t: R.Result[intern.StrId, str] = intern.intern(interner, "T");
-        if (R.is_err[intern.StrId, str](r_t)) { ret R.err[TypeId, str](R.unwrap_err[intern.StrId, str](r_t)); }
-        val r_e: R.Result[intern.StrId, str] = intern.intern(interner, "E");
-        if (R.is_err[intern.StrId, str](r_e)) { ret R.err[TypeId, str](R.unwrap_err[intern.StrId, str](r_e)); }
-        val t_id: intern.StrId = R.unwrap_ok[intern.StrId, str](r_t);
-        val e_id: intern.StrId = R.unwrap_ok[intern.StrId, str](r_e);
-
-        val r_tp: R.Result[TypeId, str] = intern_generic_param(ti, t_id, canon_tag_owner(), name, TYPE_TAG, 0);
-        if (R.is_err[TypeId, str](r_tp)) { ret r_tp; }
-        val r_ep: R.Result[TypeId, str] = intern_generic_param(ti, e_id, canon_tag_owner(), name, TYPE_TAG, 1);
-        if (R.is_err[TypeId, str](r_ep)) { ret r_ep; }
-        val t_param: TypeId = R.unwrap_ok[TypeId, str](r_tp);
-        val e_param: TypeId = R.unwrap_ok[TypeId, str](r_ep);
-
-        val r_err: R.Result[intern.StrId, str] = intern.intern(interner, "err");
-        if (R.is_err[intern.StrId, str](r_err)) { ret R.err[TypeId, str](R.unwrap_err[intern.StrId, str](r_err)); }
-        val r_ok: R.Result[intern.StrId, str] = intern.intern(interner, "ok");
-        if (R.is_err[intern.StrId, str](r_ok)) { ret R.err[TypeId, str](R.unwrap_err[intern.StrId, str](r_ok)); }
-        val err_name: intern.StrId = R.unwrap_ok[intern.StrId, str](r_err);
-        val ok_name: intern.StrId = R.unwrap_ok[intern.StrId, str](r_ok);
-
-        val start_r: R.Result[u32, str] = field_table_stage(ti, 2);
-        if (R.is_err[u32, str](start_r)) { ret R.err[TypeId, str](R.unwrap_err[u32, str](start_r)); }
-        val start: u32 = R.unwrap_ok[u32, str](start_r);
-
-        val p0: R.Result[R.Void, str] = field_table_stage_push(ti, err_name, e_param);
-        if (R.is_err[R.Void, str](p0)) { ret R.err[TypeId, str](R.unwrap_err[R.Void, str](p0)); }
-        val p1: R.Result[R.Void, str] = field_table_stage_push(ti, ok_name, t_param);
-        if (R.is_err[R.Void, str](p1)) { ret R.err[TypeId, str](R.unwrap_err[R.Void, str](p1)); }
-
-        val pub_r: R.Result[R.Void, str] = field_table_publish(ti, nom, start, 2);
-        if (R.is_err[R.Void, str](pub_r)) { ret R.err[TypeId, str](R.unwrap_err[R.Void, str](pub_r)); }
-    }
-    or (family == CANON_TAG_OPT) {
-        val r_t: R.Result[intern.StrId, str] = intern.intern(interner, "T");
-        if (R.is_err[intern.StrId, str](r_t)) { ret R.err[TypeId, str](R.unwrap_err[intern.StrId, str](r_t)); }
-        val t_id: intern.StrId = R.unwrap_ok[intern.StrId, str](r_t);
-
-        val r_tp: R.Result[TypeId, str] = intern_generic_param(ti, t_id, canon_tag_owner(), name, TYPE_TAG, 0);
-        if (R.is_err[TypeId, str](r_tp)) { ret r_tp; }
-        val t_param: TypeId = R.unwrap_ok[TypeId, str](r_tp);
-
-        val r_none: R.Result[intern.StrId, str] = intern.intern(interner, "none");
-        if (R.is_err[intern.StrId, str](r_none)) { ret R.err[TypeId, str](R.unwrap_err[intern.StrId, str](r_none)); }
-        val r_some: R.Result[intern.StrId, str] = intern.intern(interner, "some");
-        if (R.is_err[intern.StrId, str](r_some)) { ret R.err[TypeId, str](R.unwrap_err[intern.StrId, str](r_some)); }
-        val none_name: intern.StrId = R.unwrap_ok[intern.StrId, str](r_none);
-        val some_name: intern.StrId = R.unwrap_ok[intern.StrId, str](r_some);
-
-        val start_r: R.Result[u32, str] = field_table_stage(ti, 2);
-        if (R.is_err[u32, str](start_r)) { ret R.err[TypeId, str](R.unwrap_err[u32, str](start_r)); }
-        val start: u32 = R.unwrap_ok[u32, str](start_r);
-
-        val p0: R.Result[R.Void, str] = field_table_stage_push(ti, none_name, TYPE_NIL);
-        if (R.is_err[R.Void, str](p0)) { ret R.err[TypeId, str](R.unwrap_err[R.Void, str](p0)); }
-        val p1: R.Result[R.Void, str] = field_table_stage_push(ti, some_name, t_param);
-        if (R.is_err[R.Void, str](p1)) { ret R.err[TypeId, str](R.unwrap_err[R.Void, str](p1)); }
-
-        val pub_r: R.Result[R.Void, str] = field_table_publish(ti, nom, start, 2);
-        if (R.is_err[R.Void, str](pub_r)) { ret R.err[TypeId, str](R.unwrap_err[R.Void, str](pub_r)); }
-    }
-    or (family == CANON_TAG_ERR) {
-        val r_e: R.Result[intern.StrId, str] = intern.intern(interner, "E");
-        if (R.is_err[intern.StrId, str](r_e)) { ret R.err[TypeId, str](R.unwrap_err[intern.StrId, str](r_e)); }
-        val e_id: intern.StrId = R.unwrap_ok[intern.StrId, str](r_e);
-
-        val r_ep: R.Result[TypeId, str] = intern_generic_param(ti, e_id, canon_tag_owner(), name, TYPE_TAG, 0);
-        if (R.is_err[TypeId, str](r_ep)) { ret r_ep; }
-        val e_param: TypeId = R.unwrap_ok[TypeId, str](r_ep);
-
-        val r_err: R.Result[intern.StrId, str] = intern.intern(interner, "err");
-        if (R.is_err[intern.StrId, str](r_err)) { ret R.err[TypeId, str](R.unwrap_err[intern.StrId, str](r_err)); }
-        val r_ok: R.Result[intern.StrId, str] = intern.intern(interner, "ok");
-        if (R.is_err[intern.StrId, str](r_ok)) { ret R.err[TypeId, str](R.unwrap_err[intern.StrId, str](r_ok)); }
-        val err_name: intern.StrId = R.unwrap_ok[intern.StrId, str](r_err);
-        val ok_name: intern.StrId = R.unwrap_ok[intern.StrId, str](r_ok);
-
-        val start_r: R.Result[u32, str] = field_table_stage(ti, 2);
-        if (R.is_err[u32, str](start_r)) { ret R.err[TypeId, str](R.unwrap_err[u32, str](start_r)); }
-        val start: u32 = R.unwrap_ok[u32, str](start_r);
-
-        val p0: R.Result[R.Void, str] = field_table_stage_push(ti, err_name, e_param);
-        if (R.is_err[R.Void, str](p0)) { ret R.err[TypeId, str](R.unwrap_err[R.Void, str](p0)); }
-        val p1: R.Result[R.Void, str] = field_table_stage_push(ti, ok_name, TYPE_NIL);
-        if (R.is_err[R.Void, str](p1)) { ret R.err[TypeId, str](R.unwrap_err[R.Void, str](p1)); }
-
-        val pub_r: R.Result[R.Void, str] = field_table_publish(ti, nom, start, 2);
-        if (R.is_err[R.Void, str](pub_r)) { ret R.err[TypeId, str](R.unwrap_err[R.Void, str](pub_r)); }
-    }
-
-    ret R.ok[TypeId, str](nom);
-}
-
-pub fun ensure_all_canonical_tags(ti: *TypeInterner, interner: *intern.Interner) R.Result[R.Void, str] {
-    var i: u32 = 0;
-    for (i < CANON_TAG_COUNT) {
-        val r: R.Result[TypeId, str] = ensure_canon_tag(ti, i::CanonTagFamily, interner);
-        if (R.is_err[TypeId, str](r)) { ret R.err[R.Void, str](R.unwrap_err[TypeId, str](r)); }
-        i = i + 1;
-    }
-    ret R.ok_void[str]();
 }
 
 fun intern_dedup(ti: *TypeInterner, t: Type) R.Result[TypeId, str] {


### PR DESCRIPTION
Implements the v5 tagged-values contract line (doc/design/tagged-values.md): "The canonical failure types are ordinary std tags. The compiler knows none of their names." S1 on mach-std (#617) found the pinned compiler rejecting a std module that declares `res`, `opt` and `err`; L4 on #3218 listed the seeding sites. References #3226 and #617.

## Removal

- `type.mach`: `CanonTagFamily`, the `canon_tags` slots, `canonical_tag_id/family`, `is_canonical_tag`, `ensure_canon_tag`, `ensure_all_canonical_tags` are gone.
- `resolve.mach`: `seed_canonical_tags` and the seeded symbols, the `scope_lookup_chain` and `type_spelling` fallbacks to them, and the "a canonical tag name cannot also name a declared type" refusal. The vector-spelling refusal that shared the function stays as `reject_vector_spelled_type`.
- `generics.mach` and `infer.mach`: the canonical instantiation special cases for a nominal with no defining file; a nominal with no source identity is an internal failure again.
- `session.mach`: the two `ensure_all_canonical_tags` calls (init and `reset_type_projection`).
- `recipe.mach`: the `'c'` owner encoding that existed only for the seeded nil-owner nominals.

`res`, `opt` and `err` are ordinary identifiers a module may declare as tags or as anything else; declaring one twice is the ordinary duplicate definition. No compatibility path.

## Mangler defect retired

The seeded nominals carried a nil owner module, so a generic instantiated over `res[...]` failed in `mangle` ("nominal module has no canonical name"). A declared tag has an owner. New test `mach.lang.driver:a_generic_instantiated_over_a_user_declared_res_builds_and_runs` instantiates `Vector[res[i32, u8]]` over a user-declared `res`, builds and runs it on x86_64 in both profiles (mutation-checked: a wrong expected sum fails it).

## Test migration

- A shared std-shaped prelude `TAG_STD_PRELUDE` (`tag res[T, E]: u8 { err: E; ok: T; } tag opt[T]: u8 { none; some: T; } tag err[E]: u8 { err: E; ok; }`) is prepended to every `TAG_CORPUS` row by `ut_tag_corpus_range` and by the profile-agreement walk; the single-fixture sema, codegen, reflection and ABI programs that named the three bare declare them the same way; the cross-module specialization fixture now declares them `pub` in the library module and imports them.
- The three rows that pinned the refusal are replaced by `mach.lang.fe.sema:a_module_may_declare_res_opt_and_err` (a module may declare each as a tag, rec, def or fun; twice is the duplicate-definition error). Mutation control: with only the canonical branch of `reject_builtin_named_type` restored, that test fails (exit 1) with an otherwise identical tree.
- `doc/language/tag.md` transitional note and the CHANGELOG entry now state they are std declarations the compiler has no knowledge of.

## Verification

- Full suite through the from-source compiler: 2918 passed, 0 failed (baseline 2916 on dev, +2 by name: the two tests above).
- `sh test/census.sh`: all censuses ok.
- Corpus layer B on x86_64-linux: 102 cells pass, 0 fail, 0 skip. The tag corpus cases declare their own tags; none is named `res`, `opt` or `err`.
- Seed fixpoint: A by the seed, B by A, C by B, `cmp B C` byte-identical.
