### PR TITLE
codegen: notify every emitted instruction on every build and seed secrecy at the physical level (#3126)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -103,6 +103,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The aarch64 inline-asm grammar read `lsl`, `lsr` and `asr` with a register
+  count under the immediate-shift row, so the constant-time scan classed a
+  variable shift as needing no trust; the parse now retags the register-count
+  form to `lslv`/`lsrv`/`asrv`, the variable-shift class. No target declares
+  distrust of variable shifts today, so no program's verdict changed. (#3126)
+
 - Release builds inline small helpers across module boundaries. A dependency's
   raw lowered module yields a per-module `Q_INLINE_BODIES` product holding every
   body under the size bar (or `#[inline]`) that is not recursive, `noinline`,
@@ -220,6 +226,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CI rebuilds its audited compiler from published 4.26.5 and source commits reachable from main after withdrawal of the 4.30.0 release.
 
 ### Changed
+
+- Every build of a module that contains an `#[oblivious]` function records an
+  instruction notification for each emitted machine instruction on x86_64,
+  aarch64 and riscv64, the stream `--emit-asm` alone used to produce, without
+  rendering it; each notification names the MIR instruction that emitted it,
+  and after register allocation every register operand keeps the virtual
+  register it was rewritten from, so a later validator can read which
+  registers and frame slots are declared secret at every instruction. aarch64
+  gained a machine-opcode space shared by its assembly printer and inline-asm
+  grammar. Emitted bytes are unchanged; the cost is one notification record per
+  instruction in an oblivious module and nothing elsewhere (#3126, N5 phase 2
+  parts 1 and 2).
 
 - The ELF, COFF and Mach-O writers size and serialize every file from one
   checked plan. A region is placed once, with its alignment, offset and extent

--- a/doc/design/backend-census-2212.md
+++ b/doc/design/backend-census-2212.md
@@ -574,7 +574,11 @@ link admission any other way without a second capability channel.
   flags)`: the closed per-instruction effect description inline asm uses.
 - `isa.Inst`, `isa.Operand`, `isa.inst_blank`, `regid_make/class/index`: the
   physical-register stream after allocation; the `clobbers` field is frozen as
-  **unpopulated** until item 10.3 rules.
+  **unpopulated** until item 10.3 rules. Amended 2026-09-12 (#3126, accepted as
+  additive like N3's): `isa.Inst.src3`, blank by `inst_blank`, because aarch64
+  `madd`/`msub` read three registers (Rn, Rm, Ra) and a notification that drops
+  the fourth register cannot be walked soundly; no existing reader changes,
+  x86_64 and riscv64 never set it.
 - `mir.MirInstr.writes_secret`, `memory_flags`, `mir.MirVReg.secret`,
   `mir.MirOperand.required_bank`, `regalloc.verify_rewritten_operands`
   (`regalloc.mach:2322`): the post-rewrite facts N5 validates against.

--- a/doc/design/secrecy-final-effects-3126.md
+++ b/doc/design/secrecy-final-effects-3126.md
@@ -331,9 +331,11 @@ description phase 2 reuses for generated code.
 
 ## 11. The notification stream today
 
-`encode.sink_claim`/`note_push`/`note_insert_after`/`check_accounted` tie every
-emitted byte to exactly one instruction notification, including bytes inserted
-by riscv64 relaxation. Two facts phase 2 depends on:
+Phase 2 part 1 (section 15.1) replaced both facts below; they are kept as the
+inventory phase 1 took. `encode.sink_claim`/`note_push`/`note_insert_after`/
+`check_accounted` tie every emitted byte to exactly one instruction
+notification, including bytes inserted by riscv64 relaxation. Two facts phase 2
+depended on:
 
 - **The sink exists only under `--emit-asm`.** `encode_driver_asm` attaches an
   `AsmSink` only when `asm_out != nil`; on the binary path `buf.asm == nil`,
@@ -416,7 +418,7 @@ checker is unfinished, and the inventory agrees.
 Sized against sections 5, 9 and 11, the validator is larger than one lane. It
 has five parts; each is a drop-in against a frozen interface.
 
-1. **Notification stream on every build.** Split "notify" from "render":
+1. **Notification stream on every build.** DONE (section 15.1). Split "notify" from "render":
    `AsmSink` with a nil writer records `AsmNote`s and claims bytes without
    rendering; `encode_driver_asm` attaches a sink whenever the module contains
    an oblivious function, not only under `--emit-asm`. The x86_64 and aarch64
@@ -427,7 +429,7 @@ has five parts; each is a drop-in against a frozen interface.
    effect table in part 3 must accept the form record. `check_accounted` and
    `sink.refused` already fail the build if a byte escapes.
 
-2. **Seeds.** `MirAbiInput` (this lane) for entry pregs and argument-area
+2. **Seeds.** DONE (section 15.2). `MirAbiInput` (phase 1) for entry pregs and argument-area
    bytes; `MirVReg.secret` through `MirVReg.assigned` and `spill_slot` for
    every seeded vreg; `writes_secret` loads mark their destination preg at the
    notification that encodes them; `MIR_DECLASSIFY` (kept as an opcode through
@@ -478,15 +480,179 @@ has five parts; each is a drop-in against a frozen interface.
 The corpus bar for phase 2 is byte-identity: a validator must not move a
 golden.
 
+### 15.1 Part 1 as landed: the stream on every build
+
+- `encode.AsmSink` with a nil writer records `AsmNote`s and claims bytes;
+  `sink_renders(buf)` is the one gate on rendering. `encode_driver_asm`
+  attaches a sink when `asm_out != nil` or when the ISA declares
+  `EncodeHooks.stream = true` and `module_has_oblivious(m)`. The stream is a
+  declared capability, not derived from `has_assembly`: x86_64, aarch64 and
+  riscv64 declare it, mos6502 declares `false` and an oblivious function there
+  is part 4's refusal (no stream, no validation, like the whole-module
+  emitter). `sink.refused`, the per-ISA `check_accounted` and a new
+  driver-level `sink_unaccounted == 0` check at the end of the module fail the
+  build if a byte escapes. `EncoderOutput.notified` reports the instruction
+  count (0 when no stream was attached); the three `codegen.stream:*` tests
+  show a plain build of a module with one oblivious function notifying exactly
+  the instructions the `--emit-asm` rendering prints, with bytes identical to
+  the rendering's and to a build of the same function without the contract.
+- x86_64 `printer.note_inst` and `note_function`/`note_block` notify first and
+  render only for a writer. `render_bytes_directive` pushes an
+  `ASM_NOTE_BYTES` note (which claims) and renders only for a writer, so an
+  inline-asm data directive is in the stream on every ISA the way riscv64's
+  already was.
+- aarch64 gained its machine-opcode space, `arm64/inst.mach:MachOp`, the same
+  split riscv64 makes between `riscv.Opcode` (the selection rows) and
+  `riscv.inst.MachOp` (what a notification carries). `arm64.Opcode` is a MIR
+  row alias and cannot name `sdiv`, `msub`, `fcvtzs` or `cbnz`; the new space
+  names every instruction the encoder emits and every row the inline-asm
+  grammar accepts (the grammar's `A64M_*` codes are now `mop.*`, one space for
+  both). The printer classifies its form record to a `MachOp` (`classify`),
+  renders `inst.mnemonic(op)` from that one table, and `note_inst` translates
+  the form record to an `isa.Inst` (`to_inst`: opcode, dst/src1/src2/src3 as
+  the regids and base/index/disp the encoder already built, operation width in
+  `size`, condition, writeback and vector element width in `flags`) before
+  rendering. Aliases are named by the spelling the assembler reads back
+  (`orr` with `xzr` is `MOV`, `subs` to `xzr` is `CMP`, `madd` with `xzr` is
+  `MUL`); the register-count shifts are `LSLV`/`LSRV`/`ASRV`, distinct from the
+  bitfield `LSL`/`LSR`/`ASR` even though both render as `lsl`, because only the
+  first is the variable-latency member. `encode.stream:translation_round_trips_
+  against_the_printer_for_every_emitted_base` drives every base word the
+  encoder can emit through its emit helper and checks the notification's
+  spelling against the rendered line and, wherever the grammar has a row for
+  that spelling, against the grammar's code; `inst.mnemonic:spellings_are_the_
+  assembler_mnemonics` pins the 111 spellings the grammar cannot cross-check.
+  The grammar has no vector rows, so a NEON spelling shared with a scalar row
+  (`add`, `mov`) is exempt from the cross-check: part 3's rows close that.
+- **Frozen-interface amendment (additive).** `isa.Inst` gained `src3`, blank
+  by `inst_blank`. aarch64 `madd`/`msub` read three registers and `isa.Inst`
+  held two; a notification that drops the fourth register cannot be walked
+  soundly, and the alternative (a parallel operand beside the `isa.Inst`)
+  would make part 3's table key on two records. x86_64 and riscv64 never set
+  it. Section 11 of `backend-census-2212.md` lists `isa.Inst` as frozen; this
+  is the same kind of additive field phase 1 added to `AsmNote` and is flagged
+  for the owner in the PR.
+- `AsmNote.mi` is the `MirInstr` whose encoding emitted the note (nil for
+  prologue, epilogue and stack-probe bytes; riscv64 relaxation re-notes
+  inherit the guard's). The driver resets the notes after each function at a
+  marked consumer point, so a walk sees one function's notifications complete
+  and bounded in memory; riscv64 no longer resets inside `encode_function`.
+- The consumer seam for part 4, not yet wired: the driver calls the walk at
+  the marked point with `(f, sink.notes, sink.note_count)`, and the ISA's
+  effect description (part 3) reaches it through `EncodeHooks`, a per-ISA
+  `effects` slot beside `stream`. The notes cannot travel out through
+  `EncoderOutput` instead: `encoding.mach` and `mir.mach` sit below `isa.mach`
+  in the import graph and cannot name an `isa.Inst`, and an opaque pointer
+  there would be the fail-open shape #2212 forbids.
+
+### 15.2 Part 2 as landed: the seeds and the provenance decision
+
+- **Provenance decision: `rewrite_instr` retains the origin vreg.** Every
+  rewritten register operand is `mir.op_preg_of(preg, origin)`: the assigned
+  register keeps the vreg it was rewritten from in `MirOperand.vreg`, the
+  reload scratch keeps the spilled vreg it aliases, and the spill store's
+  register operand keeps it too (its slot operand was already keyed by the
+  vreg). `verify_rewritten_operands` checks only `kind`, no reader of `.vreg`
+  on a `PREG` operand existed (every post-allocation reader is on `MEM`, where
+  `.vreg` is the slot key), and the `MirVReg.secret` seed is only a seed with
+  a location: a register carries many vregs over a function, so `assigned`
+  alone says where a secret lives, never when. The alternative, taking seeds
+  at the `MirInstr` the sink names, would have left `MirVReg.secret` unread
+  and made part 4 a pure re-derivation from `MirAbiInput` and `writes_secret`
+  loads, trusting the in-register dataflow it is meant to check. With
+  provenance the walk can compare its physical taint against the vreg seeds at
+  every operand. Memory base and index registers do not carry provenance: the
+  early walk refused every secret base and index before allocation, so their
+  seed is public by construction, and the physical walk checks the base
+  register's derived taint anyway. `regalloc.rewrite_instr:a_spilled_secret_
+  keeps_its_slot_key_through_the_scratch` and `..._destination_keeps_its_
+  origin_through_the_store` pin the reload and store shapes.
+- **Seeds are per operand, not per register.** `encode.note_seeds(f, note,
+  out)` fills `NoteSeeds`: for each operand of `note.mi` the origin vreg and
+  its declared secrecy, `dst_secret` for a `writes_secret` load, `barrier` for
+  a declassify. A set keyed by register was tried first and is wrong: an
+  instruction like `xor r1, r1, r2` after allocation carries a dying secret
+  source and a born public destination in the same `r1`, and only the operand
+  position tells them apart. The walk reads sources before the destination.
+- **The barrier survives selection and coalescing.** Selection retags
+  `MIR_DECLASSIFY` to the ISA move (`x64.MOV`, `arm64.MOV`/`FMOV`,
+  `riscv.MOV`/`FMV`), so the opcode is gone after `isel.run`; `rules.retag`
+  sets `MirInstr.declassifies` at that moment and expansions copy it
+  (`mir.instr_declassifies` is the reader). The allocator then coalesces the
+  declassify's public destination web into its (derived-secret) source web,
+  because `try_coalesce` compares seeds and a computed secret is not one, and
+  drops the resulting self-copy. Every drop site (`drop_self_copies`, the
+  same-register path of `rewrite_instr`, `drop_self_copies_physical`) now
+  keeps a zero-byte `ISA_USE` marker (`mir.declassify_marker`) with
+  `declassifies = true` and `declassified = <vreg>`, and each ISA's encode loop
+  pushes an `ASM_NOTE_BARRIER` after the instruction's bytes for any
+  instruction that declassifies. The barrier note names the downgraded
+  register through the operand (a real move) or through `declassified` and
+  `MirVReg.assigned`/`spill_slot` (a dropped self-copy). Bytes are unchanged:
+  the marker emits nothing and the printers skip it. `codegen.seeds:*` walks
+  the post-allocation instructions of the phase 1 shaped fixture on each ISA
+  and checks the seed at every register operand against
+  `ctvalidate.derive_secret_vregs` (the early walk's fixpoint, now exposed): a
+  seeded operand is in the walk's set, the one derived value is in the walk's
+  set and not a seed, and the barrier is the marker naming that value.
+- `writes_secret` is read at the notification of the load that carries it
+  (`dst_secret`), and `MirAbiInput` is read from `f.abi_inputs` at the
+  function's `ASM_NOTE_FUNC`; neither needed a new carrier.
+- The per-ISA `encode.stream:notes_name_their_instruction_and_carry_the_
+  barrier` tests pin the stream shape a walk consumes: `FUNC`, `BLOCK`, one
+  `INST` per emitted instruction with `mi` set, the `BARRIER` between its
+  instruction's bytes and the next.
+
+### 15.3 A hole found on the way, fixed
+
+The aarch64 inline-asm grammar accepted `lsl x0, x1, x2` (a register count)
+under the `lsl` row, which `asm_ct_class` classes `CT_OP_NONE`, while the
+same instruction spelled `lslv` is `CT_OP_VAR_SHIFT`. The parse now retags the
+three shift rows to the v-form when the count operand is a register, so a
+secret count is refused on a target that does not trust variable shifts
+(`asm_ct_scan:register_count_shift_alias_is_a_variable_shift`). Today every
+ISA declares `ct_trust_var_shift = true`, so no program's outcome changed.
+
+### 15.4 Measured cost
+
+Three repetitions each, same machine, `--no-cache`, wall time of the whole
+build and the per-module codegen time the `-vv` report prints (1 ms
+resolution). `dev` is a compiler built from `a151921cd`, `new` is this branch;
+both compiled the same sources.
+
+| build | dev wall | new wall | dev codegen | new codegen |
+|---|---|---|---|---|
+| corpus case project with oblivious modules (`meas.obl` 1 fn, `std.crypto.ct` 38 fns, `std.system.os.secret` 1 fn) | 616, 629, 661 ms | 615, 620, 628 ms | 63, 64, 64 ms | 64, 65, 65 ms |
+| same project without its own oblivious function (`std.system.os.secret` still linked) | 612, 613, 619 ms | 613, 621, 623 ms | 62, 63, 66 ms | 64, 66, 68 ms |
+| compiler self-build, 279 modules, one oblivious module (`mach.lang.ct.probe`) | 32.8, 33.0, 33.7 s | 32.8, 33.8, 34.4 s | 2.0, 2.2, 2.4 s | 2.3, 2.4, 2.5 s |
+
+Per module: `meas.case` (no oblivious function, no sink attached) 1 to 3 ms
+on both; `std.crypto.ct` (38 oblivious functions) 2 to 3 ms on `dev`, 3 to 4
+ms on `new`; `meas.obl` 0.2 to 1 ms on both. The stream's cost on a
+non-oblivious module is a function-count scan (`module_has_oblivious`), below
+the timer's resolution; on an oblivious module it is one `AsmNote` (about 300
+bytes, one struct copy) per emitted instruction, bounded by the instruction
+count and freed per function, at most 1 ms on the largest oblivious module in
+the standard library.
+
+Byte identity: the seed fixpoint holds (`A` by the seed, `B` by `A`, `C` by
+`B`, `B == C`), the corpus layer B is unchanged on x86_64-linux, aarch64-linux
+and riscv64-linux (306 cells), and two cross-builds pin the stream itself as
+byte-neutral on a module set that contains oblivious functions: a
+generation-B compiler from this branch and a generation-C compiler from
+`a151921cd` produce byte-identical binaries from the `a151921cd` source, and
+a generation-C `a151921cd` compiler and this branch's generation-A compiler
+produce byte-identical binaries from this branch's source.
+
 ## 16. Acceptance bullets of #3126 mapped to this lane
 
 | bullet | status |
 |---|---|
-| legalization, selection, allocation, spill/reload, flags, frame effects in final validation | inventory (sections 3 to 9); phase 2 parts 1 to 4 |
+| legalization, selection, allocation, spill/reload, flags, frame effects in final validation | inventory (sections 3 to 9); phase 2 parts 1 and 2 done (15.1, 15.2), 3 and 4 open |
 | whole-module emitter guarantee defined | section 12, validated |
-| encoding and relaxation reach every emitted instruction | section 11 (stream exists under `--emit-asm` only); phase 2 part 1 |
+| encoding and relaxation reach every emitted instruction | done: the stream exists on every build of a module with an oblivious function (15.1) |
 | late secret-dependent branches, addresses, variable-latency uses rejected by mutation controls | phase 2 part 5; classes and sites named in section 9 |
 | inline asm uses the same closed effect descriptions | section 10, validated; phase 2 part 3 reuses the table |
 | unknown effects are not public or constant-time by default | early walk and asm walk, validated (`failclosed:*`, `ct_check_item`); phase 2 part 3 |
 | leakage model and target assumptions documented | section 1 |
-| secret-safe boundary tests with mach-std#550 | `MirAbiInput` recorded (section 14); consumer is phase 2 part 2 |
+| secret-safe boundary tests with mach-std#550 | `MirAbiInput` recorded (section 14); read at `ASM_NOTE_FUNC` by part 4 through the seeds of 15.2 |

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -2441,3 +2441,284 @@ test "mach.lang.be.codegen.scratch:module_images_survive_reclaimed_working_stora
     if (attempts == 0) { ret 8; }
     ret 0;
 }
+
+# an oblivious function at the vreg level, the shape the early walk sees:
+# v0 is a declared secret, v1 public, v2 is computed from both (derived, not
+# seeded), v3 declassifies v2, v4 is public arithmetic on the result
+fun t_oblivious_fixture(alloc: *A.Allocator, name: intern.StrId, oblivious: bool) R.Result[mir.MirFunction, str] {
+    var f: mir.MirFunction;
+    f.name      = name;
+    f.oblivious = oblivious;
+    val rv: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](alloc, 5::usize);
+    if (R.is_err[*mir.MirVReg, str](rv)) { ret R.err[mir.MirFunction, str](R.unwrap_err[*mir.MirVReg, str](rv)); }
+    f.vregs = R.unwrap_ok[*mir.MirVReg, str](rv);
+    f.vreg_count = 5;
+    f.vreg_cap   = 5;
+    var v: u32 = 0;
+    for (v < 5) { f.vregs[v] = mir.vreg(v, mir.REG_CLASS_GP, false, v == 0); v = v + 1; }
+
+    val rb: R.Result[*mir.MirBlock, str] = A.zallocate[mir.MirBlock](alloc, 1::usize);
+    if (R.is_err[*mir.MirBlock, str](rb)) { ret R.err[mir.MirFunction, str](R.unwrap_err[*mir.MirBlock, str](rb)); }
+    f.blocks      = R.unwrap_ok[*mir.MirBlock, str](rb);
+    f.block_count = 1;
+    f.block_cap   = 1;
+    val ri: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](alloc, 6::usize);
+    if (R.is_err[*mir.MirInstr, str](ri)) { ret R.err[mir.MirFunction, str](R.unwrap_err[*mir.MirInstr, str](ri)); }
+    val instrs: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](ri);
+
+    var k: u32 = 0;
+    for (k < 6) {
+        var n: u32 = 3;
+        if (k == 0 || k == 1 || k == 3) { n = 2; }
+        if (k == 5) { n = 0; }
+        var ops: *mir.MirOperand = nil;
+        if (n > 0) {
+            val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](alloc, n::usize);
+            if (R.is_err[*mir.MirOperand, str](ro)) { ret R.err[mir.MirFunction, str](R.unwrap_err[*mir.MirOperand, str](ro)); }
+            ops = R.unwrap_ok[*mir.MirOperand, str](ro);
+        }
+        if (k == 0) { ops[0] = mir.op_vreg(0); ops[1] = mir.op_imm(5); instrs[k] = mir.instr(mir.MIR_MOV, ops, 2, 8, 8); }
+        if (k == 1) { ops[0] = mir.op_vreg(1); ops[1] = mir.op_imm(7); instrs[k] = mir.instr(mir.MIR_MOV, ops, 2, 8, 8); }
+        if (k == 2) { ops[0] = mir.op_vreg(2); ops[1] = mir.op_vreg(0); ops[2] = mir.op_vreg(1); instrs[k] = mir.instr(mir.MIR_XOR, ops, 3, 8, 8); }
+        if (k == 3) { ops[0] = mir.op_vreg(3); ops[1] = mir.op_vreg(2); instrs[k] = mir.instr(mir.MIR_DECLASSIFY, ops, 2, 8, 8); }
+        if (k == 4) { ops[0] = mir.op_vreg(4); ops[1] = mir.op_vreg(3); ops[2] = mir.op_vreg(1); instrs[k] = mir.instr(mir.MIR_ADD, ops, 3, 8, 8); }
+        if (k == 5) { instrs[k] = mir.instr(mir.MIR_RET, nil, 0, 0, 0); }
+        instrs[k].loc = source.loc_nil();
+        k = k + 1;
+    }
+    f.blocks[0].id          = 0;
+    f.blocks[0].instrs      = instrs;
+    f.blocks[0].instr_count = 6;
+    f.blocks[0].instr_cap   = 6;
+    ret R.ok[mir.MirFunction, str](f);
+}
+
+# the pipeline from the early walk to allocation, as codegen_scratch runs it
+fun t_allocate_fixture(tgt: *target.Target, m: *mir.MirModule) R.Result[R.Void, str] {
+    val rc: R.Result[R.Void, str] = ctvalidate.run(tgt, m);
+    if (R.is_err[R.Void, str](rc)) { ret rc; }
+    val rl: R.Result[R.Void, str] = legalize.run(tgt, m);
+    if (R.is_err[R.Void, str](rl)) { ret rl; }
+    val ri: R.Result[R.Void, str] = isel.run(tgt, m);
+    if (R.is_err[R.Void, str](ri)) { ret ri; }
+    val ra: R.Result[R.Void, str] = regalloc.run(tgt, m);
+    if (R.is_err[R.Void, str](ra)) { ret ra; }
+    ret frame.run(tgt, m);
+}
+
+var t_asm_capture: [16384]u8;
+var t_asm_capture_len: usize = 0;
+
+fun t_asm_capture_write(ctx: ptr, buf: *u8, len: usize) R.Result[usize, str] {
+    var i: usize = 0;
+    for (i < len) {
+        if (t_asm_capture_len < 16383) {
+            t_asm_capture[t_asm_capture_len] = buf[i];
+            t_asm_capture_len = t_asm_capture_len + 1;
+        }
+        i = i + 1;
+    }
+    ret R.ok[usize, str](len);
+}
+
+# instruction lines in the rendering: indented by two spaces, not a directive
+fun t_asm_capture_instruction_lines() u32 {
+    var n: u32 = 0;
+    var i: usize = 0;
+    var at_line_start: bool = true;
+    for (i < t_asm_capture_len) {
+        if (at_line_start && i + 1 < t_asm_capture_len
+            && t_asm_capture[i] == ' '::u8 && t_asm_capture[i + 1] == ' '::u8) {
+            n = n + 1;
+        }
+        at_line_start = t_asm_capture[i] == '\n'::u8;
+        i = i + 1;
+    }
+    ret n;
+}
+
+fun t_bytes_equal(a: *u8, an: u32, b: *u8, bn: u32) bool {
+    if (an != bn) { ret false; }
+    var i: u32 = 0;
+    for (i < an) {
+        if (a[i] != b[i]) { ret false; }
+        i = i + 1;
+    }
+    ret true;
+}
+
+fun t_encoder_output_release(alloc: *A.Allocator, enc: *encode.EncoderOutput) {
+    var ctx: CodegenContext;
+    ctx.alloc = alloc;
+    encoder_output_dnit(?ctx, enc);
+}
+
+# the stream exists on a plain build of a module with an oblivious function,
+# notifies exactly the instructions the --emit-asm rendering prints, and
+# leaves the emitted bytes identical to a build without the stream
+fun t_stream_matches_rendering(arch: str, os_name: str, abi: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var interner: intern.Interner = intern.init(?alloc);
+    fin { intern.dnit(?interner); }
+    var reg: target.TargetRegistry = target.registry_init();
+    fin { target.registry_dnit(?reg); }
+    if (R.is_err[R.Void, str](target.register_all(?reg, target_testing.debug_descriptor))) { ret 2; }
+    val ts: R.Result[target.Target, str] = target.select(?reg, arch, os_name, abi);
+    if (R.is_err[target.Target, str](ts)) { ret 3; }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](ts);
+    val nr: R.Result[intern.StrId, str] = intern.intern(?interner, "seeded");
+    if (R.is_err[intern.StrId, str](nr)) { ret 4; }
+    val name: intern.StrId = R.unwrap_ok[intern.StrId, str](nr);
+
+    # the oblivious module: plain build, then the rendering
+    var m: mir.MirModule = mir.MirModule{alloc: ?alloc, interner: ?interner};
+    fin { mir.dnit_module(?m); }
+    val rf: R.Result[mir.MirFunction, str] = t_oblivious_fixture(?alloc, name, true);
+    if (R.is_err[mir.MirFunction, str](rf)) { ret 5; }
+    if (R.is_err[R.Void, str](mir.push_function(?m, R.unwrap_ok[mir.MirFunction, str](rf)))) { ret 5; }
+    if (R.is_err[R.Void, str](t_allocate_fixture(?tgt, ?m))) { ret 6; }
+
+    val plain_r: R.Result[encode.EncoderOutput, str] = encode.run(?tgt, ?m, nil);
+    if (R.is_err[encode.EncoderOutput, str](plain_r)) { ret 7; }
+    var plain: encode.EncoderOutput = R.unwrap_ok[encode.EncoderOutput, str](plain_r);
+    fin { t_encoder_output_release(?alloc, ?plain); }
+    if (plain.notified == 0) { ret 8; }
+
+    var w: writer.Writer;
+    w.ctx     = nil;
+    w.f_write = t_asm_capture_write;
+    t_asm_capture_len = 0;
+    val asm_r: R.Result[encode.EncoderOutput, str] = encode.run(?tgt, ?m, ?w);
+    if (R.is_err[encode.EncoderOutput, str](asm_r)) { ret 9; }
+    var rendered: encode.EncoderOutput = R.unwrap_ok[encode.EncoderOutput, str](asm_r);
+    fin { t_encoder_output_release(?alloc, ?rendered); }
+    if (rendered.notified != plain.notified)                       { ret 10; }
+    if (t_asm_capture_instruction_lines() != plain.notified)       { ret 11; }
+    if (!t_bytes_equal(plain.text, plain.text_len, rendered.text, rendered.text_len)) { ret 12; }
+
+    # the same function without the contract: no stream, the same bytes
+    var open: mir.MirModule = mir.MirModule{alloc: ?alloc, interner: ?interner};
+    fin { mir.dnit_module(?open); }
+    val rg: R.Result[mir.MirFunction, str] = t_oblivious_fixture(?alloc, name, false);
+    if (R.is_err[mir.MirFunction, str](rg)) { ret 13; }
+    if (R.is_err[R.Void, str](mir.push_function(?open, R.unwrap_ok[mir.MirFunction, str](rg)))) { ret 13; }
+    if (R.is_err[R.Void, str](t_allocate_fixture(?tgt, ?open))) { ret 14; }
+    val open_r: R.Result[encode.EncoderOutput, str] = encode.run(?tgt, ?open, nil);
+    if (R.is_err[encode.EncoderOutput, str](open_r)) { ret 15; }
+    var silent: encode.EncoderOutput = R.unwrap_ok[encode.EncoderOutput, str](open_r);
+    fin { t_encoder_output_release(?alloc, ?silent); }
+    if (silent.notified != 0) { ret 16; }
+    if (!t_bytes_equal(plain.text, plain.text_len, silent.text, silent.text_len)) { ret 17; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.stream:x86_64_plain_build_notifies_every_rendered_instruction" {
+    ret t_stream_matches_rendering("x86_64", "linux", "sysv64");
+}
+
+test "mach.lang.be.codegen.stream:aarch64_plain_build_notifies_every_rendered_instruction" {
+    ret t_stream_matches_rendering("aarch64", "linux", "aapcs64");
+}
+
+test "mach.lang.be.codegen.stream:riscv64_plain_build_notifies_every_rendered_instruction" {
+    ret t_stream_matches_rendering("riscv64", "linux", "lp64d");
+}
+
+# after allocation every register operand names its origin vreg, and the seed
+# read at the instruction a notification names agrees with the early walk's
+# fixpoint wherever the walk's answer is a seed; the one derived value (v2,
+# computed from a secret) is the walk's, not a seed, and the declassify is
+# the barrier
+fun t_seeds_match_walk(arch: str, os_name: str, abi: str) i32 {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var interner: intern.Interner = intern.init(?alloc);
+    fin { intern.dnit(?interner); }
+    var reg: target.TargetRegistry = target.registry_init();
+    fin { target.registry_dnit(?reg); }
+    if (R.is_err[R.Void, str](target.register_all(?reg, target_testing.debug_descriptor))) { ret 2; }
+    val ts: R.Result[target.Target, str] = target.select(?reg, arch, os_name, abi);
+    if (R.is_err[target.Target, str](ts)) { ret 3; }
+    var tgt: target.Target = R.unwrap_ok[target.Target, str](ts);
+    val nr: R.Result[intern.StrId, str] = intern.intern(?interner, "seeded");
+    if (R.is_err[intern.StrId, str](nr)) { ret 4; }
+
+    var m: mir.MirModule = mir.MirModule{alloc: ?alloc, interner: ?interner};
+    fin { mir.dnit_module(?m); }
+    val rf: R.Result[mir.MirFunction, str] = t_oblivious_fixture(?alloc, R.unwrap_ok[intern.StrId, str](nr), true);
+    if (R.is_err[mir.MirFunction, str](rf)) { ret 5; }
+    if (R.is_err[R.Void, str](mir.push_function(?m, R.unwrap_ok[mir.MirFunction, str](rf)))) { ret 5; }
+    val f: *mir.MirFunction = ?m.functions[0];
+
+    val wr: R.Result[*bool, str] = ctvalidate.derive_secret_vregs(f, ?alloc);
+    if (R.is_err[*bool, str](wr)) { ret 6; }
+    val walk: *bool = R.unwrap_ok[*bool, str](wr);
+    fin { A.deallocate[bool](?alloc, walk, 5::usize); }
+    if (!walk[0] || walk[1] || !walk[2] || walk[3] || walk[4]) { ret 7; }
+
+    if (R.is_err[R.Void, str](t_allocate_fixture(?tgt, ?m))) { ret 8; }
+
+    var seen_seed: u32 = 0;
+    var seen_barrier: u32 = 0;
+    var seen_derived: u32 = 0;
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            var note: encode.AsmNote = encode.note_blank();
+            note.mi = mi;
+            if (mir.instr_declassifies(mi)) { note.kind = encode.ASM_NOTE_BARRIER; }
+            var seeds: encode.NoteSeeds;
+            encode.note_seeds(f, ?note, ?seeds);
+            if (seeds.barrier) {
+                seen_barrier = seen_barrier + 1;
+                # the coalesced declassify is a zero-byte marker naming the downgraded vreg
+                if (mi.opcode != isa.ISA_USE::mir.MirOpcode || mi.operand_count != 0) { ret 18; }
+                if (seeds.count != 1 || seeds.origin[0] != 2 || seeds.secret[0]) { ret 19; }
+                if (!walk[seeds.origin[0]]) { ret 20; }
+                ii = ii + 1;
+                cnt;
+            }
+            if (seeds.dst_secret) { ret 9; }
+            if (seeds.count != mi.operand_count) { ret 9; }
+            var k: u32 = 0;
+            for (k < mi.operand_count) {
+                val op: *mir.MirOperand = ?mi.operands[k];
+                if (op.kind == mir.MIR_OP_VREG) { ret 10; }
+                if (op.kind != mir.MIR_OP_PREG) { k = k + 1; cnt; }
+                val origin: u32 = seeds.origin[k];
+                if (origin != mir.operand_origin(op)) { ret 11; }
+                if (origin == mir.MIR_VREG_NIL || origin >= f.vreg_count) { ret 11; }
+                val listed: bool = seeds.secret[k];
+                if (f.vregs[origin].secret != listed) { ret 12; }
+                if (listed) { seen_seed = seen_seed + 1; }
+                # the walk's derived taint is what the seed set does not carry
+                if (walk[origin] && !f.vregs[origin].secret) {
+                    if (origin != 2 || listed) { ret 13; }
+                    seen_derived = seen_derived + 1;
+                }
+                if (!walk[origin] && listed) { ret 14; }
+                k = k + 1;
+            }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+    if (seen_seed == 0 || seen_barrier != 1 || seen_derived == 0) { ret 15; }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.seeds:x86_64_register_provenance_matches_the_vreg_walk" {
+    ret t_seeds_match_walk("x86_64", "linux", "sysv64");
+}
+
+test "mach.lang.be.codegen.seeds:aarch64_register_provenance_matches_the_vreg_walk" {
+    ret t_seeds_match_walk("aarch64", "linux", "aapcs64");
+}
+
+test "mach.lang.be.codegen.seeds:riscv64_register_provenance_matches_the_vreg_walk" {
+    ret t_seeds_match_walk("riscv64", "linux", "lp64d");
+}

--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -75,21 +75,7 @@ fun validate_function(tgt: *target.Target, f: *mir.MirFunction, interner: *inter
         pt = R.unwrap_ok[*bool, str](rp);
     }
 
-    var changed: bool = true;
-    for (changed) {
-        changed = false;
-        var bi: u32 = 0;
-        for (bi < f.block_count) {
-            val blk: *mir.MirBlock = ?f.blocks[bi];
-            clear_pregs(pt, np);
-            var ii: u32 = 0;
-            for (ii < blk.instr_count) {
-                if (apply_instr(?blk.instrs[ii], vt, pt, np)) { changed = true; }
-                ii = ii + 1;
-            }
-            bi = bi + 1;
-        }
-    }
+    fixpoint(f, vt, pt, np);
 
     var bj: u32 = 0;
     for (bj < f.block_count) {
@@ -111,6 +97,53 @@ fun validate_function(tgt: *target.Target, f: *mir.MirFunction, interner: *inter
 
     free_taint(alloc, vt, nv, pt, np);
     ret R.ok_void[str]();
+}
+
+fun fixpoint(f: *mir.MirFunction, vt: *bool, pt: *bool, np: u32) {
+    var changed: bool = true;
+    for (changed) {
+        changed = false;
+        var bi: u32 = 0;
+        for (bi < f.block_count) {
+            val blk: *mir.MirBlock = ?f.blocks[bi];
+            clear_pregs(pt, np);
+            var ii: u32 = 0;
+            for (ii < blk.instr_count) {
+                if (apply_instr(?blk.instrs[ii], vt, pt, np)) { changed = true; }
+                ii = ii + 1;
+            }
+            bi = bi + 1;
+        }
+    }
+}
+
+# the per-vreg fixpoint the early walk reaches, seeded from MirVReg.secret:
+# what a post-allocation consumer compares its physical seeds against. one
+# bool per vreg, the caller frees vreg_count entries; nil for no vregs.
+pub fun derive_secret_vregs(f: *mir.MirFunction, alloc: *A.Allocator) R.Result[*bool, str] {
+    val nv: u32 = f.vreg_count;
+    if (nv == 0) { ret R.ok[*bool, str](nil); }
+    val rv: R.Result[*bool, str] = A.allocate[bool](alloc, nv::usize);
+    if (R.is_err[*bool, str](rv)) { ret rv; }
+    val vt: *bool = R.unwrap_ok[*bool, str](rv);
+    var i: u32 = 0;
+    for (i < nv) { vt[i] = f.vregs[i].secret; i = i + 1; }
+
+    val mp: u32 = max_preg(f);
+    var np: u32 = 0;
+    if (mp != NO_PREG) { np = mp + 1; }
+    var pt: *bool = nil;
+    if (np > 0) {
+        val rp: R.Result[*bool, str] = A.allocate[bool](alloc, np::usize);
+        if (R.is_err[*bool, str](rp)) {
+            A.deallocate[bool](alloc, vt, nv::usize);
+            ret rp;
+        }
+        pt = R.unwrap_ok[*bool, str](rp);
+    }
+    fixpoint(f, vt, pt, np);
+    if (pt != nil) { A.deallocate[bool](alloc, pt, np::usize); }
+    ret R.ok[*bool, str](vt);
 }
 
 fun free_taint(alloc: *A.Allocator, vt: *bool, nv: u32, pt: *bool, np: u32) {

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -119,6 +119,8 @@ pub rec AsmNote {
     byte_len: u32;
     loc: source.SrcLoc;
     inline_site: u32;
+    # the MirInstr whose encoding emitted this note, nil for bytes with no MIR origin
+    mi:    *mir.MirInstr;
     inst:  isa.Inst;
     name:  intern.StrId;
     id:    u32;
@@ -149,6 +151,7 @@ pub fun note_blank() AsmNote {
     n.byte_len = 0;
     n.loc = source.loc_nil();
     n.inline_site = 0;
+    n.mi   = nil;
     n.kind = ASM_NOTE_INST;
     n.off  = 0;
     n.inst = isa.inst_blank();
@@ -168,6 +171,7 @@ pub fun note_push(buf: *ByteBuf, n: *AsmNote) R.Result[R.Void, str] {
     if (s.mi != nil) {
         s.notes[s.note_count].loc = s.mi.loc;
         s.notes[s.note_count].inline_site = s.mi.inline_site;
+        s.notes[s.note_count].mi = s.mi;
     }
     if (n.kind == ASM_NOTE_INST || n.kind == ASM_NOTE_BYTES) {
         if (buf.len < n.off::usize || buf.len - n.off::usize > 0xFFFFFFFF::usize) {
@@ -305,6 +309,12 @@ pub fun sink_active(buf: *ByteBuf) bool {
     ret !buf.asm.failed;
 }
 
+# rendering is gated on a writer; notification and byte accounting are not
+pub fun sink_renders(buf: *ByteBuf) bool {
+    if (!sink_active(buf)) { ret false; }
+    ret buf.asm.out != nil;
+}
+
 pub fun sink_claim(buf: *ByteBuf, start: usize) {
     if (buf == nil || buf.asm == nil) { ret; }
     val s: *AsmSink = buf.asm;
@@ -342,10 +352,13 @@ pub fun render_bytes_text(out: *writer.Writer, bytes: *u8, n: usize) R.Result[R.
 
 pub fun render_bytes_directive(buf: *ByteBuf, bytes: *u8, n: usize, start: usize) R.Result[R.Void, str] {
     if (!sink_active(buf)) { ret R.ok_void[str](); }
-    val res: R.Result[R.Void, str] = render_bytes_text(buf.asm.out, bytes, n);
-    if (R.is_err[R.Void, str](res)) { ret res; }
-    sink_claim(buf, start);
-    ret R.ok_void[str]();
+    var note: AsmNote = note_blank();
+    note.kind = ASM_NOTE_BYTES;
+    note.off  = start::u32;
+    val kept: R.Result[R.Void, str] = note_push(buf, ?note);
+    if (R.is_err[R.Void, str](kept)) { ret kept; }
+    if (!sink_renders(buf)) { ret R.ok_void[str](); }
+    ret render_bytes_text(buf.asm.out, bytes, n);
 }
 
 fun hex_digit(v: u8) u8 {
@@ -499,6 +512,17 @@ pub def PatchBranchFn: fun(*EncodeState, *BranchFixup, u32) R.Result[R.Void, str
 pub rec EncodeHooks {
     encode_function: EncodeFunctionFn;
     patch_branch:    PatchBranchFn;
+    # declared: every emitted byte reaches the sink through one instruction notification
+    stream:          bool;
+}
+
+pub fun module_has_oblivious(m: *mir.MirModule) bool {
+    var fi: u32 = 0;
+    for (fi < m.function_len) {
+        if (m.functions[fi].oblivious) { ret true; }
+        fi = fi + 1;
+    }
+    ret false;
 }
 
 pub fun encode_driver(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.MirModule, hooks: *EncodeHooks) R.Result[EncoderOutput, str] {
@@ -559,9 +583,12 @@ pub fun encode_driver_asm(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.
     var st: EncodeState;
     state_init(?st, alloc, m, tgt);
 
+    # the stream exists under --emit-asm and on every build of a module with an
+    # oblivious function; a nil writer notifies and claims without rendering
     var sink: AsmSink = sink_init(asm_out, m.interner);
-    if (asm_out != nil) { st.buf.asm = ?sink; }
+    if (asm_out != nil || (hooks.stream && module_has_oblivious(m))) { st.buf.asm = ?sink; }
 
+    var notified: u32 = 0;
     var fi: u32 = 0;
     for (fi < m.function_len) {
         st.last_inline_site = 0;
@@ -575,6 +602,10 @@ pub fun encode_driver_asm(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.
         if (st.sym_count > pre_sym_count) {
             st.syms[pre_sym_count].size = st.buf.len::u32 - st.syms[pre_sym_count].offset;
         }
+        if (sink.failed) { brk; }
+        # one function's notifications are complete here; a consumer runs before the reset
+        notified = notified + note_inst_count(?st.buf);
+        notes_reset(?st.buf);
         fi = fi + 1;
     }
 
@@ -588,6 +619,12 @@ pub fun encode_driver_asm(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.
         state_dnit(?st);
         ret R.err[EncoderOutput, str](
             "--emit-asm: an instruction notification claimed a byte range that does not begin where the previous one ended");
+    }
+    if (sink_unaccounted(?st.buf) > 0) {
+        notes_free(?st.buf);
+        state_dnit(?st);
+        ret R.err[EncoderOutput, str](
+            "--emit-asm: the encoder emitted bytes that no instruction notification claimed");
     }
     notes_free(?st.buf);
 
@@ -663,6 +700,7 @@ pub fun encode_driver_asm(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.
     out.const_count  = st.const_count;
     out.frames       = st.frames;
     out.frame_count  = st.frame_count;
+    out.notified     = notified;
 
     scratch_release(?st);
     ret R.ok[EncoderOutput, str](out);

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -110,6 +110,8 @@ pub val ASM_NOTE_INST:  u8 = 0;
 pub val ASM_NOTE_FUNC:  u8 = 1;
 pub val ASM_NOTE_BLOCK: u8 = 2;
 pub val ASM_NOTE_BYTES: u8 = 3;
+# a declassify barrier: no bytes, the MirInstr names the register it downgrades
+pub val ASM_NOTE_BARRIER: u8 = 4;
 
 pub val ASM_NOTE_BYTES_WIDTH: usize = 4;
 
@@ -185,6 +187,18 @@ pub fun note_push(buf: *ByteBuf, n: *AsmNote) R.Result[R.Void, str] {
         sink_claim(buf, n.off::usize);
     }
     ret R.ok_void[str]();
+}
+
+# the barrier reaches the stream whether or not the move it selected to emitted
+# bytes (a coalesced self-copy emits none); it follows the instruction's bytes
+pub fun note_barrier(buf: *ByteBuf, mi: *mir.MirInstr) R.Result[R.Void, str] {
+    if (!sink_active(buf)) { ret R.ok_void[str](); }
+    if (!mir.instr_declassifies(mi)) { ret R.ok_void[str](); }
+    var n: AsmNote = note_blank();
+    n.kind = ASM_NOTE_BARRIER;
+    n.off  = buf.len::u32;
+    n.mi   = mi;
+    ret note_push(buf, ?n);
 }
 
 pub fun note_insert_after(buf: *ByteBuf, idx: u32, n: *AsmNote, nbytes: u32) R.Result[R.Void, str] {
@@ -375,6 +389,60 @@ pub fun sink_unaccounted(buf: *ByteBuf) usize {
     if (!sink_active(buf)) { ret 0; }
     if (buf.len <= buf.asm.accounted) { ret 0; }
     ret buf.len - buf.asm.accounted;
+}
+
+pub val NOTE_SEED_MAX: u32 = 16;
+
+# the secrecy seeds a notification carries, per operand of the MirInstr it
+# encodes: the origin vreg each register or slot operand was rewritten from
+# and that vreg's declared secrecy. per operand, not per register: one
+# register can carry a dying secret source and a born public destination in
+# the same instruction, so a set keyed by register cannot say which
+pub rec NoteSeeds {
+    count:      u32;
+    origin:     [NOTE_SEED_MAX]u32;
+    secret:     [NOTE_SEED_MAX]bool;
+    # a writes_secret load: operand 0 is secret by declaration
+    dst_secret: bool;
+    # an ASM_NOTE_BARRIER: operand 0 is public after this point
+    barrier:    bool;
+}
+
+pub fun note_seeds_clear(out: *NoteSeeds) {
+    out.count      = 0;
+    out.dst_secret = false;
+    out.barrier    = false;
+}
+
+# every seed the walk needs at one notification. a note without a MirInstr
+# (prologue, epilogue, relaxation) carries no seed. operands past
+# NOTE_SEED_MAX are not described; no MIR instruction has that many.
+pub fun note_seeds(f: *mir.MirFunction, n: *AsmNote, out: *NoteSeeds) {
+    note_seeds_clear(out);
+    if (f == nil || n == nil || n.mi == nil) { ret; }
+    val mi: *mir.MirInstr = n.mi;
+    out.barrier = n.kind == ASM_NOTE_BARRIER;
+    if (out.barrier && mi.operand_count == 0) {
+        # a dropped self-copy: the downgraded vreg names its own carrier
+        out.count     = 1;
+        out.origin[0] = mi.declassified;
+        out.secret[0] = mi.declassified != mir.MIR_VREG_NIL && mi.declassified < f.vreg_count
+                        && f.vregs[mi.declassified].secret;
+        ret;
+    }
+    val defines: bool = mi.operand_count > 0 && mir.instr_defines_shape(mi);
+    var k: u32 = 0;
+    for (k < mi.operand_count && k < NOTE_SEED_MAX) {
+        val op: *mir.MirOperand = ?mi.operands[k];
+        out.origin[k] = mir.operand_origin(op);
+        out.secret[k] = mir.operand_seed_secret(f, op);
+        if (k == 0 && defines && mi.writes_secret && op.kind == mir.MIR_OP_PREG) {
+            out.dst_secret = true;
+            out.secret[k]  = true;
+        }
+        k = k + 1;
+    }
+    out.count = k;
 }
 
 pub fun sink_set_mir(buf: *ByteBuf, mi: *mir.MirInstr) {
@@ -2167,4 +2235,58 @@ test "mach.lang.be.codegen.encode.emit_byte:doubling_is_still_exact_at_ordinary_
     }
     buf_dnit(?buf);
     ret bad;
+}
+
+# the seed reader: a load declared writes_secret seeds its destination, a
+# frame-slot operand seeds by its slot key, a precolored register and an
+# immediate carry no origin, and a note with no MirInstr carries nothing
+test "mach.lang.be.codegen.encode.note_seeds:declared_destination_slot_key_and_no_origin" {
+    var vregs: [2]mir.MirVReg;
+    vregs[0] = mir.vreg(0, 0, false, false);
+    vregs[1] = mir.vreg(1, 0, false, true);
+    vregs[1].spill_slot = 0;
+    var f: mir.MirFunction;
+    f.vregs = ?vregs[0];
+    f.vreg_count = 2;
+
+    var ops: [2]mir.MirOperand;
+    ops[0] = mir.op_preg_of(3, 0);
+    ops[1] = mir.op_mem_preg(5, 16);
+    var load: mir.MirInstr = mir.instr(mir.MIR_LOAD, ?ops[0], 2, 8, 8);
+    load.writes_secret = true;
+    var n: AsmNote = note_blank();
+    n.mi = ?load;
+    var seeds: NoteSeeds;
+    note_seeds(?f, ?n, ?seeds);
+    if (seeds.count != 2 || !seeds.dst_secret || seeds.barrier) { ret 1; }
+    if (seeds.origin[0] != 0 || !seeds.secret[0])               { ret 2; }
+    if (seeds.origin[1] != mir.MIR_VREG_NIL || seeds.secret[1]) { ret 3; }
+
+    # without the declaration a public origin stays public
+    load.writes_secret = false;
+    note_seeds(?f, ?n, ?seeds);
+    if (seeds.dst_secret || seeds.secret[0]) { ret 4; }
+
+    var sops: [2]mir.MirOperand;
+    sops[0] = mir.op_mem_slot(1, 0);
+    sops[1] = mir.op_preg(9);
+    var store: mir.MirInstr = mir.instr(mir.MIR_MOV, ?sops[0], 2, 8, 8);
+    n.mi = ?store;
+    note_seeds(?f, ?n, ?seeds);
+    if (seeds.count != 2 || seeds.dst_secret)                   { ret 5; }
+    if (seeds.origin[0] != 1 || !seeds.secret[0])               { ret 6; }
+    if (seeds.origin[1] != mir.MIR_VREG_NIL || seeds.secret[1]) { ret 7; }
+
+    var iops: [2]mir.MirOperand;
+    iops[0] = mir.op_preg_of(3, 1);
+    iops[1] = mir.op_imm(4);
+    var mov: mir.MirInstr = mir.instr(mir.MIR_MOV, ?iops[0], 2, 8, 8);
+    n.mi = ?mov;
+    note_seeds(?f, ?n, ?seeds);
+    if (seeds.count != 2 || seeds.origin[0] != 1 || !seeds.secret[0] || seeds.origin[1] != mir.MIR_VREG_NIL) { ret 8; }
+
+    n.mi = nil;
+    note_seeds(?f, ?n, ?seeds);
+    if (seeds.count != 0 || seeds.barrier || seeds.dst_secret) { ret 9; }
+    ret 0;
 }

--- a/src/lang/be/codegen/encoding.mach
+++ b/src/lang/be/codegen/encoding.mach
@@ -21,6 +21,8 @@ pub rec EncoderOutput {
     const_count:  u32;
     frames:       *of.FrameUnwind;
     frame_count:  u32;
+    # instruction notifications the sink recorded, 0 when no stream was attached
+    notified:     u32;
 }
 
 pub def LineRow: debug_input.LineRow;

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -136,6 +136,11 @@ pub fun fused_cbr_opcode(cmp: MirOpcode) MirOpcode {
 }
 
 
+# the only downgrade: the declassify opcode before selection, the flag after
+pub fun instr_declassifies(mi: *MirInstr) bool {
+    ret mi.opcode == MIR_DECLASSIFY || mi.declassifies;
+}
+
 pub fun instr_defines_shape(mi: *MirInstr) bool {
     if (mi.operand_count == 0)             { ret false; }
     if (has(mi.opcode, MIRF_NO_SHAPE))     { ret false; }
@@ -810,6 +815,10 @@ pub rec MirInstr {
 
     writes_secret:     bool;
     memory_flags:      u8;
+    # selection retags MIR_DECLASSIFY to the ISA move; the barrier survives here
+    declassifies:      bool;
+    # the vreg a dropped declassify self-copy downgraded, once it has no operands
+    declassified:      u32;
 }
 
 pub fun instr(opcode: MirOpcode, operands: *MirOperand, operand_count: u32,
@@ -820,8 +829,25 @@ pub fun instr(opcode: MirOpcode, operands: *MirOperand, operand_count: u32,
     mi.operand_count = operand_count;
     mi.width         = width;
     mi.src_width     = src_width;
+    mi.declassified  = MIR_VREG_NIL;
     ret mi;
 }
+
+# a dropped declassify self-copy becomes a zero-byte use that keeps the
+# barrier and names the vreg it downgraded; its carrier is read through
+# MirVReg.assigned and spill_slot
+pub fun declassify_marker(src: *MirInstr, v: u32) MirInstr {
+    var mi: MirInstr = @src;
+    mi.opcode        = ISA_USE_OPCODE;
+    mi.operands      = nil;
+    mi.operand_count = 0;
+    mi.declassifies  = true;
+    mi.declassified  = v;
+    ret mi;
+}
+
+# isa.ISA_USE, spelled here because mir sits below isa in the import graph
+pub val ISA_USE_OPCODE: MirOpcode = 0xFFFB;
 
 pub fun instr_like(src: *MirInstr, operands: *MirOperand, operand_count: u32) MirInstr {
     var mi: MirInstr = @src;
@@ -1124,6 +1150,30 @@ pub fun op_preg(preg: u32) MirOperand {
     o.index_is_preg = false;
     o.sym_got       = false;
     ret o;
+}
+
+# a physical operand that remembers the vreg it was rewritten from; the seed
+# secrecy of that vreg is what the post-allocation walk reads at this use
+pub fun op_preg_of(preg: u32, origin: u32) MirOperand {
+    var o: MirOperand = op_preg(preg);
+    o.vreg = origin;
+    ret o;
+}
+
+# the vreg an operand carries the secrecy of after allocation: the origin of a
+# rewritten register operand, the slot key of a frame-slot memory operand,
+# MIR_VREG_NIL for a precolored register, a preg-based address, an immediate
+# or a symbol
+pub fun operand_origin(op: *MirOperand) u32 {
+    if (op.kind == MIR_OP_PREG) { ret op.vreg; }
+    if (op.kind == MIR_OP_MEM)  { ret op.vreg; }
+    ret MIR_VREG_NIL;
+}
+
+pub fun operand_seed_secret(f: *MirFunction, op: *MirOperand) bool {
+    val origin: u32 = operand_origin(op);
+    if (origin == MIR_VREG_NIL || origin >= f.vreg_count) { ret false; }
+    ret f.vregs[origin].secret;
 }
 
 pub fun op_imm(imm: i64) MirOperand {

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -1064,7 +1064,12 @@ fun drop_self_copies(tgt: *target.Target, ctx: *AllocCtx) {
                 val b: *mir.MirOperand = ?mi.operands[1];
                 drop = a.kind == mir.MIR_OP_VREG && b.kind == mir.MIR_OP_VREG && a.vreg == b.vreg;
             }
-            if (drop) {
+            if (drop && mir.instr_declassifies(mi)) {
+                val marker: mir.MirInstr = mir.declassify_marker(mi, mi.operands[0].vreg);
+                A.deallocate[mir.MirOperand](ctx.alloc, mi.operands, mi.operand_count::usize);
+                blk.instrs[write] = marker;
+                write = write + 1;
+            } or (drop) {
                 if (mi.operands != nil && mi.operand_count > 0) {
                     A.deallocate[mir.MirOperand](ctx.alloc, mi.operands, mi.operand_count::usize);
                 }
@@ -2471,7 +2476,12 @@ fun drop_self_copies_physical(tgt: *target.Target, ctx: *AllocCtx) {
                 val b: *mir.MirOperand = ?mi.operands[1];
                 drop = a.kind == mir.MIR_OP_PREG && b.kind == mir.MIR_OP_PREG && a.preg == b.preg;
             }
-            if (drop) {
+            if (drop && mir.instr_declassifies(mi)) {
+                val marker: mir.MirInstr = mir.declassify_marker(mi, mi.operands[0].vreg);
+                A.deallocate[mir.MirOperand](ctx.alloc, mi.operands, mi.operand_count::usize);
+                blk.instrs[write] = marker;
+                write = write + 1;
+            } or (drop) {
                 if (mi.operands != nil && mi.operand_count > 0) {
                     A.deallocate[mir.MirOperand](ctx.alloc, mi.operands, mi.operand_count::usize);
                 }
@@ -2618,7 +2628,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                         ret R.err[R.Void, str](regalloc_msg(ctx, "regalloc: no free register for spilled destination in '", "'", "regalloc: no free register for spilled destination"));
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    ops[k] = mir.op_preg(tmp::u32);
+                    ops[k] = mir.op_preg_of(tmp::u32, v);
                     store_dst_vreg = v;
                     store_dst_tmp  = tmp;
                 } or {
@@ -2633,7 +2643,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                         if (R.is_err[R.Void, str](er)) { free_ops(ctx, ops, n); ret er; }
                         store_dst_reloaded = true;
                     }
-                    ops[k] = mir.op_preg(store_dst_tmp::u32);
+                    ops[k] = mir.op_preg_of(store_dst_tmp::u32, v);
                 } or (is_spilled(ctx, v)) {
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, is_entry, src_pos);
                     if (tmp < 0) {
@@ -2643,7 +2653,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
                     val er: R.Result[R.Void, str] = emit_reload(ctx, dst, wp, tmp::u32, v, mi.loc, mi.inline_site);
                     if (R.is_err[R.Void, str](er)) { free_ops(ctx, ops, n); ret er; }
-                    ops[k] = mir.op_preg(tmp::u32);
+                    ops[k] = mir.op_preg_of(tmp::u32, v);
                 } or {
                     ops[k] = preg_of(ctx, v);
                 }
@@ -2697,6 +2707,17 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
         && ops[0].kind == mir.MIR_OP_PREG && ops[1].kind == mir.MIR_OP_PREG
         && ops[0].preg == ops[1].preg
         && operand_bank_matches(?ops[0]) && operand_bank_matches(?ops[1])) {
+        # a declassify keeps a zero-byte marker: the barrier must reach the
+        # stream even when the move it selected to is a self-copy
+        if (mir.instr_declassifies(mi)) {
+            dst[@wp] = mir.declassify_marker(mi, ops[0].vreg);
+            @wp = @wp + 1;
+            free_ops(ctx, ops, n);
+            if (mi.operands != nil && mi.operand_count > 0) {
+                A.deallocate[mir.MirOperand](ctx.alloc, mi.operands, mi.operand_count::usize);
+            }
+            ret R.ok_void[str]();
+        }
         free_ops(ctx, ops, n);
         if (mi.dbg_binding_count > 0) {
             dst[@wp].opcode            = isa.ISA_USE::mir.MirOpcode;
@@ -2734,8 +2755,10 @@ fun instr_defines_ops(mi: *mir.MirInstr, ops: *mir.MirOperand, n: u32) bool {
     ret ops[0].kind == mir.MIR_OP_VREG;
 }
 
+# the rewritten operand keeps its origin vreg as provenance: the seed the
+# physical secrecy walk reads at the instruction the notification names
 fun preg_of(ctx: *AllocCtx, v: u32) mir.MirOperand {
-    ret mir.op_preg(assigned_preg(ctx, v));
+    ret mir.op_preg_of(assigned_preg(ctx, v), v);
 }
 
 fun assigned_preg(ctx: *AllocCtx, v: u32) u32 {
@@ -2783,7 +2806,7 @@ fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32, 
     val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
     if (R.is_err[*mir.MirOperand, str](ro)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](ro)); }
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro);
-    ops[0] = mir.op_preg(tmp);
+    ops[0] = mir.op_preg_of(tmp, v);
     ops[0].required_bank = mir.BANK_GP;
     ops[1] = mir.op_mem_slot(v, 0);
     dst[@wp].opcode        = mir.MIR_MOV;
@@ -2805,7 +2828,7 @@ fun emit_store(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, v: u32, tmp: u32, l
     if (R.is_err[*mir.MirOperand, str](ro)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](ro)); }
     val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro);
     ops[0] = mir.op_mem_slot(v, 0);
-    ops[1] = mir.op_preg(tmp);
+    ops[1] = mir.op_preg_of(tmp, v);
     ops[1].required_bank = mir.BANK_GP;
     dst[@wp].opcode        = mir.MIR_MOV;
     dst[@wp].operands      = ops;
@@ -4075,6 +4098,68 @@ test "mach.lang.be.codegen.regalloc.rewrite_instr:a_spilled_secret_keeps_its_slo
     val use: *mir.MirInstr = ?dst[1];
     if (use.opcode != mir.MIR_ADD || use.operands[2].kind != mir.MIR_OP_PREG || use.operands[2].preg != 9) { ret 9; }
     if (!f.vregs[0].secret || f.vregs[1].secret) { ret 10; }
+
+    # provenance: the scratch names the secret it aliases at both the reload
+    # and the use, and the assigned register names its public vreg
+    if (mir.operand_origin(?reload.operands[0]) != 0 || !mir.operand_seed_secret(?f, ?reload.operands[0])) { ret 11; }
+    if (mir.operand_origin(?reload.operands[1]) != 0 || !mir.operand_seed_secret(?f, ?reload.operands[1])) { ret 12; }
+    if (mir.operand_origin(?use.operands[2]) != 0 || !mir.operand_seed_secret(?f, ?use.operands[2]))       { ret 13; }
+    if (mir.operand_origin(?use.operands[0]) != 1 || mir.operand_seed_secret(?f, ?use.operands[0]))        { ret 14; }
+    if (mir.operand_origin(?use.operands[1]) != 1 || mir.operand_seed_secret(?f, ?use.operands[1]))        { ret 15; }
+    ret 0;
+}
+
+# a spilled destination stores through the scratch, and the store names the
+# vreg it homes as provenance on both its register and its slot
+test "mach.lang.be.codegen.regalloc.rewrite_instr:a_spilled_secret_destination_keeps_its_origin_through_the_store" {
+    var backing: A.Allocator;
+    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    var scratch_arena: arena.Arena;
+    if (O.is_some[str](arena.init(?scratch_arena, ?backing, 65536))) { ret 1; }
+    fin { arena.dnit(?scratch_arena); }
+    var alloc: A.Allocator;
+    if (O.is_some[str](arena.make(?alloc, ?scratch_arena))) { ret 1; }
+    var vregs: [2]mir.MirVReg;
+    vregs[0] = mir.vreg(0, REG_CLASS_GP, false, true);
+    vregs[0].spill_slot = 0;
+    vregs[1] = mir.vreg(1, REG_CLASS_GP, false, false);
+    vregs[1].assigned = 7;
+    var f: mir.MirFunction;
+    f.vregs = ?vregs[0];
+    f.vreg_count = 2;
+    var scratch: [1]isa.Register;
+    scratch[0].id = 9;
+    var ctx: AllocCtx;
+    ctx.alloc = ?alloc;
+    ctx.f = ?f;
+    ctx.spill_width = 8;
+    ctx.reload_scratch = ?scratch[0];
+    ctx.reload_scratch_count = 1;
+    var tgt: target.Target;
+    val ar: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](?alloc, 2::usize);
+    if (R.is_err[*mir.MirOperand, str](ar)) { ret 1; }
+    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ar);
+    ops[0] = mir.op_vreg(0);
+    ops[1] = mir.op_vreg(1);
+    var mi: mir.MirInstr = mir.instr(mir.MIR_MOV, ops, 2, 8, 8);
+    if (R.is_err[R.Void, str](rules.capture_operand_banks(?f, ?mi))) { ret 2; }
+    var dst: [4]mir.MirInstr;
+    var written: u32 = 0;
+    fin {
+        var i: u32 = 0;
+        for (i < written) { free_ops(?ctx, dst[i].operands, dst[i].operand_count); i = i + 1; }
+    }
+    if (R.is_err[R.Void, str](rewrite_instr(?tgt, ?ctx, ?mi, ?dst[0], ?written, false, 0))) { ret 3; }
+    if (written != 2) { ret 4; }
+    val mov: *mir.MirInstr = ?dst[0];
+    if (mov.operands[0].kind != mir.MIR_OP_PREG || mov.operands[0].preg != 9) { ret 5; }
+    if (mir.operand_origin(?mov.operands[0]) != 0 || !mir.operand_seed_secret(?f, ?mov.operands[0])) { ret 6; }
+    if (mir.operand_origin(?mov.operands[1]) != 1 || mir.operand_seed_secret(?f, ?mov.operands[1]))  { ret 7; }
+    val store: *mir.MirInstr = ?dst[1];
+    if (store.opcode != mir.MIR_MOV || store.operands[0].kind != mir.MIR_OP_MEM) { ret 8; }
+    if (mir.operand_origin(?store.operands[0]) != 0 || !mir.operand_seed_secret(?f, ?store.operands[0])) { ret 9; }
+    if (store.operands[1].kind != mir.MIR_OP_PREG || store.operands[1].preg != 9) { ret 10; }
+    if (mir.operand_origin(?store.operands[1]) != 0 || !mir.operand_seed_secret(?f, ?store.operands[1])) { ret 11; }
     ret 0;
 }
 

--- a/src/lang/be/codegen/rules.mach
+++ b/src/lang/be/codegen/rules.mach
@@ -186,6 +186,7 @@ pub fun emit(builder: *ExpansionBuilder, opcode: u32, operands: *mir.MirOperand,
     piece.vec_lane      = source.vec_lane;
     piece.writes_secret = source.writes_secret;
     piece.memory_flags = source.memory_flags;
+    piece.declassifies  = mir.instr_declassifies(source);
     piece.loc           = source.loc;
     piece.inline_site   = source.inline_site;
     if (builder.emitted == 0) {
@@ -196,6 +197,12 @@ pub fun emit(builder: *ExpansionBuilder, opcode: u32, operands: *mir.MirOperand,
     builder.cursor  = builder.cursor + 1;
     builder.emitted = builder.emitted + 1;
     ret R.ok[*mir.MirInstr, str](piece);
+}
+
+# a retag loses the generic opcode; the declassify barrier is kept as a flag
+fun retag(mi: *mir.MirInstr, to: u32) {
+    if (mir.instr_declassifies(mi)) { mi.declassifies = true; }
+    mi.opcode = to;
 }
 
 fun gate_admits(gate: RuleGate, mi: *mir.MirInstr) bool {
@@ -502,7 +509,7 @@ fun select_block(pack: *RulePack, a: *A.Allocator, tgt: *isa.BackendTarget, f: *
     if (!needs_expand) {
         i = 0;
         for (i < n) {
-            if (rules_for[i].kind == RULE_RETAG) { b.instrs[i].opcode = rules_for[i].to; }
+            if (rules_for[i].kind == RULE_RETAG) { retag(?b.instrs[i], rules_for[i].to); }
             i = i + 1;
         }
         free_rule_cache(a, rules_for, n, cache_on_heap);
@@ -545,7 +552,7 @@ fun select_block(pack: *RulePack, a: *A.Allocator, tgt: *isa.BackendTarget, f: *
             free_source_operands(a, mi);
         }
         or {
-            if (rule.kind == RULE_RETAG) { mi.opcode = rule.to; }
+            if (rule.kind == RULE_RETAG) { retag(mi, rule.to); }
             dst[w] = @mi;
             w = w + 1;
         }

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -89,6 +89,8 @@ pub rec Inst {
     dst:      Operand;
     src1:     Operand;
     src2:     Operand;
+    # a fourth operand for the ISAs whose instructions read three sources (aarch64 madd/msub)
+    src3:     Operand;
     size:     u8;
     flags:    u16;
     clobbers: u32;
@@ -1908,6 +1910,7 @@ pub fun inst_blank() Inst {
     mi.dst      = make_none();
     mi.src1     = make_none();
     mi.src2     = make_none();
+    mi.src3     = make_none();
     mi.size     = 0;
     mi.flags    = 0;
     mi.clobbers = 0;

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -26,6 +26,7 @@ use mach.lang.target.isa;
 use iasm: mach.lang.target.isa.asm;
 use mach.lang.target.isa.arm64;
 use mach.lang.target.isa.arm64.printer;
+use mop: mach.lang.target.isa.arm64.inst;
 use mach.lang.target.of;
 
 val ADD_X: u32 = 0x8B000000; val ADD_W: u32 = 0x0B000000;
@@ -2878,6 +2879,7 @@ pub fun encode_arm64(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.MirMo
     var hooks: encode.EncodeHooks;
     hooks.encode_function = encode_function_arm64;
     hooks.patch_branch    = patch_branch_arm64;
+    hooks.stream          = true;
     ret encode.encode_driver(alloc, tgt, m, ?hooks);
 }
 
@@ -2916,6 +2918,7 @@ pub fun encode_arm64_asm(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.M
     var hooks: encode.EncodeHooks;
     hooks.encode_function = encode_function_arm64;
     hooks.patch_branch    = patch_branch_arm64;
+    hooks.stream          = true;
     ret encode.encode_driver_asm(alloc, tgt, m, ?hooks, out);
 }
 
@@ -3012,53 +3015,6 @@ val A64P_MRS:      u16 = 23;
 val A64F_COND_SHIFT: u16 = 8;
 val A64F_COND_MASK:  u16 = 0x0F00;
 
-val A64M_NOP:   u32 = 0;
-val A64M_YIELD: u32 = 1;
-val A64M_RET:   u32 = 2;
-val A64M_SVC:   u32 = 3;
-val A64M_BRK:   u32 = 4;
-val A64M_MOV:   u32 = 5;
-val A64M_MOVZ:  u32 = 6;
-val A64M_MOVK:  u32 = 7;
-val A64M_ADD:   u32 = 8;
-val A64M_SUB:   u32 = 9;
-val A64M_AND:   u32 = 10;
-val A64M_ORR:   u32 = 11;
-val A64M_EOR:   u32 = 12;
-val A64M_CMP:   u32 = 13;
-val A64M_CSET:  u32 = 14;
-val A64M_ADRP:  u32 = 15;
-val A64M_BL:    u32 = 16;
-val A64M_BLR:   u32 = 17;
-val A64M_BR:    u32 = 18;
-val A64M_B:     u32 = 19;
-val A64M_CBZ:   u32 = 20;
-val A64M_CBNZ:  u32 = 21;
-val A64M_LDR:   u32 = 22;
-val A64M_STR:   u32 = 23;
-val A64M_LDRB:  u32 = 24;
-val A64M_STRB:  u32 = 25;
-val A64M_LDRH:  u32 = 26;
-val A64M_STRH:  u32 = 27;
-val A64M_LDP:   u32 = 28;
-val A64M_STP:   u32 = 29;
-val A64M_DMB:   u32 = 30;
-val A64M_LDAR:  u32 = 31;
-val A64M_STLR:  u32 = 32;
-val A64M_LDAXR: u32 = 33;
-val A64M_STLXR: u32 = 34;
-val A64M_LSL:   u32 = 35;
-val A64M_LSR:   u32 = 36;
-val A64M_ASR:   u32 = 37;
-val A64M_LSLV:  u32 = 38;
-val A64M_LSRV:  u32 = 39;
-val A64M_ASRV:  u32 = 40;
-val A64M_MSR:   u32 = 41;
-val A64M_MRS:   u32 = 42;
-val A64M_HVC:   u32 = 43;
-val A64M_SMC:   u32 = 44;
-val A64M_WFI:   u32 = 45;
-val A64M_WFE:   u32 = 46;
 
 val A64_CALLER_SAVED: u32 = 0x4007FFFF;
 
@@ -3069,64 +3025,64 @@ val A64_LR_READ: u32 = 0x40000000;
 val A64_MNEMONIC_COUNT: usize = 48;
 
 val A64_MNEMONICS: [A64_MNEMONIC_COUNT]iasm.Mnemonic = [A64_MNEMONIC_COUNT]iasm.Mnemonic{
-    iasm.Mnemonic{ name: "nop",   code: A64M_NOP,   form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: A64P_NULLARY, words: 1 },
-    iasm.Mnemonic{ name: "yield", code: A64M_YIELD, form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: A64P_NULLARY, words: 1 },
-    iasm.Mnemonic{ name: "ret",   code: A64M_RET,   form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: A64_LR_READ, flags: A64P_NULLARY, words: 1 },
-    iasm.Mnemonic{ name: "ret",   code: A64M_RET,   form: iasm.AF_OPS,  writes: iasm.AW_NONE, implicit: 0, flags: A64P_RET_REG, words: 1 },
+    iasm.Mnemonic{ name: "nop",   code: mop.NOP::u32,   form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: A64P_NULLARY, words: 1 },
+    iasm.Mnemonic{ name: "yield", code: mop.YIELD::u32, form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: A64P_NULLARY, words: 1 },
+    iasm.Mnemonic{ name: "ret",   code: mop.RET::u32,   form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: A64_LR_READ, flags: A64P_NULLARY, words: 1 },
+    iasm.Mnemonic{ name: "ret",   code: mop.RET::u32,   form: iasm.AF_OPS,  writes: iasm.AW_NONE, implicit: 0, flags: A64P_RET_REG, words: 1 },
 
-    iasm.Mnemonic{ name: "wfi", code: A64M_WFI, form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: A64P_NULLARY, words: 1 },
-    iasm.Mnemonic{ name: "wfe", code: A64M_WFE, form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: A64P_NULLARY, words: 1 },
+    iasm.Mnemonic{ name: "wfi", code: mop.WFI::u32, form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: A64P_NULLARY, words: 1 },
+    iasm.Mnemonic{ name: "wfe", code: mop.WFE::u32, form: iasm.AF_NONE, writes: iasm.AW_NONE, implicit: 0, flags: A64P_NULLARY, words: 1 },
 
-    iasm.Mnemonic{ name: "svc", code: A64M_SVC, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 1, flags: A64P_IMM16, words: 1 },
-    iasm.Mnemonic{ name: "brk", code: A64M_BRK, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_IMM16, words: 1 },
-    iasm.Mnemonic{ name: "hvc", code: A64M_HVC, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: A64_SMCCC_CLOBBER, flags: A64P_IMM16, words: 1 },
-    iasm.Mnemonic{ name: "smc", code: A64M_SMC, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: A64_SMCCC_CLOBBER, flags: A64P_IMM16, words: 1 },
+    iasm.Mnemonic{ name: "svc", code: mop.SVC::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 1, flags: A64P_IMM16, words: 1 },
+    iasm.Mnemonic{ name: "brk", code: mop.BRK::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_IMM16, words: 1 },
+    iasm.Mnemonic{ name: "hvc", code: mop.HVC::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: A64_SMCCC_CLOBBER, flags: A64P_IMM16, words: 1 },
+    iasm.Mnemonic{ name: "smc", code: mop.SMC::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: A64_SMCCC_CLOBBER, flags: A64P_IMM16, words: 1 },
 
-    iasm.Mnemonic{ name: "movz", code: A64M_MOVZ, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_MOVEWIDE, words: 1 },
-    iasm.Mnemonic{ name: "movk", code: A64M_MOVK, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_MOVEWIDE, words: 1 },
-    iasm.Mnemonic{ name: "mov",  code: A64M_MOV,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_MOV,      words: iasm.WORDS_VARIABLE },
-    iasm.Mnemonic{ name: "add",  code: A64M_ADD,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_ADDSUB,   words: 1 },
-    iasm.Mnemonic{ name: "sub",  code: A64M_SUB,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_ADDSUB,   words: 1 },
-    iasm.Mnemonic{ name: "and",  code: A64M_AND,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_LOGICAL,  words: 1 },
-    iasm.Mnemonic{ name: "orr",  code: A64M_ORR,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_LOGICAL,  words: 1 },
-    iasm.Mnemonic{ name: "eor",  code: A64M_EOR,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_LOGICAL,  words: 1 },
-    iasm.Mnemonic{ name: "cset", code: A64M_CSET, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_CSET,     words: 1 },
-    iasm.Mnemonic{ name: "adrp", code: A64M_ADRP, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_ADRP,     words: 1 },
+    iasm.Mnemonic{ name: "movz", code: mop.MOVZ::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_MOVEWIDE, words: 1 },
+    iasm.Mnemonic{ name: "movk", code: mop.MOVK::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_MOVEWIDE, words: 1 },
+    iasm.Mnemonic{ name: "mov",  code: mop.MOV::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_MOV,      words: iasm.WORDS_VARIABLE },
+    iasm.Mnemonic{ name: "add",  code: mop.ADD::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_ADDSUB,   words: 1 },
+    iasm.Mnemonic{ name: "sub",  code: mop.SUB::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_ADDSUB,   words: 1 },
+    iasm.Mnemonic{ name: "and",  code: mop.AND::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_LOGICAL,  words: 1 },
+    iasm.Mnemonic{ name: "orr",  code: mop.ORR::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_LOGICAL,  words: 1 },
+    iasm.Mnemonic{ name: "eor",  code: mop.EOR::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_LOGICAL,  words: 1 },
+    iasm.Mnemonic{ name: "cset", code: mop.CSET::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_CSET,     words: 1 },
+    iasm.Mnemonic{ name: "adrp", code: mop.ADRP::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_ADRP,     words: 1 },
 
-    iasm.Mnemonic{ name: "cmp", code: A64M_CMP, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_CMP, words: 1 },
+    iasm.Mnemonic{ name: "cmp", code: mop.CMP::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_CMP, words: 1 },
 
-    iasm.Mnemonic{ name: "blr",  code: A64M_BLR,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: A64_CALLER_SAVED, flags: A64P_BR_REG, words: 1 },
-    iasm.Mnemonic{ name: "bl",   code: A64M_BL,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: A64_CALLER_SAVED, flags: A64P_BL,     words: 1 },
-    iasm.Mnemonic{ name: "br",   code: A64M_BR,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: A64_CALLER_SAVED, flags: A64P_BR_REG, words: 1 },
-    iasm.Mnemonic{ name: "b",    code: A64M_B,    form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0,                flags: A64P_B,      words: 1 },
-    iasm.Mnemonic{ name: "cbz",  code: A64M_CBZ,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0,                flags: A64P_CBR,    words: 1 },
-    iasm.Mnemonic{ name: "cbnz", code: A64M_CBNZ, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0,                flags: A64P_CBR,    words: 1 },
+    iasm.Mnemonic{ name: "blr",  code: mop.BLR::u32,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: A64_CALLER_SAVED, flags: A64P_BR_REG, words: 1 },
+    iasm.Mnemonic{ name: "bl",   code: mop.BL::u32,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: A64_CALLER_SAVED, flags: A64P_BL,     words: 1 },
+    iasm.Mnemonic{ name: "br",   code: mop.BR::u32,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: A64_CALLER_SAVED, flags: A64P_BR_REG, words: 1 },
+    iasm.Mnemonic{ name: "b",    code: mop.B::u32,    form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0,                flags: A64P_B,      words: 1 },
+    iasm.Mnemonic{ name: "cbz",  code: mop.CBZ::u32,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0,                flags: A64P_CBR,    words: 1 },
+    iasm.Mnemonic{ name: "cbnz", code: mop.CBNZ::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0,                flags: A64P_CBR,    words: 1 },
 
-    iasm.Mnemonic{ name: "ldrb", code: A64M_LDRB, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDST, words: 1 },
-    iasm.Mnemonic{ name: "strb", code: A64M_STRB, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_LDST, words: 1 },
-    iasm.Mnemonic{ name: "ldrh", code: A64M_LDRH, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDST, words: 1 },
-    iasm.Mnemonic{ name: "strh", code: A64M_STRH, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_LDST, words: 1 },
-    iasm.Mnemonic{ name: "ldr",  code: A64M_LDR,  form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDST, words: 1 },
-    iasm.Mnemonic{ name: "str",  code: A64M_STR,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_LDST, words: 1 },
+    iasm.Mnemonic{ name: "ldrb", code: mop.LDRB::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDST, words: 1 },
+    iasm.Mnemonic{ name: "strb", code: mop.STRB::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_LDST, words: 1 },
+    iasm.Mnemonic{ name: "ldrh", code: mop.LDRH::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDST, words: 1 },
+    iasm.Mnemonic{ name: "strh", code: mop.STRH::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_LDST, words: 1 },
+    iasm.Mnemonic{ name: "ldr",  code: mop.LDR::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDST, words: 1 },
+    iasm.Mnemonic{ name: "str",  code: mop.STR::u32,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_LDST, words: 1 },
 
-    iasm.Mnemonic{ name: "ldp", code: A64M_LDP, form: iasm.AF_OPS, writes: iasm.AW_OP0 | iasm.AW_OP1 | iasm.AW_WB_BASE, implicit: 0, flags: A64P_LDSTP, words: 1 },
-    iasm.Mnemonic{ name: "stp", code: A64M_STP, form: iasm.AF_OPS, writes: iasm.AW_WB_BASE,                             implicit: 0, flags: A64P_LDSTP, words: 1 },
+    iasm.Mnemonic{ name: "ldp", code: mop.LDP::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0 | iasm.AW_OP1 | iasm.AW_WB_BASE, implicit: 0, flags: A64P_LDSTP, words: 1 },
+    iasm.Mnemonic{ name: "stp", code: mop.STP::u32, form: iasm.AF_OPS, writes: iasm.AW_WB_BASE,                             implicit: 0, flags: A64P_LDSTP, words: 1 },
 
-    iasm.Mnemonic{ name: "ldaxr", code: A64M_LDAXR, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDORD, words: 1 },
-    iasm.Mnemonic{ name: "ldar",  code: A64M_LDAR,  form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDORD, words: 1 },
-    iasm.Mnemonic{ name: "stlxr", code: A64M_STLXR, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_STLXR, words: 1 },
-    iasm.Mnemonic{ name: "stlr",  code: A64M_STLR,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_LDORD, words: 1 },
-    iasm.Mnemonic{ name: "dmb",   code: A64M_DMB,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_DMB,   words: 1 },
+    iasm.Mnemonic{ name: "ldaxr", code: mop.LDAXR::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDORD, words: 1 },
+    iasm.Mnemonic{ name: "ldar",  code: mop.LDAR::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_LDORD, words: 1 },
+    iasm.Mnemonic{ name: "stlxr", code: mop.STLXR::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_STLXR, words: 1 },
+    iasm.Mnemonic{ name: "stlr",  code: mop.STLR::u32,  form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_LDORD, words: 1 },
+    iasm.Mnemonic{ name: "dmb",   code: mop.DMB::u32,   form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_DMB,   words: 1 },
 
-    iasm.Mnemonic{ name: "lslv", code: A64M_LSLV, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
-    iasm.Mnemonic{ name: "lsrv", code: A64M_LSRV, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
-    iasm.Mnemonic{ name: "asrv", code: A64M_ASRV, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "lslv", code: mop.LSLV::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "lsrv", code: mop.LSRV::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "asrv", code: mop.ASRV::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
 
-    iasm.Mnemonic{ name: "msr", code: A64M_MSR, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_MSR, words: 1 },
-    iasm.Mnemonic{ name: "mrs", code: A64M_MRS, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_MRS, words: 1 },
-    iasm.Mnemonic{ name: "lsl",  code: A64M_LSL,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
-    iasm.Mnemonic{ name: "lsr",  code: A64M_LSR,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
-    iasm.Mnemonic{ name: "asr",  code: A64M_ASR,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "msr", code: mop.MSR::u32, form: iasm.AF_OPS, writes: iasm.AW_NONE, implicit: 0, flags: A64P_MSR, words: 1 },
+    iasm.Mnemonic{ name: "mrs", code: mop.MRS::u32, form: iasm.AF_OPS, writes: iasm.AW_OP0,  implicit: 0, flags: A64P_MRS, words: 1 },
+    iasm.Mnemonic{ name: "lsl",  code: mop.LSL::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "lsr",  code: mop.LSR::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
+    iasm.Mnemonic{ name: "asr",  code: mop.ASR::u32,  form: iasm.AF_OPS, writes: iasm.AW_OP0, implicit: 0, flags: A64P_SHIFT, words: 1 },
 };
 
 fun a64_pattern(flags: u16) u16 { ret flags & 0x00FF; }
@@ -3146,7 +3102,7 @@ fun a64_decode_bcond(body: str, lo: usize, hi: usize, m: *iasm.Mnemonic, n_out: 
     if (!asm_parse_cond((?buf[0])::str, ?cc)) { ret false; }
 
     m.name     = nil;
-    m.code     = A64M_B;
+    m.code     = mop.B::u32;
     m.form     = iasm.AF_OPS;
     m.writes   = iasm.AW_NONE;
     m.implicit = 0;
@@ -3589,25 +3545,25 @@ fun a64_emit(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, item: *i
     val pat: u16 = a64_pattern(item.flags);
 
     if (pat == A64P_NULLARY) {
-        if (item.code == A64M_NOP)   { emit_nullary(st, NOP_WORD);   ret R.ok_void[str](); }
-        if (item.code == A64M_YIELD) { emit_nullary(st, YIELD_WORD); ret R.ok_void[str](); }
-        if (item.code == A64M_WFE)   { emit_nullary(st, WFE_WORD);   ret R.ok_void[str](); }
-        if (item.code == A64M_WFI)   { emit_nullary(st, WFI_WORD);   ret R.ok_void[str](); }
+        if (item.code == mop.NOP::u32)   { emit_nullary(st, NOP_WORD);   ret R.ok_void[str](); }
+        if (item.code == mop.YIELD::u32) { emit_nullary(st, YIELD_WORD); ret R.ok_void[str](); }
+        if (item.code == mop.WFE::u32)   { emit_nullary(st, WFE_WORD);   ret R.ok_void[str](); }
+        if (item.code == mop.WFI::u32)   { emit_nullary(st, WFI_WORD);   ret R.ok_void[str](); }
         emit_nullary(st, RET_WORD);
         ret R.ok_void[str]();
     }
     if (pat == A64P_RET_REG) { emit_branch_reg(st, RET_BASE, item.ops[0].reg::u32); ret R.ok_void[str](); }
     if (pat == A64P_BR_REG) {
         var base: u32 = BR_BASE;
-        if (item.code == A64M_BLR) { base = BLR_BASE; }
+        if (item.code == mop.BLR::u32) { base = BLR_BASE; }
         emit_branch_reg(st, base, item.ops[0].reg::u32);
         ret R.ok_void[str]();
     }
     if (pat == A64P_IMM16) {
         var base: u32 = BRK_BASE;
-        if (item.code == A64M_SVC) { base = SVC_BASE; }
-        or (item.code == A64M_HVC) { base = HVC_BASE; }
-        or (item.code == A64M_SMC) { base = SMC_BASE; }
+        if (item.code == mop.SVC::u32) { base = SVC_BASE; }
+        or (item.code == mop.HVC::u32) { base = HVC_BASE; }
+        or (item.code == mop.SMC::u32) { base = SMC_BASE; }
         emit_imm16(st, base, item.ops[0].imm::u32);
         ret R.ok_void[str]();
     }
@@ -3671,7 +3627,7 @@ fun a64_emit_movewide(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void
     var hw: u32 = 0;
     if (item.nops == 3) { hw = item.ops[2].imm::u32; }
     var base: u32 = pick(use64, MOVZ_X, MOVZ_W);
-    if (item.code == A64M_MOVK) { base = pick(use64, MOVK_X, MOVK_W); }
+    if (item.code == mop.MOVK::u32) { base = pick(use64, MOVK_X, MOVK_W); }
     emit_movewide(st, base, item.ops[0].reg::u32, hw, item.ops[1].imm::u32);
     ret R.ok_void[str]();
 }
@@ -3681,7 +3637,7 @@ fun a64_emit_addsub(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) 
     val rn: *iasm.Operand = ?item.ops[1];
     val op3: *iasm.Operand = ?item.ops[2];
     val use64: bool = a64_is64(rd);
-    val is_sub: bool = item.code == A64M_SUB;
+    val is_sub: bool = item.code == mop.SUB::u32;
 
     if (op3.kind == iasm.AOP_IMM) {
         var base: u32 = pick(use64, ADDI_X, ADDI_W);
@@ -3723,8 +3679,8 @@ fun a64_emit_logical(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void,
     val use64: bool = a64_is64(?item.ops[0]);
     var bx: u32 = AND_X;
     var bw: u32 = AND_W;
-    if (item.code == A64M_ORR)      { bx = ORR_X; bw = ORR_W; }
-    or (item.code == A64M_EOR)      { bx = EOR_X; bw = EOR_W; }
+    if (item.code == mop.ORR::u32)      { bx = ORR_X; bw = ORR_W; }
+    or (item.code == mop.EOR::u32)      { bx = EOR_X; bw = EOR_W; }
     emit_alu3(st, pick(use64, bx, bw), item.ops[0].reg::u32, item.ops[1].reg::u32, item.ops[2].reg::u32);
     ret R.ok_void[str]();
 }
@@ -3790,7 +3746,7 @@ fun a64_emit_branch(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, i
     or (pat == A64P_CBR) {
         val use64: bool = a64_is64(?item.ops[0]);
         base = pick(use64, CBZ_X, CBZ_W);
-        if (item.code == A64M_CBNZ) { base = pick(use64, CBNZ_X, CBNZ_W); }
+        if (item.code == mop.CBNZ::u32) { base = pick(use64, CBNZ_X, CBNZ_W); }
         rt     = item.ops[0].reg::u32;
         has_rt = true;
         word   = pack_cbnz(base, rt);
@@ -3804,11 +3760,11 @@ fun a64_emit_branch(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, i
 fun a64_emit_ldst(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) R.Result[R.Void, str] {
     val rt: *iasm.Operand = ?item.ops[0];
     val mem: *iasm.Operand = ?item.ops[1];
-    val is_load: bool = item.code == A64M_LDR || item.code == A64M_LDRB || item.code == A64M_LDRH;
+    val is_load: bool = item.code == mop.LDR::u32 || item.code == mop.LDRB::u32 || item.code == mop.LDRH::u32;
     var w: u8 = 4;
     if (a64_is64(rt))                                          { w = 8; }
-    if (item.code == A64M_LDRB || item.code == A64M_STRB)      { w = 1; }
-    or (item.code == A64M_LDRH || item.code == A64M_STRH)      { w = 2; }
+    if (item.code == mop.LDRB::u32 || item.code == mop.STRB::u32)      { w = 1; }
+    or (item.code == mop.LDRH::u32 || item.code == mop.STRH::u32)      { w = 2; }
 
     val fr: R.Result[A64Access, str] = int_access(w, is_load);
     if (R.is_err[A64Access, str](fr)) { ret R.err[R.Void, str](R.unwrap_err[A64Access, str](fr)); }
@@ -3859,7 +3815,7 @@ fun a64_offset_message(c: *iasm.Cursor, off: i64) str {
 
 fun a64_emit_ldstp(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void, str] {
     val mem: *iasm.Operand = ?item.ops[2];
-    val is_load: bool = item.code == A64M_LDP;
+    val is_load: bool = item.code == mop.LDP::u32;
     var disp: i64 = 0;
     var base_word: u32 = pick(is_load, LDP_OFF_X, STP_OFF_X);
     if (item.nops == 4) {
@@ -3879,8 +3835,8 @@ fun a64_emit_ldstp(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void, s
 fun a64_emit_ldord(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void, str] {
     val use64: bool = a64_is64(?item.ops[0]);
     var base: u32 = pick(use64, LDAXR_X, LDAXR_W);
-    if (item.code == A64M_LDAR)      { base = pick(use64, LDAR_X, LDAR_W); }
-    or (item.code == A64M_STLR)      { base = pick(use64, STLR_X, STLR_W); }
+    if (item.code == mop.LDAR::u32)      { base = pick(use64, LDAR_X, LDAR_W); }
+    or (item.code == mop.STLR::u32)      { base = pick(use64, STLR_X, STLR_W); }
     emit_ldst(st, base, item.ops[0].reg::u32, item.ops[1].reg::u32, 0);
     ret R.ok_void[str]();
 }
@@ -3896,9 +3852,9 @@ fun a64_emit_shift(st: *encode.EncodeState, item: *iasm.Item) R.Result[R.Void, s
     var width: u32 = 32;
     if (use64) { width = 64; }
 
-    val vform: bool = item.code == A64M_LSLV || item.code == A64M_LSRV || item.code == A64M_ASRV;
-    val is_lsr: bool = item.code == A64M_LSR || item.code == A64M_LSRV;
-    val is_asr: bool = item.code == A64M_ASR || item.code == A64M_ASRV;
+    val vform: bool = item.code == mop.LSLV::u32 || item.code == mop.LSRV::u32 || item.code == mop.ASRV::u32;
+    val is_lsr: bool = item.code == mop.LSR::u32 || item.code == mop.LSRV::u32;
+    val is_asr: bool = item.code == mop.ASR::u32 || item.code == mop.ASRV::u32;
 
     if (cnt.kind == iasm.AOP_IMM && !vform) {
         val sh: u32 = cnt.imm::u32 & (width - 1);
@@ -3986,7 +3942,7 @@ fun a64_grammar() iasm.Grammar {
 
 fun a64_no_fall(item: *iasm.Item) bool {
     if (item.kind != iasm.AI_INST) { ret false; }
-    ret item.code == A64M_BRK;
+    ret item.code == mop.BRK::u32;
 }
 
 pub fun asm_returns(body: str) bool {
@@ -7278,44 +7234,44 @@ test "mach.lang.target.isa.arm64.encode:unnamed_forms_are_refused" {
 }
 
 pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {
-    if (code == A64M_MOV  || code == A64M_MOVZ || code == A64M_MOVK ||
-        code == A64M_ADRP || code == A64M_LDR  || code == A64M_STR  ||
-        code == A64M_LDRB || code == A64M_STRB || code == A64M_LDRH ||
-        code == A64M_STRH || code == A64M_LDP  || code == A64M_STP) {
+    if (code == mop.MOV::u32  || code == mop.MOVZ::u32 || code == mop.MOVK::u32 ||
+        code == mop.ADRP::u32 || code == mop.LDR::u32  || code == mop.STR::u32  ||
+        code == mop.LDRB::u32 || code == mop.STRB::u32 || code == mop.LDRH::u32 ||
+        code == mop.STRH::u32 || code == mop.LDP::u32  || code == mop.STP::u32) {
         ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
     }
-    if (code == A64M_ADD || code == A64M_SUB || code == A64M_AND ||
-        code == A64M_ORR || code == A64M_EOR) {
+    if (code == mop.ADD::u32 || code == mop.SUB::u32 || code == mop.AND::u32 ||
+        code == mop.ORR::u32 || code == mop.EOR::u32) {
         ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
     }
-    if (code == A64M_CMP) {
+    if (code == mop.CMP::u32) {
         ret ct.flags_defined(ct.asm_op(ct.CT_OP_NONE));
     }
-    if (code == A64M_CSET) {
+    if (code == mop.CSET::u32) {
         ret ct.flags_read(ct.asm_op(ct.CT_OP_NONE));
     }
-    if (code == A64M_LSL || code == A64M_LSR || code == A64M_ASR) {
+    if (code == mop.LSL::u32 || code == mop.LSR::u32 || code == mop.ASR::u32) {
         ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
     }
-    if (code == A64M_LSLV || code == A64M_LSRV || code == A64M_ASRV) {
+    if (code == mop.LSLV::u32 || code == mop.LSRV::u32 || code == mop.ASRV::u32) {
         ret ct.flags_untouched(ct.asm_op(ct.CT_OP_VAR_SHIFT));
     }
-    if (code == A64M_LDAXR || code == A64M_LDAR || code == A64M_STLXR ||
-        code == A64M_STLR  || code == A64M_DMB  || code == A64M_YIELD) {
+    if (code == mop.LDAXR::u32 || code == mop.LDAR::u32 || code == mop.STLXR::u32 ||
+        code == mop.STLR::u32  || code == mop.DMB::u32  || code == mop.YIELD::u32) {
         ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
     }
     if (a64_pattern(flags) == A64P_BCOND) { ret ct.asm_branch_flags(); }
 
-    if (code == A64M_B   || code == A64M_BL  || code == A64M_SVC || code == A64M_BRK ||
-        code == A64M_NOP || code == A64M_MSR ||
-        code == A64M_HVC || code == A64M_SMC || code == A64M_WFI || code == A64M_WFE) {
+    if (code == mop.B::u32   || code == mop.BL::u32  || code == mop.SVC::u32 || code == mop.BRK::u32 ||
+        code == mop.NOP::u32 || code == mop.MSR::u32 ||
+        code == mop.HVC::u32 || code == mop.SMC::u32 || code == mop.WFI::u32 || code == mop.WFE::u32) {
         ret ct.asm_op(ct.CT_OP_NONE);
     }
-    if (code == A64M_MRS) {
+    if (code == mop.MRS::u32) {
         ret ct.flags_read(ct.asm_op(ct.CT_OP_NONE));
     }
-    if (code == A64M_CBZ  || code == A64M_CBNZ || code == A64M_BLR ||
-        code == A64M_BR   || code == A64M_RET) {
+    if (code == mop.CBZ::u32  || code == mop.CBNZ::u32 || code == mop.BLR::u32 ||
+        code == mop.BR::u32   || code == mop.RET::u32) {
         ret ct.asm_branch_reg();
     }
     ret ct.asm_unknown();
@@ -7353,32 +7309,32 @@ test "mach.lang.target.isa.arm64.encode.asm_ct_scan:a_spill_does_not_launder_a_s
 test "mach.lang.target.isa.arm64.encode.asm_ct_class:branches_are_register_conditioned" {
     var bad: i32 = 0;
 
-    if (!asm_ct_class(A64M_CBZ, 0).cond_reg)   { bad = 1; }
-    if (!asm_ct_class(A64M_CBNZ, 0).cond_reg)  { bad = 1; }
+    if (!asm_ct_class(mop.CBZ::u32, 0).cond_reg)   { bad = 1; }
+    if (!asm_ct_class(mop.CBNZ::u32, 0).cond_reg)  { bad = 1; }
     var i: usize = 0;
     for (i < A64_MNEMONIC_COUNT) {
         if (asm_ct_class(A64_MNEMONICS[i].code, A64_MNEMONICS[i].flags).cond_flags) { bad = 1; }
         i = i + 1;
     }
-    if (asm_ct_class(A64M_B, 0).cond_reg)  { bad = 1; }
-    if (asm_ct_class(A64M_BL, 0).cond_reg) { bad = 1; }
+    if (asm_ct_class(mop.B::u32, 0).cond_reg)  { bad = 1; }
+    if (asm_ct_class(mop.BL::u32, 0).cond_reg) { bad = 1; }
 
     var fi: usize = 0;
     for (fi < A64_MNEMONIC_COUNT) {
         val fc: ct.AsmClass = asm_ct_class(A64_MNEMONICS[fi].code, A64_MNEMONICS[fi].flags);
-        if (fc.reads_flags && A64_MNEMONICS[fi].code != A64M_CSET && A64_MNEMONICS[fi].code != A64M_MRS) { bad = 1; }
-        if (fc.defines_flags && A64_MNEMONICS[fi].code != A64M_CMP) { bad = 1; }
+        if (fc.reads_flags && A64_MNEMONICS[fi].code != mop.CSET::u32 && A64_MNEMONICS[fi].code != mop.MRS::u32) { bad = 1; }
+        if (fc.defines_flags && A64_MNEMONICS[fi].code != mop.CMP::u32) { bad = 1; }
         if (fc.opaque_flags)  { bad = 1; }
         fi = fi + 1;
     }
-    if (!asm_ct_class(A64M_CSET, 0).reads_flags) { bad = 1; }
-    if (!asm_ct_class(A64M_MRS, 0).reads_flags)  { bad = 1; }
-    if (!asm_ct_class(A64M_CMP, 0).defines_flags) { bad = 1; }
+    if (!asm_ct_class(mop.CSET::u32, 0).reads_flags) { bad = 1; }
+    if (!asm_ct_class(mop.MRS::u32, 0).reads_flags)  { bad = 1; }
+    if (!asm_ct_class(mop.CMP::u32, 0).defines_flags) { bad = 1; }
 
-    if (asm_ct_class(A64M_LSLV, 0).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
-    if (asm_ct_class(A64M_LSRV, 0).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
-    if (asm_ct_class(A64M_ASRV, 0).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
-    if (asm_ct_class(A64M_LSL, 0).op != ct.CT_OP_NONE) { bad = 1; }
+    if (asm_ct_class(mop.LSLV::u32, 0).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(mop.LSRV::u32, 0).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(mop.ASRV::u32, 0).op != ct.CT_OP_VAR_SHIFT) { bad = 1; }
+    if (asm_ct_class(mop.LSL::u32, 0).op != ct.CT_OP_NONE) { bad = 1; }
     i = 0;
     for (i < A64_MNEMONIC_COUNT) {
         val op: ct.CtOp = asm_ct_class(A64_MNEMONICS[i].code, A64_MNEMONICS[i].flags).op;
@@ -7393,9 +7349,9 @@ test "mach.lang.target.isa.arm64.encode.asm_ct_class:branches_are_register_condi
 test "mach.lang.target.isa.arm64.encode.asm_ct_class:indirect_transfers_are_register_conditioned" {
     var bad: i32 = 0;
 
-    if (!asm_ct_class(A64M_BR, 0).cond_reg)  { bad = 1; }
-    if (!asm_ct_class(A64M_BLR, 0).cond_reg) { bad = 1; }
-    if (!asm_ct_class(A64M_RET, 0).cond_reg) { bad = 1; }
+    if (!asm_ct_class(mop.BR::u32, 0).cond_reg)  { bad = 1; }
+    if (!asm_ct_class(mop.BLR::u32, 0).cond_reg) { bad = 1; }
+    if (!asm_ct_class(mop.RET::u32, 0).cond_reg) { bad = 1; }
 
     ret bad;
 }
@@ -7529,7 +7485,7 @@ test "mach.lang.target.isa.arm64.encode.asm_ct_class:decode_channel_is_classifie
                 accepted = accepted + 1;
                 val cls: ct.AsmClass = asm_ct_class(m.code, m.flags);
                 if (!cls.cond_flags) { bad = 1; }
-                if (m.code != A64M_B) { bad = 1; }
+                if (m.code != mop.B::u32) { bad = 1; }
             }
             b = b + 1;
         }

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -2832,8 +2832,10 @@ fun encode_function_arm64(st: *encode.EncodeState, f: *mir.MirFunction) R.Result
             }
             encode.sink_set_mir(?st.buf, mi);
             val ei: R.Result[R.Void, str] = encode_mir_instr(st, f, fn_base, mi);
+            val eb: R.Result[R.Void, str] = encode.note_barrier(?st.buf, mi);
             encode.sink_set_mir(?st.buf, nil);
             if (R.is_err[R.Void, str](ei)) { ret ei; }
+            if (R.is_err[R.Void, str](eb)) { ret eb; }
             val ra: R.Result[R.Void, str] = check_accounted(st, mi.opcode::u16);
             if (R.is_err[R.Void, str](ra)) { ret ra; }
             ii = ii + 1;
@@ -3345,6 +3347,13 @@ fun a64_parse(c: *iasm.Cursor, s: *iasm.Stmt, item: *iasm.Item) R.Result[R.Void,
         }
         if (pat == A64P_SHIFT && item.ops[2].kind != iasm.AOP_REG && item.ops[2].kind != iasm.AOP_IMM) {
             ret R.err[R.Void, str]("encode: inline-asm shift count must be a register or immediate");
+        }
+        # `lsl` with a register count is the lslv alias: the variable-latency
+        # member, and the constant-time class must see it as one
+        if (pat == A64P_SHIFT && item.ops[2].kind == iasm.AOP_REG) {
+            if (item.code == mop.LSL::u32) { item.code = mop.LSLV::u32; }
+            if (item.code == mop.LSR::u32) { item.code = mop.LSRV::u32; }
+            if (item.code == mop.ASR::u32) { item.code = mop.ASRV::u32; }
         }
         if (item.ops[2].kind == iasm.AOP_REG && item.ops[0].size != item.ops[2].size) {
             ret R.err[R.Void, str]("encode: inline-asm operands are different widths; aarch64 has one size flag for the whole instruction");
@@ -7306,6 +7315,26 @@ test "mach.lang.target.isa.arm64.encode.asm_ct_scan:a_spill_does_not_launder_a_s
     ret bad;
 }
 
+# the preferred `lsl` spelling with a register count is lslv: the variable
+# shift class, refused on a secret count when the target does not trust it
+test "mach.lang.target.isa.arm64.encode.asm_ct_scan:register_count_shift_alias_is_a_variable_shift" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var bad: i32 = 0;
+    var names: [1]str;
+    names[0] = "c";
+
+    val alias: str = "ldr x2, {c}\nlsl x0, x1, x2";
+    val spelled: str = "ldr x2, {c}\nlslv x0, x1, x2";
+    val immediate: str = "ldr x2, {c}\nlsl x0, x2, 3";
+    if (!R.is_err[R.Void, str](asm_ct_scan(alias, ?names[0], 1, false, false, ?alloc)))   { bad = bad + 1; }
+    if (!R.is_err[R.Void, str](asm_ct_scan(spelled, ?names[0], 1, false, false, ?alloc))) { bad = bad + 2; }
+    if (R.is_err[R.Void, str](asm_ct_scan(alias, ?names[0], 1, false, true, ?alloc)))     { bad = bad + 4; }
+    if (R.is_err[R.Void, str](asm_ct_scan(immediate, ?names[0], 1, false, false, ?alloc))) { bad = bad + 8; }
+    if (R.is_err[R.Void, str](asm_ct_scan(alias, ?names[0], 0, false, false, ?alloc)))    { bad = bad + 16; }
+    ret bad;
+}
+
 test "mach.lang.target.isa.arm64.encode.asm_ct_class:branches_are_register_conditioned" {
     var bad: i32 = 0;
 
@@ -7585,4 +7614,292 @@ test "mach.lang.target.isa.arm64.encode:native_opcode_domain_refuses_unknown_and
         i = i + 1;
     }
     ret 0;
+}
+
+# every notification names the MirInstr whose encoding emitted it, in
+# emission order, and a declassify marker reaches the stream as a barrier
+# with no bytes between the instructions around it
+test "mach.lang.target.isa.arm64.encode.stream:notes_name_their_instruction_and_carry_the_barrier" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var interner: intern.Interner = intern.init(?alloc);
+    var st: encode.EncodeState;
+    encode.state_blank(?st, ?alloc, nil);
+    st.interner = ?interner;
+    var sink: encode.AsmSink = encode.sink_init(nil, ?interner);
+    st.buf.asm = ?sink;
+
+    var vregs: [1]mir.MirVReg;
+    vregs[0] = mir.vreg(0, mir.REG_CLASS_GP, false, true);
+    vregs[0].assigned = isa.regid_make(isa.REG_CLASS_ID_GP, 0)::u32;
+    var mov_ops: [2]mir.MirOperand;
+    mov_ops[0] = mir.op_preg_of(isa.regid_make(isa.REG_CLASS_ID_GP, 0)::u32, 0);
+    mov_ops[0].required_bank = mir.BANK_GP;
+    mov_ops[1] = mir.op_imm(5);
+    var instrs: [3]mir.MirInstr;
+    instrs[0] = mir.instr(arm64.MOV::u32, ?mov_ops[0], 2, 8, 8);
+    instrs[1] = mir.declassify_marker(?instrs[0], 0);
+    instrs[2] = mir.instr(arm64.RET::u32, nil, 0, 0, 0);
+    var blk: mir.MirBlock;
+    blk.id = 0; blk.instrs = ?instrs[0]; blk.instr_count = 3;
+    var f: mir.MirFunction;
+    f.name = intern.STR_NIL;
+    f.blocks = ?blk; f.block_count = 1;
+    f.vregs = ?vregs[0]; f.vreg_count = 1;
+    f.frame.omit = true;
+    f.oblivious = true;
+
+    val r: R.Result[R.Void, str] = encode_function_arm64(?st, ?f);
+    if (R.is_err[R.Void, str](r)) { ret 2; }
+    if (sink.failed || sink.refused != 0)              { ret 3; }
+    if (encode.sink_unaccounted(?st.buf) != 0)          { ret 4; }
+    if (encode.note_inst_count(?st.buf) != 2)           { ret 5; }
+
+    # FUNC, BLOCK, then one INST for the move, the BARRIER, one INST for the return
+    val n: u32 = encode.note_count(?st.buf);
+    if (n != 5) { ret 6; }
+    val head: *encode.AsmNote = encode.note_at(?st.buf, 0);
+    val label: *encode.AsmNote = encode.note_at(?st.buf, 1);
+    val mov: *encode.AsmNote = encode.note_at(?st.buf, 2);
+    val bar: *encode.AsmNote = encode.note_at(?st.buf, 3);
+    val fin_note: *encode.AsmNote = encode.note_at(?st.buf, 4);
+    if (head.kind != encode.ASM_NOTE_FUNC || label.kind != encode.ASM_NOTE_BLOCK) { ret 7; }
+    if (mov.kind != encode.ASM_NOTE_INST || mov.mi != ?instrs[0] || mov.byte_len == 0) { ret 8; }
+    if (bar.kind != encode.ASM_NOTE_BARRIER || bar.mi != ?instrs[1]) { ret 9; }
+    if (bar.off != mov.off + mov.byte_len) { ret 10; }
+    if (fin_note.kind != encode.ASM_NOTE_INST || fin_note.mi != ?instrs[2] || fin_note.off != bar.off) { ret 11; }
+
+    var seeds: encode.NoteSeeds;
+    encode.note_seeds(?f, mov, ?seeds);
+    if (seeds.barrier || seeds.count != 2 || seeds.origin[0] != 0 || !seeds.secret[0] || seeds.secret[1]) { ret 12; }
+    encode.note_seeds(?f, bar, ?seeds);
+    if (!seeds.barrier || seeds.count != 1 || seeds.origin[0] != 0 || !seeds.secret[0]) { ret 13; }
+    encode.note_seeds(?f, head, ?seeds);
+    if (seeds.count != 0 || seeds.barrier) { ret 14; }
+
+    encode.notes_free(?st.buf);
+    encode.buf_dnit(?st.buf);
+    ret 0;
+}
+
+# the grammar row the assembler would pick for a rendered mnemonic; the
+# register-count shifts render with the preferred `lsl` spelling that the
+# grammar retags to the v-form once it sees the register operand
+fun t_grammar_code(name: str) u32 {
+    var r: u32 = 0;
+    for (r < A64_MNEMONIC_COUNT) {
+        if (str_equals(A64_MNEMONICS[r].name, name)) { ret A64_MNEMONICS[r].code; }
+        r = r + 1;
+    }
+    ret 0xFFFFFFFF;
+}
+
+fun t_grammar_agrees(code: u32, op: mop.MachOp) bool {
+    if (code == op::u32) { ret true; }
+    if (op == mop.LSLV && code == mop.LSL::u32) { ret true; }
+    if (op == mop.LSRV && code == mop.LSR::u32) { ret true; }
+    if (op == mop.ASRV && code == mop.ASR::u32) { ret true; }
+    ret false;
+}
+
+# the rendered mnemonic of each instruction note equals the machine-opcode
+# spelling the notification carries, and wherever the inline-asm grammar
+# has a row for that spelling its code is the same opcode: the notification
+# names what an assembler would read back from the printed line
+fun t_roundtrip_check(st: *encode.EncodeState, text: str) i32 {
+    val n: u32 = encode.note_count(?st.buf);
+    var pos: usize = 0;
+    var ni: u32 = 0;
+    var cross_checked: u32 = 0;
+    for (ni < n) {
+        val note: *encode.AsmNote = encode.note_at(?st.buf, ni);
+        if (note.kind != encode.ASM_NOTE_INST) { ni = ni + 1; cnt; }
+        val op: mop.MachOp = note.inst.opcode::mop.MachOp;
+        if (!mop.known(op)) { ret 100 + ni::i32; }
+        val want: str = mop.mnemonic(op);
+        # the next instruction line: two spaces, then the mnemonic token
+        for (pos < str_len(text) && !(text[pos] == ' '::char && text[pos + 1] == ' '::char)) {
+            for (pos < str_len(text) && text[pos] != '\n'::char) { pos = pos + 1; }
+            if (pos < str_len(text)) { pos = pos + 1; }
+        }
+        if (pos >= str_len(text)) { ret 200 + ni::i32; }
+        pos = pos + 2;
+        val wl: usize = str_len(want);
+        if (!str_region_equals(text, pos, wl, want)) { ret 300 + ni::i32; }
+        val tail: char = text[pos + wl];
+        if (op == mop.BCOND) {
+            if (tail == ' '::char || tail == '\n'::char) { ret 400 + ni::i32; }
+        } or (tail != ' '::char && tail != '\n'::char) { ret 500 + ni::i32; }
+        # the grammar has no vector rows: a NEON spelling shared with a scalar
+        # row (add, mov) names a different instruction there
+        if (op != mop.BCOND && op < mop.V_FADD) {
+            val code: u32 = t_grammar_code(want);
+            if (code != 0xFFFFFFFF) {
+                if (!t_grammar_agrees(code, op)) { ret 600 + ni::i32; }
+                cross_checked = cross_checked + 1;
+            }
+        }
+        for (pos < str_len(text) && text[pos] != '\n'::char) { pos = pos + 1; }
+        if (pos < str_len(text)) { pos = pos + 1; }
+        ni = ni + 1;
+    }
+    if (cross_checked < 60) { ret 700 + cross_checked::i32; }
+    ret 0;
+}
+
+# every base word the encoder can emit, through the helper that emits it,
+# translates to a known machine opcode whose spelling is the mnemonic the
+# printer renders for the same form record
+test "mach.lang.target.isa.arm64.encode.stream:translation_round_trips_against_the_printer_for_every_emitted_base" {
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm(?st, ?alloc, ?interner);
+    val gr: R.Result[intern.StrId, str] = intern.intern(?interner, "g");
+    if (R.is_err[intern.StrId, str](gr)) { ret 1; }
+    val g: intern.StrId = R.unwrap_ok[intern.StrId, str](gr);
+
+    var w: writer.Writer;
+    w.ctx     = nil;
+    w.f_write = printer.test_sink_write;
+    printer.test_sink_reset();
+    var sink: encode.AsmSink = encode.sink_init(?w, ?interner);
+    st.buf.asm = ?sink;
+
+    val alu: [52]u32 = [52]u32{
+        ADD_X, ADD_W, SUB_X, SUB_W, AND_X, AND_W, ORR_X, ORR_W, EOR_X, EOR_W, ORN_X, ORN_W,
+        MUL_X, MUL_W, LSLV_X, LSLV_W, LSRV_X, LSRV_W, ASRV_X, ASRV_W, SDIV_X, SDIV_W, UDIV_X, UDIV_W,
+        SUBS_REG_X, SUBS_REG_W,
+        FADD_S, FADD_D, FSUB_S, FSUB_D, FMUL_S, FMUL_D, FDIV_S, FDIV_D, FNEG_S, FNEG_D,
+        FMOV_S, FMOV_D, FCVT_S2D, FCVT_D2S, FCMP_S, FCMP_D,
+        SCVTF_S_W, SCVTF_D_X, UCVTF_S_W, UCVTF_D_X, FCVTZS_W_S, FCVTZS_X_D, FCVTZU_W_S, FCVTZU_X_D,
+        FMOV_S_FROM_W, FMOV_X_FROM_D };
+    var i: u32 = 0;
+    for (i < 52) { emit_alu3(?st, alu[i], 1, 2, 3); i = i + 1; }
+    # the aliases: mov, neg, mvn, cmp, and the sp-relative sub
+    emit_alu3(?st, ORR_X, 1, ZR, 3);
+    emit_alu3(?st, SUB_X, 1, ZR, 3);
+    emit_alu3(?st, ORN_X, 1, ZR, 3);
+    emit_alu3(?st, SUBS_REG_X, ZR, 2, 3);
+    emit_alu3(?st, SUB_SP_REG_X, ZR, ZR, 16);
+    emit_alu3_sh(?st, ADD_X, 1, 2, 3, 4);
+
+    val asi: [8]u32 = [8]u32{ ADDI_X, ADDI_W, SUBI_X, SUBI_W, ADDS_IMM_X, ADDS_IMM_W, SUBS_IMM_X, SUBS_IMM_W };
+    i = 0;
+    for (i < 8) { emit_addsub_imm(?st, asi[i], 1, 2, 5, 0); i = i + 1; }
+    emit_addsub_imm(?st, ADDI_X, 29, ZR, 0, 0);
+    emit_addsub_imm(?st, ADDS_IMM_X, ZR, 2, 1, 0);
+    emit_addsub_imm(?st, SUBS_IMM_X, ZR, 2, 1, 0);
+    emit_addsub_imm(?st, SUBI_X, ZR, ZR, 2, 1);
+    emit_addsub_imm_sym(?st, ADDI_X, 0, 0, g, printer.MOD_PCREL_LO, 0);
+
+    # bitfield aliases: uxtb, uxth, sxtb, sxth, sxtw, lsr, asr, lsl, ubfx, ubfiz, sbfx, sbfiz
+    emit_bitfield(?st, UBFM_W, 0, 1, 0, 7);
+    emit_bitfield(?st, UBFM_W, 0, 1, 0, 15);
+    emit_bitfield(?st, SBFM_W, 0, 1, 0, 7);
+    emit_bitfield(?st, SBFM_X, 0, 1, 0, 15);
+    emit_bitfield(?st, SBFM_X, 0, 1, 0, 31);
+    emit_bitfield(?st, UBFM_X, 4, 5, 4, 63);
+    emit_bitfield(?st, SBFM_X, 4, 5, 4, 63);
+    emit_bitfield(?st, UBFM_X, 0, 3, 32, 31);
+    emit_bitfield(?st, UBFM_X, 0, 1, 3, 10);
+    emit_bitfield(?st, UBFM_X, 0, 1, 60, 3);
+    emit_bitfield(?st, SBFM_X, 0, 1, 3, 10);
+    emit_bitfield(?st, SBFM_X, 0, 1, 60, 3);
+
+    emit_movewide(?st, MOVZ_X, 17, 3, 0x8000);
+    emit_movewide(?st, MOVZ_W, 17, 0, 0);
+    emit_movewide(?st, MOVZ_X, 17, 1, 0);
+    emit_movewide(?st, MOVK_X, 16, 1, 0xFFFF);
+    emit_movewide(?st, MOVK_W, 16, 0, 1);
+    emit_fmov_imm(?st, 0, 0x70, true);
+    emit_fmov_imm(?st, 0, 0x70, false);
+
+    emit_madd(?st, MSUB_X, 0, 1, 2, 3);
+    emit_madd(?st, MSUB_W, 0, 1, 2, ZR);
+    emit_madd(?st, 0x9B000000, 0, 1, 2, 3);
+    emit_madd(?st, 0x1B000000, 0, 1, 2, ZR);
+    emit_cset(?st, CSINC_X, 0, CC_EQ);
+    emit_cset(?st, CSINC_W, 0, CC_NE);
+
+    val lds: [32]u32 = [32]u32{
+        STRB_OFF, LDRB_OFF, STRH_OFF, LDRH_OFF, STRW_OFF, LDRW_OFF, STR_OFF_X, LDR_OFF_X,
+        LDR_D_OFF, STR_D_OFF, LDR_S_OFF, STR_S_OFF, LDR_H_OFF, STR_H_OFF, LDR_B_OFF, STR_B_OFF,
+        LDR_Q_OFF, STR_Q_OFF, LDAR_X, LDAR_W, STLR_X, STLR_W, LDAXR_X, LDAXR_W,
+        STRB_OFF, LDRB_OFF, STRH_OFF, LDRH_OFF, STRW_OFF, LDRW_OFF, STR_OFF_X, LDR_OFF_X };
+    i = 0;
+    for (i < 24) { emit_ldst(?st, lds[i], 1, 2, 1); i = i + 1; }
+    emit_ldst_sym(?st, LDR_OFF_X, 1, 2, g, printer.MOD_PCREL_LO, 0);
+    val ldu: [18]u32 = [18]u32{
+        STURB, LDURB, STURH, LDURH, STURW, LDURW, STUR_X, LDUR_X,
+        LDUR_D_FP, STUR_D_FP, LDUR_S_FP, STUR_S_FP, LDUR_H_FP, STUR_H_FP, LDUR_B_FP, STUR_B_FP,
+        LDUR_Q_FP, STUR_Q_FP };
+    i = 0;
+    for (i < 18) { emit_ldur(?st, ldu[i], 1, 2, 0x1FF); i = i + 1; }
+    val ldr: [18]u32 = [18]u32{
+        STRB_REG, LDRB_REG, STRH_REG, LDRH_REG, STRW_REG, LDRW_REG, STR_REG_X, LDR_REG_X,
+        LDR_D_REG, STR_D_REG, LDR_S_REG, STR_S_REG, LDR_H_REG, STR_H_REG, LDR_B_REG, STR_B_REG,
+        LDR_Q_REG, STR_Q_REG };
+    i = 0;
+    for (i < 18) { emit_ldst_reg(?st, ldr[i], 1, 2, 3); i = i + 1; }
+    val ldp: [8]u32 = [8]u32{ STP_PRE_X, LDP_POST_X, STP_OFF_X, LDP_OFF_X, STP_OFF_D, LDP_OFF_D, STP_POST_X, LDP_PRE_X };
+    i = 0;
+    for (i < 8) { emit_ldstp(?st, ldp[i], 29, 30, 31, 2); i = i + 1; }
+
+    val lane: u32 = mir.vec_lane_make(mir.VEC_LANE_INT, 4, 4);
+    val flane: u32 = mir.vec_lane_make(mir.VEC_LANE_FLOAT, 4, 4);
+    val neon: [18]u32 = [18]u32{
+        VFADD, VFSUB, VFMUL, VFDIV, VADD, VSUB, VMUL, VAND, VORR, VEOR,
+        VCMEQ, VCMGT_S, VCMGE_S, VCMHI_U, VCMHS_U, VFCMEQ, VFCMGT, VFCMGE };
+    i = 0;
+    for (i < 18) {
+        var l: u32 = lane;
+        if (i < 4 || i >= 15) { l = flane; }
+        emit_neon_3same(?st, neon[i], 2, 2, 0, 1, l);
+        i = i + 1;
+    }
+    emit_neon_3same(?st, VORR, 0, 5, 6, 6, mir.vec_lane_make(mir.VEC_LANE_INT, 1, 16));
+    emit_neon_2misc(?st, VNOT, 0, 1);
+    emit_neon_umov(?st, VUMOV_W, 0, 1, 0, 1, mir.vec_lane_make(mir.VEC_LANE_INT, 1, 16));
+    emit_neon_umov(?st, VUMOV_W, 2, 1, 0, 1, lane);
+    emit_neon_umov(?st, VUMOV_X, 3, 1, 0, 1, mir.vec_lane_make(mir.VEC_LANE_INT, 8, 2));
+    emit_neon_dup_el(?st, 2, 1, 0, 1, lane);
+    emit_neon_ins_gp(?st, 2, 1, 0, 1, lane, 4);
+    emit_neon_ins_el(?st, 2, 1, 2, 0, 1, lane);
+
+    emit_branch_block(?st, B_BASE, 0, false, 3);
+    emit_branch_block(?st, CBNZ_X, 1, true, 3);
+    emit_branch_block(?st, CBZ_W, 1, true, 3);
+    emit_branch_block(?st, BCOND | CC_EQ, 0, false, 3);
+    emit_branch_block(?st, BCOND | CC_LT, 0, false, 3);
+    emit_branch_sym(?st, BL_BASE, g, 0);
+    emit_branch_pcrel(?st, CBNZ_W, 1, true, 2);
+    emit_branch_local(?st, B_BASE, B_BASE, 0, false, 1, true);
+    emit_branch_reg(?st, BLR_BASE, 1);
+    emit_branch_reg(?st, BR_BASE, 1);
+    emit_branch_reg(?st, RET_BASE, 30);
+    emit_adrp(?st, 0, g, printer.MOD_PCREL_HI, 0);
+    emit_nullary(?st, RET_WORD);
+    emit_nullary(?st, NOP_WORD);
+    emit_nullary(?st, YIELD_WORD);
+    emit_nullary(?st, WFE_WORD);
+    emit_nullary(?st, WFI_WORD);
+    emit_imm16(?st, BRK_BASE, 0);
+    emit_imm16(?st, SVC_BASE, 0);
+    emit_imm16(?st, HVC_BASE, 0);
+    emit_imm16(?st, SMC_BASE, 1);
+    emit_barrier(?st, 15);
+    emit_msr_imm(?st, 3, 6, 1);
+    a64_emit_sysreg(?st, MRS_BASE, a64_sysreg_pack(3, 3, 14, 0, 2), 0);
+    a64_emit_sysreg(?st, MSR_REG_BASE, a64_sysreg_pack(3, 3, 14, 3, 1), 1);
+    emit_stxr(?st, STLXR_X, 0, 1, 2);
+    emit_stxr(?st, STLXR_W, 0, 1, 2);
+
+    if (sink.failed) { ret 2; }
+    if (sink.refused != 0 || encode.sink_unaccounted(?st.buf) != 0) { ret 3; }
+    if (encode.note_inst_count(?st.buf) * 4 != st.buf.len::u32) { ret 4; }
+    val code: i32 = t_roundtrip_check(?st, printer.test_sink_text());
+    encode.notes_free(?st.buf);
+    encode.buf_dnit(?st.buf);
+    ret code;
 }

--- a/src/lang/target/isa/arm64/inst.mach
+++ b/src/lang/target/isa/arm64/inst.mach
@@ -1,0 +1,312 @@
+use std.types.bool.bool;
+use std.types.string.str;
+
+# the aarch64 machine-opcode space: one member per instruction the encoder
+# emits or the inline-asm grammar accepts, named by the assembler spelling the
+# printer renders. `arm64.Opcode` is the selection space (a MIR row alias);
+# this is what an instruction notification carries, the same split riscv makes
+# between `riscv.Opcode` and `riscv.inst.MachOp`.
+pub def MachOp: u16;
+
+pub val MOP_NONE: MachOp = 0;
+
+pub val NOP:   MachOp = 1;
+pub val YIELD: MachOp = 2;
+pub val WFE:   MachOp = 3;
+pub val WFI:   MachOp = 4;
+pub val RET:   MachOp = 5;
+pub val SVC:   MachOp = 6;
+pub val BRK:   MachOp = 7;
+pub val HVC:   MachOp = 8;
+pub val SMC:   MachOp = 9;
+
+pub val MOV:  MachOp = 10;
+pub val MOVZ: MachOp = 11;
+pub val MOVK: MachOp = 12;
+pub val MVN:  MachOp = 13;
+pub val NEG:  MachOp = 14;
+
+pub val ADD:  MachOp = 15;
+pub val ADDS: MachOp = 16;
+pub val SUB:  MachOp = 17;
+pub val SUBS: MachOp = 18;
+pub val CMP:  MachOp = 19;
+pub val CMN:  MachOp = 20;
+pub val AND:  MachOp = 21;
+pub val ORR:  MachOp = 22;
+pub val ORN:  MachOp = 23;
+pub val EOR:  MachOp = 24;
+
+pub val MUL:  MachOp = 25;
+pub val MNEG: MachOp = 26;
+pub val MADD: MachOp = 27;
+pub val MSUB: MachOp = 28;
+pub val SDIV: MachOp = 29;
+pub val UDIV: MachOp = 30;
+
+# immediate shifts are bitfield aliases; the register-count forms are the
+# variable-latency members and keep their own members even though the
+# printer renders both with the preferred `lsl`/`lsr`/`asr` spelling
+pub val LSL:  MachOp = 31;
+pub val LSR:  MachOp = 32;
+pub val ASR:  MachOp = 33;
+pub val LSLV: MachOp = 34;
+pub val LSRV: MachOp = 35;
+pub val ASRV: MachOp = 36;
+
+pub val UBFX:  MachOp = 37;
+pub val UBFIZ: MachOp = 38;
+pub val SBFX:  MachOp = 39;
+pub val SBFIZ: MachOp = 40;
+pub val UXTB:  MachOp = 41;
+pub val UXTH:  MachOp = 42;
+pub val SXTB:  MachOp = 43;
+pub val SXTH:  MachOp = 44;
+pub val SXTW:  MachOp = 45;
+
+pub val CSET: MachOp = 46;
+pub val ADRP: MachOp = 47;
+
+pub val B:     MachOp = 48;
+pub val BCOND: MachOp = 49;
+pub val BL:    MachOp = 50;
+pub val BLR:   MachOp = 51;
+pub val BR:    MachOp = 52;
+pub val CBZ:   MachOp = 53;
+pub val CBNZ:  MachOp = 54;
+
+pub val LDR:   MachOp = 55;
+pub val STR:   MachOp = 56;
+pub val LDRB:  MachOp = 57;
+pub val STRB:  MachOp = 58;
+pub val LDRH:  MachOp = 59;
+pub val STRH:  MachOp = 60;
+pub val LDUR:  MachOp = 61;
+pub val STUR:  MachOp = 62;
+pub val LDURB: MachOp = 63;
+pub val STURB: MachOp = 64;
+pub val LDURH: MachOp = 65;
+pub val STURH: MachOp = 66;
+pub val LDP:   MachOp = 67;
+pub val STP:   MachOp = 68;
+pub val LDAR:  MachOp = 69;
+pub val STLR:  MachOp = 70;
+pub val LDAXR: MachOp = 71;
+pub val STLXR: MachOp = 72;
+pub val DMB:   MachOp = 73;
+pub val MSR:   MachOp = 74;
+pub val MRS:   MachOp = 75;
+
+pub val FADD:   MachOp = 76;
+pub val FSUB:   MachOp = 77;
+pub val FMUL:   MachOp = 78;
+pub val FDIV:   MachOp = 79;
+pub val FNEG:   MachOp = 80;
+pub val FMOV:   MachOp = 81;
+pub val FCVT:   MachOp = 82;
+pub val FCMP:   MachOp = 83;
+pub val SCVTF:  MachOp = 84;
+pub val UCVTF:  MachOp = 85;
+pub val FCVTZS: MachOp = 86;
+pub val FCVTZU: MachOp = 87;
+
+pub val V_FADD:  MachOp = 88;
+pub val V_FSUB:  MachOp = 89;
+pub val V_FMUL:  MachOp = 90;
+pub val V_FDIV:  MachOp = 91;
+pub val V_ADD:   MachOp = 92;
+pub val V_SUB:   MachOp = 93;
+pub val V_MUL:   MachOp = 94;
+pub val V_AND:   MachOp = 95;
+pub val V_ORR:   MachOp = 96;
+pub val V_EOR:   MachOp = 97;
+pub val V_MVN:   MachOp = 98;
+pub val V_MOV:   MachOp = 99;
+pub val V_CMEQ:  MachOp = 100;
+pub val V_CMGT:  MachOp = 101;
+pub val V_CMGE:  MachOp = 102;
+pub val V_CMHI:  MachOp = 103;
+pub val V_CMHS:  MachOp = 104;
+pub val V_FCMEQ: MachOp = 105;
+pub val V_FCMGT: MachOp = 106;
+pub val V_FCMGE: MachOp = 107;
+
+# lane moves: `umov` for a sub-word lane read, the `mov` alias for a word or
+# doubleword lane read, `mov` for every lane insert and the scalar dup
+pub val UMOV:     MachOp = 108;
+pub val MOV_LANE: MachOp = 109;
+pub val INS:      MachOp = 110;
+pub val DUP:      MachOp = 111;
+
+pub val MOP_LAST: MachOp = DUP;
+
+pub fun known(op: MachOp) bool {
+    ret op != MOP_NONE && op <= MOP_LAST;
+}
+
+# the assembler spelling the printer renders; nil outside the catalog
+pub fun mnemonic(op: MachOp) str {
+    if (op == NOP)   { ret "nop"; }
+    if (op == YIELD) { ret "yield"; }
+    if (op == WFE)   { ret "wfe"; }
+    if (op == WFI)   { ret "wfi"; }
+    if (op == RET)   { ret "ret"; }
+    if (op == SVC)   { ret "svc"; }
+    if (op == BRK)   { ret "brk"; }
+    if (op == HVC)   { ret "hvc"; }
+    if (op == SMC)   { ret "smc"; }
+
+    if (op == MOV)  { ret "mov"; }
+    if (op == MOVZ) { ret "movz"; }
+    if (op == MOVK) { ret "movk"; }
+    if (op == MVN)  { ret "mvn"; }
+    if (op == NEG)  { ret "neg"; }
+
+    if (op == ADD)  { ret "add"; }
+    if (op == ADDS) { ret "adds"; }
+    if (op == SUB)  { ret "sub"; }
+    if (op == SUBS) { ret "subs"; }
+    if (op == CMP)  { ret "cmp"; }
+    if (op == CMN)  { ret "cmn"; }
+    if (op == AND)  { ret "and"; }
+    if (op == ORR)  { ret "orr"; }
+    if (op == ORN)  { ret "orn"; }
+    if (op == EOR)  { ret "eor"; }
+
+    if (op == MUL)  { ret "mul"; }
+    if (op == MNEG) { ret "mneg"; }
+    if (op == MADD) { ret "madd"; }
+    if (op == MSUB) { ret "msub"; }
+    if (op == SDIV) { ret "sdiv"; }
+    if (op == UDIV) { ret "udiv"; }
+
+    if (op == LSL || op == LSLV) { ret "lsl"; }
+    if (op == LSR || op == LSRV) { ret "lsr"; }
+    if (op == ASR || op == ASRV) { ret "asr"; }
+
+    if (op == UBFX)  { ret "ubfx"; }
+    if (op == UBFIZ) { ret "ubfiz"; }
+    if (op == SBFX)  { ret "sbfx"; }
+    if (op == SBFIZ) { ret "sbfiz"; }
+    if (op == UXTB)  { ret "uxtb"; }
+    if (op == UXTH)  { ret "uxth"; }
+    if (op == SXTB)  { ret "sxtb"; }
+    if (op == SXTH)  { ret "sxth"; }
+    if (op == SXTW)  { ret "sxtw"; }
+
+    if (op == CSET) { ret "cset"; }
+    if (op == ADRP) { ret "adrp"; }
+
+    if (op == B)     { ret "b"; }
+    if (op == BCOND) { ret "b."; }
+    if (op == BL)    { ret "bl"; }
+    if (op == BLR)   { ret "blr"; }
+    if (op == BR)    { ret "br"; }
+    if (op == CBZ)   { ret "cbz"; }
+    if (op == CBNZ)  { ret "cbnz"; }
+
+    if (op == LDR)   { ret "ldr"; }
+    if (op == STR)   { ret "str"; }
+    if (op == LDRB)  { ret "ldrb"; }
+    if (op == STRB)  { ret "strb"; }
+    if (op == LDRH)  { ret "ldrh"; }
+    if (op == STRH)  { ret "strh"; }
+    if (op == LDUR)  { ret "ldur"; }
+    if (op == STUR)  { ret "stur"; }
+    if (op == LDURB) { ret "ldurb"; }
+    if (op == STURB) { ret "sturb"; }
+    if (op == LDURH) { ret "ldurh"; }
+    if (op == STURH) { ret "sturh"; }
+    if (op == LDP)   { ret "ldp"; }
+    if (op == STP)   { ret "stp"; }
+    if (op == LDAR)  { ret "ldar"; }
+    if (op == STLR)  { ret "stlr"; }
+    if (op == LDAXR) { ret "ldaxr"; }
+    if (op == STLXR) { ret "stlxr"; }
+    if (op == DMB)   { ret "dmb"; }
+    if (op == MSR)   { ret "msr"; }
+    if (op == MRS)   { ret "mrs"; }
+
+    if (op == FADD)   { ret "fadd"; }
+    if (op == FSUB)   { ret "fsub"; }
+    if (op == FMUL)   { ret "fmul"; }
+    if (op == FDIV)   { ret "fdiv"; }
+    if (op == FNEG)   { ret "fneg"; }
+    if (op == FMOV)   { ret "fmov"; }
+    if (op == FCVT)   { ret "fcvt"; }
+    if (op == FCMP)   { ret "fcmp"; }
+    if (op == SCVTF)  { ret "scvtf"; }
+    if (op == UCVTF)  { ret "ucvtf"; }
+    if (op == FCVTZS) { ret "fcvtzs"; }
+    if (op == FCVTZU) { ret "fcvtzu"; }
+
+    if (op == V_FADD)  { ret "fadd"; }
+    if (op == V_FSUB)  { ret "fsub"; }
+    if (op == V_FMUL)  { ret "fmul"; }
+    if (op == V_FDIV)  { ret "fdiv"; }
+    if (op == V_ADD)   { ret "add"; }
+    if (op == V_SUB)   { ret "sub"; }
+    if (op == V_MUL)   { ret "mul"; }
+    if (op == V_AND)   { ret "and"; }
+    if (op == V_ORR)   { ret "orr"; }
+    if (op == V_EOR)   { ret "eor"; }
+    if (op == V_MVN)   { ret "mvn"; }
+    if (op == V_MOV)   { ret "mov"; }
+    if (op == V_CMEQ)  { ret "cmeq"; }
+    if (op == V_CMGT)  { ret "cmgt"; }
+    if (op == V_CMGE)  { ret "cmge"; }
+    if (op == V_CMHI)  { ret "cmhi"; }
+    if (op == V_CMHS)  { ret "cmhs"; }
+    if (op == V_FCMEQ) { ret "fcmeq"; }
+    if (op == V_FCMGT) { ret "fcmgt"; }
+    if (op == V_FCMGE) { ret "fcmge"; }
+
+    if (op == UMOV)     { ret "umov"; }
+    if (op == MOV_LANE) { ret "mov"; }
+    if (op == INS)      { ret "mov"; }
+    if (op == DUP)      { ret "mov"; }
+    ret nil;
+}
+
+# `isa.Inst.flags` layout for an aarch64 notification
+pub val FLAG_COND:    u16 = 0x000F;
+pub val FLAG_WB_PRE:  u16 = 0x0010;
+pub val FLAG_WB_POST: u16 = 0x0020;
+pub val FLAG_ELEM:    u16 = 0x0F00;
+val FLAG_ELEM_SHIFT:  u16 = 8;
+
+pub fun cond_of(flags: u16) u32 {
+    ret (flags & FLAG_COND)::u32;
+}
+
+# the vector element width in bytes, 0 for a scalar instruction
+pub fun elem_bytes(flags: u16) u8 {
+    ret ((flags & FLAG_ELEM) >> FLAG_ELEM_SHIFT)::u8;
+}
+
+pub fun with_elem_bytes(flags: u16, eb: u8) u16 {
+    ret (flags & ~FLAG_ELEM) | ((eb::u16 << FLAG_ELEM_SHIFT) & FLAG_ELEM);
+}
+
+test "mach.lang.target.isa.arm64.inst.mnemonic:every_member_is_named_and_the_catalog_is_closed" {
+    var op: MachOp = 1;
+    for (op <= MOP_LAST) {
+        if (mnemonic(op) == nil) { ret op::i32; }
+        if (!known(op))          { ret 1000 + op::i32; }
+        op = op + 1;
+    }
+    if (mnemonic(MOP_NONE) != nil)     { ret 2001; }
+    if (mnemonic(MOP_LAST + 1) != nil) { ret 2002; }
+    if (known(MOP_NONE) || known(MOP_LAST + 1)) { ret 2003; }
+    ret 0;
+}
+
+test "mach.lang.target.isa.arm64.inst.flags:element_width_shares_the_word_with_condition_and_writeback" {
+    val f: u16 = with_elem_bytes(FLAG_WB_PRE | 0x3, 8);
+    if (elem_bytes(f) != 8)            { ret 1; }
+    if (cond_of(f) != 3)               { ret 2; }
+    if ((f & FLAG_WB_PRE) == 0)        { ret 3; }
+    if (elem_bytes(with_elem_bytes(f, 0)) != 0) { ret 4; }
+    if (elem_bytes(0) != 0)            { ret 5; }
+    ret 0;
+}

--- a/src/lang/target/isa/arm64/inst.mach
+++ b/src/lang/target/isa/arm64/inst.mach
@@ -1,5 +1,6 @@
 use std.types.bool.bool;
 use std.types.string.str;
+use std.types.string.str_equals;
 
 # the aarch64 machine-opcode space: one member per instruction the encoder
 # emits or the inline-asm grammar accepts, named by the assembler spelling the
@@ -308,5 +309,123 @@ test "mach.lang.target.isa.arm64.inst.flags:element_width_shares_the_word_with_c
     if ((f & FLAG_WB_PRE) == 0)        { ret 3; }
     if (elem_bytes(with_elem_bytes(f, 0)) != 0) { ret 4; }
     if (elem_bytes(0) != 0)            { ret 5; }
+    ret 0;
+}
+
+# the spelling of every member, pinned against the assembler's own: the
+# printer and the notification share one table, so this is the only reader
+# that can catch a member renamed to another instruction's mnemonic
+test "mach.lang.target.isa.arm64.inst.mnemonic:spellings_are_the_assembler_mnemonics" {
+    if (!str_equals(mnemonic(NOP), "nop")) { ret 1; }
+    if (!str_equals(mnemonic(YIELD), "yield")) { ret 2; }
+    if (!str_equals(mnemonic(WFE), "wfe")) { ret 3; }
+    if (!str_equals(mnemonic(WFI), "wfi")) { ret 4; }
+    if (!str_equals(mnemonic(RET), "ret")) { ret 5; }
+    if (!str_equals(mnemonic(SVC), "svc")) { ret 6; }
+    if (!str_equals(mnemonic(BRK), "brk")) { ret 7; }
+    if (!str_equals(mnemonic(HVC), "hvc")) { ret 8; }
+    if (!str_equals(mnemonic(SMC), "smc")) { ret 9; }
+    if (!str_equals(mnemonic(MOV), "mov")) { ret 10; }
+    if (!str_equals(mnemonic(MOVZ), "movz")) { ret 11; }
+    if (!str_equals(mnemonic(MOVK), "movk")) { ret 12; }
+    if (!str_equals(mnemonic(MVN), "mvn")) { ret 13; }
+    if (!str_equals(mnemonic(NEG), "neg")) { ret 14; }
+    if (!str_equals(mnemonic(ADD), "add")) { ret 15; }
+    if (!str_equals(mnemonic(ADDS), "adds")) { ret 16; }
+    if (!str_equals(mnemonic(SUB), "sub")) { ret 17; }
+    if (!str_equals(mnemonic(SUBS), "subs")) { ret 18; }
+    if (!str_equals(mnemonic(CMP), "cmp")) { ret 19; }
+    if (!str_equals(mnemonic(CMN), "cmn")) { ret 20; }
+    if (!str_equals(mnemonic(AND), "and")) { ret 21; }
+    if (!str_equals(mnemonic(ORR), "orr")) { ret 22; }
+    if (!str_equals(mnemonic(ORN), "orn")) { ret 23; }
+    if (!str_equals(mnemonic(EOR), "eor")) { ret 24; }
+    if (!str_equals(mnemonic(MUL), "mul")) { ret 25; }
+    if (!str_equals(mnemonic(MNEG), "mneg")) { ret 26; }
+    if (!str_equals(mnemonic(MADD), "madd")) { ret 27; }
+    if (!str_equals(mnemonic(MSUB), "msub")) { ret 28; }
+    if (!str_equals(mnemonic(SDIV), "sdiv")) { ret 29; }
+    if (!str_equals(mnemonic(UDIV), "udiv")) { ret 30; }
+    if (!str_equals(mnemonic(LSL), "lsl")) { ret 31; }
+    if (!str_equals(mnemonic(LSLV), "lsl")) { ret 32; }
+    if (!str_equals(mnemonic(LSR), "lsr")) { ret 33; }
+    if (!str_equals(mnemonic(LSRV), "lsr")) { ret 34; }
+    if (!str_equals(mnemonic(ASR), "asr")) { ret 35; }
+    if (!str_equals(mnemonic(ASRV), "asr")) { ret 36; }
+    if (!str_equals(mnemonic(UBFX), "ubfx")) { ret 37; }
+    if (!str_equals(mnemonic(UBFIZ), "ubfiz")) { ret 38; }
+    if (!str_equals(mnemonic(SBFX), "sbfx")) { ret 39; }
+    if (!str_equals(mnemonic(SBFIZ), "sbfiz")) { ret 40; }
+    if (!str_equals(mnemonic(UXTB), "uxtb")) { ret 41; }
+    if (!str_equals(mnemonic(UXTH), "uxth")) { ret 42; }
+    if (!str_equals(mnemonic(SXTB), "sxtb")) { ret 43; }
+    if (!str_equals(mnemonic(SXTH), "sxth")) { ret 44; }
+    if (!str_equals(mnemonic(SXTW), "sxtw")) { ret 45; }
+    if (!str_equals(mnemonic(CSET), "cset")) { ret 46; }
+    if (!str_equals(mnemonic(ADRP), "adrp")) { ret 47; }
+    if (!str_equals(mnemonic(B), "b")) { ret 48; }
+    if (!str_equals(mnemonic(BCOND), "b.")) { ret 49; }
+    if (!str_equals(mnemonic(BL), "bl")) { ret 50; }
+    if (!str_equals(mnemonic(BLR), "blr")) { ret 51; }
+    if (!str_equals(mnemonic(BR), "br")) { ret 52; }
+    if (!str_equals(mnemonic(CBZ), "cbz")) { ret 53; }
+    if (!str_equals(mnemonic(CBNZ), "cbnz")) { ret 54; }
+    if (!str_equals(mnemonic(LDR), "ldr")) { ret 55; }
+    if (!str_equals(mnemonic(STR), "str")) { ret 56; }
+    if (!str_equals(mnemonic(LDRB), "ldrb")) { ret 57; }
+    if (!str_equals(mnemonic(STRB), "strb")) { ret 58; }
+    if (!str_equals(mnemonic(LDRH), "ldrh")) { ret 59; }
+    if (!str_equals(mnemonic(STRH), "strh")) { ret 60; }
+    if (!str_equals(mnemonic(LDUR), "ldur")) { ret 61; }
+    if (!str_equals(mnemonic(STUR), "stur")) { ret 62; }
+    if (!str_equals(mnemonic(LDURB), "ldurb")) { ret 63; }
+    if (!str_equals(mnemonic(STURB), "sturb")) { ret 64; }
+    if (!str_equals(mnemonic(LDURH), "ldurh")) { ret 65; }
+    if (!str_equals(mnemonic(STURH), "sturh")) { ret 66; }
+    if (!str_equals(mnemonic(LDP), "ldp")) { ret 67; }
+    if (!str_equals(mnemonic(STP), "stp")) { ret 68; }
+    if (!str_equals(mnemonic(LDAR), "ldar")) { ret 69; }
+    if (!str_equals(mnemonic(STLR), "stlr")) { ret 70; }
+    if (!str_equals(mnemonic(LDAXR), "ldaxr")) { ret 71; }
+    if (!str_equals(mnemonic(STLXR), "stlxr")) { ret 72; }
+    if (!str_equals(mnemonic(DMB), "dmb")) { ret 73; }
+    if (!str_equals(mnemonic(MSR), "msr")) { ret 74; }
+    if (!str_equals(mnemonic(MRS), "mrs")) { ret 75; }
+    if (!str_equals(mnemonic(FADD), "fadd")) { ret 76; }
+    if (!str_equals(mnemonic(FSUB), "fsub")) { ret 77; }
+    if (!str_equals(mnemonic(FMUL), "fmul")) { ret 78; }
+    if (!str_equals(mnemonic(FDIV), "fdiv")) { ret 79; }
+    if (!str_equals(mnemonic(FNEG), "fneg")) { ret 80; }
+    if (!str_equals(mnemonic(FMOV), "fmov")) { ret 81; }
+    if (!str_equals(mnemonic(FCVT), "fcvt")) { ret 82; }
+    if (!str_equals(mnemonic(FCMP), "fcmp")) { ret 83; }
+    if (!str_equals(mnemonic(SCVTF), "scvtf")) { ret 84; }
+    if (!str_equals(mnemonic(UCVTF), "ucvtf")) { ret 85; }
+    if (!str_equals(mnemonic(FCVTZS), "fcvtzs")) { ret 86; }
+    if (!str_equals(mnemonic(FCVTZU), "fcvtzu")) { ret 87; }
+    if (!str_equals(mnemonic(V_FADD), "fadd")) { ret 88; }
+    if (!str_equals(mnemonic(V_FSUB), "fsub")) { ret 89; }
+    if (!str_equals(mnemonic(V_FMUL), "fmul")) { ret 90; }
+    if (!str_equals(mnemonic(V_FDIV), "fdiv")) { ret 91; }
+    if (!str_equals(mnemonic(V_ADD), "add")) { ret 92; }
+    if (!str_equals(mnemonic(V_SUB), "sub")) { ret 93; }
+    if (!str_equals(mnemonic(V_MUL), "mul")) { ret 94; }
+    if (!str_equals(mnemonic(V_AND), "and")) { ret 95; }
+    if (!str_equals(mnemonic(V_ORR), "orr")) { ret 96; }
+    if (!str_equals(mnemonic(V_EOR), "eor")) { ret 97; }
+    if (!str_equals(mnemonic(V_MVN), "mvn")) { ret 98; }
+    if (!str_equals(mnemonic(V_MOV), "mov")) { ret 99; }
+    if (!str_equals(mnemonic(V_CMEQ), "cmeq")) { ret 100; }
+    if (!str_equals(mnemonic(V_CMGT), "cmgt")) { ret 101; }
+    if (!str_equals(mnemonic(V_CMGE), "cmge")) { ret 102; }
+    if (!str_equals(mnemonic(V_CMHI), "cmhi")) { ret 103; }
+    if (!str_equals(mnemonic(V_CMHS), "cmhs")) { ret 104; }
+    if (!str_equals(mnemonic(V_FCMEQ), "fcmeq")) { ret 105; }
+    if (!str_equals(mnemonic(V_FCMGT), "fcmgt")) { ret 106; }
+    if (!str_equals(mnemonic(V_FCMGE), "fcmge")) { ret 107; }
+    if (!str_equals(mnemonic(UMOV), "umov")) { ret 108; }
+    if (!str_equals(mnemonic(MOV_LANE), "mov")) { ret 109; }
+    if (!str_equals(mnemonic(INS), "mov")) { ret 110; }
+    if (!str_equals(mnemonic(DUP), "mov")) { ret 111; }
     ret 0;
 }

--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -19,6 +19,7 @@ use enc: mach.lang.be.codegen.encode;
 use mach.lang.be.codegen.mir;
 use mach.lang.intern;
 use mach.lang.target.isa;
+use mop: mach.lang.target.isa.arm64.inst;
 
 pub val FORM_ALU3: u8 = 1;
 pub val FORM_ADDSUB_IMM: u8 = 2;
@@ -107,6 +108,13 @@ pub fun vec(n: u32, bytes: u8) isa.Operand {
 }
 
 pub fun note_function(buf: *enc.ByteBuf, interner: *intern.Interner, f: *mir.MirFunction) R.Result[R.Void, str] {
+    var note: enc.AsmNote = enc.note_blank();
+    note.kind = enc.ASM_NOTE_FUNC;
+    note.off  = buf.len::u32;
+    note.name = f.name;
+    val kept: R.Result[R.Void, str] = enc.note_push(buf, ?note);
+    if (R.is_err[R.Void, str](kept)) { ret kept; }
+    if (!enc.sink_renders(buf)) { ret R.ok_void[str](); }
     val out: *writer.Writer = buf.asm.out;
     val res_nl: R.Result[R.Void, str] = emit_str(out, "\n# ");
     if (R.is_err[R.Void, str](res_nl)) { ret res_nl; }
@@ -116,6 +124,13 @@ pub fun note_function(buf: *enc.ByteBuf, interner: *intern.Interner, f: *mir.Mir
 }
 
 pub fun note_block(buf: *enc.ByteBuf, id: u32) R.Result[R.Void, str] {
+    var note: enc.AsmNote = enc.note_blank();
+    note.kind = enc.ASM_NOTE_BLOCK;
+    note.off  = buf.len::u32;
+    note.id   = id;
+    val kept: R.Result[R.Void, str] = enc.note_push(buf, ?note);
+    if (R.is_err[R.Void, str](kept)) { ret kept; }
+    if (!enc.sink_renders(buf)) { ret R.ok_void[str](); }
     val out: *writer.Writer = buf.asm.out;
     val res_dot: R.Result[R.Void, str] = emit_str(out, ".");
     if (R.is_err[R.Void, str](res_dot)) { ret res_dot; }
@@ -126,13 +141,340 @@ pub fun note_block(buf: *enc.ByteBuf, id: u32) R.Result[R.Void, str] {
 
 val INST_BYTES: usize = 4;
 
+# the notification carries the form record translated to an `isa.Inst` in the
+# machine-opcode space; rendering is a separate step that needs a writer
 pub fun note_inst(buf: *enc.ByteBuf, i: *Inst) {
-    val res: R.Result[R.Void, str] = render_inst(buf, i);
-    if (R.is_err[R.Void, str](res)) {
-        enc.sink_fail(buf, R.unwrap_err[R.Void, str](res));
+    val mi: isa.Inst = to_inst(i);
+    if (mi.opcode == mop.MOP_NONE::u16) {
+        enc.sink_fail(buf, "--emit-asm: an emitted aarch64 instruction has no machine opcode");
         ret;
     }
-    enc.sink_claim(buf, buf.len - INST_BYTES);
+    var note: enc.AsmNote = enc.note_blank();
+    note.off  = (buf.len - INST_BYTES)::u32;
+    note.inst = mi;
+    val kept: R.Result[R.Void, str] = enc.note_push(buf, ?note);
+    if (R.is_err[R.Void, str](kept)) {
+        enc.sink_fail(buf, R.unwrap_err[R.Void, str](kept));
+        ret;
+    }
+    if (!enc.sink_renders(buf)) { ret; }
+    val res: R.Result[R.Void, str] = render_inst(buf, i);
+    if (R.is_err[R.Void, str](res)) { enc.sink_fail(buf, R.unwrap_err[R.Void, str](res)); }
+}
+
+# the machine opcode of a form record: the alias the printer renders, so the
+# opcode names the same instruction an assembler would read back
+pub fun classify(i: *Inst) mop.MachOp {
+    if (i.form == FORM_ALU3)         { ret classify_alu3(i); }
+    if (i.form == FORM_ADDSUB_IMM)   { ret classify_addsub_imm(i); }
+    if (i.form == FORM_BITFIELD)     { ret classify_bitfield(i); }
+    if (i.form == FORM_MOVEWIDE)     { ret classify_movewide(i); }
+    if (i.form == FORM_FMOV_IMM)     { ret mop.FMOV; }
+    if (i.form == FORM_MADD)         { ret classify_madd(i); }
+    if (i.form == FORM_CSET)         { ret classify_cset(i); }
+    if (i.form == FORM_LDST)         { ret classify_ldst(i.base); }
+    if (i.form == FORM_LDSTP)        { ret classify_ldstp(i.base); }
+    if (i.form == FORM_NEON_3SAME)   { ret classify_neon_3same(i); }
+    if (i.form == FORM_NEON_2MISC)   { ret classify_neon_2misc(i.base); }
+    if (i.form == FORM_NEON_LANE_RD) { ret classify_neon_lane_read(i); }
+    if (i.form == FORM_NEON_LANE_WR) { ret mop.INS; }
+    if (i.form == FORM_BRANCH)       { ret classify_branch(i.base); }
+    if (i.form == FORM_BRANCH_REG)   { ret classify_branch_reg(i.base); }
+    if (i.form == FORM_ADRP)         { ret mop.ADRP; }
+    if (i.form == FORM_NULLARY)      { ret classify_nullary(i.base); }
+    if (i.form == FORM_IMM16)        { ret classify_imm16(i.base); }
+    if (i.form == FORM_BARRIER)      { ret classify_barrier(i.base); }
+    if (i.form == FORM_STXR)         { ret classify_stxr(i.base); }
+    if (i.form == FORM_SYSREG_IMM)   { ret classify_sysreg_imm(i.base); }
+    if (i.form == FORM_SYSREG)       { ret classify_sysreg(i.base); }
+    ret mop.MOP_NONE;
+}
+
+# registers are already regids and memory is base/index/disp in the form
+# record; the translation adds the opcode, the operation width and the
+# vector element width, and keeps the fourth register a madd/msub reads
+pub fun to_inst(i: *Inst) isa.Inst {
+    var mi: isa.Inst = isa.inst_blank();
+    mi.opcode = classify(i)::u16;
+    mi.dst    = i.dst;
+    mi.src1   = i.src1;
+    mi.src2   = i.src2;
+    mi.src3   = i.src3;
+    mi.size   = operation_width(i);
+    mi.flags  = i.flags & (mop.FLAG_COND | mop.FLAG_WB_PRE | mop.FLAG_WB_POST);
+    if (i.form == FORM_BRANCH && (i.base & 0xFF000000) == 0x54000000) {
+        mi.flags = (mi.flags & ~mop.FLAG_COND) | ((i.base & 0xF)::u16);
+    }
+    if (i.vec_lane != 0) {
+        mi.flags = mop.with_elem_bytes(mi.flags, mir.vec_lane_elem_bytes(i.vec_lane));
+    }
+    ret mi;
+}
+
+fun operation_width(i: *Inst) u8 {
+    if (i.dst.kind == isa.OPK_REG)  { ret i.dst.size; }
+    if (i.src1.kind == isa.OPK_REG) { ret i.src1.size; }
+    if (i.src2.kind == isa.OPK_REG) { ret i.src2.size; }
+    if (i.dst.kind == isa.OPK_MEM)  { ret i.dst.size; }
+    if (i.src1.kind == isa.OPK_MEM) { ret i.src1.size; }
+    ret 0;
+}
+
+fun classify_alu3(i: *Inst) mop.MachOp {
+    val base: u32 = i.base;
+    val zero_rn: bool = is_zero_reg(?i.src1) && i.src2.kind == isa.OPK_REG;
+    if (base == 0x8B000000 || base == 0x0B000000) { ret mop.ADD; }
+    if (base == 0xCB000000 || base == 0x4B000000) { if (zero_rn) { ret mop.NEG; } ret mop.SUB; }
+    if (base == 0x8A000000 || base == 0x0A000000) { ret mop.AND; }
+    if (base == 0xAA000000 || base == 0x2A000000) { if (zero_rn) { ret mop.MOV; } ret mop.ORR; }
+    if (base == 0xCA000000 || base == 0x4A000000) { ret mop.EOR; }
+    if (base == 0xAA200000 || base == 0x2A200000) { if (zero_rn) { ret mop.MVN; } ret mop.ORN; }
+    if (base == 0x9B007C00 || base == 0x1B007C00) { ret mop.MUL; }
+    if (base == 0x9AC02000 || base == 0x1AC02000) { ret mop.LSLV; }
+    if (base == 0x9AC02400 || base == 0x1AC02400) { ret mop.LSRV; }
+    if (base == 0x9AC02800 || base == 0x1AC02800) { ret mop.ASRV; }
+    if (base == 0x9AC00C00 || base == 0x1AC00C00) { ret mop.SDIV; }
+    if (base == 0x9AC00800 || base == 0x1AC00800) { ret mop.UDIV; }
+    if (base == 0xEB000000 || base == 0x6B000000) { if (is_zero_reg(?i.dst)) { ret mop.CMP; } ret mop.SUBS; }
+    if (base == 0xCB2063FF)                       { ret mop.SUB; }
+
+    if (base == 0x1E202800 || base == 0x1E602800) { ret mop.FADD; }
+    if (base == 0x1E203800 || base == 0x1E603800) { ret mop.FSUB; }
+    if (base == 0x1E200800 || base == 0x1E600800) { ret mop.FMUL; }
+    if (base == 0x1E201800 || base == 0x1E601800) { ret mop.FDIV; }
+    if (base == 0x1E214000 || base == 0x1E614000) { ret mop.FNEG; }
+    if (base == 0x1E204000 || base == 0x1E604000) { ret mop.FMOV; }
+    if (base == 0x1E22C000 || base == 0x1E624000) { ret mop.FCVT; }
+    if (base == 0x1E202000 || base == 0x1E602000) { ret mop.FCMP; }
+
+    if (base == 0x1E220000 || base == 0x1E620000 ||
+        base == 0x9E220000 || base == 0x9E620000) { ret mop.SCVTF; }
+    if (base == 0x1E230000 || base == 0x1E630000 ||
+        base == 0x9E230000 || base == 0x9E630000) { ret mop.UCVTF; }
+    if (base == 0x1E380000 || base == 0x9E380000 ||
+        base == 0x1E780000 || base == 0x9E780000) { ret mop.FCVTZS; }
+    if (base == 0x1E390000 || base == 0x9E390000 ||
+        base == 0x1E790000 || base == 0x9E790000) { ret mop.FCVTZU; }
+
+    if (base == 0x1E270000 || base == 0x9E670000 ||
+        base == 0x1E260000 || base == 0x9E660000) { ret mop.FMOV; }
+    ret mop.MOP_NONE;
+}
+
+fun classify_addsub_imm(i: *Inst) mop.MachOp {
+    val base: u32 = i.base;
+    val plain_add: bool = base == 0x91000000 || base == 0x11000000;
+    if (plain_add && i.src2.kind == isa.OPK_IMM && i.src2.imm == 0 &&
+        i.src3.kind == isa.OPK_NONE && (is_reg31(?i.dst) || is_reg31(?i.src1))) { ret mop.MOV; }
+    if (plain_add)                                { ret mop.ADD; }
+    if (base == 0xD1000000 || base == 0x51000000) { ret mop.SUB; }
+    if (base == 0xB1000000 || base == 0x31000000) { if (is_zero_reg(?i.dst)) { ret mop.CMN; } ret mop.ADDS; }
+    if (base == 0xF1000000 || base == 0x71000000) { if (is_zero_reg(?i.dst)) { ret mop.CMP; } ret mop.SUBS; }
+    ret mop.MOP_NONE;
+}
+
+fun classify_bitfield(i: *Inst) mop.MachOp {
+    var signed: bool = false;
+    var wide:   bool = false;
+    if (i.base == 0xD3400000)      { wide = true; }
+    or (i.base == 0x53000000)      { }
+    or (i.base == 0x93400000)      { wide = true; signed = true; }
+    or (i.base == 0x13000000)      { signed = true; }
+    or                             { ret mop.MOP_NONE; }
+
+    var width: u32 = 32;
+    if (wide) { width = 64; }
+    val immr: u32 = i.src2.imm::u32;
+    val imms: u32 = i.src3.imm::u32;
+
+    val extend: bool = immr == 0 && (imms == 7 || imms == 15 || (imms == 31 && wide));
+    if (extend && (signed || !wide)) {
+        if (signed) {
+            if (imms == 15) { ret mop.SXTH; }
+            if (imms == 31) { ret mop.SXTW; }
+            ret mop.SXTB;
+        }
+        if (imms == 15) { ret mop.UXTH; }
+        ret mop.UXTB;
+    }
+    if (imms == width - 1) {
+        if (signed) { ret mop.ASR; }
+        ret mop.LSR;
+    }
+    if (!signed && imms + 1 == immr) { ret mop.LSL; }
+    if (signed) {
+        if (imms < immr) { ret mop.SBFIZ; }
+        ret mop.SBFX;
+    }
+    if (imms < immr) { ret mop.UBFIZ; }
+    ret mop.UBFX;
+}
+
+fun movewide_folds(i: *Inst) bool {
+    val keep: bool = i.base == 0xF2800000 || i.base == 0x72800000;
+    val imm16: u64 = i.src2.imm::u64;
+    var sh: u64 = 0;
+    if (i.src3.kind != isa.OPK_NONE) { sh = i.src3.imm::u64; }
+    ret !keep && (imm16 != 0 || sh == 0);
+}
+
+fun classify_movewide(i: *Inst) mop.MachOp {
+    if (i.base == 0xD2800000 || i.base == 0x52800000) {
+        if (movewide_folds(i)) { ret mop.MOV; }
+        ret mop.MOVZ;
+    }
+    if (i.base == 0xF2800000 || i.base == 0x72800000) { ret mop.MOVK; }
+    ret mop.MOP_NONE;
+}
+
+fun classify_madd(i: *Inst) mop.MachOp {
+    val degenerate: bool = is_zero_reg(?i.src3);
+    if (i.base == 0x9B000000 || i.base == 0x1B000000) { if (degenerate) { ret mop.MUL; } ret mop.MADD; }
+    if (i.base == 0x9B008000 || i.base == 0x1B008000) { if (degenerate) { ret mop.MNEG; } ret mop.MSUB; }
+    ret mop.MOP_NONE;
+}
+
+fun classify_cset(i: *Inst) mop.MachOp {
+    if (i.base != 0x9A800400 && i.base != 0x1A800400) { ret mop.MOP_NONE; }
+    if (cond_name((i.flags & FLAG_COND)::u32 ^ 1) == nil) { ret mop.MOP_NONE; }
+    ret mop.CSET;
+}
+
+fun classify_ldst(base: u32) mop.MachOp {
+    if (base == 0x39400000 || base == 0x38606800) { ret mop.LDRB; }
+    if (base == 0x39000000 || base == 0x38206800) { ret mop.STRB; }
+    if (base == 0x79400000 || base == 0x78606800) { ret mop.LDRH; }
+    if (base == 0x79000000 || base == 0x78206800) { ret mop.STRH; }
+    if (base == 0xB9400000 || base == 0xF9400000 || base == 0xFD400000 ||
+        base == 0xBD400000 || base == 0x3DC00000 || base == 0xB8606800 ||
+        base == 0xF8606800 || base == 0xFC606800 || base == 0xBC606800 ||
+        base == 0x3CE06800 ||
+        base == 0x3D400000 || base == 0x7D400000 ||
+        base == 0x3C606800 || base == 0x7C606800) { ret mop.LDR; }
+    if (base == 0xB9000000 || base == 0xF9000000 || base == 0xFD000000 ||
+        base == 0xBD000000 || base == 0x3D800000 || base == 0xB8206800 ||
+        base == 0xF8206800 || base == 0xFC206800 || base == 0xBC206800 ||
+        base == 0x3CA06800 ||
+        base == 0x3D000000 || base == 0x7D000000 ||
+        base == 0x3C206800 || base == 0x7C206800) { ret mop.STR; }
+    if (base == 0x38400000)                       { ret mop.LDURB; }
+    if (base == 0x38000000)                       { ret mop.STURB; }
+    if (base == 0x78400000)                       { ret mop.LDURH; }
+    if (base == 0x78000000)                       { ret mop.STURH; }
+    if (base == 0xB8400000 || base == 0xF8400000 || base == 0xFC400000 ||
+        base == 0xBC400000 || base == 0x3CC00000 ||
+        base == 0x3C400000 || base == 0x7C400000) { ret mop.LDUR; }
+    if (base == 0xB8000000 || base == 0xF8000000 || base == 0xFC000000 ||
+        base == 0xBC000000 || base == 0x3C800000 ||
+        base == 0x3C000000 || base == 0x7C000000) { ret mop.STUR; }
+    if (base == 0xC8DFFC00 || base == 0x88DFFC00) { ret mop.LDAR; }
+    if (base == 0xC89FFC00 || base == 0x889FFC00) { ret mop.STLR; }
+    if (base == 0xC85FFC00 || base == 0x885FFC00) { ret mop.LDAXR; }
+    ret mop.MOP_NONE;
+}
+
+pub fun ldst_loads(op: mop.MachOp) bool {
+    ret op == mop.LDR || op == mop.LDRB || op == mop.LDRH || op == mop.LDUR ||
+        op == mop.LDURB || op == mop.LDURH || op == mop.LDAR || op == mop.LDAXR || op == mop.LDP;
+}
+
+fun classify_ldstp(base: u32) mop.MachOp {
+    if (base == 0xA9800000 || base == 0xA8800000 ||
+        base == 0xA9000000 || base == 0x6D000000) { ret mop.STP; }
+    if (base == 0xA9C00000 || base == 0xA8C00000 ||
+        base == 0xA9400000 || base == 0x6D400000) { ret mop.LDP; }
+    ret mop.MOP_NONE;
+}
+
+fun classify_neon_3same(i: *Inst) mop.MachOp {
+    val base: u32 = i.base;
+    if (base == 0x4E20D400) { ret mop.V_FADD; }
+    if (base == 0x4EA0D400) { ret mop.V_FSUB; }
+    if (base == 0x6E20DC00) { ret mop.V_FMUL; }
+    if (base == 0x6E20FC00) { ret mop.V_FDIV; }
+    if (base == 0x4E208400) { ret mop.V_ADD; }
+    if (base == 0x6E208400) { ret mop.V_SUB; }
+    if (base == 0x4E209C00) { ret mop.V_MUL; }
+    if (base == 0x4E201C00) { ret mop.V_AND; }
+    if (base == 0x4EA01C00) { if (i.src1.reg == i.src2.reg) { ret mop.V_MOV; } ret mop.V_ORR; }
+    if (base == 0x6E201C00) { ret mop.V_EOR; }
+    if (base == 0x6E208C00) { ret mop.V_CMEQ; }
+    if (base == 0x4E203400) { ret mop.V_CMGT; }
+    if (base == 0x4E203C00) { ret mop.V_CMGE; }
+    if (base == 0x6E203400) { ret mop.V_CMHI; }
+    if (base == 0x6E203C00) { ret mop.V_CMHS; }
+    if (base == 0x4E20E400) { ret mop.V_FCMEQ; }
+    if (base == 0x6EA0E400) { ret mop.V_FCMGT; }
+    if (base == 0x6E20E400) { ret mop.V_FCMGE; }
+    ret mop.MOP_NONE;
+}
+
+fun classify_neon_2misc(base: u32) mop.MachOp {
+    if (base == 0x6E205800) { ret mop.V_MVN; }
+    ret mop.MOP_NONE;
+}
+
+fun classify_neon_lane_read(i: *Inst) mop.MachOp {
+    if (isa.regid_class(i.dst.reg) == isa.REG_CLASS_ID_XMM) { ret mop.DUP; }
+    if (mir.vec_lane_elem_bytes(i.vec_lane) < 4) { ret mop.UMOV; }
+    ret mop.MOV_LANE;
+}
+
+fun classify_branch(base: u32) mop.MachOp {
+    if (base == 0x14000000) { ret mop.B; }
+    if (base == 0x94000000) { ret mop.BL; }
+    if (base == 0xB5000000 || base == 0x35000000) { ret mop.CBNZ; }
+    if (base == 0xB4000000 || base == 0x34000000) { ret mop.CBZ; }
+    if ((base & 0xFF000000) == 0x54000000) {
+        if (cond_name(base & 0xF) == nil) { ret mop.MOP_NONE; }
+        ret mop.BCOND;
+    }
+    ret mop.MOP_NONE;
+}
+
+fun classify_branch_reg(base: u32) mop.MachOp {
+    if (base == 0xD63F0000) { ret mop.BLR; }
+    if (base == 0xD61F0000) { ret mop.BR; }
+    if (base == 0xD65F0000) { ret mop.RET; }
+    ret mop.MOP_NONE;
+}
+
+fun classify_nullary(base: u32) mop.MachOp {
+    if (base == 0xD65F03C0) { ret mop.RET; }
+    if (base == 0xD503201F) { ret mop.NOP; }
+    if (base == 0xD503203F) { ret mop.YIELD; }
+    if (base == 0xD503205F) { ret mop.WFE; }
+    if (base == 0xD503207F) { ret mop.WFI; }
+    ret mop.MOP_NONE;
+}
+
+fun classify_imm16(base: u32) mop.MachOp {
+    if (base == 0xD4200000) { ret mop.BRK; }
+    if (base == 0xD4000001) { ret mop.SVC; }
+    if (base == 0xD4000002) { ret mop.HVC; }
+    if (base == 0xD4000003) { ret mop.SMC; }
+    ret mop.MOP_NONE;
+}
+
+fun classify_barrier(base: u32) mop.MachOp {
+    if (base == 0xD50330BF) { ret mop.DMB; }
+    ret mop.MOP_NONE;
+}
+
+fun classify_stxr(base: u32) mop.MachOp {
+    if (base == 0xC800FC00 || base == 0x8800FC00) { ret mop.STLXR; }
+    ret mop.MOP_NONE;
+}
+
+fun classify_sysreg_imm(base: u32) mop.MachOp {
+    if (base == 0xD500401F) { ret mop.MSR; }
+    ret mop.MOP_NONE;
+}
+
+fun classify_sysreg(base: u32) mop.MachOp {
+    if (base == 0xD5300000) { ret mop.MRS; }
+    if (base == 0xD5100000) { ret mop.MSR; }
+    ret mop.MOP_NONE;
 }
 
 fun render_inst(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
@@ -171,65 +513,17 @@ fun render_body(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     ret R.err[R.Void, str]("--emit-asm: an emitted aarch64 instruction has no renderable form");
 }
 
-fun alu3_mnem(base: u32) str {
-    if (base == 0x8B000000 || base == 0x0B000000) { ret "add"; }
-    if (base == 0xCB000000 || base == 0x4B000000) { ret "sub"; }
-    if (base == 0x8A000000 || base == 0x0A000000) { ret "and"; }
-    if (base == 0xAA000000 || base == 0x2A000000) { ret "orr"; }
-    if (base == 0xCA000000 || base == 0x4A000000) { ret "eor"; }
-    if (base == 0xAA200000 || base == 0x2A200000) { ret "orn"; }
-    if (base == 0x9B007C00 || base == 0x1B007C00) { ret "mul"; }
-    if (base == 0x9AC02000 || base == 0x1AC02000) { ret "lsl"; }
-    if (base == 0x9AC02400 || base == 0x1AC02400) { ret "lsr"; }
-    if (base == 0x9AC02800 || base == 0x1AC02800) { ret "asr"; }
-    if (base == 0x9AC00C00 || base == 0x1AC00C00) { ret "sdiv"; }
-    if (base == 0x9AC00800 || base == 0x1AC00800) { ret "udiv"; }
-    if (base == 0xEB000000 || base == 0x6B000000) { ret "subs"; }
-    if (base == 0xCB2063FF)                       { ret "sub"; }
-
-    if (base == 0x1E202800 || base == 0x1E602800) { ret "fadd"; }
-    if (base == 0x1E203800 || base == 0x1E603800) { ret "fsub"; }
-    if (base == 0x1E200800 || base == 0x1E600800) { ret "fmul"; }
-    if (base == 0x1E201800 || base == 0x1E601800) { ret "fdiv"; }
-    if (base == 0x1E214000 || base == 0x1E614000) { ret "fneg"; }
-    if (base == 0x1E204000 || base == 0x1E604000) { ret "fmov"; }
-    if (base == 0x1E22C000 || base == 0x1E624000) { ret "fcvt"; }
-    if (base == 0x1E202000 || base == 0x1E602000) { ret "fcmp"; }
-
-    if (base == 0x1E220000 || base == 0x1E620000 ||
-        base == 0x9E220000 || base == 0x9E620000) { ret "scvtf"; }
-    if (base == 0x1E230000 || base == 0x1E630000 ||
-        base == 0x9E230000 || base == 0x9E630000) { ret "ucvtf"; }
-    if (base == 0x1E380000 || base == 0x9E380000 ||
-        base == 0x1E780000 || base == 0x9E780000) { ret "fcvtzs"; }
-    if (base == 0x1E390000 || base == 0x9E390000 ||
-        base == 0x1E790000 || base == 0x9E790000) { ret "fcvtzu"; }
-
-    if (base == 0x1E270000 || base == 0x9E670000 ||
-        base == 0x1E260000 || base == 0x9E660000) { ret "fmov"; }
-    ret nil;
-}
 
 fun render_alu3(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    var mnem: str = alu3_mnem(i.base);
-    if (mnem == nil) {
+    val op: mop.MachOp = classify_alu3(i);
+    if (op == mop.MOP_NONE) {
         ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted three-register base word");
     }
+    val drop_rn:  bool = op == mop.MOV || op == mop.NEG || op == mop.MVN;
+    val drop_dst: bool = op == mop.CMP;
 
-    var drop_rn: bool = false;
-    if (is_zero_reg(?i.src1) && i.src2.kind == isa.OPK_REG) {
-        if (i.base == 0xAA000000 || i.base == 0x2A000000) { mnem = "mov"; drop_rn = true; }
-        if (i.base == 0xCB000000 || i.base == 0x4B000000) { mnem = "neg"; drop_rn = true; }
-        if (i.base == 0xAA200000 || i.base == 0x2A200000) { mnem = "mvn"; drop_rn = true; }
-    }
-    var drop_dst: bool = false;
-    if (is_zero_reg(?i.dst) && (i.base == 0xEB000000 || i.base == 0x6B000000)) {
-        mnem = "cmp";
-        drop_dst = true;
-    }
-
-    val rw: R.Result[R.Void, str] = emit_str(out, mnem);
+    val rw: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
     if (R.is_err[R.Void, str](rw)) { ret rw; }
 
     val sp: bool = i.base == 0xCB2063FF;
@@ -252,27 +546,17 @@ fun render_alu3(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     ret emit_shift(out, ?i.src3);
 }
 
-fun addsub_imm_mnem(base: u32) str {
-    if (base == 0x91000000 || base == 0x11000000) { ret "add"; }
-    if (base == 0xD1000000 || base == 0x51000000) { ret "sub"; }
-    if (base == 0xB1000000 || base == 0x31000000) { ret "adds"; }
-    if (base == 0xF1000000 || base == 0x71000000) { ret "subs"; }
-    ret nil;
-}
 
 fun render_addsub_imm(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    val mnem: str = addsub_imm_mnem(i.base);
-    if (mnem == nil) {
+    val op: mop.MachOp = classify_addsub_imm(i);
+    if (op == mop.MOP_NONE) {
         ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted add/sub-immediate base word");
     }
-    val flags: bool = i.base == 0xB1000000 || i.base == 0x31000000 ||
-                      i.base == 0xF1000000 || i.base == 0x71000000;
-    val plain_add: bool = i.base == 0x91000000 || i.base == 0x11000000;
+    val flags: bool = op == mop.ADDS || op == mop.SUBS || op == mop.CMN || op == mop.CMP;
 
-    if (plain_add && i.src2.kind == isa.OPK_IMM && i.src2.imm == 0 &&
-        i.src3.kind == isa.OPK_NONE && (is_reg31(?i.dst) || is_reg31(?i.src1))) {
-        val rm: R.Result[R.Void, str] = emit_str(out, "mov");
+    if (op == mop.MOV) {
+        val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
         if (R.is_err[R.Void, str](rm)) { ret rm; }
         val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, true);
         if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
@@ -281,15 +565,8 @@ fun render_addsub_imm(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
         ret R.ok_void[str]();
     }
 
-    var head: str = mnem;
-    var drop_dst: bool = false;
-    if (flags && is_zero_reg(?i.dst)) {
-        drop_dst = true;
-        head = "cmp";
-        if (i.base == 0xB1000000 || i.base == 0x31000000) { head = "cmn"; }
-    }
-
-    val rw: R.Result[R.Void, str] = emit_str(out, head);
+    val drop_dst: bool = op == mop.CMP || op == mop.CMN;
+    val rw: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
     if (R.is_err[R.Void, str](rw)) { ret rw; }
     var n: u32 = 0;
     if (!drop_dst) {
@@ -309,31 +586,18 @@ fun render_addsub_imm(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
 
 fun render_bitfield(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    var signed: bool = false;
-    var wide:   bool = false;
-    if (i.base == 0xD3400000)      { wide = true; }
-    or (i.base == 0x53000000)      { }
-    or (i.base == 0x93400000)      { wide = true; signed = true; }
-    or (i.base == 0x13000000)      { signed = true; }
-    or {
+    val op: mop.MachOp = classify_bitfield(i);
+    if (op == mop.MOP_NONE) {
         ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted bitfield base word");
     }
-
+    val wide: bool = i.base == 0xD3400000 || i.base == 0x93400000;
     var width: u32 = 32;
     if (wide) { width = 64; }
     val immr: u32 = i.src2.imm::u32;
     val imms: u32 = i.src3.imm::u32;
 
-    val extend: bool = immr == 0 && (imms == 7 || imms == 15 || (imms == 31 && wide));
-    if (extend && (signed || !wide)) {
-        var mnem: str = "uxtb";
-        if (imms == 15) { mnem = "uxth"; }
-        if (signed) {
-            mnem = "sxtb";
-            if (imms == 15) { mnem = "sxth"; }
-            if (imms == 31) { mnem = "sxtw"; }
-        }
-        val rm: R.Result[R.Void, str] = emit_str(out, mnem);
+    if (op == mop.UXTB || op == mop.UXTH || op == mop.SXTB || op == mop.SXTH || op == mop.SXTW) {
+        val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
         if (R.is_err[R.Void, str](rm)) { ret rm; }
         val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
         if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
@@ -341,30 +605,17 @@ fun render_bitfield(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
         src.size = 4;
         ret emit_sep_operand(buf, i, ?src, 1, false);
     }
+    if (op == mop.LSR || op == mop.ASR) { ret render_shift_alias(buf, i, mop.mnemonic(op), immr); }
+    if (op == mop.LSL)                  { ret render_shift_alias(buf, i, mop.mnemonic(op), width - 1 - imms); }
 
-    if (imms == width - 1) {
-        var mnem: str = "lsr";
-        if (signed) { mnem = "asr"; }
-        ret render_shift_alias(buf, i, mnem, immr);
-    }
-    if (!signed && imms + 1 == immr) {
-        ret render_shift_alias(buf, i, "lsl", width - 1 - imms);
-    }
-
-    var mnem: str = "ubfx";
-    var lsb:  u32 = immr;
-    var len:  u32 = imms - immr + 1;
-    if (imms < immr) {
-        mnem = "ubfiz";
-        lsb  = width - immr;
-        len  = imms + 1;
-    }
-    if (signed) {
-        mnem = "sbfx";
-        if (imms < immr) { mnem = "sbfiz"; }
+    var lsb: u32 = immr;
+    var len: u32 = imms - immr + 1;
+    if (op == mop.UBFIZ || op == mop.SBFIZ) {
+        lsb = width - immr;
+        len = imms + 1;
     }
 
-    val rm: R.Result[R.Void, str] = emit_str(out, mnem);
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
     val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
     if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
@@ -394,34 +645,23 @@ fun render_shift_alias(buf: *enc.ByteBuf, i: *Inst, mnem: str, sh: u32) R.Result
 
 fun render_movewide(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    var keep: bool = false;
-    var wide: bool = false;
-    if (i.base == 0xD2800000)      { wide = true; }
-    or (i.base == 0x52800000)      { }
-    or (i.base == 0xF2800000)      { wide = true; keep = true; }
-    or (i.base == 0x72800000)      { keep = true; }
-    or {
+    val op: mop.MachOp = classify_movewide(i);
+    if (op == mop.MOP_NONE) {
         ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted move-wide base word");
     }
-
+    val wide: bool = i.base == 0xD2800000 || i.base == 0xF2800000;
     val imm16: u64 = i.src2.imm::u64;
     var sh: u64 = 0;
     if (i.src3.kind != isa.OPK_NONE) { sh = i.src3.imm::u64; }
 
-    val folds: bool = !keep && (imm16 != 0 || sh == 0);
-    var mnem: str = "movk";
-    if (!keep) {
-        mnem = "movz";
-        if (folds) { mnem = "mov"; }
-    }
-    val rm: R.Result[R.Void, str] = emit_str(out, mnem);
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
     val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
     if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
     val rc: R.Result[R.Void, str] = emit_str(out, ", ");
     if (R.is_err[R.Void, str](rc)) { ret rc; }
 
-    if (folds) {
+    if (op == mop.MOV) {
         var v: u64 = imm16 << sh;
         if (!wide) { v = v & 0xFFFFFFFF; }
         ret emit_hex_imm(out, signed_at_width(v, wide));
@@ -434,20 +674,12 @@ fun render_movewide(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
 
 fun render_madd(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    var sub: bool = false;
-    if (i.base == 0x9B000000 || i.base == 0x1B000000)      { }
-    or (i.base == 0x9B008000 || i.base == 0x1B008000)      { sub = true; }
-    or {
+    val op: mop.MachOp = classify_madd(i);
+    if (op == mop.MOP_NONE) {
         ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted multiply-accumulate base word");
     }
-    val degenerate: bool = is_zero_reg(?i.src3);
-    var mnem: str = "madd";
-    if (sub) { mnem = "msub"; }
-    if (degenerate) {
-        mnem = "mul";
-        if (sub) { mnem = "mneg"; }
-    }
-    val rm: R.Result[R.Void, str] = emit_str(out, mnem);
+    val degenerate: bool = op == mop.MUL || op == mop.MNEG;
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
     var n: u32 = 0;
     val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, n, false);
@@ -474,7 +706,7 @@ fun render_cset(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     if (cc == nil) {
         ret R.err[R.Void, str]("--emit-asm: an emitted aarch64 cset names no condition");
     }
-    val rm: R.Result[R.Void, str] = emit_str(out, "cset");
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(mop.CSET));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
     val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
     if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
@@ -483,55 +715,18 @@ fun render_cset(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     ret emit_str(out, cc);
 }
 
-fun ldst_mnem(base: u32) str {
-    if (base == 0x39400000 || base == 0x38606800) { ret "ldrb"; }
-    if (base == 0x39000000 || base == 0x38206800) { ret "strb"; }
-    if (base == 0x79400000 || base == 0x78606800) { ret "ldrh"; }
-    if (base == 0x79000000 || base == 0x78206800) { ret "strh"; }
-    if (base == 0xB9400000 || base == 0xF9400000 || base == 0xFD400000 ||
-        base == 0xBD400000 || base == 0x3DC00000 || base == 0xB8606800 ||
-        base == 0xF8606800 || base == 0xFC606800 || base == 0xBC606800 ||
-        base == 0x3CE06800 ||
-        base == 0x3D400000 || base == 0x7D400000 ||
-        base == 0x3C606800 || base == 0x7C606800) { ret "ldr"; }
-    if (base == 0xB9000000 || base == 0xF9000000 || base == 0xFD000000 ||
-        base == 0xBD000000 || base == 0x3D800000 || base == 0xB8206800 ||
-        base == 0xF8206800 || base == 0xFC206800 || base == 0xBC206800 ||
-        base == 0x3CA06800 ||
-        base == 0x3D000000 || base == 0x7D000000 ||
-        base == 0x3C206800 || base == 0x7C206800) { ret "str"; }
-    if (base == 0x38400000)                       { ret "ldurb"; }
-    if (base == 0x38000000)                       { ret "sturb"; }
-    if (base == 0x78400000)                       { ret "ldurh"; }
-    if (base == 0x78000000)                       { ret "sturh"; }
-    if (base == 0xB8400000 || base == 0xF8400000 || base == 0xFC400000 ||
-        base == 0xBC400000 || base == 0x3CC00000 ||
-        base == 0x3C400000 || base == 0x7C400000) { ret "ldur"; }
-    if (base == 0xB8000000 || base == 0xF8000000 || base == 0xFC000000 ||
-        base == 0xBC000000 || base == 0x3C800000 ||
-        base == 0x3C000000 || base == 0x7C000000) { ret "stur"; }
-    if (base == 0xC8DFFC00 || base == 0x88DFFC00) { ret "ldar"; }
-    if (base == 0xC89FFC00 || base == 0x889FFC00) { ret "stlr"; }
-    if (base == 0xC85FFC00 || base == 0x885FFC00) { ret "ldaxr"; }
-    ret nil;
-}
 
-fun ldst_is_load(base: u32) bool {
-    val m: str = ldst_mnem(base);
-    if (m == nil) { ret false; }
-    ret m[0] == 'l'::char;
-}
 
 fun render_ldst(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    val mnem: str = ldst_mnem(i.base);
-    if (mnem == nil) {
+    val op: mop.MachOp = classify_ldst(i.base);
+    if (op == mop.MOP_NONE) {
         ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted load/store base word");
     }
-    val rm: R.Result[R.Void, str] = emit_str(out, mnem);
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
 
-    if (ldst_is_load(i.base)) {
+    if (ldst_loads(op)) {
         val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
         if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
         ret emit_sep_operand(buf, i, ?i.src1, 1, false);
@@ -543,17 +738,13 @@ fun render_ldst(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
 
 fun render_ldstp(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    var mnem: str = nil;
-    if (i.base == 0xA9800000 || i.base == 0xA8800000 ||
-        i.base == 0xA9000000 || i.base == 0x6D000000) { mnem = "stp"; }
-    if (i.base == 0xA9C00000 || i.base == 0xA8C00000 ||
-        i.base == 0xA9400000 || i.base == 0x6D400000) { mnem = "ldp"; }
-    if (mnem == nil) {
+    val op: mop.MachOp = classify_ldstp(i.base);
+    if (op == mop.MOP_NONE) {
         ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted load/store-pair base word");
     }
-    val load: bool = mnem[0] == 'l'::char;
+    val load: bool = op == mop.LDP;
 
-    val rm: R.Result[R.Void, str] = emit_str(out, mnem);
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
 
     var ra: *isa.Operand = ?i.src1;
@@ -568,27 +759,6 @@ fun render_ldstp(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     ret emit_sep_operand(buf, i, mem, 2, false);
 }
 
-fun neon_3same_mnem(base: u32) str {
-    if (base == 0x4E20D400) { ret "fadd"; }
-    if (base == 0x4EA0D400) { ret "fsub"; }
-    if (base == 0x6E20DC00) { ret "fmul"; }
-    if (base == 0x6E20FC00) { ret "fdiv"; }
-    if (base == 0x4E208400) { ret "add"; }
-    if (base == 0x6E208400) { ret "sub"; }
-    if (base == 0x4E209C00) { ret "mul"; }
-    if (base == 0x4E201C00) { ret "and"; }
-    if (base == 0x4EA01C00) { ret "orr"; }
-    if (base == 0x6E201C00) { ret "eor"; }
-    if (base == 0x6E208C00) { ret "cmeq"; }
-    if (base == 0x4E203400) { ret "cmgt"; }
-    if (base == 0x4E203C00) { ret "cmge"; }
-    if (base == 0x6E203400) { ret "cmhi"; }
-    if (base == 0x6E203C00) { ret "cmhs"; }
-    if (base == 0x4E20E400) { ret "fcmeq"; }
-    if (base == 0x6EA0E400) { ret "fcmgt"; }
-    if (base == 0x6E20E400) { ret "fcmge"; }
-    ret nil;
-}
 
 fun neon_is_bitwise(base: u32) bool {
     ret base == 0x4E201C00 || base == 0x4EA01C00 || base == 0x6E201C00;
@@ -606,8 +776,8 @@ fun neon_arrangement(base: u32, lane: u32) str {
 
 fun render_neon_3same(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    val mnem: str = neon_3same_mnem(i.base);
-    if (mnem == nil) {
+    val op: mop.MachOp = classify_neon_3same(i);
+    if (op == mop.MOP_NONE) {
         ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted NEON three-register base word");
     }
     val arr: str = neon_arrangement(i.base, i.vec_lane);
@@ -615,29 +785,23 @@ fun render_neon_3same(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
         ret R.err[R.Void, str]("--emit-asm: an emitted NEON instruction has no lane arrangement");
     }
 
-    if (i.base == 0x4EA01C00 && i.src1.reg == i.src2.reg) {
-        val rv: R.Result[R.Void, str] = emit_str(out, "mov");
-        if (R.is_err[R.Void, str](rv)) { ret rv; }
-        val rd: R.Result[R.Void, str] = emit_sep_vec(out, " ", ?i.dst, arr);
-        if (R.is_err[R.Void, str](rd)) { ret rd; }
-        ret emit_sep_vec(out, ", ", ?i.src1, arr);
-    }
-
-    val rm: R.Result[R.Void, str] = emit_str(out, mnem);
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
     val rd: R.Result[R.Void, str] = emit_sep_vec(out, " ", ?i.dst, arr);
     if (R.is_err[R.Void, str](rd)) { ret rd; }
     val rn: R.Result[R.Void, str] = emit_sep_vec(out, ", ", ?i.src1, arr);
     if (R.is_err[R.Void, str](rn)) { ret rn; }
+    if (op == mop.V_MOV) { ret R.ok_void[str](); }
     ret emit_sep_vec(out, ", ", ?i.src2, arr);
 }
 
 fun render_neon_2misc(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    if (i.base != 0x6E205800) {
+    val op: mop.MachOp = classify_neon_2misc(i.base);
+    if (op == mop.MOP_NONE) {
         ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted NEON two-register base word");
     }
-    val rm: R.Result[R.Void, str] = emit_str(out, "mvn");
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
     val rd: R.Result[R.Void, str] = emit_sep_vec(out, " ", ?i.dst, ".16b");
     if (R.is_err[R.Void, str](rd)) { ret rd; }
@@ -677,11 +841,7 @@ fun render_neon_lane_read(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
         ret R.err[R.Void, str]("--emit-asm: an emitted NEON lane read carries no lane index");
     }
 
-    var mnem: str = "mov";
-    if (isa.regid_class(i.dst.reg) != isa.REG_CLASS_ID_XMM
-        && mir.vec_lane_elem_bytes(i.vec_lane) < 4) { mnem = "umov"; }
-
-    val rm: R.Result[R.Void, str] = emit_str(out, mnem);
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(classify_neon_lane_read(i)));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
     val rs: R.Result[R.Void, str] = emit_str(out, " ");
     if (R.is_err[R.Void, str](rs)) { ret rs; }
@@ -700,7 +860,7 @@ fun render_neon_lane_write(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
         ret R.err[R.Void, str]("--emit-asm: an emitted NEON lane write carries no lane index");
     }
 
-    val rm: R.Result[R.Void, str] = emit_str(out, "mov");
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(mop.INS));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
     val rd: R.Result[R.Void, str] = emit_sep_lane(out, " ", ?i.dst, elem, i.src2.imm);
     if (R.is_err[R.Void, str](rd)) { ret rd; }
@@ -718,32 +878,26 @@ fun render_neon_lane_write(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
 
 fun render_branch(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    var mnem: str = nil;
-    var reg:  bool = false;
-    if (i.base == 0x14000000) { mnem = "b"; }
-    or (i.base == 0x94000000) { mnem = "bl"; }
-    or (i.base == 0xB5000000 || i.base == 0x35000000) { mnem = "cbnz"; reg = true; }
-    or (i.base == 0xB4000000 || i.base == 0x34000000) { mnem = "cbz";  reg = true; }
-    or ((i.base & 0xFF000000) == 0x54000000) {
-        val cc: str = cond_name(i.base & 0xF);
-        if (cc == nil) {
+    val op: mop.MachOp = classify_branch(i.base);
+    if (op == mop.MOP_NONE) {
+        if ((i.base & 0xFF000000) == 0x54000000) {
             ret R.err[R.Void, str]("--emit-asm: an emitted aarch64 conditional branch names no condition");
         }
-        val rb: R.Result[R.Void, str] = emit_str(out, "b.");
+        ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted branch base word");
+    }
+    if (op == mop.BCOND) {
+        val rb: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
         if (R.is_err[R.Void, str](rb)) { ret rb; }
-        val rc: R.Result[R.Void, str] = emit_str(out, cc);
+        val rc: R.Result[R.Void, str] = emit_str(out, cond_name(i.base & 0xF));
         if (R.is_err[R.Void, str](rc)) { ret rc; }
         val rs: R.Result[R.Void, str] = emit_str(out, " ");
         if (R.is_err[R.Void, str](rs)) { ret rs; }
         ret render_target(buf, i);
     }
-    or {
-        ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted branch base word");
-    }
 
-    val rm: R.Result[R.Void, str] = emit_str(out, mnem);
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
-    if (reg) {
+    if (op == mop.CBZ || op == mop.CBNZ) {
         val rt: R.Result[u32, str] = render_slot(buf, i, ?i.src1, 0, false);
         if (R.is_err[u32, str](rt)) { ret unwrap_slot_err(rt); }
         val rc: R.Result[R.Void, str] = emit_str(out, ", ");
@@ -779,14 +933,11 @@ fun render_target(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
 
 fun render_branch_reg(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    var mnem: str = nil;
-    if (i.base == 0xD63F0000) { mnem = "blr"; }
-    or (i.base == 0xD61F0000) { mnem = "br"; }
-    or (i.base == 0xD65F0000) { mnem = "ret"; }
-    or {
+    val op: mop.MachOp = classify_branch_reg(i.base);
+    if (op == mop.MOP_NONE) {
         ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted register-branch base word");
     }
-    val rm: R.Result[R.Void, str] = emit_str(out, mnem);
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
     val rn: R.Result[u32, str] = render_slot(buf, i, ?i.src1, 0, false);
     if (R.is_err[u32, str](rn)) { ret unwrap_slot_err(rn); }
@@ -795,7 +946,7 @@ fun render_branch_reg(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
 
 fun render_adrp(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    val rm: R.Result[R.Void, str] = emit_str(out, "adrp");
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(mop.ADRP));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
     val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
     if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
@@ -803,25 +954,20 @@ fun render_adrp(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
 }
 
 fun render_nullary(out: *writer.Writer, i: *Inst) R.Result[R.Void, str] {
-    if (i.base == 0xD65F03C0) { ret emit_str(out, "ret"); }
-    if (i.base == 0xD503201F) { ret emit_str(out, "nop"); }
-    if (i.base == 0xD503203F) { ret emit_str(out, "yield"); }
-    if (i.base == 0xD503205F) { ret emit_str(out, "wfe"); }
-    if (i.base == 0xD503207F) { ret emit_str(out, "wfi"); }
-    ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted operand-less instruction word");
+    val op: mop.MachOp = classify_nullary(i.base);
+    if (op == mop.MOP_NONE) {
+        ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted operand-less instruction word");
+    }
+    ret emit_str(out, mop.mnemonic(op));
 }
 
 fun render_imm16(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    var mnem: str = nil;
-    if (i.base == 0xD4200000) { mnem = "brk"; }
-    or (i.base == 0xD4000001) { mnem = "svc"; }
-    or (i.base == 0xD4000002) { mnem = "hvc"; }
-    or (i.base == 0xD4000003) { mnem = "smc"; }
-    or {
+    val op: mop.MachOp = classify_imm16(i.base);
+    if (op == mop.MOP_NONE) {
         ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted immediate-only base word");
     }
-    val rm: R.Result[R.Void, str] = emit_str(out, mnem);
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
     val rs: R.Result[R.Void, str] = emit_str(out, " ");
     if (R.is_err[R.Void, str](rs)) { ret rs; }
@@ -829,15 +975,17 @@ fun render_imm16(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
 }
 
 fun render_barrier(out: *writer.Writer, i: *Inst) R.Result[R.Void, str] {
-    if (i.base != 0xD50330BF) {
+    if (classify_barrier(i.base) == mop.MOP_NONE) {
         ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted barrier base word");
     }
     val name: str = barrier_name(i.src1.imm::u32);
     if (name == nil) {
         ret R.err[R.Void, str]("--emit-asm: an emitted aarch64 barrier names no domain");
     }
-    val rm: R.Result[R.Void, str] = emit_str(out, "dmb ");
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(mop.DMB));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
+    val rs: R.Result[R.Void, str] = emit_str(out, " ");
+    if (R.is_err[R.Void, str](rs)) { ret rs; }
     ret emit_str(out, name);
 }
 
@@ -859,10 +1007,10 @@ fun barrier_name(crm: u32) str {
 
 fun render_stxr(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    if (i.base != 0xC800FC00 && i.base != 0x8800FC00) {
+    if (classify_stxr(i.base) == mop.MOP_NONE) {
         ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted exclusive-store base word");
     }
-    val rm: R.Result[R.Void, str] = emit_str(out, "stlxr");
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(mop.STLXR));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
     val rs: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
     if (R.is_err[u32, str](rs)) { ret unwrap_slot_err(rs); }
@@ -872,7 +1020,7 @@ fun render_stxr(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
 }
 
 fun render_sysreg_imm(out: *writer.Writer, i: *Inst) R.Result[R.Void, str] {
-    if (i.base != 0xD500401F) {
+    if (classify_sysreg_imm(i.base) == mop.MOP_NONE) {
         ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted PSTATE-field base word");
     }
     val packed: u32 = i.src1.imm::u32;
@@ -880,8 +1028,10 @@ fun render_sysreg_imm(out: *writer.Writer, i: *Inst) R.Result[R.Void, str] {
     if (name == nil) {
         ret R.err[R.Void, str]("--emit-asm: an emitted aarch64 msr-immediate names no PSTATE field");
     }
-    val rm: R.Result[R.Void, str] = emit_str(out, "msr ");
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(mop.MSR));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
+    val rs: R.Result[R.Void, str] = emit_str(out, " ");
+    if (R.is_err[R.Void, str](rs)) { ret rs; }
     val rn: R.Result[R.Void, str] = emit_str(out, name);
     if (R.is_err[R.Void, str](rn)) { ret rn; }
     val rc: R.Result[R.Void, str] = emit_str(out, ", ");
@@ -902,25 +1052,26 @@ fun pstate_field_name(op1: u32, op2: u32) str {
 }
 
 fun render_sysreg(out: *writer.Writer, i: *Inst) R.Result[R.Void, str] {
-    if (i.base == 0xD5300000) {
-        val rm: R.Result[R.Void, str] = emit_str(out, "mrs ");
-        if (R.is_err[R.Void, str](rm)) { ret rm; }
+    val op: mop.MachOp = classify_sysreg(i.base);
+    if (op == mop.MOP_NONE) {
+        ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted system-register base word");
+    }
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(op));
+    if (R.is_err[R.Void, str](rm)) { ret rm; }
+    val rs: R.Result[R.Void, str] = emit_str(out, " ");
+    if (R.is_err[R.Void, str](rs)) { ret rs; }
+    if (op == mop.MRS) {
         val rr: R.Result[R.Void, str] = emit_reg(out, ?i.dst, false);
         if (R.is_err[R.Void, str](rr)) { ret rr; }
         val rc: R.Result[R.Void, str] = emit_str(out, ", ");
         if (R.is_err[R.Void, str](rc)) { ret rc; }
         ret emit_sysreg_numeric(out, i.src1.imm::u32);
     }
-    if (i.base == 0xD5100000) {
-        val rm: R.Result[R.Void, str] = emit_str(out, "msr ");
-        if (R.is_err[R.Void, str](rm)) { ret rm; }
-        val rn: R.Result[R.Void, str] = emit_sysreg_numeric(out, i.src1.imm::u32);
-        if (R.is_err[R.Void, str](rn)) { ret rn; }
-        val rc: R.Result[R.Void, str] = emit_str(out, ", ");
-        if (R.is_err[R.Void, str](rc)) { ret rc; }
-        ret emit_reg(out, ?i.dst, false);
-    }
-    ret R.err[R.Void, str]("--emit-asm: no aarch64 mnemonic for an emitted system-register base word");
+    val rn: R.Result[R.Void, str] = emit_sysreg_numeric(out, i.src1.imm::u32);
+    if (R.is_err[R.Void, str](rn)) { ret rn; }
+    val rc: R.Result[R.Void, str] = emit_str(out, ", ");
+    if (R.is_err[R.Void, str](rc)) { ret rc; }
+    ret emit_reg(out, ?i.dst, false);
 }
 
 fun emit_sysreg_numeric(out: *writer.Writer, packed: u32) R.Result[R.Void, str] {
@@ -1027,7 +1178,7 @@ fun emit_shift(out: *writer.Writer, op: *isa.Operand) R.Result[R.Void, str] {
 
 fun render_fmov_imm(buf: *enc.ByteBuf, i: *Inst) R.Result[R.Void, str] {
     val out: *writer.Writer = buf.asm.out;
-    val rm: R.Result[R.Void, str] = emit_str(out, "fmov");
+    val rm: R.Result[R.Void, str] = emit_str(out, mop.mnemonic(mop.FMOV));
     if (R.is_err[R.Void, str](rm)) { ret rm; }
     val rd: R.Result[u32, str] = render_slot(buf, i, ?i.dst, 0, false);
     if (R.is_err[u32, str](rd)) { ret unwrap_slot_err(rd); }
@@ -1242,10 +1393,16 @@ pub fun test_sink_text() str {
     ret (?test_sink_buf[0])::str;
 }
 
+# the fixture emits the word it notifies, so the notification has an extent
 fun rendered_is(buf: *enc.ByteBuf, i: *Inst, want: str) i32 {
     test_sink_reset();
+    val before: u32 = enc.note_inst_count(buf);
+    enc.emit_u32(buf, i.base);
     note_inst(buf, i);
     if (buf.asm.failed) { ret 1; }
+    if (enc.note_inst_count(buf) != before + 1) { ret 1; }
+    val n: *enc.AsmNote = enc.note_at(buf, enc.note_count(buf) - 1);
+    if (n == nil || n.byte_len != 4 || n.inst.opcode != classify(i)::u16) { ret 1; }
     val got: str = test_sink_text();
     if (!str_starts_with(got, "  "))                     { ret 1; }
     if (!str_region_equals(got, 2, str_len(want), want)) { ret 1; }

--- a/src/lang/target/isa/mos6502/encode.mach
+++ b/src/lang/target/isa/mos6502/encode.mach
@@ -36,6 +36,7 @@ pub fun encode_mos6502(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.Mir
     var hooks: enc.EncodeHooks;
     hooks.encode_function = encode_function;
     hooks.patch_branch    = patch_branch;
+    hooks.stream          = false;
     ret enc.encode_driver(alloc, tgt, m, ?hooks);
 }
 

--- a/src/lang/target/isa/riscv/encode.mach
+++ b/src/lang/target/isa/riscv/encode.mach
@@ -2329,13 +2329,10 @@ fun encode_function_riscv64(st: *encode.EncodeState, f: *mir.MirFunction) R.Resu
     if (R.is_err[R.Void, str](rh)) { ret rh; }
 
     val res: R.Result[R.Void, str] = encode_function_body(st, f);
-    if (R.is_err[R.Void, str](res)) {
-        encode.notes_reset(?st.buf);
-        ret res;
-    }
-    val rr: R.Result[R.Void, str] = printer.render_notes(?st.buf);
-    encode.notes_reset(?st.buf);
-    ret rr;
+    if (R.is_err[R.Void, str](res)) { ret res; }
+    # the notes stay until the driver has consumed them; rendering needs a writer
+    if (!encode.sink_renders(?st.buf)) { ret R.ok_void[str](); }
+    ret printer.render_notes(?st.buf);
 }
 
 fun extension_admission(bits: u32, op: inst.MachOp) R.Result[R.Void, str] {
@@ -2516,6 +2513,7 @@ pub fun encode_riscv64(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.Mir
     var hooks: encode.EncodeHooks;
     hooks.encode_function = encode_function_riscv64;
     hooks.patch_branch    = patch_branch_riscv64;
+    hooks.stream          = true;
     ret encode.encode_driver(alloc, tgt, m, ?hooks);
 }
 
@@ -2524,6 +2522,7 @@ pub fun encode_riscv64_asm(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir
     var hooks: encode.EncodeHooks;
     hooks.encode_function = encode_function_riscv64;
     hooks.patch_branch    = patch_branch_riscv64;
+    hooks.stream          = true;
     ret encode.encode_driver_asm(alloc, tgt, m, ?hooks, out);
 }
 

--- a/src/lang/target/isa/riscv/encode.mach
+++ b/src/lang/target/isa/riscv/encode.mach
@@ -2182,6 +2182,7 @@ fun renote_relaxed_branch(st: *encode.EncodeState, guard_pos: u32, jal_pos: u32,
     var jump: encode.AsmNote = encode.note_blank();
     jump.loc = guard.loc;
     jump.inline_site = guard.inline_site;
+    jump.mi   = guard.mi;
     jump.off  = jal_pos;
     jump.inst = build_inst(inst.JAL, RZERO, 0, 0, 0);
     jump.inst.src1 = isa.make_block_label(target_block);
@@ -2208,6 +2209,7 @@ fun renote_trampoline(st: *encode.EncodeState, auipc_pos: u32, jalr_pos: u32, ta
     var lo: encode.AsmNote = encode.note_blank();
     lo.loc = hi.loc;
     lo.inline_site = hi.inline_site;
+    lo.mi   = hi.mi;
     lo.off  = jalr_pos;
     lo.inst = build_inst(inst.JALR, RZERO, SCRATCH, 0, 0);
     lo.inst.src1.sym_mod = isa.SYM_MOD_PCREL_LO;
@@ -2426,8 +2428,10 @@ fun encode_function_body(st: *encode.EncodeState, f: *mir.MirFunction) R.Result[
             }
             encode.sink_set_mir(?st.buf, mi);
             val ei: R.Result[R.Void, str] = encode_mir_instr(st, f, fn_base, mi);
+            val eb: R.Result[R.Void, str] = encode.note_barrier(?st.buf, mi);
             encode.sink_set_mir(?st.buf, nil);
             if (R.is_err[R.Void, str](ei)) { ret ei; }
+            if (R.is_err[R.Void, str](eb)) { ret eb; }
             if (mi.opcode != mir.MIR_ASM) {
                 val ar: R.Result[R.Void, str] = check_generated_extensions(st, generated_start);
                 if (R.is_err[R.Void, str](ar)) { ret ar; }
@@ -6371,5 +6375,71 @@ test "mach.lang.target.isa.riscv.encode:selected_extensions_bound_generated_and_
         op = op + 1;
     }
     if (inst.required_extensions(inst.MOP_NONE) != 0 || inst.required_extensions(inst.MOP_LAST + 1) != 0) { ret 12; }
+    ret 0;
+}
+
+# every notification names the MirInstr whose encoding emitted it, in
+# emission order, and a declassify marker reaches the stream as a barrier
+# with no bytes between the instructions around it
+test "mach.lang.target.isa.riscv.encode.stream:notes_name_their_instruction_and_carry_the_barrier" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var interner: intern.Interner = intern.init(?alloc);
+    var st: encode.EncodeState;
+    encode.state_blank(?st, ?alloc, rv64_machine());
+    st.interner = ?interner;
+    var sink: encode.AsmSink = encode.sink_init(nil, ?interner);
+    st.buf.asm = ?sink;
+
+    var vregs: [1]mir.MirVReg;
+    vregs[0] = mir.vreg(0, mir.REG_CLASS_GP, false, true);
+    vregs[0].assigned = isa.regid_make(isa.REG_CLASS_ID_GP, 10)::u32;
+    var mov_ops: [2]mir.MirOperand;
+    mov_ops[0] = mir.op_preg_of(isa.regid_make(isa.REG_CLASS_ID_GP, 10)::u32, 0);
+    mov_ops[0].required_bank = mir.BANK_GP;
+    mov_ops[1] = mir.op_imm(5);
+    var instrs: [3]mir.MirInstr;
+    instrs[0] = mir.instr(riscv.MOV::u32, ?mov_ops[0], 2, 8, 8);
+    instrs[1] = mir.declassify_marker(?instrs[0], 0);
+    instrs[2] = mir.instr(riscv.RET::u32, nil, 0, 0, 0);
+    var blk: mir.MirBlock;
+    blk.id = 0; blk.instrs = ?instrs[0]; blk.instr_count = 3;
+    var f: mir.MirFunction;
+    f.name = intern.STR_NIL;
+    f.blocks = ?blk; f.block_count = 1;
+    f.vregs = ?vregs[0]; f.vreg_count = 1;
+    f.frame.omit = true;
+    f.oblivious = true;
+
+    val r: R.Result[R.Void, str] = encode_function_riscv64(?st, ?f);
+    if (R.is_err[R.Void, str](r)) { ret 2; }
+    if (sink.failed || sink.refused != 0)              { ret 3; }
+    if (encode.sink_unaccounted(?st.buf) != 0)          { ret 4; }
+    if (encode.note_inst_count(?st.buf) != 2)           { ret 5; }
+
+    # FUNC, BLOCK, then one INST for the move, the BARRIER, one INST for the return
+    val n: u32 = encode.note_count(?st.buf);
+    if (n != 5) { ret 6; }
+    val head: *encode.AsmNote = encode.note_at(?st.buf, 0);
+    val label: *encode.AsmNote = encode.note_at(?st.buf, 1);
+    val mov: *encode.AsmNote = encode.note_at(?st.buf, 2);
+    val bar: *encode.AsmNote = encode.note_at(?st.buf, 3);
+    val fin_note: *encode.AsmNote = encode.note_at(?st.buf, 4);
+    if (head.kind != encode.ASM_NOTE_FUNC || label.kind != encode.ASM_NOTE_BLOCK) { ret 7; }
+    if (mov.kind != encode.ASM_NOTE_INST || mov.mi != ?instrs[0] || mov.byte_len == 0) { ret 8; }
+    if (bar.kind != encode.ASM_NOTE_BARRIER || bar.mi != ?instrs[1]) { ret 9; }
+    if (bar.off != mov.off + mov.byte_len) { ret 10; }
+    if (fin_note.kind != encode.ASM_NOTE_INST || fin_note.mi != ?instrs[2] || fin_note.off != bar.off) { ret 11; }
+
+    var seeds: encode.NoteSeeds;
+    encode.note_seeds(?f, mov, ?seeds);
+    if (seeds.barrier || seeds.count != 2 || seeds.origin[0] != 0 || !seeds.secret[0] || seeds.secret[1]) { ret 12; }
+    encode.note_seeds(?f, bar, ?seeds);
+    if (!seeds.barrier || seeds.count != 1 || seeds.origin[0] != 0 || !seeds.secret[0]) { ret 13; }
+    encode.note_seeds(?f, head, ?seeds);
+    if (seeds.count != 0 || seeds.barrier) { ret 14; }
+
+    encode.notes_free(?st.buf);
+    encode.buf_dnit(?st.buf);
     ret 0;
 }

--- a/src/lang/target/isa/riscv/printer.mach
+++ b/src/lang/target/isa/riscv/printer.mach
@@ -45,6 +45,7 @@ fun render_note(out: *writer.Writer, interner: *intern.Interner, n: *enc.AsmNote
     if (n.kind == enc.ASM_NOTE_BYTES) {
         ret enc.render_bytes_text(out, ?n.bytes[0], enc.ASM_NOTE_BYTES_WIDTH);
     }
+    if (n.kind == enc.ASM_NOTE_BARRIER) { ret R.ok_void[str](); }
     ret render_inst(out, interner, ?n.inst);
 }
 

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2167,6 +2167,7 @@ pub fun encode_x64(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.MirModu
     var hooks: enc.EncodeHooks;
     hooks.encode_function = encode_function;
     hooks.patch_branch    = patch_branch_x86;
+    hooks.stream          = true;
     ret enc.encode_driver(alloc, tgt, m, ?hooks);
 }
 
@@ -2175,6 +2176,7 @@ pub fun encode_x64_asm(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.Mir
     var hooks: enc.EncodeHooks;
     hooks.encode_function = encode_function;
     hooks.patch_branch    = patch_branch_x86;
+    hooks.stream          = true;
 
     val res_header: R.Result[R.Void, str] = printer.emit_header(out);
     if (R.is_err[R.Void, str](res_header)) {

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2245,8 +2245,10 @@ fun encode_function(st: *enc.EncodeState, f: *mir.MirFunction) R.Result[R.Void, 
             }
             enc.sink_set_mir(?st.buf, mi);
             val ei: R.Result[R.Void, str] = encode_mir_instr(st, f, fn_base, mi);
+            val eb: R.Result[R.Void, str] = enc.note_barrier(?st.buf, mi);
             enc.sink_set_mir(?st.buf, nil);
             if (R.is_err[R.Void, str](ei)) { ret ei; }
+            if (R.is_err[R.Void, str](eb)) { ret eb; }
             val ra: R.Result[R.Void, str] = check_accounted(st, mi.opcode::u16);
             if (R.is_err[R.Void, str](ra)) { ret ra; }
             ii = ii + 1;
@@ -7618,5 +7620,71 @@ test "mach.lang.target.isa.x64.encode:native_opcode_domain_refuses_unknown_and_t
     staged.dst = isa.make_mem(x64.RBX, 0, -1, 0, 8);
     staged.src1 = isa.make_mem(x64.RDX, 0, -1, 0, 8);
     if (encode_inst(?staged, ?st.buf) > 0) { ret 7; }
+    ret 0;
+}
+
+# every notification names the MirInstr whose encoding emitted it, in
+# emission order, and a declassify marker reaches the stream as a barrier
+# with no bytes between the instructions around it
+test "mach.lang.target.isa.x64.encode.stream:notes_name_their_instruction_and_carry_the_barrier" {
+    var alloc: A.Allocator;
+    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    var interner: intern.Interner = intern.init(?alloc);
+    var st: enc.EncodeState;
+    enc.state_blank(?st, ?alloc, x64_machine());
+    st.interner = ?interner;
+    var sink: enc.AsmSink = enc.sink_init(nil, ?interner);
+    st.buf.asm = ?sink;
+
+    var vregs: [1]mir.MirVReg;
+    vregs[0] = mir.vreg(0, mir.REG_CLASS_GP, false, true);
+    vregs[0].assigned = isa.regid_make(isa.REG_CLASS_ID_GP, 0)::u32;
+    var mov_ops: [2]mir.MirOperand;
+    mov_ops[0] = mir.op_preg_of(isa.regid_make(isa.REG_CLASS_ID_GP, 0)::u32, 0);
+    mov_ops[0].required_bank = mir.BANK_GP;
+    mov_ops[1] = mir.op_imm(5);
+    var instrs: [3]mir.MirInstr;
+    instrs[0] = mir.instr(x64.MOV::u32, ?mov_ops[0], 2, 8, 8);
+    instrs[1] = mir.declassify_marker(?instrs[0], 0);
+    instrs[2] = mir.instr(x64.RET::u32, nil, 0, 0, 0);
+    var blk: mir.MirBlock;
+    blk.id = 0; blk.instrs = ?instrs[0]; blk.instr_count = 3;
+    var f: mir.MirFunction;
+    f.name = intern.STR_NIL;
+    f.blocks = ?blk; f.block_count = 1;
+    f.vregs = ?vregs[0]; f.vreg_count = 1;
+    f.frame.omit = true;
+    f.oblivious = true;
+
+    val r: R.Result[R.Void, str] = encode_function(?st, ?f);
+    if (R.is_err[R.Void, str](r)) { ret 2; }
+    if (sink.failed || sink.refused != 0)              { ret 3; }
+    if (enc.sink_unaccounted(?st.buf) != 0)          { ret 4; }
+    if (enc.note_inst_count(?st.buf) != 2)           { ret 5; }
+
+    # FUNC, BLOCK, then one INST for the move, the BARRIER, one INST for the return
+    val n: u32 = enc.note_count(?st.buf);
+    if (n != 5) { ret 6; }
+    val head: *enc.AsmNote = enc.note_at(?st.buf, 0);
+    val label: *enc.AsmNote = enc.note_at(?st.buf, 1);
+    val mov: *enc.AsmNote = enc.note_at(?st.buf, 2);
+    val bar: *enc.AsmNote = enc.note_at(?st.buf, 3);
+    val fin_note: *enc.AsmNote = enc.note_at(?st.buf, 4);
+    if (head.kind != enc.ASM_NOTE_FUNC || label.kind != enc.ASM_NOTE_BLOCK) { ret 7; }
+    if (mov.kind != enc.ASM_NOTE_INST || mov.mi != ?instrs[0] || mov.byte_len == 0) { ret 8; }
+    if (bar.kind != enc.ASM_NOTE_BARRIER || bar.mi != ?instrs[1]) { ret 9; }
+    if (bar.off != mov.off + mov.byte_len) { ret 10; }
+    if (fin_note.kind != enc.ASM_NOTE_INST || fin_note.mi != ?instrs[2] || fin_note.off != bar.off) { ret 11; }
+
+    var seeds: enc.NoteSeeds;
+    enc.note_seeds(?f, mov, ?seeds);
+    if (seeds.barrier || seeds.count != 2 || seeds.origin[0] != 0 || !seeds.secret[0] || seeds.secret[1]) { ret 12; }
+    enc.note_seeds(?f, bar, ?seeds);
+    if (!seeds.barrier || seeds.count != 1 || seeds.origin[0] != 0 || !seeds.secret[0]) { ret 13; }
+    enc.note_seeds(?f, head, ?seeds);
+    if (seeds.count != 0 || seeds.barrier) { ret 14; }
+
+    enc.notes_free(?st.buf);
+    enc.buf_dnit(?st.buf);
     ret 0;
 }

--- a/src/lang/target/isa/x64/printer.mach
+++ b/src/lang/target/isa/x64/printer.mach
@@ -31,6 +31,7 @@ pub fun note_function(buf: *enc.ByteBuf, interner: *intern.Interner, f: *mir.Mir
     note.name = f.name;
     val kept: R.Result[R.Void, str] = enc.note_push(buf, ?note);
     if (R.is_err[R.Void, str](kept)) { ret kept; }
+    if (!enc.sink_renders(buf)) { ret R.ok_void[str](); }
     val out: *writer.Writer = buf.asm.out;
     val res_nl: R.Result[R.Void, str] = emit_str(out, "\n# ");
     if (R.is_err[R.Void, str](res_nl)) { ret res_nl; }
@@ -46,6 +47,7 @@ pub fun note_block(buf: *enc.ByteBuf, id: u32) R.Result[R.Void, str] {
     note.id = id;
     val kept: R.Result[R.Void, str] = enc.note_push(buf, ?note);
     if (R.is_err[R.Void, str](kept)) { ret kept; }
+    if (!enc.sink_renders(buf)) { ret R.ok_void[str](); }
     val out: *writer.Writer = buf.asm.out;
     val res_dot: R.Result[R.Void, str] = emit_str(out, ".");
     if (R.is_err[R.Void, str](res_dot)) { ret res_dot; }
@@ -54,17 +56,19 @@ pub fun note_block(buf: *enc.ByteBuf, id: u32) R.Result[R.Void, str] {
     ret emit_str(out, ":\n");
 }
 
+# notify first, render only for a writer: the stream is the same on every build
 pub fun note_inst(buf: *enc.ByteBuf, mi: *isa.Inst, start: usize) {
-    val res: R.Result[R.Void, str] = render_inst(buf, mi);
-    if (R.is_err[R.Void, str](res)) {
-        enc.sink_fail(buf, R.unwrap_err[R.Void, str](res));
-        ret;
-    }
     var note: enc.AsmNote = enc.note_blank();
     note.off = start::u32;
     note.inst = @mi;
     val kept: R.Result[R.Void, str] = enc.note_push(buf, ?note);
-    if (R.is_err[R.Void, str](kept)) { enc.sink_fail(buf, R.unwrap_err[R.Void, str](kept)); }
+    if (R.is_err[R.Void, str](kept)) {
+        enc.sink_fail(buf, R.unwrap_err[R.Void, str](kept));
+        ret;
+    }
+    if (!enc.sink_renders(buf)) { ret; }
+    val res: R.Result[R.Void, str] = render_inst(buf, mi);
+    if (R.is_err[R.Void, str](res)) { enc.sink_fail(buf, R.unwrap_err[R.Void, str](res)); }
 }
 
 fun render_inst(buf: *enc.ByteBuf, mi: *isa.Inst) R.Result[R.Void, str] {


### PR DESCRIPTION
Roadmap N5, #3126 phase 2 parts 1 and 2 of the five specified in
`doc/design/secrecy-final-effects-3126.md` section 15. No walk and no refusals
here; the stream and the seeds exist on every build with zero byte change and a
measured cost.

## Part 1: the notification stream on every build

- `AsmSink` separates notification from rendering: a nil writer records
  `AsmNote`s and claims bytes, `sink_renders` gates rendering. The driver
  attaches a sink when `--emit-asm` asks for one or when the ISA declares
  `EncodeHooks.stream` and the module contains an oblivious function (x86_64,
  aarch64, riscv64 declare it; mos6502 declares `false`). `sink.refused`,
  the per-ISA `check_accounted` and a module-level unaccounted check fail the
  build if a byte escapes. `EncoderOutput.notified` reports the count.
- x86_64 and aarch64 `note_inst` (and the function/block notes, and inline-asm
  data directives) notify then render only for a writer.
- aarch64 gained `arm64/inst.mach:MachOp`, its machine-opcode space (the
  riscv `Opcode`/`inst.MachOp` split). The inline-asm grammar rows and every
  notification share it. The printer classifies its form record to a `MachOp`,
  renders from that one table, and translates the form record to an `isa.Inst`
  (regids, base/index/disp, width, condition/writeback/element flags).
- `AsmNote.mi` names the `MirInstr` whose encoding emitted the note; the
  driver resets notes per function at the marked consumer point for part 4.
- **Frozen-interface amendment, additive, for the owner:** `isa.Inst.src3`
  (blank by `inst_blank`), because aarch64 `madd`/`msub` read three registers.
  x86_64 and riscv64 never set it. Same kind of addition phase 1 made to
  `AsmNote`; `backend-census-2212.md` section 11 is not edited here.

## Part 2: seeds and the provenance decision

- **Decision: `rewrite_instr` retains the origin vreg** on every rewritten
  register operand (`mir.op_preg_of`), including the reload scratch and the
  spill store. Justified in 15.2: `MirVReg.secret` is only a seed with a
  location, and `assigned` alone says where, never when. Memory base/index
  provenance is omitted with the reason recorded.
- `encode.note_seeds` reads, **per operand**, the origin and its declared
  secrecy, the `writes_secret` destination, and the barrier. Per operand
  because one register carries a dying secret source and a born public
  destination in the same instruction (found by the test).
- The declassify barrier survives selection (`MirInstr.declassifies`, set by
  `rules.retag`) and every self-copy drop (the allocator coalesces the
  declassify's public web into its derived-secret source web and drops the
  self-copy): a zero-byte `ISA_USE` marker keeps it and each ISA pushes an
  `ASM_NOTE_BARRIER` after the instruction's bytes. Bytes unchanged.
- `ctvalidate.derive_secret_vregs` exposes the early walk's fixpoint.

## Found on the way

The aarch64 inline-asm grammar read `lsl x0, x1, x2` under the immediate row
(`CT_OP_NONE`) while `lslv` is `CT_OP_VAR_SHIFT`; the parse retags the
register-count form. No verdict changes today (every ISA trusts variable
shifts). Changelog entry under Fixed.

## Verification

- Suite: 2945 passed, 0 failed (baseline 2929 at a151921cd, +16 by name, none
  removed), run through the from-source compiler.
- `sh test/census.sh`: 10 ok.
- Corpus layer B on x86_64-linux, aarch64-linux, riscv64-linux: 306 pass, 0
  fail, 0 skip.
- x86_64 link leg: 140 pass / 0 fail / 0 skip.
- Seed fixpoint: A by the seed, B by A, C by B; `B == C` byte-identical.
  Cross-controls: a gen-B compiler from this branch and a gen-C compiler from
  a151921cd produce byte-identical binaries from the a151921cd source (which
  has an oblivious module), and gen-C a151921cd vs this branch's gen-A produce
  byte-identical binaries from this branch's source.
- Mutation controls: renaming a grammar-covered aarch64 spelling fails the
  round-trip test; the spelling pin covers the rest.
- Measurement (3 reps, `--no-cache`, in 15.4): corpus-case project with
  oblivious modules dev 616/629/661 ms vs new 615/620/628 ms; without its own
  oblivious function dev 612/613/619 vs new 613/621/623 ms; compiler
  self-build dev 32.8/33.0/33.7 s vs new 32.8/33.8/34.4 s. Per module the
  stream's cost on a non-oblivious module is below the 1 ms timer; on
  `std.crypto.ct` (38 oblivious functions) at most 1 ms.

Refs #3126.
