### PR TITLE
backend: migrate codegen, linker and object outcomes to res, opt and err with typed domains (#3226)

### DIFF
--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -1,18 +1,19 @@
 use std.types.canonical.opt;
+use std.types.canonical.err;
 use std.types.canonical.res;
-use writer: mach.lang.legacy.writer;
+use writer: std.io.writer;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 use std.memory;
-use page: mach.lang.legacy.page;
-use arena: mach.lang.legacy.arena;
-use alloc_test: mach.lang.legacy.testing;
+use page: std.allocator.page;
+use arena: std.allocator.arena;
+use alloc_test: std.allocator.testing;
 use std.system.os;
 
-use A: mach.lang.legacy.allocator;
+use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -88,12 +89,23 @@ rec CodegenContext {
     session: *session.Session;
 }
 
+# translation shim (#3226): the legacy carrier the build and driver lanes read
+# until their call sites migrate to `codegen_unit`
 pub fun codegen_module(s: *session.Session, tgt: *target.Target,
                        irmod: *ir.Module, deps: unit.IrSet, asm_out: *writer.Writer,
                        placement_policy: u32, dbg: DebugInfo) R.Result[of.ObjectImage, fail.Fail] {
+    val r: res[of.ObjectImage, fail.Fail] = codegen_unit(s, tgt, irmod, deps, asm_out, placement_policy, dbg);
+    if (sel r.err) { ret R.err[of.ObjectImage, fail.Fail](r.err); }
+    ret R.ok[of.ObjectImage, fail.Fail](r.ok);
+}
+
+pub fun codegen_unit(s: *session.Session, tgt: *target.Target,
+                     irmod: *ir.Module, deps: unit.IrSet, asm_out: *writer.Writer,
+                     placement_policy: u32, dbg: DebugInfo) res[of.ObjectImage, fail.Fail] {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) {
-        ret R.err[of.ObjectImage, fail.Fail](fail.message("codegen: scratch backing allocator failed"));
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) {
+        ret res[of.ObjectImage, fail.Fail].err{fail.message("codegen: scratch backing allocator failed")};
     }
     ret codegen_with_backing(s, tgt, irmod, deps, asm_out, placement_policy, dbg, ?backing);
 }
@@ -101,113 +113,113 @@ pub fun codegen_module(s: *session.Session, tgt: *target.Target,
 fun codegen_with_backing(s: *session.Session, tgt: *target.Target,
                         irmod: *ir.Module, deps: unit.IrSet, asm_out: *writer.Writer,
                         placement_policy: u32, dbg: DebugInfo,
-                        backing: *A.Allocator) R.Result[of.ObjectImage, fail.Fail] {
-    if (s == nil) { ret R.err[of.ObjectImage, fail.Fail](fail.message("codegen: nil session")); }
+                        backing: *A.Allocator) res[of.ObjectImage, fail.Fail] {
+    if (s == nil) { ret res[of.ObjectImage, fail.Fail].err{fail.message("codegen: nil session")}; }
     var scratch: arena.Arena;
-    val initialized: O.Option[str] = arena.init(?scratch, backing, 0);
-    if (O.is_some[str](initialized)) { ret R.err[of.ObjectImage, fail.Fail](fail.message(O.unwrap[str](initialized))); }
+    val initialized: err[A.Error] = arena.init(?scratch, backing, 0);
+    if (sel initialized.err) { ret res[of.ObjectImage, fail.Fail].err{fail.refused(initialized.err)}; }
     fin { arena.dnit(?scratch); }
     var alloc: A.Allocator;
-    val bound: O.Option[str] = arena.make(?alloc, ?scratch);
-    if (O.is_some[str](bound)) { ret R.err[of.ObjectImage, fail.Fail](fail.message(O.unwrap[str](bound))); }
+    val bound: err[A.Error] = arena.make(?alloc, ?scratch);
+    if (sel bound.err) { ret res[of.ObjectImage, fail.Fail].err{fail.refused(bound.err)}; }
     var context: CodegenContext = CodegenContext{alloc: ?alloc, session: s};
-    val emitted: R.Result[of.ObjectImage, fail.Fail] = codegen_scratch(?context, tgt, irmod, deps, asm_out, placement_policy, dbg);
-    if (R.is_err[of.ObjectImage, fail.Fail](emitted)) {
-        val error: fail.Fail = R.unwrap_err[of.ObjectImage, fail.Fail](emitted);
-        if (sel error.reported) { ret R.err[of.ObjectImage, fail.Fail](error); }
+    val emitted: res[of.ObjectImage, fail.Fail] = codegen_scratch(?context, tgt, irmod, deps, asm_out, placement_policy, dbg);
+    if (sel emitted.err) {
+        val error: fail.Fail = emitted.err;
+        if (sel error.reported) { ret res[of.ObjectImage, fail.Fail].err{error}; }
         val stable: R.Result[intern.StrId, str] = intern.intern(?s.interner, fail.describe(error));
         if (R.is_err[intern.StrId, str](stable)) {
-            ret R.err[of.ObjectImage, fail.Fail](fail.message("codegen: allocation failure retaining diagnostic"));
+            ret res[of.ObjectImage, fail.Fail].err{fail.message("codegen: allocation failure retaining diagnostic")};
         }
         val text: O.Option[str] = intern.lookup(?s.interner, R.unwrap_ok[intern.StrId, str](stable));
-        if (O.is_none[str](text)) { ret R.err[of.ObjectImage, fail.Fail](fail.message("codegen: retained diagnostic is missing")); }
-        ret R.err[of.ObjectImage, fail.Fail](fail.message(O.unwrap[str](text)));
+        if (O.is_none[str](text)) { ret res[of.ObjectImage, fail.Fail].err{fail.message("codegen: retained diagnostic is missing")}; }
+        ret res[of.ObjectImage, fail.Fail].err{fail.message(O.unwrap[str](text))};
     }
-    var temporary: of.ObjectImage = R.unwrap_ok[of.ObjectImage, fail.Fail](emitted);
+    var temporary: of.ObjectImage = emitted.ok;
     fin { obj.dnit(?temporary); }
     val names: intern.ReinternMap = intern.ReinternMap{
         base_len: s.interner.base_len + s.interner.len, ids: nil, len: 0};
-    ret fail.lift[of.ObjectImage](obj.rehome_remap(s.alloc, ?s.interner, ?temporary, names));
+    ret obj.rehome(s.alloc, ?s.interner, ?temporary, names);
 }
 
 fun codegen_scratch(s: *CodegenContext, tgt: *target.Target,
                        irmod: *ir.Module, deps: unit.IrSet, asm_out: *writer.Writer,
-                       placement_policy: u32, dbg: DebugInfo) R.Result[of.ObjectImage, fail.Fail] {
-    if (s == nil)     { ret R.err[of.ObjectImage, fail.Fail](fail.message("codegen: nil session")); }
-    if (tgt == nil)   { ret R.err[of.ObjectImage, fail.Fail](fail.message("codegen: nil target")); }
-    if (irmod == nil) { ret R.err[of.ObjectImage, fail.Fail](fail.message("codegen: nil ir module")); }
+                       placement_policy: u32, dbg: DebugInfo) res[of.ObjectImage, fail.Fail] {
+    if (s == nil)     { ret res[of.ObjectImage, fail.Fail].err{fail.message("codegen: nil session")}; }
+    if (tgt == nil)   { ret res[of.ObjectImage, fail.Fail].err{fail.message("codegen: nil target")}; }
+    if (irmod == nil) { ret res[of.ObjectImage, fail.Fail].err{fail.message("codegen: nil ir module")}; }
 
-    val res_lower: R.Result[mir.MirModule, str] = lower.lower_ir(tgt, irmod, s.alloc, ?s.session.interner, ?s.session.sources);
-    if (R.is_err[mir.MirModule, str](res_lower)) {
-        ret R.err[of.ObjectImage, fail.Fail](fail.message(R.unwrap_err[mir.MirModule, str](res_lower)));
+    val res_lower: res[mir.MirModule, fail.Fail] = lower.lower_module(tgt, irmod, s.alloc, ?s.session.interner, ?s.session.sources);
+    if (sel res_lower.err) {
+        ret res[of.ObjectImage, fail.Fail].err{res_lower.err};
     }
-    var mir_module: mir.MirModule = R.unwrap_ok[mir.MirModule, str](res_lower);
+    var mir_module: mir.MirModule = res_lower.ok;
 
     if (isa.emits_whole_module(tgt.isa)) {
-        val res_whole: R.Result[of.ObjectImage, str] = whole_module_image(s, tgt, irmod, ?mir_module, deps);
+        val res_whole: res[of.ObjectImage, fail.Fail] = whole_module_image(s, tgt, irmod, ?mir_module, deps);
         mir.dnit_module(?mir_module);
-        ret fail.lift[of.ObjectImage](res_whole);
+        ret res_whole;
     }
 
-    val res_looprotate: R.Result[R.Void, str] = looprotate.run(tgt, ?mir_module);
-    if (R.is_err[R.Void, str](res_looprotate)) {
+    val res_looprotate: err[fail.Fail] = looprotate.run(tgt, ?mir_module);
+    if (sel res_looprotate.err) {
         mir.dnit_module(?mir_module);
-        ret R.err[of.ObjectImage, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_looprotate)));
+        ret res[of.ObjectImage, fail.Fail].err{res_looprotate.err};
     }
 
-    val res_ctvalidate: R.Result[R.Void, str] = ctvalidate.run(tgt, ?mir_module);
-    if (R.is_err[R.Void, str](res_ctvalidate)) {
+    val res_ctvalidate: err[fail.Fail] = ctvalidate.validate(tgt, ?mir_module);
+    if (sel res_ctvalidate.err) {
         mir.dnit_module(?mir_module);
-        ret R.err[of.ObjectImage, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_ctvalidate)));
+        ret res[of.ObjectImage, fail.Fail].err{res_ctvalidate.err};
     }
 
-    val res_legalize: R.Result[R.Void, str] = legalize.run(tgt, ?mir_module);
-    if (R.is_err[R.Void, str](res_legalize)) {
+    val res_legalize: err[fail.Fail] = legalize.run(tgt, ?mir_module);
+    if (sel res_legalize.err) {
         mir.dnit_module(?mir_module);
-        ret R.err[of.ObjectImage, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_legalize)));
+        ret res[of.ObjectImage, fail.Fail].err{res_legalize.err};
     }
 
-    val res_isel: R.Result[R.Void, str] = isel.run(tgt, ?mir_module);
-    if (R.is_err[R.Void, str](res_isel)) {
+    val res_isel: err[fail.Fail] = isel.run(tgt, ?mir_module);
+    if (sel res_isel.err) {
         mir.dnit_module(?mir_module);
-        ret R.err[of.ObjectImage, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_isel)));
+        ret res[of.ObjectImage, fail.Fail].err{res_isel.err};
     }
 
-    val res_regalloc: R.Result[R.Void, str] = regalloc.run(tgt, ?mir_module);
-    if (R.is_err[R.Void, str](res_regalloc)) {
+    val res_regalloc: err[fail.Fail] = regalloc.run(tgt, ?mir_module);
+    if (sel res_regalloc.err) {
         mir.dnit_module(?mir_module);
-        ret R.err[of.ObjectImage, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_regalloc)));
+        ret res[of.ObjectImage, fail.Fail].err{res_regalloc.err};
     }
 
-    val res_order: R.Result[R.Void, str] = compute_emission_order_module(?mir_module, tgt, resolve_placement_policy(placement_policy));
-    if (R.is_err[R.Void, str](res_order)) {
+    val res_order: err[fail.Fail] = compute_emission_order_module(?mir_module, tgt, resolve_placement_policy(placement_policy));
+    if (sel res_order.err) {
         mir.dnit_module(?mir_module);
-        ret R.err[of.ObjectImage, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_order)));
+        ret res[of.ObjectImage, fail.Fail].err{res_order.err};
     }
 
-    val res_frame: R.Result[R.Void, str] = frame.run(tgt, ?mir_module);
-    if (R.is_err[R.Void, str](res_frame)) {
+    val res_frame: err[fail.Fail] = frame.run(tgt, ?mir_module);
+    if (sel res_frame.err) {
         mir.dnit_module(?mir_module);
-        ret R.err[of.ObjectImage, fail.Fail](fail.message(R.unwrap_err[R.Void, str](res_frame)));
+        ret res[of.ObjectImage, fail.Fail].err{res_frame.err};
     }
 
-    val res_encode: R.Result[encode.EncoderOutput, str] = encode.run(tgt, ?mir_module, asm_out);
-    if (R.is_err[encode.EncoderOutput, str](res_encode)) {
+    val res_encode: res[encode.EncoderOutput, fail.Fail] = encode.run(tgt, ?mir_module, asm_out);
+    if (sel res_encode.err) {
         mir.dnit_module(?mir_module);
-        ret R.err[of.ObjectImage, fail.Fail](fail.message(R.unwrap_err[encode.EncoderOutput, str](res_encode)));
+        ret res[of.ObjectImage, fail.Fail].err{res_encode.err};
     }
-    val enc: encode.EncoderOutput = R.unwrap_ok[encode.EncoderOutput, str](res_encode);
+    val enc: encode.EncoderOutput = res_encode.ok;
 
-    val res_pack: R.Result[of.ObjectImage, str] = pack_image(s, tgt, irmod, ?mir_module, ?enc, dbg);
+    val res_pack: res[of.ObjectImage, fail.Fail] = pack_image(s, tgt, irmod, ?mir_module, ?enc, dbg);
     mir.dnit_module(?mir_module);
-    ret fail.lift[of.ObjectImage](res_pack);
+    ret res_pack;
 }
 
 fun whole_module_image(s: *CodegenContext, tgt: *target.Target, irmod: *ir.Module,
-                       mirmod: *mir.MirModule, deps: unit.IrSet) R.Result[of.ObjectImage, str] {
+                       mirmod: *mir.MirModule, deps: unit.IrSet) res[of.ObjectImage, fail.Fail] {
     var u: unit.Unit;
-    val ru: R.Result[R.Void, str] = unit.init(s.alloc, deps.len + 1, ?u);
-    if (R.is_err[R.Void, str](ru)) { ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](ru)); }
+    val ru: err[fail.Fail] = unit.init(s.alloc, deps.len + 1, ?u);
+    if (sel ru.err) { ret res[of.ObjectImage, fail.Fail].err{ru.err}; }
     u.root = 0;
     u.mods[0].ir  = irmod;
     u.mods[0].mir = mirmod;
@@ -215,20 +227,20 @@ fun whole_module_image(s: *CodegenContext, tgt: *target.Target, irmod: *ir.Modul
     var i: u32 = 0;
     for (i < deps.len) {
         val dm: *ir.Module = deps.mods[i];
-        val rd: R.Result[mir.MirModule, str] = lower.lower_ir(tgt, dm, s.alloc, ?s.session.interner, ?s.session.sources);
-        if (R.is_err[mir.MirModule, str](rd)) {
+        val rd: res[mir.MirModule, fail.Fail] = lower.lower_module(tgt, dm, s.alloc, ?s.session.interner, ?s.session.sources);
+        if (sel rd.err) {
             unit_release(s, ?u, i);
-            ret R.err[of.ObjectImage, str](R.unwrap_err[mir.MirModule, str](rd));
+            ret res[of.ObjectImage, fail.Fail].err{rd.err};
         }
-        val rb: R.Result[*mir.MirModule, str] = A.allocate[mir.MirModule](s.alloc, 1::usize);
-        if (R.is_err[*mir.MirModule, str](rb)) {
-            var dead: mir.MirModule = R.unwrap_ok[mir.MirModule, str](rd);
+        val rb: res[*mir.MirModule, A.Error] = A.allocate[mir.MirModule](s.alloc, 1::usize);
+        if (sel rb.err) {
+            var dead: mir.MirModule = rd.ok;
             mir.dnit_module(?dead);
             unit_release(s, ?u, i);
-            ret R.err[of.ObjectImage, str](R.unwrap_err[*mir.MirModule, str](rb));
+            ret res[of.ObjectImage, fail.Fail].err{fail.refused(rb.err)};
         }
-        val box: *mir.MirModule = R.unwrap_ok[*mir.MirModule, str](rb);
-        box[0] = R.unwrap_ok[mir.MirModule, str](rd);
+        val box: *mir.MirModule = rb.ok;
+        box[0] = rd.ok;
         u.mods[i + 1].ir  = dm;
         u.mods[i + 1].mir = box;
         i = i + 1;
@@ -236,15 +248,15 @@ fun whole_module_image(s: *CodegenContext, tgt: *target.Target, irmod: *ir.Modul
 
     i = 0;
     for (i < u.len) {
-        val res_ct: R.Result[R.Void, str] = ctvalidate.run(tgt, u.mods[i].mir);
-        if (R.is_err[R.Void, str](res_ct)) {
+        val res_ct: err[fail.Fail] = ctvalidate.validate(tgt, u.mods[i].mir);
+        if (sel res_ct.err) {
             unit_release(s, ?u, deps.len);
-            ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](res_ct));
+            ret res[of.ObjectImage, fail.Fail].err{res_ct.err};
         }
         i = i + 1;
     }
 
-    val img: R.Result[of.ObjectImage, str] = emit_spirv_image(s, tgt, irmod, ?u);
+    val img: res[of.ObjectImage, fail.Fail] = emit_spirv_image(s, tgt, irmod, ?u);
     unit_release(s, ?u, deps.len);
     ret img;
 }
@@ -258,20 +270,20 @@ pub fun resolve_placement_policy(requested: u32) u32 {
     ret requested;
 }
 
-fun compute_emission_order_module(m: *mir.MirModule, tgt: *target.Target, policy: u32) R.Result[R.Void, str] {
-    if (policy != PLACEMENT_POLICY_VERSION) { ret R.err[R.Void, str]("codegen: unknown placement policy version"); }
+fun compute_emission_order_module(m: *mir.MirModule, tgt: *target.Target, policy: u32) err[fail.Fail] {
+    if (policy != PLACEMENT_POLICY_VERSION) { ret err[fail.Fail].err{fail.message("codegen: unknown placement policy version")}; }
     var fi: u32 = 0;
     for (fi < m.function_len) {
         val f: *mir.MirFunction = ?m.functions[fi];
         if (f.block_count > 0) {
-            val co: R.Result[R.Void, str] = compute_emission_order(m.alloc, f);
-            if (R.is_err[R.Void, str](co)) { ret co; }
-            val pp: R.Result[R.Void, str] = apply_placement_policy(m.alloc, f, tgt);
-            if (R.is_err[R.Void, str](pp)) { ret pp; }
+            val co: err[fail.Fail] = compute_emission_order(m.alloc, f);
+            if (sel co.err) { ret co; }
+            val pp: err[fail.Fail] = apply_placement_policy(m.alloc, f, tgt);
+            if (sel pp.err) { ret pp; }
         }
         fi = fi + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun block_is_trap_terminated(f: *mir.MirFunction, block_idx: u32, tgt: *target.Target) bool {
@@ -282,20 +294,20 @@ fun block_is_trap_terminated(f: *mir.MirFunction, block_idx: u32, tgt: *target.T
     ret tgt.arch.is_trap_terminator(term.opcode::u32);
 }
 
-fun apply_placement_policy(alloc: *A.Allocator, f: *mir.MirFunction, tgt: *target.Target) R.Result[R.Void, str] {
+fun apply_placement_policy(alloc: *A.Allocator, f: *mir.MirFunction, tgt: *target.Target) err[fail.Fail] {
     val n: u32 = f.block_count;
-    if (n <= 1) { ret R.ok_void[str](); }
+    if (n <= 1) { ret err[fail.Fail].ok{}; }
 
-    val rh: R.Result[*u32, str] = A.allocate[u32](alloc, n::usize);
-    if (R.is_err[*u32, str](rh)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](rh)); }
-    val hot: *u32 = R.unwrap_ok[*u32, str](rh);
+    val rh: res[*u32, A.Error] = A.allocate[u32](alloc, n::usize);
+    if (sel rh.err) { ret err[fail.Fail].err{fail.refused(rh.err)}; }
+    val hot: *u32 = rh.ok;
 
-    val rc: R.Result[*u32, str] = A.allocate[u32](alloc, n::usize);
-    if (R.is_err[*u32, str](rc)) {
+    val rc: res[*u32, A.Error] = A.allocate[u32](alloc, n::usize);
+    if (sel rc.err) {
         A.deallocate[u32](alloc, hot, n::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](rc));
+        ret err[fail.Fail].err{fail.refused(rc.err)};
     }
-    val cold: *u32 = R.unwrap_ok[*u32, str](rc);
+    val cold: *u32 = rc.ok;
 
     var hot_n:  u32 = 0;
     var cold_n: u32 = 0;
@@ -321,10 +333,10 @@ fun apply_placement_policy(alloc: *A.Allocator, f: *mir.MirFunction, tgt: *targe
 
     A.deallocate[u32](alloc, hot, n::usize);
     A.deallocate[u32](alloc, cold, n::usize);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun compute_emission_order(alloc: *A.Allocator, f: *mir.MirFunction) R.Result[R.Void, str] {
+fun compute_emission_order(alloc: *A.Allocator, f: *mir.MirFunction) err[fail.Fail] {
     val n: u32 = f.block_count;
 
     var max_id: u32 = 0;
@@ -334,61 +346,61 @@ fun compute_emission_order(alloc: *A.Allocator, f: *mir.MirFunction) R.Result[R.
         mi = mi + 1;
     }
     val idx_cap: u32 = max_id + 1;
-    val ri: R.Result[*u32, str] = A.allocate[u32](alloc, idx_cap::usize);
-    if (R.is_err[*u32, str](ri)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](ri)); }
-    val idx: *u32 = R.unwrap_ok[*u32, str](ri);
+    val ri: res[*u32, A.Error] = A.allocate[u32](alloc, idx_cap::usize);
+    if (sel ri.err) { ret err[fail.Fail].err{fail.refused(ri.err)}; }
+    val idx: *u32 = ri.ok;
     var j: u32 = 0;
     for (j < idx_cap) { idx[j] = EMIT_ORDER_NIL; j = j + 1; }
     var k: u32 = 0;
     for (k < n) { idx[f.blocks[k].id] = k; k = k + 1; }
 
-    val rv: R.Result[*bool, str] = A.allocate[bool](alloc, n::usize);
-    if (R.is_err[*bool, str](rv)) {
+    val rv: res[*bool, A.Error] = A.allocate[bool](alloc, n::usize);
+    if (sel rv.err) {
         A.deallocate[u32](alloc, idx, idx_cap::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*bool, str](rv));
+        ret err[fail.Fail].err{fail.refused(rv.err)};
     }
-    val visited: *bool = R.unwrap_ok[*bool, str](rv);
+    val visited: *bool = rv.ok;
     var i: u32 = 0;
     for (i < n) { visited[i] = false; i = i + 1; }
 
-    val rs: R.Result[*u32, str] = A.allocate[u32](alloc, n::usize);
-    if (R.is_err[*u32, str](rs)) {
+    val rs: res[*u32, A.Error] = A.allocate[u32](alloc, n::usize);
+    if (sel rs.err) {
         A.deallocate[u32](alloc, idx, idx_cap::usize);
         A.deallocate[bool](alloc, visited, n::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](rs));
+        ret err[fail.Fail].err{fail.refused(rs.err)};
     }
-    val stack: *u32 = R.unwrap_ok[*u32, str](rs);
+    val stack: *u32 = rs.ok;
 
-    val re: R.Result[*u32, str] = A.allocate[u32](alloc, n::usize);
-    if (R.is_err[*u32, str](re)) {
+    val re: res[*u32, A.Error] = A.allocate[u32](alloc, n::usize);
+    if (sel re.err) {
         A.deallocate[u32](alloc, idx, idx_cap::usize);
         A.deallocate[bool](alloc, visited, n::usize);
         A.deallocate[u32](alloc, stack, n::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](re));
+        ret err[fail.Fail].err{fail.refused(re.err)};
     }
-    val succ_ix: *u32 = R.unwrap_ok[*u32, str](re);
+    val succ_ix: *u32 = re.ok;
 
-    val rp: R.Result[*u32, str] = A.allocate[u32](alloc, n::usize);
-    if (R.is_err[*u32, str](rp)) {
+    val rp: res[*u32, A.Error] = A.allocate[u32](alloc, n::usize);
+    if (sel rp.err) {
         A.deallocate[u32](alloc, idx, idx_cap::usize);
         A.deallocate[bool](alloc, visited, n::usize);
         A.deallocate[u32](alloc, stack, n::usize);
         A.deallocate[u32](alloc, succ_ix, n::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](rp));
+        ret err[fail.Fail].err{fail.refused(rp.err)};
     }
-    val post: *u32 = R.unwrap_ok[*u32, str](rp);
+    val post: *u32 = rp.ok;
     var post_count: u32 = 0;
 
-    val ro: R.Result[*u32, str] = A.allocate[u32](alloc, n::usize);
-    if (R.is_err[*u32, str](ro)) {
+    val ro: res[*u32, A.Error] = A.allocate[u32](alloc, n::usize);
+    if (sel ro.err) {
         A.deallocate[u32](alloc, idx, idx_cap::usize);
         A.deallocate[bool](alloc, visited, n::usize);
         A.deallocate[u32](alloc, stack, n::usize);
         A.deallocate[u32](alloc, succ_ix, n::usize);
         A.deallocate[u32](alloc, post, n::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](ro));
+        ret err[fail.Fail].err{fail.refused(ro.err)};
     }
-    val order: *u32 = R.unwrap_ok[*u32, str](ro);
+    val order: *u32 = ro.ok;
 
     var sp: u32 = 0;
     stack[0]    = 0;
@@ -435,7 +447,7 @@ fun compute_emission_order(alloc: *A.Allocator, f: *mir.MirFunction) R.Result[R.
     A.deallocate[u32](alloc, post, n::usize);
 
     f.emit_order = order;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun emission_next_unvisited_succ(f: *mir.MirFunction, b: u32, six: *u32, visited: *bool,
@@ -476,31 +488,31 @@ fun unit_release(s: *CodegenContext, u: *unit.Unit, n: u32) {
     unit.dnit(s.alloc, u);
 }
 
-fun finish_codegen_image(image: of.ObjectImage) R.Result[of.ObjectImage, str] {
+fun finish_codegen_image(image: of.ObjectImage) res[of.ObjectImage, fail.Fail] {
     val valid: R.Result[R.Void, str] = of.validate_owned_object_or_dnit(?image);
     if (R.is_err[R.Void, str](valid)) {
-        ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](valid));
+        ret res[of.ObjectImage, fail.Fail].err{fail.message(R.unwrap_err[R.Void, str](valid))};
     }
-    ret R.ok[of.ObjectImage, str](image);
+    ret res[of.ObjectImage, fail.Fail].ok{image};
 }
 
 fun emit_spirv_image(s: *CodegenContext, tgt: *target.Target, irmod: *ir.Module,
-                     u: *unit.Unit) R.Result[of.ObjectImage, str] {
+                     u: *unit.Unit) res[of.ObjectImage, fail.Fail] {
     var bytes: *u8 = nil;
     var len:   u32 = 0;
     var backend_target: isa.BackendTarget = resolved.backend_target(tgt);
     val r: R.Result[R.Void, str] = tgt.isa.emitter.emit_module(s.alloc, ?backend_target, u, ?bytes, ?len);
-    if (R.is_err[R.Void, str](r)) { ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](r)); }
+    if (R.is_err[R.Void, str](r)) { ret res[of.ObjectImage, fail.Fail].err{fail.message(R.unwrap_err[R.Void, str](r))}; }
 
-    val res_image: R.Result[of.ObjectImage, str] = obj.init(s.alloc, ?s.session.interner, irmod.name);
-    if (R.is_err[of.ObjectImage, str](res_image)) { ret res_image; }
-    var image: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](res_image);
+    val res_image: res[of.ObjectImage, fail.Fail] = obj.image_init(s.alloc, ?s.session.interner, irmod.name);
+    if (sel res_image.err) { ret res_image; }
+    var image: of.ObjectImage = res_image.ok;
 
     val res_name: R.Result[intern.StrId, str] = intern.intern(?s.session.interner, ".spirv");
     if (R.is_err[intern.StrId, str](res_name)) {
         if (bytes != nil && len > 0) { A.deallocate[u8](s.alloc, bytes, len::usize); }
         obj.dnit(?image);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[intern.StrId, str](res_name));
+        ret res[of.ObjectImage, fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](res_name))};
     }
     var sec: of.Section;
     sec.name  = R.unwrap_ok[intern.StrId, str](res_name);
@@ -509,17 +521,17 @@ fun emit_spirv_image(s: *CodegenContext, tgt: *target.Target, irmod: *ir.Module,
     sec.len   = len;
     sec.align = 4;
     sec.flags = 0;
-    val res_sec: R.Result[u32, str] = obj.install_section(?image, ?sec);
-    if (R.is_err[u32, str](res_sec)) {
+    val res_sec: res[u32, fail.Fail] = obj.section_install(?image, ?sec);
+    if (sel res_sec.err) {
         obj.dnit(?image);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[u32, str](res_sec));
+        ret res[of.ObjectImage, fail.Fail].err{res_sec.err};
     }
     ret finish_codegen_image(image);
 }
 
-pub fun prepare_debug_types(s: *session.Session) R.Result[R.Void, str] {
+pub fun prepare_debug(s: *session.Session) err[fail.Fail] {
     if (s == nil) {
-        ret R.err[R.Void, str]("codegen: cannot prepare debug types without a session");
+        ret err[fail.Fail].err{fail.message("codegen: cannot prepare debug types without a session")};
     }
     var tid: u32 = 0;
     for (tid < semtype.type_count(?s.types)) {
@@ -528,16 +540,22 @@ pub fun prepare_debug_types(s: *session.Session) R.Result[R.Void, str] {
         if (O.is_some[*semtype.Type](ot)
             && O.unwrap[*semtype.Type](ot).kind == semtype.TYPE_INSTANCE) {
             val prepared: R.Result[R.Void, str] = generics.ensure_fields(s, type_id);
-            if (R.is_err[R.Void, str](prepared)) { ret prepared; }
+            if (R.is_err[R.Void, str](prepared)) { ret fail.lift_err(prepared); }
             val oft: O.Option[*semtype.FieldTable] = semtype.field_table_for(?s.types, type_id);
             if (O.is_none[*semtype.FieldTable](oft)
                 || O.unwrap[*semtype.FieldTable](oft).epoch != semtype.field_epoch(?s.types)) {
-                ret R.err[R.Void, str]("codegen: failed to finalize generic type fields for debug production");
+                ret err[fail.Fail].err{fail.message("codegen: failed to finalize generic type fields for debug production")};
             }
         }
         tid = tid + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
+}
+
+# translation shim (#3226): the legacy carrier the driver reads until its
+# call sites migrate to `prepare_debug`
+pub fun prepare_debug_types(s: *session.Session) R.Result[R.Void, str] {
+    ret fail.lower_unit(prepare_debug(s));
 }
 
 fun debug_types_ready(s: *session.Session) bool {
@@ -599,27 +617,27 @@ fun encoder_output_dnit(s: *CodegenContext, enc: *encode.EncoderOutput) {
 }
 
 fun pack_image(s: *CodegenContext, tgt: *target.Target, irmod: *ir.Module,
-               mirmod: *mir.MirModule, enc: *encode.EncoderOutput, dbg: DebugInfo) R.Result[of.ObjectImage, str] {
-    val res_output: R.Result[R.Void, str] = validate_encoder_output(?s.session.interner, s.alloc, enc);
-    if (R.is_err[R.Void, str](res_output)) {
+               mirmod: *mir.MirModule, enc: *encode.EncoderOutput, dbg: DebugInfo) res[of.ObjectImage, fail.Fail] {
+    val res_output: err[fail.Fail] = validate_encoder_output(?s.session.interner, s.alloc, enc);
+    if (sel res_output.err) {
         encoder_output_dnit(s, enc);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](res_output));
+        ret res[of.ObjectImage, fail.Fail].err{res_output.err};
     }
 
-    val res_layout: R.Result[TextLayout, str] = build_text_layout(s, irmod, enc);
-    if (R.is_err[TextLayout, str](res_layout)) {
+    val res_layout: res[TextLayout, fail.Fail] = build_text_layout(s, irmod, enc);
+    if (sel res_layout.err) {
         encoder_output_dnit(s, enc);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[TextLayout, str](res_layout));
+        ret res[of.ObjectImage, fail.Fail].err{res_layout.err};
     }
-    var text_layout: TextLayout = R.unwrap_ok[TextLayout, str](res_layout);
+    var text_layout: TextLayout = res_layout.ok;
 
-    val res_image: R.Result[of.ObjectImage, str] = obj.init(s.alloc, ?s.session.interner, irmod.name);
-    if (R.is_err[of.ObjectImage, str](res_image)) {
+    val res_image: res[of.ObjectImage, fail.Fail] = obj.image_init(s.alloc, ?s.session.interner, irmod.name);
+    if (sel res_image.err) {
         text_layout_dnit(s, ?text_layout);
         encoder_output_dnit(s, enc);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[of.ObjectImage, str](res_image));
+        ret res[of.ObjectImage, fail.Fail].err{res_image.err};
     }
-    var image: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](res_image);
+    var image: of.ObjectImage = res_image.ok;
 
     image.machine_flags = isa.machine_flags(tgt.isa, tgt.abi.float_arg_bits, false);
 
@@ -630,95 +648,95 @@ fun pack_image(s: *CodegenContext, tgt: *target.Target, irmod: *ir.Module,
         text_layout_dnit(s, ?text_layout);
         encoder_output_dnit(s, enc);
         obj.dnit(?image);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[*u8, str](attr_r));
+        ret res[of.ObjectImage, fail.Fail].err{fail.message(R.unwrap_err[*u8, str](attr_r))};
     }
     image.attributes = R.unwrap_ok[*u8, str](attr_r);
     image.attributes_len = attr_len;
 
-    val res_sections: R.Result[R.Void, str] = apply_text_layout(s, ?image, enc, ?text_layout);
-    if (R.is_err[R.Void, str](res_sections)) {
+    val res_sections: err[fail.Fail] = apply_text_layout(s, ?image, enc, ?text_layout);
+    if (sel res_sections.err) {
         text_layout_dnit(s, ?text_layout);
         encoder_output_dnit(s, enc);
         obj.dnit(?image);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](res_sections));
+        ret res[of.ObjectImage, fail.Fail].err{res_sections.err};
     }
 
-    val res_text: R.Result[u32, str] = pack_text(s, ?image, enc, ?text_layout);
-    if (R.is_err[u32, str](res_text)) {
+    val res_text: res[u32, fail.Fail] = pack_text(s, ?image, enc, ?text_layout);
+    if (sel res_text.err) {
         text_layout_dnit(s, ?text_layout);
         encoder_output_dnit(s, enc);
         obj.dnit(?image);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[u32, str](res_text));
+        ret res[of.ObjectImage, fail.Fail].err{res_text.err};
     }
-    val text_sec: u32 = R.unwrap_ok[u32, str](res_text);
+    val text_sec: u32 = res_text.ok;
     text_layout.text_sec = text_sec;
 
-    val res_symbols: R.Result[R.Void, str] = pack_symbols(?image, irmod, enc, ?text_layout);
-    if (R.is_err[R.Void, str](res_symbols)) {
+    val res_symbols: err[fail.Fail] = pack_symbols(?image, irmod, enc, ?text_layout);
+    if (sel res_symbols.err) {
         text_layout_dnit(s, ?text_layout);
         encoder_output_dnit(s, enc);
         obj.dnit(?image);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](res_symbols));
+        ret res[of.ObjectImage, fail.Fail].err{res_symbols.err};
     }
 
-    val res_frames: R.Result[R.Void, str] = pack_frames(?image, enc, ?text_layout);
-    if (R.is_err[R.Void, str](res_frames)) {
+    val res_frames: err[fail.Fail] = pack_frames(?image, enc, ?text_layout);
+    if (sel res_frames.err) {
         text_layout_dnit(s, ?text_layout);
         encoder_output_dnit(s, enc);
         obj.dnit(?image);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](res_frames));
+        ret res[of.ObjectImage, fail.Fail].err{res_frames.err};
     }
 
     var deferred: obj.DeferredRelocs = obj.deferred_init(s.alloc);
 
-    val res_relocs: R.Result[R.Void, str] = pack_relocs(tgt, ?deferred, enc, ?text_layout);
-    if (R.is_err[R.Void, str](res_relocs)) {
+    val res_relocs: err[fail.Fail] = pack_relocs(tgt, ?deferred, enc, ?text_layout);
+    if (sel res_relocs.err) {
         text_layout_dnit(s, ?text_layout);
         obj.deferred_dnit(?deferred);
         encoder_output_dnit(s, enc);
         obj.dnit(?image);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](res_relocs));
+        ret res[of.ObjectImage, fail.Fail].err{res_relocs.err};
     }
     pack_rows(enc, ?text_layout);
     text_layout_dnit(s, ?text_layout);
 
-    val res_globals: R.Result[R.Void, str] = pack_globals(s, tgt, ?image, ?deferred, irmod);
-    if (R.is_err[R.Void, str](res_globals)) {
+    val res_globals: err[fail.Fail] = pack_globals(s, tgt, ?image, ?deferred, irmod);
+    if (sel res_globals.err) {
         obj.deferred_dnit(?deferred);
         encoder_output_dnit(s, enc);
         obj.dnit(?image);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](res_globals));
+        ret res[of.ObjectImage, fail.Fail].err{res_globals.err};
     }
 
-    val res_pool: R.Result[R.Void, str] = pack_constpool(s, ?image, enc);
+    val res_pool: err[fail.Fail] = pack_constpool(s, ?image, enc);
     encode.consts_free(s.alloc, enc.consts, enc.const_count, enc.const_count);
     enc.consts      = nil;
     enc.const_count = 0;
-    if (R.is_err[R.Void, str](res_pool)) {
+    if (sel res_pool.err) {
         obj.deferred_dnit(?deferred);
         encoder_output_dnit(s, enc);
         obj.dnit(?image);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](res_pool));
+        ret res[of.ObjectImage, fail.Fail].err{res_pool.err};
     }
 
-    val res_bind: R.Result[R.Void, str] = obj.flush_deferred(?image, ?deferred);
+    val res_bind: err[fail.Fail] = obj.flush_deferred(?image, ?deferred);
     obj.deferred_dnit(?deferred);
-    if (R.is_err[R.Void, str](res_bind)) {
+    if (sel res_bind.err) {
         encoder_output_dnit(s, enc);
         obj.dnit(?image);
-        ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](res_bind));
+        ret res[of.ObjectImage, fail.Fail].err{res_bind.err};
     }
 
     if (dbg.emit && tgt.debug != nil) {
         if (tgt.debug.produce == nil) {
             encoder_output_dnit(s, enc);
             obj.dnit(?image);
-            ret R.err[of.ObjectImage, str]("codegen: debug producer registered no produce hook");
+            ret res[of.ObjectImage, fail.Fail].err{fail.message("codegen: debug producer registered no produce hook")};
         }
         if (!debug_types_ready(s.session)) {
             encoder_output_dnit(s, enc);
             obj.dnit(?image);
-            ret R.err[of.ObjectImage, str]("codegen: debug type view was not finalized before code generation");
+            ret res[of.ObjectImage, fail.Fail].err{fail.message("codegen: debug type view was not finalized before code generation")};
         }
         var req: of.DebugProduceRequest;
         req.program.alloc         = s.alloc;
@@ -749,7 +767,7 @@ fun pack_image(s: *CodegenContext, tgt: *target.Target, irmod: *ir.Module,
         if (R.is_err[R.Void, str](res_dwarf)) {
             encoder_output_dnit(s, enc);
             obj.dnit(?image);
-            ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](res_dwarf));
+            ret res[of.ObjectImage, fail.Fail].err{fail.message(R.unwrap_err[R.Void, str](res_dwarf))};
         }
     }
 
@@ -758,10 +776,10 @@ fun pack_image(s: *CodegenContext, tgt: *target.Target, irmod: *ir.Module,
 }
 
 fun pack_text(s: *CodegenContext, image: *of.ObjectImage, enc: *encode.EncoderOutput,
-              text_layout: *TextLayout) R.Result[u32, str] {
+              text_layout: *TextLayout) res[u32, fail.Fail] {
     val res_name: R.Result[intern.StrId, str] = intern.intern(?s.session.interner, ".text");
     if (R.is_err[intern.StrId, str](res_name)) {
-        ret R.err[u32, str](R.unwrap_err[intern.StrId, str](res_name));
+        ret res[u32, fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](res_name))};
     }
 
     var sec: of.Section;
@@ -773,7 +791,7 @@ fun pack_text(s: *CodegenContext, image: *of.ObjectImage, enc: *encode.EncoderOu
     if (text_layout.placement_count == 0) {
         sec.bytes = enc.text;
         sec.len   = enc.text_len;
-        val res_add: R.Result[u32, str] = obj.install_section(image, ?sec);
+        val res_add: res[u32, fail.Fail] = obj.section_install(image, ?sec);
         enc.text     = nil;
         enc.text_len = 0;
         ret res_add;
@@ -785,14 +803,14 @@ fun pack_text(s: *CodegenContext, image: *of.ObjectImage, enc: *encode.EncoderOu
         sec.len   = 0;
     }
     or {
-        val res_buf: R.Result[*u8, str] = A.allocate[u8](s.alloc, new_len::usize);
-        if (R.is_err[*u8, str](res_buf)) {
+        val res_buf: res[*u8, A.Error] = A.allocate[u8](s.alloc, new_len::usize);
+        if (sel res_buf.err) {
             A.deallocate[u8](s.alloc, enc.text, enc.text_len::usize);
             enc.text     = nil;
             enc.text_len = 0;
-            ret R.err[u32, str](R.unwrap_err[*u8, str](res_buf));
+            ret res[u32, fail.Fail].err{fail.refused(res_buf.err)};
         }
-        val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
+        val buf: *u8 = res_buf.ok;
 
         var write_pos: u32 = 0;
         var prev_end:  u32 = 0;
@@ -811,7 +829,7 @@ fun pack_text(s: *CodegenContext, image: *of.ObjectImage, enc: *encode.EncoderOu
             A.deallocate[u8](s.alloc, enc.text, enc.text_len::usize);
             enc.text     = nil;
             enc.text_len = 0;
-            ret R.err[u32, str]("codegen: text layout copy did not match its planned extent");
+            ret res[u32, fail.Fail].err{fail.message("codegen: text layout copy did not match its planned extent")};
         }
 
         sec.bytes = buf;
@@ -821,12 +839,12 @@ fun pack_text(s: *CodegenContext, image: *of.ObjectImage, enc: *encode.EncoderOu
     A.deallocate[u8](s.alloc, enc.text, enc.text_len::usize);
     enc.text     = nil;
     enc.text_len = 0;
-    val res_add: R.Result[u32, str] = obj.install_section(image, ?sec);
+    val res_add: res[u32, fail.Fail] = obj.section_install(image, ?sec);
     ret res_add;
 }
 
 fun pack_symbols(image: *of.ObjectImage, irmod: *ir.Module,
-                 enc: *encode.EncoderOutput, text_layout: *TextLayout) R.Result[R.Void, str] {
+                 enc: *encode.EncoderOutput, text_layout: *TextLayout) err[fail.Fail] {
     var i: u32 = 0;
     for (i < enc.symbol_count) {
         val mark: *encode.SymbolMark = ?enc.symbols[i];
@@ -850,32 +868,32 @@ fun pack_symbols(image: *of.ObjectImage, irmod: *ir.Module,
         sym.fallback = of.SYMBOL_NONE;
         sym.align    = 1;
 
-        val res_sym: R.Result[u32, str] = obj.add_symbol(image, sym);
-        if (R.is_err[u32, str](res_sym)) {
-            ret R.err[R.Void, str](R.unwrap_err[u32, str](res_sym));
+        val res_sym: res[u32, fail.Fail] = obj.symbol_add(image, sym);
+        if (sel res_sym.err) {
+            ret err[fail.Fail].err{res_sym.err};
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun pack_frames(image: *of.ObjectImage, enc: *encode.EncoderOutput,
-                text_layout: *TextLayout) R.Result[R.Void, str] {
+                text_layout: *TextLayout) err[fail.Fail] {
     var i: u32 = 0;
     for (i < enc.frame_count) {
         val site: PlacedSite = text_layout_place(text_layout, enc.frames[i].offset);
         var fr: of.FrameUnwind = enc.frames[i];
         fr.section = of.section_id(site.sec);
         fr.offset  = site.off;
-        val res_fr: R.Result[R.Void, str] = obj.add_frame(image, ?fr);
-        if (R.is_err[R.Void, str](res_fr)) { ret res_fr; }
+        val res_fr: err[fail.Fail] = obj.add_frame(image, ?fr);
+        if (sel res_fr.err) { ret res_fr; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun pack_relocs(tgt: *target.Target, deferred: *obj.DeferredRelocs, enc: *encode.EncoderOutput,
-                text_layout: *TextLayout) R.Result[R.Void, str] {
+                text_layout: *TextLayout) err[fail.Fail] {
     val batch_base: u32 = deferred.count;
     var i: u32 = 0;
     for (i < enc.reloc_count) {
@@ -893,19 +911,19 @@ fun pack_relocs(tgt: *target.Target, deferred: *obj.DeferredRelocs, enc: *encode
         rec.pair         = 0;
         if (pr.pair != 0) {
             if (pr.pair > enc.reloc_count) {
-                ret R.err[R.Void, str]("codegen: encoder relocation pair index is out of range");
+                ret err[fail.Fail].err{fail.message("codegen: encoder relocation pair index is out of range")};
             }
             rec.pair = batch_base + pr.pair;
         }
 
-        val res_rel: R.Result[R.Void, str] =
+        val res_rel: err[fail.Fail] =
             obj.defer_relocation_for_target(deferred, rec, tgt, of.SK_TEXT, true);
-        if (R.is_err[R.Void, str](res_rel)) {
+        if (sel res_rel.err) {
             ret res_rel;
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun pack_rows(enc: *encode.EncoderOutput, text_layout: *TextLayout) {
@@ -937,16 +955,16 @@ fun pack_rows(enc: *encode.EncoderOutput, text_layout: *TextLayout) {
     }
 }
 
-fun section_bytes_copy(image: *of.ObjectImage, src: *u8, len: u32) R.Result[*u8, str] {
-    if (src == nil || len == 0) { ret R.ok[*u8, str](src); }
-    val res_buf: R.Result[*u8, str] = A.allocate[u8](image.alloc, len::usize);
-    if (R.is_err[*u8, str](res_buf)) { ret res_buf; }
-    val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
+fun section_bytes_copy(image: *of.ObjectImage, src: *u8, len: u32) res[*u8, fail.Fail] {
+    if (src == nil || len == 0) { ret res[*u8, fail.Fail].ok{src}; }
+    val res_buf: res[*u8, A.Error] = A.allocate[u8](image.alloc, len::usize);
+    if (sel res_buf.err) { ret res[*u8, fail.Fail].err{fail.refused(res_buf.err)}; }
+    val buf: *u8 = res_buf.ok;
     memory.raw_copy(buf::ptr, src::ptr, len::usize);
-    ret R.ok[*u8, str](buf);
+    ret res[*u8, fail.Fail].ok{buf};
 }
 
-fun add_global_symbol(image: *of.ObjectImage, g: *ir.Global, sec_idx: u32, sec_len: u32) R.Result[R.Void, str] {
+fun add_global_symbol(image: *of.ObjectImage, g: *ir.Global, sec_idx: u32, sec_len: u32) err[fail.Fail] {
     var flags: u32 = of.SYM_OBJ_FLAG_OBJECT;
     if (!g.is_local) { flags = flags | of.SYM_OBJ_FLAG_GLOBAL; }
 
@@ -959,9 +977,9 @@ fun add_global_symbol(image: *of.ObjectImage, g: *ir.Global, sec_idx: u32, sec_l
     sym.fallback = of.SYMBOL_NONE;
     sym.align    = 1;
 
-    val res: R.Result[u32, str] = obj.add_symbol(image, sym);
-    if (R.is_err[u32, str](res)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res)); }
-    ret R.ok_void[str]();
+    val res: res[u32, fail.Fail] = obj.symbol_add(image, sym);
+    if (sel res.err) { ret err[fail.Fail].err{res.err}; }
+    ret err[fail.Fail].ok{};
 }
 
 fun embed_section_of(image: *of.ObjectImage, irmod: *ir.Module, upto: u32, bytes: *u8, len: u32,
@@ -995,7 +1013,7 @@ fun section_index_of(image: *of.ObjectImage, name: intern.StrId) i64 {
 }
 
 fun pack_globals(s: *CodegenContext, tgt: *target.Target, image: *of.ObjectImage,
-                 deferred: *obj.DeferredRelocs, irmod: *ir.Module) R.Result[R.Void, str] {
+                 deferred: *obj.DeferredRelocs, irmod: *ir.Module) err[fail.Fail] {
     val machine: layout.Machine = resolved.layout_machine(tgt);
     var i: u32 = 0;
     for (i < irmod.global_len) {
@@ -1003,8 +1021,8 @@ fun pack_globals(s: *CodegenContext, tgt: *target.Target, image: *of.ObjectImage
 
         if (g.is_extern) {
             val flags: u32 = of.SYM_OBJ_FLAG_OBJECT | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_GLOBAL;
-            val res_extern: R.Result[R.Void, str] = image_extern_symbol_add(image, g.name, flags);
-            if (R.is_err[R.Void, str](res_extern)) { ret res_extern; }
+            val res_extern: err[fail.Fail] = image_extern_symbol_add(image, g.name, flags);
+            if (sel res_extern.err) { ret res_extern; }
             i = i + 1;
             cnt;
         }
@@ -1012,23 +1030,23 @@ fun pack_globals(s: *CodegenContext, tgt: *target.Target, image: *of.ObjectImage
         var bytes: *u8 = nil;
         var len:   u32 = 0;
         if (g.init.kind == value.VAL_CONST_BYTES) {
-            val res_copy: R.Result[*u8, str] = section_bytes_copy(image, g.init.data.bytes.ptr, g.init.data.bytes.len);
-            if (R.is_err[*u8, str](res_copy)) { ret R.err[R.Void, str](R.unwrap_err[*u8, str](res_copy)); }
-            bytes = R.unwrap_ok[*u8, str](res_copy);
+            val res_copy: res[*u8, fail.Fail] = section_bytes_copy(image, g.init.data.bytes.ptr, g.init.data.bytes.len);
+            if (sel res_copy.err) { ret err[fail.Fail].err{res_copy.err}; }
+            bytes = res_copy.ok;
             len   = g.init.data.bytes.len;
         }
         or (g.init.kind == value.VAL_CONST_AGG) {
-            val res_copy: R.Result[*u8, str] = section_bytes_copy(image, g.init.data.agg.bytes, g.init.data.agg.len);
-            if (R.is_err[*u8, str](res_copy)) { ret R.err[R.Void, str](R.unwrap_err[*u8, str](res_copy)); }
-            bytes = R.unwrap_ok[*u8, str](res_copy);
+            val res_copy: res[*u8, fail.Fail] = section_bytes_copy(image, g.init.data.agg.bytes, g.init.data.agg.len);
+            if (sel res_copy.err) { ret err[fail.Fail].err{res_copy.err}; }
+            bytes = res_copy.ok;
             len   = g.init.data.agg.len;
         }
         or (g.init.kind == value.VAL_CONST_INT || g.init.kind == value.VAL_CONST_FLOAT) {
             val gsz: u32 = type.byte_size_for_machine(?irmod.types, g.ty, machine);
             if (gsz > 0 && gsz <= 8) {
-                val res_bytes: R.Result[*u8, str] = A.allocate[u8](image.alloc, gsz::usize);
-                if (R.is_err[*u8, str](res_bytes)) { ret R.err[R.Void, str](R.unwrap_err[*u8, str](res_bytes)); }
-                bytes = R.unwrap_ok[*u8, str](res_bytes);
+                val res_bytes: res[*u8, A.Error] = A.allocate[u8](image.alloc, gsz::usize);
+                if (sel res_bytes.err) { ret err[fail.Fail].err{fail.refused(res_bytes.err)}; }
+                bytes = res_bytes.ok;
                 var bits: u64 = g.init.data.int_lit;
                 if (g.init.kind == value.VAL_CONST_FLOAT && is_f32_type(?irmod.types, g.ty)) {
                     bits = float.f64_to_f32_bits(bits)::u64;
@@ -1041,7 +1059,7 @@ fun pack_globals(s: *CodegenContext, tgt: *target.Target, image: *of.ObjectImage
                 len = gsz;
             }
             or (g.init.data.int_lit != 0) {
-                ret R.err[R.Void, str]("be.codegen.pack_globals: non-zero scalar constant global initializer has unsupported size (expected 1..8 bytes)");
+                ret err[fail.Fail].err{fail.message("be.codegen.pack_globals: non-zero scalar constant global initializer has unsupported size (expected 1..8 bytes)")};
             }
         }
 
@@ -1066,7 +1084,7 @@ fun pack_globals(s: *CodegenContext, tgt: *target.Target, image: *of.ObjectImage
         if (sec_name == intern.STR_NIL) {
             val res_name: R.Result[intern.StrId, str] = intern.intern(?s.session.interner, sname);
             if (R.is_err[intern.StrId, str](res_name)) {
-                ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](res_name));
+                ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](res_name))};
             }
             sec_name = R.unwrap_ok[intern.StrId, str](res_name);
         }
@@ -1087,8 +1105,8 @@ fun pack_globals(s: *CodegenContext, tgt: *target.Target, image: *of.ObjectImage
                 if (bytes != nil && sec_len > 0) {
                     A.deallocate[u8](image.alloc, bytes, sec_len::usize);
                 }
-                val res_alias: R.Result[R.Void, str] = add_global_symbol(image, g, dup::u32, sec_len);
-                if (R.is_err[R.Void, str](res_alias)) { ret res_alias; }
+                val res_alias: err[fail.Fail] = add_global_symbol(image, g, dup::u32, sec_len);
+                if (sel res_alias.err) { ret res_alias; }
                 i = i + 1;
                 cnt;
             }
@@ -1104,30 +1122,30 @@ fun pack_globals(s: *CodegenContext, tgt: *target.Target, image: *of.ObjectImage
         if (g.is_embed) { sec.flags = of.SEC_FLAG_MERGEABLE; }
         if (g.section == intern.STR_NIL) { sec.flags = sec.flags | of.SEC_FLAG_COALESCE; }
 
-        val res_section: R.Result[u32, str] = obj.install_section(image, ?sec);
-        if (R.is_err[u32, str](res_section)) {
-            ret R.err[R.Void, str](R.unwrap_err[u32, str](res_section));
+        val res_section: res[u32, fail.Fail] = obj.section_install(image, ?sec);
+        if (sel res_section.err) {
+            ret err[fail.Fail].err{res_section.err};
         }
-        val sec_idx: u32 = R.unwrap_ok[u32, str](res_section);
+        val sec_idx: u32 = res_section.ok;
 
-        val res_sym: R.Result[R.Void, str] = add_global_symbol(image, g, sec_idx, sec_len);
-        if (R.is_err[R.Void, str](res_sym)) { ret res_sym; }
+        val res_sym: err[fail.Fail] = add_global_symbol(image, g, sec_idx, sec_len);
+        if (sel res_sym.err) { ret res_sym; }
 
         if (g.init.kind == value.VAL_CONST_AGG) {
-            val res_agg: R.Result[R.Void, str] = pack_agg_relocs(tgt, deferred, ?g.init, sec_idx, tgt.isa.pointer_width);
-            if (R.is_err[R.Void, str](res_agg)) { ret res_agg; }
+            val res_agg: err[fail.Fail] = pack_agg_relocs(tgt, deferred, ?g.init, sec_idx, tgt.isa.pointer_width);
+            if (sel res_agg.err) { ret res_agg; }
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun pack_constpool(s: *CodegenContext, image: *of.ObjectImage, enc: *encode.EncoderOutput) R.Result[R.Void, str] {
-    if (enc.const_count == 0) { ret R.ok_void[str](); }
+fun pack_constpool(s: *CodegenContext, image: *of.ObjectImage, enc: *encode.EncoderOutput) err[fail.Fail] {
+    if (enc.const_count == 0) { ret err[fail.Fail].ok{}; }
 
     val res_name: R.Result[intern.StrId, str] = intern.intern(?s.session.interner, ".rodata.cst");
     if (R.is_err[intern.StrId, str](res_name)) {
-        ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](res_name));
+        ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](res_name))};
     }
     val sec_name: intern.StrId = R.unwrap_ok[intern.StrId, str](res_name);
 
@@ -1135,42 +1153,42 @@ fun pack_constpool(s: *CodegenContext, image: *of.ObjectImage, enc: *encode.Enco
     for (i < enc.const_count) {
         val e: *encode.ConstEntry = ?enc.consts[i];
 
-        val res_copy: R.Result[*u8, str] = section_bytes_copy(image, e.bytes, e.len);
-        if (R.is_err[*u8, str](res_copy)) { ret R.err[R.Void, str](R.unwrap_err[*u8, str](res_copy)); }
+        val res_copy: res[*u8, fail.Fail] = section_bytes_copy(image, e.bytes, e.len);
+        if (sel res_copy.err) { ret err[fail.Fail].err{res_copy.err}; }
 
         var sec: of.Section;
         sec.name  = sec_name;
         sec.kind  = of.SK_RODATA;
-        sec.bytes = R.unwrap_ok[*u8, str](res_copy);
+        sec.bytes = res_copy.ok;
         sec.len   = e.len;
         sec.align = e.align;
         sec.flags = of.SEC_FLAG_MERGEABLE | of.SEC_FLAG_COALESCE;
 
-        val res_sec: R.Result[u32, str] = obj.install_section(image, ?sec);
-        if (R.is_err[u32, str](res_sec)) {
-            ret R.err[R.Void, str](R.unwrap_err[u32, str](res_sec));
+        val res_sec: res[u32, fail.Fail] = obj.section_install(image, ?sec);
+        if (sel res_sec.err) {
+            ret err[fail.Fail].err{res_sec.err};
         }
 
         var sym: of.Symbol;
         sym.name    = e.sym;
-        sym.section = of.section_id(R.unwrap_ok[u32, str](res_sec));
+        sym.section = of.section_id(res_sec.ok);
         sym.offset  = 0;
         sym.size    = e.len;
         sym.flags   = of.SYM_OBJ_FLAG_OBJECT;
         sym.fallback = of.SYMBOL_NONE;
         sym.align    = e.align;
 
-        val res_sym: R.Result[u32, str] = obj.add_symbol(image, sym);
-        if (R.is_err[u32, str](res_sym)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_sym)); }
+        val res_sym: res[u32, fail.Fail] = obj.symbol_add(image, sym);
+        if (sel res_sym.err) { ret err[fail.Fail].err{res_sym.err}; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun pack_agg_relocs(tgt: *target.Target, deferred: *obj.DeferredRelocs, init: *value.Value, sec_idx: u32,
-                    pointer_width: u32) R.Result[R.Void, str] {
+                    pointer_width: u32) err[fail.Fail] {
     val kind_r: R.Result[of.RelocKind, str] = of.abs_kind_for_pointer_width(pointer_width);
-    if (R.is_err[of.RelocKind, str](kind_r)) { ret R.err[R.Void, str](R.unwrap_err[of.RelocKind, str](kind_r)); }
+    if (R.is_err[of.RelocKind, str](kind_r)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[of.RelocKind, str](kind_r))}; }
     val kind: of.RelocKind = R.unwrap_ok[of.RelocKind, str](kind_r);
 
     var i: u32 = 0;
@@ -1189,12 +1207,12 @@ fun pack_agg_relocs(tgt: *target.Target, deferred: *obj.DeferredRelocs, init: *v
         rec.extern_flags = flags;
         rec.pair         = 0;
 
-        val res_rel: R.Result[R.Void, str] =
+        val res_rel: err[fail.Fail] =
             obj.defer_relocation_for_target(deferred, rec, tgt, of.SK_DATA, true);
-        if (R.is_err[R.Void, str](res_rel)) { ret res_rel; }
+        if (sel res_rel.err) { ret res_rel; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun encoder_span_valid[T](items: *T, count: u32) bool {
@@ -1204,8 +1222,8 @@ fun encoder_span_valid[T](items: *T, count: u32) bool {
 # the encoder wrote every member here, so one outside its catalog is internal;
 # the message names the catalog and the tag when the caller owns a diagnostic
 # interner, and still names the catalog when it does not
-fun validate_encoder_output(itn: *intern.Interner, alloc: *A.Allocator, enc: *encode.EncoderOutput) R.Result[R.Void, str] {
-    if (enc == nil) { ret R.err[R.Void, str]("codegen: nil encoder output"); }
+fun validate_encoder_output(itn: *intern.Interner, alloc: *A.Allocator, enc: *encode.EncoderOutput) err[fail.Fail] {
+    if (enc == nil) { ret err[fail.Fail].err{fail.message("codegen: nil encoder output")}; }
     if (!encoder_span_valid[u8](enc.text, enc.text_len)
         || !encoder_span_valid[encode.SymbolMark](enc.symbols, enc.symbol_count)
         || !encoder_span_valid[encode.PendingReloc](enc.relocations, enc.reloc_count)
@@ -1214,13 +1232,13 @@ fun validate_encoder_output(itn: *intern.Interner, alloc: *A.Allocator, enc: *en
         || !encoder_span_valid[encode.InlinePc](enc.inline_pcs, enc.inline_pc_count)
         || !encoder_span_valid[encode.ConstEntry](enc.consts, enc.const_count)
         || !encoder_span_valid[of.FrameUnwind](enc.frames, enc.frame_count)) {
-        ret R.err[R.Void, str]("codegen: encoder output has a noncanonical collection view");
+        ret err[fail.Fail].err{fail.message("codegen: encoder output has a noncanonical collection view")};
     }
     var i: u32 = 0;
     for (i < enc.reloc_count) {
         if (!of.reloc_kind_valid(enc.relocations[i].kind)) {
-            ret R.err[R.Void, str](fail.catalog_message_or(itn, alloc, fail.unknown_member("RelocKind", enc.relocations[i].kind::u32),
-                "codegen: encoder output has an unknown RelocKind"));
+            ret err[fail.Fail].err{fail.message(fail.catalog_message_or(itn, alloc, fail.unknown_member("RelocKind", enc.relocations[i].kind::u32),
+                "codegen: encoder output has an unknown RelocKind"))};
         }
         i = i + 1;
     }
@@ -1228,11 +1246,11 @@ fun validate_encoder_output(itn: *intern.Interner, alloc: *A.Allocator, enc: *en
     for (i < enc.const_count) {
         val e: *encode.ConstEntry = ?enc.consts[i];
         if (e.kind < encode.CONST_F32 || e.kind > encode.CONST_VEC) {
-            ret R.err[R.Void, str](fail.catalog_message_or(itn, alloc, fail.unknown_member("ConstKind", e.kind::u32),
-                "codegen: encoder output has an unknown ConstKind"));
+            ret err[fail.Fail].err{fail.message(fail.catalog_message_or(itn, alloc, fail.unknown_member("ConstKind", e.kind::u32),
+                "codegen: encoder output has an unknown ConstKind"))};
         }
         if (e.bytes == nil || e.len == 0 || e.align == 0 || (e.align & (e.align - 1)) != 0) {
-            ret R.err[R.Void, str]("codegen: encoder output has an invalid constant-pool entry");
+            ret err[fail.Fail].err{fail.message("codegen: encoder output has an invalid constant-pool entry")};
         }
         i = i + 1;
     }
@@ -1240,23 +1258,23 @@ fun validate_encoder_output(itn: *intern.Interner, alloc: *A.Allocator, enc: *en
     for (i < enc.frame_count) {
         val fr: *of.FrameUnwind = ?enc.frames[i];
         if (fr.step_count > of.FRAME_STEP_CAP) {
-            ret R.err[R.Void, str]("codegen: encoder output has too many unwind steps");
+            ret err[fail.Fail].err{fail.message("codegen: encoder output has too many unwind steps")};
         }
         var k: u32 = 0;
         for (k < fr.step_count) {
             if (fr.steps[k].kind < of.FRAME_STEP_PUSH || fr.steps[k].kind > of.FRAME_STEP_SAVE_VEC) {
-                ret R.err[R.Void, str](fail.catalog_message_or(itn, alloc, fail.unknown_member("FrameStepKind", fr.steps[k].kind::u32),
-                    "codegen: encoder output has an unknown FrameStepKind"));
+                ret err[fail.Fail].err{fail.message(fail.catalog_message_or(itn, alloc, fail.unknown_member("FrameStepKind", fr.steps[k].kind::u32),
+                    "codegen: encoder output has an unknown FrameStepKind"))};
             }
             k = k + 1;
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun build_text_layout(s: *CodegenContext, irmod: *ir.Module,
-                      enc: *encode.EncoderOutput) R.Result[TextLayout, str] {
+                      enc: *encode.EncoderOutput) res[TextLayout, fail.Fail] {
     var text_layout: TextLayout;
     text_layout.placements      = nil;
     text_layout.placement_count = 0;
@@ -1265,11 +1283,11 @@ fun build_text_layout(s: *CodegenContext, irmod: *ir.Module,
     text_layout.text_sec        = of.SECTION_EXTERNAL;
 
     if (enc.symbol_count > 0) {
-        val res_buf: R.Result[*SectionPlacement, str] = A.allocate[SectionPlacement](s.alloc, enc.symbol_count::usize);
-        if (R.is_err[*SectionPlacement, str](res_buf)) {
-            ret R.err[TextLayout, str](R.unwrap_err[*SectionPlacement, str](res_buf));
+        val res_buf: res[*SectionPlacement, A.Error] = A.allocate[SectionPlacement](s.alloc, enc.symbol_count::usize);
+        if (sel res_buf.err) {
+            ret res[TextLayout, fail.Fail].err{fail.refused(res_buf.err)};
         }
-        text_layout.placements = R.unwrap_ok[*SectionPlacement, str](res_buf);
+        text_layout.placements = res_buf.ok;
         text_layout.placement_cap = enc.symbol_count;
     }
 
@@ -1279,12 +1297,12 @@ fun build_text_layout(s: *CodegenContext, irmod: *ir.Module,
         if (function_is_defined(irmod, mark.name)) {
             val sname: intern.StrId = function_section_name(irmod, mark.name);
             if (sname != intern.STR_NIL) {
-                val planned: R.Result[R.Void, str] = section_placement_plan(
+                val planned: err[fail.Fail] = section_placement_plan(
                     text_layout.placements, ?text_layout.placement_count, text_layout.placement_cap,
                     sname, mark.offset, mark.size, enc.text_len);
-                if (R.is_err[R.Void, str](planned)) {
+                if (sel planned.err) {
                     text_layout_dnit(s, ?text_layout);
-                    ret R.err[TextLayout, str](R.unwrap_err[R.Void, str](planned));
+                    ret res[TextLayout, fail.Fail].err{planned.err};
                 }
             }
         }
@@ -1297,12 +1315,12 @@ fun build_text_layout(s: *CodegenContext, irmod: *ir.Module,
         text_layout.placement_cap = 0;
     }
 
-    val valid: R.Result[R.Void, str] = validate_text_metadata(?text_layout, enc);
-    if (R.is_err[R.Void, str](valid)) {
+    val valid: err[fail.Fail] = validate_text_metadata(?text_layout, enc);
+    if (sel valid.err) {
         text_layout_dnit(s, ?text_layout);
-        ret R.err[TextLayout, str](R.unwrap_err[R.Void, str](valid));
+        ret res[TextLayout, fail.Fail].err{valid.err};
     }
-    ret R.ok[TextLayout, str](text_layout);
+    ret res[TextLayout, fail.Fail].ok{text_layout};
 }
 
 fun text_layout_dnit(s: *CodegenContext, text_layout: *TextLayout) {
@@ -1317,35 +1335,35 @@ fun text_layout_dnit(s: *CodegenContext, text_layout: *TextLayout) {
 }
 
 fun apply_text_layout(s: *CodegenContext, image: *of.ObjectImage, enc: *encode.EncoderOutput,
-                      text_layout: *TextLayout) R.Result[R.Void, str] {
+                      text_layout: *TextLayout) err[fail.Fail] {
     var i: u32 = 0;
     for (i < text_layout.placement_count) {
-        val res_sec: R.Result[u32, str] = func_section_add(
+        val res_sec: res[u32, fail.Fail] = func_section_add(
             s, image, text_layout.placements[i].name, enc,
             text_layout.placements[i].text_start, text_layout.placements[i].text_end);
-        if (R.is_err[u32, str](res_sec)) {
-            ret R.err[R.Void, str](R.unwrap_err[u32, str](res_sec));
+        if (sel res_sec.err) {
+            ret err[fail.Fail].err{res_sec.err};
         }
-        text_layout.placements[i].sec = R.unwrap_ok[u32, str](res_sec);
+        text_layout.placements[i].sec = res_sec.ok;
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun section_placement_plan(placements: *SectionPlacement, count: *u32, cap: u32,
                            name: intern.StrId, start: u32, size: u32,
-                           text_len: u32) R.Result[R.Void, str] {
+                           text_len: u32) err[fail.Fail] {
     if (placements == nil || count == nil) {
-        ret R.err[R.Void, str]("codegen: section placement plan has no storage");
+        ret err[fail.Fail].err{fail.message("codegen: section placement plan has no storage")};
     }
     if (size == 0) {
-        ret R.err[R.Void, str]("codegen: a sectioned function has an empty encoded extent");
+        ret err[fail.Fail].err{fail.message("codegen: a sectioned function has an empty encoded extent")};
     }
     if (@count >= cap) {
-        ret R.err[R.Void, str]("codegen: section placement plan exceeds its capacity");
+        ret err[fail.Fail].err{fail.message("codegen: section placement plan exceeds its capacity")};
     }
     if (start > text_len || size > text_len - start) {
-        ret R.err[R.Void, str]("codegen: a sectioned function lies outside encoded text");
+        ret err[fail.Fail].err{fail.message("codegen: a sectioned function lies outside encoded text")};
     }
     val end: u32 = start + size;
     var insert: u32 = 0;
@@ -1353,10 +1371,10 @@ fun section_placement_plan(placements: *SectionPlacement, count: *u32, cap: u32,
         insert = insert + 1;
     }
     if (insert > 0 && placements[insert - 1].text_end > start) {
-        ret R.err[R.Void, str]("codegen: sectioned function extents overlap");
+        ret err[fail.Fail].err{fail.message("codegen: sectioned function extents overlap")};
     }
     if (insert < @count && end > placements[insert].text_start) {
-        ret R.err[R.Void, str]("codegen: sectioned function extents overlap");
+        ret err[fail.Fail].err{fail.message("codegen: sectioned function extents overlap")};
     }
     var i: u32 = @count;
     for (i > insert) {
@@ -1368,19 +1386,19 @@ fun section_placement_plan(placements: *SectionPlacement, count: *u32, cap: u32,
     placements[insert].name = name;
     placements[insert].sec = of.SECTION_EXTERNAL;
     @count = @count + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun func_section_add(s: *CodegenContext, image: *of.ObjectImage, sname: intern.StrId,
-                     enc: *encode.EncoderOutput, start: u32, end: u32) R.Result[u32, str] {
+                     enc: *encode.EncoderOutput, start: u32, end: u32) res[u32, fail.Fail] {
     if (s == nil || image == nil || enc == nil || enc.text == nil
         || start >= end || end > enc.text_len) {
-        ret R.err[u32, str]("codegen: invalid function-section extent");
+        ret res[u32, fail.Fail].err{fail.message("codegen: invalid function-section extent")};
     }
     val len: u32 = end - start;
-    val res_buf: R.Result[*u8, str] = A.allocate[u8](s.alloc, len::usize);
-    if (R.is_err[*u8, str](res_buf)) { ret R.err[u32, str](R.unwrap_err[*u8, str](res_buf)); }
-    val buf: *u8 = R.unwrap_ok[*u8, str](res_buf);
+    val res_buf: res[*u8, A.Error] = A.allocate[u8](s.alloc, len::usize);
+    if (sel res_buf.err) { ret res[u32, fail.Fail].err{fail.refused(res_buf.err)}; }
+    val buf: *u8 = res_buf.ok;
 
     memory.raw_copy(buf::ptr, (enc.text::usize + start::usize)::ptr, len::usize);
 
@@ -1391,11 +1409,11 @@ fun func_section_add(s: *CodegenContext, image: *of.ObjectImage, sname: intern.S
     sec.len   = len;
     sec.align = 16;
     sec.flags = 0;
-    val res_add: R.Result[u32, str] = obj.install_section(image, ?sec);
+    val res_add: res[u32, fail.Fail] = obj.section_install(image, ?sec);
     ret res_add;
 }
 
-fun image_extern_symbol_add(image: *of.ObjectImage, name: intern.StrId, flags: u32) R.Result[R.Void, str] {
+fun image_extern_symbol_add(image: *of.ObjectImage, name: intern.StrId, flags: u32) err[fail.Fail] {
     var sym: of.Symbol;
     sym.name    = name;
     sym.section = of.external_section();
@@ -1405,16 +1423,16 @@ fun image_extern_symbol_add(image: *of.ObjectImage, name: intern.StrId, flags: u
     sym.fallback = of.SYMBOL_NONE;
     sym.align    = 1;
 
-    val res_sym: R.Result[u32, str] = obj.add_symbol(image, sym);
-    if (R.is_err[u32, str](res_sym)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_sym)); }
-    ret R.ok_void[str]();
+    val res_sym: res[u32, fail.Fail] = obj.symbol_add(image, sym);
+    if (sel res_sym.err) { ret err[fail.Fail].err{res_sym.err}; }
+    ret err[fail.Fail].ok{};
 }
 
 fun text_layout_place(text_layout: *TextLayout, offset: u32) PlacedSite {
-    val opt_pl: O.Option[*SectionPlacement] = placement_for(
+    val opt_pl: opt[*SectionPlacement] = placement_for(
         text_layout.placements, text_layout.placement_count, offset);
-    if (O.is_some[*SectionPlacement](opt_pl)) {
-        val p: *SectionPlacement = O.unwrap[*SectionPlacement](opt_pl);
+    if (sel opt_pl.some) {
+        val p: *SectionPlacement = opt_pl.some;
         ret PlacedSite{sec: p.sec, off: offset - p.text_start};
     }
     ret PlacedSite{
@@ -1423,139 +1441,139 @@ fun text_layout_place(text_layout: *TextLayout, offset: u32) PlacedSite {
     };
 }
 
-fun placement_for(placements: *SectionPlacement, count: u32, offset: u32) O.Option[*SectionPlacement] {
+fun placement_for(placements: *SectionPlacement, count: u32, offset: u32) opt[*SectionPlacement] {
     var i: u32 = 0;
     for (i < count) {
         val p: *SectionPlacement = ?placements[i];
-        if (offset >= p.text_start && offset < p.text_end) { ret O.some[*SectionPlacement](p); }
+        if (offset >= p.text_start && offset < p.text_end) { ret opt[*SectionPlacement].some{p}; }
         i = i + 1;
     }
-    ret O.none[*SectionPlacement]();
+    ret opt[*SectionPlacement].none{};
 }
 
 fun text_layout_source_site(text_layout: *TextLayout, offset: u32,
-                            allow_end: bool) R.Result[PlacedSite, str] {
+                            allow_end: bool) res[PlacedSite, fail.Fail] {
     if (text_layout == nil
         || (text_layout.placement_count > 0 && text_layout.placements == nil)) {
-        ret R.err[PlacedSite, str]("codegen: text layout has no placement storage");
+        ret res[PlacedSite, fail.Fail].err{fail.message("codegen: text layout has no placement storage")};
     }
     if (offset > text_layout.text_len || (!allow_end && offset == text_layout.text_len)) {
-        ret R.err[PlacedSite, str]("codegen: encoded text point lies outside its source extent");
+        ret res[PlacedSite, fail.Fail].err{fail.message("codegen: encoded text point lies outside its source extent")};
     }
     var i: u32 = 0;
     for (i < text_layout.placement_count) {
         val p: *SectionPlacement = ?text_layout.placements[i];
         if (offset >= p.text_start && offset < p.text_end) {
-            ret R.ok[PlacedSite, str](PlacedSite{sec: i + 1, off: offset - p.text_start});
+            ret res[PlacedSite, fail.Fail].ok{PlacedSite{sec: i + 1, off: offset - p.text_start}};
         }
         i = i + 1;
     }
-    ret R.ok[PlacedSite, str](PlacedSite{
+    ret res[PlacedSite, fail.Fail].ok{PlacedSite{
         sec: 0,
         off: rebased_text_offset(text_layout.placements, text_layout.placement_count, offset),
-    });
+    }};
 }
 
 fun text_layout_validate_range(text_layout: *TextLayout, start: u32,
-                               end: u32) R.Result[R.Void, str] {
+                               end: u32) err[fail.Fail] {
     if (start >= end || start >= text_layout.text_len || end > text_layout.text_len) {
-        ret R.err[R.Void, str]("codegen: encoded text range lies outside its source extent");
+        ret err[fail.Fail].err{fail.message("codegen: encoded text range lies outside its source extent")};
     }
-    val res_first: R.Result[PlacedSite, str] = text_layout_source_site(text_layout, start, false);
-    if (R.is_err[PlacedSite, str](res_first)) {
-        ret R.err[R.Void, str](R.unwrap_err[PlacedSite, str](res_first));
+    val res_first: res[PlacedSite, fail.Fail] = text_layout_source_site(text_layout, start, false);
+    if (sel res_first.err) {
+        ret err[fail.Fail].err{res_first.err};
     }
-    val res_last: R.Result[PlacedSite, str] = text_layout_source_site(text_layout, end - 1, false);
-    if (R.is_err[PlacedSite, str](res_last)) {
-        ret R.err[R.Void, str](R.unwrap_err[PlacedSite, str](res_last));
+    val res_last: res[PlacedSite, fail.Fail] = text_layout_source_site(text_layout, end - 1, false);
+    if (sel res_last.err) {
+        ret err[fail.Fail].err{res_last.err};
     }
-    val first: PlacedSite = R.unwrap_ok[PlacedSite, str](res_first);
-    val last:  PlacedSite = R.unwrap_ok[PlacedSite, str](res_last);
+    val first: PlacedSite = res_first.ok;
+    val last:  PlacedSite = res_last.ok;
     if (first.sec != last.sec || last.off < first.off
         || last.off - first.off != end - start - 1) {
-        ret R.err[R.Void, str]("codegen: encoded text range crosses an output-section boundary");
+        ret err[fail.Fail].err{fail.message("codegen: encoded text range crosses an output-section boundary")};
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun validate_text_metadata(text_layout: *TextLayout,
-                           enc: *encode.EncoderOutput) R.Result[R.Void, str] {
+                           enc: *encode.EncoderOutput) err[fail.Fail] {
     var i: u32 = 0;
     for (i < enc.symbol_count) {
         val mark: *encode.SymbolMark = ?enc.symbols[i];
         if (mark.offset > text_layout.text_len
             || mark.size > text_layout.text_len - mark.offset) {
-            ret R.err[R.Void, str]("codegen: encoded symbol lies outside text");
+            ret err[fail.Fail].err{fail.message("codegen: encoded symbol lies outside text")};
         }
         if (mark.size == 0) {
-            val point: R.Result[PlacedSite, str] = text_layout_source_site(text_layout, mark.offset, true);
-            if (R.is_err[PlacedSite, str](point)) {
-                ret R.err[R.Void, str]("codegen: encoded symbol lies outside text");
+            val point: res[PlacedSite, fail.Fail] = text_layout_source_site(text_layout, mark.offset, true);
+            if (sel point.err) {
+                ret err[fail.Fail].err{fail.message("codegen: encoded symbol lies outside text")};
             }
         }
         or {
-            val range: R.Result[R.Void, str] = text_layout_validate_range(
+            val range: err[fail.Fail] = text_layout_validate_range(
                 text_layout, mark.offset, mark.offset + mark.size);
-            if (R.is_err[R.Void, str](range)) {
-                ret R.err[R.Void, str]("codegen: encoded symbol crosses an output-section boundary");
+            if (sel range.err) {
+                ret err[fail.Fail].err{fail.message("codegen: encoded symbol crosses an output-section boundary")};
             }
         }
         i = i + 1;
     }
     i = 0;
     for (i < enc.frame_count) {
-        val point: R.Result[PlacedSite, str] = text_layout_source_site(
+        val point: res[PlacedSite, fail.Fail] = text_layout_source_site(
             text_layout, enc.frames[i].offset, true);
-        if (R.is_err[PlacedSite, str](point)) {
-            ret R.err[R.Void, str]("codegen: unwind frame lies outside text");
+        if (sel point.err) {
+            ret err[fail.Fail].err{fail.message("codegen: unwind frame lies outside text")};
         }
         i = i + 1;
     }
     i = 0;
     for (i < enc.reloc_count) {
-        val point: R.Result[PlacedSite, str] = text_layout_source_site(
+        val point: res[PlacedSite, fail.Fail] = text_layout_source_site(
             text_layout, enc.relocations[i].offset, false);
-        if (R.is_err[PlacedSite, str](point)) {
-            ret R.err[R.Void, str]("codegen: relocation lies outside text");
+        if (sel point.err) {
+            ret err[fail.Fail].err{fail.message("codegen: relocation lies outside text")};
         }
         i = i + 1;
     }
     i = 0;
     for (i < enc.row_count) {
-        val point: R.Result[PlacedSite, str] = text_layout_source_site(
+        val point: res[PlacedSite, fail.Fail] = text_layout_source_site(
             text_layout, enc.rows[i].text_offset, true);
-        if (R.is_err[PlacedSite, str](point)) {
-            ret R.err[R.Void, str]("codegen: line row lies outside text");
+        if (sel point.err) {
+            ret err[fail.Fail].err{fail.message("codegen: line row lies outside text")};
         }
         i = i + 1;
     }
     i = 0;
     for (i < enc.varloc_count) {
         val vl: *encode.VarLoc = ?enc.varlocs[i];
-        val point: R.Result[PlacedSite, str] = text_layout_source_site(
+        val point: res[PlacedSite, fail.Fail] = text_layout_source_site(
             text_layout, vl.text_offset, false);
-        if (R.is_err[PlacedSite, str](point)) {
-            ret R.err[R.Void, str]("codegen: variable location starts outside text");
+        if (sel point.err) {
+            ret err[fail.Fail].err{fail.message("codegen: variable location starts outside text")};
         }
         if (vl.end_offset != 0) {
-            val range: R.Result[R.Void, str] = text_layout_validate_range(
+            val range: err[fail.Fail] = text_layout_validate_range(
                 text_layout, vl.text_offset, vl.end_offset);
-            if (R.is_err[R.Void, str](range)) {
-                ret R.err[R.Void, str]("codegen: variable location range crosses an output-section boundary");
+            if (sel range.err) {
+                ret err[fail.Fail].err{fail.message("codegen: variable location range crosses an output-section boundary")};
             }
         }
         i = i + 1;
     }
     i = 0;
     for (i < enc.inline_pc_count) {
-        val point: R.Result[PlacedSite, str] = text_layout_source_site(
+        val point: res[PlacedSite, fail.Fail] = text_layout_source_site(
             text_layout, enc.inline_pcs[i].text_offset, false);
-        if (R.is_err[PlacedSite, str](point)) {
-            ret R.err[R.Void, str]("codegen: inline PC lies outside text");
+        if (sel point.err) {
+            ret err[fail.Fail].err{fail.message("codegen: inline PC lies outside text")};
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun total_excised(placements: *SectionPlacement, count: u32) u32 {
@@ -1580,33 +1598,34 @@ fun rebased_text_offset(placements: *SectionPlacement, count: u32, offset: u32) 
     ret offset - shift;
 }
 
-fun function_defined_get(irmod: *ir.Module, name: intern.StrId) O.Option[*ir.Function] {
+fun function_defined_get(irmod: *ir.Module, name: intern.StrId) opt[*ir.Function] {
     var i: u32 = 0;
     for (i < irmod.function_len) {
         val fn: *ir.Function = ?irmod.functions[i];
         if (fn.name == name && (fn.flags & ir.FN_FLAG_EXTERN) == 0) {
-            ret O.some[*ir.Function](fn);
+            ret opt[*ir.Function].some{fn};
         }
         i = i + 1;
     }
-    ret O.none[*ir.Function]();
+    ret opt[*ir.Function].none{};
 }
 
 fun function_is_defined(irmod: *ir.Module, name: intern.StrId) bool {
-    ret O.is_some[*ir.Function](function_defined_get(irmod, name));
+    val defined: opt[*ir.Function] = function_defined_get(irmod, name);
+    ret sel defined.some;
 }
 
 fun function_section_name(irmod: *ir.Module, name: intern.StrId) intern.StrId {
-    val opt_fn: O.Option[*ir.Function] = function_defined_get(irmod, name);
-    if (O.is_none[*ir.Function](opt_fn)) { ret intern.STR_NIL; }
-    val fn: *ir.Function = O.unwrap[*ir.Function](opt_fn);
+    val opt_fn: opt[*ir.Function] = function_defined_get(irmod, name);
+    if (sel opt_fn.none) { ret intern.STR_NIL; }
+    val fn: *ir.Function = opt_fn.some;
     ret fn.section;
 }
 
 fun function_is_weak(irmod: *ir.Module, name: intern.StrId) bool {
-    val opt_fn: O.Option[*ir.Function] = function_defined_get(irmod, name);
-    if (O.is_none[*ir.Function](opt_fn)) { ret false; }
-    val fn: *ir.Function = O.unwrap[*ir.Function](opt_fn);
+    val opt_fn: opt[*ir.Function] = function_defined_get(irmod, name);
+    if (sel opt_fn.none) { ret false; }
+    val fn: *ir.Function = opt_fn.some;
     ret (fn.flags & ir.FN_FLAG_WEAK) != 0;
 }
 
@@ -1620,12 +1639,15 @@ fun is_f32_type(types: *type.IrTypeTable, id: type.IrTypeId) bool {
 test "mach.lang.be.codegen.section_placement_plan:sorts_and_rejects_invalid_extents" {
     var placements: [3]SectionPlacement;
     var count: u32 = 0;
-    if (R.is_err[R.Void, str](section_placement_plan(?placements[0], ?count, 3,
-        3::intern.StrId, 16, 4, 32))) { ret 1; }
-    if (R.is_err[R.Void, str](section_placement_plan(?placements[0], ?count, 3,
-        1::intern.StrId, 0, 8, 32))) { ret 2; }
-    if (R.is_err[R.Void, str](section_placement_plan(?placements[0], ?count, 3,
-        2::intern.StrId, 8, 8, 32))) { ret 3; }
+    val section_placement_plan_r: err[fail.Fail] = section_placement_plan(?placements[0], ?count, 3,
+        3::intern.StrId, 16, 4, 32);
+    if (sel section_placement_plan_r.err) { ret 1; }
+    val section_placement_plan_r2: err[fail.Fail] = section_placement_plan(?placements[0], ?count, 3,
+        1::intern.StrId, 0, 8, 32);
+    if (sel section_placement_plan_r2.err) { ret 2; }
+    val section_placement_plan_r3: err[fail.Fail] = section_placement_plan(?placements[0], ?count, 3,
+        2::intern.StrId, 8, 8, 32);
+    if (sel section_placement_plan_r3.err) { ret 3; }
     if (count != 3) { ret 4; }
     if (placements[0].text_start != 0 || placements[0].text_end != 8
         || placements[0].name != 1::intern.StrId) { ret 5; }
@@ -1635,15 +1657,19 @@ test "mach.lang.be.codegen.section_placement_plan:sorts_and_rejects_invalid_exte
         || placements[2].name != 3::intern.StrId) { ret 7; }
 
     var bad_count: u32 = count;
-    if (R.is_ok[R.Void, str](section_placement_plan(?placements[0], ?bad_count, 3,
-        4::intern.StrId, 20, 1, 32))) { ret 8; }
+    val section_placement_plan_r4: err[fail.Fail] = section_placement_plan(?placements[0], ?bad_count, 3,
+        4::intern.StrId, 20, 1, 32);
+    if (sel section_placement_plan_r4.ok) { ret 8; }
     bad_count = 1;
-    if (R.is_ok[R.Void, str](section_placement_plan(?placements[0], ?bad_count, 3,
-        4::intern.StrId, 7, 2, 32))) { ret 9; }
-    if (R.is_ok[R.Void, str](section_placement_plan(?placements[0], ?bad_count, 3,
-        4::intern.StrId, 31, 2, 32))) { ret 10; }
-    if (R.is_ok[R.Void, str](section_placement_plan(?placements[0], ?bad_count, 3,
-        4::intern.StrId, 20, 0, 32))) { ret 11; }
+    val section_placement_plan_r5: err[fail.Fail] = section_placement_plan(?placements[0], ?bad_count, 3,
+        4::intern.StrId, 7, 2, 32);
+    if (sel section_placement_plan_r5.ok) { ret 9; }
+    val section_placement_plan_r6: err[fail.Fail] = section_placement_plan(?placements[0], ?bad_count, 3,
+        4::intern.StrId, 31, 2, 32);
+    if (sel section_placement_plan_r6.ok) { ret 10; }
+    val section_placement_plan_r7: err[fail.Fail] = section_placement_plan(?placements[0], ?bad_count, 3,
+        4::intern.StrId, 20, 0, 32);
+    if (sel section_placement_plan_r7.ok) { ret 11; }
     ret 0;
 }
 
@@ -1730,19 +1756,23 @@ test "mach.lang.be.codegen.pack_relocs:carries_the_encoder_pair_index_to_the_ima
     var deferred: obj.DeferredRelocs = obj.deferred_init(?alloc);
     fin { obj.deferred_dnit(?deferred); }
 
-    if (R.is_err[R.Void, str](pack_relocs(?tgt, ?deferred, ?enc, ?text_layout))) { ret 3; }
+    val pack_relocs_r: err[fail.Fail] = pack_relocs(?tgt, ?deferred, ?enc, ?text_layout);
+    if (sel pack_relocs_r.err) { ret 3; }
     if (deferred.count != 2)         { ret 4; }
     if (deferred.items[0].pair != 0) { ret 5; }
     if (deferred.items[1].pair != 1) { ret 6; }
 
-    var image: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](
-        obj.init(?alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](img_name)));
+    val image_r: res[of.ObjectImage, fail.Fail] = obj.image_init(?alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](img_name));
+    if (sel image_r.err) { ret 7; }
+    var image: of.ObjectImage = image_r.ok;
     var standin: of.Relocation;
     standin.section = of.section_id(0); standin.offset = 0; standin.kind = of.RK_ABS64;
     standin.sym = 0; standin.addend = 0; standin.sym2 = of.SYMBOL_NONE; standin.pair = 0;
-    if (R.is_err[R.Void, str](obj.add_relocation(?image, standin))) { ret 7; }
+    val add_relocation_r: err[fail.Fail] = obj.add_relocation(?image, standin);
+    if (sel add_relocation_r.err) { ret 7; }
 
-    if (R.is_err[R.Void, str](obj.flush_deferred(?image, ?deferred))) { ret 8; }
+    val flush_deferred_r: err[fail.Fail] = obj.flush_deferred(?image, ?deferred);
+    if (sel flush_deferred_r.err) { ret 8; }
     if (image.reloc_count != 3)          { ret 9; }
     if (image.relocations[1].pair != 0)  { ret 10; }
     if (image.relocations[2].pair != 2)  { ret 11; }
@@ -1804,29 +1834,37 @@ test "mach.lang.be.codegen.text_layout:preflights_points_and_half_open_ranges" {
     enc.inline_pcs      = ?inline_pcs[0];
     enc.inline_pc_count = 1;
 
-    if (R.is_err[R.Void, str](validate_encoder_output(nil, nil, ?enc))) { ret 1; }
-    if (R.is_err[R.Void, str](validate_text_metadata(?text_layout, ?enc))) { ret 2; }
+    val validate_encoder_output_r: err[fail.Fail] = validate_encoder_output(nil, nil, ?enc);
+    if (sel validate_encoder_output_r.err) { ret 1; }
+    val validate_text_metadata_r: err[fail.Fail] = validate_text_metadata(?text_layout, ?enc);
+    if (sel validate_text_metadata_r.err) { ret 2; }
 
     varlocs[0].end_offset = 17;
-    if (R.is_ok[R.Void, str](validate_text_metadata(?text_layout, ?enc))) { ret 3; }
+    val validate_text_metadata_r2: err[fail.Fail] = validate_text_metadata(?text_layout, ?enc);
+    if (sel validate_text_metadata_r2.ok) { ret 3; }
     varlocs[0].end_offset = 7;
-    if (R.is_ok[R.Void, str](validate_text_metadata(?text_layout, ?enc))) { ret 4; }
+    val validate_text_metadata_r3: err[fail.Fail] = validate_text_metadata(?text_layout, ?enc);
+    if (sel validate_text_metadata_r3.ok) { ret 4; }
     varlocs[0].end_offset = 16;
 
     rows[1].text_offset = 25;
-    if (R.is_ok[R.Void, str](validate_text_metadata(?text_layout, ?enc))) { ret 5; }
+    val validate_text_metadata_r4: err[fail.Fail] = validate_text_metadata(?text_layout, ?enc);
+    if (sel validate_text_metadata_r4.ok) { ret 5; }
     rows[1].text_offset = 24;
 
     inline_pcs[0].text_offset = 24;
-    if (R.is_ok[R.Void, str](validate_text_metadata(?text_layout, ?enc))) { ret 6; }
+    val validate_text_metadata_r5: err[fail.Fail] = validate_text_metadata(?text_layout, ?enc);
+    if (sel validate_text_metadata_r5.ok) { ret 6; }
     inline_pcs[0].text_offset = 15;
 
     symbols[0].offset = 4;
-    if (R.is_ok[R.Void, str](validate_text_metadata(?text_layout, ?enc))) { ret 7; }
+    val validate_text_metadata_r6: err[fail.Fail] = validate_text_metadata(?text_layout, ?enc);
+    if (sel validate_text_metadata_r6.ok) { ret 7; }
     symbols[0].offset = 0;
 
     relocations[0].offset = 24;
-    if (R.is_ok[R.Void, str](validate_text_metadata(?text_layout, ?enc))) { ret 8; }
+    val validate_text_metadata_r7: err[fail.Fail] = validate_text_metadata(?text_layout, ?enc);
+    if (sel validate_text_metadata_r7.ok) { ret 8; }
     relocations[0].offset = 8;
 
     pack_rows(?enc, ?text_layout);
@@ -1900,7 +1938,8 @@ test "mach.lang.be.codegen.embed_section_of:shares_only_on_a_full_match" {
 
 test "mach.lang.be.codegen.pack_symbols:function_size_survives_an_intervening_gap" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
 
     var itn: intern.Interner = intern.init(?alloc);
 
@@ -1934,9 +1973,9 @@ test "mach.lang.be.codegen.pack_symbols:function_size_survives_an_intervening_ga
     text_layout.text_len        = 28;
     text_layout.text_sec        = 0;
 
-    val pr: R.Result[R.Void, str] = pack_symbols(?image, ?irmod, ?enc, ?text_layout);
+    val pr: err[fail.Fail] = pack_symbols(?image, ?irmod, ?enc, ?text_layout);
     ir.dnit(?irmod);
-    if (R.is_err[R.Void, str](pr)) { obj.dnit(?image); ret 1; }
+    if (sel pr.err) { obj.dnit(?image); ret 1; }
 
     var bad: i32 = 0;
     if (image.symbol_count != 2)          { bad = 1; }
@@ -2025,9 +2064,9 @@ test "mach.lang.be.codegen.encoder_output_dnit:frees_the_complete_exact_owner" {
     var tracker: CgTracker;
     # cap comfortably above the session's own allocation count, whose silent truncation
     # would otherwise turn a later real free into a false owner mismatch
-    val res_entries: R.Result[*CgTrackEntry, str] = A.allocate[CgTrackEntry](?page_alloc, 256::usize);
-    if (R.is_err[*CgTrackEntry, str](res_entries)) { ret 1; }
-    tracker.entries  = R.unwrap_ok[*CgTrackEntry, str](res_entries);
+    val res_entries: res[*CgTrackEntry, A.Error] = A.allocate[CgTrackEntry](?page_alloc, 256::usize);
+    if (sel res_entries.err) { ret 1; }
+    tracker.entries  = res_entries.ok;
     tracker.cap      = 256;
     tracker.count    = 0;
     tracker.live     = 0;
@@ -2046,48 +2085,48 @@ test "mach.lang.be.codegen.encoder_output_dnit:frees_the_complete_exact_owner" {
     var context: CodegenContext = CodegenContext{alloc: ?alloc, session: ?s};
 
     var enc: encode.EncoderOutput;
-    val rtext: R.Result[*u8, str] = A.allocate[u8](?alloc, 11::usize);
-    if (R.is_err[*u8, str](rtext)) { session.dnit(?s); ret 1; }
-    enc.text = R.unwrap_ok[*u8, str](rtext);
+    val rtext: res[*u8, A.Error] = A.allocate[u8](?alloc, 11::usize);
+    if (sel rtext.err) { session.dnit(?s); ret 1; }
+    enc.text = rtext.ok;
     enc.text_len = 11;
 
-    val rconsts: R.Result[*encode.ConstEntry, str] = A.allocate[encode.ConstEntry](?alloc, 1::usize);
-    if (R.is_err[*encode.ConstEntry, str](rconsts)) { session.dnit(?s); ret 1; }
-    enc.consts = R.unwrap_ok[*encode.ConstEntry, str](rconsts);
+    val rconsts: res[*encode.ConstEntry, A.Error] = A.allocate[encode.ConstEntry](?alloc, 1::usize);
+    if (sel rconsts.err) { session.dnit(?s); ret 1; }
+    enc.consts = rconsts.ok;
     enc.const_count = 1;
-    val rconst_bytes: R.Result[*u8, str] = A.allocate[u8](?alloc, 13::usize);
-    if (R.is_err[*u8, str](rconst_bytes)) { session.dnit(?s); ret 1; }
-    enc.consts[0].bytes = R.unwrap_ok[*u8, str](rconst_bytes);
+    val rconst_bytes: res[*u8, A.Error] = A.allocate[u8](?alloc, 13::usize);
+    if (sel rconst_bytes.err) { session.dnit(?s); ret 1; }
+    enc.consts[0].bytes = rconst_bytes.ok;
     enc.consts[0].len = 13;
 
-    val rsym: R.Result[*encode.SymbolMark, str] = A.allocate[encode.SymbolMark](?alloc, 2::usize);
-    if (R.is_err[*encode.SymbolMark, str](rsym)) { session.dnit(?s); ret 1; }
-    enc.symbols = R.unwrap_ok[*encode.SymbolMark, str](rsym);
+    val rsym: res[*encode.SymbolMark, A.Error] = A.allocate[encode.SymbolMark](?alloc, 2::usize);
+    if (sel rsym.err) { session.dnit(?s); ret 1; }
+    enc.symbols = rsym.ok;
     enc.symbol_count = 2;
 
-    val rrel: R.Result[*encode.PendingReloc, str] = A.allocate[encode.PendingReloc](?alloc, 3::usize);
-    if (R.is_err[*encode.PendingReloc, str](rrel)) { session.dnit(?s); ret 1; }
-    enc.relocations = R.unwrap_ok[*encode.PendingReloc, str](rrel);
+    val rrel: res[*encode.PendingReloc, A.Error] = A.allocate[encode.PendingReloc](?alloc, 3::usize);
+    if (sel rrel.err) { session.dnit(?s); ret 1; }
+    enc.relocations = rrel.ok;
     enc.reloc_count = 3;
 
-    val rrow: R.Result[*encode.LineRow, str] = A.allocate[encode.LineRow](?alloc, 4::usize);
-    if (R.is_err[*encode.LineRow, str](rrow)) { session.dnit(?s); ret 1; }
-    enc.rows = R.unwrap_ok[*encode.LineRow, str](rrow);
+    val rrow: res[*encode.LineRow, A.Error] = A.allocate[encode.LineRow](?alloc, 4::usize);
+    if (sel rrow.err) { session.dnit(?s); ret 1; }
+    enc.rows = rrow.ok;
     enc.row_count = 4;
 
-    val rvl: R.Result[*encode.VarLoc, str] = A.allocate[encode.VarLoc](?alloc, 5::usize);
-    if (R.is_err[*encode.VarLoc, str](rvl)) { session.dnit(?s); ret 1; }
-    enc.varlocs = R.unwrap_ok[*encode.VarLoc, str](rvl);
+    val rvl: res[*encode.VarLoc, A.Error] = A.allocate[encode.VarLoc](?alloc, 5::usize);
+    if (sel rvl.err) { session.dnit(?s); ret 1; }
+    enc.varlocs = rvl.ok;
     enc.varloc_count = 5;
 
-    val rip: R.Result[*encode.InlinePc, str] = A.allocate[encode.InlinePc](?alloc, 6::usize);
-    if (R.is_err[*encode.InlinePc, str](rip)) { session.dnit(?s); ret 1; }
-    enc.inline_pcs = R.unwrap_ok[*encode.InlinePc, str](rip);
+    val rip: res[*encode.InlinePc, A.Error] = A.allocate[encode.InlinePc](?alloc, 6::usize);
+    if (sel rip.err) { session.dnit(?s); ret 1; }
+    enc.inline_pcs = rip.ok;
     enc.inline_pc_count = 6;
 
-    val rfr: R.Result[*of.FrameUnwind, str] = A.allocate[of.FrameUnwind](?alloc, 7::usize);
-    if (R.is_err[*of.FrameUnwind, str](rfr)) { session.dnit(?s); ret 1; }
-    enc.frames = R.unwrap_ok[*of.FrameUnwind, str](rfr);
+    val rfr: res[*of.FrameUnwind, A.Error] = A.allocate[of.FrameUnwind](?alloc, 7::usize);
+    if (sel rfr.err) { session.dnit(?s); ret 1; }
+    enc.frames = rfr.ok;
     enc.frame_count = 7;
 
     encoder_output_dnit(?context, ?enc);
@@ -2112,40 +2151,47 @@ test "mach.lang.be.codegen.encoder_output_dnit:frees_the_complete_exact_owner" {
 
 fun t_placement_fixture(alloc: *A.Allocator) mir.MirFunction {
     var f: mir.MirFunction;
-    val rb: R.Result[*mir.MirBlock, str] = A.zallocate[mir.MirBlock](alloc, 4::usize);
-    f.blocks      = R.unwrap_ok[*mir.MirBlock, str](rb);
+    val rb: res[*mir.MirBlock, A.Error] = A.zallocate[mir.MirBlock](alloc, 4::usize);
+    if (sel rb.err) { ret f; }
+    f.blocks      = rb.ok;
     f.block_count = 4;
 
-    val ro0: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](alloc, 2::usize);
-    val ops0: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro0);
+    val ro0: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](alloc, 2::usize);
+    if (sel ro0.err) { ret f; }
+    val ops0: *mir.MirOperand = ro0.ok;
     ops0[0] = mir.op_block(1);
     ops0[1] = mir.op_block(2);
-    val ri0: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](alloc, 1::usize);
-    val instrs0: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](ri0);
+    val ri0: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](alloc, 1::usize);
+    if (sel ri0.err) { ret f; }
+    val instrs0: *mir.MirInstr = ri0.ok;
     instrs0[0] = mir.instr(mir.MIR_CBR, ops0, 2, 0, 0);
     f.blocks[0].id          = 0;
     f.blocks[0].instrs      = instrs0;
     f.blocks[0].instr_count = 1;
 
-    val ro1: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](alloc, 1::usize);
-    val ops1: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro1);
+    val ro1: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](alloc, 1::usize);
+    if (sel ro1.err) { ret f; }
+    val ops1: *mir.MirOperand = ro1.ok;
     ops1[0] = mir.op_block(3);
-    val ri1: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](alloc, 1::usize);
-    val instrs1: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](ri1);
+    val ri1: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](alloc, 1::usize);
+    if (sel ri1.err) { ret f; }
+    val instrs1: *mir.MirInstr = ri1.ok;
     instrs1[0] = mir.instr(mir.MIR_BR, ops1, 1, 0, 0);
     f.blocks[1].id          = 1;
     f.blocks[1].instrs      = instrs1;
     f.blocks[1].instr_count = 1;
 
-    val ri2: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](alloc, 1::usize);
-    val instrs2: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](ri2);
+    val ri2: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](alloc, 1::usize);
+    if (sel ri2.err) { ret f; }
+    val instrs2: *mir.MirInstr = ri2.ok;
     instrs2[0] = mir.instr(mir.MIR_UNREACHABLE, nil, 0, 0, 0);
     f.blocks[2].id          = 2;
     f.blocks[2].instrs      = instrs2;
     f.blocks[2].instr_count = 1;
 
-    val ri3: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](alloc, 1::usize);
-    val instrs3: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](ri3);
+    val ri3: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](alloc, 1::usize);
+    if (sel ri3.err) { ret f; }
+    val instrs3: *mir.MirInstr = ri3.ok;
     instrs3[0] = mir.instr(mir.MIR_RET, nil, 0, 0, 0);
     f.blocks[3].id          = 3;
     f.blocks[3].instrs      = instrs3;
@@ -2172,20 +2218,23 @@ fun t_placement_machine() isa.RegMachine {
 
 test "mach.lang.be.codegen.apply_placement_policy:sinks_unreachable_block_after_hot_chain" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
 
     var machine: isa.RegMachine = t_placement_machine();
     var tgt: target.Target;
     tgt.arch = ?machine;
     var f: mir.MirFunction = t_placement_fixture(?backing);
-    if (R.is_err[R.Void, str](compute_emission_order(?backing, ?f))) { ret 1; }
+    val compute_emission_order_r: err[fail.Fail] = compute_emission_order(?backing, ?f);
+    if (sel compute_emission_order_r.err) { ret 1; }
 
     if (f.emit_order[0] != 0) { ret 1; }
     if (f.emit_order[1] != 2) { ret 1; }
     if (f.emit_order[2] != 1) { ret 1; }
     if (f.emit_order[3] != 3) { ret 1; }
 
-    if (R.is_err[R.Void, str](apply_placement_policy(?backing, ?f, ?tgt))) { ret 1; }
+    val apply_placement_policy_r: err[fail.Fail] = apply_placement_policy(?backing, ?f, ?tgt);
+    if (sel apply_placement_policy_r.err) { ret 1; }
 
     if (f.emit_order[0] != 0) { ret 1; }
     if (f.emit_order[1] != 1) { ret 1; }
@@ -2197,15 +2246,19 @@ test "mach.lang.be.codegen.apply_placement_policy:sinks_unreachable_block_after_
 
 test "mach.lang.be.codegen.apply_placement_policy:idempotent_on_an_already_placed_order" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
 
     var machine: isa.RegMachine = t_placement_machine();
     var tgt: target.Target;
     tgt.arch = ?machine;
     var f: mir.MirFunction = t_placement_fixture(?backing);
-    if (R.is_err[R.Void, str](compute_emission_order(?backing, ?f))) { ret 1; }
-    if (R.is_err[R.Void, str](apply_placement_policy(?backing, ?f, ?tgt))) { ret 1; }
-    if (R.is_err[R.Void, str](apply_placement_policy(?backing, ?f, ?tgt))) { ret 1; }
+    val compute_emission_order_r: err[fail.Fail] = compute_emission_order(?backing, ?f);
+    if (sel compute_emission_order_r.err) { ret 1; }
+    val apply_placement_policy_r: err[fail.Fail] = apply_placement_policy(?backing, ?f, ?tgt);
+    if (sel apply_placement_policy_r.err) { ret 1; }
+    val apply_placement_policy_r2: err[fail.Fail] = apply_placement_policy(?backing, ?f, ?tgt);
+    if (sel apply_placement_policy_r2.err) { ret 1; }
 
     if (f.emit_order[0] != 0) { ret 1; }
     if (f.emit_order[1] != 1) { ret 1; }
@@ -2217,19 +2270,22 @@ test "mach.lang.be.codegen.apply_placement_policy:idempotent_on_an_already_place
 
 fun t_placement_cold_entry_fixture(alloc: *A.Allocator) mir.MirFunction {
     var f: mir.MirFunction;
-    val rb: R.Result[*mir.MirBlock, str] = A.zallocate[mir.MirBlock](alloc, 2::usize);
-    f.blocks      = R.unwrap_ok[*mir.MirBlock, str](rb);
+    val rb: res[*mir.MirBlock, A.Error] = A.zallocate[mir.MirBlock](alloc, 2::usize);
+    if (sel rb.err) { ret f; }
+    f.blocks      = rb.ok;
     f.block_count = 2;
 
-    val ri0: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](alloc, 1::usize);
-    val instrs0: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](ri0);
+    val ri0: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](alloc, 1::usize);
+    if (sel ri0.err) { ret f; }
+    val instrs0: *mir.MirInstr = ri0.ok;
     instrs0[0] = mir.instr(mir.MIR_UNREACHABLE, nil, 0, 0, 0);
     f.blocks[0].id          = 0;
     f.blocks[0].instrs      = instrs0;
     f.blocks[0].instr_count = 1;
 
-    val ri1: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](alloc, 1::usize);
-    val instrs1: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](ri1);
+    val ri1: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](alloc, 1::usize);
+    if (sel ri1.err) { ret f; }
+    val instrs1: *mir.MirInstr = ri1.ok;
     instrs1[0] = mir.instr(mir.MIR_RET, nil, 0, 0, 0);
     f.blocks[1].id          = 1;
     f.blocks[1].instrs      = instrs1;
@@ -2240,17 +2296,20 @@ fun t_placement_cold_entry_fixture(alloc: *A.Allocator) mir.MirFunction {
 
 test "mach.lang.be.codegen.apply_placement_policy:never_moves_the_entry_out_of_first_position" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
 
     var machine: isa.RegMachine = t_placement_machine();
     var tgt: target.Target;
     tgt.arch = ?machine;
     var f: mir.MirFunction = t_placement_cold_entry_fixture(?backing);
-    if (R.is_err[R.Void, str](compute_emission_order(?backing, ?f))) { ret 1; }
+    val compute_emission_order_r: err[fail.Fail] = compute_emission_order(?backing, ?f);
+    if (sel compute_emission_order_r.err) { ret 1; }
     if (f.emit_order[0] != 0) { ret 1; }
     if (f.emit_order[1] != 1) { ret 1; }
 
-    if (R.is_err[R.Void, str](apply_placement_policy(?backing, ?f, ?tgt))) { ret 1; }
+    val apply_placement_policy_r: err[fail.Fail] = apply_placement_policy(?backing, ?f, ?tgt);
+    if (sel apply_placement_policy_r.err) { ret 1; }
     if (f.emit_order[0] != 0) { ret 1; }
     if (f.emit_order[1] != 1) { ret 1; }
 
@@ -2260,17 +2319,20 @@ test "mach.lang.be.codegen.apply_placement_policy:never_moves_the_entry_out_of_f
 fun t_emit_order_block2(alloc: *A.Allocator, id0: u32, id1: u32, id2: u32,
                         pos1: u32, pos2: u32, first: u32, second: u32) mir.MirFunction {
     var f: mir.MirFunction;
-    val rb: R.Result[*mir.MirBlock, str] = A.zallocate[mir.MirBlock](alloc, 3::usize);
-    f.blocks      = R.unwrap_ok[*mir.MirBlock, str](rb);
+    val rb: res[*mir.MirBlock, A.Error] = A.zallocate[mir.MirBlock](alloc, 3::usize);
+    if (sel rb.err) { ret f; }
+    f.blocks      = rb.ok;
     f.block_count = 3;
 
-    val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](alloc, 2::usize);
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro);
+    val ro: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](alloc, 2::usize);
+    if (sel ro.err) { ret f; }
+    val ops: *mir.MirOperand = ro.ok;
     ops[0] = mir.op_block(first);
     ops[1] = mir.op_block(second);
 
-    val ri: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](alloc, 1::usize);
-    val instrs: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](ri);
+    val ri: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](alloc, 1::usize);
+    if (sel ri.err) { ret f; }
+    val instrs: *mir.MirInstr = ri.ok;
     instrs[0] = mir.instr(mir.MIR_CBR, ops, 2, 0, 0);
 
     f.blocks[0].id          = id0;
@@ -2286,16 +2348,19 @@ fun t_emit_order_block2(alloc: *A.Allocator, id0: u32, id1: u32, id2: u32,
 
 test "mach.lang.be.codegen.compute_emission_order:follows_operand_visit_order" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
 
     var fa: mir.MirFunction = t_emit_order_block2(?backing, 0, 1, 2, 1, 2, 1, 2);
-    if (R.is_err[R.Void, str](compute_emission_order(?backing, ?fa))) { ret 1; }
+    val compute_emission_order_r: err[fail.Fail] = compute_emission_order(?backing, ?fa);
+    if (sel compute_emission_order_r.err) { ret 1; }
     if (fa.emit_order[0] != 0) { ret 1; }
     if (fa.emit_order[1] != 2) { ret 1; }
     if (fa.emit_order[2] != 1) { ret 1; }
 
     var fb: mir.MirFunction = t_emit_order_block2(?backing, 0, 1, 2, 1, 2, 2, 1);
-    if (R.is_err[R.Void, str](compute_emission_order(?backing, ?fb))) { ret 1; }
+    val compute_emission_order_r2: err[fail.Fail] = compute_emission_order(?backing, ?fb);
+    if (sel compute_emission_order_r2.err) { ret 1; }
     if (fb.emit_order[0] != 0) { ret 1; }
     if (fb.emit_order[1] != 1) { ret 1; }
     if (fb.emit_order[2] != 2) { ret 1; }
@@ -2305,22 +2370,26 @@ test "mach.lang.be.codegen.compute_emission_order:follows_operand_visit_order" {
 
 test "mach.lang.be.codegen.compute_emission_order:insensitive_to_block_id_and_array_position" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
 
     var fa: mir.MirFunction = t_emit_order_block2(?backing, 0, 1, 2, 1, 2, 1, 2);
-    if (R.is_err[R.Void, str](compute_emission_order(?backing, ?fa))) { ret 1; }
+    val compute_emission_order_r: err[fail.Fail] = compute_emission_order(?backing, ?fa);
+    if (sel compute_emission_order_r.err) { ret 1; }
     if (fa.blocks[fa.emit_order[0]].id != 0) { ret 1; }
     if (fa.blocks[fa.emit_order[1]].id != 2) { ret 1; }
     if (fa.blocks[fa.emit_order[2]].id != 1) { ret 1; }
 
     var fb: mir.MirFunction = t_emit_order_block2(?backing, 0, 9, 4, 2, 1, 9, 4);
-    if (R.is_err[R.Void, str](compute_emission_order(?backing, ?fb))) { ret 1; }
+    val compute_emission_order_r2: err[fail.Fail] = compute_emission_order(?backing, ?fb);
+    if (sel compute_emission_order_r2.err) { ret 1; }
     if (fb.blocks[fb.emit_order[0]].id != 0) { ret 1; }
     if (fb.blocks[fb.emit_order[1]].id != 4) { ret 1; }
     if (fb.blocks[fb.emit_order[2]].id != 9) { ret 1; }
 
     var fc: mir.MirFunction = t_emit_order_block2(?backing, 0, 9, 4, 1, 2, 9, 4);
-    if (R.is_err[R.Void, str](compute_emission_order(?backing, ?fc))) { ret 1; }
+    val compute_emission_order_r3: err[fail.Fail] = compute_emission_order(?backing, ?fc);
+    if (sel compute_emission_order_r3.err) { ret 1; }
     if (fc.blocks[fc.emit_order[0]].id != 0) { ret 1; }
     if (fc.blocks[fc.emit_order[1]].id != 4) { ret 1; }
     if (fc.blocks[fc.emit_order[2]].id != 9) { ret 1; }
@@ -2330,37 +2399,39 @@ test "mach.lang.be.codegen.compute_emission_order:insensitive_to_block_id_and_ar
 
 test "mach.lang.be.codegen.finish_codegen_image:publishes_only_valid_owned_images" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var itn: intern.Interner = intern.init(?alloc);
 
-    val empty_r: R.Result[of.ObjectImage, str] = obj.init(?alloc, ?itn, intern.STR_NIL);
-    if (R.is_err[of.ObjectImage, str](empty_r)) { intern.dnit(?itn); ret 1; }
-    val published_r: R.Result[of.ObjectImage, str] =
-        finish_codegen_image(R.unwrap_ok[of.ObjectImage, str](empty_r));
-    if (R.is_err[of.ObjectImage, str](published_r)) { intern.dnit(?itn); ret 1; }
-    var published: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](published_r);
+    val empty_r: res[of.ObjectImage, fail.Fail] = obj.image_init(?alloc, ?itn, intern.STR_NIL);
+    if (sel empty_r.err) { intern.dnit(?itn); ret 1; }
+    val published_r: res[of.ObjectImage, fail.Fail] =
+        finish_codegen_image(empty_r.ok);
+    if (sel published_r.err) { intern.dnit(?itn); ret 1; }
+    var published: of.ObjectImage = published_r.ok;
     obj.dnit(?published);
 
-    val malformed_r: R.Result[of.ObjectImage, str] = obj.init(?alloc, ?itn, intern.STR_NIL);
-    if (R.is_err[of.ObjectImage, str](malformed_r)) { intern.dnit(?itn); ret 1; }
-    var malformed: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](malformed_r);
-    val bytes_r: R.Result[*u8, str] = A.allocate[u8](?alloc, 4::usize);
-    if (R.is_err[*u8, str](bytes_r)) { obj.dnit(?malformed); intern.dnit(?itn); ret 1; }
+    val malformed_r: res[of.ObjectImage, fail.Fail] = obj.image_init(?alloc, ?itn, intern.STR_NIL);
+    if (sel malformed_r.err) { intern.dnit(?itn); ret 1; }
+    var malformed: of.ObjectImage = malformed_r.ok;
+    val bytes_r: res[*u8, A.Error] = A.allocate[u8](?alloc, 4::usize);
+    if (sel bytes_r.err) { obj.dnit(?malformed); intern.dnit(?itn); ret 1; }
     var sec: of.Section;
     sec.name = intern.STR_NIL;
     sec.kind = of.SK_TEXT;
-    sec.bytes = R.unwrap_ok[*u8, str](bytes_r);
+    sec.bytes = bytes_r.ok;
     sec.len = 4;
     sec.align = 3;
     sec.flags = 0;
-    if (R.is_err[u32, str](obj.install_section(?malformed, ?sec))) {
+    val section_install_r: res[u32, fail.Fail] = obj.section_install(?malformed, ?sec);
+    if (sel section_install_r.err) {
         obj.dnit(?malformed);
         intern.dnit(?itn);
         ret 1;
     }
-    val rejected: R.Result[of.ObjectImage, str] = finish_codegen_image(malformed);
-    if (R.is_ok[of.ObjectImage, str](rejected)) {
-        var unexpected: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](rejected);
+    val rejected: res[of.ObjectImage, fail.Fail] = finish_codegen_image(malformed);
+    if (sel rejected.ok) {
+        var unexpected: of.ObjectImage = rejected.ok;
         obj.dnit(?unexpected);
         intern.dnit(?itn);
         ret 1;
@@ -2373,7 +2444,8 @@ test "mach.lang.be.codegen.finish_codegen_image:publishes_only_valid_owned_image
 
 test "mach.lang.be.codegen.scratch:module_images_survive_reclaimed_working_storage" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
@@ -2400,27 +2472,28 @@ test "mach.lang.be.codegen.scratch:module_images_survive_reclaimed_working_stora
     var attempts: usize = 0;
     for (ordinal <= attempts) {
         var tracking: alloc_test.Testing;
-        if (O.is_some[str](alloc_test.make(?tracking))) { ret 2; }
+        val make_r2: err[A.Error] = alloc_test.make(?tracking);
+        if (sel make_r2.err) { ret 2; }
         tracking.fail_at = ordinal;
-        val emitted: R.Result[of.ObjectImage, fail.Fail] = codegen_with_backing(?s, ?tgt, ?module,
+        val emitted: res[of.ObjectImage, fail.Fail] = codegen_with_backing(?s, ?tgt, ?module,
             unit.ir_set_empty(), nil, PLACEMENT_POLICY_VERSION, no_debug(), ?tracking.a);
         if (ordinal == 0) { attempts = tracking.attempts; }
         val clean: bool = tracking.live == 0 && tracking.double_frees == 0 && tracking.exhausted == 0;
         alloc_test.dnit(?tracking);
         if (!clean) { ret 3; }
         if (ordinal != 0) {
-            if (R.is_ok[of.ObjectImage, fail.Fail](emitted)) {
-                var unexpected: of.ObjectImage = R.unwrap_ok[of.ObjectImage, fail.Fail](emitted);
+            if (sel emitted.ok) {
+                var unexpected: of.ObjectImage = emitted.ok;
                 obj.dnit(?unexpected);
                 ret 4;
             }
-            val error: fail.Fail = R.unwrap_err[of.ObjectImage, fail.Fail](emitted);
+            val error: fail.Fail = emitted.err;
             if (!sel error.message) { ret 5; }
             if (error.message == nil || error.message[0] == 0) { ret 5; }
         }
         or {
-            if (R.is_err[of.ObjectImage, fail.Fail](emitted)) { ret 6; }
-            var image: of.ObjectImage = R.unwrap_ok[of.ObjectImage, fail.Fail](emitted);
+            if (sel emitted.err) { ret 6; }
+            var image: of.ObjectImage = emitted.ok;
             var good: bool = image.alloc == ?alloc && image.interner == ?s.interner;
             var found: bool = false;
             var i: u32 = 0;
@@ -2448,26 +2521,26 @@ test "mach.lang.be.codegen.scratch:module_images_survive_reclaimed_working_stora
 # an oblivious function at the vreg level, the shape the early walk sees:
 # v0 is a declared secret, v1 public, v2 is computed from both (derived, not
 # seeded), v3 declassifies v2, v4 is public arithmetic on the result
-fun t_oblivious_fixture(alloc: *A.Allocator, name: intern.StrId, oblivious: bool) R.Result[mir.MirFunction, str] {
+fun t_oblivious_fixture(alloc: *A.Allocator, name: intern.StrId, oblivious: bool) res[mir.MirFunction, fail.Fail] {
     var f: mir.MirFunction;
     f.name      = name;
     f.oblivious = oblivious;
-    val rv: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](alloc, 5::usize);
-    if (R.is_err[*mir.MirVReg, str](rv)) { ret R.err[mir.MirFunction, str](R.unwrap_err[*mir.MirVReg, str](rv)); }
-    f.vregs = R.unwrap_ok[*mir.MirVReg, str](rv);
+    val rv: res[*mir.MirVReg, A.Error] = A.allocate[mir.MirVReg](alloc, 5::usize);
+    if (sel rv.err) { ret res[mir.MirFunction, fail.Fail].err{fail.refused(rv.err)}; }
+    f.vregs = rv.ok;
     f.vreg_count = 5;
     f.vreg_cap   = 5;
     var v: u32 = 0;
     for (v < 5) { f.vregs[v] = mir.vreg(v, mir.REG_CLASS_GP, false, v == 0); v = v + 1; }
 
-    val rb: R.Result[*mir.MirBlock, str] = A.zallocate[mir.MirBlock](alloc, 1::usize);
-    if (R.is_err[*mir.MirBlock, str](rb)) { ret R.err[mir.MirFunction, str](R.unwrap_err[*mir.MirBlock, str](rb)); }
-    f.blocks      = R.unwrap_ok[*mir.MirBlock, str](rb);
+    val rb: res[*mir.MirBlock, A.Error] = A.zallocate[mir.MirBlock](alloc, 1::usize);
+    if (sel rb.err) { ret res[mir.MirFunction, fail.Fail].err{fail.refused(rb.err)}; }
+    f.blocks      = rb.ok;
     f.block_count = 1;
     f.block_cap   = 1;
-    val ri: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](alloc, 6::usize);
-    if (R.is_err[*mir.MirInstr, str](ri)) { ret R.err[mir.MirFunction, str](R.unwrap_err[*mir.MirInstr, str](ri)); }
-    val instrs: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](ri);
+    val ri: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](alloc, 6::usize);
+    if (sel ri.err) { ret res[mir.MirFunction, fail.Fail].err{fail.refused(ri.err)}; }
+    val instrs: *mir.MirInstr = ri.ok;
 
     var k: u32 = 0;
     for (k < 6) {
@@ -2476,9 +2549,9 @@ fun t_oblivious_fixture(alloc: *A.Allocator, name: intern.StrId, oblivious: bool
         if (k == 5) { n = 0; }
         var ops: *mir.MirOperand = nil;
         if (n > 0) {
-            val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](alloc, n::usize);
-            if (R.is_err[*mir.MirOperand, str](ro)) { ret R.err[mir.MirFunction, str](R.unwrap_err[*mir.MirOperand, str](ro)); }
-            ops = R.unwrap_ok[*mir.MirOperand, str](ro);
+            val ro: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](alloc, n::usize);
+            if (sel ro.err) { ret res[mir.MirFunction, fail.Fail].err{fail.refused(ro.err)}; }
+            ops = ro.ok;
         }
         if (k == 0) { ops[0] = mir.op_vreg(0); ops[1] = mir.op_imm(5); instrs[k] = mir.instr(mir.MIR_MOV, ops, 2, 8, 8); }
         if (k == 1) { ops[0] = mir.op_vreg(1); ops[1] = mir.op_imm(7); instrs[k] = mir.instr(mir.MIR_MOV, ops, 2, 8, 8); }
@@ -2493,19 +2566,19 @@ fun t_oblivious_fixture(alloc: *A.Allocator, name: intern.StrId, oblivious: bool
     f.blocks[0].instrs      = instrs;
     f.blocks[0].instr_count = 6;
     f.blocks[0].instr_cap   = 6;
-    ret R.ok[mir.MirFunction, str](f);
+    ret res[mir.MirFunction, fail.Fail].ok{f};
 }
 
 # the pipeline from the early walk to allocation, as codegen_scratch runs it
-fun t_allocate_fixture(tgt: *target.Target, m: *mir.MirModule) R.Result[R.Void, str] {
-    val rc: R.Result[R.Void, str] = ctvalidate.run(tgt, m);
-    if (R.is_err[R.Void, str](rc)) { ret rc; }
-    val rl: R.Result[R.Void, str] = legalize.run(tgt, m);
-    if (R.is_err[R.Void, str](rl)) { ret rl; }
-    val ri: R.Result[R.Void, str] = isel.run(tgt, m);
-    if (R.is_err[R.Void, str](ri)) { ret ri; }
-    val ra: R.Result[R.Void, str] = regalloc.run(tgt, m);
-    if (R.is_err[R.Void, str](ra)) { ret ra; }
+fun t_allocate_fixture(tgt: *target.Target, m: *mir.MirModule) err[fail.Fail] {
+    val rc: err[fail.Fail] = ctvalidate.validate(tgt, m);
+    if (sel rc.err) { ret rc; }
+    val rl: err[fail.Fail] = legalize.run(tgt, m);
+    if (sel rl.err) { ret rl; }
+    val ri: err[fail.Fail] = isel.run(tgt, m);
+    if (sel ri.err) { ret ri; }
+    val ra: err[fail.Fail] = regalloc.run(tgt, m);
+    if (sel ra.err) { ret ra; }
     ret frame.run(tgt, m);
 }
 
@@ -2561,7 +2634,8 @@ fun t_encoder_output_release(alloc: *A.Allocator, enc: *encode.EncoderOutput) {
 # leaves the emitted bytes identical to a build without the stream
 fun t_stream_matches_rendering(arch: str, os_name: str, abi: str) i32 {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var interner: intern.Interner = intern.init(?alloc);
     fin { intern.dnit(?interner); }
     var reg: target.TargetRegistry = target.registry_init();
@@ -2577,14 +2651,16 @@ fun t_stream_matches_rendering(arch: str, os_name: str, abi: str) i32 {
     # the oblivious module: plain build, then the rendering
     var m: mir.MirModule = mir.MirModule{alloc: ?alloc, interner: ?interner};
     fin { mir.dnit_module(?m); }
-    val rf: R.Result[mir.MirFunction, str] = t_oblivious_fixture(?alloc, name, true);
-    if (R.is_err[mir.MirFunction, str](rf)) { ret 5; }
-    if (R.is_err[R.Void, str](mir.push_function(?m, R.unwrap_ok[mir.MirFunction, str](rf)))) { ret 5; }
-    if (R.is_err[R.Void, str](t_allocate_fixture(?tgt, ?m))) { ret 6; }
+    val rf: res[mir.MirFunction, fail.Fail] = t_oblivious_fixture(?alloc, name, true);
+    if (sel rf.err) { ret 5; }
+    val push_function_r: err[fail.Fail] = mir.push_function(?m, rf.ok);
+    if (sel push_function_r.err) { ret 5; }
+    val t_allocate_fixture_r: err[fail.Fail] = t_allocate_fixture(?tgt, ?m);
+    if (sel t_allocate_fixture_r.err) { ret 6; }
 
-    val plain_r: R.Result[encode.EncoderOutput, str] = encode.run(?tgt, ?m, nil);
-    if (R.is_err[encode.EncoderOutput, str](plain_r)) { ret 7; }
-    var plain: encode.EncoderOutput = R.unwrap_ok[encode.EncoderOutput, str](plain_r);
+    val plain_r: res[encode.EncoderOutput, fail.Fail] = encode.run(?tgt, ?m, nil);
+    if (sel plain_r.err) { ret 7; }
+    var plain: encode.EncoderOutput = plain_r.ok;
     fin { t_encoder_output_release(?alloc, ?plain); }
     if (plain.notified == 0) { ret 8; }
 
@@ -2592,9 +2668,9 @@ fun t_stream_matches_rendering(arch: str, os_name: str, abi: str) i32 {
     w.ctx     = nil;
     w.f_write = t_asm_capture_write;
     t_asm_capture_len = 0;
-    val asm_r: R.Result[encode.EncoderOutput, str] = encode.run(?tgt, ?m, ?w);
-    if (R.is_err[encode.EncoderOutput, str](asm_r)) { ret 9; }
-    var rendered: encode.EncoderOutput = R.unwrap_ok[encode.EncoderOutput, str](asm_r);
+    val asm_r: res[encode.EncoderOutput, fail.Fail] = encode.run(?tgt, ?m, ?w);
+    if (sel asm_r.err) { ret 9; }
+    var rendered: encode.EncoderOutput = asm_r.ok;
     fin { t_encoder_output_release(?alloc, ?rendered); }
     if (rendered.notified != plain.notified)                       { ret 10; }
     if (t_asm_capture_instruction_lines() != plain.notified)       { ret 11; }
@@ -2603,13 +2679,15 @@ fun t_stream_matches_rendering(arch: str, os_name: str, abi: str) i32 {
     # the same function without the contract: no stream, the same bytes
     var open: mir.MirModule = mir.MirModule{alloc: ?alloc, interner: ?interner};
     fin { mir.dnit_module(?open); }
-    val rg: R.Result[mir.MirFunction, str] = t_oblivious_fixture(?alloc, name, false);
-    if (R.is_err[mir.MirFunction, str](rg)) { ret 13; }
-    if (R.is_err[R.Void, str](mir.push_function(?open, R.unwrap_ok[mir.MirFunction, str](rg)))) { ret 13; }
-    if (R.is_err[R.Void, str](t_allocate_fixture(?tgt, ?open))) { ret 14; }
-    val open_r: R.Result[encode.EncoderOutput, str] = encode.run(?tgt, ?open, nil);
-    if (R.is_err[encode.EncoderOutput, str](open_r)) { ret 15; }
-    var silent: encode.EncoderOutput = R.unwrap_ok[encode.EncoderOutput, str](open_r);
+    val rg: res[mir.MirFunction, fail.Fail] = t_oblivious_fixture(?alloc, name, false);
+    if (sel rg.err) { ret 13; }
+    val push_function_r2: err[fail.Fail] = mir.push_function(?open, rg.ok);
+    if (sel push_function_r2.err) { ret 13; }
+    val t_allocate_fixture_r2: err[fail.Fail] = t_allocate_fixture(?tgt, ?open);
+    if (sel t_allocate_fixture_r2.err) { ret 14; }
+    val open_r: res[encode.EncoderOutput, fail.Fail] = encode.run(?tgt, ?open, nil);
+    if (sel open_r.err) { ret 15; }
+    var silent: encode.EncoderOutput = open_r.ok;
     fin { t_encoder_output_release(?alloc, ?silent); }
     if (silent.notified != 0) { ret 16; }
     if (!t_bytes_equal(plain.text, plain.text_len, silent.text, silent.text_len)) { ret 17; }
@@ -2635,7 +2713,8 @@ test "mach.lang.be.codegen.stream:riscv64_plain_build_notifies_every_rendered_in
 # the barrier
 fun t_seeds_match_walk(arch: str, os_name: str, abi: str) i32 {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var interner: intern.Interner = intern.init(?alloc);
     fin { intern.dnit(?interner); }
     var reg: target.TargetRegistry = target.registry_init();
@@ -2649,18 +2728,20 @@ fun t_seeds_match_walk(arch: str, os_name: str, abi: str) i32 {
 
     var m: mir.MirModule = mir.MirModule{alloc: ?alloc, interner: ?interner};
     fin { mir.dnit_module(?m); }
-    val rf: R.Result[mir.MirFunction, str] = t_oblivious_fixture(?alloc, R.unwrap_ok[intern.StrId, str](nr), true);
-    if (R.is_err[mir.MirFunction, str](rf)) { ret 5; }
-    if (R.is_err[R.Void, str](mir.push_function(?m, R.unwrap_ok[mir.MirFunction, str](rf)))) { ret 5; }
+    val rf: res[mir.MirFunction, fail.Fail] = t_oblivious_fixture(?alloc, R.unwrap_ok[intern.StrId, str](nr), true);
+    if (sel rf.err) { ret 5; }
+    val push_function_r: err[fail.Fail] = mir.push_function(?m, rf.ok);
+    if (sel push_function_r.err) { ret 5; }
     val f: *mir.MirFunction = ?m.functions[0];
 
-    val wr: R.Result[*bool, str] = ctvalidate.derive_secret_vregs(f, ?alloc);
-    if (R.is_err[*bool, str](wr)) { ret 6; }
-    val walk: *bool = R.unwrap_ok[*bool, str](wr);
+    val wr: res[*bool, fail.Fail] = ctvalidate.derive_secret_vregs(f, ?alloc);
+    if (sel wr.err) { ret 6; }
+    val walk: *bool = wr.ok;
     fin { A.deallocate[bool](?alloc, walk, 5::usize); }
     if (!walk[0] || walk[1] || !walk[2] || walk[3] || walk[4]) { ret 7; }
 
-    if (R.is_err[R.Void, str](t_allocate_fixture(?tgt, ?m))) { ret 8; }
+    val t_allocate_fixture_r: err[fail.Fail] = t_allocate_fixture(?tgt, ?m);
+    if (sel t_allocate_fixture_r.err) { ret 8; }
 
     var seen_seed: u32 = 0;
     var seen_barrier: u32 = 0;

--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -1,15 +1,18 @@
 use std.types.bool.bool;
+use std.types.canonical.res;
+use std.types.canonical.opt;
+use std.types.canonical.err;
 use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_contains;
 use std.types.string.str_len;
-use format: mach.lang.legacy.format;
+use format: std.format;
 
-use page: mach.lang.legacy.page;
+use page: std.allocator.page;
 
-use A: mach.lang.legacy.allocator;
+use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -21,10 +24,10 @@ use mach.lang.intern;
 use mach.lang.target.isa;
 use target: mach.lang.target.resolved;
 
-pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[R.Void, str] {
-    if (tgt == nil)     { ret R.err[R.Void, str]("ctvalidate: nil target"); }
-    if (tgt.isa == nil) { ret R.err[R.Void, str]("ctvalidate: target has no instruction set"); }
-    if (m == nil)       { ret R.err[R.Void, str]("ctvalidate: nil mir module"); }
+pub fun validate(tgt: *target.Target, m: *mir.MirModule) err[fail.Fail] {
+    if (tgt == nil)     { ret err[fail.Fail].err{fail.message("ctvalidate: nil target")}; }
+    if (tgt.isa == nil) { ret err[fail.Fail].err{fail.message("ctvalidate: target has no instruction set")}; }
+    if (m == nil)       { ret err[fail.Fail].err{fail.message("ctvalidate: nil mir module")}; }
 
     val unverifiable: bool = isa.emits_whole_module(tgt.isa);
 
@@ -33,46 +36,54 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[R.Void, str] {
         val f: *mir.MirFunction = ?m.functions[i];
         if (f.oblivious) {
             if (unverifiable) {
-                ret R.err[R.Void, str](unverifiable_msg(m.alloc, m.interner, f.name, tgt.isa.name));
+                ret err[fail.Fail].err{fail.message(unverifiable_msg(m.alloc, m.interner, f.name, tgt.isa.name))};
             }
-            val res: R.Result[R.Void, str] = validate_function(tgt, f, m.interner, m.alloc);
-            if (R.is_err[R.Void, str](res)) { ret res; }
+            val result: err[fail.Fail] = validate_function(tgt, f, m.interner, m.alloc);
+            if (sel result.err) { ret result; }
         }
         i = i + 1;
     }
+    ret err[fail.Fail].ok{};
+}
+
+# translation shim (#3226): the legacy carrier the fuzz lane reads until its
+# call site migrates to `validate`
+pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[R.Void, str] {
+    val r: err[fail.Fail] = validate(tgt, m);
+    if (sel r.err) { ret R.err[R.Void, str](fail.describe(r.err)); }
     ret R.ok_void[str]();
 }
 
-fun validate_function(tgt: *target.Target, f: *mir.MirFunction, interner: *intern.Interner, alloc: *A.Allocator) R.Result[R.Void, str] {
-    if (f.block_count == 0) { ret R.ok_void[str](); }
+fun validate_function(tgt: *target.Target, f: *mir.MirFunction, interner: *intern.Interner, alloc: *A.Allocator) err[fail.Fail] {
+    if (f.block_count == 0) { ret err[fail.Fail].ok{}; }
 
     val nv: u32 = f.vreg_count;
     val mp: u32 = max_preg(f);
     var np: u32 = 0;
     if (mp != NO_PREG) { np = mp + 1; }
 
-    val shape: R.Result[R.Void, str] = validate_operand_ranges(f, nv, np, interner, alloc);
-    if (R.is_err[R.Void, str](shape)) { ret shape; }
+    val shape: err[fail.Fail] = validate_operand_ranges(f, nv, np, interner, alloc);
+    if (sel shape.err) { ret shape; }
 
-    if (nv == 0 && np == 0) { ret R.ok_void[str](); }
+    if (nv == 0 && np == 0) { ret err[fail.Fail].ok{}; }
 
     var vt: *bool = nil;
     if (nv > 0) {
-        val rv: R.Result[*bool, str] = A.allocate[bool](alloc, nv::usize);
-        if (R.is_err[*bool, str](rv)) { ret R.err[R.Void, str](R.unwrap_err[*bool, str](rv)); }
-        vt = R.unwrap_ok[*bool, str](rv);
+        val rv: res[*bool, A.Error] = A.allocate[bool](alloc, nv::usize);
+        if (sel rv.err) { ret err[fail.Fail].err{fail.refused(rv.err)}; }
+        vt = rv.ok;
         var i: u32 = 0;
         for (i < nv) { vt[i] = f.vregs[i].secret; i = i + 1; }
     }
 
     var pt: *bool = nil;
     if (np > 0) {
-        val rp: R.Result[*bool, str] = A.allocate[bool](alloc, np::usize);
-        if (R.is_err[*bool, str](rp)) {
+        val rp: res[*bool, A.Error] = A.allocate[bool](alloc, np::usize);
+        if (sel rp.err) {
             free_taint(alloc, vt, nv, pt, np);
-            ret R.err[R.Void, str](R.unwrap_err[*bool, str](rp));
+            ret err[fail.Fail].err{fail.refused(rp.err)};
         }
-        pt = R.unwrap_ok[*bool, str](rp);
+        pt = rp.ok;
     }
 
     fixpoint(f, vt, pt, np);
@@ -84,8 +95,8 @@ fun validate_function(tgt: *target.Target, f: *mir.MirFunction, interner: *inter
         var ij: u32 = 0;
         for (ij < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[ij];
-            val chk: R.Result[R.Void, str] = check_instr(tgt, f, mi, vt, pt, interner, alloc);
-            if (R.is_err[R.Void, str](chk)) {
+            val chk: err[fail.Fail] = check_instr(tgt, f, mi, vt, pt, interner, alloc);
+            if (sel chk.err) {
                 free_taint(alloc, vt, nv, pt, np);
                 ret chk;
             }
@@ -96,7 +107,7 @@ fun validate_function(tgt: *target.Target, f: *mir.MirFunction, interner: *inter
     }
 
     free_taint(alloc, vt, nv, pt, np);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun fixpoint(f: *mir.MirFunction, vt: *bool, pt: *bool, np: u32) {
@@ -120,12 +131,12 @@ fun fixpoint(f: *mir.MirFunction, vt: *bool, pt: *bool, np: u32) {
 # the per-vreg fixpoint the early walk reaches, seeded from MirVReg.secret:
 # what a post-allocation consumer compares its physical seeds against. one
 # bool per vreg, the caller frees vreg_count entries; nil for no vregs.
-pub fun derive_secret_vregs(f: *mir.MirFunction, alloc: *A.Allocator) R.Result[*bool, str] {
+pub fun derive_secret_vregs(f: *mir.MirFunction, alloc: *A.Allocator) res[*bool, fail.Fail] {
     val nv: u32 = f.vreg_count;
-    if (nv == 0) { ret R.ok[*bool, str](nil); }
-    val rv: R.Result[*bool, str] = A.allocate[bool](alloc, nv::usize);
-    if (R.is_err[*bool, str](rv)) { ret rv; }
-    val vt: *bool = R.unwrap_ok[*bool, str](rv);
+    if (nv == 0) { ret res[*bool, fail.Fail].ok{nil}; }
+    val rv: res[*bool, A.Error] = A.allocate[bool](alloc, nv::usize);
+    if (sel rv.err) { ret res[*bool, fail.Fail].err{fail.refused(rv.err)}; }
+    val vt: *bool = rv.ok;
     var i: u32 = 0;
     for (i < nv) { vt[i] = f.vregs[i].secret; i = i + 1; }
 
@@ -134,16 +145,16 @@ pub fun derive_secret_vregs(f: *mir.MirFunction, alloc: *A.Allocator) R.Result[*
     if (mp != NO_PREG) { np = mp + 1; }
     var pt: *bool = nil;
     if (np > 0) {
-        val rp: R.Result[*bool, str] = A.allocate[bool](alloc, np::usize);
-        if (R.is_err[*bool, str](rp)) {
+        val rp: res[*bool, A.Error] = A.allocate[bool](alloc, np::usize);
+        if (sel rp.err) {
             A.deallocate[bool](alloc, vt, nv::usize);
-            ret rp;
+            ret res[*bool, fail.Fail].err{fail.refused(rp.err)};
         }
-        pt = R.unwrap_ok[*bool, str](rp);
+        pt = rp.ok;
     }
     fixpoint(f, vt, pt, np);
     if (pt != nil) { A.deallocate[bool](alloc, pt, np::usize); }
-    ret R.ok[*bool, str](vt);
+    ret res[*bool, fail.Fail].ok{vt};
 }
 
 fun free_taint(alloc: *A.Allocator, vt: *bool, nv: u32, pt: *bool, np: u32) {
@@ -190,7 +201,7 @@ fun clear_pregs(pt: *bool, np: u32) {
     for (i < np) { pt[i] = false; i = i + 1; }
 }
 
-fun validate_operand_ranges(f: *mir.MirFunction, nv: u32, np: u32, interner: *intern.Interner, alloc: *A.Allocator) R.Result[R.Void, str] {
+fun validate_operand_ranges(f: *mir.MirFunction, nv: u32, np: u32, interner: *intern.Interner, alloc: *A.Allocator) err[fail.Fail] {
     var bi: u32 = 0;
     for (bi < f.block_count) {
         val blk: *mir.MirBlock = ?f.blocks[bi];
@@ -201,26 +212,26 @@ fun validate_operand_ranges(f: *mir.MirFunction, nv: u32, np: u32, interner: *in
             for (k < mi.operand_count) {
                 val op: *mir.MirOperand = ?mi.operands[k];
                 if (!operand_kind_known(op.kind)) {
-                    ret R.err[R.Void, str](malformed_msg(alloc, interner, f.name, RANGE_OPERAND_KIND_DETAIL));
+                    ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_OPERAND_KIND_DETAIL))};
                 }
                 if (op.kind == mir.MIR_OP_VREG && op.vreg >= nv) {
-                    ret R.err[R.Void, str](malformed_msg(alloc, interner, f.name, RANGE_VREG_DETAIL));
+                    ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_VREG_DETAIL))};
                 }
                 if (op.kind == mir.MIR_OP_PREG && op.preg >= np) {
-                    ret R.err[R.Void, str](malformed_msg(alloc, interner, f.name, RANGE_PREG_DETAIL));
+                    ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_PREG_DETAIL))};
                 }
                 if (op.kind == mir.MIR_OP_MEM) {
                     if (op.vreg == mir.MIR_VREG_NIL && op.preg >= np) {
-                        ret R.err[R.Void, str](malformed_msg(alloc, interner, f.name, RANGE_MEM_BASE_DETAIL));
+                        ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_MEM_BASE_DETAIL))};
                     }
                     if (op.vreg != mir.MIR_VREG_NIL && op.vreg >= nv) {
-                        ret R.err[R.Void, str](malformed_msg(alloc, interner, f.name, RANGE_MEM_BASE_DETAIL));
+                        ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_MEM_BASE_DETAIL))};
                     }
                     if (op.index != mir.MIR_VREG_NIL && op.index_is_preg && op.index >= np) {
-                        ret R.err[R.Void, str](malformed_msg(alloc, interner, f.name, RANGE_MEM_INDEX_DETAIL));
+                        ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_MEM_INDEX_DETAIL))};
                     }
                     if (op.index != mir.MIR_VREG_NIL && !op.index_is_preg && op.index >= nv) {
-                        ret R.err[R.Void, str](malformed_msg(alloc, interner, f.name, RANGE_MEM_INDEX_DETAIL));
+                        ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_MEM_INDEX_DETAIL))};
                     }
                 }
                 k = k + 1;
@@ -229,7 +240,7 @@ fun validate_operand_ranges(f: *mir.MirFunction, nv: u32, np: u32, interner: *in
         }
         bi = bi + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun mem_base_secret(op: *mir.MirOperand, vt: *bool, pt: *bool) bool {
@@ -280,30 +291,30 @@ fun apply_instr(mi: *mir.MirInstr, vt: *bool, pt: *bool, np: u32) bool {
     ret false;
 }
 
-fun check_instr(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr, vt: *bool, pt: *bool, interner: *intern.Interner, alloc: *A.Allocator) R.Result[R.Void, str] {
+fun check_instr(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr, vt: *bool, pt: *bool, interner: *intern.Interner, alloc: *A.Allocator) err[fail.Fail] {
     if (mi.opcode == mir.MIR_ASM) {
         ret check_asm(tgt, f, mi, interner, alloc);
     }
     if (mi.opcode == mir.MIR_CBR) {
         if (mi.operand_count >= 1 && operand_secret(?mi.operands[0], vt, pt)) {
-            ret R.err[R.Void, str](leak_msg(alloc, interner, f.name,
-                "uses a secret value as a conditional-branch condition; the branch decides the taken path, so its timing reveals the secret. select branch-free (a masked select) over public data, or `:>T`-declassify the value when disclosure is intended"));
+            ret err[fail.Fail].err{fail.message(leak_msg(alloc, interner, f.name,
+                "uses a secret value as a conditional-branch condition; the branch decides the taken path, so its timing reveals the secret. select branch-free (a masked select) over public data, or `:>T`-declassify the value when disclosure is intended"))};
         }
     }
     if (mi.opcode == mir.MIR_CALL) {
         if (mi.operand_count >= 1 && operand_secret(?mi.operands[0], vt, pt)) {
-            ret R.err[R.Void, str](leak_msg(alloc, interner, f.name,
-                "calls through a secret function pointer; the branch target, hence the taken path and its timing, depends on the secret. dispatch on public data, or `:>T`-declassify the pointer when disclosure is intended"));
+            ret err[fail.Fail].err{fail.message(leak_msg(alloc, interner, f.name,
+                "calls through a secret function pointer; the branch target, hence the taken path and its timing, depends on the secret. dispatch on public data, or `:>T`-declassify the pointer when disclosure is intended"))};
         }
     }
     if (mir.is_fused_cbr(mi.opcode)) {
         if (mi.operand_count >= 1 && operand_secret(?mi.operands[0], vt, pt)) {
-            ret R.err[R.Void, str](leak_msg(alloc, interner, f.name,
-                "compares a secret value in a conditional branch; the branch's taken path reveals the secret. select branch-free over public data, or `:>T`-declassify when disclosure is intended"));
+            ret err[fail.Fail].err{fail.message(leak_msg(alloc, interner, f.name,
+                "compares a secret value in a conditional branch; the branch's taken path reveals the secret. select branch-free over public data, or `:>T`-declassify when disclosure is intended"))};
         }
         if (mi.operand_count >= 2 && operand_secret(?mi.operands[1], vt, pt)) {
-            ret R.err[R.Void, str](leak_msg(alloc, interner, f.name,
-                "compares a secret value in a conditional branch; the branch's taken path reveals the secret. select branch-free over public data, or `:>T`-declassify when disclosure is intended"));
+            ret err[fail.Fail].err{fail.message(leak_msg(alloc, interner, f.name,
+                "compares a secret value in a conditional branch; the branch's taken path reveals the secret. select branch-free over public data, or `:>T`-declassify when disclosure is intended"))};
         }
     }
     var k: u32 = 0;
@@ -311,51 +322,51 @@ fun check_instr(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr, vt:
         val op: *mir.MirOperand = ?mi.operands[k];
         if (op.kind == mir.MIR_OP_MEM) {
             if (mem_base_secret(op, vt, pt)) {
-                ret R.err[R.Void, str](leak_msg(alloc, interner, f.name,
-                    "uses a secret value as a memory address; a secret-dependent load or store address leaks the secret through the memory-access pattern. index at a public offset, or `:>T`-declassify the pointer when disclosure is intended"));
+                ret err[fail.Fail].err{fail.message(leak_msg(alloc, interner, f.name,
+                    "uses a secret value as a memory address; a secret-dependent load or store address leaks the secret through the memory-access pattern. index at a public offset, or `:>T`-declassify the pointer when disclosure is intended"))};
             }
             if (mem_index_secret(op, vt, pt)) {
-                ret R.err[R.Void, str](leak_msg(alloc, interner, f.name,
-                    "uses a secret value as a memory index; a secret-dependent load or store address leaks the secret through the memory-access pattern. index at a public offset, or `:>T`-declassify the index when disclosure is intended"));
+                ret err[fail.Fail].err{fail.message(leak_msg(alloc, interner, f.name,
+                    "uses a secret value as a memory index; a secret-dependent load or store address leaks the secret through the memory-access pattern. index at a public offset, or `:>T`-declassify the index when disclosure is intended"))};
             }
         }
         k = k + 1;
     }
-    val cr: R.Result[ct.CtOp, str] = mir.ct_op(mi.opcode);
-    if (R.is_err[ct.CtOp, str](cr)) {
-        ret R.err[R.Void, str](malformed_msg(alloc, interner, f.name, R.unwrap_err[ct.CtOp, str](cr)));
+    val cr: res[ct.CtOp, fail.Fail] = mir.ct_op(mi.opcode);
+    if (sel cr.err) {
+        ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, fail.describe(cr.err)))};
     }
-    val cop: ct.CtOp = R.unwrap_ok[ct.CtOp, str](cr);
+    val cop: ct.CtOp = cr.ok;
     if (cop != ct.CT_OP_NONE) {
         val declared: O.Option[ct.CtCap] = ct.ct_cap(cop);
         if (O.is_none[ct.CtCap](declared)) {
-            ret R.err[R.Void, str](malformed_msg(alloc, interner, f.name,
-                fail.catalog_message_or(interner, alloc, fail.unknown_member("CtOp", cop::u32), "unknown CtOp tag")));
+            ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name,
+                fail.catalog_message_or(interner, alloc, fail.unknown_member("CtOp", cop::u32), "unknown CtOp tag")))};
         }
         val cap: ct.CtCap = O.unwrap[ct.CtCap](declared);
         if (!ct.target_provides(tgt.model.ct_trust_mul, tgt.model.ct_trust_var_shift, cap)) {
             if (ct_secret_operand(mi, cop, vt, pt)) {
-                ret R.err[R.Void, str](leak_msg(alloc, interner, f.name, ct_op_detail(cop)));
+                ret err[fail.Fail].err{fail.message(leak_msg(alloc, interner, f.name, ct_op_detail(cop)))};
             }
         }
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun check_asm(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr,
-              interner: *intern.Interner, alloc: *A.Allocator) R.Result[R.Void, str] {
+              interner: *intern.Interner, alloc: *A.Allocator) err[fail.Fail] {
     if (tgt.arch == nil || !tgt.arch.has_assembly || mi.asm_block == nil) {
-        ret R.err[R.Void, str](leak_msg(alloc, interner, f.name,
-            "contains inline assembly, which cannot be verified constant-time and is not permitted in a #[oblivious] function; express the operation with the constant-time primitives, or move it to a non-oblivious function and `:>T`-declassify at the boundary"));
+        ret err[fail.Fail].err{fail.message(leak_msg(alloc, interner, f.name,
+            "contains inline assembly, which cannot be verified constant-time and is not permitted in a #[oblivious] function; express the operation with the constant-time primitives, or move it to a non-oblivious function and `:>T`-declassify at the boundary"))};
     }
     val blk: *mir.MirAsm = mi.asm_block;
 
     var names: *str = nil;
     var n: u32 = 0;
     if (blk.bind_count > 0) {
-        val rn: R.Result[*str, str] = A.allocate[str](alloc, blk.bind_count::usize);
-        if (R.is_err[*str, str](rn)) { ret R.err[R.Void, str](R.unwrap_err[*str, str](rn)); }
-        names = R.unwrap_ok[*str, str](rn);
+        val rn: res[*str, A.Error] = A.allocate[str](alloc, blk.bind_count::usize);
+        if (sel rn.err) { ret err[fail.Fail].err{fail.refused(rn.err)}; }
+        names = rn.ok;
         var i: u32 = 0;
         for (i < blk.bind_count) {
             val b: *mir.MirAsmBind = ?blk.binds[i];
@@ -376,9 +387,9 @@ fun check_asm(tgt: *target.Target, f: *mir.MirFunction, mi: *mir.MirInstr,
     if (names != nil) { A.deallocate[str](alloc, names, blk.bind_count::usize); }
 
     if (R.is_err[R.Void, str](r)) {
-        ret R.err[R.Void, str](leak_msg(alloc, interner, f.name, R.unwrap_err[R.Void, str](r)));
+        ret err[fail.Fail].err{fail.message(leak_msg(alloc, interner, f.name, R.unwrap_err[R.Void, str](r)))};
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun ct_secret_operand(mi: *mir.MirInstr, cop: ct.CtOp, vt: *bool, pt: *bool) bool {
@@ -414,18 +425,18 @@ fun ct_op_detail(cop: ct.CtOp) str {
 fun leak_msg(alloc: *A.Allocator, interner: *intern.Interner, name_id: intern.StrId, detail: str) str {
     if (interner == nil) { ret detail; }
     val name: str = fn_name(interner, name_id);
-    val res: R.Result[str, str] = format.sprint(alloc, "codegen: #[oblivious] function `{}` {}", name, detail);
-    if (R.is_err[str, str](res)) { ret detail; }
-    ret stable(alloc, interner, R.unwrap_ok[str, str](res), detail);
+    val result: res[str, format.FormatError] = format.sprint(alloc, "codegen: #[oblivious] function `{}` {}", name, detail);
+    if (sel result.err) { ret detail; }
+    ret stable(alloc, interner, result.ok, detail);
 }
 
 fun malformed_msg(alloc: *A.Allocator, interner: *intern.Interner, name_id: intern.StrId, detail: str) str {
     if (interner == nil) { ret detail; }
     val name: str = fn_name(interner, name_id);
-    val res: R.Result[str, str] = format.sprint(alloc,
+    val result: res[str, format.FormatError] = format.sprint(alloc,
         "codegen: #[oblivious] function `{}` cannot be validated constant-time: {}", name, detail);
-    if (R.is_err[str, str](res)) { ret detail; }
-    ret stable(alloc, interner, R.unwrap_ok[str, str](res), detail);
+    if (sel result.err) { ret detail; }
+    ret stable(alloc, interner, result.ok, detail);
 }
 
 val RANGE_OPERAND_KIND_DETAIL: str = "an instruction operand has a kind outside the machine-operand catalog, so its secrecy cannot be decided; the machine program is malformed";
@@ -437,11 +448,11 @@ val RANGE_MEM_INDEX_DETAIL: str = "a memory operand's index register lies outsid
 fun unverifiable_msg(alloc: *A.Allocator, interner: *intern.Interner, name_id: intern.StrId, arch: str) str {
     if (interner == nil) { ret UNVERIFIABLE_DETAIL; }
     val name: str = fn_name(interner, name_id);
-    val res: R.Result[str, str] = format.sprint(alloc,
+    val result: res[str, format.FormatError] = format.sprint(alloc,
         "codegen: #[oblivious] function `{}` cannot be compiled for the `{}` target: its back half emits a module for a downstream compiler to translate rather than the instructions that execute, and neither that translation nor the device's timing behaviour is covered by mach's leakage model, so the constant-time contract can be neither validated nor upheld. compile the oblivious function for a machine target and pass this one only public data",
         name, arch);
-    if (R.is_err[str, str](res)) { ret UNVERIFIABLE_DETAIL; }
-    ret stable(alloc, interner, R.unwrap_ok[str, str](res), UNVERIFIABLE_DETAIL);
+    if (sel result.err) { ret UNVERIFIABLE_DETAIL; }
+    ret stable(alloc, interner, result.ok, UNVERIFIABLE_DETAIL);
 }
 
 val UNVERIFIABLE_DETAIL: str = "codegen: a #[oblivious] function cannot be compiled for a target whose back half emits a module for a downstream compiler to translate rather than the instructions that execute; the constant-time contract can be neither validated nor upheld there. compile the oblivious function for a machine target and pass this one only public data";
@@ -551,8 +562,8 @@ test "mach.lang.be.codegen.ctvalidate.rederive:phi_join_branch" {
     blocks[2] = t_block(2, ?b2i[0], 1);
 
     var f: mir.MirFunction = t_fn(true, ?blocks[0], 3, ?vregs[0], 3);
-    val r: R.Result[R.Void, str] = validate_function(?t, ?f, nil, ?alloc);
-    if (!R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = validate_function(?t, ?f, nil, ?alloc);
+    if (!sel r.err) { ret 1; }
     ret 0;
 }
 
@@ -578,8 +589,8 @@ test "mach.lang.be.codegen.ctvalidate.rederive:inlined_return_address" {
     var blocks: [1]mir.MirBlock;
     blocks[0] = t_block(0, ?b0i[0], 3);
     var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 4);
-    val r: R.Result[R.Void, str] = validate_function(?t, ?f, nil, ?alloc);
-    if (!R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = validate_function(?t, ?f, nil, ?alloc);
+    if (!sel r.err) { ret 1; }
     ret 0;
 }
 
@@ -614,8 +625,8 @@ test "mach.lang.be.codegen.ctvalidate.rederive:rotated_loop_backedge" {
     blocks[1] = t_block(1, ?b1i[0], 2);
     blocks[2] = t_block(2, ?b2i[0], 1);
     var f: mir.MirFunction = t_fn(true, ?blocks[0], 3, ?vregs[0], 4);
-    val r: R.Result[R.Void, str] = validate_function(?t, ?f, nil, ?alloc);
-    if (!R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = validate_function(?t, ?f, nil, ?alloc);
+    if (!sel r.err) { ret 1; }
     ret 0;
 }
 
@@ -643,8 +654,8 @@ test "mach.lang.be.codegen.ctvalidate.barrier:declassify_stops_taint" {
     var blocks: [1]mir.MirBlock;
     blocks[0] = t_block(0, ?b0i[0], 4);
     var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 4);
-    val r: R.Result[R.Void, str] = validate_function(?t, ?f, nil, ?alloc);
-    if (!R.is_ok[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = validate_function(?t, ?f, nil, ?alloc);
+    if (!sel r.ok) { ret 1; }
     ret 0;
 }
 
@@ -665,9 +676,11 @@ test "mach.lang.be.codegen.ctvalidate.varlat:secret_multiply_capability" {
     var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 3);
 
     var t_no: target.Target = t_target(false, true);
-    if (!R.is_err[R.Void, str](validate_function(?t_no, ?f, nil, ?alloc))) { ret 1; }
+    val validate_function_r: err[fail.Fail] = validate_function(?t_no, ?f, nil, ?alloc);
+    if (!sel validate_function_r.err) { ret 1; }
     var t_yes: target.Target = t_target(true, true);
-    if (!R.is_ok[R.Void, str](validate_function(?t_yes, ?f, nil, ?alloc))) { ret 1; }
+    val validate_function_r2: err[fail.Fail] = validate_function(?t_yes, ?f, nil, ?alloc);
+    if (!sel validate_function_r2.ok) { ret 1; }
     ret 0;
 }
 
@@ -686,15 +699,18 @@ test "mach.lang.be.codegen.ctvalidate.varlat:secret_shift_count_only" {
     var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 3);
 
     var t_no: target.Target = t_target(false, false);
-    if (!R.is_err[R.Void, str](validate_function(?t_no, ?f, nil, ?alloc))) { ret 1; }
+    val validate_function_r: err[fail.Fail] = validate_function(?t_no, ?f, nil, ?alloc);
+    if (!sel validate_function_r.err) { ret 1; }
     var t_yes: target.Target = t_target(false, true);
-    if (!R.is_ok[R.Void, str](validate_function(?t_yes, ?f, nil, ?alloc))) { ret 1; }
+    val validate_function_r2: err[fail.Fail] = validate_function(?t_yes, ?f, nil, ?alloc);
+    if (!sel validate_function_r2.ok) { ret 1; }
 
     var shl2: [3]mir.MirOperand; shl2[0] = mir.op_vreg(2); shl2[1] = mir.op_vreg(0); shl2[2] = mir.op_imm(3);
     var b0i2: [1]mir.MirInstr; b0i2[0] = t_instr(mir.MIR_SHL, ?shl2[0], 3);
     var blocks2: [1]mir.MirBlock; blocks2[0] = t_block(0, ?b0i2[0], 1);
     var f2: mir.MirFunction = t_fn(true, ?blocks2[0], 1, ?vregs[0], 3);
-    if (!R.is_ok[R.Void, str](validate_function(?t_no, ?f2, nil, ?alloc))) { ret 1; }
+    val validate_function_r3: err[fail.Fail] = validate_function(?t_no, ?f2, nil, ?alloc);
+    if (!sel validate_function_r3.ok) { ret 1; }
     ret 0;
 }
 
@@ -711,7 +727,8 @@ test "mach.lang.be.codegen.ctvalidate.varlat:secret_divide_and_precolor" {
     var b0i: [1]mir.MirInstr; b0i[0] = t_instr(mir.MIR_DIV_S, ?dv[0], 3);
     var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?b0i[0], 1);
     var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 3);
-    if (!R.is_err[R.Void, str](validate_function(?t, ?f, nil, ?alloc))) { ret 1; }
+    val validate_function_r: err[fail.Fail] = validate_function(?t, ?f, nil, ?alloc);
+    if (!sel validate_function_r.err) { ret 1; }
 
     var mov: [2]mir.MirOperand; mov[0] = mir.op_preg(0); mov[1] = mir.op_vreg(0);
     var dv2: [2]mir.MirOperand; dv2[0] = mir.op_preg(0); dv2[1] = mir.op_vreg(1);
@@ -720,7 +737,8 @@ test "mach.lang.be.codegen.ctvalidate.varlat:secret_divide_and_precolor" {
     p0i[1] = t_instr(mir.MIR_DIV_S, ?dv2[0], 2);
     var pblocks: [1]mir.MirBlock; pblocks[0] = t_block(0, ?p0i[0], 2);
     var pf: mir.MirFunction = t_fn(true, ?pblocks[0], 1, ?vregs[0], 3);
-    if (!R.is_err[R.Void, str](validate_function(?t, ?pf, nil, ?alloc))) { ret 1; }
+    val validate_function_r2: err[fail.Fail] = validate_function(?t, ?pf, nil, ?alloc);
+    if (!sel validate_function_r2.err) { ret 1; }
     ret 0;
 }
 
@@ -745,7 +763,8 @@ test "mach.lang.be.codegen.ctvalidate.clean:valid_oblivious_no_false_positive" {
     b0i[3] = t_instr(mir.MIR_RET,   nil, 0);
     var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?b0i[0], 4);
     var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 4);
-    if (!R.is_ok[R.Void, str](validate_function(?t, ?f, nil, ?alloc))) { ret 1; }
+    val validate_function_r: err[fail.Fail] = validate_function(?t, ?f, nil, ?alloc);
+    if (!sel validate_function_r.ok) { ret 1; }
     ret 0;
 }
 
@@ -786,13 +805,15 @@ test "mach.lang.be.codegen.ctvalidate.control:secret_indirect_call" {
     var si: [1]mir.MirInstr; si[0] = t_instr(mir.MIR_CALL, ?c_sec[0], 1);
     var sblocks: [1]mir.MirBlock; sblocks[0] = t_block(0, ?si[0], 1);
     var sf: mir.MirFunction = t_fn(true, ?sblocks[0], 1, ?vregs[0], 2);
-    if (!R.is_err[R.Void, str](validate_function(?t, ?sf, nil, ?alloc))) { ret 1; }
+    val validate_function_r: err[fail.Fail] = validate_function(?t, ?sf, nil, ?alloc);
+    if (!sel validate_function_r.err) { ret 1; }
 
     var c_pub: [1]mir.MirOperand; c_pub[0] = mir.op_vreg(1);
     var pi: [1]mir.MirInstr; pi[0] = t_instr(mir.MIR_CALL, ?c_pub[0], 1);
     var pblocks: [1]mir.MirBlock; pblocks[0] = t_block(0, ?pi[0], 1);
     var pf: mir.MirFunction = t_fn(true, ?pblocks[0], 1, ?vregs[0], 2);
-    if (!R.is_ok[R.Void, str](validate_function(?t, ?pf, nil, ?alloc))) { ret 1; }
+    val validate_function_r2: err[fail.Fail] = validate_function(?t, ?pf, nil, ?alloc);
+    if (!sel validate_function_r2.ok) { ret 1; }
     ret 0;
 }
 
@@ -810,7 +831,8 @@ test "mach.lang.be.codegen.ctvalidate.opaque:inline_asm_forbidden" {
     var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?ai[0], 1);
 
     var of: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 1);
-    if (!R.is_err[R.Void, str](validate_function(?t, ?of, nil, ?alloc))) { ret 1; }
+    val validate_function_r: err[fail.Fail] = validate_function(?t, ?of, nil, ?alloc);
+    if (!sel validate_function_r.err) { ret 1; }
 
     var funcs: [1]mir.MirFunction; funcs[0] = t_fn(false, ?blocks[0], 1, ?vregs[0], 1);
     var mm: mir.MirModule; mm.alloc = ?alloc; mm.interner = nil; mm.functions = ?funcs[0]; mm.function_len = 1;
@@ -853,9 +875,9 @@ test "mach.lang.be.codegen.ctvalidate.scope:whole_module_backend_refused" {
 }
 
 fun t_ct(op: mir.MirOpcode) ct.CtOp {
-    val r: R.Result[ct.CtOp, str] = mir.ct_op(op);
-    if (R.is_err[ct.CtOp, str](r)) { ret 0xFF; }
-    ret R.unwrap_ok[ct.CtOp, str](r);
+    val r: res[ct.CtOp, fail.Fail] = mir.ct_op(op);
+    if (sel r.err) { ret 0xFF; }
+    ret r.ok;
 }
 
 test "mach.lang.be.codegen.ctvalidate.classify:mir_ct_op_table" {
@@ -887,10 +909,13 @@ test "mach.lang.be.codegen.ctvalidate.failclosed:unknown_opcode_rejected" {
     b0i[0] = t_instr(0xDEAD, ?ops[0], 1);
     var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?b0i[0], 1);
     var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 1);
-    if (!R.is_err[R.Void, str](validate_function(?t, ?f, nil, ?alloc))) { ret 1; }
+    val validate_function_r: err[fail.Fail] = validate_function(?t, ?f, nil, ?alloc);
+    if (!sel validate_function_r.err) { ret 1; }
 
-    if (!R.is_err[ct.CtOp, str](mir.ct_op(0xDEAD))) { ret 1; }
-    if (!R.is_ok[ct.CtOp, str](mir.ct_op(mir.MIR_ADD))) { ret 1; }
+    val ct_op_r: res[ct.CtOp, fail.Fail] = mir.ct_op(0xDEAD);
+    if (!sel ct_op_r.err) { ret 1; }
+    val ct_op_r2: res[ct.CtOp, fail.Fail] = mir.ct_op(mir.MIR_ADD);
+    if (!sel ct_op_r2.ok) { ret 1; }
     ret 0;
 }
 
@@ -907,19 +932,22 @@ test "mach.lang.be.codegen.ctvalidate.failclosed:out_of_range_registers_rejected
     var gi: [1]mir.MirInstr; gi[0] = t_instr(mir.MIR_MOV, ?good[0], 2);
     var gb: [1]mir.MirBlock; gb[0] = t_block(0, ?gi[0], 1);
     var gf: mir.MirFunction = t_fn(true, ?gb[0], 1, ?vregs[0], 2);
-    if (!R.is_ok[R.Void, str](validate_function(?t, ?gf, nil, ?alloc))) { ret 1; }
+    val validate_function_r: err[fail.Fail] = validate_function(?t, ?gf, nil, ?alloc);
+    if (!sel validate_function_r.ok) { ret 1; }
 
     var vops: [2]mir.MirOperand; vops[0] = mir.op_vreg(1); vops[1] = mir.op_vreg(7);
     var vi: [1]mir.MirInstr; vi[0] = t_instr(mir.MIR_MOV, ?vops[0], 2);
     var vb: [1]mir.MirBlock; vb[0] = t_block(0, ?vi[0], 1);
     var vf: mir.MirFunction = t_fn(true, ?vb[0], 1, ?vregs[0], 2);
-    if (!R.is_err[R.Void, str](validate_function(?t, ?vf, nil, ?alloc))) { ret 1; }
+    val validate_function_r2: err[fail.Fail] = validate_function(?t, ?vf, nil, ?alloc);
+    if (!sel validate_function_r2.err) { ret 1; }
 
     var mops: [2]mir.MirOperand; mops[0] = mir.op_vreg(1); mops[1] = mir.op_mem_value(9, 0);
     var mi2: [1]mir.MirInstr; mi2[0] = t_instr(mir.MIR_LOAD, ?mops[0], 2);
     var mb2: [1]mir.MirBlock; mb2[0] = t_block(0, ?mi2[0], 1);
     var mf: mir.MirFunction = t_fn(true, ?mb2[0], 1, ?vregs[0], 2);
-    if (!R.is_err[R.Void, str](validate_function(?t, ?mf, nil, ?alloc))) { ret 1; }
+    val validate_function_r3: err[fail.Fail] = validate_function(?t, ?mf, nil, ?alloc);
+    if (!sel validate_function_r3.err) { ret 1; }
 
     var pops: [2]mir.MirOperand; pops[0] = mir.op_vreg(1); pops[1] = mir.op_preg(3);
     var pi: [2]mir.MirInstr;
@@ -927,7 +955,8 @@ test "mach.lang.be.codegen.ctvalidate.failclosed:out_of_range_registers_rejected
     pi[1] = t_instr(mir.MIR_RET, nil, 0);
     var pb: [1]mir.MirBlock; pb[0] = t_block(0, ?pi[0], 2);
     var pf: mir.MirFunction = t_fn(true, ?pb[0], 1, ?vregs[0], 2);
-    if (!R.is_ok[R.Void, str](validate_function(?t, ?pf, nil, ?alloc))) { ret 1; }
+    val validate_function_r4: err[fail.Fail] = validate_function(?t, ?pf, nil, ?alloc);
+    if (!sel validate_function_r4.ok) { ret 1; }
     ret 0;
 }
 
@@ -947,7 +976,8 @@ test "mach.lang.be.codegen.ctvalidate.failclosed:secret_memory_base_preg" {
     ins[1] = t_instr(mir.MIR_LOAD, ?ld[0], 2);
     var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?ins[0], 2);
     var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 2);
-    if (!R.is_err[R.Void, str](validate_function(?t, ?f, nil, ?alloc))) { ret 1; }
+    val validate_function_r: err[fail.Fail] = validate_function(?t, ?f, nil, ?alloc);
+    if (!sel validate_function_r.err) { ret 1; }
 
     var pub_mk: [2]mir.MirOperand; pub_mk[0] = mir.op_preg(2); pub_mk[1] = mir.op_vreg(1);
     var pub_ins: [2]mir.MirInstr;
@@ -955,7 +985,8 @@ test "mach.lang.be.codegen.ctvalidate.failclosed:secret_memory_base_preg" {
     pub_ins[1] = t_instr(mir.MIR_LOAD, ?ld[0], 2);
     var pub_blocks: [1]mir.MirBlock; pub_blocks[0] = t_block(0, ?pub_ins[0], 2);
     var pf: mir.MirFunction = t_fn(true, ?pub_blocks[0], 1, ?vregs[0], 2);
-    if (!R.is_ok[R.Void, str](validate_function(?t, ?pf, nil, ?alloc))) { ret 1; }
+    val validate_function_r2: err[fail.Fail] = validate_function(?t, ?pf, nil, ?alloc);
+    if (!sel validate_function_r2.ok) { ret 1; }
     ret 0;
 }
 
@@ -975,12 +1006,13 @@ test "mach.lang.be.codegen.ctvalidate.failclosed:operand_kind_outside_the_catalo
     ins[1] = t_instr(mir.MIR_RET, nil, 0);
     var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?ins[0], 2);
     var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 2);
-    val r: R.Result[R.Void, str] = validate_function(?t, ?f, nil, ?alloc);
-    if (!R.is_err[R.Void, str](r)) { ret 1; }
-    if (!str_contains(R.unwrap_err[R.Void, str](r), "outside the machine-operand catalog")) { ret 1; }
+    val r: err[fail.Fail] = validate_function(?t, ?f, nil, ?alloc);
+    if (!sel r.err) { ret 1; }
+    if (!str_contains(fail.describe(r.err), "outside the machine-operand catalog")) { ret 1; }
 
     ops[1].kind = mir.MIR_OP_VREG;
     var pf: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 2);
-    if (!R.is_ok[R.Void, str](validate_function(?t, ?pf, nil, ?alloc))) { ret 1; }
+    val validate_function_r: err[fail.Fail] = validate_function(?t, ?pf, nil, ?alloc);
+    if (!sel validate_function_r.ok) { ret 1; }
     ret 0;
 }

--- a/src/lang/be/codegen/debug_input.mach
+++ b/src/lang/be/codegen/debug_input.mach
@@ -1,8 +1,8 @@
 use std.types.bool.bool;
-use map: mach.lang.legacy.map;
+use map: std.collections.map;
 use std.types.size.usize;
 
-use A: mach.lang.legacy.allocator;
+use A: std.allocator;
 
 use mach.lang.be.codegen.mir;
 use mach.lang.intern;

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -1,6 +1,9 @@
 use std.types.canonical.opt;
+use std.types.canonical.res;
+use std.types.canonical.err;
+use mach.lang.fail;
 use std.system.panic.panic;
-use map: mach.lang.legacy.map;
+use map: std.collections.map;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -9,7 +12,7 @@ use std.types.string.str;
 use std.types.string.str_len;
 use std.types.string.str_equals;
 
-use A: mach.lang.legacy.allocator;
+use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -28,7 +31,7 @@ use semtype: mach.lang.type;
 use mach.lang.target.of;
 use mach.lang.target.of.bin;
 
-use page: mach.lang.legacy.page;
+use page: std.allocator.page;
 
 val DW_TAG_compile_unit:     u8 = 0x11;
 val DW_TAG_base_type:        u8 = 0x24;
@@ -369,9 +372,9 @@ fun type_ctx_dnit(tc: *TypeCtx) {
 fun type_reserve(tc: *TypeCtx) bool {
     if (tc.ntypes < tc.type_cap) { ret true; }
     if (tc.type_cap == 0) {
-        val ra: R.Result[*TypeDie, str] = A.allocate[TypeDie](tc.alloc, 8::usize);
-        if (R.is_err[*TypeDie, str](ra)) { ret false; }
-        tc.types    = R.unwrap_ok[*TypeDie, str](ra);
+        val ra: res[*TypeDie, A.Error] = A.allocate[TypeDie](tc.alloc, 8::usize);
+        if (sel ra.err) { ret false; }
+        tc.types    = ra.ok;
         tc.type_cap = 8;
         ret true;
     }
@@ -382,9 +385,9 @@ fun type_reserve(tc: *TypeCtx) bool {
         layout.usize_to_u32(R.unwrap_ok[layout.CheckedCount[TypeDie], layout.CheckCause](doubled).value);
     if (R.is_err[u32, layout.CheckCause](fits)) { ret false; }
     val new_cap: u32 = R.unwrap_ok[u32, layout.CheckCause](fits);
-    val rr: R.Result[*TypeDie, str] = A.reallocate[TypeDie](tc.alloc, tc.types, tc.type_cap::usize, new_cap::usize);
-    if (R.is_err[*TypeDie, str](rr)) { ret false; }
-    tc.types    = R.unwrap_ok[*TypeDie, str](rr);
+    val rr: res[*TypeDie, A.Error] = A.reallocate[TypeDie](tc.alloc, tc.types, tc.type_cap::usize, new_cap::usize);
+    if (sel rr.err) { ret false; }
+    tc.types    = rr.ok;
     tc.type_cap = new_cap;
     ret true;
 }
@@ -392,9 +395,9 @@ fun type_reserve(tc: *TypeCtx) bool {
 fun memb_reserve(tc: *TypeCtx) bool {
     if (tc.nmemb < tc.memb_cap) { ret true; }
     if (tc.memb_cap == 0) {
-        val ra: R.Result[*TypeMember, str] = A.allocate[TypeMember](tc.alloc, 16::usize);
-        if (R.is_err[*TypeMember, str](ra)) { ret false; }
-        tc.membs    = R.unwrap_ok[*TypeMember, str](ra);
+        val ra: res[*TypeMember, A.Error] = A.allocate[TypeMember](tc.alloc, 16::usize);
+        if (sel ra.err) { ret false; }
+        tc.membs    = ra.ok;
         tc.memb_cap = 16;
         ret true;
     }
@@ -405,9 +408,9 @@ fun memb_reserve(tc: *TypeCtx) bool {
         layout.usize_to_u32(R.unwrap_ok[layout.CheckedCount[TypeMember], layout.CheckCause](doubled).value);
     if (R.is_err[u32, layout.CheckCause](fits)) { ret false; }
     val new_cap: u32 = R.unwrap_ok[u32, layout.CheckCause](fits);
-    val rr: R.Result[*TypeMember, str] = A.reallocate[TypeMember](tc.alloc, tc.membs, tc.memb_cap::usize, new_cap::usize);
-    if (R.is_err[*TypeMember, str](rr)) { ret false; }
-    tc.membs    = R.unwrap_ok[*TypeMember, str](rr);
+    val rr: res[*TypeMember, A.Error] = A.reallocate[TypeMember](tc.alloc, tc.membs, tc.memb_cap::usize, new_cap::usize);
+    if (sel rr.err) { ret false; }
+    tc.membs    = rr.ok;
     tc.memb_cap = new_cap;
     ret true;
 }
@@ -488,28 +491,29 @@ fun push_rng_reloc(list: *RngReloc, count: *u32, cap: u32, off: u32, sym: intern
     @count = @count + 1;
 }
 
-fun debug_type_align(s: *debug_input.DebugProgram, tid: u32) O.Option[u32] {
-    if (s.type_aligns == nil) { ret O.none[u32](); }
-    val res: R.Result[*u32, str] = map.get[u32, u32](s.type_aligns, ?tid);
-    if (R.is_err[*u32, str](res)) { ret O.none[u32](); }
-    ret O.some[u32](@R.unwrap_ok[*u32, str](res));
+fun debug_type_align(s: *debug_input.DebugProgram, tid: u32) opt[u32] {
+    if (s.type_aligns == nil) { ret opt[u32].none{}; }
+    val result: opt[*u32] = map.get[u32, u32](s.type_aligns, ?tid);
+    if (sel result.none) { ret opt[u32].none{}; }
+    ret opt[u32].some{@result.some};
 }
 
 fun debug_type_is_packed(s: *debug_input.DebugProgram, tid: u32) bool {
     if (s.type_packed == nil) { ret false; }
-    ret R.is_ok[*u32, str](map.get[u32, u32](s.type_packed, ?tid));
+    val packed: opt[*u32] = map.get[u32, u32](s.type_packed, ?tid);
+    ret sel packed.some;
 }
 
-fun sem_base_type(s: *debug_input.DebugProgram, tid: semtype.TypeId, address_size: u8) O.Option[TypeDie] {
-    if (tid == semtype.TYPE_NIL || tid == semtype.TYPE_ERROR) { ret O.none[TypeDie](); }
+fun sem_base_type(s: *debug_input.DebugProgram, tid: semtype.TypeId, address_size: u8) opt[TypeDie] {
+    if (tid == semtype.TYPE_NIL || tid == semtype.TYPE_ERROR) { ret opt[TypeDie].none{}; }
     val to: O.Option[*semtype.Type] = semtype.get(s.types, semtype.strip_secret(s.types, tid));
-    if (O.is_none[*semtype.Type](to)) { ret O.none[TypeDie](); }
+    if (O.is_none[*semtype.Type](to)) { ret opt[TypeDie].none{}; }
     ret base_die_of_kind(O.unwrap[*semtype.Type](to).kind, address_size);
 }
 
-fun base_die_of_kind(kind: semtype.TypeKind, address_size: u8) O.Option[TypeDie] {
+fun base_die_of_kind(kind: semtype.TypeKind, address_size: u8) opt[TypeDie] {
     val d: semtype.PrimDesc = semtype.prim_desc(kind);
-    if (d.class == semtype.PRIM_CLASS_NONE) { ret O.none[TypeDie](); }
+    if (d.class == semtype.PRIM_CLASS_NONE) { ret opt[TypeDie].none{}; }
 
     var bt: TypeDie;
     bt.kind       = TK_BASE;
@@ -531,30 +535,30 @@ fun base_die_of_kind(kind: semtype.TypeKind, address_size: u8) O.Option[TypeDie]
         if (d.signed) { bt.encoding = DW_ATE_signed; } or { bt.encoding = DW_ATE_unsigned; }
         bt.byte_size = (d.bits / 8)::u32;
     }
-    ret O.some[TypeDie](bt);
+    ret opt[TypeDie].some{bt};
 }
 
-fun sem_to_ir(s: *debug_input.DebugProgram, dtypes: *ir_type.IrTypeTable, sem: semtype.TypeId) R.Result[ir_type.IrTypeId, str] {
-    if (sem == semtype.TYPE_NIL) { ret ir_type.intern_void(dtypes); }
+fun sem_to_ir(s: *debug_input.DebugProgram, dtypes: *ir_type.IrTypeTable, sem: semtype.TypeId) res[ir_type.IrTypeId, fail.Fail] {
+    if (sem == semtype.TYPE_NIL) { ret fail.lift_res[ir_type.IrTypeId](ir_type.intern_void(dtypes)); }
     val to: O.Option[*semtype.Type] = semtype.get(s.types, sem);
-    if (O.is_none[*semtype.Type](to)) { ret ir_type.intern_void(dtypes); }
+    if (O.is_none[*semtype.Type](to)) { ret fail.lift_res[ir_type.IrTypeId](ir_type.intern_void(dtypes)); }
     val t: *semtype.Type = O.unwrap[*semtype.Type](to);
     val k: semtype.TypeKind = t.kind;
 
     if (k == semtype.TYPE_SECRET) { ret sem_to_ir(s, dtypes, t.data.secret.base); }
 
     val d: semtype.PrimDesc = semtype.prim_desc(k);
-    if (d.class == semtype.PRIM_CLASS_INT)   { ret ir_type.intern_int(dtypes, d.bits); }
-    if (d.class == semtype.PRIM_CLASS_FLOAT) { ret ir_type.intern_float(dtypes, d.bits); }
-    if (d.class == semtype.PRIM_CLASS_PTR)   { ret ir_type.intern_ptr(dtypes); }
-    if (k == semtype.TYPE_POINTER)           { ret ir_type.intern_ptr(dtypes); }
+    if (d.class == semtype.PRIM_CLASS_INT)   { ret fail.lift_res[ir_type.IrTypeId](ir_type.intern_int(dtypes, d.bits)); }
+    if (d.class == semtype.PRIM_CLASS_FLOAT) { ret fail.lift_res[ir_type.IrTypeId](ir_type.intern_float(dtypes, d.bits)); }
+    if (d.class == semtype.PRIM_CLASS_PTR)   { ret fail.lift_res[ir_type.IrTypeId](ir_type.intern_ptr(dtypes)); }
+    if (k == semtype.TYPE_POINTER)           { ret fail.lift_res[ir_type.IrTypeId](ir_type.intern_ptr(dtypes)); }
 
     if (k == semtype.TYPE_ARRAY) {
         val ebase: semtype.TypeId = t.data.array.base;
         val ecount: u32 = t.data.array.count;
-        val rb: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, dtypes, ebase);
-        if (R.is_err[ir_type.IrTypeId, str](rb)) { ret rb; }
-        ret ir_type.intern_array(dtypes, R.unwrap_ok[ir_type.IrTypeId, str](rb), ecount);
+        val rb: res[ir_type.IrTypeId, fail.Fail] = sem_to_ir(s, dtypes, ebase);
+        if (sel rb.err) { ret rb; }
+        ret fail.lift_res[ir_type.IrTypeId](ir_type.intern_array(dtypes, rb.ok, ecount));
     }
 
     if (k == semtype.TYPE_VECTOR) {
@@ -562,62 +566,62 @@ fun sem_to_ir(s: *debug_input.DebugProgram, dtypes: *ir_type.IrTypeTable, sem: s
         val lanes: u32 = t.data.vector.lanes;
         var res_elem: R.Result[ir_type.IrTypeId, str] = ir_type.intern_int(dtypes, ed.bits);
         if (ed.class == semtype.PRIM_CLASS_FLOAT) { res_elem = ir_type.intern_float(dtypes, ed.bits); }
-        if (R.is_err[ir_type.IrTypeId, str](res_elem)) { ret res_elem; }
-        ret ir_type.intern_vector(dtypes, R.unwrap_ok[ir_type.IrTypeId, str](res_elem), lanes);
+        if (R.is_err[ir_type.IrTypeId, str](res_elem)) { ret fail.lift_res[ir_type.IrTypeId](res_elem); }
+        ret fail.lift_res[ir_type.IrTypeId](ir_type.intern_vector(dtypes, R.unwrap_ok[ir_type.IrTypeId, str](res_elem), lanes));
     }
 
     if (k == semtype.TYPE_REC || k == semtype.TYPE_UNI || k == semtype.TYPE_INSTANCE) {
         ret sem_to_ir_nominal(s, dtypes, sem, semtype.is_union(s.types, sem));
     }
 
-    ret ir_type.intern_ptr(dtypes);
+    ret fail.lift_res[ir_type.IrTypeId](ir_type.intern_ptr(dtypes));
 }
 
-fun sem_to_ir_nominal(s: *debug_input.DebugProgram, dtypes: *ir_type.IrTypeTable, tid: semtype.TypeId, is_union: bool) R.Result[ir_type.IrTypeId, str] {
+fun sem_to_ir_nominal(s: *debug_input.DebugProgram, dtypes: *ir_type.IrTypeTable, tid: semtype.TypeId, is_union: bool) res[ir_type.IrTypeId, fail.Fail] {
     val t: O.Option[*semtype.Type] = semtype.get(s.types, tid);
     if (O.is_some[*semtype.Type](t) && O.unwrap[*semtype.Type](t).kind == semtype.TYPE_INSTANCE) {
         val ft: O.Option[*semtype.FieldTable] = semtype.field_table_for(s.types, tid);
         if (O.is_none[*semtype.FieldTable](ft)
             || O.unwrap[*semtype.FieldTable](ft).epoch != s.field_epoch) {
-            ret R.err[ir_type.IrTypeId, str]("dwarf.sem_to_ir: instance field table was not finalized for debug production");
+            ret res[ir_type.IrTypeId, fail.Fail].err{fail.message("dwarf.sem_to_ir: instance field table was not finalized for debug production")};
         }
     }
     var nom_align: u32 = 0;
-    val ta: O.Option[u32] = debug_type_align(s, tid::u32);
+    val ta: opt[u32] = debug_type_align(s, tid::u32);
     val nom_packed: bool = debug_type_is_packed(s, tid::u32);
-    if (O.is_some[u32](ta)) { nom_align = O.unwrap[u32](ta); }
+    if (sel ta.some) { nom_align = ta.some; }
 
     val fields_len: u32 = semtype.field_count(s.types, tid);
     if (fields_len == 0) {
-        if (is_union) { ret ir_type.intern_union(dtypes, nil, 0, nom_align, nom_packed); }
-        ret ir_type.intern_struct(dtypes, nil, 0, nom_align, nom_packed);
+        if (is_union) { ret fail.lift_res[ir_type.IrTypeId](ir_type.intern_union(dtypes, nil, 0, nom_align, nom_packed)); }
+        ret fail.lift_res[ir_type.IrTypeId](ir_type.intern_struct(dtypes, nil, 0, nom_align, nom_packed));
     }
 
-    val rbuf: R.Result[*ir_type.IrTypeId, str] = A.allocate[ir_type.IrTypeId](s.alloc, fields_len::usize);
-    if (R.is_err[*ir_type.IrTypeId, str](rbuf)) { ret R.err[ir_type.IrTypeId, str](R.unwrap_err[*ir_type.IrTypeId, str](rbuf)); }
-    val buf: *ir_type.IrTypeId = R.unwrap_ok[*ir_type.IrTypeId, str](rbuf);
+    val rbuf: res[*ir_type.IrTypeId, A.Error] = A.allocate[ir_type.IrTypeId](s.alloc, fields_len::usize);
+    if (sel rbuf.err) { ret res[ir_type.IrTypeId, fail.Fail].err{fail.refused(rbuf.err)}; }
+    val buf: *ir_type.IrTypeId = rbuf.ok;
 
     var i: u32 = 0;
     for (i < fields_len) {
         val fe: O.Option[*semtype.FieldEntry] = semtype.field_at(s.types, tid, i);
         if (O.is_none[*semtype.FieldEntry](fe)) {
             A.deallocate[ir_type.IrTypeId](s.alloc, buf, fields_len::usize);
-            ret R.err[ir_type.IrTypeId, str]("dwarf.sem_to_ir: corrupt field table");
+            ret res[ir_type.IrTypeId, fail.Fail].err{fail.message("dwarf.sem_to_ir: corrupt field table")};
         }
-        val rf: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, dtypes, O.unwrap[*semtype.FieldEntry](fe).ty);
-        if (R.is_err[ir_type.IrTypeId, str](rf)) {
+        val rf: res[ir_type.IrTypeId, fail.Fail] = sem_to_ir(s, dtypes, O.unwrap[*semtype.FieldEntry](fe).ty);
+        if (sel rf.err) {
             A.deallocate[ir_type.IrTypeId](s.alloc, buf, fields_len::usize);
             ret rf;
         }
-        buf[i] = R.unwrap_ok[ir_type.IrTypeId, str](rf);
+        buf[i] = rf.ok;
         i = i + 1;
     }
 
-    var res: R.Result[ir_type.IrTypeId, str];
-    if (is_union) { res = ir_type.intern_union(dtypes, buf, fields_len, nom_align, nom_packed); }
-    or            { res = ir_type.intern_struct(dtypes, buf, fields_len, nom_align, nom_packed); }
+    var result: R.Result[ir_type.IrTypeId, str];
+    if (is_union) { result = ir_type.intern_union(dtypes, buf, fields_len, nom_align, nom_packed); }
+    or            { result = ir_type.intern_struct(dtypes, buf, fields_len, nom_align, nom_packed); }
     A.deallocate[ir_type.IrTypeId](s.alloc, buf, fields_len::usize);
-    ret res;
+    ret fail.lift_res[ir_type.IrTypeId](result);
 }
 
 fun frame_base_reg(tgt: *debug_input.DebugProgram) i32 {
@@ -657,27 +661,27 @@ fun file_slot(ft: *FileTable, id: source.FileId) i32 {
     ret -1;
 }
 
-fun copy_exact(alloc: *A.Allocator, b: *enc.ByteBuf) R.Result[*u8, str] {
-    if (b.len == 0) { ret R.ok[*u8, str](nil); }
-    val r: R.Result[*u8, str] = A.allocate[u8](alloc, b.len);
-    if (R.is_err[*u8, str](r)) { ret r; }
-    val out: *u8 = R.unwrap_ok[*u8, str](r);
+fun copy_exact(alloc: *A.Allocator, b: *enc.ByteBuf) res[*u8, fail.Fail] {
+    if (b.len == 0) { ret res[*u8, fail.Fail].ok{nil}; }
+    val r: res[*u8, A.Error] = A.allocate[u8](alloc, b.len);
+    if (sel r.err) { ret res[*u8, fail.Fail].err{fail.refused(r.err)}; }
+    val out: *u8 = r.ok;
     var i: usize = 0;
     for (i < b.len) { out[i] = b.data[i]; i = i + 1; }
-    ret R.ok[*u8, str](out);
+    ret res[*u8, fail.Fail].ok{out};
 }
 
-fun add_debug_section(image: *of.ObjectImage, name: intern.StrId, b: *enc.ByteBuf) R.Result[u32, str] {
-    val rb: R.Result[*u8, str] = copy_exact(image.alloc, b);
-    if (R.is_err[*u8, str](rb)) { ret R.err[u32, str](R.unwrap_err[*u8, str](rb)); }
+fun add_debug_section(image: *of.ObjectImage, name: intern.StrId, b: *enc.ByteBuf) res[u32, fail.Fail] {
+    val rb: res[*u8, fail.Fail] = copy_exact(image.alloc, b);
+    if (sel rb.err) { ret res[u32, fail.Fail].err{rb.err}; }
     var sec: of.Section;
     sec.name  = name;
     sec.kind  = of.SK_DEBUG;
-    sec.bytes = R.unwrap_ok[*u8, str](rb);
+    sec.bytes = rb.ok;
     sec.len   = b.len::u32;
     sec.align = 1;
     sec.flags = 0;
-    val added: R.Result[u32, str] = obj.install_section(image, ?sec);
+    val added: res[u32, fail.Fail] = obj.section_install(image, ?sec);
     ret added;
 }
 
@@ -1686,12 +1690,12 @@ fun gather_funcs(image: *of.ObjectImage, mirmod: *mir.MirModule, text_sec: u32, 
     }
 }
 
-fun intern_anchor(itn: *intern.Interner, base: str, suffix: str) R.Result[intern.StrId, str] {
+fun intern_anchor(itn: *intern.Interner, base: str, suffix: str) res[intern.StrId, fail.Fail] {
     val lb: usize = str_len(base);
     val ls: usize = str_len(suffix);
-    val rb: R.Result[*u8, str] = A.allocate[u8](itn.a, lb + ls + 1);
-    if (R.is_err[*u8, str](rb)) { ret R.err[intern.StrId, str](R.unwrap_err[*u8, str](rb)); }
-    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+    val rb: res[*u8, A.Error] = A.allocate[u8](itn.a, lb + ls + 1);
+    if (sel rb.err) { ret res[intern.StrId, fail.Fail].err{fail.refused(rb.err)}; }
+    val buf: *u8 = rb.ok;
     var w: usize = 0;
     var i: usize = 0;
     for (i < lb) { buf[w] = base[i]; w = w + 1; i = i + 1; }
@@ -1700,18 +1704,18 @@ fun intern_anchor(itn: *intern.Interner, base: str, suffix: str) R.Result[intern
     buf[w] = 0;
     val ri: R.Result[intern.StrId, str] = intern.intern(itn, buf::str);
     A.deallocate[u8](itn.a, buf, lb + ls + 1);
-    ret ri;
+    ret fail.lift_res[intern.StrId](ri);
 }
 
-fun add_reloc(image: *of.ObjectImage, sec: u32, offset: u32, kind: of.RelocKind, sym: intern.StrId) R.Result[R.Void, str] {
+fun add_reloc(image: *of.ObjectImage, sec: u32, offset: u32, kind: of.RelocKind, sym: intern.StrId) err[fail.Fail] {
     ret add_reloc_addend(image, sec, offset, kind, sym, 0);
 }
 
 fun add_reloc_addend(image: *of.ObjectImage, sec: u32, offset: u32, kind: of.RelocKind,
-                     sym: intern.StrId, addend: i64) R.Result[R.Void, str] {
+                     sym: intern.StrId, addend: i64) err[fail.Fail] {
     val sym_ix: u32 = obj.symbol_index(image, sym);
     if (sym_ix == of.SYMBOL_NONE) {
-        ret R.err[R.Void, str]("dwarf: relocation target absent from the image symbol table");
+        ret err[fail.Fail].err{fail.message("dwarf: relocation target absent from the image symbol table")};
     }
 
     var rel: of.Relocation;
@@ -1758,38 +1762,38 @@ fun inline_tree_valid(fn: *ir.Function) bool {
     ret true;
 }
 
-fun validate_request(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
-    if (req == nil) { ret R.err[R.Void, str]("dwarf.produce: nil request"); }
-    if (req.image == nil) { ret R.err[R.Void, str]("dwarf.produce: nil object image"); }
+fun validate_request(req: *of.DebugProduceRequest) err[fail.Fail] {
+    if (req == nil) { ret err[fail.Fail].err{fail.message("dwarf.produce: nil request")}; }
+    if (req.image == nil) { ret err[fail.Fail].err{fail.message("dwarf.produce: nil object image")}; }
     val s: *debug_input.DebugProgram = ?req.program;
     val image: *of.ObjectImage = req.image;
     if (s.alloc == nil || s.interner == nil || s.types == nil || s.sources == nil
         || s.type_aligns == nil || s.type_packed == nil
         || s.ir_module == nil || s.mir_module == nil || s.pointer_width == 0
         || s.dwarf_reg == nil) {
-        ret R.err[R.Void, str]("dwarf.produce: incomplete debug program view");
+        ret err[fail.Fail].err{fail.message("dwarf.produce: incomplete debug program view")};
     }
     if (s.field_epoch != semtype.field_epoch(s.types)) {
-        ret R.err[R.Void, str]("dwarf.produce: debug type view is stale");
+        ret err[fail.Fail].err{fail.message("dwarf.produce: debug type view is stale")};
     }
     if (s.layout.ptr_width != s.pointer_width) {
-        ret R.err[R.Void, str]("dwarf.produce: debug layout does not match the target pointer width");
+        ret err[fail.Fail].err{fail.message("dwarf.produce: debug layout does not match the target pointer width")};
     }
     if (image.interner != s.interner) {
-        ret R.err[R.Void, str]("dwarf.produce: object image does not share the debug program interner");
+        ret err[fail.Fail].err{fail.message("dwarf.produce: object image does not share the debug program interner")};
     }
     val image_valid: R.Result[R.Void, str] = of.validate_owned_object(image);
     if (R.is_err[R.Void, str](image_valid)) {
-        ret image_valid;
+        ret fail.lift_err(image_valid);
     }
     if (((req.row_count == 0) != (req.rows == nil))
         || ((req.varloc_count == 0) != (req.varlocs == nil))
         || ((req.inline_pc_count == 0) != (req.inline_pcs == nil))) {
-        ret R.err[R.Void, str]("dwarf.produce: debug input has a noncanonical span shape");
+        ret err[fail.Fail].err{fail.message("dwarf.produce: debug input has a noncanonical span shape")};
     }
     if (req.text_section >= image.section_count
         || image.sections[req.text_section].kind != of.SK_TEXT) {
-        ret R.err[R.Void, str]("dwarf.produce: text section is absent or has the wrong section kind");
+        ret err[fail.Fail].err{fail.message("dwarf.produce: text section is absent or has the wrong section kind")};
     }
     val text_len: u32 = image.sections[req.text_section].len;
     var sym_i: u32 = 0;
@@ -1797,7 +1801,7 @@ fun validate_request(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
         val sym: *of.Symbol = ?image.symbols[sym_i];
         if ((sym.flags & of.SYM_OBJ_FLAG_FUNCTION) != 0 && of.section_index(sym.section) == req.text_section
             && (sym.offset > text_len || sym.size > text_len - sym.offset)) {
-            ret R.err[R.Void, str]("dwarf.produce: function symbol lies outside the text section");
+            ret err[fail.Fail].err{fail.message("dwarf.produce: function symbol lies outside the text section")};
         }
         sym_i = sym_i + 1;
     }
@@ -1805,10 +1809,10 @@ fun validate_request(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
     for (row_i < req.row_count) {
         val row: *enc.LineRow = ?req.rows[row_i];
         if (row.sec != req.text_section || row.text_offset > text_len) {
-            ret R.err[R.Void, str]("dwarf.produce: line row lies outside the selected text section");
+            ret err[fail.Fail].err{fail.message("dwarf.produce: line row lies outside the selected text section")};
         }
         if (row_i > 0 && req.rows[row_i - 1].text_offset > row.text_offset) {
-            ret R.err[R.Void, str]("dwarf.produce: line rows are not monotonic within a section");
+            ret err[fail.Fail].err{fail.message("dwarf.produce: line rows are not monotonic within a section")};
         }
         row_i = row_i + 1;
     }
@@ -1816,14 +1820,14 @@ fun validate_request(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
     for (inline_i < req.inline_pc_count) {
         val pc: *enc.InlinePc = ?req.inline_pcs[inline_i];
         if (pc.sec != req.text_section || pc.text_offset >= text_len) {
-            ret R.err[R.Void, str]("dwarf.produce: inline PC lies outside the selected text section");
+            ret err[fail.Fail].err{fail.message("dwarf.produce: inline PC lies outside the selected text section")};
         }
         if (inline_i > 0 && req.inline_pcs[inline_i - 1].text_offset > pc.text_offset) {
-            ret R.err[R.Void, str]("dwarf.produce: inline PCs are not monotonic within a section");
+            ret err[fail.Fail].err{fail.message("dwarf.produce: inline PCs are not monotonic within a section")};
         }
         val fn: *ir.Function = ir_function_at(image, s.ir_module, pc.sec, pc.text_offset);
         if (!inline_tree_valid(fn) || (pc.inline_site != 0 && pc.inline_site > fn.inline_site_len)) {
-            ret R.err[R.Void, str]("dwarf.produce: inline PC refers to an invalid inline site");
+            ret err[fail.Fail].err{fail.message("dwarf.produce: inline PC refers to an invalid inline site")};
         }
         inline_i = inline_i + 1;
     }
@@ -1833,26 +1837,26 @@ fun validate_request(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
         if (loc.sec != req.text_section || loc.text_offset >= text_len
             || (loc.end_offset != 0
                 && (loc.end_offset < loc.text_offset || loc.end_offset > text_len))) {
-            ret R.err[R.Void, str]("dwarf.produce: variable location range lies outside the selected text section");
+            ret err[fail.Fail].err{fail.message("dwarf.produce: variable location range lies outside the selected text section")};
         }
         val fn: *ir.Function = ir_function_at(image, s.ir_module, loc.sec, loc.text_offset);
         if (fn == nil || loc.iid >= fn.instr_len) {
-            ret R.err[R.Void, str]("dwarf.produce: variable location refers to an invalid instruction");
+            ret err[fail.Fail].err{fail.message("dwarf.produce: variable location refers to an invalid instruction")};
         }
         if (loc.end_offset != 0) {
             val end_fn: *ir.Function = ir_function_at(image, s.ir_module, loc.sec, loc.end_offset - 1);
             if (end_fn != fn) {
-                ret R.err[R.Void, str]("dwarf.produce: variable location crosses a function boundary");
+                ret err[fail.Fail].err{fail.message("dwarf.produce: variable location crosses a function boundary")};
             }
         }
         var_i = var_i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
-    val valid: R.Result[R.Void, str] = validate_request(req);
-    if (R.is_err[R.Void, str](valid)) { ret valid; }
+pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
+    val valid: err[fail.Fail] = validate_request(req);
+    if (sel valid.err) { ret valid; }
     val s: *debug_input.DebugProgram = ?req.program;
     val image: *of.ObjectImage = req.image;
     val irmod: *ir.Module = s.ir_module;
@@ -1867,25 +1871,25 @@ pub fun produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
     val comp_dir_id: intern.StrId = req.comp_dir;
     val text_sec: u32 = req.text_section;
     val nfuncs: u32 = count_funcs(image, text_sec);
-    if (nfuncs == 0) { ret R.ok_void[str](); }
+    if (nfuncs == 0) { ret err[fail.Fail].ok{}; }
 
     val fb_reg:      i32 = frame_base_reg(s);
     val fb_omit_reg: i32 = frame_base_omit_reg(s);
     if (fb_reg < 0 || fb_omit_reg < 0) {
-        ret R.err[R.Void, str]("dwarf.produce: target has no DWARF register mapping for its frame or stack pointer register");
+        ret err[fail.Fail].err{fail.message("dwarf.produce: target has no DWARF register mapping for its frame or stack pointer register")};
     }
 
     val address_size: u8 = s.pointer_width::u8;
     val ak_r: R.Result[of.RelocKind, str] = of.abs_kind_for_pointer_width(s.pointer_width);
-    if (R.is_err[of.RelocKind, str](ak_r)) { ret R.err[R.Void, str](R.unwrap_err[of.RelocKind, str](ak_r)); }
+    if (R.is_err[of.RelocKind, str](ak_r)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[of.RelocKind, str](ak_r))}; }
     val addr_kind: of.RelocKind = R.unwrap_ok[of.RelocKind, str](ak_r);
     val itn: *intern.Interner = image.interner;
     val producer: str = resolve(itn, producer_id);
     val comp_dir: str = resolve(itn, comp_dir_id);
 
-    val rf: R.Result[*DwFunc, str] = A.allocate[DwFunc](s.alloc, nfuncs::usize);
-    if (R.is_err[*DwFunc, str](rf)) { ret R.err[R.Void, str](R.unwrap_err[*DwFunc, str](rf)); }
-    val funcs: *DwFunc = R.unwrap_ok[*DwFunc, str](rf);
+    val rf: res[*DwFunc, A.Error] = A.allocate[DwFunc](s.alloc, nfuncs::usize);
+    if (sel rf.err) { ret err[fail.Fail].err{fail.refused(rf.err)}; }
+    val funcs: *DwFunc = rf.ok;
     gather_funcs(image, mirmod, text_sec, funcs);
 
     val text_len: u32 = image.sections[text_sec].len;
@@ -1910,9 +1914,9 @@ pub fun produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
     var name: str = comp_dir;
     if (ft.count > 0) { name = file_path(s, ft.ids[0]); }
 
-    val rs2: R.Result[*DwFunc, str] = A.allocate[DwFunc](s.alloc, nfuncs::usize);
-    if (R.is_err[*DwFunc, str](rs2)) { A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize); ret R.err[R.Void, str](R.unwrap_err[*DwFunc, str](rs2)); }
-    val subs: *DwFunc = R.unwrap_ok[*DwFunc, str](rs2);
+    val rs2: res[*DwFunc, A.Error] = A.allocate[DwFunc](s.alloc, nfuncs::usize);
+    if (sel rs2.err) { A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize); ret err[fail.Fail].err{fail.refused(rs2.err)}; }
+    val subs: *DwFunc = rs2.ok;
     var nsub: u32 = 0;
     var si: u32 = 0;
     for (si < nfuncs) {
@@ -1926,17 +1930,17 @@ pub fun produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
 
     var var_cap: u32 = varloc_count;
     if (var_cap == 0) { var_cap = 1; }
-    val rv: R.Result[*DwVar, str] = A.allocate[DwVar](s.alloc, var_cap::usize);
-    if (R.is_err[*DwVar, str](rv)) { A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize); ret R.err[R.Void, str](R.unwrap_err[*DwVar, str](rv)); }
-    val vars: *DwVar = R.unwrap_ok[*DwVar, str](rv);
+    val rv: res[*DwVar, A.Error] = A.allocate[DwVar](s.alloc, var_cap::usize);
+    if (sel rv.err) { A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize); ret err[fail.Fail].err{fail.refused(rv.err)}; }
+    val vars: *DwVar = rv.ok;
 
     val range_cap: u32 = var_cap;
-    val rgr: R.Result[*LocRange, str] = A.allocate[LocRange](s.alloc, range_cap::usize);
-    if (R.is_err[*LocRange, str](rgr)) {
+    val rgr: res[*LocRange, A.Error] = A.allocate[LocRange](s.alloc, range_cap::usize);
+    if (sel rgr.err) {
         A.deallocate[DwVar](s.alloc, vars, var_cap::usize); A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*LocRange, str](rgr));
+        ret err[fail.Fail].err{fail.refused(rgr.err)};
     }
-    val ranges: *LocRange = R.unwrap_ok[*LocRange, str](rgr);
+    val ranges: *LocRange = rgr.ok;
 
     var tc: TypeCtx = type_ctx_init(s.alloc);
     var strtab: StrTab;
@@ -1950,7 +1954,7 @@ pub fun produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
         enc.buf_dnit(?strtab.buf); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
-        ret R.err[R.Void, str](O.unwrap[str](rdt));
+        ret err[fail.Fail].err{fail.message(O.unwrap[str](rdt))};
     }
     gather_subprograms(s, irmod, subs, nsub, rows, row_count, varlocs, varloc_count, text_sec, ?ft, address_size,
                        ?tc, ?strtab, ?dtypes, vars, ?var_count, var_cap, ranges, ?range_count, range_cap);
@@ -1960,38 +1964,38 @@ pub fun produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
     var lv: u32 = 0;
     for (lv < var_count) { if (vars[lv].loc_kind == VLOC_LOCLIST) { has_loclists = true; } lv = lv + 1; }
 
-    val ra: R.Result[*u32, str] = A.allocate[u32](s.alloc, nfuncs::usize);
-    if (R.is_err[*u32, str](ra)) {
+    val ra: res[*u32, A.Error] = A.allocate[u32](s.alloc, nfuncs::usize);
+    if (sel ra.err) {
         enc.buf_dnit(?strtab.buf); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](ra));
+        ret err[fail.Fail].err{fail.refused(ra.err)};
     }
-    val addr_off: *u32 = R.unwrap_ok[*u32, str](ra);
+    val addr_off: *u32 = ra.ok;
 
     val reloc_cap: u32 = 2 + 2 * nsub + tc.ntypes + tc.nmemb + 2 * var_count + 2 * tot_sites;
-    val rr2: R.Result[*InfoReloc, str] = A.allocate[InfoReloc](s.alloc, reloc_cap::usize);
-    if (R.is_err[*InfoReloc, str](rr2)) {
+    val rr2: res[*InfoReloc, A.Error] = A.allocate[InfoReloc](s.alloc, reloc_cap::usize);
+    if (sel rr2.err) {
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); enc.buf_dnit(?strtab.buf);
         type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*InfoReloc, str](rr2));
+        ret err[fail.Fail].err{fail.refused(rr2.err)};
     }
-    val info_relocs: *InfoReloc = R.unwrap_ok[*InfoReloc, str](rr2);
+    val info_relocs: *InfoReloc = rr2.ok;
     var info_reloc_count: u32 = 0;
 
     val loc_reloc_cap: u32 = var_count + 1;
-    val rlr: R.Result[*LocReloc, str] = A.allocate[LocReloc](s.alloc, loc_reloc_cap::usize);
-    if (R.is_err[*LocReloc, str](rlr)) {
+    val rlr: res[*LocReloc, A.Error] = A.allocate[LocReloc](s.alloc, loc_reloc_cap::usize);
+    if (sel rlr.err) {
         A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); enc.buf_dnit(?strtab.buf);
         type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*LocReloc, str](rlr));
+        ret err[fail.Fail].err{fail.refused(rlr.err)};
     }
-    val loc_relocs: *LocReloc = R.unwrap_ok[*LocReloc, str](rlr);
+    val loc_relocs: *LocReloc = rlr.ok;
     var loc_reloc_count: u32 = 0;
 
     var b_abbrev:   enc.ByteBuf = enc.buf_init(s.alloc);
@@ -2004,31 +2008,31 @@ pub fun produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
     if (inl_cap == 0) { inl_cap = 1; }
     var ir_cap: u32 = inline_pc_count * max_depth;
     if (ir_cap == 0) { ir_cap = 1; }
-    val rinl: R.Result[*DwInline, str] = A.allocate[DwInline](s.alloc, inl_cap::usize);
-    if (R.is_err[*DwInline, str](rinl)) {
+    val rinl: res[*DwInline, A.Error] = A.allocate[DwInline](s.alloc, inl_cap::usize);
+    if (sel rinl.err) {
         enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
         A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*DwInline, str](rinl));
+        ret err[fail.Fail].err{fail.refused(rinl.err)};
     }
-    val inlines: *DwInline = R.unwrap_ok[*DwInline, str](rinl);
-    val rirng: R.Result[*DwInlineRange, str] = A.allocate[DwInlineRange](s.alloc, ir_cap::usize);
-    if (R.is_err[*DwInlineRange, str](rirng)) {
+    val inlines: *DwInline = rinl.ok;
+    val rirng: res[*DwInlineRange, A.Error] = A.allocate[DwInlineRange](s.alloc, ir_cap::usize);
+    if (sel rirng.err) {
         A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
         enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
         A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*DwInlineRange, str](rirng));
+        ret err[fail.Fail].err{fail.refused(rirng.err)};
     }
-    val iranges: *DwInlineRange = R.unwrap_ok[*DwInlineRange, str](rirng);
+    val iranges: *DwInlineRange = rirng.ok;
     var ninl: u32 = 0;
     var nir:  u32 = 0;
-    val rgi: R.Result[R.Void, str] = gather_inlines(s, irmod, subs, nsub, inline_pcs, inline_pc_count, text_sec, ?ft, inlines, ?ninl, inl_cap, iranges, ?nir, ir_cap);
-    if (R.is_err[R.Void, str](rgi)) {
+    val rgi: err[fail.Fail] = gather_inlines(s, irmod, subs, nsub, inline_pcs, inline_pc_count, text_sec, ?ft, inlines, ?ninl, inl_cap, iranges, ?nir, ir_cap);
+    if (sel rgi.err) {
         A.deallocate[DwInlineRange](s.alloc, iranges, ir_cap::usize); A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
         enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
         A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
@@ -2040,22 +2044,22 @@ pub fun produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
 
     val has_rnglists: bool = true;
     val rng_reloc_cap: u32 = nsub + inl_cap + 1;
-    val rrr: R.Result[*RngReloc, str] = A.allocate[RngReloc](s.alloc, rng_reloc_cap::usize);
-    if (R.is_err[*RngReloc, str](rrr)) {
+    val rrr: res[*RngReloc, A.Error] = A.allocate[RngReloc](s.alloc, rng_reloc_cap::usize);
+    if (sel rrr.err) {
         A.deallocate[DwInlineRange](s.alloc, iranges, ir_cap::usize); A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
         enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
         A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*RngReloc, str](rrr));
+        ret err[fail.Fail].err{fail.refused(rrr.err)};
     }
-    val rng_relocs: *RngReloc = R.unwrap_ok[*RngReloc, str](rrr);
+    val rng_relocs: *RngReloc = rrr.ok;
     var rng_reloc_count: u32 = 0;
 
     val fixup_cap: u32 = tc.ntypes + tc.nmemb + 1;
-    val rfx: R.Result[*TypeFixup, str] = A.allocate[TypeFixup](s.alloc, fixup_cap::usize);
-    if (R.is_err[*TypeFixup, str](rfx)) {
+    val rfx: res[*TypeFixup, A.Error] = A.allocate[TypeFixup](s.alloc, fixup_cap::usize);
+    if (sel rfx.err) {
         A.deallocate[RngReloc](s.alloc, rng_relocs, rng_reloc_cap::usize);
         A.deallocate[DwInlineRange](s.alloc, iranges, ir_cap::usize); A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
         enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
@@ -2063,9 +2067,9 @@ pub fun produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*TypeFixup, str](rfx));
+        ret err[fail.Fail].err{fail.refused(rfx.err)};
     }
-    val type_fixups: *TypeFixup = R.unwrap_ok[*TypeFixup, str](rfx);
+    val type_fixups: *TypeFixup = rfx.ok;
 
     build_abbrev(?b_abbrev);
     build_line(s, funcs, nfuncs, rows, row_count, text_sec, address_size, comp_dir, name, ?ft, ?b_line, addr_off);
@@ -2081,7 +2085,7 @@ pub fun produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
                subs, nsub, ?tc, vars, info_relocs, ?info_reloc_count, reloc_cap, ?stmt_off,
                s, irmod, ?strtab, inlines, ninl, iranges, type_fixups, fixup_cap);
 
-    val pr: R.Result[R.Void, str] = install(s, image, itn, funcs, nfuncs,
+    val pr: err[fail.Fail] = install(s, image, itn, funcs, nfuncs,
                                           ?b_abbrev, ?b_line, ?b_info, ?strtab.buf, ?b_loclists, has_loclists,
                                           ?b_rnglists, has_rnglists, addr_off, addr_kind, stmt_off, info_relocs, info_reloc_count,
                                           loc_relocs, loc_reloc_count, rng_relocs, rng_reloc_count);
@@ -2104,8 +2108,14 @@ pub fun produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
     A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
     A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize);
     A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
-    if (R.is_err[R.Void, str](pr)) { ret pr; }
-    ret R.ok_void[str]();
+    if (sel pr.err) { ret pr; }
+    ret err[fail.Fail].ok{};
+}
+
+# translation shim (#3226): the DebugProduceFn vtable entry keeps its legacy
+# carrier until target/of migrates the vtable typedefs
+pub fun produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
+    ret fail.lower_unit(produce_debug(req));
 }
 
 
@@ -2152,9 +2162,9 @@ fun gather_subprograms(s: *debug_input.DebugProgram, irmod: *ir.Module,
         if (fn.disp == intern.STR_NIL) { nm = resolve(s.interner, fn.name); }
         fn.disp_off = str_off(strtab, nm);
 
-        val first: O.Option[source.SrcLoc] = first_row_loc(rows, row_count, text_sec, fn.offset, fn.offset + fn.size);
-        if (O.is_some[source.SrcLoc](first)) {
-            val pl: PosLine = pos_of(s, O.unwrap[source.SrcLoc](first), ft);
+        val first: opt[source.SrcLoc] = first_row_loc(rows, row_count, text_sec, fn.offset, fn.offset + fn.size);
+        if (sel first.some) {
+            val pl: PosLine = pos_of(s, first.some, ft);
             fn.decl_file = pl.file;
             fn.decl_line = pl.line::u32;
         }
@@ -2204,7 +2214,7 @@ fun inline_caps(irmod: *ir.Module, funcs: *DwFunc, nfuncs: u32, total: *u32, max
 fun gather_inlines(s: *debug_input.DebugProgram, irmod: *ir.Module, funcs: *DwFunc, nfuncs: u32,
                    inline_pcs: *enc.InlinePc, inline_pc_count: u32, text_sec: u32, ft: *FileTable,
                    out: *DwInline, ninl: *u32, inl_cap: u32,
-                   iranges: *DwInlineRange, nir: *u32, ir_cap: u32) R.Result[R.Void, str] {
+                   iranges: *DwInlineRange, nir: *u32, ir_cap: u32) err[fail.Fail] {
     var i: u32 = 0;
     for (i < nfuncs) {
         val opt_idx: O.Option[u32] = ir.function_lookup(irmod, funcs[i].name);
@@ -2216,7 +2226,7 @@ fun gather_inlines(s: *debug_input.DebugProgram, irmod: *ir.Module, funcs: *DwFu
 
         var k: u32 = 1;
         for (k <= irfn.inline_site_len) {
-            if (@ninl >= inl_cap) { ret R.err[R.Void, str]("dwarf.gather_inlines: inline-instance capacity exceeded"); }
+            if (@ninl >= inl_cap) { ret err[fail.Fail].err{fail.message("dwarf.gather_inlines: inline-instance capacity exceeded")}; }
             val site: *ir.InlineSite = ?irfn.inline_sites[k - 1];
             val di: *DwInline = ?out[@ninl];
             di.func_idx    = i;
@@ -2247,7 +2257,7 @@ fun gather_inlines(s: *debug_input.DebugProgram, irmod: *ir.Module, funcs: *DwFu
                     for (jn < inline_pc_count && inline_pcs[jn].sec != text_sec) { jn = jn + 1; }
                     if (jn < inline_pc_count && inline_pcs[jn].text_offset < hi) { seg_end = inline_pcs[jn].text_offset; }
                     if (o < seg_end) {
-                        if (@nir >= ir_cap) { ret R.err[R.Void, str]("dwarf.gather_inlines: inline-range capacity exceeded"); }
+                        if (@nir >= ir_cap) { ret err[fail.Fail].err{fail.message("dwarf.gather_inlines: inline-range capacity exceeded")}; }
                         iranges[@nir].start = o;
                         iranges[@nir].end   = seg_end;
                         @nir = @nir + 1;
@@ -2262,7 +2272,7 @@ fun gather_inlines(s: *debug_input.DebugProgram, irmod: *ir.Module, funcs: *DwFu
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun gather_vars(s: *debug_input.DebugProgram, irmod: *ir.Module, dtypes: *ir_type.IrTypeTable, irfn: *ir.Function, lo: u32, hi: u32,
@@ -2275,9 +2285,9 @@ fun gather_vars(s: *debug_input.DebugProgram, irmod: *ir.Module, dtypes: *ir_typ
     for (i < varloc_count) {
         val vl: *enc.VarLoc = ?varlocs[i];
         if (vl.sec != text_sec || vl.text_offset < lo || vl.text_offset >= hi) { i = i + 1; cnt; }
-        val obt: O.Option[u32] = varloc_ident(s, irmod, dtypes, irfn, vl, address_size, tc, strtab);
-        if (O.is_none[u32](obt)) { i = i + 1; cnt; }
-        val name_off: u32 = O.unwrap[u32](obt);
+        val obt: opt[u32] = varloc_ident(s, irmod, dtypes, irfn, vl, address_size, tc, strtab);
+        if (sel obt.none) { i = i + 1; cnt; }
+        val name_off: u32 = obt.some;
         val vsite: u32 = ir.instr_inline_site_of(irfn, vl.iid::id.InstructionId);
 
         var found: bool = false;
@@ -2313,9 +2323,9 @@ fun gather_vars(s: *debug_input.DebugProgram, irmod: *ir.Module, dtypes: *ir_typ
             val vl: *enc.VarLoc = ?varlocs[k];
             if (vl.sec != text_sec || vl.text_offset < lo || vl.text_offset >= hi) { k = k + 1; cnt; }
             if (@range_count >= range_cap) { k = k + 1; cnt; }
-            val oid: O.Option[u32] = varloc_ident(s, irmod, dtypes, irfn, vl, address_size, tc, strtab);
-            if (O.is_none[u32](oid)) { k = k + 1; cnt; }
-            if (O.unwrap[u32](oid) != v.name_off) { k = k + 1; cnt; }
+            val oid: opt[u32] = varloc_ident(s, irmod, dtypes, irfn, vl, address_size, tc, strtab);
+            if (sel oid.none) { k = k + 1; cnt; }
+            if (oid.some != v.name_off) { k = k + 1; cnt; }
 
             var kind: u8 = VLOC_NONE;
             var reg:  i32 = 0;
@@ -2439,13 +2449,13 @@ fun cmp_sub_home(tgt: *debug_input.DebugProgram, sub: u8, raw_reg: i32, raw_off:
 }
 
 fun varloc_ident(s: *debug_input.DebugProgram, irmod: *ir.Module, dtypes: *ir_type.IrTypeTable, irfn: *ir.Function,
-                 vl: *enc.VarLoc, address_size: u8, tc: *TypeCtx, strtab: *StrTab) O.Option[u32] {
+                 vl: *enc.VarLoc, address_size: u8, tc: *TypeCtx, strtab: *StrTab) opt[u32] {
     val odv: O.Option[*ir.DbgVar] = ir.dbg_var_get(irfn, vl.iid::id.InstructionId);
-    if (O.is_none[*ir.DbgVar](odv)) { ret O.none[u32](); }
+    if (O.is_none[*ir.DbgVar](odv)) { ret opt[u32].none{}; }
     val dv: *ir.DbgVar = O.unwrap[*ir.DbgVar](odv);
-    if (dv.name == intern.STR_NIL) { ret O.none[u32](); }
-    if (type_intern(s, dtypes, tc, strtab, dv.ty_sem, address_size) < 0) { ret O.none[u32](); }
-    ret O.some[u32](str_off(strtab, resolve(s.interner, dv.name)));
+    if (dv.name == intern.STR_NIL) { ret opt[u32].none{}; }
+    if (type_intern(s, dtypes, tc, strtab, dv.ty_sem, address_size) < 0) { ret opt[u32].none{}; }
+    ret opt[u32].some{str_off(strtab, resolve(s.interner, dv.name))};
 }
 
 fun sort_ranges(ranges: *LocRange, start: u32, end: u32) {
@@ -2555,8 +2565,8 @@ fun type_intern(s: *debug_input.DebugProgram, dtypes: *ir_type.IrTypeTable, tc: 
 
     if (kind == semtype.TYPE_SECRET) { ret type_intern(s, dtypes, tc, strtab, t.data.secret.base, address_size); }
 
-    val obt: O.Option[TypeDie] = sem_base_type(s, sem, address_size);
-    if (O.is_some[TypeDie](obt)) { ret base_intern(tc, strtab, O.unwrap[TypeDie](obt)); }
+    val obt: opt[TypeDie] = sem_base_type(s, sem, address_size);
+    if (sel obt.some) { ret base_intern(tc, strtab, obt.some); }
 
     val found: i32 = comp_find(tc, sem);
     if (found >= 0) { ret found; }
@@ -2591,9 +2601,9 @@ fun type_intern(s: *debug_input.DebugProgram, dtypes: *ir_type.IrTypeTable, tc: 
     if (kind == semtype.TYPE_VECTOR) {
         val ekind: semtype.TypeKind = t.data.vector.element;
         val lanes: u32              = t.data.vector.lanes;
-        val obk: O.Option[TypeDie] = base_die_of_kind(ekind, address_size);
-        if (O.is_none[TypeDie](obk)) { ret -1; }
-        val el: i32 = base_intern(tc, strtab, O.unwrap[TypeDie](obk));
+        val obk: opt[TypeDie] = base_die_of_kind(ekind, address_size);
+        if (sel obk.none) { ret -1; }
+        val el: i32 = base_intern(tc, strtab, obk.some);
         if (el < 0) { ret -1; }
         val ix: i32 = comp_reserve(tc, TK_VECTOR, sem);
         if (ix < 0) { ret -1; }
@@ -2611,9 +2621,9 @@ fun type_intern(s: *debug_input.DebugProgram, dtypes: *ir_type.IrTypeTable, tc: 
 
 fun struct_intern(s: *debug_input.DebugProgram, dtypes: *ir_type.IrTypeTable, tc: *TypeCtx,
                   strtab: *StrTab, sem: semtype.TypeId, address_size: u8) i32 {
-    val rir: R.Result[ir_type.IrTypeId, str] = sem_to_ir(s, dtypes, sem);
-    if (R.is_err[ir_type.IrTypeId, str](rir)) { ret -1; }
-    val ir_ty: ir_type.IrTypeId = R.unwrap_ok[ir_type.IrTypeId, str](rir);
+    val rir: res[ir_type.IrTypeId, fail.Fail] = sem_to_ir(s, dtypes, sem);
+    if (sel rir.err) { ret -1; }
+    val ir_ty: ir_type.IrTypeId = rir.ok;
 
     val to: O.Option[*semtype.Type] = semtype.get(s.types, sem);
     if (O.is_none[*semtype.Type](to)) { ret -1; }
@@ -2687,7 +2697,7 @@ fun ptr_base_type(address_size: u8) TypeDie {
     ret bt;
 }
 
-fun first_row_loc(rows: *enc.LineRow, row_count: u32, text_sec: u32, start: u32, end: u32) O.Option[source.SrcLoc] {
+fun first_row_loc(rows: *enc.LineRow, row_count: u32, text_sec: u32, start: u32, end: u32) opt[source.SrcLoc] {
     var found: bool = false;
     var best_off: u32 = 0;
     var best_loc: source.SrcLoc;
@@ -2701,8 +2711,8 @@ fun first_row_loc(rows: *enc.LineRow, row_count: u32, text_sec: u32, start: u32,
         }
         r = r + 1;
     }
-    if (found) { ret O.some[source.SrcLoc](best_loc); }
-    ret O.none[source.SrcLoc]();
+    if (found) { ret opt[source.SrcLoc].some{best_loc}; }
+    ret opt[source.SrcLoc].none{};
 }
 
 fun install_into(s: *debug_input.DebugProgram, image: *of.ObjectImage, itn: *intern.Interner,
@@ -2712,72 +2722,72 @@ fun install_into(s: *debug_input.DebugProgram, image: *of.ObjectImage, itn: *int
             addr_off: *u32, addr_kind: of.RelocKind, stmt_off: u32,
             info_relocs: *InfoReloc, info_reloc_count: u32,
             loc_relocs: *LocReloc, loc_reloc_count: u32,
-            rng_relocs: *RngReloc, rng_reloc_count: u32) R.Result[R.Void, str] {
+            rng_relocs: *RngReloc, rng_reloc_count: u32) err[fail.Fail] {
     val n_abbrev: R.Result[intern.StrId, str] = intern.intern(itn, ".debug_abbrev");
-    if (R.is_err[intern.StrId, str](n_abbrev)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](n_abbrev)); }
+    if (R.is_err[intern.StrId, str](n_abbrev)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](n_abbrev))}; }
     val n_line: R.Result[intern.StrId, str] = intern.intern(itn, ".debug_line");
-    if (R.is_err[intern.StrId, str](n_line)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](n_line)); }
+    if (R.is_err[intern.StrId, str](n_line)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](n_line))}; }
     val n_info: R.Result[intern.StrId, str] = intern.intern(itn, ".debug_info");
-    if (R.is_err[intern.StrId, str](n_info)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](n_info)); }
+    if (R.is_err[intern.StrId, str](n_info)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](n_info))}; }
     val n_str: R.Result[intern.StrId, str] = intern.intern(itn, ".debug_str");
-    if (R.is_err[intern.StrId, str](n_str)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](n_str)); }
+    if (R.is_err[intern.StrId, str](n_str)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](n_str))}; }
 
-    val ra: R.Result[u32, str] = add_debug_section(image, R.unwrap_ok[intern.StrId, str](n_abbrev), b_abbrev);
-    if (R.is_err[u32, str](ra)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](ra)); }
-    val rl: R.Result[u32, str] = add_debug_section(image, R.unwrap_ok[intern.StrId, str](n_line), b_line);
-    if (R.is_err[u32, str](rl)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rl)); }
-    val line_sec: u32 = R.unwrap_ok[u32, str](rl);
-    val ri: R.Result[u32, str] = add_debug_section(image, R.unwrap_ok[intern.StrId, str](n_info), b_info);
-    if (R.is_err[u32, str](ri)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](ri)); }
-    val info_sec: u32 = R.unwrap_ok[u32, str](ri);
-    val rs: R.Result[u32, str] = add_debug_section(image, R.unwrap_ok[intern.StrId, str](n_str), b_str);
-    if (R.is_err[u32, str](rs)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rs)); }
-    val str_sec: u32 = R.unwrap_ok[u32, str](rs);
+    val ra: res[u32, fail.Fail] = add_debug_section(image, R.unwrap_ok[intern.StrId, str](n_abbrev), b_abbrev);
+    if (sel ra.err) { ret err[fail.Fail].err{ra.err}; }
+    val rl: res[u32, fail.Fail] = add_debug_section(image, R.unwrap_ok[intern.StrId, str](n_line), b_line);
+    if (sel rl.err) { ret err[fail.Fail].err{rl.err}; }
+    val line_sec: u32 = rl.ok;
+    val ri: res[u32, fail.Fail] = add_debug_section(image, R.unwrap_ok[intern.StrId, str](n_info), b_info);
+    if (sel ri.err) { ret err[fail.Fail].err{ri.err}; }
+    val info_sec: u32 = ri.ok;
+    val rs: res[u32, fail.Fail] = add_debug_section(image, R.unwrap_ok[intern.StrId, str](n_str), b_str);
+    if (sel rs.err) { ret err[fail.Fail].err{rs.err}; }
+    val str_sec: u32 = rs.ok;
 
-    val anchor_r: R.Result[intern.StrId, str] = intern_anchor(itn, resolve(itn, image.name), ".debug_line");
-    if (R.is_err[intern.StrId, str](anchor_r)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](anchor_r)); }
-    val anchor: intern.StrId = R.unwrap_ok[intern.StrId, str](anchor_r);
-    val sr: R.Result[u32, str] = add_anchor(image, anchor, line_sec);
-    if (R.is_err[u32, str](sr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](sr)); }
+    val anchor_r: res[intern.StrId, fail.Fail] = intern_anchor(itn, resolve(itn, image.name), ".debug_line");
+    if (sel anchor_r.err) { ret err[fail.Fail].err{anchor_r.err}; }
+    val anchor: intern.StrId = anchor_r.ok;
+    val sr: res[u32, fail.Fail] = add_anchor(image, anchor, line_sec);
+    if (sel sr.err) { ret err[fail.Fail].err{sr.err}; }
 
-    val sanchor_r: R.Result[intern.StrId, str] = intern_anchor(itn, resolve(itn, image.name), ".debug_str");
-    if (R.is_err[intern.StrId, str](sanchor_r)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](sanchor_r)); }
-    val str_anchor: intern.StrId = R.unwrap_ok[intern.StrId, str](sanchor_r);
-    val sar: R.Result[u32, str] = add_anchor(image, str_anchor, str_sec);
-    if (R.is_err[u32, str](sar)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](sar)); }
+    val sanchor_r: res[intern.StrId, fail.Fail] = intern_anchor(itn, resolve(itn, image.name), ".debug_str");
+    if (sel sanchor_r.err) { ret err[fail.Fail].err{sanchor_r.err}; }
+    val str_anchor: intern.StrId = sanchor_r.ok;
+    val sar: res[u32, fail.Fail] = add_anchor(image, str_anchor, str_sec);
+    if (sel sar.err) { ret err[fail.Fail].err{sar.err}; }
 
     var loclists_sec: u32 = 0;
     var loclists_anchor: intern.StrId = intern.STR_NIL;
     if (has_loclists) {
         val n_ll: R.Result[intern.StrId, str] = intern.intern(itn, ".debug_loclists");
-        if (R.is_err[intern.StrId, str](n_ll)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](n_ll)); }
-        val rll: R.Result[u32, str] = add_debug_section(image, R.unwrap_ok[intern.StrId, str](n_ll), b_loclists);
-        if (R.is_err[u32, str](rll)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rll)); }
-        loclists_sec = R.unwrap_ok[u32, str](rll);
-        val llanchor_r: R.Result[intern.StrId, str] = intern_anchor(itn, resolve(itn, image.name), ".debug_loclists");
-        if (R.is_err[intern.StrId, str](llanchor_r)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](llanchor_r)); }
-        loclists_anchor = R.unwrap_ok[intern.StrId, str](llanchor_r);
-        val llar: R.Result[u32, str] = add_anchor(image, loclists_anchor, loclists_sec);
-        if (R.is_err[u32, str](llar)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](llar)); }
+        if (R.is_err[intern.StrId, str](n_ll)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](n_ll))}; }
+        val rll: res[u32, fail.Fail] = add_debug_section(image, R.unwrap_ok[intern.StrId, str](n_ll), b_loclists);
+        if (sel rll.err) { ret err[fail.Fail].err{rll.err}; }
+        loclists_sec = rll.ok;
+        val llanchor_r: res[intern.StrId, fail.Fail] = intern_anchor(itn, resolve(itn, image.name), ".debug_loclists");
+        if (sel llanchor_r.err) { ret err[fail.Fail].err{llanchor_r.err}; }
+        loclists_anchor = llanchor_r.ok;
+        val llar: res[u32, fail.Fail] = add_anchor(image, loclists_anchor, loclists_sec);
+        if (sel llar.err) { ret err[fail.Fail].err{llar.err}; }
     }
 
     var rnglists_sec: u32 = 0;
     var rnglists_anchor: intern.StrId = intern.STR_NIL;
     if (has_rnglists) {
         val n_rl: R.Result[intern.StrId, str] = intern.intern(itn, ".debug_rnglists");
-        if (R.is_err[intern.StrId, str](n_rl)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](n_rl)); }
-        val rrl: R.Result[u32, str] = add_debug_section(image, R.unwrap_ok[intern.StrId, str](n_rl), b_rnglists);
-        if (R.is_err[u32, str](rrl)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rrl)); }
-        rnglists_sec = R.unwrap_ok[u32, str](rrl);
-        val rlanchor_r: R.Result[intern.StrId, str] = intern_anchor(itn, resolve(itn, image.name), ".debug_rnglists");
-        if (R.is_err[intern.StrId, str](rlanchor_r)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](rlanchor_r)); }
-        rnglists_anchor = R.unwrap_ok[intern.StrId, str](rlanchor_r);
-        val rlar: R.Result[u32, str] = add_anchor(image, rnglists_anchor, rnglists_sec);
-        if (R.is_err[u32, str](rlar)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rlar)); }
+        if (R.is_err[intern.StrId, str](n_rl)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](n_rl))}; }
+        val rrl: res[u32, fail.Fail] = add_debug_section(image, R.unwrap_ok[intern.StrId, str](n_rl), b_rnglists);
+        if (sel rrl.err) { ret err[fail.Fail].err{rrl.err}; }
+        rnglists_sec = rrl.ok;
+        val rlanchor_r: res[intern.StrId, fail.Fail] = intern_anchor(itn, resolve(itn, image.name), ".debug_rnglists");
+        if (sel rlanchor_r.err) { ret err[fail.Fail].err{rlanchor_r.err}; }
+        rnglists_anchor = rlanchor_r.ok;
+        val rlar: res[u32, fail.Fail] = add_anchor(image, rnglists_anchor, rnglists_sec);
+        if (sel rlar.err) { ret err[fail.Fail].err{rlar.err}; }
     }
 
-    val r2: R.Result[R.Void, str] = add_reloc(image, info_sec, stmt_off, of.RK_ABS32, anchor);
-    if (R.is_err[R.Void, str](r2)) { ret r2; }
+    val r2: err[fail.Fail] = add_reloc(image, info_sec, stmt_off, of.RK_ABS32, anchor);
+    if (sel r2.err) { ret r2; }
 
     var k: u32 = 0;
     for (k < info_reloc_count) {
@@ -2786,34 +2796,34 @@ fun install_into(s: *debug_input.DebugProgram, image: *of.ObjectImage, itn: *int
         if (ir2.target == IRLT_STR)     { sym = str_anchor; }
         or (ir2.target == IRLT_LOCLIST) { sym = loclists_anchor; }
         or (ir2.target == IRLT_RNGLIST) { sym = rnglists_anchor; }
-        val rk: R.Result[R.Void, str] = add_reloc_addend(image, info_sec, ir2.off, ir2.kind, sym, ir2.addend);
-        if (R.is_err[R.Void, str](rk)) { ret rk; }
+        val rk: err[fail.Fail] = add_reloc_addend(image, info_sec, ir2.off, ir2.kind, sym, ir2.addend);
+        if (sel rk.err) { ret rk; }
         k = k + 1;
     }
 
     var li: u32 = 0;
     for (li < loc_reloc_count) {
         val lr: *LocReloc = ?loc_relocs[li];
-        val rlrx: R.Result[R.Void, str] = add_reloc(image, loclists_sec, lr.off, addr_kind, lr.sym);
-        if (R.is_err[R.Void, str](rlrx)) { ret rlrx; }
+        val rlrx: err[fail.Fail] = add_reloc(image, loclists_sec, lr.off, addr_kind, lr.sym);
+        if (sel rlrx.err) { ret rlrx; }
         li = li + 1;
     }
 
     var ri3: u32 = 0;
     for (ri3 < rng_reloc_count) {
         val rr3: *RngReloc = ?rng_relocs[ri3];
-        val rrx: R.Result[R.Void, str] = add_reloc(image, rnglists_sec, rr3.off, addr_kind, rr3.sym);
-        if (R.is_err[R.Void, str](rrx)) { ret rrx; }
+        val rrx: err[fail.Fail] = add_reloc(image, rnglists_sec, rr3.off, addr_kind, rr3.sym);
+        if (sel rrx.err) { ret rrx; }
         ri3 = ri3 + 1;
     }
 
     var i: u32 = 0;
     for (i < nfuncs) {
-        val rr: R.Result[R.Void, str] = add_reloc(image, line_sec, addr_off[i], addr_kind, funcs[i].name);
-        if (R.is_err[R.Void, str](rr)) { ret rr; }
+        val rr: err[fail.Fail] = add_reloc(image, line_sec, addr_off[i], addr_kind, funcs[i].name);
+        if (sel rr.err) { ret rr; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun install(s: *debug_input.DebugProgram, image: *of.ObjectImage, itn: *intern.Interner,
@@ -2823,35 +2833,35 @@ fun install(s: *debug_input.DebugProgram, image: *of.ObjectImage, itn: *intern.I
             addr_off: *u32, addr_kind: of.RelocKind, stmt_off: u32,
             info_relocs: *InfoReloc, info_reloc_count: u32,
             loc_relocs: *LocReloc, loc_reloc_count: u32,
-            rng_relocs: *RngReloc, rng_reloc_count: u32) R.Result[R.Void, str] {
+            rng_relocs: *RngReloc, rng_reloc_count: u32) err[fail.Fail] {
     var sections: *of.Section = nil;
     var symbols: *of.Symbol = nil;
     var relocations: *of.Relocation = nil;
     if (image.section_count > 0) {
-        val sr: R.Result[*of.Section, str] = A.allocate[of.Section](image.alloc, image.section_count::usize);
-        if (R.is_err[*of.Section, str](sr)) { ret R.err[R.Void, str](R.unwrap_err[*of.Section, str](sr)); }
-        sections = R.unwrap_ok[*of.Section, str](sr);
+        val sr: res[*of.Section, A.Error] = A.allocate[of.Section](image.alloc, image.section_count::usize);
+        if (sel sr.err) { ret err[fail.Fail].err{fail.refused(sr.err)}; }
+        sections = sr.ok;
         var i: u32 = 0;
         for (i < image.section_count) { sections[i] = image.sections[i]; i = i + 1; }
     }
     if (image.symbol_count > 0) {
-        val yr: R.Result[*of.Symbol, str] = A.allocate[of.Symbol](image.alloc, image.symbol_count::usize);
-        if (R.is_err[*of.Symbol, str](yr)) {
+        val yr: res[*of.Symbol, A.Error] = A.allocate[of.Symbol](image.alloc, image.symbol_count::usize);
+        if (sel yr.err) {
             if (sections != nil) { A.deallocate[of.Section](image.alloc, sections, image.section_count::usize); }
-            ret R.err[R.Void, str](R.unwrap_err[*of.Symbol, str](yr));
+            ret err[fail.Fail].err{fail.refused(yr.err)};
         }
-        symbols = R.unwrap_ok[*of.Symbol, str](yr);
+        symbols = yr.ok;
         var i: u32 = 0;
         for (i < image.symbol_count) { symbols[i] = image.symbols[i]; i = i + 1; }
     }
     if (image.reloc_count > 0) {
-        val rr: R.Result[*of.Relocation, str] = A.allocate[of.Relocation](image.alloc, image.reloc_count::usize);
-        if (R.is_err[*of.Relocation, str](rr)) {
+        val rr: res[*of.Relocation, A.Error] = A.allocate[of.Relocation](image.alloc, image.reloc_count::usize);
+        if (sel rr.err) {
             if (sections != nil) { A.deallocate[of.Section](image.alloc, sections, image.section_count::usize); }
             if (symbols != nil) { A.deallocate[of.Symbol](image.alloc, symbols, image.symbol_count::usize); }
-            ret R.err[R.Void, str](R.unwrap_err[*of.Relocation, str](rr));
+            ret err[fail.Fail].err{fail.refused(rr.err)};
         }
-        relocations = R.unwrap_ok[*of.Relocation, str](rr);
+        relocations = rr.ok;
         var i: u32 = 0;
         for (i < image.reloc_count) { relocations[i] = image.relocations[i]; i = i + 1; }
     }
@@ -2864,11 +2874,11 @@ fun install(s: *debug_input.DebugProgram, image: *of.ObjectImage, itn: *intern.I
     work.symbol_cap = image.symbol_count;
     work.relocations = relocations;
     work.reloc_cap = image.reloc_count;
-    val installed: R.Result[R.Void, str] = install_into(s, ?work, itn, funcs, nfuncs,
+    val installed: err[fail.Fail] = install_into(s, ?work, itn, funcs, nfuncs,
         b_abbrev, b_line, b_info, b_str, b_loclists, has_loclists, b_rnglists, has_rnglists,
         addr_off, addr_kind, stmt_off, info_relocs, info_reloc_count,
         loc_relocs, loc_reloc_count, rng_relocs, rng_reloc_count);
-    if (R.is_err[R.Void, str](installed)) {
+    if (sel installed.err) {
         var si: u32 = old_section_count;
         for (si < work.section_count) {
             if (work.sections[si].bytes != nil) {
@@ -2919,12 +2929,14 @@ fun t_debug_reg(reg: i32) i32 {
 }
 
 fun t_request_rejected(req: *of.DebugProduceRequest) bool {
-    ret R.is_err[R.Void, str](validate_request(req));
+    val validated: err[fail.Fail] = validate_request(req);
+    ret sel validated.err;
 }
 
 test "mach.lang.be.codegen.dwarf.validate_request:rejects_malformed_program_image_and_streams" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
@@ -2950,12 +2962,12 @@ test "mach.lang.be.codegen.dwarf.validate_request:rejects_malformed_program_imag
     mirmod.function_len = 0;
     mirmod.function_cap = 0;
 
-    val image_r: R.Result[of.ObjectImage, str] = obj.init(?alloc, ?s.interner, name);
-    if (R.is_err[of.ObjectImage, str](image_r)) { ir.dnit(?irmod); session.dnit(?s); ret 1; }
-    var image: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](image_r);
-    val bytes_r: R.Result[*u8, str] = A.allocate[u8](?alloc, 8::usize);
-    if (R.is_err[*u8, str](bytes_r)) { obj.dnit(?image); ir.dnit(?irmod); session.dnit(?s); ret 1; }
-    val bytes: *u8 = R.unwrap_ok[*u8, str](bytes_r);
+    val image_r: res[of.ObjectImage, fail.Fail] = obj.image_init(?alloc, ?s.interner, name);
+    if (sel image_r.err) { ir.dnit(?irmod); session.dnit(?s); ret 1; }
+    var image: of.ObjectImage = image_r.ok;
+    val bytes_r: res[*u8, A.Error] = A.allocate[u8](?alloc, 8::usize);
+    if (sel bytes_r.err) { obj.dnit(?image); ir.dnit(?irmod); session.dnit(?s); ret 1; }
+    val bytes: *u8 = bytes_r.ok;
     var bi: u32 = 0;
     for (bi < 8) { bytes[bi] = 0; bi = bi + 1; }
     var text: of.Section;
@@ -2965,7 +2977,8 @@ test "mach.lang.be.codegen.dwarf.validate_request:rejects_malformed_program_imag
     text.len = 8;
     text.align = 1;
     text.flags = 0;
-    if (R.is_err[u32, str](obj.install_section(?image, ?text))) {
+    val section_install_r: res[u32, fail.Fail] = obj.section_install(?image, ?text);
+    if (sel section_install_r.err) {
         obj.dnit(?image); ir.dnit(?irmod); session.dnit(?s); ret 1;
     }
     var bss: of.Section;
@@ -2975,7 +2988,8 @@ test "mach.lang.be.codegen.dwarf.validate_request:rejects_malformed_program_imag
     bss.len = 8;
     bss.align = 1;
     bss.flags = 0;
-    if (R.is_err[u32, str](obj.install_section(?image, ?bss))) {
+    val section_install_r2: res[u32, fail.Fail] = obj.section_install(?image, ?bss);
+    if (sel section_install_r2.err) {
         obj.dnit(?image); ir.dnit(?irmod); session.dnit(?s); ret 1;
     }
     var sym: of.Symbol;
@@ -2986,7 +3000,8 @@ test "mach.lang.be.codegen.dwarf.validate_request:rejects_malformed_program_imag
     sym.flags = of.SYM_OBJ_FLAG_FUNCTION;
     sym.fallback = of.SYMBOL_NONE;
     sym.align = 1;
-    if (R.is_err[u32, str](obj.add_symbol(?image, sym))) {
+    val symbol_add_r: res[u32, fail.Fail] = obj.symbol_add(?image, sym);
+    if (sel symbol_add_r.err) {
         obj.dnit(?image); ir.dnit(?irmod); session.dnit(?s); ret 1;
     }
 
@@ -3148,7 +3163,8 @@ fun dwarf_install_allocator(p: *DwarfInstallProbe) A.Allocator {
 
 test "mach.lang.be.codegen.dwarf.install:failure_leaves_the_original_image_unchanged" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
     var probe: DwarfInstallProbe;
     probe.backing = backing;
     probe.calls = 0;
@@ -3158,10 +3174,10 @@ test "mach.lang.be.codegen.dwarf.install:failure_leaves_the_original_image_uncha
     var itn: intern.Interner = intern.init(?backing);
     val name_r: R.Result[intern.StrId, str] = intern.intern(?itn, "rollback");
     if (R.is_err[intern.StrId, str](name_r)) { intern.dnit(?itn); ret 1; }
-    val image_r: R.Result[of.ObjectImage, str] = obj.init(?image_alloc, ?itn,
+    val image_r: res[of.ObjectImage, fail.Fail] = obj.image_init(?image_alloc, ?itn,
         R.unwrap_ok[intern.StrId, str](name_r));
-    if (R.is_err[of.ObjectImage, str](image_r)) { intern.dnit(?itn); ret 1; }
-    var image: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](image_r);
+    if (sel image_r.err) { intern.dnit(?itn); ret 1; }
+    var image: of.ObjectImage = image_r.ok;
     var bytes: enc.ByteBuf = enc.buf_init(?backing);
     enc.emit_byte(?bytes, 0);
     if (bytes.len != 1) { enc.buf_dnit(?bytes); obj.dnit(?image); intern.dnit(?itn); ret 1; }
@@ -3169,11 +3185,11 @@ test "mach.lang.be.codegen.dwarf.install:failure_leaves_the_original_image_uncha
     program.alloc = ?backing;
 
     probe.fail_at = probe.calls + 3;
-    val installed: R.Result[R.Void, str] = install(?program, ?image, ?itn, nil, 0,
+    val installed: err[fail.Fail] = install(?program, ?image, ?itn, nil, 0,
         ?bytes, ?bytes, ?bytes, ?bytes, ?bytes, false, ?bytes, false,
         nil, of.RK_ABS64, 0, nil, 0, nil, 0, nil, 0);
     var bad: i32 = 0;
-    if (R.is_ok[R.Void, str](installed)) { bad = 1; }
+    if (sel installed.ok) { bad = 1; }
     if (image.sections != nil || image.section_count != 0
         || image.symbols != nil || image.symbol_count != 0
         || image.relocations != nil || image.reloc_count != 0) { bad = 1; }
@@ -3185,7 +3201,7 @@ test "mach.lang.be.codegen.dwarf.install:failure_leaves_the_original_image_uncha
     ret bad;
 }
 
-fun add_anchor(image: *of.ObjectImage, name: intern.StrId, sec: u32) R.Result[u32, str] {
+fun add_anchor(image: *of.ObjectImage, name: intern.StrId, sec: u32) res[u32, fail.Fail] {
     var asym: of.Symbol;
     asym.name    = name;
     asym.section = of.section_id(sec);
@@ -3194,7 +3210,7 @@ fun add_anchor(image: *of.ObjectImage, name: intern.StrId, sec: u32) R.Result[u3
     asym.flags   = of.SYM_OBJ_FLAG_GLOBAL;
     asym.fallback = of.SYMBOL_NONE;
     asym.align    = 1;
-    ret obj.add_symbol(image, asym);
+    ret obj.symbol_add(image, asym);
 }
 
 fun buf_eq(b: *enc.ByteBuf, expect: *u8, n: usize) bool {
@@ -3503,7 +3519,8 @@ test "mach.lang.be.codegen.dwarf.emit_type_dies:vector" {
 
 test "mach.lang.be.codegen.dwarf.sem_to_ir:vector" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
@@ -3518,10 +3535,9 @@ test "mach.lang.be.codegen.dwarf.sem_to_ir:vector" {
         if (R.is_err[ir.Module, str](im)) { code = 1; }
         or {
             var m: ir.Module = R.unwrap_ok[ir.Module, str](im);
-            val ri: R.Result[ir_type.IrTypeId, str] = sem_to_ir(?program, ?m.types, vec_sem);
-            if (R.is_err[ir_type.IrTypeId, str](ri)) { code = 1; }
-            or {
-                val ot: O.Option[*ir_type.IrType] = ir_type.get(?m.types, R.unwrap_ok[ir_type.IrTypeId, str](ri));
+            val ri: res[ir_type.IrTypeId, fail.Fail] = sem_to_ir(?program, ?m.types, vec_sem);
+            if (sel ri.ok) {
+                val ot: O.Option[*ir_type.IrType] = ir_type.get(?m.types, ri.ok);
                 if (O.is_none[*ir_type.IrType](ot)) { code = 1; }
                 or {
                     val it: *ir_type.IrType = O.unwrap[*ir_type.IrType](ot);
@@ -3529,6 +3545,7 @@ test "mach.lang.be.codegen.dwarf.sem_to_ir:vector" {
                     if (it.data.vector_.lanes != 4)     { code = 1; }
                 }
             }
+            or { code = 1; }
             ir.dnit(?m);
         }
     }
@@ -3974,7 +3991,8 @@ test "mach.lang.be.codegen.dwarf.memb_reserve:refuses_capacity_overflow_before_r
 
 test "mach.lang.be.codegen.dwarf.sem_base_type:agrees_with_prim_catalog" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
@@ -3983,17 +4001,19 @@ test "mach.lang.be.codegen.dwarf.sem_base_type:agrees_with_prim_catalog" {
     var code: i32 = 0;
     var k: u32 = 0;
     for (k < semtype.PRIM_COUNT) {
-        val opt_die: O.Option[TypeDie] = sem_base_type(?program, k::semtype.TypeId, 8);
-        if (O.is_none[TypeDie](opt_die)) { code = 1; }
-        or {
-            val die: TypeDie = O.unwrap[TypeDie](opt_die);
+        val opt_die: opt[TypeDie] = sem_base_type(?program, k::semtype.TypeId, 8);
+        if (sel opt_die.some) {
+            val die: TypeDie = opt_die.some;
             if (!str_equals(die.name, semtype.prim_name(k::semtype.TypeKind))) { code = 1; }
         }
+        or { code = 1; }
         val secret_r: R.Result[semtype.TypeId, str] = semtype.intern_secret(?s.types, k::semtype.TypeId);
         if (R.is_ok[semtype.TypeId, str](secret_r)) {
-            val sdie: O.Option[TypeDie] = sem_base_type(?program, R.unwrap_ok[semtype.TypeId, str](secret_r), 8);
-            if (O.is_none[TypeDie](sdie)) { code = 1; }
-            or (!str_equals(O.unwrap[TypeDie](sdie).name, semtype.prim_name(k::semtype.TypeKind))) { code = 1; }
+            val sdie: opt[TypeDie] = sem_base_type(?program, R.unwrap_ok[semtype.TypeId, str](secret_r), 8);
+            if (sel sdie.some) {
+                if (!str_equals(sdie.some.name, semtype.prim_name(k::semtype.TypeKind))) { code = 1; }
+            }
+            or { code = 1; }
         }
         k = k + 1;
     }
@@ -4066,7 +4086,8 @@ test "mach.lang.be.codegen.dwarf.frame_base_reg:absent_mapping_returns_negative_
 
 test "mach.lang.be.codegen.dwarf.inline_caps:reflects_nested_depth" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
@@ -4112,7 +4133,8 @@ test "mach.lang.be.codegen.dwarf.inline_caps:reflects_nested_depth" {
 
 fun t_stream_request(check: fun(*of.DebugProduceRequest) i32) i32 {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val sr: R.Result[session.Session, str] = session.init(?alloc);
     if (R.is_err[session.Session, str](sr)) { ret 1; }
     var s: session.Session = R.unwrap_ok[session.Session, str](sr);
@@ -4131,18 +4153,19 @@ fun t_stream_request(check: fun(*of.DebugProduceRequest) i32) i32 {
     mirmod.alloc = ?alloc;
     mirmod.interner = ?s.interner;
     mirmod.srcmap = ?s.sources;
-    val image_r: R.Result[of.ObjectImage, str] = obj.init(?alloc, ?s.interner, name);
-    if (R.is_err[of.ObjectImage, str](image_r)) { ir.dnit(?irmod); session.dnit(?s); ret 1; }
-    var image: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](image_r);
-    val br: R.Result[*u8, str] = A.allocate[u8](?alloc, 8::usize);
-    if (R.is_err[*u8, str](br)) { obj.dnit(?image); ir.dnit(?irmod); session.dnit(?s); ret 1; }
+    val image_r: res[of.ObjectImage, fail.Fail] = obj.image_init(?alloc, ?s.interner, name);
+    if (sel image_r.err) { ir.dnit(?irmod); session.dnit(?s); ret 1; }
+    var image: of.ObjectImage = image_r.ok;
+    val br: res[*u8, A.Error] = A.allocate[u8](?alloc, 8::usize);
+    if (sel br.err) { obj.dnit(?image); ir.dnit(?irmod); session.dnit(?s); ret 1; }
     var section: of.Section;
     section.name = name;
     section.kind = of.SK_TEXT;
-    section.bytes = R.unwrap_ok[*u8, str](br);
+    section.bytes = br.ok;
     section.len = 8;
     section.align = 1;
-    if (R.is_err[u32, str](obj.install_section(?image, ?section))) {
+    val section_install_r: res[u32, fail.Fail] = obj.section_install(?image, ?section);
+    if (sel section_install_r.err) {
         obj.dnit(?image); ir.dnit(?irmod); session.dnit(?s); ret 1;
     }
     var symbol: of.Symbol;
@@ -4153,7 +4176,8 @@ fun t_stream_request(check: fun(*of.DebugProduceRequest) i32) i32 {
     symbol.flags = of.SYM_OBJ_FLAG_FUNCTION;
     symbol.fallback = of.SYMBOL_NONE;
     symbol.align = 1;
-    if (R.is_err[u32, str](obj.add_symbol(?image, symbol))) {
+    val symbol_add_r: res[u32, fail.Fail] = obj.symbol_add(?image, symbol);
+    if (sel symbol_add_r.err) {
         obj.dnit(?image); ir.dnit(?irmod); session.dnit(?s); ret 1;
     }
     var req: of.DebugProduceRequest;
@@ -4172,8 +4196,8 @@ fun t_stream_request(check: fun(*of.DebugProduceRequest) i32) i32 {
 }
 
 fun t_request_error_is(req: *of.DebugProduceRequest, expected: str) bool {
-    val r: R.Result[R.Void, str] = validate_request(req);
-    ret R.is_err[R.Void, str](r) && str_equals(R.unwrap_err[R.Void, str](r), expected);
+    val r: err[fail.Fail] = validate_request(req);
+    ret sel r.err && str_equals(fail.describe(r.err), expected);
 }
 
 fun t_stream_order_contract(req: *of.DebugProduceRequest) i32 {
@@ -4250,14 +4274,14 @@ fun t_stream_order_contract(req: *of.DebugProduceRequest) i32 {
 fun t_large_ordered_streams(req: *of.DebugProduceRequest) i32 {
     val count: usize = 100000;
     val alloc: *A.Allocator = req.program.alloc;
-    val rr: R.Result[*debug_input.LineRow, str] = A.allocate[debug_input.LineRow](alloc, count);
-    if (R.is_err[*debug_input.LineRow, str](rr)) { ret 2; }
-    val rows: *debug_input.LineRow = R.unwrap_ok[*debug_input.LineRow, str](rr);
-    val pr: R.Result[*debug_input.InlinePc, str] = A.allocate[debug_input.InlinePc](alloc, count);
-    if (R.is_err[*debug_input.InlinePc, str](pr)) {
+    val rr: res[*debug_input.LineRow, A.Error] = A.allocate[debug_input.LineRow](alloc, count);
+    if (sel rr.err) { ret 2; }
+    val rows: *debug_input.LineRow = rr.ok;
+    val pr: res[*debug_input.InlinePc, A.Error] = A.allocate[debug_input.InlinePc](alloc, count);
+    if (sel pr.err) {
         A.deallocate[debug_input.LineRow](alloc, rows, count); ret 3;
     }
-    val pcs: *debug_input.InlinePc = R.unwrap_ok[*debug_input.InlinePc, str](pr);
+    val pcs: *debug_input.InlinePc = pr.ok;
     var i: usize = 0;
     for (i < count) {
         val offset: u32 = (i / 20000)::u32;

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -1,6 +1,8 @@
 use std.types.canonical.opt;
-use format: mach.lang.legacy.format;
-use writer: mach.lang.legacy.writer;
+use std.types.canonical.res;
+use std.types.canonical.err;
+use format: std.format;
+use writer: std.io.writer;
 use std.system.panic.panic;
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -9,11 +11,11 @@ use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_len;
 
-use page: mach.lang.legacy.page;
-use map: mach.lang.legacy.map;
+use page: std.allocator.page;
+use map: std.collections.map;
 use std.memory;
 
-use A: mach.lang.legacy.allocator;
+use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -60,26 +62,26 @@ pub val CONST_VEC: u8 = encoding.CONST_VEC;
 pub def ConstEntry: encoding.ConstEntry;
 
 pub fun run(tgt: *target.Target, m: *mir.MirModule,
-            asm_out: *writer.Writer) R.Result[EncoderOutput, str] {
-    if (tgt == nil) { ret R.err[EncoderOutput, str]("encode: nil target"); }
-    if (m == nil)   { ret R.err[EncoderOutput, str]("encode: nil mir module"); }
+            asm_out: *writer.Writer) res[EncoderOutput, fail.Fail] {
+    if (tgt == nil) { ret res[EncoderOutput, fail.Fail].err{fail.message("encode: nil target")}; }
+    if (m == nil)   { ret res[EncoderOutput, fail.Fail].err{fail.message("encode: nil mir module")}; }
     if (tgt.arch == nil) {
-        ret R.err[EncoderOutput, str]("encode: target has no ISA vtable");
+        ret res[EncoderOutput, fail.Fail].err{fail.message("encode: target has no ISA vtable")};
     }
     if (tgt.arch.encode == nil) {
-        ret R.err[EncoderOutput, str]("encode: ISA registered no encoder");
+        ret res[EncoderOutput, fail.Fail].err{fail.message("encode: ISA registered no encoder")};
     }
 
     if (asm_out != nil) {
         if (!tgt.arch.has_assembly) {
-            ret R.err[EncoderOutput, str]("--emit-asm: the target architecture registered no assembly printer");
+            ret res[EncoderOutput, fail.Fail].err{fail.message("--emit-asm: the target architecture registered no assembly printer")};
         }
         var backend_target: isa.BackendTarget = target.backend_target(tgt);
-        ret tgt.arch.assembly.emit(m.alloc, ?backend_target, m, asm_out);
+        ret fail.lift_res[EncoderOutput](tgt.arch.assembly.emit(m.alloc, ?backend_target, m, asm_out));
     }
 
     var backend_target: isa.BackendTarget = target.backend_target(tgt);
-    ret tgt.arch.encode(m.alloc, ?backend_target, m);
+    ret fail.lift_res[EncoderOutput](tgt.arch.encode(m.alloc, ?backend_target, m));
 }
 
 val BYTEBUF_INIT_CAP: usize = 256;
@@ -167,8 +169,8 @@ pub fun note_push(buf: *ByteBuf, n: *AsmNote) R.Result[R.Void, str] {
     if (!sink_active(buf)) { ret R.ok_void[str](); }
     val s: *AsmSink = buf.asm;
     if (s.note_count >= s.note_cap) {
-        val res_grow: R.Result[R.Void, str] = grow_notes(s, buf.alloc);
-        if (R.is_err[R.Void, str](res_grow)) { ret res_grow; }
+        val res_grow: err[fail.Fail] = grow_notes(s, buf.alloc);
+        if (sel res_grow.err) { ret fail.lower_unit(res_grow); }
     }
     s.notes[s.note_count] = @n;
     if (s.mi != nil) {
@@ -212,8 +214,8 @@ pub fun note_insert_after(buf: *ByteBuf, idx: u32, n: *AsmNote, nbytes: u32) R.R
         ret R.err[R.Void, str]("--emit-asm: an inserted instruction notification does not cover the text gap that was opened for it");
     }
     if (s.note_count >= s.note_cap) {
-        val res_grow: R.Result[R.Void, str] = grow_notes(s, buf.alloc);
-        if (R.is_err[R.Void, str](res_grow)) { ret res_grow; }
+        val res_grow: err[fail.Fail] = grow_notes(s, buf.alloc);
+        if (sel res_grow.err) { ret fail.lower_unit(res_grow); }
     }
     var i: u32 = s.note_count;
     val at: u32 = idx + 1;
@@ -276,39 +278,39 @@ pub fun notes_free(buf: *ByteBuf) {
     s.note_insts = 0;
 }
 
-fun grow_cap[T](alloc: *A.Allocator, data: **T, cap: *u32, init_cap: u32) R.Result[R.Void, str] {
+fun grow_cap[T](alloc: *A.Allocator, data: **T, cap: *u32, init_cap: u32) err[fail.Fail] {
     if (@data == nil) {
-        val res_alloc: R.Result[*T, str] = A.allocate[T](alloc, init_cap::usize);
-        if (R.is_err[*T, str](res_alloc)) { ret R.err[R.Void, str](R.unwrap_err[*T, str](res_alloc)); }
-        @data = R.unwrap_ok[*T, str](res_alloc);
+        val res_alloc: res[*T, A.Error] = A.allocate[T](alloc, init_cap::usize);
+        if (sel res_alloc.err) { ret err[fail.Fail].err{fail.refused(res_alloc.err)}; }
+        @data = res_alloc.ok;
         @cap  = init_cap;
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
     val current: layout.CheckedCount[T] = layout.count[T]((@cap)::usize);
     val required_r: R.Result[layout.CheckedCount[T], layout.CheckCause] =
         layout.count_add[T](current, layout.count[T](1::usize));
     if (R.is_err[layout.CheckedCount[T], layout.CheckCause](required_r)) {
-        ret R.err[R.Void, str]("encode: growth count overflow");
+        ret err[fail.Fail].err{fail.message("encode: growth count overflow")};
     }
     val required: layout.CheckedCount[T] = R.unwrap_ok[layout.CheckedCount[T], layout.CheckCause](required_r);
     val grown_r: R.Result[layout.CheckedCount[T], layout.CheckCause] = layout.count_grow[T](current, required);
     if (R.is_err[layout.CheckedCount[T], layout.CheckCause](grown_r)) {
-        ret R.err[R.Void, str]("encode: growth count overflow");
+        ret err[fail.Fail].err{fail.message("encode: growth count overflow")};
     }
     val new_cap_fits: R.Result[u32, layout.CheckCause] = layout.usize_to_u32(
         R.unwrap_ok[layout.CheckedCount[T], layout.CheckCause](grown_r).value);
     if (R.is_err[u32, layout.CheckCause](new_cap_fits)) {
-        ret R.err[R.Void, str]("encode: growth capacity exceeds the u32 limit");
+        ret err[fail.Fail].err{fail.message("encode: growth capacity exceeds the u32 limit")};
     }
     val new_cap: u32 = R.unwrap_ok[u32, layout.CheckCause](new_cap_fits);
-    val res_realloc: R.Result[*T, str] = A.reallocate[T](alloc, @data, (@cap)::usize, new_cap::usize);
-    if (R.is_err[*T, str](res_realloc)) { ret R.err[R.Void, str](R.unwrap_err[*T, str](res_realloc)); }
-    @data = R.unwrap_ok[*T, str](res_realloc);
+    val res_realloc: res[*T, A.Error] = A.reallocate[T](alloc, @data, (@cap)::usize, new_cap::usize);
+    if (sel res_realloc.err) { ret err[fail.Fail].err{fail.refused(res_realloc.err)}; }
+    @data = res_realloc.ok;
     @cap  = new_cap;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun grow_notes(s: *AsmSink, alloc: *A.Allocator) R.Result[R.Void, str] {
+fun grow_notes(s: *AsmSink, alloc: *A.Allocator) err[fail.Fail] {
     ret grow_cap[AsmNote](alloc, ?s.notes, ?s.note_cap, ASM_NOTE_INIT_CAP);
 }
 
@@ -342,26 +344,26 @@ pub fun sink_claim(buf: *ByteBuf, start: usize) {
 }
 
 pub fun render_bytes_text(out: *writer.Writer, bytes: *u8, n: usize) R.Result[R.Void, str] {
-    val ri: R.Result[usize, str] = format.write_str(out, "  .byte ");
-    if (R.is_err[usize, str](ri)) { ret R.err[R.Void, str](R.unwrap_err[usize, str](ri)); }
+    val ri: res[usize, writer.WriteError] = format.write_str(out, "  .byte ");
+    if (sel ri.err) { ret R.err[R.Void, str](fail.describe(fail.write_refused(ri.err))); }
     var i: usize = 0;
     for (i < n) {
         if (i > 0) {
-            val rc: R.Result[usize, str] = format.write_str(out, ", ");
-            if (R.is_err[usize, str](rc)) { ret R.err[R.Void, str](R.unwrap_err[usize, str](rc)); }
+            val rc: res[usize, writer.WriteError] = format.write_str(out, ", ");
+            if (sel rc.err) { ret R.err[R.Void, str](fail.describe(fail.write_refused(rc.err))); }
         }
-        val rb: R.Result[usize, str] = format.write_str(out, "0x");
-        if (R.is_err[usize, str](rb)) { ret R.err[R.Void, str](R.unwrap_err[usize, str](rb)); }
+        val rb: res[usize, writer.WriteError] = format.write_str(out, "0x");
+        if (sel rb.err) { ret R.err[R.Void, str](fail.describe(fail.write_refused(rb.err))); }
         var hex: [3]u8;
         hex[0] = hex_digit((bytes[i] >> 4) & 0xF);
         hex[1] = hex_digit(bytes[i] & 0xF);
         hex[2] = 0;
-        val rh: R.Result[usize, str] = format.write_str(out, (?hex[0])::str);
-        if (R.is_err[usize, str](rh)) { ret R.err[R.Void, str](R.unwrap_err[usize, str](rh)); }
+        val rh: res[usize, writer.WriteError] = format.write_str(out, (?hex[0])::str);
+        if (sel rh.err) { ret R.err[R.Void, str](fail.describe(fail.write_refused(rh.err))); }
         i = i + 1;
     }
-    val rn: R.Result[usize, str] = format.write_str(out, "\n");
-    if (R.is_err[usize, str](rn)) { ret R.err[R.Void, str](R.unwrap_err[usize, str](rn)); }
+    val rn: res[usize, writer.WriteError] = format.write_str(out, "\n");
+    if (sel rn.err) { ret R.err[R.Void, str](fail.describe(fail.write_refused(rn.err))); }
     ret R.ok_void[str]();
 }
 
@@ -482,11 +484,9 @@ pub fun emit_byte(buf: *ByteBuf, byte: u8) {
             }
             new_cap = R.unwrap_ok[layout.CheckedCount[layout.ByteUnit], layout.CheckCause](doubled).value;
         }
-        val res_realloc: R.Result[*u8, str] = A.reallocate[u8](buf.alloc, buf.data, buf.cap, new_cap);
-        if (R.is_err[*u8, str](res_realloc)) {
-            panic("encode: byte buffer realloc failed\n");
-        }
-        buf.data = R.unwrap_ok[*u8, str](res_realloc);
+        val res_realloc: res[*u8, A.Error] = A.reallocate[u8](buf.alloc, buf.data, buf.cap, new_cap);
+        if (sel res_realloc.ok) { buf.data = res_realloc.ok; }
+        or { panic("encode: byte buffer realloc failed\n"); }
         buf.cap  = new_cap;
     }
     buf.data[buf.len] = byte;
@@ -594,27 +594,38 @@ pub fun module_has_oblivious(m: *mir.MirModule) bool {
     ret false;
 }
 
-pub fun encode_driver(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.MirModule, hooks: *EncodeHooks) R.Result[EncoderOutput, str] {
-    ret encode_driver_asm(alloc, tgt, m, hooks, nil);
+pub fun encode_module(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.MirModule, hooks: *EncodeHooks) res[EncoderOutput, fail.Fail] {
+    ret encode_module_asm(alloc, tgt, m, hooks, nil);
 }
 
-fun apply_emission_order_module(alloc: *A.Allocator, m: *mir.MirModule) R.Result[R.Void, str] {
+# translation shims (#3226): the legacy carriers the per-ISA encoders read
+# until target/isa migrates to `encode_module` and `encode_module_asm`
+pub fun encode_driver(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.MirModule, hooks: *EncodeHooks) R.Result[EncoderOutput, str] {
+    ret fail.lower[EncoderOutput](encode_module_asm(alloc, tgt, m, hooks, nil));
+}
+
+pub fun encode_driver_asm(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.MirModule,
+                          hooks: *EncodeHooks, asm_out: *writer.Writer) R.Result[EncoderOutput, str] {
+    ret fail.lower[EncoderOutput](encode_module_asm(alloc, tgt, m, hooks, asm_out));
+}
+
+fun apply_emission_order_module(alloc: *A.Allocator, m: *mir.MirModule) err[fail.Fail] {
     var fi: u32 = 0;
     for (fi < m.function_len) {
-        val ao: R.Result[R.Void, str] = apply_emission_order(alloc, ?m.functions[fi]);
-        if (R.is_err[R.Void, str](ao)) { ret ao; }
+        val ao: err[fail.Fail] = apply_emission_order(alloc, ?m.functions[fi]);
+        if (sel ao.err) { ret ao; }
         fi = fi + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun apply_emission_order(alloc: *A.Allocator, f: *mir.MirFunction) R.Result[R.Void, str] {
+fun apply_emission_order(alloc: *A.Allocator, f: *mir.MirFunction) err[fail.Fail] {
     val n: u32 = f.block_count;
-    if (n <= 1 || f.emit_order == nil) { ret R.ok_void[str](); }
+    if (n <= 1 || f.emit_order == nil) { ret err[fail.Fail].ok{}; }
 
-    val rt: R.Result[*mir.MirBlock, str] = A.allocate[mir.MirBlock](alloc, n::usize);
-    if (R.is_err[*mir.MirBlock, str](rt)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirBlock, str](rt)); }
-    val tmp: *mir.MirBlock = R.unwrap_ok[*mir.MirBlock, str](rt);
+    val rt: res[*mir.MirBlock, A.Error] = A.allocate[mir.MirBlock](alloc, n::usize);
+    if (sel rt.err) { ret err[fail.Fail].err{fail.refused(rt.err)}; }
+    val tmp: *mir.MirBlock = rt.ok;
 
     var i: u32 = 0;
     for (i < n) {
@@ -631,23 +642,23 @@ fun apply_emission_order(alloc: *A.Allocator, f: *mir.MirFunction) R.Result[R.Vo
     i = 0;
     for (i < n) { f.emit_order[i] = i; i = i + 1; }
 
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun encode_driver_asm(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.MirModule,
-                          hooks: *EncodeHooks, asm_out: *writer.Writer) R.Result[EncoderOutput, str] {
-    if (tgt == nil)   { ret R.err[EncoderOutput, str]("encode: nil target"); }
-    if (m == nil)     { ret R.err[EncoderOutput, str]("encode: nil mir module"); }
-    if (hooks == nil) { ret R.err[EncoderOutput, str]("encode: nil encode hooks"); }
+pub fun encode_module_asm(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.MirModule,
+                          hooks: *EncodeHooks, asm_out: *writer.Writer) res[EncoderOutput, fail.Fail] {
+    if (tgt == nil)   { ret res[EncoderOutput, fail.Fail].err{fail.message("encode: nil target")}; }
+    if (m == nil)     { ret res[EncoderOutput, fail.Fail].err{fail.message("encode: nil mir module")}; }
+    if (hooks == nil) { ret res[EncoderOutput, fail.Fail].err{fail.message("encode: nil encode hooks")}; }
     if (hooks.encode_function == nil) {
-        ret R.err[EncoderOutput, str]("encode: ISA supplied no per-function encode hook");
+        ret res[EncoderOutput, fail.Fail].err{fail.message("encode: ISA supplied no per-function encode hook")};
     }
     if (hooks.patch_branch == nil) {
-        ret R.err[EncoderOutput, str]("encode: ISA supplied no per-branch patch hook");
+        ret res[EncoderOutput, fail.Fail].err{fail.message("encode: ISA supplied no per-branch patch hook")};
     }
 
-    val res_layout: R.Result[R.Void, str] = apply_emission_order_module(alloc, m);
-    if (R.is_err[R.Void, str](res_layout)) { ret R.err[EncoderOutput, str](R.unwrap_err[R.Void, str](res_layout)); }
+    val res_layout: err[fail.Fail] = apply_emission_order_module(alloc, m);
+    if (sel res_layout.err) { ret res[EncoderOutput, fail.Fail].err{res_layout.err}; }
 
     var st: EncodeState;
     state_init(?st, alloc, m, tgt);
@@ -666,7 +677,7 @@ pub fun encode_driver_asm(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.
         if (R.is_err[R.Void, str](res_encode)) {
             notes_free(?st.buf);
             state_dnit(?st);
-            ret R.err[EncoderOutput, str](R.unwrap_err[R.Void, str](res_encode));
+            ret res[EncoderOutput, fail.Fail].err{fail.message(R.unwrap_err[R.Void, str](res_encode))};
         }
         if (st.sym_count > pre_sym_count) {
             st.syms[pre_sym_count].size = st.buf.len::u32 - st.syms[pre_sym_count].offset;
@@ -681,75 +692,73 @@ pub fun encode_driver_asm(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.
     if (sink.failed) {
         notes_free(?st.buf);
         state_dnit(?st);
-        ret R.err[EncoderOutput, str](sink.err);
+        ret res[EncoderOutput, fail.Fail].err{fail.message(sink.err)};
     }
     if (sink.refused > 0) {
         notes_free(?st.buf);
         state_dnit(?st);
-        ret R.err[EncoderOutput, str](
-            "--emit-asm: an instruction notification claimed a byte range that does not begin where the previous one ended");
+        ret res[EncoderOutput, fail.Fail].err{fail.message("--emit-asm: an instruction notification claimed a byte range that does not begin where the previous one ended")};
     }
     if (sink_unaccounted(?st.buf) > 0) {
         notes_free(?st.buf);
         state_dnit(?st);
-        ret R.err[EncoderOutput, str](
-            "--emit-asm: the encoder emitted bytes that no instruction notification claimed");
+        ret res[EncoderOutput, fail.Fail].err{fail.message("--emit-asm: the encoder emitted bytes that no instruction notification claimed")};
     }
     notes_free(?st.buf);
 
     map.dnit[u64, RelocPairSite](?st.reloc_pair_sites);
-    val res_patch: R.Result[R.Void, str] = patch_branches(?st, hooks);
-    if (R.is_err[R.Void, str](res_patch)) {
+    val res_patch: err[fail.Fail] = patch_branches(?st, hooks);
+    if (sel res_patch.err) {
         state_dnit(?st);
-        ret R.err[EncoderOutput, str](R.unwrap_err[R.Void, str](res_patch));
+        ret res[EncoderOutput, fail.Fail].err{res_patch.err};
     }
 
-    val res_shrink: R.Result[R.Void, str] = shrink_text(?st);
-    if (R.is_err[R.Void, str](res_shrink)) {
+    val res_shrink: err[fail.Fail] = shrink_text(?st);
+    if (sel res_shrink.err) {
         state_dnit(?st);
-        ret R.err[EncoderOutput, str](R.unwrap_err[R.Void, str](res_shrink));
+        ret res[EncoderOutput, fail.Fail].err{res_shrink.err};
     }
 
-    val res_pool: R.Result[R.Void, str] = shrink_consts(?st);
-    if (R.is_err[R.Void, str](res_pool)) {
+    val res_pool: err[fail.Fail] = shrink_consts(?st);
+    if (sel res_pool.err) {
         state_dnit(?st);
-        ret R.err[EncoderOutput, str](R.unwrap_err[R.Void, str](res_pool));
+        ret res[EncoderOutput, fail.Fail].err{res_pool.err};
     }
 
-    val res_syms: R.Result[R.Void, str] = shrink_syms(?st);
-    if (R.is_err[R.Void, str](res_syms)) {
+    val res_syms: err[fail.Fail] = shrink_syms(?st);
+    if (sel res_syms.err) {
         state_dnit(?st);
-        ret R.err[EncoderOutput, str](R.unwrap_err[R.Void, str](res_syms));
+        ret res[EncoderOutput, fail.Fail].err{res_syms.err};
     }
 
-    val res_relocs: R.Result[R.Void, str] = shrink_relocs(?st);
-    if (R.is_err[R.Void, str](res_relocs)) {
+    val res_relocs: err[fail.Fail] = shrink_relocs(?st);
+    if (sel res_relocs.err) {
         state_dnit(?st);
-        ret R.err[EncoderOutput, str](R.unwrap_err[R.Void, str](res_relocs));
+        ret res[EncoderOutput, fail.Fail].err{res_relocs.err};
     }
 
-    val res_rows: R.Result[R.Void, str] = shrink_rows(?st);
-    if (R.is_err[R.Void, str](res_rows)) {
+    val res_rows: err[fail.Fail] = shrink_rows(?st);
+    if (sel res_rows.err) {
         state_dnit(?st);
-        ret R.err[EncoderOutput, str](R.unwrap_err[R.Void, str](res_rows));
+        ret res[EncoderOutput, fail.Fail].err{res_rows.err};
     }
 
-    val res_varlocs: R.Result[R.Void, str] = shrink_varlocs(?st);
-    if (R.is_err[R.Void, str](res_varlocs)) {
+    val res_varlocs: err[fail.Fail] = shrink_varlocs(?st);
+    if (sel res_varlocs.err) {
         state_dnit(?st);
-        ret R.err[EncoderOutput, str](R.unwrap_err[R.Void, str](res_varlocs));
+        ret res[EncoderOutput, fail.Fail].err{res_varlocs.err};
     }
 
-    val res_inline_pcs: R.Result[R.Void, str] = shrink_inline_pcs(?st);
-    if (R.is_err[R.Void, str](res_inline_pcs)) {
+    val res_inline_pcs: err[fail.Fail] = shrink_inline_pcs(?st);
+    if (sel res_inline_pcs.err) {
         state_dnit(?st);
-        ret R.err[EncoderOutput, str](R.unwrap_err[R.Void, str](res_inline_pcs));
+        ret res[EncoderOutput, fail.Fail].err{res_inline_pcs.err};
     }
 
-    val res_frames: R.Result[R.Void, str] = shrink_frames(?st);
-    if (R.is_err[R.Void, str](res_frames)) {
+    val res_frames: err[fail.Fail] = shrink_frames(?st);
+    if (sel res_frames.err) {
         state_dnit(?st);
-        ret R.err[EncoderOutput, str](R.unwrap_err[R.Void, str](res_frames));
+        ret res[EncoderOutput, fail.Fail].err{res_frames.err};
     }
 
     var out: EncoderOutput;
@@ -772,7 +781,7 @@ pub fun encode_driver_asm(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.
     out.notified     = notified;
 
     scratch_release(?st);
-    ret R.ok[EncoderOutput, str](out);
+    ret res[EncoderOutput, fail.Fail].ok{out};
 }
 
 pub fun classify_refs(mi: *mir.MirInstr, target_block: *u32, has_block: *bool,
@@ -806,8 +815,8 @@ pub fun classify_refs(mi: *mir.MirInstr, target_block: *u32, has_block: *bool,
 
 pub fun push_symbol(st: *EncodeState, name: intern.StrId, offset: u32, flags: u32) R.Result[R.Void, str] {
     if (st.sym_count >= st.sym_cap) {
-        val res_grow: R.Result[R.Void, str] = grow_symbols(st);
-        if (R.is_err[R.Void, str](res_grow)) { ret res_grow; }
+        val res_grow: err[fail.Fail] = grow_symbols(st);
+        if (sel res_grow.err) { ret fail.lower_unit(res_grow); }
     }
     st.syms[st.sym_count].name   = name;
     st.syms[st.sym_count].offset = offset;
@@ -819,8 +828,8 @@ pub fun push_symbol(st: *EncodeState, name: intern.StrId, offset: u32, flags: u3
 
 pub fun push_frame(st: *EncodeState, offset: u32) R.Result[R.Void, str] {
     if (st.frame_count >= st.frame_cap) {
-        val res_grow: R.Result[R.Void, str] = grow_frames(st);
-        if (R.is_err[R.Void, str](res_grow)) { ret res_grow; }
+        val res_grow: err[fail.Fail] = grow_frames(st);
+        if (sel res_grow.err) { ret fail.lower_unit(res_grow); }
     }
     st.frames[st.frame_count].section    = of.section_id(0);
     st.frames[st.frame_count].offset     = offset;
@@ -845,14 +854,14 @@ pub fun push_frame_step(st: *EncodeState, kind: u8, reg: u8, end_off: u32, value
     ret R.ok_void[str]();
 }
 
-fun grow_frames(st: *EncodeState) R.Result[R.Void, str] {
+fun grow_frames(st: *EncodeState) err[fail.Fail] {
     ret grow_cap[of.FrameUnwind](st.alloc, ?st.frames, ?st.frame_cap, DRIVER_INIT_CAP);
 }
 
 pub fun push_reloc(st: *EncodeState, offset: u32, kind: of.RelocKind, sym: intern.StrId, addend: i32) R.Result[R.Void, str] {
     if (st.reloc_count >= st.reloc_cap) {
-        val res_grow: R.Result[R.Void, str] = grow_relocs(st);
-        if (R.is_err[R.Void, str](res_grow)) { ret res_grow; }
+        val res_grow: err[fail.Fail] = grow_relocs(st);
+        if (sel res_grow.err) { ret fail.lower_unit(res_grow); }
     }
     st.relocs[st.reloc_count].offset = offset;
     st.relocs[st.reloc_count].kind   = kind;
@@ -892,10 +901,10 @@ pub fun bind_reloc_pair_site(st: *EncodeState, high_kind: of.RelocKind,
     var site: RelocPairSite;
     site.reloc_index = reloc_index;
     site.label       = intern.STR_NIL;
-    val inserted: R.Result[bool, str] =
+    val inserted: res[bool, A.Error] =
         map.insert[u64, RelocPairSite](?st.reloc_pair_sites, key, site);
-    if (R.is_err[bool, str](inserted)) {
-        ret R.err[R.Void, str](R.unwrap_err[bool, str](inserted));
+    if (sel inserted.err) {
+        ret R.err[R.Void, str](fail.describe(fail.refused(inserted.err)));
     }
     ret R.ok_void[str]();
 }
@@ -903,16 +912,16 @@ pub fun bind_reloc_pair_site(st: *EncodeState, high_kind: of.RelocKind,
 pub fun reloc_pair_site(st: *EncodeState, high_kind: of.RelocKind,
                         sym: intern.StrId) R.Result[*RelocPairSite, str] {
     val key: u64 = reloc_pair_key(high_kind, sym);
-    val found: R.Result[*RelocPairSite, str] =
+    val found: opt[*RelocPairSite] =
         map.get[u64, RelocPairSite](?st.reloc_pair_sites, ?key);
-    if (R.is_err[*RelocPairSite, str](found)) { ret found; }
-    val site: *RelocPairSite = R.unwrap_ok[*RelocPairSite, str](found);
+    if (sel found.none) { ret R.err[*RelocPairSite, str]("encode: relocation pair site is absent"); }
+    val site: *RelocPairSite = found.some;
     if (site.reloc_index >= st.reloc_count
         || st.relocs[site.reloc_index].kind != high_kind
         || st.relocs[site.reloc_index].sym != sym) {
         ret R.err[*RelocPairSite, str]("encode: relocation pair site no longer identifies its high relocation");
     }
-    ret found;
+    ret R.ok[*RelocPairSite, str](site);
 }
 
 pub fun const_align(kind: u8, len: u32) u32 {
@@ -941,8 +950,8 @@ pub fun intern_const(st: *EncodeState, bytes: *u8, len: u32, kind: u8) R.Result[
     }
 
     if (st.const_count >= st.const_cap) {
-        val res_grow: R.Result[R.Void, str] = grow_consts(st);
-        if (R.is_err[R.Void, str](res_grow)) { ret R.err[intern.StrId, str](R.unwrap_err[R.Void, str](res_grow)); }
+        val res_grow: err[fail.Fail] = grow_consts(st);
+        if (sel res_grow.err) { ret R.err[intern.StrId, str](fail.describe(res_grow.err)); }
     }
 
     var name: [32]u8;
@@ -954,9 +963,9 @@ pub fun intern_const(st: *EncodeState, bytes: *u8, len: u32, kind: u8) R.Result[
     val res_sym: R.Result[intern.StrId, str] = intern.intern(st.interner, (?name[0])::str);
     if (R.is_err[intern.StrId, str](res_sym)) { ret res_sym; }
 
-    val res_copy: R.Result[*u8, str] = A.allocate[u8](st.alloc, len::usize);
-    if (R.is_err[*u8, str](res_copy)) { ret R.err[intern.StrId, str](R.unwrap_err[*u8, str](res_copy)); }
-    val buf: *u8 = R.unwrap_ok[*u8, str](res_copy);
+    val res_copy: res[*u8, A.Error] = A.allocate[u8](st.alloc, len::usize);
+    if (sel res_copy.err) { ret R.err[intern.StrId, str](fail.describe(fail.refused(res_copy.err))); }
+    val buf: *u8 = res_copy.ok;
     memory.raw_copy(buf::ptr, bytes::ptr, len::usize);
 
     st.consts[st.const_count].bytes = buf;
@@ -993,14 +1002,14 @@ pub fun intern_float_const(st: *EncodeState, bits: u64, width: u8) R.Result[inte
     ret intern_const(st, ?img[0], width::u32, kind);
 }
 
-fun grow_consts(st: *EncodeState) R.Result[R.Void, str] {
+fun grow_consts(st: *EncodeState) err[fail.Fail] {
     ret grow_cap[ConstEntry](st.alloc, ?st.consts, ?st.const_cap, DRIVER_INIT_CAP);
 }
 
 pub fun push_fixup(st: *EncodeState, patch_pos: u32, next_ip: u32, target_block: u32, fn_text_base: u32) R.Result[R.Void, str] {
     if (st.fixup_count >= st.fixup_cap) {
-        val res_grow: R.Result[R.Void, str] = grow_fixups(st);
-        if (R.is_err[R.Void, str](res_grow)) { ret res_grow; }
+        val res_grow: err[fail.Fail] = grow_fixups(st);
+        if (sel res_grow.err) { ret fail.lower_unit(res_grow); }
     }
     st.fixups[st.fixup_count].patch_pos    = patch_pos;
     st.fixups[st.fixup_count].next_ip      = next_ip;
@@ -1012,8 +1021,8 @@ pub fun push_fixup(st: *EncodeState, patch_pos: u32, next_ip: u32, target_block:
 
 pub fun push_block(st: *EncodeState, fn_text_base: u32, block_id: u32, offset: u32) R.Result[R.Void, str] {
     if (st.block_count >= st.block_cap) {
-        val res_grow: R.Result[R.Void, str] = grow_blocks(st);
-        if (R.is_err[R.Void, str](res_grow)) { ret res_grow; }
+        val res_grow: err[fail.Fail] = grow_blocks(st);
+        if (sel res_grow.err) { ret fail.lower_unit(res_grow); }
     }
     st.blocks[st.block_count].fn_text_base = fn_text_base;
     st.blocks[st.block_count].block_id     = block_id;
@@ -1039,8 +1048,8 @@ pub fun branch_falls_through(st: *EncodeState, target_block: u32) bool {
 pub fun push_row(st: *EncodeState, text_offset: u32, loc: source.SrcLoc) R.Result[R.Void, str] {
     if (!source.loc_is_valid(loc)) { ret R.ok_void[str](); }
     if (st.row_count >= st.row_cap) {
-        val res_grow: R.Result[R.Void, str] = grow_rows(st);
-        if (R.is_err[R.Void, str](res_grow)) { ret res_grow; }
+        val res_grow: err[fail.Fail] = grow_rows(st);
+        if (sel res_grow.err) { ret fail.lower_unit(res_grow); }
     }
     st.rows[st.row_count].text_offset = text_offset;
     st.rows[st.row_count].sec         = 0;
@@ -1049,7 +1058,7 @@ pub fun push_row(st: *EncodeState, text_offset: u32, loc: source.SrcLoc) R.Resul
     ret R.ok_void[str]();
 }
 
-pub fun push_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction, vreg: u32, iid: u32) R.Result[R.Void, str] {
+pub fun push_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction, vreg: u32, iid: u32) err[fail.Fail] {
     var kind: u8  = VARLOC_NONE;
     var reg:  i32 = 0;
     var off:  i64 = 0;
@@ -1079,8 +1088,8 @@ pub fun push_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction, vr
     }
 
     if (st.varloc_count >= st.varloc_cap) {
-        val res_grow: R.Result[R.Void, str] = grow_varlocs(st);
-        if (R.is_err[R.Void, str](res_grow)) { ret res_grow; }
+        val res_grow: err[fail.Fail] = grow_varlocs(st);
+        if (sel res_grow.err) { ret res_grow; }
     }
     st.varlocs[st.varloc_count].text_offset = text_offset;
     st.varlocs[st.varloc_count].sec         = 0;
@@ -1091,7 +1100,7 @@ pub fun push_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction, vr
     st.varlocs[st.varloc_count].off_storage = storage;
     varloc_clear_cmp(?st.varlocs[st.varloc_count]);
     st.varloc_count = st.varloc_count + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun varloc_clear_cmp(vl: *VarLoc) {
@@ -1134,7 +1143,7 @@ fun cmp_operand_home(fn: *mir.MirFunction, is_imm: bool, vreg: u32, imm: i64,
     }
 }
 
-pub fun push_cmp_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction, bind: *mir.MirDbgBinding) R.Result[R.Void, str] {
+pub fun push_cmp_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction, bind: *mir.MirDbgBinding) err[fail.Fail] {
     var lk: u8 = VARLOC_NONE; var lr: i32 = 0; var lo: i64 = 0;
     var rk: u8 = VARLOC_NONE; var rr: i32 = 0; var ro: i64 = 0;
     cmp_operand_home(fn, bind.lhs_is_imm, bind.vreg, bind.imm, ?lk, ?lr, ?lo);
@@ -1149,8 +1158,8 @@ pub fun push_cmp_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction
     or (bind.cmp_op == mir.MIR_SEL_CBR_LE_S || bind.cmp_op == mir.MIR_SEL_CBR_LE_U)   { rel = CMPREL_LE; }
 
     if (st.varloc_count >= st.varloc_cap) {
-        val res_grow: R.Result[R.Void, str] = grow_varlocs(st);
-        if (R.is_err[R.Void, str](res_grow)) { ret res_grow; }
+        val res_grow: err[fail.Fail] = grow_varlocs(st);
+        if (sel res_grow.err) { ret res_grow; }
     }
     val vl: *VarLoc = ?st.varlocs[st.varloc_count];
     vl.text_offset = text_offset;
@@ -1169,7 +1178,7 @@ pub fun push_cmp_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction
     vl.cmp_signed  = mir.is_signed_cmp(bind.cmp_op);
     vl.cmp_width   = bind.cmp_width;
     st.varloc_count = st.varloc_count + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 pub fun close_cmp_varlocs(st: *EncodeState, instr_start: u32, instr_end: u32) {
@@ -1188,16 +1197,16 @@ pub fun emit_var_bindings(st: *EncodeState, fn: *mir.MirFunction, mi: *mir.MirIn
     var i: u32 = 0;
     for (i < mi.dbg_binding_count) {
         val bind: *mir.MirDbgBinding = ?mi.dbg_bindings[i];
-        var r: R.Result[R.Void, str] = R.ok_void[str]();
+        var r: err[fail.Fail] = err[fail.Fail].ok{};
         if (bind.cmp_op != 0) { r = push_cmp_varloc(st, at, fn, bind); }
         or                    { r = push_varloc(st, at, fn, bind.vreg, bind.iid); }
-        if (R.is_err[R.Void, str](r)) { ret r; }
+        if (sel r.err) { ret fail.lower_unit(r); }
         i = i + 1;
     }
     ret R.ok_void[str]();
 }
 
-fun grow_varlocs(st: *EncodeState) R.Result[R.Void, str] {
+fun grow_varlocs(st: *EncodeState) err[fail.Fail] {
     ret grow_cap[VarLoc](st.alloc, ?st.varlocs, ?st.varloc_cap, DRIVER_INIT_CAP);
 }
 
@@ -1329,132 +1338,132 @@ fun scratch_release(st: *EncodeState) {
     st.block_cap   = 0;
 }
 
-fun shrink_text(st: *EncodeState) R.Result[R.Void, str] {
-    if (st.buf.data == nil) { ret R.ok_void[str](); }
+fun shrink_text(st: *EncodeState) err[fail.Fail] {
+    if (st.buf.data == nil) { ret err[fail.Fail].ok{}; }
     if (st.buf.len == 0) {
         A.deallocate[u8](st.alloc, st.buf.data, st.buf.cap);
         st.buf.data = nil;
         st.buf.cap  = 0;
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
-    if (st.buf.cap == st.buf.len) { ret R.ok_void[str](); }
-    val res_shrink: R.Result[*u8, str] = A.reallocate[u8](st.alloc, st.buf.data, st.buf.cap, st.buf.len);
-    if (R.is_err[*u8, str](res_shrink)) { ret R.err[R.Void, str](R.unwrap_err[*u8, str](res_shrink)); }
-    st.buf.data = R.unwrap_ok[*u8, str](res_shrink);
+    if (st.buf.cap == st.buf.len) { ret err[fail.Fail].ok{}; }
+    val res_shrink: res[*u8, A.Error] = A.reallocate[u8](st.alloc, st.buf.data, st.buf.cap, st.buf.len);
+    if (sel res_shrink.err) { ret err[fail.Fail].err{fail.refused(res_shrink.err)}; }
+    st.buf.data = res_shrink.ok;
     st.buf.cap  = st.buf.len;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun shrink_consts(st: *EncodeState) R.Result[R.Void, str] {
-    if (st.consts == nil) { ret R.ok_void[str](); }
+fun shrink_consts(st: *EncodeState) err[fail.Fail] {
+    if (st.consts == nil) { ret err[fail.Fail].ok{}; }
     if (st.const_count == 0) {
         A.deallocate[ConstEntry](st.alloc, st.consts, st.const_cap::usize);
         st.consts    = nil;
         st.const_cap = 0;
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
-    if (st.const_cap == st.const_count) { ret R.ok_void[str](); }
-    val res: R.Result[*ConstEntry, str] = A.reallocate[ConstEntry](st.alloc, st.consts, st.const_cap::usize, st.const_count::usize);
-    if (R.is_err[*ConstEntry, str](res)) { ret R.err[R.Void, str](R.unwrap_err[*ConstEntry, str](res)); }
-    st.consts    = R.unwrap_ok[*ConstEntry, str](res);
+    if (st.const_cap == st.const_count) { ret err[fail.Fail].ok{}; }
+    val result: res[*ConstEntry, A.Error] = A.reallocate[ConstEntry](st.alloc, st.consts, st.const_cap::usize, st.const_count::usize);
+    if (sel result.err) { ret err[fail.Fail].err{fail.refused(result.err)}; }
+    st.consts    = result.ok;
     st.const_cap = st.const_count;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun shrink_syms(st: *EncodeState) R.Result[R.Void, str] {
-    if (st.syms == nil) { ret R.ok_void[str](); }
+fun shrink_syms(st: *EncodeState) err[fail.Fail] {
+    if (st.syms == nil) { ret err[fail.Fail].ok{}; }
     if (st.sym_count == 0) {
         A.deallocate[SymbolMark](st.alloc, st.syms, st.sym_cap::usize);
         st.syms    = nil;
         st.sym_cap = 0;
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
-    if (st.sym_cap == st.sym_count) { ret R.ok_void[str](); }
-    val res: R.Result[*SymbolMark, str] = A.reallocate[SymbolMark](st.alloc, st.syms, st.sym_cap::usize, st.sym_count::usize);
-    if (R.is_err[*SymbolMark, str](res)) { ret R.err[R.Void, str](R.unwrap_err[*SymbolMark, str](res)); }
-    st.syms    = R.unwrap_ok[*SymbolMark, str](res);
+    if (st.sym_cap == st.sym_count) { ret err[fail.Fail].ok{}; }
+    val result: res[*SymbolMark, A.Error] = A.reallocate[SymbolMark](st.alloc, st.syms, st.sym_cap::usize, st.sym_count::usize);
+    if (sel result.err) { ret err[fail.Fail].err{fail.refused(result.err)}; }
+    st.syms    = result.ok;
     st.sym_cap = st.sym_count;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun shrink_relocs(st: *EncodeState) R.Result[R.Void, str] {
-    if (st.relocs == nil) { ret R.ok_void[str](); }
+fun shrink_relocs(st: *EncodeState) err[fail.Fail] {
+    if (st.relocs == nil) { ret err[fail.Fail].ok{}; }
     if (st.reloc_count == 0) {
         A.deallocate[PendingReloc](st.alloc, st.relocs, st.reloc_cap::usize);
         st.relocs    = nil;
         st.reloc_cap = 0;
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
-    if (st.reloc_cap == st.reloc_count) { ret R.ok_void[str](); }
-    val res: R.Result[*PendingReloc, str] = A.reallocate[PendingReloc](st.alloc, st.relocs, st.reloc_cap::usize, st.reloc_count::usize);
-    if (R.is_err[*PendingReloc, str](res)) { ret R.err[R.Void, str](R.unwrap_err[*PendingReloc, str](res)); }
-    st.relocs    = R.unwrap_ok[*PendingReloc, str](res);
+    if (st.reloc_cap == st.reloc_count) { ret err[fail.Fail].ok{}; }
+    val result: res[*PendingReloc, A.Error] = A.reallocate[PendingReloc](st.alloc, st.relocs, st.reloc_cap::usize, st.reloc_count::usize);
+    if (sel result.err) { ret err[fail.Fail].err{fail.refused(result.err)}; }
+    st.relocs    = result.ok;
     st.reloc_cap = st.reloc_count;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun shrink_rows(st: *EncodeState) R.Result[R.Void, str] {
-    if (st.rows == nil) { ret R.ok_void[str](); }
+fun shrink_rows(st: *EncodeState) err[fail.Fail] {
+    if (st.rows == nil) { ret err[fail.Fail].ok{}; }
     if (st.row_count == 0) {
         A.deallocate[LineRow](st.alloc, st.rows, st.row_cap::usize);
         st.rows    = nil;
         st.row_cap = 0;
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
-    if (st.row_cap == st.row_count) { ret R.ok_void[str](); }
-    val res: R.Result[*LineRow, str] = A.reallocate[LineRow](st.alloc, st.rows, st.row_cap::usize, st.row_count::usize);
-    if (R.is_err[*LineRow, str](res)) { ret R.err[R.Void, str](R.unwrap_err[*LineRow, str](res)); }
-    st.rows    = R.unwrap_ok[*LineRow, str](res);
+    if (st.row_cap == st.row_count) { ret err[fail.Fail].ok{}; }
+    val result: res[*LineRow, A.Error] = A.reallocate[LineRow](st.alloc, st.rows, st.row_cap::usize, st.row_count::usize);
+    if (sel result.err) { ret err[fail.Fail].err{fail.refused(result.err)}; }
+    st.rows    = result.ok;
     st.row_cap = st.row_count;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun shrink_varlocs(st: *EncodeState) R.Result[R.Void, str] {
-    if (st.varlocs == nil) { ret R.ok_void[str](); }
+fun shrink_varlocs(st: *EncodeState) err[fail.Fail] {
+    if (st.varlocs == nil) { ret err[fail.Fail].ok{}; }
     if (st.varloc_count == 0) {
         A.deallocate[VarLoc](st.alloc, st.varlocs, st.varloc_cap::usize);
         st.varlocs    = nil;
         st.varloc_cap = 0;
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
-    if (st.varloc_cap == st.varloc_count) { ret R.ok_void[str](); }
-    val res: R.Result[*VarLoc, str] = A.reallocate[VarLoc](st.alloc, st.varlocs, st.varloc_cap::usize, st.varloc_count::usize);
-    if (R.is_err[*VarLoc, str](res)) { ret R.err[R.Void, str](R.unwrap_err[*VarLoc, str](res)); }
-    st.varlocs    = R.unwrap_ok[*VarLoc, str](res);
+    if (st.varloc_cap == st.varloc_count) { ret err[fail.Fail].ok{}; }
+    val result: res[*VarLoc, A.Error] = A.reallocate[VarLoc](st.alloc, st.varlocs, st.varloc_cap::usize, st.varloc_count::usize);
+    if (sel result.err) { ret err[fail.Fail].err{fail.refused(result.err)}; }
+    st.varlocs    = result.ok;
     st.varloc_cap = st.varloc_count;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun shrink_inline_pcs(st: *EncodeState) R.Result[R.Void, str] {
-    if (st.inline_pcs == nil) { ret R.ok_void[str](); }
+fun shrink_inline_pcs(st: *EncodeState) err[fail.Fail] {
+    if (st.inline_pcs == nil) { ret err[fail.Fail].ok{}; }
     if (st.inline_pc_count == 0) {
         A.deallocate[InlinePc](st.alloc, st.inline_pcs, st.inline_pc_cap::usize);
         st.inline_pcs    = nil;
         st.inline_pc_cap = 0;
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
-    if (st.inline_pc_cap == st.inline_pc_count) { ret R.ok_void[str](); }
-    val res: R.Result[*InlinePc, str] = A.reallocate[InlinePc](st.alloc, st.inline_pcs, st.inline_pc_cap::usize, st.inline_pc_count::usize);
-    if (R.is_err[*InlinePc, str](res)) { ret R.err[R.Void, str](R.unwrap_err[*InlinePc, str](res)); }
-    st.inline_pcs    = R.unwrap_ok[*InlinePc, str](res);
+    if (st.inline_pc_cap == st.inline_pc_count) { ret err[fail.Fail].ok{}; }
+    val result: res[*InlinePc, A.Error] = A.reallocate[InlinePc](st.alloc, st.inline_pcs, st.inline_pc_cap::usize, st.inline_pc_count::usize);
+    if (sel result.err) { ret err[fail.Fail].err{fail.refused(result.err)}; }
+    st.inline_pcs    = result.ok;
     st.inline_pc_cap = st.inline_pc_count;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun shrink_frames(st: *EncodeState) R.Result[R.Void, str] {
-    if (st.frames == nil) { ret R.ok_void[str](); }
+fun shrink_frames(st: *EncodeState) err[fail.Fail] {
+    if (st.frames == nil) { ret err[fail.Fail].ok{}; }
     if (st.frame_count == 0) {
         A.deallocate[of.FrameUnwind](st.alloc, st.frames, st.frame_cap::usize);
         st.frames    = nil;
         st.frame_cap = 0;
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
-    if (st.frame_cap == st.frame_count) { ret R.ok_void[str](); }
-    val res: R.Result[*of.FrameUnwind, str] = A.reallocate[of.FrameUnwind](st.alloc, st.frames, st.frame_cap::usize, st.frame_count::usize);
-    if (R.is_err[*of.FrameUnwind, str](res)) { ret R.err[R.Void, str](R.unwrap_err[*of.FrameUnwind, str](res)); }
-    st.frames    = R.unwrap_ok[*of.FrameUnwind, str](res);
+    if (st.frame_cap == st.frame_count) { ret err[fail.Fail].ok{}; }
+    val result: res[*of.FrameUnwind, A.Error] = A.reallocate[of.FrameUnwind](st.alloc, st.frames, st.frame_cap::usize, st.frame_count::usize);
+    if (sel result.err) { ret err[fail.Fail].err{fail.refused(result.err)}; }
+    st.frames    = result.ok;
     st.frame_cap = st.frame_count;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 test "mach.lang.be.codegen.encode.shrink_arrays:cap_equals_count_after_shrink" {
@@ -1464,48 +1473,54 @@ test "mach.lang.be.codegen.encode.shrink_arrays:cap_equals_count_after_shrink" {
     var st: EncodeState;
     t_row_state(?alloc, ?st);
 
-    val rsym: R.Result[*SymbolMark, str] = A.allocate[SymbolMark](?alloc, 8::usize);
-    if (R.is_err[*SymbolMark, str](rsym)) { ret 1; }
-    st.syms = R.unwrap_ok[*SymbolMark, str](rsym);
+    val rsym: res[*SymbolMark, A.Error] = A.allocate[SymbolMark](?alloc, 8::usize);
+    if (sel rsym.err) { ret 1; }
+    st.syms = rsym.ok;
     st.sym_cap = 8;
     st.sym_count = 3;
 
-    val rrel: R.Result[*PendingReloc, str] = A.allocate[PendingReloc](?alloc, 8::usize);
-    if (R.is_err[*PendingReloc, str](rrel)) { ret 1; }
-    st.relocs = R.unwrap_ok[*PendingReloc, str](rrel);
+    val rrel: res[*PendingReloc, A.Error] = A.allocate[PendingReloc](?alloc, 8::usize);
+    if (sel rrel.err) { ret 1; }
+    st.relocs = rrel.ok;
     st.reloc_cap = 8;
     st.reloc_count = 2;
 
-    val rrow: R.Result[*LineRow, str] = A.allocate[LineRow](?alloc, 8::usize);
-    if (R.is_err[*LineRow, str](rrow)) { ret 1; }
-    st.rows = R.unwrap_ok[*LineRow, str](rrow);
+    val rrow: res[*LineRow, A.Error] = A.allocate[LineRow](?alloc, 8::usize);
+    if (sel rrow.err) { ret 1; }
+    st.rows = rrow.ok;
     st.row_cap = 8;
     st.row_count = 4;
 
-    val rvl: R.Result[*VarLoc, str] = A.allocate[VarLoc](?alloc, 8::usize);
-    if (R.is_err[*VarLoc, str](rvl)) { ret 1; }
-    st.varlocs = R.unwrap_ok[*VarLoc, str](rvl);
+    val rvl: res[*VarLoc, A.Error] = A.allocate[VarLoc](?alloc, 8::usize);
+    if (sel rvl.err) { ret 1; }
+    st.varlocs = rvl.ok;
     st.varloc_cap = 8;
     st.varloc_count = 1;
 
-    val rip: R.Result[*InlinePc, str] = A.allocate[InlinePc](?alloc, 8::usize);
-    if (R.is_err[*InlinePc, str](rip)) { ret 1; }
-    st.inline_pcs = R.unwrap_ok[*InlinePc, str](rip);
+    val rip: res[*InlinePc, A.Error] = A.allocate[InlinePc](?alloc, 8::usize);
+    if (sel rip.err) { ret 1; }
+    st.inline_pcs = rip.ok;
     st.inline_pc_cap = 8;
     st.inline_pc_count = 0;
 
-    val rfr: R.Result[*of.FrameUnwind, str] = A.allocate[of.FrameUnwind](?alloc, 8::usize);
-    if (R.is_err[*of.FrameUnwind, str](rfr)) { ret 1; }
-    st.frames = R.unwrap_ok[*of.FrameUnwind, str](rfr);
+    val rfr: res[*of.FrameUnwind, A.Error] = A.allocate[of.FrameUnwind](?alloc, 8::usize);
+    if (sel rfr.err) { ret 1; }
+    st.frames = rfr.ok;
     st.frame_cap = 8;
     st.frame_count = 5;
 
-    if (R.is_err[R.Void, str](shrink_syms(?st)))       { state_dnit(?st); ret 1; }
-    if (R.is_err[R.Void, str](shrink_relocs(?st)))     { state_dnit(?st); ret 1; }
-    if (R.is_err[R.Void, str](shrink_rows(?st)))       { state_dnit(?st); ret 1; }
-    if (R.is_err[R.Void, str](shrink_varlocs(?st)))    { state_dnit(?st); ret 1; }
-    if (R.is_err[R.Void, str](shrink_inline_pcs(?st))) { state_dnit(?st); ret 1; }
-    if (R.is_err[R.Void, str](shrink_frames(?st)))     { state_dnit(?st); ret 1; }
+    val shrink_syms_r: err[fail.Fail] = shrink_syms(?st);
+    if (sel shrink_syms_r.err)       { state_dnit(?st); ret 1; }
+    val shrink_relocs_r: err[fail.Fail] = shrink_relocs(?st);
+    if (sel shrink_relocs_r.err)     { state_dnit(?st); ret 1; }
+    val shrink_rows_r: err[fail.Fail] = shrink_rows(?st);
+    if (sel shrink_rows_r.err)       { state_dnit(?st); ret 1; }
+    val shrink_varlocs_r: err[fail.Fail] = shrink_varlocs(?st);
+    if (sel shrink_varlocs_r.err)    { state_dnit(?st); ret 1; }
+    val shrink_inline_pcs_r: err[fail.Fail] = shrink_inline_pcs(?st);
+    if (sel shrink_inline_pcs_r.err) { state_dnit(?st); ret 1; }
+    val shrink_frames_r: err[fail.Fail] = shrink_frames(?st);
+    if (sel shrink_frames_r.err)     { state_dnit(?st); ret 1; }
 
     if (st.sym_cap != st.sym_count)                    { state_dnit(?st); ret 1; }
     if (st.reloc_cap != st.reloc_count)                { state_dnit(?st); ret 1; }
@@ -1518,19 +1533,19 @@ test "mach.lang.be.codegen.encode.shrink_arrays:cap_equals_count_after_shrink" {
     ret 0;
 }
 
-fun patch_branches(st: *EncodeState, hooks: *EncodeHooks) R.Result[R.Void, str] {
-    if (st.buf.data == nil) { ret R.ok_void[str](); }
+fun patch_branches(st: *EncodeState, hooks: *EncodeHooks) err[fail.Fail] {
+    if (st.buf.data == nil) { ret err[fail.Fail].ok{}; }
     var i: u32 = 0;
     for (i < st.fixup_count) {
         val fx: *BranchFixup = ?st.fixups[i];
         val res_off: R.Result[u32, str] = block_offset(st, fx.fn_text_base, fx.target_block);
-        if (R.is_err[u32, str](res_off)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_off)); }
+        if (R.is_err[u32, str](res_off)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[u32, str](res_off))}; }
         val target_off: u32 = R.unwrap_ok[u32, str](res_off);
         val res_patch: R.Result[R.Void, str] = hooks.patch_branch(st, fx, target_off);
-        if (R.is_err[R.Void, str](res_patch)) { ret res_patch; }
+        if (R.is_err[R.Void, str](res_patch)) { ret fail.lift_err(res_patch); }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 pub fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) R.Result[u32, str] {
@@ -1570,9 +1585,9 @@ pub fun insert_text(st: *EncodeState, pos: u32, nbytes: u32) R.Result[R.Void, st
             new_cap_c = R.unwrap_ok[layout.CheckedCount[layout.ByteUnit], layout.CheckCause](doubled_r);
         }
         val new_cap: usize = new_cap_c.value;
-        val res_realloc: R.Result[*u8, str] = A.reallocate[u8](st.buf.alloc, st.buf.data, st.buf.cap, new_cap);
-        if (R.is_err[*u8, str](res_realloc)) { ret R.err[R.Void, str](R.unwrap_err[*u8, str](res_realloc)); }
-        st.buf.data = R.unwrap_ok[*u8, str](res_realloc);
+        val res_realloc: res[*u8, A.Error] = A.reallocate[u8](st.buf.alloc, st.buf.data, st.buf.cap, new_cap);
+        if (sel res_realloc.err) { ret R.err[R.Void, str](fail.describe(fail.refused(res_realloc.err))); }
+        st.buf.data = res_realloc.ok;
         st.buf.cap  = new_cap;
     }
 
@@ -1644,35 +1659,35 @@ pub fun insert_text(st: *EncodeState, pos: u32, nbytes: u32) R.Result[R.Void, st
     ret R.ok_void[str]();
 }
 
-fun grow_symbols(st: *EncodeState) R.Result[R.Void, str] {
+fun grow_symbols(st: *EncodeState) err[fail.Fail] {
     ret grow_cap[SymbolMark](st.alloc, ?st.syms, ?st.sym_cap, DRIVER_INIT_CAP);
 }
 
-fun grow_relocs(st: *EncodeState) R.Result[R.Void, str] {
+fun grow_relocs(st: *EncodeState) err[fail.Fail] {
     ret grow_cap[PendingReloc](st.alloc, ?st.relocs, ?st.reloc_cap, DRIVER_INIT_CAP);
 }
 
-fun grow_fixups(st: *EncodeState) R.Result[R.Void, str] {
+fun grow_fixups(st: *EncodeState) err[fail.Fail] {
     ret grow_cap[BranchFixup](st.alloc, ?st.fixups, ?st.fixup_cap, DRIVER_INIT_CAP);
 }
 
-fun grow_blocks(st: *EncodeState) R.Result[R.Void, str] {
+fun grow_blocks(st: *EncodeState) err[fail.Fail] {
     ret grow_cap[BlockOffset](st.alloc, ?st.blocks, ?st.block_cap, DRIVER_INIT_CAP);
 }
 
-fun grow_rows(st: *EncodeState) R.Result[R.Void, str] {
+fun grow_rows(st: *EncodeState) err[fail.Fail] {
     ret grow_cap[LineRow](st.alloc, ?st.rows, ?st.row_cap, DRIVER_INIT_CAP);
 }
 
-fun grow_inline_pcs(st: *EncodeState) R.Result[R.Void, str] {
+fun grow_inline_pcs(st: *EncodeState) err[fail.Fail] {
     ret grow_cap[InlinePc](st.alloc, ?st.inline_pcs, ?st.inline_pc_cap, DRIVER_INIT_CAP);
 }
 
 pub fun push_inline_pc(st: *EncodeState, text_offset: u32, inline_site: u32) R.Result[R.Void, str] {
     if (inline_site == st.last_inline_site) { ret R.ok_void[str](); }
     if (st.inline_pc_count >= st.inline_pc_cap) {
-        val res_grow: R.Result[R.Void, str] = grow_inline_pcs(st);
-        if (R.is_err[R.Void, str](res_grow)) { ret res_grow; }
+        val res_grow: err[fail.Fail] = grow_inline_pcs(st);
+        if (sel res_grow.err) { ret fail.lower_unit(res_grow); }
     }
     st.inline_pcs[st.inline_pc_count].text_offset = text_offset;
     st.inline_pcs[st.inline_pc_count].sec         = 0;
@@ -1708,13 +1723,13 @@ pub fun opcode_failure(st: *EncodeState, f: *mir.MirFunction, architecture: str,
     var name: str = "<unknown>";
     val found_name: O.Option[str] = intern.lookup(st.interner, f.name);
     if (O.is_some[str](found_name)) { name = O.unwrap[str](found_name); }
-    val catalog: R.Result[str, str] = format.sprint(st.alloc, "{}.Opcode", architecture);
-    if (R.is_err[str, str](catalog)) { ret R.err[R.Void, str](R.unwrap_err[str, str](catalog)); }
-    val catalog_name: str = R.unwrap_ok[str, str](catalog);
+    val catalog: res[str, format.FormatError] = format.sprint(st.alloc, "{}.Opcode", architecture);
+    if (sel catalog.err) { ret R.err[R.Void, str](fail.describe(fail.format_refused(catalog.err))); }
+    val catalog_name: str = catalog.ok;
     fin { A.deallocate[u8](st.alloc, catalog_name, str_len(catalog_name) + 1); }
-    val where: R.Result[str, str] = format.sprint(st.alloc, "'{}'", name);
-    if (R.is_err[str, str](where)) { ret R.err[R.Void, str](R.unwrap_err[str, str](where)); }
-    val where_text: str = R.unwrap_ok[str, str](where);
+    val where: res[str, format.FormatError] = format.sprint(st.alloc, "'{}'", name);
+    if (sel where.err) { ret R.err[R.Void, str](fail.describe(fail.format_refused(where.err))); }
+    val where_text: str = where.ok;
     fin { A.deallocate[u8](st.alloc, where_text, str_len(where_text) + 1); }
     val member: fail.Catalog = fail.unknown_member_in(catalog_name, opcode, where_text);
     ret R.err[R.Void, str](fail.catalog_message(st.interner, st.alloc, member));
@@ -1731,9 +1746,9 @@ pub fun asm_located_message(st: *EncodeState, loc: source.SrcLoc, msg: str) str 
     val lp: usize = str_len(file.path);
     val lm: usize = str_len(msg);
     val total_cap: usize = lp + 1 + 20 + 1 + 20 + 2 + lm + 1;
-    val rb: R.Result[*u8, str] = A.allocate[u8](st.alloc, total_cap);
-    if (R.is_err[*u8, str](rb)) { ret msg; }
-    val buf: *u8 = R.unwrap_ok[*u8, str](rb);
+    val rb: res[*u8, A.Error] = A.allocate[u8](st.alloc, total_cap);
+    if (sel rb.err) { ret msg; }
+    val buf: *u8 = rb.ok;
 
     var k: usize = 0;
     var j: usize = 0;
@@ -1822,9 +1837,9 @@ test "mach.lang.be.codegen.encode.push_varloc:reg_frame_dead" {
     fn.frame.slots = ?slots[0]; fn.frame.slot_count = 1; fn.frame.slot_cap = 1;
     fn.frame.size = 0; fn.frame.align = 0; fn.frame.outgoing_size = 0;
 
-    val ra: R.Result[R.Void, str] = push_varloc(?st, 0, ?fn, 0, 100); if (R.is_err[R.Void, str](ra)) { code = 1; }
-    val rb: R.Result[R.Void, str] = push_varloc(?st, 4, ?fn, 1, 101); if (R.is_err[R.Void, str](rb)) { code = 1; }
-    val rc: R.Result[R.Void, str] = push_varloc(?st, 8, ?fn, 2, 102); if (R.is_err[R.Void, str](rc)) { code = 1; }
+    val ra: err[fail.Fail] = push_varloc(?st, 0, ?fn, 0, 100); if (sel ra.err) { code = 1; }
+    val rb: err[fail.Fail] = push_varloc(?st, 4, ?fn, 1, 101); if (sel rb.err) { code = 1; }
+    val rc: err[fail.Fail] = push_varloc(?st, 8, ?fn, 2, 102); if (sel rc.err) { code = 1; }
 
     if (st.varloc_count != 3) { code = 1; }
     if (st.varlocs[0].kind != VARLOC_REG || st.varlocs[0].reg != 7 || st.varlocs[0].iid != 100) { code = 1; }
@@ -1861,23 +1876,23 @@ test "mach.lang.be.codegen.encode.push_cmp_varloc:homes_digest_and_close" {
     bind.iid = 100; bind.cmp_op = mir.MIR_SEL_CBR_LT_U; bind.cmp_width = 2;
     bind.lhs_is_imm = false; bind.vreg = 0; bind.imm = 0;
     bind.rhs_is_imm = true;  bind.vreg2 = mir.MIR_VREG_NIL; bind.imm2 = 40000;
-    val ra: R.Result[R.Void, str] = push_cmp_varloc(?st, 12, ?fn, ?bind);
-    if (R.is_err[R.Void, str](ra)) { code = 1; }
+    val ra: err[fail.Fail] = push_cmp_varloc(?st, 12, ?fn, ?bind);
+    if (sel ra.err) { code = 1; }
 
     bind.iid = 101; bind.cmp_op = mir.MIR_SEL_CBR_LE_S; bind.cmp_width = 8;
     bind.lhs_is_imm = false; bind.vreg = 1;
     bind.rhs_is_imm = false; bind.vreg2 = 0;
-    val rb: R.Result[R.Void, str] = push_cmp_varloc(?st, 12, ?fn, ?bind);
-    if (R.is_err[R.Void, str](rb)) { code = 1; }
+    val rb: err[fail.Fail] = push_cmp_varloc(?st, 12, ?fn, ?bind);
+    if (sel rb.err) { code = 1; }
 
-    val rp: R.Result[R.Void, str] = push_varloc(?st, 12, ?fn, 0, 102);
-    if (R.is_err[R.Void, str](rp)) { code = 1; }
+    val rp: err[fail.Fail] = push_varloc(?st, 12, ?fn, 0, 102);
+    if (sel rp.err) { code = 1; }
 
     bind.iid = 103; bind.cmp_op = mir.MIR_SEL_CBR_EQ; bind.cmp_width = 4;
     bind.lhs_is_imm = false; bind.vreg = 2;
     bind.rhs_is_imm = true;  bind.imm2 = 0;
-    val rd: R.Result[R.Void, str] = push_cmp_varloc(?st, 12, ?fn, ?bind);
-    if (R.is_err[R.Void, str](rd)) { code = 1; }
+    val rd: err[fail.Fail] = push_cmp_varloc(?st, 12, ?fn, ?bind);
+    if (sel rd.err) { code = 1; }
 
     close_cmp_varlocs(?st, 12, 20);
 
@@ -1924,7 +1939,7 @@ test "mach.lang.be.codegen.encode.push_varloc:slot_spill_owner_is_direct_frame" 
     fn.frame.slots = ?slots[0]; fn.frame.slot_count = 1; fn.frame.slot_cap = 1;
     fn.frame.size = 0; fn.frame.align = 0; fn.frame.outgoing_size = 0;
 
-    val r: R.Result[R.Void, str] = push_varloc(?st, 0, ?fn, 0, 200); if (R.is_err[R.Void, str](r)) { code = 1; }
+    val r: err[fail.Fail] = push_varloc(?st, 0, ?fn, 0, 200); if (sel r.err) { code = 1; }
 
     if (st.varloc_count != 1) { code = 1; }
     if (st.varlocs[0].kind != VARLOC_FRAME || st.varlocs[0].off != -32 || !st.varlocs[0].off_storage) { code = 1; }
@@ -2159,10 +2174,10 @@ test "mach.lang.be.codegen.encode.grow_cap:refuses_u32_capacity_overflow_before_
     var data: *SymbolMark = ?dummy;
     var cap: u32 = 0xFFFFFFFF;
 
-    val r: R.Result[R.Void, str] = grow_cap[SymbolMark](?alloc, ?data, ?cap, DRIVER_INIT_CAP);
+    val r: err[fail.Fail] = grow_cap[SymbolMark](?alloc, ?data, ?cap, DRIVER_INIT_CAP);
 
     var bad: i32 = 0;
-    if (!R.is_err[R.Void, str](r))      { bad = 1; }
+    if (!sel r.err)      { bad = 1; }
     if (probe.reallocate_calls != 0)  { bad = 2; }
     if (probe.allocate_calls != 0)    { bad = 3; }
     if (cap != 0xFFFFFFFF)            { bad = 4; }
@@ -2183,10 +2198,10 @@ test "mach.lang.be.codegen.encode.grow_cap:allocates_the_seed_capacity_when_empt
     var data: *SymbolMark = nil;
     var cap: u32 = 0;
 
-    val r: R.Result[R.Void, str] = grow_cap[SymbolMark](?alloc, ?data, ?cap, DRIVER_INIT_CAP);
+    val r: err[fail.Fail] = grow_cap[SymbolMark](?alloc, ?data, ?cap, DRIVER_INIT_CAP);
 
     var bad: i32 = 0;
-    if (!R.is_err[R.Void, str](r))      { bad = 1; }
+    if (!sel r.err)      { bad = 1; }
     if (probe.allocate_calls != 1)    { bad = 2; }
     if (probe.reallocate_calls != 0)  { bad = 3; }
     ret bad;

--- a/src/lang/be/codegen/frame.mach
+++ b/src/lang/be/codegen/frame.mach
@@ -1,4 +1,8 @@
 use std.types.bool.bool;
+use std.types.canonical.res;
+use std.types.canonical.opt;
+use std.types.canonical.err;
+use mach.lang.fail;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
@@ -6,10 +10,10 @@ use std.types.string.str;
 
 use O: std.types.option;
 use R: std.types.result;
-use page: mach.lang.legacy.page;
+use page: std.allocator.page;
 use std.types.string.str_contains;
-use A: mach.lang.legacy.allocator;
-use format: mach.lang.legacy.format;
+use A: std.allocator;
+use format: std.format;
 use mach.lang.target.of;
 
 use mach.lang.be.codegen.mir;
@@ -24,10 +28,10 @@ pub val DEFAULT_STACK_ALIGN: u32 = 16;
 rec FrameByteUnit {
 }
 
-pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[R.Void, str] {
-    if (m == nil) { ret R.err[R.Void, str]("frame.run: nil mir module"); }
+pub fun run(tgt: *target.Target, m: *mir.MirModule) err[fail.Fail] {
+    if (m == nil) { ret err[fail.Fail].err{fail.message("frame.run: nil mir module")}; }
     if (tgt == nil || tgt.abi == nil) {
-        ret R.err[R.Void, str]("frame.run: target has no ABI");
+        ret err[fail.Fail].err{fail.message("frame.run: target has no ABI")};
     }
 
     val align: u32 = stack_align(tgt);
@@ -37,24 +41,24 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[R.Void, str] {
     var fi: u32 = 0;
     for (fi < m.function_len) {
         val func: *mir.MirFunction = ?m.functions[fi];
-        val laid_out: R.Result[R.Void, str] = layout_function(func, align);
-        if (R.is_err[R.Void, str](laid_out)) { ret laid_out; }
+        val laid_out: err[fail.Fail] = layout_function(func, align);
+        if (sel laid_out.err) { ret laid_out; }
         func.frame.omit = omits_frame(func, tgt.model.frame_ptr_reg::u32,
                                       tgt.model.stack_ptr_reg::u32);
-        val distd: R.Result[R.Void, str] = set_frame_dist(tgt, func);
-        if (R.is_err[R.Void, str](distd)) { ret distd; }
+        val distd: err[fail.Fail] = set_frame_dist(tgt, func);
+        if (sel distd.err) { ret distd; }
 
-        val over: R.Result[R.Void, str] = check_frame_fits(m, func, reserve);
-        if (R.is_err[R.Void, str](over)) { ret over; }
+        val over: err[fail.Fail] = check_frame_fits(m, func, reserve);
+        if (sel over.err) { ret over; }
         fi = fi + 1;
     }
 
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun check_frame_fits(m: *mir.MirModule, func: *mir.MirFunction, reserve: u64) R.Result[R.Void, str] {
-    if (reserve == 0) { ret R.ok_void[str](); }
-    if (func.frame.size::u64 < reserve) { ret R.ok_void[str](); }
+fun check_frame_fits(m: *mir.MirModule, func: *mir.MirFunction, reserve: u64) err[fail.Fail] {
+    if (reserve == 0) { ret err[fail.Fail].ok{}; }
+    if (func.frame.size::u64 < reserve) { ret err[fail.Fail].ok{}; }
 
     var name: str = "<unknown>";
     if (m.interner != nil) {
@@ -62,25 +66,25 @@ fun check_frame_fits(m: *mir.MirModule, func: *mir.MirFunction, reserve: u64) R.
         if (O.is_some[str](o)) { name = O.unwrap[str](o); }
     }
 
-    val r: R.Result[str, str] = format.sprint(m.alloc,
+    val r: res[str, format.FormatError] = format.sprint(m.alloc,
         "frame: `{}` needs a {}-byte stack frame, which its target's {}-byte stack reserve cannot hold; raise `stack_reserve` on the target, or move the large locals off the stack",
         name, func.frame.size::u64, reserve);
-    if (R.is_err[str, str](r)) {
-        ret R.err[R.Void, str]("frame: a function's stack frame exceeds the target's stack reserve");
+    if (sel r.err) {
+        ret err[fail.Fail].err{fail.message("frame: a function's stack frame exceeds the target's stack reserve")};
     }
-    ret R.err[R.Void, str](R.unwrap_ok[str, str](r));
+    ret err[fail.Fail].err{fail.message(r.ok)};
 }
 
-fun set_frame_dist(tgt: *target.Target, func: *mir.MirFunction) R.Result[R.Void, str] {
+fun set_frame_dist(tgt: *target.Target, func: *mir.MirFunction) err[fail.Fail] {
     if (tgt.arch == nil || tgt.arch.frame_dist == nil) {
-        ret R.err[R.Void, str]("frame: target declares no frame-distance model; an instruction set that reaches frame insertion must declare one");
+        ret err[fail.Fail].err{fail.message("frame: target declares no frame-distance model; an instruction set that reaches frame insertion must declare one")};
     }
     var base_dist: u32 = 0;
     var fp_dist:   u32 = 0;
     tgt.arch.frame_dist(?tgt.model, func, ?base_dist, ?fp_dist);
     func.frame.base_dist = base_dist;
     func.frame.fp_dist   = fp_dist;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 pub fun omits_frame(func: *mir.MirFunction, fp: u32, sp: u32) bool {
@@ -122,15 +126,15 @@ fun operand_is_frame_relative(o: *mir.MirOperand, fp: u32, sp: u32) bool {
 }
 
 pub fun slot_offset(frame: *mir.MirFrame, v: u32) O.Option[i64] {
-    val opt_slot: O.Option[*mir.MirSlot] = slot_find(frame, v);
-    if (!O.is_some[*mir.MirSlot](opt_slot)) { ret O.none[i64](); }
-    ret O.some[i64](O.unwrap[*mir.MirSlot](opt_slot).offset - frame.fp_dist::i64);
+    val opt_slot: opt[*mir.MirSlot] = slot_find(frame, v);
+    if (!sel opt_slot.some) { ret O.none[i64](); }
+    ret O.some[i64](opt_slot.some.offset - frame.fp_dist::i64);
 }
 
 pub fun slot_sp_offset(frame: *mir.MirFrame, v: u32) O.Option[i64] {
-    val opt_slot: O.Option[*mir.MirSlot] = slot_find(frame, v);
-    if (!O.is_some[*mir.MirSlot](opt_slot)) { ret O.none[i64](); }
-    ret O.some[i64](frame.base_dist::i64 + O.unwrap[*mir.MirSlot](opt_slot).offset);
+    val opt_slot: opt[*mir.MirSlot] = slot_find(frame, v);
+    if (!sel opt_slot.some) { ret O.none[i64](); }
+    ret O.some[i64](frame.base_dist::i64 + opt_slot.some.offset);
 }
 
 pub fun slots_from_sp(frame: *mir.MirFrame) bool {
@@ -138,13 +142,14 @@ pub fun slots_from_sp(frame: *mir.MirFrame) bool {
 }
 
 pub fun is_slot(frame: *mir.MirFrame, v: u32) bool {
-    ret O.is_some[*mir.MirSlot](slot_find(frame, v));
+    val found: opt[*mir.MirSlot] = slot_find(frame, v);
+    ret sel found.some;
 }
 
 pub fun is_alloca_slot(frame: *mir.MirFrame, v: u32) bool {
-    val opt_slot: O.Option[*mir.MirSlot] = slot_find(frame, v);
-    if (!O.is_some[*mir.MirSlot](opt_slot)) { ret false; }
-    ret O.unwrap[*mir.MirSlot](opt_slot).kind == mir.SLOT_ALLOCA;
+    val opt_slot: opt[*mir.MirSlot] = slot_find(frame, v);
+    if (!sel opt_slot.some) { ret false; }
+    ret opt_slot.some.kind == mir.SLOT_ALLOCA;
 }
 
 fun stack_align(tgt: *target.Target) u32 {
@@ -152,7 +157,7 @@ fun stack_align(tgt: *target.Target) u32 {
     ret tgt.abi.stack_align;
 }
 
-fun layout_function(func: *mir.MirFunction, align: u32) R.Result[R.Void, str] {
+fun layout_function(func: *mir.MirFunction, align: u32) err[fail.Fail] {
     val frame: *mir.MirFrame = ?func.frame;
     frame.align = align;
     frame.realign = over_alignment(frame, align);
@@ -160,7 +165,7 @@ fun layout_function(func: *mir.MirFunction, align: u32) R.Result[R.Void, str] {
     val align_r: R.Result[layout.CheckedAlignment[FrameByteUnit], layout.CheckCause] =
         layout.alignment[FrameByteUnit](align::usize);
     if (R.is_err[layout.CheckedAlignment[FrameByteUnit], layout.CheckCause](align_r)) {
-        ret R.err[R.Void, str]("frame: stack alignment is invalid");
+        ret err[fail.Fail].err{fail.message("frame: stack alignment is invalid")};
     }
     val frame_align: layout.CheckedAlignment[FrameByteUnit] =
         R.unwrap_ok[layout.CheckedAlignment[FrameByteUnit], layout.CheckCause](align_r);
@@ -187,13 +192,13 @@ fun layout_function(func: *mir.MirFunction, align: u32) R.Result[R.Void, str] {
         val aligned_r: R.Result[layout.CheckedOffset[FrameByteUnit], layout.CheckCause] =
             layout.align_offset_up[FrameByteUnit](layout.offset[FrameByteUnit]((-offset)::usize), frame_align);
         if (R.is_err[layout.CheckedOffset[FrameByteUnit], layout.CheckCause](aligned_r)) {
-            ret R.err[R.Void, str]("frame: stack frame size overflows while rounding up to the stack alignment");
+            ret err[fail.Fail].err{fail.message("frame: stack frame size overflows while rounding up to the stack alignment")};
         }
         size = R.unwrap_ok[layout.CheckedOffset[FrameByteUnit], layout.CheckCause](aligned_r).value;
     }
     val size_fits: R.Result[u32, layout.CheckCause] = layout.usize_to_u32(size);
     if (R.is_err[u32, layout.CheckCause](size_fits)) {
-        ret R.err[R.Void, str]("frame: stack frame size exceeds the u32 limit");
+        ret err[fail.Fail].err{fail.message("frame: stack frame size exceeds the u32 limit")};
     }
     frame.size = R.unwrap_ok[u32, layout.CheckCause](size_fits);
 
@@ -201,16 +206,16 @@ fun layout_function(func: *mir.MirFunction, align: u32) R.Result[R.Void, str] {
         val outgoing_r: R.Result[layout.CheckedOffset[FrameByteUnit], layout.CheckCause] =
             layout.align_offset_up[FrameByteUnit](layout.offset[FrameByteUnit](frame.outgoing_size::usize), frame_align);
         if (R.is_err[layout.CheckedOffset[FrameByteUnit], layout.CheckCause](outgoing_r)) {
-            ret R.err[R.Void, str]("frame: outgoing argument area overflows while rounding up to the stack alignment");
+            ret err[fail.Fail].err{fail.message("frame: outgoing argument area overflows while rounding up to the stack alignment")};
         }
         val outgoing_fits: R.Result[u32, layout.CheckCause] = layout.usize_to_u32(
             R.unwrap_ok[layout.CheckedOffset[FrameByteUnit], layout.CheckCause](outgoing_r).value);
         if (R.is_err[u32, layout.CheckCause](outgoing_fits)) {
-            ret R.err[R.Void, str]("frame: outgoing argument area exceeds the u32 limit");
+            ret err[fail.Fail].err{fail.message("frame: outgoing argument area exceeds the u32 limit")};
         }
         frame.outgoing_size = R.unwrap_ok[u32, layout.CheckCause](outgoing_fits);
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun over_alignment(frame: *mir.MirFrame, align: u32) u32 {
@@ -260,18 +265,18 @@ fun slot_is_asm_bound(func: *mir.MirFunction, v: u32) bool {
     ret false;
 }
 
-fun slot_find(frame: *mir.MirFrame, v: u32) O.Option[*mir.MirSlot] {
-    if (frame == nil)       { ret O.none[*mir.MirSlot](); }
-    if (frame.slots == nil) { ret O.none[*mir.MirSlot](); }
+fun slot_find(frame: *mir.MirFrame, v: u32) opt[*mir.MirSlot] {
+    if (frame == nil)       { ret opt[*mir.MirSlot].none{}; }
+    if (frame.slots == nil) { ret opt[*mir.MirSlot].none{}; }
 
     var i: u32 = 0;
     for (i < frame.slot_count) {
         if (frame.slots[i].value == v) {
-            ret O.some[*mir.MirSlot](?frame.slots[i]);
+            ret opt[*mir.MirSlot].some{?frame.slots[i]};
         }
         i = i + 1;
     }
-    ret O.none[*mir.MirSlot]();
+    ret opt[*mir.MirSlot].none{};
 }
 
 test "mach.lang.be.codegen.frame.slot_offset:alloca_and_spill_lookup" {
@@ -822,12 +827,12 @@ nil, nil,
     tgt.model.frame_ptr_reg = TEST_FP::i32;
     tgt.model.stack_ptr_reg = TEST_SP::i32;
 
-    val undeclared: R.Result[R.Void, str] = run(?tgt, ?m);
-    if (!R.is_err[R.Void, str](undeclared)) { ret 1; }
+    val undeclared: err[fail.Fail] = run(?tgt, ?m);
+    if (!sel undeclared.err) { ret 1; }
 
     tgt.arch = ?machine;
-    val r: R.Result[R.Void, str] = run(?tgt, ?m);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = run(?tgt, ?m);
+    if (sel r.err) { ret 1; }
 
     if (!funcs[0].frame.omit) { ret 1; }
     if (funcs[1].frame.omit)  { ret 1; }
@@ -858,23 +863,26 @@ test "mach.lang.be.codegen.frame.check_frame_fits:boundary_is_exact" {
     var bad: i32 = 0;
 
     f.frame.size = 1048575;
-    if (R.is_err[R.Void, str](check_frame_fits(?m, ?f, 1048576)) && bad == 0) { bad = 2; }
+    val check_frame_fits_r: err[fail.Fail] = check_frame_fits(?m, ?f, 1048576);
+    if (sel check_frame_fits_r.err && bad == 0) { bad = 2; }
 
     f.frame.size = 1048576;
-    if (R.is_ok[R.Void, str](check_frame_fits(?m, ?f, 1048576)) && bad == 0) { bad = 3; }
+    val check_frame_fits_r2: err[fail.Fail] = check_frame_fits(?m, ?f, 1048576);
+    if (sel check_frame_fits_r2.ok && bad == 0) { bad = 3; }
 
     f.frame.size = 1107824;
-    val over: R.Result[R.Void, str] = check_frame_fits(?m, ?f, 1048576);
-    if (R.is_ok[R.Void, str](over)) { bad = 4; }
-    or {
-        val msg: str = R.unwrap_err[R.Void, str](over);
+    val over: err[fail.Fail] = check_frame_fits(?m, ?f, 1048576);
+    if (sel over.err) {
+        val msg: str = fail.describe(over.err);
         if (!str_contains(msg, "fat")     && bad == 0) { bad = 5; }
         if (!str_contains(msg, "1107824") && bad == 0) { bad = 6; }
         if (!str_contains(msg, "1048576") && bad == 0) { bad = 7; }
     }
+    or { bad = 4; }
 
     f.frame.size = 999999999;
-    if (R.is_err[R.Void, str](check_frame_fits(?m, ?f, 0)) && bad == 0) { bad = 8; }
+    val check_frame_fits_r3: err[fail.Fail] = check_frame_fits(?m, ?f, 0);
+    if (sel check_frame_fits_r3.err && bad == 0) { bad = 8; }
 
     ret bad;
 }
@@ -915,8 +923,8 @@ test "mach.lang.be.codegen.frame.layout_function:refuses_a_frame_size_past_the_u
     func.frame.slot_count = 1;
     func.frame.slot_cap   = 1;
 
-    val r: R.Result[R.Void, str] = layout_function(?func, 16);
-    if (!R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = layout_function(?func, 16);
+    if (!sel r.err) { ret 1; }
     ret 0;
 }
 
@@ -930,8 +938,8 @@ test "mach.lang.be.codegen.frame.layout_function:refuses_an_outgoing_area_past_t
 
     func.frame.outgoing_size = 0xFFFFFFFF;
 
-    val r: R.Result[R.Void, str] = layout_function(?func, 16);
-    if (!R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = layout_function(?func, 16);
+    if (!sel r.err) { ret 1; }
     ret 0;
 }
 
@@ -955,8 +963,8 @@ test "mach.lang.be.codegen.frame.layout_function:ordinary_frame_still_succeeds" 
     func.frame.slot_cap   = 1;
     func.frame.outgoing_size = 24;
 
-    val r: R.Result[R.Void, str] = layout_function(?func, 16);
-    if (R.is_err[R.Void, str](r))         { ret 1; }
+    val r: err[fail.Fail] = layout_function(?func, 16);
+    if (sel r.err)         { ret 1; }
     if (func.frame.size != 32)          { ret 2; }
     if (func.frame.outgoing_size != 32) { ret 3; }
     ret 0;

--- a/src/lang/be/codegen/isel.mach
+++ b/src/lang/be/codegen/isel.mach
@@ -1,8 +1,10 @@
 use std.types.bool.bool;
+use std.types.canonical.err;
+use mach.lang.fail;
 use std.types.bool.true;
 use std.types.string.str;
 
-use A: mach.lang.legacy.allocator;
+use A: std.allocator;
 use R: std.types.result;
 
 use mach.lang.be.codegen.mir;
@@ -10,23 +12,23 @@ use mach.lang.target;
 use mach.lang.target.isa;
 use target_view: mach.lang.target.resolved;
 
-pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[R.Void, str] {
-    if (tgt == nil) { ret R.err[R.Void, str]("isel: nil target"); }
-    if (m == nil)   { ret R.err[R.Void, str]("isel: nil mir module"); }
+pub fun run(tgt: *target.Target, m: *mir.MirModule) err[fail.Fail] {
+    if (tgt == nil) { ret err[fail.Fail].err{fail.message("isel: nil target")}; }
+    if (m == nil)   { ret err[fail.Fail].err{fail.message("isel: nil mir module")}; }
     if (tgt.arch == nil) {
-        ret R.err[R.Void, str]("isel: target has no ISA vtable");
+        ret err[fail.Fail].err{fail.message("isel: target has no ISA vtable")};
     }
     if (tgt.arch.select == nil) {
-        ret R.err[R.Void, str]("isel: ISA registered no instruction selector");
+        ret err[fail.Fail].err{fail.message("isel: ISA registered no instruction selector")};
     }
-    val input: R.Result[R.Void, str] = mir.validate_catalog(m);
-    if (R.is_err[R.Void, str](input)) { ret input; }
+    val input: err[fail.Fail] = mir.validate_catalog(m);
+    if (sel input.err) { ret input; }
     var backend_target: isa.BackendTarget = target_view.backend_target(tgt);
     var i: u32 = 0;
     for (i < m.function_len) {
         val res_select: R.Result[R.Void, str] =
             tgt.arch.select(m.alloc, ?backend_target, ?m.functions[i]);
-        if (R.is_err[R.Void, str](res_select)) { ret res_select; }
+        if (R.is_err[R.Void, str](res_select)) { ret fail.lift_err(res_select); }
         i = i + 1;
     }
 
@@ -34,9 +36,8 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[R.Void, str] {
 }
 
 
-use page: mach.lang.legacy.page;
-use T: mach.lang.legacy.testing;
-use O: std.types.option;
+use page: std.allocator.page;
+use T: std.allocator.testing;
 use std.types.string.str_contains;
 use mach.lang.intern;
 use target_testing: mach.lang.target.testing;
@@ -50,7 +51,8 @@ fun t_catalog_select(a: *A.Allocator, tgt: *isa.BackendTarget, f: *mir.MirFuncti
 
 test "mach.lang.be.codegen.isel:catalog_validation_brackets_the_selector_callback" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var interner: intern.Interner = intern.init(?alloc);
     fin { intern.dnit(?interner); }
     var registry: target.TargetRegistry = target.registry_init();
@@ -64,7 +66,9 @@ test "mach.lang.be.codegen.isel:catalog_validation_brackets_the_selector_callbac
     var block: mir.MirBlock = mir.MirBlock{instrs: ?instruction, instr_count: 1};
     var function: mir.MirFunction = mir.MirFunction{blocks: ?block, block_count: 1};
     var module: mir.MirModule = mir.MirModule{alloc: ?alloc, interner: ?interner, functions: ?function, function_len: 1};
-    if (R.is_err[R.Void, str](run(?tgt, ?module)) || instruction.opcode != x64.ASM_BLOCK::u32) { ret 4; }
+    val run_r: err[fail.Fail] = run(?tgt, ?module);
+    if (sel run_r.err) { ret 4; }
+    if (instruction.opcode != x64.ASM_BLOCK::u32) { ret 4; }
     var machine: isa.RegMachine = @tgt.arch;
     machine.select = t_catalog_select;
     tgt.arch = ?machine;
@@ -78,9 +82,9 @@ test "mach.lang.be.codegen.isel:catalog_validation_brackets_the_selector_callbac
         if (mode == 0) { instruction.opcode = 200; instruction.operand_count = 0; }
         if (mode == 1) { operand.kind = 200; }
         if (mode == 2) { function.callee_mask_fp = 1; }
-        val result: R.Result[R.Void, str] = run(?tgt, ?module);
-        if (R.is_ok[R.Void, str](result)) { ret 5; }
-        val message: str = R.unwrap_err[R.Void, str](result);
+        val result: err[fail.Fail] = run(?tgt, ?module);
+        if (sel result.ok) { ret 5; }
+        val message: str = fail.describe(result.err);
         if (mode == 0 && !str_contains(message, "unknown MirOpcode tag 200")) { ret 6; }
         if (mode != 0 && !str_contains(message, "unknown MirOperandKind tag 200")) { ret 7; }
         if (mode < 2 && function.callee_mask != 0) { ret 8; }
@@ -88,14 +92,16 @@ test "mach.lang.be.codegen.isel:catalog_validation_brackets_the_selector_callbac
         mode = mode + 1;
     }
     var testing: T.Testing;
-    if (O.is_some[str](T.make(?testing))) { ret 10; }
+    val make_r2: err[A.Error] = T.make(?testing);
+    if (sel make_r2.err) { ret 10; }
     fin { T.dnit(?testing); }
     module.alloc = T.allocator_of(?testing);
     T.fail_at_ordinal(?testing, 1);
     instruction.opcode = 200;
     function.callee_mask = 0;
-    val refused: R.Result[R.Void, str] = run(?tgt, ?module);
-    if (R.is_ok[R.Void, str](refused) || !str_contains(R.unwrap_err[R.Void, str](refused), "out of memory")) { ret 11; }
+    val refused: err[fail.Fail] = run(?tgt, ?module);
+    if (sel refused.ok) { ret 11; }
+    if (!str_contains(fail.describe(refused.err), "out of memory")) { ret 11; }
     if (function.callee_mask != 0 || T.leaked(?testing) || T.double_free_count(?testing) != 0) { ret 12; }
     ret 0;
 }

--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -1,14 +1,16 @@
 use std.types.bool.bool;
+use std.types.canonical.res;
+use std.types.canonical.err;
+use mach.lang.fail;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 
-use page: mach.lang.legacy.page;
-use format: mach.lang.legacy.format;
+use page: std.allocator.page;
+use format: std.format;
 
-use A: mach.lang.legacy.allocator;
-use R: std.types.result;
+use A: std.allocator;
 
 use mach.lang.be.codegen.mir;
 use mach.lang.target.isa;
@@ -47,12 +49,12 @@ rec LanePlan {
 
 val LANE_NONE: u32 = 0xFFFFFFFF;
 
-pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[R.Void, str] {
-    if (tgt == nil) { ret R.err[R.Void, str]("legalize: nil target"); }
-    if (m == nil)   { ret R.err[R.Void, str]("legalize: nil mir module"); }
+pub fun run(tgt: *target.Target, m: *mir.MirModule) err[fail.Fail] {
+    if (tgt == nil) { ret err[fail.Fail].err{fail.message("legalize: nil target")}; }
+    if (m == nil)   { ret err[fail.Fail].err{fail.message("legalize: nil mir module")}; }
 
     val maw: u32 = tgt.model.max_alu_width;
-    if (maw == 0) { ret R.ok_void[str](); }
+    if (maw == 0) { ret err[fail.Fail].ok{}; }
 
     var mach: Machine;
     mach.lane_width = maw::u8;
@@ -70,11 +72,11 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[R.Void, str] {
 
     var i: u32 = 0;
     for (i < m.function_len) {
-        val res_fn: R.Result[R.Void, str] = legalize_function(m.alloc, ?mach, ?m.functions[i]);
-        if (R.is_err[R.Void, str](res_fn)) { ret res_fn; }
+        val res_fn: err[fail.Fail] = legalize_function(m.alloc, ?mach, ?m.functions[i]);
+        if (sel res_fn.err) { ret res_fn; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun function_needs_legalize(f: *mir.MirFunction, mach: *Machine) bool {
@@ -129,36 +131,36 @@ fun instr_rides_fp_bank(f: *mir.MirFunction, mi: *mir.MirInstr) bool {
     ret false;
 }
 
-fun legalize_function(alloc: *A.Allocator, mach: *Machine, f: *mir.MirFunction) R.Result[R.Void, str] {
-    if (!function_needs_legalize(f, mach)) { ret R.ok_void[str](); }
+fun legalize_function(alloc: *A.Allocator, mach: *Machine, f: *mir.MirFunction) err[fail.Fail] {
+    if (!function_needs_legalize(f, mach)) { ret err[fail.Fail].ok{}; }
 
     var plan: LanePlan;
-    val res_plan: R.Result[R.Void, str] = plan_lanes(alloc, mach, f, ?plan);
-    if (R.is_err[R.Void, str](res_plan)) { ret res_plan; }
+    val res_plan: err[fail.Fail] = plan_lanes(alloc, mach, f, ?plan);
+    if (sel res_plan.err) { ret res_plan; }
 
     var bi: u32 = 0;
     for (bi < f.block_count) {
-        val res_b: R.Result[R.Void, str] = legalize_block(alloc, ?plan, f, ?f.blocks[bi]);
-        if (R.is_err[R.Void, str](res_b)) { free_plan(alloc, ?plan); ret res_b; }
+        val res_b: err[fail.Fail] = legalize_block(alloc, ?plan, f, ?f.blocks[bi]);
+        if (sel res_b.err) { free_plan(alloc, ?plan); ret res_b; }
         bi = bi + 1;
     }
 
     free_plan(alloc, ?plan);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun plan_lanes(alloc: *A.Allocator, mach: *Machine, f: *mir.MirFunction, out: *LanePlan) R.Result[R.Void, str] {
+fun plan_lanes(alloc: *A.Allocator, mach: *Machine, f: *mir.MirFunction, out: *LanePlan) err[fail.Fail] {
     val maw: u8 = mach.lane_width;
     val n: u32 = f.vreg_count;
-    val res_base: R.Result[*u32, str] = A.allocate[u32](alloc, n::usize);
-    if (R.is_err[*u32, str](res_base)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](res_base)); }
-    val res_cnt: R.Result[*u8, str] = A.allocate[u8](alloc, n::usize);
-    if (R.is_err[*u8, str](res_cnt)) {
-        A.deallocate[u32](alloc, R.unwrap_ok[*u32, str](res_base), n::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*u8, str](res_cnt));
+    val res_base: res[*u32, A.Error] = A.allocate[u32](alloc, n::usize);
+    if (sel res_base.err) { ret err[fail.Fail].err{fail.refused(res_base.err)}; }
+    val res_cnt: res[*u8, A.Error] = A.allocate[u8](alloc, n::usize);
+    if (sel res_cnt.err) {
+        A.deallocate[u32](alloc, res_base.ok, n::usize);
+        ret err[fail.Fail].err{fail.refused(res_cnt.err)};
     }
-    out.lane_base  = R.unwrap_ok[*u32, str](res_base);
-    out.lane_count = R.unwrap_ok[*u8, str](res_cnt);
+    out.lane_base  = res_base.ok;
+    out.lane_count = res_cnt.ok;
     out.orig_count = n;
     out.lane_width = maw;
     out.mach       = @mach;
@@ -187,12 +189,12 @@ fun plan_lanes(alloc: *A.Allocator, mach: *Machine, f: *mir.MirFunction, out: *L
                 val dv: u32 = mi.operands[0].vreg;
                 if (dv < n && out.lane_base[dv] == LANE_NONE) {
                     val nlanes: u32 = (mi.width / maw)::u32;
-                    val res_l: R.Result[u32, str] = alloc_lanes(alloc, f, dv, nlanes);
-                    if (R.is_err[u32, str](res_l)) {
+                    val res_l: res[u32, fail.Fail] = alloc_lanes(alloc, f, dv, nlanes);
+                    if (sel res_l.err) {
                         free_plan(alloc, out);
-                        ret R.err[R.Void, str](R.unwrap_err[u32, str](res_l));
+                        ret err[fail.Fail].err{res_l.err};
                     }
-                    out.lane_base[dv]  = R.unwrap_ok[u32, str](res_l);
+                    out.lane_base[dv]  = res_l.ok;
                     out.lane_count[dv] = nlanes::u8;
                 }
             }
@@ -200,38 +202,38 @@ fun plan_lanes(alloc: *A.Allocator, mach: *Machine, f: *mir.MirFunction, out: *L
         }
         bi = bi + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun alloc_lanes(alloc: *A.Allocator, f: *mir.MirFunction, wide: u32, nlanes: u32) R.Result[u32, str] {
+fun alloc_lanes(alloc: *A.Allocator, f: *mir.MirFunction, wide: u32, nlanes: u32) res[u32, fail.Fail] {
     val cls: u32 = f.vregs[wide].class;
     var base: u32 = mir.MIR_VREG_NIL;
     var i: u32 = 0;
     for (i < nlanes) {
-        val res_v: R.Result[u32, str] = new_vreg(alloc, f, cls);
-        if (R.is_err[u32, str](res_v)) { ret res_v; }
-        val vid: u32 = R.unwrap_ok[u32, str](res_v);
+        val res_v: res[u32, fail.Fail] = new_vreg(alloc, f, cls);
+        if (sel res_v.err) { ret res_v; }
+        val vid: u32 = res_v.ok;
         # a lane is the wide value: the seed the validator and the allocator read must follow it
         f.vregs[vid].secret = f.vregs[wide].secret;
         if (i == 0) { base = vid; }
         i = i + 1;
     }
-    ret R.ok[u32, str](base);
+    ret res[u32, fail.Fail].ok{base};
 }
 
-fun new_vreg(alloc: *A.Allocator, f: *mir.MirFunction, cls: u32) R.Result[u32, str] {
+fun new_vreg(alloc: *A.Allocator, f: *mir.MirFunction, cls: u32) res[u32, fail.Fail] {
     if (f.vreg_count >= f.vreg_cap) {
         var new_cap: u32 = f.vreg_cap * 2;
         if (new_cap == 0) { new_cap = mir.INITIAL_VREG_CAP; }
-        val res_v: R.Result[*mir.MirVReg, str] = A.reallocate[mir.MirVReg](alloc, f.vregs, f.vreg_cap::usize, new_cap::usize);
-        if (R.is_err[*mir.MirVReg, str](res_v)) { ret R.err[u32, str](R.unwrap_err[*mir.MirVReg, str](res_v)); }
-        f.vregs    = R.unwrap_ok[*mir.MirVReg, str](res_v);
+        val res_v: res[*mir.MirVReg, A.Error] = A.reallocate[mir.MirVReg](alloc, f.vregs, f.vreg_cap::usize, new_cap::usize);
+        if (sel res_v.err) { ret res[u32, fail.Fail].err{fail.refused(res_v.err)}; }
+        f.vregs    = res_v.ok;
         f.vreg_cap = new_cap;
     }
     val vid: u32 = f.vreg_count;
     f.vregs[vid] = mir.vreg(vid, cls, false, false);
     f.vreg_count = f.vreg_count + 1;
-    ret R.ok[u32, str](vid);
+    ret res[u32, fail.Fail].ok{vid};
 }
 
 fun free_plan(alloc: *A.Allocator, plan: *LanePlan) {
@@ -239,9 +241,9 @@ fun free_plan(alloc: *A.Allocator, plan: *LanePlan) {
     if (plan.lane_count != nil) { A.deallocate[u8](alloc, plan.lane_count, plan.orig_count::usize); plan.lane_count = nil; }
 }
 
-fun legalize_block(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, b: *mir.MirBlock) R.Result[R.Void, str] {
+fun legalize_block(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, b: *mir.MirBlock) err[fail.Fail] {
     val n: u32 = b.instr_count;
-    if (n == 0) { ret R.ok_void[str](); }
+    if (n == 0) { ret err[fail.Fail].ok{}; }
 
     var total:        u32  = 0;
     var needs_expand: bool = false;
@@ -249,28 +251,28 @@ fun legalize_block(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, b:
     for (i < n) {
         val mi: *mir.MirInstr = ?b.instrs[i];
         if (instr_needs_legalize(f, mi, ?plan.mach)) {
-            val res_c: R.Result[u32, str] = expansion_count(alloc, plan, f, mi);
-            if (R.is_err[u32, str](res_c)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_c)); }
-            total = total + R.unwrap_ok[u32, str](res_c);
+            val res_c: res[u32, fail.Fail] = expansion_count(alloc, plan, f, mi);
+            if (sel res_c.err) { ret err[fail.Fail].err{res_c.err}; }
+            total = total + res_c.ok;
             needs_expand = true;
         }
         or { total = total + 1; }
         i = i + 1;
     }
 
-    if (!needs_expand) { ret R.ok_void[str](); }
+    if (!needs_expand) { ret err[fail.Fail].ok{}; }
 
-    val res_dst: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](alloc, total::usize);
-    if (R.is_err[*mir.MirInstr, str](res_dst)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirInstr, str](res_dst)); }
-    val dst: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](res_dst);
+    val res_dst: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](alloc, total::usize);
+    if (sel res_dst.err) { ret err[fail.Fail].err{fail.refused(res_dst.err)}; }
+    val dst: *mir.MirInstr = res_dst.ok;
 
     var w: u32 = 0;
     i = 0;
     for (i < n) {
         val mi: *mir.MirInstr = ?b.instrs[i];
         if (instr_needs_legalize(f, mi, ?plan.mach)) {
-            val res_e: R.Result[R.Void, str] = expand_instr(alloc, plan, f, mi, dst, ?w);
-            if (R.is_err[R.Void, str](res_e)) {
+            val res_e: err[fail.Fail] = expand_instr(alloc, plan, f, mi, dst, ?w);
+            if (sel res_e.err) {
                 free_pieces(alloc, dst, w);
                 A.deallocate[mir.MirInstr](alloc, dst, total::usize);
                 ret res_e;
@@ -287,7 +289,7 @@ fun legalize_block(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, b:
     if (w != total) {
         free_pieces(alloc, dst, w);
         A.deallocate[mir.MirInstr](alloc, dst, total::usize);
-        ret R.err[R.Void, str]("legalize: an expansion emitted a different number of pieces than it counted (internal compiler error, see briar-systems/mach#2778)");
+        ret err[fail.Fail].err{fail.message("legalize: an expansion emitted a different number of pieces than it counted (internal compiler error, see briar-systems/mach#2778)")};
     }
 
     if (b.instrs != nil && b.instr_cap > 0) {
@@ -296,7 +298,7 @@ fun legalize_block(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, b:
     b.instrs      = dst;
     b.instr_count = w;
     b.instr_cap   = total;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun free_pieces(alloc: *A.Allocator, dst: *mir.MirInstr, count: u32) {
@@ -323,7 +325,7 @@ fun free_source_operands(alloc: *A.Allocator, mi: *mir.MirInstr) {
 }
 
 fun expansion_count(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction,
-                    mi: *mir.MirInstr) R.Result[u32, str] {
+                    mi: *mir.MirInstr) res[u32, fail.Fail] {
     val op: mir.MirOpcode = mi.opcode;
     val nl: u32 = wide_lane_count(plan, mi);
 
@@ -332,27 +334,27 @@ fun expansion_count(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction,
     if (instr_is_memory(mi)) { ret memory_piece_count(alloc, plan, mi); }
 
     if (op == mir.MIR_AND || op == mir.MIR_OR || op == mir.MIR_XOR || op == mir.MIR_NOT) {
-        ret R.ok[u32, str](nl);
+        ret res[u32, fail.Fail].ok{nl};
     }
     if (is_shift(op)) { ret shift_piece_count(alloc, plan, mi); }
     if (op == mir.MIR_MOV || op == mir.MIR_DECLASSIFY || op == mir.MIR_BITCAST) {
-        ret R.ok[u32, str](nl);
+        ret res[u32, fail.Fail].ok{nl};
     }
     if (op == mir.MIR_ADD || op == mir.MIR_SUB || op == mir.MIR_NEG) {
-        ret R.ok[u32, str](addsub_chain_piece_count(nl));
+        ret res[u32, fail.Fail].ok{addsub_chain_piece_count(nl)};
     }
     if (op == mir.MIR_ZEXT) {
-        ret R.ok[u32, str](dst_lane_count(plan, mi));
+        ret res[u32, fail.Fail].ok{dst_lane_count(plan, mi)};
     }
     if (op == mir.MIR_SEXT) {
         val dl: u32 = dst_lane_count(plan, mi);
         val sl: u32 = src_lane_count(plan, mi);
         var n: u32 = dl;
         if (dl > sl) { n = n + 1; }
-        ret R.ok[u32, str](n);
+        ret res[u32, fail.Fail].ok{n};
     }
     if (op == mir.MIR_TRUNC) {
-        ret R.ok[u32, str](dst_lane_count(plan, mi));
+        ret res[u32, fail.Fail].ok{dst_lane_count(plan, mi)};
     }
     if (op == mir.MIR_MUL) { ret mul_piece_count(alloc, plan, mi); }
     if (op == mir.MIR_DIV_S || op == mir.MIR_DIV_U ||
@@ -360,7 +362,7 @@ fun expansion_count(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction,
         ret divmod_piece_count(alloc, plan, mi);
     }
     if (mir.is_cmp_opcode(op)) { ret cmp_piece_count(alloc, plan, mi); }
-    ret R.err[u32, str](unsupported_message(alloc, op, mi.width));
+    ret res[u32, fail.Fail].err{fail.message(unsupported_message(alloc, op, mi.width))};
 }
 
 fun wide_lane_count(plan: *LanePlan, mi: *mir.MirInstr) u32 {
@@ -400,29 +402,29 @@ fun base_needs_staging(plan: *LanePlan, mem: *mir.MirOperand) bool {
         plan.lane_base[mem.vreg] != LANE_NONE;
 }
 
-fun memory_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
-    if (mi.operand_count != 2) { ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width)); }
+fun memory_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) res[u32, fail.Fail] {
+    if (mi.operand_count != 2) { ret res[u32, fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))}; }
     val mx: i32 = addr_operand_index(mi);
     val vx: u32 = 1 - mx::u32;
     var n: u32 = wide_lane_count(plan, mi);
     if (!operand_is_lane_ready(plan, ?mi.operands[vx], n)) {
-        ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret res[u32, fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     val mem: *mir.MirOperand = ?mi.operands[mx::u32];
     if (base_needs_staging(plan, mem)) {
         val pl: u32 = plan.lane_count[mem.vreg]::u32;
         if (pl != 2 || plan.mach.stage_lo < 0 || plan.mach.stage_hi < 0) {
-            ret R.err[u32, str]("legalize: a runtime pointer needs a two-register address-staging pair this target does not reserve");
+            ret res[u32, fail.Fail].err{fail.message("legalize: a runtime pointer needs a two-register address-staging pair this target does not reserve")};
         }
         n = n + pl;
     }
-    ret R.ok[u32, str](n);
+    ret res[u32, fail.Fail].ok{n};
 }
 
 fun expand_memory(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
-                  dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
-    val rc: R.Result[u32, str] = memory_piece_count(alloc, plan, mi);
-    if (R.is_err[u32, str](rc)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rc)); }
+                  dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
+    val rc: res[u32, fail.Fail] = memory_piece_count(alloc, plan, mi);
+    if (sel rc.err) { ret err[fail.Fail].err{rc.err}; }
 
     val mx:  u32 = addr_operand_index(mi)::u32;
     val vx:  u32 = 1 - mx;
@@ -433,10 +435,10 @@ fun expand_memory(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
     var base: mir.MirOperand = mi.operands[mx];
     if (base_needs_staging(plan, ?base)) {
         val lo: u32 = plan.lane_base[base.vreg];
-        val r1: R.Result[R.Void, str] = emit_stage_move(alloc, dst, cursor, mi, plan.mach.stage_lo, lo, lw);
-        if (R.is_err[R.Void, str](r1)) { ret r1; }
-        val r2: R.Result[R.Void, str] = emit_stage_move(alloc, dst, cursor, mi, plan.mach.stage_hi, lo + 1, lw);
-        if (R.is_err[R.Void, str](r2)) { ret r2; }
+        val r1: err[fail.Fail] = emit_stage_move(alloc, dst, cursor, mi, plan.mach.stage_lo, lo, lw);
+        if (sel r1.err) { ret r1; }
+        val r2: err[fail.Fail] = emit_stage_move(alloc, dst, cursor, mi, plan.mach.stage_hi, lo + 1, lw);
+        if (sel r2.err) { ret r2; }
         base = mir.op_mem_preg(plan.mach.stage_lo::u32, base.imm);
     }
 
@@ -453,15 +455,15 @@ fun expand_memory(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
             ops[0] = lane_operand(plan, ?mi.operands[vx], i);
             ops[1] = mem;
         }
-        val r: R.Result[R.Void, str] = emit_piece(alloc, dst, cursor, mi, opcode, ?ops[0], 2, lw);
-        if (R.is_err[R.Void, str](r)) { ret r; }
+        val r: err[fail.Fail] = emit_piece(alloc, dst, cursor, mi, opcode, ?ops[0], 2, lw);
+        if (sel r.err) { ret r; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun emit_stage_move(alloc: *A.Allocator, dst: *mir.MirInstr, cursor: *u32, src: *mir.MirInstr,
-                    preg: i32, lane: u32, lw: u8) R.Result[R.Void, str] {
+                    preg: i32, lane: u32, lw: u8) err[fail.Fail] {
     var ops: [2]mir.MirOperand;
     ops[0] = mir.op_preg(preg::u32);
     ops[1] = mir.op_vreg(lane);
@@ -469,7 +471,7 @@ fun emit_stage_move(alloc: *A.Allocator, dst: *mir.MirInstr, cursor: *u32, src: 
 }
 
 fun expand_instr(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
-                 dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
+                 dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
     val op: mir.MirOpcode = mi.opcode;
 
     if (conv_is_wide(?plan.mach, mi)) {
@@ -515,19 +517,19 @@ fun expand_instr(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: 
     if (op == mir.MIR_TRUNC) {
         ret expand_trunc(alloc, plan, mi, dst, cursor);
     }
-    ret R.err[R.Void, str](unsupported_message(alloc, op, mi.width));
+    ret err[fail.Fail].err{fail.message(unsupported_message(alloc, op, mi.width))};
 }
 
 fun emit_piece(alloc: *A.Allocator, dst: *mir.MirInstr, cursor: *u32, src: *mir.MirInstr,
-               opcode: mir.MirOpcode, ops: *mir.MirOperand, nops: u32, width: u8) R.Result[R.Void, str] {
+               opcode: mir.MirOpcode, ops: *mir.MirOperand, nops: u32, width: u8) err[fail.Fail] {
     if (src.vec_lane != mir.VEC_LANE_NONE) {
-        ret R.err[R.Void, str]("internal compiler error: width legalization cannot expand a vector-lane instruction without a lane-aware piece emitter; vec_lane would be silently dropped");
+        ret err[fail.Fail].err{fail.message("internal compiler error: width legalization cannot expand a vector-lane instruction without a lane-aware piece emitter; vec_lane would be silently dropped")};
     }
     var arr: *mir.MirOperand = nil;
     if (nops > 0) {
-        val res_a: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](alloc, nops::usize);
-        if (R.is_err[*mir.MirOperand, str](res_a)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](res_a)); }
-        arr = R.unwrap_ok[*mir.MirOperand, str](res_a);
+        val res_a: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](alloc, nops::usize);
+        if (sel res_a.err) { ret err[fail.Fail].err{fail.refused(res_a.err)}; }
+        arr = res_a.ok;
         var j: u32 = 0;
         for (j < nops) { arr[j] = ops[j]; j = j + 1; }
     }
@@ -539,7 +541,7 @@ fun emit_piece(alloc: *A.Allocator, dst: *mir.MirInstr, cursor: *u32, src: *mir.
     p.writes_secret = src.writes_secret;
     p.memory_flags = src.memory_flags;
     @cursor = ci + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun lane_operand(plan: *LanePlan, op: *mir.MirOperand, i: u32) mir.MirOperand {
@@ -582,9 +584,9 @@ fun operands_are_lane_ready(plan: *LanePlan, mi: *mir.MirInstr, start: u32) bool
 }
 
 fun expand_bitwise(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
-                   dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
+                   dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
     if (mi.operand_count != 3 || !operands_are_lane_ready(plan, mi, 1)) {
-        ret R.err[R.Void, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     val nl: u32 = wide_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
@@ -594,17 +596,17 @@ fun expand_bitwise(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
         ops[0] = lane_operand(plan, ?mi.operands[0], i);
         ops[1] = lane_operand(plan, ?mi.operands[1], i);
         ops[2] = lane_operand(plan, ?mi.operands[2], i);
-        val r: R.Result[R.Void, str] = emit_piece(alloc, dst, cursor, mi, mi.opcode, ?ops[0], 3, lw);
-        if (R.is_err[R.Void, str](r)) { ret r; }
+        val r: err[fail.Fail] = emit_piece(alloc, dst, cursor, mi, mi.opcode, ?ops[0], 3, lw);
+        if (sel r.err) { ret r; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun expand_not(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
-               dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
+               dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
     if (mi.operand_count != 2 || !operands_are_lane_ready(plan, mi, 1)) {
-        ret R.err[R.Void, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     val nl: u32 = wide_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
@@ -613,19 +615,19 @@ fun expand_not(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
         var ops: [2]mir.MirOperand;
         ops[0] = lane_operand(plan, ?mi.operands[0], i);
         ops[1] = lane_operand(plan, ?mi.operands[1], i);
-        val r: R.Result[R.Void, str] = emit_piece(alloc, dst, cursor, mi, mir.MIR_NOT, ?ops[0], 2, lw);
-        if (R.is_err[R.Void, str](r)) { ret r; }
+        val r: err[fail.Fail] = emit_piece(alloc, dst, cursor, mi, mir.MIR_NOT, ?ops[0], 2, lw);
+        if (sel r.err) { ret r; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun expand_mov(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
-               dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
+               dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
     val nl: u32 = wide_lane_count(plan, mi);
     if (mi.operand_count != 2 || !operand_is_lane_ready(plan, ?mi.operands[0], nl) ||
         !operand_is_lane_ready(plan, ?mi.operands[1], nl)) {
-        ret R.err[R.Void, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     val lw: u8  = plan.lane_width;
     # a declassify is the taint barrier; its lanes must stay one or the barrier is gone
@@ -636,18 +638,18 @@ fun expand_mov(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
         var ops: [2]mir.MirOperand;
         ops[0] = lane_operand(plan, ?mi.operands[0], i);
         ops[1] = lane_operand(plan, ?mi.operands[1], i);
-        val r: R.Result[R.Void, str] = emit_piece(alloc, dst, cursor, mi, piece_op, ?ops[0], 2, lw);
-        if (R.is_err[R.Void, str](r)) { ret r; }
+        val r: err[fail.Fail] = emit_piece(alloc, dst, cursor, mi, piece_op, ?ops[0], 2, lw);
+        if (sel r.err) { ret r; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun expand_addsub(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
-                  dst: *mir.MirInstr, cursor: *u32, is_sub: bool) R.Result[R.Void, str] {
+                  dst: *mir.MirInstr, cursor: *u32, is_sub: bool) err[fail.Fail] {
     if (mi.operand_count != 3 || !operands_are_lane_ready(plan, mi, 1) ||
         mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg] == LANE_NONE) {
-        ret R.err[R.Void, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     val nl: u32 = wide_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
@@ -668,7 +670,7 @@ fun expand_addsub(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi:
 fun emit_addsub_chain(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
                       dst: *mir.MirInstr, cursor: *u32,
                       d_ops: *mir.MirOperand, a_ops: *mir.MirOperand, b_ops: *mir.MirOperand,
-                      nl: u32, lw: u8, is_sub: bool) R.Result[R.Void, str] {
+                      nl: u32, lw: u8, is_sub: bool) err[fail.Fail] {
     val mi: *mir.MirInstr = src;
     val cmp:  mir.MirOpcode = mir.MIR_CMP_LT_U;
     var op0:  mir.MirOpcode = mir.MIR_ADD;
@@ -684,64 +686,64 @@ fun emit_addsub_chain(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirIns
         val is_top: bool = i == nl - 1;
 
         if (is_low) {
-            val r1: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, op0, d, a, b, lw);
-            if (R.is_err[R.Void, str](r1)) { ret r1; }
-            val res_c: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](res_c)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_c)); }
-            carry = R.unwrap_ok[u32, str](res_c);
+            val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, op0, d, a, b, lw);
+            if (sel r1.err) { ret r1; }
+            val res_c: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel res_c.err) { ret err[fail.Fail].err{res_c.err}; }
+            carry = res_c.ok;
             val cop: mir.MirOperand = mir.op_vreg(carry);
-            var rc: R.Result[R.Void, str];
+            var rc: err[fail.Fail];
             if (is_sub) { rc = emit_bin(alloc, dst, cursor, mi, cmp, cop, a, b, lw); }
             or          { rc = emit_bin(alloc, dst, cursor, mi, cmp, cop, d, a, lw); }
-            if (R.is_err[R.Void, str](rc)) { ret rc; }
+            if (sel rc.err) { ret rc; }
         }
         or (is_top) {
-            val res_t: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](res_t)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_t)); }
-            val t: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](res_t));
-            val r1: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, op0, t, a, b, lw);
-            if (R.is_err[R.Void, str](r1)) { ret r1; }
-            val r2: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, op0, d, t, mir.op_vreg(carry), lw);
-            if (R.is_err[R.Void, str](r2)) { ret r2; }
+            val res_t: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel res_t.err) { ret err[fail.Fail].err{res_t.err}; }
+            val t: mir.MirOperand = mir.op_vreg(res_t.ok);
+            val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, op0, t, a, b, lw);
+            if (sel r1.err) { ret r1; }
+            val r2: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, op0, d, t, mir.op_vreg(carry), lw);
+            if (sel r2.err) { ret r2; }
         }
         or {
-            val res_t: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](res_t)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_t)); }
-            val t: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](res_t));
+            val res_t: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel res_t.err) { ret err[fail.Fail].err{res_t.err}; }
+            val t: mir.MirOperand = mir.op_vreg(res_t.ok);
             val cin: mir.MirOperand = mir.op_vreg(carry);
 
-            val r1: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, op0, t, a, b, lw);
-            if (R.is_err[R.Void, str](r1)) { ret r1; }
+            val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, op0, t, a, b, lw);
+            if (sel r1.err) { ret r1; }
 
-            val res_ct: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](res_ct)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_ct)); }
-            val ct: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](res_ct));
-            var rct: R.Result[R.Void, str];
+            val res_ct: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel res_ct.err) { ret err[fail.Fail].err{res_ct.err}; }
+            val ct: mir.MirOperand = mir.op_vreg(res_ct.ok);
+            var rct: err[fail.Fail];
             if (is_sub) { rct = emit_bin(alloc, dst, cursor, mi, cmp, ct, a, b, lw); }
             or          { rct = emit_bin(alloc, dst, cursor, mi, cmp, ct, t, a, lw); }
-            if (R.is_err[R.Void, str](rct)) { ret rct; }
+            if (sel rct.err) { ret rct; }
 
-            val r3: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, op0, d, t, cin, lw);
-            if (R.is_err[R.Void, str](r3)) { ret r3; }
+            val r3: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, op0, d, t, cin, lw);
+            if (sel r3.err) { ret r3; }
 
-            val res_cd: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](res_cd)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_cd)); }
-            val cd: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](res_cd));
-            var rcd: R.Result[R.Void, str];
+            val res_cd: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel res_cd.err) { ret err[fail.Fail].err{res_cd.err}; }
+            val cd: mir.MirOperand = mir.op_vreg(res_cd.ok);
+            var rcd: err[fail.Fail];
             if (is_sub) { rcd = emit_bin(alloc, dst, cursor, mi, cmp, cd, t, cin, lw); }
             or          { rcd = emit_bin(alloc, dst, cursor, mi, cmp, cd, d, t, lw); }
-            if (R.is_err[R.Void, str](rcd)) { ret rcd; }
+            if (sel rcd.err) { ret rcd; }
 
-            val res_co: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](res_co)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_co)); }
-            val co: u32 = R.unwrap_ok[u32, str](res_co);
-            val r5: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_OR, mir.op_vreg(co), ct, cd, lw);
-            if (R.is_err[R.Void, str](r5)) { ret r5; }
+            val res_co: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel res_co.err) { ret err[fail.Fail].err{res_co.err}; }
+            val co: u32 = res_co.ok;
+            val r5: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_OR, mir.op_vreg(co), ct, cd, lw);
+            if (sel r5.err) { ret r5; }
             carry = co;
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun addsub_chain_piece_count(nl: u32) u32 {
@@ -750,10 +752,10 @@ fun addsub_chain_piece_count(nl: u32) u32 {
 }
 
 fun expand_neg(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
-               dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
+               dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
     if (mi.operand_count != 2 || !operands_are_lane_ready(plan, mi, 1) ||
         mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg] == LANE_NONE) {
-        ret R.err[R.Void, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     var sub: mir.MirInstr = @mi;
     var ops: [3]mir.MirOperand;
@@ -831,23 +833,23 @@ fun shift_stage_count(bits: u32) u32 {
     ret s;
 }
 
-fun shift_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
+fun shift_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) res[u32, fail.Fail] {
     val nl: u32 = wide_lane_count(plan, mi);
     if (mi.operand_count != 3 || nl > MAX_SHIFT_LANES) {
-        ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret res[u32, fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     if (mi.operands[0].kind != mir.MIR_OP_VREG ||
         !operand_is_lane_ready(plan, ?mi.operands[0], nl) ||
         !operand_is_lane_ready(plan, ?mi.operands[1], nl) ||
         !operand_is_lane_ready(plan, ?mi.operands[2], 1)) {
-        ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret res[u32, fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
 
     val lb:   u32 = plan.lane_width::u32 * 8;
     val bits: u32 = nl * lb;
     val stages: u32 = shift_stage_count(bits);
     if (stages == 0) {
-        ret R.err[u32, str]("legalize: a shift at a width that is not a power of two is unsupported on this target");
+        ret res[u32, fail.Fail].err{fail.message("legalize: a shift at a width that is not a power of two is unsupported on this target")};
     }
 
     val left:  bool = mi.opcode == mir.MIR_SHL;
@@ -857,7 +859,7 @@ fun shift_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) R
         val c: u32 = (mi.operands[2].imm & (bits - 1)::i64)::u32;
         var total: u32 = const_shift_pieces(nl, c / lb, c % lb, left, arith);
         if (needs_sign_fill(arith, c / lb)) { total = total + 1; }
-        ret R.ok[u32, str](total);
+        ret res[u32, fail.Fail].ok{total};
     }
 
     var total: u32 = 0;
@@ -872,11 +874,11 @@ fun shift_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) R
         total = total + 3 * nl;
         j = j + 1;
     }
-    ret R.ok[u32, str](total);
+    ret res[u32, fail.Fail].ok{total};
 }
 
 fun emit_copy(alloc: *A.Allocator, dst: *mir.MirInstr, cursor: *u32, src: *mir.MirInstr,
-              d: mir.MirOperand, a: mir.MirOperand, w: u8) R.Result[R.Void, str] {
+              d: mir.MirOperand, a: mir.MirOperand, w: u8) err[fail.Fail] {
     var ops: [2]mir.MirOperand;
     ops[0] = d;
     ops[1] = a;
@@ -887,7 +889,7 @@ fun emit_const_shift(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInst
                      dst: *mir.MirInstr, cursor: *u32,
                      in_ops: *mir.MirOperand, out_ops: *mir.MirOperand, nl: u32, lw: u8,
                      k: u32, r: u32, left: bool, arith: bool,
-                     fill: mir.MirOperand) R.Result[R.Void, str] {
+                     fill: mir.MirOperand) err[fail.Fail] {
     val lb: u32 = lw::u32 * 8;
     var step: i32 = 1;
     var i:    i32 = 0;
@@ -902,64 +904,64 @@ fun emit_const_shift(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInst
         val out:  mir.MirOperand = out_ops[i::u32];
 
         if (kind == SL_FILL) {
-            val r1: R.Result[R.Void, str] = emit_copy(alloc, dst, cursor, src, out, fill, lw);
-            if (R.is_err[R.Void, str](r1)) { ret r1; }
+            val r1: err[fail.Fail] = emit_copy(alloc, dst, cursor, src, out, fill, lw);
+            if (sel r1.err) { ret r1; }
         }
         or (kind == SL_COPY) {
-            val r1: R.Result[R.Void, str] = emit_copy(alloc, dst, cursor, src, out, in_ops[a::u32], lw);
-            if (R.is_err[R.Void, str](r1)) { ret r1; }
+            val r1: err[fail.Fail] = emit_copy(alloc, dst, cursor, src, out, in_ops[a::u32], lw);
+            if (sel r1.err) { ret r1; }
         }
         or (kind == SL_ONE || kind == SL_SIGN) {
             var one: mir.MirOpcode = mir.MIR_SHR_U;
             if (left)            { one = mir.MIR_SHL; }
             or (kind == SL_SIGN) { one = mir.MIR_SHR_S; }
-            val r1: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, one, out,
+            val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, one, out,
                                                    in_ops[a::u32], mir.op_imm(r::i64), lw);
-            if (R.is_err[R.Void, str](r1)) { ret r1; }
+            if (sel r1.err) { ret r1; }
         }
         or {
             var nb: mir.MirOperand = fill;
             if (b >= 0) { nb = in_ops[b::u32]; }
 
-            val rt1: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](rt1)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rt1)); }
-            val t1: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rt1));
-            val rt2: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](rt2)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rt2)); }
-            val t2: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rt2));
+            val rt1: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel rt1.err) { ret err[fail.Fail].err{rt1.err}; }
+            val t1: mir.MirOperand = mir.op_vreg(rt1.ok);
+            val rt2: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel rt2.err) { ret err[fail.Fail].err{rt2.err}; }
+            val t2: mir.MirOperand = mir.op_vreg(rt2.ok);
 
             var main_op:  mir.MirOpcode = mir.MIR_SHR_U;
             var cross_op: mir.MirOpcode = mir.MIR_SHL;
             if (left) { main_op = mir.MIR_SHL; cross_op = mir.MIR_SHR_U; }
 
-            val r1: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, main_op, t1,
+            val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, main_op, t1,
                                                    in_ops[a::u32], mir.op_imm(r::i64), lw);
-            if (R.is_err[R.Void, str](r1)) { ret r1; }
-            val r2: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, cross_op, t2,
+            if (sel r1.err) { ret r1; }
+            val r2: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, cross_op, t2,
                                                    nb, mir.op_imm((lb - r)::i64), lw);
-            if (R.is_err[R.Void, str](r2)) { ret r2; }
-            val r3: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_OR, out, t1, t2, lw);
-            if (R.is_err[R.Void, str](r3)) { ret r3; }
+            if (sel r2.err) { ret r2; }
+            val r3: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_OR, out, t1, t2, lw);
+            if (sel r3.err) { ret r3; }
         }
         i = i + step;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun emit_sign_fill(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
                    dst: *mir.MirInstr, cursor: *u32, top: mir.MirOperand, lw: u8,
-                   out: *mir.MirOperand) R.Result[R.Void, str] {
-    val rv: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](rv)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rv)); }
-    @out = mir.op_vreg(R.unwrap_ok[u32, str](rv));
+                   out: *mir.MirOperand) err[fail.Fail] {
+    val rv: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+    if (sel rv.err) { ret err[fail.Fail].err{rv.err}; }
+    @out = mir.op_vreg(rv.ok);
     ret emit_bin(alloc, dst, cursor, src, mir.MIR_SHR_S, @out, top,
                  mir.op_imm((lw::u32 * 8 - 1)::i64), lw);
 }
 
 fun expand_shift(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
-                 dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
-    val rc: R.Result[u32, str] = shift_piece_count(alloc, plan, mi);
-    if (R.is_err[u32, str](rc)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rc)); }
+                 dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
+    val rc: res[u32, fail.Fail] = shift_piece_count(alloc, plan, mi);
+    if (sel rc.err) { ret err[fail.Fail].err{rc.err}; }
 
     val nl: u32 = wide_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
@@ -981,9 +983,9 @@ fun expand_shift(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: 
         val c: u32 = (mi.operands[2].imm & (bits - 1)::i64)::u32;
         var fill: mir.MirOperand = mir.op_imm(0);
         if (needs_sign_fill(arith, c / lb)) {
-            val rf: R.Result[R.Void, str] = emit_sign_fill(alloc, f, mi, dst, cursor,
+            val rf: err[fail.Fail] = emit_sign_fill(alloc, f, mi, dst, cursor,
                                                          src_ops[nl - 1], lw, ?fill);
-            if (R.is_err[R.Void, str](rf)) { ret rf; }
+            if (sel rf.err) { ret rf; }
         }
         ret emit_const_shift(alloc, f, mi, dst, cursor, ?src_ops[0], ?dst_ops[0], nl, lw,
                              c / lb, c % lb, left, arith, fill);
@@ -995,16 +997,16 @@ fun expand_shift(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: 
 fun emit_shift_barrel(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
                       dst: *mir.MirInstr, cursor: *u32,
                       src_ops: *mir.MirOperand, dst_ops: *mir.MirOperand, nl: u32, lw: u8,
-                      left: bool, arith: bool) R.Result[R.Void, str] {
+                      left: bool, arith: bool) err[fail.Fail] {
     val lb:     u32 = lw::u32 * 8;
     val stages: u32 = shift_stage_count(nl * lb);
     val cnt: mir.MirOperand = lane_operand(plan, ?mi.operands[2], 0);
 
     var fill: mir.MirOperand = mir.op_imm(0);
     if (arith && nl > 1) {
-        val rf: R.Result[R.Void, str] = emit_sign_fill(alloc, f, mi, dst, cursor,
+        val rf: err[fail.Fail] = emit_sign_fill(alloc, f, mi, dst, cursor,
                                                      src_ops[nl - 1], lw, ?fill);
-        if (R.is_err[R.Void, str](rf)) { ret rf; }
+        if (sel rf.err) { ret rf; }
     }
 
     var cur: [MAX_SHIFT_LANES]mir.MirOperand;
@@ -1017,38 +1019,38 @@ fun emit_shift_barrel(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction,
     for (j < stages) {
         var bit_src: mir.MirOperand = cnt;
         if (j > 0) {
-            val rt: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](rt)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rt)); }
-            bit_src = mir.op_vreg(R.unwrap_ok[u32, str](rt));
-            val r1: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SHR_U,
+            val rt: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
+            bit_src = mir.op_vreg(rt.ok);
+            val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SHR_U,
                                                    bit_src, cnt, mir.op_imm(j::i64), lw);
-            if (R.is_err[R.Void, str](r1)) { ret r1; }
+            if (sel r1.err) { ret r1; }
         }
-        val rb: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rb)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rb)); }
-        val bit: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rb));
-        val r2: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, bit,
+        val rb: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rb.err) { ret err[fail.Fail].err{rb.err}; }
+        val bit: mir.MirOperand = mir.op_vreg(rb.ok);
+        val r2: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, bit,
                                                bit_src, mir.op_imm(1), lw);
-        if (R.is_err[R.Void, str](r2)) { ret r2; }
+        if (sel r2.err) { ret r2; }
 
-        val rm: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rm)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rm)); }
-        val mask: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rm));
-        val r3: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SUB, mask,
+        val rm: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rm.err) { ret err[fail.Fail].err{rm.err}; }
+        val mask: mir.MirOperand = mir.op_vreg(rm.ok);
+        val r3: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SUB, mask,
                                                mir.op_imm(0), bit, lw);
-        if (R.is_err[R.Void, str](r3)) { ret r3; }
+        if (sel r3.err) { ret r3; }
 
         i = 0;
         for (i < nl) {
-            val rs: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](rs)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rs)); }
-            sh[i] = mir.op_vreg(R.unwrap_ok[u32, str](rs));
+            val rs: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel rs.err) { ret err[fail.Fail].err{rs.err}; }
+            sh[i] = mir.op_vreg(rs.ok);
             i = i + 1;
         }
         val c: u32 = 1 << j;
-        val r4: R.Result[R.Void, str] = emit_const_shift(alloc, f, mi, dst, cursor, ?cur[0], ?sh[0],
+        val r4: err[fail.Fail] = emit_const_shift(alloc, f, mi, dst, cursor, ?cur[0], ?sh[0],
                                                        nl, lw, c / lb, c % lb, left, arith, fill);
-        if (R.is_err[R.Void, str](r4)) { ret r4; }
+        if (sel r4.err) { ret r4; }
 
         if (j == stages - 1) {
             i = 0;
@@ -1057,29 +1059,29 @@ fun emit_shift_barrel(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction,
         or {
             i = 0;
             for (i < nl) {
-                val rn: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-                if (R.is_err[u32, str](rn)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rn)); }
-                nxt[i] = mir.op_vreg(R.unwrap_ok[u32, str](rn));
+                val rn: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
+                nxt[i] = mir.op_vreg(rn.ok);
                 i = i + 1;
             }
         }
 
         i = 0;
         for (i < nl) {
-            val rx: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](rx)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rx)); }
-            val x: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rx));
-            val r5: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, x, cur[i], sh[i], lw);
-            if (R.is_err[R.Void, str](r5)) { ret r5; }
+            val rx: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel rx.err) { ret err[fail.Fail].err{rx.err}; }
+            val x: mir.MirOperand = mir.op_vreg(rx.ok);
+            val r5: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, x, cur[i], sh[i], lw);
+            if (sel r5.err) { ret r5; }
 
-            val ry: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](ry)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](ry)); }
-            val y: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](ry));
-            val r6: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, y, x, mask, lw);
-            if (R.is_err[R.Void, str](r6)) { ret r6; }
+            val ry: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel ry.err) { ret err[fail.Fail].err{ry.err}; }
+            val y: mir.MirOperand = mir.op_vreg(ry.ok);
+            val r6: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, y, x, mask, lw);
+            if (sel r6.err) { ret r6; }
 
-            val r7: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, nxt[i], cur[i], y, lw);
-            if (R.is_err[R.Void, str](r7)) { ret r7; }
+            val r7: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, nxt[i], cur[i], y, lw);
+            if (sel r7.err) { ret r7; }
             i = i + 1;
         }
 
@@ -1087,7 +1089,7 @@ fun emit_shift_barrel(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction,
         for (i < nl) { cur[i] = nxt[i]; i = i + 1; }
         j = j + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun double_and_add_pieces(nl: u32, stages: u32) u32 {
@@ -1114,43 +1116,43 @@ fun accum_lane_pieces(nl: u32, p: u32) u32 {
 
 fun emit_accumulate_lane(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
                          dst: *mir.MirInstr, cursor: *u32, acc: *mir.MirOperand,
-                         nl: u32, lw: u8, p: u32, v: mir.MirOperand) R.Result[R.Void, str] {
-    if (lane_is_seed_zero(acc[p])) { acc[p] = v; ret R.ok_void[str](); }
+                         nl: u32, lw: u8, p: u32, v: mir.MirOperand) err[fail.Fail] {
+    if (lane_is_seed_zero(acc[p])) { acc[p] = v; ret err[fail.Fail].ok{}; }
 
-    val rt: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](rt)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rt)); }
-    val t: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rt));
-    val r1: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_ADD, t, acc[p], v, lw);
-    if (R.is_err[R.Void, str](r1)) { ret r1; }
+    val rt: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+    if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
+    val t: mir.MirOperand = mir.op_vreg(rt.ok);
+    val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_ADD, t, acc[p], v, lw);
+    if (sel r1.err) { ret r1; }
 
-    if (p == nl - 1) { acc[p] = t; ret R.ok_void[str](); }
+    if (p == nl - 1) { acc[p] = t; ret err[fail.Fail].ok{}; }
 
-    val rc: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](rc)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rc)); }
-    var carry: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rc));
-    val r2: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_LT_U, carry, t, v, lw);
-    if (R.is_err[R.Void, str](r2)) { ret r2; }
+    val rc: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+    if (sel rc.err) { ret err[fail.Fail].err{rc.err}; }
+    var carry: mir.MirOperand = mir.op_vreg(rc.ok);
+    val r2: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_LT_U, carry, t, v, lw);
+    if (sel r2.err) { ret r2; }
     acc[p] = t;
 
     var k: u32 = p + 1;
     for (k < nl) {
-        val rn: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rn)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rn)); }
-        val n: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rn));
-        val r3: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_ADD, n, acc[k], carry, lw);
-        if (R.is_err[R.Void, str](r3)) { ret r3; }
+        val rn: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
+        val n: mir.MirOperand = mir.op_vreg(rn.ok);
+        val r3: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_ADD, n, acc[k], carry, lw);
+        if (sel r3.err) { ret r3; }
         acc[k] = n;
-        if (k == nl - 1) { ret R.ok_void[str](); }
+        if (k == nl - 1) { ret err[fail.Fail].ok{}; }
 
-        val rc2: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rc2)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rc2)); }
-        val c2: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rc2));
-        val r4: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_LT_U, c2, n, carry, lw);
-        if (R.is_err[R.Void, str](r4)) { ret r4; }
+        val rc2: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rc2.err) { ret err[fail.Fail].err{rc2.err}; }
+        val c2: mir.MirOperand = mir.op_vreg(rc2.ok);
+        val r4: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_LT_U, c2, n, carry, lw);
+        if (sel r4.err) { ret r4; }
         carry = c2;
         k = k + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun lane_product_pieces(native: bool, want_hi: bool, lane_bits: u32) u32 {
@@ -1165,12 +1167,12 @@ fun lane_product_pieces(native: bool, want_hi: bool, lane_bits: u32) u32 {
 fun emit_lane_product(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, src: *mir.MirInstr,
                       dst: *mir.MirInstr, cursor: *u32,
                       a: mir.MirOperand, b: mir.MirOperand,
-                      lo: mir.MirOperand, hi: mir.MirOperand, want_hi: bool) R.Result[R.Void, str] {
+                      lo: mir.MirOperand, hi: mir.MirOperand, want_hi: bool) err[fail.Fail] {
     val lw: u8 = plan.lane_width;
     if (plan.mach.mul_hi != 0) {
-        val r1: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_MUL, lo, a, b, lw);
-        if (R.is_err[R.Void, str](r1)) { ret r1; }
-        if (!want_hi) { ret R.ok_void[str](); }
+        val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_MUL, lo, a, b, lw);
+        if (sel r1.err) { ret r1; }
+        if (!want_hi) { ret err[fail.Fail].ok{}; }
         ret emit_bin(alloc, dst, cursor, src, mir.MIR_MUL_HI_U, hi, a, b, lw);
     }
 
@@ -1213,27 +1215,27 @@ fun mul_schoolbook_pieces(plan: *LanePlan, nl: u32) u32 {
     ret total + nl;
 }
 
-fun mul_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
+fun mul_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) res[u32, fail.Fail] {
     val nl: u32 = wide_lane_count(plan, mi);
     if (mi.operand_count != 3 || nl > MAX_SHIFT_LANES ||
         mi.operands[0].kind != mir.MIR_OP_VREG || !operand_is_lane_ready(plan, ?mi.operands[0], nl) ||
         !operand_is_lane_ready(plan, ?mi.operands[1], nl) || !operand_is_lane_ready(plan, ?mi.operands[2], nl)) {
-        ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret res[u32, fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     if (plan.mach.mul_hi != 0 && plan.mach.mul_hi != plan.lane_width) {
-        ret R.err[u32, str]("legalize: this target declares a widening multiply at a width other than its ALU width, which this pass does not model (see briar-systems/mach#2778)");
+        ret res[u32, fail.Fail].err{fail.message("legalize: this target declares a widening multiply at a width other than its ALU width, which this pass does not model (see briar-systems/mach#2778)")};
     }
     if (plan.mach.mul_hi != 0 && !plan.mach.has_mul) {
-        ret R.err[u32, str]("legalize: this target declares the high half of a multiply but no multiply (see briar-systems/mach#2778)");
+        ret res[u32, fail.Fail].err{fail.message("legalize: this target declares the high half of a multiply but no multiply (see briar-systems/mach#2778)")};
     }
-    if (nl > 1) { ret R.ok[u32, str](mul_schoolbook_pieces(plan, nl)); }
-    ret R.ok[u32, str](double_and_add_pieces(nl, nl * plan.lane_width::u32 * 8));
+    if (nl > 1) { ret res[u32, fail.Fail].ok{mul_schoolbook_pieces(plan, nl)}; }
+    ret res[u32, fail.Fail].ok{double_and_add_pieces(nl, nl * plan.lane_width::u32 * 8)};
 }
 
 fun expand_mul(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
-               dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
-    val rc: R.Result[u32, str] = mul_piece_count(alloc, plan, mi);
-    if (R.is_err[u32, str](rc)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rc)); }
+               dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
+    val rc: res[u32, fail.Fail] = mul_piece_count(alloc, plan, mi);
+    if (sel rc.err) { ret err[fail.Fail].err{rc.err}; }
 
     val nl: u32 = wide_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
@@ -1265,26 +1267,26 @@ fun expand_mul(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *m
             val p: u32 = i + j;
             val want_hi: bool = p + 1 < nl;
 
-            val rl: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](rl)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rl)); }
-            val lo: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rl));
+            val rl: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel rl.err) { ret err[fail.Fail].err{rl.err}; }
+            val lo: mir.MirOperand = mir.op_vreg(rl.ok);
 
             var hi: mir.MirOperand = mir.op_imm(0);
             if (want_hi) {
-                val rh: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-                if (R.is_err[u32, str](rh)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rh)); }
-                hi = mir.op_vreg(R.unwrap_ok[u32, str](rh));
+                val rh: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                if (sel rh.err) { ret err[fail.Fail].err{rh.err}; }
+                hi = mir.op_vreg(rh.ok);
             }
 
-            val rp: R.Result[R.Void, str] = emit_lane_product(alloc, plan, f, mi, dst, cursor,
+            val rp: err[fail.Fail] = emit_lane_product(alloc, plan, f, mi, dst, cursor,
                                                             a_ops[i], b_ops[j], lo, hi, want_hi);
-            if (R.is_err[R.Void, str](rp)) { ret rp; }
+            if (sel rp.err) { ret rp; }
 
-            val ra: R.Result[R.Void, str] = emit_accumulate_lane(alloc, f, mi, dst, cursor, ?acc[0], nl, lw, p, lo);
-            if (R.is_err[R.Void, str](ra)) { ret ra; }
+            val ra: err[fail.Fail] = emit_accumulate_lane(alloc, f, mi, dst, cursor, ?acc[0], nl, lw, p, lo);
+            if (sel ra.err) { ret ra; }
             if (want_hi) {
-                val rb: R.Result[R.Void, str] = emit_accumulate_lane(alloc, f, mi, dst, cursor, ?acc[0], nl, lw, p + 1, hi);
-                if (R.is_err[R.Void, str](rb)) { ret rb; }
+                val rb: err[fail.Fail] = emit_accumulate_lane(alloc, f, mi, dst, cursor, ?acc[0], nl, lw, p + 1, hi);
+                if (sel rb.err) { ret rb; }
             }
             j = j + 1;
         }
@@ -1296,17 +1298,17 @@ fun expand_mul(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *m
         var ops: [2]mir.MirOperand;
         ops[0] = dst_ops[i];
         ops[1] = acc[i];
-        val rm: R.Result[R.Void, str] = emit_piece(alloc, dst, cursor, mi, mir.MIR_MOV, ?ops[0], 2, lw);
-        if (R.is_err[R.Void, str](rm)) { ret rm; }
+        val rm: err[fail.Fail] = emit_piece(alloc, dst, cursor, mi, mir.MIR_MOV, ?ops[0], 2, lw);
+        if (sel rm.err) { ret rm; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun emit_double_and_add(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, src: *mir.MirInstr,
                         dst: *mir.MirInstr, cursor: *u32,
                         a_in: *mir.MirOperand, b_in: *mir.MirOperand, out: *mir.MirOperand,
-                        nl: u32, stages: u32) R.Result[R.Void, str] {
+                        nl: u32, stages: u32) err[fail.Fail] {
     val mi: *mir.MirInstr = src;
     val lw: u8 = plan.lane_width;
 
@@ -1323,28 +1325,28 @@ fun emit_double_and_add(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunctio
 
     var j: u32 = 0;
     for (j < stages) {
-        val rb: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rb)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rb)); }
-        val bit: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rb));
-        val r1: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, bit, mplier[0], mir.op_imm(1), lw);
-        if (R.is_err[R.Void, str](r1)) { ret r1; }
+        val rb: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rb.err) { ret err[fail.Fail].err{rb.err}; }
+        val bit: mir.MirOperand = mir.op_vreg(rb.ok);
+        val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, bit, mplier[0], mir.op_imm(1), lw);
+        if (sel r1.err) { ret r1; }
 
-        val rm: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rm)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rm)); }
-        val mask: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rm));
-        val r2: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SUB, mask, mir.op_imm(0), bit, lw);
-        if (R.is_err[R.Void, str](r2)) { ret r2; }
+        val rm: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rm.err) { ret err[fail.Fail].err{rm.err}; }
+        val mask: mir.MirOperand = mir.op_vreg(rm.ok);
+        val r2: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SUB, mask, mir.op_imm(0), bit, lw);
+        if (sel r2.err) { ret r2; }
 
         var cand: [MAX_SHIFT_LANES]mir.MirOperand;
         i = 0;
         for (i < nl) {
-            val rc2: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](rc2)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rc2)); }
-            cand[i] = mir.op_vreg(R.unwrap_ok[u32, str](rc2));
+            val rc2: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel rc2.err) { ret err[fail.Fail].err{rc2.err}; }
+            cand[i] = mir.op_vreg(rc2.ok);
             i = i + 1;
         }
-        val r3: R.Result[R.Void, str] = emit_addsub_chain(alloc, f, mi, dst, cursor, ?cand[0], ?result[0], ?mcand[0], nl, lw, false);
-        if (R.is_err[R.Void, str](r3)) { ret r3; }
+        val r3: err[fail.Fail] = emit_addsub_chain(alloc, f, mi, dst, cursor, ?cand[0], ?result[0], ?mcand[0], nl, lw, false);
+        if (sel r3.err) { ret r3; }
 
         val is_last: bool = j == stages - 1;
         var nxt: [MAX_SHIFT_LANES]mir.MirOperand;
@@ -1352,28 +1354,28 @@ fun emit_double_and_add(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunctio
         for (i < nl) {
             if (is_last) { nxt[i] = out[i]; }
             or {
-                val rn: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-                if (R.is_err[u32, str](rn)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rn)); }
-                nxt[i] = mir.op_vreg(R.unwrap_ok[u32, str](rn));
+                val rn: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
+                nxt[i] = mir.op_vreg(rn.ok);
             }
             i = i + 1;
         }
         i = 0;
         for (i < nl) {
-            val rx: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](rx)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rx)); }
-            val x: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rx));
-            val r4: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, x, result[i], cand[i], lw);
-            if (R.is_err[R.Void, str](r4)) { ret r4; }
+            val rx: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel rx.err) { ret err[fail.Fail].err{rx.err}; }
+            val x: mir.MirOperand = mir.op_vreg(rx.ok);
+            val r4: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, x, result[i], cand[i], lw);
+            if (sel r4.err) { ret r4; }
 
-            val ry: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](ry)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](ry)); }
-            val y: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](ry));
-            val r5: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, y, x, mask, lw);
-            if (R.is_err[R.Void, str](r5)) { ret r5; }
+            val ry: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel ry.err) { ret err[fail.Fail].err{ry.err}; }
+            val y: mir.MirOperand = mir.op_vreg(ry.ok);
+            val r5: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, y, x, mask, lw);
+            if (sel r5.err) { ret r5; }
 
-            val r6: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, nxt[i], result[i], y, lw);
-            if (R.is_err[R.Void, str](r6)) { ret r6; }
+            val r6: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, nxt[i], result[i], y, lw);
+            if (sel r6.err) { ret r6; }
             i = i + 1;
         }
         i = 0;
@@ -1383,32 +1385,32 @@ fun emit_double_and_add(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunctio
             var nmc: [MAX_SHIFT_LANES]mir.MirOperand;
             i = 0;
             for (i < nl) {
-                val rmc: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-                if (R.is_err[u32, str](rmc)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rmc)); }
-                nmc[i] = mir.op_vreg(R.unwrap_ok[u32, str](rmc));
+                val rmc: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                if (sel rmc.err) { ret err[fail.Fail].err{rmc.err}; }
+                nmc[i] = mir.op_vreg(rmc.ok);
                 i = i + 1;
             }
-            val r7: R.Result[R.Void, str] = emit_const_shift(alloc, f, mi, dst, cursor, ?mcand[0], ?nmc[0], nl, lw, 0, 1, true, false, mir.op_imm(0));
-            if (R.is_err[R.Void, str](r7)) { ret r7; }
+            val r7: err[fail.Fail] = emit_const_shift(alloc, f, mi, dst, cursor, ?mcand[0], ?nmc[0], nl, lw, 0, 1, true, false, mir.op_imm(0));
+            if (sel r7.err) { ret r7; }
             i = 0;
             for (i < nl) { mcand[i] = nmc[i]; i = i + 1; }
 
             var nmp: [MAX_SHIFT_LANES]mir.MirOperand;
             i = 0;
             for (i < nl) {
-                val rmp: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-                if (R.is_err[u32, str](rmp)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rmp)); }
-                nmp[i] = mir.op_vreg(R.unwrap_ok[u32, str](rmp));
+                val rmp: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                if (sel rmp.err) { ret err[fail.Fail].err{rmp.err}; }
+                nmp[i] = mir.op_vreg(rmp.ok);
                 i = i + 1;
             }
-            val r8: R.Result[R.Void, str] = emit_const_shift(alloc, f, mi, dst, cursor, ?mplier[0], ?nmp[0], nl, lw, 0, 1, false, false, mir.op_imm(0));
-            if (R.is_err[R.Void, str](r8)) { ret r8; }
+            val r8: err[fail.Fail] = emit_const_shift(alloc, f, mi, dst, cursor, ?mplier[0], ?nmp[0], nl, lw, 0, 1, false, false, mir.op_imm(0));
+            if (sel r8.err) { ret r8; }
             i = 0;
             for (i < nl) { mplier[i] = nmp[i]; i = i + 1; }
         }
         j = j + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun div_is_signed(op: mir.MirOpcode) bool {
@@ -1441,54 +1443,54 @@ fun divmod_zero_fixup_pieces(nl: u32, signed: bool) u32 {
     ret total;
 }
 
-fun divmod_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
+fun divmod_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) res[u32, fail.Fail] {
     val nl: u32 = wide_lane_count(plan, mi);
     if (mi.operand_count != 3 || nl > MAX_SHIFT_LANES ||
         mi.operands[0].kind != mir.MIR_OP_VREG || !operand_is_lane_ready(plan, ?mi.operands[0], nl) ||
         !operand_is_lane_ready(plan, ?mi.operands[1], nl) || !operand_is_lane_ready(plan, ?mi.operands[2], nl)) {
-        ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret res[u32, fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     val bits: u32 = nl * plan.lane_width::u32 * 8;
     var total: u32 = bits * divmod_stage_pieces(nl) + divmod_zero_fixup_pieces(nl, div_is_signed(mi.opcode));
     if (div_is_signed(mi.opcode)) {
         total = total + divmod_signed_pieces(nl, div_wants_remainder(mi.opcode));
     }
-    ret R.ok[u32, str](total);
+    ret res[u32, fail.Fail].ok{total};
 }
 
-fun new_lane_temps(alloc: *A.Allocator, f: *mir.MirFunction, out: *mir.MirOperand, n: u32) R.Result[R.Void, str] {
+fun new_lane_temps(alloc: *A.Allocator, f: *mir.MirFunction, out: *mir.MirOperand, n: u32) err[fail.Fail] {
     var i: u32 = 0;
     for (i < n) {
-        val r: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](r)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](r)); }
-        out[i] = mir.op_vreg(R.unwrap_ok[u32, str](r));
+        val r: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel r.err) { ret err[fail.Fail].err{r.err}; }
+        out[i] = mir.op_vreg(r.ok);
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun emit_wide_abs(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
                   dst: *mir.MirInstr, cursor: *u32,
                   v_ops: *mir.MirOperand, out: *mir.MirOperand, sign: *mir.MirOperand,
-                  nl: u32, lw: u8) R.Result[R.Void, str] {
+                  nl: u32, lw: u8) err[fail.Fail] {
     val lb: u32 = lw::u32 * 8;
-    val rs: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](rs)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rs)); }
-    val s: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rs));
-    val r1: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_SHR_S, s,
+    val rs: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+    if (sel rs.err) { ret err[fail.Fail].err{rs.err}; }
+    val s: mir.MirOperand = mir.op_vreg(rs.ok);
+    val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_SHR_S, s,
                                            v_ops[nl - 1], mir.op_imm((lb - 1)::i64), lw);
-    if (R.is_err[R.Void, str](r1)) { ret r1; }
+    if (sel r1.err) { ret r1; }
     @sign = s;
 
     var xr: [MAX_SHIFT_LANES]mir.MirOperand;
     var sb: [MAX_SHIFT_LANES]mir.MirOperand;
     var i: u32 = 0;
     for (i < nl) {
-        val rt: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rt)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rt)); }
-        xr[i] = mir.op_vreg(R.unwrap_ok[u32, str](rt));
-        val rx: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_XOR, xr[i], v_ops[i], s, lw);
-        if (R.is_err[R.Void, str](rx)) { ret rx; }
+        val rt: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
+        xr[i] = mir.op_vreg(rt.ok);
+        val rx: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_XOR, xr[i], v_ops[i], s, lw);
+        if (sel rx.err) { ret rx; }
         sb[i] = s;
         i = i + 1;
     }
@@ -1498,16 +1500,16 @@ fun emit_wide_abs(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
 fun emit_apply_sign(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
                     dst: *mir.MirInstr, cursor: *u32,
                     v_ops: *mir.MirOperand, out: *mir.MirOperand, s: mir.MirOperand,
-                    nl: u32, lw: u8) R.Result[R.Void, str] {
+                    nl: u32, lw: u8) err[fail.Fail] {
     var xr: [MAX_SHIFT_LANES]mir.MirOperand;
     var sb: [MAX_SHIFT_LANES]mir.MirOperand;
     var i: u32 = 0;
     for (i < nl) {
-        val rt: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rt)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rt)); }
-        xr[i] = mir.op_vreg(R.unwrap_ok[u32, str](rt));
-        val rx: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_XOR, xr[i], v_ops[i], s, lw);
-        if (R.is_err[R.Void, str](rx)) { ret rx; }
+        val rt: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
+        xr[i] = mir.op_vreg(rt.ok);
+        val rx: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_XOR, xr[i], v_ops[i], s, lw);
+        if (sel rx.err) { ret rx; }
         sb[i] = s;
         i = i + 1;
     }
@@ -1515,9 +1517,9 @@ fun emit_apply_sign(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr
 }
 
 fun expand_divmod(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
-                  dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
-    val rc: R.Result[u32, str] = divmod_piece_count(alloc, plan, mi);
-    if (R.is_err[u32, str](rc)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rc)); }
+                  dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
+    val rc: res[u32, fail.Fail] = divmod_piece_count(alloc, plan, mi);
+    if (sel rc.err) { ret err[fail.Fail].err{rc.err}; }
 
     val nl: u32 = wide_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
@@ -1545,16 +1547,16 @@ fun expand_divmod(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi:
     var sb: mir.MirOperand = mir.op_imm(0);
     if (signed) {
         var an: [MAX_SHIFT_LANES]mir.MirOperand;
-        val ra: R.Result[R.Void, str] = new_lane_temps(alloc, f, ?an[0], nl);
-        if (R.is_err[R.Void, str](ra)) { ret ra; }
-        val r1: R.Result[R.Void, str] = emit_wide_abs(alloc, f, mi, dst, cursor, ?num[0], ?an[0], ?sa, nl, lw);
-        if (R.is_err[R.Void, str](r1)) { ret r1; }
+        val ra: err[fail.Fail] = new_lane_temps(alloc, f, ?an[0], nl);
+        if (sel ra.err) { ret ra; }
+        val r1: err[fail.Fail] = emit_wide_abs(alloc, f, mi, dst, cursor, ?num[0], ?an[0], ?sa, nl, lw);
+        if (sel r1.err) { ret r1; }
 
         var bn: [MAX_SHIFT_LANES]mir.MirOperand;
-        val rb2: R.Result[R.Void, str] = new_lane_temps(alloc, f, ?bn[0], nl);
-        if (R.is_err[R.Void, str](rb2)) { ret rb2; }
-        val r2: R.Result[R.Void, str] = emit_wide_abs(alloc, f, mi, dst, cursor, ?den[0], ?bn[0], ?sb, nl, lw);
-        if (R.is_err[R.Void, str](r2)) { ret r2; }
+        val rb2: err[fail.Fail] = new_lane_temps(alloc, f, ?bn[0], nl);
+        if (sel rb2.err) { ret rb2; }
+        val r2: err[fail.Fail] = emit_wide_abs(alloc, f, mi, dst, cursor, ?den[0], ?bn[0], ?sb, nl, lw);
+        if (sel r2.err) { ret r2; }
 
         i = 0;
         for (i < nl) { num[i] = an[i]; den[i] = bn[i]; i = i + 1; }
@@ -1562,90 +1564,90 @@ fun expand_divmod(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi:
 
     var j: u32 = 0;
     for (j < bits) {
-        val rh: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rh)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rh)); }
-        val hs: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rh));
-        val e1: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SHR_U, hs,
+        val rh: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rh.err) { ret err[fail.Fail].err{rh.err}; }
+        val hs: mir.MirOperand = mir.op_vreg(rh.ok);
+        val e1: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SHR_U, hs,
                                                num[nl - 1], mir.op_imm((lb - 1)::i64), lw);
-        if (R.is_err[R.Void, str](e1)) { ret e1; }
-        val rh2: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rh2)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rh2)); }
-        val hb: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rh2));
-        val e2: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, hb, hs, mir.op_imm(1), lw);
-        if (R.is_err[R.Void, str](e2)) { ret e2; }
+        if (sel e1.err) { ret e1; }
+        val rh2: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rh2.err) { ret err[fail.Fail].err{rh2.err}; }
+        val hb: mir.MirOperand = mir.op_vreg(rh2.ok);
+        val e2: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, hb, hs, mir.op_imm(1), lw);
+        if (sel e2.err) { ret e2; }
 
         var rsh: [MAX_SHIFT_LANES]mir.MirOperand;
-        val rt1: R.Result[R.Void, str] = new_lane_temps(alloc, f, ?rsh[0], nl);
-        if (R.is_err[R.Void, str](rt1)) { ret rt1; }
-        val e3: R.Result[R.Void, str] = emit_const_shift(alloc, f, mi, dst, cursor, ?rem[0], ?rsh[0],
+        val rt1: err[fail.Fail] = new_lane_temps(alloc, f, ?rsh[0], nl);
+        if (sel rt1.err) { ret rt1; }
+        val e3: err[fail.Fail] = emit_const_shift(alloc, f, mi, dst, cursor, ?rem[0], ?rsh[0],
                                                        nl, lw, 0, 1, true, false, mir.op_imm(0));
-        if (R.is_err[R.Void, str](e3)) { ret e3; }
-        val rl0: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rl0)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rl0)); }
-        val rlo: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rl0));
-        val e4: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_OR, rlo, rsh[0], hb, lw);
-        if (R.is_err[R.Void, str](e4)) { ret e4; }
+        if (sel e3.err) { ret e3; }
+        val rl0: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rl0.err) { ret err[fail.Fail].err{rl0.err}; }
+        val rlo: mir.MirOperand = mir.op_vreg(rl0.ok);
+        val e4: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_OR, rlo, rsh[0], hb, lw);
+        if (sel e4.err) { ret e4; }
         rsh[0] = rlo;
 
         var nsh: [MAX_SHIFT_LANES]mir.MirOperand;
-        val rt2: R.Result[R.Void, str] = new_lane_temps(alloc, f, ?nsh[0], nl);
-        if (R.is_err[R.Void, str](rt2)) { ret rt2; }
-        val e5: R.Result[R.Void, str] = emit_const_shift(alloc, f, mi, dst, cursor, ?num[0], ?nsh[0],
+        val rt2: err[fail.Fail] = new_lane_temps(alloc, f, ?nsh[0], nl);
+        if (sel rt2.err) { ret rt2; }
+        val e5: err[fail.Fail] = emit_const_shift(alloc, f, mi, dst, cursor, ?num[0], ?nsh[0],
                                                        nl, lw, 0, 1, true, false, mir.op_imm(0));
-        if (R.is_err[R.Void, str](e5)) { ret e5; }
+        if (sel e5.err) { ret e5; }
 
-        val rlt: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rlt)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rlt)); }
-        val lt: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rlt));
-        val e6: R.Result[R.Void, str] = emit_wide_rel(alloc, f, mi, dst, cursor, lt, ?rsh[0], ?den[0],
+        val rlt: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rlt.err) { ret err[fail.Fail].err{rlt.err}; }
+        val lt: mir.MirOperand = mir.op_vreg(rlt.ok);
+        val e6: err[fail.Fail] = emit_wide_rel(alloc, f, mi, dst, cursor, lt, ?rsh[0], ?den[0],
                                                     nl, lw, false, false);
-        if (R.is_err[R.Void, str](e6)) { ret e6; }
-        val rge: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rge)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rge)); }
-        val ge: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rge));
-        val e7: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, ge, lt, mir.op_imm(1), lw);
-        if (R.is_err[R.Void, str](e7)) { ret e7; }
+        if (sel e6.err) { ret e6; }
+        val rge: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rge.err) { ret err[fail.Fail].err{rge.err}; }
+        val ge: mir.MirOperand = mir.op_vreg(rge.ok);
+        val e7: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, ge, lt, mir.op_imm(1), lw);
+        if (sel e7.err) { ret e7; }
 
-        val rq: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rq)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rq)); }
-        val qlo: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rq));
-        val e8: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_OR, qlo, nsh[0], ge, lw);
-        if (R.is_err[R.Void, str](e8)) { ret e8; }
+        val rq: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rq.err) { ret err[fail.Fail].err{rq.err}; }
+        val qlo: mir.MirOperand = mir.op_vreg(rq.ok);
+        val e8: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_OR, qlo, nsh[0], ge, lw);
+        if (sel e8.err) { ret e8; }
         nsh[0] = qlo;
 
-        val rm: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rm)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rm)); }
-        val mask: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rm));
-        val e9: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SUB, mask, mir.op_imm(0), ge, lw);
-        if (R.is_err[R.Void, str](e9)) { ret e9; }
+        val rm: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rm.err) { ret err[fail.Fail].err{rm.err}; }
+        val mask: mir.MirOperand = mir.op_vreg(rm.ok);
+        val e9: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SUB, mask, mir.op_imm(0), ge, lw);
+        if (sel e9.err) { ret e9; }
 
         var md: [MAX_SHIFT_LANES]mir.MirOperand;
         i = 0;
         for (i < nl) {
-            val rd: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](rd)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rd)); }
-            md[i] = mir.op_vreg(R.unwrap_ok[u32, str](rd));
-            val rx: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, md[i], den[i], mask, lw);
-            if (R.is_err[R.Void, str](rx)) { ret rx; }
+            val rd: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
+            md[i] = mir.op_vreg(rd.ok);
+            val rx: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, md[i], den[i], mask, lw);
+            if (sel rx.err) { ret rx; }
             i = i + 1;
         }
 
         var nrem: [MAX_SHIFT_LANES]mir.MirOperand;
-        val rt3: R.Result[R.Void, str] = new_lane_temps(alloc, f, ?nrem[0], nl);
-        if (R.is_err[R.Void, str](rt3)) { ret rt3; }
-        val e10: R.Result[R.Void, str] = emit_addsub_chain(alloc, f, mi, dst, cursor, ?nrem[0], ?rsh[0], ?md[0], nl, lw, true);
-        if (R.is_err[R.Void, str](e10)) { ret e10; }
+        val rt3: err[fail.Fail] = new_lane_temps(alloc, f, ?nrem[0], nl);
+        if (sel rt3.err) { ret rt3; }
+        val e10: err[fail.Fail] = emit_addsub_chain(alloc, f, mi, dst, cursor, ?nrem[0], ?rsh[0], ?md[0], nl, lw, true);
+        if (sel e10.err) { ret e10; }
 
         i = 0;
         for (i < nl) { rem[i] = nrem[i]; num[i] = nsh[i]; i = i + 1; }
         j = j + 1;
     }
 
-    var res: [MAX_SHIFT_LANES]mir.MirOperand;
+    var lanes: [MAX_SHIFT_LANES]mir.MirOperand;
     i = 0;
     for (i < nl) {
-        res[i] = num[i];
-        if (want_rem) { res[i] = rem[i]; }
+        lanes[i] = num[i];
+        if (want_rem) { lanes[i] = rem[i]; }
         i = i + 1;
     }
 
@@ -1656,22 +1658,22 @@ fun expand_divmod(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi:
     if (signed) {
         var s: mir.MirOperand = sa;
         if (!want_rem) {
-            val rq2: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](rq2)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rq2)); }
-            s = mir.op_vreg(R.unwrap_ok[u32, str](rq2));
-            val rs2: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, s, sa, sb, lw);
-            if (R.is_err[R.Void, str](rs2)) { ret rs2; }
+            val rq2: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel rq2.err) { ret err[fail.Fail].err{rq2.err}; }
+            s = mir.op_vreg(rq2.ok);
+            val rs2: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, s, sa, sb, lw);
+            if (sel rs2.err) { ret rs2; }
         }
         var sres: [MAX_SHIFT_LANES]mir.MirOperand;
-        val rst: R.Result[R.Void, str] = new_lane_temps(alloc, f, ?sres[0], nl);
-        if (R.is_err[R.Void, str](rst)) { ret rst; }
-        val rap: R.Result[R.Void, str] = emit_apply_sign(alloc, f, mi, dst, cursor, ?res[0], ?sres[0], s, nl, lw);
-        if (R.is_err[R.Void, str](rap)) { ret rap; }
+        val rst: err[fail.Fail] = new_lane_temps(alloc, f, ?sres[0], nl);
+        if (sel rst.err) { ret rst; }
+        val rap: err[fail.Fail] = emit_apply_sign(alloc, f, mi, dst, cursor, ?lanes[0], ?sres[0], s, nl, lw);
+        if (sel rap.err) { ret rap; }
         i = 0;
-        for (i < nl) { res[i] = sres[i]; i = i + 1; }
+        for (i < nl) { lanes[i] = sres[i]; i = i + 1; }
     }
 
-    ret emit_divmod_zero_fixup(alloc, f, mi, dst, cursor, ?res[0], ?od[0], ?on[0], ?d_ops[0],
+    ret emit_divmod_zero_fixup(alloc, f, mi, dst, cursor, ?lanes[0], ?od[0], ?on[0], ?d_ops[0],
                                nl, lw, want_rem);
 }
 
@@ -1682,83 +1684,83 @@ fun lane_mask(lw: u8) i64 {
 
 fun emit_divmod_zero_fixup(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
                            dst: *mir.MirInstr, cursor: *u32,
-                           res: *mir.MirOperand, den: *mir.MirOperand, num: *mir.MirOperand,
-                           d_ops: *mir.MirOperand, nl: u32, lw: u8, rem: bool) R.Result[R.Void, str] {
+                           result: *mir.MirOperand, den: *mir.MirOperand, num: *mir.MirOperand,
+                           d_ops: *mir.MirOperand, nl: u32, lw: u8, rem: bool) err[fail.Fail] {
     var acc: mir.MirOperand = den[0];
     var i: u32 = 1;
     for (i < nl) {
-        val ra: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](ra)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](ra)); }
-        val nx: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](ra));
-        val r1: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_OR, nx, acc, den[i], lw);
-        if (R.is_err[R.Void, str](r1)) { ret r1; }
+        val ra: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel ra.err) { ret err[fail.Fail].err{ra.err}; }
+        val nx: mir.MirOperand = mir.op_vreg(ra.ok);
+        val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_OR, nx, acc, den[i], lw);
+        if (sel r1.err) { ret r1; }
         acc = nx;
         i = i + 1;
     }
 
     var divisor: mir.MirOperand = acc;
     if (mir.has(src.opcode, mir.MIRF_DIV_SIGNED)) {
-        val rz: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rz)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rz)); }
-        val z: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rz));
-        val r2: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_EQ, z, acc, mir.op_imm(0), lw);
-        if (R.is_err[R.Void, str](r2)) { ret r2; }
-        val rn: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rn)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rn)); }
-        val nonzero: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rn));
-        val r3: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_SUB, nonzero, mir.op_imm(1), z, lw);
-        if (R.is_err[R.Void, str](r3)) { ret r3; }
+        val rz: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rz.err) { ret err[fail.Fail].err{rz.err}; }
+        val z: mir.MirOperand = mir.op_vreg(rz.ok);
+        val r2: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_EQ, z, acc, mir.op_imm(0), lw);
+        if (sel r2.err) { ret r2; }
+        val rn: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
+        val nonzero: mir.MirOperand = mir.op_vreg(rn.ok);
+        val r3: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_SUB, nonzero, mir.op_imm(1), z, lw);
+        if (sel r3.err) { ret r3; }
 
         val lane_bits: u32 = lw::u32 * 8;
         val lane_min: i64 = (1::i64 << (lane_bits - 1)::u64) & lane_mask(lw);
         var ov: mir.MirOperand = mir.op_imm(1);
         i = 0;
         for (i < nl) {
-            val rd1: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](rd1)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rd1)); }
-            val dm: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rd1));
-            val e1: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_EQ, dm, den[i], mir.op_imm(lane_mask(lw)), lw);
-            if (R.is_err[R.Void, str](e1)) { ret e1; }
+            val rd1: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel rd1.err) { ret err[fail.Fail].err{rd1.err}; }
+            val dm: mir.MirOperand = mir.op_vreg(rd1.ok);
+            val e1: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_EQ, dm, den[i], mir.op_imm(lane_mask(lw)), lw);
+            if (sel e1.err) { ret e1; }
             var want: i64 = 0;
             if (i == nl - 1) { want = lane_min; }
-            val rn1: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](rn1)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rn1)); }
-            val nm: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rn1));
-            val e2: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_EQ, nm, num[i], mir.op_imm(want), lw);
-            if (R.is_err[R.Void, str](e2)) { ret e2; }
-            val ra1: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](ra1)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](ra1)); }
-            val both: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](ra1));
-            val e3: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_AND, both, dm, nm, lw);
-            if (R.is_err[R.Void, str](e3)) { ret e3; }
-            val ra2: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](ra2)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](ra2)); }
-            val next: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](ra2));
-            val e4: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_AND, next, ov, both, lw);
-            if (R.is_err[R.Void, str](e4)) { ret e4; }
+            val rn1: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel rn1.err) { ret err[fail.Fail].err{rn1.err}; }
+            val nm: mir.MirOperand = mir.op_vreg(rn1.ok);
+            val e2: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_EQ, nm, num[i], mir.op_imm(want), lw);
+            if (sel e2.err) { ret e2; }
+            val ra1: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel ra1.err) { ret err[fail.Fail].err{ra1.err}; }
+            val both: mir.MirOperand = mir.op_vreg(ra1.ok);
+            val e3: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_AND, both, dm, nm, lw);
+            if (sel e3.err) { ret e3; }
+            val ra2: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel ra2.err) { ret err[fail.Fail].err{ra2.err}; }
+            val next: mir.MirOperand = mir.op_vreg(ra2.ok);
+            val e4: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_AND, next, ov, both, lw);
+            if (sel e4.err) { ret e4; }
             ov = next;
             i = i + 1;
         }
-        val rd2: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rd2)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rd2)); }
-        divisor = mir.op_vreg(R.unwrap_ok[u32, str](rd2));
-        val r4: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_SUB, divisor, nonzero, ov, lw);
-        if (R.is_err[R.Void, str](r4)) { ret r4; }
+        val rd2: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rd2.err) { ret err[fail.Fail].err{rd2.err}; }
+        divisor = mir.op_vreg(rd2.ok);
+        val r4: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_SUB, divisor, nonzero, ov, lw);
+        if (sel r4.err) { ret r4; }
     }
 
-    val rp: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](rp)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rp)); }
-    val probe: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rp));
-    val r5: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_DIV_U, probe, mir.op_imm(1), divisor, lw);
-    if (R.is_err[R.Void, str](r5)) { ret r5; }
+    val rp: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+    if (sel rp.err) { ret err[fail.Fail].err{rp.err}; }
+    val probe: mir.MirOperand = mir.op_vreg(rp.ok);
+    val r5: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_DIV_U, probe, mir.op_imm(1), divisor, lw);
+    if (sel r5.err) { ret r5; }
 
     i = 0;
     for (i < nl) {
-        val e5: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_OR, d_ops[i], res[i], mir.op_imm(0), lw);
-        if (R.is_err[R.Void, str](e5)) { ret e5; }
+        val e5: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_OR, d_ops[i], result[i], mir.op_imm(0), lw);
+        if (sel e5.err) { ret e5; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun cmp_is_equality(op: mir.MirOpcode) bool {
@@ -1791,24 +1793,24 @@ fun cmp_rel_pieces(signed: bool, le: bool) u32 {
 fun emit_lane_rel(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
                   dst: *mir.MirInstr, cursor: *u32,
                   d: mir.MirOperand, a: mir.MirOperand, b: mir.MirOperand, lw: u8,
-                  signed: bool, le: bool) R.Result[R.Void, str] {
+                  signed: bool, le: bool) err[fail.Fail] {
     var x: mir.MirOperand = a;
     var y: mir.MirOperand = b;
     if (le) { x = b; y = a; }
 
     if (signed) {
         val bias: mir.MirOperand = mir.op_imm(1::i64 << (lw::i64 * 8 - 1));
-        val rx: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rx)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rx)); }
-        val bx: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rx));
-        val r1: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_XOR, bx, x, bias, lw);
-        if (R.is_err[R.Void, str](r1)) { ret r1; }
+        val rx: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rx.err) { ret err[fail.Fail].err{rx.err}; }
+        val bx: mir.MirOperand = mir.op_vreg(rx.ok);
+        val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_XOR, bx, x, bias, lw);
+        if (sel r1.err) { ret r1; }
 
-        val ry: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](ry)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](ry)); }
-        val by: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](ry));
-        val r2: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_XOR, by, y, bias, lw);
-        if (R.is_err[R.Void, str](r2)) { ret r2; }
+        val ry: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel ry.err) { ret err[fail.Fail].err{ry.err}; }
+        val by: mir.MirOperand = mir.op_vreg(ry.ok);
+        val r2: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_XOR, by, y, bias, lw);
+        if (sel r2.err) { ret r2; }
 
         x = bx;
         y = by;
@@ -1816,27 +1818,27 @@ fun emit_lane_rel(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
 
     if (!le) { ret emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_LT_U, d, x, y, lw); }
 
-    val rt: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](rt)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rt)); }
-    val t: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rt));
-    val r3: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_LT_U, t, x, y, lw);
-    if (R.is_err[R.Void, str](r3)) { ret r3; }
+    val rt: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+    if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
+    val t: mir.MirOperand = mir.op_vreg(rt.ok);
+    val r3: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_LT_U, t, x, y, lw);
+    if (sel r3.err) { ret r3; }
     ret emit_bin(alloc, dst, cursor, src, mir.MIR_XOR, d, t, mir.op_imm(1), lw);
 }
 
-fun cmp_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) R.Result[u32, str] {
+fun cmp_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) res[u32, fail.Fail] {
     val nl: u32 = wide_lane_count(plan, mi);
     if (mi.operand_count != 3 || nl > MAX_SHIFT_LANES ||
         !cmp_dest_is_native(plan, ?mi.operands[0]) ||
         !operand_is_lane_ready(plan, ?mi.operands[1], nl) ||
         !operand_is_lane_ready(plan, ?mi.operands[2], nl)) {
-        ret R.err[u32, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret res[u32, fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
 
     val op: mir.MirOpcode = mi.opcode;
-    if (cmp_is_equality(op)) { ret R.ok[u32, str](2 * nl - 1); }
+    if (cmp_is_equality(op)) { ret res[u32, fail.Fail].ok{2 * nl - 1}; }
 
-    ret R.ok[u32, str](wide_rel_pieces(nl, cmp_is_signed(op), cmp_is_le(op)));
+    ret res[u32, fail.Fail].ok{wide_rel_pieces(nl, cmp_is_signed(op), cmp_is_le(op))};
 }
 
 fun wide_rel_pieces(nl: u32, signed: bool, le: bool) u32 {
@@ -1850,16 +1852,16 @@ fun wide_rel_pieces(nl: u32, signed: bool, le: bool) u32 {
 }
 
 fun expand_cmp(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
-               dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
-    val rc: R.Result[u32, str] = cmp_piece_count(alloc, plan, mi);
-    if (R.is_err[u32, str](rc)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rc)); }
+               dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
+    val rc: res[u32, fail.Fail] = cmp_piece_count(alloc, plan, mi);
+    if (sel rc.err) { ret err[fail.Fail].err{rc.err}; }
 
     if (cmp_is_equality(mi.opcode)) { ret expand_cmp_equality(alloc, plan, f, mi, dst, cursor); }
     ret expand_cmp_ordered(alloc, plan, f, mi, dst, cursor);
 }
 
 fun expand_cmp_equality(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
-                        dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
+                        dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
     val nl: u32 = wide_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
     val d:  mir.MirOperand = mi.operands[0];
@@ -1873,34 +1875,34 @@ fun expand_cmp_equality(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunctio
     for (i < nl) {
         var out: mir.MirOperand = d;
         if (nl > 1) {
-            val rt: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](rt)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rt)); }
-            out = mir.op_vreg(R.unwrap_ok[u32, str](rt));
+            val rt: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
+            out = mir.op_vreg(rt.ok);
         }
-        val rl: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, lane_op, out,
+        val rl: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, lane_op, out,
                                                lane_operand(plan, ?mi.operands[1], i),
                                                lane_operand(plan, ?mi.operands[2], i), lw);
-        if (R.is_err[R.Void, str](rl)) { ret rl; }
+        if (sel rl.err) { ret rl; }
 
         if (i == 0) { acc = out; }
         or {
             var jd: mir.MirOperand = d;
             if (i < nl - 1) {
-                val rj: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-                if (R.is_err[u32, str](rj)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rj)); }
-                jd = mir.op_vreg(R.unwrap_ok[u32, str](rj));
+                val rj: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                if (sel rj.err) { ret err[fail.Fail].err{rj.err}; }
+                jd = mir.op_vreg(rj.ok);
             }
-            val rr: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, join, jd, acc, out, lw);
-            if (R.is_err[R.Void, str](rr)) { ret rr; }
+            val rr: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, join, jd, acc, out, lw);
+            if (sel rr.err) { ret rr; }
             acc = jd;
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun expand_cmp_ordered(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
-                       dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
+                       dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
     val nl: u32 = wide_lane_count(plan, mi);
     var a_ops: [MAX_SHIFT_LANES]mir.MirOperand;
     var b_ops: [MAX_SHIFT_LANES]mir.MirOperand;
@@ -1917,56 +1919,56 @@ fun expand_cmp_ordered(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction
 fun emit_wide_rel(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
                   dst: *mir.MirInstr, cursor: *u32, d: mir.MirOperand,
                   a_ops: *mir.MirOperand, b_ops: *mir.MirOperand,
-                  nl: u32, lw: u8, signed: bool, le: bool) R.Result[R.Void, str] {
+                  nl: u32, lw: u8, signed: bool, le: bool) err[fail.Fail] {
     val mi: *mir.MirInstr = src;
 
-    var res: mir.MirOperand = d;
+    var result: mir.MirOperand = d;
     if (nl > 1) {
-        val r0: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](r0)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](r0)); }
-        res = mir.op_vreg(R.unwrap_ok[u32, str](r0));
+        val r0: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel r0.err) { ret err[fail.Fail].err{r0.err}; }
+        result = mir.op_vreg(r0.ok);
     }
-    val rb: R.Result[R.Void, str] = emit_lane_rel(alloc, f, mi, dst, cursor, res,
+    val rb: err[fail.Fail] = emit_lane_rel(alloc, f, mi, dst, cursor, result,
                                                 a_ops[0], b_ops[0], lw,
                                                 signed && nl == 1, le);
-    if (R.is_err[R.Void, str](rb)) { ret rb; }
+    if (sel rb.err) { ret rb; }
 
     var i: u32 = 1;
     for (i < nl) {
         val a: mir.MirOperand = a_ops[i];
         val b: mir.MirOperand = b_ops[i];
 
-        val rl: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rl)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rl)); }
-        val lt: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rl));
-        val r1: R.Result[R.Void, str] = emit_lane_rel(alloc, f, mi, dst, cursor, lt, a, b, lw,
+        val rl: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rl.err) { ret err[fail.Fail].err{rl.err}; }
+        val lt: mir.MirOperand = mir.op_vreg(rl.ok);
+        val r1: err[fail.Fail] = emit_lane_rel(alloc, f, mi, dst, cursor, lt, a, b, lw,
                                                     signed && i == nl - 1, false);
-        if (R.is_err[R.Void, str](r1)) { ret r1; }
+        if (sel r1.err) { ret r1; }
 
-        val re: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](re)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](re)); }
-        val eq: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](re));
-        val r2: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_CMP_EQ, eq, a, b, lw);
-        if (R.is_err[R.Void, str](r2)) { ret r2; }
+        val re: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel re.err) { ret err[fail.Fail].err{re.err}; }
+        val eq: mir.MirOperand = mir.op_vreg(re.ok);
+        val r2: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_CMP_EQ, eq, a, b, lw);
+        if (sel r2.err) { ret r2; }
 
-        val rg: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rg)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rg)); }
-        val g: mir.MirOperand = mir.op_vreg(R.unwrap_ok[u32, str](rg));
-        val r3: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, g, eq, res, lw);
-        if (R.is_err[R.Void, str](r3)) { ret r3; }
+        val rg: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        if (sel rg.err) { ret err[fail.Fail].err{rg.err}; }
+        val g: mir.MirOperand = mir.op_vreg(rg.ok);
+        val r3: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, g, eq, result, lw);
+        if (sel r3.err) { ret r3; }
 
         var out: mir.MirOperand = d;
         if (i < nl - 1) {
-            val ro: R.Result[u32, str] = new_vreg(alloc, f, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](ro)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](ro)); }
-            out = mir.op_vreg(R.unwrap_ok[u32, str](ro));
+            val ro: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            if (sel ro.err) { ret err[fail.Fail].err{ro.err}; }
+            out = mir.op_vreg(ro.ok);
         }
-        val r4: R.Result[R.Void, str] = emit_bin(alloc, dst, cursor, mi, mir.MIR_OR, out, lt, g, lw);
-        if (R.is_err[R.Void, str](r4)) { ret r4; }
-        res = out;
+        val r4: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_OR, out, lt, g, lw);
+        if (sel r4.err) { ret r4; }
+        result = out;
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun dst_lane_count(plan: *LanePlan, mi: *mir.MirInstr) u32 {
@@ -1982,10 +1984,10 @@ fun src_lane_count(plan: *LanePlan, mi: *mir.MirInstr) u32 {
 }
 
 fun expand_zext(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
-                dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
+                dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
     if (mi.operand_count != 2 ||
         mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg] == LANE_NONE) {
-        ret R.err[R.Void, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     val dl: u32 = dst_lane_count(plan, mi);
     val sl: u32 = src_lane_count(plan, mi);
@@ -1996,18 +1998,18 @@ fun expand_zext(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
         ops[0] = lane_operand(plan, ?mi.operands[0], i);
         if (i < sl) { ops[1] = lane_operand(plan, ?mi.operands[1], i); }
         or          { ops[1] = mir.op_imm(0); }
-        val r: R.Result[R.Void, str] = emit_piece(alloc, dst, cursor, mi, mir.MIR_MOV, ?ops[0], 2, lw);
-        if (R.is_err[R.Void, str](r)) { ret r; }
+        val r: err[fail.Fail] = emit_piece(alloc, dst, cursor, mi, mir.MIR_MOV, ?ops[0], 2, lw);
+        if (sel r.err) { ret r; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun expand_sext(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
-                dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
+                dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
     if (mi.operand_count != 2 ||
         mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg] == LANE_NONE) {
-        ret R.err[R.Void, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     val dl: u32 = dst_lane_count(plan, mi);
     val sl: u32 = src_lane_count(plan, mi);
@@ -2016,8 +2018,8 @@ fun expand_sext(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *
     var fill: mir.MirOperand = mir.op_imm(0);
     if (dl > sl) {
         val top: mir.MirOperand = lane_operand(plan, ?mi.operands[1], sl - 1);
-        val rf: R.Result[R.Void, str] = emit_sign_fill(alloc, f, mi, dst, cursor, top, lw, ?fill);
-        if (R.is_err[R.Void, str](rf)) { ret rf; }
+        val rf: err[fail.Fail] = emit_sign_fill(alloc, f, mi, dst, cursor, top, lw, ?fill);
+        if (sel rf.err) { ret rf; }
     }
 
     var i: u32 = 0;
@@ -2026,17 +2028,17 @@ fun expand_sext(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *
         ops[0] = lane_operand(plan, ?mi.operands[0], i);
         if (i < sl) { ops[1] = lane_operand(plan, ?mi.operands[1], i); }
         or          { ops[1] = fill; }
-        val r: R.Result[R.Void, str] = emit_piece(alloc, dst, cursor, mi, mir.MIR_MOV, ?ops[0], 2, lw);
-        if (R.is_err[R.Void, str](r)) { ret r; }
+        val r: err[fail.Fail] = emit_piece(alloc, dst, cursor, mi, mir.MIR_MOV, ?ops[0], 2, lw);
+        if (sel r.err) { ret r; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun expand_trunc(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
-                 dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
+                 dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
     if (mi.operand_count != 2) {
-        ret R.err[R.Void, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     val dl: u32 = dst_lane_count(plan, mi);
     val lw: u8  = plan.lane_width;
@@ -2045,11 +2047,11 @@ fun expand_trunc(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
         var ops: [2]mir.MirOperand;
         ops[0] = lane_operand(plan, ?mi.operands[0], i);
         ops[1] = lane_operand(plan, ?mi.operands[1], i);
-        val r: R.Result[R.Void, str] = emit_piece(alloc, dst, cursor, mi, mir.MIR_MOV, ?ops[0], 2, lw);
-        if (R.is_err[R.Void, str](r)) { ret r; }
+        val r: err[fail.Fail] = emit_piece(alloc, dst, cursor, mi, mir.MIR_MOV, ?ops[0], 2, lw);
+        if (sel r.err) { ret r; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 rec ConvEmit {
@@ -2071,9 +2073,9 @@ fun cv_emit(cv: *ConvEmit, opcode: mir.MirOpcode, ops: *mir.MirOperand, nops: u3
     if (cv.dst == nil || cv.fail) { ret; }
     var arr: *mir.MirOperand = nil;
     if (nops > 0) {
-        val res_a: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](cv.alloc, nops::usize);
-        if (R.is_err[*mir.MirOperand, str](res_a)) { cv.fail = true; ret; }
-        arr = R.unwrap_ok[*mir.MirOperand, str](res_a);
+        val res_a: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](cv.alloc, nops::usize);
+        if (sel res_a.err) { cv.fail = true; ret; }
+        arr = res_a.ok;
         var j: u32 = 0;
         for (j < nops) { arr[j] = ops[j]; j = j + 1; }
     }
@@ -2099,9 +2101,9 @@ fun cv2(cv: *ConvEmit, opcode: mir.MirOpcode, d: mir.MirOperand, a: mir.MirOpera
 
 fun cv_tmp(cv: *ConvEmit, cls: u32) mir.MirOperand {
     if (cv.dst == nil || cv.fail) { ret mir.op_vreg(mir.MIR_VREG_NIL); }
-    val r: R.Result[u32, str] = new_vreg(cv.alloc, cv.f, cls);
-    if (R.is_err[u32, str](r)) { cv.fail = true; ret mir.op_vreg(mir.MIR_VREG_NIL); }
-    ret mir.op_vreg(R.unwrap_ok[u32, str](r));
+    val r: res[u32, fail.Fail] = new_vreg(cv.alloc, cv.f, cls);
+    if (sel r.err) { cv.fail = true; ret mir.op_vreg(mir.MIR_VREG_NIL); }
+    ret mir.op_vreg(r.ok);
 }
 
 fun cv_gp(cv: *ConvEmit) mir.MirOperand { ret cv_tmp(cv, mir.REG_CLASS_GP); }
@@ -2371,19 +2373,19 @@ fun conv_is_wide(mach: *Machine, mi: *mir.MirInstr) bool {
 }
 
 fun conv_prepare(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
-                 dst: *mir.MirInstr, cursor: *u32, out: *ConvEmit) R.Result[R.Void, str] {
+                 dst: *mir.MirInstr, cursor: *u32, out: *ConvEmit) err[fail.Fail] {
     if (plan.lane_width != 4 || conv_int_width(mi) != 8) {
-        ret R.err[R.Void, str](unsupported_message(alloc, mi.opcode, mi.width));
+        ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     val ii: u32 = 1 - (conv_float_operand(mi.opcode)::u32);
     if (mi.opcode == mir.MIR_FP_TO_SI || mi.opcode == mir.MIR_FP_TO_UI) {
         val d: *mir.MirOperand = ?mi.operands[0];
         if (d.kind != mir.MIR_OP_VREG || plan.lane_base[d.vreg] == LANE_NONE) {
-            ret R.err[R.Void, str](unsupported_message(alloc, mi.opcode, mi.width));
+            ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
         }
     } or {
         if (!operand_is_lane_ready(plan, ?mi.operands[ii], 2)) {
-            ret R.err[R.Void, str](unsupported_message(alloc, mi.opcode, mi.width));
+            ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
         }
     }
     out.alloc  = alloc;
@@ -2393,33 +2395,33 @@ fun conv_prepare(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: 
     out.cursor = cursor;
     out.fp_cls = plan.mach.fp_class;
     out.fail   = false;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun conv_run(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
-             dst: *mir.MirInstr, cursor: *u32) R.Result[R.Void, str] {
+             dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
     var cv: ConvEmit;
-    val pr: R.Result[R.Void, str] = conv_prepare(alloc, plan, f, mi, dst, cursor, ?cv);
-    if (R.is_err[R.Void, str](pr)) { ret pr; }
+    val pr: err[fail.Fail] = conv_prepare(alloc, plan, f, mi, dst, cursor, ?cv);
+    if (sel pr.err) { ret pr; }
     if (mi.opcode == mir.MIR_SI_TO_FP || mi.opcode == mir.MIR_UI_TO_FP) {
         cv_int_to_fp(?cv, plan, mi);
     } or {
         cv_fp_to_int(?cv, plan, mi);
     }
-    if (cv.fail) { ret R.err[R.Void, str]("legalize: out of memory expanding a wide float conversion"); }
-    ret R.ok_void[str]();
+    if (cv.fail) { ret err[fail.Fail].err{fail.message("legalize: out of memory expanding a wide float conversion")}; }
+    ret err[fail.Fail].ok{};
 }
 
 fun conv_piece_count(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction,
-                     mi: *mir.MirInstr) R.Result[u32, str] {
+                     mi: *mir.MirInstr) res[u32, fail.Fail] {
     var n: u32 = 0;
-    val r: R.Result[R.Void, str] = conv_run(alloc, plan, f, mi, nil, ?n);
-    if (R.is_err[R.Void, str](r)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](r)); }
-    ret R.ok[u32, str](n);
+    val r: err[fail.Fail] = conv_run(alloc, plan, f, mi, nil, ?n);
+    if (sel r.err) { ret res[u32, fail.Fail].err{r.err}; }
+    ret res[u32, fail.Fail].ok{n};
 }
 
 fun emit_bin(alloc: *A.Allocator, dst: *mir.MirInstr, cursor: *u32, src: *mir.MirInstr,
-             opcode: mir.MirOpcode, d: mir.MirOperand, a: mir.MirOperand, b: mir.MirOperand, w: u8) R.Result[R.Void, str] {
+             opcode: mir.MirOpcode, d: mir.MirOperand, a: mir.MirOperand, b: mir.MirOperand, w: u8) err[fail.Fail] {
     var ops: [3]mir.MirOperand;
     ops[0] = d;
     ops[1] = a;
@@ -2429,10 +2431,10 @@ fun emit_bin(alloc: *A.Allocator, dst: *mir.MirInstr, cursor: *u32, src: *mir.Mi
 
 fun unsupported_message(alloc: *A.Allocator, op: mir.MirOpcode, width: u8) str {
     val family: str = unsupported_family(op);
-    val rj: R.Result[str, str] =
+    val rj: res[str, format.FormatError] =
         format.sprint(alloc, "{} ({}, {} bytes wide)", family, mir.opcode_name(op), width);
-    if (R.is_err[str, str](rj)) { ret family; }
-    ret R.unwrap_ok[str, str](rj);
+    if (sel rj.err) { ret family; }
+    ret rj.ok;
 }
 
 fun unsupported_family(op: mir.MirOpcode) str {
@@ -2470,8 +2472,9 @@ fun t_mach(maw: u8, ptr: u8) Machine {
 }
 
 fun t_vregs(alloc: *A.Allocator, f: *mir.MirFunction, n: u32) {
-    val r: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](alloc, n::usize);
-    f.vregs     = R.unwrap_ok[*mir.MirVReg, str](r);
+    val r: res[*mir.MirVReg, A.Error] = A.allocate[mir.MirVReg](alloc, n::usize);
+    if (sel r.err) { ret; }
+    f.vregs     = r.ok;
     f.vreg_count = n;
     f.vreg_cap   = n;
     var i: u32 = 0;
@@ -2486,8 +2489,9 @@ fun t_vregs(alloc: *A.Allocator, f: *mir.MirFunction, n: u32) {
 }
 
 fun t_block(alloc: *A.Allocator, b: *mir.MirBlock, n: u32) {
-    val r: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](alloc, n::usize);
-    b.instrs      = R.unwrap_ok[*mir.MirInstr, str](r);
+    val r: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](alloc, n::usize);
+    if (sel r.err) { ret; }
+    b.instrs      = r.ok;
     b.instr_count = n;
     b.instr_cap   = n;
     b.id          = 0;
@@ -2495,8 +2499,9 @@ fun t_block(alloc: *A.Allocator, b: *mir.MirBlock, n: u32) {
 
 fun t_instr(alloc: *A.Allocator, b: *mir.MirBlock, ix: u32, opcode: mir.MirOpcode,
             ops: *mir.MirOperand, nops: u32, width: u8) {
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](alloc, nops::usize);
-    val arr: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](alloc, nops::usize);
+    if (sel r.err) { ret; }
+    val arr: *mir.MirOperand = r.ok;
     var j: u32 = 0;
     for (j < nops) { arr[j] = ops[j]; j = j + 1; }
     b.instrs[ix].opcode        = opcode;
@@ -2518,8 +2523,8 @@ test "mach.lang.be.codegen.legalize.emit_piece:refuses_to_silently_drop_a_vector
     var src: mir.MirInstr = mir.instr(mir.MIR_ADD, nil, 0, 4, 4);
     src.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 4, 4);
 
-    val r: R.Result[R.Void, str] = emit_piece(?alloc, dst.instrs, ?cursor, ?src, mir.MIR_ADD, nil, 0, 4);
-    if (R.is_err[R.Void, str](r) == false) { ret 1; }
+    val r: err[fail.Fail] = emit_piece(?alloc, dst.instrs, ?cursor, ?src, mir.MIR_ADD, nil, 0, 4);
+    if (sel r.err == false) { ret 1; }
     ret 0;
 }
 
@@ -2541,8 +2546,8 @@ test "mach.lang.be.codegen.legalize:inert_on_native_width" {
     val before_vregs: u32           = f.vreg_count;
 
     var mach: Machine = t_mach(8, 8);
-    val r: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f);
-    if (R.is_err[R.Void, str](r))         { ret 1; }
+    val r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel r.err)         { ret 1; }
     if (b.instrs != before_ptr)         { ret 1; }
     if (b.instr_count != before_count)  { ret 1; }
     if (f.vreg_count != before_vregs)   { ret 1; }
@@ -2569,8 +2574,8 @@ test "mach.lang.be.codegen.legalize:expands_wide_add_carry_chain" {
     f.blocks = ?b; f.block_count = 1;
 
     var mach: Machine = t_mach(1, 2);
-    val r: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel r.err) { ret 1; }
 
     if (f.vreg_count != 11) { ret 1; }
 
@@ -2612,13 +2617,15 @@ test "mach.lang.be.codegen.legalize:expands_a_wide_divide" {
     t_divmod_fn(?alloc, ?f, ?b, mir.MIR_DIV_U, 2, 1000, 7);
 
     var plan: LanePlan;
-    if (R.is_err[R.Void, str](plan_lanes(?alloc, ?mach, ?f, ?plan))) { ret 1; }
-    val rc: R.Result[u32, str] = divmod_piece_count(?alloc, ?plan, ?b.instrs[2]);
-    if (R.is_err[u32, str](rc)) { ret 1; }
-    val want: u32 = R.unwrap_ok[u32, str](rc);
+    val plan_lanes_r: err[fail.Fail] = plan_lanes(?alloc, ?mach, ?f, ?plan);
+    if (sel plan_lanes_r.err) { ret 1; }
+    val rc: res[u32, fail.Fail] = divmod_piece_count(?alloc, ?plan, ?b.instrs[2]);
+    if (sel rc.err) { ret 1; }
+    val want: u32 = rc.ok;
     free_plan(?alloc, ?plan);
 
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+    val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel legalize_function_r.err) { ret 1; }
     if (b.instr_count != 4 + want) { ret 1; }
     var i: u32 = 0;
     var probes: u32 = 0;
@@ -2667,12 +2674,14 @@ test "mach.lang.be.codegen.legalize:divide_family_costs_agree" {
         var b: mir.MirBlock;
         t_divmod_fn(?alloc, ?f, ?b, ops[k], 2, 1000, 7);
         var plan: LanePlan;
-        if (R.is_err[R.Void, str](plan_lanes(?alloc, ?mach, ?f, ?plan))) { ret 1; }
-        val rc: R.Result[u32, str] = divmod_piece_count(?alloc, ?plan, ?b.instrs[2]);
-        if (R.is_err[u32, str](rc)) { ret 1; }
-        val n: u32 = R.unwrap_ok[u32, str](rc);
+        val plan_lanes_r: err[fail.Fail] = plan_lanes(?alloc, ?mach, ?f, ?plan);
+        if (sel plan_lanes_r.err) { ret 1; }
+        val rc: res[u32, fail.Fail] = divmod_piece_count(?alloc, ?plan, ?b.instrs[2]);
+        if (sel rc.err) { ret 1; }
+        val n: u32 = rc.ok;
         free_plan(?alloc, ?plan);
-        if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+        val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+        if (sel legalize_function_r.err) { ret 1; }
         if (b.instr_count != 4 + n) { ret 1; }
         if (k == 0) { du = n; } or (k == 1) { ds = n; } or (k == 2) { ru = n; } or { rs = n; }
         k = k + 1;
@@ -2702,12 +2711,14 @@ test "mach.lang.be.codegen.legalize:multiply_costs_agree_at_every_lane_count" {
             var b: mir.MirBlock;
             t_divmod_fn(?alloc, ?f, ?b, mir.MIR_MUL, widths[k], 1000, 7);
             var plan: LanePlan;
-            if (R.is_err[R.Void, str](plan_lanes(?alloc, ?mach, ?f, ?plan))) { ret 1; }
-            val rc: R.Result[u32, str] = mul_piece_count(?alloc, ?plan, ?b.instrs[2]);
-            if (R.is_err[u32, str](rc)) { ret 1; }
-            val n: u32 = R.unwrap_ok[u32, str](rc);
+            val plan_lanes_r: err[fail.Fail] = plan_lanes(?alloc, ?mach, ?f, ?plan);
+            if (sel plan_lanes_r.err) { ret 1; }
+            val rc: res[u32, fail.Fail] = mul_piece_count(?alloc, ?plan, ?b.instrs[2]);
+            if (sel rc.err) { ret 1; }
+            val n: u32 = rc.ok;
             free_plan(?alloc, ?plan);
-            if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+            val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+            if (sel legalize_function_r.err) { ret 1; }
             if (b.instr_count != 2 * widths[k]::u32 + n) { ret 1; }
             k = k + 1;
         }
@@ -2726,7 +2737,8 @@ test "mach.lang.be.codegen.legalize:a_declared_widening_multiply_selects_the_nat
 
     var mach: Machine = t_mach(4, 4);
     mach.mul_hi = 4;
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+    val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel legalize_function_r.err) { ret 1; }
 
     if (b.instr_count != 4 + 8) { ret 1; }
 
@@ -2749,7 +2761,8 @@ test "mach.lang.be.codegen.legalize:a_declared_widening_multiply_selects_the_nat
     var b2: mir.MirBlock;
     t_divmod_fn(?alloc, ?f2, ?b2, mir.MIR_MUL, 8, 1000, 7);
     var m2: Machine = t_mach(4, 4);
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?m2, ?f2))) { ret 1; }
+    val legalize_function_r2: err[fail.Fail] = legalize_function(?alloc, ?m2, ?f2);
+    if (sel legalize_function_r2.err) { ret 1; }
     var muls2:   u32 = 0;
     var shifts2: u32 = 0;
     i = 4;
@@ -2774,7 +2787,8 @@ test "mach.lang.be.codegen.legalize:refuses_an_unmodelled_widening_multiply" {
     t_divmod_fn(?alloc, ?f, ?b, mir.MIR_MUL, 4, 1000, 7);
     var m1: Machine = t_mach(1, 2);
     m1.mul_hi = 4;
-    if (!R.is_err[R.Void, str](legalize_function(?alloc, ?m1, ?f))) { ret 1; }
+    val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?m1, ?f);
+    if (!sel legalize_function_r.err) { ret 1; }
 
     var f2: mir.MirFunction;
     var b2: mir.MirBlock;
@@ -2782,14 +2796,16 @@ test "mach.lang.be.codegen.legalize:refuses_an_unmodelled_widening_multiply" {
     var m2: Machine = t_mach(1, 2);
     m2.mul_hi  = 1;
     m2.has_mul = false;
-    if (!R.is_err[R.Void, str](legalize_function(?alloc, ?m2, ?f2))) { ret 1; }
+    val legalize_function_r2: err[fail.Fail] = legalize_function(?alloc, ?m2, ?f2);
+    if (!sel legalize_function_r2.err) { ret 1; }
 
     var f3: mir.MirFunction;
     var b3: mir.MirBlock;
     t_divmod_fn(?alloc, ?f3, ?b3, mir.MIR_MUL, 4, 1000, 7);
     var m3: Machine = t_mach(1, 2);
     m3.mul_hi = 1;
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?m3, ?f3))) { ret 1; }
+    val legalize_function_r3: err[fail.Fail] = legalize_function(?alloc, ?m3, ?f3);
+    if (sel legalize_function_r3.err) { ret 1; }
     ret 0;
 }
 
@@ -2807,8 +2823,8 @@ test "mach.lang.be.codegen.legalize:rejects_unsupported_wide_op" {
     f.blocks = ?b; f.block_count = 1;
 
     var mach: Machine = t_mach(1, 2);
-    val r: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f);
-    if (!R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (!sel r.err) { ret 1; }
     ret 0;
 }
 
@@ -2826,8 +2842,8 @@ test "mach.lang.be.codegen.legalize:expands_wide_access_at_a_fixed_base" {
     f.blocks = ?b; f.block_count = 1;
 
     var mach: Machine = t_mach(1, 2);
-    val r: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f);
-    if (R.is_err[R.Void, str](r))  { ret 1; }
+    val r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel r.err)  { ret 1; }
     if (b.instr_count != 4)      { ret 1; }
 
     var i: u32 = 0;
@@ -2859,8 +2875,8 @@ test "mach.lang.be.codegen.legalize:expands_a_wide_access_at_a_symbol" {
     b.instrs[0].memory_flags = mir.MEMORY_VOLATILE;
 
     var mach: Machine = t_mach(2, 2);
-    val r: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel r.err) { ret 1; }
     if (b.instr_count != 2)     { ret 1; }
 
     var i: u32 = 0;
@@ -2891,8 +2907,8 @@ test "mach.lang.be.codegen.legalize:refuses_a_wide_access_with_no_address_operan
     f.blocks = ?b; f.block_count = 1;
 
     var mach: Machine = t_mach(2, 2);
-    val r: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f);
-    if (!R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (!sel r.err) { ret 1; }
     ret 0;
 }
 
@@ -2910,8 +2926,8 @@ test "mach.lang.be.codegen.legalize:expands_wide_preg_move_onto_consecutive_regs
     f.blocks = ?b; f.block_count = 1;
 
     var mach: Machine = t_mach(1, 2);
-    val r: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel r.err) { ret 1; }
     if (b.instr_count != 2)     { ret 1; }
     if (b.instrs[0].operands[0].vreg != 1 || b.instrs[0].operands[1].preg != 4) { ret 1; }
     if (b.instrs[1].operands[0].vreg != 2 || b.instrs[1].operands[1].preg != 5) { ret 1; }
@@ -2937,7 +2953,8 @@ test "mach.lang.be.codegen.legalize:lanes_of_a_secret_wide_value_stay_secret" {
     f.blocks = ?b; f.block_count = 1;
 
     var mach: Machine = t_mach(1, 2);
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+    val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel legalize_function_r.err) { ret 1; }
     if (b.instr_count != 4 || f.vreg_count != 6) { ret 2; }
     var i: u32 = 2;
     for (i < 4) {
@@ -2959,7 +2976,8 @@ test "mach.lang.be.codegen.legalize:lanes_of_a_secret_wide_value_stay_secret" {
     t_instr(?alloc, ?gb, 0, mir.MIR_MOV, ?seed[0], 2, 2);
     t_instr(?alloc, ?gb, 1, mir.MIR_MOV, ?mv[0], 2, 2);
     g.blocks = ?gb; g.block_count = 1;
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?g))) { ret 6; }
+    val legalize_function_r2: err[fail.Fail] = legalize_function(?alloc, ?mach, ?g);
+    if (sel legalize_function_r2.err) { ret 6; }
     i = 0;
     for (i < g.vreg_count) {
         if (g.vregs[i].secret) { ret 7; }
@@ -2987,7 +3005,8 @@ test "mach.lang.be.codegen.legalize:a_wide_declassify_keeps_its_barrier_per_lane
     f.blocks = ?b; f.block_count = 1;
 
     var mach: Machine = t_mach(1, 2);
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+    val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel legalize_function_r.err) { ret 1; }
     if (b.instr_count != 4) { ret 2; }
     if (b.instrs[0].opcode != mir.MIR_MOV || b.instrs[1].opcode != mir.MIR_MOV) { ret 7; }
     var i: u32 = 2;
@@ -3005,7 +3024,8 @@ test "mach.lang.be.codegen.legalize:a_wide_declassify_keeps_its_barrier_per_lane
     t_instr(?alloc, ?gb, 0, mir.MIR_MOV, ?seed[0], 2, 2);
     t_instr(?alloc, ?gb, 1, mir.MIR_MOV, ?dc[0], 2, 2);
     g.blocks = ?gb; g.block_count = 1;
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?g))) { ret 5; }
+    val legalize_function_r2: err[fail.Fail] = legalize_function(?alloc, ?mach, ?g);
+    if (sel legalize_function_r2.err) { ret 5; }
     if (gb.instrs[2].opcode != mir.MIR_MOV || gb.instrs[3].opcode != mir.MIR_MOV) { ret 6; }
     ret 0;
 }
@@ -3033,8 +3053,8 @@ test "mach.lang.be.codegen.legalize:stages_runtime_pointer_into_the_address_pair
     f.blocks = ?b; f.block_count = 1;
 
     var mach: Machine = t_mach(1, 2);
-    val r: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel r.err) { ret 1; }
     if (b.instr_count != 15) { ret 1; }
 
     if (b.instrs[6].operands[0].preg != 6) { ret 1; }
@@ -3075,8 +3095,8 @@ test "mach.lang.be.codegen.legalize:value_base_is_inert_on_a_wide_pointer_target
     val before_vregs: u32           = f.vreg_count;
 
     var mach: Machine = t_mach(8, 8);
-    val r: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f);
-    if (R.is_err[R.Void, str](r))       { ret 1; }
+    val r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel r.err)       { ret 1; }
     if (b.instrs != before_ptr)       { ret 1; }
     if (b.instr_count != 1)           { ret 1; }
     if (f.vreg_count != before_vregs) { ret 1; }
@@ -3108,8 +3128,8 @@ test "mach.lang.be.codegen.legalize:expands_constant_wide_shift_as_a_template" {
     t_shift_fn(?alloc, ?f, ?b, mir.MIR_SHL, 4, mir.op_imm(3));
 
     var mach: Machine = t_mach(1, 2);
-    val r: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel r.err) { ret 1; }
 
     if (b.instr_count != 15) { ret 1; }
     if (b.instrs[5].opcode != mir.MIR_SHL)      { ret 1; }
@@ -3132,20 +3152,23 @@ test "mach.lang.be.codegen.legalize:expands_constant_wide_shift_as_a_template" {
     var f1: mir.MirFunction;
     var b1: mir.MirBlock;
     t_shift_fn(?alloc, ?f1, ?b1, mir.MIR_SHR_S, 1, mir.op_imm(3));
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f1))) { ret 1; }
+    val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f1);
+    if (sel legalize_function_r.err) { ret 1; }
     if (b1.instr_count != 3)                     { ret 1; }
     if (b1.instrs[2].opcode != mir.MIR_SHR_S)    { ret 1; }
 
     var f2: mir.MirFunction;
     var b2: mir.MirBlock;
     t_shift_fn(?alloc, ?f2, ?b2, mir.MIR_SHR_S, 2, mir.op_imm(3));
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f2))) { ret 1; }
+    val legalize_function_r2: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f2);
+    if (sel legalize_function_r2.err) { ret 1; }
     if (b2.instr_count != 7)                     { ret 1; }
 
     var f3: mir.MirFunction;
     var b3: mir.MirBlock;
     t_shift_fn(?alloc, ?f3, ?b3, mir.MIR_SHR_S, 2, mir.op_imm(8));
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f3))) { ret 1; }
+    val legalize_function_r3: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f3);
+    if (sel legalize_function_r3.err) { ret 1; }
     if (b3.instr_count != 6)                     { ret 1; }
     if (b3.instrs[3].opcode != mir.MIR_SHR_S)    { ret 1; }
     ret 0;
@@ -3165,7 +3188,8 @@ test "mach.lang.be.codegen.legalize:expands_runtime_shift_as_a_masked_barrel" {
         var b: mir.MirBlock;
         t_shift_fn(?alloc, ?f, ?b, mir.MIR_SHL, widths[w], mir.op_vreg(2));
         var mach: Machine = t_mach(1, 2);
-        if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+        val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+        if (sel legalize_function_r.err) { ret 1; }
         if (b.instr_count != widths[w]::u32 + 1 + shl[w]) { ret 1; }
         if (f.block_count != 1)                           { ret 1; }
         var i: u32 = 0;
@@ -3178,7 +3202,8 @@ test "mach.lang.be.codegen.legalize:expands_runtime_shift_as_a_masked_barrel" {
         var f2: mir.MirFunction;
         var b2: mir.MirBlock;
         t_shift_fn(?alloc, ?f2, ?b2, mir.MIR_SHR_S, widths[w], mir.op_vreg(2));
-        if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f2))) { ret 1; }
+        val legalize_function_r2: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f2);
+        if (sel legalize_function_r2.err) { ret 1; }
         if (b2.instr_count != widths[w]::u32 + 1 + shrs[w]) { ret 1; }
         w = w + 1;
     }
@@ -3193,12 +3218,14 @@ test "mach.lang.be.codegen.legalize:normalizes_an_out_of_range_shift_count" {
     var f3: mir.MirFunction;
     var b3: mir.MirBlock;
     t_shift_fn(?alloc, ?f3, ?b3, mir.MIR_SHL, 2, mir.op_imm(3));
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f3))) { ret 1; }
+    val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f3);
+    if (sel legalize_function_r.err) { ret 1; }
 
     var f19: mir.MirFunction;
     var b19: mir.MirBlock;
     t_shift_fn(?alloc, ?f19, ?b19, mir.MIR_SHL, 2, mir.op_imm(19));
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f19))) { ret 1; }
+    val legalize_function_r2: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f19);
+    if (sel legalize_function_r2.err) { ret 1; }
 
     if (b19.instr_count != b3.instr_count) { ret 1; }
     var i: u32 = 0;
@@ -3217,7 +3244,8 @@ test "mach.lang.be.codegen.legalize:normalizes_an_out_of_range_shift_count" {
     var f16: mir.MirFunction;
     var b16: mir.MirBlock;
     t_shift_fn(?alloc, ?f16, ?b16, mir.MIR_SHL, 2, mir.op_imm(16));
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f16))) { ret 1; }
+    val legalize_function_r3: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f16);
+    if (sel legalize_function_r3.err) { ret 1; }
     if (b16.instr_count != 5)                  { ret 1; }
     if (b16.instrs[3].opcode != mir.MIR_MOV)   { ret 1; }
     if (b16.instrs[4].opcode != mir.MIR_MOV)   { ret 1; }
@@ -3242,14 +3270,15 @@ test "mach.lang.be.codegen.legalize:shift_is_inert_on_a_variable_shift_machine" 
 
     var mach: Machine = t_mach(8, 8);
     mach.var_shift = true;
-    val r: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f);
-    if (R.is_err[R.Void, str](r))       { ret 1; }
+    val r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel r.err)       { ret 1; }
     if (b.instrs != before_ptr)       { ret 1; }
     if (b.instr_count != 1)           { ret 1; }
     if (f.vreg_count != before_vregs) { ret 1; }
 
     mach.var_shift = false;
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+    val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel legalize_function_r.err) { ret 1; }
     if (b.instrs == before_ptr) { ret 1; }
     ret 0;
 }
@@ -3278,7 +3307,8 @@ test "mach.lang.be.codegen.legalize:expands_wide_equality_lane_wise" {
     var f: mir.MirFunction;
     var b: mir.MirBlock;
     t_cmp_fn(?alloc, ?f, ?b, mir.MIR_CMP_EQ, 2);
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+    val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel legalize_function_r.err) { ret 1; }
 
     if (b.instr_count != 7) { ret 1; }
     if (b.instrs[4].opcode != mir.MIR_CMP_EQ) { ret 1; }
@@ -3293,7 +3323,8 @@ test "mach.lang.be.codegen.legalize:expands_wide_equality_lane_wise" {
     var f2: mir.MirFunction;
     var b2: mir.MirBlock;
     t_cmp_fn(?alloc, ?f2, ?b2, mir.MIR_CMP_NE, 2);
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f2))) { ret 1; }
+    val legalize_function_r2: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f2);
+    if (sel legalize_function_r2.err) { ret 1; }
     if (b2.instr_count != 7)                    { ret 1; }
     if (b2.instrs[4].opcode != mir.MIR_CMP_NE)  { ret 1; }
     if (b2.instrs[5].opcode != mir.MIR_CMP_NE)  { ret 1; }
@@ -3319,7 +3350,8 @@ test "mach.lang.be.codegen.legalize:expands_wide_ordered_as_a_lexicographic_walk
     var f: mir.MirFunction;
     var b: mir.MirBlock;
     t_cmp_fn(?alloc, ?f, ?b, mir.MIR_CMP_LT_U, 2);
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+    val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel legalize_function_r.err) { ret 1; }
 
     if (b.instr_count != 9) { ret 1; }
 
@@ -3340,7 +3372,8 @@ test "mach.lang.be.codegen.legalize:expands_wide_ordered_as_a_lexicographic_walk
     var fs: mir.MirFunction;
     var bs: mir.MirBlock;
     t_cmp_fn(?alloc, ?fs, ?bs, mir.MIR_CMP_LT_S, 2);
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?fs))) { ret 1; }
+    val legalize_function_r2: err[fail.Fail] = legalize_function(?alloc, ?mach, ?fs);
+    if (sel legalize_function_r2.err) { ret 1; }
     if (bs.instr_count != 11)                     { ret 1; }
     if (bs.instrs[4].opcode != mir.MIR_CMP_LT_U)  { ret 1; }
     if (bs.instrs[4].operands[1].vreg != 3)       { ret 1; }
@@ -3364,7 +3397,8 @@ test "mach.lang.be.codegen.legalize:expands_wide_ordered_as_a_lexicographic_walk
     var fl: mir.MirFunction;
     var bl: mir.MirBlock;
     t_cmp_fn(?alloc, ?fl, ?bl, mir.MIR_CMP_LE_U, 2);
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?fl))) { ret 1; }
+    val legalize_function_r3: err[fail.Fail] = legalize_function(?alloc, ?mach, ?fl);
+    if (sel legalize_function_r3.err) { ret 1; }
     if (bl.instr_count != 10)                    { ret 1; }
     if (bl.instrs[4].opcode != mir.MIR_CMP_LT_U) { ret 1; }
     if (bl.instrs[4].operands[1].vreg != 5)      { ret 1; }
@@ -3401,7 +3435,8 @@ test "mach.lang.be.codegen.legalize:pins_wide_comparison_piece_counts" {
             var f: mir.MirFunction;
             var b: mir.MirBlock;
             t_cmp_fn(?alloc, ?f, ?b, ops[r], widths[c]);
-            if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+            val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+            if (sel legalize_function_r.err) { ret 1; }
             if (b.instr_count != 2 * widths[c]::u32 + want[r * 3 + c]) { ret 1; }
             if (b.instrs[b.instr_count - 1].operands[0].kind != mir.MIR_OP_VREG) { ret 1; }
             if (b.instrs[b.instr_count - 1].operands[0].vreg != 0)               { ret 1; }
@@ -3420,7 +3455,8 @@ test "mach.lang.be.codegen.legalize:leaves_a_comparison_destination_unsplit" {
     var f: mir.MirFunction;
     var b: mir.MirBlock;
     t_cmp_fn(?alloc, ?f, ?b, mir.MIR_CMP_EQ, 8);
-    if (R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+    val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel legalize_function_r.err) { ret 1; }
 
     if (b.instrs[16].operands[0].vreg != 19) { ret 1; }
 
@@ -3464,7 +3500,8 @@ test "mach.lang.be.codegen.legalize:rejects_a_wide_comparison_of_an_unsupported_
     f.blocks = ?b; f.block_count = 1;
 
     val before: *mir.MirInstr = b.instrs;
-    if (!R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+    val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (!sel legalize_function_r.err) { ret 1; }
     if (b.instrs != before)     { ret 1; }
     if (b.instr_count != 3)     { ret 1; }
     ret 0;
@@ -3478,7 +3515,8 @@ test "mach.lang.be.codegen.legalize:rejects_a_shift_at_a_non_power_of_two_width"
     var b: mir.MirBlock;
     t_shift_fn(?alloc, ?f, ?b, mir.MIR_SHL, 3, mir.op_vreg(2));
     var mach: Machine = t_mach(1, 2);
-    if (!R.is_err[R.Void, str](legalize_function(?alloc, ?mach, ?f))) { ret 1; }
+    val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (!sel legalize_function_r.err) { ret 1; }
     ret 0;
 }
 
@@ -3502,8 +3540,8 @@ test "mach.lang.be.codegen.legalize:a_float_is_not_split_into_integer_lanes" {
     val before_vregs: u32           = f.vreg_count;
 
     var mach: Machine = t_mach(4, 4);
-    val r: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f);
-    if (R.is_err[R.Void, str](r))        { ret 1; }
+    val r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel r.err)        { ret 1; }
     if (b.instrs != before_ptr)        { ret 1; }
     if (b.instr_count != before_count) { ret 1; }
     if (f.vreg_count != before_vregs)  { ret 1; }
@@ -3517,8 +3555,8 @@ test "mach.lang.be.codegen.legalize:a_float_is_not_split_into_integer_lanes" {
     t_instr(?alloc, ?gb, 0, mir.MIR_MOV, ?gi[0], 2, 8);
     gf.blocks = ?gb; gf.block_count = 1;
 
-    val gr: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?gf);
-    if (R.is_err[R.Void, str](gr))   { ret 1; }
+    val gr: err[fail.Fail] = legalize_function(?alloc, ?mach, ?gf);
+    if (sel gr.err)   { ret 1; }
     if (gb.instr_count != 2)       { ret 1; }
     if (gf.vreg_count <= 2)        { ret 1; }
 
@@ -3530,8 +3568,8 @@ test "mach.lang.be.codegen.legalize:a_float_is_not_split_into_integer_lanes" {
     sf.blocks = ?sb; sf.block_count = 1;
 
     var m8: Machine = t_mach(1, 2);
-    val sr: R.Result[R.Void, str] = legalize_function(?alloc, ?m8, ?sf);
-    if (R.is_err[R.Void, str](sr)) { ret 1; }
+    val sr: err[fail.Fail] = legalize_function(?alloc, ?m8, ?sf);
+    if (sel sr.err) { ret 1; }
     if (sb.instr_count != 8)     { ret 1; }
     if (sf.vreg_count <= 2)      { ret 1; }
     ret 0;
@@ -3577,8 +3615,8 @@ test "mach.lang.be.codegen.legalize:open_codes_a_wide_int_float_conversion" {
     var f1: mir.MirFunction;
     var b1: mir.MirBlock;
     t_conv_fn(?alloc, ?f1, ?b1, mir.MIR_SI_TO_FP, fp, 8, 8);
-    val r1: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f1);
-    if (R.is_err[R.Void, str](r1))          { ret 1; }
+    val r1: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f1);
+    if (sel r1.err)          { ret 1; }
     if (t_has_wide_conv(?b1, 4))          { ret 1; }
     if (b1.instr_count != 11)             { ret 1; }
     if (f1.vregs[0].class != fp)          { ret 1; }
@@ -3586,24 +3624,24 @@ test "mach.lang.be.codegen.legalize:open_codes_a_wide_int_float_conversion" {
     var f2: mir.MirFunction;
     var b2: mir.MirBlock;
     t_conv_fn(?alloc, ?f2, ?b2, mir.MIR_FP_TO_UI, fp, 8, 8);
-    val r2: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f2);
-    if (R.is_err[R.Void, str](r2))          { ret 1; }
+    val r2: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f2);
+    if (sel r2.err)          { ret 1; }
     if (t_has_wide_conv(?b2, 4))          { ret 1; }
     if (b2.instr_count != 14)             { ret 1; }
 
     var f3: mir.MirFunction;
     var b3: mir.MirBlock;
     t_conv_fn(?alloc, ?f3, ?b3, mir.MIR_FP_TO_SI, fp, 8, 8);
-    val r3: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f3);
-    if (R.is_err[R.Void, str](r3))          { ret 1; }
+    val r3: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f3);
+    if (sel r3.err)          { ret 1; }
     if (t_has_wide_conv(?b3, 4))          { ret 1; }
     if (b3.instr_count != 43)             { ret 1; }
 
     var f4: mir.MirFunction;
     var b4: mir.MirBlock;
     t_conv_fn(?alloc, ?f4, ?b4, mir.MIR_SI_TO_FP, fp, 4, 8);
-    val r4: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f4);
-    if (R.is_err[R.Void, str](r4))          { ret 1; }
+    val r4: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f4);
+    if (sel r4.err)          { ret 1; }
     if (t_has_wide_conv(?b4, 4))          { ret 1; }
     if (b4.instr_count != 44)             { ret 1; }
 
@@ -3611,8 +3649,8 @@ test "mach.lang.be.codegen.legalize:open_codes_a_wide_int_float_conversion" {
     var b5: mir.MirBlock;
     t_conv_fn(?alloc, ?f5, ?b5, mir.MIR_SI_TO_FP, mir.REG_CLASS_GP, 8, 8);
     var m8: Machine = t_mach(1, 2);
-    val r5: R.Result[R.Void, str] = legalize_function(?alloc, ?m8, ?f5);
-    if (R.is_ok[R.Void, str](r5))           { ret 1; }
+    val r5: err[fail.Fail] = legalize_function(?alloc, ?m8, ?f5);
+    if (sel r5.ok)           { ret 1; }
     ret 0;
 }
 
@@ -3630,8 +3668,8 @@ test "mach.lang.be.codegen.legalize:a_wide_conversion_is_inert_on_a_wide_alu" {
 
     var mach: Machine = t_mach(8, 8);
     mach.fp_class = fp;
-    val r: R.Result[R.Void, str] = legalize_function(?alloc, ?mach, ?f);
-    if (R.is_err[R.Void, str](r))        { ret 1; }
+    val r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
+    if (sel r.err)        { ret 1; }
     if (b.instrs != before_ptr)        { ret 1; }
     if (b.instr_count != before_count) { ret 1; }
     if (f.vreg_count != before_vregs)  { ret 1; }

--- a/src/lang/be/codegen/looprotate.mach
+++ b/src/lang/be/codegen/looprotate.mach
@@ -1,27 +1,29 @@
 use std.types.bool.bool;
+use std.types.canonical.res;
+use std.types.canonical.err;
+use mach.lang.fail;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 
-use page: mach.lang.legacy.page;
+use page: std.allocator.page;
 
-use A: mach.lang.legacy.allocator;
-use R: std.types.result;
+use A: std.allocator;
 
 use mach.lang.be.codegen.mir;
 use mach.lang.source;
 use mach.lang.target;
 
-pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[R.Void, str] {
-    if (m == nil) { ret R.err[R.Void, str]("looprotate: nil mir module"); }
+pub fun run(tgt: *target.Target, m: *mir.MirModule) err[fail.Fail] {
+    if (m == nil) { ret err[fail.Fail].err{fail.message("looprotate: nil mir module")}; }
     var fi: u32 = 0;
     for (fi < m.function_len) {
-        val r: R.Result[R.Void, str] = rotate_function(m.alloc, ?m.functions[fi]);
-        if (R.is_err[R.Void, str](r)) { ret r; }
+        val r: err[fail.Fail] = rotate_function(m.alloc, ?m.functions[fi]);
+        if (sel r.err) { ret r; }
         fi = fi + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 rec LoopScratch {
@@ -32,32 +34,32 @@ rec LoopScratch {
     block_count:  u32;
 }
 
-fun rotate_function(alloc: *A.Allocator, f: *mir.MirFunction) R.Result[R.Void, str] {
-    if (f.block_count == 0) { ret R.ok_void[str](); }
+fun rotate_function(alloc: *A.Allocator, f: *mir.MirFunction) err[fail.Fail] {
+    if (f.block_count == 0) { ret err[fail.Fail].ok{}; }
 
     var sc: LoopScratch;
-    val si: R.Result[R.Void, str] = scratch_init(alloc, f, ?sc);
-    if (R.is_err[R.Void, str](si)) { ret si; }
+    val si: err[fail.Fail] = scratch_init(alloc, f, ?sc);
+    if (sel si.err) { ret si; }
 
-    val rp: R.Result[R.Void, str] = rebuild_preds(alloc, f, ?sc);
-    if (R.is_err[R.Void, str](rp)) { scratch_dnit(alloc, ?sc); ret rp; }
+    val rp: err[fail.Fail] = rebuild_preds(alloc, f, ?sc);
+    if (sel rp.err) { scratch_dnit(alloc, ?sc); ret rp; }
 
     var bi: u32 = 0;
     for (bi < f.block_count) {
-        val rotated_r: R.Result[bool, str] = try_rotate_header(alloc, f, ?sc, ?f.blocks[bi]);
-        if (R.is_err[bool, str](rotated_r)) { scratch_dnit(alloc, ?sc); ret R.err[R.Void, str](R.unwrap_err[bool, str](rotated_r)); }
-        if (R.unwrap_ok[bool, str](rotated_r)) {
-            val rp2: R.Result[R.Void, str] = rebuild_preds(alloc, f, ?sc);
-            if (R.is_err[R.Void, str](rp2)) { scratch_dnit(alloc, ?sc); ret rp2; }
+        val rotated_r: res[bool, fail.Fail] = try_rotate_header(alloc, f, ?sc, ?f.blocks[bi]);
+        if (sel rotated_r.err) { scratch_dnit(alloc, ?sc); ret err[fail.Fail].err{rotated_r.err}; }
+        if (rotated_r.ok) {
+            val rp2: err[fail.Fail] = rebuild_preds(alloc, f, ?sc);
+            if (sel rp2.err) { scratch_dnit(alloc, ?sc); ret rp2; }
         }
         bi = bi + 1;
     }
 
     scratch_dnit(alloc, ?sc);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun scratch_init(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) R.Result[R.Void, str] {
+fun scratch_init(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) err[fail.Fail] {
     sc.id_index     = nil;
     sc.id_index_cap = 0;
     sc.in_loop      = nil;
@@ -72,30 +74,30 @@ fun scratch_init(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) R.R
     }
 
     val cap: u32 = max_id + 1;
-    val ri: R.Result[*u32, str] = A.allocate[u32](alloc, cap::usize);
-    if (R.is_err[*u32, str](ri)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](ri)); }
-    sc.id_index     = R.unwrap_ok[*u32, str](ri);
+    val ri: res[*u32, A.Error] = A.allocate[u32](alloc, cap::usize);
+    if (sel ri.err) { ret err[fail.Fail].err{fail.refused(ri.err)}; }
+    sc.id_index     = ri.ok;
     sc.id_index_cap = cap;
     var k: u32 = 0;
     for (k < cap) { sc.id_index[k] = mir.MIR_VREG_NIL; k = k + 1; }
     k = 0;
     for (k < f.block_count) { sc.id_index[f.blocks[k].id] = k; k = k + 1; }
 
-    val rb: R.Result[*bool, str] = A.allocate[bool](alloc, f.block_count::usize);
-    if (R.is_err[*bool, str](rb)) {
+    val rb: res[*bool, A.Error] = A.allocate[bool](alloc, f.block_count::usize);
+    if (sel rb.err) {
         scratch_dnit(alloc, sc);
-        ret R.err[R.Void, str](R.unwrap_err[*bool, str](rb));
+        ret err[fail.Fail].err{fail.refused(rb.err)};
     }
-    sc.in_loop = R.unwrap_ok[*bool, str](rb);
+    sc.in_loop = rb.ok;
 
-    val rs: R.Result[*u32, str] = A.allocate[u32](alloc, f.block_count::usize);
-    if (R.is_err[*u32, str](rs)) {
+    val rs: res[*u32, A.Error] = A.allocate[u32](alloc, f.block_count::usize);
+    if (sel rs.err) {
         scratch_dnit(alloc, sc);
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](rs));
+        ret err[fail.Fail].err{fail.refused(rs.err)};
     }
-    sc.stack = R.unwrap_ok[*u32, str](rs);
+    sc.stack = rs.ok;
 
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun scratch_dnit(alloc: *A.Allocator, sc: *LoopScratch) {
@@ -126,30 +128,30 @@ fun find_block(f: *mir.MirFunction, sc: *LoopScratch, id: u32) *mir.MirBlock {
 }
 
 fun try_rotate_header(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch,
-                      h: *mir.MirBlock) R.Result[bool, str] {
-    if (h.instr_count == 0) { ret R.ok[bool, str](false); }
+                      h: *mir.MirBlock) res[bool, fail.Fail] {
+    if (h.instr_count == 0) { ret res[bool, fail.Fail].ok{false}; }
     val term: *mir.MirInstr = ?h.instrs[h.instr_count - 1];
-    if (term.opcode != mir.MIR_CBR)   { ret R.ok[bool, str](false); }
-    if (term.operand_count < 3)       { ret R.ok[bool, str](false); }
+    if (term.opcode != mir.MIR_CBR)   { ret res[bool, fail.Fail].ok{false}; }
+    if (term.operand_count < 3)       { ret res[bool, fail.Fail].ok{false}; }
 
     val cond_op: *mir.MirOperand = ?term.operands[0];
-    if (cond_op.kind != mir.MIR_OP_VREG) { ret R.ok[bool, str](false); }
-    if (term.operands[1].kind != mir.MIR_OP_BLOCK) { ret R.ok[bool, str](false); }
-    if (term.operands[2].kind != mir.MIR_OP_BLOCK) { ret R.ok[bool, str](false); }
+    if (cond_op.kind != mir.MIR_OP_VREG) { ret res[bool, fail.Fail].ok{false}; }
+    if (term.operands[1].kind != mir.MIR_OP_BLOCK) { ret res[bool, fail.Fail].ok{false}; }
+    if (term.operands[2].kind != mir.MIR_OP_BLOCK) { ret res[bool, fail.Fail].ok{false}; }
 
     val cond_vreg: u32 = cond_op.vreg;
     val b_id: u32 = term.operands[1].imm::u32;
     val e_id: u32 = term.operands[2].imm::u32;
-    if (b_id == e_id)  { ret R.ok[bool, str](false); }
-    if (b_id == h.id)  { ret R.ok[bool, str](false); }
-    if (e_id == h.id)  { ret R.ok[bool, str](false); }
+    if (b_id == e_id)  { ret res[bool, fail.Fail].ok{false}; }
+    if (b_id == h.id)  { ret res[bool, fail.Fail].ok{false}; }
+    if (e_id == h.id)  { ret res[bool, fail.Fail].ok{false}; }
 
-    if (h.pred_count < 2) { ret R.ok[bool, str](false); }
+    if (h.pred_count < 2) { ret res[bool, fail.Fail].ok{false}; }
 
-    if (!test_clonable(h, cond_vreg)) { ret R.ok[bool, str](false); }
-    if (!defs_confined(f, h))         { ret R.ok[bool, str](false); }
+    if (!test_clonable(h, cond_vreg)) { ret res[bool, fail.Fail].ok{false}; }
+    if (!defs_confined(f, h))         { ret res[bool, fail.Fail].ok{false}; }
 
-    if (!mark_loop(f, sc, b_id, h.id, e_id)) { ret R.ok[bool, str](false); }
+    if (!mark_loop(f, sc, b_id, h.id, e_id)) { ret res[bool, fail.Fail].ok{false}; }
     var p_id: u32 = mir.MIR_VREG_NIL;
     var outside: u32 = 0;
     var inside: u32 = 0;
@@ -164,20 +166,20 @@ fun try_rotate_header(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch
         }
         pi = pi + 1;
     }
-    if (outside != 1) { ret R.ok[bool, str](false); }
-    if (inside == 0)  { ret R.ok[bool, str](false); }
-    if (p_id == h.id) { ret R.ok[bool, str](false); }
-    if (p_id == e_id) { ret R.ok[bool, str](false); }
+    if (outside != 1) { ret res[bool, fail.Fail].ok{false}; }
+    if (inside == 0)  { ret res[bool, fail.Fail].ok{false}; }
+    if (p_id == h.id) { ret res[bool, fail.Fail].ok{false}; }
+    if (p_id == e_id) { ret res[bool, fail.Fail].ok{false}; }
 
     val p: *mir.MirBlock = find_block(f, sc, p_id);
-    if (p == nil)                { ret R.ok[bool, str](false); }
-    if (!ends_in_br_to(p, h.id)) { ret R.ok[bool, str](false); }
+    if (p == nil)                { ret res[bool, fail.Fail].ok{false}; }
+    if (!ends_in_br_to(p, h.id)) { ret res[bool, fail.Fail].ok{false}; }
 
-    val rotated: R.Result[R.Void, str] = rotate(alloc, f, h, p, b_id, e_id, cond_vreg);
+    val rotated: err[fail.Fail] = rotate(alloc, f, h, p, b_id, e_id, cond_vreg);
 
-    if (R.is_err[R.Void, str](rotated)) { ret R.err[bool, str](R.unwrap_err[R.Void, str](rotated)); }
+    if (sel rotated.err) { ret res[bool, fail.Fail].err{rotated.err}; }
 
-    ret R.ok[bool, str](true);
+    ret res[bool, fail.Fail].ok{true};
 }
 
 fun mark_loop(f: *mir.MirFunction, sc: *LoopScratch, b_id: u32, h_id: u32, e_id: u32) bool {
@@ -218,11 +220,11 @@ fun mark_loop(f: *mir.MirFunction, sc: *LoopScratch, b_id: u32, h_id: u32, e_id:
 }
 
 fun rotate(alloc: *A.Allocator, f: *mir.MirFunction, h: *mir.MirBlock, p: *mir.MirBlock,
-           b_id: u32, e_id: u32, cond_vreg: u32) R.Result[R.Void, str] {
+           b_id: u32, e_id: u32, cond_vreg: u32) err[fail.Fail] {
     val orig_vregs: u32 = f.vreg_count;
-    val rr: R.Result[*u32, str] = A.allocate[u32](alloc, orig_vregs::usize);
-    if (R.is_err[*u32, str](rr)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](rr)); }
-    val remap: *u32 = R.unwrap_ok[*u32, str](rr);
+    val rr: res[*u32, A.Error] = A.allocate[u32](alloc, orig_vregs::usize);
+    if (sel rr.err) { ret err[fail.Fail].err{fail.refused(rr.err)}; }
+    val remap: *u32 = rr.ok;
     var i: u32 = 0;
     for (i < orig_vregs) { remap[i] = mir.MIR_VREG_NIL; i = i + 1; }
 
@@ -234,21 +236,21 @@ fun rotate(alloc: *A.Allocator, f: *mir.MirFunction, h: *mir.MirBlock, p: *mir.M
 
     var k: u32 = 0;
     for (k < h.instr_count - 1) {
-        val cl: R.Result[mir.MirInstr, str] = clone_compute(alloc, f, ?h.instrs[k], remap, orig_vregs);
-        if (R.is_err[mir.MirInstr, str](cl)) { A.deallocate[u32](alloc, remap, orig_vregs::usize); ret R.err[R.Void, str](R.unwrap_err[mir.MirInstr, str](cl)); }
-        val ap: R.Result[R.Void, str] = append_instr(alloc, p, R.unwrap_ok[mir.MirInstr, str](cl));
-        if (R.is_err[R.Void, str](ap)) { A.deallocate[u32](alloc, remap, orig_vregs::usize); ret ap; }
+        val cl: res[mir.MirInstr, fail.Fail] = clone_compute(alloc, f, ?h.instrs[k], remap, orig_vregs);
+        if (sel cl.err) { A.deallocate[u32](alloc, remap, orig_vregs::usize); ret err[fail.Fail].err{cl.err}; }
+        val ap: err[fail.Fail] = append_instr(alloc, p, cl.ok);
+        if (sel ap.err) { A.deallocate[u32](alloc, remap, orig_vregs::usize); ret ap; }
         k = k + 1;
     }
 
     val hb: *mir.MirInstr = ?h.instrs[h.instr_count - 1];
-    val gr: R.Result[mir.MirInstr, str] = clone_guard_cbr(alloc, hb, remap, orig_vregs, cond_vreg, b_id, e_id);
-    if (R.is_err[mir.MirInstr, str](gr)) { A.deallocate[u32](alloc, remap, orig_vregs::usize); ret R.err[R.Void, str](R.unwrap_err[mir.MirInstr, str](gr)); }
-    val ap2: R.Result[R.Void, str] = append_instr(alloc, p, R.unwrap_ok[mir.MirInstr, str](gr));
-    if (R.is_err[R.Void, str](ap2)) { A.deallocate[u32](alloc, remap, orig_vregs::usize); ret ap2; }
+    val gr: res[mir.MirInstr, fail.Fail] = clone_guard_cbr(alloc, hb, remap, orig_vregs, cond_vreg, b_id, e_id);
+    if (sel gr.err) { A.deallocate[u32](alloc, remap, orig_vregs::usize); ret err[fail.Fail].err{gr.err}; }
+    val ap2: err[fail.Fail] = append_instr(alloc, p, gr.ok);
+    if (sel ap2.err) { A.deallocate[u32](alloc, remap, orig_vregs::usize); ret ap2; }
 
     A.deallocate[u32](alloc, remap, orig_vregs::usize);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun test_clonable(h: *mir.MirBlock, cond_vreg: u32) bool {
@@ -314,15 +316,15 @@ fun clonable_opcode(op: mir.MirOpcode) bool {
 
 
 fun clone_compute(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
-                  remap: *u32, orig_vregs: u32) R.Result[mir.MirInstr, str] {
+                  remap: *u32, orig_vregs: u32) res[mir.MirInstr, fail.Fail] {
     val old_dest: u32 = src.operands[0].vreg;
-    val nd: R.Result[u32, str] = add_vreg_like(alloc, f, old_dest);
-    if (R.is_err[u32, str](nd)) { ret R.err[mir.MirInstr, str](R.unwrap_err[u32, str](nd)); }
-    val new_dest: u32 = R.unwrap_ok[u32, str](nd);
+    val nd: res[u32, fail.Fail] = add_vreg_like(alloc, f, old_dest);
+    if (sel nd.err) { ret res[mir.MirInstr, fail.Fail].err{nd.err}; }
+    val new_dest: u32 = nd.ok;
 
-    val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](alloc, src.operand_count::usize);
-    if (R.is_err[*mir.MirOperand, str](ro)) { ret R.err[mir.MirInstr, str](R.unwrap_err[*mir.MirOperand, str](ro)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro);
+    val ro: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](alloc, src.operand_count::usize);
+    if (sel ro.err) { ret res[mir.MirInstr, fail.Fail].err{fail.refused(ro.err)}; }
+    val ops: *mir.MirOperand = ro.ok;
 
     var k: u32 = 1;
     for (k < src.operand_count) {
@@ -332,14 +334,14 @@ fun clone_compute(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
     remap[old_dest] = new_dest;
     ops[0] = mir.op_vreg(new_dest);
 
-    ret R.ok[mir.MirInstr, str](make_instr(src, ops, src.operand_count));
+    ret res[mir.MirInstr, fail.Fail].ok{make_instr(src, ops, src.operand_count)};
 }
 
 fun clone_guard_cbr(alloc: *A.Allocator, src: *mir.MirInstr, remap: *u32, orig_vregs: u32,
-                    cond_vreg: u32, b_id: u32, e_id: u32) R.Result[mir.MirInstr, str] {
-    val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](alloc, 3::usize);
-    if (R.is_err[*mir.MirOperand, str](ro)) { ret R.err[mir.MirInstr, str](R.unwrap_err[*mir.MirOperand, str](ro)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro);
+                    cond_vreg: u32, b_id: u32, e_id: u32) res[mir.MirInstr, fail.Fail] {
+    val ro: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](alloc, 3::usize);
+    if (sel ro.err) { ret res[mir.MirInstr, fail.Fail].err{fail.refused(ro.err)}; }
+    val ops: *mir.MirOperand = ro.ok;
 
     var cond: mir.MirOperand = mir.op_vreg(cond_vreg);
     if (cond_vreg < orig_vregs && remap[cond_vreg] != mir.MIR_VREG_NIL) {
@@ -349,7 +351,7 @@ fun clone_guard_cbr(alloc: *A.Allocator, src: *mir.MirInstr, remap: *u32, orig_v
     ops[1] = mir.op_block(b_id);
     ops[2] = mir.op_block(e_id);
 
-    ret R.ok[mir.MirInstr, str](make_instr(src, ops, 3));
+    ret res[mir.MirInstr, fail.Fail].ok{make_instr(src, ops, 3)};
 }
 
 fun remap_operand(src: mir.MirOperand, remap: *u32, orig_vregs: u32) mir.MirOperand {
@@ -376,34 +378,34 @@ fun make_instr(src: *mir.MirInstr, ops: *mir.MirOperand, n: u32) mir.MirInstr {
     ret mi;
 }
 
-fun add_vreg_like(alloc: *A.Allocator, f: *mir.MirFunction, like: u32) R.Result[u32, str] {
+fun add_vreg_like(alloc: *A.Allocator, f: *mir.MirFunction, like: u32) res[u32, fail.Fail] {
     if (f.vreg_count >= f.vreg_cap) {
         var new_cap: u32 = f.vreg_cap * 2;
         if (new_cap < mir.INITIAL_VREG_CAP) { new_cap = mir.INITIAL_VREG_CAP; }
-        val rg: R.Result[*mir.MirVReg, str] = A.reallocate[mir.MirVReg](alloc, f.vregs, f.vreg_cap::usize, new_cap::usize);
-        if (R.is_err[*mir.MirVReg, str](rg)) { ret R.err[u32, str](R.unwrap_err[*mir.MirVReg, str](rg)); }
-        f.vregs    = R.unwrap_ok[*mir.MirVReg, str](rg);
+        val rg: res[*mir.MirVReg, A.Error] = A.reallocate[mir.MirVReg](alloc, f.vregs, f.vreg_cap::usize, new_cap::usize);
+        if (sel rg.err) { ret res[u32, fail.Fail].err{fail.refused(rg.err)}; }
+        f.vregs    = rg.ok;
         f.vreg_cap = new_cap;
     }
     val vid: u32 = f.vreg_count;
     f.vregs[vid] = mir.vreg(vid, f.vregs[like].class, f.vregs[like].vector, f.vregs[like].secret);
     f.vregs[vid].ty = f.vregs[like].ty;
     f.vreg_count = f.vreg_count + 1;
-    ret R.ok[u32, str](vid);
+    ret res[u32, fail.Fail].ok{vid};
 }
 
-fun append_instr(alloc: *A.Allocator, mb: *mir.MirBlock, mi: mir.MirInstr) R.Result[R.Void, str] {
+fun append_instr(alloc: *A.Allocator, mb: *mir.MirBlock, mi: mir.MirInstr) err[fail.Fail] {
     if (mb.instr_count >= mb.instr_cap) {
         var new_cap: u32 = mb.instr_cap * 2;
         if (new_cap < mir.INITIAL_INSTR_CAP) { new_cap = mir.INITIAL_INSTR_CAP; }
-        val rg: R.Result[*mir.MirInstr, str] = A.reallocate[mir.MirInstr](alloc, mb.instrs, mb.instr_cap::usize, new_cap::usize);
-        if (R.is_err[*mir.MirInstr, str](rg)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirInstr, str](rg)); }
-        mb.instrs    = R.unwrap_ok[*mir.MirInstr, str](rg);
+        val rg: res[*mir.MirInstr, A.Error] = A.reallocate[mir.MirInstr](alloc, mb.instrs, mb.instr_cap::usize, new_cap::usize);
+        if (sel rg.err) { ret err[fail.Fail].err{fail.refused(rg.err)}; }
+        mb.instrs    = rg.ok;
         mb.instr_cap = new_cap;
     }
     mb.instrs[mb.instr_count] = mi;
     mb.instr_count = mb.instr_count + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun ends_in_br_to(mb: *mir.MirBlock, target: u32) bool {
@@ -415,7 +417,7 @@ fun ends_in_br_to(mb: *mir.MirBlock, target: u32) bool {
     ret t.operands[0].imm::u32 == target;
 }
 
-fun rebuild_preds(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) R.Result[R.Void, str] {
+fun rebuild_preds(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) err[fail.Fail] {
     var i: u32 = 0;
     for (i < f.block_count) { f.blocks[i].pred_count = 0; i = i + 1; }
 
@@ -430,8 +432,8 @@ fun rebuild_preds(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) R.
                 if (op.kind == mir.MIR_OP_BLOCK) {
                     val succ: *mir.MirBlock = find_block(f, sc, op.imm::u32);
                     if (succ != nil) {
-                        val ap: R.Result[R.Void, str] = pred_append(alloc, succ, mb.id);
-                        if (R.is_err[R.Void, str](ap)) { ret ap; }
+                        val ap: err[fail.Fail] = pred_append(alloc, succ, mb.id);
+                        if (sel ap.err) { ret ap; }
                     }
                 }
                 k = k + 1;
@@ -439,26 +441,27 @@ fun rebuild_preds(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) R.
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun pred_append(alloc: *A.Allocator, mb: *mir.MirBlock, pred: u32) R.Result[R.Void, str] {
+fun pred_append(alloc: *A.Allocator, mb: *mir.MirBlock, pred: u32) err[fail.Fail] {
     if (mb.pred_count >= mb.pred_cap) {
         var new_cap: u32 = mb.pred_cap * 2;
         if (new_cap < mir.INITIAL_INSTR_CAP) { new_cap = mir.INITIAL_INSTR_CAP; }
-        val rg: R.Result[*u32, str] = A.reallocate[u32](alloc, mb.preds, mb.pred_cap::usize, new_cap::usize);
-        if (R.is_err[*u32, str](rg)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](rg)); }
-        mb.preds    = R.unwrap_ok[*u32, str](rg);
+        val rg: res[*u32, A.Error] = A.reallocate[u32](alloc, mb.preds, mb.pred_cap::usize, new_cap::usize);
+        if (sel rg.err) { ret err[fail.Fail].err{fail.refused(rg.err)}; }
+        mb.preds    = rg.ok;
         mb.pred_cap = new_cap;
     }
     mb.preds[mb.pred_count] = pred;
     mb.pred_count = mb.pred_count + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun t_ops(alloc: *A.Allocator, src: *mir.MirOperand, n: u32) *mir.MirOperand {
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](alloc, n::usize);
-    val out: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](alloc, n::usize);
+    if (sel r.err) { ret nil; }
+    val out: *mir.MirOperand = r.ok;
     var i: u32 = 0;
     for (i < n) { out[i] = src[i]; i = i + 1; }
     ret out;
@@ -477,12 +480,13 @@ fun t_instr(alloc: *A.Allocator, op: mir.MirOpcode, ops: *mir.MirOperand, n: u32
 }
 
 fun t_block(alloc: *A.Allocator, id: u32, instrs: *mir.MirInstr, n: u32) mir.MirBlock {
-    val r: R.Result[*mir.MirInstr, str] = A.allocate[mir.MirInstr](alloc, n::usize);
-    val own: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](r);
+    var b: mir.MirBlock;
+    val r: res[*mir.MirInstr, A.Error] = A.allocate[mir.MirInstr](alloc, n::usize);
+    if (sel r.err) { ret b; }
+    val own: *mir.MirInstr = r.ok;
     var i: u32 = 0;
     for (i < n) { own[i] = instrs[i]; i = i + 1; }
 
-    var b: mir.MirBlock;
     b.id          = id;
     b.instrs      = own;
     b.instr_count = n;
@@ -498,8 +502,9 @@ fun t_fn(alloc: *A.Allocator, blocks: *mir.MirBlock, nb: u32, nv: u32) mir.MirFu
     f.blocks      = blocks;
     f.block_count = nb;
     f.block_cap   = nb;
-    val r: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](alloc, nv::usize);
-    f.vregs      = R.unwrap_ok[*mir.MirVReg, str](r);
+    val r: res[*mir.MirVReg, A.Error] = A.allocate[mir.MirVReg](alloc, nv::usize);
+    if (sel r.err) { ret f; }
+    f.vregs      = r.ok;
     f.vreg_count = nv;
     f.vreg_cap   = nv;
     var i: u32 = 0;
@@ -567,8 +572,8 @@ test "mach.lang.be.codegen.looprotate.try_rotate_header:multi_block_body" {
     blocks[5] = t_block(?alloc, 5, ?b5i[0], 1);
 
     var f: mir.MirFunction = t_fn(?alloc, ?blocks[0], 6, 4);
-    val r: R.Result[R.Void, str] = rotate_function(?alloc, ?f);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = rotate_function(?alloc, ?f);
+    if (sel r.err) { ret 1; }
 
     if (f.blocks[0].instr_count != 3)                       { ret 1; }
     if (f.blocks[0].instrs[1].opcode != mir.MIR_CMP_LT_S)   { ret 1; }
@@ -616,8 +621,8 @@ test "mach.lang.be.codegen.looprotate.try_rotate_header:memory_bound_test" {
     blocks[3] = t_block(?alloc, 3, ?b3i[0], 1);
 
     var f: mir.MirFunction = t_fn(?alloc, ?blocks[0], 4, 4);
-    val r: R.Result[R.Void, str] = rotate_function(?alloc, ?f);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = rotate_function(?alloc, ?f);
+    if (sel r.err) { ret 1; }
 
     if (f.blocks[0].instr_count != 4)                     { ret 1; }
     if (f.blocks[0].instrs[1].opcode != mir.MIR_LOAD)     { ret 1; }
@@ -661,8 +666,8 @@ test "mach.lang.be.codegen.looprotate.try_rotate_header:declines_escaping_test_d
     blocks[3] = t_block(?alloc, 3, ?b3i[0], 1);
 
     var f: mir.MirFunction = t_fn(?alloc, ?blocks[0], 4, 3);
-    val r: R.Result[R.Void, str] = rotate_function(?alloc, ?f);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = rotate_function(?alloc, ?f);
+    if (sel r.err) { ret 1; }
 
     if (f.blocks[0].instr_count != 2)      { ret 1; }
     if (!ends_in_br_to(?f.blocks[0], 1))   { ret 1; }
@@ -705,8 +710,8 @@ test "mach.lang.be.codegen.looprotate.try_rotate_header:declines_two_entries" {
     blocks[4] = t_block(?alloc, 4, ?b4i[0], 1);
 
     var f: mir.MirFunction = t_fn(?alloc, ?blocks[0], 5, 3);
-    val r: R.Result[R.Void, str] = rotate_function(?alloc, ?f);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = rotate_function(?alloc, ?f);
+    if (sel r.err) { ret 1; }
 
     if (f.blocks[0].instr_count != 1)    { ret 1; }
     if (f.blocks[1].instr_count != 1)    { ret 1; }

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -1,5 +1,8 @@
-use page: mach.lang.legacy.page;
-use format: mach.lang.legacy.format;
+use page: std.allocator.page;
+use std.types.canonical.res;
+use std.types.canonical.opt;
+use std.types.canonical.err;
+use format: std.format;
 use std.memory;
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -10,7 +13,7 @@ use std.types.string.str_contains;
 use std.types.string.str_equals;
 use std.types.string.str_len;
 
-use A: mach.lang.legacy.allocator;
+use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -613,57 +616,65 @@ pub val BANK_NONE:    OperandBank = 4;
 
 # g/f require a bank, v is gp scalar or fp vector, a is typed transport, n forbids registers
 # a final star repeats the preceding operand contract
-pub fun validate_bank_pattern(pattern: str) R.Result[R.Void, str] {
-    if (pattern == nil || str_len(pattern) == 0) { ret R.err[R.Void, str]("mir: opcode omits its operand bank contract"); }
+pub fun validate_bank_pattern(pattern: str) err[fail.Fail] {
+    if (pattern == nil || str_len(pattern) == 0) { ret err[fail.Fail].err{fail.message("mir: opcode omits its operand bank contract")}; }
     val n: usize = str_len(pattern);
     var i: usize = 0;
     for (i < n) {
         val c: u8 = pattern[i];
         if (c == '*'::u8) {
-            if (i == 0 || i + 1 != n) { ret R.err[R.Void, str]("mir: malformed repeated operand bank contract"); }
+            if (i == 0 || i + 1 != n) { ret err[fail.Fail].err{fail.message("mir: malformed repeated operand bank contract")}; }
         }
         or (c != 'g'::u8 && c != 'f'::u8 && c != 'v'::u8 && c != 'a'::u8 && c != 'n'::u8) {
-            ret R.err[R.Void, str]("mir: opcode declares an unknown operand bank");
+            ret err[fail.Fail].err{fail.message("mir: opcode declares an unknown operand bank")};
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun validate_operand_banks() R.Result[R.Void, str] {
+pub fun check_operand_banks() err[fail.Fail] {
     var i: u32 = 0;
     for (i < SELECTION_CATALOG_COUNT) {
-        val checked: R.Result[R.Void, str] = validate_bank_pattern(SELECTION_CATALOG[i].operand_banks);
-        if (R.is_err[R.Void, str](checked)) { ret checked; }
+        val checked: err[fail.Fail] = validate_bank_pattern(SELECTION_CATALOG[i].operand_banks);
+        if (sel checked.err) { ret checked; }
         i = i + 1;
     }
+    ret err[fail.Fail].ok{};
+}
+
+# translation shim (#3226): the legacy carrier target/isa reads until its
+# call sites migrate to `check_operand_banks`
+pub fun validate_operand_banks() R.Result[R.Void, str] {
+    val r: err[fail.Fail] = check_operand_banks();
+    if (sel r.err) { ret R.err[R.Void, str](fail.describe(r.err)); }
     ret R.ok_void[str]();
 }
 
-pub fun operand_bank(op: MirOpcode, index: u32, vector: bool) R.Result[OperandBank, str] {
-    val described: R.Result[*MirOpDescriptor, str] = describe(op);
-    if (R.is_err[*MirOpDescriptor, str](described)) { ret R.err[OperandBank, str](R.unwrap_err[*MirOpDescriptor, str](described)); }
-    val pattern: str = R.unwrap_ok[*MirOpDescriptor, str](described).operand_banks;
-    val checked: R.Result[R.Void, str] = validate_bank_pattern(pattern);
-    if (R.is_err[R.Void, str](checked)) { ret R.err[OperandBank, str](R.unwrap_err[R.Void, str](checked)); }
+pub fun operand_bank(op: MirOpcode, index: u32, vector: bool) res[OperandBank, fail.Fail] {
+    val described: res[*MirOpDescriptor, fail.Fail] = describe(op);
+    if (sel described.err) { ret res[OperandBank, fail.Fail].err{described.err}; }
+    val pattern: str = described.ok.operand_banks;
+    val checked: err[fail.Fail] = validate_bank_pattern(pattern);
+    if (sel checked.err) { ret res[OperandBank, fail.Fail].err{checked.err}; }
     val n: usize = str_len(pattern);
     var at: usize = index::usize;
     if (pattern[n - 1] == '*'::u8 && at >= n - 1) { at = n - 2; }
-    if (at >= n) { ret R.err[OperandBank, str]("mir: register operand has no declared bank slot"); }
+    if (at >= n) { ret res[OperandBank, fail.Fail].err{fail.message("mir: register operand has no declared bank slot")}; }
     val c: u8 = pattern[at];
-    if (c == 'g'::u8 || (c == 'v'::u8 && !vector)) { ret R.ok[OperandBank, str](BANK_GP); }
-    if (c == 'f'::u8 || (c == 'v'::u8 && vector)) { ret R.ok[OperandBank, str](BANK_FP); }
-    if (c == 'a'::u8) { ret R.ok[OperandBank, str](BANK_EITHER); }
-    ret R.ok[OperandBank, str](BANK_NONE);
+    if (c == 'g'::u8 || (c == 'v'::u8 && !vector)) { ret res[OperandBank, fail.Fail].ok{BANK_GP}; }
+    if (c == 'f'::u8 || (c == 'v'::u8 && vector)) { ret res[OperandBank, fail.Fail].ok{BANK_FP}; }
+    if (c == 'a'::u8) { ret res[OperandBank, fail.Fail].ok{BANK_EITHER}; }
+    ret res[OperandBank, fail.Fail].ok{BANK_NONE};
 }
 
-pub fun describe(op: MirOpcode) R.Result[*MirOpDescriptor, str] {
+pub fun describe(op: MirOpcode) res[*MirOpDescriptor, fail.Fail] {
     var i: u32 = 0;
     for (i < SELECTION_CATALOG_COUNT) {
-        if (SELECTION_CATALOG[i].op == op) { ret R.ok[*MirOpDescriptor, str](?SELECTION_CATALOG[i]); }
+        if (SELECTION_CATALOG[i].op == op) { ret res[*MirOpDescriptor, fail.Fail].ok{?SELECTION_CATALOG[i]}; }
         i = i + 1;
     }
-    ret R.err[*MirOpDescriptor, str]("mir: machine opcode has no catalog entry");
+    ret res[*MirOpDescriptor, fail.Fail].err{fail.message("mir: machine opcode has no catalog entry")};
 }
 
 pub fun desc(op: MirOpcode) *MirOpDescriptor {
@@ -683,18 +694,18 @@ pub fun ct_class(op: MirOpcode) MirCtClass {
     ret desc(op).ct_class;
 }
 
-pub fun ct_op(op: MirOpcode) R.Result[ct.CtOp, str] {
-    val dr: R.Result[*MirOpDescriptor, str] = describe(op);
-    if (R.is_err[*MirOpDescriptor, str](dr)) {
-        ret R.err[ct.CtOp, str]("mir: opcode is not in the selection catalog, so its constant-time class is undeclared");
+pub fun ct_op(op: MirOpcode) res[ct.CtOp, fail.Fail] {
+    val dr: res[*MirOpDescriptor, fail.Fail] = describe(op);
+    if (sel dr.err) {
+        ret res[ct.CtOp, fail.Fail].err{fail.message("mir: opcode is not in the selection catalog, so its constant-time class is undeclared")};
     }
-    val c: MirCtClass = R.unwrap_ok[*MirOpDescriptor, str](dr).ct_class;
-    if (c == MCT_INT_MUL)    { ret R.ok[ct.CtOp, str](ct.CT_OP_INT_MUL); }
-    if (c == MCT_INT_DIVMOD) { ret R.ok[ct.CtOp, str](ct.CT_OP_INT_DIVMOD); }
-    if (c == MCT_VAR_SHIFT)  { ret R.ok[ct.CtOp, str](ct.CT_OP_VAR_SHIFT); }
-    if (c == MCT_FLOAT)      { ret R.ok[ct.CtOp, str](ct.CT_OP_FLOAT); }
-    if (c == MCT_NONE)       { ret R.ok[ct.CtOp, str](ct.CT_OP_NONE); }
-    ret R.err[ct.CtOp, str]("mir: catalog constant-time class has no validator mapping");
+    val c: MirCtClass = dr.ok.ct_class;
+    if (c == MCT_INT_MUL)    { ret res[ct.CtOp, fail.Fail].ok{ct.CT_OP_INT_MUL}; }
+    if (c == MCT_INT_DIVMOD) { ret res[ct.CtOp, fail.Fail].ok{ct.CT_OP_INT_DIVMOD}; }
+    if (c == MCT_VAR_SHIFT)  { ret res[ct.CtOp, fail.Fail].ok{ct.CT_OP_VAR_SHIFT}; }
+    if (c == MCT_FLOAT)      { ret res[ct.CtOp, fail.Fail].ok{ct.CT_OP_FLOAT}; }
+    if (c == MCT_NONE)       { ret res[ct.CtOp, fail.Fail].ok{ct.CT_OP_NONE}; }
+    ret res[ct.CtOp, fail.Fail].err{fail.message("mir: catalog constant-time class has no validator mapping")};
 }
 
 pub fun is_terminator(op: MirOpcode) bool {
@@ -1025,39 +1036,38 @@ pub fun opcode_name(op: MirOpcode) str {
 pub fun instr_refusal(alloc: *A.Allocator, srcmap: *source.SourceMap,
                       fn_name: str, mi: *MirInstr, what: str) str {
     if (mi == nil) {
-        val fj: R.Result[str, str] = format.sprint(alloc, "{} (in {})", what, fn_name);
-        if (R.is_err[str, str](fj)) { ret what; }
-        ret R.unwrap_ok[str, str](fj);
+        val fj: res[str, format.FormatError] = format.sprint(alloc, "{} (in {})", what, fn_name);
+        if (sel fj.err) { ret what; }
+        ret fj.ok;
     }
 
     val opc: str = opcode_name(mi.opcode);
-    val where: O.Option[str] = refusal_where(mi.loc, srcmap, alloc);
+    val where: opt[str] = refusal_where(mi.loc, srcmap, alloc);
 
-    var rj: R.Result[str, str];
-    if (O.is_some[str](where)) {
-        rj = format.sprint(alloc, "{} ({} in {}, at {})", what, opc, fn_name,
-                           O.unwrap[str](where));
+    if (sel where.some) {
+        val rj: res[str, format.FormatError] = format.sprint(alloc, "{} ({} in {}, at {})", what, opc, fn_name,
+                           where.some);
+        if (sel rj.err) { ret what; }
+        ret rj.ok;
     }
-    or {
-        rj = format.sprint(alloc, "{} ({} in {}; no source location on this instruction)",
-                           what, opc, fn_name);
-    }
-    if (R.is_err[str, str](rj)) { ret what; }
-    ret R.unwrap_ok[str, str](rj);
+    val rj: res[str, format.FormatError] = format.sprint(alloc, "{} ({} in {}; no source location on this instruction)",
+                       what, opc, fn_name);
+    if (sel rj.err) { ret what; }
+    ret rj.ok;
 }
 
 fun refusal_where(l: source.SrcLoc, srcmap: *source.SourceMap,
-                  alloc: *A.Allocator) O.Option[str] {
-    if (!source.loc_is_valid(l)) { ret O.none[str](); }
-    if (srcmap == nil)           { ret O.none[str](); }
+                  alloc: *A.Allocator) opt[str] {
+    if (!source.loc_is_valid(l)) { ret opt[str].none{}; }
+    if (srcmap == nil)           { ret opt[str].none{}; }
     val of: O.Option[*source.SourceFile] = source.get(srcmap, l.file);
-    if (O.is_none[*source.SourceFile](of)) { ret O.none[str](); }
+    if (O.is_none[*source.SourceFile](of)) { ret opt[str].none{}; }
     val f: *source.SourceFile = O.unwrap[*source.SourceFile](of);
 
     val p: source.Position = source.position(f, l.offset);
-    val rj: R.Result[str, str] = format.sprint(alloc, "{}:{}:{}", f.path, p.line, p.col);
-    if (R.is_err[str, str](rj)) { ret O.none[str](); }
-    ret O.some[str](R.unwrap_ok[str, str](rj));
+    val rj: res[str, format.FormatError] = format.sprint(alloc, "{}:{}:{}", f.path, p.line, p.col);
+    if (sel rj.err) { ret opt[str].none{}; }
+    ret opt[str].some{rj.ok};
 }
 
 pub rec MirModule {
@@ -1070,19 +1080,19 @@ pub rec MirModule {
 }
 
 # the module interner owns failure text independently of temporary backend storage
-pub fun catalog_failure(m: *MirModule, catalog: str, tag: u32) R.Result[R.Void, str] {
-    ret R.err[R.Void, str](fail.catalog_message(m.interner, m.alloc, fail.unknown_member(catalog, tag)));
+pub fun catalog_failure(m: *MirModule, catalog: str, tag: u32) err[fail.Fail] {
+    ret err[fail.Fail].err{fail.message(fail.catalog_message(m.interner, m.alloc, fail.unknown_member(catalog, tag)))};
 }
 
-pub fun validate_catalog(m: *MirModule) R.Result[R.Void, str] {
+pub fun validate_catalog(m: *MirModule) err[fail.Fail] {
     ret validate_records(m, true);
 }
 
-pub fun validate_operands(m: *MirModule) R.Result[R.Void, str] {
+pub fun validate_operands(m: *MirModule) err[fail.Fail] {
     ret validate_records(m, false);
 }
 
-fun validate_records(m: *MirModule, generic_opcodes: bool) R.Result[R.Void, str] {
+fun validate_records(m: *MirModule, generic_opcodes: bool) err[fail.Fail] {
     var fi: u32 = 0;
     for (fi < m.function_len) {
         val f: *MirFunction = ?m.functions[fi];
@@ -1092,7 +1102,8 @@ fun validate_records(m: *MirModule, generic_opcodes: bool) R.Result[R.Void, str]
             var ii: u32 = 0;
             for (ii < block.instr_count) {
                 val instruction: *MirInstr = ?block.instrs[ii];
-                if (generic_opcodes && R.is_err[*MirOpDescriptor, str](describe(instruction.opcode))) {
+                val described: res[*MirOpDescriptor, fail.Fail] = describe(instruction.opcode);
+                if (generic_opcodes && sel described.err) {
                     ret catalog_failure(m, "MirOpcode", instruction.opcode);
                 }
                 var oi: u32 = 0;
@@ -1107,7 +1118,7 @@ fun validate_records(m: *MirModule, generic_opcodes: bool) R.Result[R.Void, str]
         }
         fi = fi + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 pub val INITIAL_FN_CAP:    u32 = 8;
@@ -1277,25 +1288,25 @@ pub fun vreg_is_fp(fn: *MirFunction, vreg: u32) bool {
     ret fn.vregs[vreg].class != REG_CLASS_GP && fn.vregs[vreg].class != REG_CLASS_VALUE;
 }
 
-pub fun push_function(mm: *MirModule, mf: MirFunction) R.Result[R.Void, str] {
+pub fun push_function(mm: *MirModule, mf: MirFunction) err[fail.Fail] {
     if (mm.function_len == mm.function_cap) {
         var new_cap: u32 = mm.function_cap * 2;
 
         if (new_cap == 0) { new_cap = INITIAL_FN_CAP; }
 
         if (mm.functions == nil) {
-            val res_alloc: R.Result[*MirFunction, str] = A.allocate[MirFunction](mm.alloc, new_cap::usize);
-            if (R.is_err[*MirFunction, str](res_alloc)) {
-                ret R.err[R.Void, str](R.unwrap_err[*MirFunction, str](res_alloc));
+            val res_alloc: res[*MirFunction, A.Error] = A.allocate[MirFunction](mm.alloc, new_cap::usize);
+            if (sel res_alloc.err) {
+                ret err[fail.Fail].err{fail.refused(res_alloc.err)};
             }
-            mm.functions = R.unwrap_ok[*MirFunction, str](res_alloc);
+            mm.functions = res_alloc.ok;
         }
         or {
-            val res_realloc: R.Result[*MirFunction, str] = A.reallocate[MirFunction](mm.alloc, mm.functions, mm.function_cap::usize, new_cap::usize);
-            if (R.is_err[*MirFunction, str](res_realloc)) {
-                ret R.err[R.Void, str](R.unwrap_err[*MirFunction, str](res_realloc));
+            val res_realloc: res[*MirFunction, A.Error] = A.reallocate[MirFunction](mm.alloc, mm.functions, mm.function_cap::usize, new_cap::usize);
+            if (sel res_realloc.err) {
+                ret err[fail.Fail].err{fail.refused(res_realloc.err)};
             }
-            mm.functions = R.unwrap_ok[*MirFunction, str](res_realloc);
+            mm.functions = res_realloc.ok;
         }
 
         mm.function_cap = new_cap;
@@ -1303,20 +1314,20 @@ pub fun push_function(mm: *MirModule, mf: MirFunction) R.Result[R.Void, str] {
 
     mm.functions[mm.function_len] = mf;
     mm.function_len = mm.function_len + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun instr_attach_dbg(a: *A.Allocator, mi: *MirInstr, iid: u32, vreg: u32) R.Result[R.Void, str] {
+pub fun instr_attach_dbg(a: *A.Allocator, mi: *MirInstr, iid: u32, vreg: u32) err[fail.Fail] {
     val n: u32 = mi.dbg_binding_count;
     if (mi.dbg_bindings == nil) {
-        val ra: R.Result[*MirDbgBinding, str] = A.allocate[MirDbgBinding](a, 1::usize);
-        if (R.is_err[*MirDbgBinding, str](ra)) { ret R.err[R.Void, str](R.unwrap_err[*MirDbgBinding, str](ra)); }
-        mi.dbg_bindings = R.unwrap_ok[*MirDbgBinding, str](ra);
+        val ra: res[*MirDbgBinding, A.Error] = A.allocate[MirDbgBinding](a, 1::usize);
+        if (sel ra.err) { ret err[fail.Fail].err{fail.refused(ra.err)}; }
+        mi.dbg_bindings = ra.ok;
     }
     or {
-        val rr: R.Result[*MirDbgBinding, str] = A.reallocate[MirDbgBinding](a, mi.dbg_bindings, n::usize, (n + 1)::usize);
-        if (R.is_err[*MirDbgBinding, str](rr)) { ret R.err[R.Void, str](R.unwrap_err[*MirDbgBinding, str](rr)); }
-        mi.dbg_bindings = R.unwrap_ok[*MirDbgBinding, str](rr);
+        val rr: res[*MirDbgBinding, A.Error] = A.reallocate[MirDbgBinding](a, mi.dbg_bindings, n::usize, (n + 1)::usize);
+        if (sel rr.err) { ret err[fail.Fail].err{fail.refused(rr.err)}; }
+        mi.dbg_bindings = rr.ok;
     }
     mi.dbg_bindings[n].iid  = iid;
     mi.dbg_bindings[n].vreg = vreg;
@@ -1328,7 +1339,7 @@ pub fun instr_attach_dbg(a: *A.Allocator, mi: *MirInstr, iid: u32, vreg: u32) R.
     mi.dbg_bindings[n].imm        = 0;
     mi.dbg_bindings[n].imm2       = 0;
     mi.dbg_binding_count = n + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 pub fun dnit_module(mm: *MirModule) {
@@ -1740,23 +1751,33 @@ test "mach.lang.be.codegen.mir:catalog_pins_the_predicates_it_absorbed" {
     if (ct_class(MIR_ADD) != MCT_NONE)          { ret 1; }
     if (ct_class(0xDEAD::MirOpcode) != MCT_NONE) { ret 1; }
 
-    if (R.is_err[*MirOpDescriptor, str](describe(MIR_ADD)))         { ret 1; }
-    if (R.is_ok[*MirOpDescriptor, str](describe(0xDEAD::MirOpcode))) { ret 1; }
+    val describe_r: res[*MirOpDescriptor, fail.Fail] = describe(MIR_ADD);
+    if (sel describe_r.err)         { ret 1; }
+    val describe_r2: res[*MirOpDescriptor, fail.Fail] = describe(0xDEAD::MirOpcode);
+    if (sel describe_r2.ok) { ret 1; }
     ret 0;
 }
 
 test "mach.lang.be.codegen.mir:operand_bank_catalog_rejects_undeclared_banks" {
-    if (R.is_err[R.Void, str](validate_operand_banks())) { ret 1; }
-    if (R.is_ok[R.Void, str](validate_bank_pattern(nil))) { ret 2; }
-    if (R.is_ok[R.Void, str](validate_bank_pattern("gx"))) { ret 3; }
-    if (R.is_ok[R.Void, str](validate_bank_pattern("*g"))) { ret 4; }
-    if (R.is_ok[R.Void, str](validate_bank_pattern("g*f"))) { ret 5; }
-    if (R.is_ok[OperandBank, str](operand_bank(MIR_OP_NONE, 0, false))) { ret 6; }
-    val to_int: R.Result[OperandBank, str] = operand_bank(MIR_FP_TO_SI, 0, false);
-    val from_float: R.Result[OperandBank, str] = operand_bank(MIR_FP_TO_SI, 1, false);
-    if (R.is_err[OperandBank, str](to_int) || R.is_err[OperandBank, str](from_float)) { ret 7; }
-    if (R.unwrap_ok[OperandBank, str](to_int) != BANK_GP || R.unwrap_ok[OperandBank, str](from_float) != BANK_FP) { ret 8; }
-    val vector_compare: R.Result[OperandBank, str] = operand_bank(MIR_FCMP, 0, true);
-    if (R.is_err[OperandBank, str](vector_compare) || R.unwrap_ok[OperandBank, str](vector_compare) != BANK_FP) { ret 9; }
+    val check_operand_banks_r: err[fail.Fail] = check_operand_banks();
+    if (sel check_operand_banks_r.err) { ret 1; }
+    val validate_bank_pattern_r: err[fail.Fail] = validate_bank_pattern(nil);
+    if (sel validate_bank_pattern_r.ok) { ret 2; }
+    val validate_bank_pattern_r2: err[fail.Fail] = validate_bank_pattern("gx");
+    if (sel validate_bank_pattern_r2.ok) { ret 3; }
+    val validate_bank_pattern_r3: err[fail.Fail] = validate_bank_pattern("*g");
+    if (sel validate_bank_pattern_r3.ok) { ret 4; }
+    val validate_bank_pattern_r4: err[fail.Fail] = validate_bank_pattern("g*f");
+    if (sel validate_bank_pattern_r4.ok) { ret 5; }
+    val operand_bank_r: res[OperandBank, fail.Fail] = operand_bank(MIR_OP_NONE, 0, false);
+    if (sel operand_bank_r.ok) { ret 6; }
+    val to_int: res[OperandBank, fail.Fail] = operand_bank(MIR_FP_TO_SI, 0, false);
+    val from_float: res[OperandBank, fail.Fail] = operand_bank(MIR_FP_TO_SI, 1, false);
+    if (sel to_int.err) { ret 7; }
+    if (sel from_float.err) { ret 7; }
+    if (to_int.ok != BANK_GP || from_float.ok != BANK_FP) { ret 8; }
+    val vector_compare: res[OperandBank, fail.Fail] = operand_bank(MIR_FCMP, 0, true);
+    if (sel vector_compare.err) { ret 9; }
+    if (vector_compare.ok != BANK_FP) { ret 9; }
     ret 0;
 }

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -1,14 +1,17 @@
-use page: mach.lang.legacy.page;
+use page: std.allocator.page;
+use std.types.canonical.res;
+use std.types.canonical.err;
+use mach.lang.fail;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 
-use A: mach.lang.legacy.allocator;
+use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
-use V: mach.lang.legacy.vector;
+use V: std.collections.vector;
 
 use mach.lang.intern;
 use mach.lang.be.codegen.mir;
@@ -33,35 +36,35 @@ val CONV_ABI:  [7]str = [7]str{"sysv64", "win64", "sysv64", "aapcs64", "lp64d", 
 
 val MAX_GP_ARG_REGS: i32 = 16;
 
-pub fun require_abi(tgt: *target.Target) R.Result[R.Void, str] {
-    if (tgt == nil)     { ret R.err[R.Void, str]("mir.lower_ir: nil target"); }
-    if (tgt.abi == nil) { ret R.err[R.Void, str]("mir.lower_ir: target has no ABI vtable"); }
-    if (tgt.isa == nil) { ret R.err[R.Void, str]("mir.lower_ir: target has no ISA vtable"); }
+pub fun require_abi(tgt: *target.Target) err[fail.Fail] {
+    if (tgt == nil)     { ret err[fail.Fail].err{fail.message("mir.lower_ir: nil target")}; }
+    if (tgt.abi == nil) { ret err[fail.Fail].err{fail.message("mir.lower_ir: target has no ABI vtable")}; }
+    if (tgt.isa == nil) { ret err[fail.Fail].err{fail.message("mir.lower_ir: target has no ISA vtable")}; }
     if (tgt.abi.arg_passing == nil || tgt.abi.ret_passing == nil) {
-        ret R.err[R.Void, str]("mir.lower_ir: ABI vtable exposes no arg/ret classifier");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: ABI vtable exposes no arg/ret classifier")};
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun abi_gp_arg_reg(tgt: *target.Target, index: i32, out: *i32) R.Result[R.Void, str] {
+pub fun abi_gp_arg_reg(tgt: *target.Target, index: i32, out: *i32) err[fail.Fail] {
     if (tgt.abi.gp_arg_regs == nil) {
-        ret R.err[R.Void, str]("mir.lower_ir: ABI vtable exposes no GP argument register file");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: ABI vtable exposes no GP argument register file")};
     }
     var regs: [16]isa.Register;
     val n: i32 = tgt.abi.gp_arg_regs(?regs[0]);
     if (index < 0 || index >= n || index >= MAX_GP_ARG_REGS) {
-        ret R.err[R.Void, str]("mir.lower_ir: GP argument register index out of range");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: GP argument register index out of range")};
     }
     @out = regs[index].id;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun abi_va_model(tgt: *target.Target, out: *abi.VaModel) R.Result[R.Void, str] {
+pub fun abi_va_model(tgt: *target.Target, out: *abi.VaModel) err[fail.Fail] {
     if (tgt.abi.va_model == nil) {
-        ret R.err[R.Void, str]("mir.lower_ir: a variadic call is not supported by this calling convention (no variadic save model)");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: a variadic call is not supported by this calling convention (no variadic save model)")};
     }
     @out = tgt.abi.va_model();
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 val EB_NO_CLASS: u8 = 0;
@@ -387,9 +390,9 @@ fun is_stack_slot_class(class: abi.ParamClass) bool {
 }
 
 pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type: type.IrTypeId,
-                           out: *abi.SigLayout) R.Result[R.Void, str] {
-    val rok: R.Result[R.Void, str] = require_abi(ctx.tgt);
-    if (R.is_err[R.Void, str](rok)) { ret rok; }
+                           out: *abi.SigLayout) err[fail.Fail] {
+    val rok: err[fail.Fail] = require_abi(ctx.tgt);
+    if (sel rok.err) { ret rok; }
 
     val classify_arg: abi.ArgPassingFn = ctx.tgt.abi.arg_passing;
     val classify_ret: abi.RetPassingFn = ctx.tgt.abi.ret_passing;
@@ -430,16 +433,16 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
         out.gp_used   = gp_used;
         out.fp_used   = fp_used;
         out.stack_off = stack_off;
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
     val t: *type.IrType = O.unwrap[*type.IrType](opt_sig);
 
     val pc: u32 = t.data.fn.param_count;
     var slots: *abi.ParamSlot = nil;
     if (pc > 0) {
-        val sb: R.Result[*abi.ParamSlot, str] = A.allocate[abi.ParamSlot](ctx.alloc, pc::usize);
-        if (R.is_err[*abi.ParamSlot, str](sb)) { ret R.err[R.Void, str](R.unwrap_err[*abi.ParamSlot, str](sb)); }
-        slots = R.unwrap_ok[*abi.ParamSlot, str](sb);
+        val sb: res[*abi.ParamSlot, A.Error] = A.allocate[abi.ParamSlot](ctx.alloc, pc::usize);
+        if (sel sb.err) { ret err[fail.Fail].err{fail.refused(sb.err)}; }
+        slots = sb.ok;
     }
 
     var i: u32 = 0;
@@ -480,7 +483,7 @@ pub fun classify_signature(ctx: *context.LowerCtx, sig: type.IrTypeId, ret_type:
     out.gp_used     = gp_used;
     out.fp_used     = fp_used;
     out.stack_off   = stack_off;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 pub fun sig_layout_free(ctx: *context.LowerCtx, layout: *abi.SigLayout) {
@@ -516,43 +519,43 @@ fun value_operand(ctx: *context.LowerCtx, v: value.Value) mir.MirOperand {
 }
 
 fun push_value_instr(ctx: *context.LowerCtx, mb: *mir.MirBlock, opcode: mir.MirOpcode,
-                     ops: *mir.MirOperand, count: u32) R.Result[R.Void, str] {
-    val pushed: R.Result[R.Void, str] = context.push_instr(ctx, mb, mir.instr(opcode, ops, count, 0, 0));
-    if (R.is_err[R.Void, str](pushed)) { A.deallocate[mir.MirOperand](ctx.alloc, ops, count::usize); }
+                     ops: *mir.MirOperand, count: u32) err[fail.Fail] {
+    val pushed: err[fail.Fail] = context.push_instr(ctx, mb, mir.instr(opcode, ops, count, 0, 0));
+    if (sel pushed.err) { A.deallocate[mir.MirOperand](ctx.alloc, ops, count::usize); }
     ret pushed;
 }
 
 fun lower_value_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.Instruction,
-                     iid: id.InstructionId, ret_type: type.IrTypeId, slots: *abi.SigLayout) R.Result[R.Void, str] {
+                     iid: id.InstructionId, ret_type: type.IrTypeId, slots: *abi.SigLayout) err[fail.Fail] {
     val sig: O.Option[*type.IrType] = type.get(ctx.types, inst.aux_ty);
-    if (O.is_none[*type.IrType](sig)) { ret R.err[R.Void, str]("mir.abi: logical call requires a typed signature"); }
+    if (O.is_none[*type.IrType](sig)) { ret err[fail.Fail].err{fail.message("mir.abi: logical call requires a typed signature")}; }
     val fn_ty: *type.IrType = O.unwrap[*type.IrType](sig);
     if (fn_ty.kind != type.IRT_FN || fn_ty.data.fn.variadic || inst.operand_count - 1 != slots.param_count) {
-        ret R.err[R.Void, str]("mir.abi: logical call requires exact nonvariadic arguments");
+        ret err[fail.Fail].err{fail.message("mir.abi: logical call requires exact nonvariadic arguments")};
     }
     if (!value_slot_valid(?slots.ret_slot, type.byte_size_for_machine(ctx.types, ret_type, ctx.layout)::u64)) {
-        ret R.err[R.Void, str]("mir.abi: invalid logical result slot");
+        ret err[fail.Fail].err{fail.message("mir.abi: invalid logical result slot")};
     }
     var i: u32 = 0;
     for (i < slots.param_count) {
         if (!value_slot_valid(?slots.params[i], type.byte_size_for_machine(ctx.types, fn_ty.data.fn.params[i], ctx.layout)::u64)) {
-            ret R.err[R.Void, str]("mir.abi: invalid logical argument slot");
+            ret err[fail.Fail].err{fail.message("mir.abi: invalid logical argument slot")};
         }
         i = i + 1;
     }
     val dst: u32 = context.instr_vreg(ctx, iid);
     var result: mir.MirOperand = mir.op_vreg(dst);
     if (context.value_is_aggregate(ctx, ret_type)) {
-        if (dst == mir.MIR_VREG_NIL) { ret R.err[R.Void, str]("mir.abi: logical composite call has no result owner"); }
-        val home: R.Result[R.Void, str] = context.alloc_object_storage(ctx, mb, dst, ret_type);
-        if (R.is_err[R.Void, str](home)) { ret home; }
+        if (dst == mir.MIR_VREG_NIL) { ret err[fail.Fail].err{fail.message("mir.abi: logical composite call has no result owner")}; }
+        val home: err[fail.Fail] = context.alloc_object_storage(ctx, mb, dst, ret_type);
+        if (sel home.err) { ret home; }
         result = mir.op_mem_value(dst, 0);
     }
-    if (inst.operand_count == 0xFFFFFFFF) { ret R.err[R.Void, str]("mir.abi: logical call operand extent overflow"); }
+    if (inst.operand_count == 0xFFFFFFFF) { ret err[fail.Fail].err{fail.message("mir.abi: logical call operand extent overflow")}; }
     val count: u32 = inst.operand_count + 1;
-    val ar: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, count::usize);
-    if (R.is_err[*mir.MirOperand, str](ar)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](ar)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ar);
+    val ar: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, count::usize);
+    if (sel ar.err) { ret err[fail.Fail].err{fail.refused(ar.err)}; }
+    val ops: *mir.MirOperand = ar.ok;
     ops[0] = context.lower_value(ctx, inst.operands[0]);
     ops[1] = result;
     i = 0;
@@ -560,41 +563,41 @@ fun lower_value_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instructi
     ret push_value_instr(ctx, mb, mir.MIR_VALUE_CALL, ops, count);
 }
 
-fun lower_value_params(ctx: *context.LowerCtx, mb: *mir.MirBlock, slots: *abi.SigLayout) R.Result[R.Void, str] {
+fun lower_value_params(ctx: *context.LowerCtx, mb: *mir.MirBlock, slots: *abi.SigLayout) err[fail.Fail] {
     if (slots.param_count != ctx.param_count || slots.param_count != ctx.fn.param_count) {
-        ret R.err[R.Void, str]("mir.abi: logical parameter signature does not match its bindings");
+        ret err[fail.Fail].err{fail.message("mir.abi: logical parameter signature does not match its bindings")};
     }
     var i: u32 = 0;
     for (i < slots.param_count) {
         val ty: type.IrTypeId = ctx.fn.params[i].ty;
         if (!value_slot_valid(?slots.params[i], type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64)) {
-            ret R.err[R.Void, str]("mir.abi: invalid logical parameter slot");
+            ret err[fail.Fail].err{fail.message("mir.abi: invalid logical parameter slot")};
         }
         val dst: u32 = ctx.param_vregs[i];
         var dest: mir.MirOperand = mir.op_vreg(dst);
         if (context.value_is_aggregate(ctx, ty)) {
-            val home: R.Result[R.Void, str] = context.alloc_object_storage(ctx, mb, dst, ty);
-            if (R.is_err[R.Void, str](home)) { ret home; }
+            val home: err[fail.Fail] = context.alloc_object_storage(ctx, mb, dst, ty);
+            if (sel home.err) { ret home; }
             dest = mir.op_mem_value(dst, 0);
         }
-        val ar: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-        if (R.is_err[*mir.MirOperand, str](ar)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](ar)); }
-        val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ar);
+        val ar: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+        if (sel ar.err) { ret err[fail.Fail].err{fail.refused(ar.err)}; }
+        val ops: *mir.MirOperand = ar.ok;
         ops[0] = dest;
         ops[1] = mir.op_imm(i::i64);
-        val pushed: R.Result[R.Void, str] = push_value_instr(ctx, mb, mir.MIR_VALUE_PARAM, ops, 2);
-        if (R.is_err[R.Void, str](pushed)) { ret pushed; }
+        val pushed: err[fail.Fail] = push_value_instr(ctx, mb, mir.MIR_VALUE_PARAM, ops, 2);
+        if (sel pushed.err) { ret pushed; }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
+pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.Instruction, iid: id.InstructionId) err[fail.Fail] {
     if (inst.operand_count == 0) {
-        ret R.err[R.Void, str]("mir.lower_ir: call with no callee operand");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: call with no callee operand")};
     }
-    val rok: R.Result[R.Void, str] = require_abi(ctx.tgt);
-    if (R.is_err[R.Void, str](rok)) { ret rok; }
+    val rok: err[fail.Fail] = require_abi(ctx.tgt);
+    if (sel rok.err) { ret rok; }
 
     var pending_registers: mir.MirBlock;
     fin { mir.dnit_block(ctx.alloc, ?pending_registers); }
@@ -606,11 +609,11 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     val sig: type.IrTypeId = inst.aux_ty;
     val ret_type: type.IrTypeId = call_ret_type(ctx, sig, inst.ty);
     var layout: abi.SigLayout;
-    val cls: R.Result[R.Void, str] = classify_signature(ctx, sig, ret_type, ?layout);
-    if (R.is_err[R.Void, str](cls)) { ret cls; }
+    val cls: err[fail.Fail] = classify_signature(ctx, sig, ret_type, ?layout);
+    if (sel cls.err) { ret cls; }
 
     if (context.values_convention(ctx)) {
-        val vr: R.Result[R.Void, str] = lower_value_call(ctx, mb, inst, iid, ret_type, ?layout);
+        val vr: err[fail.Fail] = lower_value_call(ctx, mb, inst, iid, ret_type, ?layout);
         sig_layout_free(ctx, ?layout);
         ret vr;
     }
@@ -641,40 +644,40 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     val res_dst: u32 = context.instr_vreg(ctx, iid);
     var sret_ptr: u32 = mir.MIR_VREG_NIL;
     if (ret_mem && res_dst != mir.MIR_VREG_NIL) {
-        var ra: R.Result[R.Void, str] = R.ok_void[str]();
+        var ra: err[fail.Fail] = err[fail.Fail].ok{};
         var owned_size: u64 = ret_size;
         if (rslot.class != abi.CLASS_SRET) {
             val extent: R.Result[u64, str] = abi.carrier_storage_extent(?rslot);
             if (R.is_err[u64, str](extent)) {
                 sig_layout_free(ctx, ?layout);
-                ret R.err[R.Void, str](R.unwrap_err[u64, str](extent));
+                ret err[fail.Fail].err{fail.message(R.unwrap_err[u64, str](extent))};
             }
             owned_size = R.unwrap_ok[u64, str](extent);
             val alignment: R.Result[u32, str] = abi.carrier_storage_alignment(?rslot);
             if (R.is_err[u32, str](alignment)) {
                 sig_layout_free(ctx, ?layout);
-                ret R.err[R.Void, str](R.unwrap_err[u32, str](alignment));
+                ret err[fail.Fail].err{fail.message(R.unwrap_err[u32, str](alignment))};
             }
             if (R.unwrap_ok[u32, str](alignment) > ret_storage_align) {
                 ret_storage_align = R.unwrap_ok[u32, str](alignment);
             }
         }
         ra = context.alloc_result_storage(ctx, mb, res_dst, owned_size, ret_storage_align);
-        if (R.is_err[R.Void, str](ra)) {
+        if (sel ra.err) {
             sig_layout_free(ctx, ?layout);
             ret ra;
         }
         sret_ptr = res_dst;
     }
     or (ret_sret_register && res_dst != mir.MIR_VREG_NIL) {
-        val sa: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](sa)) {
+        val sa: res[u32, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+        if (sel sa.err) {
             sig_layout_free(ctx, ?layout);
-            ret R.err[R.Void, str](R.unwrap_err[u32, str](sa));
+            ret err[fail.Fail].err{sa.err};
         }
-        sret_ptr = R.unwrap_ok[u32, str](sa);
-        val ra: R.Result[R.Void, str] = context.alloc_result_storage(ctx, mb, sret_ptr, ret_size, context.ret_align(ctx, ret_type));
-        if (R.is_err[R.Void, str](ra)) {
+        sret_ptr = sa.ok;
+        val ra: err[fail.Fail] = context.alloc_result_storage(ctx, mb, sret_ptr, ret_size, context.ret_align(ctx, ret_type));
+        if (sel ra.err) {
             sig_layout_free(ctx, ?layout);
             ret ra;
         }
@@ -683,9 +686,9 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     if (rslot.class == abi.CLASS_SRET) {
         if (sret_ptr != mir.MIR_VREG_NIL) {
             val sret_reg: i32 = ctx.tgt.abi.indirect_result_reg;
-            val pre: R.Result[R.Void, str] = context.emit_mov_w(ctx, registers,
+            val pre: err[fail.Fail] = context.emit_mov_w(ctx, registers,
                 mir.op_preg(sret_reg::u32), mir.op_vreg(sret_ptr), ptr_move_width(ctx));
-            if (R.is_err[R.Void, str](pre)) {
+            if (sel pre.err) {
                 sig_layout_free(ctx, ?layout);
                 ret pre;
             }
@@ -709,8 +712,8 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
             val avec: bool = context.value_is_vector(ctx, av.ty);
             if (afl) {
                 var vafl: abi.VaModel;
-                val vfr: R.Result[R.Void, str] = abi_va_model(ctx.tgt, ?vafl);
-                if (R.is_err[R.Void, str](vfr)) {
+                val vfr: err[fail.Fail] = abi_va_model(ctx.tgt, ?vafl);
+                if (sel vfr.err) {
                     sig_layout_free(ctx, ?layout);
                     ret vfr;
                 }
@@ -726,39 +729,39 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
             soff = stack_off;
         }
 
-        val aor: R.Result[mir.MirOperand, str] = lower_value_addr(ctx, mb, av);
-        if (R.is_err[mir.MirOperand, str](aor)) {
+        val aor: res[mir.MirOperand, fail.Fail] = lower_value_addr(ctx, mb, av);
+        if (sel aor.err) {
             sig_layout_free(ctx, ?layout);
-            ret R.err[R.Void, str](R.unwrap_err[mir.MirOperand, str](aor));
+            ret err[fail.Fail].err{aor.err};
         }
-        val argop: mir.MirOperand = R.unwrap_ok[mir.MirOperand, str](aor);
+        val argop: mir.MirOperand = aor.ok;
 
         # the carriers, the caller's copy and every temporary between them are secret when any byte of the object is
         ctx.cur_writes_secret = av.secret;
-        val er: R.Result[R.Void, str] = emit_arg_slot(ctx, mb, registers, slot, argop, soff, aag, av.ty,
+        val er: err[fail.Fail] = emit_arg_slot(ctx, mb, registers, slot, argop, soff, aag, av.ty,
                                                     natural_stack_slot(ctx.tgt, pidx >= layout.param_count));
         ctx.cur_writes_secret = false;
-        if (R.is_err[R.Void, str](er)) {
+        if (sel er.err) {
             sig_layout_free(ctx, ?layout);
             ret er;
         }
 
         if (pidx >= layout.param_count && slot.class == abi.CLASS_FP) {
             var vamodel: abi.VaModel;
-            val vmr: R.Result[R.Void, str] = abi_va_model(ctx.tgt, ?vamodel);
-            if (R.is_err[R.Void, str](vmr)) {
+            val vmr: err[fail.Fail] = abi_va_model(ctx.tgt, ?vamodel);
+            if (sel vmr.err) {
                 sig_layout_free(ctx, ?layout);
                 ret vmr;
             }
             if (vamodel.float_dup_gp) {
                 var dup_reg: i32 = 0;
-                val dr: R.Result[R.Void, str] = abi_gp_arg_reg(ctx.tgt, gp_used + fp_used, ?dup_reg);
-                if (R.is_err[R.Void, str](dr)) {
+                val dr: err[fail.Fail] = abi_gp_arg_reg(ctx.tgt, gp_used + fp_used, ?dup_reg);
+                if (sel dr.err) {
                     sig_layout_free(ctx, ?layout);
                     ret dr;
                 }
-                val dm: R.Result[R.Void, str] = emit_call_reg(ctx, mb, registers, mir.op_preg(dup_reg::u32), argop, ctx.tgt.model.gpr_width::u8);
-                if (R.is_err[R.Void, str](dm)) {
+                val dm: err[fail.Fail] = emit_call_reg(ctx, mb, registers, mir.op_preg(dup_reg::u32), argop, ctx.tgt.model.gpr_width::u8);
+                if (sel dm.err) {
                     sig_layout_free(ctx, ?layout);
                     ret dm;
                 }
@@ -785,79 +788,79 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
 
     if (variadic_call) {
         var vamodel: abi.VaModel;
-        val vmr: R.Result[R.Void, str] = abi_va_model(ctx.tgt, ?vamodel);
-        if (R.is_err[R.Void, str](vmr)) { ret vmr; }
+        val vmr: err[fail.Fail] = abi_va_model(ctx.tgt, ?vamodel);
+        if (sel vmr.err) { ret vmr; }
         if (vamodel.vector_count_reg >= 0) {
-            val al: R.Result[R.Void, str] = context.emit_mov_w(ctx, registers,
+            val al: err[fail.Fail] = context.emit_mov_w(ctx, registers,
                 mir.op_preg(vamodel.vector_count_reg::u32), mir.op_imm(fp_used::i64), 4::u8);
-            if (R.is_err[R.Void, str](al)) { ret al; }
+            if (sel al.err) { ret al; }
         }
     }
 
-    val placed: R.Result[R.Void, str] = append_deferred(ctx, mb, ?pending_registers);
-    if (R.is_err[R.Void, str](placed)) { ret placed; }
+    val placed: err[fail.Fail] = append_deferred(ctx, mb, ?pending_registers);
+    if (sel placed.err) { ret placed; }
 
-    val rcall: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 1::usize);
-    if (R.is_err[*mir.MirOperand, str](rcall)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](rcall)); }
-    val callops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rcall);
+    val rcall: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 1::usize);
+    if (sel rcall.err) { ret err[fail.Fail].err{fail.refused(rcall.err)}; }
+    val callops: *mir.MirOperand = rcall.ok;
     callops[0] = context.lower_value(ctx, inst.operands[0]);
     var cmi: mir.MirInstr = mir.instr(mir.MIR_CALL, callops, 1,
                                       ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
-    val pc: R.Result[R.Void, str] = context.push_instr(ctx, mb, cmi);
-    if (R.is_err[R.Void, str](pc)) { ret pc; }
+    val pc: err[fail.Fail] = context.push_instr(ctx, mb, cmi);
+    if (sel pc.err) { ret pc; }
 
     val dst: u32 = context.instr_vreg(ctx, iid);
     if (dst != mir.MIR_VREG_NIL && rslot.class != abi.CLASS_SRET) {
         ctx.cur_writes_secret = inst.secret;
-        val rr: R.Result[R.Void, str] = emit_ret_slot_to_vreg(ctx, mb, rslot, dst, ret_aggr, ret_type, ret_storage_align);
+        val rr: err[fail.Fail] = emit_ret_slot_to_vreg(ctx, mb, rslot, dst, ret_aggr, ret_type, ret_storage_align);
         ctx.cur_writes_secret = false;
-        if (R.is_err[R.Void, str](rr)) { ret rr; }
+        if (sel rr.err) { ret rr; }
     }
     if (ret_sret_register && dst != mir.MIR_VREG_NIL) {
-        var lr: R.Result[R.Void, str] = R.ok_void[str]();
+        var lr: err[fail.Fail] = err[fail.Fail].ok{};
         if (ret_vector_register) {
             lr = context.load_subwidth_vector(ctx, mb, mir.op_vreg(dst), mir.op_mem_value(sret_ptr, 0), ret_type);
         } or {
             lr = context.emit_load_from_w(ctx, mb, dst, mir.op_mem_value(sret_ptr, 0), ret_size::u8);
         }
-        if (R.is_err[R.Void, str](lr)) { ret lr; }
+        if (sel lr.err) { ret lr; }
     }
     if (dst != mir.MIR_VREG_NIL) {
-        val rres: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 1::usize);
-        if (R.is_err[*mir.MirOperand, str](rres)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](rres)); }
-        val resops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rres);
+        val rres: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 1::usize);
+        if (sel rres.err) { ret err[fail.Fail].err{fail.refused(rres.err)}; }
+        val resops: *mir.MirOperand = rres.ok;
         resops[0] = mir.op_vreg(dst);
         var rmi: mir.MirInstr = mir.instr(mir.MIR_CALL_RES, resops, 1,
                                           ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
-        val pr: R.Result[R.Void, str] = context.push_instr(ctx, mb, rmi);
-        if (R.is_err[R.Void, str](pr)) { ret pr; }
+        val pr: err[fail.Fail] = context.push_instr(ctx, mb, rmi);
+        if (sel pr.err) { ret pr; }
     }
 
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 
 fun emit_call_reg(ctx: *context.LowerCtx, preparation: *mir.MirBlock, registers: *mir.MirBlock,
-                  dst: mir.MirOperand, src: mir.MirOperand, width: u8) R.Result[R.Void, str] {
+                  dst: mir.MirOperand, src: mir.MirOperand, width: u8) err[fail.Fail] {
     var value: mir.MirOperand = src;
     if (registers != preparation && src.kind == mir.MIR_OP_MEM) {
         val class: u32 = isa.regid_class(dst.preg::i32)::u32;
-        val rv: R.Result[u32, str] = context.new_vreg_vec(ctx, class, class != mir.REG_CLASS_GP && width > 8);
-        if (R.is_err[u32, str](rv)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rv)); }
-        val v: u32 = R.unwrap_ok[u32, str](rv);
+        val rv: res[u32, fail.Fail] = context.new_vreg_vec(ctx, class, class != mir.REG_CLASS_GP && width > 8);
+        if (sel rv.err) { ret err[fail.Fail].err{rv.err}; }
+        val v: u32 = rv.ok;
         ctx.f.vregs[v].secret = ctx.cur_writes_secret;
-        val loaded: R.Result[R.Void, str] = context.emit_mov_w(ctx, preparation, mir.op_vreg(v), src, width);
-        if (R.is_err[R.Void, str](loaded)) { ret loaded; }
+        val loaded: err[fail.Fail] = context.emit_mov_w(ctx, preparation, mir.op_vreg(v), src, width);
+        if (sel loaded.err) { ret loaded; }
         value = mir.op_vreg(v);
     }
     ret context.emit_mov_w(ctx, registers, dst, value, width);
 }
 
-fun append_deferred(ctx: *context.LowerCtx, mb: *mir.MirBlock, deferred: *mir.MirBlock) R.Result[R.Void, str] {
+fun append_deferred(ctx: *context.LowerCtx, mb: *mir.MirBlock, deferred: *mir.MirBlock) err[fail.Fail] {
     var i: u32 = 0;
     for (i < deferred.instr_count) {
-        val grown: R.Result[R.Void, str] = context.grow_instr(ctx, mb);
-        if (R.is_err[R.Void, str](grown)) { ret grown; }
+        val grown: err[fail.Fail] = context.grow_instr(ctx, mb);
+        if (sel grown.err) { ret grown; }
         mb.instrs[mb.instr_count] = deferred.instrs[i];
         mb.instr_count = mb.instr_count + 1;
         deferred.instrs[i].operands = nil;
@@ -866,16 +869,16 @@ fun append_deferred(ctx: *context.LowerCtx, mb: *mir.MirBlock, deferred: *mir.Mi
         deferred.instrs[i].dbg_binding_count = 0;
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun lower_value_addr(ctx: *context.LowerCtx, mb: *mir.MirBlock, v: value.Value) R.Result[mir.MirOperand, str] {
+fun lower_value_addr(ctx: *context.LowerCtx, mb: *mir.MirBlock, v: value.Value) res[mir.MirOperand, fail.Fail] {
     val op: mir.MirOperand = context.lower_value(ctx, v);
-    if (op.kind != mir.MIR_OP_SYM || !ctx.tgt.model.flat_addressing) { ret R.ok[mir.MirOperand, str](op); }
+    if (op.kind != mir.MIR_OP_SYM || !ctx.tgt.model.flat_addressing) { ret res[mir.MirOperand, fail.Fail].ok{op}; }
     var addr: u32 = mir.MIR_VREG_NIL;
-    val ar: R.Result[R.Void, str] = context.addr_to_vreg(ctx, mb, op, ?addr);
-    if (R.is_err[R.Void, str](ar)) { ret R.err[mir.MirOperand, str](R.unwrap_err[R.Void, str](ar)); }
-    ret R.ok[mir.MirOperand, str](mir.op_vreg(addr));
+    val ar: err[fail.Fail] = context.addr_to_vreg(ctx, mb, op, ?addr);
+    if (sel ar.err) { ret res[mir.MirOperand, fail.Fail].err{ar.err}; }
+    ret res[mir.MirOperand, fail.Fail].ok{mir.op_vreg(addr)};
 }
 
 rec PiecePlan {
@@ -896,79 +899,79 @@ fun carrier_access_legal(ctx: *context.LowerCtx, piece: *abi.ParamPiece, align: 
     ret piece.kind == abi.PIECE_GP && isa.moves_unaligned_gp(?ctx.tgt.model, piece.width::u32);
 }
 
-fun allocate_carrier(ctx: *context.LowerCtx, width: u8) R.Result[u32, str] {
-    val kr: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](kr)) { ret kr; }
-    val key: u32 = R.unwrap_ok[u32, str](kr);
-    val ar: R.Result[R.Void, str] = context.add_alloca_slot(ctx, key,
+fun allocate_carrier(ctx: *context.LowerCtx, width: u8) res[u32, fail.Fail] {
+    val kr: res[u32, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel kr.err) { ret kr; }
+    val key: u32 = kr.ok;
+    val ar: err[fail.Fail] = context.add_alloca_slot(ctx, key,
         width::u64, width::u32, mir.SLOT_TY_NIL);
-    if (R.is_err[R.Void, str](ar)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](ar)); }
-    ret R.ok[u32, str](key);
+    if (sel ar.err) { ret res[u32, fail.Fail].err{ar.err}; }
+    ret res[u32, fail.Fail].ok{key};
 }
 
 fun load_piece_carrier(ctx: *context.LowerCtx, mb: *mir.MirBlock, registers: *mir.MirBlock,
                        reg: mir.MirOperand, source: mir.MirOperand,
-                       logical_width: u8, carrier_width: u8, direct: bool) R.Result[R.Void, str] {
+                       logical_width: u8, carrier_width: u8, direct: bool) err[fail.Fail] {
     if (logical_width == carrier_width && direct) {
         ret emit_call_reg(ctx, mb, registers, reg, source, carrier_width);
     }
-    val kr: R.Result[u32, str] = allocate_carrier(ctx, carrier_width);
-    if (R.is_err[u32, str](kr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](kr)); }
-    val key: u32 = R.unwrap_ok[u32, str](kr);
+    val kr: res[u32, fail.Fail] = allocate_carrier(ctx, carrier_width);
+    if (sel kr.err) { ret err[fail.Fail].err{kr.err}; }
+    val key: u32 = kr.ok;
     var off: u64 = 0;
     for (logical_width < carrier_width && off < carrier_width::u64) {
         val width: u8 = context.copy_chunk_width(ctx.tgt, carrier_width::u64 - off);
-        val zero: R.Result[R.Void, str] = context.push_store_chunk(ctx, mb,
+        val zero: err[fail.Fail] = context.push_store_chunk(ctx, mb,
             mir.op_mem_slot(key, off::i64), mir.op_imm(0), width);
-        if (R.is_err[R.Void, str](zero)) { ret zero; }
+        if (sel zero.err) { ret zero; }
         off = off + width::u64;
     }
-    val copied: R.Result[R.Void, str] = context.copy_aggregate(ctx, mb,
+    val copied: err[fail.Fail] = context.copy_aggregate(ctx, mb,
         mir.op_mem_slot(key, 0), source, logical_width::u64);
-    if (R.is_err[R.Void, str](copied)) { ret copied; }
+    if (sel copied.err) { ret copied; }
     ret emit_call_reg(ctx, mb, registers, reg, mir.op_mem_slot(key, 0), carrier_width);
 }
 
-fun zero_range(ctx: *context.LowerCtx, mb: *mir.MirBlock, plan: PiecePlan, from: u64, to: u64) R.Result[R.Void, str] {
+fun zero_range(ctx: *context.LowerCtx, mb: *mir.MirBlock, plan: PiecePlan, from: u64, to: u64) err[fail.Fail] {
     var off: u64 = from;
     for (off < to) {
         val width: u8 = context.copy_chunk_width(ctx.tgt, to - off);
         var mem: mir.MirOperand = mir.op_mem_value(plan.mem_base, off::i64);
         if (plan.mem_slot) { mem = mir.op_mem_slot(plan.mem_base, off::i64); }
-        val zero: R.Result[R.Void, str] = context.push_store_chunk(ctx, mb, mem, mir.op_imm(0), width);
-        if (R.is_err[R.Void, str](zero)) { ret zero; }
+        val zero: err[fail.Fail] = context.push_store_chunk(ctx, mb, mem, mir.op_imm(0), width);
+        if (sel zero.err) { ret zero; }
         off = off + width::u64;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 # a convention may deliver nothing for a padding-only eightbyte; the logical object still owns those bytes,
 # so the store side zeroes every logical byte no piece delivers before the pieces land
-fun zero_undelivered_bytes(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: *abi.ParamSlot, plan: PiecePlan) R.Result[R.Void, str] {
+fun zero_undelivered_bytes(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: *abi.ParamSlot, plan: PiecePlan) err[fail.Fail] {
     var cursor: u64 = 0;
     var i: u32 = 0;
     for (i < slot.piece_count) {
         val p: *abi.ParamPiece = ?slot.pieces[i];
         val wr: R.Result[u8, str] = abi.piece_memory_width(slot, p);
-        if (R.is_err[u8, str](wr)) { ret R.err[R.Void, str](R.unwrap_err[u8, str](wr)); }
+        if (R.is_err[u8, str](wr)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[u8, str](wr))}; }
         val start: u64 = p.src_off::u64;
         if (start > cursor) {
-            val zr: R.Result[R.Void, str] = zero_range(ctx, mb, plan, cursor, start);
-            if (R.is_err[R.Void, str](zr)) { ret zr; }
+            val zr: err[fail.Fail] = zero_range(ctx, mb, plan, cursor, start);
+            if (sel zr.err) { ret zr; }
         }
         val end: u64 = start + R.unwrap_ok[u8, str](wr)::u64;
         if (end > cursor) { cursor = end; }
         i = i + 1;
     }
     if (cursor < slot.size) { ret zero_range(ctx, mb, plan, cursor, slot.size); }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun materialize_pieces(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, plan: PiecePlan) R.Result[R.Void, str] {
+fun materialize_pieces(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, plan: PiecePlan) err[fail.Fail] {
     val er: R.Result[u64, str] = abi.carrier_storage_extent(?slot);
-    if (R.is_err[u64, str](er)) { ret R.err[R.Void, str](R.unwrap_err[u64, str](er)); }
+    if (R.is_err[u64, str](er)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[u64, str](er))}; }
     if (plan.store && plan.owned_extent < R.unwrap_ok[u64, str](er)) {
-        ret R.err[R.Void, str]("mir.abi: carrier stores exceed owned destination storage");
+        ret err[fail.Fail].err{fail.message("mir.abi: carrier stores exceed owned destination storage")};
     }
     var pending: mir.MirBlock;
     fin { mir.dnit_block(ctx.alloc, ?pending); }
@@ -979,20 +982,20 @@ fun materialize_pieces(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.Para
     var registers: *mir.MirBlock = plan.registers;
     if (!plan.store && registers == mb) { registers = ?pending; }
     if (plan.store) {
-        val zr: R.Result[R.Void, str] = zero_undelivered_bytes(ctx, mb, ?slot, plan);
-        if (R.is_err[R.Void, str](zr)) { ret zr; }
+        val zr: err[fail.Fail] = zero_undelivered_bytes(ctx, mb, ?slot, plan);
+        if (sel zr.err) { ret zr; }
     }
     var i: u32 = 0;
     for (i < slot.piece_count) {
         val p: abi.ParamPiece = slot.pieces[i];
         val wr: R.Result[u8, str] = abi.piece_memory_width(?slot, ?slot.pieces[i]);
-        if (R.is_err[u8, str](wr)) { ret R.err[R.Void, str](R.unwrap_err[u8, str](wr)); }
+        if (R.is_err[u8, str](wr)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[u8, str](wr))}; }
         val logical_width: u8 = R.unwrap_ok[u8, str](wr);
         var mem: mir.MirOperand = mir.op_mem_value(plan.mem_base, p.src_off);
         if (plan.mem_slot) { mem = mir.op_mem_slot(plan.mem_base, p.src_off); }
         if (p.kind == abi.PIECE_STACK) {
             if (!plan.stack_ok) {
-                ret R.err[R.Void, str]("mir.lower_ir: return slot carries an outgoing stack chunk");
+                ret err[fail.Fail].err{fail.message("mir.lower_ir: return slot carries an outgoing stack chunk")};
             }
             val stk: mir.MirOperand = mir.op_mem_preg(plan.stack_base, plan.stack_off + p.stk_off);
             var src: mir.MirOperand = mem;
@@ -1000,49 +1003,49 @@ fun materialize_pieces(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.Para
             var transfers: *mir.MirBlock = mb;
             if (plan.store) { src = stk; dst = mem; }
             if (plan.store) { transfers = copies; }
-            val copied: R.Result[R.Void, str] = context.copy_aggregate(ctx, transfers, dst, src, logical_width::u64);
-            if (R.is_err[R.Void, str](copied)) { ret copied; }
+            val copied: err[fail.Fail] = context.copy_aggregate(ctx, transfers, dst, src, logical_width::u64);
+            if (sel copied.err) { ret copied; }
         } or {
             val reg: mir.MirOperand = mir.op_preg(p.reg::u32);
             val direct: bool = carrier_access_legal(ctx, ?p, plan.mem_align);
             if (plan.store) {
                 if (direct) {
-                    val st: R.Result[R.Void, str] = context.emit_store_to_w(ctx, mb, mem, reg, p.width);
-                    if (R.is_err[R.Void, str](st)) { ret st; }
+                    val st: err[fail.Fail] = context.emit_store_to_w(ctx, mb, mem, reg, p.width);
+                    if (sel st.err) { ret st; }
                 } or {
-                    val kr: R.Result[u32, str] = allocate_carrier(ctx, p.width);
-                    if (R.is_err[u32, str](kr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](kr)); }
-                    val carrier: mir.MirOperand = mir.op_mem_slot(R.unwrap_ok[u32, str](kr), 0);
-                    val st: R.Result[R.Void, str] = context.emit_store_to_w(ctx, mb, carrier, reg, p.width);
-                    if (R.is_err[R.Void, str](st)) { ret st; }
+                    val kr: res[u32, fail.Fail] = allocate_carrier(ctx, p.width);
+                    if (sel kr.err) { ret err[fail.Fail].err{kr.err}; }
+                    val carrier: mir.MirOperand = mir.op_mem_slot(kr.ok, 0);
+                    val st: err[fail.Fail] = context.emit_store_to_w(ctx, mb, carrier, reg, p.width);
+                    if (sel st.err) { ret st; }
                     # the owned home includes carrier padding
-                    val cr: R.Result[R.Void, str] = context.copy_aggregate(ctx, copies, mem, carrier, p.width::u64);
-                    if (R.is_err[R.Void, str](cr)) { ret cr; }
+                    val cr: err[fail.Fail] = context.copy_aggregate(ctx, copies, mem, carrier, p.width::u64);
+                    if (sel cr.err) { ret cr; }
                 }
             } or {
-                val mr: R.Result[R.Void, str] = load_piece_carrier(ctx, mb, registers,
+                val mr: err[fail.Fail] = load_piece_carrier(ctx, mb, registers,
                     reg, mem, logical_width, p.width, direct);
-                if (R.is_err[R.Void, str](mr)) { ret mr; }
+                if (sel mr.err) { ret mr; }
             }
         }
         i = i + 1;
     }
     if (copies == ?pending_copies && pending_copies.instr_count != 0) {
-        val cr: R.Result[R.Void, str] = append_deferred(ctx, mb, ?pending_copies);
-        if (R.is_err[R.Void, str](cr)) { ret cr; }
+        val cr: err[fail.Fail] = append_deferred(ctx, mb, ?pending_copies);
+        if (sel cr.err) { ret cr; }
     }
     if (registers == ?pending) { ret append_deferred(ctx, mb, ?pending); }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, registers: *mir.MirBlock, slot: abi.ParamSlot, argop: mir.MirOperand,
-                  stack_off: i64, is_aggr: bool, ty: type.IrTypeId, natural: bool) R.Result[R.Void, str] {
+                  stack_off: i64, is_aggr: bool, ty: type.IrTypeId, natural: bool) err[fail.Fail] {
     val size: u64 = type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
 
     if (is_aggr && (slot.class == abi.CLASS_BYREF || slot.class == abi.CLASS_STACK_BYREF)) {
         var owned: u32 = mir.MIR_VREG_NIL;
-        val cr: R.Result[R.Void, str] = copy_aggregate_to_temp(ctx, mb, argop, ty, ?owned);
-        if (R.is_err[R.Void, str](cr)) { ret cr; }
+        val cr: err[fail.Fail] = copy_aggregate_to_temp(ctx, mb, argop, ty, ?owned);
+        if (sel cr.err) { ret cr; }
         if (slot.class == abi.CLASS_STACK_BYREF) {
             val sp: u32 = ctx.tgt.model.stack_ptr_reg::u32;
             ret context.emit_store_to(ctx, mb, mir.op_mem_preg(sp, stack_off), mir.op_vreg(owned));
@@ -1051,8 +1054,8 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, registers: *mir.Mir
     }
     if (slot.class == abi.CLASS_VEC_BYREF || slot.class == abi.CLASS_VEC_STACK_BYREF) {
         var addr: u32 = mir.MIR_VREG_NIL;
-        val sr: R.Result[R.Void, str] = spill_vector_to_temp(ctx, mb, slot, argop, ty, ?addr);
-        if (R.is_err[R.Void, str](sr)) { ret sr; }
+        val sr: err[fail.Fail] = spill_vector_to_temp(ctx, mb, slot, argop, ty, ?addr);
+        if (sel sr.err) { ret sr; }
         if (slot.class == abi.CLASS_VEC_STACK_BYREF) {
             val sp: u32 = ctx.tgt.model.stack_ptr_reg::u32;
             ret context.emit_store_to(ctx, mb, mir.op_mem_preg(sp, stack_off), mir.op_vreg(addr));
@@ -1062,8 +1065,8 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, registers: *mir.Mir
     if (slot.class == abi.CLASS_STACK_BYREF) {
         val sp: u32 = ctx.tgt.model.stack_ptr_reg::u32;
         var base: u32 = mir.MIR_VREG_NIL;
-        val ar: R.Result[R.Void, str] = context.addr_to_vreg(ctx, mb, argop, ?base);
-        if (R.is_err[R.Void, str](ar)) { ret ar; }
+        val ar: err[fail.Fail] = context.addr_to_vreg(ctx, mb, argop, ?base);
+        if (sel ar.err) { ret ar; }
         ret context.emit_store_to(ctx, mb, mir.op_mem_preg(sp, stack_off), mir.op_vreg(base));
     }
     if (slot.class == abi.CLASS_STACK) {
@@ -1079,15 +1082,15 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, registers: *mir.Mir
     }
     if (slot.class == abi.CLASS_BYREF) {
         var base: u32 = mir.MIR_VREG_NIL;
-        val ar: R.Result[R.Void, str] = context.addr_to_vreg(ctx, mb, argop, ?base);
-        if (R.is_err[R.Void, str](ar)) { ret ar; }
+        val ar: err[fail.Fail] = context.addr_to_vreg(ctx, mb, argop, ?base);
+        if (sel ar.err) { ret ar; }
         ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg::u32), mir.op_vreg(base), ptr_move_width(ctx));
     }
 
     if (is_aggr) {
         var base: u32 = mir.MIR_VREG_NIL;
-        val ar: R.Result[R.Void, str] = context.addr_to_vreg(ctx, mb, argop, ?base);
-        if (R.is_err[R.Void, str](ar)) { ret ar; }
+        val ar: err[fail.Fail] = context.addr_to_vreg(ctx, mb, argop, ?base);
+        if (sel ar.err) { ret ar; }
         var plan: PiecePlan;
         plan.registers = registers;
         plan.store      = false;
@@ -1100,75 +1103,75 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, registers: *mir.Mir
         ret materialize_pieces(ctx, mb, slot, plan);
     }
     if (slot.class == abi.CLASS_FP) {
-        val fw: R.Result[u8, str] = fp_move_width(ctx, ty);
-        if (R.is_err[u8, str](fw)) { ret R.err[R.Void, str](R.unwrap_err[u8, str](fw)); }
-        ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg::u32), argop, R.unwrap_ok[u8, str](fw));
+        val fw: res[u8, fail.Fail] = fp_move_width(ctx, ty);
+        if (sel fw.err) { ret err[fail.Fail].err{fw.err}; }
+        ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg::u32), argop, fw.ok);
     }
     ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg::u32), argop, scalar_reg_move_width(ctx.tgt.model.gpr_width, size));
 }
 
 fun copy_aggregate_to_temp(ctx: *context.LowerCtx, mb: *mir.MirBlock, src: mir.MirOperand,
-                           ty: type.IrTypeId, out_addr: *u32) R.Result[R.Void, str] {
+                           ty: type.IrTypeId, out_addr: *u32) err[fail.Fail] {
     val size:  u64 = type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
     val align: u32 = type.byte_align_for_machine(ctx.types, ty, ctx.layout);
-    val res_key: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](res_key)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_key)); }
-    val sk: u32 = R.unwrap_ok[u32, str](res_key);
+    val res_key: res[u32, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel res_key.err) { ret err[fail.Fail].err{res_key.err}; }
+    val sk: u32 = res_key.ok;
 
-    val sr: R.Result[R.Void, str] = context.add_spill_slot_aligned(ctx, sk, size, align);
-    if (R.is_err[R.Void, str](sr)) { ret sr; }
+    val sr: err[fail.Fail] = context.add_spill_slot_aligned(ctx, sk, size, align);
+    if (sel sr.err) { ret sr; }
 
-    val cr: R.Result[R.Void, str] = context.copy_aggregate(ctx, mb, mir.op_mem_slot(sk, 0), src, size);
-    if (R.is_err[R.Void, str](cr)) { ret cr; }
+    val cr: err[fail.Fail] = context.copy_aggregate(ctx, mb, mir.op_mem_slot(sk, 0), src, size);
+    if (sel cr.err) { ret cr; }
 
     ret context.emit_lea_slot(ctx, mb, mir.op_mem_slot(sk, 0), out_addr);
 }
 
 fun spill_vector_to_temp(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot,
-                         val_op: mir.MirOperand, ty: type.IrTypeId, out_addr: *u32) R.Result[R.Void, str] {
+                         val_op: mir.MirOperand, ty: type.IrTypeId, out_addr: *u32) err[fail.Fail] {
     val logical_size:  u64 = type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
     val size:  u64 = slot.indirect_size;
     val align: u32 = slot.indirect_align;
     if (size < logical_size || align == 0 || (align & (align - 1)) != 0) {
-        ret R.err[R.Void, str]("mir.abi.spill_vector_to_temp: ABI vector placement has invalid indirect storage");
+        ret err[fail.Fail].err{fail.message("mir.abi.spill_vector_to_temp: ABI vector placement has invalid indirect storage")};
     }
-    val res_key: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](res_key)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_key)); }
-    val sk: u32 = R.unwrap_ok[u32, str](res_key);
+    val res_key: res[u32, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel res_key.err) { ret err[fail.Fail].err{res_key.err}; }
+    val sk: u32 = res_key.ok;
 
-    val sr: R.Result[R.Void, str] = context.add_spill_slot_aligned(ctx, sk, size, align);
-    if (R.is_err[R.Void, str](sr)) { ret sr; }
+    val sr: err[fail.Fail] = context.add_spill_slot_aligned(ctx, sk, size, align);
+    if (sel sr.err) { ret sr; }
 
-    var st: R.Result[R.Void, str] = R.ok_void[str]();
+    var st: err[fail.Fail] = err[fail.Fail].ok{};
     if (context.value_is_vector(ctx, ty)) {
         st = context.store_subwidth_vector(ctx, mb, mir.op_mem_slot(sk, 0), val_op, ty);
     } or {
         st = context.copy_aggregate(ctx, mb, mir.op_mem_slot(sk, 0), val_op, size);
     }
-    if (R.is_err[R.Void, str](st)) { ret st; }
+    if (sel st.err) { ret st; }
 
     ret context.emit_lea_slot(ctx, mb, mir.op_mem_slot(sk, 0), out_addr);
 }
 
-fun fp_move_width(ctx: *context.LowerCtx, ty: type.IrTypeId) R.Result[u8, str] {
+fun fp_move_width(ctx: *context.LowerCtx, ty: type.IrTypeId) res[u8, fail.Fail] {
     val size: u64 = type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
     if (context.value_is_vector(ctx, ty)) {
         val vw: u64 = (ctx.tgt.model.vector_bits / 8)::u64;
         if (vw == 0 || size > vw) {
-            ret R.err[u8, str]("mir.abi.fp_move_width: vector wider than the target's vector register; an over-width vector's placement is a multi-piece split the convention classifier must decide");
+            ret res[u8, fail.Fail].err{fail.message("mir.abi.fp_move_width: vector wider than the target's vector register; an over-width vector's placement is a multi-piece split the convention classifier must decide")};
         }
-        ret R.ok[u8, str](vw::u8);
+        ret res[u8, fail.Fail].ok{vw::u8};
     }
-    if (size == 4) { ret R.ok[u8, str](4); }
-    if (size == 8) { ret R.ok[u8, str](8); }
-    ret R.err[u8, str]("mir.abi.fp_move_width: CLASS_FP scalar of unsupported size (expected 4 or 8 bytes)");
+    if (size == 4) { ret res[u8, fail.Fail].ok{4}; }
+    if (size == 8) { ret res[u8, fail.Fail].ok{8}; }
+    ret res[u8, fail.Fail].err{fail.message("mir.abi.fp_move_width: CLASS_FP scalar of unsupported size (expected 4 or 8 bytes)")};
 }
 
-fun capture_slot_reg(ctx: *context.LowerCtx, mb: *mir.MirBlock, dst: u32, slot: abi.ParamSlot, ty: type.IrTypeId) R.Result[R.Void, str] {
+fun capture_slot_reg(ctx: *context.LowerCtx, mb: *mir.MirBlock, dst: u32, slot: abi.ParamSlot, ty: type.IrTypeId) err[fail.Fail] {
     if (slot.class == abi.CLASS_FP) {
-        val fw: R.Result[u8, str] = fp_move_width(ctx, ty);
-        if (R.is_err[u8, str](fw)) { ret R.err[R.Void, str](R.unwrap_err[u8, str](fw)); }
-        ret context.emit_fmov(ctx, mb, mir.op_vreg(dst), mir.op_preg(slot.reg::u32), R.unwrap_ok[u8, str](fw));
+        val fw: res[u8, fail.Fail] = fp_move_width(ctx, ty);
+        if (sel fw.err) { ret err[fail.Fail].err{fw.err}; }
+        ret context.emit_fmov(ctx, mb, mir.op_vreg(dst), mir.op_preg(slot.reg::u32), fw.ok);
     }
     val size: u64 = type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
     ret context.emit_mov_w(ctx, mb, mir.op_vreg(dst), mir.op_preg(slot.reg::u32),
@@ -1199,11 +1202,11 @@ fun record_outgoing_size(ctx: *context.LowerCtx, bytes: i64) {
     }
 }
 
-fun emit_ret_slot_to_vreg(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, dst: u32, is_aggr: bool, ty: type.IrTypeId, owned_align: u32) R.Result[R.Void, str] {
+fun emit_ret_slot_to_vreg(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, dst: u32, is_aggr: bool, ty: type.IrTypeId, owned_align: u32) err[fail.Fail] {
 
     if (is_aggr) {
         val extent: R.Result[u64, str] = abi.carrier_storage_extent(?slot);
-        if (R.is_err[u64, str](extent)) { ret R.err[R.Void, str](R.unwrap_err[u64, str](extent)); }
+        if (R.is_err[u64, str](extent)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[u64, str](extent))}; }
         var plan: PiecePlan;
         plan.owned_extent = R.unwrap_ok[u64, str](extent);
         plan.registers = mb;
@@ -1219,29 +1222,29 @@ fun emit_ret_slot_to_vreg(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.P
     ret capture_slot_reg(ctx, mb, dst, slot, ty);
 }
 
-fun append_abi_input(inputs: *V.Vector[mir.MirAbiInput], input: mir.MirAbiInput) R.Result[R.Void, str] {
+fun append_abi_input(inputs: *V.Vector[mir.MirAbiInput], input: mir.MirAbiInput) err[fail.Fail] {
     if (input.width == 0 || input.logical_width > input.width) {
-        ret R.err[R.Void, str]("mir.abi: invalid incoming carrier extent");
+        ret err[fail.Fail].err{fail.message("mir.abi: invalid incoming carrier extent")};
     }
     if (input.location == mir.ABI_INPUT_REGISTER) {
         if (input.reg == mir.MIR_VREG_NIL) {
-            ret R.err[R.Void, str]("mir.abi: incoming carrier has no physical register");
+            ret err[fail.Fail].err{fail.message("mir.abi: incoming carrier has no physical register")};
         }
     } or (input.location != mir.ABI_INPUT_ARG_STACK || input.offset < 0) {
-        ret R.err[R.Void, str]("mir.abi: invalid incoming argument-area location");
+        ret err[fail.Fail].err{fail.message("mir.abi: invalid incoming argument-area location")};
     }
-    val pushed: R.Result[usize, str] = V.push[mir.MirAbiInput](inputs, input);
-    if (R.is_err[usize, str](pushed)) { ret R.err[R.Void, str](R.unwrap_err[usize, str](pushed)); }
-    ret R.ok_void[str]();
+    val pushed: res[usize, A.Error] = V.push[mir.MirAbiInput](inputs, input);
+    if (sel pushed.err) { ret err[fail.Fail].err{fail.refused(pushed.err)}; }
+    ret err[fail.Fail].ok{};
 }
 
 fun record_param_input(ctx: *context.LowerCtx, inputs: *V.Vector[mir.MirAbiInput],
-                       index: u32, slot: abi.ParamSlot) R.Result[R.Void, str] {
+                       index: u32, slot: abi.ParamSlot) err[fail.Fail] {
     val param: value.Value = ctx.fn.params[index];
     val ty: O.Option[*type.IrType] = type.get(ctx.types, param.ty);
-    if (O.is_none[*type.IrType](ty)) { ret R.err[R.Void, str]("mir.abi: incoming parameter type is absent"); }
+    if (O.is_none[*type.IrType](ty)) { ret err[fail.Fail].err{fail.message("mir.abi: incoming parameter type is absent")}; }
     val size: u64 = type.byte_size_for_machine(ctx.types, param.ty, ctx.layout)::u64;
-    if (size == 0) { ret R.ok_void[str](); }
+    if (size == 0) { ret err[fail.Fail].ok{}; }
     val aggregate: bool = context.value_is_aggregate(ctx, param.ty);
     val indirect: bool = slot.class == abi.CLASS_BYREF || slot.class == abi.CLASS_STACK_BYREF
         || slot.class == abi.CLASS_VEC_BYREF || slot.class == abi.CLASS_VEC_STACK_BYREF;
@@ -1264,7 +1267,7 @@ fun record_param_input(ctx: *context.LowerCtx, inputs: *V.Vector[mir.MirAbiInput
             input.location = mir.ABI_INPUT_ARG_STACK;
             input.offset = slot.offset;
         } or {
-            if (slot.reg < 0) { ret R.err[R.Void, str]("mir.abi: indirect input has no physical register"); }
+            if (slot.reg < 0) { ret err[fail.Fail].err{fail.message("mir.abi: indirect input has no physical register")}; }
             input.reg = slot.reg::u32;
         }
         ret append_abi_input(inputs, input);
@@ -1281,52 +1284,52 @@ fun record_param_input(ctx: *context.LowerCtx, inputs: *V.Vector[mir.MirAbiInput
         ret append_abi_input(inputs, input);
     }
     if (slot.class != abi.CLASS_GP && slot.class != abi.CLASS_FP) {
-        ret R.err[R.Void, str]("mir.abi: incoming parameter has no native carrier class");
+        ret err[fail.Fail].err{fail.message("mir.abi: incoming parameter has no native carrier class")};
     }
     if (slot.piece_count == 0 || slot.piece_count > abi.PARAM_MAX_PIECES) {
-        ret R.err[R.Void, str]("mir.abi: incoming parameter has invalid carrier pieces");
+        ret err[fail.Fail].err{fail.message("mir.abi: incoming parameter has invalid carrier pieces")};
     }
     var i: u32 = 0;
     for (i < slot.piece_count) {
         val piece: abi.ParamPiece = slot.pieces[i];
         val wr: R.Result[u8, str] = abi.piece_memory_width(?slot, ?slot.pieces[i]);
-        if (R.is_err[u8, str](wr)) { ret R.err[R.Void, str](R.unwrap_err[u8, str](wr)); }
+        if (R.is_err[u8, str](wr)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[u8, str](wr))}; }
         input.logical_width = R.unwrap_ok[u8, str](wr)::u64;
         input.width = piece.width::u64;
         input.location = mir.ABI_INPUT_REGISTER;
         input.offset = 0;
         if (piece.kind == abi.PIECE_STACK) {
             if (piece.stk_off < 0 || slot.offset < 0 || slot.offset > 0x7FFFFFFFFFFFFFFF - piece.stk_off) {
-                ret R.err[R.Void, str]("mir.abi: incoming stack piece offset overflow");
+                ret err[fail.Fail].err{fail.message("mir.abi: incoming stack piece offset overflow")};
             }
             input.location = mir.ABI_INPUT_ARG_STACK;
             input.reg = mir.MIR_VREG_NIL;
             input.offset = slot.offset + piece.stk_off;
             input.width = input.logical_width;
         } or {
-            if (piece.reg < 0) { ret R.err[R.Void, str]("mir.abi: incoming piece has no physical register"); }
+            if (piece.reg < 0) { ret err[fail.Fail].err{fail.message("mir.abi: incoming piece has no physical register")}; }
             input.reg = piece.reg::u32;
         }
         if (input.logical_width != 0) {
-            val added: R.Result[R.Void, str] = append_abi_input(inputs, input);
-            if (R.is_err[R.Void, str](added)) { ret added; }
+            val added: err[fail.Fail] = append_abi_input(inputs, input);
+            if (sel added.err) { ret added; }
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun record_abi_inputs(ctx: *context.LowerCtx, slots: *abi.SigLayout) R.Result[R.Void, str] {
+fun record_abi_inputs(ctx: *context.LowerCtx, slots: *abi.SigLayout) err[fail.Fail] {
     if (slots.param_count != ctx.param_count || ctx.param_count != ctx.fn.param_count) {
-        ret R.err[R.Void, str]("mir.abi: incoming signature does not match declared parameters");
+        ret err[fail.Fail].err{fail.message("mir.abi: incoming signature does not match declared parameters")};
     }
     if (ctx.f.abi_inputs != nil || ctx.f.abi_input_count != 0 || ctx.f.abi_input_cap != 0) {
-        ret R.err[R.Void, str]("mir.abi: incoming carrier facts were already recorded");
+        ret err[fail.Fail].err{fail.message("mir.abi: incoming carrier facts were already recorded")};
     }
     var inputs: V.Vector[mir.MirAbiInput] = V.init[mir.MirAbiInput](ctx.alloc);
     fin { V.dnit[mir.MirAbiInput](?inputs); }
     if (slots.ret_slot.class == abi.CLASS_SRET) {
-        if (ctx.tgt.abi.indirect_result_reg < 0) { ret R.err[R.Void, str]("mir.abi: indirect result has no physical register"); }
+        if (ctx.tgt.abi.indirect_result_reg < 0) { ret err[fail.Fail].err{fail.message("mir.abi: indirect result has no physical register")}; }
         var result: mir.MirAbiInput;
         result.argument = mir.ABI_INPUT_SRET;
         result.reg = ctx.tgt.abi.indirect_result_reg::u32;
@@ -1335,13 +1338,13 @@ fun record_abi_inputs(ctx: *context.LowerCtx, slots: *abi.SigLayout) R.Result[R.
         result.secret = false;
         result.content = mir.ABI_CONTENT_OUTPUT;
         result.content_size = type.byte_size_for_machine(ctx.types, context.fn_return_type(ctx), ctx.layout)::u64;
-        val added: R.Result[R.Void, str] = append_abi_input(?inputs, result);
-        if (R.is_err[R.Void, str](added)) { ret added; }
+        val added: err[fail.Fail] = append_abi_input(?inputs, result);
+        if (sel added.err) { ret added; }
     }
     var i: u32 = 0;
     for (i < slots.param_count) {
-        val added: R.Result[R.Void, str] = record_param_input(ctx, ?inputs, i, slots.params[i]);
-        if (R.is_err[R.Void, str](added)) { ret added; }
+        val added: err[fail.Fail] = record_param_input(ctx, ?inputs, i, slots.params[i]);
+        if (sel added.err) { ret added; }
         i = i + 1;
     }
     ctx.f.abi_inputs = inputs.data;
@@ -1350,26 +1353,26 @@ fun record_abi_inputs(ctx: *context.LowerCtx, slots: *abi.SigLayout) R.Result[R.
     inputs.data = nil;
     inputs.len = 0;
     inputs.cap = 0;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[R.Void, str] {
+pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) err[fail.Fail] {
     var copies: mir.MirBlock;
     fin { mir.dnit_block(ctx.alloc, ?copies); }
     val ret_type: type.IrTypeId = context.fn_return_type(ctx);
     var layout: abi.SigLayout;
-    val cls: R.Result[R.Void, str] = classify_signature(ctx, ctx.fn.sig, ret_type, ?layout);
-    if (R.is_err[R.Void, str](cls)) { ret cls; }
+    val cls: err[fail.Fail] = classify_signature(ctx, ctx.fn.sig, ret_type, ?layout);
+    if (sel cls.err) { ret cls; }
 
     if (context.values_convention(ctx)) {
-        val vr: R.Result[R.Void, str] = lower_value_params(ctx, mb, ?layout);
+        val vr: err[fail.Fail] = lower_value_params(ctx, mb, ?layout);
         sig_layout_free(ctx, ?layout);
         ret vr;
     }
 
     if (ctx.f.oblivious) {
-        val inputs: R.Result[R.Void, str] = record_abi_inputs(ctx, ?layout);
-        if (R.is_err[R.Void, str](inputs)) {
+        val inputs: err[fail.Fail] = record_abi_inputs(ctx, ?layout);
+        if (sel inputs.err) {
             sig_layout_free(ctx, ?layout);
             ret inputs;
         }
@@ -1377,15 +1380,15 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[R.Void,
 
     if (layout.ret_slot.class == abi.CLASS_SRET) {
         val sret_reg: i32 = ctx.tgt.abi.indirect_result_reg;
-        val svr: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](svr)) {
+        val svr: res[u32, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+        if (sel svr.err) {
             sig_layout_free(ctx, ?layout);
-            ret R.err[R.Void, str](R.unwrap_err[u32, str](svr));
+            ret err[fail.Fail].err{svr.err};
         }
-        val sv: u32 = R.unwrap_ok[u32, str](svr);
-        val mv: R.Result[R.Void, str] = context.emit_mov_w(ctx, mb, mir.op_vreg(sv), mir.op_preg(sret_reg::u32),
+        val sv: u32 = svr.ok;
+        val mv: err[fail.Fail] = context.emit_mov_w(ctx, mb, mir.op_vreg(sv), mir.op_preg(sret_reg::u32),
                                                          ptr_move_width(ctx));
-        if (R.is_err[R.Void, str](mv)) {
+        if (sel mv.err) {
             sig_layout_free(ctx, ?layout);
             ret mv;
         }
@@ -1403,9 +1406,9 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[R.Void,
 
         if (pag || param_has_use(ctx.fn, i)) {
             ctx.cur_writes_secret = ctx.fn.params[i].secret;
-            val er: R.Result[R.Void, str] = emit_param_slot(ctx, mb, ?copies, slot, pv, pty, slot.offset, pag);
+            val er: err[fail.Fail] = emit_param_slot(ctx, mb, ?copies, slot, pv, pty, slot.offset, pag);
             ctx.cur_writes_secret = false;
-            if (R.is_err[R.Void, str](er)) {
+            if (sel er.err) {
                 sig_layout_free(ctx, ?layout);
                 ret er;
             }
@@ -1418,15 +1421,15 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[R.Void,
 }
 
 fun capture_vector_byref(ctx: *context.LowerCtx, mb: *mir.MirBlock, pv: u32,
-                         ty: type.IrTypeId, src: mir.MirOperand) R.Result[R.Void, str] {
+                         ty: type.IrTypeId, src: mir.MirOperand) err[fail.Fail] {
     if (!context.value_is_vector(ctx, ty)) {
         ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), src, ptr_move_width(ctx));
     }
-    val ar: R.Result[u32, str] = context.new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](ar)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](ar)); }
-    val addr: u32 = R.unwrap_ok[u32, str](ar);
-    val mr: R.Result[R.Void, str] = context.emit_mov_w(ctx, mb, mir.op_vreg(addr), src, ptr_move_width(ctx));
-    if (R.is_err[R.Void, str](mr)) { ret mr; }
+    val ar: res[u32, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel ar.err) { ret err[fail.Fail].err{ar.err}; }
+    val addr: u32 = ar.ok;
+    val mr: err[fail.Fail] = context.emit_mov_w(ctx, mb, mir.op_vreg(addr), src, ptr_move_width(ctx));
+    if (sel mr.err) { ret mr; }
     if (context.subwidth_vector_memory(ctx, ty)) {
         ret context.load_subwidth_vector(ctx, mb, mir.op_vreg(pv), mir.op_mem_value(addr, 0), ty);
     }
@@ -1435,7 +1438,7 @@ fun capture_vector_byref(ctx: *context.LowerCtx, mb: *mir.MirBlock, pv: u32,
 }
 
 fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, copies: *mir.MirBlock, slot: abi.ParamSlot, pv: u32, ty: type.IrTypeId,
-                    stack_off: i64, is_aggr: bool) R.Result[R.Void, str] {
+                    stack_off: i64, is_aggr: bool) err[fail.Fail] {
     val size: u64 = type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
     val arg_base: i64 = ctx.tgt.model.incoming_arg_base;
     if (slot.class == abi.CLASS_VEC_STACK_BYREF) {
@@ -1469,14 +1472,14 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, copies: *mir.MirB
 
     if (is_aggr) {
         val extent: R.Result[u64, str] = abi.carrier_storage_extent(?slot);
-        if (R.is_err[u64, str](extent)) { ret R.err[R.Void, str](R.unwrap_err[u64, str](extent)); }
+        if (R.is_err[u64, str](extent)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[u64, str](extent))}; }
         val alignment: R.Result[u32, str] = abi.carrier_storage_alignment(?slot);
-        if (R.is_err[u32, str](alignment)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](alignment)); }
+        if (R.is_err[u32, str](alignment)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[u32, str](alignment))}; }
         var owned_align: u32 = context.ret_align(ctx, ty);
         if (ctx.tgt.model.gpr_width > owned_align) { owned_align = ctx.tgt.model.gpr_width; }
         if (R.unwrap_ok[u32, str](alignment) > owned_align) { owned_align = R.unwrap_ok[u32, str](alignment); }
-        val sr: R.Result[R.Void, str] = context.add_spill_slot_aligned(ctx, pv, R.unwrap_ok[u64, str](extent), owned_align);
-        if (R.is_err[R.Void, str](sr)) { ret sr; }
+        val sr: err[fail.Fail] = context.add_spill_slot_aligned(ctx, pv, R.unwrap_ok[u64, str](extent), owned_align);
+        if (sel sr.err) { ret sr; }
         var plan: PiecePlan;
         plan.owned_extent = R.unwrap_ok[u64, str](extent);
         plan.registers = mb;
@@ -1531,7 +1534,7 @@ fun instr_names_param(fn: *ir.Function, iid: id.InstructionId, param_ix: u32) bo
     ret false;
 }
 
-pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.Instruction) R.Result[R.Void, str] {
+pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.Instruction) err[fail.Fail] {
     if (inst.operand_count == 0) {
         ret emit_bare_ret(ctx, mb);
     }
@@ -1540,46 +1543,46 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
     val rsz:  u64  = type.byte_size_for_machine(ctx.types, rt, ctx.layout)::u64;
     val rag:  bool = context.value_is_aggregate(ctx, rt);
     var layout: abi.SigLayout;
-    val cls: R.Result[R.Void, str] = classify_signature(ctx, ctx.fn.sig, rt, ?layout);
-    if (R.is_err[R.Void, str](cls)) { ret cls; }
+    val cls: err[fail.Fail] = classify_signature(ctx, ctx.fn.sig, rt, ?layout);
+    if (sel cls.err) { ret cls; }
     val slot: abi.ParamSlot = layout.ret_slot;
     sig_layout_free(ctx, ?layout);
-    val rvr: R.Result[mir.MirOperand, str] = lower_value_addr(ctx, mb, rv);
-    if (R.is_err[mir.MirOperand, str](rvr)) { ret R.err[R.Void, str](R.unwrap_err[mir.MirOperand, str](rvr)); }
-    val rvop: mir.MirOperand = R.unwrap_ok[mir.MirOperand, str](rvr);
+    val rvr: res[mir.MirOperand, fail.Fail] = lower_value_addr(ctx, mb, rv);
+    if (sel rvr.err) { ret err[fail.Fail].err{rvr.err}; }
+    val rvop: mir.MirOperand = rvr.ok;
     ctx.cur_writes_secret = rv.secret;
     fin { ctx.cur_writes_secret = false; }
 
 
     if (context.values_convention(ctx)) {
-        if (!value_slot_valid(?slot, rsz)) { ret R.err[R.Void, str]("mir.abi: invalid logical result slot"); }
-        val ar: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 1::usize);
-        if (R.is_err[*mir.MirOperand, str](ar)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](ar)); }
-        val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ar);
+        if (!value_slot_valid(?slot, rsz)) { ret err[fail.Fail].err{fail.message("mir.abi: invalid logical result slot")}; }
+        val ar: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 1::usize);
+        if (sel ar.err) { ret err[fail.Fail].err{fail.refused(ar.err)}; }
+        val ops: *mir.MirOperand = ar.ok;
         ops[0] = value_operand(ctx, rv);
         ret push_value_instr(ctx, mb, mir.MIR_RET, ops, 1);
     }
     if (slot.class == abi.CLASS_SRET) {
         if (ctx.sret_vreg == mir.MIR_VREG_NIL) {
-            ret R.err[R.Void, str]("mir.lower_ir: sret return without a captured result-storage pointer");
+            ret err[fail.Fail].err{fail.message("mir.lower_ir: sret return without a captured result-storage pointer")};
         }
         if (context.value_is_vector(ctx, rv.ty)) {
-            val sr: R.Result[R.Void, str] = context.store_subwidth_vector(ctx, mb, mir.op_mem_value(ctx.sret_vreg, 0), rvop, rt);
-            if (R.is_err[R.Void, str](sr)) { ret sr; }
+            val sr: err[fail.Fail] = context.store_subwidth_vector(ctx, mb, mir.op_mem_value(ctx.sret_vreg, 0), rvop, rt);
+            if (sel sr.err) { ret sr; }
         } or (rag || context.value_is_vector(ctx, rt)) {
-            val cr: R.Result[R.Void, str] = context.copy_aggregate(ctx, mb, mir.op_mem_value(ctx.sret_vreg, 0), rvop, rsz);
-            if (R.is_err[R.Void, str](cr)) { ret cr; }
+            val cr: err[fail.Fail] = context.copy_aggregate(ctx, mb, mir.op_mem_value(ctx.sret_vreg, 0), rvop, rsz);
+            if (sel cr.err) { ret cr; }
         } or {
-            val sr: R.Result[R.Void, str] = context.emit_store_to_w(ctx, mb, mir.op_mem_value(ctx.sret_vreg, 0), rvop, rsz::u8);
-            if (R.is_err[R.Void, str](sr)) { ret sr; }
+            val sr: err[fail.Fail] = context.emit_store_to_w(ctx, mb, mir.op_mem_value(ctx.sret_vreg, 0), rvop, rsz::u8);
+            if (sel sr.err) { ret sr; }
         }
-        val mr: R.Result[R.Void, str] = context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32),
+        val mr: err[fail.Fail] = context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32),
                                                          mir.op_vreg(ctx.sret_vreg), ptr_move_width(ctx));
-        if (R.is_err[R.Void, str](mr)) { ret mr; }
+        if (sel mr.err) { ret mr; }
     } or (rag) {
         var base: u32 = mir.MIR_VREG_NIL;
-        val ar: R.Result[R.Void, str] = context.addr_to_vreg(ctx, mb, rvop, ?base);
-        if (R.is_err[R.Void, str](ar)) { ret ar; }
+        val ar: err[fail.Fail] = context.addr_to_vreg(ctx, mb, rvop, ?base);
+        if (sel ar.err) { ret ar; }
         var plan: PiecePlan;
         plan.registers = mb;
         plan.store      = false;
@@ -1589,29 +1592,30 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
         plan.stack_base = 0;
         plan.stack_off  = 0;
         plan.stack_ok   = false;
-        val mr: R.Result[R.Void, str] = materialize_pieces(ctx, mb, slot, plan);
-        if (R.is_err[R.Void, str](mr)) { ret mr; }
+        val mr: err[fail.Fail] = materialize_pieces(ctx, mb, slot, plan);
+        if (sel mr.err) { ret mr; }
     } or (slot.class == abi.CLASS_FP) {
-        val fw: R.Result[u8, str] = fp_move_width(ctx, rt);
-        if (R.is_err[u8, str](fw)) { ret R.err[R.Void, str](R.unwrap_err[u8, str](fw)); }
-        val mr: R.Result[R.Void, str] = context.emit_fmov(ctx, mb, mir.op_preg(slot.reg::u32), rvop, R.unwrap_ok[u8, str](fw));
-        if (R.is_err[R.Void, str](mr)) { ret mr; }
+        val fw: res[u8, fail.Fail] = fp_move_width(ctx, rt);
+        if (sel fw.err) { ret err[fail.Fail].err{fw.err}; }
+        val mr: err[fail.Fail] = context.emit_fmov(ctx, mb, mir.op_preg(slot.reg::u32), rvop, fw.ok);
+        if (sel mr.err) { ret mr; }
     } or (slot.reg >= 0) {
-        val mr: R.Result[R.Void, str] = context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32), rvop, scalar_reg_move_width(ctx.tgt.model.gpr_width, rsz));
-        if (R.is_err[R.Void, str](mr)) { ret mr; }
+        val mr: err[fail.Fail] = context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32), rvop, scalar_reg_move_width(ctx.tgt.model.gpr_width, rsz));
+        if (sel mr.err) { ret mr; }
     }
 
     ret emit_bare_ret(ctx, mb);
 }
 
-fun emit_bare_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock) R.Result[R.Void, str] {
+fun emit_bare_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock) err[fail.Fail] {
     var mi: mir.MirInstr = mir.instr(mir.MIR_RET, nil, 0, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
     ret context.push_instr(ctx, mb, mi);
 }
 
 test "mach.lang.be.codegen.mir.abi.classify_signature:win64_uses_one_platform_boundary" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val ir_r: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
     if (R.is_err[ir.Module, str](ir_r)) { ret 1; }
     var m: ir.Module = R.unwrap_ok[ir.Module, str](ir_r);
@@ -1641,9 +1645,9 @@ test "mach.lang.be.codegen.mir.abi.classify_signature:win64_uses_one_platform_bo
     ctx.types = ?m.types;
 
     var layout: abi.SigLayout;
-    val cls: R.Result[R.Void, str] = classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](sig_r),
+    val cls: err[fail.Fail] = classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](sig_r),
                                                        R.unwrap_ok[type.IrTypeId, str](void_r), ?layout);
-    if (R.is_err[R.Void, str](cls)) { ir.dnit(?m); ret 1; }
+    if (sel cls.err) { ir.dnit(?m); ret 1; }
     var bad: i32 = 0;
     if (layout.param_count != 1)                  { bad = 1; }
     or (layout.params[0].class != abi.CLASS_VEC_BYREF) { bad = 1; }
@@ -1837,18 +1841,23 @@ probe_arg, probe_ret,
     t.isa = ?vt;
     t.abi = ?av;
 
-    if (R.is_err[R.Void, str](require_abi(?t))) { ret 1; }
+    val require_abi_r: err[fail.Fail] = require_abi(?t);
+    if (sel require_abi_r.err) { ret 1; }
 
     var reg: i32 = 0;
-    if (!R.is_err[R.Void, str](abi_gp_arg_reg(?t, 0, ?reg))) { ret 1; }
+    val abi_gp_arg_reg_r: err[fail.Fail] = abi_gp_arg_reg(?t, 0, ?reg);
+    if (!sel abi_gp_arg_reg_r.err) { ret 1; }
     var vm: abi.VaModel;
-    if (!R.is_err[R.Void, str](abi_va_model(?t, ?vm))) { ret 1; }
+    val abi_va_model_r: err[fail.Fail] = abi_va_model(?t, ?vm);
+    if (!sel abi_va_model_r.err) { ret 1; }
 
     av.arg_passing = nil;
-    if (!R.is_err[R.Void, str](require_abi(?t))) { ret 1; }
+    val require_abi_r2: err[fail.Fail] = require_abi(?t);
+    if (!sel require_abi_r2.err) { ret 1; }
     av.arg_passing = probe_arg;
     av.ret_passing = nil;
-    if (!R.is_err[R.Void, str](require_abi(?t))) { ret 1; }
+    val require_abi_r3: err[fail.Fail] = require_abi(?t);
+    if (!sel require_abi_r3.err) { ret 1; }
     ret 0;
 }
 
@@ -1936,7 +1945,8 @@ test "mach.lang.be.codegen.mir.abi.gp_arg_regs:no_convention_exceeds_the_shared_
 
 test "mach.lang.be.codegen.mir.abi.classify_signature:odd_vector_sret_shifts_mixed_arguments" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val mr: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
     if (R.is_err[ir.Module, str](mr)) { ret 1; }
     var m: ir.Module = R.unwrap_ok[ir.Module, str](mr);
@@ -1965,8 +1975,8 @@ test "mach.lang.be.codegen.mir.abi.classify_signature:odd_vector_sret_shifts_mix
     ctx.m = ?m;
     ctx.types = ?m.types;
     var slots: abi.SigLayout;
-    val sr: R.Result[R.Void, str] = classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](sig_r), vector, ?slots);
-    if (R.is_err[R.Void, str](sr)) { ret 1; }
+    val sr: err[fail.Fail] = classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](sig_r), vector, ?slots);
+    if (sel sr.err) { ret 1; }
     fin { sig_layout_free(?ctx, ?slots); }
     if (slots.ret_slot.class != abi.CLASS_SRET || slots.param_count != 5) { ret 2; }
     if (slots.params[0].reg != 2 || slots.params[1].reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 2) || slots.params[2].reg != 9) { ret 3; }
@@ -1977,7 +1987,8 @@ test "mach.lang.be.codegen.mir.abi.classify_signature:odd_vector_sret_shifts_mix
 
 test "mach.lang.be.codegen.mir.abi:incoming_security_facts_preserve_carriers_and_indirect_contents" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val mr: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
     if (R.is_err[ir.Module, str](mr)) { ret 1; }
     var m: ir.Module = R.unwrap_ok[ir.Module, str](mr);
@@ -2023,9 +2034,11 @@ test "mach.lang.be.codegen.mir.abi:incoming_security_facts_preserve_carriers_and
     ctx.f = ?f;
     ctx.param_count = 7;
     var slots: abi.SigLayout;
-    if (R.is_err[R.Void, str](classify_signature(?ctx, fn.sig, array, ?slots))) { ret 2; }
+    val classify_signature_r: err[fail.Fail] = classify_signature(?ctx, fn.sig, array, ?slots);
+    if (sel classify_signature_r.err) { ret 2; }
     fin { sig_layout_free(?ctx, ?slots); }
-    if (R.is_err[R.Void, str](record_abi_inputs(?ctx, ?slots))) { ret 3; }
+    val record_abi_inputs_r: err[fail.Fail] = record_abi_inputs(?ctx, ?slots);
+    if (sel record_abi_inputs_r.err) { ret 3; }
     if (f.abi_input_count != 8) { ret 4; }
     val inputs: *mir.MirAbiInput = f.abi_inputs;
     if (inputs[0].argument != mir.ABI_INPUT_SRET || inputs[0].reg != 1
@@ -2057,7 +2070,9 @@ test "mach.lang.be.codegen.mir.abi:incoming_security_facts_preserve_carriers_and
         || inputs[6].secret || inputs[6].content != mir.ABI_CONTENT_PUBLIC || inputs[6].content_size != 24
         || inputs[7].secret || inputs[7].content != mir.ABI_CONTENT_PUBLIC || inputs[7].content_size != 16) { ret 9; }
     params[0].secret = false;
-    if (!inputs[1].secret || !R.is_err[R.Void, str](record_abi_inputs(?ctx, ?slots))) { ret 10; }
+    val recorded_again: err[fail.Fail] = record_abi_inputs(?ctx, ?slots);
+    if (!inputs[1].secret) { ret 10; }
+    if (!sel recorded_again.err) { ret 10; }
     mir.dnit_function(?alloc, ?f);
     if (f.abi_inputs != nil || f.abi_input_count != 0 || f.abi_input_cap != 0) { ret 11; }
     ret 0;
@@ -2065,7 +2080,8 @@ test "mach.lang.be.codegen.mir.abi:incoming_security_facts_preserve_carriers_and
 
 fun t_call_preparation(indirect: bool, sret: bool) i32 {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val mr: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
     if (R.is_err[ir.Module, str](mr)) { ret 1; }
     var m: ir.Module = R.unwrap_ok[ir.Module, str](mr);
@@ -2093,9 +2109,9 @@ fun t_call_preparation(indirect: bool, sret: bool) i32 {
     if (R.is_err[u32, str](ir.function_add(?m, intern.STR_NIL, sig, ir.FN_FLAG_EXTERN))) { ret 1; }
     var f: mir.MirFunction;
     fin { mir.dnit_function(?alloc, ?f); }
-    val fr: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](?alloc, 8);
-    if (R.is_err[*mir.MirVReg, str](fr)) { ret 1; }
-    f.vregs = R.unwrap_ok[*mir.MirVReg, str](fr);
+    val fr: res[*mir.MirVReg, A.Error] = A.allocate[mir.MirVReg](?alloc, 8);
+    if (sel fr.err) { ret 1; }
+    f.vregs = fr.ok;
     f.vreg_cap = 8;
     f.vreg_count = 3;
     f.vregs[0] = mir.vreg(0, mir.REG_CLASS_GP, false, false);
@@ -2130,7 +2146,8 @@ fun t_call_preparation(indirect: bool, sret: bool) i32 {
     fin { mir.dnit_block(?alloc, ?mb); }
     var iid: id.InstructionId = id.INSTR_NIL;
     if (sret) { iid = 0; }
-    if (R.is_err[R.Void, str](lower_call(?ctx, ?mb, ?call, iid))) { ret 2; }
+    val lower_call_r: err[fail.Fail] = lower_call(?ctx, ?mb, ?call, iid);
+    if (sel lower_call_r.err) { ret 2; }
     var saw_register: bool = false;
     var copies: u32 = 0;
     var registers: u32 = 0;
@@ -2287,7 +2304,8 @@ fun t_carrier_materialization(tgt: *target.Target, slot: abi.ParamSlot,
                               store: bool, separate: bool, insufficient: bool,
                               align: u32, base: u32, strict: bool) i32 {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var f: mir.MirFunction;
     fin { mir.dnit_function(?alloc, ?f); }
     var ctx: context.LowerCtx;
@@ -2295,11 +2313,12 @@ fun t_carrier_materialization(tgt: *target.Target, slot: abi.ParamSlot,
     ctx.tgt = tgt;
     ctx.layout = target.layout_machine(tgt);
     ctx.f = ?f;
-    val vr: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](?alloc, 16);
-    if (R.is_err[*mir.MirVReg, str](vr)) { ret 2; }
-    f.vregs = R.unwrap_ok[*mir.MirVReg, str](vr);
+    val vr: res[*mir.MirVReg, A.Error] = A.allocate[mir.MirVReg](?alloc, 16);
+    if (sel vr.err) { ret 2; }
+    f.vregs = vr.ok;
     f.vreg_cap = 16;
-    if (R.is_err[u32, str](context.new_vreg(?ctx, mir.REG_CLASS_GP))) { ret 2; }
+    val new_vreg_r: res[u32, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
+    if (sel new_vreg_r.err) { ret 2; }
     var mb: mir.MirBlock;
     fin { mir.dnit_block(?alloc, ?mb); }
     var registers: mir.MirBlock;
@@ -2317,13 +2336,17 @@ fun t_carrier_materialization(tgt: *target.Target, slot: abi.ParamSlot,
     if (separate) { plan.registers = ?registers; }
     plan.owned_extent = extent;
     if (insufficient) { plan.owned_extent = extent - 1; }
-    val mr: R.Result[R.Void, str] = materialize_pieces(?ctx, ?mb, slot, plan);
+    val mr: err[fail.Fail] = materialize_pieces(?ctx, ?mb, slot, plan);
     if (insufficient) {
-        if (!R.is_err[R.Void, str](mr) || mb.instr_count != 0) { ret 4; }
+        if (!sel mr.err) { ret 4; }
+        if (mb.instr_count != 0) { ret 4; }
         ret 0;
     }
-    if (R.is_err[R.Void, str](mr)) { ret 5; }
-    if (separate && R.is_err[R.Void, str](append_deferred(?ctx, ?mb, ?registers))) { ret 6; }
+    if (sel mr.err) { ret 5; }
+    if (separate) {
+        val appended: err[fail.Fail] = append_deferred(?ctx, ?mb, ?registers);
+        if (sel appended.err) { ret 6; }
+    }
     var bytes: CarrierBytes;
     bytes.base[0] = base;
     bytes.strict_alignment = strict;
@@ -2489,7 +2512,8 @@ fun t_incoming_arg(index: i32, size: u64, align: u64, is_float: bool, fp_eightby
 
 test "mach.lang.be.codegen.mir.abi:incoming_copies_follow_all_parameter_captures" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val mr: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
     if (R.is_err[ir.Module, str](mr)) { ret 1; }
     var m: ir.Module = R.unwrap_ok[ir.Module, str](mr);
@@ -2522,9 +2546,9 @@ test "mach.lang.be.codegen.mir.abi:incoming_copies_follow_all_parameter_captures
     var f: mir.MirFunction;
     f.oblivious = true;
     fin { mir.dnit_function(?alloc, ?f); }
-    val regs: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](?alloc, mir.INITIAL_VREG_CAP::usize);
-    if (R.is_err[*mir.MirVReg, str](regs)) { ret 1; }
-    f.vregs = R.unwrap_ok[*mir.MirVReg, str](regs);
+    val regs: res[*mir.MirVReg, A.Error] = A.allocate[mir.MirVReg](?alloc, mir.INITIAL_VREG_CAP::usize);
+    if (sel regs.err) { ret 1; }
+    f.vregs = regs.ok;
     f.vreg_cap = mir.INITIAL_VREG_CAP;
     var pv: [3]u32 = [3]u32{0, 1, 2};
     var ctx: context.LowerCtx;
@@ -2537,12 +2561,16 @@ test "mach.lang.be.codegen.mir.abi:incoming_copies_follow_all_parameter_captures
     ctx.f = ?f;
     ctx.param_vregs = ?pv[0];
     ctx.param_count = 3;
-    if (R.is_err[u32, str](context.new_vreg(?ctx, mir.REG_CLASS_GP)) ||
-        R.is_err[u32, str](context.new_vreg(?ctx, mir.REG_CLASS_GP)) ||
-        R.is_err[u32, str](context.new_vreg(?ctx, mir.REG_CLASS_GP))) { ret 1; }
+    val new_vreg_r: res[u32, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
+    val new_vreg_r2: res[u32, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
+    val new_vreg_r3: res[u32, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
+    if (sel new_vreg_r.err) { ret 1; }
+    if (sel new_vreg_r2.err) { ret 1; }
+    if (sel new_vreg_r3.err) { ret 1; }
     var mb: mir.MirBlock;
     fin { mir.dnit_block(?alloc, ?mb); }
-    if (R.is_err[R.Void, str](lower_params(?ctx, ?mb))) { ret 2; }
+    val lower_params_r: err[fail.Fail] = lower_params(?ctx, ?mb);
+    if (sel lower_params_r.err) { ret 2; }
     if (f.abi_input_count != 5 || f.abi_inputs[0].secret || f.abi_inputs[1].secret
         || f.abi_inputs[2].secret || f.abi_inputs[3].secret || f.abi_inputs[4].secret) { ret 4; }
     if (f.abi_inputs[0].width != 4 || f.abi_inputs[1].width != 8
@@ -2592,7 +2620,8 @@ test "mach.lang.be.codegen.mir.abi:incoming_copies_follow_all_parameter_captures
 
 fun t_result_carrier_alignment(element_bits: u32, count: u32) i32 {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val mr: R.Result[ir.Module, str] = ir.init(?alloc, intern.STR_NIL);
     if (R.is_err[ir.Module, str](mr)) { ret 1; }
     var m: ir.Module = R.unwrap_ok[ir.Module, str](mr);
@@ -2614,9 +2643,9 @@ fun t_result_carrier_alignment(element_bits: u32, count: u32) i32 {
     if (R.is_err[u32, str](ir.function_add(?m, intern.STR_NIL, sig, ir.FN_FLAG_EXTERN))) { ret 1; }
     var f: mir.MirFunction;
     fin { mir.dnit_function(?alloc, ?f); }
-    val regs: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](?alloc, mir.INITIAL_VREG_CAP::usize);
-    if (R.is_err[*mir.MirVReg, str](regs)) { ret 1; }
-    f.vregs = R.unwrap_ok[*mir.MirVReg, str](regs);
+    val regs: res[*mir.MirVReg, A.Error] = A.allocate[mir.MirVReg](?alloc, mir.INITIAL_VREG_CAP::usize);
+    if (sel regs.err) { ret 1; }
+    f.vregs = regs.ok;
     f.vreg_cap = mir.INITIAL_VREG_CAP;
     var iv: [1]u32 = [1]u32{0};
     var ctx: context.LowerCtx;
@@ -2628,7 +2657,8 @@ fun t_result_carrier_alignment(element_bits: u32, count: u32) i32 {
     ctx.f = ?f;
     ctx.instr_vregs = ?iv[0];
     ctx.instr_count = 1;
-    if (R.is_err[u32, str](context.new_vreg(?ctx, mir.REG_CLASS_GP))) { ret 1; }
+    val new_vreg_r: res[u32, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
+    if (sel new_vreg_r.err) { ret 1; }
     var callee: value.Value = value.fn(0, sig);
     var call: instruction.Instruction;
     call.kind = instruction.OP_CALL;
@@ -2638,7 +2668,8 @@ fun t_result_carrier_alignment(element_bits: u32, count: u32) i32 {
     call.operand_count = 1;
     var mb: mir.MirBlock;
     fin { mir.dnit_block(?alloc, ?mb); }
-    if (R.is_err[R.Void, str](lower_call(?ctx, ?mb, ?call, 0))) { ret 2; }
+    val lower_call_r: err[fail.Fail] = lower_call(?ctx, ?mb, ?call, 0);
+    if (sel lower_call_r.err) { ret 2; }
     if (f.frame.slot_count == 0 || f.frame.slots[0].align != 8 || f.frame.slots[0].size != 16) { ret 3; }
     if (type.byte_align_for_machine(?m.types, array, ctx.layout) != element_bits / 8 ||
         type.byte_size_for_machine(?m.types, array, ctx.layout) != element_bits / 8 * count) { ret 4; }
@@ -2673,7 +2704,7 @@ val REC_PK9:   u32 = 12;
 val REC_PKA:   u32 = 13;
 val REC_PKARR: u32 = 14;
 
-fun t_rec_shape(types: *type.IrTypeTable, which: u32) R.Result[type.IrTypeId, str] {
+fun t_rec_shape(types: *type.IrTypeTable, which: u32) res[type.IrTypeId, fail.Fail] {
     val u8r: R.Result[type.IrTypeId, str] = type.intern_int(types, 8);
     val u32r: R.Result[type.IrTypeId, str] = type.intern_int(types, 32);
     val i64r: R.Result[type.IrTypeId, str] = type.intern_int(types, 64);
@@ -2681,7 +2712,7 @@ fun t_rec_shape(types: *type.IrTypeTable, which: u32) R.Result[type.IrTypeId, st
     val f64r: R.Result[type.IrTypeId, str] = type.intern_float(types, 64);
     if (R.is_err[type.IrTypeId, str](u8r) || R.is_err[type.IrTypeId, str](u32r)
         || R.is_err[type.IrTypeId, str](i64r) || R.is_err[type.IrTypeId, str](f32r) || R.is_err[type.IrTypeId, str](f64r)) {
-        ret R.err[type.IrTypeId, str]("leaf");
+        ret res[type.IrTypeId, fail.Fail].err{fail.message("leaf")};
     }
     val u8t:  type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](u8r);
     val u32t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](u32r);
@@ -2694,12 +2725,12 @@ fun t_rec_shape(types: *type.IrTypeTable, which: u32) R.Result[type.IrTypeId, st
     var align: u32 = 0;
     var packed: bool = false;
     if (which == REC_P1)  { count = 1; }
-    or (which == REC_T3)  { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, u8t, 2); if (R.is_err[type.IrTypeId, str](a)) { ret a; } fields[1] = R.unwrap_ok[type.IrTypeId, str](a); }
+    or (which == REC_T3)  { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, u8t, 2); if (R.is_err[type.IrTypeId, str](a)) { ret fail.lift_res[type.IrTypeId](a); } fields[1] = R.unwrap_ok[type.IrTypeId, str](a); }
     or (which == REC_S8)  { fields[1] = u32t; }
-    or (which == REC_T9)  { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, u8t, 8); if (R.is_err[type.IrTypeId, str](a)) { ret a; } fields[1] = R.unwrap_ok[type.IrTypeId, str](a); }
+    or (which == REC_T9)  { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, u8t, 8); if (R.is_err[type.IrTypeId, str](a)) { ret fail.lift_res[type.IrTypeId](a); } fields[1] = R.unwrap_ok[type.IrTypeId, str](a); }
     or (which == REC_T16) { fields[1] = i64t; }
-    or (which == REC_O24) { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, i64t, 2); if (R.is_err[type.IrTypeId, str](a)) { ret a; } fields[1] = R.unwrap_ok[type.IrTypeId, str](a); }
-    or (which == REC_NEST) { val inner: R.Result[type.IrTypeId, str] = t_rec_shape(types, REC_S8); if (R.is_err[type.IrTypeId, str](inner)) { ret inner; } fields[1] = R.unwrap_ok[type.IrTypeId, str](inner); }
+    or (which == REC_O24) { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, i64t, 2); if (R.is_err[type.IrTypeId, str](a)) { ret fail.lift_res[type.IrTypeId](a); } fields[1] = R.unwrap_ok[type.IrTypeId, str](a); }
+    or (which == REC_NEST) { val inner: res[type.IrTypeId, fail.Fail] = t_rec_shape(types, REC_S8); if (sel inner.err) { ret inner; } fields[1] = inner.ok; }
     or (which == REC_AL16) { fields[1] = u8t; align = 16; }
     or (which == REC_TF16) { fields[1] = f64t; }
     or (which == REC_TF8) { fields[1] = f32t; }
@@ -2712,14 +2743,14 @@ fun t_rec_shape(types: *type.IrTypeTable, which: u32) R.Result[type.IrTypeId, st
         ef[0] = u32t;
         ef[1] = u8t;
         val inner: R.Result[type.IrTypeId, str] = type.intern_struct(types, ?ef[0], 2, 0, true);
-        if (R.is_err[type.IrTypeId, str](inner)) { ret inner; }
+        if (R.is_err[type.IrTypeId, str](inner)) { ret fail.lift_res[type.IrTypeId](inner); }
         val a: R.Result[type.IrTypeId, str] = type.intern_array(types, R.unwrap_ok[type.IrTypeId, str](inner), 2);
-        if (R.is_err[type.IrTypeId, str](a)) { ret a; }
+        if (R.is_err[type.IrTypeId, str](a)) { ret fail.lift_res[type.IrTypeId](a); }
         fields[0] = R.unwrap_ok[type.IrTypeId, str](a);
         count = 1;
     }
-    or { ret R.err[type.IrTypeId, str]("shape"); }
-    ret type.intern_struct(types, ?fields[0], count, align, packed);
+    or { ret res[type.IrTypeId, fail.Fail].err{fail.message("shape")}; }
+    ret fail.lift_res[type.IrTypeId](type.intern_struct(types, ?fields[0], count, align, packed));
 }
 
 rec RecTransport {
@@ -2743,9 +2774,9 @@ fun t_rec_transport(alloc: *A.Allocator, isa_name: str, os_name: str, abi_name: 
     val tr: R.Result[target.Target, str] = treg.select(?reg, isa_name, os_name, abi_name);
     if (R.is_err[target.Target, str](tr)) { ret 3; }
     var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
-    val sr: R.Result[type.IrTypeId, str] = t_rec_shape(?m.types, which);
-    if (R.is_err[type.IrTypeId, str](sr)) { ret 4; }
-    var rec_t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](sr);
+    val sr: res[type.IrTypeId, fail.Fail] = t_rec_shape(?m.types, which);
+    if (sel sr.err) { ret 4; }
+    var rec_t: type.IrTypeId = sr.ok;
     val vr: R.Result[type.IrTypeId, str] = type.intern_void(?m.types);
     if (R.is_err[type.IrTypeId, str](vr)) { ret 5; }
     val void_t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](vr);
@@ -2760,12 +2791,14 @@ fun t_rec_transport(alloc: *A.Allocator, isa_name: str, os_name: str, abi_name: 
     ctx.m      = ?m;
     ctx.types  = ?m.types;
     var layout: abi.SigLayout;
-    if (R.is_err[R.Void, str](classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](ar), void_t, ?layout))) { ret 6; }
+    val classify_signature_r: err[fail.Fail] = classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](ar), void_t, ?layout);
+    if (sel classify_signature_r.err) { ret 6; }
     if (layout.param_count != 1) { sig_layout_free(?ctx, ?layout); ret 7; }
     out.arg = layout.params[0];
     sig_layout_free(?ctx, ?layout);
     var rlayout: abi.SigLayout;
-    if (R.is_err[R.Void, str](classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](rr), rec_t, ?rlayout))) { ret 8; }
+    val classify_signature_r2: err[fail.Fail] = classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](rr), rec_t, ?rlayout);
+    if (sel classify_signature_r2.err) { ret 8; }
     out.ret = rlayout.ret_slot;
     sig_layout_free(?ctx, ?rlayout);
     out.size  = type.byte_size_for_machine(?m.types, rec_t, ctx.layout)::u64;
@@ -3026,7 +3059,8 @@ fun t_packed_cells(alloc: *A.Allocator) i32 {
 
 test "mach.lang.be.codegen.mir.abi:packed_record_with_unaligned_field_is_sysv_memory_class" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val r: i32 = t_packed_cells(?alloc);
     if (r != 0) { ret 30 + r; }
     ret 0;
@@ -3034,7 +3068,8 @@ test "mach.lang.be.codegen.mir.abi:packed_record_with_unaligned_field_is_sysv_me
 
 test "mach.lang.be.codegen.mir.abi:record_transport_classifies_by_layout_on_every_convention" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     # exit codes: convention block of thirty plus the failing cell
     val sysv: i32 = t_sysv_cells(?alloc);
     if (sysv != 0) { ret 30 + sysv; }
@@ -3072,7 +3107,7 @@ val TAG_SHAPE_COUNT: u32 = 12;
 # sweep because its cells differ per convention
 val TAG_PKA:   u32 = 12;
 
-fun t_tag_shape(types: *type.IrTypeTable, which: u32) R.Result[type.IrTypeId, str] {
+fun t_tag_shape(types: *type.IrTypeTable, which: u32) res[type.IrTypeId, fail.Fail] {
     val vr: R.Result[type.IrTypeId, str] = type.intern_void(types);
     val u8r: R.Result[type.IrTypeId, str] = type.intern_int(types, 8);
     val u32r: R.Result[type.IrTypeId, str] = type.intern_int(types, 32);
@@ -3081,7 +3116,7 @@ fun t_tag_shape(types: *type.IrTypeTable, which: u32) R.Result[type.IrTypeId, st
     val f64r: R.Result[type.IrTypeId, str] = type.intern_float(types, 64);
     if (R.is_err[type.IrTypeId, str](vr) || R.is_err[type.IrTypeId, str](u8r) || R.is_err[type.IrTypeId, str](u32r)
         || R.is_err[type.IrTypeId, str](i64r) || R.is_err[type.IrTypeId, str](f32r) || R.is_err[type.IrTypeId, str](f64r)) {
-        ret R.err[type.IrTypeId, str]("leaf");
+        ret res[type.IrTypeId, fail.Fail].err{fail.message("leaf")};
     }
     val void_t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](vr);
     val u8t:    type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](u8r);
@@ -3096,20 +3131,20 @@ fun t_tag_shape(types: *type.IrTypeTable, which: u32) R.Result[type.IrTypeId, st
     var align: u32 = 0;
     var packed: bool = false;
     if (which == TAG_P1)  { cases[1] = void_t; }
-    or (which == TAG_T3)  { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, u8t, 2); if (R.is_err[type.IrTypeId, str](a)) { ret a; } cases[1] = R.unwrap_ok[type.IrTypeId, str](a); }
+    or (which == TAG_T3)  { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, u8t, 2); if (R.is_err[type.IrTypeId, str](a)) { ret fail.lift_res[type.IrTypeId](a); } cases[1] = R.unwrap_ok[type.IrTypeId, str](a); }
     or (which == TAG_S8)  { cases[1] = u32t; }
-    or (which == TAG_T9)  { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, u8t, 8); if (R.is_err[type.IrTypeId, str](a)) { ret a; } cases[1] = R.unwrap_ok[type.IrTypeId, str](a); }
+    or (which == TAG_T9)  { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, u8t, 8); if (R.is_err[type.IrTypeId, str](a)) { ret fail.lift_res[type.IrTypeId](a); } cases[1] = R.unwrap_ok[type.IrTypeId, str](a); }
     or (which == TAG_T16) { cases[1] = i64t; }
-    or (which == TAG_O24) { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, i64t, 2); if (R.is_err[type.IrTypeId, str](a)) { ret a; } cases[1] = R.unwrap_ok[type.IrTypeId, str](a); cases[2] = u8t; count = 3; }
-    or (which == TAG_NEST) { val inner: R.Result[type.IrTypeId, str] = t_tag_shape(types, TAG_S8); if (R.is_err[type.IrTypeId, str](inner)) { ret inner; } cases[1] = R.unwrap_ok[type.IrTypeId, str](inner); }
+    or (which == TAG_O24) { val a: R.Result[type.IrTypeId, str] = type.intern_array(types, i64t, 2); if (R.is_err[type.IrTypeId, str](a)) { ret fail.lift_res[type.IrTypeId](a); } cases[1] = R.unwrap_ok[type.IrTypeId, str](a); cases[2] = u8t; count = 3; }
+    or (which == TAG_NEST) { val inner: res[type.IrTypeId, fail.Fail] = t_tag_shape(types, TAG_S8); if (sel inner.err) { ret inner; } cases[1] = inner.ok; }
     or (which == TAG_PK9) { cases[1] = i64t; packed = true; }
     or (which == TAG_AL16) { cases[1] = u8t; align = 16; }
     or (which == TAG_TF16) { cases[1] = f64t; }
     or (which == TAG_TF8) { cases[1] = f32t; }
     or (which == TAG_TFM) { cases[1] = f64t; cases[2] = i64t; count = 3; }
     or (which == TAG_PKA) { cases[1] = i64t; disc = 8; packed = true; }
-    or { ret R.err[type.IrTypeId, str]("shape"); }
-    ret type.intern_tag(types, ?cases[0], count, disc, align, packed);
+    or { ret res[type.IrTypeId, fail.Fail].err{fail.message("shape")}; }
+    ret fail.lift_res[type.IrTypeId](type.intern_tag(types, ?cases[0], count, disc, align, packed));
 }
 
 rec TagTransport {
@@ -3133,9 +3168,9 @@ fun t_tag_transport(alloc: *A.Allocator, isa_name: str, os_name: str, abi_name: 
     val tr: R.Result[target.Target, str] = treg.select(?reg, isa_name, os_name, abi_name);
     if (R.is_err[target.Target, str](tr)) { ret 3; }
     var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
-    val sr: R.Result[type.IrTypeId, str] = t_tag_shape(?m.types, which);
-    if (R.is_err[type.IrTypeId, str](sr)) { ret 4; }
-    var tag: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](sr);
+    val sr: res[type.IrTypeId, fail.Fail] = t_tag_shape(?m.types, which);
+    if (sel sr.err) { ret 4; }
+    var tag: type.IrTypeId = sr.ok;
     val vr: R.Result[type.IrTypeId, str] = type.intern_void(?m.types);
     if (R.is_err[type.IrTypeId, str](vr)) { ret 5; }
     val void_t: type.IrTypeId = R.unwrap_ok[type.IrTypeId, str](vr);
@@ -3150,12 +3185,14 @@ fun t_tag_transport(alloc: *A.Allocator, isa_name: str, os_name: str, abi_name: 
     ctx.m      = ?m;
     ctx.types  = ?m.types;
     var layout: abi.SigLayout;
-    if (R.is_err[R.Void, str](classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](ar), void_t, ?layout))) { ret 6; }
+    val classify_signature_r: err[fail.Fail] = classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](ar), void_t, ?layout);
+    if (sel classify_signature_r.err) { ret 6; }
     if (layout.param_count != 1) { sig_layout_free(?ctx, ?layout); ret 7; }
     out.arg = layout.params[0];
     sig_layout_free(?ctx, ?layout);
     var rlayout: abi.SigLayout;
-    if (R.is_err[R.Void, str](classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](rr), tag, ?rlayout))) { ret 8; }
+    val classify_signature_r2: err[fail.Fail] = classify_signature(?ctx, R.unwrap_ok[type.IrTypeId, str](rr), tag, ?rlayout);
+    if (sel classify_signature_r2.err) { ret 8; }
     out.ret = rlayout.ret_slot;
     sig_layout_free(?ctx, ?rlayout);
     out.size  = type.byte_size_for_machine(?m.types, tag, ctx.layout)::u64;
@@ -3340,7 +3377,8 @@ fun t_tag_packed_cells(alloc: *A.Allocator) i32 {
 
 test "mach.lang.be.codegen.mir.abi:packed_tag_with_unaligned_payload_is_sysv_memory_class" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val r: i32 = t_tag_packed_cells(?alloc);
     if (r != 0) { ret 30 + r; }
     ret 0;
@@ -3348,7 +3386,8 @@ test "mach.lang.be.codegen.mir.abi:packed_tag_with_unaligned_payload_is_sysv_mem
 
 test "mach.lang.be.codegen.mir.abi:tag_transport_classifies_as_the_record_of_its_layout_on_every_convention" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     # exit codes: convention block of thirty plus the failing cell
     val sysv: i32 = t_tag_sysv_cells(?alloc);
     if (sysv != 0) { ret 30 + sysv; }

--- a/src/lang/be/codegen/mir/bulk.mach
+++ b/src/lang/be/codegen/mir/bulk.mach
@@ -1,14 +1,15 @@
 use std.types.canonical.opt;
-use A: mach.lang.legacy.allocator;
-use page: mach.lang.legacy.page;
-use arena: mach.lang.legacy.arena;
+use std.types.canonical.res;
+use std.types.canonical.err;
+use mach.lang.fail;
+use A: std.allocator;
+use page: std.allocator.page;
+use arena: std.allocator.arena;
 use mach.lang.be.codegen.ctvalidate;
 use mach.lang.target.isa;
-use O: std.types.option;
 use mach.lang.target.resolved;
 use mach.lang.target.abi;
 use target_testing: mach.lang.target.testing;
-use R: std.types.result;
 use std.types.bool.bool;
 use std.types.bool.true;
 use std.types.bool.false;
@@ -28,14 +29,14 @@ rec Expansion {
     pending: mir.MirInstr;
 }
 
-fun append_block(e: *Expansion, id: u32) R.Result[u32, str] {
+fun append_block(e: *Expansion, id: u32) res[u32, fail.Fail] {
     val f: *mir.MirFunction = e.ctx.f;
     if (f.block_count == f.block_cap) {
         var cap: u32 = f.block_cap * 2;
         if (cap < 8) { cap = 8; }
-        val rr: R.Result[*mir.MirBlock, str] = A.reallocate[mir.MirBlock](e.ctx.alloc, f.blocks, f.block_cap::usize, cap::usize);
-        if (R.is_err[*mir.MirBlock, str](rr)) { ret R.err[u32, str](R.unwrap_err[*mir.MirBlock, str](rr)); }
-        f.blocks = R.unwrap_ok[*mir.MirBlock, str](rr);
+        val rr: res[*mir.MirBlock, A.Error] = A.reallocate[mir.MirBlock](e.ctx.alloc, f.blocks, f.block_cap::usize, cap::usize);
+        if (sel rr.err) { ret res[u32, fail.Fail].err{fail.refused(rr.err)}; }
+        f.blocks = rr.ok;
         f.block_cap = cap;
     }
     val ix: u32 = f.block_count;
@@ -43,24 +44,24 @@ fun append_block(e: *Expansion, id: u32) R.Result[u32, str] {
     block.id = id;
     f.blocks[ix] = block;
     f.block_count = ix + 1;
-    ret R.ok[u32, str](ix);
+    ret res[u32, fail.Fail].ok{ix};
 }
 
-fun fresh_block(e: *Expansion) R.Result[u32, str] {
+fun fresh_block(e: *Expansion) res[u32, fail.Fail] {
     val id: u32 = e.next_id;
     e.next_id = id + 1;
     ret append_block(e, id);
 }
 
-fun emit(e: *Expansion, bi: u32, opcode: mir.MirOpcode, operands: *mir.MirOperand, n: u32, width: u8) R.Result[R.Void, str] {
-    val rr: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](e.ctx.alloc, n::usize);
-    if (R.is_err[*mir.MirOperand, str](rr)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](rr)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rr);
+fun emit(e: *Expansion, bi: u32, opcode: mir.MirOpcode, operands: *mir.MirOperand, n: u32, width: u8) err[fail.Fail] {
+    val rr: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](e.ctx.alloc, n::usize);
+    if (sel rr.err) { ret err[fail.Fail].err{fail.refused(rr.err)}; }
+    val ops: *mir.MirOperand = rr.ok;
     var i: u32 = 0;
     for (i < n) { ops[i] = operands[i]; i = i + 1; }
     val mb: *mir.MirBlock = ?e.ctx.f.blocks[bi];
-    val gr: R.Result[R.Void, str] = context.grow_instr(e.ctx, mb);
-    if (R.is_err[R.Void, str](gr)) {
+    val gr: err[fail.Fail] = context.grow_instr(e.ctx, mb);
+    if (sel gr.err) {
         A.deallocate[mir.MirOperand](e.ctx.alloc, ops, n::usize);
         ret gr;
     }
@@ -71,36 +72,36 @@ fun emit(e: *Expansion, bi: u32, opcode: mir.MirOpcode, operands: *mir.MirOperan
     if (opcode == mir.MIR_LOAD || opcode == mir.MIR_STORE) { mi.memory_flags = e.origin.memory_flags; }
     mb.instrs[mb.instr_count] = mi;
     mb.instr_count = mb.instr_count + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun emit2(e: *Expansion, bi: u32, opcode: mir.MirOpcode, a: mir.MirOperand, b: mir.MirOperand, width: u8) R.Result[R.Void, str] {
+fun emit2(e: *Expansion, bi: u32, opcode: mir.MirOpcode, a: mir.MirOperand, b: mir.MirOperand, width: u8) err[fail.Fail] {
     var ops: [2]mir.MirOperand = [2]mir.MirOperand{a, b};
     ret emit(e, bi, opcode, ?ops[0], 2, width);
 }
 
-fun emit3(e: *Expansion, bi: u32, opcode: mir.MirOpcode, a: mir.MirOperand, b: mir.MirOperand, c: mir.MirOperand, width: u8) R.Result[R.Void, str] {
+fun emit3(e: *Expansion, bi: u32, opcode: mir.MirOpcode, a: mir.MirOperand, b: mir.MirOperand, c: mir.MirOperand, width: u8) err[fail.Fail] {
     var ops: [3]mir.MirOperand = [3]mir.MirOperand{a, b, c};
     ret emit(e, bi, opcode, ?ops[0], 3, width);
 }
 
-fun branch(e: *Expansion, bi: u32, target: u32) R.Result[R.Void, str] {
+fun branch(e: *Expansion, bi: u32, target: u32) err[fail.Fail] {
     var op: mir.MirOperand = mir.op_block(e.ctx.f.blocks[target].id);
     ret emit(e, bi, mir.MIR_BR, ?op, 1, e.ctx.tgt.model.pointer_width::u8);
 }
 
-fun conditional(e: *Expansion, bi: u32, cond: u32, yes: u32, no: u32) R.Result[R.Void, str] {
+fun conditional(e: *Expansion, bi: u32, cond: u32, yes: u32, no: u32) err[fail.Fail] {
     ret emit3(e, bi, mir.MIR_CBR, mir.op_vreg(cond), mir.op_block(e.ctx.f.blocks[yes].id),
                  mir.op_block(e.ctx.f.blocks[no].id), e.ctx.tgt.model.pointer_width::u8);
 }
 
-fun address(e: *Expansion, bi: u32, mem: mir.MirOperand) R.Result[u32, str] {
-    val rv: R.Result[u32, str] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](rv)) { ret rv; }
-    val v: u32 = R.unwrap_ok[u32, str](rv);
-    val er: R.Result[R.Void, str] = emit2(e, bi, mir.MIR_GEP, mir.op_vreg(v), mem, e.ctx.tgt.model.pointer_width::u8);
-    if (R.is_err[R.Void, str](er)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](er)); }
-    ret R.ok[u32, str](v);
+fun address(e: *Expansion, bi: u32, mem: mir.MirOperand) res[u32, fail.Fail] {
+    val rv: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel rv.err) { ret rv; }
+    val v: u32 = rv.ok;
+    val er: err[fail.Fail] = emit2(e, bi, mir.MIR_GEP, mir.op_vreg(v), mem, e.ctx.tgt.model.pointer_width::u8);
+    if (sel er.err) { ret res[u32, fail.Fail].err{er.err}; }
+    ret res[u32, fail.Fail].ok{v};
 }
 
 fun piece_width(remaining: u64, mask: u32, word: u8) u8 {
@@ -120,7 +121,7 @@ fun piece_count(size: u64, mask: u32, word: u8) u32 {
     ret count;
 }
 
-fun small(e: *Expansion, bi: u32, dst: mir.MirOperand, src: mir.MirOperand, size: u64, copy: bool, mask: u32) R.Result[R.Void, str] {
+fun small(e: *Expansion, bi: u32, dst: mir.MirOperand, src: mir.MirOperand, size: u64, copy: bool, mask: u32) err[fail.Fail] {
     var values: [8]u32;
     val word: u8 = e.ctx.tgt.model.gpr_width::u8;
     var off: u64 = 0;
@@ -128,12 +129,12 @@ fun small(e: *Expansion, bi: u32, dst: mir.MirOperand, src: mir.MirOperand, size
     if (copy) {
         for (off < size) {
             val width: u8 = piece_width(size - off, mask, word);
-            val rv: R.Result[u32, str] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](rv)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rv)); }
-            values[pi] = R.unwrap_ok[u32, str](rv);
+            val rv: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+            if (sel rv.err) { ret err[fail.Fail].err{rv.err}; }
+            values[pi] = rv.ok;
             e.ctx.f.vregs[values[pi]].secret = e.origin.writes_secret;
-            val er: R.Result[R.Void, str] = emit2(e, bi, mir.MIR_LOAD, mir.op_vreg(values[pi]), context.mem_at(src, off::i64), width);
-            if (R.is_err[R.Void, str](er)) { ret er; }
+            val er: err[fail.Fail] = emit2(e, bi, mir.MIR_LOAD, mir.op_vreg(values[pi]), context.mem_at(src, off::i64), width);
+            if (sel er.err) { ret er; }
             off = off + width::u64;
             pi = pi + 1;
         }
@@ -144,101 +145,101 @@ fun small(e: *Expansion, bi: u32, dst: mir.MirOperand, src: mir.MirOperand, size
         val width: u8 = piece_width(size - off, mask, word);
         var value: mir.MirOperand = mir.op_imm(0);
         if (copy) { value = mir.op_vreg(values[pi]); }
-        val er: R.Result[R.Void, str] = emit2(e, bi, mir.MIR_STORE, context.mem_at(dst, off::i64), value, width);
-        if (R.is_err[R.Void, str](er)) { ret er; }
+        val er: err[fail.Fail] = emit2(e, bi, mir.MIR_STORE, context.mem_at(dst, off::i64), value, width);
+        if (sel er.err) { ret er; }
         off = off + width::u64;
         pi = pi + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun loop_path(e: *Expansion, dst: u32, src: u32, size: u64, copy: bool, backward: bool, width: u8, mask: u32, done: u32) R.Result[u32, str] {
-    val rs: R.Result[u32, str] = fresh_block(e);
-    if (R.is_err[u32, str](rs)) { ret rs; }
-    val setup: u32 = R.unwrap_ok[u32, str](rs);
-    val rb: R.Result[u32, str] = fresh_block(e);
-    if (R.is_err[u32, str](rb)) { ret rb; }
-    val body: u32 = R.unwrap_ok[u32, str](rb);
-    val rt: R.Result[u32, str] = fresh_block(e);
-    if (R.is_err[u32, str](rt)) { ret rt; }
-    val tail: u32 = R.unwrap_ok[u32, str](rt);
-    val rd: R.Result[u32, str] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](rd)) { ret rd; }
-    val d: u32 = R.unwrap_ok[u32, str](rd);
-    val rsrc: R.Result[u32, str] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](rsrc)) { ret rsrc; }
-    val s: u32 = R.unwrap_ok[u32, str](rsrc);
-    val rc: R.Result[u32, str] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](rc)) { ret rc; }
-    val count: u32 = R.unwrap_ok[u32, str](rc);
-    val rv: R.Result[u32, str] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](rv)) { ret rv; }
-    val value: u32 = R.unwrap_ok[u32, str](rv);
+fun loop_path(e: *Expansion, dst: u32, src: u32, size: u64, copy: bool, backward: bool, width: u8, mask: u32, done: u32) res[u32, fail.Fail] {
+    val rs: res[u32, fail.Fail] = fresh_block(e);
+    if (sel rs.err) { ret rs; }
+    val setup: u32 = rs.ok;
+    val rb: res[u32, fail.Fail] = fresh_block(e);
+    if (sel rb.err) { ret rb; }
+    val body: u32 = rb.ok;
+    val rt: res[u32, fail.Fail] = fresh_block(e);
+    if (sel rt.err) { ret rt; }
+    val tail: u32 = rt.ok;
+    val rd: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel rd.err) { ret rd; }
+    val d: u32 = rd.ok;
+    val rsrc: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel rsrc.err) { ret rsrc; }
+    val s: u32 = rsrc.ok;
+    val rc: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel rc.err) { ret rc; }
+    val count: u32 = rc.ok;
+    val rv: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel rv.err) { ret rv; }
+    val value: u32 = rv.ok;
     e.ctx.f.vregs[value].secret = e.origin.writes_secret;
-    val rq: R.Result[u32, str] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](rq)) { ret rq; }
-    val more: u32 = R.unwrap_ok[u32, str](rq);
+    val rq: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel rq.err) { ret rq; }
+    val more: u32 = rq.ok;
     val pw: u8 = e.ctx.tgt.model.pointer_width::u8;
     val remainder: u64 = size % width::u64;
     val whole: u64 = size - remainder;
     var initial: i64 = 0;
     if (backward) { initial = whole::i64; }
 
-    val ed: R.Result[R.Void, str] = emit3(e, setup, mir.MIR_ADD, mir.op_vreg(d), mir.op_vreg(dst), mir.op_imm(initial), pw);
-    if (R.is_err[R.Void, str](ed)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](ed)); }
+    val ed: err[fail.Fail] = emit3(e, setup, mir.MIR_ADD, mir.op_vreg(d), mir.op_vreg(dst), mir.op_imm(initial), pw);
+    if (sel ed.err) { ret res[u32, fail.Fail].err{ed.err}; }
     if (copy) {
-        val es: R.Result[R.Void, str] = emit3(e, setup, mir.MIR_ADD, mir.op_vreg(s), mir.op_vreg(src), mir.op_imm(initial), pw);
-        if (R.is_err[R.Void, str](es)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](es)); }
+        val es: err[fail.Fail] = emit3(e, setup, mir.MIR_ADD, mir.op_vreg(s), mir.op_vreg(src), mir.op_imm(initial), pw);
+        if (sel es.err) { ret res[u32, fail.Fail].err{es.err}; }
     }
     if (backward) {
-        val et: R.Result[R.Void, str] = small(e, setup, mir.op_mem_value(d, 0), mir.op_mem_value(s, 0), remainder, copy, mask);
-        if (R.is_err[R.Void, str](et)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](et)); }
+        val et: err[fail.Fail] = small(e, setup, mir.op_mem_value(d, 0), mir.op_mem_value(s, 0), remainder, copy, mask);
+        if (sel et.err) { ret res[u32, fail.Fail].err{et.err}; }
     }
-    val ec: R.Result[R.Void, str] = emit2(e, setup, mir.MIR_MOV, mir.op_vreg(count), mir.op_imm(whole::i64), pw);
-    if (R.is_err[R.Void, str](ec)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](ec)); }
-    val eb: R.Result[R.Void, str] = branch(e, setup, body);
-    if (R.is_err[R.Void, str](eb)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](eb)); }
+    val ec: err[fail.Fail] = emit2(e, setup, mir.MIR_MOV, mir.op_vreg(count), mir.op_imm(whole::i64), pw);
+    if (sel ec.err) { ret res[u32, fail.Fail].err{ec.err}; }
+    val eb: err[fail.Fail] = branch(e, setup, body);
+    if (sel eb.err) { ret res[u32, fail.Fail].err{eb.err}; }
 
     if (backward) {
-        val edb: R.Result[R.Void, str] = emit3(e, body, mir.MIR_SUB, mir.op_vreg(d), mir.op_vreg(d), mir.op_imm(width::i64), pw);
-        if (R.is_err[R.Void, str](edb)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](edb)); }
+        val edb: err[fail.Fail] = emit3(e, body, mir.MIR_SUB, mir.op_vreg(d), mir.op_vreg(d), mir.op_imm(width::i64), pw);
+        if (sel edb.err) { ret res[u32, fail.Fail].err{edb.err}; }
         if (copy) {
-            val esb: R.Result[R.Void, str] = emit3(e, body, mir.MIR_SUB, mir.op_vreg(s), mir.op_vreg(s), mir.op_imm(width::i64), pw);
-            if (R.is_err[R.Void, str](esb)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](esb)); }
+            val esb: err[fail.Fail] = emit3(e, body, mir.MIR_SUB, mir.op_vreg(s), mir.op_vreg(s), mir.op_imm(width::i64), pw);
+            if (sel esb.err) { ret res[u32, fail.Fail].err{esb.err}; }
         }
     }
     var stored: mir.MirOperand = mir.op_imm(0);
     if (copy) {
-        val el: R.Result[R.Void, str] = emit2(e, body, mir.MIR_LOAD, mir.op_vreg(value), mir.op_mem_value(s, 0), width);
-        if (R.is_err[R.Void, str](el)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](el)); }
+        val el: err[fail.Fail] = emit2(e, body, mir.MIR_LOAD, mir.op_vreg(value), mir.op_mem_value(s, 0), width);
+        if (sel el.err) { ret res[u32, fail.Fail].err{el.err}; }
         stored = mir.op_vreg(value);
     }
-    val ew: R.Result[R.Void, str] = emit2(e, body, mir.MIR_STORE, mir.op_mem_value(d, 0), stored, width);
-    if (R.is_err[R.Void, str](ew)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](ew)); }
+    val ew: err[fail.Fail] = emit2(e, body, mir.MIR_STORE, mir.op_mem_value(d, 0), stored, width);
+    if (sel ew.err) { ret res[u32, fail.Fail].err{ew.err}; }
     if (!backward) {
-        val edf: R.Result[R.Void, str] = emit3(e, body, mir.MIR_ADD, mir.op_vreg(d), mir.op_vreg(d), mir.op_imm(width::i64), pw);
-        if (R.is_err[R.Void, str](edf)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](edf)); }
+        val edf: err[fail.Fail] = emit3(e, body, mir.MIR_ADD, mir.op_vreg(d), mir.op_vreg(d), mir.op_imm(width::i64), pw);
+        if (sel edf.err) { ret res[u32, fail.Fail].err{edf.err}; }
         if (copy) {
-            val esf: R.Result[R.Void, str] = emit3(e, body, mir.MIR_ADD, mir.op_vreg(s), mir.op_vreg(s), mir.op_imm(width::i64), pw);
-            if (R.is_err[R.Void, str](esf)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](esf)); }
+            val esf: err[fail.Fail] = emit3(e, body, mir.MIR_ADD, mir.op_vreg(s), mir.op_vreg(s), mir.op_imm(width::i64), pw);
+            if (sel esf.err) { ret res[u32, fail.Fail].err{esf.err}; }
         }
     }
-    val en: R.Result[R.Void, str] = emit3(e, body, mir.MIR_SUB, mir.op_vreg(count), mir.op_vreg(count), mir.op_imm(width::i64), pw);
-    if (R.is_err[R.Void, str](en)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](en)); }
-    val eq: R.Result[R.Void, str] = emit3(e, body, mir.MIR_CMP_NE, mir.op_vreg(more), mir.op_vreg(count), mir.op_imm(0), pw);
-    if (R.is_err[R.Void, str](eq)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](eq)); }
-    val ej: R.Result[R.Void, str] = conditional(e, body, more, body, tail);
-    if (R.is_err[R.Void, str](ej)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](ej)); }
+    val en: err[fail.Fail] = emit3(e, body, mir.MIR_SUB, mir.op_vreg(count), mir.op_vreg(count), mir.op_imm(width::i64), pw);
+    if (sel en.err) { ret res[u32, fail.Fail].err{en.err}; }
+    val eq: err[fail.Fail] = emit3(e, body, mir.MIR_CMP_NE, mir.op_vreg(more), mir.op_vreg(count), mir.op_imm(0), pw);
+    if (sel eq.err) { ret res[u32, fail.Fail].err{eq.err}; }
+    val ej: err[fail.Fail] = conditional(e, body, more, body, tail);
+    if (sel ej.err) { ret res[u32, fail.Fail].err{ej.err}; }
     if (!backward) {
-        val et: R.Result[R.Void, str] = small(e, tail, mir.op_mem_value(d, 0), mir.op_mem_value(s, 0), remainder, copy, mask);
-        if (R.is_err[R.Void, str](et)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](et)); }
+        val et: err[fail.Fail] = small(e, tail, mir.op_mem_value(d, 0), mir.op_mem_value(s, 0), remainder, copy, mask);
+        if (sel et.err) { ret res[u32, fail.Fail].err{et.err}; }
     }
-    val ee: R.Result[R.Void, str] = branch(e, tail, done);
-    if (R.is_err[R.Void, str](ee)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](ee)); }
-    ret R.ok[u32, str](setup);
+    val ee: err[fail.Fail] = branch(e, tail, done);
+    if (sel ee.err) { ret res[u32, fail.Fail].err{ee.err}; }
+    ret res[u32, fail.Fail].ok{setup};
 }
 
-fun expand_one(e: *Expansion, bi: u32) R.Result[u32, str] {
+fun expand_one(e: *Expansion, bi: u32) res[u32, fail.Fail] {
     val mi: *mir.MirInstr = e.origin;
     val copy: bool = mi.opcode == mir.MIR_MEMCPY;
     val size: u64 = mi.operands[mi.operand_count - 1].imm::u64;
@@ -256,109 +257,109 @@ fun expand_one(e: *Expansion, bi: u32) R.Result[u32, str] {
         }
     }
     if (piece_count(size, mask, word) <= SNAPSHOT_PIECES) {
-        val er: R.Result[R.Void, str] = small(e, bi, dst, src, size, copy, mask);
-        if (R.is_err[R.Void, str](er)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](er)); }
-        ret R.ok[u32, str](bi);
+        val er: err[fail.Fail] = small(e, bi, dst, src, size, copy, mask);
+        if (sel er.err) { ret res[u32, fail.Fail].err{er.err}; }
+        ret res[u32, fail.Fail].ok{bi};
     }
     for (word::u64 > size) { word = word / 2; }
-    val rd: R.Result[u32, str] = address(e, bi, dst);
-    if (R.is_err[u32, str](rd)) { ret rd; }
-    val d: u32 = R.unwrap_ok[u32, str](rd);
+    val rd: res[u32, fail.Fail] = address(e, bi, dst);
+    if (sel rd.err) { ret rd; }
+    val d: u32 = rd.ok;
     var s: u32 = mir.MIR_VREG_NIL;
     if (copy) {
-        val rs: R.Result[u32, str] = address(e, bi, src);
-        if (R.is_err[u32, str](rs)) { ret rs; }
-        s = R.unwrap_ok[u32, str](rs);
+        val rs: res[u32, fail.Fail] = address(e, bi, src);
+        if (sel rs.err) { ret rs; }
+        s = rs.ok;
     }
-    val re: R.Result[u32, str] = fresh_block(e);
-    if (R.is_err[u32, str](re)) { ret re; }
-    val done: u32 = R.unwrap_ok[u32, str](re);
+    val re: res[u32, fail.Fail] = fresh_block(e);
+    if (sel re.err) { ret re; }
+    val done: u32 = re.ok;
     val pw: u8 = e.ctx.tgt.model.pointer_width::u8;
     if ((mask & word::u32) != 0) {
-        val rf: R.Result[u32, str] = loop_path(e, d, s, size, copy, false, word, mask, done);
-        if (R.is_err[u32, str](rf)) { ret rf; }
+        val rf: res[u32, fail.Fail] = loop_path(e, d, s, size, copy, false, word, mask, done);
+        if (sel rf.err) { ret rf; }
         if (!copy) {
-            val ej: R.Result[R.Void, str] = branch(e, bi, R.unwrap_ok[u32, str](rf));
-            if (R.is_err[R.Void, str](ej)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](ej)); }
-            ret R.ok[u32, str](done);
+            val ej: err[fail.Fail] = branch(e, bi, rf.ok);
+            if (sel ej.err) { ret res[u32, fail.Fail].err{ej.err}; }
+            ret res[u32, fail.Fail].ok{done};
         }
-        val rb: R.Result[u32, str] = loop_path(e, d, s, size, true, true, word, mask, done);
-        if (R.is_err[u32, str](rb)) { ret rb; }
-        val rq: R.Result[u32, str] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rq)) { ret rq; }
-        val before: u32 = R.unwrap_ok[u32, str](rq);
-        val ec: R.Result[R.Void, str] = emit3(e, bi, mir.MIR_CMP_LT_U, mir.op_vreg(before), mir.op_vreg(d), mir.op_vreg(s), pw);
-        if (R.is_err[R.Void, str](ec)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](ec)); }
-        val ej: R.Result[R.Void, str] = conditional(e, bi, before, R.unwrap_ok[u32, str](rf), R.unwrap_ok[u32, str](rb));
-        if (R.is_err[R.Void, str](ej)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](ej)); }
-        ret R.ok[u32, str](done);
+        val rb: res[u32, fail.Fail] = loop_path(e, d, s, size, true, true, word, mask, done);
+        if (sel rb.err) { ret rb; }
+        val rq: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+        if (sel rq.err) { ret rq; }
+        val before: u32 = rq.ok;
+        val ec: err[fail.Fail] = emit3(e, bi, mir.MIR_CMP_LT_U, mir.op_vreg(before), mir.op_vreg(d), mir.op_vreg(s), pw);
+        if (sel ec.err) { ret res[u32, fail.Fail].err{ec.err}; }
+        val ej: err[fail.Fail] = conditional(e, bi, before, rf.ok, rb.ok);
+        if (sel ej.err) { ret res[u32, fail.Fail].err{ej.err}; }
+        ret res[u32, fail.Fail].ok{done};
     }
-    val ra: R.Result[u32, str] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](ra)) { ret ra; }
-    val unaligned: u32 = R.unwrap_ok[u32, str](ra);
+    val ra: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel ra.err) { ret ra; }
+    val unaligned: u32 = ra.ok;
     var combined: mir.MirOperand = mir.op_vreg(d);
     if (copy) {
-        val eo: R.Result[R.Void, str] = emit3(e, bi, mir.MIR_OR, mir.op_vreg(unaligned), mir.op_vreg(d), mir.op_vreg(s), pw);
-        if (R.is_err[R.Void, str](eo)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](eo)); }
+        val eo: err[fail.Fail] = emit3(e, bi, mir.MIR_OR, mir.op_vreg(unaligned), mir.op_vreg(d), mir.op_vreg(s), pw);
+        if (sel eo.err) { ret res[u32, fail.Fail].err{eo.err}; }
         combined = mir.op_vreg(unaligned);
     }
-    val ea: R.Result[R.Void, str] = emit3(e, bi, mir.MIR_AND, mir.op_vreg(unaligned), combined, mir.op_imm((word - 1)::i64), pw);
-    if (R.is_err[R.Void, str](ea)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](ea)); }
-    val rw: R.Result[u32, str] = loop_path(e, d, s, size, copy, false, word, word::u32 * 2 - 1, done);
-    if (R.is_err[u32, str](rw)) { ret rw; }
-    val rb: R.Result[u32, str] = loop_path(e, d, s, size, copy, false, 1, 1, done);
-    if (R.is_err[u32, str](rb)) { ret rb; }
+    val ea: err[fail.Fail] = emit3(e, bi, mir.MIR_AND, mir.op_vreg(unaligned), combined, mir.op_imm((word - 1)::i64), pw);
+    if (sel ea.err) { ret res[u32, fail.Fail].err{ea.err}; }
+    val rw: res[u32, fail.Fail] = loop_path(e, d, s, size, copy, false, word, word::u32 * 2 - 1, done);
+    if (sel rw.err) { ret rw; }
+    val rb: res[u32, fail.Fail] = loop_path(e, d, s, size, copy, false, 1, 1, done);
+    if (sel rb.err) { ret rb; }
     if (!copy) {
-        val ej: R.Result[R.Void, str] = conditional(e, bi, unaligned, R.unwrap_ok[u32, str](rb), R.unwrap_ok[u32, str](rw));
-        if (R.is_err[R.Void, str](ej)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](ej)); }
-        ret R.ok[u32, str](done);
+        val ej: err[fail.Fail] = conditional(e, bi, unaligned, rb.ok, rw.ok);
+        if (sel ej.err) { ret res[u32, fail.Fail].err{ej.err}; }
+        ret res[u32, fail.Fail].ok{done};
     }
-    val rbackw: R.Result[u32, str] = loop_path(e, d, s, size, true, true, word, word::u32 * 2 - 1, done);
-    if (R.is_err[u32, str](rbackw)) { ret rbackw; }
-    val rbackb: R.Result[u32, str] = loop_path(e, d, s, size, true, true, 1, 1, done);
-    if (R.is_err[u32, str](rbackb)) { ret rbackb; }
-    val rf: R.Result[u32, str] = fresh_block(e);
-    if (R.is_err[u32, str](rf)) { ret rf; }
-    val forward: u32 = R.unwrap_ok[u32, str](rf);
-    val rback: R.Result[u32, str] = fresh_block(e);
-    if (R.is_err[u32, str](rback)) { ret rback; }
-    val backward: u32 = R.unwrap_ok[u32, str](rback);
-    val ef: R.Result[R.Void, str] = conditional(e, forward, unaligned, R.unwrap_ok[u32, str](rb), R.unwrap_ok[u32, str](rw));
-    if (R.is_err[R.Void, str](ef)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](ef)); }
-    val eb: R.Result[R.Void, str] = conditional(e, backward, unaligned, R.unwrap_ok[u32, str](rbackb), R.unwrap_ok[u32, str](rbackw));
-    if (R.is_err[R.Void, str](eb)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](eb)); }
-    val rq: R.Result[u32, str] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](rq)) { ret rq; }
-    val before: u32 = R.unwrap_ok[u32, str](rq);
-    val ec: R.Result[R.Void, str] = emit3(e, bi, mir.MIR_CMP_LT_U, mir.op_vreg(before), mir.op_vreg(d), mir.op_vreg(s), pw);
-    if (R.is_err[R.Void, str](ec)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](ec)); }
-    val ej: R.Result[R.Void, str] = conditional(e, bi, before, forward, backward);
-    if (R.is_err[R.Void, str](ej)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](ej)); }
-    ret R.ok[u32, str](done);
+    val rbackw: res[u32, fail.Fail] = loop_path(e, d, s, size, true, true, word, word::u32 * 2 - 1, done);
+    if (sel rbackw.err) { ret rbackw; }
+    val rbackb: res[u32, fail.Fail] = loop_path(e, d, s, size, true, true, 1, 1, done);
+    if (sel rbackb.err) { ret rbackb; }
+    val rf: res[u32, fail.Fail] = fresh_block(e);
+    if (sel rf.err) { ret rf; }
+    val forward: u32 = rf.ok;
+    val rback: res[u32, fail.Fail] = fresh_block(e);
+    if (sel rback.err) { ret rback; }
+    val backward: u32 = rback.ok;
+    val ef: err[fail.Fail] = conditional(e, forward, unaligned, rb.ok, rw.ok);
+    if (sel ef.err) { ret res[u32, fail.Fail].err{ef.err}; }
+    val eb: err[fail.Fail] = conditional(e, backward, unaligned, rbackb.ok, rbackw.ok);
+    if (sel eb.err) { ret res[u32, fail.Fail].err{eb.err}; }
+    val rq: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel rq.err) { ret rq; }
+    val before: u32 = rq.ok;
+    val ec: err[fail.Fail] = emit3(e, bi, mir.MIR_CMP_LT_U, mir.op_vreg(before), mir.op_vreg(d), mir.op_vreg(s), pw);
+    if (sel ec.err) { ret res[u32, fail.Fail].err{ec.err}; }
+    val ej: err[fail.Fail] = conditional(e, bi, before, forward, backward);
+    if (sel ej.err) { ret res[u32, fail.Fail].err{ej.err}; }
+    ret res[u32, fail.Fail].ok{done};
 }
 
-fun move_bindings(e: *Expansion, dst: *mir.MirInstr, src: *mir.MirInstr) R.Result[R.Void, str] {
-    if (src.dbg_binding_count == 0) { ret R.ok_void[str](); }
+fun move_bindings(e: *Expansion, dst: *mir.MirInstr, src: *mir.MirInstr) err[fail.Fail] {
+    if (src.dbg_binding_count == 0) { ret err[fail.Fail].ok{}; }
     val old: u32 = dst.dbg_binding_count;
     val count: u32 = old + src.dbg_binding_count;
-    val rr: R.Result[*mir.MirDbgBinding, str] = A.reallocate[mir.MirDbgBinding](e.ctx.alloc, dst.dbg_bindings, old::usize, count::usize);
-    if (R.is_err[*mir.MirDbgBinding, str](rr)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirDbgBinding, str](rr)); }
-    dst.dbg_bindings = R.unwrap_ok[*mir.MirDbgBinding, str](rr);
+    val rr: res[*mir.MirDbgBinding, A.Error] = A.reallocate[mir.MirDbgBinding](e.ctx.alloc, dst.dbg_bindings, old::usize, count::usize);
+    if (sel rr.err) { ret err[fail.Fail].err{fail.refused(rr.err)}; }
+    dst.dbg_bindings = rr.ok;
     var i: u32 = 0;
     for (i < src.dbg_binding_count) { dst.dbg_bindings[old + i] = src.dbg_bindings[i]; i = i + 1; }
     dst.dbg_binding_count = count;
     A.deallocate[mir.MirDbgBinding](e.ctx.alloc, src.dbg_bindings, src.dbg_binding_count::usize);
     src.dbg_bindings = nil;
     src.dbg_binding_count = 0;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun move_instr(e: *Expansion, bi: u32, mi: *mir.MirInstr) R.Result[R.Void, str] {
+fun move_instr(e: *Expansion, bi: u32, mi: *mir.MirInstr) err[fail.Fail] {
     val mb: *mir.MirBlock = ?e.ctx.f.blocks[bi];
-    val gr: R.Result[R.Void, str] = context.grow_instr(e.ctx, mb);
-    if (R.is_err[R.Void, str](gr)) { ret gr; }
-    val dr: R.Result[R.Void, str] = move_bindings(e, mi, ?e.pending);
-    if (R.is_err[R.Void, str](dr)) { ret dr; }
+    val gr: err[fail.Fail] = context.grow_instr(e.ctx, mb);
+    if (sel gr.err) { ret gr; }
+    val dr: err[fail.Fail] = move_bindings(e, mi, ?e.pending);
+    if (sel dr.err) { ret dr; }
     mb.instrs[mb.instr_count] = @mi;
     mb.instr_count = mb.instr_count + 1;
     mi.operands = nil;
@@ -366,14 +367,14 @@ fun move_instr(e: *Expansion, bi: u32, mi: *mir.MirInstr) R.Result[R.Void, str] 
     mi.dbg_bindings = nil;
     mi.dbg_binding_count = 0;
     mi.asm_block = nil;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun rebuild_preds(e: *Expansion) R.Result[R.Void, str] {
+fun rebuild_preds(e: *Expansion) err[fail.Fail] {
     val f: *mir.MirFunction = e.ctx.f;
-    val rr: R.Result[*u32, str] = A.allocate[u32](e.ctx.alloc, e.next_id::usize);
-    if (R.is_err[*u32, str](rr)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](rr)); }
-    val indices: *u32 = R.unwrap_ok[*u32, str](rr);
+    val rr: res[*u32, A.Error] = A.allocate[u32](e.ctx.alloc, e.next_id::usize);
+    if (sel rr.err) { ret err[fail.Fail].err{fail.refused(rr.err)}; }
+    val indices: *u32 = rr.ok;
     fin { A.deallocate[u32](e.ctx.alloc, indices, e.next_id::usize); }
     var bi: u32 = 0;
     for (bi < f.block_count) { indices[f.blocks[bi].id] = bi; bi = bi + 1; }
@@ -398,9 +399,9 @@ fun rebuild_preds(e: *Expansion) R.Result[R.Void, str] {
     for (bi < f.block_count) {
         val mb: *mir.MirBlock = ?f.blocks[bi];
         if (mb.pred_cap > 0) {
-            val rp: R.Result[*u32, str] = A.allocate[u32](e.ctx.alloc, mb.pred_cap::usize);
-            if (R.is_err[*u32, str](rp)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](rp)); }
-            mb.preds = R.unwrap_ok[*u32, str](rp);
+            val rp: res[*u32, A.Error] = A.allocate[u32](e.ctx.alloc, mb.pred_cap::usize);
+            if (sel rp.err) { ret err[fail.Fail].err{fail.refused(rp.err)}; }
+            mb.preds = rp.ok;
         }
         bi = bi + 1;
     }
@@ -422,11 +423,11 @@ fun rebuild_preds(e: *Expansion) R.Result[R.Void, str] {
         }
         bi = bi + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun expand(ctx: *context.LowerCtx) R.Result[R.Void, str] {
-    if (!ctx.tgt.model.flat_addressing) { ret R.ok_void[str](); }
+pub fun expand(ctx: *context.LowerCtx) err[fail.Fail] {
+    if (!ctx.tgt.model.flat_addressing) { ret err[fail.Fail].ok{}; }
     var found: bool = false;
     var next_id: u32 = 0;
     var bi: u32 = 0;
@@ -441,7 +442,7 @@ pub fun expand(ctx: *context.LowerCtx) R.Result[R.Void, str] {
         }
         bi = bi + 1;
     }
-    if (!found) { ret R.ok_void[str](); }
+    if (!found) { ret err[fail.Fail].ok{}; }
     var old: mir.MirFunction;
     old.blocks = ctx.f.blocks;
     old.block_count = ctx.f.block_count;
@@ -460,23 +461,23 @@ pub fun expand(ctx: *context.LowerCtx) R.Result[R.Void, str] {
     }
     bi = 0;
     for (bi < old.block_count) {
-        val rb: R.Result[u32, str] = append_block(?e, old.blocks[bi].id);
-        if (R.is_err[u32, str](rb)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rb)); }
-        var current: u32 = R.unwrap_ok[u32, str](rb);
+        val rb: res[u32, fail.Fail] = append_block(?e, old.blocks[bi].id);
+        if (sel rb.err) { ret err[fail.Fail].err{rb.err}; }
+        var current: u32 = rb.ok;
         var ii: u32 = 0;
         for (ii < old.blocks[bi].instr_count) {
             val mi: *mir.MirInstr = ?old.blocks[bi].instrs[ii];
             if (mi.opcode == mir.MIR_MEMCPY || mi.opcode == mir.MIR_MEMZERO) {
                 e.origin = mi;
-                val er: R.Result[u32, str] = expand_one(?e, current);
-                if (R.is_err[u32, str](er)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](er)); }
-                current = R.unwrap_ok[u32, str](er);
-                val dr: R.Result[R.Void, str] = move_bindings(?e, ?e.pending, mi);
-                if (R.is_err[R.Void, str](dr)) { ret dr; }
+                val er: res[u32, fail.Fail] = expand_one(?e, current);
+                if (sel er.err) { ret err[fail.Fail].err{er.err}; }
+                current = er.ok;
+                val dr: err[fail.Fail] = move_bindings(?e, ?e.pending, mi);
+                if (sel dr.err) { ret dr; }
             }
             or {
-                val mr: R.Result[R.Void, str] = move_instr(?e, current, mi);
-                if (R.is_err[R.Void, str](mr)) { ret mr; }
+                val mr: err[fail.Fail] = move_instr(?e, current, mi);
+                if (sel mr.err) { ret mr; }
             }
             ii = ii + 1;
         }
@@ -485,34 +486,34 @@ pub fun expand(ctx: *context.LowerCtx) R.Result[R.Void, str] {
     ret rebuild_preds(?e);
 }
 
-fun t_setup(ctx: *context.LowerCtx, size: u64, copy: bool) R.Result[R.Void, str] {
-    val rv: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](ctx.alloc, 8);
-    if (R.is_err[*mir.MirVReg, str](rv)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirVReg, str](rv)); }
-    ctx.f.vregs = R.unwrap_ok[*mir.MirVReg, str](rv);
+fun t_setup(ctx: *context.LowerCtx, size: u64, copy: bool) err[fail.Fail] {
+    val rv: res[*mir.MirVReg, A.Error] = A.allocate[mir.MirVReg](ctx.alloc, 8);
+    if (sel rv.err) { ret err[fail.Fail].err{fail.refused(rv.err)}; }
+    ctx.f.vregs = rv.ok;
     ctx.f.vreg_cap = 8;
     ctx.f.vreg_count = 2;
     ctx.f.vregs[0] = mir.vreg(0, mir.REG_CLASS_GP, false, false);
     ctx.f.vregs[1] = mir.vreg(1, mir.REG_CLASS_GP, false, false);
     var e: Expansion;
     e.ctx = ctx;
-    val rb: R.Result[u32, str] = append_block(?e, 7);
-    if (R.is_err[u32, str](rb)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rb)); }
+    val rb: res[u32, fail.Fail] = append_block(?e, 7);
+    if (sel rb.err) { ret err[fail.Fail].err{rb.err}; }
     var origin: mir.MirInstr = mir.instr(mir.MIR_RET, nil, 0, 0, 0);
     origin.inline_site = 19;
     origin.writes_secret = true;
     e.origin = ?origin;
     if (copy) {
-        val er: R.Result[R.Void, str] = emit3(?e, 0, mir.MIR_MEMCPY, mir.op_mem_value(1, 0), mir.op_mem_value(0, 0), mir.op_imm(size::i64), ctx.tgt.model.pointer_width::u8);
-        if (R.is_err[R.Void, str](er)) { ret er; }
+        val er: err[fail.Fail] = emit3(?e, 0, mir.MIR_MEMCPY, mir.op_mem_value(1, 0), mir.op_mem_value(0, 0), mir.op_imm(size::i64), ctx.tgt.model.pointer_width::u8);
+        if (sel er.err) { ret er; }
     }
     or {
-        val er: R.Result[R.Void, str] = emit2(?e, 0, mir.MIR_MEMZERO, mir.op_mem_value(1, 0), mir.op_imm(size::i64), ctx.tgt.model.pointer_width::u8);
-        if (R.is_err[R.Void, str](er)) { ret er; }
+        val er: err[fail.Fail] = emit2(?e, 0, mir.MIR_MEMZERO, mir.op_mem_value(1, 0), mir.op_imm(size::i64), ctx.tgt.model.pointer_width::u8);
+        if (sel er.err) { ret er; }
     }
     ctx.f.blocks[0].instrs[0].writes_secret = true;
     ctx.f.blocks[0].instrs[0].memory_flags = mir.MEMORY_VOLATILE;
-    val dr: R.Result[R.Void, str] = mir.instr_attach_dbg(ctx.alloc, ?ctx.f.blocks[0].instrs[0], 29, 1);
-    if (R.is_err[R.Void, str](dr)) { ret dr; }
+    val dr: err[fail.Fail] = mir.instr_attach_dbg(ctx.alloc, ?ctx.f.blocks[0].instrs[0], 29, 1);
+    if (sel dr.err) { ret dr; }
     ctx.f.blocks[0].instrs[0].dbg_bindings[0].cmp_width = 4;
     var ret_inst: mir.MirInstr = mir.instr(mir.MIR_RET, nil, 0, ctx.tgt.model.pointer_width::u8, ctx.tgt.model.pointer_width::u8);
     ret context.push_instr(ctx, ?ctx.f.blocks[0], ret_inst);
@@ -592,7 +593,8 @@ fun t_case(size: u64, src: u64, dst: u64, copy: bool, pointer_width: u32, word: 
 
 fun t_case_model(size: u64, src: u64, dst: u64, copy: bool, pointer_width: u32, word: u32, unaligned_widths: u32, volatile: bool) i32 {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var tgt: resolved.Target;
     tgt.model.flat_addressing = true;
     tgt.model.pointer_width = pointer_width;
@@ -606,9 +608,11 @@ fun t_case_model(size: u64, src: u64, dst: u64, copy: bool, pointer_width: u32, 
     tgt.abi = ?convention;
     ctx.tgt = ?tgt;
     ctx.f = ?f;
-    if (R.is_err[R.Void, str](t_setup(?ctx, size, copy))) { ret 2; }
+    val t_setup_r: err[fail.Fail] = t_setup(?ctx, size, copy);
+    if (sel t_setup_r.err) { ret 2; }
     if (!volatile) { f.blocks[0].instrs[0].memory_flags = 0; }
-    if (R.is_err[R.Void, str](expand(?ctx))) { ret 3; }
+    val expand_r: err[fail.Fail] = expand(?ctx);
+    if (sel expand_r.err) { ret 3; }
     var bytes: [1024]u8;
     var i: u64 = 0;
     for (i < 1024) { bytes[i] = (i % 251)::u8; i = i + 1; }
@@ -653,7 +657,8 @@ test "mach.lang.be.codegen.mir.bulk:snapshot_overlap_and_exact_extent" {
 
 test "mach.lang.be.codegen.mir.bulk:bounded_shape_secrecy_and_debug_ownership" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var sizes: [7]u64 = [7]u64{0, 3, 16, 17, 65, 65536, 1048577};
     var si: u32 = 0;
     for (si < 7) {
@@ -669,8 +674,10 @@ test "mach.lang.be.codegen.mir.bulk:bounded_shape_secrecy_and_debug_ownership" {
     tgt.abi = ?convention;
     ctx.tgt = ?tgt;
         ctx.f = ?f;
-        if (R.is_err[R.Void, str](t_setup(?ctx, sizes[si], true))) { ret 2; }
-        if (R.is_err[R.Void, str](expand(?ctx))) { ret 3; }
+        val t_setup_r: err[fail.Fail] = t_setup(?ctx, sizes[si], true);
+        if (sel t_setup_r.err) { ret 2; }
+        val expand_r: err[fail.Fail] = expand(?ctx);
+        if (sel expand_r.err) { ret 3; }
         if (f.block_count > 16 || f.vreg_count > 64 || f.blocks[0].id != 7) { ret 4; }
         var instructions: u32 = 0;
         var bindings: u32 = 0;
@@ -761,10 +768,11 @@ fun t_deallocate(ctx: ptr, item: ptr, size: usize, align: usize) i64 {
 
 test "mach.lang.be.codegen.mir.bulk:every_allocation_failure_releases_owned_storage" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
-    var fail: u32 = 0;
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
+    var failing: u32 = 0;
     var allocation_count: u32 = 0;
-    for (fail == 0 || fail <= allocation_count) {
+    for (failing == 0 || failing <= allocation_count) {
         var probe: AllocationProbe;
         probe.backing = backing;
         var alloc: A.Allocator;
@@ -783,33 +791,37 @@ test "mach.lang.be.codegen.mir.bulk:every_allocation_failure_releases_owned_stor
     tgt.abi = ?convention;
     ctx.tgt = ?tgt;
         ctx.f = ?f;
-        if (R.is_err[R.Void, str](t_setup(?ctx, 257, true))) { mir.dnit_function(?alloc, ?f); ret 2; }
+        val t_setup_r: err[fail.Fail] = t_setup(?ctx, 257, true);
+        if (sel t_setup_r.err) { mir.dnit_function(?alloc, ?f); ret 2; }
         val before: u32 = probe.calls;
-        if (fail != 0) { probe.fail_at = before + fail; }
-        val result: R.Result[R.Void, str] = expand(?ctx);
+        if (failing != 0) { probe.fail_at = before + failing; }
+        val result: err[fail.Fail] = expand(?ctx);
         mir.dnit_function(?alloc, ?f);
         if (probe.live != 0) { ret 3; }
-        if (fail == 0) {
-            if (R.is_err[R.Void, str](result)) { ret 4; }
+        if (failing == 0) {
+            if (sel result.err) { ret 4; }
             allocation_count = probe.calls - before;
             if (allocation_count == 0) { ret 5; }
         } or {
-            if (R.is_ok[R.Void, str](result)) { ret 6; }
+            if (sel result.ok) { ret 6; }
             if (probe.calls < probe.fail_at) { ret 7; }
         }
-        fail = fail + 1;
+        failing = failing + 1;
     }
     ret 0;
 }
 
 test "mach.lang.be.codegen.mir.bulk:secret_payload_accepts_public_addresses_and_refuses_secret_addresses" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
     var scratch: arena.Arena;
-    if (O.is_some[str](arena.init(?scratch, ?backing, 65536))) { ret 1; }
+    val init_r: err[A.Error] = arena.init(?scratch, ?backing, 65536);
+    if (sel init_r.err) { ret 1; }
     fin { arena.dnit(?scratch); }
     var alloc: A.Allocator;
-    if (O.is_some[str](arena.make(?alloc, ?scratch))) { ret 1; }
+    val make_r2: err[A.Error] = arena.make(?alloc, ?scratch);
+    if (sel make_r2.err) { ret 1; }
     var tgt: resolved.Target;
     tgt.model.flat_addressing = true;
     tgt.model.pointer_width = 8;
@@ -825,18 +837,23 @@ test "mach.lang.be.codegen.mir.bulk:secret_payload_accepts_public_addresses_and_
     tgt.abi = ?convention;
     ctx.tgt = ?tgt;
     ctx.f = ?f;
-    if (R.is_err[R.Void, str](t_setup(?ctx, 257, true))) { ret 2; }
-    if (R.is_err[R.Void, str](expand(?ctx))) { ret 3; }
+    val t_setup_r: err[fail.Fail] = t_setup(?ctx, 257, true);
+    if (sel t_setup_r.err) { ret 2; }
+    val expand_r: err[fail.Fail] = expand(?ctx);
+    if (sel expand_r.err) { ret 3; }
     var module: mir.MirModule;
     module.alloc = ?alloc;
     module.functions = ?f;
     module.function_len = 1;
-    if (R.is_err[R.Void, str](ctvalidate.run(?tgt, ?module))) { ret 4; }
+    val validate_r: err[fail.Fail] = ctvalidate.validate(?tgt, ?module);
+    if (sel validate_r.err) { ret 4; }
     f.vregs[0].secret = true;
-    if (!R.is_err[R.Void, str](ctvalidate.run(?tgt, ?module))) { ret 5; }
+    val validate_r2: err[fail.Fail] = ctvalidate.validate(?tgt, ?module);
+    if (!sel validate_r2.err) { ret 5; }
     f.vregs[0].secret = false;
     f.vregs[1].secret = true;
-    if (!R.is_err[R.Void, str](ctvalidate.run(?tgt, ?module))) { ret 6; }
+    val validate_r3: err[fail.Fail] = ctvalidate.validate(?tgt, ?module);
+    if (!sel validate_r3.err) { ret 6; }
     ret 0;
 }
 
@@ -869,7 +886,8 @@ test "mach.lang.be.codegen.mir.bulk:unaligned_pieces_keep_snapshot_tails_and_vol
 
 test "mach.lang.be.codegen.mir.bulk:common_copies_bound_live_pieces_and_large_copies_only_branch_on_direction" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var sizes: [6]u64 = [6]u64{15, 16, 17, 64, 65, 65536};
     var mode: u32 = 0;
     for (mode < 2) {
@@ -888,9 +906,11 @@ test "mach.lang.be.codegen.mir.bulk:common_copies_bound_live_pieces_and_large_co
     tgt.abi = ?convention;
     ctx.tgt = ?tgt;
             ctx.f = ?f;
-            if (R.is_err[R.Void, str](t_setup(?ctx, sizes[si], mode == 1))) { ret 2; }
+            val t_setup_r: err[fail.Fail] = t_setup(?ctx, sizes[si], mode == 1);
+            if (sel t_setup_r.err) { ret 2; }
             f.blocks[0].instrs[0].memory_flags = 0;
-            if (R.is_err[R.Void, str](expand(?ctx))) { ret 3; }
+            val expand_r: err[fail.Fail] = expand(?ctx);
+            if (sel expand_r.err) { ret 3; }
             var instructions: u32 = 0;
             var loaded: u64 = 0;
             var stored: u64 = 0;

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -1,13 +1,16 @@
 use std.system.panic.panic;
+use std.types.canonical.res;
+use std.types.canonical.err;
+use mach.lang.fail;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 
-use page: mach.lang.legacy.page;
+use page: std.allocator.page;
 
-use A: mach.lang.legacy.allocator;
+use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -61,22 +64,22 @@ pub rec LowerCtx {
     pending_cap:   u32;
 }
 
-pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) R.Result[R.Void, str] {
+pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) err[fail.Fail] {
     ctx.layout = target.layout_machine(tgt);
     if (ctx.param_count > 0) {
-        val res_params: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, ctx.param_count::usize);
-        if (R.is_err[*u32, str](res_params)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](res_params)); }
-        ctx.param_vregs = R.unwrap_ok[*u32, str](res_params);
+        val res_params: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, ctx.param_count::usize);
+        if (sel res_params.err) { ret err[fail.Fail].err{fail.refused(res_params.err)}; }
+        ctx.param_vregs = res_params.ok;
     }
 
     if (ctx.instr_count > 0) {
-        val res_instrs: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, ctx.instr_count::usize);
-        if (R.is_err[*u32, str](res_instrs)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](res_instrs)); }
-        ctx.instr_vregs = R.unwrap_ok[*u32, str](res_instrs);
+        val res_instrs: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, ctx.instr_count::usize);
+        if (sel res_instrs.err) { ret err[fail.Fail].err{fail.refused(res_instrs.err)}; }
+        ctx.instr_vregs = res_instrs.ok;
 
-        val res_keys: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, ctx.instr_count::usize);
-        if (R.is_err[*u32, str](res_keys)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](res_keys)); }
-        ctx.slot_key_vregs = R.unwrap_ok[*u32, str](res_keys);
+        val res_keys: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, ctx.instr_count::usize);
+        if (sel res_keys.err) { ret err[fail.Fail].err{fail.refused(res_keys.err)}; }
+        ctx.slot_key_vregs = res_keys.ok;
 
         var i: u32 = 0;
         for (i < ctx.instr_count) {
@@ -88,9 +91,9 @@ pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) R.Resul
     var i: u32 = 0;
     for (i < ctx.param_count) {
         val reg_class: u32 = reg_class_of(ctx, tgt, fn.params[i].ty);
-        val res_vreg: R.Result[u32, str] = new_vreg_vec(ctx, reg_class, value_is_vector(ctx, fn.params[i].ty));
-        if (R.is_err[u32, str](res_vreg)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_vreg)); }
-        val pv: u32 = R.unwrap_ok[u32, str](res_vreg);
+        val res_vreg: res[u32, fail.Fail] = new_vreg_vec(ctx, reg_class, value_is_vector(ctx, fn.params[i].ty));
+        if (sel res_vreg.err) { ret err[fail.Fail].err{res_vreg.err}; }
+        val pv: u32 = res_vreg.ok;
         ctx.param_vregs[i] = pv;
         ctx.f.vregs[pv].ty = fn.params[i].ty::u32;
         if (fn.params[i].secret && !value_is_aggregate(ctx, fn.params[i].ty)) { ctx.f.vregs[pv].secret = true; }
@@ -103,9 +106,9 @@ pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) R.Resul
         val inst: *instruction.Instruction = ?fn.instrs[i];
         if (defines_value(ctx, inst)) {
             val reg_class: u32 = reg_class_of(ctx, tgt, inst.ty);
-            val res_vreg: R.Result[u32, str] = new_vreg_vec(ctx, reg_class, value_is_vector(ctx, inst.ty));
-            if (R.is_err[u32, str](res_vreg)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_vreg)); }
-            val rv: u32 = R.unwrap_ok[u32, str](res_vreg);
+            val res_vreg: res[u32, fail.Fail] = new_vreg_vec(ctx, reg_class, value_is_vector(ctx, inst.ty));
+            if (sel res_vreg.err) { ret err[fail.Fail].err{res_vreg.err}; }
+            val rv: u32 = res_vreg.ok;
             ctx.instr_vregs[i] = rv;
             ctx.f.vregs[rv].ty = inst.ty::u32;
             if (inst.secret && (inst.kind == instruction.OP_LOAD || inst.kind == instruction.OP_CALL)
@@ -116,7 +119,7 @@ pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) R.Resul
         i = i + 1;
     }
 
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 pub fun ctx_dnit(ctx: *LowerCtx) {
@@ -138,37 +141,37 @@ pub fun ctx_dnit(ctx: *LowerCtx) {
     }
 }
 
-pub fun push_pending_dbg(ctx: *LowerCtx, iid: u32, vreg: u32) R.Result[R.Void, str] {
+pub fun push_pending_dbg(ctx: *LowerCtx, iid: u32, vreg: u32) err[fail.Fail] {
     if (ctx.pending_count >= ctx.pending_cap) {
         var new_cap: u32 = ctx.pending_cap * 2;
         if (new_cap < 4) { new_cap = 4; }
         if (ctx.pending == nil) {
-            val ra: R.Result[*mir.MirDbgBinding, str] = A.allocate[mir.MirDbgBinding](ctx.alloc, new_cap::usize);
-            if (R.is_err[*mir.MirDbgBinding, str](ra)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirDbgBinding, str](ra)); }
-            ctx.pending = R.unwrap_ok[*mir.MirDbgBinding, str](ra);
+            val ra: res[*mir.MirDbgBinding, A.Error] = A.allocate[mir.MirDbgBinding](ctx.alloc, new_cap::usize);
+            if (sel ra.err) { ret err[fail.Fail].err{fail.refused(ra.err)}; }
+            ctx.pending = ra.ok;
         }
         or {
-            val rr: R.Result[*mir.MirDbgBinding, str] = A.reallocate[mir.MirDbgBinding](ctx.alloc, ctx.pending, ctx.pending_cap::usize, new_cap::usize);
-            if (R.is_err[*mir.MirDbgBinding, str](rr)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirDbgBinding, str](rr)); }
-            ctx.pending = R.unwrap_ok[*mir.MirDbgBinding, str](rr);
+            val rr: res[*mir.MirDbgBinding, A.Error] = A.reallocate[mir.MirDbgBinding](ctx.alloc, ctx.pending, ctx.pending_cap::usize, new_cap::usize);
+            if (sel rr.err) { ret err[fail.Fail].err{fail.refused(rr.err)}; }
+            ctx.pending = rr.ok;
         }
         ctx.pending_cap = new_cap;
     }
     ctx.pending[ctx.pending_count].iid  = iid;
     ctx.pending[ctx.pending_count].vreg = vreg;
     ctx.pending_count = ctx.pending_count + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun drain_pending_dbg(ctx: *LowerCtx, mi: *mir.MirInstr) R.Result[R.Void, str] {
+pub fun drain_pending_dbg(ctx: *LowerCtx, mi: *mir.MirInstr) err[fail.Fail] {
     var i: u32 = 0;
     for (i < ctx.pending_count) {
-        val ra: R.Result[R.Void, str] = mir.instr_attach_dbg(ctx.alloc, mi, ctx.pending[i].iid, ctx.pending[i].vreg);
-        if (R.is_err[R.Void, str](ra)) { ret ra; }
+        val ra: err[fail.Fail] = mir.instr_attach_dbg(ctx.alloc, mi, ctx.pending[i].iid, ctx.pending[i].vreg);
+        if (sel ra.err) { ret ra; }
         i = i + 1;
     }
     ctx.pending_count = 0;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 # the convention declares how values cross a call: a values convention has no banks, so every vreg is a value
@@ -176,13 +179,13 @@ pub fun values_convention(ctx: *LowerCtx) bool {
     ret ctx.tgt.abi.passing == abi.PASSING_VALUES;
 }
 
-pub fun new_vreg(ctx: *LowerCtx, reg_class: u32) R.Result[u32, str] {
+pub fun new_vreg(ctx: *LowerCtx, reg_class: u32) res[u32, fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     if (f.vreg_count >= f.vreg_cap) {
         val new_cap: u32 = f.vreg_cap * 2;
-        val res_vregs: R.Result[*mir.MirVReg, str] = A.reallocate[mir.MirVReg](ctx.alloc, f.vregs, f.vreg_cap::usize, new_cap::usize);
-        if (R.is_err[*mir.MirVReg, str](res_vregs)) { ret R.err[u32, str](R.unwrap_err[*mir.MirVReg, str](res_vregs)); }
-        f.vregs    = R.unwrap_ok[*mir.MirVReg, str](res_vregs);
+        val res_vregs: res[*mir.MirVReg, A.Error] = A.reallocate[mir.MirVReg](ctx.alloc, f.vregs, f.vreg_cap::usize, new_cap::usize);
+        if (sel res_vregs.err) { ret res[u32, fail.Fail].err{fail.refused(res_vregs.err)}; }
+        f.vregs    = res_vregs.ok;
         f.vreg_cap = new_cap;
     }
     val vid: u32 = f.vreg_count;
@@ -190,13 +193,13 @@ pub fun new_vreg(ctx: *LowerCtx, reg_class: u32) R.Result[u32, str] {
     if (values_convention(ctx)) { selected_class = mir.REG_CLASS_VALUE; }
     f.vregs[vid] = mir.vreg(vid, selected_class, false, false);
     f.vreg_count = f.vreg_count + 1;
-    ret R.ok[u32, str](vid);
+    ret res[u32, fail.Fail].ok{vid};
 }
 
-pub fun new_vreg_vec(ctx: *LowerCtx, reg_class: u32, vector: bool) R.Result[u32, str] {
-    val r: R.Result[u32, str] = new_vreg(ctx, reg_class);
-    if (R.is_err[u32, str](r)) { ret r; }
-    ctx.f.vregs[R.unwrap_ok[u32, str](r)].vector = vector;
+pub fun new_vreg_vec(ctx: *LowerCtx, reg_class: u32, vector: bool) res[u32, fail.Fail] {
+    val r: res[u32, fail.Fail] = new_vreg(ctx, reg_class);
+    if (sel r.err) { ret r; }
+    ctx.f.vregs[r.ok].vector = vector;
     ret r;
 }
 
@@ -348,7 +351,7 @@ pub fun mem_operand_of(ctx: *LowerCtx, v: value.Value) mir.MirOperand {
     ret op;
 }
 
-pub fun push_instr(ctx: *LowerCtx, mb: *mir.MirBlock, mi: mir.MirInstr) R.Result[R.Void, str] {
+pub fun push_instr(ctx: *LowerCtx, mb: *mir.MirBlock, mi: mir.MirInstr) err[fail.Fail] {
     var ni: mir.MirInstr = mi;
     if (ni.opcode != mir.MIR_ASM) { ni.asm_block = nil; }
     ni.loc = ctx.cur_loc;
@@ -358,65 +361,65 @@ pub fun push_instr(ctx: *LowerCtx, mb: *mir.MirBlock, mi: mir.MirInstr) R.Result
     ni.memory_flags = ctx.cur_memory_flags;
     ni.dbg_bindings      = nil;
     ni.dbg_binding_count = 0;
-    val res_drain: R.Result[R.Void, str] = drain_pending_dbg(ctx, ?ni);
-    if (R.is_err[R.Void, str](res_drain)) { ret res_drain; }
-    val res_grow: R.Result[R.Void, str] = grow_instr(ctx, mb);
-    if (R.is_err[R.Void, str](res_grow)) { ret res_grow; }
+    val res_drain: err[fail.Fail] = drain_pending_dbg(ctx, ?ni);
+    if (sel res_drain.err) { ret res_drain; }
+    val res_grow: err[fail.Fail] = grow_instr(ctx, mb);
+    if (sel res_grow.err) { ret res_grow; }
     mb.instrs[mb.instr_count] = ni;
     mb.instr_count = mb.instr_count + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun grow_instr(ctx: *LowerCtx, mb: *mir.MirBlock) R.Result[R.Void, str] {
+pub fun grow_instr(ctx: *LowerCtx, mb: *mir.MirBlock) err[fail.Fail] {
     if (mb.instr_count >= mb.instr_cap) {
         var new_cap: u32 = mb.instr_cap * 2;
         if (new_cap < mir.INITIAL_INSTR_CAP) { new_cap = mir.INITIAL_INSTR_CAP; }
-        val res_instrs: R.Result[*mir.MirInstr, str] = A.reallocate[mir.MirInstr](ctx.alloc, mb.instrs, mb.instr_cap::usize, new_cap::usize);
-        if (R.is_err[*mir.MirInstr, str](res_instrs)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirInstr, str](res_instrs)); }
-        mb.instrs    = R.unwrap_ok[*mir.MirInstr, str](res_instrs);
+        val res_instrs: res[*mir.MirInstr, A.Error] = A.reallocate[mir.MirInstr](ctx.alloc, mb.instrs, mb.instr_cap::usize, new_cap::usize);
+        if (sel res_instrs.err) { ret err[fail.Fail].err{fail.refused(res_instrs.err)}; }
+        mb.instrs    = res_instrs.ok;
         mb.instr_cap = new_cap;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun emit_mov(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: mir.MirOperand) R.Result[R.Void, str] {
+pub fun emit_mov(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: mir.MirOperand) err[fail.Fail] {
     ret inst2(ctx, mb, mir.MIR_MOV, dst, src, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 }
 
-pub fun emit_mov_w(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: mir.MirOperand, w: u8) R.Result[R.Void, str] {
+pub fun emit_mov_w(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: mir.MirOperand, w: u8) err[fail.Fail] {
     ret inst2(ctx, mb, mir.MIR_MOV, dst, src, w, w);
 }
 
-pub fun emit_declassify(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: mir.MirOperand, w: u8) R.Result[R.Void, str] {
+pub fun emit_declassify(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: mir.MirOperand, w: u8) err[fail.Fail] {
     ret inst2(ctx, mb, mir.MIR_DECLASSIFY, dst, src, w, w);
 }
 
-pub fun emit_fmov(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: mir.MirOperand, w: u8) R.Result[R.Void, str] {
+pub fun emit_fmov(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: mir.MirOperand, w: u8) err[fail.Fail] {
     ret inst2(ctx, mb, mir.MIR_MOV, dst, src, w, w);
 }
 
-pub fun emit_store_to(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, src: mir.MirOperand) R.Result[R.Void, str] {
+pub fun emit_store_to(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, src: mir.MirOperand) err[fail.Fail] {
     ret inst2(ctx, mb, mir.MIR_STORE, mem, src, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 }
 
-pub fun emit_store_to_w(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, src: mir.MirOperand, width: u8) R.Result[R.Void, str] {
+pub fun emit_store_to_w(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, src: mir.MirOperand, width: u8) err[fail.Fail] {
     ret inst2(ctx, mb, mir.MIR_STORE, mem, src, width, width);
 }
 
-pub fun emit_load_from_w(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, mem: mir.MirOperand, width: u8) R.Result[R.Void, str] {
+pub fun emit_load_from_w(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, mem: mir.MirOperand, width: u8) err[fail.Fail] {
     ret inst2(ctx, mb, mir.MIR_LOAD, mir.op_vreg(dst), mem, width, width);
 }
 
-pub fun push_store_chunk(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, src: mir.MirOperand, w: u8) R.Result[R.Void, str] {
+pub fun push_store_chunk(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, src: mir.MirOperand, w: u8) err[fail.Fail] {
     ret inst2(ctx, mb, mir.MIR_STORE, mem, src, w, w);
 }
 
 pub fun store_vector_register(ctx: *LowerCtx, mb: *mir.MirBlock, dest: mir.MirOperand,
-                              value: mir.MirOperand, ty: ir_type.IrTypeId) R.Result[R.Void, str] {
+                              value: mir.MirOperand, ty: ir_type.IrTypeId) err[fail.Fail] {
     val reg_w: u8 = op_width_of(ctx, ty);
-    val sr: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](sr)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](sr)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](sr);
+    val sr: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel sr.err) { ret err[fail.Fail].err{fail.refused(sr.err)}; }
+    val ops: *mir.MirOperand = sr.ok;
     ops[0] = dest;
     ops[1] = value;
     var store: mir.MirInstr = mir.instr(mir.MIR_STORE, ops, 2, reg_w, reg_w);
@@ -432,16 +435,16 @@ pub fun mem_at(m: mir.MirOperand, off: i64) mir.MirOperand {
 }
 
 pub fun store_subwidth_vector(ctx: *LowerCtx, mb: *mir.MirBlock, dest: mir.MirOperand,
-                              value: mir.MirOperand, ty: ir_type.IrTypeId) R.Result[R.Void, str] {
+                              value: mir.MirOperand, ty: ir_type.IrTypeId) err[fail.Fail] {
     val mem_w: u8 = mem_width_of(ctx, ty);
     val reg_w: u8 = op_width_of(ctx, ty);
     if (mem_w > reg_w) {
-        ret R.err[R.Void, str]("mir.context.store_subwidth_vector: vector wider than the target's vector register; an over-width vector's placement is a split, not a single move");
+        ret err[fail.Fail].err{fail.message("mir.context.store_subwidth_vector: vector wider than the target's vector register; an over-width vector's placement is a split, not a single move")};
     }
     if (isa.moves_vector_memory(?ctx.tgt.model, mem_w::u32)) {
-        val dr: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-        if (R.is_err[*mir.MirOperand, str](dr)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](dr)); }
-        val dops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](dr);
+        val dr: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+        if (sel dr.err) { ret err[fail.Fail].err{fail.refused(dr.err)}; }
+        val dops: *mir.MirOperand = dr.ok;
         dops[0] = dest;
         dops[1] = value;
         var di: mir.MirInstr = mir.instr(mir.MIR_STORE, dops, 2, mem_w, mem_w);
@@ -449,45 +452,45 @@ pub fun store_subwidth_vector(ctx: *LowerCtx, mb: *mir.MirBlock, dest: mir.MirOp
         ret push_instr(ctx, mb, di);
     }
     val align: u32 = ir_type.byte_align_for_machine(ctx.types, ty, ctx.layout);
-    val skr: R.Result[u32, str] = new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](skr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](skr)); }
-    val sk: u32 = R.unwrap_ok[u32, str](skr);
-    val ar: R.Result[R.Void, str] = add_alloca_slot(ctx, sk, reg_w::u64, align, ty::u32);
-    if (R.is_err[R.Void, str](ar)) { ret ar; }
+    val skr: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel skr.err) { ret err[fail.Fail].err{skr.err}; }
+    val sk: u32 = skr.ok;
+    val ar: err[fail.Fail] = add_alloca_slot(ctx, sk, reg_w::u64, align, ty::u32);
+    if (sel ar.err) { ret ar; }
 
-    val psp: R.Result[R.Void, str] = store_vector_register(ctx, mb, mir.op_mem_slot(sk, 0), value, ty);
-    if (R.is_err[R.Void, str](psp)) { ret psp; }
+    val psp: err[fail.Fail] = store_vector_register(ctx, mb, mir.op_mem_slot(sk, 0), value, ty);
+    if (sel psp.err) { ret psp; }
 
     var off: i64 = 0;
     for (off::u32 < mem_w::u32) {
         val chunk: u8 = copy_chunk_width(ctx.tgt, (mem_w::u32 - off::u32)::u64);
 
-        val tr: R.Result[u32, str] = new_vreg(ctx, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](tr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](tr)); }
-        val tmp: u32 = R.unwrap_ok[u32, str](tr);
+        val tr: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+        if (sel tr.err) { ret err[fail.Fail].err{tr.err}; }
+        val tmp: u32 = tr.ok;
 
-        val ld: R.Result[R.Void, str] = emit_load_from_w(ctx, mb, tmp, mir.op_mem_slot(sk, off), chunk);
-        if (R.is_err[R.Void, str](ld)) { ret ld; }
+        val ld: err[fail.Fail] = emit_load_from_w(ctx, mb, tmp, mir.op_mem_slot(sk, off), chunk);
+        if (sel ld.err) { ret ld; }
 
-        val st: R.Result[R.Void, str] = push_store_chunk(ctx, mb, mem_at(dest, off), mir.op_vreg(tmp), chunk);
-        if (R.is_err[R.Void, str](st)) { ret st; }
+        val st: err[fail.Fail] = push_store_chunk(ctx, mb, mem_at(dest, off), mir.op_vreg(tmp), chunk);
+        if (sel st.err) { ret st; }
 
         off = off + chunk::i64;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 pub fun load_subwidth_vector(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand,
-                             src: mir.MirOperand, ty: ir_type.IrTypeId) R.Result[R.Void, str] {
+                             src: mir.MirOperand, ty: ir_type.IrTypeId) err[fail.Fail] {
     val mem_w: u8 = mem_width_of(ctx, ty);
     val reg_w: u8 = op_width_of(ctx, ty);
     if (mem_w > reg_w) {
-        ret R.err[R.Void, str]("mir.context.load_subwidth_vector: vector wider than the target's vector register; an over-width vector's placement is a split, not a single move");
+        ret err[fail.Fail].err{fail.message("mir.context.load_subwidth_vector: vector wider than the target's vector register; an over-width vector's placement is a split, not a single move")};
     }
     if (isa.moves_vector_memory(?ctx.tgt.model, mem_w::u32)) {
-        val dr: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-        if (R.is_err[*mir.MirOperand, str](dr)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](dr)); }
-        val dops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](dr);
+        val dr: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+        if (sel dr.err) { ret err[fail.Fail].err{fail.refused(dr.err)}; }
+        val dops: *mir.MirOperand = dr.ok;
         dops[0] = dst;
         dops[1] = src;
         var di: mir.MirInstr = mir.instr(mir.MIR_LOAD, dops, 2, mem_w, mem_w);
@@ -495,17 +498,17 @@ pub fun load_subwidth_vector(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOper
         ret push_instr(ctx, mb, di);
     }
     val align: u32 = ir_type.byte_align_for_machine(ctx.types, ty, ctx.layout);
-    val skr: R.Result[u32, str] = new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](skr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](skr)); }
-    val sk: u32 = R.unwrap_ok[u32, str](skr);
-    val ar: R.Result[R.Void, str] = add_alloca_slot(ctx, sk, reg_w::u64, align, ty::u32);
-    if (R.is_err[R.Void, str](ar)) { ret ar; }
+    val skr: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel skr.err) { ret err[fail.Fail].err{skr.err}; }
+    val sk: u32 = skr.ok;
+    val ar: err[fail.Fail] = add_alloca_slot(ctx, sk, reg_w::u64, align, ty::u32);
+    if (sel ar.err) { ret ar; }
 
     var zoff: i64 = 0;
     for (zoff::u32 < reg_w::u32) {
         val zc: u8 = copy_chunk_width(ctx.tgt, (reg_w::u32 - zoff::u32)::u64);
-        val zs: R.Result[R.Void, str] = push_store_chunk(ctx, mb, mir.op_mem_slot(sk, zoff), mir.op_imm(0), zc);
-        if (R.is_err[R.Void, str](zs)) { ret zs; }
+        val zs: err[fail.Fail] = push_store_chunk(ctx, mb, mir.op_mem_slot(sk, zoff), mir.op_imm(0), zc);
+        if (sel zs.err) { ret zs; }
         zoff = zoff + zc::i64;
     }
 
@@ -513,22 +516,22 @@ pub fun load_subwidth_vector(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOper
     for (off::u32 < mem_w::u32) {
         val chunk: u8 = copy_chunk_width(ctx.tgt, (mem_w::u32 - off::u32)::u64);
 
-        val tr: R.Result[u32, str] = new_vreg(ctx, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](tr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](tr)); }
-        val tmp: u32 = R.unwrap_ok[u32, str](tr);
+        val tr: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+        if (sel tr.err) { ret err[fail.Fail].err{tr.err}; }
+        val tmp: u32 = tr.ok;
 
-        val ld: R.Result[R.Void, str] = emit_load_from_w(ctx, mb, tmp, mem_at(src, off), chunk);
-        if (R.is_err[R.Void, str](ld)) { ret ld; }
+        val ld: err[fail.Fail] = emit_load_from_w(ctx, mb, tmp, mem_at(src, off), chunk);
+        if (sel ld.err) { ret ld; }
 
-        val st: R.Result[R.Void, str] = push_store_chunk(ctx, mb, mir.op_mem_slot(sk, off), mir.op_vreg(tmp), chunk);
-        if (R.is_err[R.Void, str](st)) { ret st; }
+        val st: err[fail.Fail] = push_store_chunk(ctx, mb, mir.op_mem_slot(sk, off), mir.op_vreg(tmp), chunk);
+        if (sel st.err) { ret st; }
 
         off = off + chunk::i64;
     }
 
-    val fr: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](fr)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](fr)); }
-    val fops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](fr);
+    val fr: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel fr.err) { ret err[fail.Fail].err{fail.refused(fr.err)}; }
+    val fops: *mir.MirOperand = fr.ok;
     fops[0] = dst;
     fops[1] = mir.op_mem_slot(sk, 0);
     var fi: mir.MirInstr = mir.instr(mir.MIR_LOAD, fops, 2, reg_w, reg_w);
@@ -551,62 +554,62 @@ pub fun copy_chunk_width(tgt: *target.Target, remaining: u64) u8 {
     ret 1;
 }
 
-pub fun emit_bin(ctx: *LowerCtx, mb: *mir.MirBlock, op: mir.MirOpcode, dst: u32, a: mir.MirOperand, b: mir.MirOperand) R.Result[R.Void, str] {
+pub fun emit_bin(ctx: *LowerCtx, mb: *mir.MirBlock, op: mir.MirOpcode, dst: u32, a: mir.MirOperand, b: mir.MirOperand) err[fail.Fail] {
     ret inst3(ctx, mb, op, mir.op_vreg(dst), a, b, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 }
 
-pub fun emit_lea_preg(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, base_preg: u32, disp: i64) R.Result[R.Void, str] {
+pub fun emit_lea_preg(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, base_preg: u32, disp: i64) err[fail.Fail] {
     ret inst2(ctx, mb, mir.MIR_GEP, mir.op_vreg(dst), mir.op_mem_preg(base_preg, disp), ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 }
 
-pub fun emit_lea_slot(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, out: *u32) R.Result[R.Void, str] {
-    val res_vreg: R.Result[u32, str] = new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](res_vreg)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_vreg)); }
-    val v: u32 = R.unwrap_ok[u32, str](res_vreg);
+pub fun emit_lea_slot(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, out: *u32) err[fail.Fail] {
+    val res_vreg: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel res_vreg.err) { ret err[fail.Fail].err{res_vreg.err}; }
+    val v: u32 = res_vreg.ok;
 
-    val res_emit: R.Result[R.Void, str] = inst2(ctx, mb, mir.MIR_GEP, mir.op_vreg(v), mem, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
-    if (R.is_err[R.Void, str](res_emit)) { ret res_emit; }
+    val res_emit: err[fail.Fail] = inst2(ctx, mb, mir.MIR_GEP, mir.op_vreg(v), mem, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
+    if (sel res_emit.err) { ret res_emit; }
     @out = v;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun addr_to_vreg(ctx: *LowerCtx, mb: *mir.MirBlock, argop: mir.MirOperand, out_vreg: *u32) R.Result[R.Void, str] {
+pub fun addr_to_vreg(ctx: *LowerCtx, mb: *mir.MirBlock, argop: mir.MirOperand, out_vreg: *u32) err[fail.Fail] {
     if (argop.kind == mir.MIR_OP_VREG) {
         @out_vreg = argop.vreg;
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
-    val res_vreg: R.Result[u32, str] = new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](res_vreg)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_vreg)); }
-    val v: u32 = R.unwrap_ok[u32, str](res_vreg);
+    val res_vreg: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel res_vreg.err) { ret err[fail.Fail].err{res_vreg.err}; }
+    val v: u32 = res_vreg.ok;
 
-    val res_emit: R.Result[R.Void, str] = inst2(ctx, mb, mir.MIR_GEP, mir.op_vreg(v), argop, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
-    if (R.is_err[R.Void, str](res_emit)) { ret res_emit; }
+    val res_emit: err[fail.Fail] = inst2(ctx, mb, mir.MIR_GEP, mir.op_vreg(v), argop, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
+    if (sel res_emit.err) { ret res_emit; }
     @out_vreg = v;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun copy_aggregate(ctx: *LowerCtx, mb: *mir.MirBlock, dst_mem: mir.MirOperand, src: mir.MirOperand, size: u64) R.Result[R.Void, str] {
+pub fun copy_aggregate(ctx: *LowerCtx, mb: *mir.MirBlock, dst_mem: mir.MirOperand, src: mir.MirOperand, size: u64) err[fail.Fail] {
     var source: mir.MirOperand = src;
     if (source.kind == mir.MIR_OP_VREG) { source = mir.op_mem_value(source.vreg, 0); }
     ret inst3(ctx, mb, mir.MIR_MEMCPY, dst_mem, source, mir.op_imm(size::i64),
               ctx.tgt.model.pointer_width::u8, ctx.tgt.model.pointer_width::u8);
 }
 
-pub fun alloc_object_storage(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, ty: ir_type.IrTypeId) R.Result[R.Void, str] {
-    val res_key: R.Result[u32, str] = new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](res_key)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_key)); }
-    val sk: u32 = R.unwrap_ok[u32, str](res_key);
+pub fun alloc_object_storage(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, ty: ir_type.IrTypeId) err[fail.Fail] {
+    val res_key: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel res_key.err) { ret err[fail.Fail].err{res_key.err}; }
+    val sk: u32 = res_key.ok;
 
     val size:  u64 = ir_type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
     val align: u32 = ir_type.byte_align_for_machine(ctx.types, ty, ctx.layout);
-    val res_slot: R.Result[R.Void, str] = add_alloca_slot(ctx, sk, size, align, ty);
-    if (R.is_err[R.Void, str](res_slot)) { ret res_slot; }
+    val res_slot: err[fail.Fail] = add_alloca_slot(ctx, sk, size, align, ty);
+    if (sel res_slot.err) { ret res_slot; }
 
     ret inst2(ctx, mb, mir.MIR_ALLOCA, mir.op_vreg(dst), mir.op_mem_slot(sk, 0),
               ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 }
 
-pub fun add_alloca_slot(ctx: *LowerCtx, value_id: u32, size: u64, align: u32, ty: u32) R.Result[R.Void, str] {
+pub fun add_alloca_slot(ctx: *LowerCtx, value_id: u32, size: u64, align: u32, ty: u32) err[fail.Fail] {
     var al: u32 = align;
     if (al == 0) { al = 1; }
     var sz: u32 = size::u32;
@@ -614,7 +617,7 @@ pub fun add_alloca_slot(ctx: *LowerCtx, value_id: u32, size: u64, align: u32, ty
     ret frame_slot_add(ctx, value_id, mir.SLOT_ALLOCA, sz, al, ty);
 }
 
-pub fun add_spill_slot(ctx: *LowerCtx, value_id: u32, size: u64) R.Result[R.Void, str] {
+pub fun add_spill_slot(ctx: *LowerCtx, value_id: u32, size: u64) err[fail.Fail] {
     val word: u64 = ctx.tgt.model.gpr_width::u64;
     var padded: u64 = round_up_word(size, word);
     if (padded == 0) { padded = word; }
@@ -626,13 +629,13 @@ fun round_up_word(n: u64, word: u64) u64 {
     ret (n + word - 1) & ~(word - 1);
 }
 
-pub fun alloc_result_storage(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, size: u64, align: u32) R.Result[R.Void, str] {
-    val res_key: R.Result[u32, str] = new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](res_key)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](res_key)); }
-    val sk: u32 = R.unwrap_ok[u32, str](res_key);
+pub fun alloc_result_storage(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, size: u64, align: u32) err[fail.Fail] {
+    val res_key: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel res_key.err) { ret err[fail.Fail].err{res_key.err}; }
+    val sk: u32 = res_key.ok;
 
-    val res_slot: R.Result[R.Void, str] = add_spill_slot_aligned(ctx, sk, size, align);
-    if (R.is_err[R.Void, str](res_slot)) { ret res_slot; }
+    val res_slot: err[fail.Fail] = add_spill_slot_aligned(ctx, sk, size, align);
+    if (sel res_slot.err) { ret res_slot; }
 
     ret inst2(ctx, mb, mir.MIR_ALLOCA, mir.op_vreg(dst), mir.op_mem_slot(sk, 0), ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 }
@@ -690,7 +693,7 @@ fun gp_class_index(tgt: *target.Target) u32 {
     ret mir.REG_CLASS_GP;
 }
 
-pub fun add_spill_slot_aligned(ctx: *LowerCtx, value_id: u32, size: u64, align: u32) R.Result[R.Void, str] {
+pub fun add_spill_slot_aligned(ctx: *LowerCtx, value_id: u32, size: u64, align: u32) err[fail.Fail] {
     var al: u32 = align;
     if (al == 0) { al = 1; }
     var sz: u32 = round_up_word(size, ctx.tgt.model.gpr_width::u64)::u32;
@@ -698,15 +701,15 @@ pub fun add_spill_slot_aligned(ctx: *LowerCtx, value_id: u32, size: u64, align: 
     ret frame_slot_add(ctx, value_id, mir.SLOT_SPILL, sz, al, mir.SLOT_TY_NIL);
 }
 
-fun frame_slot_add(ctx: *LowerCtx, value_id: u32, kind: mir.MirSlotKind, size: u32, align: u32, ty: u32) R.Result[R.Void, str] {
+fun frame_slot_add(ctx: *LowerCtx, value_id: u32, kind: mir.MirSlotKind, size: u32, align: u32, ty: u32) err[fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     val frame: *mir.MirFrame = ?f.frame;
     if (frame.slot_count >= frame.slot_cap) {
         var new_cap: u32 = frame.slot_cap * 2;
         if (new_cap < mir.INITIAL_SLOT_CAP) { new_cap = mir.INITIAL_SLOT_CAP; }
-        val res_slots: R.Result[*mir.MirSlot, str] = A.reallocate[mir.MirSlot](ctx.alloc, frame.slots, frame.slot_cap::usize, new_cap::usize);
-        if (R.is_err[*mir.MirSlot, str](res_slots)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirSlot, str](res_slots)); }
-        frame.slots    = R.unwrap_ok[*mir.MirSlot, str](res_slots);
+        val res_slots: res[*mir.MirSlot, A.Error] = A.reallocate[mir.MirSlot](ctx.alloc, frame.slots, frame.slot_cap::usize, new_cap::usize);
+        if (sel res_slots.err) { ret err[fail.Fail].err{fail.refused(res_slots.err)}; }
+        frame.slots    = res_slots.ok;
         frame.slot_cap = new_cap;
     }
     val si: u32 = frame.slot_count;
@@ -717,14 +720,14 @@ fun frame_slot_add(ctx: *LowerCtx, value_id: u32, kind: mir.MirSlotKind, size: u
     frame.slots[si].align  = align;
     frame.slots[si].ty     = ty;
     frame.slot_count = frame.slot_count + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun inst2(ctx: *LowerCtx, mb: *mir.MirBlock, opcode: mir.MirOpcode, op0: mir.MirOperand, op1: mir.MirOperand,
-          width: u8, src_width: u8) R.Result[R.Void, str] {
-    val res_ops: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](res_ops)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](res_ops)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](res_ops);
+          width: u8, src_width: u8) err[fail.Fail] {
+    val res_ops: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel res_ops.err) { ret err[fail.Fail].err{fail.refused(res_ops.err)}; }
+    val ops: *mir.MirOperand = res_ops.ok;
     ops[0] = op0;
     ops[1] = op1;
     var mi: mir.MirInstr = mir.instr(opcode, ops, 2, width, src_width);
@@ -732,10 +735,10 @@ fun inst2(ctx: *LowerCtx, mb: *mir.MirBlock, opcode: mir.MirOpcode, op0: mir.Mir
 }
 
 fun inst3(ctx: *LowerCtx, mb: *mir.MirBlock, opcode: mir.MirOpcode, op0: mir.MirOperand, op1: mir.MirOperand,
-          op2: mir.MirOperand, width: u8, src_width: u8) R.Result[R.Void, str] {
-    val res_ops: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 3::usize);
-    if (R.is_err[*mir.MirOperand, str](res_ops)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](res_ops)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](res_ops);
+          op2: mir.MirOperand, width: u8, src_width: u8) err[fail.Fail] {
+    val res_ops: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 3::usize);
+    if (sel res_ops.err) { ret err[fail.Fail].err{fail.refused(res_ops.err)}; }
+    val ops: *mir.MirOperand = res_ops.ok;
     ops[0] = op0;
     ops[1] = op1;
     ops[2] = op2;
@@ -866,8 +869,8 @@ test "mach.lang.be.codegen.mir.context.vector_scaffolding" {
     if (!value_is_vector(?ctx, vecty))                           { ir_type.dnit(?types); ret 1; }
 
     var mb: mir.MirBlock;
-    val sr: R.Result[R.Void, str] = store_vector_register(?ctx, ?mb, mir.op_mem_slot(1, 0), mir.op_vreg(2), narrowty);
-    if (R.is_err[R.Void, str](sr))                                 { ir_type.dnit(?types); ret 1; }
+    val sr: err[fail.Fail] = store_vector_register(?ctx, ?mb, mir.op_mem_slot(1, 0), mir.op_vreg(2), narrowty);
+    if (sel sr.err)                                 { ir_type.dnit(?types); ret 1; }
     if (mb.instr_count != 1)                                     { ir_type.dnit(?types); ret 1; }
     if (mb.instrs[0].opcode != mir.MIR_STORE)                     { ir_type.dnit(?types); ret 1; }
     if (mb.instrs[0].width != 16 || mb.instrs[0].src_width != 16) { ir_type.dnit(?types); ret 1; }

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -1,16 +1,20 @@
-use page: mach.lang.legacy.page;
-use map: mach.lang.legacy.map;
-use format: mach.lang.legacy.format;
+use page: std.allocator.page;
+use std.types.canonical.res;
+use std.types.string.StrError;
+use std.types.canonical.opt;
+use std.types.canonical.err;
+use map: std.collections.map;
+use format: std.format;
 use std.types.bool.bool;
 use std.types.string.str_contains;
 use std.types.bool.true;
 use std.types.bool.false;
 use std.types.size.usize;
 use std.types.string.str;
-use mach.lang.legacy.string.str_join;
+use std.types.string.str_join;
 use std.types.string.str_len;
 
-use A: mach.lang.legacy.allocator;
+use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -34,9 +38,9 @@ use target_testing: mach.lang.target.testing;
 use target: mach.lang.target.resolved;
 use mach.lang.target.isa;
 
-pub fun lower_ir(tgt: *target.Target, m: *ir.Module, alloc: *A.Allocator, interner: *intern.Interner, srcmap: *source.SourceMap) R.Result[mir.MirModule, str] {
+pub fun lower_module(tgt: *target.Target, m: *ir.Module, alloc: *A.Allocator, interner: *intern.Interner, srcmap: *source.SourceMap) res[mir.MirModule, fail.Fail] {
     if (tgt == nil || m == nil) {
-        ret R.err[mir.MirModule, str]("mir.lower_ir: nil target or module");
+        ret res[mir.MirModule, fail.Fail].err{fail.message("mir.lower_ir: nil target or module")};
     }
 
     var mm: mir.MirModule;
@@ -47,32 +51,40 @@ pub fun lower_ir(tgt: *target.Target, m: *ir.Module, alloc: *A.Allocator, intern
     mm.function_len = 0;
     mm.function_cap = 0;
 
-    val rf: R.Result[*mir.MirFunction, str] = A.allocate[mir.MirFunction](alloc, mir.INITIAL_FN_CAP::usize);
-    if (R.is_err[*mir.MirFunction, str](rf)) {
-        ret R.err[mir.MirModule, str](R.unwrap_err[*mir.MirFunction, str](rf));
+    val rf: res[*mir.MirFunction, A.Error] = A.allocate[mir.MirFunction](alloc, mir.INITIAL_FN_CAP::usize);
+    if (sel rf.err) {
+        ret res[mir.MirModule, fail.Fail].err{fail.refused(rf.err)};
     }
-    mm.functions    = R.unwrap_ok[*mir.MirFunction, str](rf);
+    mm.functions    = rf.ok;
     mm.function_cap = mir.INITIAL_FN_CAP;
 
     var fi: u32 = 0;
     for (fi < m.function_len) {
-        val lf: R.Result[mir.MirFunction, str] = lower_function(tgt, m, ?m.functions[fi], alloc, interner);
-        if (R.is_err[mir.MirFunction, str](lf)) {
+        val lf: res[mir.MirFunction, fail.Fail] = lower_function(tgt, m, ?m.functions[fi], alloc, interner);
+        if (sel lf.err) {
             mir.dnit_module(?mm);
-            ret R.err[mir.MirModule, str](R.unwrap_err[mir.MirFunction, str](lf));
+            ret res[mir.MirModule, fail.Fail].err{lf.err};
         }
-        val push: R.Result[R.Void, str] = mir.push_function(?mm, R.unwrap_ok[mir.MirFunction, str](lf));
-        if (R.is_err[R.Void, str](push)) {
+        val push: err[fail.Fail] = mir.push_function(?mm, lf.ok);
+        if (sel push.err) {
             mir.dnit_module(?mm);
-            ret R.err[mir.MirModule, str](R.unwrap_err[R.Void, str](push));
+            ret res[mir.MirModule, fail.Fail].err{push.err};
         }
         fi = fi + 1;
     }
 
-    ret R.ok[mir.MirModule, str](mm);
+    ret res[mir.MirModule, fail.Fail].ok{mm};
 }
 
-fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, alloc: *A.Allocator, interner: *intern.Interner) R.Result[mir.MirFunction, str] {
+# translation shim (#3226): the legacy carrier the driver tests read until
+# their call sites migrate to `lower_module`
+pub fun lower_ir(tgt: *target.Target, m: *ir.Module, alloc: *A.Allocator, interner: *intern.Interner, srcmap: *source.SourceMap) R.Result[mir.MirModule, str] {
+    val r: res[mir.MirModule, fail.Fail] = lower_module(tgt, m, alloc, interner, srcmap);
+    if (sel r.err) { ret R.err[mir.MirModule, str](fail.describe(r.err)); }
+    ret R.ok[mir.MirModule, str](r.ok);
+}
+
+fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, alloc: *A.Allocator, interner: *intern.Interner) res[mir.MirFunction, fail.Fail] {
     var mf: mir.MirFunction;
     mf.name                = fn.name;
     mf.blocks              = nil;
@@ -100,14 +112,14 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, alloc: 
     mf.naked               = (fn.flags & ir.FN_FLAG_NAKED) != 0;
 
     if ((fn.flags & ir.FN_FLAG_EXTERN) != 0 || fn.block_count == 0) {
-        ret R.ok[mir.MirFunction, str](mf);
+        ret res[mir.MirFunction, fail.Fail].ok{mf};
     }
 
-    val rv: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](alloc, mir.INITIAL_VREG_CAP::usize);
-    if (R.is_err[*mir.MirVReg, str](rv)) {
-        ret R.err[mir.MirFunction, str](R.unwrap_err[*mir.MirVReg, str](rv));
+    val rv: res[*mir.MirVReg, A.Error] = A.allocate[mir.MirVReg](alloc, mir.INITIAL_VREG_CAP::usize);
+    if (sel rv.err) {
+        ret res[mir.MirFunction, fail.Fail].err{fail.refused(rv.err)};
     }
-    mf.vregs    = R.unwrap_ok[*mir.MirVReg, str](rv);
+    mf.vregs    = rv.ok;
     mf.vreg_cap = mir.INITIAL_VREG_CAP;
 
     var ctx: lctx.LowerCtx;
@@ -134,53 +146,53 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, alloc: 
     ctx.pending_count  = 0;
     ctx.pending_cap    = 0;
 
-    val setup: R.Result[R.Void, str] = lctx.ctx_setup(?ctx, tgt, fn);
-    if (R.is_err[R.Void, str](setup)) {
+    val setup: err[fail.Fail] = lctx.ctx_setup(?ctx, tgt, fn);
+    if (sel setup.err) {
         lctx.ctx_dnit(?ctx);
         mir.dnit_function(alloc, ?mf);
-        ret R.err[mir.MirFunction, str](R.unwrap_err[R.Void, str](setup));
+        ret res[mir.MirFunction, fail.Fail].err{setup.err};
     }
 
-    val rb: R.Result[*mir.MirBlock, str] = A.allocate[mir.MirBlock](alloc, fn.block_count::usize);
-    if (R.is_err[*mir.MirBlock, str](rb)) {
+    val rb: res[*mir.MirBlock, A.Error] = A.allocate[mir.MirBlock](alloc, fn.block_count::usize);
+    if (sel rb.err) {
         lctx.ctx_dnit(?ctx);
         mir.dnit_function(alloc, ?mf);
-        ret R.err[mir.MirFunction, str](R.unwrap_err[*mir.MirBlock, str](rb));
+        ret res[mir.MirFunction, fail.Fail].err{fail.refused(rb.err)};
     }
-    mf.blocks    = R.unwrap_ok[*mir.MirBlock, str](rb);
+    mf.blocks    = rb.ok;
     mf.block_cap = fn.block_count;
 
     var bi: u32 = 0;
     for (bi < fn.block_count) {
         val is_entry: bool = bi == 0;
-        val lb: R.Result[R.Void, str] = lower_block(?ctx, fn, ?fn.blocks[bi], is_entry);
-        if (R.is_err[R.Void, str](lb)) {
+        val lb: err[fail.Fail] = lower_block(?ctx, fn, ?fn.blocks[bi], is_entry);
+        if (sel lb.err) {
             lctx.ctx_dnit(?ctx);
             mir.dnit_function(alloc, ?mf);
-            ret R.err[mir.MirFunction, str](R.unwrap_err[R.Void, str](lb));
+            ret res[mir.MirFunction, fail.Fail].err{lb.err};
         }
         bi = bi + 1;
     }
 
-    val lph: R.Result[R.Void, str] = lower_phis(?ctx, fn);
-    if (R.is_err[R.Void, str](lph)) {
+    val lph: err[fail.Fail] = lower_phis(?ctx, fn);
+    if (sel lph.err) {
         lctx.ctx_dnit(?ctx);
         mir.dnit_function(alloc, ?mf);
-        ret R.err[mir.MirFunction, str](R.unwrap_err[R.Void, str](lph));
+        ret res[mir.MirFunction, fail.Fail].err{lph.err};
     }
 
-    val lbk: R.Result[R.Void, str] = bulk.expand(?ctx);
-    if (R.is_err[R.Void, str](lbk)) {
+    val lbk: err[fail.Fail] = bulk.expand(?ctx);
+    if (sel lbk.err) {
         lctx.ctx_dnit(?ctx);
         mir.dnit_function(alloc, ?mf);
-        ret R.err[mir.MirFunction, str](R.unwrap_err[R.Void, str](lbk));
+        ret res[mir.MirFunction, fail.Fail].err{lbk.err};
     }
 
     lctx.ctx_dnit(?ctx);
-    ret R.ok[mir.MirFunction, str](mf);
+    ret res[mir.MirFunction, fail.Fail].ok{mf};
 }
 
-fun lower_block(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block, is_entry: bool) R.Result[R.Void, str] {
+fun lower_block(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block, is_entry: bool) err[fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     val mb: *mir.MirBlock = ?f.blocks[f.block_count];
     mb.id          = blk.id::u32;
@@ -192,40 +204,40 @@ fun lower_block(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block, is_entry:
     mb.pred_cap    = 0;
     f.block_count = f.block_count + 1;
 
-    val cp: R.Result[R.Void, str] = copy_preds(ctx, mb, blk);
-    if (R.is_err[R.Void, str](cp)) { ret cp; }
+    val cp: err[fail.Fail] = copy_preds(ctx, mb, blk);
+    if (sel cp.err) { ret cp; }
 
     if (is_entry) {
-        val lp: R.Result[R.Void, str] = mabi.lower_params(ctx, mb);
-        if (R.is_err[R.Void, str](lp)) { ret lp; }
+        val lp: err[fail.Fail] = mabi.lower_params(ctx, mb);
+        if (sel lp.err) { ret lp; }
     }
 
     var ii: u32 = 0;
     for (ii < blk.instr_count) {
-        val ei: R.Result[R.Void, str] = lower_instr(ctx, fn, mb, blk.instructions[ii]);
-        if (R.is_err[R.Void, str](ei)) { ret ei; }
+        val ei: err[fail.Fail] = lower_instr(ctx, fn, mb, blk.instructions[ii]);
+        if (sel ei.err) { ret ei; }
         ii = ii + 1;
     }
 
     if (blk.terminator != id.INSTR_NIL) {
-        val et: R.Result[R.Void, str] = lower_instr(ctx, fn, mb, blk.terminator);
-        if (R.is_err[R.Void, str](et)) { ret et; }
+        val et: err[fail.Fail] = lower_instr(ctx, fn, mb, blk.terminator);
+        if (sel et.err) { ret et; }
     }
 
     if (ctx.pending_count > 0 && mb.instr_count > 0) {
-        val fl: R.Result[R.Void, str] = lctx.drain_pending_dbg(ctx, ?mb.instrs[mb.instr_count - 1]);
-        if (R.is_err[R.Void, str](fl)) { ret fl; }
+        val fl: err[fail.Fail] = lctx.drain_pending_dbg(ctx, ?mb.instrs[mb.instr_count - 1]);
+        if (sel fl.err) { ret fl; }
     }
     ctx.pending_count = 0;
 
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun copy_preds(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, blk: *ir.Block) R.Result[R.Void, str] {
-    if (blk.pred_count == 0) { ret R.ok_void[str](); }
-    val r: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, blk.pred_count::usize);
-    if (R.is_err[*u32, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](r)); }
-    mb.preds    = R.unwrap_ok[*u32, str](r);
+fun copy_preds(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, blk: *ir.Block) err[fail.Fail] {
+    if (blk.pred_count == 0) { ret err[fail.Fail].ok{}; }
+    val r: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, blk.pred_count::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    mb.preds    = r.ok;
     mb.pred_cap = blk.pred_count;
     var i: u32 = 0;
     for (i < blk.pred_count) {
@@ -233,71 +245,71 @@ fun copy_preds(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, blk: *ir.Block) R.Result[
         i = i + 1;
     }
     mb.pred_count = blk.pred_count;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun lower_phis(ctx: *lctx.LowerCtx, fn: *ir.Function) R.Result[R.Void, str] {
+fun lower_phis(ctx: *lctx.LowerCtx, fn: *ir.Function) err[fail.Fail] {
     var bi: u32 = 0;
     for (bi < fn.block_count) {
         val blk: *ir.Block = ?fn.blocks[bi];
         if (blk.phi_count > 0) {
-            val r: R.Result[R.Void, str] = lower_block_phis(ctx, fn, blk);
-            if (R.is_err[R.Void, str](r)) { ret r; }
+            val r: err[fail.Fail] = lower_block_phis(ctx, fn, blk);
+            if (sel r.err) { ret r; }
         }
         bi = bi + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun lower_block_phis(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block) R.Result[R.Void, str] {
+fun lower_block_phis(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block) err[fail.Fail] {
     val np: u32 = blk.phi_count;
-    val rd: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, np::usize);
-    if (R.is_err[*u32, str](rd)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](rd)); }
-    val dsts: *u32 = R.unwrap_ok[*u32, str](rd);
-    val rs: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, np::usize);
-    if (R.is_err[*mir.MirOperand, str](rs)) {
+    val rd: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, np::usize);
+    if (sel rd.err) { ret err[fail.Fail].err{fail.refused(rd.err)}; }
+    val dsts: *u32 = rd.ok;
+    val rs: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, np::usize);
+    if (sel rs.err) {
         A.deallocate[u32](ctx.alloc, dsts, np::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](rs));
+        ret err[fail.Fail].err{fail.refused(rs.err)};
     }
-    val srcs: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rs);
-    val rw: R.Result[*u8, str] = A.allocate[u8](ctx.alloc, np::usize);
-    if (R.is_err[*u8, str](rw)) {
+    val srcs: *mir.MirOperand = rs.ok;
+    val rw: res[*u8, A.Error] = A.allocate[u8](ctx.alloc, np::usize);
+    if (sel rw.err) {
         A.deallocate[u32](ctx.alloc, dsts, np::usize);
         A.deallocate[mir.MirOperand](ctx.alloc, srcs, np::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*u8, str](rw));
+        ret err[fail.Fail].err{fail.refused(rw.err)};
     }
-    val wids: *u8 = R.unwrap_ok[*u8, str](rw);
+    val wids: *u8 = rw.ok;
 
-    var err_msg: str = nil;
+    var failure: err[fail.Fail] = err[fail.Fail].ok{};
     var pi: u32 = 0;
-    for (pi < blk.pred_count && err_msg == nil) {
+    for (pi < blk.pred_count && sel failure.ok) {
         val pred_id: u32 = blk.preds[pi]::u32;
         var pred_mb: *mir.MirBlock = mir_block_by_id(ctx.f, pred_id);
         if (pred_mb == nil) {
-            err_msg = "mir.lower_ir: phi predecessor block has no MIR block";
+            failure = err[fail.Fail].err{fail.message("mir.lower_ir: phi predecessor block has no MIR block")};
             pi = pi + 1;
             cnt;
         }
 
         if (block_ends_in_cbr(pred_mb)) {
-            val sr: R.Result[*mir.MirBlock, str] = split_critical_edge(ctx, pred_mb, blk.id::u32);
-            if (R.is_err[*mir.MirBlock, str](sr)) { err_msg = R.unwrap_err[*mir.MirBlock, str](sr); pi = pi + 1; cnt; }
-            pred_mb = R.unwrap_ok[*mir.MirBlock, str](sr);
+            val sr: res[*mir.MirBlock, fail.Fail] = split_critical_edge(ctx, pred_mb, blk.id::u32);
+            if (sel sr.err) { failure = err[fail.Fail].err{sr.err}; pi = pi + 1; cnt; }
+            pred_mb = sr.ok;
         }
 
         var nc: u32 = 0;
         var hi: u32 = 0;
-        for (hi < blk.phi_count && err_msg == nil) {
+        for (hi < blk.phi_count && sel failure.ok) {
             val phi_opt: O.Option[*instr.Instruction] = ir.instruction_get(fn, blk.phis[hi]);
             if (!O.is_some[*instr.Instruction](phi_opt)) {
-                err_msg = "mir.lower_ir: dangling phi instruction id";
+                failure = err[fail.Fail].err{fail.message("mir.lower_ir: dangling phi instruction id")};
                 hi = hi + 1;
                 cnt;
             }
             val phi: *instr.Instruction = O.unwrap[*instr.Instruction](phi_opt);
             val dst_vreg: u32 = lctx.instr_vreg(ctx, blk.phis[hi]);
             if (dst_vreg == mir.MIR_VREG_NIL) {
-                err_msg = "mir.lower_ir: phi defines no result vreg";
+                failure = err[fail.Fail].err{fail.message("mir.lower_ir: phi defines no result vreg")};
                 hi = hi + 1;
                 cnt;
             }
@@ -314,16 +326,16 @@ fun lower_block_phis(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block) R.Re
                 k = k + 2;
             }
             if (!found) {
-                err_msg = phi_edge_err(ctx, blk.id::u32, pred_id, dst_vreg);
+                failure = err[fail.Fail].err{fail.message(phi_edge_err(ctx, blk.id::u32, pred_id, dst_vreg))};
                 hi = hi + 1;
                 cnt;
             }
             hi = hi + 1;
         }
 
-        if (err_msg == nil && nc > 0) {
-            val r: R.Result[R.Void, str] = emit_edge_copies(ctx, pred_mb, dsts, srcs, wids, nc);
-            if (R.is_err[R.Void, str](r)) { err_msg = R.unwrap_err[R.Void, str](r); }
+        if (sel failure.ok && nc > 0) {
+            val r: err[fail.Fail] = emit_edge_copies(ctx, pred_mb, dsts, srcs, wids, nc);
+            if (sel r.err) { failure = err[fail.Fail].err{r.err}; }
         }
         pi = pi + 1;
     }
@@ -331,17 +343,16 @@ fun lower_block_phis(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block) R.Re
     A.deallocate[u32](ctx.alloc, dsts, np::usize);
     A.deallocate[mir.MirOperand](ctx.alloc, srcs, np::usize);
     A.deallocate[u8](ctx.alloc, wids, np::usize);
-    if (err_msg != nil) { ret R.err[R.Void, str](err_msg); }
-    ret R.ok_void[str]();
+    ret failure;
 }
 
 fun phi_edge_err(ctx: *lctx.LowerCtx, block_id: u32, pred_id: u32, dst_vreg: u32) str {
     val fallback: str = "mir.lower_ir: phi has no incoming value for a predecessor edge";
-    val rj: R.Result[str, str] = format.sprint(ctx.alloc,
+    val rj: res[str, format.FormatError] = format.sprint(ctx.alloc,
         "mir.lower_ir: phi in block {} has no incoming value for predecessor block {} (result vreg {})",
         block_id, pred_id, dst_vreg);
-    if (R.is_err[str, str](rj)) { ret fallback; }
-    ret R.unwrap_ok[str, str](rj);
+    if (sel rj.err) { ret fallback; }
+    ret rj.ok;
 }
 
 fun mir_block_by_id(f: *mir.MirFunction, block_id: u32) *mir.MirBlock {
@@ -353,10 +364,10 @@ fun mir_block_by_id(f: *mir.MirFunction, block_id: u32) *mir.MirBlock {
     ret nil;
 }
 
-fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, srcs: *mir.MirOperand, wids: *u8, n: u32) R.Result[R.Void, str] {
-    val re: R.Result[*bool, str] = A.allocate[bool](ctx.alloc, n::usize);
-    if (R.is_err[*bool, str](re)) { ret R.err[R.Void, str](R.unwrap_err[*bool, str](re)); }
-    val done: *bool = R.unwrap_ok[*bool, str](re);
+fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, srcs: *mir.MirOperand, wids: *u8, n: u32) err[fail.Fail] {
+    val re: res[*bool, A.Error] = A.allocate[bool](ctx.alloc, n::usize);
+    if (sel re.err) { ret err[fail.Fail].err{fail.refused(re.err)}; }
+    val done: *bool = re.ok;
 
     var remaining: u32 = 0;
     var i: u32 = 0;
@@ -370,15 +381,15 @@ fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, sr
         i = i + 1;
     }
 
-    var err_msg: str = nil;
-    for (remaining > 0 && err_msg == nil) {
+    var failure: err[fail.Fail] = err[fail.Fail].ok{};
+    for (remaining > 0 && sel failure.ok) {
         var progressed: bool = false;
         var j: u32 = 0;
         for (j < n) {
             if (done[j] == false && !dst_is_pending_src(dsts, srcs, done, n, dsts[j])) {
-                val mv: R.Result[R.Void, str] = insert_mov_before_terminator(ctx, pred_mb,
+                val mv: err[fail.Fail] = insert_mov_before_terminator(ctx, pred_mb,
                     mir.op_vreg(dsts[j]), srcs[j], wids[j]);
-                if (R.is_err[R.Void, str](mv)) { err_msg = R.unwrap_err[R.Void, str](mv); j = n; cnt; }
+                if (sel mv.err) { failure = err[fail.Fail].err{mv.err}; j = n; cnt; }
                 done[j] = true;
                 remaining = remaining - 1;
                 progressed = true;
@@ -386,18 +397,18 @@ fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, sr
             j = j + 1;
         }
 
-        if (err_msg == nil && progressed == false && remaining > 0) {
+        if (sel failure.ok && progressed == false && remaining > 0) {
             var c: u32 = 0;
             for (done[c]) { c = c + 1; }
             val freed: u32 = dsts[c];
             val cls: u32 = ctx.f.vregs[freed].class;
-            val tr: R.Result[u32, str] = lctx.new_vreg_vec(ctx, cls, ctx.f.vregs[freed].vector);
-            if (R.is_err[u32, str](tr)) { err_msg = R.unwrap_err[u32, str](tr); cnt; }
-            val tmp: u32 = R.unwrap_ok[u32, str](tr);
+            val tr: res[u32, fail.Fail] = lctx.new_vreg_vec(ctx, cls, ctx.f.vregs[freed].vector);
+            if (sel tr.err) { failure = err[fail.Fail].err{tr.err}; cnt; }
+            val tmp: u32 = tr.ok;
             ctx.f.vregs[tmp].ty = ctx.f.vregs[freed].ty;
-            val sv: R.Result[R.Void, str] = insert_mov_before_terminator(ctx, pred_mb,
+            val sv: err[fail.Fail] = insert_mov_before_terminator(ctx, pred_mb,
                 mir.op_vreg(tmp), mir.op_vreg(freed), ctx.tgt.model.gpr_width::u8);
-            if (R.is_err[R.Void, str](sv)) { err_msg = R.unwrap_err[R.Void, str](sv); cnt; }
+            if (sel sv.err) { failure = err[fail.Fail].err{sv.err}; cnt; }
             var d: u32 = 0;
             for (d < n) {
                 if (done[d] == false && srcs[d].kind == mir.MIR_OP_VREG && srcs[d].vreg == freed) {
@@ -409,8 +420,7 @@ fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, sr
     }
 
     A.deallocate[bool](ctx.alloc, done, n::usize);
-    if (err_msg != nil) { ret R.err[R.Void, str](err_msg); }
-    ret R.ok_void[str]();
+    ret failure;
 }
 
 fun dst_is_pending_src(dsts: *u32, srcs: *mir.MirOperand, done: *bool, n: u32, v: u32) bool {
@@ -431,18 +441,18 @@ fun imm_merge_width(ctx: *lctx.LowerCtx, wid: u8) u8 {
     ret w;
 }
 
-fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: mir.MirOperand, wid: u8) R.Result[R.Void, str] {
+fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: mir.MirOperand, wid: u8) err[fail.Fail] {
     if (mb.instr_count == 0) {
-        ret R.err[R.Void, str]("mir.lower_ir: phi predecessor block has no terminator");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: phi predecessor block has no terminator")};
     }
     val term: *mir.MirInstr = ?mb.instrs[mb.instr_count - 1];
     if (!is_mir_terminator(term.opcode)) {
-        ret R.err[R.Void, str]("mir.lower_ir: phi predecessor block does not end in a terminator");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: phi predecessor block does not end in a terminator")};
     }
 
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](r)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    val ops: *mir.MirOperand = r.ok;
     ops[0] = dst;
     ops[1] = src;
     var mi: mir.MirInstr = mir.instr(mir.MIR_MOV, ops, 2, 0, 0);
@@ -464,15 +474,15 @@ fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mi
     mi.inline_site       = term.inline_site;
     mi.writes_secret     = false;
 
-    val gr: R.Result[R.Void, str] = lctx.grow_instr(ctx, mb);
-    if (R.is_err[R.Void, str](gr)) {
+    val gr: err[fail.Fail] = lctx.grow_instr(ctx, mb);
+    if (sel gr.err) {
         A.deallocate[mir.MirOperand](ctx.alloc, ops, 2::usize);
         ret gr;
     }
     mb.instrs[mb.instr_count] = mb.instrs[mb.instr_count - 1];
     mb.instrs[mb.instr_count - 1] = mi;
     mb.instr_count = mb.instr_count + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun is_mir_terminator(o: mir.MirOpcode) bool {
@@ -485,17 +495,17 @@ fun block_ends_in_cbr(mb: *mir.MirBlock) bool {
     ret mb.instrs[mb.instr_count - 1].opcode == mir.MIR_CBR;
 }
 
-fun grow_block(ctx: *lctx.LowerCtx) R.Result[R.Void, str] {
+fun grow_block(ctx: *lctx.LowerCtx) err[fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     if (f.block_count >= f.block_cap) {
         var new_cap: u32 = f.block_cap * 2;
         if (new_cap < f.block_count + 1) { new_cap = f.block_count + 1; }
-        val r: R.Result[*mir.MirBlock, str] = A.reallocate[mir.MirBlock](ctx.alloc, f.blocks, f.block_cap::usize, new_cap::usize);
-        if (R.is_err[*mir.MirBlock, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirBlock, str](r)); }
-        f.blocks    = R.unwrap_ok[*mir.MirBlock, str](r);
+        val r: res[*mir.MirBlock, A.Error] = A.reallocate[mir.MirBlock](ctx.alloc, f.blocks, f.block_cap::usize, new_cap::usize);
+        if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+        f.blocks    = r.ok;
         f.block_cap = new_cap;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun fresh_block_id(f: *mir.MirFunction) u32 {
@@ -508,12 +518,12 @@ fun fresh_block_id(f: *mir.MirFunction) u32 {
     ret max_id + 1;
 }
 
-fun split_critical_edge(ctx: *lctx.LowerCtx, pred: *mir.MirBlock, succ_id: u32) R.Result[*mir.MirBlock, str] {
+fun split_critical_edge(ctx: *lctx.LowerCtx, pred: *mir.MirBlock, succ_id: u32) res[*mir.MirBlock, fail.Fail] {
     val pred_id: u32 = pred.id;
     val new_id:  u32 = fresh_block_id(ctx.f);
 
-    val gr: R.Result[R.Void, str] = grow_block(ctx);
-    if (R.is_err[R.Void, str](gr)) { ret R.err[*mir.MirBlock, str](R.unwrap_err[R.Void, str](gr)); }
+    val gr: err[fail.Fail] = grow_block(ctx);
+    if (sel gr.err) { ret res[*mir.MirBlock, fail.Fail].err{gr.err}; }
 
     val f: *mir.MirFunction = ctx.f;
     val b: *mir.MirBlock = ?f.blocks[f.block_count];
@@ -525,23 +535,23 @@ fun split_critical_edge(ctx: *lctx.LowerCtx, pred: *mir.MirBlock, succ_id: u32) 
     b.pred_count  = 0;
     b.pred_cap    = 0;
 
-    val rb: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 1::usize);
-    if (R.is_err[*mir.MirOperand, str](rb)) { ret R.err[*mir.MirBlock, str](R.unwrap_err[*mir.MirOperand, str](rb)); }
-    val bops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rb);
+    val rb: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 1::usize);
+    if (sel rb.err) { ret res[*mir.MirBlock, fail.Fail].err{fail.refused(rb.err)}; }
+    val bops: *mir.MirOperand = rb.ok;
     bops[0] = mir.op_block(succ_id);
     var br: mir.MirInstr = mir.instr(mir.MIR_BR, bops, 1,
                                      ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 
-    val ri: R.Result[*mir.MirInstr, str] = A.allocate[mir.MirInstr](ctx.alloc, 1::usize);
-    if (R.is_err[*mir.MirInstr, str](ri)) { A.deallocate[mir.MirOperand](ctx.alloc, bops, 1::usize); ret R.err[*mir.MirBlock, str](R.unwrap_err[*mir.MirInstr, str](ri)); }
-    b.instrs      = R.unwrap_ok[*mir.MirInstr, str](ri);
+    val ri: res[*mir.MirInstr, A.Error] = A.allocate[mir.MirInstr](ctx.alloc, 1::usize);
+    if (sel ri.err) { A.deallocate[mir.MirOperand](ctx.alloc, bops, 1::usize); ret res[*mir.MirBlock, fail.Fail].err{fail.refused(ri.err)}; }
+    b.instrs      = ri.ok;
     b.instrs[0]   = br;
     b.instr_count = 1;
     b.instr_cap   = 1;
 
-    val rp: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, 1::usize);
-    if (R.is_err[*u32, str](rp)) { ret R.err[*mir.MirBlock, str](R.unwrap_err[*u32, str](rp)); }
-    b.preds      = R.unwrap_ok[*u32, str](rp);
+    val rp: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, 1::usize);
+    if (sel rp.err) { ret res[*mir.MirBlock, fail.Fail].err{fail.refused(rp.err)}; }
+    b.preds      = rp.ok;
     b.preds[0]   = pred_id;
     b.pred_count = 1;
     b.pred_cap   = 1;
@@ -551,7 +561,7 @@ fun split_critical_edge(ctx: *lctx.LowerCtx, pred: *mir.MirBlock, succ_id: u32) 
     retarget_cbr(mir_block_by_id(f, pred_id), succ_id, new_id);
     replace_pred(mir_block_by_id(f, succ_id), pred_id, new_id);
 
-    ret R.ok[*mir.MirBlock, str](?f.blocks[f.block_count - 1]);
+    ret res[*mir.MirBlock, fail.Fail].ok{?f.blocks[f.block_count - 1]};
 }
 
 fun retarget_cbr(mb: *mir.MirBlock, from: u32, to: u32) {
@@ -575,10 +585,10 @@ fun replace_pred(mb: *mir.MirBlock, from: u32, to: u32) {
     }
 }
 
-fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: id.InstructionId) err[fail.Fail] {
     val gi: O.Option[*instr.Instruction] = ir.instruction_get(fn, iid);
     if (!O.is_some[*instr.Instruction](gi)) {
-        ret R.err[R.Void, str]("mir.lower_ir: dangling instruction id");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: dangling instruction id")};
     }
     val inst: *instr.Instruction = O.unwrap[*instr.Instruction](gi);
 
@@ -593,13 +603,13 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     if (is_float_op(ctx, inst)) { cop = ct.CT_OP_FLOAT; }
     val declared_cap: O.Option[ct.CtCap] = ct.ct_cap(cop);
     if (O.is_none[ct.CtCap](declared_cap)) {
-        ret R.err[R.Void, str](fail.catalog_message_or(ctx.interner, ctx.alloc, fail.unknown_member("CtOp", cop::u32), "unknown CtOp tag"));
+        ret err[fail.Fail].err{fail.message(fail.catalog_message_or(ctx.interner, ctx.alloc, fail.unknown_member("CtOp", cop::u32), "unknown CtOp tag"))};
     }
     val ccap: ct.CtCap = O.unwrap[ct.CtCap](declared_cap);
     if (ccap != ct.CT_CAP_OK
         && !ct.target_provides(ctx.tgt.model.ct_trust_mul, ctx.tgt.model.ct_trust_var_shift, ccap)
         && instr_has_secret_ct_operand(inst, cop)) {
-        ret R.err[R.Void, str](secret_ct_op_unsupported(cop));
+        ret err[fail.Fail].err{fail.message(secret_ct_op_unsupported(cop))};
     }
 
     val route: opdesc.LowerRoute = opdesc.lower_route(inst.kind);
@@ -607,7 +617,7 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
     if (route != opdesc.LOWER_PHI && route != opdesc.LOWER_DBG
         && instr_touches_vector(ctx, inst)) {
         if (!ctx.tgt.model.has_v128) {
-            ret R.err[R.Void, str](vector_unsupported(ctx));
+            ret err[fail.Fail].err{fail.message(vector_unsupported(ctx))};
         }
         if (ctx.tgt.model.vector_compute_generic && is_vector_compute(inst.kind)) {
             ret lower_generic(ctx, mb, inst, iid);
@@ -621,7 +631,7 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
         ret mabi.lower_ret(ctx, mb, inst);
     }
     if (route == opdesc.LOWER_PHI) {
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
     if (route == opdesc.LOWER_DBG) {
         var vreg: u32 = mir.MIR_VREG_NIL;
@@ -799,29 +809,29 @@ fun vector_unsupported(ctx: *lctx.LowerCtx) str {
     val arch:     str = ctx.tgt.isa.name;
     if (arch == nil) { ret fallback; }
 
-    val jr: R.Result[str, str] = str_join(ctx.alloc, prefix, arch);
-    if (R.is_err[str, str](jr)) { ret fallback; }
-    ret intern_owned(ctx, R.unwrap_ok[str, str](jr), fallback);
+    val jr: res[str, StrError] = str_join(ctx.alloc, prefix, arch);
+    if (sel jr.err) { ret fallback; }
+    ret intern_owned(ctx, jr.ok, fallback);
 }
 
-fun lower_cbr(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_cbr(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
     if (inst.operand_count < 3) {
-        ret R.err[R.Void, str]("mir.lower_ir: conditional branch missing operands");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: conditional branch missing operands")};
     }
 
     var cond: mir.MirOperand = lctx.lower_operand(ctx, inst, 0);
     if (cond.kind == mir.MIR_OP_IMM) {
-        val rv: R.Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](rv)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](rv)); }
-        val creg: u32 = R.unwrap_ok[u32, str](rv);
-        val mv: R.Result[R.Void, str] = lctx.emit_mov(ctx, mb, mir.op_vreg(creg), cond);
-        if (R.is_err[R.Void, str](mv)) { ret mv; }
+        val rv: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+        if (sel rv.err) { ret err[fail.Fail].err{rv.err}; }
+        val creg: u32 = rv.ok;
+        val mv: err[fail.Fail] = lctx.emit_mov(ctx, mb, mir.op_vreg(creg), cond);
+        if (sel mv.err) { ret mv; }
         cond = mir.op_vreg(creg);
     }
 
-    val rop: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 3::usize);
-    if (R.is_err[*mir.MirOperand, str](rop)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](rop)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rop);
+    val rop: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 3::usize);
+    if (sel rop.err) { ret err[fail.Fail].err{fail.refused(rop.err)}; }
+    val ops: *mir.MirOperand = rop.ok;
     ops[0] = cond;
     ops[1] = lctx.lower_operand(ctx, inst, 1);
     ops[2] = lctx.lower_operand(ctx, inst, 2);
@@ -837,39 +847,39 @@ fun asm_bind_message(ctx: *lctx.LowerCtx, prefix: str, name_id: intern.StrId, su
     if (O.is_none[str](no)) { ret fallback; }
     val nm: str = O.unwrap[str](no);
 
-    val jr: R.Result[str, str] = str_join(ctx.alloc, prefix, nm, suffix);
-    if (R.is_err[str, str](jr)) { ret fallback; }
-    ret intern_owned(ctx, R.unwrap_ok[str, str](jr), fallback);
+    val jr: res[str, StrError] = str_join(ctx.alloc, prefix, nm, suffix);
+    if (sel jr.err) { ret fallback; }
+    ret intern_owned(ctx, jr.ok, fallback);
 }
 
-fun lower_asm_instr(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_asm_instr(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, iid: id.InstructionId) err[fail.Fail] {
     var key: id.InstructionId = iid;
-    val pr: R.Result[*ir.IrAsm, str] = map.get[id.InstructionId, ir.IrAsm](?ctx.fn.asm_blocks, ?key);
-    if (R.is_err[*ir.IrAsm, str](pr)) {
-        ret R.err[R.Void, str]("mir.lower_ir: OP_ASM instruction has no asm payload");
+    val pr: opt[*ir.IrAsm] = map.get[id.InstructionId, ir.IrAsm](?ctx.fn.asm_blocks, ?key);
+    if (sel pr.none) {
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: OP_ASM instruction has no asm payload")};
     }
-    val src: *ir.IrAsm = R.unwrap_ok[*ir.IrAsm, str](pr);
+    val src: *ir.IrAsm = pr.some;
 
     val isa_opt: O.Option[str] = intern.lookup(ctx.interner, src.isa);
-    if (!O.is_some[str](isa_opt)) { ret R.err[R.Void, str]("mir.lower_ir: inline-asm ISA tag not interned"); }
+    if (!O.is_some[str](isa_opt)) { ret err[fail.Fail].err{fail.message("mir.lower_ir: inline-asm ISA tag not interned")}; }
     val body_opt: O.Option[str] = intern.lookup(ctx.interner, src.body);
-    if (!O.is_some[str](body_opt)) { ret R.err[R.Void, str]("mir.lower_ir: inline-asm body not interned"); }
+    if (!O.is_some[str](body_opt)) { ret err[fail.Fail].err{fail.message("mir.lower_ir: inline-asm body not interned")}; }
 
-    val rp: R.Result[*mir.MirAsm, str] = A.allocate[mir.MirAsm](ctx.alloc, 1::usize);
-    if (R.is_err[*mir.MirAsm, str](rp)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirAsm, str](rp)); }
-    val payload: *mir.MirAsm = R.unwrap_ok[*mir.MirAsm, str](rp);
+    val rp: res[*mir.MirAsm, A.Error] = A.allocate[mir.MirAsm](ctx.alloc, 1::usize);
+    if (sel rp.err) { ret err[fail.Fail].err{fail.refused(rp.err)}; }
+    val payload: *mir.MirAsm = rp.ok;
     payload.isa        = O.unwrap[str](isa_opt);
     payload.body       = O.unwrap[str](body_opt);
     payload.binds      = nil;
     payload.bind_count = 0;
 
     if (src.bind_count > 0) {
-        val rb: R.Result[*mir.MirAsmBind, str] = A.allocate[mir.MirAsmBind](ctx.alloc, src.bind_count::usize);
-        if (R.is_err[*mir.MirAsmBind, str](rb)) {
+        val rb: res[*mir.MirAsmBind, A.Error] = A.allocate[mir.MirAsmBind](ctx.alloc, src.bind_count::usize);
+        if (sel rb.err) {
             A.deallocate[mir.MirAsm](ctx.alloc, payload, 1::usize);
-            ret R.err[R.Void, str](R.unwrap_err[*mir.MirAsmBind, str](rb));
+            ret err[fail.Fail].err{fail.refused(rb.err)};
         }
-        payload.binds = R.unwrap_ok[*mir.MirAsmBind, str](rb);
+        payload.binds = rb.ok;
         var k: u32 = 0;
         for (k < src.bind_count) {
             var vreg: u32 = lctx.slot_key_vreg(ctx, src.binds[k].instr);
@@ -878,7 +888,7 @@ fun lower_asm_instr(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, iid: id.InstructionI
                 val msg: str = asm_bind_message(ctx, "inline-asm local '", src.binds[k].name, "' has no addressable storage slot", "inline-asm local has no addressable storage slot");
                 A.deallocate[mir.MirAsmBind](ctx.alloc, payload.binds, src.bind_count::usize);
                 A.deallocate[mir.MirAsm](ctx.alloc, payload, 1::usize);
-                ret R.err[R.Void, str](msg);
+                ret err[fail.Fail].err{fail.message(msg)};
             }
             payload.binds[k] = mir.asm_bind(src.binds[k].name, vreg, src.binds[k].secret);
             k = k + 1;
@@ -889,37 +899,37 @@ fun lower_asm_instr(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, iid: id.InstructionI
     var mi: mir.MirInstr = mir.instr(mir.MIR_ASM, nil, 0, 0, 0);
     mi.asm_block     = payload;
 
-    val push: R.Result[R.Void, str] = lctx.push_instr(ctx, mb, mi);
-    if (R.is_err[R.Void, str](push)) {
+    val push: err[fail.Fail] = lctx.push_instr(ctx, mb, mi);
+    if (sel push.err) {
         if (payload.binds != nil) { A.deallocate[mir.MirAsmBind](ctx.alloc, payload.binds, payload.bind_count::usize); }
         A.deallocate[mir.MirAsm](ctx.alloc, payload, 1::usize);
         ret push;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun narrow_shift_value(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction,
-                       value: mir.MirOperand, natural_w: u8, w: u8) R.Result[mir.MirOperand, str] {
-    if (inst.kind == instr.OP_SHL) { ret R.ok[mir.MirOperand, str](value); }
-    if (natural_w >= w)            { ret R.ok[mir.MirOperand, str](value); }
+                       value: mir.MirOperand, natural_w: u8, w: u8) res[mir.MirOperand, fail.Fail] {
+    if (inst.kind == instr.OP_SHL) { ret res[mir.MirOperand, fail.Fail].ok{value}; }
+    if (natural_w >= w)            { ret res[mir.MirOperand, fail.Fail].ok{value}; }
 
-    val vr: R.Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](vr)) { ret R.err[mir.MirOperand, str](R.unwrap_err[u32, str](vr)); }
-    val v: u32 = R.unwrap_ok[u32, str](vr);
+    val vr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel vr.err) { ret res[mir.MirOperand, fail.Fail].err{vr.err}; }
+    val v: u32 = vr.ok;
 
-    val pr: R.Result[R.Void, str] = emit_promote(ctx, mb, mir.op_vreg(v), value, w, natural_w,
+    val pr: err[fail.Fail] = emit_promote(ctx, mb, mir.op_vreg(v), value, w, natural_w,
                                                inst.kind == instr.OP_SHR_S);
-    if (R.is_err[R.Void, str](pr)) { ret R.err[mir.MirOperand, str](R.unwrap_err[R.Void, str](pr)); }
-    ret R.ok[mir.MirOperand, str](mir.op_vreg(v));
+    if (sel pr.err) { ret res[mir.MirOperand, fail.Fail].err{pr.err}; }
+    ret res[mir.MirOperand, fail.Fail].ok{mir.op_vreg(v)};
 }
 
-fun lower_shift(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_shift(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
     if (inst.operand_count < 2) {
-        ret R.err[R.Void, str]("mir.lower_ir: shift missing value or count operand");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: shift missing value or count operand")};
     }
     val dst: u32 = lctx.instr_vreg(ctx, iid);
     if (dst == mir.MIR_VREG_NIL) {
-        ret R.err[R.Void, str]("mir.lower_ir: shift defines no result vreg");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: shift defines no result vreg")};
     }
     val natural_w: u8 = lctx.op_width_of(ctx, inst.ty);
     val w: u8 = lctx.clamp_alu_width(ctx.tgt.model.alu_min_width, natural_w);
@@ -931,23 +941,23 @@ fun lower_shift(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
     val raw: mir.MirOperand = lctx.lower_value(ctx, inst.operands[0]);
     val count: mir.MirOperand = lctx.lower_value(ctx, inst.operands[1]);
 
-    val rv: R.Result[mir.MirOperand, str] = narrow_shift_value(ctx, mb, inst, raw, natural_w, w);
-    if (R.is_err[mir.MirOperand, str](rv)) { ret R.err[R.Void, str](R.unwrap_err[mir.MirOperand, str](rv)); }
-    val value: mir.MirOperand = R.unwrap_ok[mir.MirOperand, str](rv);
+    val rv: res[mir.MirOperand, fail.Fail] = narrow_shift_value(ctx, mb, inst, raw, natural_w, w);
+    if (sel rv.err) { ret err[fail.Fail].err{rv.err}; }
+    val value: mir.MirOperand = rv.ok;
 
     var count_op: mir.MirOperand = count;
     if (count.kind != mir.MIR_OP_IMM) {
         val cnt_reg: i32 = ctx.tgt.model.shift_count_reg;
         if (cnt_reg >= 0) {
-            val mc: R.Result[R.Void, str] = lctx.emit_mov_w(ctx, mb, mir.op_preg(cnt_reg::u32), count, w);
-            if (R.is_err[R.Void, str](mc)) { ret mc; }
+            val mc: err[fail.Fail] = lctx.emit_mov_w(ctx, mb, mir.op_preg(cnt_reg::u32), count, w);
+            if (sel mc.err) { ret mc; }
             count_op = mir.op_preg(cnt_reg::u32);
         }
     }
 
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 3::usize);
-    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](r)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 3::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    val ops: *mir.MirOperand = r.ok;
     ops[0] = mir.op_vreg(dst);
     ops[1] = value;
     ops[2] = count_op;
@@ -955,13 +965,13 @@ fun lower_shift(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
     ret lctx.push_instr(ctx, mb, mi);
 }
 
-fun lower_div(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_div(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
     if (inst.operand_count < 2) {
-        ret R.err[R.Void, str]("mir.lower_ir: division missing dividend or divisor operand");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: division missing dividend or divisor operand")};
     }
     val dst: u32 = lctx.instr_vreg(ctx, iid);
     if (dst == mir.MIR_VREG_NIL) {
-        ret R.err[R.Void, str]("mir.lower_ir: division defines no result vreg");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: division defines no result vreg")};
     }
     val acc_reg: i32 = ctx.tgt.model.div_reg;
     val hi_reg:  i32 = ctx.tgt.model.div_hi_reg;
@@ -977,27 +987,27 @@ fun lower_div(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     val dividend: mir.MirOperand = lctx.lower_value(ctx, inst.operands[0]);
     val divisor:  mir.MirOperand = lctx.lower_value(ctx, inst.operands[1]);
 
-    val mr: R.Result[R.Void, str] = emit_promote(ctx, mb, mir.op_preg(acc_reg::u32), dividend, w, natural_w, signed);
-    if (R.is_err[R.Void, str](mr)) { ret mr; }
+    val mr: err[fail.Fail] = emit_promote(ctx, mb, mir.op_preg(acc_reg::u32), dividend, w, natural_w, signed);
+    if (sel mr.err) { ret mr; }
 
     var div_op: mir.MirOperand = divisor;
     if (natural_w < w || divisor.kind == mir.MIR_OP_IMM) {
-        val bvr: R.Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](bvr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](bvr)); }
-        val bv: u32 = R.unwrap_ok[u32, str](bvr);
-        val ex: R.Result[R.Void, str] = emit_promote(ctx, mb, mir.op_vreg(bv), divisor, w, natural_w, signed);
-        if (R.is_err[R.Void, str](ex)) { ret ex; }
+        val bvr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+        if (sel bvr.err) { ret err[fail.Fail].err{bvr.err}; }
+        val bv: u32 = bvr.ok;
+        val ex: err[fail.Fail] = emit_promote(ctx, mb, mir.op_vreg(bv), divisor, w, natural_w, signed);
+        if (sel ex.err) { ret ex; }
         div_op = mir.op_vreg(bv);
     }
 
-    val rop: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](rop)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](rop)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rop);
+    val rop: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel rop.err) { ret err[fail.Fail].err{fail.refused(rop.err)}; }
+    val ops: *mir.MirOperand = rop.ok;
     ops[0] = mir.op_preg(acc_reg::u32);
     ops[1] = div_op;
     var mi: mir.MirInstr = mir.instr(inst.kind::u32, ops, 2, w, w);
-    val pd: R.Result[R.Void, str] = lctx.push_instr(ctx, mb, mi);
-    if (R.is_err[R.Void, str](pd)) { ret pd; }
+    val pd: err[fail.Fail] = lctx.push_instr(ctx, mb, mi);
+    if (sel pd.err) { ret pd; }
 
     var res_reg: i32 = acc_reg;
     if (inst.kind == instr.OP_REM_S || inst.kind == instr.OP_REM_U) {
@@ -1007,7 +1017,7 @@ fun lower_div(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
 }
 
 fun lower_div_three_address(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction,
-                            iid: id.InstructionId, dst: u32) R.Result[R.Void, str] {
+                            iid: id.InstructionId, dst: u32) err[fail.Fail] {
     val signed: bool = inst.kind == instr.OP_DIV_S || inst.kind == instr.OP_REM_S;
 
     val natural_w: u8 = lctx.op_width_of(ctx, inst.ty);
@@ -1019,27 +1029,27 @@ fun lower_div_three_address(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr
 
     var n_op: mir.MirOperand = dividend;
     if (natural_w < w || dividend.kind == mir.MIR_OP_IMM) {
-        val nvr: R.Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](nvr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](nvr)); }
-        val nv: u32 = R.unwrap_ok[u32, str](nvr);
-        val ne: R.Result[R.Void, str] = emit_promote(ctx, mb, mir.op_vreg(nv), dividend, w, natural_w, signed);
-        if (R.is_err[R.Void, str](ne)) { ret ne; }
+        val nvr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+        if (sel nvr.err) { ret err[fail.Fail].err{nvr.err}; }
+        val nv: u32 = nvr.ok;
+        val ne: err[fail.Fail] = emit_promote(ctx, mb, mir.op_vreg(nv), dividend, w, natural_w, signed);
+        if (sel ne.err) { ret ne; }
         n_op = mir.op_vreg(nv);
     }
 
     var m_op: mir.MirOperand = divisor;
     if (natural_w < w || divisor.kind == mir.MIR_OP_IMM) {
-        val mvr: R.Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](mvr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](mvr)); }
-        val mv: u32 = R.unwrap_ok[u32, str](mvr);
-        val me: R.Result[R.Void, str] = emit_promote(ctx, mb, mir.op_vreg(mv), divisor, w, natural_w, signed);
-        if (R.is_err[R.Void, str](me)) { ret me; }
+        val mvr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+        if (sel mvr.err) { ret err[fail.Fail].err{mvr.err}; }
+        val mv: u32 = mvr.ok;
+        val me: err[fail.Fail] = emit_promote(ctx, mb, mir.op_vreg(mv), divisor, w, natural_w, signed);
+        if (sel me.err) { ret me; }
         m_op = mir.op_vreg(mv);
     }
 
-    val rop: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 3::usize);
-    if (R.is_err[*mir.MirOperand, str](rop)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](rop)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rop);
+    val rop: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 3::usize);
+    if (sel rop.err) { ret err[fail.Fail].err{fail.refused(rop.err)}; }
+    val ops: *mir.MirOperand = rop.ok;
     ops[0] = mir.op_vreg(dst);
     ops[1] = n_op;
     ops[2] = m_op;
@@ -1059,16 +1069,16 @@ fun narrow_imm_value(imm: i64, width: u8, signed: bool) i64 {
 }
 
 fun emit_promote(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, src: mir.MirOperand,
-                 dst_w: u8, src_w: u8, signed: bool) R.Result[R.Void, str] {
+                 dst_w: u8, src_w: u8, signed: bool) err[fail.Fail] {
     if (src_w >= dst_w) {
         ret lctx.emit_mov_w(ctx, mb, dst, src, dst_w);
     }
     if (src.kind == mir.MIR_OP_IMM) {
         ret lctx.emit_mov_w(ctx, mb, dst, mir.op_imm(narrow_imm_value(src.imm, src_w, signed)), dst_w);
     }
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](r)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    val ops: *mir.MirOperand = r.ok;
     ops[0] = dst;
     ops[1] = src;
     var mi: mir.MirInstr = mir.instr(mir.MIR_ZEXT, ops, 2, dst_w, src_w);
@@ -1076,7 +1086,7 @@ fun emit_promote(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, sr
     ret lctx.push_instr(ctx, mb, mi);
 }
 
-fun lower_generic(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_generic(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
     val dst: u32 = lctx.instr_vreg(ctx, iid);
     val has_dst: bool = dst != mir.MIR_VREG_NIL;
     var total: u32 = inst.operand_count;
@@ -1084,9 +1094,9 @@ fun lower_generic(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructi
 
     var ops: *mir.MirOperand = nil;
     if (total > 0) {
-        val rop: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, total::usize);
-        if (R.is_err[*mir.MirOperand, str](rop)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](rop)); }
-        ops = R.unwrap_ok[*mir.MirOperand, str](rop);
+        val rop: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, total::usize);
+        if (sel rop.err) { ret err[fail.Fail].err{fail.refused(rop.err)}; }
+        ops = rop.ok;
     }
 
     var base: u32 = 0;
@@ -1100,17 +1110,17 @@ fun lower_generic(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructi
         var op: mir.MirOperand = lctx.lower_operand(ctx, inst, k);
         if (op.kind == mir.MIR_OP_SYM) {
             var av: u32 = mir.MIR_VREG_NIL;
-            val ar: R.Result[R.Void, str] = lctx.addr_to_vreg(ctx, mb, op, ?av);
-            if (R.is_err[R.Void, str](ar)) { ret ar; }
+            val ar: err[fail.Fail] = lctx.addr_to_vreg(ctx, mb, op, ?av);
+            if (sel ar.err) { ret ar; }
             op = mir.op_vreg(av);
         }
         if (op.kind == mir.MIR_OP_IMM && mir.operand_requires_reg(inst.kind::u32, base + k)) {
-            val cvr: R.Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-            if (R.is_err[u32, str](cvr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](cvr)); }
-            val cv: u32 = R.unwrap_ok[u32, str](cvr);
+            val cvr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+            if (sel cvr.err) { ret err[fail.Fail].err{cvr.err}; }
+            val cv: u32 = cvr.ok;
             val cw: u8 = lctx.op_width_of(ctx, inst.operands[k].ty);
-            val ce: R.Result[R.Void, str] = lctx.emit_mov_w(ctx, mb, mir.op_vreg(cv), op, cw);
-            if (R.is_err[R.Void, str](ce)) { ret ce; }
+            val ce: err[fail.Fail] = lctx.emit_mov_w(ctx, mb, mir.op_vreg(cv), op, cw);
+            if (sel ce.err) { ret ce; }
             op = mir.op_vreg(cv);
         }
         ops[base + k] = op;
@@ -1198,18 +1208,18 @@ fun float_cmp_cc(k: instr.InstrKind) u8 {
     ret mir.FCC_LE;
 }
 
-fun lower_float_op(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_float_op(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
     if (inst.operand_count < 2) {
-        ret R.err[R.Void, str]("mir.lower_ir: float op missing operand");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: float op missing operand")};
     }
     val dst: u32 = lctx.instr_vreg(ctx, iid);
     if (dst == mir.MIR_VREG_NIL) {
-        ret R.err[R.Void, str]("mir.lower_ir: float op defines no result vreg");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: float op defines no result vreg")};
     }
 
-    val rop: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 3::usize);
-    if (R.is_err[*mir.MirOperand, str](rop)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](rop)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rop);
+    val rop: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 3::usize);
+    if (sel rop.err) { ret err[fail.Fail].err{fail.refused(rop.err)}; }
+    val ops: *mir.MirOperand = rop.ok;
     ops[0] = mir.op_vreg(dst);
     ops[1] = lctx.lower_value(ctx, inst.operands[0]);
     ops[2] = lctx.lower_value(ctx, inst.operands[1]);
@@ -1249,50 +1259,50 @@ fun bitcast_needs_frame(ctx: *lctx.LowerCtx, inst: *instr.Instruction) bool {
     ret !isa.moves_cross_bank(?ctx.tgt.model, w::u32);
 }
 
-fun lower_bitcast_via_frame(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_bitcast_via_frame(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
     val dst: u32 = lctx.instr_vreg(ctx, iid);
     if (dst == mir.MIR_VREG_NIL) {
-        ret R.err[R.Void, str]("mir.lower_ir: cross-bank reinterpret defines no result vreg");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: cross-bank reinterpret defines no result vreg")};
     }
     val w: u8 = lctx.op_width_of(ctx, inst.ty);
 
-    val skr: R.Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](skr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](skr)); }
-    val sk: u32 = R.unwrap_ok[u32, str](skr);
+    val skr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel skr.err) { ret err[fail.Fail].err{skr.err}; }
+    val sk: u32 = skr.ok;
 
-    val ar: R.Result[R.Void, str] = lctx.add_spill_slot_aligned(ctx, sk, w::u64, w::u32);
-    if (R.is_err[R.Void, str](ar)) { ret ar; }
+    val ar: err[fail.Fail] = lctx.add_spill_slot_aligned(ctx, sk, w::u64, w::u32);
+    if (sel ar.err) { ret ar; }
 
-    val sr: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](sr)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](sr)); }
-    val sops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](sr);
+    val sr: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel sr.err) { ret err[fail.Fail].err{fail.refused(sr.err)}; }
+    val sops: *mir.MirOperand = sr.ok;
     sops[0] = mir.op_mem_slot(sk, 0);
     sops[1] = lctx.lower_value(ctx, inst.operands[0]);
     var si: mir.MirInstr = mir.instr(mir.MIR_MOV, sops, 2, w, w);
-    val spr: R.Result[R.Void, str] = lctx.push_instr(ctx, mb, si);
-    if (R.is_err[R.Void, str](spr)) { ret spr; }
+    val spr: err[fail.Fail] = lctx.push_instr(ctx, mb, si);
+    if (sel spr.err) { ret spr; }
 
-    val lr: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](lr)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](lr)); }
-    val lops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](lr);
+    val lr: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel lr.err) { ret err[fail.Fail].err{fail.refused(lr.err)}; }
+    val lops: *mir.MirOperand = lr.ok;
     lops[0] = mir.op_vreg(dst);
     lops[1] = mir.op_mem_slot(sk, 0);
     var li: mir.MirInstr = mir.instr(mir.MIR_MOV, lops, 2, w, w);
     ret lctx.push_instr(ctx, mb, li);
 }
 
-fun lower_float_neg(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_float_neg(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
     if (inst.operand_count < 1) {
-        ret R.err[R.Void, str]("mir.lower_ir: float negate missing operand");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: float negate missing operand")};
     }
     val dst: u32 = lctx.instr_vreg(ctx, iid);
     if (dst == mir.MIR_VREG_NIL) {
-        ret R.err[R.Void, str]("mir.lower_ir: float negate defines no result vreg");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: float negate defines no result vreg")};
     }
 
-    val rop: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](rop)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](rop)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](rop);
+    val rop: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel rop.err) { ret err[fail.Fail].err{fail.refused(rop.err)}; }
+    val ops: *mir.MirOperand = rop.ok;
     ops[0] = mir.op_vreg(dst);
     ops[1] = lctx.lower_value(ctx, inst.operands[0]);
 
@@ -1309,13 +1319,13 @@ fun is_float_kind(ctx: *lctx.LowerCtx, inst: *instr.Instruction) bool {
     ret false;
 }
 
-fun lower_alloca(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_alloca(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
     if (inst.operand_count == 0) {
-        ret R.err[R.Void, str]("mir.lower_ir: alloca with no count operand");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: alloca with no count operand")};
     }
     val cv: value.Value = inst.operands[0];
     if (cv.kind != value.VAL_CONST_INT) {
-        ret R.err[R.Void, str]("variable-length alloca is not supported; use a constant size");
+        ret err[fail.Fail].err{fail.message("variable-length alloca is not supported; use a constant size")};
     }
     val count: u64 = cv.data.int_lit;
 
@@ -1325,23 +1335,23 @@ fun lower_alloca(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructio
 
     val dst: u32 = lctx.instr_vreg(ctx, iid);
     if (dst == mir.MIR_VREG_NIL) {
-        ret R.err[R.Void, str]("mir.lower_ir: alloca defines no result vreg");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: alloca defines no result vreg")};
     }
 
-    val skr: R.Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](skr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](skr)); }
-    val sk: u32 = R.unwrap_ok[u32, str](skr);
+    val skr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel skr.err) { ret err[fail.Fail].err{skr.err}; }
+    val sk: u32 = skr.ok;
 
-    val ar: R.Result[R.Void, str] = lctx.add_alloca_slot(ctx, sk, total, elem_align, inst.aux_ty::u32);
-    if (R.is_err[R.Void, str](ar)) { ret ar; }
+    val ar: err[fail.Fail] = lctx.add_alloca_slot(ctx, sk, total, elem_align, inst.aux_ty::u32);
+    if (sel ar.err) { ret ar; }
 
     if (ctx.slot_key_vregs != nil && iid::u32 < ctx.instr_count) {
         ctx.slot_key_vregs[iid::u32] = sk;
     }
 
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](r)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    val ops: *mir.MirOperand = r.ok;
     ops[0] = mir.op_vreg(dst);
     ops[1] = mir.op_mem_slot(sk, 0);
     var mi: mir.MirInstr = mir.instr(mir.MIR_ALLOCA, ops, 2,
@@ -1349,18 +1359,18 @@ fun lower_alloca(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructio
     ret lctx.push_instr(ctx, mb, mi);
 }
 
-fun lower_vec_extract(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_vec_extract(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
     val dst: u32 = lctx.instr_vreg(ctx, iid);
     if (dst == mir.MIR_VREG_NIL) {
-        ret R.err[R.Void, str]("mir.lower_ir: vector lane read defines no result vreg");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: vector lane read defines no result vreg")};
     }
     if (inst.operands[1].kind != value.VAL_CONST_INT) {
-        ret R.err[R.Void, str]("mir.lower_ir: vector lane index is not a constant");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: vector lane index is not a constant")};
     }
 
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 3::usize);
-    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](r)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 3::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    val ops: *mir.MirOperand = r.ok;
     ops[0] = mir.op_vreg(dst);
     ops[1] = lctx.lower_value(ctx, inst.operands[0]);
     ops[2] = mir.op_imm(inst.operands[1].data.int_lit::i64);
@@ -1369,18 +1379,18 @@ fun lower_vec_extract(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instr
     ret lctx.push_instr(ctx, mb, mi);
 }
 
-fun lower_vec_insert(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_vec_insert(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
     val dst: u32 = lctx.instr_vreg(ctx, iid);
     if (dst == mir.MIR_VREG_NIL) {
-        ret R.err[R.Void, str]("mir.lower_ir: vector lane write defines no result vreg");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: vector lane write defines no result vreg")};
     }
     if (inst.operands[1].kind != value.VAL_CONST_INT) {
-        ret R.err[R.Void, str]("mir.lower_ir: vector lane index is not a constant");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: vector lane index is not a constant")};
     }
 
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 4::usize);
-    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](r)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 4::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    val ops: *mir.MirOperand = r.ok;
     ops[0] = mir.op_vreg(dst);
     ops[1] = lctx.lower_value(ctx, inst.operands[0]);
     ops[2] = mir.op_imm(inst.operands[1].data.int_lit::i64);
@@ -1390,19 +1400,19 @@ fun lower_vec_insert(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instru
     ret lctx.push_instr(ctx, mb, mi);
 }
 
-fun lower_vec_build(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_vec_build(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
     val dst: u32 = lctx.instr_vreg(ctx, iid);
     if (dst == mir.MIR_VREG_NIL) {
-        ret R.err[R.Void, str]("mir.lower_ir: vector build defines no result vreg");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: vector build defines no result vreg")};
     }
     if (inst.operand_count == 0) {
-        ret R.err[R.Void, str]("mir.lower_ir: vector build with no lanes");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: vector build with no lanes")};
     }
 
     val n: u32 = inst.operand_count + 1;
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, n::usize);
-    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](r)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, n::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    val ops: *mir.MirOperand = r.ok;
     ops[0] = mir.op_vreg(dst);
     var i: u32 = 0;
     for (i < inst.operand_count) {
@@ -1414,24 +1424,24 @@ fun lower_vec_build(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruc
     ret lctx.push_instr(ctx, mb, mi);
 }
 
-fun lower_load(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_load(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
     if (inst.operand_count == 0) {
-        ret R.err[R.Void, str]("mir.lower_ir: load with no pointer operand");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: load with no pointer operand")};
     }
     val dst: u32 = lctx.instr_vreg(ctx, iid);
     if (dst == mir.MIR_VREG_NIL) {
-        ret R.err[R.Void, str]("mir.lower_ir: load defines no result vreg");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: load defines no result vreg")};
     }
     var mem: mir.MirOperand = lctx.mem_operand_of(ctx, inst.operands[0]);
     if (ctx.tgt.model.flat_addressing && mem.kind == mir.MIR_OP_SYM && lctx.value_is_float(ctx, inst.ty)) {
         var base: u32 = mir.MIR_VREG_NIL;
-        val ar: R.Result[R.Void, str] = lctx.addr_to_vreg(ctx, mb, mem, ?base);
-        if (R.is_err[R.Void, str](ar)) { ret ar; }
+        val ar: err[fail.Fail] = lctx.addr_to_vreg(ctx, mb, mem, ?base);
+        if (sel ar.err) { ret ar; }
         mem = mir.op_mem_value(base, 0);
     }
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](r)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    val ops: *mir.MirOperand = r.ok;
     ops[0] = mir.op_vreg(dst);
     ops[1] = mem;
     val acc_w: u8 = lctx.mem_width_of(ctx, inst.ty);
@@ -1444,9 +1454,9 @@ fun lower_load(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction,
     ret lctx.push_instr(ctx, mb, mi);
 }
 
-fun lower_store(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction) R.Result[R.Void, str] {
+fun lower_store(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction) err[fail.Fail] {
     if (inst.operand_count < 2) {
-        ret R.err[R.Void, str]("mir.lower_ir: store missing value or pointer operand");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: store missing value or pointer operand")};
     }
     if (lctx.value_is_aggregate(ctx, inst.operands[0].ty)) {
         ret lower_store_aggregate(ctx, mb, inst);
@@ -1454,20 +1464,20 @@ fun lower_store(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
     var stored: mir.MirOperand = lctx.lower_value(ctx, inst.operands[0]);
     if (stored.kind == mir.MIR_OP_SYM) {
         var addr: u32 = mir.MIR_VREG_NIL;
-        val ar: R.Result[R.Void, str] = lctx.addr_to_vreg(ctx, mb, stored, ?addr);
-        if (R.is_err[R.Void, str](ar)) { ret ar; }
+        val ar: err[fail.Fail] = lctx.addr_to_vreg(ctx, mb, stored, ?addr);
+        if (sel ar.err) { ret ar; }
         stored = mir.op_vreg(addr);
     }
     var dest: mir.MirOperand = lctx.mem_operand_of(ctx, inst.operands[1]);
     if (ctx.tgt.model.flat_addressing && dest.kind == mir.MIR_OP_SYM && lctx.value_is_float(ctx, inst.operands[0].ty)) {
         var dbase: u32 = mir.MIR_VREG_NIL;
-        val dr: R.Result[R.Void, str] = lctx.addr_to_vreg(ctx, mb, dest, ?dbase);
-        if (R.is_err[R.Void, str](dr)) { ret dr; }
+        val dr: err[fail.Fail] = lctx.addr_to_vreg(ctx, mb, dest, ?dbase);
+        if (sel dr.err) { ret dr; }
         dest = mir.op_mem_value(dbase, 0);
     }
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](r)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    val ops: *mir.MirOperand = r.ok;
     ops[0] = dest;
     ops[1] = stored;
     val st_w: u8 = lctx.mem_width_of(ctx, inst.operands[0].ty);
@@ -1479,24 +1489,24 @@ fun lower_store(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
     ret lctx.push_instr(ctx, mb, mi);
 }
 
-fun lower_store_aggregate(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction) R.Result[R.Void, str] {
+fun lower_store_aggregate(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction) err[fail.Fail] {
     val size: u32 = ir_type.byte_size_for_machine(ctx.types, inst.operands[0].ty, ctx.layout);
     ret lctx.copy_aggregate(ctx, mb, agg_pointer_mem(ctx, inst.operands[1], 0),
                             agg_pointer_mem(ctx, inst.operands[0], 0), size::u64);
 }
 
-fun lower_memzero(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction) R.Result[R.Void, str] {
+fun lower_memzero(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction) err[fail.Fail] {
     if (inst.operand_count < 1) {
-        ret R.err[R.Void, str]("mir.lower_ir: memzero missing destination pointer operand");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: memzero missing destination pointer operand")};
     }
     if (inst.aux_ty == ir_type.IRT_NIL) {
-        ret R.err[R.Void, str]("mir.lower_ir: memzero is missing its pointee type");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: memzero is missing its pointee type")};
     }
     val size: u32 = ir_type.byte_size_for_machine(ctx.types, inst.aux_ty, ctx.layout);
 
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](r)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    val ops: *mir.MirOperand = r.ok;
     ops[0] = agg_pointer_mem(ctx, inst.operands[0], 0);
     ops[1] = mir.op_imm(size::i64);
     var mi: mir.MirInstr = mir.instr(mir.MIR_MEMZERO, ops, 2,
@@ -1515,19 +1525,19 @@ fun agg_pointer_mem(ctx: *lctx.LowerCtx, v: value.Value, disp: i64) mir.MirOpera
     ret op;
 }
 
-fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) R.Result[R.Void, str] {
+fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
     if (inst.operand_count == 0) {
-        ret R.err[R.Void, str]("mir.lower_ir: gep with no base operand");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: gep with no base operand")};
     }
     val dst: u32 = lctx.instr_vreg(ctx, iid);
     if (dst == mir.MIR_VREG_NIL) {
-        ret R.err[R.Void, str]("mir.lower_ir: gep defines no result vreg");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: gep defines no result vreg")};
     }
 
     val base: mir.MirOperand = lctx.mem_operand_of(ctx, inst.operands[0]);
 
     if (inst.operand_count > 1 && inst.aux_ty == ir_type.IRT_NIL) {
-        ret R.err[R.Void, str]("mir.lower_ir: gep with indices is missing its source pointee type");
+        ret err[fail.Fail].err{fail.message("mir.lower_ir: gep with indices is missing its source pointee type")};
     }
 
     if (!ctx.tgt.model.flat_addressing) {
@@ -1551,7 +1561,7 @@ fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
         } or {
             val ct_opt: O.Option[*ir_type.IrType] = ir_type.get(ctx.types, cur_ty);
             if (!O.is_some[*ir_type.IrType](ct_opt)) {
-                ret R.err[R.Void, str]("mir.lower_ir: gep index walks off a non-aggregate type");
+                ret err[fail.Fail].err{fail.message("mir.lower_ir: gep index walks off a non-aggregate type")};
             }
             val ct: *ir_type.IrType = O.unwrap[*ir_type.IrType](ct_opt);
             if (ct.kind == ir_type.IRT_ARRAY) {
@@ -1563,21 +1573,21 @@ fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
             } or (ct.kind == ir_type.IRT_STRUCT || ct.kind == ir_type.IRT_UNION || ct.kind == ir_type.IRT_TAG) {
                 is_struct = true;
             } or {
-                ret R.err[R.Void, str]("mir.lower_ir: gep index into a non-aggregate type");
+                ret err[fail.Fail].err{fail.message("mir.lower_ir: gep index into a non-aggregate type")};
             }
         }
 
         if (is_struct) {
             if (v.kind != value.VAL_CONST_INT) {
-                ret R.err[R.Void, str]("mir.lower_ir: gep struct field index must be constant");
+                ret err[fail.Fail].err{fail.message("mir.lower_ir: gep struct field index must be constant")};
             }
             val field_ix: u32 = v.data.int_lit::u32;
-            val fo: R.Result[i64, str] = struct_field_offset(ctx, cur_ty, field_ix);
-            if (R.is_err[i64, str](fo)) { ret R.err[R.Void, str](R.unwrap_err[i64, str](fo)); }
-            disp = disp + R.unwrap_ok[i64, str](fo);
-            val ft: R.Result[ir_type.IrTypeId, str] = struct_field_type(ctx, cur_ty, field_ix);
-            if (R.is_err[ir_type.IrTypeId, str](ft)) { ret R.err[R.Void, str](R.unwrap_err[ir_type.IrTypeId, str](ft)); }
-            cur_ty = R.unwrap_ok[ir_type.IrTypeId, str](ft);
+            val fo: res[i64, fail.Fail] = struct_field_offset(ctx, cur_ty, field_ix);
+            if (sel fo.err) { ret err[fail.Fail].err{fo.err}; }
+            disp = disp + fo.ok;
+            val ft: res[ir_type.IrTypeId, fail.Fail] = struct_field_type(ctx, cur_ty, field_ix);
+            if (sel ft.err) { ret err[fail.Fail].err{ft.err}; }
+            cur_ty = ft.ok;
             k = k + 1;
             cnt;
         }
@@ -1589,32 +1599,32 @@ fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
         }
 
         var new_scale: u8 = 0;
-        val ir: R.Result[u32, str] = fold_runtime_index(ctx, mb, lctx.lower_value(ctx, v), stride, idx_vreg, idx_scale, ?new_scale);
-        if (R.is_err[u32, str](ir)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](ir)); }
-        idx_vreg  = R.unwrap_ok[u32, str](ir);
+        val ir: res[u32, fail.Fail] = fold_runtime_index(ctx, mb, lctx.lower_value(ctx, v), stride, idx_vreg, idx_scale, ?new_scale);
+        if (sel ir.err) { ret err[fail.Fail].err{ir.err}; }
+        idx_vreg  = ir.ok;
         idx_scale = new_scale;
         k = k + 1;
     }
 
-    val mem: R.Result[mir.MirOperand, str] = fold_gep_mem(ctx, mb, base, idx_vreg, idx_scale, disp);
-    if (R.is_err[mir.MirOperand, str](mem)) { ret R.err[R.Void, str](R.unwrap_err[mir.MirOperand, str](mem)); }
+    val mem: res[mir.MirOperand, fail.Fail] = fold_gep_mem(ctx, mb, base, idx_vreg, idx_scale, disp);
+    if (sel mem.err) { ret err[fail.Fail].err{mem.err}; }
 
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](r)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    val ops: *mir.MirOperand = r.ok;
     ops[0] = mir.op_vreg(dst);
-    ops[1] = R.unwrap_ok[mir.MirOperand, str](mem);
+    ops[1] = mem.ok;
     var mi: mir.MirInstr = mir.instr(mir.MIR_GEP, ops, 2,
                                      ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
     ret lctx.push_instr(ctx, mb, mi);
 }
 
 fun lower_gep_structural(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction,
-                         dst: u32, base: mir.MirOperand) R.Result[R.Void, str] {
+                         dst: u32, base: mir.MirOperand) err[fail.Fail] {
     val n: usize = (inst.operand_count + 1)::usize;
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, n);
-    if (R.is_err[*mir.MirOperand, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](r)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, n);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    val ops: *mir.MirOperand = r.ok;
     ops[0] = mir.op_vreg(dst);
     ops[1] = base;
     var k: u32 = 1;
@@ -1628,64 +1638,64 @@ fun lower_gep_structural(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.In
 }
 
 fun fold_runtime_index(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, idxop: mir.MirOperand, stride: u64,
-                       acc: u32, acc_scale: u8, scale_out: *u8) R.Result[u32, str] {
+                       acc: u32, acc_scale: u8, scale_out: *u8) res[u32, fail.Fail] {
     if (idxop.kind != mir.MIR_OP_VREG) {
-        ret R.err[u32, str]("mir.lower_ir: gep runtime index is not a register value");
+        ret res[u32, fail.Fail].err{fail.message("mir.lower_ir: gep runtime index is not a register value")};
     }
     val idxv: u32 = idxop.vreg;
 
     if (acc == mir.MIR_VREG_NIL && is_sib_scale(stride)) {
         @scale_out = stride::u8;
-        ret R.ok[u32, str](idxv);
+        ret res[u32, fail.Fail].ok{idxv};
     }
 
-    val tr: R.Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](tr)) { ret R.err[u32, str](R.unwrap_err[u32, str](tr)); }
-    val t: u32 = R.unwrap_ok[u32, str](tr);
-    val mr: R.Result[R.Void, str] = lctx.emit_bin(ctx, mb, mir.MIR_MUL, t, mir.op_vreg(idxv), mir.op_imm(stride::i64));
-    if (R.is_err[R.Void, str](mr)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](mr)); }
+    val tr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel tr.err) { ret res[u32, fail.Fail].err{tr.err}; }
+    val t: u32 = tr.ok;
+    val mr: err[fail.Fail] = lctx.emit_bin(ctx, mb, mir.MIR_MUL, t, mir.op_vreg(idxv), mir.op_imm(stride::i64));
+    if (sel mr.err) { ret res[u32, fail.Fail].err{mr.err}; }
 
     if (acc == mir.MIR_VREG_NIL) {
         @scale_out = 1;
-        ret R.ok[u32, str](t);
+        ret res[u32, fail.Fail].ok{t};
     }
 
     var acc_term: u32 = acc;
     if (acc_scale > 1) {
-        val sr: R.Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](sr)) { ret R.err[u32, str](R.unwrap_err[u32, str](sr)); }
-        acc_term = R.unwrap_ok[u32, str](sr);
-        val smr: R.Result[R.Void, str] = lctx.emit_bin(ctx, mb, mir.MIR_MUL, acc_term, mir.op_vreg(acc), mir.op_imm(acc_scale::i64));
-        if (R.is_err[R.Void, str](smr)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](smr)); }
+        val sr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+        if (sel sr.err) { ret res[u32, fail.Fail].err{sr.err}; }
+        acc_term = sr.ok;
+        val smr: err[fail.Fail] = lctx.emit_bin(ctx, mb, mir.MIR_MUL, acc_term, mir.op_vreg(acc), mir.op_imm(acc_scale::i64));
+        if (sel smr.err) { ret res[u32, fail.Fail].err{smr.err}; }
     }
-    val ar: R.Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-    if (R.is_err[u32, str](ar)) { ret R.err[u32, str](R.unwrap_err[u32, str](ar)); }
-    val sum: u32 = R.unwrap_ok[u32, str](ar);
-    val adr: R.Result[R.Void, str] = lctx.emit_bin(ctx, mb, mir.MIR_ADD, sum, mir.op_vreg(acc_term), mir.op_vreg(t));
-    if (R.is_err[R.Void, str](adr)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](adr)); }
+    val ar: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel ar.err) { ret res[u32, fail.Fail].err{ar.err}; }
+    val sum: u32 = ar.ok;
+    val adr: err[fail.Fail] = lctx.emit_bin(ctx, mb, mir.MIR_ADD, sum, mir.op_vreg(acc_term), mir.op_vreg(t));
+    if (sel adr.err) { ret res[u32, fail.Fail].err{adr.err}; }
     @scale_out = 1;
-    ret R.ok[u32, str](sum);
+    ret res[u32, fail.Fail].ok{sum};
 }
 
 fun is_sib_scale(s: u64) bool {
     ret s == 1 || s == 2 || s == 4 || s == 8;
 }
 
-fun fold_gep_mem(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, base: mir.MirOperand, idx_vreg: u32, idx_scale: u8, disp: i64) R.Result[mir.MirOperand, str] {
+fun fold_gep_mem(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, base: mir.MirOperand, idx_vreg: u32, idx_scale: u8, disp: i64) res[mir.MirOperand, fail.Fail] {
     var o: mir.MirOperand = base;
     if (base.kind == mir.MIR_OP_IMM) {
-        val vr: R.Result[u32, str] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-        if (R.is_err[u32, str](vr)) { ret R.err[mir.MirOperand, str](R.unwrap_err[u32, str](vr)); }
-        val vbase: u32 = R.unwrap_ok[u32, str](vr);
-        val mv: R.Result[R.Void, str] = lctx.emit_mov(ctx, mb, mir.op_vreg(vbase), mir.op_imm(base.imm));
-        if (R.is_err[R.Void, str](mv)) { ret R.err[mir.MirOperand, str](R.unwrap_err[R.Void, str](mv)); }
+        val vr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+        if (sel vr.err) { ret res[mir.MirOperand, fail.Fail].err{vr.err}; }
+        val vbase: u32 = vr.ok;
+        val mv: err[fail.Fail] = lctx.emit_mov(ctx, mb, mir.op_vreg(vbase), mir.op_imm(base.imm));
+        if (sel mv.err) { ret res[mir.MirOperand, fail.Fail].err{mv.err}; }
         var m: mir.MirOperand = mir.op_mem_value(vbase, disp);
         if (idx_vreg != mir.MIR_VREG_NIL) {
             m.index         = idx_vreg;
             m.scale         = idx_scale;
             m.index_is_preg = false;
         }
-        ret R.ok[mir.MirOperand, str](m);
+        ret res[mir.MirOperand, fail.Fail].ok{m};
     }
     if (base.kind == mir.MIR_OP_MEM) {
         o.imm = base.imm + disp;
@@ -1694,68 +1704,68 @@ fun fold_gep_mem(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, base: mir.MirOperand, i
             o.scale         = idx_scale;
             o.index_is_preg = false;
         }
-        ret R.ok[mir.MirOperand, str](o);
+        ret res[mir.MirOperand, fail.Fail].ok{o};
     }
     if (base.kind == mir.MIR_OP_SYM) {
         if (idx_vreg == mir.MIR_VREG_NIL) {
             o.sym_off = base.sym_off + disp::i32;
-            ret R.ok[mir.MirOperand, str](o);
+            ret res[mir.MirOperand, fail.Fail].ok{o};
         }
         var sbase: u32 = mir.MIR_VREG_NIL;
-        val ar: R.Result[R.Void, str] = lctx.addr_to_vreg(ctx, mb, base, ?sbase);
-        if (R.is_err[R.Void, str](ar)) { ret R.err[mir.MirOperand, str](R.unwrap_err[R.Void, str](ar)); }
+        val ar: err[fail.Fail] = lctx.addr_to_vreg(ctx, mb, base, ?sbase);
+        if (sel ar.err) { ret res[mir.MirOperand, fail.Fail].err{ar.err}; }
         var m: mir.MirOperand = mir.op_mem_value(sbase, disp);
         m.index         = idx_vreg;
         m.scale         = idx_scale;
         m.index_is_preg = false;
-        ret R.ok[mir.MirOperand, str](m);
+        ret res[mir.MirOperand, fail.Fail].ok{m};
     }
-    ret R.err[mir.MirOperand, str]("mir.lower_ir: gep base is neither a memory nor a symbol reference");
+    ret res[mir.MirOperand, fail.Fail].err{fail.message("mir.lower_ir: gep base is neither a memory nor a symbol reference")};
 }
 
-fun struct_field_offset(ctx: *lctx.LowerCtx, struct_ty: ir_type.IrTypeId, ix: u32) R.Result[i64, str] {
+fun struct_field_offset(ctx: *lctx.LowerCtx, struct_ty: ir_type.IrTypeId, ix: u32) res[i64, fail.Fail] {
     val st_opt: O.Option[*ir_type.IrType] = ir_type.get(ctx.types, struct_ty);
     if (!O.is_some[*ir_type.IrType](st_opt)) {
-        ret R.err[i64, str]("mir.lower_ir: gep struct type not found");
+        ret res[i64, fail.Fail].err{fail.message("mir.lower_ir: gep struct type not found")};
     }
     val st: *ir_type.IrType = O.unwrap[*ir_type.IrType](st_opt);
     if (st.kind == ir_type.IRT_TAG) {
         if (ix >= st.data.tag_.case_count) {
-            ret R.err[i64, str]("mir.lower_ir: gep tag case index out of range");
+            ret res[i64, fail.Fail].err{fail.message("mir.lower_ir: gep tag case index out of range")};
         }
-        ret R.ok[i64, str](ir_type.byte_offset_for_machine(ctx.types, struct_ty, ix, ctx.layout)::i64);
+        ret res[i64, fail.Fail].ok{ir_type.byte_offset_for_machine(ctx.types, struct_ty, ix, ctx.layout)::i64};
     }
     if (st.kind == ir_type.IRT_UNION) {
         if (ix >= st.data.struct_.field_count) {
-            ret R.err[i64, str]("mir.lower_ir: gep union member index out of range");
+            ret res[i64, fail.Fail].err{fail.message("mir.lower_ir: gep union member index out of range")};
         }
-        ret R.ok[i64, str](0::i64);
+        ret res[i64, fail.Fail].ok{0::i64};
     }
     if (st.kind != ir_type.IRT_STRUCT) {
-        ret R.err[i64, str]("mir.lower_ir: gep struct index into a non-struct type");
+        ret res[i64, fail.Fail].err{fail.message("mir.lower_ir: gep struct index into a non-struct type")};
     }
     if (ix >= st.data.struct_.field_count) {
-        ret R.err[i64, str]("mir.lower_ir: gep struct field index out of range");
+        ret res[i64, fail.Fail].err{fail.message("mir.lower_ir: gep struct field index out of range")};
     }
-    ret R.ok[i64, str](ir_type.byte_offset_for_machine(ctx.types, struct_ty, ix, ctx.layout)::i64);
+    ret res[i64, fail.Fail].ok{ir_type.byte_offset_for_machine(ctx.types, struct_ty, ix, ctx.layout)::i64};
 }
 
-fun struct_field_type(ctx: *lctx.LowerCtx, struct_ty: ir_type.IrTypeId, ix: u32) R.Result[ir_type.IrTypeId, str] {
+fun struct_field_type(ctx: *lctx.LowerCtx, struct_ty: ir_type.IrTypeId, ix: u32) res[ir_type.IrTypeId, fail.Fail] {
     val st_opt: O.Option[*ir_type.IrType] = ir_type.get(ctx.types, struct_ty);
     if (!O.is_some[*ir_type.IrType](st_opt)) {
-        ret R.err[ir_type.IrTypeId, str]("mir.lower_ir: gep struct type not found");
+        ret res[ir_type.IrTypeId, fail.Fail].err{fail.message("mir.lower_ir: gep struct type not found")};
     }
     val st: *ir_type.IrType = O.unwrap[*ir_type.IrType](st_opt);
     if (st.kind == ir_type.IRT_TAG) {
         if (ix >= st.data.tag_.case_count) {
-            ret R.err[ir_type.IrTypeId, str]("mir.lower_ir: gep tag case index out of range");
+            ret res[ir_type.IrTypeId, fail.Fail].err{fail.message("mir.lower_ir: gep tag case index out of range")};
         }
-        ret R.ok[ir_type.IrTypeId, str](st.data.tag_.cases[ix]);
+        ret res[ir_type.IrTypeId, fail.Fail].ok{st.data.tag_.cases[ix]};
     }
     if ((st.kind != ir_type.IRT_STRUCT && st.kind != ir_type.IRT_UNION) || ix >= st.data.struct_.field_count) {
-        ret R.err[ir_type.IrTypeId, str]("mir.lower_ir: gep struct field index out of range");
+        ret res[ir_type.IrTypeId, fail.Fail].err{fail.message("mir.lower_ir: gep struct field index out of range")};
     }
-    ret R.ok[ir_type.IrTypeId, str](st.data.struct_.fields[ix]);
+    ret res[ir_type.IrTypeId, fail.Fail].ok{st.data.struct_.fields[ix]};
 }
 
 fun t_lower_diamond_phi(alloc: *A.Allocator, cover_both: bool, out_err: *str) bool {
@@ -1823,9 +1833,9 @@ fun t_lower_diamond_phi(alloc: *A.Allocator, cover_both: bool, out_err: *str) bo
     if (R.is_err[value.Value, str](builder.emit_add(?bld, p, c))) { ret false; }
     if (R.is_err[R.Void, str](builder.emit_ret_void(?bld)))         { ret false; }
 
-    val lr: R.Result[mir.MirModule, str] = lower_ir(?tgt, ?m, alloc, ?itn, ?smap);
-    if (R.is_err[mir.MirModule, str](lr)) {
-        out_err[0] = R.unwrap_err[mir.MirModule, str](lr);
+    val lr: res[mir.MirModule, fail.Fail] = lower_module(?tgt, ?m, alloc, ?itn, ?smap);
+    if (sel lr.err) {
+        out_err[0] = fail.describe(lr.err);
         ret false;
     }
     ret true;
@@ -1834,22 +1844,23 @@ fun t_lower_diamond_phi(alloc: *A.Allocator, cover_both: bool, out_err: *str) bo
 test "mach.lang.be.codegen.mir.lower.lower_block_phis:missing_incoming" {
     var alloc: A.Allocator;
     page.make(?alloc);
-    var err: str = nil;
+    var error: str = nil;
 
-    if (!t_lower_diamond_phi(?alloc, true, ?err)) { ret 1; }
+    if (!t_lower_diamond_phi(?alloc, true, ?error)) { ret 1; }
 
-    if (t_lower_diamond_phi(?alloc, false, ?err)) { ret 1; }
-    if (err == nil)                                  { ret 1; }
-    if (!str_contains(err, "no incoming value"))     { ret 1; }
-    if (!str_contains(err, "block 3"))               { ret 1; }
-    if (!str_contains(err, "block 2"))               { ret 1; }
-    if (!str_contains(err, "result vreg"))           { ret 1; }
+    if (t_lower_diamond_phi(?alloc, false, ?error)) { ret 1; }
+    if (error == nil)                                  { ret 1; }
+    if (!str_contains(error, "no incoming value"))     { ret 1; }
+    if (!str_contains(error, "block 3"))               { ret 1; }
+    if (!str_contains(error, "block 2"))               { ret 1; }
+    if (!str_contains(error, "result vreg"))           { ret 1; }
     ret 0;
 }
 
 test "mach.lang.be.codegen.mir.lower:volatile_memory_flags_follow_each_ir_instruction" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var types: ir_type.IrTypeTable;
     if (O.is_some[str](ir_type.init(?types, ?alloc))) { ret 1; }
     fin { ir_type.dnit(?types); }
@@ -1885,8 +1896,10 @@ test "mach.lang.be.codegen.mir.lower:volatile_memory_flags_follow_each_ir_instru
     ctx.param_count = 1;
     var mb: mir.MirBlock;
     fin { mir.dnit_block(?alloc, ?mb); }
-    if (R.is_err[R.Void, str](lower_instr(?ctx, ?fn, ?mb, 0))) { ret 2; }
-    if (R.is_err[R.Void, str](lower_instr(?ctx, ?fn, ?mb, 1))) { ret 3; }
+    val lower_instr_r: err[fail.Fail] = lower_instr(?ctx, ?fn, ?mb, 0);
+    if (sel lower_instr_r.err) { ret 2; }
+    val lower_instr_r2: err[fail.Fail] = lower_instr(?ctx, ?fn, ?mb, 1);
+    if (sel lower_instr_r2.err) { ret 3; }
     if (mb.instr_count != 2) { ret 4; }
     if (mb.instrs[0].opcode != mir.MIR_MEMZERO || mb.instrs[1].opcode != mir.MIR_MEMZERO) { ret 5; }
     if (mb.instrs[0].memory_flags != mir.MEMORY_VOLATILE) { ret 6; }

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -1,8 +1,11 @@
 use std.types.canonical.opt;
-use page: mach.lang.legacy.page;
-use arena: mach.lang.legacy.arena;
+use std.types.canonical.res;
+use std.types.canonical.err;
+use mach.lang.fail;
+use page: std.allocator.page;
+use arena: std.allocator.arena;
 use std.collections.sort;
-use format: mach.lang.legacy.format;
+use format: std.format;
 use std.system.panic.panic;
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -12,7 +15,7 @@ use std.types.string.str;
 use std.types.string.str_len;
 use std.types.string.str_contains;
 
-use A: mach.lang.legacy.allocator;
+use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -112,9 +115,9 @@ fun ctx_fn_name(ctx: *AllocCtx) str {
 
 fun regalloc_msg(ctx: *AllocCtx, prefix: str, suffix: str, fallback: str) str {
     val name: str = ctx_fn_name(ctx);
-    val res_msg: R.Result[str, str] = format.sprint(ctx.alloc, "{}{}{}", prefix, name, suffix);
-    if (R.is_err[str, str](res_msg)) { ret fallback; }
-    val buf: str = R.unwrap_ok[str, str](res_msg);
+    val res_msg: res[str, format.FormatError] = format.sprint(ctx.alloc, "{}{}{}", prefix, name, suffix);
+    if (sel res_msg.err) { ret fallback; }
+    val buf: str = res_msg.ok;
     val ir: R.Result[intern.StrId, str] = intern.intern(ctx.interner, buf);
     A.deallocate[u8](ctx.alloc, buf, str_len(buf) + 1);
     if (R.is_err[intern.StrId, str](ir)) { ret fallback; }
@@ -123,58 +126,58 @@ fun regalloc_msg(ctx: *AllocCtx, prefix: str, suffix: str, fallback: str) str {
     ret fallback;
 }
 
-pub fun run(tgt: *target.Target, m: *mir.MirModule) R.Result[R.Void, str] {
-    if (tgt == nil)      { ret R.err[R.Void, str]("regalloc.run: nil target"); }
-    if (m == nil)        { ret R.err[R.Void, str]("regalloc.run: nil mir module"); }
-    if (tgt.abi == nil)  { ret R.err[R.Void, str]("regalloc.run: target has no ABI vtable"); }
-    if (tgt.arch == nil) { ret R.err[R.Void, str]("regalloc.run: target has no ISA vtable"); }
+pub fun run(tgt: *target.Target, m: *mir.MirModule) err[fail.Fail] {
+    if (tgt == nil)      { ret err[fail.Fail].err{fail.message("regalloc.run: nil target")}; }
+    if (m == nil)        { ret err[fail.Fail].err{fail.message("regalloc.run: nil mir module")}; }
+    if (tgt.abi == nil)  { ret err[fail.Fail].err{fail.message("regalloc.run: target has no ABI vtable")}; }
+    if (tgt.arch == nil) { ret err[fail.Fail].err{fail.message("regalloc.run: target has no ISA vtable")}; }
     if (tgt.abi.callee_saved == nil) {
-        ret R.err[R.Void, str]("regalloc.run: ABI vtable exposes no callee-saved register file");
+        ret err[fail.Fail].err{fail.message("regalloc.run: ABI vtable exposes no callee-saved register file")};
     }
 
-    val input: R.Result[R.Void, str] = mir.validate_operands(m);
-    if (R.is_err[R.Void, str](input)) { ret input; }
-    val model: R.Result[R.Void, str] = validate_register_model(tgt, m);
-    if (R.is_err[R.Void, str](model)) { ret model; }
+    val input: err[fail.Fail] = mir.validate_operands(m);
+    if (sel input.err) { ret input; }
+    val model: err[fail.Fail] = validate_register_model(tgt, m);
+    if (sel model.err) { ret model; }
     var fi: u32 = 0;
     for (fi < m.function_len) {
-        val classes: R.Result[R.Void, str] = validate_vreg_classes(tgt, m, ?m.functions[fi]);
-        if (R.is_err[R.Void, str](classes)) { ret classes; }
-        val af: R.Result[R.Void, str] = alloc_function(tgt, m, ?m.functions[fi]);
-        if (R.is_err[R.Void, str](af)) { ret af; }
+        val classes: err[fail.Fail] = validate_vreg_classes(tgt, m, ?m.functions[fi]);
+        if (sel classes.err) { ret classes; }
+        val af: err[fail.Fail] = alloc_function(tgt, m, ?m.functions[fi]);
+        if (sel af.err) { ret af; }
         fi = fi + 1;
     }
     ret mir.validate_operands(m);
 }
 
-fun validate_register_model(tgt: *target.Target, m: *mir.MirModule) R.Result[R.Void, str] {
+fun validate_register_model(tgt: *target.Target, m: *mir.MirModule) err[fail.Fail] {
     if (tgt.model.reg_class_len == 0 || tgt.model.reg_classes == nil) {
-        ret R.err[R.Void, str]("regalloc: target has no register class model");
+        ret err[fail.Fail].err{fail.message("regalloc: target has no register class model")};
     }
     var ci: u32 = 0;
     for (ci < tgt.model.reg_class_len) {
         val kind: isa.RegClassKind = tgt.model.reg_classes[ci].kind;
         if (kind > isa.RC_FLAGS) { ret mir.catalog_failure(m, "RegClassKind", kind::u32); }
         if ((ci == REG_CLASS_GP) != (kind == isa.RC_GENERAL)) {
-            ret R.err[R.Void, str]("regalloc: target general register class does not match the MIR general bank");
+            ret err[fail.Fail].err{fail.message("regalloc: target general register class does not match the MIR general bank")};
         }
         ci = ci + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun validate_vreg_classes(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) R.Result[R.Void, str] {
+fun validate_vreg_classes(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) err[fail.Fail] {
     var vi: u32 = 0;
     for (vi < f.vreg_count) {
         val class: u32 = f.vregs[vi].class;
         if (class >= tgt.model.reg_class_len) { ret mir.catalog_failure(m, "MirRegisterClass", class); }
         val kind: isa.RegClassKind = tgt.model.reg_classes[class].kind;
         if (kind == isa.RC_VECTOR || kind == isa.RC_FLAGS) {
-            ret R.err[R.Void, str]("regalloc: declared target register class is unsupported for MIR virtual registers");
+            ret err[fail.Fail].err{fail.message("regalloc: declared target register class is unsupported for MIR virtual registers")};
         }
         vi = vi + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun fp_class_index(tgt: *target.Target) u32 {
@@ -191,8 +194,8 @@ fun bank_count(tgt: *target.Target, class: u32) u32 {
     ret tgt.model.reg_classes[class].len;
 }
 
-fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) R.Result[R.Void, str] {
-    if (f.block_count == 0) { ret R.ok_void[str](); }
+fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) err[fail.Fail] {
+    if (f.block_count == 0) { ret err[fail.Fail].ok{}; }
     if (f.vreg_count == 0)  {
         f.callee_mask = asm_callee_mask(tgt, f);
         val fp_scratch: u32 = fp_scratch_callee_mask(tgt);
@@ -203,8 +206,8 @@ fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) 
     }
 
     var ctx: AllocCtx;
-    val ic: R.Result[R.Void, str] = ctx_init(?ctx, tgt, m, f);
-    if (R.is_err[R.Void, str](ic)) { ret ic; }
+    val ic: err[fail.Fail] = ctx_init(?ctx, tgt, m, f);
+    if (sel ic.err) { ret ic; }
 
     if (function_has_divide(?ctx)) {
         reserve_reg(?ctx, tgt.arch.div_reg);
@@ -215,63 +218,63 @@ fun alloc_function(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) 
         reserve_reg(?ctx, tgt.arch.shift_count_reg);
     }
 
-    val vs: R.Result[R.Void, str] = build_vreg_slot_flags(?ctx);
-    if (R.is_err[R.Void, str](vs)) { ctx_dnit(?ctx); ret vs; }
+    val vs: err[fail.Fail] = build_vreg_slot_flags(?ctx);
+    if (sel vs.err) { ctx_dnit(?ctx); ret vs; }
 
-    val ds: R.Result[R.Void, str] = sweep_dead_movs(tgt, ?ctx);
-    if (R.is_err[R.Void, str](ds)) { ctx_dnit(?ctx); ret ds; }
+    val ds: err[fail.Fail] = sweep_dead_movs(tgt, ?ctx);
+    if (sel ds.err) { ctx_dnit(?ctx); ret ds; }
 
-    val cc: R.Result[R.Void, str] = coalesce_copies(tgt, ?ctx);
-    if (R.is_err[R.Void, str](cc)) { ctx_dnit(?ctx); ret cc; }
+    val cc: err[fail.Fail] = coalesce_copies(tgt, ?ctx);
+    if (sel cc.err) { ctx_dnit(?ctx); ret cc; }
 
-    val bo: R.Result[R.Void, str] = build_order(?ctx);
-    if (R.is_err[R.Void, str](bo)) { ctx_dnit(?ctx); ret bo; }
+    val bo: err[fail.Fail] = build_order(?ctx);
+    if (sel bo.err) { ctx_dnit(?ctx); ret bo; }
 
-    val ao: R.Result[R.Void, str] = apply_order(?ctx);
-    if (R.is_err[R.Void, str](ao)) { ctx_dnit(?ctx); ret ao; }
+    val ao: err[fail.Fail] = apply_order(?ctx);
+    if (sel ao.err) { ctx_dnit(?ctx); ret ao; }
 
-    val fl: R.Result[R.Void, str] = flatten(?ctx);
-    if (R.is_err[R.Void, str](fl)) { ctx_dnit(?ctx); ret fl; }
+    val fl: err[fail.Fail] = flatten(?ctx);
+    if (sel fl.err) { ctx_dnit(?ctx); ret fl; }
 
-    val bs: R.Result[R.Void, str] = build_block_spans(?ctx);
-    if (R.is_err[R.Void, str](bs)) { ctx_dnit(?ctx); ret bs; }
+    val bs: err[fail.Fail] = build_block_spans(?ctx);
+    if (sel bs.err) { ctx_dnit(?ctx); ret bs; }
 
     build_ranges(?ctx);
 
-    val lv: R.Result[R.Void, str] = extend_liveness(?ctx);
-    if (R.is_err[R.Void, str](lv)) { ctx_dnit(?ctx); ret lv; }
+    val lv: err[fail.Fail] = extend_liveness(?ctx);
+    if (sel lv.err) { ctx_dnit(?ctx); ret lv; }
 
-    val mc: R.Result[R.Void, str] = mark_call_crossing(?ctx);
-    if (R.is_err[R.Void, str](mc)) { ctx_dnit(?ctx); ret mc; }
+    val mc: err[fail.Fail] = mark_call_crossing(?ctx);
+    if (sel mc.err) { ctx_dnit(?ctx); ret mc; }
 
     build_hints(tgt, ?ctx);
 
-    val sc: R.Result[R.Void, str] = linear_scan(tgt, ?ctx);
-    if (R.is_err[R.Void, str](sc)) { ctx_dnit(?ctx); ret sc; }
+    val sc: err[fail.Fail] = linear_scan(tgt, ?ctx);
+    if (sel sc.err) { ctx_dnit(?ctx); ret sc; }
 
-    val sp: R.Result[R.Void, str] = spill_across_calls(tgt, ?ctx);
-    if (R.is_err[R.Void, str](sp)) { ctx_dnit(?ctx); ret sp; }
+    val sp: err[fail.Fail] = spill_across_calls(tgt, ?ctx);
+    if (sel sp.err) { ctx_dnit(?ctx); ret sp; }
 
-    val rw: R.Result[R.Void, str] = rewrite(tgt, ?ctx);
-    if (R.is_err[R.Void, str](rw)) { ctx_dnit(?ctx); ret rw; }
+    val rw: err[fail.Fail] = rewrite(tgt, ?ctx);
+    if (sel rw.err) { ctx_dnit(?ctx); ret rw; }
 
-    val vf: R.Result[R.Void, str] = verify_allocation(tgt, ?ctx);
-    if (R.is_err[R.Void, str](vf)) { ctx_dnit(?ctx); ret vf; }
+    val vf: err[fail.Fail] = verify_allocation(tgt, ?ctx);
+    if (sel vf.err) { ctx_dnit(?ctx); ret vf; }
 
-    val vo: R.Result[R.Void, str] = verify_rewritten_operands(tgt, ctx.f);
-    if (R.is_err[R.Void, str](vo)) { ctx_dnit(?ctx); ret vo; }
+    val vo: err[fail.Fail] = verify_rewritten_operands(tgt, ctx.f);
+    if (sel vo.err) { ctx_dnit(?ctx); ret vo; }
 
     drop_self_copies_physical(tgt, ?ctx);
     record_callee_mask(tgt, ?ctx);
 
-    val ro: R.Result[R.Void, str] = restore_order(?ctx);
-    if (R.is_err[R.Void, str](ro)) { ctx_dnit(?ctx); ret ro; }
+    val ro: err[fail.Fail] = restore_order(?ctx);
+    if (sel ro.err) { ctx_dnit(?ctx); ret ro; }
 
     ctx_dnit(?ctx);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) R.Result[R.Void, str] {
+fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) err[fail.Fail] {
     ctx.alloc        = m.alloc;
     ctx.interner     = m.interner;
     ctx.f            = f;
@@ -310,13 +313,13 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
     ctx.hints                = nil;
     ctx.anchor_until         = nil;
 
-    val ro: R.Result[*u32, str] = A.allocate[u32](m.alloc, f.block_count::usize);
-    if (R.is_err[*u32, str](ro)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](ro)); }
-    ctx.order = R.unwrap_ok[*u32, str](ro);
+    val ro: res[*u32, A.Error] = A.allocate[u32](m.alloc, f.block_count::usize);
+    if (sel ro.err) { ret err[fail.Fail].err{fail.refused(ro.err)}; }
+    ctx.order = ro.ok;
 
-    val rr: R.Result[*LiveRange, str] = A.allocate[LiveRange](m.alloc, f.vreg_count::usize);
-    if (R.is_err[*LiveRange, str](rr)) { ctx_dnit(ctx); ret R.err[R.Void, str](R.unwrap_err[*LiveRange, str](rr)); }
-    ctx.ranges = R.unwrap_ok[*LiveRange, str](rr);
+    val rr: res[*LiveRange, A.Error] = A.allocate[LiveRange](m.alloc, f.vreg_count::usize);
+    if (sel rr.err) { ctx_dnit(ctx); ret err[fail.Fail].err{fail.refused(rr.err)}; }
+    ctx.ranges = rr.ok;
 
     var vi: u32 = 0;
     for (vi < f.vreg_count) {
@@ -330,21 +333,21 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
     }
 
     if (ctx.gp_count > 0) {
-        val rcs: R.Result[*bool, str] = A.allocate[bool](m.alloc, ctx.gp_count::usize);
-        if (R.is_err[*bool, str](rcs)) { ctx_dnit(ctx); ret R.err[R.Void, str](R.unwrap_err[*bool, str](rcs)); }
-        ctx.callee_saved = R.unwrap_ok[*bool, str](rcs);
-        val rrv: R.Result[*bool, str] = A.allocate[bool](m.alloc, ctx.gp_count::usize);
-        if (R.is_err[*bool, str](rrv)) { ctx_dnit(ctx); ret R.err[R.Void, str](R.unwrap_err[*bool, str](rrv)); }
-        ctx.reserved = R.unwrap_ok[*bool, str](rrv);
-        val rgb: R.Result[*bool, str] = A.allocate[bool](m.alloc, ctx.gp_count::usize);
-        if (R.is_err[*bool, str](rgb)) { ctx_dnit(ctx); ret R.err[R.Void, str](R.unwrap_err[*bool, str](rgb)); }
-        ctx.gp_busy = R.unwrap_ok[*bool, str](rgb);
-        val rpe: R.Result[*i64, str] = A.allocate[i64](m.alloc, ctx.gp_count::usize);
-        if (R.is_err[*i64, str](rpe)) { ctx_dnit(ctx); ret R.err[R.Void, str](R.unwrap_err[*i64, str](rpe)); }
-        ctx.pinned_end = R.unwrap_ok[*i64, str](rpe);
-        val rpr: R.Result[*i64, str] = A.allocate[i64](m.alloc, ctx.gp_count::usize);
-        if (R.is_err[*i64, str](rpr)) { ctx_dnit(ctx); ret R.err[R.Void, str](R.unwrap_err[*i64, str](rpr)); }
-        ctx.param_reg_end = R.unwrap_ok[*i64, str](rpr);
+        val rcs: res[*bool, A.Error] = A.allocate[bool](m.alloc, ctx.gp_count::usize);
+        if (sel rcs.err) { ctx_dnit(ctx); ret err[fail.Fail].err{fail.refused(rcs.err)}; }
+        ctx.callee_saved = rcs.ok;
+        val rrv: res[*bool, A.Error] = A.allocate[bool](m.alloc, ctx.gp_count::usize);
+        if (sel rrv.err) { ctx_dnit(ctx); ret err[fail.Fail].err{fail.refused(rrv.err)}; }
+        ctx.reserved = rrv.ok;
+        val rgb: res[*bool, A.Error] = A.allocate[bool](m.alloc, ctx.gp_count::usize);
+        if (sel rgb.err) { ctx_dnit(ctx); ret err[fail.Fail].err{fail.refused(rgb.err)}; }
+        ctx.gp_busy = rgb.ok;
+        val rpe: res[*i64, A.Error] = A.allocate[i64](m.alloc, ctx.gp_count::usize);
+        if (sel rpe.err) { ctx_dnit(ctx); ret err[fail.Fail].err{fail.refused(rpe.err)}; }
+        ctx.pinned_end = rpe.ok;
+        val rpr: res[*i64, A.Error] = A.allocate[i64](m.alloc, ctx.gp_count::usize);
+        if (sel rpr.err) { ctx_dnit(ctx); ret err[fail.Fail].err{fail.refused(rpr.err)}; }
+        ctx.param_reg_end = rpr.ok;
 
         var gi: u32 = 0;
         for (gi < ctx.gp_count) {
@@ -360,15 +363,15 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
     }
 
     if (ctx.fp_count > 0) {
-        val rfb: R.Result[*bool, str] = A.allocate[bool](m.alloc, ctx.fp_count::usize);
-        if (R.is_err[*bool, str](rfb)) { ctx_dnit(ctx); ret R.err[R.Void, str](R.unwrap_err[*bool, str](rfb)); }
-        ctx.fp_busy = R.unwrap_ok[*bool, str](rfb);
-        val rfp: R.Result[*i64, str] = A.allocate[i64](m.alloc, ctx.fp_count::usize);
-        if (R.is_err[*i64, str](rfp)) { ctx_dnit(ctx); ret R.err[R.Void, str](R.unwrap_err[*i64, str](rfp)); }
-        ctx.fp_pinned_end = R.unwrap_ok[*i64, str](rfp);
-        val rfc: R.Result[*bool, str] = A.allocate[bool](m.alloc, ctx.fp_count::usize);
-        if (R.is_err[*bool, str](rfc)) { ctx_dnit(ctx); ret R.err[R.Void, str](R.unwrap_err[*bool, str](rfc)); }
-        ctx.fp_callee_saved = R.unwrap_ok[*bool, str](rfc);
+        val rfb: res[*bool, A.Error] = A.allocate[bool](m.alloc, ctx.fp_count::usize);
+        if (sel rfb.err) { ctx_dnit(ctx); ret err[fail.Fail].err{fail.refused(rfb.err)}; }
+        ctx.fp_busy = rfb.ok;
+        val rfp: res[*i64, A.Error] = A.allocate[i64](m.alloc, ctx.fp_count::usize);
+        if (sel rfp.err) { ctx_dnit(ctx); ret err[fail.Fail].err{fail.refused(rfp.err)}; }
+        ctx.fp_pinned_end = rfp.ok;
+        val rfc: res[*bool, A.Error] = A.allocate[bool](m.alloc, ctx.fp_count::usize);
+        if (sel rfc.err) { ctx_dnit(ctx); ret err[fail.Fail].err{fail.refused(rfc.err)}; }
+        ctx.fp_callee_saved = rfc.ok;
         var fii: u32 = 0;
         for (fii < ctx.fp_count) {
             ctx.fp_busy[fii] = false;
@@ -380,13 +383,13 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
 
     seed_callee_saved(tgt, ctx);
 
-    val ra: R.Result[*u32, str] = A.allocate[u32](m.alloc, f.vreg_count::usize);
-    if (R.is_err[*u32, str](ra)) { ctx_dnit(ctx); ret R.err[R.Void, str](R.unwrap_err[*u32, str](ra)); }
-    ctx.active = R.unwrap_ok[*u32, str](ra);
+    val ra: res[*u32, A.Error] = A.allocate[u32](m.alloc, f.vreg_count::usize);
+    if (sel ra.err) { ctx_dnit(ctx); ret err[fail.Fail].err{fail.refused(ra.err)}; }
+    ctx.active = ra.ok;
 
-    val rh: R.Result[*CopyHint, str] = A.allocate[CopyHint](m.alloc, f.vreg_count::usize);
-    if (R.is_err[*CopyHint, str](rh)) { ctx_dnit(ctx); ret R.err[R.Void, str](R.unwrap_err[*CopyHint, str](rh)); }
-    ctx.hints = R.unwrap_ok[*CopyHint, str](rh);
+    val rh: res[*CopyHint, A.Error] = A.allocate[CopyHint](m.alloc, f.vreg_count::usize);
+    if (sel rh.err) { ctx_dnit(ctx); ret err[fail.Fail].err{fail.refused(rh.err)}; }
+    ctx.hints = rh.ok;
     var hi: u32 = 0;
     for (hi < f.vreg_count) {
         ctx.hints[hi].src_vreg     = mir.MIR_VREG_NIL;
@@ -398,13 +401,13 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
         hi = hi + 1;
     }
 
-    val rau: R.Result[*i64, str] = A.allocate[i64](m.alloc, f.vreg_count::usize);
-    if (R.is_err[*i64, str](rau)) { ctx_dnit(ctx); ret R.err[R.Void, str](R.unwrap_err[*i64, str](rau)); }
-    ctx.anchor_until = R.unwrap_ok[*i64, str](rau);
+    val rau: res[*i64, A.Error] = A.allocate[i64](m.alloc, f.vreg_count::usize);
+    if (sel rau.err) { ctx_dnit(ctx); ret err[fail.Fail].err{fail.refused(rau.err)}; }
+    ctx.anchor_until = rau.ok;
     var ai: u32 = 0;
     for (ai < f.vreg_count) { ctx.anchor_until[ai] = -1; ai = ai + 1; }
 
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun ctx_dnit(ctx: *AllocCtx) {
@@ -586,38 +589,38 @@ fun function_has_reg_shift(ctx: *AllocCtx) bool {
     ret false;
 }
 
-fun build_order(ctx: *AllocCtx) R.Result[R.Void, str] {
+fun build_order(ctx: *AllocCtx) err[fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     val n: u32 = f.block_count;
 
-    val bx: R.Result[R.Void, str] = fill_block_id_index(ctx);
-    if (R.is_err[R.Void, str](bx)) { ret bx; }
+    val bx: err[fail.Fail] = fill_block_id_index(ctx);
+    if (sel bx.err) { ret bx; }
 
-    val rv: R.Result[*bool, str] = A.allocate[bool](ctx.alloc, n::usize);
-    if (R.is_err[*bool, str](rv)) { ret R.err[R.Void, str](R.unwrap_err[*bool, str](rv)); }
-    val visited: *bool = R.unwrap_ok[*bool, str](rv);
+    val rv: res[*bool, A.Error] = A.allocate[bool](ctx.alloc, n::usize);
+    if (sel rv.err) { ret err[fail.Fail].err{fail.refused(rv.err)}; }
+    val visited: *bool = rv.ok;
     var i: u32 = 0;
     for (i < n) { visited[i] = false; i = i + 1; }
 
-    val rs: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, n::usize);
-    if (R.is_err[*u32, str](rs)) { A.deallocate[bool](ctx.alloc, visited, n::usize); ret R.err[R.Void, str](R.unwrap_err[*u32, str](rs)); }
-    val stack: *u32 = R.unwrap_ok[*u32, str](rs);
-    val re: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, n::usize);
-    if (R.is_err[*u32, str](re)) {
+    val rs: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, n::usize);
+    if (sel rs.err) { A.deallocate[bool](ctx.alloc, visited, n::usize); ret err[fail.Fail].err{fail.refused(rs.err)}; }
+    val stack: *u32 = rs.ok;
+    val re: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, n::usize);
+    if (sel re.err) {
         A.deallocate[bool](ctx.alloc, visited, n::usize);
         A.deallocate[u32](ctx.alloc, stack, n::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](re));
+        ret err[fail.Fail].err{fail.refused(re.err)};
     }
-    val succ_ix: *u32 = R.unwrap_ok[*u32, str](re);
+    val succ_ix: *u32 = re.ok;
 
-    val rp: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, n::usize);
-    if (R.is_err[*u32, str](rp)) {
+    val rp: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, n::usize);
+    if (sel rp.err) {
         A.deallocate[bool](ctx.alloc, visited, n::usize);
         A.deallocate[u32](ctx.alloc, stack, n::usize);
         A.deallocate[u32](ctx.alloc, succ_ix, n::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](rp));
+        ret err[fail.Fail].err{fail.refused(rp.err)};
     }
-    val post: *u32 = R.unwrap_ok[*u32, str](rp);
+    val post: *u32 = rp.ok;
     var post_count: u32 = 0;
 
     var sp: u32 = 0;
@@ -662,7 +665,7 @@ fun build_order(ctx: *AllocCtx) R.Result[R.Void, str] {
     A.deallocate[u32](ctx.alloc, stack, n::usize);
     A.deallocate[u32](ctx.alloc, succ_ix, n::usize);
     A.deallocate[u32](ctx.alloc, post, n::usize);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun next_unvisited_succ(ctx: *AllocCtx, b: u32, six: *u32, visited: *bool) u32 {
@@ -684,10 +687,10 @@ fun next_unvisited_succ(ctx: *AllocCtx, b: u32, six: *u32, visited: *bool) u32 {
     ret RANGE_NIL;
 }
 
-fun fill_block_id_index(ctx: *AllocCtx) R.Result[R.Void, str] {
+fun fill_block_id_index(ctx: *AllocCtx) err[fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     val n: u32 = f.block_count;
-    if (n == 0) { ret R.ok_void[str](); }
+    if (n == 0) { ret err[fail.Fail].ok{}; }
 
     if (ctx.block_id_index == nil) {
         var max_id: u32 = 0;
@@ -697,9 +700,9 @@ fun fill_block_id_index(ctx: *AllocCtx) R.Result[R.Void, str] {
             i = i + 1;
         }
         val cap: u32 = max_id + 1;
-        val r: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, cap::usize);
-        if (R.is_err[*u32, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](r)); }
-        ctx.block_id_index     = R.unwrap_ok[*u32, str](r);
+        val r: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, cap::usize);
+        if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+        ctx.block_id_index     = r.ok;
         ctx.block_id_index_cap = cap;
     }
 
@@ -707,7 +710,7 @@ fun fill_block_id_index(ctx: *AllocCtx) R.Result[R.Void, str] {
     for (j < ctx.block_id_index_cap) { ctx.block_id_index[j] = RANGE_NIL; j = j + 1; }
     var k: u32 = 0;
     for (k < n) { ctx.block_id_index[f.blocks[k].id] = k; k = k + 1; }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun block_index_of(ctx: *AllocCtx, bid: u32) u32 {
@@ -715,14 +718,14 @@ fun block_index_of(ctx: *AllocCtx, bid: u32) u32 {
     ret ctx.block_id_index[bid];
 }
 
-fun apply_order(ctx: *AllocCtx) R.Result[R.Void, str] {
+fun apply_order(ctx: *AllocCtx) err[fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     val n: u32 = f.block_count;
-    if (n <= 1) { ret R.ok_void[str](); }
+    if (n <= 1) { ret err[fail.Fail].ok{}; }
 
-    val rt: R.Result[*mir.MirBlock, str] = A.allocate[mir.MirBlock](ctx.alloc, n::usize);
-    if (R.is_err[*mir.MirBlock, str](rt)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirBlock, str](rt)); }
-    val tmp: *mir.MirBlock = R.unwrap_ok[*mir.MirBlock, str](rt);
+    val rt: res[*mir.MirBlock, A.Error] = A.allocate[mir.MirBlock](ctx.alloc, n::usize);
+    if (sel rt.err) { ret err[fail.Fail].err{fail.refused(rt.err)}; }
+    val tmp: *mir.MirBlock = rt.ok;
 
     var i: u32 = 0;
     for (i < n) {
@@ -739,14 +742,14 @@ fun apply_order(ctx: *AllocCtx) R.Result[R.Void, str] {
     ret fill_block_id_index(ctx);
 }
 
-fun restore_order(ctx: *AllocCtx) R.Result[R.Void, str] {
+fun restore_order(ctx: *AllocCtx) err[fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     val n: u32 = f.block_count;
-    if (n <= 1) { ret R.ok_void[str](); }
+    if (n <= 1) { ret err[fail.Fail].ok{}; }
 
-    val rt: R.Result[*mir.MirBlock, str] = A.allocate[mir.MirBlock](ctx.alloc, n::usize);
-    if (R.is_err[*mir.MirBlock, str](rt)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirBlock, str](rt)); }
-    val tmp: *mir.MirBlock = R.unwrap_ok[*mir.MirBlock, str](rt);
+    val rt: res[*mir.MirBlock, A.Error] = A.allocate[mir.MirBlock](ctx.alloc, n::usize);
+    if (sel rt.err) { ret err[fail.Fail].err{fail.refused(rt.err)}; }
+    val tmp: *mir.MirBlock = rt.ok;
 
     var i: u32 = 0;
     for (i < n) {
@@ -760,10 +763,10 @@ fun restore_order(ctx: *AllocCtx) R.Result[R.Void, str] {
     }
     A.deallocate[mir.MirBlock](ctx.alloc, tmp, n::usize);
 
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun flatten(ctx: *AllocCtx) R.Result[R.Void, str] {
+fun flatten(ctx: *AllocCtx) err[fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     var total: u32 = 0;
     var bi: u32 = 0;
@@ -772,15 +775,15 @@ fun flatten(ctx: *AllocCtx) R.Result[R.Void, str] {
         bi = bi + 1;
     }
     ctx.flat_count = total;
-    if (total == 0) { ctx.flat = nil; ret R.ok_void[str](); }
+    if (total == 0) { ctx.flat = nil; ret err[fail.Fail].ok{}; }
 
-    val rf: R.Result[*FlatInstr, str] = A.allocate[FlatInstr](ctx.alloc, total::usize);
-    if (R.is_err[*FlatInstr, str](rf)) {
+    val rf: res[*FlatInstr, A.Error] = A.allocate[FlatInstr](ctx.alloc, total::usize);
+    if (sel rf.err) {
         ctx.flat = nil;
         ctx.flat_count = 0;
-        ret R.err[R.Void, str](R.unwrap_err[*FlatInstr, str](rf));
+        ret err[fail.Fail].err{fail.refused(rf.err)};
     }
-    ctx.flat = R.unwrap_ok[*FlatInstr, str](rf);
+    ctx.flat = rf.ok;
 
     var p: u32 = 0;
     bi = 0;
@@ -797,7 +800,7 @@ fun flatten(ctx: *AllocCtx) R.Result[R.Void, str] {
         }
         bi = bi + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun flat_instr(ctx: *AllocCtx, pos: u32) *mir.MirInstr {
@@ -891,15 +894,15 @@ fun is_dead_mov(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr, reads: *
     ret reads[d.vreg] == 0;
 }
 
-fun sweep_dead_movs(tgt: *target.Target, ctx: *AllocCtx) R.Result[R.Void, str] {
+fun sweep_dead_movs(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     val nv: u32 = f.vreg_count;
-    if (nv == 0)                     { ret R.ok_void[str](); }
-    if (tgt.arch.is_reg_move == nil) { ret R.ok_void[str](); }
+    if (nv == 0)                     { ret err[fail.Fail].ok{}; }
+    if (tgt.arch.is_reg_move == nil) { ret err[fail.Fail].ok{}; }
 
-    val rr: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, nv::usize);
-    if (R.is_err[*u32, str](rr)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](rr)); }
-    val reads: *u32 = R.unwrap_ok[*u32, str](rr);
+    val rr: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, nv::usize);
+    if (sel rr.err) { ret err[fail.Fail].err{fail.refused(rr.err)}; }
+    val reads: *u32 = rr.ok;
 
     var changed: bool = true;
     for (changed) {
@@ -935,7 +938,7 @@ fun sweep_dead_movs(tgt: *target.Target, ctx: *AllocCtx) R.Result[R.Void, str] {
     }
 
     A.deallocate[u32](ctx.alloc, reads, nv::usize);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun instr_reads_vreg(mi: *mir.MirInstr, v: u32) bool {
@@ -1088,21 +1091,21 @@ fun drop_self_copies(tgt: *target.Target, ctx: *AllocCtx) {
     }
 }
 
-fun coalesce_copies(tgt: *target.Target, ctx: *AllocCtx) R.Result[R.Void, str] {
+fun coalesce_copies(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     val nv: u32 = f.vreg_count;
-    if (nv == 0)                     { ret R.ok_void[str](); }
-    if (tgt.arch.is_reg_move == nil) { ret R.ok_void[str](); }
+    if (nv == 0)                     { ret err[fail.Fail].ok{}; }
+    if (tgt.arch.is_reg_move == nil) { ret err[fail.Fail].ok{}; }
 
-    val rp: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, nv::usize);
-    if (R.is_err[*u32, str](rp)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](rp)); }
-    val parent: *u32 = R.unwrap_ok[*u32, str](rp);
-    val rw: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, nv::usize);
-    if (R.is_err[*u32, str](rw)) {
+    val rp: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, nv::usize);
+    if (sel rp.err) { ret err[fail.Fail].err{fail.refused(rp.err)}; }
+    val parent: *u32 = rp.ok;
+    val rw: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, nv::usize);
+    if (sel rw.err) {
         A.deallocate[u32](ctx.alloc, parent, nv::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](rw));
+        ret err[fail.Fail].err{fail.refused(rw.err)};
     }
-    val web_defs: *u32 = R.unwrap_ok[*u32, str](rw);
+    val web_defs: *u32 = rw.ok;
 
     var i: u32 = 0;
     for (i < nv) { parent[i] = i; web_defs[i] = 0; i = i + 1; }
@@ -1127,7 +1130,7 @@ fun coalesce_copies(tgt: *target.Target, ctx: *AllocCtx) R.Result[R.Void, str] {
 
     A.deallocate[u32](ctx.alloc, web_defs, nv::usize);
     A.deallocate[u32](ctx.alloc, parent, nv::usize);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun reads_in_window(ctx: *AllocCtx, d: u32, from: i64, to: i64) bool {
@@ -1222,34 +1225,34 @@ fun maybe_reverse_hint(ctx: *AllocCtx, mi: *mir.MirInstr, pos: u32, nv: u32) {
     ctx.hints[sv].dst_copy_pos = p;
 }
 
-fun extend_liveness(ctx: *AllocCtx) R.Result[R.Void, str] {
+fun extend_liveness(ctx: *AllocCtx) err[fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     val nb: u32 = f.block_count;
     val nv: u32 = f.vreg_count;
-    if (nb == 0 || nv == 0) { ret R.ok_void[str](); }
+    if (nb == 0 || nv == 0) { ret err[fail.Fail].ok{}; }
 
     val total: usize = (nb::usize) * (nv::usize);
-    val use_set: R.Result[*bool, str] = A.allocate[bool](ctx.alloc, total);
-    if (R.is_err[*bool, str](use_set)) { ret R.err[R.Void, str](R.unwrap_err[*bool, str](use_set)); }
-    val uses: *bool = R.unwrap_ok[*bool, str](use_set);
-    val def_set: R.Result[*bool, str] = A.allocate[bool](ctx.alloc, total);
-    if (R.is_err[*bool, str](def_set)) { A.deallocate[bool](ctx.alloc, uses, total); ret R.err[R.Void, str](R.unwrap_err[*bool, str](def_set)); }
-    val defs: *bool = R.unwrap_ok[*bool, str](def_set);
-    val in_set: R.Result[*bool, str] = A.allocate[bool](ctx.alloc, total);
-    if (R.is_err[*bool, str](in_set)) {
+    val use_set: res[*bool, A.Error] = A.allocate[bool](ctx.alloc, total);
+    if (sel use_set.err) { ret err[fail.Fail].err{fail.refused(use_set.err)}; }
+    val uses: *bool = use_set.ok;
+    val def_set: res[*bool, A.Error] = A.allocate[bool](ctx.alloc, total);
+    if (sel def_set.err) { A.deallocate[bool](ctx.alloc, uses, total); ret err[fail.Fail].err{fail.refused(def_set.err)}; }
+    val defs: *bool = def_set.ok;
+    val in_set: res[*bool, A.Error] = A.allocate[bool](ctx.alloc, total);
+    if (sel in_set.err) {
         A.deallocate[bool](ctx.alloc, uses, total);
         A.deallocate[bool](ctx.alloc, defs, total);
-        ret R.err[R.Void, str](R.unwrap_err[*bool, str](in_set));
+        ret err[fail.Fail].err{fail.refused(in_set.err)};
     }
-    val live_in: *bool = R.unwrap_ok[*bool, str](in_set);
-    val out_set: R.Result[*bool, str] = A.allocate[bool](ctx.alloc, total);
-    if (R.is_err[*bool, str](out_set)) {
+    val live_in: *bool = in_set.ok;
+    val out_set: res[*bool, A.Error] = A.allocate[bool](ctx.alloc, total);
+    if (sel out_set.err) {
         A.deallocate[bool](ctx.alloc, uses, total);
         A.deallocate[bool](ctx.alloc, defs, total);
         A.deallocate[bool](ctx.alloc, live_in, total);
-        ret R.err[R.Void, str](R.unwrap_err[*bool, str](out_set));
+        ret err[fail.Fail].err{fail.refused(out_set.err)};
     }
-    val live_out: *bool = R.unwrap_ok[*bool, str](out_set);
+    val live_out: *bool = out_set.ok;
 
     var z: usize = 0;
     for (z < total) {
@@ -1306,7 +1309,7 @@ fun extend_liveness(ctx: *AllocCtx) R.Result[R.Void, str] {
     A.deallocate[bool](ctx.alloc, defs, total);
     A.deallocate[bool](ctx.alloc, live_in, total);
     A.deallocate[bool](ctx.alloc, live_out, total);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun extend_range_for_block(lr: *LiveRange, span: BlockSpan, live_in: bool, live_out: bool) {
@@ -1314,14 +1317,14 @@ fun extend_range_for_block(lr: *LiveRange, span: BlockSpan, live_in: bool, live_
     if (live_out && span.end > lr.end_pos)                   { lr.end_pos = span.end; }
 }
 
-fun build_block_spans(ctx: *AllocCtx) R.Result[R.Void, str] {
+fun build_block_spans(ctx: *AllocCtx) err[fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     val n: u32 = f.block_count;
-    if (n == 0) { ret R.ok_void[str](); }
+    if (n == 0) { ret err[fail.Fail].ok{}; }
 
-    val r: R.Result[*BlockSpan, str] = A.allocate[BlockSpan](ctx.alloc, n::usize);
-    if (R.is_err[*BlockSpan, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*BlockSpan, str](r)); }
-    ctx.block_spans = R.unwrap_ok[*BlockSpan, str](r);
+    val r: res[*BlockSpan, A.Error] = A.allocate[BlockSpan](ctx.alloc, n::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    ctx.block_spans = r.ok;
 
     var i: u32 = 0;
     for (i < n) { ctx.block_spans[i].start = -1; ctx.block_spans[i].end = -1; i = i + 1; }
@@ -1332,7 +1335,7 @@ fun build_block_spans(ctx: *AllocCtx) R.Result[R.Void, str] {
         ctx.block_spans[b].end = pos::i64;
         pos = pos + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun compute_use_def(ctx: *AllocCtx, uses: *bool, defs: *bool, nv: u32) {
@@ -1422,13 +1425,13 @@ fun or_row(dst: *bool, dbase: usize, src: *bool, sbase: usize, nv: u32) {
     }
 }
 
-fun mark_call_crossing(ctx: *AllocCtx) R.Result[R.Void, str] {
+fun mark_call_crossing(ctx: *AllocCtx) err[fail.Fail] {
     val n: u32 = ctx.flat_count;
-    if (n == 0) { ret R.ok_void[str](); }
+    if (n == 0) { ret err[fail.Fail].ok{}; }
 
-    val r: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, (n + 1)::usize);
-    if (R.is_err[*u32, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](r)); }
-    val prefix: *u32 = R.unwrap_ok[*u32, str](r);
+    val r: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, (n + 1)::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    val prefix: *u32 = r.ok;
     prefix[0] = 0;
     var p: u32 = 0;
     for (p < n) {
@@ -1450,22 +1453,22 @@ fun mark_call_crossing(ctx: *AllocCtx) R.Result[R.Void, str] {
     }
 
     A.deallocate[u32](ctx.alloc, prefix, (n + 1)::usize);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun linear_scan(tgt: *target.Target, ctx: *AllocCtx) R.Result[R.Void, str] {
+fun linear_scan(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
     reserve_param_registers(ctx);
-    val br: R.Result[R.Void, str] = build_arg_reservations(ctx);
-    if (R.is_err[R.Void, str](br)) { ret br; }
+    val br: err[fail.Fail] = build_arg_reservations(ctx);
+    if (sel br.err) { ret br; }
 
     val nv: u32 = ctx.f.vreg_count;
-    val ro: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, nv::usize);
-    if (R.is_err[*u32, str](ro)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](ro)); }
-    val order: *u32 = R.unwrap_ok[*u32, str](ro);
+    val ro: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, nv::usize);
+    if (sel ro.err) { ret err[fail.Fail].err{fail.refused(ro.err)}; }
+    val order: *u32 = ro.ok;
     var i: u32 = 0;
     for (i < nv) { order[i] = i; i = i + 1; }
-    val sb: R.Result[R.Void, str] = sort_by_start(ctx, order, nv);
-    if (R.is_err[R.Void, str](sb)) {
+    val sb: err[fail.Fail] = sort_by_start(ctx, order, nv);
+    if (sel sb.err) {
         A.deallocate[u32](ctx.alloc, order, nv::usize);
         ret sb;
     }
@@ -1513,14 +1516,14 @@ fun linear_scan(tgt: *target.Target, ctx: *AllocCtx) R.Result[R.Void, str] {
         if (preg >= 0) {
             assign(ctx, v, preg::u32, lr.reg_class);
         } or {
-            val sr: R.Result[R.Void, str] = spill_on_pressure(ctx, v);
-            if (R.is_err[R.Void, str](sr)) { A.deallocate[u32](ctx.alloc, order, nv::usize); ret sr; }
+            val sr: err[fail.Fail] = spill_on_pressure(ctx, v);
+            if (sel sr.err) { A.deallocate[u32](ctx.alloc, order, nv::usize); ret sr; }
         }
         oi = oi + 1;
     }
 
     A.deallocate[u32](ctx.alloc, order, nv::usize);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun reserve_param_registers(ctx: *AllocCtx) {
@@ -1554,26 +1557,26 @@ fun reserve_param_registers(ctx: *AllocCtx) {
     }
 }
 
-fun build_arg_reservations(ctx: *AllocCtx) R.Result[R.Void, str] {
+fun build_arg_reservations(ctx: *AllocCtx) err[fail.Fail] {
     ctx.arg_res_count = 0;
     ctx.def_res_count = 0;
-    if (ctx.flat_count == 0) { ret R.ok_void[str](); }
+    if (ctx.flat_count == 0) { ret err[fail.Fail].ok{}; }
 
-    val rr: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, ctx.flat_count::usize);
-    if (R.is_err[*u32, str](rr)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](rr)); }
-    ctx.arg_res_reg = R.unwrap_ok[*u32, str](rr);
-    val rs: R.Result[*i64, str] = A.allocate[i64](ctx.alloc, ctx.flat_count::usize);
-    if (R.is_err[*i64, str](rs)) { ret R.err[R.Void, str](R.unwrap_err[*i64, str](rs)); }
-    ctx.arg_res_start = R.unwrap_ok[*i64, str](rs);
-    val re: R.Result[*i64, str] = A.allocate[i64](ctx.alloc, ctx.flat_count::usize);
-    if (R.is_err[*i64, str](re)) { ret R.err[R.Void, str](R.unwrap_err[*i64, str](re)); }
-    ctx.arg_res_end = R.unwrap_ok[*i64, str](re);
-    val dr: R.Result[*u32, str] = A.allocate[u32](ctx.alloc, ctx.flat_count::usize);
-    if (R.is_err[*u32, str](dr)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](dr)); }
-    ctx.def_res_reg = R.unwrap_ok[*u32, str](dr);
-    val dp: R.Result[*i64, str] = A.allocate[i64](ctx.alloc, ctx.flat_count::usize);
-    if (R.is_err[*i64, str](dp)) { ret R.err[R.Void, str](R.unwrap_err[*i64, str](dp)); }
-    ctx.def_res_pos = R.unwrap_ok[*i64, str](dp);
+    val rr: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, ctx.flat_count::usize);
+    if (sel rr.err) { ret err[fail.Fail].err{fail.refused(rr.err)}; }
+    ctx.arg_res_reg = rr.ok;
+    val rs: res[*i64, A.Error] = A.allocate[i64](ctx.alloc, ctx.flat_count::usize);
+    if (sel rs.err) { ret err[fail.Fail].err{fail.refused(rs.err)}; }
+    ctx.arg_res_start = rs.ok;
+    val re: res[*i64, A.Error] = A.allocate[i64](ctx.alloc, ctx.flat_count::usize);
+    if (sel re.err) { ret err[fail.Fail].err{fail.refused(re.err)}; }
+    ctx.arg_res_end = re.ok;
+    val dr: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, ctx.flat_count::usize);
+    if (sel dr.err) { ret err[fail.Fail].err{fail.refused(dr.err)}; }
+    ctx.def_res_reg = dr.ok;
+    val dp: res[*i64, A.Error] = A.allocate[i64](ctx.alloc, ctx.flat_count::usize);
+    if (sel dp.err) { ret err[fail.Fail].err{fail.refused(dp.err)}; }
+    ctx.def_res_pos = dp.ok;
 
     var pos: u32 = 0;
     for (pos < ctx.flat_count) {
@@ -1606,7 +1609,7 @@ fun build_arg_reservations(ctx: *AllocCtx) R.Result[R.Void, str] {
         }
         pos = pos + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun instr_defines_preg(mi: *mir.MirInstr) bool {
@@ -1659,14 +1662,14 @@ fun release_pins(ctx: *AllocCtx, current_start: i64) {
     }
 }
 
-fun build_vreg_slot_flags(ctx: *AllocCtx) R.Result[R.Void, str] {
+fun build_vreg_slot_flags(ctx: *AllocCtx) err[fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     val nv: u32 = f.vreg_count;
-    if (nv == 0) { ret R.ok_void[str](); }
+    if (nv == 0) { ret err[fail.Fail].ok{}; }
 
-    val r: R.Result[*bool, str] = A.allocate[bool](ctx.alloc, nv::usize);
-    if (R.is_err[*bool, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*bool, str](r)); }
-    ctx.vreg_slot_flag = R.unwrap_ok[*bool, str](r);
+    val r: res[*bool, A.Error] = A.allocate[bool](ctx.alloc, nv::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    ctx.vreg_slot_flag = r.ok;
     var i: u32 = 0;
     for (i < nv) { ctx.vreg_slot_flag[i] = false; i = i + 1; }
 
@@ -1677,7 +1680,7 @@ fun build_vreg_slot_flags(ctx: *AllocCtx) R.Result[R.Void, str] {
         if (owner < nv) { ctx.vreg_slot_flag[owner] = true; }
         s = s + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun vreg_has_slot(ctx: *AllocCtx, v: u32) bool {
@@ -1701,11 +1704,11 @@ fun range_key_cmp(a: *RangeKey, b: *RangeKey) i64 {
     ret 0;
 }
 
-fun sort_by_start(ctx: *AllocCtx, order: *u32, count: u32) R.Result[R.Void, str] {
-    if (count < 2) { ret R.ok_void[str](); }
-    val keys_r: R.Result[*RangeKey, str] = A.allocate[RangeKey](ctx.alloc, count::usize);
-    if (R.is_err[*RangeKey, str](keys_r)) { ret R.err[R.Void, str](R.unwrap_err[*RangeKey, str](keys_r)); }
-    val keys: *RangeKey = R.unwrap_ok[*RangeKey, str](keys_r);
+fun sort_by_start(ctx: *AllocCtx, order: *u32, count: u32) err[fail.Fail] {
+    if (count < 2) { ret err[fail.Fail].ok{}; }
+    val keys_r: res[*RangeKey, A.Error] = A.allocate[RangeKey](ctx.alloc, count::usize);
+    if (sel keys_r.err) { ret err[fail.Fail].err{fail.refused(keys_r.err)}; }
+    val keys: *RangeKey = keys_r.ok;
     var i: u32 = 0;
     for (i < count) {
         keys[i].start   = ctx.ranges[order[i]].start;
@@ -1720,7 +1723,7 @@ fun sort_by_start(ctx: *AllocCtx, order: *u32, count: u32) R.Result[R.Void, str]
         i = i + 1;
     }
     A.deallocate[RangeKey](ctx.alloc, keys, count::usize);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun expire_active(ctx: *AllocCtx, current_start: i64) {
@@ -1981,7 +1984,7 @@ fun assign(ctx: *AllocCtx, v: u32, preg: u32, reg_class: u32) {
     ctx.active_count = ctx.active_count + 1;
 }
 
-fun spill_on_pressure(ctx: *AllocCtx, v: u32) R.Result[R.Void, str] {
+fun spill_on_pressure(ctx: *AllocCtx, v: u32) err[fail.Fail] {
     val lr: *LiveRange = ?ctx.ranges[v];
     val victim: u32 = find_spill_victim(ctx, lr.reg_class);
     if (victim == mir.MIR_VREG_NIL) {
@@ -1994,8 +1997,8 @@ fun spill_on_pressure(ctx: *AllocCtx, v: u32) R.Result[R.Void, str] {
     }
 
     val freed: u32 = ctx.f.vregs[victim].assigned;
-    val sr: R.Result[R.Void, str] = spill_vreg(ctx, victim);
-    if (R.is_err[R.Void, str](sr)) { ret sr; }
+    val sr: err[fail.Fail] = spill_vreg(ctx, victim);
+    if (sel sr.err) { ret sr; }
     free_assigned_id(ctx, victim, lr.reg_class, freed);
     remove_active(ctx, victim);
 
@@ -2007,7 +2010,7 @@ fun spill_on_pressure(ctx: *AllocCtx, v: u32) R.Result[R.Void, str] {
     }
     if (preg >= 0) {
         assign(ctx, v, preg::u32, lr.reg_class);
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
     ret spill_vreg(ctx, v);
 }
@@ -2065,16 +2068,16 @@ fun find_spill_victim(ctx: *AllocCtx, reg_class: u32) u32 {
     ret best;
 }
 
-fun spill_vreg(ctx: *AllocCtx, v: u32) R.Result[R.Void, str] {
+fun spill_vreg(ctx: *AllocCtx, v: u32) err[fail.Fail] {
     val mv: *mir.MirVReg = ?ctx.f.vregs[v];
-    if (mv.spill_slot >= 0) { ret R.ok_void[str](); }
+    if (mv.spill_slot >= 0) { ret err[fail.Fail].ok{}; }
     mv.assigned = mir.MIR_VREG_NIL;
 
     val size: u32 = class_width(ctx, ?ctx.ranges[v]);
-    val sr: R.Result[i32, str] = add_spill_slot(ctx, v, size);
-    if (R.is_err[i32, str](sr)) { ret R.err[R.Void, str](R.unwrap_err[i32, str](sr)); }
-    mv.spill_slot = R.unwrap_ok[i32, str](sr);
-    ret R.ok_void[str]();
+    val sr: res[i32, fail.Fail] = add_spill_slot(ctx, v, size);
+    if (sel sr.err) { ret err[fail.Fail].err{sr.err}; }
+    mv.spill_slot = sr.ok;
+    ret err[fail.Fail].ok{};
 }
 
 fun class_width(ctx: *AllocCtx, lr: *LiveRange) u32 {
@@ -2087,14 +2090,14 @@ fun spill_slot_align(ctx: *AllocCtx, value_id: u32) u32 {
     ret ctx.spill_width::u32;
 }
 
-fun add_spill_slot(ctx: *AllocCtx, value_id: u32, size: u32) R.Result[i32, str] {
+fun add_spill_slot(ctx: *AllocCtx, value_id: u32, size: u32) res[i32, fail.Fail] {
     val frame: *mir.MirFrame = ?ctx.f.frame;
     if (frame.slot_count >= frame.slot_cap) {
         val current: layout.CheckedCount[mir.MirSlot] = layout.count[mir.MirSlot](frame.slot_cap::usize);
         val required_r: R.Result[layout.CheckedCount[mir.MirSlot], layout.CheckCause] =
             layout.count_add[mir.MirSlot](current, layout.count[mir.MirSlot](1::usize));
         if (R.is_err[layout.CheckedCount[mir.MirSlot], layout.CheckCause](required_r)) {
-            ret R.err[i32, str]("regalloc: spill slot table growth count overflow");
+            ret res[i32, fail.Fail].err{fail.message("regalloc: spill slot table growth count overflow")};
         }
         var required: layout.CheckedCount[mir.MirSlot] =
             R.unwrap_ok[layout.CheckedCount[mir.MirSlot], layout.CheckCause](required_r);
@@ -2102,23 +2105,23 @@ fun add_spill_slot(ctx: *AllocCtx, value_id: u32, size: u32) R.Result[i32, str] 
         val grown_r: R.Result[layout.CheckedCount[mir.MirSlot], layout.CheckCause] =
             layout.count_grow[mir.MirSlot](current, required);
         if (R.is_err[layout.CheckedCount[mir.MirSlot], layout.CheckCause](grown_r)) {
-            ret R.err[i32, str]("regalloc: spill slot table growth count overflow");
+            ret res[i32, fail.Fail].err{fail.message("regalloc: spill slot table growth count overflow")};
         }
         val new_cap_fits: R.Result[u32, layout.CheckCause] = layout.usize_to_u32(
             R.unwrap_ok[layout.CheckedCount[mir.MirSlot], layout.CheckCause](grown_r).value);
         if (R.is_err[u32, layout.CheckCause](new_cap_fits)) {
-            ret R.err[i32, str]("regalloc: spill slot table capacity exceeds the u32 limit");
+            ret res[i32, fail.Fail].err{fail.message("regalloc: spill slot table capacity exceeds the u32 limit")};
         }
         val new_cap: u32 = R.unwrap_ok[u32, layout.CheckCause](new_cap_fits);
-        val r: R.Result[*mir.MirSlot, str] = A.reallocate[mir.MirSlot](ctx.alloc, frame.slots, frame.slot_cap::usize, new_cap::usize);
-        if (R.is_err[*mir.MirSlot, str](r)) { ret R.err[i32, str](R.unwrap_err[*mir.MirSlot, str](r)); }
-        frame.slots    = R.unwrap_ok[*mir.MirSlot, str](r);
+        val r: res[*mir.MirSlot, A.Error] = A.reallocate[mir.MirSlot](ctx.alloc, frame.slots, frame.slot_cap::usize, new_cap::usize);
+        if (sel r.err) { ret res[i32, fail.Fail].err{fail.refused(r.err)}; }
+        frame.slots    = r.ok;
         frame.slot_cap = new_cap;
     }
     val si: u32 = frame.slot_count;
     val si_fits: R.Result[i32, layout.CheckCause] = layout.usize_to_i32(si::usize);
     if (R.is_err[i32, layout.CheckCause](si_fits)) {
-        ret R.err[i32, str]("regalloc: spill slot index exceeds the i32 limit");
+        ret res[i32, fail.Fail].err{fail.message("regalloc: spill slot index exceeds the i32 limit")};
     }
     frame.slots[si].value  = value_id;
     frame.slots[si].kind   = mir.SLOT_SPILL;
@@ -2126,7 +2129,7 @@ fun add_spill_slot(ctx: *AllocCtx, value_id: u32, size: u32) R.Result[i32, str] 
     frame.slots[si].size   = size;
     frame.slots[si].align  = spill_slot_align(ctx, value_id);
     frame.slot_count = frame.slot_count + 1;
-    ret R.ok[i32, str](R.unwrap_ok[i32, layout.CheckCause](si_fits));
+    ret res[i32, fail.Fail].ok{R.unwrap_ok[i32, layout.CheckCause](si_fits)};
 }
 
 fun asm_instr_clobbers(tgt: *target.Target, mi: *mir.MirInstr, gp: *u32, fp: *u32) bool {
@@ -2245,7 +2248,7 @@ fun isa_reserved_gp_mask(tgt: *target.Target) u32 {
 
 fun asm_callee_mask(tgt: *target.Target, f: *mir.MirFunction) u32 {
     val cs: u32 = abi_callee_saved_gp_mask(tgt);
-    val res: u32 = isa_reserved_gp_mask(tgt);
+    val result: u32 = isa_reserved_gp_mask(tgt);
     var mask: u32 = 0;
     var bi: u32 = 0;
     for (bi < f.block_count) {
@@ -2255,7 +2258,7 @@ fun asm_callee_mask(tgt: *target.Target, f: *mir.MirFunction) u32 {
             var agp: u32 = 0;
             var afp: u32 = 0;
             if (asm_instr_clobbers(tgt, ?blk.instrs[ii], ?agp, ?afp)) {
-                mask = mask | (agp & cs & ~res);
+                mask = mask | (agp & cs & ~result);
             }
             ii = ii + 1;
         }
@@ -2284,7 +2287,7 @@ fun asm_callee_mask_fp(tgt: *target.Target, f: *mir.MirFunction) u32 {
     ret mask;
 }
 
-fun spill_across_calls(tgt: *target.Target, ctx: *AllocCtx) R.Result[R.Void, str] {
+fun spill_across_calls(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
     var pos: u32 = 0;
     for (pos < ctx.flat_count) {
         if (!ctx.flat[pos].is_call) { pos = pos + 1; cnt; }
@@ -2317,14 +2320,14 @@ fun spill_across_calls(tgt: *target.Target, ctx: *AllocCtx) R.Result[R.Void, str
                 must_spill = true;
             }
             if (must_spill) {
-                val sr: R.Result[R.Void, str] = spill_vreg(ctx, v);
-                if (R.is_err[R.Void, str](sr)) { ret sr; }
+                val sr: err[fail.Fail] = spill_vreg(ctx, v);
+                if (sel sr.err) { ret sr; }
             }
             v = v + 1;
         }
         pos = pos + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun rewritten_preg_ok(tgt: *target.Target, preg: u32) bool {
@@ -2362,7 +2365,7 @@ fun operand_bank_matches(op: *mir.MirOperand) bool {
         || (op.required_bank == mir.BANK_FP && class == isa.REG_CLASS_ID_XMM);
 }
 
-fun verify_rewritten_operands(tgt: *target.Target, f: *mir.MirFunction) R.Result[R.Void, str] {
+fun verify_rewritten_operands(tgt: *target.Target, f: *mir.MirFunction) err[fail.Fail] {
     var bi: u32 = 0;
     for (bi < f.block_count) {
         val blk: *mir.MirBlock = ?f.blocks[bi];
@@ -2373,22 +2376,22 @@ fun verify_rewritten_operands(tgt: *target.Target, f: *mir.MirFunction) R.Result
             for (k < mi.operand_count) {
                 val op: *mir.MirOperand = ?mi.operands[k];
                 if (op.kind == mir.MIR_OP_VREG) {
-                    ret R.err[R.Void, str]("regalloc: a virtual register survived rewriting");
+                    ret err[fail.Fail].err{fail.message("regalloc: a virtual register survived rewriting")};
                 }
                 if (op.kind == mir.MIR_OP_PREG && !rewritten_preg_ok(tgt, op.preg)) {
-                    ret R.err[R.Void, str]("regalloc: a rewritten operand names a physical register outside every register class");
+                    ret err[fail.Fail].err{fail.message("regalloc: a rewritten operand names a physical register outside every register class")};
                 }
                 if (op.kind == mir.MIR_OP_PREG && !operand_bank_matches(op)) {
-                    ret R.err[R.Void, str]("regalloc: a rewritten register operand violates its selected bank constraint");
+                    ret err[fail.Fail].err{fail.message("regalloc: a rewritten register operand violates its selected bank constraint")};
                 }
                 if (op.kind == mir.MIR_OP_MEM) {
                     if (op.vreg == mir.MIR_VREG_NIL
                         && (!rewritten_preg_ok(tgt, op.preg) || isa.regid_class(op.preg::i32) != isa.REG_CLASS_ID_GP)) {
-                        ret R.err[R.Void, str]("regalloc: a rewritten memory base is not a valid general-bank register");
+                        ret err[fail.Fail].err{fail.message("regalloc: a rewritten memory base is not a valid general-bank register")};
                     }
                     if (op.index != mir.MIR_VREG_NIL && op.index_is_preg
                         && (!rewritten_preg_ok(tgt, op.index) || isa.regid_class(op.index::i32) != isa.REG_CLASS_ID_GP)) {
-                        ret R.err[R.Void, str]("regalloc: a rewritten memory index is not a valid general-bank register");
+                        ret err[fail.Fail].err{fail.message("regalloc: a rewritten memory index is not a valid general-bank register")};
                     }
                 }
                 k = k + 1;
@@ -2397,10 +2400,10 @@ fun verify_rewritten_operands(tgt: *target.Target, f: *mir.MirFunction) R.Result
         }
         bi = bi + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun verify_allocation(tgt: *target.Target, ctx: *AllocCtx) R.Result[R.Void, str] {
+fun verify_allocation(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
     var v: u32 = 0;
     for (v < ctx.f.vreg_count) {
         val mv: *mir.MirVReg = ?ctx.f.vregs[v];
@@ -2413,19 +2416,19 @@ fun verify_allocation(tgt: *target.Target, ctx: *AllocCtx) R.Result[R.Void, str]
 
         if (lr.reg_class == REG_CLASS_GP) {
             if (rclass != isa.REG_CLASS_ID_GP || ridx < 0 || ridx::u32 >= ctx.gp_count) {
-                ret R.err[R.Void, str](regalloc_msg(ctx, "regalloc: invalid GP register id assigned in '", "'", "regalloc: invalid GP register id assigned"));
+                ret err[fail.Fail].err{fail.message(regalloc_msg(ctx, "regalloc: invalid GP register id assigned in '", "'", "regalloc: invalid GP register id assigned"))};
             }
             if (ctx.reserved[ridx::u32]) {
-                ret R.err[R.Void, str](regalloc_msg(ctx, "regalloc: a reserved register was assigned in '", "'", "regalloc: a reserved register was assigned"));
+                ret err[fail.Fail].err{fail.message(regalloc_msg(ctx, "regalloc: a reserved register was assigned in '", "'", "regalloc: a reserved register was assigned"))};
             }
         } or {
             if (rclass != isa.REG_CLASS_ID_XMM || ridx < 0 || ridx::u32 >= ctx.fp_count) {
-                ret R.err[R.Void, str](regalloc_msg(ctx, "regalloc: invalid FP register id assigned in '", "'", "regalloc: invalid FP register id assigned"));
+                ret err[fail.Fail].err{fail.message(regalloc_msg(ctx, "regalloc: invalid FP register id assigned in '", "'", "regalloc: invalid FP register id assigned"))};
             }
         }
         v = v + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun record_callee_mask(tgt: *target.Target, ctx: *AllocCtx) {
@@ -2500,23 +2503,23 @@ fun drop_self_copies_physical(tgt: *target.Target, ctx: *AllocCtx) {
     }
 }
 
-fun rewrite(tgt: *target.Target, ctx: *AllocCtx) R.Result[R.Void, str] {
+fun rewrite(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     var bi: u32 = 0;
     var flat_base: u32 = 0;
     for (bi < f.block_count) {
         val blk: *mir.MirBlock = ?f.blocks[bi];
         val orig_count: u32 = blk.instr_count;
-        val rb: R.Result[R.Void, str] = rewrite_block(tgt, ctx, blk, bi == 0, flat_base);
-        if (R.is_err[R.Void, str](rb)) { ret rb; }
+        val rb: err[fail.Fail] = rewrite_block(tgt, ctx, blk, bi == 0, flat_base);
+        if (sel rb.err) { ret rb; }
         flat_base = flat_base + orig_count;
         bi = bi + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun rewrite_block(tgt: *target.Target, ctx: *AllocCtx, blk: *mir.MirBlock, is_entry: bool, flat_base: u32) R.Result[R.Void, str] {
-    if (blk.instr_count == 0) { ret R.ok_void[str](); }
+fun rewrite_block(tgt: *target.Target, ctx: *AllocCtx, blk: *mir.MirBlock, is_entry: bool, flat_base: u32) err[fail.Fail] {
+    if (blk.instr_count == 0) { ret err[fail.Fail].ok{}; }
 
     var total: u32 = 0;
     var ii: u32 = 0;
@@ -2525,16 +2528,16 @@ fun rewrite_block(tgt: *target.Target, ctx: *AllocCtx, blk: *mir.MirBlock, is_en
         ii = ii + 1;
     }
 
-    val rn: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](ctx.alloc, total::usize);
-    if (R.is_err[*mir.MirInstr, str](rn)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirInstr, str](rn)); }
-    val dst: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](rn);
+    val rn: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](ctx.alloc, total::usize);
+    if (sel rn.err) { ret err[fail.Fail].err{fail.refused(rn.err)}; }
+    val dst: *mir.MirInstr = rn.ok;
     var w: u32 = 0;
 
     ii = 0;
     for (ii < blk.instr_count) {
         val mi: *mir.MirInstr = ?blk.instrs[ii];
-        val re: R.Result[R.Void, str] = rewrite_instr(tgt, ctx, mi, dst, ?w, is_entry, flat_base + ii);
-        if (R.is_err[R.Void, str](re)) {
+        val re: err[fail.Fail] = rewrite_instr(tgt, ctx, mi, dst, ?w, is_entry, flat_base + ii);
+        if (sel re.err) {
             var d: u32 = 0;
             for (d < w) {
                 if (dst[d].operands != nil && dst[d].operand_count > 0) {
@@ -2554,7 +2557,7 @@ fun rewrite_block(tgt: *target.Target, ctx: *AllocCtx, blk: *mir.MirBlock, is_en
     blk.instrs      = dst;
     blk.instr_count = w;
     blk.instr_cap   = total;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun extra_movs(ctx: *AllocCtx, mi: *mir.MirInstr) u32 {
@@ -2592,13 +2595,13 @@ fun is_storage_slot(ctx: *AllocCtx, v: u32) bool {
 }
 
 fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
-                  dst: *mir.MirInstr, wp: *u32, is_entry: bool, src_pos: u32) R.Result[R.Void, str] {
+                  dst: *mir.MirInstr, wp: *u32, is_entry: bool, src_pos: u32) err[fail.Fail] {
     val n: u32 = mi.operand_count;
     var ops: *mir.MirOperand = nil;
     if (n > 0) {
-        val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, n::usize);
-        if (R.is_err[*mir.MirOperand, str](ro)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](ro)); }
-        ops = R.unwrap_ok[*mir.MirOperand, str](ro);
+        val ro: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, n::usize);
+        if (sel ro.err) { ret err[fail.Fail].err{fail.refused(ro.err)}; }
+        ops = ro.ok;
         var c: u32 = 0;
         for (c < n) { ops[c] = mi.operands[c]; c = c + 1; }
     }
@@ -2626,7 +2629,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, is_entry, src_pos);
                     if (tmp < 0) {
                         free_ops(ctx, ops, n);
-                        ret R.err[R.Void, str](regalloc_msg(ctx, "regalloc: no free register for spilled destination in '", "'", "regalloc: no free register for spilled destination"));
+                        ret err[fail.Fail].err{fail.message(regalloc_msg(ctx, "regalloc: no free register for spilled destination in '", "'", "regalloc: no free register for spilled destination"))};
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
                     ops[k] = mir.op_preg_of(tmp::u32, v);
@@ -2640,8 +2643,8 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                     ops[k] = mir.op_mem_slot(v, 0);
                 } or (store_dst_tmp >= 0 && v == store_dst_vreg) {
                     if (!store_dst_reloaded) {
-                        val er: R.Result[R.Void, str] = emit_reload(ctx, dst, wp, store_dst_tmp::u32, v, mi.loc, mi.inline_site);
-                        if (R.is_err[R.Void, str](er)) { free_ops(ctx, ops, n); ret er; }
+                        val er: err[fail.Fail] = emit_reload(ctx, dst, wp, store_dst_tmp::u32, v, mi.loc, mi.inline_site);
+                        if (sel er.err) { free_ops(ctx, ops, n); ret er; }
                         store_dst_reloaded = true;
                     }
                     ops[k] = mir.op_preg_of(store_dst_tmp::u32, v);
@@ -2649,11 +2652,11 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, is_entry, src_pos);
                     if (tmp < 0) {
                         free_ops(ctx, ops, n);
-                        ret R.err[R.Void, str](regalloc_msg(ctx, "regalloc: no free register for spilled source in '", "'", "regalloc: no free register for spilled source"));
+                        ret err[fail.Fail].err{fail.message(regalloc_msg(ctx, "regalloc: no free register for spilled source in '", "'", "regalloc: no free register for spilled source"))};
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    val er: R.Result[R.Void, str] = emit_reload(ctx, dst, wp, tmp::u32, v, mi.loc, mi.inline_site);
-                    if (R.is_err[R.Void, str](er)) { free_ops(ctx, ops, n); ret er; }
+                    val er: err[fail.Fail] = emit_reload(ctx, dst, wp, tmp::u32, v, mi.loc, mi.inline_site);
+                    if (sel er.err) { free_ops(ctx, ops, n); ret er; }
                     ops[k] = mir.op_preg_of(tmp::u32, v);
                 } or {
                     ops[k] = preg_of(ctx, v);
@@ -2667,11 +2670,11 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, is_entry, src_pos);
                     if (tmp < 0) {
                         free_ops(ctx, ops, n);
-                        ret R.err[R.Void, str](regalloc_msg(ctx, "regalloc: no free register for spilled MEM base in '", "'", "regalloc: no free register for spilled MEM base"));
+                        ret err[fail.Fail].err{fail.message(regalloc_msg(ctx, "regalloc: no free register for spilled MEM base in '", "'", "regalloc: no free register for spilled MEM base"))};
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    val er: R.Result[R.Void, str] = emit_reload(ctx, dst, wp, tmp::u32, v, mi.loc, mi.inline_site);
-                    if (R.is_err[R.Void, str](er)) { free_ops(ctx, ops, n); ret er; }
+                    val er: err[fail.Fail] = emit_reload(ctx, dst, wp, tmp::u32, v, mi.loc, mi.inline_site);
+                    if (sel er.err) { free_ops(ctx, ops, n); ret er; }
                     ops[k].vreg = mir.MIR_VREG_NIL;
                     ops[k].preg = tmp::u32;
                 } or {
@@ -2685,11 +2688,11 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, is_entry, src_pos);
                     if (tmp < 0) {
                         free_ops(ctx, ops, n);
-                        ret R.err[R.Void, str](regalloc_msg(ctx, "regalloc: no free register for spilled MEM index in '", "'", "regalloc: no free register for spilled MEM index"));
+                        ret err[fail.Fail].err{fail.message(regalloc_msg(ctx, "regalloc: no free register for spilled MEM index in '", "'", "regalloc: no free register for spilled MEM index"))};
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    val er: R.Result[R.Void, str] = emit_reload(ctx, dst, wp, tmp::u32, iv, mi.loc, mi.inline_site);
-                    if (R.is_err[R.Void, str](er)) { free_ops(ctx, ops, n); ret er; }
+                    val er: err[fail.Fail] = emit_reload(ctx, dst, wp, tmp::u32, iv, mi.loc, mi.inline_site);
+                    if (sel er.err) { free_ops(ctx, ops, n); ret er; }
                     ops[k].index         = tmp::u32;
                     ops[k].index_is_preg = true;
                 } or {
@@ -2717,7 +2720,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
             if (mi.operands != nil && mi.operand_count > 0) {
                 A.deallocate[mir.MirOperand](ctx.alloc, mi.operands, mi.operand_count::usize);
             }
-            ret R.ok_void[str]();
+            ret err[fail.Fail].ok{};
         }
         free_ops(ctx, ops, n);
         if (mi.dbg_binding_count > 0) {
@@ -2733,7 +2736,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
         if (mi.operands != nil && mi.operand_count > 0) {
             A.deallocate[mir.MirOperand](ctx.alloc, mi.operands, mi.operand_count::usize);
         }
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
 
     dst[@wp] = mir.instr_like(mi, ops, n);
@@ -2744,10 +2747,10 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
     }
 
     if (store_dst_vreg != mir.MIR_VREG_NIL) {
-        val sr: R.Result[R.Void, str] = emit_store(ctx, dst, wp, store_dst_vreg, store_dst_tmp::u32, mi.loc, mi.inline_site);
-        if (R.is_err[R.Void, str](sr)) { ret sr; }
+        val sr: err[fail.Fail] = emit_store(ctx, dst, wp, store_dst_vreg, store_dst_tmp::u32, mi.loc, mi.inline_site);
+        if (sel sr.err) { ret sr; }
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun instr_defines_ops(mi: *mir.MirInstr, ops: *mir.MirOperand, n: u32) bool {
@@ -2800,13 +2803,13 @@ fun id_claimed(claimed: *i32, count: u32, id: i32) bool {
     ret false;
 }
 
-fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32, loc: source.SrcLoc, inline_site: u32) R.Result[R.Void, str] {
+fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32, loc: source.SrcLoc, inline_site: u32) err[fail.Fail] {
     if (isa.regid_class(tmp::i32) != isa.REG_CLASS_ID_GP) {
-        ret R.err[R.Void, str]("regalloc: spill transport requires a general-bank scratch register");
+        ret err[fail.Fail].err{fail.message("regalloc: spill transport requires a general-bank scratch register")};
     }
-    val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](ro)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](ro)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro);
+    val ro: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel ro.err) { ret err[fail.Fail].err{fail.refused(ro.err)}; }
+    val ops: *mir.MirOperand = ro.ok;
     ops[0] = mir.op_preg_of(tmp, v);
     ops[0].required_bank = mir.BANK_GP;
     ops[1] = mir.op_mem_slot(v, 0);
@@ -2818,16 +2821,16 @@ fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32, 
     dst[@wp].loc           = loc;
     dst[@wp].inline_site   = inline_site;
     @wp = @wp + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun emit_store(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, v: u32, tmp: u32, loc: source.SrcLoc, inline_site: u32) R.Result[R.Void, str] {
+fun emit_store(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, v: u32, tmp: u32, loc: source.SrcLoc, inline_site: u32) err[fail.Fail] {
     if (isa.regid_class(tmp::i32) != isa.REG_CLASS_ID_GP) {
-        ret R.err[R.Void, str]("regalloc: spill transport requires a general-bank scratch register");
+        ret err[fail.Fail].err{fail.message("regalloc: spill transport requires a general-bank scratch register")};
     }
-    val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](ro)) { ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](ro)); }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro);
+    val ro: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
+    if (sel ro.err) { ret err[fail.Fail].err{fail.refused(ro.err)}; }
+    val ops: *mir.MirOperand = ro.ok;
     ops[0] = mir.op_mem_slot(v, 0);
     ops[1] = mir.op_preg_of(tmp, v);
     ops[1].required_bank = mir.BANK_GP;
@@ -2839,7 +2842,7 @@ fun emit_store(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, v: u32, tmp: u32, l
     dst[@wp].loc           = loc;
     dst[@wp].inline_site   = inline_site;
     @wp = @wp + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun free_ops(ctx: *AllocCtx, ops: *mir.MirOperand, n: u32) {
@@ -2911,7 +2914,8 @@ test "mach.lang.be.codegen.regalloc.seed_reserved:x18_reserved_on_darwin_only" {
 
 test "mach.lang.be.codegen.regalloc.verify_allocation:accepts_a_well_formed_assignment" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var reg: target.TargetRegistry = target.registry_init();
     fin { target.registry_dnit(?reg); }
     if (R.is_err[R.Void, str](target.register_all(?reg, target_testing.debug_descriptor))) { ret 1; }
@@ -2946,14 +2950,15 @@ test "mach.lang.be.codegen.regalloc.verify_allocation:accepts_a_well_formed_assi
     ctx.fp_count  = 4;
     ctx.reserved  = ?reserved[0];
 
-    val vr: R.Result[R.Void, str] = verify_allocation(?tgt, ?ctx);
-    if (R.is_err[R.Void, str](vr)) { ret 1; }
+    val vr: err[fail.Fail] = verify_allocation(?tgt, ?ctx);
+    if (sel vr.err) { ret 1; }
     ret 0;
 }
 
 test "mach.lang.be.codegen.regalloc.verify_allocation:rejects_a_cross_class_register_id" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var reg: target.TargetRegistry = target.registry_init();
     fin { target.registry_dnit(?reg); }
     if (R.is_err[R.Void, str](target.register_all(?reg, target_testing.debug_descriptor))) { ret 1; }
@@ -2986,14 +2991,15 @@ test "mach.lang.be.codegen.regalloc.verify_allocation:rejects_a_cross_class_regi
     ctx.fp_count  = 4;
     ctx.reserved  = ?reserved[0];
 
-    val vr: R.Result[R.Void, str] = verify_allocation(?tgt, ?ctx);
-    if (R.is_ok[R.Void, str](vr)) { ret 1; }
+    val vr: err[fail.Fail] = verify_allocation(?tgt, ?ctx);
+    if (sel vr.ok) { ret 1; }
     ret 0;
 }
 
 test "mach.lang.be.codegen.regalloc.verify_allocation:rejects_a_reserved_register" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var reg: target.TargetRegistry = target.registry_init();
     fin { target.registry_dnit(?reg); }
     if (R.is_err[R.Void, str](target.register_all(?reg, target_testing.debug_descriptor))) { ret 1; }
@@ -3027,18 +3033,19 @@ test "mach.lang.be.codegen.regalloc.verify_allocation:rejects_a_reserved_registe
     ctx.fp_count  = 4;
     ctx.reserved  = ?reserved[0];
 
-    val vr: R.Result[R.Void, str] = verify_allocation(?tgt, ?ctx);
-    if (R.is_ok[R.Void, str](vr)) { ret 1; }
+    val vr: err[fail.Fail] = verify_allocation(?tgt, ?ctx);
+    if (sel vr.ok) { ret 1; }
 
     reserved[2] = false;
-    val vr2: R.Result[R.Void, str] = verify_allocation(?tgt, ?ctx);
-    if (R.is_err[R.Void, str](vr2)) { ret 1; }
+    val vr2: err[fail.Fail] = verify_allocation(?tgt, ?ctx);
+    if (sel vr2.err) { ret 1; }
     ret 0;
 }
 
 test "mach.lang.be.codegen.regalloc.sort_by_start:orders_by_start_then_end_then_original_index" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
 
     var ranges: [5]LiveRange;
     ranges[0].start = 10; ranges[0].end_pos = 20;
@@ -3055,8 +3062,8 @@ test "mach.lang.be.codegen.regalloc.sort_by_start:orders_by_start_then_end_then_
     var i: u32 = 0;
     for (i < 5) { order[i] = i; i = i + 1; }
 
-    val r: R.Result[R.Void, str] = sort_by_start(?ctx, ?order[0], 5);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = sort_by_start(?ctx, ?order[0], 5);
+    if (sel r.err) { ret 1; }
 
     if (order[0] != 4) { ret 1; }
     if (order[1] != 2) { ret 1; }
@@ -3068,14 +3075,15 @@ test "mach.lang.be.codegen.regalloc.sort_by_start:orders_by_start_then_end_then_
 
 test "mach.lang.be.codegen.regalloc.sort_by_start:leaves_short_orders_untouched" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var ctx: AllocCtx;
     ctx.alloc = ?alloc;
 
     var order0: [1]u32;
     order0[0] = 77;
-    val r0: R.Result[R.Void, str] = sort_by_start(?ctx, ?order0[0], 0);
-    if (R.is_err[R.Void, str](r0)) { ret 1; }
+    val r0: err[fail.Fail] = sort_by_start(?ctx, ?order0[0], 0);
+    if (sel r0.err) { ret 1; }
     if (order0[0] != 77) { ret 1; }
 
     var ranges: [1]LiveRange;
@@ -3083,8 +3091,8 @@ test "mach.lang.be.codegen.regalloc.sort_by_start:leaves_short_orders_untouched"
     ctx.ranges = ?ranges[0];
     var order1: [1]u32;
     order1[0] = 0;
-    val r1: R.Result[R.Void, str] = sort_by_start(?ctx, ?order1[0], 1);
-    if (R.is_err[R.Void, str](r1)) { ret 1; }
+    val r1: err[fail.Fail] = sort_by_start(?ctx, ?order1[0], 1);
+    if (sel r1.err) { ret 1; }
     if (order1[0] != 0) { ret 1; }
     ret 0;
 }
@@ -3251,7 +3259,8 @@ test "mach.lang.be.codegen.regalloc.sweep_dead_movs:retallies_to_a_fixpoint" {
     var ctx: AllocCtx;
     t_ctx(?ctx, ?alloc, ?f, ?slots[0]);
 
-    if (R.is_err[R.Void, str](sweep_dead_movs(?t, ?ctx))) { ret 1; }
+    val sweep_dead_movs_r: err[fail.Fail] = sweep_dead_movs(?t, ?ctx);
+    if (sel sweep_dead_movs_r.err) { ret 1; }
 
     if (b.instr_count != 2) { ret 1; }
     if (b.instrs[0].operands[0].kind != mir.MIR_OP_VREG)  { ret 1; }
@@ -3288,8 +3297,9 @@ test "mach.lang.be.codegen.regalloc.phi_neg_i32_signed_compare:1851" {
 }
 
 fun t_vregs(alloc: *A.Allocator, f: *mir.MirFunction, n: u32) {
-    val r: R.Result[*mir.MirVReg, str] = A.allocate[mir.MirVReg](alloc, n::usize);
-    f.vregs      = R.unwrap_ok[*mir.MirVReg, str](r);
+    val r: res[*mir.MirVReg, A.Error] = A.allocate[mir.MirVReg](alloc, n::usize);
+    if (sel r.err) { ret; }
+    f.vregs      = r.ok;
     f.vreg_count = n;
     f.vreg_cap   = n;
     var i: u32 = 0;
@@ -3305,16 +3315,18 @@ fun t_vregs(alloc: *A.Allocator, f: *mir.MirFunction, n: u32) {
 }
 
 fun t_block(alloc: *A.Allocator, b: *mir.MirBlock, n: u32) {
-    val r: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](alloc, n::usize);
-    b.instrs      = R.unwrap_ok[*mir.MirInstr, str](r);
+    val r: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](alloc, n::usize);
+    if (sel r.err) { ret; }
+    b.instrs      = r.ok;
     b.instr_count = n;
     b.instr_cap   = n;
     b.id          = 0;
 }
 
 fun t_mov(alloc: *A.Allocator, b: *mir.MirBlock, ix: u32, dst: mir.MirOperand, src: mir.MirOperand) {
-    val r: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](alloc, 2::usize);
-    val arr: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](r);
+    val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](alloc, 2::usize);
+    if (sel r.err) { ret; }
+    val arr: *mir.MirOperand = r.ok;
     arr[0] = dst;
     arr[1] = src;
     b.instrs[ix].opcode        = mir.MIR_MOV;
@@ -3367,7 +3379,8 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:single_assignment_web_is_mer
     var ctx: AllocCtx;
     t_ctx(?ctx, ?alloc, ?f, ?slots[0]);
 
-    if (R.is_err[R.Void, str](coalesce_copies(?t, ?ctx))) { ret 1; }
+    val coalesce_copies_r: err[fail.Fail] = coalesce_copies(?t, ?ctx);
+    if (sel coalesce_copies_r.err) { ret 1; }
 
     if (b.instr_count != 2) { ret 1; }
     if (b.instrs[1].operands[1].kind != mir.MIR_OP_VREG) { ret 1; }
@@ -3401,7 +3414,8 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:refuses_to_merge_a_secret_wi
     slots[0] = false; slots[1] = false;
     var ctx: AllocCtx;
     t_ctx(?ctx, ?alloc, ?f, ?slots[0]);
-    if (R.is_err[R.Void, str](coalesce_copies(?t, ?ctx))) { ret 1; }
+    val coalesce_copies_r: err[fail.Fail] = coalesce_copies(?t, ?ctx);
+    if (sel coalesce_copies_r.err) { ret 1; }
     if (b.instr_count != 3) { ret 2; }
     if (b.instrs[1].operands[0].vreg != 1 || b.instrs[1].operands[1].vreg != 0) { ret 3; }
 
@@ -3422,14 +3436,16 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:refuses_to_merge_a_secret_wi
     slots2[0] = false; slots2[1] = false;
     var ctx2: AllocCtx;
     t_ctx(?ctx2, ?alloc, ?f2, ?slots2[0]);
-    if (R.is_err[R.Void, str](coalesce_copies(?t, ?ctx2))) { ret 4; }
+    val coalesce_copies_r2: err[fail.Fail] = coalesce_copies(?t, ?ctx2);
+    if (sel coalesce_copies_r2.err) { ret 4; }
     if (b2.instr_count != 2) { ret 5; }
     ret 0;
 }
 
 fun t_selected_copy(t: *target.Target, opcode: u32, copied: bool) bool {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret false; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret false; }
     var f: mir.MirFunction;
     var b: mir.MirBlock;
     f.blocks = ?b;
@@ -3459,7 +3475,8 @@ fun t_selected_copy(t: *target.Target, opcode: u32, copied: bool) bool {
     var ctx: AllocCtx;
     t_ctx(?ctx, ?alloc, ?f, ?slots[0]);
     ctx.spill_width = t.model.spill_width::u8;
-    if (R.is_err[R.Void, str](coalesce_copies(t, ?ctx))) { ret false; }
+    val coalesce_copies_r: err[fail.Fail] = coalesce_copies(t, ?ctx);
+    if (sel coalesce_copies_r.err) { ret false; }
     if (!copied) { ret b.instr_count == 3 && b.instrs[1].opcode == opcode; }
     ret b.instr_count == 2 && b.instrs[1].operands[1].kind == mir.MIR_OP_VREG &&
         b.instrs[1].operands[1].vreg == 0;
@@ -3512,7 +3529,8 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:refuses_unsafe_shapes" {
     var ctx: AllocCtx;
     t_ctx(?ctx, ?alloc, ?f, ?slots[0]);
 
-    if (R.is_err[R.Void, str](coalesce_copies(?t, ?ctx))) { ret 1; }
+    val coalesce_copies_r: err[fail.Fail] = coalesce_copies(?t, ?ctx);
+    if (sel coalesce_copies_r.err) { ret 1; }
     if (b.instr_count != 4) { ret 1; }
 
     var f2: mir.MirFunction;
@@ -3532,7 +3550,8 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:refuses_unsafe_shapes" {
     slots2[0] = false; slots2[1] = false;
     var ctx2: AllocCtx;
     t_ctx(?ctx2, ?alloc, ?f2, ?slots2[0]);
-    if (R.is_err[R.Void, str](coalesce_copies(?t, ?ctx2))) { ret 1; }
+    val coalesce_copies_r2: err[fail.Fail] = coalesce_copies(?t, ?ctx2);
+    if (sel coalesce_copies_r2.err) { ret 1; }
     if (b2.instr_count != 3) { ret 1; }
 
     var f3: mir.MirFunction;
@@ -3550,7 +3569,8 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:refuses_unsafe_shapes" {
     slots3[0] = false; slots3[1] = true;
     var ctx3: AllocCtx;
     t_ctx(?ctx3, ?alloc, ?f3, ?slots3[0]);
-    if (R.is_err[R.Void, str](coalesce_copies(?t, ?ctx3))) { ret 1; }
+    val coalesce_copies_r3: err[fail.Fail] = coalesce_copies(?t, ?ctx3);
+    if (sel coalesce_copies_r3.err) { ret 1; }
     if (b3.instr_count != 3) { ret 1; }
 
     ret 0;
@@ -3810,10 +3830,10 @@ test "mach.lang.be.codegen.regalloc.add_spill_slot:refuses_u32_capacity_overflow
     ctx.alloc = ?alloc;
     ctx.f     = ?f;
 
-    val r: R.Result[i32, str] = add_spill_slot(?ctx, 0, 8);
+    val r: res[i32, fail.Fail] = add_spill_slot(?ctx, 0, 8);
 
     var bad: i32 = 0;
-    if (!R.is_err[i32, str](r))       { bad = 1; }
+    if (!sel r.err)       { bad = 1; }
     if (probe.reallocate_calls != 0)  { bad = 2; }
     if (probe.allocate_calls != 0)    { bad = 3; }
     ret bad;
@@ -3832,10 +3852,10 @@ test "mach.lang.be.codegen.regalloc.add_spill_slot:refuses_a_slot_index_past_the
     ctx.alloc = ?alloc;
     ctx.f     = ?f;
 
-    val r: R.Result[i32, str] = add_spill_slot(?ctx, 0, 8);
+    val r: res[i32, fail.Fail] = add_spill_slot(?ctx, 0, 8);
 
     var bad: i32 = 0;
-    if (!R.is_err[i32, str](r)) { bad = 1; }
+    if (!sel r.err) { bad = 1; }
     ret bad;
 }
 
@@ -3844,30 +3864,30 @@ test "mach.lang.be.codegen.regalloc.build_order_apply_order_restore_order:round_
     page.make(?alloc);
 
     var f: mir.MirFunction;
-    val rb: R.Result[*mir.MirBlock, str] = A.zallocate[mir.MirBlock](?alloc, 4::usize);
-    if (R.is_err[*mir.MirBlock, str](rb)) { ret 1; }
-    f.blocks      = R.unwrap_ok[*mir.MirBlock, str](rb);
+    val rb: res[*mir.MirBlock, A.Error] = A.zallocate[mir.MirBlock](?alloc, 4::usize);
+    if (sel rb.err) { ret 1; }
+    f.blocks      = rb.ok;
     f.block_count = 4;
 
-    val ro0: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](?alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](ro0)) { ret 1; }
-    val ops0: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro0);
+    val ro0: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?alloc, 2::usize);
+    if (sel ro0.err) { ret 1; }
+    val ops0: *mir.MirOperand = ro0.ok;
     ops0[0] = mir.op_block(1);
     ops0[1] = mir.op_block(3);
 
-    val ri0: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](?alloc, 1::usize);
-    if (R.is_err[*mir.MirInstr, str](ri0)) { ret 1; }
-    val instrs0: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](ri0);
+    val ri0: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](?alloc, 1::usize);
+    if (sel ri0.err) { ret 1; }
+    val instrs0: *mir.MirInstr = ri0.ok;
     instrs0[0] = mir.instr(mir.MIR_CBR, ops0, 2, 0, 0);
 
-    val ro1: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](?alloc, 1::usize);
-    if (R.is_err[*mir.MirOperand, str](ro1)) { ret 1; }
-    val ops1: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro1);
+    val ro1: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?alloc, 1::usize);
+    if (sel ro1.err) { ret 1; }
+    val ops1: *mir.MirOperand = ro1.ok;
     ops1[0] = mir.op_block(2);
 
-    val ri1: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](?alloc, 1::usize);
-    if (R.is_err[*mir.MirInstr, str](ri1)) { ret 1; }
-    val instrs1: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](ri1);
+    val ri1: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](?alloc, 1::usize);
+    if (sel ri1.err) { ret 1; }
+    val instrs1: *mir.MirInstr = ri1.ok;
     instrs1[0] = mir.instr(mir.MIR_BR, ops1, 1, 0, 0);
 
     f.blocks[0].id          = 0;
@@ -3881,21 +3901,24 @@ test "mach.lang.be.codegen.regalloc.build_order_apply_order_restore_order:round_
     f.blocks[3].id          = 3;
     f.blocks[3].instr_count = 0;
 
-    val ord_r: R.Result[*u32, str] = A.allocate[u32](?alloc, 4::usize);
-    if (R.is_err[*u32, str](ord_r)) { ret 1; }
+    val ord_r: res[*u32, A.Error] = A.allocate[u32](?alloc, 4::usize);
+    if (sel ord_r.err) { ret 1; }
 
     var ctx: AllocCtx;
     ctx.alloc = ?alloc;
     ctx.f     = ?f;
-    ctx.order = R.unwrap_ok[*u32, str](ord_r);
+    ctx.order = ord_r.ok;
 
-    if (R.is_err[R.Void, str](build_order(?ctx))) { ret 1; }
+    val build_order_r: err[fail.Fail] = build_order(?ctx);
+    if (sel build_order_r.err) { ret 1; }
     if (ctx.order[0] != 0 || ctx.order[1] != 3 || ctx.order[2] != 1 || ctx.order[3] != 2) { ret 1; }
 
-    if (R.is_err[R.Void, str](apply_order(?ctx))) { ret 1; }
+    val apply_order_r: err[fail.Fail] = apply_order(?ctx);
+    if (sel apply_order_r.err) { ret 1; }
     if (f.blocks[0].id != 0 || f.blocks[1].id != 3 || f.blocks[2].id != 1 || f.blocks[3].id != 2) { ret 1; }
 
-    if (R.is_err[R.Void, str](restore_order(?ctx))) { ret 1; }
+    val restore_order_r: err[fail.Fail] = restore_order(?ctx);
+    if (sel restore_order_r.err) { ret 1; }
     if (f.blocks[0].id != 0 || f.blocks[1].id != 1 || f.blocks[2].id != 2 || f.blocks[3].id != 3) { ret 1; }
 
     ret 0;
@@ -3922,29 +3945,39 @@ test "mach.lang.be.codegen.regalloc.verify_rewritten_operands:walks_the_program_
     f.blocks = ?blk[0];
     f.block_count = 1;
 
-    if (R.is_err[R.Void, str](rules.capture_operand_banks(?f, ?ins[0]))) { ret 1; }
-    if (R.is_err[R.Void, str](verify_rewritten_operands(?tgt, ?f))) { ret 1; }
+    val capture_operand_banks_r: err[fail.Fail] = rules.capture_operand_banks(?f, ?ins[0]);
+    if (sel capture_operand_banks_r.err) { ret 1; }
+    val verify_rewritten_operands_r: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
+    if (sel verify_rewritten_operands_r.err) { ret 1; }
     ops[1] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_GP, (gp + 40)::i32)::u32);
-    if (R.is_ok[R.Void, str](verify_rewritten_operands(?tgt, ?f)))  { ret 2; }
+    val verify_rewritten_operands_r2: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
+    if (sel verify_rewritten_operands_r2.ok)  { ret 2; }
     ops[1] = mir.op_preg(isa.regid_make(7, 0)::u32);
-    if (R.is_ok[R.Void, str](verify_rewritten_operands(?tgt, ?f)))  { ret 3; }
+    val verify_rewritten_operands_r3: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
+    if (sel verify_rewritten_operands_r3.ok)  { ret 3; }
     ops[1] = mir.op_vreg(0);
-    if (R.is_ok[R.Void, str](verify_rewritten_operands(?tgt, ?f)))  { ret 4; }
+    val verify_rewritten_operands_r4: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
+    if (sel verify_rewritten_operands_r4.ok)  { ret 4; }
     ops[1] = mir.op_mem_preg(isa.regid_make(isa.REG_CLASS_ID_GP, (gp + 40)::i32)::u32, 0);
-    if (R.is_ok[R.Void, str](verify_rewritten_operands(?tgt, ?f)))  { ret 5; }
+    val verify_rewritten_operands_r5: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
+    if (sel verify_rewritten_operands_r5.ok)  { ret 5; }
     ops[1] = mir.op_mem_preg(tgt.model.stack_ptr_reg::u32, 0);
-    if (R.is_err[R.Void, str](verify_rewritten_operands(?tgt, ?f))) { ret 6; }
+    val verify_rewritten_operands_r6: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
+    if (sel verify_rewritten_operands_r6.err) { ret 6; }
     ret 0;
 }
 
 fun t_spilled_update(mode: u32) i32 {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
     var scratch_arena: arena.Arena;
-    if (O.is_some[str](arena.init(?scratch_arena, ?backing, 65536))) { ret 1; }
+    val init_r: err[A.Error] = arena.init(?scratch_arena, ?backing, 65536);
+    if (sel init_r.err) { ret 1; }
     fin { arena.dnit(?scratch_arena); }
     var alloc: A.Allocator;
-    if (O.is_some[str](arena.make(?alloc, ?scratch_arena))) { ret 1; }
+    val make_r2: err[A.Error] = arena.make(?alloc, ?scratch_arena);
+    if (sel make_r2.err) { ret 1; }
     var vregs: [1]mir.MirVReg;
     vregs[0] = mir.vreg(0, REG_CLASS_GP, false, false);
     vregs[0].spill_slot = 0;
@@ -3961,9 +3994,9 @@ fun t_spilled_update(mode: u32) i32 {
     ctx.reload_scratch_count = 1;
     var tgt: target.Target;
     val count: u32 = 3;
-    val ar: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](?alloc, count::usize);
-    if (R.is_err[*mir.MirOperand, str](ar)) { ret 1; }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ar);
+    val ar: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?alloc, count::usize);
+    if (sel ar.err) { ret 1; }
+    val ops: *mir.MirOperand = ar.ok;
     ops[0] = mir.op_vreg(0);
     ops[1] = mir.op_vreg(0);
     ops[2] = mir.op_imm(8);
@@ -3974,7 +4007,8 @@ fun t_spilled_update(mode: u32) i32 {
     } or (mode == 2) {
         ops[1] = mir.op_imm(100);
     }
-    if (R.is_err[R.Void, str](rules.capture_operand_banks(?f, ?mi))) { ret 8; }
+    val capture_operand_banks_r: err[fail.Fail] = rules.capture_operand_banks(?f, ?mi);
+    if (sel capture_operand_banks_r.err) { ret 8; }
     var dst: [5]mir.MirInstr;
     var written: u32 = 0;
     fin {
@@ -3985,11 +4019,13 @@ fun t_spilled_update(mode: u32) i32 {
         }
     }
     val wrong_scratch: u32 = isa.regid_make(isa.REG_CLASS_ID_XMM, 0)::u32;
-    if (R.is_ok[R.Void, str](emit_reload(?ctx, ?dst[0], ?written, wrong_scratch, 0, mi.loc, 0))) { free_ops(?ctx, ops, count); ret 9; }
-    if (R.is_ok[R.Void, str](emit_store(?ctx, ?dst[0], ?written, 0, wrong_scratch, mi.loc, 0))) { free_ops(?ctx, ops, count); ret 9; }
+    val emit_reload_r: err[fail.Fail] = emit_reload(?ctx, ?dst[0], ?written, wrong_scratch, 0, mi.loc, 0);
+    if (sel emit_reload_r.ok) { free_ops(?ctx, ops, count); ret 9; }
+    val emit_store_r: err[fail.Fail] = emit_store(?ctx, ?dst[0], ?written, 0, wrong_scratch, mi.loc, 0);
+    if (sel emit_store_r.ok) { free_ops(?ctx, ops, count); ret 9; }
     if (written != 0) { free_ops(?ctx, ops, count); ret 9; }
-    val rr: R.Result[R.Void, str] = rewrite_instr(?tgt, ?ctx, ?mi, ?dst[0], ?written, false, 0);
-    if (R.is_err[R.Void, str](rr)) { ret 2; }
+    val rr: err[fail.Fail] = rewrite_instr(?tgt, ?ctx, ?mi, ?dst[0], ?written, false, 0);
+    if (sel rr.err) { ret 2; }
     var slot: i64 = 40;
     var reg: i64 = 999;
     var loads: u32 = 0;
@@ -4048,12 +4084,15 @@ fun t_spilled_update(mode: u32) i32 {
 # physical facts a post-allocation validator seeds from (#3126)
 test "mach.lang.be.codegen.regalloc.rewrite_instr:a_spilled_secret_keeps_its_slot_key_through_the_scratch" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
     var scratch_arena: arena.Arena;
-    if (O.is_some[str](arena.init(?scratch_arena, ?backing, 65536))) { ret 1; }
+    val init_r: err[A.Error] = arena.init(?scratch_arena, ?backing, 65536);
+    if (sel init_r.err) { ret 1; }
     fin { arena.dnit(?scratch_arena); }
     var alloc: A.Allocator;
-    if (O.is_some[str](arena.make(?alloc, ?scratch_arena))) { ret 1; }
+    val make_r2: err[A.Error] = arena.make(?alloc, ?scratch_arena);
+    if (sel make_r2.err) { ret 1; }
     var vregs: [2]mir.MirVReg;
     vregs[0] = mir.vreg(0, REG_CLASS_GP, false, true);
     vregs[0].spill_slot = 0;
@@ -4071,21 +4110,23 @@ test "mach.lang.be.codegen.regalloc.rewrite_instr:a_spilled_secret_keeps_its_slo
     ctx.reload_scratch = ?scratch[0];
     ctx.reload_scratch_count = 1;
     var tgt: target.Target;
-    val ar: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](?alloc, 3::usize);
-    if (R.is_err[*mir.MirOperand, str](ar)) { ret 1; }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ar);
+    val ar: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?alloc, 3::usize);
+    if (sel ar.err) { ret 1; }
+    val ops: *mir.MirOperand = ar.ok;
     ops[0] = mir.op_vreg(1);
     ops[1] = mir.op_vreg(1);
     ops[2] = mir.op_vreg(0);
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ops, 3, 8, 8);
-    if (R.is_err[R.Void, str](rules.capture_operand_banks(?f, ?mi))) { ret 2; }
+    val capture_operand_banks_r: err[fail.Fail] = rules.capture_operand_banks(?f, ?mi);
+    if (sel capture_operand_banks_r.err) { ret 2; }
     var dst: [4]mir.MirInstr;
     var written: u32 = 0;
     fin {
         var i: u32 = 0;
         for (i < written) { free_ops(?ctx, dst[i].operands, dst[i].operand_count); i = i + 1; }
     }
-    if (R.is_err[R.Void, str](rewrite_instr(?tgt, ?ctx, ?mi, ?dst[0], ?written, false, 0))) { ret 3; }
+    val rewrite_instr_r: err[fail.Fail] = rewrite_instr(?tgt, ?ctx, ?mi, ?dst[0], ?written, false, 0);
+    if (sel rewrite_instr_r.err) { ret 3; }
     if (written != 2) { ret 4; }
 
     # the reload: the scratch is a physical alias of the secret for one instruction
@@ -4114,12 +4155,15 @@ test "mach.lang.be.codegen.regalloc.rewrite_instr:a_spilled_secret_keeps_its_slo
 # vreg it homes as provenance on both its register and its slot
 test "mach.lang.be.codegen.regalloc.rewrite_instr:a_spilled_secret_destination_keeps_its_origin_through_the_store" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
     var scratch_arena: arena.Arena;
-    if (O.is_some[str](arena.init(?scratch_arena, ?backing, 65536))) { ret 1; }
+    val init_r: err[A.Error] = arena.init(?scratch_arena, ?backing, 65536);
+    if (sel init_r.err) { ret 1; }
     fin { arena.dnit(?scratch_arena); }
     var alloc: A.Allocator;
-    if (O.is_some[str](arena.make(?alloc, ?scratch_arena))) { ret 1; }
+    val make_r2: err[A.Error] = arena.make(?alloc, ?scratch_arena);
+    if (sel make_r2.err) { ret 1; }
     var vregs: [2]mir.MirVReg;
     vregs[0] = mir.vreg(0, REG_CLASS_GP, false, true);
     vregs[0].spill_slot = 0;
@@ -4137,20 +4181,22 @@ test "mach.lang.be.codegen.regalloc.rewrite_instr:a_spilled_secret_destination_k
     ctx.reload_scratch = ?scratch[0];
     ctx.reload_scratch_count = 1;
     var tgt: target.Target;
-    val ar: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](?alloc, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](ar)) { ret 1; }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ar);
+    val ar: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?alloc, 2::usize);
+    if (sel ar.err) { ret 1; }
+    val ops: *mir.MirOperand = ar.ok;
     ops[0] = mir.op_vreg(0);
     ops[1] = mir.op_vreg(1);
     var mi: mir.MirInstr = mir.instr(mir.MIR_MOV, ops, 2, 8, 8);
-    if (R.is_err[R.Void, str](rules.capture_operand_banks(?f, ?mi))) { ret 2; }
+    val capture_operand_banks_r: err[fail.Fail] = rules.capture_operand_banks(?f, ?mi);
+    if (sel capture_operand_banks_r.err) { ret 2; }
     var dst: [4]mir.MirInstr;
     var written: u32 = 0;
     fin {
         var i: u32 = 0;
         for (i < written) { free_ops(?ctx, dst[i].operands, dst[i].operand_count); i = i + 1; }
     }
-    if (R.is_err[R.Void, str](rewrite_instr(?tgt, ?ctx, ?mi, ?dst[0], ?written, false, 0))) { ret 3; }
+    val rewrite_instr_r: err[fail.Fail] = rewrite_instr(?tgt, ?ctx, ?mi, ?dst[0], ?written, false, 0);
+    if (sel rewrite_instr_r.err) { ret 3; }
     if (written != 2) { ret 4; }
     val mov: *mir.MirInstr = ?dst[0];
     if (mov.operands[0].kind != mir.MIR_OP_PREG || mov.operands[0].preg != 9) { ret 5; }
@@ -4192,20 +4238,24 @@ fun t_verify_bank_slots(tgt: *target.Target, opcode: mir.MirOpcode, bank0: mir.O
     blk.instrs = ?mi; blk.instr_count = 1;
     var f: mir.MirFunction;
     f.blocks = ?blk; f.block_count = 1;
-    if (R.is_err[R.Void, str](rules.capture_operand_banks(?f, ?mi))) { ret 1; }
-    if (R.is_err[R.Void, str](verify_rewritten_operands(tgt, ?f))) { ret 2; }
+    val capture_operand_banks_r: err[fail.Fail] = rules.capture_operand_banks(?f, ?mi);
+    if (sel capture_operand_banks_r.err) { ret 1; }
+    val verify_rewritten_operands_r: err[fail.Fail] = verify_rewritten_operands(tgt, ?f);
+    if (sel verify_rewritten_operands_r.err) { ret 2; }
     k = 0;
     for (k < count) {
         val original: u32 = ops[k].preg;
         var wrong: i32 = isa.REG_CLASS_ID_XMM;
         if (expected[k] == mir.BANK_FP) { wrong = isa.REG_CLASS_ID_GP; }
         ops[k].preg = isa.regid_make(wrong, 1 + k::i32)::u32;
-        if (R.is_ok[R.Void, str](verify_rewritten_operands(tgt, ?f))) { ret 3; }
+        val verify_rewritten_operands_r2: err[fail.Fail] = verify_rewritten_operands(tgt, ?f);
+        if (sel verify_rewritten_operands_r2.ok) { ret 3; }
         ops[k].preg = original;
         k = k + 1;
     }
     ops[0].required_bank = mir.BANK_UNKNOWN;
-    if (R.is_ok[R.Void, str](verify_rewritten_operands(tgt, ?f))) { ret 4; }
+    val verify_rewritten_operands_r3: err[fail.Fail] = verify_rewritten_operands(tgt, ?f);
+    if (sel verify_rewritten_operands_r3.ok) { ret 4; }
     ret 0;
 }
 
@@ -4229,23 +4279,30 @@ test "mach.lang.be.codegen.regalloc.verify_rewritten_operands:enforces_individua
     var mi: mir.MirInstr = mir.instr(mir.MIR_MOV, ?ops[0], 2, 8, 8);
     var blk: mir.MirBlock; blk.instrs = ?mi; blk.instr_count = 1;
     var f: mir.MirFunction; f.blocks = ?blk; f.block_count = 1;
-    if (R.is_err[R.Void, str](rules.capture_operand_banks(?f, ?mi))) { ret 10; }
-    if (R.is_err[R.Void, str](verify_rewritten_operands(?tgt, ?f))) { ret 11; }
+    val capture_operand_banks_r: err[fail.Fail] = rules.capture_operand_banks(?f, ?mi);
+    if (sel capture_operand_banks_r.err) { ret 10; }
+    val verify_rewritten_operands_r: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
+    if (sel verify_rewritten_operands_r.err) { ret 11; }
     ops[1].preg = isa.regid_make(isa.REG_CLASS_ID_XMM, 1)::u32;
-    if (R.is_ok[R.Void, str](verify_rewritten_operands(?tgt, ?f))) { ret 12; }
+    val verify_rewritten_operands_r2: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
+    if (sel verify_rewritten_operands_r2.ok) { ret 12; }
     ops[1].preg = tgt.model.stack_ptr_reg::u32;
     ops[1].index_is_preg = true;
     ops[1].index = isa.regid_make(isa.REG_CLASS_ID_XMM, 1)::u32;
-    if (R.is_ok[R.Void, str](verify_rewritten_operands(?tgt, ?f))) { ret 13; }
-    if (R.is_ok[R.Void, str](alloc_function(?tgt, nil, ?f))) { ret 15; }
+    val verify_rewritten_operands_r3: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
+    if (sel verify_rewritten_operands_r3.ok) { ret 13; }
+    val alloc_function_r: err[fail.Fail] = alloc_function(?tgt, nil, ?f);
+    if (sel alloc_function_r.ok) { ret 15; }
     ops[1].index = 2;
-    if (R.is_err[R.Void, str](verify_rewritten_operands(?tgt, ?f))) { ret 14; }
+    val verify_rewritten_operands_r4: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
+    if (sel verify_rewritten_operands_r4.err) { ret 14; }
     ret 0;
 }
 
 test "mach.lang.be.codegen.regalloc:unknown_catalog_inputs_never_use_the_fp_or_nonregister_defaults" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var interner: intern.Interner = intern.init(?alloc);
     fin { intern.dnit(?interner); }
     var registry: target.TargetRegistry = target.registry_init();
@@ -4257,16 +4314,20 @@ test "mach.lang.be.codegen.regalloc:unknown_catalog_inputs_never_use_the_fp_or_n
     var reg: mir.MirVReg = mir.vreg(0, REG_CLASS_GP, false, false);
     var function: mir.MirFunction = mir.MirFunction{vregs: ?reg, vreg_count: 1};
     var module: mir.MirModule = mir.MirModule{alloc: ?alloc, interner: ?interner, functions: ?function, function_len: 1};
-    if (R.is_err[R.Void, str](run(?tgt, ?module))) { ret 4; }
+    val run_r: err[fail.Fail] = run(?tgt, ?module);
+    if (sel run_r.err) { ret 4; }
     reg.class = fp_class_index(?tgt);
-    if (R.is_err[R.Void, str](run(?tgt, ?module))) { ret 5; }
+    val run_r2: err[fail.Fail] = run(?tgt, ?module);
+    if (sel run_r2.err) { ret 5; }
     reg.class = 200;
-    val unknown: R.Result[R.Void, str] = run(?tgt, ?module);
-    if (R.is_ok[R.Void, str](unknown) || !str_contains(R.unwrap_err[R.Void, str](unknown), "unknown MirRegisterClass tag 200")) { ret 6; }
+    val unknown: err[fail.Fail] = run(?tgt, ?module);
+    if (sel unknown.ok) { ret 6; }
+    if (!str_contains(fail.describe(unknown.err), "unknown MirRegisterClass tag 200")) { ret 6; }
     reg.class = 2;
     if (tgt.model.reg_classes[reg.class].kind != isa.RC_FLAGS) { ret 7; }
-    val unsupported: R.Result[R.Void, str] = run(?tgt, ?module);
-    if (R.is_ok[R.Void, str](unsupported) || !str_contains(R.unwrap_err[R.Void, str](unsupported), "unsupported for MIR virtual registers")) { ret 8; }
+    val unsupported: err[fail.Fail] = run(?tgt, ?module);
+    if (sel unsupported.ok) { ret 8; }
+    if (!str_contains(fail.describe(unsupported.err), "unsupported for MIR virtual registers")) { ret 8; }
     var classes: [3]isa.RegClass;
     var ci: u32 = 0;
     for (ci < 3) { classes[ci] = tgt.model.reg_classes[ci]; ci = ci + 1; }
@@ -4275,11 +4336,14 @@ test "mach.lang.be.codegen.regalloc:unknown_catalog_inputs_never_use_the_fp_or_n
     classes[1] = classes[2];
     classes[2] = float_class;
     reg.class = 2;
-    if (fp_class_index(?tgt) != reg.class || R.is_err[R.Void, str](run(?tgt, ?module))) { ret 12; }
+    if (fp_class_index(?tgt) != reg.class) { ret 12; }
+    val run_again: err[fail.Fail] = run(?tgt, ?module);
+    if (sel run_again.err) { ret 12; }
     classes[1].kind = 200;
     function.vreg_count = 0;
-    val bad_kind: R.Result[R.Void, str] = run(?tgt, ?module);
-    if (R.is_ok[R.Void, str](bad_kind) || !str_contains(R.unwrap_err[R.Void, str](bad_kind), "unknown RegClassKind tag 200")) { ret 9; }
+    val bad_kind: err[fail.Fail] = run(?tgt, ?module);
+    if (sel bad_kind.ok) { ret 9; }
+    if (!str_contains(fail.describe(bad_kind.err), "unknown RegClassKind tag 200")) { ret 9; }
     classes[1].kind = isa.RC_FLAGS;
     var operand: mir.MirOperand = mir.op_imm(7);
     var instruction: mir.MirInstr = mir.instr(mir.MIR_RET, ?operand, 1, 8, 8);
@@ -4287,7 +4351,8 @@ test "mach.lang.be.codegen.regalloc:unknown_catalog_inputs_never_use_the_fp_or_n
     function.blocks = ?block;
     function.block_count = 1;
     operand.kind = 200;
-    val bad_operand: R.Result[R.Void, str] = run(?tgt, ?module);
-    if (R.is_ok[R.Void, str](bad_operand) || !str_contains(R.unwrap_err[R.Void, str](bad_operand), "unknown MirOperandKind tag 200")) { ret 10; }
+    val bad_operand: err[fail.Fail] = run(?tgt, ?module);
+    if (sel bad_operand.ok) { ret 10; }
+    if (!str_contains(fail.describe(bad_operand.err), "unknown MirOperandKind tag 200")) { ret 10; }
     ret 0;
 }

--- a/src/lang/be/codegen/rules.mach
+++ b/src/lang/be/codegen/rules.mach
@@ -1,15 +1,17 @@
 use std.system.os;
+use std.types.canonical.res;
+use std.types.canonical.err;
+use mach.lang.fail;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 
-use A: mach.lang.legacy.allocator;
-use O: std.types.option;
+use A: std.allocator;
 use R: std.types.result;
 
-use page: mach.lang.legacy.page;
+use page: std.allocator.page;
 
 use mach.lang.be.codegen.mir;
 use mach.lang.source;
@@ -62,61 +64,67 @@ pub rec RulePack {
     fused_cbr_cc_count: u32;
 }
 
-fun typed_operand_bank(f: *mir.MirFunction, op: *mir.MirOperand) R.Result[mir.OperandBank, str] {
+fun typed_operand_bank(f: *mir.MirFunction, op: *mir.MirOperand) res[mir.OperandBank, fail.Fail] {
     if (op.kind == mir.MIR_OP_VREG) {
-        if (op.vreg >= f.vreg_count || f.vregs == nil) { ret R.err[mir.OperandBank, str]("rules: operand bank refers to a missing virtual register"); }
-        if (mir.vreg_is_fp(f, op.vreg)) { ret R.ok[mir.OperandBank, str](mir.BANK_FP); }
-        ret R.ok[mir.OperandBank, str](mir.BANK_GP);
+        if (op.vreg >= f.vreg_count || f.vregs == nil) { ret res[mir.OperandBank, fail.Fail].err{fail.message("rules: operand bank refers to a missing virtual register")}; }
+        if (mir.vreg_is_fp(f, op.vreg)) { ret res[mir.OperandBank, fail.Fail].ok{mir.BANK_FP}; }
+        ret res[mir.OperandBank, fail.Fail].ok{mir.BANK_GP};
     }
     if (op.kind == mir.MIR_OP_PREG) {
         val class: i32 = isa.regid_class(op.preg::i32);
-        if (class == isa.REG_CLASS_ID_GP) { ret R.ok[mir.OperandBank, str](mir.BANK_GP); }
-        if (class == isa.REG_CLASS_ID_XMM) { ret R.ok[mir.OperandBank, str](mir.BANK_FP); }
-        ret R.err[mir.OperandBank, str]("rules: operand bank refers to an unknown physical register class");
+        if (class == isa.REG_CLASS_ID_GP) { ret res[mir.OperandBank, fail.Fail].ok{mir.BANK_GP}; }
+        if (class == isa.REG_CLASS_ID_XMM) { ret res[mir.OperandBank, fail.Fail].ok{mir.BANK_FP}; }
+        ret res[mir.OperandBank, fail.Fail].err{fail.message("rules: operand bank refers to an unknown physical register class")};
     }
-    ret R.err[mir.OperandBank, str]("rules: operand is not a register");
+    ret res[mir.OperandBank, fail.Fail].err{fail.message("rules: operand is not a register")};
 }
 
-pub fun capture_operand_banks(f: *mir.MirFunction, mi: *mir.MirInstr) R.Result[R.Void, str] {
+pub fun capture_operand_banks(f: *mir.MirFunction, mi: *mir.MirInstr) err[fail.Fail] {
     var k: u32 = 0;
     for (k < mi.operand_count) {
         val op: *mir.MirOperand = ?mi.operands[k];
         if (op.kind == mir.MIR_OP_VREG || op.kind == mir.MIR_OP_PREG) {
-            val declared: R.Result[mir.OperandBank, str] = mir.operand_bank(mi.opcode, k, mi.vec_lane != mir.VEC_LANE_NONE);
-            if (R.is_err[mir.OperandBank, str](declared)) { ret R.err[R.Void, str](R.unwrap_err[mir.OperandBank, str](declared)); }
-            val typed: R.Result[mir.OperandBank, str] = typed_operand_bank(f, op);
-            if (R.is_err[mir.OperandBank, str](typed)) { ret R.err[R.Void, str](R.unwrap_err[mir.OperandBank, str](typed)); }
-            val actual: mir.OperandBank = R.unwrap_ok[mir.OperandBank, str](typed);
-            val required: mir.OperandBank = R.unwrap_ok[mir.OperandBank, str](declared);
+            val declared: res[mir.OperandBank, fail.Fail] = mir.operand_bank(mi.opcode, k, mi.vec_lane != mir.VEC_LANE_NONE);
+            if (sel declared.err) { ret err[fail.Fail].err{declared.err}; }
+            val typed: res[mir.OperandBank, fail.Fail] = typed_operand_bank(f, op);
+            if (sel typed.err) { ret err[fail.Fail].err{typed.err}; }
+            val actual: mir.OperandBank = typed.ok;
+            val required: mir.OperandBank = declared.ok;
             if (required != mir.BANK_EITHER && required != actual) {
-                ret R.err[R.Void, str]("rules: register operand is in the wrong bank for its machine opcode");
+                ret err[fail.Fail].err{fail.message("rules: register operand is in the wrong bank for its machine opcode")};
             }
             op.required_bank = actual;
         }
         k = k + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun select(pack: *RulePack, a: *A.Allocator, tgt: *isa.BackendTarget, f: *mir.MirFunction) R.Result[R.Void, str] {
-    if (pack == nil) { ret R.err[R.Void, str]("rules: nil rule pack"); }
-    if (a == nil)    { ret R.err[R.Void, str]("rules: nil allocator"); }
-    if (f == nil)    { ret R.err[R.Void, str]("rules: nil mir function"); }
-    if (tgt == nil)  { ret R.err[R.Void, str]("rules: nil backend target"); }
+pub fun select_function(pack: *RulePack, a: *A.Allocator, tgt: *isa.BackendTarget, f: *mir.MirFunction) err[fail.Fail] {
+    if (pack == nil) { ret err[fail.Fail].err{fail.message("rules: nil rule pack")}; }
+    if (a == nil)    { ret err[fail.Fail].err{fail.message("rules: nil allocator")}; }
+    if (f == nil)    { ret err[fail.Fail].err{fail.message("rules: nil mir function")}; }
+    if (tgt == nil)  { ret err[fail.Fail].err{fail.message("rules: nil backend target")}; }
 
     if (pack.fused_cbr_cc_count > 0) {
-        val res_combine: R.Result[R.Void, str] = combine_cbr(pack, a, f);
-        if (R.is_err[R.Void, str](res_combine)) { ret res_combine; }
+        val res_combine: err[fail.Fail] = combine_cbr(pack, a, f);
+        if (sel res_combine.err) { ret res_combine; }
     }
 
     var bi: u32 = 0;
     for (bi < f.block_count) {
-        val res_block: R.Result[R.Void, str] = select_block(pack, a, tgt, f, ?f.blocks[bi]);
-        if (R.is_err[R.Void, str](res_block)) { ret res_block; }
+        val res_block: err[fail.Fail] = select_block(pack, a, tgt, f, ?f.blocks[bi]);
+        if (sel res_block.err) { ret res_block; }
         bi = bi + 1;
     }
 
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
+}
+
+# translation shim (#3226): the legacy carrier the per-ISA rule packs read
+# until target/isa migrates to `select_function`
+pub fun select(pack: *RulePack, a: *A.Allocator, tgt: *isa.BackendTarget, f: *mir.MirFunction) R.Result[R.Void, str] {
+    ret fail.lower_unit(select_function(pack, a, tgt, f));
 }
 
 pub fun is_reg_move(pack: *RulePack, opcode: u32) bool {
@@ -141,9 +149,9 @@ pub fun find_rule(pack: *RulePack, tgt: *isa.BackendTarget, f: *mir.MirFunction,
     ret nil;
 }
 
-pub fun emit(builder: *ExpansionBuilder, opcode: u32, operands: *mir.MirOperand, operand_count: u32) R.Result[*mir.MirInstr, str] {
+pub fun emit_instr(builder: *ExpansionBuilder, opcode: u32, operands: *mir.MirOperand, operand_count: u32) res[*mir.MirInstr, fail.Fail] {
     if (builder.emitted >= builder.limit) {
-        ret R.err[*mir.MirInstr, str]("rules: expansion emitted more pieces than its rule's declared length");
+        ret res[*mir.MirInstr, fail.Fail].err{fail.message("rules: expansion emitted more pieces than its rule's declared length")};
     }
 
     var oi: u32 = 0;
@@ -151,12 +159,12 @@ pub fun emit(builder: *ExpansionBuilder, opcode: u32, operands: *mir.MirOperand,
         val op: *mir.MirOperand = ?operands[oi];
         if (op.kind == mir.MIR_OP_VREG || op.kind == mir.MIR_OP_PREG) {
             if (op.required_bank != mir.BANK_GP && op.required_bank != mir.BANK_FP) {
-                ret R.err[*mir.MirInstr, str]("rules: expansion register operand omits its selected bank constraint");
+                ret res[*mir.MirInstr, fail.Fail].err{fail.message("rules: expansion register operand omits its selected bank constraint")};
             }
-            val typed: R.Result[mir.OperandBank, str] = typed_operand_bank(builder.function, op);
-            if (R.is_err[mir.OperandBank, str](typed)) { ret R.err[*mir.MirInstr, str](R.unwrap_err[mir.OperandBank, str](typed)); }
-            if (R.unwrap_ok[mir.OperandBank, str](typed) != op.required_bank) {
-                ret R.err[*mir.MirInstr, str]("rules: expansion register operand violates its selected bank constraint");
+            val typed: res[mir.OperandBank, fail.Fail] = typed_operand_bank(builder.function, op);
+            if (sel typed.err) { ret res[*mir.MirInstr, fail.Fail].err{typed.err}; }
+            if (typed.ok != op.required_bank) {
+                ret res[*mir.MirInstr, fail.Fail].err{fail.message("rules: expansion register operand violates its selected bank constraint")};
             }
         }
         oi = oi + 1;
@@ -164,11 +172,11 @@ pub fun emit(builder: *ExpansionBuilder, opcode: u32, operands: *mir.MirOperand,
 
     var ops: *mir.MirOperand = nil;
     if (operand_count > 0) {
-        val res_ops: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](builder.allocator, operand_count::usize);
-        if (R.is_err[*mir.MirOperand, str](res_ops)) {
-            ret R.err[*mir.MirInstr, str](R.unwrap_err[*mir.MirOperand, str](res_ops));
+        val res_ops: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](builder.allocator, operand_count::usize);
+        if (sel res_ops.err) {
+            ret res[*mir.MirInstr, fail.Fail].err{fail.refused(res_ops.err)};
         }
-        ops = R.unwrap_ok[*mir.MirOperand, str](res_ops);
+        ops = res_ops.ok;
         var i: u32 = 0;
         for (i < operand_count) {
             ops[i] = operands[i];
@@ -196,7 +204,13 @@ pub fun emit(builder: *ExpansionBuilder, opcode: u32, operands: *mir.MirOperand,
 
     builder.cursor  = builder.cursor + 1;
     builder.emitted = builder.emitted + 1;
-    ret R.ok[*mir.MirInstr, str](piece);
+    ret res[*mir.MirInstr, fail.Fail].ok{piece};
+}
+
+# translation shim (#3226): the legacy carrier the per-ISA expansions read
+# until target/isa migrates to `emit_instr`
+pub fun emit(builder: *ExpansionBuilder, opcode: u32, operands: *mir.MirOperand, operand_count: u32) R.Result[*mir.MirInstr, str] {
+    ret fail.lower[*mir.MirInstr](emit_instr(builder, opcode, operands, operand_count));
 }
 
 # a retag loses the generic opcode; the declassify barrier is kept as a flag
@@ -264,16 +278,16 @@ fun defines_vreg(mi: *mir.MirInstr, v: u32) bool {
     ret mi.operands[0].kind == mir.MIR_OP_VREG && mi.operands[0].vreg == v;
 }
 
-fun combine_cbr(pack: *RulePack, a: *A.Allocator, f: *mir.MirFunction) R.Result[R.Void, str] {
+fun combine_cbr(pack: *RulePack, a: *A.Allocator, f: *mir.MirFunction) err[fail.Fail] {
     val nv: u32 = f.vreg_count;
-    if (nv == 0) { ret R.ok_void[str](); }
-    if (!function_has_cbr(f)) { ret R.ok_void[str](); }
+    if (nv == 0) { ret err[fail.Fail].ok{}; }
+    if (!function_has_cbr(f)) { ret err[fail.Fail].ok{}; }
 
-    val res_counts: R.Result[*u32, str] = A.zallocate[u32](a, nv::usize);
-    if (R.is_err[*u32, str](res_counts)) {
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](res_counts));
+    val res_counts: res[*u32, A.Error] = A.zallocate[u32](a, nv::usize);
+    if (sel res_counts.err) {
+        ret err[fail.Fail].err{fail.refused(res_counts.err)};
     }
-    val counts: *u32 = R.unwrap_ok[*u32, str](res_counts);
+    val counts: *u32 = res_counts.ok;
     count_vreg_refs(f, counts, nv);
 
     var bi: u32 = 0;
@@ -285,8 +299,8 @@ fun combine_cbr(pack: *RulePack, a: *A.Allocator, f: *mir.MirFunction) R.Result[
             val ci: u32 = fusable_cmp_index(pack, b, br, counts, nv, j);
             if (ci == FUSE_NONE) { j = j + 1; cnt; }
 
-            val res_fuse: R.Result[R.Void, str] = fuse_pair(a, b, ci, j);
-            if (R.is_err[R.Void, str](res_fuse)) {
+            val res_fuse: err[fail.Fail] = fuse_pair(a, b, ci, j);
+            if (sel res_fuse.err) {
                 A.deallocate[u32](a, counts, nv::usize);
                 ret res_fuse;
             }
@@ -295,7 +309,7 @@ fun combine_cbr(pack: *RulePack, a: *A.Allocator, f: *mir.MirFunction) R.Result[
     }
 
     A.deallocate[u32](a, counts, nv::usize);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun function_has_cbr(f: *mir.MirFunction) bool {
@@ -352,22 +366,22 @@ fun fusable_cmp_index(pack: *RulePack, b: *mir.MirBlock, br: *mir.MirInstr,
     ret k;
 }
 
-fun fuse_pair(a: *A.Allocator, b: *mir.MirBlock, ci: u32, j: u32) R.Result[R.Void, str] {
+fun fuse_pair(a: *A.Allocator, b: *mir.MirBlock, ci: u32, j: u32) err[fail.Fail] {
     val cmp: *mir.MirInstr = ?b.instrs[ci];
     val br:  *mir.MirInstr = ?b.instrs[j];
 
-    val res_ops: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](a, 4::usize);
-    if (R.is_err[*mir.MirOperand, str](res_ops)) {
-        ret R.err[R.Void, str](R.unwrap_err[*mir.MirOperand, str](res_ops));
+    val res_ops: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](a, 4::usize);
+    if (sel res_ops.err) {
+        ret err[fail.Fail].err{fail.refused(res_ops.err)};
     }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](res_ops);
+    val ops: *mir.MirOperand = res_ops.ok;
     ops[0] = cmp.operands[1];
     ops[1] = cmp.operands[2];
     ops[2] = br.operands[1];
     ops[3] = br.operands[2];
 
-    val res_dbg: R.Result[R.Void, str] = merge_dbg_bindings(a, cmp, br);
-    if (R.is_err[R.Void, str](res_dbg)) {
+    val res_dbg: err[fail.Fail] = merge_dbg_bindings(a, cmp, br);
+    if (sel res_dbg.err) {
         A.deallocate[mir.MirOperand](a, ops, 4::usize);
         ret res_dbg;
     }
@@ -387,7 +401,7 @@ fun fuse_pair(a: *A.Allocator, b: *mir.MirBlock, ci: u32, j: u32) R.Result[R.Voi
         m = m + 1;
     }
     b.instr_count = b.instr_count - 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun rewrite_cond_bindings(br: *mir.MirInstr, cond_vreg: u32, cmp: *mir.MirInstr) {
@@ -424,8 +438,8 @@ fun rewrite_cond_bindings(br: *mir.MirInstr, cond_vreg: u32, cmp: *mir.MirInstr)
     }
 }
 
-fun merge_dbg_bindings(a: *A.Allocator, cmp: *mir.MirInstr, br: *mir.MirInstr) R.Result[R.Void, str] {
-    if (cmp.dbg_binding_count == 0) { ret R.ok_void[str](); }
+fun merge_dbg_bindings(a: *A.Allocator, cmp: *mir.MirInstr, br: *mir.MirInstr) err[fail.Fail] {
+    if (cmp.dbg_binding_count == 0) { ret err[fail.Fail].ok{}; }
 
     if (br.dbg_binding_count == 0) {
         br.dbg_bindings      = cmp.dbg_bindings;
@@ -433,11 +447,11 @@ fun merge_dbg_bindings(a: *A.Allocator, cmp: *mir.MirInstr, br: *mir.MirInstr) R
     }
     or {
         val total: u32 = cmp.dbg_binding_count + br.dbg_binding_count;
-        val res_merged: R.Result[*mir.MirDbgBinding, str] = A.allocate[mir.MirDbgBinding](a, total::usize);
-        if (R.is_err[*mir.MirDbgBinding, str](res_merged)) {
-            ret R.err[R.Void, str](R.unwrap_err[*mir.MirDbgBinding, str](res_merged));
+        val res_merged: res[*mir.MirDbgBinding, A.Error] = A.allocate[mir.MirDbgBinding](a, total::usize);
+        if (sel res_merged.err) {
+            ret err[fail.Fail].err{fail.refused(res_merged.err)};
         }
-        val merged: *mir.MirDbgBinding = R.unwrap_ok[*mir.MirDbgBinding, str](res_merged);
+        val merged: *mir.MirDbgBinding = res_merged.ok;
         var i: u32 = 0;
         for (i < cmp.dbg_binding_count) {
             merged[i] = cmp.dbg_bindings[i];
@@ -456,22 +470,22 @@ fun merge_dbg_bindings(a: *A.Allocator, cmp: *mir.MirInstr, br: *mir.MirInstr) R
 
     cmp.dbg_bindings      = nil;
     cmp.dbg_binding_count = 0;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-fun select_block(pack: *RulePack, a: *A.Allocator, tgt: *isa.BackendTarget, f: *mir.MirFunction, b: *mir.MirBlock) R.Result[R.Void, str] {
+fun select_block(pack: *RulePack, a: *A.Allocator, tgt: *isa.BackendTarget, f: *mir.MirFunction, b: *mir.MirBlock) err[fail.Fail] {
     val n: u32 = b.instr_count;
-    if (n == 0) { ret R.ok_void[str](); }
+    if (n == 0) { ret err[fail.Fail].ok{}; }
 
     var stack_cache: [RULE_CACHE_STACK]*Rule;
     var rules_for: **Rule = ?stack_cache[0];
     var cache_on_heap: bool = false;
     if (n > RULE_CACHE_STACK) {
-        val res_cache: R.Result[**Rule, str] = A.allocate[*Rule](a, n::usize);
-        if (R.is_err[**Rule, str](res_cache)) {
-            ret R.err[R.Void, str](R.unwrap_err[**Rule, str](res_cache));
+        val res_cache: res[**Rule, A.Error] = A.allocate[*Rule](a, n::usize);
+        if (sel res_cache.err) {
+            ret err[fail.Fail].err{fail.refused(res_cache.err)};
         }
-        rules_for = R.unwrap_ok[**Rule, str](res_cache);
+        rules_for = res_cache.ok;
         cache_on_heap = true;
     }
 
@@ -480,8 +494,8 @@ fun select_block(pack: *RulePack, a: *A.Allocator, tgt: *isa.BackendTarget, f: *
     var i:            u32  = 0;
     for (i < n) {
         val mi:   *mir.MirInstr = ?b.instrs[i];
-        val banks: R.Result[R.Void, str] = capture_operand_banks(f, mi);
-        if (R.is_err[R.Void, str](banks)) {
+        val banks: err[fail.Fail] = capture_operand_banks(f, mi);
+        if (sel banks.err) {
             free_rule_cache(a, rules_for, n, cache_on_heap);
             ret banks;
         }
@@ -489,12 +503,12 @@ fun select_block(pack: *RulePack, a: *A.Allocator, tgt: *isa.BackendTarget, f: *
         if (rule == nil) {
             write_opcode_ice(mi.opcode);
             free_rule_cache(a, rules_for, n, cache_on_heap);
-            ret R.err[R.Void, str]("internal compiler error: unhandled MIR opcode in instruction selection");
+            ret err[fail.Fail].err{fail.message("internal compiler error: unhandled MIR opcode in instruction selection")};
         }
         if (rule.kind == RULE_EXPAND) {
             if (rule.expand == nil || rule.expansion_length == 0) {
                 free_rule_cache(a, rules_for, n, cache_on_heap);
-                ret R.err[R.Void, str]("rules: malformed expansion rule");
+                ret err[fail.Fail].err{fail.message("rules: malformed expansion rule")};
             }
             needs_expand = true;
             total = total + rule.expansion_length;
@@ -513,15 +527,15 @@ fun select_block(pack: *RulePack, a: *A.Allocator, tgt: *isa.BackendTarget, f: *
             i = i + 1;
         }
         free_rule_cache(a, rules_for, n, cache_on_heap);
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
 
-    val res_alloc: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](a, total::usize);
-    if (R.is_err[*mir.MirInstr, str](res_alloc)) {
+    val res_alloc: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](a, total::usize);
+    if (sel res_alloc.err) {
         free_rule_cache(a, rules_for, n, cache_on_heap);
-        ret R.err[R.Void, str](R.unwrap_err[*mir.MirInstr, str](res_alloc));
+        ret err[fail.Fail].err{fail.refused(res_alloc.err)};
     }
-    val dst: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](res_alloc);
+    val dst: *mir.MirInstr = res_alloc.ok;
 
     var w: u32 = 0;
     i = 0;
@@ -541,12 +555,12 @@ fun select_block(pack: *RulePack, a: *A.Allocator, tgt: *isa.BackendTarget, f: *
             if (R.is_err[R.Void, str](res_expand)) {
                 free_partial_rebuild(a, b, rules_for, i, builder.emitted, dst, total);
                 free_rule_cache(a, rules_for, n, cache_on_heap);
-                ret res_expand;
+                ret err[fail.Fail].err{fail.message(R.unwrap_err[R.Void, str](res_expand))};
             }
             if (builder.emitted != rule.expansion_length) {
                 free_partial_rebuild(a, b, rules_for, i, builder.emitted, dst, total);
                 free_rule_cache(a, rules_for, n, cache_on_heap);
-                ret R.err[R.Void, str]("rules: expansion emitted a piece count different from its rule's declared length");
+                ret err[fail.Fail].err{fail.message("rules: expansion emitted a piece count different from its rule's declared length")};
             }
             w = builder.cursor;
             free_source_operands(a, mi);
@@ -567,7 +581,7 @@ fun select_block(pack: *RulePack, a: *A.Allocator, tgt: *isa.BackendTarget, f: *
     b.instr_cap   = total;
 
     free_rule_cache(a, rules_for, n, cache_on_heap);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 val RULE_CACHE_STACK: u32 = 128;
@@ -714,8 +728,8 @@ test "mach.lang.be.codegen.rules.select:retag_pass_priority" {
     var f:   mir.MirFunction;
     t_function(?blk, ?instrs[0], 3, ?f);
 
-    val r: R.Result[R.Void, str] = select(?pack, ?alloc, ?tgt, ?f);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = select_function(?pack, ?alloc, ?tgt, ?f);
+    if (sel r.err) { ret 1; }
 
     if (instrs[0].opcode != 101) { ret 1; }
     if (instrs[1].opcode != 2)   { ret 1; }
@@ -766,8 +780,8 @@ test "mach.lang.be.codegen.rules.select:guard_routing" {
     var f:   mir.MirFunction;
     t_function(?blk, ?instrs[0], 2, ?f);
 
-    val r: R.Result[R.Void, str] = select(?pack, ?alloc, ?tgt, ?f);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = select_function(?pack, ?alloc, ?tgt, ?f);
+    if (sel r.err) { ret 1; }
 
     if (instrs[0].opcode != 700) { ret 1; }
     if (instrs[1].opcode != 701) { ret 1; }
@@ -815,8 +829,8 @@ test "mach.lang.be.codegen.rules.select:gate_routing" {
     var f:   mir.MirFunction;
     t_function(?blk, ?instrs[0], 2, ?f);
 
-    val r: R.Result[R.Void, str] = select(?pack, ?alloc, ?tgt, ?f);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = select_function(?pack, ?alloc, ?tgt, ?f);
+    if (sel r.err) { ret 1; }
 
     if (instrs[0].opcode != 501) { ret 1; }
     if (instrs[1].opcode != 502) { ret 1; }
@@ -850,22 +864,23 @@ test "mach.lang.be.codegen.rules.select:unmatched_opcode_fails" {
     var f:   mir.MirFunction;
     t_function(?blk, ?instrs[0], 1, ?f);
 
-    val r: R.Result[R.Void, str] = select(?pack, ?alloc, ?tgt, ?f);
-    if (!R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = select_function(?pack, ?alloc, ?tgt, ?f);
+    if (!sel r.err) { ret 1; }
     ret 0;
 }
 
 test "mach.lang.be.codegen.rules.select:expansion_identity_carriage" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
     var tgt: isa.BackendTarget;
 
-    val res_instrs: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](?backing, 3::usize);
-    if (R.is_err[*mir.MirInstr, str](res_instrs)) { ret 1; }
-    val instrs: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](res_instrs);
-    val res_exp_ops: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](?backing, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](res_exp_ops)) { ret 1; }
-    val exp_ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](res_exp_ops);
+    val res_instrs: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](?backing, 3::usize);
+    if (sel res_instrs.err) { ret 1; }
+    val instrs: *mir.MirInstr = res_instrs.ok;
+    val res_exp_ops: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?backing, 2::usize);
+    if (sel res_exp_ops.err) { ret 1; }
+    val exp_ops: *mir.MirOperand = res_exp_ops.ok;
     exp_ops[0] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, 0)::u32);
     exp_ops[1] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, 1)::u32);
 
@@ -920,8 +935,8 @@ test "mach.lang.be.codegen.rules.select:expansion_identity_carriage" {
     var f:   mir.MirFunction;
     t_function(?blk, instrs, 3, ?f);
 
-    val r: R.Result[R.Void, str] = select(?pack, ?backing, ?tgt, ?f);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = select_function(?pack, ?backing, ?tgt, ?f);
+    if (sel r.err) { ret 1; }
 
     if (blk.instr_count != 4) { ret 1; }
     if (blk.instr_cap != 4)   { ret 1; }
@@ -958,15 +973,16 @@ test "mach.lang.be.codegen.rules.select:expansion_identity_carriage" {
 
 test "mach.lang.be.codegen.rules.select:expansion_length_mismatch_fails" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
     var tgt: isa.BackendTarget;
 
-    val res_instrs: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](?backing, 1::usize);
-    if (R.is_err[*mir.MirInstr, str](res_instrs)) { ret 1; }
-    val instrs: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](res_instrs);
-    val res_ops: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](?backing, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](res_ops)) { ret 1; }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](res_ops);
+    val res_instrs: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](?backing, 1::usize);
+    if (sel res_instrs.err) { ret 1; }
+    val instrs: *mir.MirInstr = res_instrs.ok;
+    val res_ops: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?backing, 2::usize);
+    if (sel res_ops.err) { ret 1; }
+    val ops: *mir.MirOperand = res_ops.ok;
     ops[0] = mir.op_preg(10);
     ops[1] = mir.op_preg(11);
     instrs[0].opcode        = 9;
@@ -990,22 +1006,23 @@ test "mach.lang.be.codegen.rules.select:expansion_length_mismatch_fails" {
     var f:   mir.MirFunction;
     t_function(?blk, instrs, 1, ?f);
 
-    val r: R.Result[R.Void, str] = select(?pack, ?backing, ?tgt, ?f);
-    if (!R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = select_function(?pack, ?backing, ?tgt, ?f);
+    if (!sel r.err) { ret 1; }
     ret 0;
 }
 
 test "mach.lang.be.codegen.rules.select:expansion_over_emission_fails" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
     var tgt: isa.BackendTarget;
 
-    val res_instrs: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](?backing, 1::usize);
-    if (R.is_err[*mir.MirInstr, str](res_instrs)) { ret 1; }
-    val instrs: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](res_instrs);
-    val res_ops: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](?backing, 2::usize);
-    if (R.is_err[*mir.MirOperand, str](res_ops)) { ret 1; }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](res_ops);
+    val res_instrs: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](?backing, 1::usize);
+    if (sel res_instrs.err) { ret 1; }
+    val instrs: *mir.MirInstr = res_instrs.ok;
+    val res_ops: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?backing, 2::usize);
+    if (sel res_ops.err) { ret 1; }
+    val ops: *mir.MirOperand = res_ops.ok;
     ops[0] = mir.op_preg(10);
     ops[1] = mir.op_preg(11);
     instrs[0].opcode        = 9;
@@ -1029,17 +1046,17 @@ test "mach.lang.be.codegen.rules.select:expansion_over_emission_fails" {
     var f:   mir.MirFunction;
     t_function(?blk, instrs, 1, ?f);
 
-    val r: R.Result[R.Void, str] = select(?pack, ?backing, ?tgt, ?f);
-    if (!R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = select_function(?pack, ?backing, ?tgt, ?f);
+    if (!sel r.err) { ret 1; }
     if (blk.instrs != instrs)  { ret 1; }
     if (blk.instr_count != 1)  { ret 1; }
     ret 0;
 }
 
 fun t_heap_instr(a: *A.Allocator, mi: *mir.MirInstr, opcode: u32, operands: *mir.MirOperand, operand_count: u32) bool {
-    val ro: R.Result[*mir.MirOperand, str] = A.allocate[mir.MirOperand](a, operand_count::usize);
-    if (R.is_err[*mir.MirOperand, str](ro)) { ret false; }
-    val ops: *mir.MirOperand = R.unwrap_ok[*mir.MirOperand, str](ro);
+    val ro: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](a, operand_count::usize);
+    if (sel ro.err) { ret false; }
+    val ops: *mir.MirOperand = ro.ok;
     var i: u32 = 0;
     for (i < operand_count) {
         ops[i] = operands[i];
@@ -1053,12 +1070,13 @@ fun t_heap_instr(a: *A.Allocator, mi: *mir.MirInstr, opcode: u32, operands: *mir
 
 test "mach.lang.be.codegen.rules.combine_cbr:fuses_safe_shape" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
     var tgt: isa.BackendTarget;
 
-    val res_instrs: R.Result[*mir.MirInstr, str] = A.zallocate[mir.MirInstr](?backing, 2::usize);
-    if (R.is_err[*mir.MirInstr, str](res_instrs)) { ret 1; }
-    val instrs: *mir.MirInstr = R.unwrap_ok[*mir.MirInstr, str](res_instrs);
+    val res_instrs: res[*mir.MirInstr, A.Error] = A.zallocate[mir.MirInstr](?backing, 2::usize);
+    if (sel res_instrs.err) { ret 1; }
+    val instrs: *mir.MirInstr = res_instrs.ok;
 
     var cmp_ops: [3]mir.MirOperand;
     cmp_ops[0] = mir.op_vreg(2);
@@ -1068,9 +1086,9 @@ test "mach.lang.be.codegen.rules.combine_cbr:fuses_safe_shape" {
     instrs[0].width     = 4;
     instrs[0].src_width = 4;
     instrs[0].loc       = source.loc(3, 40);
-    val res_cb: R.Result[*mir.MirDbgBinding, str] = A.allocate[mir.MirDbgBinding](?backing, 1::usize);
-    if (R.is_err[*mir.MirDbgBinding, str](res_cb)) { ret 1; }
-    instrs[0].dbg_bindings = R.unwrap_ok[*mir.MirDbgBinding, str](res_cb);
+    val res_cb: res[*mir.MirDbgBinding, A.Error] = A.allocate[mir.MirDbgBinding](?backing, 1::usize);
+    if (sel res_cb.err) { ret 1; }
+    instrs[0].dbg_bindings = res_cb.ok;
     instrs[0].dbg_bindings[0].iid  = 7;
     instrs[0].dbg_bindings[0].cmp_op = 0;
     instrs[0].dbg_bindings[0].vreg = 2;
@@ -1084,9 +1102,9 @@ test "mach.lang.be.codegen.rules.combine_cbr:fuses_safe_shape" {
     instrs[1].width     = 1;
     instrs[1].src_width = 1;
     instrs[1].loc       = source.loc(3, 77);
-    val res_bb: R.Result[*mir.MirDbgBinding, str] = A.allocate[mir.MirDbgBinding](?backing, 1::usize);
-    if (R.is_err[*mir.MirDbgBinding, str](res_bb)) { ret 1; }
-    instrs[1].dbg_bindings = R.unwrap_ok[*mir.MirDbgBinding, str](res_bb);
+    val res_bb: res[*mir.MirDbgBinding, A.Error] = A.allocate[mir.MirDbgBinding](?backing, 1::usize);
+    if (sel res_bb.err) { ret 1; }
+    instrs[1].dbg_bindings = res_bb.ok;
     instrs[1].dbg_bindings[0].iid  = 9;
     instrs[1].dbg_bindings[0].cmp_op = 0;
     instrs[1].dbg_bindings[0].vreg = 1;
@@ -1118,8 +1136,8 @@ test "mach.lang.be.codegen.rules.combine_cbr:fuses_safe_shape" {
     vregs[2] = mir.vreg(2, mir.REG_CLASS_GP, false, false);
     f.vregs = ?vregs[0];
 
-    val r: R.Result[R.Void, str] = select(?pack, ?backing, ?tgt, ?f);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = select_function(?pack, ?backing, ?tgt, ?f);
+    if (sel r.err) { ret 1; }
 
     if (blk.instr_count != 1) { ret 1; }
     val fused: *mir.MirInstr = ?blk.instrs[0];
@@ -1150,7 +1168,8 @@ test "mach.lang.be.codegen.rules.combine_cbr:fuses_safe_shape" {
 
 test "mach.lang.be.codegen.rules.combine_cbr:declines_unsafe_shapes" {
     var backing: A.Allocator;
-    if (O.is_some[str](page.make(?backing))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?backing);
+    if (sel make_r.err) { ret 1; }
 
     var ccs: [6]u32;
     ccs[0] = mir.MIR_CMP_EQ;
@@ -1195,13 +1214,15 @@ test "mach.lang.be.codegen.rules.combine_cbr:declines_unsafe_shapes" {
     instrs[2].opcode = mir.MIR_CBR;     instrs[2].operands = ?br_ops[0];  instrs[2].operand_count = 3;
     t_function(?blk, ?instrs[0], 3, ?f);
     f.vreg_count = 4;
-    if (R.is_err[R.Void, str](combine_cbr(?pack, ?backing, ?f))) { ret 1; }
+    val combine_cbr_r: err[fail.Fail] = combine_cbr(?pack, ?backing, ?f);
+    if (sel combine_cbr_r.err) { ret 1; }
     if (blk.instr_count != 3)             { ret 1; }
     if (instrs[2].opcode != mir.MIR_CBR)  { ret 1; }
 
     instrs[1].operands      = ?redef_ops[0];
     instrs[1].operand_count = 2;
-    if (R.is_err[R.Void, str](combine_cbr(?pack, ?backing, ?f))) { ret 2; }
+    val combine_cbr_r2: err[fail.Fail] = combine_cbr(?pack, ?backing, ?f);
+    if (sel combine_cbr_r2.err) { ret 2; }
     if (blk.instr_count != 3)             { ret 2; }
     if (instrs[2].opcode != mir.MIR_CBR)  { ret 2; }
 
@@ -1216,7 +1237,8 @@ test "mach.lang.be.codegen.rules.combine_cbr:declines_unsafe_shapes" {
     blocks[1].instr_cap   = 1;
     f.blocks      = ?blocks[0];
     f.block_count = 2;
-    if (R.is_err[R.Void, str](combine_cbr(?pack, ?backing, ?f))) { ret 3; }
+    val combine_cbr_r3: err[fail.Fail] = combine_cbr(?pack, ?backing, ?f);
+    if (sel combine_cbr_r3.err) { ret 3; }
     if (blocks[0].instr_count != 1)       { ret 3; }
     if (instrs[2].opcode != mir.MIR_CBR)  { ret 3; }
 
@@ -1228,14 +1250,16 @@ test "mach.lang.be.codegen.rules.combine_cbr:declines_unsafe_shapes" {
     instrs[0].vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 4, 4);
     t_function(?blk, ?instrs[0], 2, ?f);
     f.vreg_count = 4;
-    if (R.is_err[R.Void, str](combine_cbr(?pack, ?backing, ?f))) { ret 4; }
+    val combine_cbr_r4: err[fail.Fail] = combine_cbr(?pack, ?backing, ?f);
+    if (sel combine_cbr_r4.err) { ret 4; }
     if (blk.instr_count != 2)             { ret 4; }
     if (instrs[1].opcode != mir.MIR_CBR)  { ret 4; }
     instrs[0].vec_lane = 0;
 
     pack.fused_cbr_cc_count = 1;
     ccs[0] = mir.MIR_CMP_NE;
-    if (R.is_err[R.Void, str](combine_cbr(?pack, ?backing, ?f))) { ret 5; }
+    val combine_cbr_r5: err[fail.Fail] = combine_cbr(?pack, ?backing, ?f);
+    if (sel combine_cbr_r5.err) { ret 5; }
     if (blk.instr_count != 2)             { ret 5; }
     if (instrs[1].opcode != mir.MIR_CBR)  { ret 5; }
     ret 0;
@@ -1265,28 +1289,35 @@ test "mach.lang.be.codegen.rules.capture_operand_banks:checks_opcode_before_pres
     ops[0] = mir.op_preg(1); ops[1] = mir.op_preg(2); ops[2] = mir.op_preg(3);
     var mi: mir.MirInstr = mir.instr(mir.MIR_FADD, ?ops[0], 3, 8, 8);
     var f: mir.MirFunction;
-    if (R.is_ok[R.Void, str](capture_operand_banks(?f, ?mi))) { ret 1; }
+    val capture_operand_banks_r: err[fail.Fail] = capture_operand_banks(?f, ?mi);
+    if (sel capture_operand_banks_r.ok) { ret 1; }
     var k: u32 = 0;
     for (k < 3) { ops[k] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, k::i32)::u32); k = k + 1; }
-    if (R.is_err[R.Void, str](capture_operand_banks(?f, ?mi))) { ret 2; }
+    val capture_operand_banks_r2: err[fail.Fail] = capture_operand_banks(?f, ?mi);
+    if (sel capture_operand_banks_r2.err) { ret 2; }
     mi.opcode = mir.MIR_FP_TO_SI; mi.operand_count = 2;
-    if (R.is_ok[R.Void, str](capture_operand_banks(?f, ?mi))) { ret 3; }
+    val capture_operand_banks_r3: err[fail.Fail] = capture_operand_banks(?f, ?mi);
+    if (sel capture_operand_banks_r3.ok) { ret 3; }
     ops[0] = mir.op_preg(1);
-    if (R.is_err[R.Void, str](capture_operand_banks(?f, ?mi))) { ret 4; }
+    val capture_operand_banks_r4: err[fail.Fail] = capture_operand_banks(?f, ?mi);
+    if (sel capture_operand_banks_r4.err) { ret 4; }
     if (ops[0].required_bank != mir.BANK_GP || ops[1].required_bank != mir.BANK_FP) { ret 5; }
     ops[0] = mir.op_vreg(0);
-    if (R.is_ok[R.Void, str](capture_operand_banks(?f, ?mi))) { ret 6; }
+    val capture_operand_banks_r5: err[fail.Fail] = capture_operand_banks(?f, ?mi);
+    if (sel capture_operand_banks_r5.ok) { ret 6; }
     var vregs: [1]mir.MirVReg;
     vregs[0] = mir.vreg(0, mir.REG_CLASS_GP, false, false);
     f.vregs = ?vregs[0]; f.vreg_count = 1;
-    if (R.is_err[R.Void, str](capture_operand_banks(?f, ?mi))) { ret 7; }
+    val capture_operand_banks_r6: err[fail.Fail] = capture_operand_banks(?f, ?mi);
+    if (sel capture_operand_banks_r6.err) { ret 7; }
     if (ops[0].required_bank != mir.BANK_GP) { ret 8; }
     ret 0;
 }
 
 test "mach.lang.be.codegen.rules.emit:new_registers_require_explicit_bank_constraints" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var f: mir.MirFunction;
     var source: mir.MirInstr = mir.instr(mir.MIR_ADD, nil, 0, 0, 0);
     var dst: [2]mir.MirInstr;

--- a/src/lang/be/codegen/unit.mach
+++ b/src/lang/be/codegen/unit.mach
@@ -1,11 +1,13 @@
 use std.types.bool.bool;
+use std.types.canonical.res;
+use std.types.canonical.err;
+use mach.lang.fail;
 use std.types.bool.false;
 use std.types.bool.true;
 use std.types.size.usize;
 use std.types.string.str;
 
-use A: mach.lang.legacy.allocator;
-use R: std.types.result;
+use A: std.allocator;
 
 use mach.lang.intern;
 use mach.lang.me.ir;
@@ -69,18 +71,18 @@ pub fun mir_index(u: *Unit, mi: u32, name: intern.StrId) u32 {
     ret UNIT_NONE;
 }
 
-pub fun init(a: *A.Allocator, n: u32, u: *Unit) R.Result[R.Void, str] {
+pub fun init(a: *A.Allocator, n: u32, u: *Unit) err[fail.Fail] {
     u.mods = nil;
     u.len  = 0;
     u.root = 0;
-    if (n == 0) { ret R.ok_void[str](); }
-    val r: R.Result[*UnitModule, str] = A.allocate[UnitModule](a, n::usize);
-    if (R.is_err[*UnitModule, str](r)) { ret R.err[R.Void, str](R.unwrap_err[*UnitModule, str](r)); }
-    u.mods = R.unwrap_ok[*UnitModule, str](r);
+    if (n == 0) { ret err[fail.Fail].ok{}; }
+    val r: res[*UnitModule, A.Error] = A.allocate[UnitModule](a, n::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    u.mods = r.ok;
     u.len  = n;
     var i: u32 = 0;
     for (i < n) { u.mods[i].ir = nil; u.mods[i].mir = nil; i = i + 1; }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 pub fun dnit(a: *A.Allocator, u: *Unit) {

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -1,13 +1,16 @@
 use std.types.canonical.opt;
+use std.types.canonical.res;
+use std.types.string.StrError;
+use std.types.canonical.err;
 use output: mach.lang.publication.testing;
-use txn: mach.lang.legacy.transaction;
+use txn: std.filesystem.transaction;
 use mach.lang.publication;
-use page: mach.lang.legacy.page;
-use map: mach.lang.legacy.map;
+use page: std.allocator.page;
+use map: std.collections.map;
 use std.collections.sort;
-use fs: mach.lang.legacy.filesystem;
-use vector: mach.lang.legacy.vector;
-use mach.lang.legacy.vector.Vector;
+use fs: std.filesystem;
+use vector: std.collections.vector;
+use std.collections.vector.Vector;
 use std.memory;
 use std.system.os;
 use std.types.bool.bool;
@@ -18,15 +21,15 @@ use std.types.string.str;
 use std.types.string.str_contains;
 use std.types.string.str_empty;
 use std.types.string.str_equals;
-use mach.lang.legacy.string.str_join;
+use std.types.string.str_join;
 use std.types.string.str_len;
 use std.types.string.str_starts_with;
-use mach.lang.legacy.text.str_free;
+use std.text.string.str_free;
 
-use A: mach.lang.legacy.allocator;
+use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
-use format: mach.lang.legacy.format;
+use format: std.format;
 
 use mach.lang.be.obj;
 use mach.lang.be.linker.relocatable;
@@ -191,19 +194,19 @@ rec ArchiveResolution {
     unresolved: map.Map[intern.StrId, u32];
 }
 
-fun validate_link_inputs(images: *of.ObjectImage, count: u32) R.Result[R.Void, str] {
+fun validate_link_inputs(images: *of.ObjectImage, count: u32) err[fail.Fail] {
     if (count > 0 && images == nil) {
-        ret R.err[R.Void, str]("link: nil input object collection");
+        ret err[fail.Fail].err{fail.message("link: nil input object collection")};
     }
     var i: u32 = 0;
     for (i < count) {
         val valid: R.Result[R.Void, str] = of.validate_object_view(?images[i]);
         if (R.is_err[R.Void, str](valid)) {
-            ret valid;
+            ret fail.lift_err(valid);
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
@@ -232,19 +235,19 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     }
 
     var module_count: u32 = 0;
-    val read_r: R.Result[*of.ObjectImage, str] =
+    val read_r: res[*of.ObjectImage, fail.Fail] =
         read_objects(s, tgt, obj_paths, obj_count, nil::*of.ObjectImage, 0,
                      required, ?module_count);
-    if (R.is_err[*of.ObjectImage, str](read_r)) {
-        ret R.err[R.Void, str](R.unwrap_err[*of.ObjectImage, str](read_r));
+    if (sel read_r.err) {
+        ret R.err[R.Void, str](fail.describe(read_r.err));
     }
-    val modules: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](read_r);
+    val modules: *of.ObjectImage = read_r.ok;
 
-    val r: R.Result[R.Void, str] =
+    val r: err[fail.Fail] =
         link_modules_nocapture(s, tgt, modules, module_count, 0, dynlibs, dynlib_count,
                      destination, name, mode, pie, image_options);
     free_modules(alloc, modules, module_count);
-    ret r;
+    ret fail.lower_unit(r);
 }
 
 pub rec LinkedImage {
@@ -268,17 +271,17 @@ pub fun linked_image_dnit(img: *LinkedImage, alloc: *A.Allocator) {
     img.symbol_count = 0;
 }
 
-pub fun linked_image_symbol(img: *LinkedImage, itn: *intern.Interner, name: str) O.Option[u64] {
-    if (img == nil || img.symbols == nil) { ret O.none[u64](); }
+pub fun linked_image_symbol(img: *LinkedImage, itn: *intern.Interner, name: str) opt[u64] {
+    if (img == nil || img.symbols == nil) { ret opt[u64].none{}; }
     var i: u32 = 0;
     for (i < img.symbol_count) {
-        val opt: O.Option[str] = intern.lookup(itn, img.symbols[i].name);
-        if (O.is_some[str](opt) && str_equals(O.unwrap[str](opt), name)) {
-            ret O.some[u64](img.symbols[i].vaddr);
+        val found: O.Option[str] = intern.lookup(itn, img.symbols[i].name);
+        if (O.is_some[str](found) && str_equals(O.unwrap[str](found), name)) {
+            ret opt[u64].some{img.symbols[i].vaddr};
         }
         i = i + 1;
     }
-    ret O.none[u64]();
+    ret opt[u64].none{};
 }
 
 pub fun link_images_captured(s: *session.Session, tgt: *target.Target, images: *of.ObjectImage,
@@ -306,8 +309,8 @@ pub fun link_images_captured(s: *session.Session, tgt: *target.Target, images: *
         ret R.err[R.Void, str]("link: this object format cannot hand back a linked image");
     }
 
-    ret link_modules(s, tgt, images, image_count, image_count, dynlibs,
-                     dynlib_count, nil::*publication.Destination, name, LINK_EXE, pie, image_options, out);
+    ret fail.lower_unit(link_modules(s, tgt, images, image_count, image_count, dynlibs,
+                     dynlib_count, nil::*publication.Destination, name, LINK_EXE, pie, image_options, out));
 }
 
 test "mach.lang.be.linker.link_images_captured:rejects_a_dirty_capture_target" {
@@ -345,8 +348,8 @@ pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.Object
     if (images == nil || image_count == 0) {
         ret R.err[R.Void, str]("link: no input objects");
     }
-    ret link_modules_nocapture(s, tgt, images, image_count, image_count, dynlibs,
-                     dynlib_count, destination, name, mode, pie, image_options);
+    ret fail.lower_unit(link_modules_nocapture(s, tgt, images, image_count, image_count, dynlibs,
+                     dynlib_count, destination, name, mode, pie, image_options));
 }
 
 pub fun link_mixed(s: *session.Session, tgt: *target.Target,
@@ -379,45 +382,45 @@ pub fun link_mixed(s: *session.Session, tgt: *target.Target,
     var ext_count: u32 = 0;
     var ext: *of.ObjectImage = nil;
     if (obj_paths != nil && obj_count > 0) {
-        val read_r: R.Result[*of.ObjectImage, str] =
+        val read_r: res[*of.ObjectImage, fail.Fail] =
             read_objects(s, tgt, obj_paths, obj_count, images, image_count,
                          required, ?ext_count);
-        if (R.is_err[*of.ObjectImage, str](read_r)) {
-            ret R.err[R.Void, str](R.unwrap_err[*of.ObjectImage, str](read_r));
+        if (sel read_r.err) {
+            ret R.err[R.Void, str](fail.describe(read_r.err));
         }
-        ext = R.unwrap_ok[*of.ObjectImage, str](read_r);
+        ext = read_r.ok;
     }
 
-    val total_r: R.Result[u32, str] = combined_image_count(image_count, ext_count);
-    if (R.is_err[u32, str](total_r)) {
+    val total_r: res[u32, fail.Fail] = combined_image_count(image_count, ext_count);
+    if (sel total_r.err) {
         free_modules(alloc, ext, ext_count);
-        ret R.err[R.Void, str](R.unwrap_err[u32, str](total_r));
+        ret R.err[R.Void, str](fail.describe(total_r.err));
     }
-    val total: u32 = R.unwrap_ok[u32, str](total_r);
-    val cr: R.Result[*of.ObjectImage, str] = A.allocate[of.ObjectImage](alloc, total::usize);
-    if (R.is_err[*of.ObjectImage, str](cr)) {
+    val total: u32 = total_r.ok;
+    val cr: res[*of.ObjectImage, A.Error] = A.allocate[of.ObjectImage](alloc, total::usize);
+    if (sel cr.err) {
         free_modules(alloc, ext, ext_count);
-        ret R.err[R.Void, str](R.unwrap_err[*of.ObjectImage, str](cr));
+        ret R.err[R.Void, str](fail.describe(fail.refused(cr.err)));
     }
-    val combined: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](cr);
+    val combined: *of.ObjectImage = cr.ok;
 
     var i: u32 = 0;
     for (i < image_count) { combined[i] = images[i]; i = i + 1; }
     var j: u32 = 0;
     for (j < ext_count) { combined[image_count + j] = ext[j]; j = j + 1; }
 
-    val r: R.Result[R.Void, str] =
+    val r: err[fail.Fail] =
         link_modules_nocapture(s, tgt, combined, total, image_count, dynlibs, dynlib_count,
                      destination, name, mode, pie, image_options);
 
     free_modules(alloc, ext, ext_count);
     A.deallocate[of.ObjectImage](alloc, combined, total::usize);
-    ret r;
+    ret fail.lower_unit(r);
 }
 
 fun image_machine_flags(s: *session.Session, tgt: *target.Target,
-                        modules: *of.ObjectImage, module_count: u32) R.Result[u32, str] {
-    if (!isa.declares_machine_flags(tgt.isa)) { ret R.ok[u32, str](0); }
+                        modules: *of.ObjectImage, module_count: u32) res[u32, fail.Fail] {
+    if (!isa.declares_machine_flags(tgt.isa)) { ret res[u32, fail.Fail].ok{0}; }
 
     val abi_mask: u32 = isa.machine_flags(tgt.isa, 0, false)
                       | isa.machine_flags(tgt.isa, 32, false)
@@ -429,19 +432,19 @@ fun image_machine_flags(s: *session.Session, tgt: *target.Target,
     for (i < module_count) {
         val got: u32 = modules[i].machine_flags;
         if ((got & abi_mask) != abi_bits) {
-            ret R.err[u32, str](machine_flags_mismatch_message(s, tgt, ?modules[i],
-                                                              got & abi_mask, abi_bits));
+            ret res[u32, fail.Fail].err{fail.message(machine_flags_mismatch_message(s, tgt, ?modules[i],
+                                                              got & abi_mask, abi_bits))};
         }
         feature_bits = feature_bits | (got & ~abi_mask);
         i = i + 1;
     }
-    ret R.ok[u32, str](abi_bits | feature_bits);
+    ret res[u32, fail.Fail].ok{abi_bits | feature_bits};
 }
 
 fun image_attributes(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
-                     module_count: u32, out_len: *u32) R.Result[*u8, str] {
+                     module_count: u32, out_len: *u32) res[*u8, fail.Fail] {
     @out_len = 0;
-    if (!isa.declares_attributes(tgt.isa)) { ret R.ok[*u8, str](nil); }
+    if (!isa.declares_attributes(tgt.isa)) { ret res[*u8, fail.Fail].ok{nil}; }
 
     var acc: *u8 = nil;
     var acc_len: u32 = 0;
@@ -454,7 +457,7 @@ fun image_attributes(s: *session.Session, tgt: *target.Target, modules: *of.Obje
                                                          modules[i].attributes_len, ?next_len);
         if (R.is_err[*u8, str](mr)) {
             if (acc != nil && acc_len > 0) { A.deallocate[u8](s.alloc, acc, acc_len::usize); }
-            ret mr;
+            ret fail.lift_res[*u8](mr);
         }
         val merged: *u8 = R.unwrap_ok[*u8, str](mr);
         if (acc != nil && acc_len > 0 && acc != merged) { A.deallocate[u8](s.alloc, acc, acc_len::usize); }
@@ -463,23 +466,23 @@ fun image_attributes(s: *session.Session, tgt: *target.Target, modules: *of.Obje
         i = i + 1;
     }
     @out_len = acc_len;
-    ret R.ok[*u8, str](acc);
+    ret res[*u8, fail.Fail].ok{acc};
 }
 
 fun link_modules_nocapture(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
                            module_count: u32, codegen_count: u32,
                            dynlibs: *of.DynLib, dynlib_count: u32,
                            destination: *publication.Destination, name: *u8, mode: LinkMode, pie_opt_in: bool,
-                           image_options: of.ImageOptions) R.Result[R.Void, str] {
+                           image_options: of.ImageOptions) err[fail.Fail] {
     ret link_modules(s, tgt, modules, module_count, codegen_count, dynlibs, dynlib_count,
                      destination, name, mode, pie_opt_in, image_options, nil::*LinkedImage);
 }
 
 fun synthesize_common_storage(s: *session.Session, modules: *of.ObjectImage,
                               module_count: u32, mode: LinkMode,
-                              out: *of.ObjectImage) R.Result[bool, str] {
+                              out: *of.ObjectImage) res[bool, fail.Fail] {
     if (mode == LINK_RELOCATABLE || modules == nil || module_count == 0) {
-        ret R.ok[bool, str](false);
+        ret res[bool, fail.Fail].ok{false};
     }
     val alloc: *A.Allocator = s.alloc;
 
@@ -492,11 +495,12 @@ fun synthesize_common_storage(s: *session.Session, modules: *of.ObjectImage,
             val sym: *of.Symbol = ?modules[m].symbols[sy];
             if (of.section_is_absolute(sym.section)
                 || (!of.section_is_external(sym.section) && of.section_index(sym.section) < modules[m].section_count)) {
-                if (R.is_err[*u32, str](map.get[intern.StrId, u32](?defined, ?sym.name))) {
-                    val di: R.Result[bool, str] = map.insert[intern.StrId, u32](?defined, sym.name, 0);
-                    if (R.is_err[bool, str](di)) {
+                val get_r: opt[*u32] = map.get[intern.StrId, u32](?defined, ?sym.name);
+                if (sel get_r.none) {
+                    val di: res[bool, A.Error] = map.insert[intern.StrId, u32](?defined, sym.name, 0);
+                    if (sel di.err) {
                         map.dnit[intern.StrId, u32](?defined);
-                        ret R.err[bool, str](R.unwrap_err[bool, str](di));
+                        ret res[bool, fail.Fail].err{fail.refused(di.err)};
                     }
                 }
             }
@@ -517,45 +521,46 @@ fun synthesize_common_storage(s: *session.Session, modules: *of.ObjectImage,
         for (sy < modules[m].symbol_count) {
             val sym: *of.Symbol = ?modules[m].symbols[sy];
             if ((sym.flags & of.SYM_OBJ_FLAG_COMMON) == 0) { sy = sy + 1; cnt; }
-            if (R.is_ok[*u32, str](map.get[intern.StrId, u32](?defined, ?sym.name))) { sy = sy + 1; cnt; }
+            val get_r2: opt[*u32] = map.get[intern.StrId, u32](?defined, ?sym.name);
+            if (sel get_r2.some) { sy = sy + 1; cnt; }
 
             var al: u32 = sym.align;
             if (al == 0) { al = 1; }
-            val ex: R.Result[*u32, str] = map.get[intern.StrId, u32](?slot, ?sym.name);
-            if (R.is_ok[*u32, str](ex)) {
-                val at: u32 = @R.unwrap_ok[*u32, str](ex);
+            val ex: opt[*u32] = map.get[intern.StrId, u32](?slot, ?sym.name);
+            if (sel ex.some) {
+                val at: u32 = @ex.some;
                 if (sym.size > sizes.data[at]) { sizes.data[at] = sym.size; }
                 if (al > aligns.data[at])      { aligns.data[at] = al; }
                 sy = sy + 1;
                 cnt;
             }
-            val ins: R.Result[bool, str] = map.insert[intern.StrId, u32](?slot, sym.name, names.len::u32);
-            if (R.is_err[bool, str](ins)) {
+            val ins: res[bool, A.Error] = map.insert[intern.StrId, u32](?slot, sym.name, names.len::u32);
+            if (sel ins.err) {
                 map.dnit[intern.StrId, u32](?slot);
                 map.dnit[intern.StrId, u32](?defined);
                 vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
-                ret R.err[bool, str](R.unwrap_err[bool, str](ins));
+                ret res[bool, fail.Fail].err{fail.refused(ins.err)};
             }
-            val push_n: R.Result[usize, str] = vector.push[intern.StrId](?names, sym.name);
-            if (R.is_err[usize, str](push_n)) {
+            val push_n: res[usize, A.Error] = vector.push[intern.StrId](?names, sym.name);
+            if (sel push_n.err) {
                 map.dnit[intern.StrId, u32](?slot);
                 map.dnit[intern.StrId, u32](?defined);
                 vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
-                ret R.err[bool, str](R.unwrap_err[usize, str](push_n));
+                ret res[bool, fail.Fail].err{fail.refused(push_n.err)};
             }
-            val push_s: R.Result[usize, str] = vector.push[u32](?sizes, sym.size);
-            if (R.is_err[usize, str](push_s)) {
+            val push_s: res[usize, A.Error] = vector.push[u32](?sizes, sym.size);
+            if (sel push_s.err) {
                 map.dnit[intern.StrId, u32](?slot);
                 map.dnit[intern.StrId, u32](?defined);
                 vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
-                ret R.err[bool, str](R.unwrap_err[usize, str](push_s));
+                ret res[bool, fail.Fail].err{fail.refused(push_s.err)};
             }
-            val push_a: R.Result[usize, str] = vector.push[u32](?aligns, al);
-            if (R.is_err[usize, str](push_a)) {
+            val push_a: res[usize, A.Error] = vector.push[u32](?aligns, al);
+            if (sel push_a.err) {
                 map.dnit[intern.StrId, u32](?slot);
                 map.dnit[intern.StrId, u32](?defined);
                 vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
-                ret R.err[bool, str](R.unwrap_err[usize, str](push_a));
+                ret res[bool, fail.Fail].err{fail.refused(push_a.err)};
             }
             sy = sy + 1;
         }
@@ -566,7 +571,7 @@ fun synthesize_common_storage(s: *session.Session, modules: *of.ObjectImage,
 
     if (names.len == 0) {
         vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
-        ret R.ok[bool, str](false);
+        ret res[bool, fail.Fail].ok{false};
     }
 
     var total: layout.CheckedOffset[CommonStorageUnit] = layout.offset[CommonStorageUnit](0::usize);
@@ -580,7 +585,7 @@ fun synthesize_common_storage(s: *session.Session, modules: *of.ObjectImage,
         if (R.is_err[layout.CheckedAlignment[CommonStorageUnit], layout.CheckCause](align_r)) {
             vector.dnit[u32](?offs);
             vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
-            ret R.err[bool, str]("link: common storage member has invalid alignment");
+            ret res[bool, fail.Fail].err{fail.message("link: common storage member has invalid alignment")};
         }
         val aligned_r: R.Result[layout.CheckedOffset[CommonStorageUnit], layout.CheckCause] =
             layout.align_offset_up[CommonStorageUnit](total,
@@ -588,26 +593,26 @@ fun synthesize_common_storage(s: *session.Session, modules: *of.ObjectImage,
         if (R.is_err[layout.CheckedOffset[CommonStorageUnit], layout.CheckCause](aligned_r)) {
             vector.dnit[u32](?offs);
             vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
-            ret R.err[bool, str]("link: common storage layout overflow");
+            ret res[bool, fail.Fail].err{fail.message("link: common storage layout overflow")};
         }
         total = R.unwrap_ok[layout.CheckedOffset[CommonStorageUnit], layout.CheckCause](aligned_r);
         if (total.value > 0x7FFFFFFF) {
             vector.dnit[u32](?offs);
             vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
-            ret R.err[bool, str]("link: common storage exceeds 2 GiB");
+            ret res[bool, fail.Fail].err{fail.message("link: common storage exceeds 2 GiB")};
         }
-        val push_o: R.Result[usize, str] = vector.push[u32](?offs, total.value::u32);
-        if (R.is_err[usize, str](push_o)) {
+        val push_o: res[usize, A.Error] = vector.push[u32](?offs, total.value::u32);
+        if (sel push_o.err) {
             vector.dnit[u32](?offs);
             vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
-            ret R.err[bool, str](R.unwrap_err[usize, str](push_o));
+            ret res[bool, fail.Fail].err{fail.refused(push_o.err)};
         }
         val grown_r: R.Result[layout.CheckedOffset[CommonStorageUnit], layout.CheckCause] =
             layout.offset_add[CommonStorageUnit](total, layout.count[CommonStorageUnit](sizes.data[n]::usize));
         if (R.is_err[layout.CheckedOffset[CommonStorageUnit], layout.CheckCause](grown_r)) {
             vector.dnit[u32](?offs);
             vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
-            ret R.err[bool, str]("link: common storage layout overflow");
+            ret res[bool, fail.Fail].err{fail.message("link: common storage layout overflow")};
         }
         total = R.unwrap_ok[layout.CheckedOffset[CommonStorageUnit], layout.CheckCause](grown_r);
         n = n + 1;
@@ -618,10 +623,15 @@ fun synthesize_common_storage(s: *session.Session, modules: *of.ObjectImage,
     if (R.is_err[intern.StrId, str](image_name_r) || R.is_err[intern.StrId, str](section_name_r)) {
         vector.dnit[u32](?offs);
         vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
-        ret R.err[bool, str]("link: could not intern the common storage names");
+        ret res[bool, fail.Fail].err{fail.message("link: could not intern the common storage names")};
     }
-    @out = R.unwrap_ok[of.ObjectImage, str](
-        obj.init(alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](image_name_r)));
+    val image_r: res[of.ObjectImage, fail.Fail] = obj.image_init(alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](image_name_r));
+    if (sel image_r.err) {
+        vector.dnit[u32](?offs);
+        vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
+        ret res[bool, fail.Fail].err{image_r.err};
+    }
+    @out = image_r.ok;
 
     var sec: of.Section;
     sec.name  = R.unwrap_ok[intern.StrId, str](section_name_r);
@@ -630,14 +640,14 @@ fun synthesize_common_storage(s: *session.Session, modules: *of.ObjectImage,
     sec.len   = total.value::u32;
     sec.align = sec_align;
     sec.flags = 0;
-    val sec_r: R.Result[u32, str] = obj.install_section(out, ?sec);
-    if (R.is_err[u32, str](sec_r)) {
+    val sec_r: res[u32, fail.Fail] = obj.section_install(out, ?sec);
+    if (sel sec_r.err) {
         vector.dnit[u32](?offs);
         vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
         obj.dnit(out);
-        ret R.err[bool, str](R.unwrap_err[u32, str](sec_r));
+        ret res[bool, fail.Fail].err{sec_r.err};
     }
-    val sec_ix: u32 = R.unwrap_ok[u32, str](sec_r);
+    val sec_ix: u32 = sec_r.ok;
 
     n = 0;
     for (n < names.len) {
@@ -649,12 +659,12 @@ fun synthesize_common_storage(s: *session.Session, modules: *of.ObjectImage,
         osym.flags   = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_OBJECT;
         osym.fallback = of.SYMBOL_NONE;
         osym.align    = aligns.data[n];
-        val sa: R.Result[u32, str] = obj.add_symbol(out, osym);
-        if (R.is_err[u32, str](sa)) {
+        val sa: res[u32, fail.Fail] = obj.symbol_add(out, osym);
+        if (sel sa.err) {
             vector.dnit[u32](?offs);
             vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
             obj.dnit(out);
-            ret R.err[bool, str](R.unwrap_err[u32, str](sa));
+            ret res[bool, fail.Fail].err{sa.err};
         }
         n = n + 1;
     }
@@ -663,26 +673,26 @@ fun synthesize_common_storage(s: *session.Session, modules: *of.ObjectImage,
     vector.dnit[intern.StrId](?names); vector.dnit[u32](?sizes); vector.dnit[u32](?aligns);
     val valid: R.Result[R.Void, str] = of.validate_owned_object_or_dnit(out);
     if (R.is_err[R.Void, str](valid)) {
-        ret R.err[bool, str](R.unwrap_err[R.Void, str](valid));
+        ret res[bool, fail.Fail].err{fail.message(R.unwrap_err[R.Void, str](valid))};
     }
-    ret R.ok[bool, str](true);
+    ret res[bool, fail.Fail].ok{true};
 }
 
 fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
                  module_count: u32, codegen_count: u32,
                  dynlibs: *of.DynLib, dynlib_count: u32,
                  destination: *publication.Destination, name: *u8, mode: LinkMode, pie_opt_in: bool,
-                 image_options: of.ImageOptions, capture: *LinkedImage) R.Result[R.Void, str] {
-    if (!link_mode_valid(mode)) { ret R.err[R.Void, str]("link: invalid link mode"); }
-    val inputs_valid: R.Result[R.Void, str] = validate_link_inputs(modules, module_count);
-    if (R.is_err[R.Void, str](inputs_valid)) {
+                 image_options: of.ImageOptions, capture: *LinkedImage) err[fail.Fail] {
+    if (!link_mode_valid(mode)) { ret err[fail.Fail].err{fail.message("link: invalid link mode")}; }
+    val inputs_valid: err[fail.Fail] = validate_link_inputs(modules, module_count);
+    if (sel inputs_valid.err) {
         ret inputs_valid;
     }
     val alloc0: *A.Allocator = s.alloc;
     var commons: of.ObjectImage;
-    val made_r: R.Result[bool, str] = synthesize_common_storage(s, modules, module_count, mode, ?commons);
-    if (R.is_err[bool, str](made_r)) { ret R.err[R.Void, str](R.unwrap_err[bool, str](made_r)); }
-    if (!R.unwrap_ok[bool, str](made_r)) {
+    val made_r: res[bool, fail.Fail] = synthesize_common_storage(s, modules, module_count, mode, ?commons);
+    if (sel made_r.err) { ret err[fail.Fail].err{made_r.err}; }
+    if (!made_r.ok) {
         ret link_modules_with_commons(s, tgt, modules, module_count, codegen_count,
                                       dynlibs, dynlib_count, destination, name, mode,
                                       pie_opt_in, image_options, capture);
@@ -690,15 +700,15 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
 
     if (module_count == 0xFFFFFFFF) {
         obj.dnit(?commons);
-        ret R.err[R.Void, str]("link: too many input objects to append common storage");
+        ret err[fail.Fail].err{fail.message("link: too many input objects to append common storage")};
     }
-    val all_r: R.Result[*of.ObjectImage, str] =
+    val all_r: res[*of.ObjectImage, A.Error] =
         A.allocate[of.ObjectImage](alloc0, (module_count + 1)::usize);
-    if (R.is_err[*of.ObjectImage, str](all_r)) {
+    if (sel all_r.err) {
         obj.dnit(?commons);
-        ret R.err[R.Void, str](R.unwrap_err[*of.ObjectImage, str](all_r));
+        ret err[fail.Fail].err{fail.refused(all_r.err)};
     }
-    val all: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](all_r);
+    val all: *of.ObjectImage = all_r.ok;
     var ci: u32 = 0;
     for (ci < module_count) {
         all[ci] = modules[ci];
@@ -706,7 +716,7 @@ fun link_modules(s: *session.Session, tgt: *target.Target, modules: *of.ObjectIm
     }
     all[module_count] = commons;
 
-    val linked: R.Result[R.Void, str] = link_modules_with_commons(
+    val linked: err[fail.Fail] = link_modules_with_commons(
         s, tgt, all, module_count + 1, codegen_count, dynlibs, dynlib_count,
         destination, name, mode, pie_opt_in, image_options, capture);
     A.deallocate[of.ObjectImage](alloc0, all, (module_count + 1)::usize);
@@ -724,13 +734,13 @@ fun link_modules_with_commons(s: *session.Session, tgt: *target.Target, modules:
                  module_count: u32, codegen_count: u32,
                  dynlibs: *of.DynLib, dynlib_count: u32,
                  destination: *publication.Destination, name: *u8, mode: LinkMode, pie_opt_in: bool,
-                 image_options: of.ImageOptions, capture: *LinkedImage) R.Result[R.Void, str] {
+                 image_options: of.ImageOptions, capture: *LinkedImage) err[fail.Fail] {
     val alloc: *A.Allocator = s.alloc;
     if (mode != LINK_RELOCATABLE && modules != nil) {
         var ni: u32 = 0;
         for (ni < module_count) {
             val nr: R.Result[R.Void, str] = rel.normalize_image(tgt.isa, alloc, ?modules[ni]);
-            if (R.is_err[R.Void, str](nr)) { ret nr; }
+            if (R.is_err[R.Void, str](nr)) { ret fail.lift_err(nr); }
             ni = ni + 1;
         }
     }
@@ -739,40 +749,40 @@ fun link_modules_with_commons(s: *session.Session, tgt: *target.Target, modules:
         val input_attributes_valid: R.Result[R.Void, str] = isa.validate_attributes(
             tgt.isa, ?tgt.model, modules[attribute_input].attributes, modules[attribute_input].attributes_len,
             modules[attribute_input].machine_flags);
-        if (R.is_err[R.Void, str](input_attributes_valid)) { ret input_attributes_valid; }
+        if (R.is_err[R.Void, str](input_attributes_valid)) { ret fail.lift_err(input_attributes_valid); }
         attribute_input = attribute_input + 1;
     }
-    val mf_r: R.Result[u32, str] = image_machine_flags(s, tgt, modules, module_count);
-    if (R.is_err[u32, str](mf_r)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](mf_r)); }
+    val mf_r: res[u32, fail.Fail] = image_machine_flags(s, tgt, modules, module_count);
+    if (sel mf_r.err) { ret err[fail.Fail].err{mf_r.err}; }
     var opts: of.ImageOptions = image_options;
-    opts.machine_flags = R.unwrap_ok[u32, str](mf_r);
+    opts.machine_flags = mf_r.ok;
     var attr_len: u32 = 0;
-    val at_r: R.Result[*u8, str] = image_attributes(s, tgt, modules, module_count, ?attr_len);
-    if (R.is_err[*u8, str](at_r)) { ret R.err[R.Void, str](R.unwrap_err[*u8, str](at_r)); }
-    opts.attributes = R.unwrap_ok[*u8, str](at_r);
+    val at_r: res[*u8, fail.Fail] = image_attributes(s, tgt, modules, module_count, ?attr_len);
+    if (sel at_r.err) { ret err[fail.Fail].err{at_r.err}; }
+    opts.attributes = at_r.ok;
     opts.attributes_len = attr_len;
     val attributes_valid: R.Result[R.Void, str] = isa.validate_attributes(tgt.isa, ?tgt.model, opts.attributes, attr_len, opts.machine_flags);
     if (R.is_err[R.Void, str](attributes_valid)) {
         opts_attributes_release(alloc, ?opts);
-        ret attributes_valid;
+        ret fail.lift_err(attributes_valid);
     }
     if (mode == LINK_RELOCATABLE) {
-        val combined: R.Result[of.ObjectImage, str] = relocatable.combine(
+        val combined: res[of.ObjectImage, fail.Fail] = relocatable.combine(
             alloc, ?s.interner, modules, module_count, opts.machine_flags,
             opts.attributes, opts.attributes_len);
         opts_attributes_release(alloc, ?opts);
-        if (R.is_err[of.ObjectImage, str](combined)) {
-            ret R.err[R.Void, str](R.unwrap_err[of.ObjectImage, str](combined));
+        if (sel combined.err) {
+            ret err[fail.Fail].err{combined.err};
         }
-        var image: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](combined);
+        var image: of.ObjectImage = combined.ok;
         fin { obj.dnit(?image); }
-        ret obj.emit(?image, tgt, destination);
+        ret obj.emit_image(?image, tgt, destination);
     }
     var indirect_input: u32 = 0;
     for (indirect_input < module_count) {
         if (modules[indirect_input].indirect_count != 0) {
             opts_attributes_release(alloc, ?opts);
-            ret R.err[R.Void, str]("link: native indirect symbol sections require relocatable output");
+            ret err[fail.Fail].err{fail.message("link: native indirect symbol sections require relocatable output")};
         }
         indirect_input = indirect_input + 1;
     }
@@ -785,24 +795,24 @@ fun link_modules_with_commons(s: *session.Session, tgt: *target.Target, modules:
     var local_sec_base: *u32 = nil;
     if (!str_empty(tgt.of.import_address_prefix) && mode != LINK_RELOCATABLE
         && modules != nil && module_count > 0) {
-        val sb_r: R.Result[*u32, str] =
+        val sb_r: res[*u32, A.Error] =
             A.zallocate[u32](alloc, module_count::usize);
-        if (R.is_err[*u32, str](sb_r)) {
+        if (sel sb_r.err) {
             opts_attributes_release(alloc, ?opts);
-            ret R.err[R.Void, str](R.unwrap_err[*u32, str](sb_r));
+            ret err[fail.Fail].err{fail.refused(sb_r.err)};
         }
-        local_sec_base = R.unwrap_ok[*u32, str](sb_r);
-        val local_sec_total_r: R.Result[u32, str] = total_sections(modules, module_count);
-        if (R.is_err[u32, str](local_sec_total_r)) {
+        local_sec_base = sb_r.ok;
+        val local_sec_total_r: res[u32, fail.Fail] = total_sections(modules, module_count);
+        if (sel local_sec_total_r.err) {
             A.deallocate[u32](alloc, local_sec_base, module_count::usize);
             free_atom_plan(alloc, ?local_atoms);
             opts_attributes_release(alloc, ?opts);
-            ret R.err[R.Void, str](R.unwrap_err[u32, str](local_sec_total_r));
+            ret err[fail.Fail].err{local_sec_total_r.err};
         }
-        val atom_r: R.Result[R.Void, str] = build_atom_plan(
+        val atom_r: err[fail.Fail] = build_atom_plan(
             s, modules, module_count, codegen_count, local_sec_base,
-            R.unwrap_ok[u32, str](local_sec_total_r), true, tgt.isa, ?local_atoms);
-        if (R.is_err[R.Void, str](atom_r)) {
+            local_sec_total_r.ok, true, tgt.isa, ?local_atoms);
+        if (sel atom_r.err) {
             A.deallocate[u32](alloc, local_sec_base, module_count::usize);
             free_atom_plan(alloc, ?local_atoms);
             opts_attributes_release(alloc, ?opts);
@@ -812,19 +822,19 @@ fun link_modules_with_commons(s: *session.Session, tgt: *target.Target, modules:
     }
 
     var local_imports: of.ObjectImage;
-    val made_r: R.Result[bool, str] = synthesize_local_imports(
+    val made_r: res[bool, fail.Fail] = synthesize_local_imports(
         s, tgt.of.import_address_prefix, modules, module_count, mode,
         local_sec_base, ?local_atoms, ?local_imports);
     if (local_sec_base != nil) {
         A.deallocate[u32](alloc, local_sec_base, module_count::usize);
     }
-    if (R.is_err[bool, str](made_r)) {
+    if (sel made_r.err) {
         free_atom_plan(alloc, ?local_atoms);
         opts_attributes_release(alloc, ?opts);
-        ret R.err[R.Void, str](R.unwrap_err[bool, str](made_r));
+        ret err[fail.Fail].err{made_r.err};
     }
-    if (!R.unwrap_ok[bool, str](made_r)) {
-        val linked: R.Result[R.Void, str] = link_modules_core(
+    if (!made_r.ok) {
+        val linked: err[fail.Fail] = link_modules_core(
             s, tgt, modules, module_count, codegen_count,
             dynlibs, dynlib_count, destination, name, mode, pie_opt_in, opts,
             pre_atoms, capture);
@@ -837,17 +847,17 @@ fun link_modules_with_commons(s: *session.Session, tgt: *target.Target, modules:
         obj.dnit(?local_imports);
         free_atom_plan(alloc, ?local_atoms);
         opts_attributes_release(alloc, ?opts);
-        ret R.err[R.Void, str]("link: too many input objects for local import pointers");
+        ret err[fail.Fail].err{fail.message("link: too many input objects for local import pointers")};
     }
-    val all_r: R.Result[*of.ObjectImage, str] =
+    val all_r: res[*of.ObjectImage, A.Error] =
         A.allocate[of.ObjectImage](alloc, (module_count + 1)::usize);
-    if (R.is_err[*of.ObjectImage, str](all_r)) {
+    if (sel all_r.err) {
         obj.dnit(?local_imports);
         free_atom_plan(alloc, ?local_atoms);
         opts_attributes_release(alloc, ?opts);
-        ret R.err[R.Void, str](R.unwrap_err[*of.ObjectImage, str](all_r));
+        ret err[fail.Fail].err{fail.refused(all_r.err)};
     }
-    val all: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](all_r);
+    val all: *of.ObjectImage = all_r.ok;
     var i: u32 = 0;
     for (i < module_count) {
         all[i] = modules[i];
@@ -855,7 +865,7 @@ fun link_modules_with_commons(s: *session.Session, tgt: *target.Target, modules:
     }
     all[module_count] = local_imports;
 
-    val linked: R.Result[R.Void, str] = link_modules_core(
+    val linked: err[fail.Fail] = link_modules_core(
         s, tgt, all, module_count + 1, codegen_count,
         dynlibs, dynlib_count, destination, name, mode, pie_opt_in, opts,
         pre_atoms, capture);
@@ -871,7 +881,7 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
                       dynlibs: *of.DynLib, dynlib_count: u32,
                       destination: *publication.Destination, name: *u8, mode: LinkMode, pie_opt_in: bool,
                       image_options: of.ImageOptions,
-                      pre_atoms: *AtomPlan, capture: *LinkedImage) R.Result[R.Void, str] {
+                      pre_atoms: *AtomPlan, capture: *LinkedImage) err[fail.Fail] {
     val alloc: *A.Allocator = s.alloc;
     var local_got: LocalGotPlan;
     init_local_got_plan(?local_got);
@@ -882,16 +892,16 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
     val position_independent: bool = pie || shared;
 
     if (module_count == 0) {
-        ret R.err[R.Void, str]("link: no input objects");
+        ret err[fail.Fail].err{fail.message("link: no input objects")};
     }
     if (codegen_count > module_count) {
-        ret R.err[R.Void, str]("link: codegen image count exceeds module count");
+        ret err[fail.Fail].err{fail.message("link: codegen image count exceeds module count")};
     }
 
     var debug_names: *intern.StrId = nil;
     var debug_count: u32 = 0;
-    val dn_r: R.Result[R.Void, str] = discover_debug_names(alloc, modules, module_count, ?debug_names, ?debug_count);
-    if (R.is_err[R.Void, str](dn_r)) { ret dn_r; }
+    val dn_r: err[fail.Fail] = discover_debug_names(alloc, modules, module_count, ?debug_names, ?debug_count);
+    if (sel dn_r.err) { ret dn_r; }
 
     var dm: u32 = 0;
     for (dm < module_count) {
@@ -903,86 +913,86 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
     var atoms: AtomPlan;
     init_atom_plan(?atoms);
     var strm: StrMerge;
-    val sm_r: R.Result[StrMerge, str] = build_str_merge(s, modules, module_count, patching);
-    if (R.is_err[StrMerge, str](sm_r)) {
+    val sm_r: res[StrMerge, fail.Fail] = build_str_merge(s, modules, module_count, patching);
+    if (sel sm_r.err) {
         if (debug_names != nil && debug_count > 0) { A.deallocate[intern.StrId](alloc, debug_names, debug_count::usize); }
-        ret R.err[R.Void, str](R.unwrap_err[StrMerge, str](sm_r));
+        ret err[fail.Fail].err{sm_r.err};
     }
-    strm = R.unwrap_ok[StrMerge, str](sm_r);
+    strm = sm_r.ok;
 
-    val merged_count_r: R.Result[u32, str] = merged_section_count(debug_count);
-    if (R.is_err[u32, str](merged_count_r)) {
+    val merged_count_r: res[u32, fail.Fail] = merged_section_count(debug_count);
+    if (sel merged_count_r.err) {
         if (debug_names != nil && debug_count > 0) { A.deallocate[intern.StrId](alloc, debug_names, debug_count::usize); }
         free_str_merge(?strm);
-        ret R.err[R.Void, str](R.unwrap_err[u32, str](merged_count_r));
+        ret err[fail.Fail].err{merged_count_r.err};
     }
-    val merged_count: u32 = R.unwrap_ok[u32, str](merged_count_r);
+    val merged_count: u32 = merged_count_r.ok;
     var merged: *MergedSection = nil;
-    val mrg_r: R.Result[*MergedSection, str] = A.zallocate[MergedSection](alloc, merged_count::usize);
-    if (R.is_err[*MergedSection, str](mrg_r)) {
+    val mrg_r: res[*MergedSection, A.Error] = A.zallocate[MergedSection](alloc, merged_count::usize);
+    if (sel mrg_r.err) {
         if (debug_names != nil && debug_count > 0) { A.deallocate[intern.StrId](alloc, debug_names, debug_count::usize); }
         free_str_merge(?strm);
-        ret R.err[R.Void, str](R.unwrap_err[*MergedSection, str](mrg_r));
+        ret err[fail.Fail].err{fail.refused(mrg_r.err)};
     }
-    merged = R.unwrap_ok[*MergedSection, str](mrg_r);
+    merged = mrg_r.ok;
     init_merged(merged, debug_names, debug_count);
     var merged_to_out: *u32 = nil;
 
-    val sym_total_r: R.Result[u32, str] = total_symbols(modules, module_count);
-    if (R.is_err[u32, str](sym_total_r)) {
+    val sym_total_r: res[u32, fail.Fail] = total_symbols(modules, module_count);
+    if (sel sym_total_r.err) {
         free_scratch(alloc, nil, 0, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out, nil, nil, 0, ?strm, ?atoms, ?groups);
-        ret R.err[R.Void, str](R.unwrap_err[u32, str](sym_total_r));
+        ret err[fail.Fail].err{sym_total_r.err};
     }
-    val sym_total: u32 = R.unwrap_ok[u32, str](sym_total_r);
+    val sym_total: u32 = sym_total_r.ok;
     var sym_base: *u32 = nil;
     var sym_out:  *u32 = nil;
 
-    val sec_total_r: R.Result[u32, str] = total_sections(modules, module_count);
-    if (R.is_err[u32, str](sec_total_r)) {
+    val sec_total_r: res[u32, fail.Fail] = total_sections(modules, module_count);
+    if (sel sec_total_r.err) {
         free_scratch(alloc, nil, 0, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
-        ret R.err[R.Void, str](R.unwrap_err[u32, str](sec_total_r));
+        ret err[fail.Fail].err{sec_total_r.err};
     }
-    val sec_total: u32 = R.unwrap_ok[u32, str](sec_total_r);
+    val sec_total: u32 = sec_total_r.ok;
     var placements: *Placement = nil;
     if (sec_total > 0) {
-        val pr: R.Result[*Placement, str] = A.zallocate[Placement](alloc, sec_total::usize);
-        if (R.is_err[*Placement, str](pr)) {
+        val pr: res[*Placement, A.Error] = A.zallocate[Placement](alloc, sec_total::usize);
+        if (sel pr.err) {
             free_scratch(alloc, nil, 0, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
-            ret R.err[R.Void, str](R.unwrap_err[*Placement, str](pr));
+            ret err[fail.Fail].err{fail.refused(pr.err)};
         }
-        placements = R.unwrap_ok[*Placement, str](pr);
+        placements = pr.ok;
     }
 
     var sec_base: *u32 = nil;
-    val br: R.Result[*u32, str] = A.zallocate[u32](alloc, module_count::usize);
-    if (R.is_err[*u32, str](br)) {
+    val br: res[*u32, A.Error] = A.zallocate[u32](alloc, module_count::usize);
+    if (sel br.err) {
         free_scratch(alloc, placements, sec_total, nil, 0, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](br));
+        ret err[fail.Fail].err{fail.refused(br.err)};
     }
-    sec_base = R.unwrap_ok[*u32, str](br);
+    sec_base = br.ok;
 
-    val syb_r: R.Result[*u32, str] = A.zallocate[u32](alloc, module_count::usize);
-    if (R.is_err[*u32, str](syb_r)) {
+    val syb_r: res[*u32, A.Error] = A.zallocate[u32](alloc, module_count::usize);
+    if (sel syb_r.err) {
         free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](syb_r));
+        ret err[fail.Fail].err{fail.refused(syb_r.err)};
     }
-    sym_base = R.unwrap_ok[*u32, str](syb_r);
-    val fsb_r: R.Result[R.Void, str] = fill_symbol_bases(modules, module_count, sym_base);
-    if (R.is_err[R.Void, str](fsb_r)) {
+    sym_base = syb_r.ok;
+    val fsb_r: err[fail.Fail] = fill_symbol_bases(modules, module_count, sym_base);
+    if (sel fsb_r.err) {
         free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
         ret fsb_r;
     }
 
     if (sym_total > 0) {
-        val syo_r: R.Result[*u32, str] = A.zallocate[u32](alloc, sym_total::usize);
-        if (R.is_err[*u32, str](syo_r)) {
+        val syo_r: res[*u32, A.Error] = A.zallocate[u32](alloc, sym_total::usize);
+        if (sel syo_r.err) {
             free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
-            ret R.err[R.Void, str](R.unwrap_err[*u32, str](syo_r));
+            ret err[fail.Fail].err{fail.refused(syo_r.err)};
         }
-        sym_out = R.unwrap_ok[*u32, str](syo_r);
+        sym_out = syo_r.ok;
     }
 
-    var atom_r: R.Result[R.Void, str];
+    var atom_r: err[fail.Fail];
     if (pre_atoms != nil) {
         atoms = @pre_atoms;
         init_atom_plan(pre_atoms);
@@ -992,15 +1002,15 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
         atom_r = build_atom_plan(s, modules, module_count, codegen_count, sec_base,
                                  sec_total, patching, tgt.isa, ?atoms);
     }
-    if (R.is_err[R.Void, str](atom_r)) {
+    if (sel atom_r.err) {
         free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
         ret atom_r;
     }
 
-    val acc_r: R.Result[R.Void, str] =
+    val acc_r: err[fail.Fail] =
         accumulate_sections(s, modules, module_count, merged, debug_names, debug_count,
                             placements, sec_base, ?strm, ?atoms, ?groups);
-    if (R.is_err[R.Void, str](acc_r)) {
+    if (sel acc_r.err) {
         free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
         ret acc_r;
     }
@@ -1009,20 +1019,20 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
         val ei_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, tgt.os.entry_symbol);
         if (R.is_err[intern.StrId, str](ei_r)) {
             free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
-            ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](ei_r));
+            ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](ei_r))};
         }
-        val reorder_r: R.Result[R.Void, str] =
+        val reorder_r: err[fail.Fail] =
             reorder_flat_entry_first(modules, module_count, merged, placements, sec_base,
                                      ?atoms, R.unwrap_ok[intern.StrId, str](ei_r));
-        if (R.is_err[R.Void, str](reorder_r)) {
+        if (sel reorder_r.err) {
             free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
             ret reorder_r;
         }
     }
 
-    val overlap_r: R.Result[R.Void, str] =
+    val overlap_r: err[fail.Fail] =
         validate_no_contribution_overlap(s, modules, module_count, sec_base, placements, sec_total);
-    if (R.is_err[R.Void, str](overlap_r)) {
+    if (sel overlap_r.err) {
         free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
         ret overlap_r;
     }
@@ -1031,9 +1041,9 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
     var header_reserve: u64 = 0;
     if (assign_vaddrs) {
         header_reserve = header_reserve_bytes(tgt, position_independent, nil::*of.HeaderShape);
-        val vaddr_r: R.Result[R.Void, str] =
+        val vaddr_r: err[fail.Fail] =
             assign_section_vaddrs(tgt, merged, header_reserve);
-        if (R.is_err[R.Void, str](vaddr_r)) {
+        if (sel vaddr_r.err) {
             free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
             ret vaddr_r;
         }
@@ -1043,10 +1053,10 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
     var sym_locs: map.Map[intern.StrId, SymbolLoc] =
         map.init[intern.StrId, SymbolLoc](alloc, map.hash_u32, map.eq_u32);
 
-    val collect_r: R.Result[R.Void, str] =
+    val collect_r: err[fail.Fail] =
         collect_symbols(s, modules, module_count, placements, sec_base, ?sym_locs,
                         assign_vaddrs, ?atoms);
-    if (R.is_err[R.Void, str](collect_r)) {
+    if (sel collect_r.err) {
         free_local_got_plan(alloc, ?local_got);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
@@ -1054,19 +1064,19 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
     }
 
     if (mode == LINK_EXE || shared) {
-        val gp_r: R.Result[R.Void, str] = build_local_got_plan(
+        val gp_r: err[fail.Fail] = build_local_got_plan(
             s, tgt.isa, modules, module_count, ?sym_locs, sec_base, ?atoms,
             merged, ?groups, ?local_got);
-        if (R.is_err[R.Void, str](gp_r)) {
+        if (sel gp_r.err) {
             free_local_got_plan(alloc, ?local_got);
             map.dnit[intern.StrId, SymbolLoc](?sym_locs);
             free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
             ret gp_r;
         }
         if (local_got.count > 0) {
-            val got_vaddr_r: R.Result[R.Void, str] =
+            val got_vaddr_r: err[fail.Fail] =
                 assign_section_vaddrs(tgt, merged, header_reserve);
-            if (R.is_err[R.Void, str](got_vaddr_r)) {
+            if (sel got_vaddr_r.err) {
                 free_local_got_plan(alloc, ?local_got);
                 map.dnit[intern.StrId, SymbolLoc](?sym_locs);
                 free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
@@ -1077,10 +1087,10 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
 
             map.dnit[intern.StrId, SymbolLoc](?sym_locs);
             sym_locs = map.init[intern.StrId, SymbolLoc](alloc, map.hash_u32, map.eq_u32);
-            val recollect: R.Result[R.Void, str] = collect_symbols(
+            val recollect: err[fail.Fail] = collect_symbols(
                 s, modules, module_count, placements, sec_base, ?sym_locs,
                 assign_vaddrs, ?atoms);
-            if (R.is_err[R.Void, str](recollect)) {
+            if (sel recollect.err) {
                 free_local_got_plan(alloc, ?local_got);
                 map.dnit[intern.StrId, SymbolLoc](?sym_locs);
                 free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
@@ -1094,16 +1104,16 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
             || has_unresolved_declared_imports(
                 modules, module_count, ?sym_locs));
     if (!dynamic && mode == LINK_EXE) {
-        val unresolved_r: R.Result[bool, str] = has_unresolved_attributed_imports(
+        val unresolved_r: res[bool, fail.Fail] = has_unresolved_attributed_imports(
             s, modules, module_count, dynlibs, dynlib_count, ?sym_locs,
             tgt.of.import_address_prefix, sec_base, ?atoms);
-        if (R.is_err[bool, str](unresolved_r)) {
+        if (sel unresolved_r.err) {
             free_local_got_plan(alloc, ?local_got);
             map.dnit[intern.StrId, SymbolLoc](?sym_locs);
             free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
-            ret R.err[R.Void, str](R.unwrap_err[bool, str](unresolved_r));
+            ret err[fail.Fail].err{unresolved_r.err};
         }
-        dynamic = R.unwrap_ok[bool, str](unresolved_r);
+        dynamic = unresolved_r.ok;
     }
 
     val no_loader: str = loaderless_request_message(s, tgt, mode, pie, dynamic);
@@ -1111,33 +1121,33 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
         free_local_got_plan(alloc, ?local_got);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
-        ret R.err[R.Void, str](no_loader);
+        ret err[fail.Fail].err{fail.message(no_loader)};
     }
 
     var out_img: of.ObjectImage;
-    val img_r: R.Result[of.ObjectImage, str] = obj.init(alloc, ?s.interner, image_name(modules, module_count));
-    if (R.is_err[of.ObjectImage, str](img_r)) {
+    val img_r: res[of.ObjectImage, fail.Fail] = obj.image_init(alloc, ?s.interner, image_name(modules, module_count));
+    if (sel img_r.err) {
         free_local_got_plan(alloc, ?local_got);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
-        ret R.err[R.Void, str](R.unwrap_err[of.ObjectImage, str](img_r));
+        ret err[fail.Fail].err{img_r.err};
     }
-    out_img = R.unwrap_ok[of.ObjectImage, str](img_r);
+    out_img = img_r.ok;
 
-    val mto_r: R.Result[*u32, str] = A.zallocate[u32](alloc, merged_count::usize);
-    if (R.is_err[*u32, str](mto_r)) {
+    val mto_r: res[*u32, A.Error] = A.zallocate[u32](alloc, merged_count::usize);
+    if (sel mto_r.err) {
         obj.dnit(?out_img);
         free_local_got_plan(alloc, ?local_got);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
-        ret R.err[R.Void, str](R.unwrap_err[*u32, str](mto_r));
+        ret err[fail.Fail].err{fail.refused(mto_r.err)};
     }
-    merged_to_out = R.unwrap_ok[*u32, str](mto_r);
+    merged_to_out = mto_r.ok;
 
-    val build_r: R.Result[R.Void, str] =
+    val build_r: err[fail.Fail] =
         build_merged_image(s, ?out_img, modules, module_count, merged, merged_count,
                            placements, sec_base, merged_to_out, sym_base, sym_out, ?strm, ?atoms);
-    if (R.is_err[R.Void, str](build_r)) {
+    if (sel build_r.err) {
         obj.dnit(?out_img);
         free_local_got_plan(alloc, ?local_got);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
@@ -1152,17 +1162,17 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
         free_local_got_plan(alloc, ?local_got);
         map.dnit[intern.StrId, SymbolLoc](?sym_locs);
         free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
-        ret R.err[R.Void, str](reason);
+        ret err[fail.Fail].err{fail.message(reason)};
     }
 
     var dyn: DynState;
     init_dynstate(?dyn);
     dyn.info.pie = position_independent;
     if (dynamic) {
-        val dr: R.Result[R.Void, str] =
+        val dr: err[fail.Fail] =
             build_dynamic_info(s, tgt, ?dyn, modules, module_count, ?sym_locs,
                                dynlibs, dynlib_count, sec_base, ?atoms);
-        if (R.is_err[R.Void, str](dr)) {
+        if (sel dr.err) {
             free_dynstate(alloc, ?dyn);
             obj.dnit(?out_img);
             free_local_got_plan(alloc, ?local_got);
@@ -1178,9 +1188,9 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
         val want: u64 = header_reserve_bytes(tgt, position_independent, ?shape);
         if (want > header_reserve) {
             header_reserve = want;
-            val header_vaddr_r: R.Result[R.Void, str] =
+            val header_vaddr_r: err[fail.Fail] =
                 assign_section_vaddrs(tgt, merged, header_reserve);
-            if (R.is_err[R.Void, str](header_vaddr_r)) {
+            if (sel header_vaddr_r.err) {
                 free_dynstate(alloc, ?dyn);
                 obj.dnit(?out_img);
                 free_local_got_plan(alloc, ?local_got);
@@ -1193,10 +1203,10 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
 
             map.dnit[intern.StrId, SymbolLoc](?sym_locs);
             sym_locs = map.init[intern.StrId, SymbolLoc](alloc, map.hash_u32, map.eq_u32);
-            val recollect: R.Result[R.Void, str] = collect_symbols(
+            val recollect: err[fail.Fail] = collect_symbols(
                 s, modules, module_count, placements, sec_base, ?sym_locs,
                 assign_vaddrs, ?atoms);
-            if (R.is_err[R.Void, str](recollect)) {
+            if (sel recollect.err) {
                 free_dynstate(alloc, ?dyn);
                 obj.dnit(?out_img);
                 free_local_got_plan(alloc, ?local_got);
@@ -1207,12 +1217,12 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
         }
     }
 
-    val patch_r: R.Result[R.Void, str] =
+    val patch_r: err[fail.Fail] =
         patch_relocations(s, ?out_img, modules, module_count, codegen_count,
                           placements, sec_base, merged_to_out, ?sym_locs,
                           ?dyn, ?local_got, ?strm, tgt.of,
                           tgt.isa, os_base_addr(tgt), ?atoms);
-    if (R.is_err[R.Void, str](patch_r)) {
+    if (sel patch_r.err) {
         free_dynstate(alloc, ?dyn);
         obj.dnit(?out_img);
         free_local_got_plan(alloc, ?local_got);
@@ -1221,7 +1231,7 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
         ret patch_r;
     }
 
-    var emit_r: R.Result[R.Void, str];
+    var emit_r: err[fail.Fail];
     if (shared) {
         emit_r = emit_shared_object(s, tgt, ?out_img, merged, ?groups, modules, module_count, ?sym_locs, ?dyn, destination, image_options);
     }
@@ -1238,23 +1248,23 @@ fun link_modules_core(s: *session.Session, tgt: *target.Target, modules: *of.Obj
     map.dnit[intern.StrId, SymbolLoc](?sym_locs);
     free_scratch(alloc, placements, sec_total, sec_base, module_count, merged, merged_count, debug_names, debug_count, merged_to_out, sym_base, sym_out, sym_total, ?strm, ?atoms, ?groups);
 
-    if (R.is_err[R.Void, str](emit_r)) {
+    if (sel emit_r.err) {
         ret emit_r;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun read_objects(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
                  obj_count: u32, seed: *of.ObjectImage, seed_count: u32,
                  required: intern.StrId,
-                 module_count: *u32) R.Result[*of.ObjectImage, str] {
+                 module_count: *u32) res[*of.ObjectImage, fail.Fail] {
     @module_count = 0;
     if (tgt.of.parse_object == nil) {
-        ret R.err[*of.ObjectImage, str]("link: object format has no parser");
+        ret res[*of.ObjectImage, fail.Fail].err{fail.message("link: object format has no parser")};
     }
-    val seed_valid: R.Result[R.Void, str] = validate_link_inputs(seed, seed_count);
-    if (R.is_err[R.Void, str](seed_valid)) {
-        ret R.err[*of.ObjectImage, str](R.unwrap_err[R.Void, str](seed_valid));
+    val seed_valid: err[fail.Fail] = validate_link_inputs(seed, seed_count);
+    if (sel seed_valid.err) {
+        ret res[*of.ObjectImage, fail.Fail].err{seed_valid.err};
     }
     val alloc: *A.Allocator = s.alloc;
 
@@ -1265,19 +1275,19 @@ fun read_objects(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
     var state: ArchiveResolution;
     init_archive_resolution(alloc, ?state);
     if (required != intern.STR_NIL) {
-        val rr: R.Result[R.Void, str] = archive_require(?state, required);
-        if (R.is_err[R.Void, str](rr)) {
+        val rr: err[fail.Fail] = archive_require(?state, required);
+        if (sel rr.err) {
             free_archive_resolution(?state);
-            ret R.err[*of.ObjectImage, str](R.unwrap_err[R.Void, str](rr));
+            ret res[*of.ObjectImage, fail.Fail].err{rr.err};
         }
     }
     var si: u32 = 0;
     for (si < seed_count) {
-        val nr: R.Result[R.Void, str] = archive_note_image(
+        val nr: err[fail.Fail] = archive_note_image(
             s, tgt.of.import_address_prefix, ?state, ?seed[si]);
-        if (R.is_err[R.Void, str](nr)) {
+        if (sel nr.err) {
             free_archive_resolution(?state);
-            ret R.err[*of.ObjectImage, str](R.unwrap_err[R.Void, str](nr));
+            ret res[*of.ObjectImage, fail.Fail].err{nr.err};
         }
         si = si + 1;
     }
@@ -1287,27 +1297,28 @@ fun read_objects(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
         if (obj_paths[i] == nil) {
             free_archive_resolution(?state);
             free_modules_to(alloc, modules, count, cap);
-            ret R.err[*of.ObjectImage, str]("link: nil object path");
+            ret res[*of.ObjectImage, fail.Fail].err{fail.message("link: nil object path")};
         }
 
         val path: str = obj_paths[i]::str;
 
-        val rb: R.Result[Vector[u8], str] = fs.read_bytes(alloc, path);
-        if (R.is_err[Vector[u8], str](rb)) {
+        val rb: res[Vector[u8], fs.FsError] = fs.read_bytes(alloc, path);
+        if (sel rb.err) {
             free_archive_resolution(?state);
             free_modules_to(alloc, modules, count, cap);
-            ret R.err[*of.ObjectImage, str](read_message(s, path, R.unwrap_err[Vector[u8], str](rb)));
+            ret res[*of.ObjectImage, fail.Fail].err{fail.message(read_message(s, path, fail.describe(fail.fs_refused(rb.err))))};
         }
-        var buf: Vector[u8] = R.unwrap_ok[Vector[u8], str](rb);
+        var buf: Vector[u8] = rb.ok;
 
-        var input_r: R.Result[R.Void, str];
+        var input_r: err[fail.Fail];
         if (ar.is_archive(buf.data, buf.len)) {
             input_r = parse_archive(s, tgt, path, buf.data, buf.len,
                                     ?state, ?modules, ?count, ?cap);
         }
         or {
-            input_r = parse_loose(alloc, ?s.interner, tgt, path, buf.data, buf.len, ?modules, ?count, ?cap);
-            if (R.is_ok[R.Void, str](input_r)) {
+            val loose: err[fail.Fail] = parse_loose(alloc, ?s.interner, tgt, path, buf.data, buf.len, ?modules, ?count, ?cap);
+            input_r = loose;
+            if (sel loose.ok) {
                 val accepted: *of.ObjectImage = modules;
                 input_r = archive_note_image(
                     s, tgt.of.import_address_prefix, ?state, ?accepted[count - 1]);
@@ -1315,29 +1326,29 @@ fun read_objects(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
         }
 
         vector.dnit[u8](?buf);
-        if (R.is_err[R.Void, str](input_r)) {
+        if (sel input_r.err) {
             free_archive_resolution(?state);
             free_modules_to(alloc, modules, count, cap);
-            ret R.err[*of.ObjectImage, str](R.unwrap_err[R.Void, str](input_r));
+            ret res[*of.ObjectImage, fail.Fail].err{input_r.err};
         }
 
         i = i + 1;
     }
 
     if (cap > count) {
-        val sr: R.Result[*of.ObjectImage, str] =
+        val sr: res[*of.ObjectImage, A.Error] =
             A.reallocate[of.ObjectImage](alloc, modules, cap::usize, count::usize);
-        if (R.is_err[*of.ObjectImage, str](sr)) {
+        if (sel sr.err) {
             free_archive_resolution(?state);
             free_modules_to(alloc, modules, count, cap);
-            ret R.err[*of.ObjectImage, str](R.unwrap_err[*of.ObjectImage, str](sr));
+            ret res[*of.ObjectImage, fail.Fail].err{fail.refused(sr.err)};
         }
-        modules = R.unwrap_ok[*of.ObjectImage, str](sr);
+        modules = sr.ok;
     }
 
     free_archive_resolution(?state);
     @module_count = count;
-    ret R.ok[*of.ObjectImage, str](modules);
+    ret res[*of.ObjectImage, fail.Fail].ok{modules};
 }
 
 fun init_archive_resolution(alloc: *A.Allocator, state: *ArchiveResolution) {
@@ -1351,11 +1362,13 @@ fun free_archive_resolution(state: *ArchiveResolution) {
 }
 
 fun archive_require(state: *ArchiveResolution,
-                    name: intern.StrId) R.Result[R.Void, str] {
+                    name: intern.StrId) err[fail.Fail] {
     if (map.contains[intern.StrId, u32](?state.providers, ?name)) {
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
-    ret R.void_of[bool, str](map.insert[intern.StrId, u32](?state.unresolved, name, 1));
+    val inserted: res[bool, A.Error] = map.insert[intern.StrId, u32](?state.unresolved, name, 1);
+    if (sel inserted.err) { ret err[fail.Fail].err{fail.refused(inserted.err)}; }
+    ret err[fail.Fail].ok{};
 }
 
 
@@ -1371,66 +1384,64 @@ fun archive_symbol_provides(img: *of.ObjectImage, sym: *of.Symbol) bool {
 }
 
 fun weak_fallback_name(img: *of.ObjectImage,
-                       sym: *of.Symbol) R.Result[intern.StrId, str] {
+                       sym: *of.Symbol) res[intern.StrId, fail.Fail] {
     if ((sym.flags & of.SYM_OBJ_FLAG_FALLBACK) == 0) {
-        ret R.err[intern.StrId, str]("link: symbol has no weak fallback");
+        ret res[intern.StrId, fail.Fail].err{fail.message("link: symbol has no weak fallback")};
     }
     if (sym.fallback >= img.symbol_count || sym.fallback == of.SYMBOL_NONE) {
-        ret R.err[intern.StrId, str]("link: weak fallback index is out of range");
+        ret res[intern.StrId, fail.Fail].err{fail.message("link: weak fallback index is out of range")};
     }
-    ret R.ok[intern.StrId, str](img.symbols[sym.fallback].name);
+    ret res[intern.StrId, fail.Fail].ok{img.symbols[sym.fallback].name};
 }
 
 fun archive_import_alias(s: *session.Session, prefix: str,
-                         symbol: intern.StrId) R.Result[intern.StrId, str] {
-    if (str_empty(prefix)) { ret R.ok[intern.StrId, str](symbol); }
+                         symbol: intern.StrId) res[intern.StrId, fail.Fail] {
+    if (str_empty(prefix)) { ret res[intern.StrId, fail.Fail].ok{symbol}; }
     val no: O.Option[str] = intern.lookup(?s.interner, symbol);
-    if (O.is_none[str](no)) { ret R.err[intern.StrId, str]("link: import name not interned"); }
+    if (O.is_none[str](no)) { ret res[intern.StrId, fail.Fail].err{fail.message("link: import name not interned")}; }
     val name: str = O.unwrap[str](no);
-    if (str_starts_with(name, prefix)) { ret R.ok[intern.StrId, str](symbol); }
-    val jr: R.Result[str, str] = str_join(s.alloc, prefix, name);
-    if (R.is_err[str, str](jr)) { ret R.err[intern.StrId, str](R.unwrap_err[str, str](jr)); }
-    val joined: str = R.unwrap_ok[str, str](jr);
+    if (str_starts_with(name, prefix)) { ret res[intern.StrId, fail.Fail].ok{symbol}; }
+    val jr: res[str, StrError] = str_join(s.alloc, prefix, name);
+    if (sel jr.err) { ret res[intern.StrId, fail.Fail].err{fail.str_refused(jr.err)}; }
+    val joined: str = jr.ok;
     val ir: R.Result[intern.StrId, str] = intern.intern(?s.interner, joined);
     str_free(s.alloc, joined);
-    ret ir;
+    ret fail.lift_res[intern.StrId](ir);
 }
 
 fun archive_note_provider(state: *ArchiveResolution,
-                          name: intern.StrId) R.Result[R.Void, str] {
-    val ir: R.Result[bool, str] =
+                          name: intern.StrId) err[fail.Fail] {
+    val ir: res[bool, A.Error] =
         map.insert[intern.StrId, u32](?state.providers, name, 1);
-    if (R.is_err[bool, str](ir)) { ret R.err[R.Void, str](R.unwrap_err[bool, str](ir)); }
-    val rr: R.Result[bool, str] =
-        map.remove[intern.StrId, u32](?state.unresolved, ?name);
-    if (R.is_err[bool, str](rr)) { ret R.err[R.Void, str](R.unwrap_err[bool, str](rr)); }
-    ret R.ok_void[str]();
+    if (sel ir.err) { ret err[fail.Fail].err{fail.refused(ir.err)}; }
+    map.remove[intern.StrId, u32](?state.unresolved, ?name);
+    ret err[fail.Fail].ok{};
 }
 
 fun archive_note_image(s: *session.Session, import_address_prefix: str,
                        state: *ArchiveResolution,
-                       img: *of.ObjectImage) R.Result[R.Void, str] {
+                       img: *of.ObjectImage) err[fail.Fail] {
     var i: u32 = 0;
     for (i < img.symbol_count) {
         val sym: *of.Symbol = ?img.symbols[i];
         if (archive_symbol_provides(img, sym)) {
-            val nr: R.Result[R.Void, str] = archive_note_provider(state, sym.name);
-            if (R.is_err[R.Void, str](nr)) { ret nr; }
+            val nr: err[fail.Fail] = archive_note_provider(state, sym.name);
+            if (sel nr.err) { ret nr; }
         }
         i = i + 1;
     }
     i = 0;
     for (i < img.import_count) {
-        val nr: R.Result[R.Void, str] = archive_note_provider(state, img.imports[i].symbol);
-        if (R.is_err[R.Void, str](nr)) { ret nr; }
-        val ar: R.Result[intern.StrId, str] =
+        val nr: err[fail.Fail] = archive_note_provider(state, img.imports[i].symbol);
+        if (sel nr.err) { ret nr; }
+        val ar: res[intern.StrId, fail.Fail] =
             archive_import_alias(s, import_address_prefix, img.imports[i].symbol);
-        if (R.is_err[intern.StrId, str](ar)) {
-            ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](ar));
+        if (sel ar.err) {
+            ret err[fail.Fail].err{ar.err};
         }
-        val an: R.Result[R.Void, str] =
-            archive_note_provider(state, R.unwrap_ok[intern.StrId, str](ar));
-        if (R.is_err[R.Void, str](an)) { ret an; }
+        val an: err[fail.Fail] =
+            archive_note_provider(state, ar.ok);
+        if (sel an.err) { ret an; }
         i = i + 1;
     }
     i = 0;
@@ -1438,86 +1449,86 @@ fun archive_note_image(s: *session.Session, import_address_prefix: str,
         val sym: *of.Symbol = ?img.symbols[i];
         if (!is_undefined_extern(sym)) { i = i + 1; cnt; }
         if ((sym.flags & of.SYM_OBJ_FLAG_FALLBACK) != 0) {
-            val fr: R.Result[intern.StrId, str] = weak_fallback_name(img, sym);
-            if (R.is_err[intern.StrId, str](fr)) {
-                ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](fr));
+            val fr: res[intern.StrId, fail.Fail] = weak_fallback_name(img, sym);
+            if (sel fr.err) {
+                ret err[fail.Fail].err{fr.err};
             }
-            val rr: R.Result[R.Void, str] =
-                archive_require(state, R.unwrap_ok[intern.StrId, str](fr));
-            if (R.is_err[R.Void, str](rr)) { ret rr; }
+            val rr: err[fail.Fail] =
+                archive_require(state, fr.ok);
+            if (sel rr.err) { ret rr; }
             if ((sym.flags & of.SYM_OBJ_FLAG_SEARCH) != 0) {
-                val sr: R.Result[R.Void, str] = archive_require(state, sym.name);
-                if (R.is_err[R.Void, str](sr)) { ret sr; }
+                val sr: err[fail.Fail] = archive_require(state, sym.name);
+                if (sel sr.err) { ret sr; }
             }
         }
         or ((sym.flags & of.SYM_OBJ_FLAG_WEAK) == 0) {
-            val ur: R.Result[R.Void, str] = archive_require(state, sym.name);
-            if (R.is_err[R.Void, str](ur)) { ret ur; }
+            val ur: err[fail.Fail] = archive_require(state, sym.name);
+            if (sel ur.err) { ret ur; }
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun archive_image_needed(s: *session.Session, import_address_prefix: str,
                          state: *ArchiveResolution,
-                         img: *of.ObjectImage) R.Result[bool, str] {
+                         img: *of.ObjectImage) res[bool, fail.Fail] {
     var i: u32 = 0;
     for (i < img.symbol_count) {
         val sym: *of.Symbol = ?img.symbols[i];
         if (archive_symbol_provides(img, sym)
             && map.contains[intern.StrId, u32](?state.unresolved, ?sym.name)) {
-            ret R.ok[bool, str](true);
+            ret res[bool, fail.Fail].ok{true};
         }
         i = i + 1;
     }
     i = 0;
     for (i < img.import_count) {
         if (map.contains[intern.StrId, u32](?state.unresolved, ?img.imports[i].symbol)) {
-            ret R.ok[bool, str](true);
+            ret res[bool, fail.Fail].ok{true};
         }
-        val ar: R.Result[intern.StrId, str] =
+        val ar: res[intern.StrId, fail.Fail] =
             archive_import_alias(s, import_address_prefix, img.imports[i].symbol);
-        if (R.is_err[intern.StrId, str](ar)) {
-            ret R.err[bool, str](R.unwrap_err[intern.StrId, str](ar));
+        if (sel ar.err) {
+            ret res[bool, fail.Fail].err{ar.err};
         }
-        val alias: intern.StrId = R.unwrap_ok[intern.StrId, str](ar);
+        val alias: intern.StrId = ar.ok;
         if (map.contains[intern.StrId, u32](?state.unresolved, ?alias)) {
-            ret R.ok[bool, str](true);
+            ret res[bool, fail.Fail].ok{true};
         }
         i = i + 1;
     }
-    ret R.ok[bool, str](false);
+    ret res[bool, fail.Fail].ok{false};
 }
 
-fun grow_modules(alloc: *A.Allocator, modules: **of.ObjectImage, count: *u32, cap: *u32) R.Result[u32, str] {
+fun grow_modules(alloc: *A.Allocator, modules: **of.ObjectImage, count: *u32, cap: *u32) res[u32, fail.Fail] {
     val old: u32 = @count;
     if (old == @cap) {
         val current: layout.CheckedCount[of.ObjectImage] = layout.count[of.ObjectImage]((@cap)::usize);
         val required_r: R.Result[layout.CheckedCount[of.ObjectImage], layout.CheckCause] =
             layout.count_add[of.ObjectImage](current, layout.count[of.ObjectImage](1::usize));
         if (R.is_err[layout.CheckedCount[of.ObjectImage], layout.CheckCause](required_r)) {
-            ret R.err[u32, str]("linker: module table growth count overflow");
+            ret res[u32, fail.Fail].err{fail.message("linker: module table growth count overflow")};
         }
         val required: layout.CheckedCount[of.ObjectImage] =
             R.unwrap_ok[layout.CheckedCount[of.ObjectImage], layout.CheckCause](required_r);
         val grown_r: R.Result[layout.CheckedCount[of.ObjectImage], layout.CheckCause] =
             layout.count_grow[of.ObjectImage](current, required);
         if (R.is_err[layout.CheckedCount[of.ObjectImage], layout.CheckCause](grown_r)) {
-            ret R.err[u32, str]("linker: module table growth count overflow");
+            ret res[u32, fail.Fail].err{fail.message("linker: module table growth count overflow")};
         }
         val new_cap_fits: R.Result[u32, layout.CheckCause] = layout.usize_to_u32(
             R.unwrap_ok[layout.CheckedCount[of.ObjectImage], layout.CheckCause](grown_r).value);
         if (R.is_err[u32, layout.CheckCause](new_cap_fits)) {
-            ret R.err[u32, str]("linker: module table capacity exceeds the u32 limit");
+            ret res[u32, fail.Fail].err{fail.message("linker: module table capacity exceeds the u32 limit")};
         }
         val new_cap: u32 = R.unwrap_ok[u32, layout.CheckCause](new_cap_fits);
-        val gr: R.Result[*of.ObjectImage, str] =
+        val gr: res[*of.ObjectImage, A.Error] =
             A.reallocate[of.ObjectImage](alloc, @modules, (@cap)::usize, new_cap::usize);
-        if (R.is_err[*of.ObjectImage, str](gr)) {
-            ret R.err[u32, str](R.unwrap_err[*of.ObjectImage, str](gr));
+        if (sel gr.err) {
+            ret res[u32, fail.Fail].err{fail.refused(gr.err)};
         }
-        @modules = R.unwrap_ok[*of.ObjectImage, str](gr);
+        @modules = gr.ok;
         @cap = new_cap;
     }
 
@@ -1526,7 +1537,7 @@ fun grow_modules(alloc: *A.Allocator, modules: **of.ObjectImage, count: *u32, ca
     @slot = of.object_image_init(alloc, nil, intern.STR_NIL);
 
     @count = old + 1;
-    ret R.ok[u32, str](old);
+    ret res[u32, fail.Fail].ok{old};
 }
 
 rec GmTrackEntry {
@@ -1603,9 +1614,9 @@ test "mach.lang.be.linker.grow_modules:fresh_slot_is_fully_nil_and_destructible"
     page.make(?page_alloc);
 
     var tracker: GmTracker;
-    val res_entries: R.Result[*GmTrackEntry, str] = A.allocate[GmTrackEntry](?page_alloc, 64::usize);
-    if (R.is_err[*GmTrackEntry, str](res_entries)) { ret 1; }
-    tracker.entries  = R.unwrap_ok[*GmTrackEntry, str](res_entries);
+    val res_entries: res[*GmTrackEntry, A.Error] = A.allocate[GmTrackEntry](?page_alloc, 64::usize);
+    if (sel res_entries.err) { ret 1; }
+    tracker.entries  = res_entries.ok;
     tracker.cap      = 64;
     tracker.count    = 0;
     tracker.live     = 0;
@@ -1621,9 +1632,9 @@ test "mach.lang.be.linker.grow_modules:fresh_slot_is_fully_nil_and_destructible"
     var modules: *of.ObjectImage = nil;
     var count: u32 = 0;
     var cap:   u32 = 0;
-    val gr: R.Result[u32, str] = grow_modules(?alloc, ?modules, ?count, ?cap);
-    if (R.is_err[u32, str](gr)) { ret 1; }
-    val ix: u32 = R.unwrap_ok[u32, str](gr);
+    val gr: res[u32, fail.Fail] = grow_modules(?alloc, ?modules, ?count, ?cap);
+    if (sel gr.err) { ret 1; }
+    val ix: u32 = gr.ok;
     val slot: *of.ObjectImage = ?modules[ix];
 
     if (slot.interner != nil)       { ret 1; }
@@ -1648,9 +1659,9 @@ test "mach.lang.be.linker.image_attributes:frees_intermediate_accumulators" {
     page.make(?page_alloc);
 
     var tracker: GmTracker;
-    val res_entries: R.Result[*GmTrackEntry, str] = A.allocate[GmTrackEntry](?page_alloc, 64::usize);
-    if (R.is_err[*GmTrackEntry, str](res_entries)) { ret 1; }
-    tracker.entries  = R.unwrap_ok[*GmTrackEntry, str](res_entries);
+    val res_entries: res[*GmTrackEntry, A.Error] = A.allocate[GmTrackEntry](?page_alloc, 64::usize);
+    if (sel res_entries.err) { ret 1; }
+    tracker.entries  = res_entries.ok;
     tracker.cap      = 64;
     tracker.count    = 0;
     tracker.live     = 0;
@@ -1695,9 +1706,9 @@ test "mach.lang.be.linker.image_attributes:frees_intermediate_accumulators" {
     mods[1].attributes_len = len_b;
 
     var out_len: u32 = 0;
-    val ar: R.Result[*u8, str] = image_attributes(?s, ?tgt, ?mods[0], 2, ?out_len);
-    if (R.is_err[*u8, str](ar)) { session.dnit(?s); ret 1; }
-    val merged: *u8 = R.unwrap_ok[*u8, str](ar);
+    val ar: res[*u8, fail.Fail] = image_attributes(?s, ?tgt, ?mods[0], 2, ?out_len);
+    if (sel ar.err) { session.dnit(?s); ret 1; }
+    val merged: *u8 = ar.ok;
 
     A.deallocate[u8](?alloc, mods[0].attributes, mods[0].attributes_len::usize);
     A.deallocate[u8](?alloc, mods[1].attributes, mods[1].attributes_len::usize);
@@ -1714,21 +1725,21 @@ test "mach.lang.be.linker.image_attributes:frees_intermediate_accumulators" {
 
 fun parse_loose(alloc: *A.Allocator, itn: *intern.Interner, tgt: *target.Target,
                 path: str, buf: *u8, buf_len: usize,
-                modules: **of.ObjectImage, count: *u32, cap: *u32) R.Result[R.Void, str] {
-    val gr: R.Result[u32, str] = grow_modules(alloc, modules, count, cap);
-    if (R.is_err[u32, str](gr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](gr)); }
-    val ix: u32 = R.unwrap_ok[u32, str](gr);
+                modules: **of.ObjectImage, count: *u32, cap: *u32) err[fail.Fail] {
+    val gr: res[u32, fail.Fail] = grow_modules(alloc, modules, count, cap);
+    if (sel gr.err) { ret err[fail.Fail].err{gr.err}; }
+    val ix: u32 = gr.ok;
     val arr: *of.ObjectImage = @modules;
     val pr: R.Result[R.Void, str] = tgt.of.parse_object(alloc, itn, buf, buf_len, ?arr[ix]);
-    if (R.is_err[R.Void, str](pr)) { ret pr; }
+    if (R.is_err[R.Void, str](pr)) { ret fail.lift_err(pr); }
     val nr: R.Result[intern.StrId, str] = intern.intern(itn, path);
     if (R.is_ok[intern.StrId, str](nr)) { arr[ix].name = R.unwrap_ok[intern.StrId, str](nr); }
-    ret pr;
+    ret err[fail.Fail].ok{};
 }
 
 fun parse_archive(s: *session.Session, tgt: *target.Target, path: str, buf: *u8, buf_len: usize,
                   state: *ArchiveResolution, modules: **of.ObjectImage,
-                  count: *u32, cap: *u32) R.Result[R.Void, str] {
+                  count: *u32, cap: *u32) err[fail.Fail] {
     val alloc: *A.Allocator = s.alloc;
     var candidates: *of.ObjectImage = nil;
     var candidate_count: u32 = 0;
@@ -1738,24 +1749,24 @@ fun parse_archive(s: *session.Session, tgt: *target.Target, path: str, buf: *u8,
         val st: ar.Step = ar.next_member(buf, buf_len, pos);
         if (!st.ok) {
             free_modules_to(alloc, candidates, candidate_count, candidate_cap);
-            ret R.err[R.Void, str](read_message(s, path, "malformed archive member header"));
+            ret err[fail.Fail].err{fail.message(read_message(s, path, "malformed archive member header"))};
         }
         if (st.done) { brk; }
 
         if (!ar.is_special(st.member)) {
-            val gr: R.Result[u32, str] =
+            val gr: res[u32, fail.Fail] =
                 grow_modules(alloc, ?candidates, ?candidate_count, ?candidate_cap);
-            if (R.is_err[u32, str](gr)) {
+            if (sel gr.err) {
                 free_modules_to(alloc, candidates, candidate_count, candidate_cap);
-                ret R.err[R.Void, str](R.unwrap_err[u32, str](gr));
+                ret err[fail.Fail].err{gr.err};
             }
-            val ix: u32 = R.unwrap_ok[u32, str](gr);
+            val ix: u32 = gr.ok;
             val pr: R.Result[R.Void, str] =
                 tgt.of.parse_object(alloc, ?s.interner, st.member.data, st.member.len,
                                     ?candidates[ix]);
             if (R.is_err[R.Void, str](pr)) {
                 free_modules_to(alloc, candidates, candidate_count, candidate_cap);
-                ret pr;
+                ret fail.lift_err(pr);
             }
         }
 
@@ -1764,14 +1775,14 @@ fun parse_archive(s: *session.Session, tgt: *target.Target, path: str, buf: *u8,
 
     if (candidate_count == 0) {
         free_modules_to(alloc, candidates, candidate_count, candidate_cap);
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
-    val sr: R.Result[*bool, str] = A.zallocate[bool](alloc, candidate_count::usize);
-    if (R.is_err[*bool, str](sr)) {
+    val sr: res[*bool, A.Error] = A.zallocate[bool](alloc, candidate_count::usize);
+    if (sel sr.err) {
         free_modules_to(alloc, candidates, candidate_count, candidate_cap);
-        ret R.err[R.Void, str](R.unwrap_err[*bool, str](sr));
+        ret err[fail.Fail].err{fail.refused(sr.err)};
     }
-    val selected: *bool = R.unwrap_ok[*bool, str](sr);
+    val selected: *bool = sr.ok;
 
     var progress: bool = true;
     for (progress) {
@@ -1779,29 +1790,29 @@ fun parse_archive(s: *session.Session, tgt: *target.Target, path: str, buf: *u8,
         var i: u32 = 0;
         for (i < candidate_count) {
             if (selected[i]) { i = i + 1; cnt; }
-            val needed_r: R.Result[bool, str] =
+            val needed_r: res[bool, fail.Fail] =
                 archive_image_needed(
                     s, tgt.of.import_address_prefix, state, ?candidates[i]);
-            if (R.is_err[bool, str](needed_r)) {
+            if (sel needed_r.err) {
                 free_archive_candidates(alloc, candidates, candidate_count,
                                         candidate_cap, selected);
-                ret R.err[R.Void, str](R.unwrap_err[bool, str](needed_r));
+                ret err[fail.Fail].err{needed_r.err};
             }
-            if (!R.unwrap_ok[bool, str](needed_r)) { i = i + 1; cnt; }
+            if (!needed_r.ok) { i = i + 1; cnt; }
 
-            val gr: R.Result[u32, str] = grow_modules(alloc, modules, count, cap);
-            if (R.is_err[u32, str](gr)) {
+            val gr: res[u32, fail.Fail] = grow_modules(alloc, modules, count, cap);
+            if (sel gr.err) {
                 free_archive_candidates(alloc, candidates, candidate_count,
                                         candidate_cap, selected);
-                ret R.err[R.Void, str](R.unwrap_err[u32, str](gr));
+                ret err[fail.Fail].err{gr.err};
             }
-            val dst: u32 = R.unwrap_ok[u32, str](gr);
+            val dst: u32 = gr.ok;
             val accepted: *of.ObjectImage = @modules;
             accepted[dst] = candidates[i];
             selected[i] = true;
-            val nr: R.Result[R.Void, str] = archive_note_image(
+            val nr: err[fail.Fail] = archive_note_image(
                 s, tgt.of.import_address_prefix, state, ?accepted[dst]);
-            if (R.is_err[R.Void, str](nr)) {
+            if (sel nr.err) {
                 free_archive_candidates(alloc, candidates, candidate_count,
                                         candidate_cap, selected);
                 ret nr;
@@ -1813,7 +1824,7 @@ fun parse_archive(s: *session.Session, tgt: *target.Target, path: str, buf: *u8,
 
     free_archive_candidates(alloc, candidates, candidate_count,
                             candidate_cap, selected);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun free_archive_candidates(alloc: *A.Allocator, candidates: *of.ObjectImage,
@@ -1831,81 +1842,81 @@ fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.Objec
                     merged: *MergedSection, groups: *SectionGroups,
                     sym_locs: *map.Map[intern.StrId, SymbolLoc],
                     dyn: *DynState, destination: *publication.Destination, name: *u8,
-                    image_options: of.ImageOptions, capture: *LinkedImage) R.Result[R.Void, str] {
+                    image_options: of.ImageOptions, capture: *LinkedImage) err[fail.Fail] {
     if (capture != nil && tgt.of.emit_exec_image == nil) {
-        ret R.err[R.Void, str]("link: this object format cannot hand back a linked image");
+        ret err[fail.Fail].err{fail.message("link: this object format cannot hand back a linked image")};
     }
     if (capture == nil && dyn == nil && tgt.of.emit_exec == nil) {
-        ret R.err[R.Void, str]("link: object format cannot write executables");
+        ret err[fail.Fail].err{fail.message("link: object format cannot write executables")};
     }
     if (dyn != nil && tgt.of.emit_dyn_exec == nil) {
-        ret R.err[R.Void, str]("link: object format cannot write dynamically-linked executables");
+        ret err[fail.Fail].err{fail.message("link: object format cannot write dynamically-linked executables")};
     }
     if (tgt.os == nil) {
-        ret R.err[R.Void, str]("link: target has no operating-system vtable");
+        ret err[fail.Fail].err{fail.message("link: target has no operating-system vtable")};
     }
 
     val alloc: *A.Allocator = s.alloc;
 
-    val er: R.Result[u64, str] = entry_vaddr(s, tgt, sym_locs);
-    if (R.is_err[u64, str](er)) { ret R.err[R.Void, str](R.unwrap_err[u64, str](er)); }
-    val entry: u64 = R.unwrap_ok[u64, str](er);
+    val er: res[u64, fail.Fail] = entry_vaddr(s, tgt, sym_locs);
+    if (sel er.err) { ret err[fail.Fail].err{er.err}; }
+    val entry: u64 = er.ok;
 
     var seg_count: u32 = 0;
-    val sr: R.Result[*of.LoadSegment, str] = build_load_segments(alloc, out_img, merged, groups, ?seg_count);
-    if (R.is_err[*of.LoadSegment, str](sr)) { ret R.err[R.Void, str](R.unwrap_err[*of.LoadSegment, str](sr)); }
-    val segs: *of.LoadSegment = R.unwrap_ok[*of.LoadSegment, str](sr);
+    val sr: res[*of.LoadSegment, fail.Fail] = build_load_segments(alloc, out_img, merged, groups, ?seg_count);
+    if (sel sr.err) { ret err[fail.Fail].err{sr.err}; }
+    val segs: *of.LoadSegment = sr.ok;
 
     var func_count: u32 = 0;
-    val fr: R.Result[*of.ExecFunction, str] = build_exec_functions(alloc, out_img, segs, seg_count, ?func_count);
-    if (R.is_err[*of.ExecFunction, str](fr)) {
+    val fr: res[*of.ExecFunction, fail.Fail] = build_exec_functions(alloc, out_img, segs, seg_count, ?func_count);
+    if (sel fr.err) {
         free_load_segments(alloc, segs, seg_count);
-        ret R.err[R.Void, str](R.unwrap_err[*of.ExecFunction, str](fr));
+        ret err[fail.Fail].err{fr.err};
     }
-    val funcs: *of.ExecFunction = R.unwrap_ok[*of.ExecFunction, str](fr);
+    val funcs: *of.ExecFunction = fr.ok;
 
     var exc_count: u32 = 0;
-    val xr: R.Result[*of.Section, str] = collect_exception_sections(alloc, out_img, ?exc_count);
-    if (R.is_err[*of.Section, str](xr)) {
+    val xr: res[*of.Section, fail.Fail] = collect_exception_sections(alloc, out_img, ?exc_count);
+    if (sel xr.err) {
         if (funcs != nil && func_count > 0) { A.deallocate[of.ExecFunction](alloc, funcs, func_count::usize); }
         free_load_segments(alloc, segs, seg_count);
-        ret R.err[R.Void, str](R.unwrap_err[*of.Section, str](xr));
+        ret err[fail.Fail].err{xr.err};
     }
-    val exc: *of.Section = R.unwrap_ok[*of.Section, str](xr);
+    val exc: *of.Section = xr.ok;
 
     var dbg_count: u32 = 0;
-    val dr: R.Result[*of.Section, str] = collect_debug_sections(alloc, out_img, ?dbg_count);
-    if (R.is_err[*of.Section, str](dr)) {
+    val dr: res[*of.Section, fail.Fail] = collect_debug_sections(alloc, out_img, ?dbg_count);
+    if (sel dr.err) {
         if (exc != nil && exc_count > 0) { A.deallocate[of.Section](alloc, exc, exc_count::usize); }
         if (funcs != nil && func_count > 0) { A.deallocate[of.ExecFunction](alloc, funcs, func_count::usize); }
         free_load_segments(alloc, segs, seg_count);
-        ret R.err[R.Void, str](R.unwrap_err[*of.Section, str](dr));
+        ret err[fail.Fail].err{dr.err};
     }
-    val dbg: *of.Section = R.unwrap_ok[*of.Section, str](dr);
+    val dbg: *of.Section = dr.ok;
 
-    var emit_r: R.Result[R.Void, str] = R.ok_void[str]();
+    var emit_r: err[fail.Fail] = err[fail.Fail].ok{};
 
     var symtab_count: u32 = 0;
-    val ser: R.Result[*of.SymtabEntry, str] = build_symtab_entries(alloc, out_img, segs, seg_count, ?symtab_count);
-    if (R.is_err[*of.SymtabEntry, str](ser)) {
+    val ser: res[*of.SymtabEntry, fail.Fail] = build_symtab_entries(alloc, out_img, segs, seg_count, ?symtab_count);
+    if (sel ser.err) {
         if (dbg != nil && dbg_count > 0) { A.deallocate[of.Section](alloc, dbg, dbg_count::usize); }
         if (exc != nil && exc_count > 0) { A.deallocate[of.Section](alloc, exc, exc_count::usize); }
         if (funcs != nil && func_count > 0) { A.deallocate[of.ExecFunction](alloc, funcs, func_count::usize); }
         free_load_segments(alloc, segs, seg_count);
-        ret R.err[R.Void, str](R.unwrap_err[*of.SymtabEntry, str](ser));
+        ret err[fail.Fail].err{ser.err};
     }
-    val symtab: *of.SymtabEntry = R.unwrap_ok[*of.SymtabEntry, str](ser);
+    val symtab: *of.SymtabEntry = ser.ok;
 
     if (capture != nil) {
         if (tgt.of.emit_exec_image == nil) {
-            emit_r = R.err[R.Void, str]("link: this object format cannot hand back a linked image");
+            emit_r = err[fail.Fail].err{fail.message("link: this object format cannot hand back a linked image")};
         }
         or {
             var cap_base: u64 = 0;
             var cap_size: usize = 0;
             val cb: R.Result[*u8, str] =
                 tgt.of.emit_exec_image(alloc, segs, seg_count, entry, ?cap_base, ?cap_size);
-            if (R.is_err[*u8, str](cb)) { emit_r = R.err[R.Void, str](R.unwrap_err[*u8, str](cb)); }
+            if (R.is_err[*u8, str](cb)) { emit_r = err[fail.Fail].err{fail.message(R.unwrap_err[*u8, str](cb))}; }
             or {
                 capture.bytes        = R.unwrap_ok[*u8, str](cb);
                 capture.len          = cap_size;
@@ -1916,21 +1927,21 @@ fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.Objec
         }
     }
     or (dyn == nil) {
-        emit_r = tgt.of.emit_exec(alloc, ?s.interner, ?tgt.object, segs, seg_count,
+        emit_r = fail.lift_err(tgt.of.emit_exec(alloc, ?s.interner, ?tgt.object, segs, seg_count,
                                   os_page_size(tgt), os_base_addr(tgt), entry,
                                   funcs, func_count,
                                   exc, exc_count, dbg, dbg_count,
-                                  symtab, symtab_count, destination, name, image_options);
+                                  symtab, symtab_count, destination, name, image_options));
     }
     or {
-        emit_r = tgt.of.emit_dyn_exec(alloc, ?s.interner, ?tgt.object, segs, seg_count,
+        emit_r = fail.lift_err(tgt.of.emit_dyn_exec(alloc, ?s.interner, ?tgt.object, segs, seg_count,
                                       os_page_size(tgt), os_base_addr(tgt), entry,
                                       funcs, func_count, ?dyn.info, dyn.fixups, dyn.fixup_count,
                                       exc, exc_count, dbg, dbg_count,
-                                      symtab, symtab_count, destination, name, image_options);
+                                      symtab, symtab_count, destination, name, image_options));
     }
 
-    val kept: bool = capture != nil && R.is_ok[R.Void, str](emit_r);
+    val kept: bool = capture != nil && sel emit_r.ok;
     if (!kept && symtab != nil && symtab_count > 0) { A.deallocate[of.SymtabEntry](alloc, symtab, symtab_count::usize); }
     if (dbg != nil && dbg_count > 0) { A.deallocate[of.Section](alloc, dbg, dbg_count::usize); }
     if (exc != nil && exc_count > 0) { A.deallocate[of.Section](alloc, exc, exc_count::usize); }
@@ -1939,72 +1950,69 @@ fun emit_executable(s: *session.Session, tgt: *target.Target, out_img: *of.Objec
     }
     free_load_segments(alloc, segs, seg_count);
 
-    if (R.is_err[R.Void, str](emit_r)) {
+    if (sel emit_r.err) {
         ret emit_r;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun emit_shared_object(s: *session.Session, tgt: *target.Target, out_img: *of.ObjectImage,
                        merged: *MergedSection, groups: *SectionGroups,
                        modules: *of.ObjectImage, module_count: u32,
                        sym_locs: *map.Map[intern.StrId, SymbolLoc], dyn: *DynState,
-                       destination: *publication.Destination, image_options: of.ImageOptions) R.Result[R.Void, str] {
+                       destination: *publication.Destination, image_options: of.ImageOptions) err[fail.Fail] {
     if (tgt.of.emit_shared == nil) {
-        ret R.err[R.Void, str]("link: object format cannot write shared libraries");
+        ret err[fail.Fail].err{fail.message("link: object format cannot write shared libraries")};
     }
     if (tgt.os == nil) {
-        ret R.err[R.Void, str]("link: target has no operating-system vtable");
+        ret err[fail.Fail].err{fail.message("link: target has no operating-system vtable")};
     }
 
     val alloc: *A.Allocator = s.alloc;
 
     var seg_count: u32 = 0;
-    val sr: R.Result[*of.LoadSegment, str] = build_load_segments(alloc, out_img, merged, groups, ?seg_count);
-    if (R.is_err[*of.LoadSegment, str](sr)) { ret R.err[R.Void, str](R.unwrap_err[*of.LoadSegment, str](sr)); }
-    val segs: *of.LoadSegment = R.unwrap_ok[*of.LoadSegment, str](sr);
+    val sr: res[*of.LoadSegment, fail.Fail] = build_load_segments(alloc, out_img, merged, groups, ?seg_count);
+    if (sel sr.err) { ret err[fail.Fail].err{sr.err}; }
+    val segs: *of.LoadSegment = sr.ok;
 
     var export_count: u32 = 0;
-    val xr: R.Result[*of.ExportSym, str] = collect_exports(s, modules, module_count, sym_locs, ?export_count);
-    if (R.is_err[*of.ExportSym, str](xr)) {
+    val xr: res[*of.ExportSym, fail.Fail] = collect_exports(s, modules, module_count, sym_locs, ?export_count);
+    if (sel xr.err) {
         free_load_segments(alloc, segs, seg_count);
-        ret R.err[R.Void, str](R.unwrap_err[*of.ExportSym, str](xr));
+        ret err[fail.Fail].err{xr.err};
     }
-    val exports: *of.ExportSym = R.unwrap_ok[*of.ExportSym, str](xr);
+    val exports: *of.ExportSym = xr.ok;
 
     var dbg_count: u32 = 0;
-    val dr: R.Result[*of.Section, str] = collect_debug_sections(alloc, out_img, ?dbg_count);
-    if (R.is_err[*of.Section, str](dr)) {
+    val dr: res[*of.Section, fail.Fail] = collect_debug_sections(alloc, out_img, ?dbg_count);
+    if (sel dr.err) {
         if (exports != nil && export_count > 0) { A.deallocate[of.ExportSym](alloc, exports, export_count::usize); }
         free_load_segments(alloc, segs, seg_count);
-        ret R.err[R.Void, str](R.unwrap_err[*of.Section, str](dr));
+        ret err[fail.Fail].err{dr.err};
     }
-    val dbg: *of.Section = R.unwrap_ok[*of.Section, str](dr);
+    val dbg: *of.Section = dr.ok;
 
     var symtab_count: u32 = 0;
-    val ser: R.Result[*of.SymtabEntry, str] = build_symtab_entries(alloc, out_img, segs, seg_count, ?symtab_count);
-    if (R.is_err[*of.SymtabEntry, str](ser)) {
+    val ser: res[*of.SymtabEntry, fail.Fail] = build_symtab_entries(alloc, out_img, segs, seg_count, ?symtab_count);
+    if (sel ser.err) {
         if (dbg != nil && dbg_count > 0) { A.deallocate[of.Section](alloc, dbg, dbg_count::usize); }
         if (exports != nil && export_count > 0) { A.deallocate[of.ExportSym](alloc, exports, export_count::usize); }
         free_load_segments(alloc, segs, seg_count);
-        ret R.err[R.Void, str](R.unwrap_err[*of.SymtabEntry, str](ser));
+        ret err[fail.Fail].err{ser.err};
     }
-    val symtab: *of.SymtabEntry = R.unwrap_ok[*of.SymtabEntry, str](ser);
+    val symtab: *of.SymtabEntry = ser.ok;
 
-    val emit_r: R.Result[R.Void, str] =
-        tgt.of.emit_shared(alloc, ?s.interner, ?tgt.object, segs, seg_count, os_page_size(tgt),
+    val emit_r: err[fail.Fail] =
+        fail.lift_err(tgt.of.emit_shared(alloc, ?s.interner, ?tgt.object, segs, seg_count, os_page_size(tgt),
                            exports, export_count, ?dyn.info, dbg, dbg_count,
-                           symtab, symtab_count, destination, image_options);
+                           symtab, symtab_count, destination, image_options));
 
     if (symtab != nil && symtab_count > 0) { A.deallocate[of.SymtabEntry](alloc, symtab, symtab_count::usize); }
     if (dbg != nil && dbg_count > 0) { A.deallocate[of.Section](alloc, dbg, dbg_count::usize); }
     if (exports != nil && export_count > 0) { A.deallocate[of.ExportSym](alloc, exports, export_count::usize); }
     free_load_segments(alloc, segs, seg_count);
 
-    if (R.is_err[R.Void, str](emit_r)) {
-        ret emit_r;
-    }
-    ret R.ok_void[str]();
+    ret emit_r;
 }
 
 fun is_exported_symbol(m: *of.ObjectImage, sym: *of.Symbol) bool {
@@ -2017,7 +2025,7 @@ fun is_exported_symbol(m: *of.ObjectImage, sym: *of.Symbol) bool {
 }
 
 fun collect_exports(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
-                    sym_locs: *map.Map[intern.StrId, SymbolLoc], count: *u32) R.Result[*of.ExportSym, str] {
+                    sym_locs: *map.Map[intern.StrId, SymbolLoc], count: *u32) res[*of.ExportSym, fail.Fail] {
     @count = 0;
     val alloc: *A.Allocator = s.alloc;
 
@@ -2030,9 +2038,10 @@ fun collect_exports(s: *session.Session, modules: *of.ObjectImage, module_count:
         for (sy < modules[m].symbol_count) {
             val sym: *of.Symbol = ?modules[m].symbols[sy];
             if (!is_exported_symbol(?modules[m], sym))                              { sy = sy + 1; cnt; }
-            if (R.is_ok[*u32, str](map.get[intern.StrId, u32](?seen, ?sym.name)))   { sy = sy + 1; cnt; }
-            val ins: R.Result[bool, str] = map.insert[intern.StrId, u32](?seen, sym.name, n);
-            if (R.is_err[bool, str](ins)) { map.dnit[intern.StrId, u32](?seen); ret R.err[*of.ExportSym, str](R.unwrap_err[bool, str](ins)); }
+            val get_r: opt[*u32] = map.get[intern.StrId, u32](?seen, ?sym.name);
+            if (sel get_r.some)   { sy = sy + 1; cnt; }
+            val ins: res[bool, A.Error] = map.insert[intern.StrId, u32](?seen, sym.name, n);
+            if (sel ins.err) { map.dnit[intern.StrId, u32](?seen); ret res[*of.ExportSym, fail.Fail].err{fail.refused(ins.err)}; }
             n = n + 1;
             sy = sy + 1;
         }
@@ -2040,11 +2049,11 @@ fun collect_exports(s: *session.Session, modules: *of.ObjectImage, module_count:
     }
     map.dnit[intern.StrId, u32](?seen);
 
-    if (n == 0) { ret R.ok[*of.ExportSym, str](nil); }
+    if (n == 0) { ret res[*of.ExportSym, fail.Fail].ok{nil}; }
 
-    val ar: R.Result[*of.ExportSym, str] = A.zallocate[of.ExportSym](alloc, n::usize);
-    if (R.is_err[*of.ExportSym, str](ar)) { ret R.err[*of.ExportSym, str](R.unwrap_err[*of.ExportSym, str](ar)); }
-    val out: *of.ExportSym = R.unwrap_ok[*of.ExportSym, str](ar);
+    val ar: res[*of.ExportSym, A.Error] = A.zallocate[of.ExportSym](alloc, n::usize);
+    if (sel ar.err) { ret res[*of.ExportSym, fail.Fail].err{fail.refused(ar.err)}; }
+    val out: *of.ExportSym = ar.ok;
 
     var placed: map.Map[intern.StrId, u32] =
         map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
@@ -2055,24 +2064,25 @@ fun collect_exports(s: *session.Session, modules: *of.ObjectImage, module_count:
         for (sy < modules[m].symbol_count) {
             val sym: *of.Symbol = ?modules[m].symbols[sy];
             if (!is_exported_symbol(?modules[m], sym))                              { sy = sy + 1; cnt; }
-            if (R.is_ok[*u32, str](map.get[intern.StrId, u32](?placed, ?sym.name))) { sy = sy + 1; cnt; }
+            val get_r2: opt[*u32] = map.get[intern.StrId, u32](?placed, ?sym.name);
+            if (sel get_r2.some) { sy = sy + 1; cnt; }
 
-            val loc_r: R.Result[*SymbolLoc, str] = map.get[intern.StrId, SymbolLoc](sym_locs, ?sym.name);
-            if (R.is_err[*SymbolLoc, str](loc_r)) {
+            val loc_r: opt[*SymbolLoc] = map.get[intern.StrId, SymbolLoc](sym_locs, ?sym.name);
+            if (sel loc_r.none) {
                 map.dnit[intern.StrId, u32](?placed);
                 A.deallocate[of.ExportSym](alloc, out, n::usize);
-                ret R.err[*of.ExportSym, str]("link: exported symbol missing from the resolved symbol table");
+                ret res[*of.ExportSym, fail.Fail].err{fail.message("link: exported symbol missing from the resolved symbol table")};
             }
             out[w].name    = sym.name;
-            out[w].vaddr   = R.unwrap_ok[*SymbolLoc, str](loc_r).vaddr;
+            out[w].vaddr   = loc_r.some.vaddr;
             out[w].is_func = (sym.flags & of.SYM_OBJ_FLAG_FUNCTION) != 0;
-            out[w].absolute = R.unwrap_ok[*SymbolLoc, str](loc_r).merged_index == of.SECTION_ABSOLUTE;
+            out[w].absolute = loc_r.some.merged_index == of.SECTION_ABSOLUTE;
 
-            val ins: R.Result[bool, str] = map.insert[intern.StrId, u32](?placed, sym.name, w);
-            if (R.is_err[bool, str](ins)) {
+            val ins: res[bool, A.Error] = map.insert[intern.StrId, u32](?placed, sym.name, w);
+            if (sel ins.err) {
                 map.dnit[intern.StrId, u32](?placed);
                 A.deallocate[of.ExportSym](alloc, out, n::usize);
-                ret R.err[*of.ExportSym, str](R.unwrap_err[bool, str](ins));
+                ret res[*of.ExportSym, fail.Fail].err{fail.refused(ins.err)};
             }
             w = w + 1;
             sy = sy + 1;
@@ -2082,10 +2092,10 @@ fun collect_exports(s: *session.Session, modules: *of.ObjectImage, module_count:
     map.dnit[intern.StrId, u32](?placed);
 
     @count = n;
-    ret R.ok[*of.ExportSym, str](out);
+    ret res[*of.ExportSym, fail.Fail].ok{out};
 }
 
-fun collect_debug_sections(alloc: *A.Allocator, out_img: *of.ObjectImage, count: *u32) R.Result[*of.Section, str] {
+fun collect_debug_sections(alloc: *A.Allocator, out_img: *of.ObjectImage, count: *u32) res[*of.Section, fail.Fail] {
     @count = 0;
     var n: u32 = 0;
     var i: u32 = 0;
@@ -2093,11 +2103,11 @@ fun collect_debug_sections(alloc: *A.Allocator, out_img: *of.ObjectImage, count:
         if (out_img.sections[i].kind == of.SK_DEBUG) { n = n + 1; }
         i = i + 1;
     }
-    if (n == 0) { ret R.ok[*of.Section, str](nil); }
+    if (n == 0) { ret res[*of.Section, fail.Fail].ok{nil}; }
 
-    val ar: R.Result[*of.Section, str] = A.allocate[of.Section](alloc, n::usize);
-    if (R.is_err[*of.Section, str](ar)) { ret R.err[*of.Section, str](R.unwrap_err[*of.Section, str](ar)); }
-    val out: *of.Section = R.unwrap_ok[*of.Section, str](ar);
+    val ar: res[*of.Section, A.Error] = A.allocate[of.Section](alloc, n::usize);
+    if (sel ar.err) { ret res[*of.Section, fail.Fail].err{fail.refused(ar.err)}; }
+    val out: *of.Section = ar.ok;
 
     var w: u32 = 0;
     i = 0;
@@ -2110,11 +2120,11 @@ fun collect_debug_sections(alloc: *A.Allocator, out_img: *of.ObjectImage, count:
     }
 
     @count = n;
-    ret R.ok[*of.Section, str](out);
+    ret res[*of.Section, fail.Fail].ok{out};
 }
 
 fun collect_exception_sections(alloc: *A.Allocator, out_img: *of.ObjectImage,
-                               count: *u32) R.Result[*of.Section, str] {
+                               count: *u32) res[*of.Section, fail.Fail] {
     @count = 0;
     var n: u32 = 0;
     var i: u32 = 0;
@@ -2122,11 +2132,11 @@ fun collect_exception_sections(alloc: *A.Allocator, out_img: *of.ObjectImage,
         if (out_img.sections[i].kind == of.SK_EXCEPTION) { n = n + 1; }
         i = i + 1;
     }
-    if (n == 0) { ret R.ok[*of.Section, str](nil); }
+    if (n == 0) { ret res[*of.Section, fail.Fail].ok{nil}; }
 
-    val ar: R.Result[*of.Section, str] = A.allocate[of.Section](alloc, n::usize);
-    if (R.is_err[*of.Section, str](ar)) { ret R.err[*of.Section, str](R.unwrap_err[*of.Section, str](ar)); }
-    val out: *of.Section = R.unwrap_ok[*of.Section, str](ar);
+    val ar: res[*of.Section, A.Error] = A.allocate[of.Section](alloc, n::usize);
+    if (sel ar.err) { ret res[*of.Section, fail.Fail].err{fail.refused(ar.err)}; }
+    val out: *of.Section = ar.ok;
 
     var w: u32 = 0;
     i = 0;
@@ -2138,27 +2148,27 @@ fun collect_exception_sections(alloc: *A.Allocator, out_img: *of.ObjectImage,
         i = i + 1;
     }
     @count = n;
-    ret R.ok[*of.Section, str](out);
+    ret res[*of.Section, fail.Fail].ok{out};
 }
 
 fun entry_vaddr(s: *session.Session, tgt: *target.Target,
-                sym_locs: *map.Map[intern.StrId, SymbolLoc]) R.Result[u64, str] {
+                sym_locs: *map.Map[intern.StrId, SymbolLoc]) res[u64, fail.Fail] {
     val er: R.Result[intern.StrId, str] = intern.intern(?s.interner, tgt.os.entry_symbol);
-    if (R.is_err[intern.StrId, str](er)) { ret R.err[u64, str](R.unwrap_err[intern.StrId, str](er)); }
+    if (R.is_err[intern.StrId, str](er)) { ret res[u64, fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](er))}; }
     val entry_name: intern.StrId = R.unwrap_ok[intern.StrId, str](er);
-    val rr: R.Result[intern.StrId, str] = resolved_symbol_name(sym_locs, entry_name);
-    if (R.is_err[intern.StrId, str](rr)) { ret R.err[u64, str](R.unwrap_err[intern.StrId, str](rr)); }
-    val resolved_name: intern.StrId = R.unwrap_ok[intern.StrId, str](rr);
-    val el: R.Result[*SymbolLoc, str] =
+    val rr: res[intern.StrId, fail.Fail] = resolved_symbol_name(sym_locs, entry_name);
+    if (sel rr.err) { ret res[u64, fail.Fail].err{rr.err}; }
+    val resolved_name: intern.StrId = rr.ok;
+    val el: opt[*SymbolLoc] =
         map.get[intern.StrId, SymbolLoc](sym_locs, ?resolved_name);
-    if (R.is_err[*SymbolLoc, str](el)) {
-        ret R.err[u64, str](entry_message(s, entry_name));
+    if (sel el.none) {
+        ret res[u64, fail.Fail].err{fail.message(entry_message(s, entry_name))};
     }
-    ret R.ok[u64, str](R.unwrap_ok[*SymbolLoc, str](el).vaddr);
+    ret res[u64, fail.Fail].ok{el.some.vaddr};
 }
 
 fun build_load_segments(alloc: *A.Allocator, out_img: *of.ObjectImage, merged: *MergedSection,
-                        groups: *SectionGroups, seg_count: *u32) R.Result[*of.LoadSegment, str] {
+                        groups: *SectionGroups, seg_count: *u32) res[*of.LoadSegment, fail.Fail] {
     var count: u32 = 0;
     var k: u32 = 0;
     for (k < MERGED_KIND_COUNT) {
@@ -2168,14 +2178,14 @@ fun build_load_segments(alloc: *A.Allocator, out_img: *of.ObjectImage, merged: *
         k = k + 1;
     }
     if (count == 0) {
-        ret R.err[*of.LoadSegment, str]("link: no loadable sections in any input object; verify inputs contain code or data");
+        ret res[*of.LoadSegment, fail.Fail].err{fail.message("link: no loadable sections in any input object; verify inputs contain code or data")};
     }
 
-    val sr: R.Result[*of.LoadSegment, str] = A.zallocate[of.LoadSegment](alloc, count::usize);
-    if (R.is_err[*of.LoadSegment, str](sr)) {
-        ret R.err[*of.LoadSegment, str](R.unwrap_err[*of.LoadSegment, str](sr));
+    val sr: res[*of.LoadSegment, A.Error] = A.zallocate[of.LoadSegment](alloc, count::usize);
+    if (sel sr.err) {
+        ret res[*of.LoadSegment, fail.Fail].err{fail.refused(sr.err)};
     }
-    val segs: *of.LoadSegment = R.unwrap_ok[*of.LoadSegment, str](sr);
+    val segs: *of.LoadSegment = sr.ok;
 
     var si: u32 = 0;
     k = 0;
@@ -2183,11 +2193,11 @@ fun build_load_segments(alloc: *A.Allocator, out_img: *of.ObjectImage, merged: *
         if (is_loadable_kind(merged[k].kind) && merged[k].used && merged[k].len > 0) {
             segs[si].vaddr  = merged[k].vaddr;
             segs[si].memsz  = merged[k].len::usize;
-            val seg_flags: O.Option[u32] = seg_flags_for(merged[k].kind);
-            if (O.is_none[u32](seg_flags)) {
-                ret R.err[*of.LoadSegment, str](of.section_kind_rejection(out_img.interner, alloc, merged[k].kind));
+            val seg_flags: opt[u32] = seg_flags_for(merged[k].kind);
+            if (sel seg_flags.none) {
+                ret res[*of.LoadSegment, fail.Fail].err{fail.message(of.section_kind_rejection(out_img.interner, alloc, merged[k].kind))};
             }
-            segs[si].flags  = O.unwrap[u32](seg_flags);
+            segs[si].flags  = seg_flags.some;
             if (merged[k].kind == of.SK_BSS) {
                 segs[si].filesz = 0;
                 segs[si].bytes  = nil;
@@ -2201,18 +2211,18 @@ fun build_load_segments(alloc: *A.Allocator, out_img: *of.ObjectImage, merged: *
         k = k + 1;
     }
 
-    val nr: R.Result[R.Void, str] = attach_load_sections(alloc, segs, count, merged, groups);
-    if (R.is_err[R.Void, str](nr)) {
+    val nr: err[fail.Fail] = attach_load_sections(alloc, segs, count, merged, groups);
+    if (sel nr.err) {
         free_load_segments(alloc, segs, count);
-        ret R.err[*of.LoadSegment, str](R.unwrap_err[R.Void, str](nr));
+        ret res[*of.LoadSegment, fail.Fail].err{nr.err};
     }
 
     @seg_count = count;
-    ret R.ok[*of.LoadSegment, str](segs);
+    ret res[*of.LoadSegment, fail.Fail].ok{segs};
 }
 
 fun attach_load_sections(alloc: *A.Allocator, segs: *of.LoadSegment, count: u32,
-                         merged: *MergedSection, groups: *SectionGroups) R.Result[R.Void, str] {
+                         merged: *MergedSection, groups: *SectionGroups) err[fail.Fail] {
     var si: u32 = 0;
     var k:  u32 = 0;
     for (k < MERGED_KIND_COUNT) {
@@ -2227,14 +2237,14 @@ fun attach_load_sections(alloc: *A.Allocator, segs: *of.LoadSegment, count: u32,
             i = i + 1;
         }
         if (n == 0) {
-            ret R.err[R.Void, str]("linker: mapped segment carries no named section");
+            ret err[fail.Fail].err{fail.message("linker: mapped segment carries no named section")};
         }
 
-        val ar: R.Result[*of.LoadSection, str] = A.zallocate[of.LoadSection](alloc, n::usize);
-        if (R.is_err[*of.LoadSection, str](ar)) {
-            ret R.err[R.Void, str](R.unwrap_err[*of.LoadSection, str](ar));
+        val ar: res[*of.LoadSection, A.Error] = A.zallocate[of.LoadSection](alloc, n::usize);
+        if (sel ar.err) {
+            ret err[fail.Fail].err{fail.refused(ar.err)};
         }
-        val secs: *of.LoadSection = R.unwrap_ok[*of.LoadSection, str](ar);
+        val secs: *of.LoadSection = ar.ok;
 
         var w: u32 = 0;
         i = 0;
@@ -2255,7 +2265,7 @@ fun attach_load_sections(alloc: *A.Allocator, segs: *of.LoadSegment, count: u32,
         si = si + 1;
         k = k + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun free_load_segments(alloc: *A.Allocator, segs: *of.LoadSegment, count: u32) {
@@ -2291,32 +2301,32 @@ fun frame_find(out_img: *of.ObjectImage, fidx: *u32, section: u32, offset: u32) 
 
 fun build_exec_functions(alloc: *A.Allocator, out_img: *of.ObjectImage,
                          segs: *of.LoadSegment, seg_count: u32,
-                         func_count: *u32) R.Result[*of.ExecFunction, str] {
+                         func_count: *u32) res[*of.ExecFunction, fail.Fail] {
     @func_count = 0;
-    if (out_img.symbol_count == 0) { ret R.ok[*of.ExecFunction, str](nil); }
+    if (out_img.symbol_count == 0) { ret res[*of.ExecFunction, fail.Fail].ok{nil}; }
 
-    val ar: R.Result[*of.ExecFunction, str] = A.allocate[of.ExecFunction](alloc, out_img.symbol_count::usize);
-    if (R.is_err[*of.ExecFunction, str](ar)) {
-        ret R.err[*of.ExecFunction, str](R.unwrap_err[*of.ExecFunction, str](ar));
+    val ar: res[*of.ExecFunction, A.Error] = A.allocate[of.ExecFunction](alloc, out_img.symbol_count::usize);
+    if (sel ar.err) {
+        ret res[*of.ExecFunction, fail.Fail].err{fail.refused(ar.err)};
     }
-    var funcs: *of.ExecFunction = R.unwrap_ok[*of.ExecFunction, str](ar);
+    var funcs: *of.ExecFunction = ar.ok;
     var n: u32 = 0;
 
-    val kr: R.Result[*bool, str] = A.allocate[bool](alloc, out_img.symbol_count::usize);
-    if (R.is_err[*bool, str](kr)) {
+    val kr: res[*bool, A.Error] = A.allocate[bool](alloc, out_img.symbol_count::usize);
+    if (sel kr.err) {
         A.deallocate[of.ExecFunction](alloc, funcs, out_img.symbol_count::usize);
-        ret R.err[*of.ExecFunction, str](R.unwrap_err[*bool, str](kr));
+        ret res[*of.ExecFunction, fail.Fail].err{fail.refused(kr.err)};
     }
-    var known: *bool = R.unwrap_ok[*bool, str](kr);
+    var known: *bool = kr.ok;
 
     var fidx: *u32 = nil;
     if (out_img.frame_count > 0) {
-        val fr: R.Result[*u32, str] = A.allocate[u32](alloc, out_img.frame_count::usize);
-        if (R.is_err[*u32, str](fr)) {
+        val fr: res[*u32, A.Error] = A.allocate[u32](alloc, out_img.frame_count::usize);
+        if (sel fr.err) {
             A.deallocate[of.ExecFunction](alloc, funcs, out_img.symbol_count::usize);
-            ret R.err[*of.ExecFunction, str](R.unwrap_err[*u32, str](fr));
+            ret res[*of.ExecFunction, fail.Fail].err{fail.refused(fr.err)};
         }
-        fidx = R.unwrap_ok[*u32, str](fr);
+        fidx = fr.ok;
         var k: u32 = 0;
         for (k < out_img.frame_count) { fidx[k] = k; k = k + 1; }
         k = 1;
@@ -2371,7 +2381,7 @@ fun build_exec_functions(alloc: *A.Allocator, out_img: *of.ObjectImage,
     if (n == 0) {
         A.deallocate[bool](alloc, known, out_img.symbol_count::usize);
         A.deallocate[of.ExecFunction](alloc, funcs, out_img.symbol_count::usize);
-        ret R.ok[*of.ExecFunction, str](nil);
+        ret res[*of.ExecFunction, fail.Fail].ok{nil};
     }
 
     var i: u32 = 1;
@@ -2418,20 +2428,20 @@ fun build_exec_functions(alloc: *A.Allocator, out_img: *of.ObjectImage,
 
     if (w == 0) {
         A.deallocate[of.ExecFunction](alloc, funcs, out_img.symbol_count::usize);
-        ret R.ok[*of.ExecFunction, str](nil);
+        ret res[*of.ExecFunction, fail.Fail].ok{nil};
     }
     if (w < out_img.symbol_count) {
-        val rr: R.Result[*of.ExecFunction, str] =
+        val rr: res[*of.ExecFunction, A.Error] =
             A.reallocate[of.ExecFunction](alloc, funcs, out_img.symbol_count::usize, w::usize);
-        if (R.is_err[*of.ExecFunction, str](rr)) {
+        if (sel rr.err) {
             A.deallocate[of.ExecFunction](alloc, funcs, out_img.symbol_count::usize);
-            ret R.err[*of.ExecFunction, str](R.unwrap_err[*of.ExecFunction, str](rr));
+            ret res[*of.ExecFunction, fail.Fail].err{fail.refused(rr.err)};
         }
-        funcs = R.unwrap_ok[*of.ExecFunction, str](rr);
+        funcs = rr.ok;
     }
 
     @func_count = w;
-    ret R.ok[*of.ExecFunction, str](funcs);
+    ret res[*of.ExecFunction, fail.Fail].ok{funcs};
 }
 
 rec SymtabRow {
@@ -2445,15 +2455,15 @@ rec SymtabRow {
 
 fun build_symtab_entries(alloc: *A.Allocator, out_img: *of.ObjectImage,
                          segs: *of.LoadSegment, seg_count: u32,
-                         entry_count: *u32) R.Result[*of.SymtabEntry, str] {
+                         entry_count: *u32) res[*of.SymtabEntry, fail.Fail] {
     @entry_count = 0;
-    if (out_img.symbol_count == 0) { ret R.ok[*of.SymtabEntry, str](nil); }
+    if (out_img.symbol_count == 0) { ret res[*of.SymtabEntry, fail.Fail].ok{nil}; }
 
-    val rr: R.Result[*SymtabRow, str] = A.allocate[SymtabRow](alloc, out_img.symbol_count::usize);
-    if (R.is_err[*SymtabRow, str](rr)) {
-        ret R.err[*of.SymtabEntry, str](R.unwrap_err[*SymtabRow, str](rr));
+    val rr: res[*SymtabRow, A.Error] = A.allocate[SymtabRow](alloc, out_img.symbol_count::usize);
+    if (sel rr.err) {
+        ret res[*of.SymtabEntry, fail.Fail].err{fail.refused(rr.err)};
     }
-    var rows: *SymtabRow = R.unwrap_ok[*SymtabRow, str](rr);
+    var rows: *SymtabRow = rr.ok;
     var n: u32 = 0;
 
     var si: u32 = 0;
@@ -2484,7 +2494,7 @@ fun build_symtab_entries(alloc: *A.Allocator, out_img: *of.ObjectImage,
 
     if (n == 0) {
         A.deallocate[SymtabRow](alloc, rows, out_img.symbol_count::usize);
-        ret R.ok[*of.SymtabEntry, str](nil);
+        ret res[*of.SymtabEntry, fail.Fail].ok{nil};
     }
 
     var i: u32 = 1;
@@ -2526,15 +2536,15 @@ fun build_symtab_entries(alloc: *A.Allocator, out_img: *of.ObjectImage,
 
     if (w == 0) {
         A.deallocate[SymtabRow](alloc, rows, out_img.symbol_count::usize);
-        ret R.ok[*of.SymtabEntry, str](nil);
+        ret res[*of.SymtabEntry, fail.Fail].ok{nil};
     }
 
-    val er: R.Result[*of.SymtabEntry, str] = A.allocate[of.SymtabEntry](alloc, w::usize);
-    if (R.is_err[*of.SymtabEntry, str](er)) {
+    val er: res[*of.SymtabEntry, A.Error] = A.allocate[of.SymtabEntry](alloc, w::usize);
+    if (sel er.err) {
         A.deallocate[SymtabRow](alloc, rows, out_img.symbol_count::usize);
-        ret R.err[*of.SymtabEntry, str](R.unwrap_err[*of.SymtabEntry, str](er));
+        ret res[*of.SymtabEntry, fail.Fail].err{fail.refused(er.err)};
     }
-    var entries: *of.SymtabEntry = R.unwrap_ok[*of.SymtabEntry, str](er);
+    var entries: *of.SymtabEntry = er.ok;
 
     var wi: u32 = 0;
     i = 0;
@@ -2562,7 +2572,7 @@ fun build_symtab_entries(alloc: *A.Allocator, out_img: *of.ObjectImage,
 
     A.deallocate[SymtabRow](alloc, rows, out_img.symbol_count::usize);
     @entry_count = w;
-    ret R.ok[*of.SymtabEntry, str](entries);
+    ret res[*of.SymtabEntry, fail.Fail].ok{entries};
 }
 
 rec SectionGroup {
@@ -2592,36 +2602,36 @@ fun free_section_groups(alloc: *A.Allocator, g: *SectionGroups) {
     init_section_groups(g);
 }
 
-fun grow_cap[T](alloc: *A.Allocator, data: **T, cap: *u32, initial: u32) R.Result[R.Void, str] {
+fun grow_cap[T](alloc: *A.Allocator, data: **T, cap: *u32, initial: u32) err[fail.Fail] {
     if (@data == nil) {
-        val res_alloc: R.Result[*T, str] = A.allocate[T](alloc, initial::usize);
-        if (R.is_err[*T, str](res_alloc)) { ret R.err[R.Void, str](R.unwrap_err[*T, str](res_alloc)); }
-        @data = R.unwrap_ok[*T, str](res_alloc);
+        val res_alloc: res[*T, A.Error] = A.allocate[T](alloc, initial::usize);
+        if (sel res_alloc.err) { ret err[fail.Fail].err{fail.refused(res_alloc.err)}; }
+        @data = res_alloc.ok;
         @cap  = initial;
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
     val current: layout.CheckedCount[T] = layout.count[T]((@cap)::usize);
     val required_r: R.Result[layout.CheckedCount[T], layout.CheckCause] =
         layout.count_add[T](current, layout.count[T](1::usize));
     if (R.is_err[layout.CheckedCount[T], layout.CheckCause](required_r)) {
-        ret R.err[R.Void, str]("linker: growth count overflow");
+        ret err[fail.Fail].err{fail.message("linker: growth count overflow")};
     }
     val required: layout.CheckedCount[T] = R.unwrap_ok[layout.CheckedCount[T], layout.CheckCause](required_r);
     val grown_r: R.Result[layout.CheckedCount[T], layout.CheckCause] = layout.count_grow[T](current, required);
     if (R.is_err[layout.CheckedCount[T], layout.CheckCause](grown_r)) {
-        ret R.err[R.Void, str]("linker: growth count overflow");
+        ret err[fail.Fail].err{fail.message("linker: growth count overflow")};
     }
     val new_cap_fits: R.Result[u32, layout.CheckCause] = layout.usize_to_u32(
         R.unwrap_ok[layout.CheckedCount[T], layout.CheckCause](grown_r).value);
     if (R.is_err[u32, layout.CheckCause](new_cap_fits)) {
-        ret R.err[R.Void, str]("linker: growth capacity exceeds the u32 limit");
+        ret err[fail.Fail].err{fail.message("linker: growth capacity exceeds the u32 limit")};
     }
     val new_cap: u32 = R.unwrap_ok[u32, layout.CheckCause](new_cap_fits);
-    val res_realloc: R.Result[*T, str] = A.reallocate[T](alloc, @data, (@cap)::usize, new_cap::usize);
-    if (R.is_err[*T, str](res_realloc)) { ret R.err[R.Void, str](R.unwrap_err[*T, str](res_realloc)); }
-    @data = R.unwrap_ok[*T, str](res_realloc);
+    val res_realloc: res[*T, A.Error] = A.reallocate[T](alloc, @data, (@cap)::usize, new_cap::usize);
+    if (sel res_realloc.err) { ret err[fail.Fail].err{fail.refused(res_realloc.err)}; }
+    @data = res_realloc.ok;
     @cap  = new_cap;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun section_group_index(g: *SectionGroups, slot: u32, name: intern.StrId, flags: u32) u32 {
@@ -2635,10 +2645,10 @@ fun section_group_index(g: *SectionGroups, slot: u32, name: intern.StrId, flags:
 }
 
 fun section_group_add(alloc: *A.Allocator, g: *SectionGroups, slot: u32,
-                      name: intern.StrId, flags: u32) R.Result[u32, str] {
+                      name: intern.StrId, flags: u32) res[u32, fail.Fail] {
     if (g.count == g.cap) {
-        val grown: R.Result[R.Void, str] = grow_cap[SectionGroup](alloc, ?g.items, ?g.cap, 8);
-        if (R.is_err[R.Void, str](grown)) { ret R.err[u32, str](R.unwrap_err[R.Void, str](grown)); }
+        val grown: err[fail.Fail] = grow_cap[SectionGroup](alloc, ?g.items, ?g.cap, 8);
+        if (sel grown.err) { ret res[u32, fail.Fail].err{grown.err}; }
     }
     val i: u32 = g.count;
     g.items[i].name   = name;
@@ -2649,7 +2659,7 @@ fun section_group_add(alloc: *A.Allocator, g: *SectionGroups, slot: u32,
     g.items[i].base   = 0;
     g.items[i].cursor = 0;
     g.count = i + 1;
-    ret R.ok[u32, str](i);
+    ret res[u32, fail.Fail].ok{i};
 }
 
 val ATOM_OWNS: u32 = 0xFFFFFFFF;
@@ -2685,11 +2695,11 @@ fun debug_abbrev_tables_equal(a: *of.Section, b: *of.Section) bool {
 
 fun plan_atom_coalescing(alloc: *A.Allocator, modules: *of.ObjectImage, module_count: u32,
                           sec_base: *u32, sec_total: u32,
-                          atoms: *AtomPlan) R.Result[*u32, str] {
-    if (sec_total == 0) { ret R.ok[*u32, str](nil); }
-    val ar: R.Result[*u32, str] = A.allocate[u32](alloc, sec_total::usize);
-    if (R.is_err[*u32, str](ar)) { ret ar; }
-    val dup: *u32 = R.unwrap_ok[*u32, str](ar);
+                          atoms: *AtomPlan) res[*u32, fail.Fail] {
+    if (sec_total == 0) { ret res[*u32, fail.Fail].ok{nil}; }
+    val ar: res[*u32, A.Error] = A.allocate[u32](alloc, sec_total::usize);
+    if (sel ar.err) { ret res[*u32, fail.Fail].err{fail.refused(ar.err)}; }
+    val dup: *u32 = ar.ok;
     var i: u32 = 0;
     for (i < sec_total) { dup[i] = ATOM_OWNS; i = i + 1; }
 
@@ -2718,12 +2728,12 @@ fun plan_atom_coalescing(alloc: *A.Allocator, modules: *of.ObjectImage, module_c
         }
         m = m + 1;
     }
-    ret R.ok[*u32, str](dup);
+    ret res[*u32, fail.Fail].ok{dup};
 }
 
 fun plan_section_groups(alloc: *A.Allocator, modules: *of.ObjectImage, module_count: u32,
                         merged: *MergedSection, atoms: *AtomPlan, sec_base: *u32,
-                        dup: *u32, groups: *SectionGroups) R.Result[R.Void, str] {
+                        dup: *u32, groups: *SectionGroups) err[fail.Fail] {
     var m: u32 = 0;
     for (m < module_count) {
         var sc: u32 = 0;
@@ -2736,19 +2746,19 @@ fun plan_section_groups(alloc: *A.Allocator, modules: *of.ObjectImage, module_co
             val slot: u32 = sec.kind::u32;
             var gi: u32 = section_group_index(groups, slot, sec.name, sec.flags & of.SEC_FLAG_IMAGE_MASK);
             if (gi == 0xFFFFFFFF) {
-                val ar: R.Result[u32, str] = section_group_add(alloc, groups, slot, sec.name, sec.flags & of.SEC_FLAG_IMAGE_MASK);
-                if (R.is_err[u32, str](ar)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](ar)); }
-                gi = R.unwrap_ok[u32, str](ar);
+                val ar: res[u32, fail.Fail] = section_group_add(alloc, groups, slot, sec.name, sec.flags & of.SEC_FLAG_IMAGE_MASK);
+                if (sel ar.err) { ret err[fail.Fail].err{ar.err}; }
+                gi = ar.ok;
             }
             var a: u32 = sec.align;
             if (a == 0) { a = 1; }
             if (a > groups.items[gi].align) { groups.items[gi].align = a; }
-            val off_r: R.Result[u64, str] = align_up_u64_checked(groups.items[gi].len::u64, a::u64);
-            if (R.is_err[u64, str](off_r)) { ret R.err[R.Void, str](R.unwrap_err[u64, str](off_r)); }
-            val off64: u64 = R.unwrap_ok[u64, str](off_r);
+            val off_r: res[u64, fail.Fail] = align_up_u64_checked(groups.items[gi].len::u64, a::u64);
+            if (sel off_r.err) { ret err[fail.Fail].err{off_r.err}; }
+            val off64: u64 = off_r.ok;
             val end: u64 = off64 + atom_live_len(atoms, sec_base[m] + sc, sec.len)::u64;
             if (end > 0xFFFFFFFF) {
-                ret R.err[R.Void, str]("linker: merged section group exceeds the 4 GiB u32 limit");
+                ret err[fail.Fail].err{fail.message("linker: merged section group exceeds the 4 GiB u32 limit")};
             }
             groups.items[gi].len = end::u32;
             sc = sc + 1;
@@ -2763,11 +2773,11 @@ fun plan_section_groups(alloc: *A.Allocator, modules: *of.ObjectImage, module_co
         var i: u32 = 0;
         for (i < groups.count) {
             if (groups.items[i].slot == slot) {
-                val run_r: R.Result[u64, str] = align_up_u64_checked(run, groups.items[i].align::u64);
-                if (R.is_err[u64, str](run_r)) { ret R.err[R.Void, str](R.unwrap_err[u64, str](run_r)); }
-                run = R.unwrap_ok[u64, str](run_r);
+                val run_r: res[u64, fail.Fail] = align_up_u64_checked(run, groups.items[i].align::u64);
+                if (sel run_r.err) { ret err[fail.Fail].err{run_r.err}; }
+                run = run_r.ok;
                 if (run + groups.items[i].len::u64 > 0xFFFFFFFF) {
-                    ret R.err[R.Void, str]("linker: merged section exceeds the 4 GiB u32 limit");
+                    ret err[fail.Fail].err{fail.message("linker: merged section exceeds the 4 GiB u32 limit")};
                 }
                 groups.items[i].base   = run::u32;
                 groups.items[i].cursor = run::u32;
@@ -2777,7 +2787,7 @@ fun plan_section_groups(alloc: *A.Allocator, modules: *of.ObjectImage, module_co
         }
         slot = slot + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 # a kind outside the catalog is never loadable; every image here was validated
@@ -2789,14 +2799,14 @@ fun is_loadable_kind(kind: of.SectionKind) bool {
 
 # the load-segment protection a declared kind needs, absent for a kind outside
 # the catalog
-fun seg_flags_for(kind: of.SectionKind) O.Option[u32] {
+fun seg_flags_for(kind: of.SectionKind) opt[u32] {
     val desc: O.Option[*of.SectionKindDesc] = of.section_desc(kind);
-    if (O.is_none[*of.SectionKindDesc](desc)) { ret O.none[u32](); }
+    if (O.is_none[*of.SectionKindDesc](desc)) { ret opt[u32].none{}; }
     val row: *of.SectionKindDesc = O.unwrap[*of.SectionKindDesc](desc);
     var flags: u32 = of.SEG_FLAG_READ;
     if (row.executable) { flags = flags | of.SEG_FLAG_EXECUTE; }
     if (row.writable)   { flags = flags | of.SEG_FLAG_WRITE; }
-    ret O.some[u32](flags);
+    ret opt[u32].some{flags};
 }
 
 fun merged_section_bytes(out_img: *of.ObjectImage, kind: of.SectionKind) *u8 {
@@ -2867,11 +2877,11 @@ fun warn_debug_dropped(s: *session.Session, name: intern.StrId) {
     val nm: O.Option[str] = intern.lookup(?s.interner, name);
     var on: str = "?";
     if (O.is_some[str](nm)) { on = O.unwrap[str](nm); }
-    val res: R.Result[str, str] = format.sprint(s.alloc,
+    val result: res[str, format.FormatError] = format.sprint(s.alloc,
         "debug info in '{}' uses unrelocated cross-section offsets and cannot be merged; it is left out of the link",
         on);
-    if (R.is_err[str, str](res)) { ret; }
-    val buf: str = R.unwrap_ok[str, str](res);
+    if (sel result.err) { ret; }
+    val buf: str = result.ok;
     var span: token.Span;
     span.offset = 0;
     span.len    = 0;
@@ -2880,7 +2890,7 @@ fun warn_debug_dropped(s: *session.Session, name: intern.StrId) {
 }
 
 fun discover_debug_names(alloc: *A.Allocator, modules: *of.ObjectImage, module_count: u32,
-                         out_names: **intern.StrId, out_count: *u32) R.Result[R.Void, str] {
+                         out_names: **intern.StrId, out_count: *u32) err[fail.Fail] {
     @out_names = nil;
     @out_count = 0;
     var names: *intern.StrId = nil;
@@ -2908,7 +2918,7 @@ fun discover_debug_names(alloc: *A.Allocator, modules: *of.ObjectImage, module_c
                     layout.count_add[intern.StrId](current, layout.count[intern.StrId](1::usize));
                 if (R.is_err[layout.CheckedCount[intern.StrId], layout.CheckCause](required_add)) {
                     if (names != nil && cap > 0) { A.deallocate[intern.StrId](alloc, names, cap::usize); }
-                    ret R.err[R.Void, str]("linker: debug section name table growth count overflow");
+                    ret err[fail.Fail].err{fail.message("linker: debug section name table growth count overflow")};
                 }
                 var required: layout.CheckedCount[intern.StrId] =
                     R.unwrap_ok[layout.CheckedCount[intern.StrId], layout.CheckCause](required_add);
@@ -2917,22 +2927,22 @@ fun discover_debug_names(alloc: *A.Allocator, modules: *of.ObjectImage, module_c
                     layout.count_grow[intern.StrId](current, required);
                 if (R.is_err[layout.CheckedCount[intern.StrId], layout.CheckCause](grown_r)) {
                     if (names != nil && cap > 0) { A.deallocate[intern.StrId](alloc, names, cap::usize); }
-                    ret R.err[R.Void, str]("linker: debug section name table growth count overflow");
+                    ret err[fail.Fail].err{fail.message("linker: debug section name table growth count overflow")};
                 }
                 val new_cap_fits: R.Result[u32, layout.CheckCause] = layout.usize_to_u32(
                     R.unwrap_ok[layout.CheckedCount[intern.StrId], layout.CheckCause](grown_r).value);
                 if (R.is_err[u32, layout.CheckCause](new_cap_fits)) {
                     if (names != nil && cap > 0) { A.deallocate[intern.StrId](alloc, names, cap::usize); }
-                    ret R.err[R.Void, str]("linker: debug section name table capacity exceeds the u32 limit");
+                    ret err[fail.Fail].err{fail.message("linker: debug section name table capacity exceeds the u32 limit")};
                 }
                 val new_cap: u32 = R.unwrap_ok[u32, layout.CheckCause](new_cap_fits);
-                val gr: R.Result[*intern.StrId, str] =
+                val gr: res[*intern.StrId, A.Error] =
                     A.reallocate[intern.StrId](alloc, names, cap::usize, new_cap::usize);
-                if (R.is_err[*intern.StrId, str](gr)) {
+                if (sel gr.err) {
                     if (names != nil && cap > 0) { A.deallocate[intern.StrId](alloc, names, cap::usize); }
-                    ret R.err[R.Void, str](R.unwrap_err[*intern.StrId, str](gr));
+                    ret err[fail.Fail].err{fail.refused(gr.err)};
                 }
-                names = R.unwrap_ok[*intern.StrId, str](gr);
+                names = gr.ok;
                 cap = new_cap;
             }
             names[count] = sec.name;
@@ -2949,18 +2959,18 @@ fun discover_debug_names(alloc: *A.Allocator, modules: *of.ObjectImage, module_c
             names = nil;
         }
         or {
-            val sr: R.Result[*intern.StrId, str] = A.reallocate[intern.StrId](alloc, names, cap::usize, count::usize);
-            if (R.is_err[*intern.StrId, str](sr)) {
+            val sr: res[*intern.StrId, A.Error] = A.reallocate[intern.StrId](alloc, names, cap::usize, count::usize);
+            if (sel sr.err) {
                 A.deallocate[intern.StrId](alloc, names, cap::usize);
-                ret R.err[R.Void, str](R.unwrap_err[*intern.StrId, str](sr));
+                ret err[fail.Fail].err{fail.refused(sr.err)};
             }
-            names = R.unwrap_ok[*intern.StrId, str](sr);
+            names = sr.ok;
         }
     }
 
     @out_names = names;
     @out_count = count;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 test "mach.lang.be.linker.discover_debug_names:shrinks_to_exact_capacity" {
@@ -2968,9 +2978,9 @@ test "mach.lang.be.linker.discover_debug_names:shrinks_to_exact_capacity" {
     page.make(?page_alloc);
 
     var tracker: GmTracker;
-    val res_entries: R.Result[*GmTrackEntry, str] = A.allocate[GmTrackEntry](?page_alloc, 64::usize);
-    if (R.is_err[*GmTrackEntry, str](res_entries)) { ret 1; }
-    tracker.entries  = R.unwrap_ok[*GmTrackEntry, str](res_entries);
+    val res_entries: res[*GmTrackEntry, A.Error] = A.allocate[GmTrackEntry](?page_alloc, 64::usize);
+    if (sel res_entries.err) { ret 1; }
+    tracker.entries  = res_entries.ok;
     tracker.cap      = 64;
     tracker.count    = 0;
     tracker.live     = 0;
@@ -3000,8 +3010,8 @@ test "mach.lang.be.linker.discover_debug_names:shrinks_to_exact_capacity" {
 
     var out_names: *intern.StrId = nil;
     var out_count: u32 = 0;
-    val r: R.Result[R.Void, str] = discover_debug_names(?alloc, ?mod, 1, ?out_names, ?out_count);
-    if (R.is_err[R.Void, str](r)) { ret 1; }
+    val r: err[fail.Fail] = discover_debug_names(?alloc, ?mod, 1, ?out_names, ?out_count);
+    if (sel r.err) { ret 1; }
     if (out_count != 5) { ret 1; }
 
     if (out_names != nil && out_count > 0) {
@@ -3016,28 +3026,29 @@ test "mach.lang.be.linker.discover_debug_names:shrinks_to_exact_capacity" {
 }
 
 fun str_merge_add_string(s: *session.Session, sm: *StrMerge,
-                         section: *of.Section, source_offset: u32) R.Result[u32, str] {
+                         section: *of.Section, source_offset: u32) res[u32, fail.Fail] {
     if (section.bytes == nil || source_offset >= section.len) {
-        ret R.err[u32, str]("linker: .debug_str string offset is out of range");
+        ret res[u32, fail.Fail].err{fail.message("linker: .debug_str string offset is out of range")};
     }
     var terminator: u32 = source_offset;
     for (terminator < section.len && section.bytes[terminator] != 0) {
         terminator = terminator + 1;
     }
     if (terminator >= section.len) {
-        ret R.err[u32, str]("linker: malformed .debug_str section: unterminated string");
+        ret res[u32, fail.Fail].err{fail.message("linker: malformed .debug_str section: unterminated string")};
     }
 
     val string_r: R.Result[intern.StrId, str] =
         intern.intern(?s.interner, (?section.bytes[source_offset])::str);
     if (R.is_err[intern.StrId, str](string_r)) {
-        ret R.err[u32, str](R.unwrap_err[intern.StrId, str](string_r));
+        ret res[u32, fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](string_r))};
     }
     val string_id: intern.StrId = R.unwrap_ok[intern.StrId, str](string_r);
-    if (R.is_err[*u32, str](map.get[intern.StrId, u32](?sm.offs, ?string_id))) {
+    val get_r: opt[*u32] = map.get[intern.StrId, u32](?sm.offs, ?string_id);
+    if (sel get_r.none) {
         val string_len: u64 = (terminator - source_offset)::u64 + 1;
         if (sm.buf.len::u64 > 0xFFFFFFFF - string_len) {
-            ret R.err[u32, str]("linker: merged .debug_str section exceeds the 4 GiB u32 limit");
+            ret res[u32, fail.Fail].err{fail.message("linker: merged .debug_str section exceeds the 4 GiB u32 limit")};
         }
         val merged_offset: u32 = sm.buf.len::u32;
         var index: u32 = source_offset;
@@ -3045,27 +3056,27 @@ fun str_merge_add_string(s: *session.Session, sm: *StrMerge,
             enc.emit_byte(?sm.buf, section.bytes[index]);
             index = index + 1;
         }
-        val inserted_r: R.Result[bool, str] =
+        val inserted_r: res[bool, A.Error] =
             map.insert[intern.StrId, u32](?sm.offs, string_id, merged_offset);
-        if (R.is_err[bool, str](inserted_r)) {
-            ret R.err[u32, str](R.unwrap_err[bool, str](inserted_r));
+        if (sel inserted_r.err) {
+            ret res[u32, fail.Fail].err{fail.refused(inserted_r.err)};
         }
     }
-    ret R.ok[u32, str](terminator + 1);
+    ret res[u32, fail.Fail].ok{terminator + 1};
 }
 
 fun build_str_merge(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
-                    patching: bool) R.Result[StrMerge, str] {
+                    patching: bool) res[StrMerge, fail.Fail] {
     val alloc: *A.Allocator = s.alloc;
     var sm: StrMerge;
     sm.buf    = enc.buf_init(alloc);
     sm.offs   = map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
     sm.name   = intern.STR_NIL;
     sm.active = false;
-    if (!patching) { ret R.ok[StrMerge, str](sm); }
+    if (!patching) { ret res[StrMerge, fail.Fail].ok{sm}; }
 
     val nr: R.Result[intern.StrId, str] = intern.intern(?s.interner, ".debug_str");
-    if (R.is_err[intern.StrId, str](nr)) { free_str_merge(?sm); ret R.err[StrMerge, str](R.unwrap_err[intern.StrId, str](nr)); }
+    if (R.is_err[intern.StrId, str](nr)) { free_str_merge(?sm); ret res[StrMerge, fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](nr))}; }
     sm.name = R.unwrap_ok[intern.StrId, str](nr);
 
     var m: u32 = 0;
@@ -3079,12 +3090,12 @@ fun build_str_merge(s: *session.Session, modules: *of.ObjectImage, module_count:
 
             var o: u32 = 0;
             for (o < sec.len) {
-                val added_r: R.Result[u32, str] = str_merge_add_string(s, ?sm, sec, o);
-                if (R.is_err[u32, str](added_r)) {
+                val added_r: res[u32, fail.Fail] = str_merge_add_string(s, ?sm, sec, o);
+                if (sel added_r.err) {
                     free_str_merge(?sm);
-                    ret R.err[StrMerge, str](R.unwrap_err[u32, str](added_r));
+                    ret res[StrMerge, fail.Fail].err{added_r.err};
                 }
-                o = R.unwrap_ok[u32, str](added_r);
+                o = added_r.ok;
             }
             sc = sc + 1;
         }
@@ -3103,18 +3114,18 @@ fun build_str_merge(s: *session.Session, modules: *of.ObjectImage, module_count:
                     ?modules[m].sections[of.section_index(target_symbol.section)];
                 if (target_section.kind == of.SK_DEBUG
                     && target_section.name == sm.name) {
-                    val source_offset_r: R.Result[u32, str] = debug_str_source_offset(
+                    val source_offset_r: res[u32, fail.Fail] = debug_str_source_offset(
                         target_symbol.offset, relocation.addend, target_section.len);
-                    if (R.is_err[u32, str](source_offset_r)) {
+                    if (sel source_offset_r.err) {
                         free_str_merge(?sm);
-                        ret R.err[StrMerge, str](R.unwrap_err[u32, str](source_offset_r));
+                        ret res[StrMerge, fail.Fail].err{source_offset_r.err};
                     }
-                    val suffix_r: R.Result[u32, str] = str_merge_add_string(
+                    val suffix_r: res[u32, fail.Fail] = str_merge_add_string(
                         s, ?sm, target_section,
-                        R.unwrap_ok[u32, str](source_offset_r));
-                    if (R.is_err[u32, str](suffix_r)) {
+                        source_offset_r.ok);
+                    if (sel suffix_r.err) {
                         free_str_merge(?sm);
-                        ret R.err[StrMerge, str](R.unwrap_err[u32, str](suffix_r));
+                        ret res[StrMerge, fail.Fail].err{suffix_r.err};
                     }
                 }
             }
@@ -3122,7 +3133,7 @@ fun build_str_merge(s: *session.Session, modules: *of.ObjectImage, module_count:
         }
         m = m + 1;
     }
-    ret R.ok[StrMerge, str](sm);
+    ret res[StrMerge, fail.Fail].ok{sm};
 }
 
 fun free_str_merge(sm: *StrMerge) {
@@ -3232,10 +3243,10 @@ fun atom_reloc_ref_set_target(modules: *of.ObjectImage, m: u32, sy: u32,
         reference.target_symbol = sy;
     }
     or {
-        val wr: R.Result[*AtomWinner, str] =
+        val wr: opt[*AtomWinner] =
             map.get[intern.StrId, AtomWinner](winners, ?target_sym.name);
-        if (R.is_ok[*AtomWinner, str](wr)) {
-            val winner: *AtomWinner = R.unwrap_ok[*AtomWinner, str](wr);
+        if (sel wr.some) {
+            val winner: *AtomWinner = wr.some;
             reference.target_module = winner.module;
             reference.target_symbol = winner.symbol;
         }
@@ -3318,24 +3329,24 @@ fun atom_reloc_crosses_candidate(modules: *of.ObjectImage, reference: *AtomReloc
     ret false;
 }
 
-fun fill_section_bases(modules: *of.ObjectImage, module_count: u32, sec_base: *u32) R.Result[R.Void, str] {
+fun fill_section_bases(modules: *of.ObjectImage, module_count: u32, sec_base: *u32) err[fail.Fail] {
     var flat: layout.CheckedCount[SectionCountUnit] = layout.count[SectionCountUnit](0::usize);
     var m: u32 = 0;
     for (m < module_count) {
         val flat32: R.Result[u32, layout.CheckCause] = layout.usize_to_u32(flat.value);
         if (R.is_err[u32, layout.CheckCause](flat32)) {
-            ret R.err[R.Void, str]("linker: flattened section index exceeds the u32 limit");
+            ret err[fail.Fail].err{fail.message("linker: flattened section index exceeds the u32 limit")};
         }
         sec_base[m] = R.unwrap_ok[u32, layout.CheckCause](flat32);
         val added: R.Result[layout.CheckedCount[SectionCountUnit], layout.CheckCause] =
             layout.count_add[SectionCountUnit](flat, layout.count[SectionCountUnit](modules[m].section_count::usize));
         if (R.is_err[layout.CheckedCount[SectionCountUnit], layout.CheckCause](added)) {
-            ret R.err[R.Void, str]("linker: total input section count overflow");
+            ret err[fail.Fail].err{fail.message("linker: total input section count overflow")};
         }
         flat = R.unwrap_ok[layout.CheckedCount[SectionCountUnit], layout.CheckCause](added);
         m = m + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun atom_offset_dead(plan: *AtomPlan, section: u32, off: u32) bool {
@@ -3405,27 +3416,27 @@ fun copy_live_section(dst: *u8, src: *u8, src_len: u32, plan: *AtomPlan, section
 
 fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
                     codegen_count: u32, sec_base: *u32, sec_total: u32, enabled: bool,
-                    arch: *isa.IsaVTable, plan: *AtomPlan) R.Result[R.Void, str] {
+                    arch: *isa.IsaVTable, plan: *AtomPlan) err[fail.Fail] {
     if (codegen_count > module_count) {
-        ret R.err[R.Void, str]("linker: codegen image count exceeds module count");
+        ret err[fail.Fail].err{fail.message("linker: codegen image count exceeds module count")};
     }
-    val fsb_r: R.Result[R.Void, str] = fill_section_bases(modules, module_count, sec_base);
-    if (R.is_err[R.Void, str](fsb_r)) { ret fsb_r; }
-    if (!enabled) { ret R.ok_void[str](); }
+    val fsb_r: err[fail.Fail] = fill_section_bases(modules, module_count, sec_base);
+    if (sel fsb_r.err) { ret fsb_r; }
+    if (!enabled) { ret err[fail.Fail].ok{}; }
 
-    val symbol_total_r: R.Result[u32, str] = total_symbols(modules, module_count);
-    if (R.is_err[u32, str](symbol_total_r)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](symbol_total_r)); }
-    val symbol_total: u32 = R.unwrap_ok[u32, str](symbol_total_r);
+    val symbol_total_r: res[u32, fail.Fail] = total_symbols(modules, module_count);
+    if (sel symbol_total_r.err) { ret err[fail.Fail].err{symbol_total_r.err}; }
+    val symbol_total: u32 = symbol_total_r.ok;
     var m: u32 = 0;
 
     var candidates: *AtomCandidate = nil;
     if (symbol_total > 0) {
-        val cr: R.Result[*AtomCandidate, str] =
+        val cr: res[*AtomCandidate, A.Error] =
             A.zallocate[AtomCandidate](s.alloc, symbol_total::usize);
-        if (R.is_err[*AtomCandidate, str](cr)) {
-            ret R.err[R.Void, str](R.unwrap_err[*AtomCandidate, str](cr));
+        if (sel cr.err) {
+            ret err[fail.Fail].err{fail.refused(cr.err)};
         }
-        candidates = R.unwrap_ok[*AtomCandidate, str](cr);
+        candidates = cr.ok;
     }
 
     var winners: map.Map[intern.StrId, AtomWinner] =
@@ -3442,15 +3453,15 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
                 if (candidates != nil) {
                     A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
                 }
-                ret R.err[R.Void, str](oor_section_message(s, sym.name, modules[m].name));
+                ret err[fail.Fail].err{fail.message(oor_section_message(s, sym.name, modules[m].name))};
             }
             if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0) { sy = sy + 1; cnt; }
 
             val weak: bool = (sym.flags & of.SYM_OBJ_FLAG_WEAK) != 0;
-            val existing: R.Result[*AtomWinner, str] =
+            val existing: opt[*AtomWinner] =
                 map.get[intern.StrId, AtomWinner](?winners, ?sym.name);
-            if (R.is_ok[*AtomWinner, str](existing)) {
-                val cur: *AtomWinner = R.unwrap_ok[*AtomWinner, str](existing);
+            if (sel existing.some) {
+                val cur: *AtomWinner = existing.some;
                 if (weak) {
                     candidates[candidate_count].module = m;
                     candidates[candidate_count].symbol = sy;
@@ -3463,7 +3474,7 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
                     if (candidates != nil) {
                         A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
                     }
-                    ret R.err[R.Void, str](dup_message(s, sym.name));
+                    ret err[fail.Fail].err{fail.message(dup_message(s, sym.name))};
                 }
                 candidates[candidate_count].module = cur.module;
                 candidates[candidate_count].symbol = cur.symbol;
@@ -3479,14 +3490,14 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
             winner.module = m;
             winner.symbol = sy;
             winner.weak = weak;
-            val ins: R.Result[bool, str] =
+            val ins: res[bool, A.Error] =
                 map.insert[intern.StrId, AtomWinner](?winners, sym.name, winner);
-            if (R.is_err[bool, str](ins)) {
+            if (sel ins.err) {
                 map.dnit[intern.StrId, AtomWinner](?winners);
                 if (candidates != nil) {
                     A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
                 }
-                ret R.err[R.Void, str](R.unwrap_err[bool, str](ins));
+                ret err[fail.Fail].err{fail.refused(ins.err)};
             }
             sy = sy + 1;
         }
@@ -3497,17 +3508,17 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
         if (candidates != nil) {
             A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
         }
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
 
-    val dr: R.Result[*AtomDrop, str] =
+    val dr: res[*AtomDrop, A.Error] =
         A.zallocate[AtomDrop](s.alloc, candidate_count::usize);
-    if (R.is_err[*AtomDrop, str](dr)) {
+    if (sel dr.err) {
         map.dnit[intern.StrId, AtomWinner](?winners);
         A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*AtomDrop, str](dr));
+        ret err[fail.Fail].err{fail.refused(dr.err)};
     }
-    val drops: *AtomDrop = R.unwrap_ok[*AtomDrop, str](dr);
+    val drops: *AtomDrop = dr.ok;
     var drop_count: u32 = 0;
 
     var ref_total_checked: layout.CheckedCount[AtomRelocRefCountUnit] =
@@ -3521,7 +3532,7 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
             map.dnit[intern.StrId, AtomWinner](?winners);
             A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
             A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
-            ret R.err[R.Void, str]("linker: atom relocation reference count overflow");
+            ret err[fail.Fail].err{fail.message("linker: atom relocation reference count overflow")};
         }
         ref_total_checked =
             R.unwrap_ok[layout.CheckedCount[AtomRelocRefCountUnit], layout.CheckCause](added);
@@ -3535,7 +3546,7 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
                     map.dnit[intern.StrId, AtomWinner](?winners);
                     A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
                     A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
-                    ret R.err[R.Void, str]("linker: atom relocation reference count overflow");
+                    ret err[fail.Fail].err{fail.message("linker: atom relocation reference count overflow")};
                 }
                 ref_total_checked =
                     R.unwrap_ok[layout.CheckedCount[AtomRelocRefCountUnit], layout.CheckCause](secondary);
@@ -3550,7 +3561,7 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
         map.dnit[intern.StrId, AtomWinner](?winners);
         A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
         A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
-        ret R.err[R.Void, str]("linker: atom relocation reference count exceeds the u32 limit");
+        ret err[fail.Fail].err{fail.message("linker: atom relocation reference count exceeds the u32 limit")};
     }
     val ref_total: u32 = R.unwrap_ok[u32, layout.CheckCause](ref_total_fits);
     var refs: *AtomRelocRef = nil;
@@ -3559,17 +3570,17 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
             map.dnit[intern.StrId, AtomWinner](?winners);
             A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
             A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
-            ret R.err[R.Void, str]("linker: target cannot describe relocations");
+            ret err[fail.Fail].err{fail.message("linker: target cannot describe relocations")};
         }
-        val rr: R.Result[*AtomRelocRef, str] =
+        val rr: res[*AtomRelocRef, A.Error] =
             A.zallocate[AtomRelocRef](s.alloc, ref_total::usize);
-        if (R.is_err[*AtomRelocRef, str](rr)) {
+        if (sel rr.err) {
             map.dnit[intern.StrId, AtomWinner](?winners);
             A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
             A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
-            ret R.err[R.Void, str](R.unwrap_err[*AtomRelocRef, str](rr));
+            ret err[fail.Fail].err{fail.refused(rr.err)};
         }
-        refs = R.unwrap_ok[*AtomRelocRef, str](rr);
+        refs = rr.ok;
         var rw: u32 = 0;
         m = 0;
         for (m < module_count) {
@@ -3581,7 +3592,7 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
                     A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
                     A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
                     A.deallocate[AtomRelocRef](s.alloc, refs, ref_total::usize);
-                    ret R.err[R.Void, str](named_message(s, "linker: object '", modules[m].name, "' has a relocation against a section it does not carry", "linker: a relocation names a section its object does not carry"));
+                    ret err[fail.Fail].err{fail.message(named_message(s, "linker: object '", modules[m].name, "' has a relocation against a section it does not carry", "linker: a relocation names a section its object does not carry"))};
                 }
                 val ref_traits: R.Result[rel.RelocTraits, rel.RelocError] = atom_reloc_traits(
                     relocation, ?modules[m].sections[of.section_index(relocation.section)],
@@ -3591,7 +3602,7 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
                     A.deallocate[AtomCandidate](s.alloc, candidates, symbol_total::usize);
                     A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
                     A.deallocate[AtomRelocRef](s.alloc, refs, ref_total::usize);
-                    ret R.err[R.Void, str](named_message(s, "linker: object '", modules[m].name, "' carries a relocation kind this target's catalog does not describe", "linker: an input carries a relocation kind the target's catalog does not describe"));
+                    ret err[fail.Fail].err{fail.message(named_message(s, "linker: object '", modules[m].name, "' carries a relocation kind this target's catalog does not describe", "linker: an input carries a relocation kind the target's catalog does not describe"))};
                 }
                 val traits: rel.RelocTraits = R.unwrap_ok[rel.RelocTraits, rel.RelocError](ref_traits);
                 var operand_count: u32 = 1;
@@ -3734,7 +3745,7 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
 
     if (drop_count == 0) {
         A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
 
     sort.sort[AtomDrop](drops, drop_count::usize, atom_drop_cmp);
@@ -3756,13 +3767,13 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
         di = di + 1;
     }
 
-    val sr: R.Result[*AtomSection, str] =
+    val sr: res[*AtomSection, A.Error] =
         A.zallocate[AtomSection](s.alloc, sec_total::usize);
-    if (R.is_err[*AtomSection, str](sr)) {
+    if (sel sr.err) {
         A.deallocate[AtomDrop](s.alloc, drops, candidate_count::usize);
-        ret R.err[R.Void, str](R.unwrap_err[*AtomSection, str](sr));
+        ret err[fail.Fail].err{fail.refused(sr.err)};
     }
-    val sections: *AtomSection = R.unwrap_ok[*AtomSection, str](sr);
+    val sections: *AtomSection = sr.ok;
 
     di = 0;
     var flat: u32 = 0;
@@ -3812,7 +3823,7 @@ fun build_atom_plan(s: *session.Session, modules: *of.ObjectImage, module_count:
         m = m + 1;
     }
     plan.active = true;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun debug_str_content_eq(src: *u8, src_len: u32, src_off: u32,
@@ -3842,25 +3853,25 @@ fun add_u32_counts[Unit](left: u32, right: u32) R.Result[u32, layout.CheckCause]
         R.unwrap_ok[layout.CheckedCount[Unit], layout.CheckCause](added_r).value);
 }
 
-fun combined_image_count(image_count: u32, external_count: u32) R.Result[u32, str] {
+fun combined_image_count(image_count: u32, external_count: u32) res[u32, fail.Fail] {
     val total_r: R.Result[u32, layout.CheckCause] =
         add_u32_counts[ImageCountUnit](image_count, external_count);
     if (R.is_err[u32, layout.CheckCause](total_r)) {
-        ret R.err[u32, str]("linker: combined input object count overflow");
+        ret res[u32, fail.Fail].err{fail.message("linker: combined input object count overflow")};
     }
-    ret R.ok[u32, str](R.unwrap_ok[u32, layout.CheckCause](total_r));
+    ret res[u32, fail.Fail].ok{R.unwrap_ok[u32, layout.CheckCause](total_r)};
 }
 
-fun merged_section_count(debug_count: u32) R.Result[u32, str] {
+fun merged_section_count(debug_count: u32) res[u32, fail.Fail] {
     val total_r: R.Result[u32, layout.CheckCause] =
         add_u32_counts[MergedSectionCountUnit](MERGED_KIND_COUNT, debug_count);
     if (R.is_err[u32, layout.CheckCause](total_r)) {
-        ret R.err[u32, str]("linker: merged section count overflow");
+        ret res[u32, fail.Fail].err{fail.message("linker: merged section count overflow")};
     }
-    ret R.ok[u32, str](R.unwrap_ok[u32, layout.CheckCause](total_r));
+    ret res[u32, fail.Fail].ok{R.unwrap_ok[u32, layout.CheckCause](total_r)};
 }
 
-fun total_frames(modules: *of.ObjectImage, module_count: u32) R.Result[u32, str] {
+fun total_frames(modules: *of.ObjectImage, module_count: u32) res[u32, fail.Fail] {
     var total: layout.CheckedCount[FrameCountUnit] =
         layout.count[FrameCountUnit](0::usize);
     var module_index: u32 = 0;
@@ -3869,98 +3880,98 @@ fun total_frames(modules: *of.ObjectImage, module_count: u32) R.Result[u32, str]
             layout.count_add[FrameCountUnit](total,
                 layout.count[FrameCountUnit](modules[module_index].frame_count::usize));
         if (R.is_err[layout.CheckedCount[FrameCountUnit], layout.CheckCause](added_r)) {
-            ret R.err[u32, str]("linker: total input frame count overflow");
+            ret res[u32, fail.Fail].err{fail.message("linker: total input frame count overflow")};
         }
         total = R.unwrap_ok[layout.CheckedCount[FrameCountUnit], layout.CheckCause](added_r);
         module_index = module_index + 1;
     }
     val total32_r: R.Result[u32, layout.CheckCause] = layout.usize_to_u32(total.value);
     if (R.is_err[u32, layout.CheckCause](total32_r)) {
-        ret R.err[u32, str]("linker: total input frame count exceeds the u32 limit");
+        ret res[u32, fail.Fail].err{fail.message("linker: total input frame count exceeds the u32 limit")};
     }
-    ret R.ok[u32, str](R.unwrap_ok[u32, layout.CheckCause](total32_r));
+    ret res[u32, fail.Fail].ok{R.unwrap_ok[u32, layout.CheckCause](total32_r)};
 }
 
-fun total_sections(modules: *of.ObjectImage, module_count: u32) R.Result[u32, str] {
+fun total_sections(modules: *of.ObjectImage, module_count: u32) res[u32, fail.Fail] {
     var total: layout.CheckedCount[SectionCountUnit] = layout.count[SectionCountUnit](0::usize);
     var m: u32 = 0;
     for (m < module_count) {
         val added: R.Result[layout.CheckedCount[SectionCountUnit], layout.CheckCause] =
             layout.count_add[SectionCountUnit](total, layout.count[SectionCountUnit](modules[m].section_count::usize));
         if (R.is_err[layout.CheckedCount[SectionCountUnit], layout.CheckCause](added)) {
-            ret R.err[u32, str]("linker: total input section count overflow");
+            ret res[u32, fail.Fail].err{fail.message("linker: total input section count overflow")};
         }
         total = R.unwrap_ok[layout.CheckedCount[SectionCountUnit], layout.CheckCause](added);
         m = m + 1;
     }
     val fits: R.Result[u32, layout.CheckCause] = layout.usize_to_u32(total.value);
     if (R.is_err[u32, layout.CheckCause](fits)) {
-        ret R.err[u32, str]("linker: total input section count exceeds the u32 limit");
+        ret res[u32, fail.Fail].err{fail.message("linker: total input section count exceeds the u32 limit")};
     }
-    ret R.ok[u32, str](R.unwrap_ok[u32, layout.CheckCause](fits));
+    ret res[u32, fail.Fail].ok{R.unwrap_ok[u32, layout.CheckCause](fits)};
 }
 
-fun total_symbols(modules: *of.ObjectImage, module_count: u32) R.Result[u32, str] {
+fun total_symbols(modules: *of.ObjectImage, module_count: u32) res[u32, fail.Fail] {
     var total: layout.CheckedCount[SymbolCountUnit] = layout.count[SymbolCountUnit](0::usize);
     var m: u32 = 0;
     for (m < module_count) {
         val added: R.Result[layout.CheckedCount[SymbolCountUnit], layout.CheckCause] =
             layout.count_add[SymbolCountUnit](total, layout.count[SymbolCountUnit](modules[m].symbol_count::usize));
         if (R.is_err[layout.CheckedCount[SymbolCountUnit], layout.CheckCause](added)) {
-            ret R.err[u32, str]("linker: total input symbol count overflow");
+            ret res[u32, fail.Fail].err{fail.message("linker: total input symbol count overflow")};
         }
         total = R.unwrap_ok[layout.CheckedCount[SymbolCountUnit], layout.CheckCause](added);
         m = m + 1;
     }
     val fits: R.Result[u32, layout.CheckCause] = layout.usize_to_u32(total.value);
     if (R.is_err[u32, layout.CheckCause](fits)) {
-        ret R.err[u32, str]("linker: total input symbol count exceeds the u32 limit");
+        ret res[u32, fail.Fail].err{fail.message("linker: total input symbol count exceeds the u32 limit")};
     }
-    ret R.ok[u32, str](R.unwrap_ok[u32, layout.CheckCause](fits));
+    ret res[u32, fail.Fail].ok{R.unwrap_ok[u32, layout.CheckCause](fits)};
 }
 
-fun fill_symbol_bases(modules: *of.ObjectImage, module_count: u32, sym_base: *u32) R.Result[R.Void, str] {
+fun fill_symbol_bases(modules: *of.ObjectImage, module_count: u32, sym_base: *u32) err[fail.Fail] {
     var base: layout.CheckedCount[SymbolCountUnit] = layout.count[SymbolCountUnit](0::usize);
     var m: u32 = 0;
     for (m < module_count) {
         val base32: R.Result[u32, layout.CheckCause] = layout.usize_to_u32(base.value);
         if (R.is_err[u32, layout.CheckCause](base32)) {
-            ret R.err[R.Void, str]("linker: flattened symbol index exceeds the u32 limit");
+            ret err[fail.Fail].err{fail.message("linker: flattened symbol index exceeds the u32 limit")};
         }
         sym_base[m] = R.unwrap_ok[u32, layout.CheckCause](base32);
         val added: R.Result[layout.CheckedCount[SymbolCountUnit], layout.CheckCause] =
             layout.count_add[SymbolCountUnit](base, layout.count[SymbolCountUnit](modules[m].symbol_count::usize));
         if (R.is_err[layout.CheckedCount[SymbolCountUnit], layout.CheckCause](added)) {
-            ret R.err[R.Void, str]("linker: total input symbol count overflow");
+            ret err[fail.Fail].err{fail.message("linker: total input symbol count overflow")};
         }
         base = R.unwrap_ok[layout.CheckedCount[SymbolCountUnit], layout.CheckCause](added);
         m = m + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
                         merged: *MergedSection, debug_names: *intern.StrId, debug_count: u32,
                         placements: *Placement, sec_base: *u32, strm: *StrMerge,
-                        atoms: *AtomPlan, groups: *SectionGroups) R.Result[R.Void, str] {
-    val fsb_r: R.Result[R.Void, str] = fill_section_bases(modules, module_count, sec_base);
-    if (R.is_err[R.Void, str](fsb_r)) { ret fsb_r; }
-    val sec_total_r: R.Result[u32, str] = total_sections(modules, module_count);
-    if (R.is_err[u32, str](sec_total_r)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](sec_total_r)); }
-    val sec_total: u32 = R.unwrap_ok[u32, str](sec_total_r);
-    val dr: R.Result[*u32, str] =
+                        atoms: *AtomPlan, groups: *SectionGroups) err[fail.Fail] {
+    val fsb_r: err[fail.Fail] = fill_section_bases(modules, module_count, sec_base);
+    if (sel fsb_r.err) { ret fsb_r; }
+    val sec_total_r: res[u32, fail.Fail] = total_sections(modules, module_count);
+    if (sel sec_total_r.err) { ret err[fail.Fail].err{sec_total_r.err}; }
+    val sec_total: u32 = sec_total_r.ok;
+    val dr: res[*u32, fail.Fail] =
         plan_atom_coalescing(s.alloc, modules, module_count, sec_base, sec_total, atoms);
-    if (R.is_err[*u32, str](dr)) { ret R.err[R.Void, str](R.unwrap_err[*u32, str](dr)); }
-    val dup: *u32 = R.unwrap_ok[*u32, str](dr);
+    if (sel dr.err) { ret err[fail.Fail].err{dr.err}; }
+    val dup: *u32 = dr.ok;
     fin {
         if (dup != nil && sec_total > 0) { A.deallocate[u32](s.alloc, dup, sec_total::usize); }
     }
-    val gp: R.Result[R.Void, str] =
+    val gp: err[fail.Fail] =
         plan_section_groups(s.alloc, modules, module_count, merged, atoms, sec_base, dup, groups);
-    if (R.is_err[R.Void, str](gp)) { ret gp; }
+    if (sel gp.err) { ret gp; }
 
     val an_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, ".debug_abbrev");
-    if (R.is_err[intern.StrId, str](an_r)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](an_r)); }
+    if (R.is_err[intern.StrId, str](an_r)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](an_r))}; }
     val abbrev_name: intern.StrId = R.unwrap_ok[intern.StrId, str](an_r);
     var abbrev_representative: *of.Section = nil;
 
@@ -3972,7 +3983,7 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
         for (sc < modules[m].section_count) {
             val sec: *of.Section = ?modules[m].sections[sc];
             if (sec.kind::u32 >= MERGED_KIND_COUNT) {
-                ret R.err[R.Void, str](malformed_input_member(s, "SectionKind", sec.kind::u32, modules[m].name));
+                ret err[fail.Fail].err{fail.message(malformed_input_member(s, "SectionKind", sec.kind::u32, modules[m].name))};
             }
             var ki: u32 = sec.kind::u32;
             var dedup: bool = false;
@@ -3984,7 +3995,7 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
                     if (debug_names[di] == sec.name) { ki = MERGED_KIND_COUNT + di; found = true; }
                     di = di + 1;
                 }
-                if (!found) { ret R.err[R.Void, str]("linker: debug section name not registered in the merge"); }
+                if (!found) { ret err[fail.Fail].err{fail.message("linker: debug section name not registered in the merge")}; }
                 if (sec.name == abbrev_name
                     && debug_abbrev_tables_equal(abbrev_representative, sec)) {
                     dedup = true;
@@ -4041,16 +4052,16 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
                 var gi: u32 = 0xFFFFFFFF;
                 if (is_loadable_kind(sec.kind)) {
                     gi = section_group_index(groups, ki, sec.name, sec.flags & of.SEC_FLAG_IMAGE_MASK);
-                    if (gi == 0xFFFFFFFF) { ret R.err[R.Void, str]("linker: section group not registered in the merge"); }
+                    if (gi == 0xFFFFFFFF) { ret err[fail.Fail].err{fail.message("linker: section group not registered in the merge")}; }
                     cursor = groups.items[gi].cursor::u64;
                 }
-                val off_r: R.Result[u64, str] = align_up_u64_checked(cursor, a::u64);
-                if (R.is_err[u64, str](off_r)) { ret R.err[R.Void, str](R.unwrap_err[u64, str](off_r)); }
-                val off64: u64 = R.unwrap_ok[u64, str](off_r);
+                val off_r: res[u64, fail.Fail] = align_up_u64_checked(cursor, a::u64);
+                if (sel off_r.err) { ret err[fail.Fail].err{off_r.err}; }
+                val off64: u64 = off_r.ok;
                 val contribution_len: u32 = atom_live_len(atoms, flat, sec.len);
                 val newlen: u64 = off64 + contribution_len::u64;
                 if (newlen > 0xFFFFFFFF) {
-                    ret R.err[R.Void, str](named_message(s, "linker: merged section '", merged_section_name(s, sec.kind), "' exceeds the 4 GiB u32 limit", "linker: merged section size exceeds the 4 GiB u32 limit"));
+                    ret err[fail.Fail].err{fail.message(named_message(s, "linker: merged section '", merged_section_name(s, sec.kind), "' exceeds the 4 GiB u32 limit", "linker: merged section size exceeds the 4 GiB u32 limit"))};
                 }
 
                 placements[flat].merged_index = ki;
@@ -4074,7 +4085,7 @@ fun accumulate_sections(s: *session.Session, modules: *of.ObjectImage, module_co
         }
         m = m + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 rec Contribution {
@@ -4119,12 +4130,12 @@ fun overlap_message(s: *session.Session, modules: *of.ObjectImage, module_count:
                     sec_base: *u32, a: *Contribution, b: *Contribution) str {
     val an: str = contribution_name(s, modules, module_count, sec_base, a.flat);
     val bn: str = contribution_name(s, modules, module_count, sec_base, b.flat);
-    val r: R.Result[str, str] = format.sprint(s.alloc,
+    val r: res[str, format.FormatError] = format.sprint(s.alloc,
         "linker: '{}' claims bytes {} through {} of a merged output section and '{}' claims bytes {} through {}; two contributions cannot occupy the same output range",
         an, a.offset::u64, a.offset::u64 + a.extent::u64,
         bn, b.offset::u64, b.offset::u64 + b.extent::u64);
-    if (R.is_err[str, str](r)) { ret OVERLAP_FALLBACK; }
-    val buf: str = R.unwrap_ok[str, str](r);
+    if (sel r.err) { ret OVERLAP_FALLBACK; }
+    val buf: str = r.ok;
     val ir: R.Result[intern.StrId, str] = intern.intern(?s.interner, buf);
     str_free(s.alloc, buf);
     if (R.is_err[intern.StrId, str](ir)) { ret OVERLAP_FALLBACK; }
@@ -4135,14 +4146,14 @@ fun overlap_message(s: *session.Session, modules: *of.ObjectImage, module_count:
 
 fun validate_no_contribution_overlap(s: *session.Session, modules: *of.ObjectImage,
                                      module_count: u32, sec_base: *u32,
-                                     placements: *Placement, sec_total: u32) R.Result[R.Void, str] {
-    if (sec_total < 2) { ret R.ok_void[str](); }
+                                     placements: *Placement, sec_total: u32) err[fail.Fail] {
+    if (sec_total < 2) { ret err[fail.Fail].ok{}; }
 
-    val ar: R.Result[*Contribution, str] = A.allocate[Contribution](s.alloc, sec_total::usize);
-    if (R.is_err[*Contribution, str](ar)) {
-        ret R.err[R.Void, str](R.unwrap_err[*Contribution, str](ar));
+    val ar: res[*Contribution, A.Error] = A.allocate[Contribution](s.alloc, sec_total::usize);
+    if (sel ar.err) {
+        ret err[fail.Fail].err{fail.refused(ar.err)};
     }
-    val items: *Contribution = R.unwrap_ok[*Contribution, str](ar);
+    val items: *Contribution = ar.ok;
     fin { A.deallocate[Contribution](s.alloc, items, sec_total::usize); }
 
     var n: usize = 0;
@@ -4157,7 +4168,7 @@ fun validate_no_contribution_overlap(s: *session.Session, modules: *of.ObjectIma
         }
         flat = flat + 1;
     }
-    if (n < 2) { ret R.ok_void[str](); }
+    if (n < 2) { ret err[fail.Fail].ok{}; }
 
     sort.sort[Contribution](items, n, contribution_order);
 
@@ -4167,30 +4178,29 @@ fun validate_no_contribution_overlap(s: *session.Session, modules: *of.ObjectIma
         val cur:  *Contribution = ?items[i];
         if (prev.merged_index == cur.merged_index
             && prev.offset::u64 + prev.extent::u64 > cur.offset::u64) {
-            ret R.err[R.Void, str](
-                overlap_message(s, modules, module_count, sec_base, prev, cur));
+            ret err[fail.Fail].err{fail.message(overlap_message(s, modules, module_count, sec_base, prev, cur))};
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 # one alignment for the whole linker, over the same primitive the object
 # writers' file plan uses
-fun align_up_u64_checked(value: u64, alignment: u64) R.Result[u64, str] {
+fun align_up_u64_checked(value: u64, alignment: u64) res[u64, fail.Fail] {
     val aligned: R.Result[u64, layout.CheckCause] = layout.align_u64_up(value, alignment);
     if (R.is_err[u64, layout.CheckCause](aligned)) {
         if (R.unwrap_err[u64, layout.CheckCause](aligned) == layout.CHECK_ADD_OVERFLOW) {
-            ret R.err[u64, str]("linker: layout alignment overflows the address space");
+            ret res[u64, fail.Fail].err{fail.message("linker: layout alignment overflows the address space")};
         }
-        ret R.err[u64, str]("linker: layout alignment is not a nonzero power of two");
+        ret res[u64, fail.Fail].err{fail.message("linker: layout alignment is not a nonzero power of two")};
     }
-    ret R.ok[u64, str](R.unwrap_ok[u64, layout.CheckCause](aligned));
+    ret res[u64, fail.Fail].ok{R.unwrap_ok[u64, layout.CheckCause](aligned)};
 }
 
 fun reorder_flat_entry_first(modules: *of.ObjectImage, module_count: u32,
                              merged: *MergedSection, placements: *Placement, sec_base: *u32,
-                             atoms: *AtomPlan, entry_name: intern.StrId) R.Result[R.Void, str] {
+                             atoms: *AtomPlan, entry_name: intern.StrId) err[fail.Fail] {
     var entry_flat: u32 = 0xFFFFFFFF;
     var m: u32 = 0;
     for (m < module_count) {
@@ -4206,7 +4216,7 @@ fun reorder_flat_entry_first(modules: *of.ObjectImage, module_count: u32,
         }
         m = m + 1;
     }
-    if (entry_flat == 0xFFFFFFFF) { ret R.ok_void[str](); }
+    if (entry_flat == 0xFFFFFFFF) { ret err[fail.Fail].ok{}; }
 
     val text_slot: u32 = of.SK_TEXT::u32;
 
@@ -4223,19 +4233,19 @@ fun reorder_flat_entry_first(modules: *of.ObjectImage, module_count: u32,
                     if ((pass == 0 && is_entry) || (pass == 1 && !is_entry)) {
                         var a: u32 = modules[m].sections[sc].align;
                         if (a == 0) { a = 1; }
-                        val aligned_r: R.Result[u64, str] = align_up_u64_checked(run, a::u64);
-                        if (R.is_err[u64, str](aligned_r)) {
-                            ret R.err[R.Void, str](R.unwrap_err[u64, str](aligned_r));
+                        val aligned_r: res[u64, fail.Fail] = align_up_u64_checked(run, a::u64);
+                        if (sel aligned_r.err) {
+                            ret err[fail.Fail].err{aligned_r.err};
                         }
-                        val aligned: u64 = R.unwrap_ok[u64, str](aligned_r);
+                        val aligned: u64 = aligned_r.ok;
                         val contribution: u64 =
                             atom_live_len(atoms, flat, modules[m].sections[sc].len)::u64;
                         if (aligned > 0xFFFFFFFFFFFFFFFF - contribution) {
-                            ret R.err[R.Void, str]("linker: entry-first text layout overflows the address space");
+                            ret err[fail.Fail].err{fail.message("linker: entry-first text layout overflows the address space")};
                         }
                         val next: u64 = aligned + contribution;
                         if (next > 0xFFFFFFFF) {
-                            ret R.err[R.Void, str]("linker: entry-first text layout exceeds the 4 GiB u32 limit");
+                            ret err[fail.Fail].err{fail.message("linker: entry-first text layout exceeds the 4 GiB u32 limit")};
                         }
                         placements[flat].offset = aligned::u32;
                         run = next;
@@ -4249,18 +4259,18 @@ fun reorder_flat_entry_first(modules: *of.ObjectImage, module_count: u32,
     }
 
     merged[text_slot].len = run::u32;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun assign_section_vaddrs(tgt: *target.Target, merged: *MergedSection,
-                          reserve: u64) R.Result[R.Void, str] {
+                          reserve: u64) err[fail.Fail] {
     val base: u64 = os_base_addr(tgt);
     val page: u64 = os_page_size(tgt);
     if (page == 0 || (page & (page - 1)) != 0) {
-        ret R.err[R.Void, str]("linker: target page size is not a nonzero power of two");
+        ret err[fail.Fail].err{fail.message("linker: target page size is not a nonzero power of two")};
     }
     if (base > 0xFFFFFFFFFFFFFFFF - reserve) {
-        ret R.err[R.Void, str]("linker: image base and header reserve overflow the address space");
+        ret err[fail.Fail].err{fail.message("linker: image base and header reserve overflow the address space")};
     }
 
     var va: u64 = base + reserve;
@@ -4269,20 +4279,20 @@ fun assign_section_vaddrs(tgt: *target.Target, merged: *MergedSection,
         if (merged[i].used && is_loadable_kind(merged[i].kind)) {
             var seg_align: u64 = merged[i].align::u64;
             if (seg_align < page) { seg_align = page; }
-            val aligned_r: R.Result[u64, str] = align_up_u64_checked(va, seg_align);
-            if (R.is_err[u64, str](aligned_r)) {
-                ret R.err[R.Void, str](R.unwrap_err[u64, str](aligned_r));
+            val aligned_r: res[u64, fail.Fail] = align_up_u64_checked(va, seg_align);
+            if (sel aligned_r.err) {
+                ret err[fail.Fail].err{aligned_r.err};
             }
-            val aligned: u64 = R.unwrap_ok[u64, str](aligned_r);
+            val aligned: u64 = aligned_r.ok;
             if (aligned > 0xFFFFFFFFFFFFFFFF - merged[i].len::u64) {
-                ret R.err[R.Void, str]("linker: section virtual address range overflows the address space");
+                ret err[fail.Fail].err{fail.message("linker: section virtual address range overflows the address space")};
             }
             merged[i].vaddr = aligned;
             va = aligned + merged[i].len::u64;
         }
         i = i + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun finalize_placement_vaddrs(merged: *MergedSection, placements: *Placement, sec_total: u32) {
@@ -4295,29 +4305,29 @@ fun finalize_placement_vaddrs(merged: *MergedSection, placements: *Placement, se
 }
 
 fun resolved_symbol_name(sym_locs: *map.Map[intern.StrId, SymbolLoc],
-                         name: intern.StrId) R.Result[intern.StrId, str] {
+                         name: intern.StrId) res[intern.StrId, fail.Fail] {
     var cur: intern.StrId = name;
     var hops: usize = 0;
     for (hops <= sym_locs.len) {
-        val lr: R.Result[*SymbolLoc, str] =
+        val lr: opt[*SymbolLoc] =
             map.get[intern.StrId, SymbolLoc](sym_locs, ?cur);
-        if (R.is_err[*SymbolLoc, str](lr)) {
-            ret R.ok[intern.StrId, str](cur);
+        if (sel lr.none) {
+            ret res[intern.StrId, fail.Fail].ok{cur};
         }
-        val loc: *SymbolLoc = R.unwrap_ok[*SymbolLoc, str](lr);
+        val loc: *SymbolLoc = lr.some;
         if (loc.fallback == intern.STR_NIL) {
-            ret R.ok[intern.StrId, str](cur);
+            ret res[intern.StrId, fail.Fail].ok{cur};
         }
         cur = loc.fallback;
         hops = hops + 1;
     }
-    ret R.err[intern.StrId, str]("link: weak fallback cycle");
+    ret res[intern.StrId, fail.Fail].err{fail.message("link: weak fallback cycle")};
 }
 
 fun collect_symbols(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
                     placements: *Placement, sec_base: *u32,
                     sym_locs: *map.Map[intern.StrId, SymbolLoc], have_vaddrs: bool,
-                    atoms: *AtomPlan) R.Result[R.Void, str] {
+                    atoms: *AtomPlan) err[fail.Fail] {
     var m: u32 = 0;
     for (m < module_count) {
         var sy: u32 = 0;
@@ -4325,7 +4335,7 @@ fun collect_symbols(s: *session.Session, modules: *of.ObjectImage, module_count:
             val sym: *of.Symbol = ?modules[m].symbols[sy];
             if (of.section_is_external(sym.section)) { sy = sy + 1; cnt; }
             if (!of.section_is_absolute(sym.section) && of.section_index(sym.section) >= modules[m].section_count) {
-                ret R.err[R.Void, str](oor_section_message(s, sym.name, modules[m].name));
+                ret err[fail.Fail].err{fail.message(oor_section_message(s, sym.name, modules[m].name))};
             }
             if ((sym.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0) { sy = sy + 1; cnt; }
 
@@ -4345,12 +4355,12 @@ fun collect_symbols(s: *session.Session, modules: *of.ObjectImage, module_count:
                 }
             }
 
-            val existing: R.Result[*SymbolLoc, str] =
+            val existing: opt[*SymbolLoc] =
                 map.get[intern.StrId, SymbolLoc](sym_locs, ?sym.name);
-            if (R.is_ok[*SymbolLoc, str](existing)) {
-                val cur: *SymbolLoc = R.unwrap_ok[*SymbolLoc, str](existing);
+            if (sel existing.some) {
+                val cur: *SymbolLoc = existing.some;
                 if (is_weak)   { sy = sy + 1; cnt; }
-                if (!cur.weak) { ret R.err[R.Void, str](dup_message(s, sym.name)); }
+                if (!cur.weak) { ret err[fail.Fail].err{fail.message(dup_message(s, sym.name))}; }
                 cur.vaddr = vaddr;
                 cur.section_vaddr = section_vaddr;
                 cur.merged_index = merged_index;
@@ -4367,10 +4377,10 @@ fun collect_symbols(s: *session.Session, modules: *of.ObjectImage, module_count:
             loc.weak = is_weak;
             loc.fallback = intern.STR_NIL;
 
-            val ins: R.Result[bool, str] =
+            val ins: res[bool, A.Error] =
                 map.insert[intern.StrId, SymbolLoc](sym_locs, sym.name, loc);
-            if (R.is_err[bool, str](ins)) {
-                ret R.err[R.Void, str](R.unwrap_err[bool, str](ins));
+            if (sel ins.err) {
+                ret err[fail.Fail].err{fail.refused(ins.err)};
             }
 
             sy = sy + 1;
@@ -4387,33 +4397,33 @@ fun collect_symbols(s: *session.Session, modules: *of.ObjectImage, module_count:
                 || (sym.flags & of.SYM_OBJ_FLAG_FALLBACK) == 0) {
                 sy = sy + 1; cnt;
             }
-            val fr: R.Result[intern.StrId, str] = weak_fallback_name(?modules[m], sym);
-            if (R.is_err[intern.StrId, str](fr)) {
-                ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](fr));
+            val fr: res[intern.StrId, fail.Fail] = weak_fallback_name(?modules[m], sym);
+            if (sel fr.err) {
+                ret err[fail.Fail].err{fr.err};
             }
-            val fallback: intern.StrId = R.unwrap_ok[intern.StrId, str](fr);
+            val fallback: intern.StrId = fr.ok;
             if (fallback == intern.STR_NIL) {
-                ret R.err[R.Void, str]("link: weak fallback has no symbol name");
+                ret err[fail.Fail].err{fail.message("link: weak fallback has no symbol name")};
             }
-            val existing: R.Result[*SymbolLoc, str] =
+            val existing: opt[*SymbolLoc] =
                 map.get[intern.StrId, SymbolLoc](sym_locs, ?sym.name);
-            if (R.is_err[*SymbolLoc, str](existing)) {
+            if (sel existing.some) {
+                val cur: *SymbolLoc = existing.some;
+                if (cur.fallback != intern.STR_NIL && cur.fallback != fallback) {
+                    ret err[fail.Fail].err{fail.message("link: conflicting weak fallback targets")};
+                }
+            }
+            or {
                 var loc: SymbolLoc;
                 loc.vaddr = 0;
                 loc.section_vaddr = 0;
                 loc.merged_index = 0;
                 loc.weak = true;
                 loc.fallback = fallback;
-                val ir: R.Result[bool, str] =
+                val ir: res[bool, A.Error] =
                     map.insert[intern.StrId, SymbolLoc](sym_locs, sym.name, loc);
-                if (R.is_err[bool, str](ir)) {
-                    ret R.err[R.Void, str](R.unwrap_err[bool, str](ir));
-                }
-            }
-            or {
-                val cur: *SymbolLoc = R.unwrap_ok[*SymbolLoc, str](existing);
-                if (cur.fallback != intern.STR_NIL && cur.fallback != fallback) {
-                    ret R.err[R.Void, str]("link: conflicting weak fallback targets");
+                if (sel ir.err) {
+                    ret err[fail.Fail].err{fail.refused(ir.err)};
                 }
             }
             sy = sy + 1;
@@ -4427,30 +4437,30 @@ fun collect_symbols(s: *session.Session, modules: *of.ObjectImage, module_count:
         for (sy < modules[m].symbol_count) {
             val sym: *of.Symbol = ?modules[m].symbols[sy];
             if ((sym.flags & of.SYM_OBJ_FLAG_FALLBACK) != 0) {
-                val rr: R.Result[intern.StrId, str] =
+                val rr: res[intern.StrId, fail.Fail] =
                     resolved_symbol_name(sym_locs, sym.name);
-                if (R.is_err[intern.StrId, str](rr)) {
-                    ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](rr));
+                if (sel rr.err) {
+                    ret err[fail.Fail].err{rr.err};
                 }
             }
             sy = sy + 1;
         }
         m = m + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
                        modules: *of.ObjectImage, module_count: u32,
                        merged: *MergedSection, merged_count: u32, placements: *Placement, sec_base: *u32,
                        merged_to_out: *u32, sym_base: *u32, sym_out: *u32, strm: *StrMerge,
-                       atoms: *AtomPlan) R.Result[R.Void, str] {
+                       atoms: *AtomPlan) err[fail.Fail] {
     val alloc: *A.Allocator = s.alloc;
-    val frame_total_r: R.Result[u32, str] = total_frames(modules, module_count);
-    if (R.is_err[u32, str](frame_total_r)) {
-        ret R.err[R.Void, str](R.unwrap_err[u32, str](frame_total_r));
+    val frame_total_r: res[u32, fail.Fail] = total_frames(modules, module_count);
+    if (sel frame_total_r.err) {
+        ret err[fail.Fail].err{frame_total_r.err};
     }
-    val frame_total: u32 = R.unwrap_ok[u32, str](frame_total_r);
+    val frame_total: u32 = frame_total_r.ok;
 
     var k: u32 = 0;
     for (k < merged_count) { merged_to_out[k] = 0xFFFFFFFF; k = k + 1; }
@@ -4461,9 +4471,9 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
 
         var bytes: *u8 = nil;
         if (merged[k].kind != of.SK_BSS) {
-            val zr: R.Result[*u8, str] = A.zallocate[u8](alloc, merged[k].len::usize);
-            if (R.is_err[*u8, str](zr)) { ret R.err[R.Void, str](R.unwrap_err[*u8, str](zr)); }
-            bytes = R.unwrap_ok[*u8, str](zr);
+            val zr: res[*u8, A.Error] = A.zallocate[u8](alloc, merged[k].len::usize);
+            if (sel zr.err) { ret err[fail.Fail].err{fail.refused(zr.err)}; }
+            bytes = zr.ok;
 
             if (strm.active && merged[k].kind == of.SK_DEBUG && merged[k].name == strm.name
                 && strm.buf.len > 0) {
@@ -4480,11 +4490,11 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
         sec.align = merged[k].align;
         sec.flags = 0;
 
-        val add_r: R.Result[u32, str] = obj.install_section(out_img, ?sec);
-        if (R.is_err[u32, str](add_r)) {
-            ret R.err[R.Void, str](R.unwrap_err[u32, str](add_r));
+        val add_r: res[u32, fail.Fail] = obj.section_install(out_img, ?sec);
+        if (sel add_r.err) {
+            ret err[fail.Fail].err{add_r.err};
         }
-        merged_to_out[k] = R.unwrap_ok[u32, str](add_r);
+        merged_to_out[k] = add_r.ok;
         k = k + 1;
     }
 
@@ -4521,9 +4531,9 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
             if (sym_out != nil) { sym_out[sym_base[m] + sy] = of.SYMBOL_NONE; }
             val isym: *of.Symbol = ?modules[m].symbols[sy];
             if (of.section_is_absolute(isym.section)) {
-                val added: R.Result[u32, str] = obj.add_symbol(out_img, @isym);
-                if (R.is_err[u32, str](added)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](added)); }
-                if (sym_out != nil) { sym_out[sym_base[m] + sy] = R.unwrap_ok[u32, str](added); }
+                val added: res[u32, fail.Fail] = obj.symbol_add(out_img, @isym);
+                if (sel added.err) { ret err[fail.Fail].err{added.err}; }
+                if (sym_out != nil) { sym_out[sym_base[m] + sy] = added.ok; }
                 sy = sy + 1; cnt;
             }
             if (of.section_is_external(isym.section) || of.section_index(isym.section) >= modules[m].section_count) {
@@ -4541,10 +4551,10 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
             osym.offset  = placements[flat].offset
                 + atom_live_offset(atoms, flat, isym.offset);
 
-            val sa: R.Result[u32, str] = obj.add_symbol(out_img, osym);
-            if (R.is_err[u32, str](sa)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](sa)); }
+            val sa: res[u32, fail.Fail] = obj.symbol_add(out_img, osym);
+            if (sel sa.err) { ret err[fail.Fail].err{sa.err}; }
             if (sym_out != nil) {
-                sym_out[sym_base[m] + sy] = R.unwrap_ok[u32, str](sa);
+                sym_out[sym_base[m] + sy] = sa.ok;
             }
 
             sy = sy + 1;
@@ -4553,9 +4563,9 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
     }
 
     if (frame_total > 0) {
-        val fa: R.Result[*of.FrameUnwind, str] = A.allocate[of.FrameUnwind](out_img.alloc, frame_total::usize);
-        if (R.is_err[*of.FrameUnwind, str](fa)) { ret R.err[R.Void, str](R.unwrap_err[*of.FrameUnwind, str](fa)); }
-        var out_frames: *of.FrameUnwind = R.unwrap_ok[*of.FrameUnwind, str](fa);
+        val fa: res[*of.FrameUnwind, A.Error] = A.allocate[of.FrameUnwind](out_img.alloc, frame_total::usize);
+        if (sel fa.err) { ret err[fail.Fail].err{fail.refused(fa.err)}; }
+        var out_frames: *of.FrameUnwind = fa.ok;
         var fn: u32 = 0;
         m = 0;
         for (m < module_count) {
@@ -4583,13 +4593,13 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
         }
         or {
             if (fn < frame_total) {
-                val fs: R.Result[*of.FrameUnwind, str] =
+                val fs: res[*of.FrameUnwind, A.Error] =
                     A.reallocate[of.FrameUnwind](out_img.alloc, out_frames, frame_total::usize, fn::usize);
-                if (R.is_err[*of.FrameUnwind, str](fs)) {
+                if (sel fs.err) {
                     A.deallocate[of.FrameUnwind](out_img.alloc, out_frames, frame_total::usize);
-                    ret R.err[R.Void, str](R.unwrap_err[*of.FrameUnwind, str](fs));
+                    ret err[fail.Fail].err{fail.refused(fs.err)};
                 }
-                out_frames = R.unwrap_ok[*of.FrameUnwind, str](fs);
+                out_frames = fs.ok;
             }
             out_img.frames      = out_frames;
             out_img.frame_count = fn;
@@ -4597,7 +4607,7 @@ fun build_merged_image(s: *session.Session, out_img: *of.ObjectImage,
         }
     }
 
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
@@ -4607,26 +4617,26 @@ fun patch_relocations(s: *session.Session, out_img: *of.ObjectImage,
                      dyn: *DynState, local_got: *LocalGotPlan,
                      strm: *StrMerge, format: *of.OfVTable,
                      arch: *isa.IsaVTable,
-                     image_base: u64, atoms: *AtomPlan) R.Result[R.Void, str] {
+                     image_base: u64, atoms: *AtomPlan) err[fail.Fail] {
     var m: u32 = 0;
     for (m < module_count) {
-        val pr: R.Result[R.Void, str] = patch_module_relocations(s, out_img, modules, m,
+        val pr: err[fail.Fail] = patch_module_relocations(s, out_img, modules, m,
             placements, sec_base, merged_to_out, sym_locs, dyn, local_got, strm,
             format, arch, image_base, m < codegen_count, atoms);
-        if (R.is_err[R.Void, str](pr)) { ret pr; }
+        if (sel pr.err) { ret pr; }
 
         m = m + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun difference_subtrahend_vaddr(s: *session.Session, modules: *of.ObjectImage, m: u32,
                                 sym2: u32, placements: *Placement, sec_base: *u32,
                                 merged_to_out: *u32, out_img: *of.ObjectImage,
                                 format: *of.OfVTable, image_base: u64, atoms: *AtomPlan,
-                                sym_locs: *map.Map[intern.StrId, SymbolLoc]) R.Result[u64, str] {
+                                sym_locs: *map.Map[intern.StrId, SymbolLoc]) res[u64, fail.Fail] {
     if (sym2 >= modules[m].symbol_count) {
-        ret R.err[u64, str]("link: a difference relocation names a subtrahend outside the module's symbol table");
+        ret res[u64, fail.Fail].err{fail.message("link: a difference relocation names a subtrahend outside the module's symbol table")};
     }
     val sub: *of.Symbol = ?modules[m].symbols[sym2];
     val sub_name: intern.StrId = sub.name;
@@ -4635,51 +4645,51 @@ fun difference_subtrahend_vaddr(s: *session.Session, modules: *of.ObjectImage, m
         var t: rel.RelocTarget = rel.target(0, 0, 0);
         if (!local_symbol_target(modules, m, sym2, placements, sec_base, merged_to_out,
                                  out_img, format, image_base, atoms, ?t)) {
-            ret R.err[u64, str](undef_message(s, sub_name));
+            ret res[u64, fail.Fail].err{fail.message(undef_message(s, sub_name))};
         }
-        ret R.ok[u64, str](t.vaddr);
+        ret res[u64, fail.Fail].ok{t.vaddr};
     }
 
-    val rn: R.Result[intern.StrId, str] = resolved_symbol_name(sym_locs, sub_name);
-    if (R.is_err[intern.StrId, str](rn)) {
-        ret R.err[u64, str](R.unwrap_err[intern.StrId, str](rn));
+    val rn: res[intern.StrId, fail.Fail] = resolved_symbol_name(sym_locs, sub_name);
+    if (sel rn.err) {
+        ret res[u64, fail.Fail].err{rn.err};
     }
-    val resolved_name: intern.StrId = R.unwrap_ok[intern.StrId, str](rn);
-    val sl: R.Result[*SymbolLoc, str] = map.get[intern.StrId, SymbolLoc](sym_locs, ?resolved_name);
-    if (R.is_err[*SymbolLoc, str](sl)) {
-        ret R.err[u64, str](difference_import_message(s, sub_name));
+    val resolved_name: intern.StrId = rn.ok;
+    val sl: opt[*SymbolLoc] = map.get[intern.StrId, SymbolLoc](sym_locs, ?resolved_name);
+    if (sel sl.none) {
+        ret res[u64, fail.Fail].err{fail.message(difference_import_message(s, sub_name))};
     }
-    ret R.ok[u64, str](R.unwrap_ok[*SymbolLoc, str](sl).vaddr);
+    ret res[u64, fail.Fail].ok{sl.some.vaddr};
 }
 
-fun difference_relocation_addend(addend: i64, subtrahend: u64) R.Result[i64, str] {
+fun difference_relocation_addend(addend: i64, subtrahend: u64) res[i64, fail.Fail] {
     val adjusted: R.Result[i64, rel.RelocError] =
         rel.subtract_u64_from_i64(addend, subtrahend);
     if (R.is_err[i64, rel.RelocError](adjusted)) {
-        ret R.err[i64, str]("link: difference relocation result is outside the signed 64-bit range");
+        ret res[i64, fail.Fail].err{fail.message("link: difference relocation result is outside the signed 64-bit range")};
     }
-    ret R.ok[i64, str](R.unwrap_ok[i64, rel.RelocError](adjusted));
+    ret res[i64, fail.Fail].ok{R.unwrap_ok[i64, rel.RelocError](adjusted)};
 }
 
-fun base_relocation_target(vaddr: u64, addend: i64) R.Result[u64, str] {
+fun base_relocation_target(vaddr: u64, addend: i64) res[u64, fail.Fail] {
     val adjusted: R.Result[u64, rel.RelocError] = rel.add_signed_to_u64(vaddr, addend);
     if (R.is_err[u64, rel.RelocError](adjusted)) {
-        ret R.err[u64, str]("link: PIE base relocation target is outside the 64-bit address range");
+        ret res[u64, fail.Fail].err{fail.message("link: PIE base relocation target is outside the 64-bit address range")};
     }
-    ret R.ok[u64, str](R.unwrap_ok[u64, rel.RelocError](adjusted));
+    ret res[u64, fail.Fail].ok{R.unwrap_ok[u64, rel.RelocError](adjusted)};
 }
 
 fun difference_import_message(s: *session.Session, name: intern.StrId) str {
     val n: O.Option[str] = intern.lookup(?s.interner, name);
     var shown: str = "<unknown>";
     if (O.is_some[str](n)) { shown = O.unwrap[str](n); }
-    val r: R.Result[str, str] = format.sprint(s.alloc,
+    val r: res[str, format.FormatError] = format.sprint(s.alloc,
         "link: a difference relocation subtracts `{}`, which this link does not define; the loader chooses its address, so the difference is not a link-time constant",
         shown);
-    if (R.is_err[str, str](r)) {
+    if (sel r.err) {
         ret "link: a difference relocation subtracts a symbol this link does not define";
     }
-    ret R.unwrap_ok[str, str](r);
+    ret r.ok;
 }
 
 fun local_symbol_target(modules: *of.ObjectImage, m: u32, sy: u32,
@@ -4752,26 +4762,26 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
                              sym_locs: *map.Map[intern.StrId, SymbolLoc], dyn: *DynState,
                              local_got: *LocalGotPlan, strm: *StrMerge, format: *of.OfVTable,
                              arch: *isa.IsaVTable, image_base: u64, codegen_image: bool,
-                             atoms: *AtomPlan) R.Result[R.Void, str] {
+                             atoms: *AtomPlan) err[fail.Fail] {
     var info_sec: u32 = 0xFFFFFFFF;
     var line_sec: u32 = 0xFFFFFFFF;
     var loclists_sec: u32 = 0xFFFFFFFF;
     var rnglists_sec: u32 = 0xFFFFFFFF;
     val info_name_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, ".debug_info");
     if (R.is_err[intern.StrId, str](info_name_r)) {
-        ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](info_name_r));
+        ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](info_name_r))};
     }
     val line_name_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, ".debug_line");
     if (R.is_err[intern.StrId, str](line_name_r)) {
-        ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](line_name_r));
+        ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](line_name_r))};
     }
     val loclists_name_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, ".debug_loclists");
     if (R.is_err[intern.StrId, str](loclists_name_r)) {
-        ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](loclists_name_r));
+        ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](loclists_name_r))};
     }
     val rnglists_name_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, ".debug_rnglists");
     if (R.is_err[intern.StrId, str](rnglists_name_r)) {
-        ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](rnglists_name_r));
+        ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](rnglists_name_r))};
     }
     val info_name: intern.StrId = R.unwrap_ok[intern.StrId, str](info_name_r);
     val line_name: intern.StrId = R.unwrap_ok[intern.StrId, str](line_name_r);
@@ -4795,24 +4805,24 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
         val r: *of.Relocation = ?modules[m].relocations[ri];
         if (arch == nil || arch.reloc == nil || arch.reloc.traits == nil
             || arch.reloc.apply == nil) {
-            ret R.err[R.Void, str](unsupported_message(s, arch, r.kind));
+            ret err[fail.Fail].err{fail.message(unsupported_message(s, arch, r.kind))};
         }
         if (!debug_linkable && of.section_index(r.section) < modules[m].section_count
             && modules[m].sections[of.section_index(r.section)].kind == of.SK_DEBUG) {
             ri = ri + 1; cnt;
         }
         if (of.section_index(r.section) >= modules[m].section_count) {
-            ret R.err[R.Void, str]("linker: relocation names an out-of-range section");
+            ret err[fail.Fail].err{fail.message("linker: relocation names an out-of-range section")};
         }
         val place_traits: R.Result[rel.RelocTraits, rel.RelocError] = atom_reloc_traits(
             r, ?modules[m].sections[of.section_index(r.section)], arch, codegen_image);
         if (R.is_err[rel.RelocTraits, rel.RelocError](place_traits)) {
-            ret R.err[R.Void, str](unsupported_message(s, arch, r.kind));
+            ret err[fail.Fail].err{fail.message(unsupported_message(s, arch, r.kind))};
         }
         if (r.offset::u64
             + R.unwrap_ok[rel.RelocTraits, rel.RelocError](place_traits).field_width::u64
             > modules[m].sections[of.section_index(r.section)].len::u64) {
-            ret R.err[R.Void, str]("linker: relocation offset is past the end of its section");
+            ret err[fail.Fail].err{fail.message("linker: relocation offset is past the end of its section")};
         }
 
         val flat: u32 = sec_base[m] + of.section_index(r.section);
@@ -4822,39 +4832,39 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
         val patch_va: u64 = pl.vaddr + live_off::u64;
         val out_ix: u32 = merged_to_out[pl.merged_index];
         if (out_ix == 0xFFFFFFFF) {
-            ret R.err[R.Void, str]("linker: relocation targets a section with no merged output");
+            ret err[fail.Fail].err{fail.message("linker: relocation targets a section with no merged output")};
         }
         val dst: *u8 = out_img.sections[out_ix].bytes;
         if (dst == nil) {
-            ret R.err[R.Void, str]("linker: relocation patch site lands in a BSS section");
+            ret err[fail.Fail].err{fail.message("linker: relocation patch site lands in a BSS section")};
         }
         val patch_off: u32 = pl.offset + live_off;
 
         val operand_r: R.Result[of.RelocOperand, str] =
             rel.resolve_operand(arch, ?modules[m], ri);
         if (R.is_err[of.RelocOperand, str](operand_r)) {
-            ret R.err[R.Void, str](R.unwrap_err[of.RelocOperand, str](operand_r));
+            ret err[fail.Fail].err{fail.message(R.unwrap_err[of.RelocOperand, str](operand_r))};
         }
         val operand: of.RelocOperand = R.unwrap_ok[of.RelocOperand, str](operand_r);
         val target_sym: u32 = operand.sym;
         val target_addend: i64 = operand.addend;
 
         if (target_sym >= modules[m].symbol_count) {
-            ret R.err[R.Void, str]("linker: relocation references a symbol outside its module's symbol table");
+            ret err[fail.Fail].err{fail.message("linker: relocation references a symbol outside its module's symbol table")};
         }
         val target: *of.Symbol = ?modules[m].symbols[target_sym];
         val target_name: intern.StrId = target.name;
         if (!of.section_is_external(target.section) && !of.section_is_absolute(target.section)
             && of.section_index(target.section) >= modules[m].section_count) {
-            ret R.err[R.Void, str](oor_section_message(s, target_name, modules[m].name));
+            ret err[fail.Fail].err{fail.message(oor_section_message(s, target_name, modules[m].name))};
         }
 
         if (strm.active && of.section_index(target.section) < modules[m].section_count
             && modules[m].sections[of.section_index(target.section)].kind == of.SK_DEBUG
             && modules[m].sections[of.section_index(target.section)].name == strm.name) {
-            val sp: R.Result[R.Void, str] = resolve_strp(s, modules, m, of.section_index(target.section), target, r, strm,
+            val sp: err[fail.Fail] = resolve_strp(s, modules, m, of.section_index(target.section), target, r, strm,
                 dst, patch_off, out_img.sections[out_ix].len, patch_va, arch, image_base);
-            if (R.is_err[R.Void, str](sp)) { ret sp; }
+            if (sel sp.err) { ret sp; }
             ri = ri + 1; cnt;
         }
 
@@ -4864,7 +4874,7 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
 
         if (is_dwarf_code_address(r, info_sec, line_sec, loclists_sec, rnglists_sec, arch.pointer_width)
             && !dwarf_addend_survives_remap(modules, m, target_sym, target_addend, sec_base, atoms)) {
-            ret R.err[R.Void, str](dwarf_addend_message(s, modules, m, target_name, r));
+            ret err[fail.Fail].err{fail.message(dwarf_addend_message(s, modules, m, target_name, r))};
         }
 
         if ((target.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0
@@ -4872,20 +4882,20 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
             if (!local_symbol_target(modules, m, target_sym, placements, sec_base,
                                      merged_to_out, out_img, format, image_base,
                                      atoms, ?resolved)) {
-                ret R.err[R.Void, str](undef_message(s, target_name));
+                ret err[fail.Fail].err{fail.message(undef_message(s, target_name))};
             }
         }
         or {
-            val rn: R.Result[intern.StrId, str] =
+            val rn: res[intern.StrId, fail.Fail] =
                 resolved_symbol_name(sym_locs, target_name);
-            if (R.is_err[intern.StrId, str](rn)) {
-                ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](rn));
+            if (sel rn.err) {
+                ret err[fail.Fail].err{rn.err};
             }
-            val resolved_name: intern.StrId = R.unwrap_ok[intern.StrId, str](rn);
-            val sl: R.Result[*SymbolLoc, str] =
+            val resolved_name: intern.StrId = rn.ok;
+            val sl: opt[*SymbolLoc] =
                 map.get[intern.StrId, SymbolLoc](sym_locs, ?resolved_name);
-            if (R.is_ok[*SymbolLoc, str](sl)) {
-                val loc: *SymbolLoc = R.unwrap_ok[*SymbolLoc, str](sl);
+            if (sel sl.some) {
+                val loc: *SymbolLoc = sl.some;
                 resolved = rel.target(loc.vaddr, 0, 0);
                 resolved_absolute = loc.merged_index == of.SECTION_ABSOLUTE;
                 if (loc.merged_index != of.SECTION_ABSOLUTE) {
@@ -4903,92 +4913,95 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
                 }
             }
             or {
-                val cn_r: R.Result[ImportName, str] =
+                val cn_r: res[ImportName, fail.Fail] =
                     canonical_import_name(s, format.import_address_prefix, resolved_name);
-                if (R.is_err[ImportName, str](cn_r)) {
-                    ret R.err[R.Void, str](R.unwrap_err[ImportName, str](cn_r));
+                if (sel cn_r.err) {
+                    ret err[fail.Fail].err{cn_r.err};
                 }
-                val cn: ImportName = R.unwrap_ok[ImportName, str](cn_r);
-                val imp: R.Result[u32, str] = dynstate_import_index(dyn, resolved_name);
-                if (R.is_ok[u32, str](imp) && cn.indirect && r.kind == of.RK_PC32) {
-                    val rec_i: R.Result[R.Void, str] = dynstate_add_import_addr_fixup(
+                val cn: ImportName = cn_r.ok;
+                val imp: res[u32, fail.Fail] = dynstate_import_index(dyn, resolved_name);
+                if (sel imp.ok) {
+                val import_index: u32 = imp.ok;
+                if (cn.indirect && r.kind == of.RK_PC32) {
+                    val rec_i: err[fail.Fail] = dynstate_add_import_addr_fixup(
                         s, dyn, segment_index_for(out_img, out_ix), patch_off,
-                        R.unwrap_ok[u32, str](imp), patch_va, r.kind, target_addend);
-                    if (R.is_err[R.Void, str](rec_i)) {
+                        import_index, patch_va, r.kind, target_addend);
+                    if (sel rec_i.err) {
                         ret rec_i;
                     }
                     ri = ri + 1; cnt;
                 }
-                if (R.is_ok[u32, str](imp) && is_function_branch_kind(r.kind)
-                    && dynstate_import_is_func(dyn, R.unwrap_ok[u32, str](imp))) {
-                    val rec_r: R.Result[R.Void, str] = dynstate_add_fixup(s, dyn,
+                if (is_function_branch_kind(r.kind)
+                    && dynstate_import_is_func(dyn, import_index)) {
+                    val rec_r: err[fail.Fail] = dynstate_add_fixup(s, dyn,
                         segment_index_for(out_img, out_ix), patch_off,
-                        R.unwrap_ok[u32, str](imp), patch_va, target_addend);
-                    if (R.is_err[R.Void, str](rec_r)) { ret rec_r; }
+                        import_index, patch_va, target_addend);
+                    if (sel rec_r.err) { ret rec_r; }
                     ri = ri + 1; cnt;
                 }
-                if (R.is_ok[u32, str](imp) && is_got_kind(operand.target_kind)) {
-                    val rec_g: R.Result[R.Void, str] = dynstate_add_import_addr_fixup(s, dyn,
+                if (is_got_kind(operand.target_kind)) {
+                    val rec_g: err[fail.Fail] = dynstate_add_import_addr_fixup(s, dyn,
                         segment_index_for(out_img, out_ix), patch_off,
-                        R.unwrap_ok[u32, str](imp), patch_va, r.kind, target_addend);
-                    if (R.is_err[R.Void, str](rec_g)) { ret rec_g; }
+                        import_index, patch_va, r.kind, target_addend);
+                    if (sel rec_g.err) { ret rec_g; }
                     ri = ri + 1; cnt;
                 }
-                if (R.is_ok[u32, str](imp) && of.is_pointer_abs_kind(r.kind, arch.pointer_width)
+                if (of.is_pointer_abs_kind(r.kind, arch.pointer_width)
                     && format.id == of.OF_MACHO) {
-                    val rec_b: R.Result[R.Void, str] = dynstate_add_import_addr_fixup(s, dyn,
+                    val rec_b: err[fail.Fail] = dynstate_add_import_addr_fixup(s, dyn,
                         segment_index_for(out_img, out_ix), patch_off,
-                        R.unwrap_ok[u32, str](imp), patch_va, r.kind, target_addend);
-                    if (R.is_err[R.Void, str](rec_b)) { ret rec_b; }
+                        import_index, patch_va, r.kind, target_addend);
+                    if (sel rec_b.err) { ret rec_b; }
                     ri = ri + 1; cnt;
                 }
-                ret R.err[R.Void, str](undef_message(s, resolved_name));
+                }
+                ret err[fail.Fail].err{fail.message(undef_message(s, resolved_name))};
             }
         }
 
         if (is_got_kind(operand.target_kind)) {
             if (!isa.local_got_kind(arch, operand.target_kind)) {
-                ret R.err[R.Void, str]("linker: target does not support defined GOT references");
+                ret err[fail.Fail].err{fail.message("linker: target does not support defined GOT references")};
             }
             val local: bool = !of.section_is_external(target.section)
                 && (target.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0;
             var effective: intern.StrId = target_name;
             if (!local) {
-                val er: R.Result[intern.StrId, str] =
+                val er: res[intern.StrId, fail.Fail] =
                     resolved_symbol_name(sym_locs, target_name);
-                if (R.is_err[intern.StrId, str](er)) {
-                    ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](er));
+                if (sel er.err) {
+                    ret err[fail.Fail].err{er.err};
                 }
-                effective = R.unwrap_ok[intern.StrId, str](er);
+                effective = er.ok;
             }
             val slot_i: u32 = local_got_slot_index(
                 local_got, m, target_sym, effective, local);
             if (slot_i == 0xFFFFFFFF) {
-                ret R.err[R.Void, str]("linker: defined GOT target has no synthesized slot");
+                ret err[fail.Fail].err{fail.message("linker: defined GOT target has no synthesized slot")};
             }
             val got_out: u32 = merged_to_out[of.SK_RELRO::u32];
             if (got_out == 0xFFFFFFFF || got_out >= out_img.section_count
                 || out_img.sections[got_out].bytes == nil) {
-                ret R.err[R.Void, str]("linker: synthesized GOT has no RELRO output section");
+                ret err[fail.Fail].err{fail.message("linker: synthesized GOT has no RELRO output section")};
             }
             val slot: *LocalGotSlot = ?local_got.slots[slot_i];
             if (slot.offset::u64 + arch.pointer_width::u64 > out_img.sections[got_out].len::u64) {
-                ret R.err[R.Void, str]("linker: synthesized GOT slot is outside RELRO");
+                ret err[fail.Fail].err{fail.message("linker: synthesized GOT slot is outside RELRO")};
             }
             if (!slot.initialized) {
                 if (arch.pointer_width == 4) {
                     if (resolved.vaddr > 0xFFFFFFFF) {
-                        ret R.err[R.Void, str]("linker: GOT target exceeds the pointer width");
+                        ret err[fail.Fail].err{fail.message("linker: GOT target exceeds the pointer width")};
                     }
                     bin.write_u32_le(out_img.sections[got_out].bytes, slot.offset::usize, resolved.vaddr::u32);
                 } or {
                     bin.write_u64_le(out_img.sections[got_out].bytes, slot.offset::usize, resolved.vaddr);
                 }
                 if (dyn.info.pie && !resolved_absolute) {
-                    val br: R.Result[R.Void, str] = dynstate_add_base_reloc(
+                    val br: err[fail.Fail] = dynstate_add_base_reloc(
                         s, dyn, segment_index_for(out_img, got_out),
                         slot.offset, resolved.vaddr);
-                    if (R.is_err[R.Void, str](br)) {
+                    if (sel br.err) {
                         ret br;
                     }
                 }
@@ -4996,11 +5009,11 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
             }
             val got_section: of.ExecutableSectionLocation = final_section_location_for(
                 format, image_base, out_img, got_out, slot.vaddr - slot.offset::u64);
-            val gr: R.Result[R.Void, str] = apply_one(
+            val gr: err[fail.Fail] = apply_one(
                 s, r.kind, dst, patch_off, out_img.sections[out_ix].len,
                 rel.target(slot.vaddr, got_section.vaddr, got_section.ordinal),
                 target_addend, patch_va, target_name, arch, image_base);
-            if (R.is_err[R.Void, str](gr)) {
+            if (sel gr.err) {
                 ret gr;
             }
             ri = ri + 1; cnt;
@@ -5010,111 +5023,111 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
             && (r.kind == of.RK_PC32 || r.kind == of.RK_PLT32 || r.kind == of.RK_PAGE21
                 || r.kind == of.RK_PCREL_HI20 || r.kind == of.RK_PCREL_LO12_I || r.kind == of.RK_PCREL_LO12_S
                 || r.kind == of.RK_JUMP26 || r.kind == of.RK_ADDR32NB)) {
-            ret R.err[R.Void, str]("link: position-independent relocation to an absolute definition requires unsupported runtime adjustment");
+            ret err[fail.Fail].err{fail.message("link: position-independent relocation to an absolute definition requires unsupported runtime adjustment")};
         }
         var apply_kind: of.RelocKind = r.kind;
         if (of.is_difference(r.kind)) {
-            val sv: R.Result[u64, str] = difference_subtrahend_vaddr(
+            val sv: res[u64, fail.Fail] = difference_subtrahend_vaddr(
                 s, modules, m, r.sym2, placements, sec_base, merged_to_out, out_img,
                 format, image_base, atoms, sym_locs);
-            if (R.is_err[u64, str](sv)) { ret R.err[R.Void, str](R.unwrap_err[u64, str](sv)); }
+            if (sel sv.err) { ret err[fail.Fail].err{sv.err}; }
             if (dyn.info.pie && is_loadable_kind(out_img.sections[out_ix].kind)) {
                 val sub: *of.Symbol = ?modules[m].symbols[r.sym2];
                 var sub_absolute: bool = of.section_is_absolute(sub.section);
                 if ((sub.flags & of.SYM_OBJ_FLAG_GLOBAL) != 0 || of.section_is_external(sub.section)) {
-                    val named: R.Result[intern.StrId, str] = resolved_symbol_name(sym_locs, sub.name);
-                    if (R.is_err[intern.StrId, str](named)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](named)); }
-                    val name: intern.StrId = R.unwrap_ok[intern.StrId, str](named);
-                    val located: R.Result[*SymbolLoc, str] = map.get[intern.StrId, SymbolLoc](sym_locs, ?name);
-                    if (R.is_err[*SymbolLoc, str](located)) { ret R.err[R.Void, str](undef_message(s, name)); }
-                    sub_absolute = R.unwrap_ok[*SymbolLoc, str](located).merged_index == of.SECTION_ABSOLUTE;
+                    val named: res[intern.StrId, fail.Fail] = resolved_symbol_name(sym_locs, sub.name);
+                    if (sel named.err) { ret err[fail.Fail].err{named.err}; }
+                    val name: intern.StrId = named.ok;
+                    val located: opt[*SymbolLoc] = map.get[intern.StrId, SymbolLoc](sym_locs, ?name);
+                    if (sel located.none) { ret err[fail.Fail].err{fail.message(undef_message(s, name))}; }
+                    sub_absolute = located.some.merged_index == of.SECTION_ABSOLUTE;
                 }
                 if (resolved_absolute != sub_absolute) {
-                    ret R.err[R.Void, str]("link: position-independent difference mixes absolute and image-relative definitions");
+                    ret err[fail.Fail].err{fail.message("link: position-independent difference mixes absolute and image-relative definitions")};
                 }
             }
-            val adjusted: R.Result[i64, str] = difference_relocation_addend(
-                apply_addend, R.unwrap_ok[u64, str](sv));
-            if (R.is_err[i64, str](adjusted)) {
-                ret R.err[R.Void, str](R.unwrap_err[i64, str](adjusted));
+            val adjusted: res[i64, fail.Fail] = difference_relocation_addend(
+                apply_addend, sv.ok);
+            if (sel adjusted.err) {
+                ret err[fail.Fail].err{adjusted.err};
             }
-            apply_addend = R.unwrap_ok[i64, str](adjusted);
+            apply_addend = adjusted.ok;
             val applied: O.Option[of.RelocKind] = of.difference_apply_kind(r.kind);
             if (O.is_none[of.RelocKind](applied)) {
-                ret R.err[R.Void, str](of.reloc_kind_rejection(?s.interner, s.alloc, r.kind, ""));
+                ret err[fail.Fail].err{fail.message(of.reloc_kind_rejection(?s.interner, s.alloc, r.kind, ""))};
             }
             apply_kind = O.unwrap[of.RelocKind](applied);
         }
 
-        val pr: R.Result[R.Void, str] =
+        val pr: err[fail.Fail] =
             apply_one(s, apply_kind, dst, patch_off, out_img.sections[out_ix].len, resolved,
                       apply_addend, patch_va, target_name, arch, image_base);
-        if (R.is_err[R.Void, str](pr)) {
+        if (sel pr.err) {
             ret pr;
         }
 
         if (dyn.info.pie && !resolved_absolute && of.is_pointer_abs_kind(r.kind, arch.pointer_width)
             && is_loadable_kind(out_img.sections[out_ix].kind)) {
-            val base_target: R.Result[u64, str] =
+            val base_target: res[u64, fail.Fail] =
                 base_relocation_target(resolved.vaddr, target_addend);
-            if (R.is_err[u64, str](base_target)) {
-                ret R.err[R.Void, str](R.unwrap_err[u64, str](base_target));
+            if (sel base_target.err) {
+                ret err[fail.Fail].err{base_target.err};
             }
-            val brr: R.Result[R.Void, str] = dynstate_add_base_reloc(s, dyn,
+            val brr: err[fail.Fail] = dynstate_add_base_reloc(s, dyn,
                 segment_index_for(out_img, out_ix), patch_off,
-                R.unwrap_ok[u64, str](base_target));
-            if (R.is_err[R.Void, str](brr)) { ret brr; }
+                base_target.ok);
+            if (sel brr.err) { ret brr; }
         }
 
         ri = ri + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun debug_str_source_offset(target_offset: u32, addend: i64,
-                            section_len: u32) R.Result[u32, str] {
+                            section_len: u32) res[u32, fail.Fail] {
     var source_offset: u32 = 0;
     if (!atom_effective_offset(target_offset, addend, ?source_offset)
         || source_offset >= section_len) {
-        ret R.err[u32, str]("linker: .debug_str strp target offset and addend are out of range");
+        ret res[u32, fail.Fail].err{fail.message("linker: .debug_str strp target offset and addend are out of range")};
     }
-    ret R.ok[u32, str](source_offset);
+    ret res[u32, fail.Fail].ok{source_offset};
 }
 
 fun resolve_strp(s: *session.Session, modules: *of.ObjectImage, m: u32, str_sec: u32,
                  target: *of.Symbol, r: *of.Relocation, strm: *StrMerge,
                  dst: *u8, patch_off: u32, sec_len: u32,
-                 patch_va: u64, arch: *isa.IsaVTable, image_base: u64) R.Result[R.Void, str] {
+                 patch_va: u64, arch: *isa.IsaVTable, image_base: u64) err[fail.Fail] {
     val ssec: *of.Section = ?modules[m].sections[str_sec];
     if (ssec.bytes == nil) {
-        ret R.err[R.Void, str]("linker: .debug_str strp target has no bytes");
+        ret err[fail.Fail].err{fail.message("linker: .debug_str strp target has no bytes")};
     }
-    val source_offset_r: R.Result[u32, str] =
+    val source_offset_r: res[u32, fail.Fail] =
         debug_str_source_offset(target.offset, r.addend, ssec.len);
-    if (R.is_err[u32, str](source_offset_r)) {
-        ret R.err[R.Void, str](R.unwrap_err[u32, str](source_offset_r));
+    if (sel source_offset_r.err) {
+        ret err[fail.Fail].err{source_offset_r.err};
     }
-    val src_off: u32 = R.unwrap_ok[u32, str](source_offset_r);
+    val src_off: u32 = source_offset_r.ok;
     var terminator: u32 = src_off;
     for (terminator < ssec.len && ssec.bytes[terminator] != 0) {
         terminator = terminator + 1;
     }
     if (terminator >= ssec.len) {
-        ret R.err[R.Void, str]("linker: malformed .debug_str strp target is unterminated");
+        ret err[fail.Fail].err{fail.message("linker: malformed .debug_str strp target is unterminated")};
     }
 
     val sid_r: R.Result[intern.StrId, str] = intern.intern(?s.interner, (?ssec.bytes[src_off])::str);
-    if (R.is_err[intern.StrId, str](sid_r)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](sid_r)); }
+    if (R.is_err[intern.StrId, str](sid_r)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](sid_r))}; }
     val sid: intern.StrId = R.unwrap_ok[intern.StrId, str](sid_r);
 
-    val og: R.Result[*u32, str] = map.get[intern.StrId, u32](?strm.offs, ?sid);
-    if (R.is_err[*u32, str](og)) {
-        ret R.err[R.Void, str]("linker: .debug_str strp target absent from the deduped table");
+    val og: opt[*u32] = map.get[intern.StrId, u32](?strm.offs, ?sid);
+    if (sel og.none) {
+        ret err[fail.Fail].err{fail.message("linker: .debug_str strp target absent from the deduped table")};
     }
-    val ded_off: u32 = @R.unwrap_ok[*u32, str](og);
+    val ded_off: u32 = @og.some;
 
     if (!debug_str_content_eq(ssec.bytes, ssec.len, src_off, strm.buf.data, strm.buf.len::u32, ded_off)) {
-        ret R.err[R.Void, str]("linker: .debug_str dedup remapped a strp to divergent content");
+        ret err[fail.Fail].err{fail.message("linker: .debug_str dedup remapped a strp to divergent content")};
     }
 
     ret apply_one(s, r.kind, dst, patch_off, sec_len, rel.target(ded_off::u64, 0, 0), 0, patch_va,
@@ -5215,13 +5228,13 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
                        modules: *of.ObjectImage, module_count: u32,
                        sym_locs: *map.Map[intern.StrId, SymbolLoc],
                        dynlibs: *of.DynLib, dynlib_count: u32,
-                       sec_base: *u32, atoms: *AtomPlan) R.Result[R.Void, str] {
+                       sec_base: *u32, atoms: *AtomPlan) err[fail.Fail] {
     val alloc: *A.Allocator = s.alloc;
 
     dyn.info.interp = intern.STR_NIL;
     if (!str_empty(tgt.fs_policy.dynamic_interpreter)) {
         val dr: R.Result[intern.StrId, str] = intern.intern(?s.interner, tgt.fs_policy.dynamic_interpreter);
-        if (R.is_err[intern.StrId, str](dr)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](dr)); }
+        if (R.is_err[intern.StrId, str](dr)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](dr))}; }
         dyn.info.interp = R.unwrap_ok[intern.StrId, str](dr);
     }
 
@@ -5229,7 +5242,7 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
     var implicit_soname: intern.StrId = intern.STR_NIL;
     if (dyn.info.pie && !str_empty(tgt.fs_policy.platform_lib)) {
         val pr: R.Result[intern.StrId, str] = intern.intern(?s.interner, tgt.fs_policy.platform_lib);
-        if (R.is_err[intern.StrId, str](pr)) { ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](pr)); }
+        if (R.is_err[intern.StrId, str](pr)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](pr))}; }
         implicit_soname = R.unwrap_ok[intern.StrId, str](pr);
         implicit = 1;
     }
@@ -5251,8 +5264,8 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
     if (dynlib_identity_collision(dynlibs, dynlib_count, implicit_ptr,
                                   ?collision_first, ?collision_second,
                                   ?collision_identity)) {
-        ret R.err[R.Void, str](dynlib_identity_conflict_message(
-            s, collision_identity, collision_first, collision_second));
+        ret err[fail.Fail].err{fail.message(dynlib_identity_conflict_message(
+            s, collision_identity, collision_first, collision_second))};
     }
 
     val explicit_libs: u32 = unique_dynlib_count(dynlibs, dynlib_count);
@@ -5260,17 +5273,17 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
         declared_library_count(s, modules, module_count, dynlibs, dynlib_count,
                                implicit_ptr, sym_locs, tgt.of.import_address_prefix,
                                sec_base, atoms);
-    val attributed_libs_r: R.Result[u32, str] =
+    val attributed_libs_r: res[u32, fail.Fail] =
         attributed_library_count(s, modules, module_count, dynlibs, dynlib_count,
                                  implicit_ptr, sym_locs, tgt.of.import_address_prefix,
                                  sec_base, atoms);
-    if (R.is_err[u32, str](attributed_libs_r)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](attributed_libs_r)); }
-    val attributed_libs: u32 = R.unwrap_ok[u32, str](attributed_libs_r);
+    if (sel attributed_libs_r.err) { ret err[fail.Fail].err{attributed_libs_r.err}; }
+    val attributed_libs: u32 = attributed_libs_r.ok;
     val total_libs: u32 = explicit_libs + implicit + declared_libs + attributed_libs;
     if (total_libs > 0) {
-        val lr: R.Result[*of.DynLib, str] = A.zallocate[of.DynLib](alloc, total_libs::usize);
-        if (R.is_err[*of.DynLib, str](lr)) { ret R.err[R.Void, str](R.unwrap_err[*of.DynLib, str](lr)); }
-        dyn.info.libs = R.unwrap_ok[*of.DynLib, str](lr);
+        val lr: res[*of.DynLib, A.Error] = A.zallocate[of.DynLib](alloc, total_libs::usize);
+        if (sel lr.err) { ret err[fail.Fail].err{fail.refused(lr.err)}; }
+        dyn.info.libs = lr.ok;
         var i: u32 = 0;
         var w: u32 = 0;
         for (i < dynlib_count) {
@@ -5324,15 +5337,15 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
         for (atm < module_count) {
             var atsy: u32 = 0;
             for (atsy < modules[atm].symbol_count) {
-                val cand_r: R.Result[O.Option[of.DynLib], str] = attributed_import_candidate(
+                val cand_r: res[opt[of.DynLib], fail.Fail] = attributed_import_candidate(
                     s, modules, module_count, atm, atsy, tgt.of.import_address_prefix,
                     dynlibs, dynlib_count, implicit_ptr, sym_locs, sec_base, atoms);
-                if (R.is_err[O.Option[of.DynLib], str](cand_r)) {
-                    ret R.err[R.Void, str](R.unwrap_err[O.Option[of.DynLib], str](cand_r));
+                if (sel cand_r.err) {
+                    ret err[fail.Fail].err{cand_r.err};
                 }
-                val cand: O.Option[of.DynLib] = R.unwrap_ok[O.Option[of.DynLib], str](cand_r);
-                if (O.is_some[of.DynLib](cand)) {
-                    val entry: of.DynLib = O.unwrap[of.DynLib](cand);
+                val cand: opt[of.DynLib] = cand_r.ok;
+                if (sel cand.some) {
+                    val entry: of.DynLib = cand.some;
                     if (!emitted_lib_present(dyn.info.libs, dw, entry.soname)) {
                         dyn.info.libs[dw].name   = entry.name;
                         dyn.info.libs[dw].soname = entry.soname;
@@ -5360,8 +5373,8 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
             if (O.is_some[intern.StrId](prev)
                 && !declared_attribution_matches(dynlibs, dynlib_count, implicit_ptr,
                     O.unwrap[intern.StrId](prev), d.library)) {
-                ret R.err[R.Void, str](declared_conflict_message(
-                    s, d.symbol, O.unwrap[intern.StrId](prev), d.library));
+                ret err[fail.Fail].err{fail.message(declared_conflict_message(
+                    s, d.symbol, O.unwrap[intern.StrId](prev), d.library))};
             }
             ai = ai + 1;
         }
@@ -5380,27 +5393,29 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
         for (sy < modules[m].symbol_count) {
             val sym: *of.Symbol = ?modules[m].symbols[sy];
             if (!is_undefined_extern(sym)) { sy = sy + 1; cnt; }
-            val rr: R.Result[intern.StrId, str] = resolved_symbol_name(sym_locs, sym.name);
-            if (R.is_err[intern.StrId, str](rr)) {
+            val rr: res[intern.StrId, fail.Fail] = resolved_symbol_name(sym_locs, sym.name);
+            if (sel rr.err) {
                 map.dnit[intern.StrId, u32](?seen);
-                ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](rr));
+                ret err[fail.Fail].err{rr.err};
             }
-            val effective: intern.StrId = R.unwrap_ok[intern.StrId, str](rr);
-            if (R.is_ok[*SymbolLoc, str](map.get[intern.StrId, SymbolLoc](sym_locs, ?effective))) { sy = sy + 1; cnt; }
+            val effective: intern.StrId = rr.ok;
+            val get_r: opt[*SymbolLoc] = map.get[intern.StrId, SymbolLoc](sym_locs, ?effective);
+            if (sel get_r.some) { sy = sy + 1; cnt; }
             if (!import_symbol_live(modules, module_count, sym.name, sec_base, atoms))             { sy = sy + 1; cnt; }
-            val cn_r: R.Result[ImportName, str] =
+            val cn_r: res[ImportName, fail.Fail] =
                 canonical_import_name(s, tgt.of.import_address_prefix, effective);
-            if (R.is_err[ImportName, str](cn_r)) {
+            if (sel cn_r.err) {
                 map.dnit[intern.StrId, u32](?seen);
-                ret R.err[R.Void, str](R.unwrap_err[ImportName, str](cn_r));
+                ret err[fail.Fail].err{cn_r.err};
             }
-            val cn: ImportName = R.unwrap_ok[ImportName, str](cn_r);
-            if (R.is_ok[*u32, str](map.get[intern.StrId, u32](?seen, ?cn.canonical))) {
+            val cn: ImportName = cn_r.ok;
+            val get_r2: opt[*u32] = map.get[intern.StrId, u32](?seen, ?cn.canonical);
+            if (sel get_r2.some) {
                 sy = sy + 1; cnt;
             }
-            val ins: R.Result[bool, str] =
+            val ins: res[bool, A.Error] =
                 map.insert[intern.StrId, u32](?seen, cn.canonical, n_imports);
-            if (R.is_err[bool, str](ins)) { map.dnit[intern.StrId, u32](?seen); ret R.err[R.Void, str](R.unwrap_err[bool, str](ins)); }
+            if (sel ins.err) { map.dnit[intern.StrId, u32](?seen); ret err[fail.Fail].err{fail.refused(ins.err)}; }
             n_imports = n_imports + 1;
             sy = sy + 1;
         }
@@ -5408,11 +5423,11 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
     }
     map.dnit[intern.StrId, u32](?seen);
 
-    if (n_imports == 0) { ret R.ok_void[str](); }
+    if (n_imports == 0) { ret err[fail.Fail].ok{}; }
 
-    val ir: R.Result[*of.DynImport, str] = A.zallocate[of.DynImport](alloc, n_imports::usize);
-    if (R.is_err[*of.DynImport, str](ir)) { ret R.err[R.Void, str](R.unwrap_err[*of.DynImport, str](ir)); }
-    dyn.info.imports = R.unwrap_ok[*of.DynImport, str](ir);
+    val ir: res[*of.DynImport, A.Error] = A.zallocate[of.DynImport](alloc, n_imports::usize);
+    if (sel ir.err) { ret err[fail.Fail].err{fail.refused(ir.err)}; }
+    dyn.info.imports = ir.ok;
     dyn.import_cap = n_imports;
 
     m = 0;
@@ -5421,36 +5436,39 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
         for (sy < modules[m].symbol_count) {
             val sym: *of.Symbol = ?modules[m].symbols[sy];
             if (!is_undefined_extern(sym)) { sy = sy + 1; cnt; }
-            val rr: R.Result[intern.StrId, str] = resolved_symbol_name(sym_locs, sym.name);
-            if (R.is_err[intern.StrId, str](rr)) {
-                ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](rr));
+            val rr: res[intern.StrId, fail.Fail] = resolved_symbol_name(sym_locs, sym.name);
+            if (sel rr.err) {
+                ret err[fail.Fail].err{rr.err};
             }
-            val effective: intern.StrId = R.unwrap_ok[intern.StrId, str](rr);
-            if (R.is_ok[*SymbolLoc, str](map.get[intern.StrId, SymbolLoc](sym_locs, ?effective))) { sy = sy + 1; cnt; }
+            val effective: intern.StrId = rr.ok;
+            val get_r3: opt[*SymbolLoc] = map.get[intern.StrId, SymbolLoc](sym_locs, ?effective);
+            if (sel get_r3.some) { sy = sy + 1; cnt; }
             if (!import_symbol_live(modules, module_count, sym.name, sec_base, atoms))             { sy = sy + 1; cnt; }
 
-            val cn_r: R.Result[ImportName, str] =
+            val cn_r: res[ImportName, fail.Fail] =
                 canonical_import_name(s, tgt.of.import_address_prefix, effective);
-            if (R.is_err[ImportName, str](cn_r)) {
-                ret R.err[R.Void, str](R.unwrap_err[ImportName, str](cn_r));
+            if (sel cn_r.err) {
+                ret err[fail.Fail].err{cn_r.err};
             }
-            val cn: ImportName = R.unwrap_ok[ImportName, str](cn_r);
-            val existing: R.Result[*u32, str] =
+            val cn: ImportName = cn_r.ok;
+            val existing: opt[*u32] =
                 map.get[intern.StrId, u32](?dyn.import_map, ?cn.canonical);
-            if (R.is_ok[*u32, str](existing)) {
-                val existing_idx: u32 = @R.unwrap_ok[*u32, str](existing);
-                if (R.is_err[*u32, str](map.get[intern.StrId, u32](?dyn.import_map, ?sym.name))) {
-                    val alias_r: R.Result[bool, str] =
+            if (sel existing.some) {
+                val existing_idx: u32 = @existing.some;
+                val get_r4: opt[*u32] = map.get[intern.StrId, u32](?dyn.import_map, ?sym.name);
+                if (sel get_r4.none) {
+                    val alias_r: res[bool, A.Error] =
                         map.insert[intern.StrId, u32](?dyn.import_map, sym.name, existing_idx);
-                    if (R.is_err[bool, str](alias_r)) {
-                        ret R.err[R.Void, str](R.unwrap_err[bool, str](alias_r));
+                    if (sel alias_r.err) {
+                        ret err[fail.Fail].err{fail.refused(alias_r.err)};
                     }
                 }
-                if (R.is_err[*u32, str](map.get[intern.StrId, u32](?dyn.import_map, ?effective))) {
-                    val effective_r: R.Result[bool, str] =
+                val get_r5: opt[*u32] = map.get[intern.StrId, u32](?dyn.import_map, ?effective);
+                if (sel get_r5.none) {
+                    val effective_r: res[bool, A.Error] =
                         map.insert[intern.StrId, u32](?dyn.import_map, effective, existing_idx);
-                    if (R.is_err[bool, str](effective_r)) {
-                        ret R.err[R.Void, str](R.unwrap_err[bool, str](effective_r));
+                    if (sel effective_r.err) {
+                        ret err[fail.Fail].err{fail.refused(effective_r.err)};
                     }
                 }
                 if (!cn.indirect
@@ -5473,21 +5491,20 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
             if (decl != nil) { lib_opt = O.some[intern.StrId](decl.library); }
             if (O.is_some[intern.StrId](lib_opt)) {
                 val want: intern.StrId = O.unwrap[intern.StrId](lib_opt);
-                var li_opt: O.Option[u32] =
+                var li_opt: opt[u32] =
                     dynlib_index_of(dynlibs, dynlib_count, implicit_ptr, want);
-                if (!O.is_some[u32](li_opt)) {
+                if (!sel li_opt.some) {
                     li_opt = emitted_lib_index(dyn.info.libs, explicit_libs + implicit,
                                                dyn.info.lib_count, want);
                 }
-                if (!O.is_some[u32](li_opt)) {
-                    ret R.err[R.Void, str](
-                        pinned_attribution_message(s, cn.canonical, want));
+                if (!sel li_opt.some) {
+                    ret err[fail.Fail].err{fail.message(pinned_attribution_message(s, cn.canonical, want))};
                 }
-                dyn.info.imports[idx].lib_index = O.unwrap[u32](li_opt);
+                dyn.info.imports[idx].lib_index = li_opt.some;
             }
             or (tgt.of.two_level_namespace) {
-                ret R.err[R.Void, str](unattributed_import_message(
-                    s, cn.canonical, tgt.os.c_symbol_prefix, dynlibs, dynlib_count));
+                ret err[fail.Fail].err{fail.message(unattributed_import_message(
+                    s, cn.canonical, tgt.os.c_symbol_prefix, dynlibs, dynlib_count))};
             }
             or {
                 dyn.info.imports[idx].lib_index = of.DYNLIB_ANY;
@@ -5508,26 +5525,26 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
             if (!str_empty(tgt.of.import_address_prefix)
                 && is_import_address_alias(s, dyn.info.imports[idx].symbol,
                                            tgt.of.import_address_prefix)) {
-                ret R.err[R.Void, str](import_alias_message(
-                    s, dyn.info.imports[idx].symbol, tgt.of.import_address_prefix));
+                ret err[fail.Fail].err{fail.message(import_alias_message(
+                    s, dyn.info.imports[idx].symbol, tgt.of.import_address_prefix))};
             }
-            val ins: R.Result[bool, str] =
+            val ins: res[bool, A.Error] =
                 map.insert[intern.StrId, u32](?dyn.import_map, cn.canonical, idx);
-            if (R.is_err[bool, str](ins)) {
-                ret R.err[R.Void, str](R.unwrap_err[bool, str](ins));
+            if (sel ins.err) {
+                ret err[fail.Fail].err{fail.refused(ins.err)};
             }
             if (sym.name != cn.canonical) {
-                val alias_r: R.Result[bool, str] =
+                val alias_r: res[bool, A.Error] =
                     map.insert[intern.StrId, u32](?dyn.import_map, sym.name, idx);
-                if (R.is_err[bool, str](alias_r)) {
-                    ret R.err[R.Void, str](R.unwrap_err[bool, str](alias_r));
+                if (sel alias_r.err) {
+                    ret err[fail.Fail].err{fail.refused(alias_r.err)};
                 }
             }
             if (effective != cn.canonical && effective != sym.name) {
-                val effective_r: R.Result[bool, str] =
+                val effective_r: res[bool, A.Error] =
                     map.insert[intern.StrId, u32](?dyn.import_map, effective, idx);
-                if (R.is_err[bool, str](effective_r)) {
-                    ret R.err[R.Void, str](R.unwrap_err[bool, str](effective_r));
+                if (sel effective_r.err) {
+                    ret err[fail.Fail].err{fail.refused(effective_r.err)};
                 }
             }
             dyn.info.import_count = idx + 1;
@@ -5536,11 +5553,11 @@ fun build_dynamic_info(s: *session.Session, tgt: *target.Target, dyn: *DynState,
         }
         m = m + 1;
     }
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun dynlib_index_of(dynlibs: *of.DynLib, dynlib_count: u32,
-                    implicit: *of.DynLib, lib: intern.StrId) O.Option[u32] {
+                    implicit: *of.DynLib, lib: intern.StrId) opt[u32] {
     var i: u32 = 0;
     for (i < dynlib_count) {
         if (!dynlibs[i].include_referenced
@@ -5551,7 +5568,7 @@ fun dynlib_index_of(dynlibs: *of.DynLib, dynlib_count: u32,
                 if (!dynlibs[j].include_referenced
                     && !dynlib_soname_seen_before(dynlibs, j, dynlibs[j].soname)) {
                     if (dynlibs[j].soname == dynlibs[i].soname) {
-                        ret O.some[u32](index);
+                        ret opt[u32].some{index};
                     }
                     index = index + 1;
                 }
@@ -5561,9 +5578,9 @@ fun dynlib_index_of(dynlibs: *of.DynLib, dynlib_count: u32,
         i = i + 1;
     }
     if (implicit != nil && (implicit.name == lib || implicit.soname == lib)) {
-        ret O.some[u32](unique_dynlib_count(dynlibs, dynlib_count));
+        ret opt[u32].some{unique_dynlib_count(dynlibs, dynlib_count)};
     }
-    ret O.none[u32]();
+    ret opt[u32].none{};
 }
 
 fun dynlib_identity_pair(a: *of.DynLib, b: *of.DynLib,
@@ -5642,13 +5659,13 @@ fun dynlib_soname_present(dynlibs: *of.DynLib, count: u32,
 
 fun symbol_strongly_resolved(sym_locs: *map.Map[intern.StrId, SymbolLoc],
                              name: intern.StrId) bool {
-    val rr: R.Result[intern.StrId, str] = resolved_symbol_name(sym_locs, name);
-    if (R.is_err[intern.StrId, str](rr)) { ret false; }
-    val effective: intern.StrId = R.unwrap_ok[intern.StrId, str](rr);
-    val lr: R.Result[*SymbolLoc, str] =
+    val rr: res[intern.StrId, fail.Fail] = resolved_symbol_name(sym_locs, name);
+    if (sel rr.err) { ret false; }
+    val effective: intern.StrId = rr.ok;
+    val lr: opt[*SymbolLoc] =
         map.get[intern.StrId, SymbolLoc](sym_locs, ?effective);
-    if (R.is_err[*SymbolLoc, str](lr)) { ret false; }
-    ret !R.unwrap_ok[*SymbolLoc, str](lr).weak;
+    if (sel lr.none) { ret false; }
+    ret !lr.some.weak;
 }
 
 fun declared_import_unresolved(d: *of.ImportDecl,
@@ -5719,15 +5736,15 @@ fun dynlib_name_present(dynlibs: *of.DynLib, count: u32,
     ret false;
 }
 
-fun find_referenced_dynlib(dynlibs: *of.DynLib, count: u32, name: intern.StrId) O.Option[of.DynLib] {
+fun find_referenced_dynlib(dynlibs: *of.DynLib, count: u32, name: intern.StrId) opt[of.DynLib] {
     var i: u32 = 0;
     for (i < count) {
         if (dynlibs[i].include_referenced && dynlibs[i].name == name) {
-            ret O.some[of.DynLib](dynlibs[i]);
+            ret opt[of.DynLib].some{dynlibs[i]};
         }
         i = i + 1;
     }
-    ret O.none[of.DynLib]();
+    ret opt[of.DynLib].none{};
 }
 
 fun emitted_lib_present(libs: *of.DynLib, count: u32, name: intern.StrId) bool {
@@ -5740,14 +5757,14 @@ fun emitted_lib_present(libs: *of.DynLib, count: u32, name: intern.StrId) bool {
 }
 
 fun emitted_lib_index(libs: *of.DynLib, start: u32, count: u32,
-                      name: intern.StrId) O.Option[u32] {
-    if (libs == nil) { ret O.none[u32](); }
+                      name: intern.StrId) opt[u32] {
+    if (libs == nil) { ret opt[u32].none{}; }
     var i: u32 = start;
     for (i < count) {
-        if (libs[i].name == name || libs[i].soname == name) { ret O.some[u32](i); }
+        if (libs[i].name == name || libs[i].soname == name) { ret opt[u32].some{i}; }
         i = i + 1;
     }
-    ret O.none[u32]();
+    ret opt[u32].none{};
 }
 
 fun declared_library_count(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
@@ -5807,130 +5824,132 @@ fun attributed_import_candidate(s: *session.Session, modules: *of.ObjectImage, m
                                 m: u32, sy: u32, prefix: str,
                                 dynlibs: *of.DynLib, dynlib_count: u32, implicit: *of.DynLib,
                                 sym_locs: *map.Map[intern.StrId, SymbolLoc],
-                                sec_base: *u32, atoms: *AtomPlan) R.Result[O.Option[of.DynLib], str] {
-    val none: O.Option[of.DynLib] = O.none[of.DynLib]();
+                                sec_base: *u32, atoms: *AtomPlan) res[opt[of.DynLib], fail.Fail] {
+    val none: opt[of.DynLib] = opt[of.DynLib].none{};
     val sym: *of.Symbol = ?modules[m].symbols[sy];
-    if (!is_undefined_extern(sym)) { ret R.ok[O.Option[of.DynLib], str](none); }
-    val rr: R.Result[intern.StrId, str] = resolved_symbol_name(sym_locs, sym.name);
-    if (R.is_err[intern.StrId, str](rr)) {
-        ret R.err[O.Option[of.DynLib], str](R.unwrap_err[intern.StrId, str](rr));
+    if (!is_undefined_extern(sym)) { ret res[opt[of.DynLib], fail.Fail].ok{none}; }
+    val rr: res[intern.StrId, fail.Fail] = resolved_symbol_name(sym_locs, sym.name);
+    if (sel rr.err) {
+        ret res[opt[of.DynLib], fail.Fail].err{rr.err};
     }
-    val effective: intern.StrId = R.unwrap_ok[intern.StrId, str](rr);
-    if (R.is_ok[*SymbolLoc, str](map.get[intern.StrId, SymbolLoc](sym_locs, ?effective))) {
-        ret R.ok[O.Option[of.DynLib], str](none);
+    val effective: intern.StrId = rr.ok;
+    val get_r: opt[*SymbolLoc] = map.get[intern.StrId, SymbolLoc](sym_locs, ?effective);
+    if (sel get_r.some) {
+        ret res[opt[of.DynLib], fail.Fail].ok{none};
     }
-    val cn_r: R.Result[ImportName, str] = canonical_import_name(s, prefix, effective);
-    if (R.is_err[ImportName, str](cn_r)) {
-        ret R.err[O.Option[of.DynLib], str](R.unwrap_err[ImportName, str](cn_r));
+    val cn_r: res[ImportName, fail.Fail] = canonical_import_name(s, prefix, effective);
+    if (sel cn_r.err) {
+        ret res[opt[of.DynLib], fail.Fail].err{cn_r.err};
     }
-    val canonical: intern.StrId = R.unwrap_ok[ImportName, str](cn_r).canonical;
+    val canonical: intern.StrId = cn_r.ok.canonical;
     if (declared_import_for(modules, module_count, canonical, sym_locs) != nil) {
-        ret R.ok[O.Option[of.DynLib], str](none);
+        ret res[opt[of.DynLib], fail.Fail].ok{none};
     }
     val lib_opt: O.Option[intern.StrId] = session.import_library(s, canonical);
     if (!O.is_some[intern.StrId](lib_opt)) {
-        ret R.ok[O.Option[of.DynLib], str](none);
+        ret res[opt[of.DynLib], fail.Fail].ok{none};
     }
     val lib: intern.StrId = O.unwrap[intern.StrId](lib_opt);
     if (dynlib_name_present(dynlibs, dynlib_count, implicit, lib)) {
-        ret R.ok[O.Option[of.DynLib], str](none);
+        ret res[opt[of.DynLib], fail.Fail].ok{none};
     }
     val provider: O.Option[session.LinkProvider] = session.link_provider(s, lib);
     if (O.is_some[session.LinkProvider](provider)
         && O.unwrap[session.LinkProvider](provider).is_static) {
-        ret R.ok[O.Option[of.DynLib], str](none);
+        ret res[opt[of.DynLib], fail.Fail].ok{none};
     }
-    val referenced_entry: O.Option[of.DynLib] = find_referenced_dynlib(dynlibs, dynlib_count, lib);
-    if (!O.is_some[of.DynLib](referenced_entry)) {
-        ret R.ok[O.Option[of.DynLib], str](none);
+    val referenced_entry: opt[of.DynLib] = find_referenced_dynlib(dynlibs, dynlib_count, lib);
+    if (!sel referenced_entry.some) {
+        ret res[opt[of.DynLib], fail.Fail].ok{none};
     }
     if (!declared_import_referenced(s, modules, module_count, canonical, prefix, sec_base, atoms)) {
-        ret R.ok[O.Option[of.DynLib], str](none);
+        ret res[opt[of.DynLib], fail.Fail].ok{none};
     }
-    ret R.ok[O.Option[of.DynLib], str](referenced_entry);
+    ret res[opt[of.DynLib], fail.Fail].ok{referenced_entry};
 }
 
 fun attributed_library_seen_before(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
                                    upto_m: u32, upto_sy: u32, soname: intern.StrId, prefix: str,
                                    dynlibs: *of.DynLib, dynlib_count: u32, implicit: *of.DynLib,
                                    sym_locs: *map.Map[intern.StrId, SymbolLoc],
-                                   sec_base: *u32, atoms: *AtomPlan) R.Result[bool, str] {
+                                   sec_base: *u32, atoms: *AtomPlan) res[bool, fail.Fail] {
     var m: u32 = 0;
     for (m <= upto_m && m < module_count) {
         var sy: u32 = 0;
         var end: u32 = modules[m].symbol_count;
         if (m == upto_m) { end = upto_sy; }
         for (sy < end) {
-            val cand_r: R.Result[O.Option[of.DynLib], str] = attributed_import_candidate(
+            val cand_r: res[opt[of.DynLib], fail.Fail] = attributed_import_candidate(
                 s, modules, module_count, m, sy, prefix, dynlibs, dynlib_count, implicit,
                 sym_locs, sec_base, atoms);
-            if (R.is_err[O.Option[of.DynLib], str](cand_r)) {
-                ret R.err[bool, str](R.unwrap_err[O.Option[of.DynLib], str](cand_r));
+            if (sel cand_r.err) {
+                ret res[bool, fail.Fail].err{cand_r.err};
             }
-            val cand: O.Option[of.DynLib] = R.unwrap_ok[O.Option[of.DynLib], str](cand_r);
-            if (O.is_some[of.DynLib](cand) && O.unwrap[of.DynLib](cand).soname == soname) {
-                ret R.ok[bool, str](true);
+            val cand: opt[of.DynLib] = cand_r.ok;
+            if (sel cand.some && cand.some.soname == soname) {
+                ret res[bool, fail.Fail].ok{true};
             }
             sy = sy + 1;
         }
         m = m + 1;
     }
-    ret R.ok[bool, str](false);
+    ret res[bool, fail.Fail].ok{false};
 }
 
 fun attributed_library_count(s: *session.Session, modules: *of.ObjectImage, module_count: u32,
                              dynlibs: *of.DynLib, dynlib_count: u32, implicit: *of.DynLib,
                              sym_locs: *map.Map[intern.StrId, SymbolLoc], prefix: str,
-                             sec_base: *u32, atoms: *AtomPlan) R.Result[u32, str] {
+                             sec_base: *u32, atoms: *AtomPlan) res[u32, fail.Fail] {
     var n: u32 = 0;
     var m: u32 = 0;
     for (m < module_count) {
         var sy: u32 = 0;
         for (sy < modules[m].symbol_count) {
-            val cand_r: R.Result[O.Option[of.DynLib], str] = attributed_import_candidate(
+            val cand_r: res[opt[of.DynLib], fail.Fail] = attributed_import_candidate(
                 s, modules, module_count, m, sy, prefix, dynlibs, dynlib_count, implicit,
                 sym_locs, sec_base, atoms);
-            if (R.is_err[O.Option[of.DynLib], str](cand_r)) {
-                ret R.err[u32, str](R.unwrap_err[O.Option[of.DynLib], str](cand_r));
+            if (sel cand_r.err) {
+                ret res[u32, fail.Fail].err{cand_r.err};
             }
-            val cand: O.Option[of.DynLib] = R.unwrap_ok[O.Option[of.DynLib], str](cand_r);
-            if (O.is_some[of.DynLib](cand)) {
-                val soname: intern.StrId = O.unwrap[of.DynLib](cand).soname;
-                val seen_r: R.Result[bool, str] = attributed_library_seen_before(
+            val cand: opt[of.DynLib] = cand_r.ok;
+            if (sel cand.some) {
+                val soname: intern.StrId = cand.some.soname;
+                val seen_r: res[bool, fail.Fail] = attributed_library_seen_before(
                     s, modules, module_count, m, sy, soname, prefix, dynlibs, dynlib_count, implicit,
                     sym_locs, sec_base, atoms);
-                if (R.is_err[bool, str](seen_r)) { ret R.err[u32, str](R.unwrap_err[bool, str](seen_r)); }
-                if (!R.unwrap_ok[bool, str](seen_r)) { n = n + 1; }
+                if (sel seen_r.err) { ret res[u32, fail.Fail].err{seen_r.err}; }
+                if (!seen_r.ok) { n = n + 1; }
             }
             sy = sy + 1;
         }
         m = m + 1;
     }
-    ret R.ok[u32, str](n);
+    ret res[u32, fail.Fail].ok{n};
 }
 
 fun has_unresolved_attributed_imports(s: *session.Session, modules: *of.ObjectImage,
                                       module_count: u32, dynlibs: *of.DynLib, dynlib_count: u32,
                                       sym_locs: *map.Map[intern.StrId, SymbolLoc], prefix: str,
-                                      sec_base: *u32, atoms: *AtomPlan) R.Result[bool, str] {
+                                      sec_base: *u32, atoms: *AtomPlan) res[bool, fail.Fail] {
     var m: u32 = 0;
     for (m < module_count) {
         var sy: u32 = 0;
         for (sy < modules[m].symbol_count) {
-            val cand_r: R.Result[O.Option[of.DynLib], str] = attributed_import_candidate(
+            val cand_r: res[opt[of.DynLib], fail.Fail] = attributed_import_candidate(
                 s, modules, module_count, m, sy, prefix, dynlibs, dynlib_count, nil::*of.DynLib,
                 sym_locs, sec_base, atoms);
-            if (R.is_err[O.Option[of.DynLib], str](cand_r)) {
-                ret R.err[bool, str](R.unwrap_err[O.Option[of.DynLib], str](cand_r));
+            if (sel cand_r.err) {
+                ret res[bool, fail.Fail].err{cand_r.err};
             }
-            if (O.is_some[of.DynLib](R.unwrap_ok[O.Option[of.DynLib], str](cand_r))) {
-                ret R.ok[bool, str](true);
+            val cand: opt[of.DynLib] = cand_r.ok;
+            if (sel cand.some) {
+                ret res[bool, fail.Fail].ok{true};
             }
             sy = sy + 1;
         }
         m = m + 1;
     }
-    ret R.ok[bool, str](false);
+    ret res[bool, fail.Fail].ok{false};
 }
 
 fun declared_conflict_message(s: *session.Session, sym: intern.StrId,
@@ -5964,60 +5983,60 @@ rec ImportName {
 }
 
 fun canonical_import_name(s: *session.Session, prefix: str,
-                          name: intern.StrId) R.Result[ImportName, str] {
+                          name: intern.StrId) res[ImportName, fail.Fail] {
     var out: ImportName;
     out.canonical = name;
     out.indirect = false;
-    if (str_empty(prefix)) { ret R.ok[ImportName, str](out); }
+    if (str_empty(prefix)) { ret res[ImportName, fail.Fail].ok{out}; }
 
     val text_o: O.Option[str] = intern.lookup(?s.interner, name);
-    if (!O.is_some[str](text_o)) { ret R.ok[ImportName, str](out); }
+    if (!O.is_some[str](text_o)) { ret res[ImportName, fail.Fail].ok{out}; }
     val text: str = O.unwrap[str](text_o);
     val prefix_len: usize = str_len(prefix);
     if (!str_starts_with(text, prefix) || str_len(text) <= prefix_len) {
-        ret R.ok[ImportName, str](out);
+        ret res[ImportName, fail.Fail].ok{out};
     }
 
     val cr: R.Result[intern.StrId, str] =
         intern.intern(?s.interner, (text::usize + prefix_len)::str);
     if (R.is_err[intern.StrId, str](cr)) {
-        ret R.err[ImportName, str](R.unwrap_err[intern.StrId, str](cr));
+        ret res[ImportName, fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](cr))};
     }
     out.canonical = R.unwrap_ok[intern.StrId, str](cr);
     out.indirect = true;
-    ret R.ok[ImportName, str](out);
+    ret res[ImportName, fail.Fail].ok{out};
 }
 
 fun local_import_candidate(s: *session.Session, prefix: str, sym: *of.Symbol,
                            strong: *map.Map[intern.StrId, u32],
-                           defined: *map.Map[intern.StrId, u32]) R.Result[ImportName, str] {
+                           defined: *map.Map[intern.StrId, u32]) res[ImportName, fail.Fail] {
     var none: ImportName;
     none.canonical = sym.name;
     none.indirect = false;
     if (!is_undefined_extern(sym)
         || (sym.flags & of.SYM_OBJ_FLAG_FALLBACK) != 0) {
-        ret R.ok[ImportName, str](none);
+        ret res[ImportName, fail.Fail].ok{none};
     }
 
-    val cn_r: R.Result[ImportName, str] =
+    val cn_r: res[ImportName, fail.Fail] =
         canonical_import_name(s, prefix, sym.name);
-    if (R.is_err[ImportName, str](cn_r)) {
-        ret R.err[ImportName, str](R.unwrap_err[ImportName, str](cn_r));
+    if (sel cn_r.err) {
+        ret res[ImportName, fail.Fail].err{cn_r.err};
     }
-    val cn: ImportName = R.unwrap_ok[ImportName, str](cn_r);
+    val cn: ImportName = cn_r.ok;
     if (!cn.indirect
-        || R.is_err[*u32, str](map.get[intern.StrId, u32](strong, ?cn.canonical))
-        || R.is_ok[*u32, str](map.get[intern.StrId, u32](defined, ?sym.name))) {
-        ret R.ok[ImportName, str](none);
+        || !map.contains[intern.StrId, u32](strong, ?cn.canonical)
+        || map.contains[intern.StrId, u32](defined, ?sym.name)) {
+        ret res[ImportName, fail.Fail].ok{none};
     }
-    ret R.ok[ImportName, str](cn);
+    ret res[ImportName, fail.Fail].ok{cn};
 }
 
-fun local_import_storage_size(count: u32) R.Result[u32, str] {
+fun local_import_storage_size(count: u32) res[u32, fail.Fail] {
     if (count > 0x1FFFFFFF) {
-        ret R.err[u32, str]("link: local import pointer section exceeds 32 bits");
+        ret res[u32, fail.Fail].err{fail.message("link: local import pointer section exceeds 32 bits")};
     }
-    ret R.ok[u32, str](count * 8);
+    ret res[u32, fail.Fail].ok{count * 8};
 }
 
 fun local_import_referenced(modules: *of.ObjectImage, module_count: u32,
@@ -6091,10 +6110,10 @@ fun declared_import_referenced(s: *session.Session, modules: *of.ObjectImage,
 fun synthesize_local_imports(s: *session.Session, prefix: str,
                              modules: *of.ObjectImage, module_count: u32,
                              mode: LinkMode, sec_base: *u32, atoms: *AtomPlan,
-                             out: *of.ObjectImage) R.Result[bool, str] {
+                             out: *of.ObjectImage) res[bool, fail.Fail] {
     if (str_empty(prefix) || mode == LINK_RELOCATABLE || modules == nil
         || module_count == 0) {
-        ret R.ok[bool, str](false);
+        ret res[bool, fail.Fail].ok{false};
     }
 
     val alloc: *A.Allocator = s.alloc;
@@ -6112,23 +6131,24 @@ fun synthesize_local_imports(s: *session.Session, prefix: str,
                 && of.section_index(sym.section) < modules[m].section_count
                 && (sym.flags & of.SYM_OBJ_FLAG_GLOBAL) != 0
                 && is_loadable_kind(modules[m].sections[of.section_index(sym.section)].kind)) {
-                if (R.is_err[*u32, str](map.get[intern.StrId, u32](?defined, ?sym.name))) {
-                    val di: R.Result[bool, str] =
+                val get_r: opt[*u32] = map.get[intern.StrId, u32](?defined, ?sym.name);
+                if (sel get_r.none) {
+                    val di: res[bool, A.Error] =
                         map.insert[intern.StrId, u32](?defined, sym.name, 0);
-                    if (R.is_err[bool, str](di)) {
+                    if (sel di.err) {
                         map.dnit[intern.StrId, u32](?defined);
                         map.dnit[intern.StrId, u32](?strong);
-                        ret R.err[bool, str](R.unwrap_err[bool, str](di));
+                        ret res[bool, fail.Fail].err{fail.refused(di.err)};
                     }
                 }
                 if ((sym.flags & of.SYM_OBJ_FLAG_WEAK) == 0
-                    && R.is_err[*u32, str](map.get[intern.StrId, u32](?strong, ?sym.name))) {
-                    val si: R.Result[bool, str] =
+                    && !map.contains[intern.StrId, u32](?strong, ?sym.name)) {
+                    val si: res[bool, A.Error] =
                         map.insert[intern.StrId, u32](?strong, sym.name, 0);
-                    if (R.is_err[bool, str](si)) {
+                    if (sel si.err) {
                         map.dnit[intern.StrId, u32](?defined);
                         map.dnit[intern.StrId, u32](?strong);
-                        ret R.err[bool, str](R.unwrap_err[bool, str](si));
+                        ret res[bool, fail.Fail].err{fail.refused(si.err)};
                     }
                 }
             }
@@ -6145,32 +6165,32 @@ fun synthesize_local_imports(s: *session.Session, prefix: str,
         var sy: u32 = 0;
         for (sy < modules[m].symbol_count) {
             val sym: *of.Symbol = ?modules[m].symbols[sy];
-            val cn_r: R.Result[ImportName, str] =
+            val cn_r: res[ImportName, fail.Fail] =
                 local_import_candidate(s, prefix, sym, ?strong, ?defined);
-            if (R.is_err[ImportName, str](cn_r)) {
+            if (sel cn_r.err) {
                 map.dnit[intern.StrId, u32](?seen);
                 map.dnit[intern.StrId, u32](?defined);
                 map.dnit[intern.StrId, u32](?strong);
-                ret R.err[bool, str](R.unwrap_err[ImportName, str](cn_r));
+                ret res[bool, fail.Fail].err{cn_r.err};
             }
-            val cn: ImportName = R.unwrap_ok[ImportName, str](cn_r);
+            val cn: ImportName = cn_r.ok;
             if (cn.indirect
                 && local_import_referenced(
                     modules, module_count, sym.name, sec_base, atoms)
-                && R.is_err[*u32, str](map.get[intern.StrId, u32](?seen, ?sym.name))) {
+                && !map.contains[intern.StrId, u32](?seen, ?sym.name)) {
                 if (count == 0x1FFFFFFF) {
                     map.dnit[intern.StrId, u32](?seen);
                     map.dnit[intern.StrId, u32](?defined);
                     map.dnit[intern.StrId, u32](?strong);
-                    ret R.err[bool, str]("link: local import pointer section exceeds 32 bits");
+                    ret res[bool, fail.Fail].err{fail.message("link: local import pointer section exceeds 32 bits")};
                 }
-                val ins: R.Result[bool, str] =
+                val ins: res[bool, A.Error] =
                     map.insert[intern.StrId, u32](?seen, sym.name, count);
-                if (R.is_err[bool, str](ins)) {
+                if (sel ins.err) {
                     map.dnit[intern.StrId, u32](?seen);
                     map.dnit[intern.StrId, u32](?defined);
                     map.dnit[intern.StrId, u32](?strong);
-                    ret R.err[bool, str](R.unwrap_err[bool, str](ins));
+                    ret res[bool, fail.Fail].err{fail.refused(ins.err)};
                 }
                 count = count + 1;
             }
@@ -6183,7 +6203,7 @@ fun synthesize_local_imports(s: *session.Session, prefix: str,
     if (count == 0) {
         map.dnit[intern.StrId, u32](?defined);
         map.dnit[intern.StrId, u32](?strong);
-        ret R.ok[bool, str](false);
+        ret res[bool, fail.Fail].ok{false};
     }
 
     val image_name_r: R.Result[intern.StrId, str] =
@@ -6195,62 +6215,67 @@ fun synthesize_local_imports(s: *session.Session, prefix: str,
         map.dnit[intern.StrId, u32](?defined);
         map.dnit[intern.StrId, u32](?strong);
         if (R.is_err[intern.StrId, str](image_name_r)) {
-            ret R.err[bool, str](R.unwrap_err[intern.StrId, str](image_name_r));
+            ret res[bool, fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](image_name_r))};
         }
-        ret R.err[bool, str](R.unwrap_err[intern.StrId, str](section_name_r));
+        ret res[bool, fail.Fail].err{fail.message(R.unwrap_err[intern.StrId, str](section_name_r))};
     }
-    @out = R.unwrap_ok[of.ObjectImage, str](
-        obj.init(alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](image_name_r)));
+    val image_r: res[of.ObjectImage, fail.Fail] = obj.image_init(alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](image_name_r));
+    if (sel image_r.err) {
+        map.dnit[intern.StrId, u32](?defined);
+        map.dnit[intern.StrId, u32](?strong);
+        ret res[bool, fail.Fail].err{image_r.err};
+    }
+    @out = image_r.ok;
 
-    val size_r: R.Result[u32, str] = local_import_storage_size(count);
-    if (R.is_err[u32, str](size_r)) {
+    val size_r: res[u32, fail.Fail] = local_import_storage_size(count);
+    if (sel size_r.err) {
         map.dnit[intern.StrId, u32](?defined);
         map.dnit[intern.StrId, u32](?strong);
-        ret R.err[bool, str](R.unwrap_err[u32, str](size_r));
+        ret res[bool, fail.Fail].err{size_r.err};
     }
-    val byte_count: u32 = R.unwrap_ok[u32, str](size_r);
-    val bytes_r: R.Result[*u8, str] = A.zallocate[u8](alloc, byte_count::usize);
-    if (R.is_err[*u8, str](bytes_r)) {
+    val byte_count: u32 = size_r.ok;
+    val bytes_r: res[*u8, A.Error] = A.zallocate[u8](alloc, byte_count::usize);
+    if (sel bytes_r.err) {
         map.dnit[intern.StrId, u32](?defined);
         map.dnit[intern.StrId, u32](?strong);
-        ret R.err[bool, str](R.unwrap_err[*u8, str](bytes_r));
+        ret res[bool, fail.Fail].err{fail.refused(bytes_r.err)};
     }
     var sec: of.Section;
     sec.name = R.unwrap_ok[intern.StrId, str](section_name_r);
     sec.kind = of.SK_RELRO;
-    sec.bytes = R.unwrap_ok[*u8, str](bytes_r);
+    sec.bytes = bytes_r.ok;
     sec.len = byte_count;
     sec.align = 8;
     sec.flags = 0;
-    val sec_r: R.Result[u32, str] = obj.install_section(out, ?sec);
-    if (R.is_err[u32, str](sec_r)) {
+    val sec_r: res[u32, fail.Fail] = obj.section_install(out, ?sec);
+    if (sel sec_r.err) {
         obj.dnit(out);
         map.dnit[intern.StrId, u32](?defined);
         map.dnit[intern.StrId, u32](?strong);
-        ret R.err[bool, str](R.unwrap_err[u32, str](sec_r));
+        ret res[bool, fail.Fail].err{sec_r.err};
     }
 
-    val symbols_r: R.Result[*of.Symbol, str] =
+    val symbols_r: res[*of.Symbol, A.Error] =
         A.zallocate[of.Symbol](alloc, (count * 2)::usize);
-    if (R.is_err[*of.Symbol, str](symbols_r)) {
+    if (sel symbols_r.err) {
         obj.dnit(out);
         map.dnit[intern.StrId, u32](?defined);
         map.dnit[intern.StrId, u32](?strong);
-        ret R.err[bool, str](R.unwrap_err[*of.Symbol, str](symbols_r));
+        ret res[bool, fail.Fail].err{fail.refused(symbols_r.err)};
     }
-    out.symbols = R.unwrap_ok[*of.Symbol, str](symbols_r);
+    out.symbols = symbols_r.ok;
     out.symbol_count = count * 2;
     out.symbol_cap = count * 2;
 
-    val relocs_r: R.Result[*of.Relocation, str] =
+    val relocs_r: res[*of.Relocation, A.Error] =
         A.zallocate[of.Relocation](alloc, count::usize);
-    if (R.is_err[*of.Relocation, str](relocs_r)) {
+    if (sel relocs_r.err) {
         obj.dnit(out);
         map.dnit[intern.StrId, u32](?defined);
         map.dnit[intern.StrId, u32](?strong);
-        ret R.err[bool, str](R.unwrap_err[*of.Relocation, str](relocs_r));
+        ret res[bool, fail.Fail].err{fail.refused(relocs_r.err)};
     }
-    out.relocations = R.unwrap_ok[*of.Relocation, str](relocs_r);
+    out.relocations = relocs_r.ok;
     out.reloc_count = count;
     out.reloc_cap = count;
 
@@ -6261,30 +6286,30 @@ fun synthesize_local_imports(s: *session.Session, prefix: str,
         var sy: u32 = 0;
         for (sy < modules[m].symbol_count) {
             val sym: *of.Symbol = ?modules[m].symbols[sy];
-            val cn_r: R.Result[ImportName, str] =
+            val cn_r: res[ImportName, fail.Fail] =
                 local_import_candidate(s, prefix, sym, ?strong, ?defined);
-            if (R.is_err[ImportName, str](cn_r)) {
+            if (sel cn_r.err) {
                 map.dnit[intern.StrId, u32](?seen);
                 obj.dnit(out);
                 map.dnit[intern.StrId, u32](?defined);
                 map.dnit[intern.StrId, u32](?strong);
-                ret R.err[bool, str](R.unwrap_err[ImportName, str](cn_r));
+                ret res[bool, fail.Fail].err{cn_r.err};
             }
-            val cn: ImportName = R.unwrap_ok[ImportName, str](cn_r);
+            val cn: ImportName = cn_r.ok;
             if (!cn.indirect
                 || !local_import_referenced(
                     modules, module_count, sym.name, sec_base, atoms)
-                || R.is_ok[*u32, str](map.get[intern.StrId, u32](?seen, ?sym.name))) {
+                || map.contains[intern.StrId, u32](?seen, ?sym.name)) {
                 sy = sy + 1; cnt;
             }
-            val ins: R.Result[bool, str] =
+            val ins: res[bool, A.Error] =
                 map.insert[intern.StrId, u32](?seen, sym.name, w);
-            if (R.is_err[bool, str](ins)) {
+            if (sel ins.err) {
                 map.dnit[intern.StrId, u32](?seen);
                 obj.dnit(out);
                 map.dnit[intern.StrId, u32](?defined);
                 map.dnit[intern.StrId, u32](?strong);
-                ret R.err[bool, str](R.unwrap_err[bool, str](ins));
+                ret res[bool, fail.Fail].err{fail.refused(ins.err)};
             }
 
             val alias_ix: u32 = w * 2;
@@ -6320,13 +6345,13 @@ fun synthesize_local_imports(s: *session.Session, prefix: str,
     map.dnit[intern.StrId, u32](?strong);
     if (w != count) {
         obj.dnit(out);
-        ret R.err[bool, str]("link: local import pointer synthesis changed between passes");
+        ret res[bool, fail.Fail].err{fail.message("link: local import pointer synthesis changed between passes")};
     }
     val valid: R.Result[R.Void, str] = of.validate_owned_object_or_dnit(out);
     if (R.is_err[R.Void, str](valid)) {
-        ret R.err[bool, str](R.unwrap_err[R.Void, str](valid));
+        ret res[bool, fail.Fail].err{fail.message(R.unwrap_err[R.Void, str](valid))};
     }
-    ret R.ok[bool, str](true);
+    ret res[bool, fail.Fail].ok{true};
 }
 
 fun is_undefined_extern(sym: *of.Symbol) bool {
@@ -6335,11 +6360,11 @@ fun is_undefined_extern(sym: *of.Symbol) bool {
     ret true;
 }
 
-fun dynstate_import_index(dyn: *DynState, name: intern.StrId) R.Result[u32, str] {
-    if (!dyn.active) { ret R.err[u32, str]("not dynamic"); }
-    val g: R.Result[*u32, str] = map.get[intern.StrId, u32](?dyn.import_map, ?name);
-    if (R.is_err[*u32, str](g)) { ret R.err[u32, str]("not an import"); }
-    ret R.ok[u32, str](@R.unwrap_ok[*u32, str](g));
+fun dynstate_import_index(dyn: *DynState, name: intern.StrId) res[u32, fail.Fail] {
+    if (!dyn.active) { ret res[u32, fail.Fail].err{fail.message("not dynamic")}; }
+    val g: opt[*u32] = map.get[intern.StrId, u32](?dyn.import_map, ?name);
+    if (sel g.none) { ret res[u32, fail.Fail].err{fail.message("not an import")}; }
+    ret res[u32, fail.Fail].ok{@g.some};
 }
 
 fun dynstate_import_is_func(dyn: *DynState, idx: u32) bool {
@@ -6385,22 +6410,22 @@ fun local_got_slot_index(plan: *LocalGotPlan, module: u32, symbol: u32,
 
 fun local_got_add(s: *session.Session, plan: *LocalGotPlan,
                   module: u32, symbol: u32, name: intern.StrId,
-                  local: bool) R.Result[R.Void, str] {
+                  local: bool) err[fail.Fail] {
     if (local_got_slot_index(plan, module, symbol, name, local) != 0xFFFFFFFF) {
-        ret R.ok_void[str]();
+        ret err[fail.Fail].ok{};
     }
     if (plan.count == plan.cap) {
         if (plan.cap > 0x7FFFFFFF) {
-            ret R.err[R.Void, str]("linker: synthesized GOT slot count overflow");
+            ret err[fail.Fail].err{fail.message("linker: synthesized GOT slot count overflow")};
         }
         var next: u32 = plan.cap * 2;
         if (next == 0) { next = 8; }
-        val gr: R.Result[*LocalGotSlot, str] = A.reallocate[LocalGotSlot](
+        val gr: res[*LocalGotSlot, A.Error] = A.reallocate[LocalGotSlot](
             s.alloc, plan.slots, plan.cap::usize, next::usize);
-        if (R.is_err[*LocalGotSlot, str](gr)) {
-            ret R.err[R.Void, str](R.unwrap_err[*LocalGotSlot, str](gr));
+        if (sel gr.err) {
+            ret err[fail.Fail].err{fail.refused(gr.err)};
         }
-        plan.slots = R.unwrap_ok[*LocalGotSlot, str](gr);
+        plan.slots = gr.ok;
         plan.cap = next;
     }
     val i: u32 = plan.count;
@@ -6412,7 +6437,7 @@ fun local_got_add(s: *session.Session, plan: *LocalGotPlan,
     plan.slots[i].local = local;
     plan.slots[i].initialized = false;
     plan.count = i + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun build_local_got_plan(s: *session.Session, arch: *isa.IsaVTable,
@@ -6420,10 +6445,10 @@ fun build_local_got_plan(s: *session.Session, arch: *isa.IsaVTable,
                          module_count: u32, sym_locs: *map.Map[intern.StrId, SymbolLoc],
                          sec_base: *u32, atoms: *AtomPlan,
                          merged: *MergedSection, groups: *SectionGroups,
-                         plan: *LocalGotPlan) R.Result[R.Void, str] {
-    if (!isa.declares_local_got(arch)) { ret R.ok_void[str](); }
+                         plan: *LocalGotPlan) err[fail.Fail] {
+    if (!isa.declares_local_got(arch)) { ret err[fail.Fail].ok{}; }
     val width: u32 = arch.pointer_width;
-    if (width != 4 && width != 8) { ret R.err[R.Void, str]("linker: unsupported GOT pointer width"); }
+    if (width != 4 && width != 8) { ret err[fail.Fail].err{fail.message("linker: unsupported GOT pointer width")}; }
     var m: u32 = 0;
     for (m < module_count) {
         var ri: u32 = 0;
@@ -6431,7 +6456,7 @@ fun build_local_got_plan(s: *session.Session, arch: *isa.IsaVTable,
             val r: *of.Relocation = ?modules[m].relocations[ri];
             if (!reloc_source_live(modules, m, r, sec_base, atoms)) { ri = ri + 1; cnt; }
             val resolved: R.Result[of.RelocOperand, str] = rel.resolve_operand(arch, ?modules[m], ri);
-            if (R.is_err[of.RelocOperand, str](resolved)) { ret R.err[R.Void, str](R.unwrap_err[of.RelocOperand, str](resolved)); }
+            if (R.is_err[of.RelocOperand, str](resolved)) { ret err[fail.Fail].err{fail.message(R.unwrap_err[of.RelocOperand, str](resolved))}; }
             val operand: of.RelocOperand = R.unwrap_ok[of.RelocOperand, str](resolved);
             if (!isa.local_got_kind(arch, operand.target_kind) || operand.sym >= modules[m].symbol_count) {
                 ri = ri + 1; cnt;
@@ -6445,35 +6470,35 @@ fun build_local_got_plan(s: *session.Session, arch: *isa.IsaVTable,
                 && (target.flags & of.SYM_OBJ_FLAG_GLOBAL) == 0;
             var effective: intern.StrId = target.name;
             if (!local) {
-                val rr: R.Result[intern.StrId, str] =
+                val rr: res[intern.StrId, fail.Fail] =
                     resolved_symbol_name(sym_locs, target.name);
-                if (R.is_err[intern.StrId, str](rr)) {
-                    ret R.err[R.Void, str](R.unwrap_err[intern.StrId, str](rr));
+                if (sel rr.err) {
+                    ret err[fail.Fail].err{rr.err};
                 }
-                effective = R.unwrap_ok[intern.StrId, str](rr);
-                if (R.is_err[*SymbolLoc, str](
-                        map.get[intern.StrId, SymbolLoc](sym_locs, ?effective))) {
+                effective = rr.ok;
+                val get_r: opt[*SymbolLoc] = map.get[intern.StrId, SymbolLoc](sym_locs, ?effective);
+                if (sel get_r.none) {
                     ri = ri + 1; cnt;
                 }
             }
-            val ar: R.Result[R.Void, str] =
+            val ar: err[fail.Fail] =
                 local_got_add(s, plan, m, operand.sym, effective, local);
-            if (R.is_err[R.Void, str](ar)) {
+            if (sel ar.err) {
                 ret ar;
             }
             ri = ri + 1;
         }
         m = m + 1;
     }
-    if (plan.count == 0) { ret R.ok_void[str](); }
+    if (plan.count == 0) { ret err[fail.Fail].ok{}; }
 
     val relro: u32 = of.SK_RELRO::u32;
-    val start_r: R.Result[u64, str] = align_up_u64_checked(merged[relro].len::u64, width::u64);
-    if (R.is_err[u64, str](start_r)) { ret R.err[R.Void, str](R.unwrap_err[u64, str](start_r)); }
-    val start: u64 = R.unwrap_ok[u64, str](start_r);
+    val start_r: res[u64, fail.Fail] = align_up_u64_checked(merged[relro].len::u64, width::u64);
+    if (sel start_r.err) { ret err[fail.Fail].err{start_r.err}; }
+    val start: u64 = start_r.ok;
     val end: u64 = start + plan.count::u64 * width::u64;
     if (end > 0xFFFFFFFF) {
-        ret R.err[R.Void, str]("linker: synthesized GOT exceeds the maximum section size");
+        ret err[fail.Fail].err{fail.message("linker: synthesized GOT exceeds the maximum section size")};
     }
     var i: u32 = 0;
     for (i < plan.count) {
@@ -6485,14 +6510,14 @@ fun build_local_got_plan(s: *session.Session, arch: *isa.IsaVTable,
     merged[relro].len = end::u32;
 
     val gn: intern.StrId = intern_or_nil(s, "__got");
-    val ga: R.Result[u32, str] = section_group_add(s.alloc, groups, relro, gn, 0);
-    if (R.is_err[u32, str](ga)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](ga)); }
-    val gi: u32 = R.unwrap_ok[u32, str](ga);
+    val ga: res[u32, fail.Fail] = section_group_add(s.alloc, groups, relro, gn, 0);
+    if (sel ga.err) { ret err[fail.Fail].err{ga.err}; }
+    val gi: u32 = ga.ok;
     groups.items[gi].align  = width;
     groups.items[gi].base   = start::u32;
     groups.items[gi].cursor = end::u32;
     groups.items[gi].len    = (end - start)::u32;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun finalize_local_got_vaddrs(merged: *MergedSection, plan: *LocalGotPlan) {
@@ -6533,11 +6558,11 @@ fun final_section_location_for(format: *of.OfVTable, image_base: u64,
 }
 
 fun dynstate_add_fixup(s: *session.Session, dyn: *DynState, seg_index: u32, seg_offset: u32,
-                       import_index: u32, patch_vaddr: u64, addend: i64) R.Result[R.Void, str] {
+                       import_index: u32, patch_vaddr: u64, addend: i64) err[fail.Fail] {
     val alloc: *A.Allocator = s.alloc;
     if (dyn.fixup_count == dyn.fixup_cap) {
-        val grown: R.Result[R.Void, str] = grow_cap[of.PltFixup](alloc, ?dyn.fixups, ?dyn.fixup_cap, 4);
-        if (R.is_err[R.Void, str](grown)) { ret grown; }
+        val grown: err[fail.Fail] = grow_cap[of.PltFixup](alloc, ?dyn.fixups, ?dyn.fixup_cap, 4);
+        if (sel grown.err) { ret grown; }
     }
     val ix: u32 = dyn.fixup_count;
     dyn.fixups[ix].seg_index    = seg_index;
@@ -6546,18 +6571,18 @@ fun dynstate_add_fixup(s: *session.Session, dyn: *DynState, seg_index: u32, seg_
     dyn.fixups[ix].patch_vaddr  = patch_vaddr;
     dyn.fixups[ix].addend       = addend;
     dyn.fixup_count = ix + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun dynstate_add_import_addr_fixup(s: *session.Session, dyn: *DynState,
                                    seg_index: u32, seg_offset: u32,
                                    import_index: u32, patch_vaddr: u64,
-                                   kind: of.RelocKind, addend: i64) R.Result[R.Void, str] {
+                                   kind: of.RelocKind, addend: i64) err[fail.Fail] {
     val alloc: *A.Allocator = s.alloc;
     if (dyn.info.import_addr_fixup_count == dyn.import_addr_fixup_cap) {
-        val grown: R.Result[R.Void, str] =
+        val grown: err[fail.Fail] =
             grow_cap[of.ImportAddrFixup](alloc, ?dyn.info.import_addr_fixups, ?dyn.import_addr_fixup_cap, 4);
-        if (R.is_err[R.Void, str](grown)) { ret grown; }
+        if (sel grown.err) { ret grown; }
     }
     val ix: u32 = dyn.info.import_addr_fixup_count;
     dyn.info.import_addr_fixups[ix].seg_index    = seg_index;
@@ -6567,45 +6592,45 @@ fun dynstate_add_import_addr_fixup(s: *session.Session, dyn: *DynState,
     dyn.info.import_addr_fixups[ix].kind         = kind;
     dyn.info.import_addr_fixups[ix].addend       = addend;
     dyn.info.import_addr_fixup_count = ix + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun dynstate_add_base_reloc(s: *session.Session, dyn: *DynState, seg_index: u32,
-                            seg_offset: u32, target: u64) R.Result[R.Void, str] {
+                            seg_offset: u32, target: u64) err[fail.Fail] {
     val alloc: *A.Allocator = s.alloc;
     if (dyn.info.base_reloc_count == dyn.base_reloc_cap) {
-        val grown: R.Result[R.Void, str] =
+        val grown: err[fail.Fail] =
             grow_cap[of.BaseReloc](alloc, ?dyn.info.base_relocs, ?dyn.base_reloc_cap, 8);
-        if (R.is_err[R.Void, str](grown)) { ret grown; }
+        if (sel grown.err) { ret grown; }
     }
     val ix: u32 = dyn.info.base_reloc_count;
     dyn.info.base_relocs[ix].seg_index  = seg_index;
     dyn.info.base_relocs[ix].seg_offset = seg_offset;
     dyn.info.base_relocs[ix].target     = target;
     dyn.info.base_reloc_count = ix + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun apply_one(s: *session.Session, kind: of.RelocKind,
              dst: *u8, patch_off: u32, sec_len: u32,
              target: rel.RelocTarget, addend: i64, patch_va: u64,
              sym_name: intern.StrId, arch: *isa.IsaVTable,
-             image_base: u64) R.Result[R.Void, str] {
+             image_base: u64) err[fail.Fail] {
     if (!isa.emits_relocations(arch)) {
-        ret R.err[R.Void, str](unsupported_message(s, arch, kind));
+        ret err[fail.Fail].err{fail.message(unsupported_message(s, arch, kind))};
     }
     val r: R.Result[bool, rel.RelocError] =
         arch.reloc.apply(kind, dst, patch_off, sec_len,
                          target, addend, patch_va, image_base);
-    if (!R.is_err[bool, rel.RelocError](r)) { ret R.ok_void[str](); }
-    val err: rel.RelocError = R.unwrap_err[bool, rel.RelocError](r);
-    if (err == rel.RELOC_OVERFLOW) {
-        ret R.err[R.Void, str](overflow_message(s, kind, sym_name));
+    if (!R.is_err[bool, rel.RelocError](r)) { ret err[fail.Fail].ok{}; }
+    val error: rel.RelocError = R.unwrap_err[bool, rel.RelocError](r);
+    if (error == rel.RELOC_OVERFLOW) {
+        ret err[fail.Fail].err{fail.message(overflow_message(s, kind, sym_name))};
     }
-    if (err == rel.RELOC_INVALID_INSTRUCTION) {
-        ret R.err[R.Void, str](invalid_relocation_instruction_message(s, kind));
+    if (error == rel.RELOC_INVALID_INSTRUCTION) {
+        ret err[fail.Fail].err{fail.message(invalid_relocation_instruction_message(s, kind))};
     }
-    ret R.err[R.Void, str](unsupported_message(s, arch, kind));
+    ret err[fail.Fail].err{fail.message(unsupported_message(s, arch, kind))};
 }
 
 fun intern_or_nil(s: *session.Session, name: str) intern.StrId {
@@ -6640,9 +6665,9 @@ fun header_reserve_bytes(tgt: *target.Target, pie: bool, shape: *of.HeaderShape)
     if (tgt.of == nil || tgt.of.header_span == nil || shape == nil) { ret page; }
     val want: u64 = tgt.of.header_span(shape, page);
     if (want <= page) { ret page; }
-    val rounded: R.Result[u64, str] = align_up_u64_checked(want, page);
-    if (R.is_err[u64, str](rounded)) { ret page; }
-    ret R.unwrap_ok[u64, str](rounded);
+    val rounded: res[u64, fail.Fail] = align_up_u64_checked(want, page);
+    if (sel rounded.err) { ret page; }
+    ret rounded.ok;
 }
 
 fun measure_header_shape(s: *session.Session, out_img: *of.ObjectImage, merged: *MergedSection,
@@ -6762,11 +6787,11 @@ fun dwarf_addend_message(s: *session.Session, modules: *of.ObjectImage, m: u32,
         val sn: O.Option[str] = intern.lookup(?s.interner, modules[m].sections[of.section_index(r.section)].name);
         if (O.is_some[str](sn)) { sec = O.unwrap[str](sn); }
     }
-    val res: R.Result[str, str] = format.sprint(s.alloc,
+    val result: res[str, format.FormatError] = format.sprint(s.alloc,
         "linker: {} relocation against '{}' with addend {} crosses a discarded body; its address would be stale",
         sec, O.unwrap[str](nm), r.addend);
-    if (R.is_err[str, str](res)) { ret fallback; }
-    ret R.unwrap_ok[str, str](res);
+    if (sel result.err) { ret fallback; }
+    ret result.ok;
 }
 
 fun undef_message(s: *session.Session, name: intern.StrId) str {
@@ -6986,9 +7011,9 @@ fun join2(s: *session.Session, a: str, b: str, prefix: str) str {
     val lb: usize = str_len(b);
     val total: usize = la + lb;
 
-    val r: R.Result[*u8, str] = A.allocate[u8](s.alloc, total + 1);
-    if (R.is_err[*u8, str](r)) { ret prefix; }
-    val buf: *u8 = R.unwrap_ok[*u8, str](r);
+    val r: res[*u8, A.Error] = A.allocate[u8](s.alloc, total + 1);
+    if (sel r.err) { ret prefix; }
+    val buf: *u8 = r.ok;
 
     copy_bytes(buf, 0, a, la);
     copy_bytes(buf, la, b, lb);
@@ -7009,9 +7034,9 @@ fun join3(s: *session.Session, a: str, b: str, c: str, prefix: str) str {
     val lc: usize = str_len(c);
     val total: usize = la + lb + lc;
 
-    val r: R.Result[*u8, str] = A.allocate[u8](s.alloc, total + 1);
-    if (R.is_err[*u8, str](r)) { ret prefix; }
-    val buf: *u8 = R.unwrap_ok[*u8, str](r);
+    val r: res[*u8, A.Error] = A.allocate[u8](s.alloc, total + 1);
+    if (sel r.err) { ret prefix; }
+    val buf: *u8 = r.ok;
 
     copy_bytes(buf, 0, a, la);
     copy_bytes(buf, la, b, lb);
@@ -7083,7 +7108,7 @@ fun free_modules_to(alloc: *A.Allocator, modules: *of.ObjectImage, n: u32, cap: 
     }
 }
 
-fun lt_link(s: *session.Session, name: intern.StrId, a: *of.Symbol, b: *of.Symbol) R.Result[u64, str] {
+fun lt_link(s: *session.Session, name: intern.StrId, a: *of.Symbol, b: *of.Symbol) res[u64, fail.Fail] {
     var placements: [2]Placement;
     placements[0].vaddr = 0x1000; placements[0].offset = 0; placements[0].merged_index = 0;
     placements[1].vaddr = 0x2000; placements[1].offset = 0; placements[1].merged_index = 0;
@@ -7098,21 +7123,21 @@ fun lt_link(s: *session.Session, name: intern.StrId, a: *of.Symbol, b: *of.Symbo
 
     var locs: map.Map[intern.StrId, SymbolLoc] =
         map.init[intern.StrId, SymbolLoc](s.alloc, map.hash_u32, map.eq_u32);
-    val cr: R.Result[R.Void, str] =
+    val cr: err[fail.Fail] =
         collect_symbols(s, ?mods[0], 2, ?placements[0], ?sec_base[0],
                         ?locs, true, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](cr)) {
+    if (sel cr.err) {
         map.dnit[intern.StrId, SymbolLoc](?locs);
-        ret R.err[u64, str](R.unwrap_err[R.Void, str](cr));
+        ret res[u64, fail.Fail].err{cr.err};
     }
-    val g: R.Result[*SymbolLoc, str] = map.get[intern.StrId, SymbolLoc](?locs, ?name);
-    if (R.is_err[*SymbolLoc, str](g)) {
+    val g: opt[*SymbolLoc] = map.get[intern.StrId, SymbolLoc](?locs, ?name);
+    if (sel g.none) {
         map.dnit[intern.StrId, SymbolLoc](?locs);
-        ret R.err[u64, str]("missing");
+        ret res[u64, fail.Fail].err{fail.message("missing")};
     }
-    val v: u64 = R.unwrap_ok[*SymbolLoc, str](g).vaddr;
+    val v: u64 = g.some.vaddr;
     map.dnit[intern.StrId, SymbolLoc](?locs);
-    ret R.ok[u64, str](v);
+    ret res[u64, fail.Fail].ok{v};
 }
 
 fun lt_name(s: *session.Session, name: str) intern.StrId {
@@ -7146,13 +7171,13 @@ test "mach.lang.be.linker.contribution_overlap:two_claims_on_one_range_are_named
     modules[1] = lt_image(?s, lt_name(?s, "right.o"), ?sections[1], 1,
                           nil::*of.Symbol, 0, nil::*of.Relocation, 0);
 
-    val merged_count_r: R.Result[u32, str] = merged_section_count(0);
-    if (R.is_err[u32, str](merged_count_r)) { ret 2; }
-    val merged_count: u32 = R.unwrap_ok[u32, str](merged_count_r);
-    val merged_r: R.Result[*MergedSection, str] =
+    val merged_count_r: res[u32, fail.Fail] = merged_section_count(0);
+    if (sel merged_count_r.err) { ret 2; }
+    val merged_count: u32 = merged_count_r.ok;
+    val merged_r: res[*MergedSection, A.Error] =
         A.zallocate[MergedSection](?alloc, merged_count::usize);
-    if (R.is_err[*MergedSection, str](merged_r)) { ret 3; }
-    val merged: *MergedSection = R.unwrap_ok[*MergedSection, str](merged_r);
+    if (sel merged_r.err) { ret 3; }
+    val merged: *MergedSection = merged_r.ok;
     init_merged(merged, nil::*intern.StrId, 0);
 
     var placements: [2]Placement;
@@ -7167,34 +7192,34 @@ test "mach.lang.be.linker.contribution_overlap:two_claims_on_one_range_are_named
     var groups: SectionGroups;
     init_section_groups(?groups);
 
-    val acc: R.Result[R.Void, str] = accumulate_sections(
+    val acc: err[fail.Fail] = accumulate_sections(
         ?s, ?modules[0], 2, merged, nil::*intern.StrId, 0,
         ?placements[0], ?sec_base[0], ?strm, ?atoms, ?groups);
     var bad: i32 = 0;
-    if (R.is_err[R.Void, str](acc))       { bad = 4; }
+    if (sel acc.err)       { bad = 4; }
     or (placements[0].extent != 8)      { bad = 5; }
     or (placements[1].extent != 8)      { bad = 6; }
     or (placements[1].offset != 8)      { bad = 7; }
     if (bad != 0) { ret bad; }
 
-    val clean: R.Result[R.Void, str] = validate_no_contribution_overlap(
+    val clean: err[fail.Fail] = validate_no_contribution_overlap(
         ?s, ?modules[0], 2, ?sec_base[0], ?placements[0], 2);
-    if (R.is_err[R.Void, str](clean)) { ret 8; }
+    if (sel clean.err) { ret 8; }
 
     placements[1].offset = 4;
-    val clash: R.Result[R.Void, str] = validate_no_contribution_overlap(
+    val clash: err[fail.Fail] = validate_no_contribution_overlap(
         ?s, ?modules[0], 2, ?sec_base[0], ?placements[0], 2);
-    if (!R.is_err[R.Void, str](clash)) { ret 9; }
-    val msg: str = R.unwrap_err[R.Void, str](clash);
+    if (!sel clash.err) { ret 9; }
+    val msg: str = fail.describe(clash.err);
     if (!str_contains(msg, "left.o:.text"))  { ret 10; }
     if (!str_contains(msg, "right.o:.text")) { ret 11; }
 
     placements[1].offset = 8;
     placements[1].extent = 0;
     placements[0].extent = 32;
-    val aliased: R.Result[R.Void, str] = validate_no_contribution_overlap(
+    val aliased: err[fail.Fail] = validate_no_contribution_overlap(
         ?s, ?modules[0], 2, ?sec_base[0], ?placements[0], 2);
-    if (R.is_err[R.Void, str](aliased)) { ret 12; }
+    if (sel aliased.err) { ret 12; }
     ret 0;
 }
 
@@ -7232,14 +7257,17 @@ test "mach.lang.be.linker.validate_link_inputs:checks_each_borrowed_image_before
     var image: of.ObjectImage = lt_image(
         ?s, lt_name(?s, "input"), ?section, 1,
         nil::*of.Symbol, 0, nil::*of.Relocation, 0);
-    if (R.is_err[R.Void, str](validate_link_inputs(?image, 1))) { ret 1; }
-    if (R.is_err[R.Void, str](validate_link_inputs(nil::*of.ObjectImage, 0))) { ret 1; }
-    if (R.is_ok[R.Void, str](validate_link_inputs(nil::*of.ObjectImage, 1))) { ret 1; }
+    val validate_link_inputs_r: err[fail.Fail] = validate_link_inputs(?image, 1);
+    if (sel validate_link_inputs_r.err) { ret 1; }
+    val validate_link_inputs_r2: err[fail.Fail] = validate_link_inputs(nil::*of.ObjectImage, 0);
+    if (sel validate_link_inputs_r2.err) { ret 1; }
+    val validate_link_inputs_r3: err[fail.Fail] = validate_link_inputs(nil::*of.ObjectImage, 1);
+    if (sel validate_link_inputs_r3.ok) { ret 1; }
 
     section.align = 3;
-    val invalid: R.Result[R.Void, str] = validate_link_inputs(?image, 1);
-    if (R.is_ok[R.Void, str](invalid)) { ret 1; }
-    if (!str_contains(R.unwrap_err[R.Void, str](invalid), "alignment")) { ret 1; }
+    val invalid: err[fail.Fail] = validate_link_inputs(?image, 1);
+    if (sel invalid.ok) { ret 1; }
+    if (!str_contains(fail.describe(invalid.err), "alignment")) { ret 1; }
     ret 0;
 }
 
@@ -7262,25 +7290,25 @@ test "mach.lang.be.linker.link_mode:rejects_invalid_before_input_work" {
 
     var paths: [1]*u8;
     paths[0] = "/mach-link-mode-must-not-touch-object-io"::*u8;
-    val from_paths: R.Result[R.Void, str] = t_planned_link(
+    val from_paths: err[fail.Fail] = t_planned_link(
         ?s, ?tgt, ?paths[0], 1, nil::*of.DynLib, 0, ""::*u8, "invalid"::*u8,
         invalid, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
-    if (R.is_ok[R.Void, str](from_paths)
-        || !str_contains(R.unwrap_err[R.Void, str](from_paths), "invalid link mode")) { ret 1; }
+    if (sel from_paths.ok) { ret 1; }
+    if (!str_contains(fail.describe(from_paths.err), "invalid link mode")) { ret 1; }
 
-    val from_images: R.Result[R.Void, str] = t_planned_link_images(
+    val from_images: err[fail.Fail] = t_planned_link_images(
         ?s, ?tgt, nil::*of.ObjectImage, 0, nil::*of.DynLib, 0,
         ""::*u8, "invalid"::*u8, invalid, false,
         of.image_options_default(of.SUBSYSTEM_CONSOLE));
-    if (R.is_ok[R.Void, str](from_images)
-        || !str_contains(R.unwrap_err[R.Void, str](from_images), "invalid link mode")) { ret 1; }
+    if (sel from_images.ok) { ret 1; }
+    if (!str_contains(fail.describe(from_images.err), "invalid link mode")) { ret 1; }
 
-    val from_mixed: R.Result[R.Void, str] = t_planned_link_mixed(
+    val from_mixed: err[fail.Fail] = t_planned_link_mixed(
         ?s, ?tgt, nil::*of.ObjectImage, 0, nil::**u8, 0, nil::*of.DynLib, 0,
         ""::*u8, "invalid"::*u8, invalid, false,
         of.image_options_default(of.SUBSYSTEM_CONSOLE));
-    if (R.is_ok[R.Void, str](from_mixed)
-        || !str_contains(R.unwrap_err[R.Void, str](from_mixed), "invalid link mode")) { ret 1; }
+    if (sel from_mixed.ok) { ret 1; }
+    if (!str_contains(fail.describe(from_mixed.err), "invalid link mode")) { ret 1; }
     ret 0;
 }
 
@@ -7318,13 +7346,13 @@ test "mach.lang.be.linker.debug_abbrev_merge:deduplicates_only_equal_tables" {
     modules[2] = lt_image(?s, lt_name(?s, "equal.o"), ?sections[2], 1,
                           nil::*of.Symbol, 0, nil::*of.Relocation, 0);
 
-    val merged_count_r: R.Result[u32, str] = merged_section_count(1);
-    if (R.is_err[u32, str](merged_count_r)) { session.dnit(?s); ret 2; }
-    val merged_count: u32 = R.unwrap_ok[u32, str](merged_count_r);
-    val merged_r: R.Result[*MergedSection, str] =
+    val merged_count_r: res[u32, fail.Fail] = merged_section_count(1);
+    if (sel merged_count_r.err) { session.dnit(?s); ret 2; }
+    val merged_count: u32 = merged_count_r.ok;
+    val merged_r: res[*MergedSection, A.Error] =
         A.zallocate[MergedSection](?alloc, merged_count::usize);
-    if (R.is_err[*MergedSection, str](merged_r)) { session.dnit(?s); ret 3; }
-    val merged: *MergedSection = R.unwrap_ok[*MergedSection, str](merged_r);
+    if (sel merged_r.err) { session.dnit(?s); ret 3; }
+    val merged: *MergedSection = merged_r.ok;
     var debug_names: [1]intern.StrId;
     debug_names[0] = abbrev_name;
     init_merged(merged, ?debug_names[0], 1);
@@ -7341,12 +7369,12 @@ test "mach.lang.be.linker.debug_abbrev_merge:deduplicates_only_equal_tables" {
     var groups: SectionGroups;
     init_section_groups(?groups);
 
-    val accumulated_r: R.Result[R.Void, str] = accumulate_sections(
+    val accumulated_r: err[fail.Fail] = accumulate_sections(
         ?s, ?modules[0], 3, merged, ?debug_names[0], 1,
         ?placements[0], ?sec_base[0], ?strm, ?atoms, ?groups);
     var bad: i32 = 0;
     val slot: u32 = MERGED_KIND_COUNT;
-    if (R.is_err[R.Void, str](accumulated_r)) { bad = 4; }
+    if (sel accumulated_r.err) { bad = 4; }
     or (placements[0].offset != 0)          { bad = 5; }
     or (placements[1].offset != 2)          { bad = 6; }
     or (placements[2].offset != 0)          { bad = 7; }
@@ -7491,25 +7519,29 @@ fun lt_foreign_dwarf_link(s: *session.Session, tgt: *target.Target,
     val epath: str = output.path(?etf);
 
     var ok: bool = true;
-    if (R.is_err[R.Void, str](t_planned_object(tgt, ?modules[0], apath::*u8))) { ok = false; }
-    if (ok && R.is_err[R.Void, str](t_planned_object(tgt, ?modules[1], bpath::*u8))) { ok = false; }
+    val t_planned_object_r: err[fail.Fail] = t_planned_object(tgt, ?modules[0], apath::*u8);
+    if (sel t_planned_object_r.err) { ok = false; }
+    if (ok) {
+        val t_planned_object_r: err[fail.Fail] = t_planned_object(tgt, ?modules[1], bpath::*u8);
+        if (sel t_planned_object_r.err) { ok = false; }
+    }
     if (ok) {
         var paths: [2]*u8;
         paths[0] = apath::*u8; paths[1] = bpath::*u8;
-        val lr: R.Result[R.Void, str] = t_planned_link(s, tgt, ?paths[0], 2,
+        val lr: err[fail.Fail] = t_planned_link(s, tgt, ?paths[0], 2,
             nil::*of.DynLib, 0, epath::*u8, "foreign_dwarf"::*u8,
             LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
-        if (R.is_err[R.Void, str](lr)) { ok = false; }
+        if (sel lr.err) { ok = false; }
     }
     if (ok) {
-        val rr: R.Result[Vector[u8], str] = fs.read_bytes(alloc, epath);
-        if (R.is_err[Vector[u8], str](rr)) { ok = false; }
-        or {
-            var out: Vector[u8] = R.unwrap_ok[Vector[u8], str](rr);
+        val rr: res[Vector[u8], fs.FsError] = fs.read_bytes(alloc, epath);
+        if (sel rr.ok) {
+            var out: Vector[u8] = rr.ok;
             @out_self    = lt_marker_present(out.data, out.len, 0xAA);
             @out_foreign = lt_marker_present(out.data, out.len, 0xBB);
             vector.dnit[u8](?out);
         }
+        or { ok = false; }
     }
 
 
@@ -7692,23 +7724,26 @@ fun lt_parsed_weak_dwarf_target(s: *session.Session, tgt: *target.Target) bool {
     val epath: str = output.path(?etf);
 
     var ok: bool = true;
-    if (R.is_err[R.Void, str](t_planned_object(tgt, ?modules[0], wpath::*u8))) { ok = false; }
-    if (ok && R.is_err[R.Void, str](t_planned_object(tgt, ?modules[1], lpath::*u8))) { ok = false; }
+    val t_planned_object_r: err[fail.Fail] = t_planned_object(tgt, ?modules[0], wpath::*u8);
+    if (sel t_planned_object_r.err) { ok = false; }
+    if (ok) {
+        val t_planned_object_r: err[fail.Fail] = t_planned_object(tgt, ?modules[1], lpath::*u8);
+        if (sel t_planned_object_r.err) { ok = false; }
+    }
     var paths: [2]*u8;
     paths[0] = wpath::*u8; paths[1] = lpath::*u8;
     if (ok) {
-        val lr: R.Result[R.Void, str] = t_planned_link(s, tgt, ?paths[0], 2,
+        val lr: err[fail.Fail] = t_planned_link(s, tgt, ?paths[0], 2,
             nil::*of.DynLib, 0, epath::*u8, "parsed_weak_dwarf"::*u8,
             LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
-        if (R.is_err[R.Void, str](lr)) { ok = false; }
+        if (sel lr.err) { ok = false; }
     }
 
     var out: Vector[u8];
     if (ok) {
-        val rr: R.Result[Vector[u8], str] = fs.read_bytes(alloc, epath);
-        if (R.is_err[Vector[u8], str](rr)) { ok = false; }
-        or {
-            out = R.unwrap_ok[Vector[u8], str](rr);
+        val rr: res[Vector[u8], fs.FsError] = fs.read_bytes(alloc, epath);
+        if (sel rr.ok) {
+            out = rr.ok;
             var live_addr: u64 = 0;
             d = 0;
             for (ok && d < 4) {
@@ -7734,6 +7769,7 @@ fun lt_parsed_weak_dwarf_target(s: *session.Session, tgt: *target.Target) bool {
             }
             vector.dnit[u8](?out);
         }
+        or { ok = false; }
     }
 
 
@@ -7874,23 +7910,27 @@ fun lt_dwarf_addend_crossing(s: *session.Session, tgt: *target.Target) i32 {
 
     var code: i32 = 4;
     var wrote: bool = true;
-    if (R.is_err[R.Void, str](t_planned_object(tgt, ?modules[0], wpath::*u8))) { wrote = false; }
-    if (wrote && R.is_err[R.Void, str](t_planned_object(tgt, ?modules[1], lpath::*u8))) { wrote = false; }
+    val t_planned_object_r: err[fail.Fail] = t_planned_object(tgt, ?modules[0], wpath::*u8);
+    if (sel t_planned_object_r.err) { wrote = false; }
+    if (wrote) {
+        val t_planned_object_r: err[fail.Fail] = t_planned_object(tgt, ?modules[1], lpath::*u8);
+        if (sel t_planned_object_r.err) { wrote = false; }
+    }
     if (wrote) {
         var paths: [2]*u8;
         paths[0] = wpath::*u8; paths[1] = lpath::*u8;
-        val lr: R.Result[R.Void, str] = t_planned_link(s, tgt, ?paths[0], 2,
+        val lr: err[fail.Fail] = t_planned_link(s, tgt, ?paths[0], 2,
             nil::*of.DynLib, 0, epath::*u8, "crossing_dwarf"::*u8,
             LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
-        if (R.is_err[R.Void, str](lr)) {
+        if (sel lr.err) {
             code = 3;
-            if (str_contains(R.unwrap_err[R.Void, str](lr), "crosses a discarded body")) { code = 0; }
+            if (str_contains(fail.describe(lr.err), "crosses a discarded body")) { code = 0; }
         }
         or {
             code = 4;
-            val rr: R.Result[Vector[u8], str] = fs.read_bytes(alloc, epath);
-            if (R.is_ok[Vector[u8], str](rr)) {
-                var out: Vector[u8] = R.unwrap_ok[Vector[u8], str](rr);
+            val rr: res[Vector[u8], fs.FsError] = fs.read_bytes(alloc, epath);
+            if (sel rr.ok) {
+                var out: Vector[u8] = rr.ok;
                 var anchor_va: u64 = 0;
                 var cross_va: u64 = 0;
                 var tail_va: u64 = 0;
@@ -7960,10 +8000,11 @@ fun lt_roundtrip_symbol_size(s: *session.Session, tgt: *target.Target, out: *u32
     val path: str = output.path(?tf);
 
     var ok: bool = false;
-    if (R.is_ok[R.Void, str](t_planned_object(tgt, ?img, path::*u8))) {
-        val rr: R.Result[Vector[u8], str] = fs.read_bytes(alloc, path);
-        if (R.is_ok[Vector[u8], str](rr)) {
-            var raw: Vector[u8] = R.unwrap_ok[Vector[u8], str](rr);
+    val t_planned_object_r: err[fail.Fail] = t_planned_object(tgt, ?img, path::*u8);
+    if (sel t_planned_object_r.ok) {
+        val rr: res[Vector[u8], fs.FsError] = fs.read_bytes(alloc, path);
+        if (sel rr.ok) {
+            var raw: Vector[u8] = rr.ok;
             var back: of.ObjectImage;
             val pr: R.Result[R.Void, str] = tgt.of.parse_object(
                 alloc, ?s.interner, raw.data, raw.len, ?back);
@@ -8083,28 +8124,39 @@ test "mach.lang.be.linker.archive_resolution:ordered_fixed_point" {
 
     var state: ArchiveResolution;
     init_archive_resolution(?alloc, ?state);
-    if (R.is_err[R.Void, str](archive_note_image(?s, "", ?state, ?seed))) { ret 1; }
-    val e0: R.Result[bool, str] = archive_image_needed(?s, "", ?state, ?early);
-    val u0: R.Result[bool, str] = archive_image_needed(?s, "", ?state, ?unused);
-    val d0: R.Result[bool, str] = archive_image_needed(?s, "", ?state, ?debug_only);
-    val l0: R.Result[bool, str] = archive_image_needed(?s, "", ?state, ?late);
-    if (R.is_err[bool, str](e0) || R.unwrap_ok[bool, str](e0)
-        || R.is_err[bool, str](u0) || R.unwrap_ok[bool, str](u0)
-        || R.is_err[bool, str](d0) || R.unwrap_ok[bool, str](d0)
-        || R.is_err[bool, str](l0) || !R.unwrap_ok[bool, str](l0)) { ret 1; }
-    if (R.is_err[R.Void, str](archive_note_image(?s, "", ?state, ?late))) { ret 1; }
-    val e1: R.Result[bool, str] = archive_image_needed(?s, "", ?state, ?early);
-    val c1: R.Result[bool, str] = archive_image_needed(?s, "", ?state, ?common_def);
-    if (R.is_err[bool, str](e1) || !R.unwrap_ok[bool, str](e1)
-        || R.is_err[bool, str](c1) || !R.unwrap_ok[bool, str](c1)) { ret 1; }
-    if (R.is_err[R.Void, str](archive_note_image(?s, "", ?state, ?early))) { ret 1; }
-    if (R.is_err[R.Void, str](archive_note_image(?s, "", ?state, ?common_def))) { ret 1; }
+    val archive_note_image_r: err[fail.Fail] = archive_note_image(?s, "", ?state, ?seed);
+    if (sel archive_note_image_r.err) { ret 1; }
+    val e0: res[bool, fail.Fail] = archive_image_needed(?s, "", ?state, ?early);
+    val u0: res[bool, fail.Fail] = archive_image_needed(?s, "", ?state, ?unused);
+    val d0: res[bool, fail.Fail] = archive_image_needed(?s, "", ?state, ?debug_only);
+    val l0: res[bool, fail.Fail] = archive_image_needed(?s, "", ?state, ?late);
+    if (sel e0.err) { ret 1; }
+    if (e0.ok) { ret 1; }
+    if (sel u0.err) { ret 1; }
+    if (u0.ok) { ret 1; }
+    if (sel d0.err) { ret 1; }
+    if (d0.ok) { ret 1; }
+    if (sel l0.err) { ret 1; }
+    if (!l0.ok) { ret 1; }
+    val archive_note_image_r2: err[fail.Fail] = archive_note_image(?s, "", ?state, ?late);
+    if (sel archive_note_image_r2.err) { ret 1; }
+    val e1: res[bool, fail.Fail] = archive_image_needed(?s, "", ?state, ?early);
+    val c1: res[bool, fail.Fail] = archive_image_needed(?s, "", ?state, ?common_def);
+    if (sel e1.err) { ret 1; }
+    if (!e1.ok) { ret 1; }
+    if (sel c1.err) { ret 1; }
+    if (!c1.ok) { ret 1; }
+    val archive_note_image_r3: err[fail.Fail] = archive_note_image(?s, "", ?state, ?early);
+    if (sel archive_note_image_r3.err) { ret 1; }
+    val archive_note_image_r4: err[fail.Fail] = archive_note_image(?s, "", ?state, ?common_def);
+    if (sel archive_note_image_r4.err) { ret 1; }
     var duplicate: of.ObjectImage = late;
     duplicate.symbols = ?late_syms[1]; duplicate.symbol_count = 1;
     late_syms[1].section = of.section_id(0); late_syms[1].flags = def_flags;
-    val dupe: R.Result[bool, str] = archive_image_needed(?s, "", ?state, ?duplicate);
-    if (R.is_err[bool, str](dupe) || R.unwrap_ok[bool, str](dupe)
-        || state.unresolved.len != 0) { ret 1; }
+    val dupe: res[bool, fail.Fail] = archive_image_needed(?s, "", ?state, ?duplicate);
+    if (sel dupe.err) { ret 1; }
+    if (dupe.ok) { ret 1; }
+    if (state.unresolved.len != 0) { ret 1; }
 
     free_archive_resolution(?state);
     session.dnit(?s);
@@ -8126,11 +8178,14 @@ test "mach.lang.be.linker.archive_resolution:entry_root" {
 
     var state: ArchiveResolution;
     init_archive_resolution(?alloc, ?state);
-    if (R.is_err[R.Void, str](archive_require(?state, entry))) { ret 1; }
-    val needed: R.Result[bool, str] = archive_image_needed(?s, "", ?state, ?member);
-    if (R.is_err[bool, str](needed) || !R.unwrap_ok[bool, str](needed)) { ret 1; }
-    if (R.is_err[R.Void, str](archive_note_image(?s, "", ?state, ?member))
-        || state.unresolved.len != 0) { ret 1; }
+    val archive_require_r: err[fail.Fail] = archive_require(?state, entry);
+    if (sel archive_require_r.err) { ret 1; }
+    val needed: res[bool, fail.Fail] = archive_image_needed(?s, "", ?state, ?member);
+    if (sel needed.err) { ret 1; }
+    if (!needed.ok) { ret 1; }
+    val archive_note_image_r: err[fail.Fail] = archive_note_image(?s, "", ?state, ?member);
+    if (sel archive_note_image_r.err) { ret 1; }
+    if (state.unresolved.len != 0) { ret 1; }
 
     free_archive_resolution(?state);
     session.dnit(?s);
@@ -8261,10 +8316,20 @@ test "mach.lang.be.linker.archive_resolution:test_entry_satisfies_main_before_ar
     }
 
     var bad: i32 = 0;
-    if (R.is_err[R.Void, str](t_planned_object(?tgt, ?entry_img, entry_path::*u8))) { bad = 1; }
-    if (bad == 0 && R.is_err[R.Void, str](t_planned_object(?tgt, ?crt_img, crt_path::*u8))) { bad = 1; }
-    if (bad == 0 && R.is_err[R.Void, str](t_planned_object(?tgt, ?helper_img, helper_path::*u8))) { bad = 1; }
-    if (bad == 0 && R.is_err[R.Void, str](t_planned_object(?tgt, ?stub_img, stub_path::*u8))) { bad = 1; }
+    val t_planned_object_r: err[fail.Fail] = t_planned_object(?tgt, ?entry_img, entry_path::*u8);
+    if (sel t_planned_object_r.err) { bad = 1; }
+    if (bad == 0) {
+        val t_planned_object_r: err[fail.Fail] = t_planned_object(?tgt, ?crt_img, crt_path::*u8);
+        if (sel t_planned_object_r.err) { bad = 1; }
+    }
+    if (bad == 0) {
+        val t_planned_object_r: err[fail.Fail] = t_planned_object(?tgt, ?helper_img, helper_path::*u8);
+        if (sel t_planned_object_r.err) { bad = 1; }
+    }
+    if (bad == 0) {
+        val t_planned_object_r: err[fail.Fail] = t_planned_object(?tgt, ?stub_img, stub_path::*u8);
+        if (sel t_planned_object_r.err) { bad = 1; }
+    }
 
     var crt_vec:    Vector[u8];
     var helper_vec: Vector[u8];
@@ -8273,19 +8338,19 @@ test "mach.lang.be.linker.archive_resolution:test_entry_satisfies_main_before_ar
     var have_hlp_v: bool = false;
     var have_stb_v: bool = false;
     if (bad == 0) {
-        val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, crt_path);
-        if (R.is_err[Vector[u8], str](rr)) { bad = 1; }
-        or { crt_vec = R.unwrap_ok[Vector[u8], str](rr); have_crt_v = true; }
+        val rr: res[Vector[u8], fs.FsError] = fs.read_bytes(?alloc, crt_path);
+        if (sel rr.ok) { crt_vec = rr.ok; have_crt_v = true; }
+        or { bad = 1; }
     }
     if (bad == 0) {
-        val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, helper_path);
-        if (R.is_err[Vector[u8], str](rr)) { bad = 1; }
-        or { helper_vec = R.unwrap_ok[Vector[u8], str](rr); have_hlp_v = true; }
+        val rr: res[Vector[u8], fs.FsError] = fs.read_bytes(?alloc, helper_path);
+        if (sel rr.ok) { helper_vec = rr.ok; have_hlp_v = true; }
+        or { bad = 1; }
     }
     if (bad == 0) {
-        val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, stub_path);
-        if (R.is_err[Vector[u8], str](rr)) { bad = 1; }
-        or { stub_vec = R.unwrap_ok[Vector[u8], str](rr); have_stb_v = true; }
+        val rr: res[Vector[u8], fs.FsError] = fs.read_bytes(?alloc, stub_path);
+        if (sel rr.ok) { stub_vec = rr.ok; have_stb_v = true; }
+        or { bad = 1; }
     }
 
     if (bad == 0) {
@@ -8296,34 +8361,34 @@ test "mach.lang.be.linker.archive_resolution:test_entry_satisfies_main_before_ar
         members[0].name = "crt.o";    members[0].data = crt_vec.data;    members[0].len = crt_vec.len;    members[0].sym_names = ?crt_names[0];    members[0].sym_count = 1;
         members[1].name = "helper.o"; members[1].data = helper_vec.data; members[1].len = helper_vec.len; members[1].sym_names = ?helper_names[0]; members[1].sym_count = 1;
         members[2].name = "stub.o";   members[2].data = stub_vec.data;   members[2].len = stub_vec.len;   members[2].sym_names = ?stub_names[0];   members[2].sym_count = 1;
-        val wr: R.Result[R.Void, str] = t_planned_archive(?alloc, ?members[0], 3, ar_path);
-        if (R.is_err[R.Void, str](wr)) { bad = 1; }
+        val wr: err[fail.Fail] = t_planned_archive(?alloc, ?members[0], 3, ar_path);
+        if (sel wr.err) { bad = 1; }
     }
 
     if (bad == 0) {
         var fix_paths: [2]*u8;
         fix_paths[0] = entry_path::*u8;
         fix_paths[1] = ar_path::*u8;
-        val lr: R.Result[R.Void, str] =
+        val lr: err[fail.Fail] =
             t_planned_link(?s, ?tgt, ?fix_paths[0], 2, nil::*of.DynLib, 0, exe_path::*u8,
                  "test-entry-fix", LINK_EXE, false,
                  of.image_options_default(of.SUBSYSTEM_CONSOLE));
-        if (R.is_err[R.Void, str](lr)) { bad = 1; }
+        if (sel lr.err) { bad = 1; }
     }
 
     if (bad == 0) {
         var bug_paths: [2]*u8;
         bug_paths[0] = ar_path::*u8;
         bug_paths[1] = entry_path::*u8;
-        val lr: R.Result[R.Void, str] =
+        val lr: err[fail.Fail] =
             t_planned_link(?s, ?tgt, ?bug_paths[0], 2, nil::*of.DynLib, 0, exe_path::*u8,
                  "test-entry-bug", LINK_EXE, false,
                  of.image_options_default(of.SUBSYSTEM_CONSOLE));
-        if (R.is_ok[R.Void, str](lr)) { bad = 1; }
-        or {
-            val err: str = R.unwrap_err[R.Void, str](lr);
-            if (!str_equals(err, "multiple definition of 'main'")) { bad = 1; }
+        if (sel lr.err) {
+            val error: str = fail.describe(lr.err);
+            if (!str_equals(error, "multiple definition of 'main'")) { bad = 1; }
         }
+        or { bad = 1; }
     }
 
     if (have_crt_v)  { vector.dnit[u8](?crt_vec); }
@@ -8367,15 +8432,19 @@ test "mach.lang.be.linker.archive_resolution:undefined_weak_does_not_extract" {
 
     var state: ArchiveResolution;
     init_archive_resolution(?alloc, ?state);
-    if (R.is_err[R.Void, str](archive_note_image(?s, "", ?state, ?weak_img))) { ret 1; }
-    val optional: R.Result[bool, str] = archive_image_needed(?s, "", ?state, ?provider_img);
-    if (R.is_err[bool, str](optional) || R.unwrap_ok[bool, str](optional)
-        || state.unresolved.len != 0) { ret 1; }
+    val archive_note_image_r: err[fail.Fail] = archive_note_image(?s, "", ?state, ?weak_img);
+    if (sel archive_note_image_r.err) { ret 1; }
+    val optional: res[bool, fail.Fail] = archive_image_needed(?s, "", ?state, ?provider_img);
+    if (sel optional.err) { ret 1; }
+    if (optional.ok) { ret 1; }
+    if (state.unresolved.len != 0) { ret 1; }
 
     weak_ref.flags = undef | of.SYM_OBJ_FLAG_FUNCTION;
-    if (R.is_err[R.Void, str](archive_note_image(?s, "", ?state, ?weak_img))) { ret 1; }
-    val required: R.Result[bool, str] = archive_image_needed(?s, "", ?state, ?provider_img);
-    if (R.is_err[bool, str](required) || !R.unwrap_ok[bool, str](required)) { ret 1; }
+    val archive_note_image_r2: err[fail.Fail] = archive_note_image(?s, "", ?state, ?weak_img);
+    if (sel archive_note_image_r2.err) { ret 1; }
+    val required: res[bool, fail.Fail] = archive_image_needed(?s, "", ?state, ?provider_img);
+    if (sel required.err) { ret 1; }
+    if (!required.ok) { ret 1; }
 
     free_archive_resolution(?state);
     session.dnit(?s);
@@ -8410,8 +8479,12 @@ test "mach.lang.be.linker.archive_resolution:weak_fallback_modes" {
             | modes[mi];
         var state: ArchiveResolution;
         init_archive_resolution(?alloc, ?state);
-        if (mi == 2 && R.is_err[R.Void, str](archive_require(?state, public))) { ret 1; }
-        if (R.is_err[R.Void, str](archive_note_image(?s, "", ?state, ?img))) { ret 1; }
+        if (mi == 2) {
+            val required: err[fail.Fail] = archive_require(?state, public);
+            if (sel required.err) { ret 1; }
+        }
+        val archive_note_image_r: err[fail.Fail] = archive_note_image(?s, "", ?state, ?img);
+        if (sel archive_note_image_r.err) { ret 1; }
         if (!map.contains[intern.StrId, u32](?state.unresolved, ?fallback)) { ret 1; }
         val wants_public: bool =
             map.contains[intern.StrId, u32](?state.unresolved, ?public);
@@ -8425,10 +8498,10 @@ test "mach.lang.be.linker.archive_resolution:weak_fallback_modes" {
     syms[0].fallback = 99;
     var malformed: ArchiveResolution;
     init_archive_resolution(?alloc, ?malformed);
-    val mr: R.Result[R.Void, str] = archive_note_image(?s, "", ?malformed, ?img);
+    val mr: err[fail.Fail] = archive_note_image(?s, "", ?malformed, ?img);
     free_archive_resolution(?malformed);
     session.dnit(?s);
-    if (!R.is_err[R.Void, str](mr)) { ret 1; }
+    if (!sel mr.err) { ret 1; }
     ret 0;
 }
 
@@ -8470,28 +8543,30 @@ test "mach.lang.be.linker.collect_symbols:weak_fallback_resolution" {
     var sec_base: [3]u32; sec_base[0] = 0; sec_base[1] = 0; sec_base[2] = 1;
     var locs: map.Map[intern.StrId, SymbolLoc] =
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
-    val cr: R.Result[R.Void, str] = collect_symbols(?s, ?modules[0], 3,
+    val cr: err[fail.Fail] = collect_symbols(?s, ?modules[0], 3,
         ?placements[0], ?sec_base[0], ?locs, true, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](cr)) { ret 1; }
-    val rn: R.Result[intern.StrId, str] = resolved_symbol_name(?locs, one);
-    val ol: R.Result[*SymbolLoc, str] = map.get[intern.StrId, SymbolLoc](?locs, ?one);
-    if (R.is_err[intern.StrId, str](rn) || R.unwrap_ok[intern.StrId, str](rn) != one
-        || R.is_err[*SymbolLoc, str](ol)
-        || R.unwrap_ok[*SymbolLoc, str](ol).vaddr != 0x1000) { ret 1; }
+    if (sel cr.err) { ret 1; }
+    val rn: res[intern.StrId, fail.Fail] = resolved_symbol_name(?locs, one);
+    val ol: opt[*SymbolLoc] = map.get[intern.StrId, SymbolLoc](?locs, ?one);
+    if (sel rn.err) { ret 1; }
+    if (rn.ok != one) { ret 1; }
+    if (sel ol.none) { ret 1; }
+    if (ol.some.vaddr != 0x1000) { ret 1; }
     map.dnit[intern.StrId, SymbolLoc](?locs);
 
     var same_object: [2]of.ObjectImage;
     same_object[0] = modules[0]; same_object[1] = modules[2];
     var same_base: [2]u32; same_base[0] = 0; same_base[1] = 0;
     locs = map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
-    val sc: R.Result[R.Void, str] = collect_symbols(?s, ?same_object[0], 2,
+    val sc: err[fail.Fail] = collect_symbols(?s, ?same_object[0], 2,
         ?placements[1], ?same_base[0], ?locs, true, nil::*AtomPlan);
-    val sn: R.Result[intern.StrId, str] = resolved_symbol_name(?locs, one);
-    val tl: R.Result[*SymbolLoc, str] = map.get[intern.StrId, SymbolLoc](?locs, ?two);
-    if (R.is_err[R.Void, str](sc) || R.is_err[intern.StrId, str](sn)
-        || R.unwrap_ok[intern.StrId, str](sn) != two
-        || R.is_err[*SymbolLoc, str](tl)
-        || R.unwrap_ok[*SymbolLoc, str](tl).vaddr != 0x2000) { ret 1; }
+    val sn: res[intern.StrId, fail.Fail] = resolved_symbol_name(?locs, one);
+    val tl: opt[*SymbolLoc] = map.get[intern.StrId, SymbolLoc](?locs, ?two);
+    if (sel sc.err) { ret 1; }
+    if (sel sn.err) { ret 1; }
+    if (sn.ok != two) { ret 1; }
+    if (sel tl.none) { ret 1; }
+    if (tl.some.vaddr != 0x2000) { ret 1; }
     map.dnit[intern.StrId, SymbolLoc](?locs);
 
     var chain: [3]of.Symbol;
@@ -8501,12 +8576,12 @@ test "mach.lang.be.linker.collect_symbols:weak_fallback_resolution" {
     var chain_img: of.ObjectImage = lt_image(?s, lt_name(?s, "chain"),
         nil::*of.Section, 0, ?chain[0], 3, nil::*of.Relocation, 0);
     locs = map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
-    val cc: R.Result[R.Void, str] = collect_symbols(?s, ?chain_img, 1,
+    val cc: err[fail.Fail] = collect_symbols(?s, ?chain_img, 1,
         nil::*Placement, nil::*u32, ?locs, false, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](cc)) { ret 1; }
-    val cn: R.Result[intern.StrId, str] = resolved_symbol_name(?locs, one);
-    if (R.is_err[intern.StrId, str](cn)
-        || R.unwrap_ok[intern.StrId, str](cn) != three) { ret 1; }
+    if (sel cc.err) { ret 1; }
+    val cn: res[intern.StrId, fail.Fail] = resolved_symbol_name(?locs, one);
+    if (sel cn.err) { ret 1; }
+    if (cn.ok != three) { ret 1; }
     var reg: target.TargetRegistry = target.registry_init();
     fin { target.registry_dnit(?reg); }
     if (R.is_err[R.Void, str](target.register_all(?reg, target_testing.debug_descriptor))) { ret 1; }
@@ -8515,10 +8590,11 @@ test "mach.lang.be.linker.collect_symbols:weak_fallback_resolution" {
     if (R.is_err[target.Target, str](tr)) { ret 1; }
     var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
     var dyn: DynState; init_dynstate(?dyn);
-    val dr: R.Result[R.Void, str] = build_dynamic_info(?s, ?tgt, ?dyn, ?chain_img, 1,
+    val dr: err[fail.Fail] = build_dynamic_info(?s, ?tgt, ?dyn, ?chain_img, 1,
         ?locs, nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](dr) || dyn.info.import_count != 1
-        || dyn.info.imports[0].symbol != three) { ret 1; }
+    if (sel dr.err) { ret 1; }
+    if (dyn.info.import_count != 1) { ret 1; }
+    if (dyn.info.imports[0].symbol != three) { ret 1; }
     free_dynstate(?alloc, ?dyn);
     map.dnit[intern.StrId, SymbolLoc](?locs);
 
@@ -8533,19 +8609,19 @@ test "mach.lang.be.linker.collect_symbols:weak_fallback_resolution" {
     conflict_mods[1] = lt_image(?s, lt_name(?s, "conflict-b"), nil::*of.Section, 0,
         ?conflict[2], 2, nil::*of.Relocation, 0);
     locs = map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
-    val cf: R.Result[R.Void, str] = collect_symbols(?s, ?conflict_mods[0], 2,
+    val cf: err[fail.Fail] = collect_symbols(?s, ?conflict_mods[0], 2,
         nil::*Placement, nil::*u32, ?locs, false, nil::*AtomPlan);
     map.dnit[intern.StrId, SymbolLoc](?locs);
-    if (!R.is_err[R.Void, str](cf)) { ret 1; }
+    if (!sel cf.err) { ret 1; }
 
     chain[0].fallback = 1; chain[1].fallback = 0;
     chain_img.symbol_count = 2;
     locs = map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
-    val cy: R.Result[R.Void, str] = collect_symbols(?s, ?chain_img, 1,
+    val cy: err[fail.Fail] = collect_symbols(?s, ?chain_img, 1,
         nil::*Placement, nil::*u32, ?locs, false, nil::*AtomPlan);
     map.dnit[intern.StrId, SymbolLoc](?locs);
     session.dnit(?s);
-    if (!R.is_err[R.Void, str](cy)) { ret 1; }
+    if (!sel cy.err) { ret 1; }
     ret 0;
 }
 
@@ -8598,9 +8674,9 @@ test "mach.lang.be.linker.relocatable:preserves_sections_and_remaps_relations" {
     inputs[1].indirects = ?indirect; inputs[1].indirect_count = 1;
     inputs[1].imports = ?decl; inputs[1].import_count = 1;
     var attributes: [2]u8; attributes[0] = 4; attributes[1] = 7;
-    val combined: R.Result[of.ObjectImage, str] = relocatable.combine(?alloc, ?s.interner, ?inputs[0], 2, 9, ?attributes[0], 2);
-    if (R.is_err[of.ObjectImage, str](combined)) { ret 1; }
-    var image: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](combined);
+    val combined: res[of.ObjectImage, fail.Fail] = relocatable.combine(?alloc, ?s.interner, ?inputs[0], 2, 9, ?attributes[0], 2);
+    if (sel combined.err) { ret 1; }
+    var image: of.ObjectImage = combined.ok;
     fin { obj.dnit(?image); }
     if (image.indirect_count != 2 || of.section_index(image.indirects[0].section) != 0 || image.indirects[0].symbol != 0
         || of.section_index(image.indirects[1].section) != 1 || image.indirects[1].symbol != 1
@@ -8685,12 +8761,12 @@ test "mach.lang.be.linker.read_objects:ordered_archive_end_to_end" {
         if (R.is_err[output.Output, str](tf_r)) { ret 1; }
         var tf: output.Output = R.unwrap_ok[output.Output, str](tf_r);
         fin { output.dnit(?tf); }
-        val er: R.Result[R.Void, str] = t_planned_object(?tgt, ?images[mi], output.path(?tf)::*u8);
-        if (R.is_err[R.Void, str](er)) { ret 1; }
-        val br: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, output.path(?tf));
+        val er: err[fail.Fail] = t_planned_object(?tgt, ?images[mi], output.path(?tf)::*u8);
+        if (sel er.err) { ret 1; }
+        val br: res[Vector[u8], fs.FsError] = fs.read_bytes(?alloc, output.path(?tf));
 
-        if (R.is_err[Vector[u8], str](br)) { ret 1; }
-        member_bytes[mi] = R.unwrap_ok[Vector[u8], str](br);
+        if (sel br.err) { ret 1; }
+        member_bytes[mi] = br.ok;
         mi = mi + 1;
     }
     var n0: [1]str; n0[0] = "earlier_dependency";
@@ -8711,7 +8787,8 @@ test "mach.lang.be.linker.read_objects:ordered_archive_end_to_end" {
     if (R.is_err[output.Output, str](at_r)) { ret 1; }
     var at: output.Output = R.unwrap_ok[output.Output, str](at_r);
     fin { output.dnit(?at); }
-    if (R.is_err[R.Void, str](t_planned_archive(?alloc, ?members[0], 4, output.path(?at)))) {
+    val t_planned_archive_r: err[fail.Fail] = t_planned_archive(?alloc, ?members[0], 4, output.path(?at));
+    if (sel t_planned_archive_r.err) {
 
         ret 1;
     }
@@ -8727,7 +8804,8 @@ test "mach.lang.be.linker.read_objects:ordered_archive_end_to_end" {
     if (R.is_err[output.Output, str](lt_r)) { ret 1; }
     var lt: output.Output = R.unwrap_ok[output.Output, str](lt_r);
     fin { output.dnit(?lt); }
-    if (R.is_err[R.Void, str](t_planned_object(?tgt, ?loose, output.path(?lt)::*u8))) {
+    val t_planned_object_r: err[fail.Fail] = t_planned_object(?tgt, ?loose, output.path(?lt)::*u8);
+    if (sel t_planned_object_r.err) {
         ret 1;
     }
 
@@ -8735,14 +8813,15 @@ test "mach.lang.be.linker.read_objects:ordered_archive_end_to_end" {
     paths[0] = output.path(?at)::*u8;
     paths[1] = output.path(?lt)::*u8;
     var module_count: u32 = 0;
-    val rr: R.Result[*of.ObjectImage, str] = read_objects(?s, ?tgt, ?paths[0], 2,
+    val rr: res[*of.ObjectImage, fail.Fail] = read_objects(?s, ?tgt, ?paths[0], 2,
         nil::*of.ObjectImage, 0, root, ?module_count);
 
 
     mi = 0;
     for (mi < 4) { vector.dnit[u8](?member_bytes[mi]); mi = mi + 1; }
-    if (R.is_err[*of.ObjectImage, str](rr) || module_count != 3) { ret 1; }
-    val modules: *of.ObjectImage = R.unwrap_ok[*of.ObjectImage, str](rr);
+    if (sel rr.err) { ret 1; }
+    if (module_count != 3) { ret 1; }
+    val modules: *of.ObjectImage = rr.ok;
 
     var saw_root: bool = false;
     var saw_early: bool = false;
@@ -8796,10 +8875,13 @@ test "mach.lang.be.linker.archive_resolution:import_address_alias" {
 
     var state: ArchiveResolution;
     init_archive_resolution(?alloc, ?state);
-    if (R.is_err[R.Void, str](archive_note_image(?s, "__imp_", ?state, ?seed))) { ret 1; }
-    val needed: R.Result[bool, str] = archive_image_needed(?s, "__imp_", ?state, ?record);
-    if (R.is_err[bool, str](needed) || !R.unwrap_ok[bool, str](needed)) { ret 1; }
-    if (R.is_err[R.Void, str](archive_note_image(?s, "__imp_", ?state, ?record))) { ret 1; }
+    val archive_note_image_r: err[fail.Fail] = archive_note_image(?s, "__imp_", ?state, ?seed);
+    if (sel archive_note_image_r.err) { ret 1; }
+    val needed: res[bool, fail.Fail] = archive_image_needed(?s, "__imp_", ?state, ?record);
+    if (sel needed.err) { ret 1; }
+    if (!needed.ok) { ret 1; }
+    val archive_note_image_r2: err[fail.Fail] = archive_note_image(?s, "__imp_", ?state, ?record);
+    if (sel archive_note_image_r2.err) { ret 1; }
     if (state.unresolved.len != 0
         || !map.contains[intern.StrId, u32](?state.providers, ?public)
         || !map.contains[intern.StrId, u32](?state.providers, ?indirect)) { ret 1; }
@@ -8821,21 +8903,26 @@ test "mach.lang.be.linker.dynlib_index_of:logical_and_loader_names" {
     libs[2].soname = 74;
     libs[2].rpath = intern.STR_NIL;
 
-    val logical: O.Option[u32] =
+    val logical: opt[u32] =
         dynlib_index_of(?libs[0], 3, nil::*of.DynLib, 41);
-    val alias: O.Option[u32] =
+    val alias: opt[u32] =
         dynlib_index_of(?libs[0], 3, nil::*of.DynLib, 42);
-    val loader: O.Option[u32] =
+    val loader: opt[u32] =
         dynlib_index_of(?libs[0], 3, nil::*of.DynLib, 73);
-    val other: O.Option[u32] =
+    val other: opt[u32] =
         dynlib_index_of(?libs[0], 3, nil::*of.DynLib, 74);
-    val missing: O.Option[u32] =
+    val missing: opt[u32] =
         dynlib_index_of(?libs[0], 3, nil::*of.DynLib, 99);
-    if (!O.is_some[u32](logical) || O.unwrap[u32](logical) != 0) { ret 1; }
-    if (!O.is_some[u32](alias) || O.unwrap[u32](alias) != 0)     { ret 1; }
-    if (!O.is_some[u32](loader) || O.unwrap[u32](loader) != 0)   { ret 1; }
-    if (!O.is_some[u32](other) || O.unwrap[u32](other) != 1)     { ret 1; }
-    if (O.is_some[u32](missing) || unique_dynlib_count(?libs[0], 3) != 2) { ret 1; }
+    if (!sel logical.some) { ret 1; }
+    if (logical.some != 0) { ret 1; }
+    if (!sel alias.some) { ret 1; }
+    if (alias.some != 0) { ret 1; }
+    if (!sel loader.some) { ret 1; }
+    if (loader.some != 0) { ret 1; }
+    if (!sel other.some) { ret 1; }
+    if (other.some != 1) { ret 1; }
+    if (sel missing.some) { ret 1; }
+    if (unique_dynlib_count(?libs[0], 3) != 2) { ret 1; }
     if (!declared_attribution_matches(?libs[0], 3, nil::*of.DynLib, 41, 73)) { ret 1; }
     if (!declared_attribution_matches(?libs[0], 3, nil::*of.DynLib, 73, 73)) { ret 1; }
     if (declared_attribution_matches(?libs[0], 3, nil::*of.DynLib, 41, 74))  { ret 1; }
@@ -8936,10 +9023,10 @@ test "mach.lang.be.linker.build_dynamic_info:linux_interpreter_matches_target" {
         var tgt: target.Target = R.unwrap_ok[target.Target, str](tr);
         var dyn: DynState;
         init_dynstate(?dyn);
-        val built: R.Result[R.Void, str] = build_dynamic_info(
+        val built: err[fail.Fail] = build_dynamic_info(
             ?s, ?tgt, ?dyn, nil::*of.ObjectImage, 0, ?locs,
             nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
-        if (R.is_err[R.Void, str](built)) { ret 1; }
+        if (sel built.err) { ret 1; }
         val interp: O.Option[str] = intern.lookup(?s.interner, dyn.info.interp);
         if (O.is_none[str](interp) || !str_equals(O.unwrap[str](interp), paths[i])) {
             ret 1;
@@ -8998,19 +9085,19 @@ test "mach.lang.be.linker.build_dynamic_info:rejects_import_address_alias" {
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
     var dyn: DynState;
     init_dynstate(?dyn);
-    val built: R.Result[R.Void, str] =
+    val built: err[fail.Fail] =
         build_dynamic_info(?s, ?tgt, ?dyn, ?module, 1, ?locs,
                            nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
 
     var code: i32 = 0;
-    if (R.is_ok[R.Void, str](built)) { code = 1; }
-    or {
-        val msg: str = R.unwrap_err[R.Void, str](built);
+    if (sel built.err) {
+        val msg: str = fail.describe(built.err);
         if (dyn.info.import_count != 0)                    { code = 1; }
         if (!str_contains(msg, "'__imp_Sleep'"))           { code = 1; }
         if (!str_contains(msg, "import-address alias"))    { code = 1; }
         if (!str_contains(msg, "import 'Sleep' instead"))  { code = 1; }
     }
+    or { code = 1; }
 
     val bare: intern.StrId = lt_name(?s, "__imp_");
     if (is_import_address_alias(?s, bare, "__imp_"))  { code = 1; }
@@ -9069,10 +9156,10 @@ test "mach.lang.be.linker.build_dynamic_info:declared_import_is_link_local" {
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
     var dyn: DynState;
     init_dynstate(?dyn);
-    val built: R.Result[R.Void, str] =
+    val built: err[fail.Fail] =
         build_dynamic_info(?s, ?tgt, ?dyn, ?module, 1, ?locs,
                            nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](built)) { ret 1; }
+    if (sel built.err) { ret 1; }
     if (dyn.info.lib_count != 1 || dyn.info.libs[0].soname != library
         || dyn.info.import_count != 1 || dyn.info.imports[0].symbol != export_name
         || dyn.info.imports[0].lib_index != 0 || dyn.info.imports[0].ordinal != 7
@@ -9120,16 +9207,17 @@ test "mach.lang.be.linker.build_dynamic_info:locally_resolved_declaration" {
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
     var loc: SymbolLoc;
     loc.vaddr = 0x1000; loc.weak = false; loc.fallback = intern.STR_NIL;
-    if (R.is_err[bool, str](map.insert[intern.StrId, SymbolLoc](
-        ?locs, symbol, loc))) { ret 1; }
+    val insert_r: res[bool, A.Error] = map.insert[intern.StrId, SymbolLoc](
+        ?locs, symbol, loc);
+    if (sel insert_r.err) { ret 1; }
     var dyn: DynState;
     init_dynstate(?dyn);
-    val built: R.Result[R.Void, str] = build_dynamic_info(
+    val built: err[fail.Fail] = build_dynamic_info(
         ?s, ?tgt, ?dyn, ?module, 1, ?locs,
         nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
     val remains_dynamic: bool = has_unresolved_declared_imports(
         ?module, 1, ?locs);
-    if (R.is_err[R.Void, str](built) || dyn.info.lib_count != 0
+    if (sel built.err || dyn.info.lib_count != 0
         || dyn.info.import_count != 0 || remains_dynamic) {
         ret 1;
     }
@@ -9164,15 +9252,16 @@ test "mach.lang.be.linker.build_dynamic_info:locally_resolved_declaration" {
     locs = map.init[intern.StrId, SymbolLoc](
         ?alloc, map.hash_u32, map.eq_u32);
     loc.vaddr = 0x2000; loc.weak = true; loc.fallback = intern.STR_NIL;
-    if (R.is_err[bool, str](map.insert[intern.StrId, SymbolLoc](
-        ?locs, weak_symbol, loc))) { ret 1; }
+    val insert_r2: res[bool, A.Error] = map.insert[intern.StrId, SymbolLoc](
+        ?locs, weak_symbol, loc);
+    if (sel insert_r2.err) { ret 1; }
     init_dynstate(?dyn);
-    val weak_built: R.Result[R.Void, str] = build_dynamic_info(
+    val weak_built: err[fail.Fail] = build_dynamic_info(
         ?s, ?tgt, ?dyn, ?weak_module, 1, ?locs,
         nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
     val weak_dynamic: bool = has_unresolved_declared_imports(
         ?weak_module, 1, ?locs);
-    if (R.is_err[R.Void, str](weak_built) || dyn.info.lib_count != 1
+    if (sel weak_built.err || dyn.info.lib_count != 1
         || dyn.info.libs[0].soname != declared || dyn.info.import_count != 1
         || dyn.info.imports[0].symbol != weak_symbol || !weak_dynamic) {
         ret 1;
@@ -9214,11 +9303,12 @@ test "mach.lang.be.linker.build_dynamic_info:unreferenced_declared_import_elides
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
     var dyn: DynState;
     init_dynstate(?dyn);
-    val built: R.Result[R.Void, str] = build_dynamic_info(
+    val built: err[fail.Fail] = build_dynamic_info(
         ?s, ?tgt, ?dyn, ?module, 1, ?locs,
         nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](built) || dyn.info.lib_count != 0
-        || dyn.info.import_count != 0) { ret 1; }
+    if (sel built.err) { ret 1; }
+    if (dyn.info.lib_count != 0) { ret 1; }
+    if (dyn.info.import_count != 0) { ret 1; }
 
     free_dynstate(?alloc, ?dyn);
     map.dnit[intern.StrId, SymbolLoc](?locs);
@@ -9264,12 +9354,13 @@ test "mach.lang.be.linker.build_dynamic_info:referenced_declared_import_keeps_ne
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
     var dyn: DynState;
     init_dynstate(?dyn);
-    val built: R.Result[R.Void, str] = build_dynamic_info(
+    val built: err[fail.Fail] = build_dynamic_info(
         ?s, ?tgt, ?dyn, ?module, 1, ?locs,
         nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](built) || dyn.info.lib_count != 1
-        || dyn.info.libs[0].soname != library
-        || dyn.info.import_count != 1) { ret 1; }
+    if (sel built.err) { ret 1; }
+    if (dyn.info.lib_count != 1) { ret 1; }
+    if (dyn.info.libs[0].soname != library) { ret 1; }
+    if (dyn.info.import_count != 1) { ret 1; }
 
     free_dynstate(?alloc, ?dyn);
     map.dnit[intern.StrId, SymbolLoc](?locs);
@@ -9317,20 +9408,22 @@ test "mach.lang.be.linker.build_dynamic_info:alias_only_referenced_declared_impo
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
     var dyn: DynState;
     init_dynstate(?dyn);
-    val built: R.Result[R.Void, str] = build_dynamic_info(
+    val built: err[fail.Fail] = build_dynamic_info(
         ?s, ?tgt, ?dyn, ?module, 1, ?locs,
         nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](built) || dyn.info.lib_count != 1
-        || dyn.info.libs[0].soname != library) { ret 1; }
+    if (sel built.err) { ret 1; }
+    if (dyn.info.lib_count != 1) { ret 1; }
+    if (dyn.info.libs[0].soname != library) { ret 1; }
     free_dynstate(?alloc, ?dyn);
     map.dnit[intern.StrId, SymbolLoc](?locs);
 
     var synth: of.ObjectImage;
-    val made: R.Result[bool, str] = synthesize_local_imports(
+    val made: res[bool, fail.Fail] = synthesize_local_imports(
         ?s, "__imp_", ?module, 1, LINK_EXE,
         nil::*u32, nil::*AtomPlan, ?synth);
-    if (R.is_err[bool, str](made) || R.unwrap_ok[bool, str](made)) {
-        if (R.is_ok[bool, str](made) && R.unwrap_ok[bool, str](made)) { obj.dnit(?synth); }
+    var made_wrong: bool = sel made.err;
+    if (sel made.ok && made.ok) { obj.dnit(?synth); made_wrong = true; }
+    if (made_wrong) {
         session.dnit(?s);
         ret 1;
     }
@@ -9366,11 +9459,12 @@ test "mach.lang.be.linker.build_dynamic_info:explicit_dynlib_survives_unreferenc
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
     var dyn: DynState;
     init_dynstate(?dyn);
-    val built: R.Result[R.Void, str] = build_dynamic_info(
+    val built: err[fail.Fail] = build_dynamic_info(
         ?s, ?tgt, ?dyn, ?module, 1, ?locs,
         ?dl, 1, nil::*u32, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](built) || dyn.info.lib_count != 1
-        || dyn.info.libs[0].soname != soname) { ret 1; }
+    if (sel built.err) { ret 1; }
+    if (dyn.info.lib_count != 1) { ret 1; }
+    if (dyn.info.libs[0].soname != soname) { ret 1; }
 
     free_dynstate(?alloc, ?dyn);
     map.dnit[intern.StrId, SymbolLoc](?locs);
@@ -9417,12 +9511,13 @@ test "mach.lang.be.linker.build_dynamic_info:attributed_import_referenced_synthe
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
     var dyn: DynState;
     init_dynstate(?dyn);
-    val built: R.Result[R.Void, str] = build_dynamic_info(
+    val built: err[fail.Fail] = build_dynamic_info(
         ?s, ?tgt, ?dyn, ?module, 1, ?locs,
         ?referenced_dl, 1, nil::*u32, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](built) || dyn.info.lib_count != 1
-        || dyn.info.libs[0].soname != real_soname
-        || dyn.info.import_count != 1) { ret 1; }
+    if (sel built.err) { ret 1; }
+    if (dyn.info.lib_count != 1) { ret 1; }
+    if (dyn.info.libs[0].soname != real_soname) { ret 1; }
+    if (dyn.info.import_count != 1) { ret 1; }
 
     free_dynstate(?alloc, ?dyn);
     map.dnit[intern.StrId, SymbolLoc](?locs);
@@ -9464,11 +9559,11 @@ test "mach.lang.be.linker.build_dynamic_info:attributed_import_no_referenced_ent
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
     var dyn: DynState;
     init_dynstate(?dyn);
-    val built: R.Result[R.Void, str] = build_dynamic_info(
+    val built: err[fail.Fail] = build_dynamic_info(
         ?s, ?tgt, ?dyn, ?module, 1, ?locs,
         nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
-    if (!R.is_err[R.Void, str](built)
-        || !str_contains(R.unwrap_err[R.Void, str](built), "not among the link's dependencies")) {
+    if (!sel built.err) { ret 1; }
+    if (!str_contains(fail.describe(built.err), "not among the link's dependencies")) {
         ret 1;
     }
 
@@ -9505,11 +9600,12 @@ test "mach.lang.be.linker.build_dynamic_info:attributed_import_unreferenced_synt
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
     var dyn: DynState;
     init_dynstate(?dyn);
-    val built: R.Result[R.Void, str] = build_dynamic_info(
+    val built: err[fail.Fail] = build_dynamic_info(
         ?s, ?tgt, ?dyn, ?module, 1, ?locs,
         nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](built) || dyn.info.lib_count != 0
-        || dyn.info.import_count != 0) { ret 1; }
+    if (sel built.err) { ret 1; }
+    if (dyn.info.lib_count != 0) { ret 1; }
+    if (dyn.info.import_count != 0) { ret 1; }
 
     free_dynstate(?alloc, ?dyn);
     map.dnit[intern.StrId, SymbolLoc](?locs);
@@ -9555,12 +9651,14 @@ test "mach.lang.be.linker.build_dynamic_info:attributed_import_explicit_dynlib_m
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
     var dyn: DynState;
     init_dynstate(?dyn);
-    val built: R.Result[R.Void, str] = build_dynamic_info(
+    val built: err[fail.Fail] = build_dynamic_info(
         ?s, ?tgt, ?dyn, ?module, 1, ?locs,
         ?dl, 1, nil::*u32, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](built) || dyn.info.lib_count != 1
-        || dyn.info.libs[0].soname != soname || dyn.info.libs[0].rpath != rpath
-        || dyn.info.import_count != 1) { ret 1; }
+    if (sel built.err) { ret 1; }
+    if (dyn.info.lib_count != 1) { ret 1; }
+    if (dyn.info.libs[0].soname != soname) { ret 1; }
+    if (dyn.info.libs[0].rpath != rpath) { ret 1; }
+    if (dyn.info.import_count != 1) { ret 1; }
 
     free_dynstate(?alloc, ?dyn);
     map.dnit[intern.StrId, SymbolLoc](?locs);
@@ -9609,11 +9707,12 @@ test "mach.lang.be.linker.build_dynamic_info:attributed_import_alias_only_refere
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
     var dyn: DynState;
     init_dynstate(?dyn);
-    val built: R.Result[R.Void, str] = build_dynamic_info(
+    val built: err[fail.Fail] = build_dynamic_info(
         ?s, ?tgt, ?dyn, ?module, 1, ?locs,
         ?referenced_dl, 1, nil::*u32, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](built) || dyn.info.lib_count != 1
-        || dyn.info.libs[0].soname != real_soname) { ret 1; }
+    if (sel built.err) { ret 1; }
+    if (dyn.info.lib_count != 1) { ret 1; }
+    if (dyn.info.libs[0].soname != real_soname) { ret 1; }
 
     free_dynstate(?alloc, ?dyn);
     map.dnit[intern.StrId, SymbolLoc](?locs);
@@ -9662,18 +9761,20 @@ test "mach.lang.be.linker.build_dynamic_info:coff_import_address_alias" {
     var dyn: DynState;
     init_dynstate(?dyn);
 
-    val built: R.Result[R.Void, str] = build_dynamic_info(
+    val built: err[fail.Fail] = build_dynamic_info(
         ?s, ?tgt, ?dyn, ?module, 1, ?locs, ?dep, 1,
         nil::*u32, nil::*AtomPlan);
-    val direct_idx: R.Result[u32, str] = dynstate_import_index(?dyn, direct);
-    val indirect_idx: R.Result[u32, str] = dynstate_import_index(?dyn, indirect);
-    if (R.is_err[R.Void, str](built) || dyn.info.import_count != 1
-        || dyn.info.imports[0].symbol != direct
-        || dyn.info.imports[0].lib_index != 0
-        || !dyn.info.imports[0].is_func
-        || R.is_err[u32, str](direct_idx) || R.is_err[u32, str](indirect_idx)
-        || R.unwrap_ok[u32, str](direct_idx) != 0
-        || R.unwrap_ok[u32, str](indirect_idx) != 0) { ret 1; }
+    val direct_idx: res[u32, fail.Fail] = dynstate_import_index(?dyn, direct);
+    val indirect_idx: res[u32, fail.Fail] = dynstate_import_index(?dyn, indirect);
+    if (sel built.err) { ret 1; }
+    if (dyn.info.import_count != 1) { ret 1; }
+    if (dyn.info.imports[0].symbol != direct) { ret 1; }
+    if (dyn.info.imports[0].lib_index != 0) { ret 1; }
+    if (!dyn.info.imports[0].is_func) { ret 1; }
+    if (sel direct_idx.err) { ret 1; }
+    if (sel indirect_idx.err) { ret 1; }
+    if (direct_idx.ok != 0) { ret 1; }
+    if (indirect_idx.ok != 0) { ret 1; }
 
     free_dynstate(?alloc, ?dyn);
     map.dnit[intern.StrId, SymbolLoc](?locs);
@@ -9747,10 +9848,12 @@ test "mach.lang.be.linker.synthesize_local_imports:defined_local_import" {
                           ?refs[0], 6, ?ref_reloc, 1);
 
     var synth: of.ObjectImage;
-    val made: R.Result[bool, str] = synthesize_local_imports(
+    val made: res[bool, fail.Fail] = synthesize_local_imports(
         ?s, "__imp_", ?modules[0], 2, LINK_EXE,
         nil::*u32, nil::*AtomPlan, ?synth);
-    if (R.is_err[bool, str](made) || !R.unwrap_ok[bool, str](made)
+    var made_wrong: bool = sel made.err;
+    if (sel made.ok && !made.ok) { made_wrong = true; }
+    if (made_wrong
         || synth.section_count != 1 || synth.sections[0].kind != of.SK_RELRO
         || synth.sections[0].len != 8 || synth.sections[0].align != 8
         || synth.symbol_count != 2 || synth.reloc_count != 1
@@ -9762,18 +9865,19 @@ test "mach.lang.be.linker.synthesize_local_imports:defined_local_import" {
         || of.section_index(synth.relocations[0].section) != 0 || synth.relocations[0].offset != 0
         || synth.relocations[0].kind != of.RK_ABS64
         || synth.relocations[0].sym != 1 || synth.relocations[0].addend != 0) {
-        if (R.is_ok[bool, str](made) && R.unwrap_ok[bool, str](made)) { obj.dnit(?synth); }
+        if (sel made.ok && made.ok) { obj.dnit(?synth); }
         session.dnit(?s);
         ret 1;
     }
     obj.dnit(?synth);
 
     var untouched: of.ObjectImage;
-    val relocatable: R.Result[bool, str] = synthesize_local_imports(
+    val relocatable: res[bool, fail.Fail] = synthesize_local_imports(
         ?s, "__imp_", ?modules[0], 2, LINK_RELOCATABLE,
         nil::*u32, nil::*AtomPlan, ?untouched);
-    if (R.is_err[bool, str](relocatable)
-        || R.unwrap_ok[bool, str](relocatable)) {
+    var relocatable_wrong: bool = sel relocatable.err;
+    if (sel relocatable.ok && relocatable.ok) { relocatable_wrong = true; }
+    if (relocatable_wrong) {
         session.dnit(?s);
         ret 1;
     }
@@ -9784,24 +9888,24 @@ test "mach.lang.be.linker.synthesize_local_imports:defined_local_import" {
     corrupt_modules[0] = lt_image(?s, lt_name(?s, "corrupt-local-def"), ?text, 1,
                                   ?corrupt_def, 1, nil::*of.Relocation, 0);
     corrupt_modules[1] = modules[1];
-    val malformed: R.Result[bool, str] = synthesize_local_imports(
+    val malformed: res[bool, fail.Fail] = synthesize_local_imports(
         ?s, "__imp_", ?corrupt_modules[0], 2, LINK_EXE,
         nil::*u32, nil::*AtomPlan, ?untouched);
     var corrupt_locs: map.Map[intern.StrId, SymbolLoc] =
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
-    val diagnosed: R.Result[R.Void, str] = collect_symbols(
+    val diagnosed: err[fail.Fail] = collect_symbols(
         ?s, ?corrupt_modules[0], 2, nil::*Placement, nil::*u32,
         ?corrupt_locs, false, nil::*AtomPlan);
     map.dnit[intern.StrId, SymbolLoc](?corrupt_locs);
-    val max_size: R.Result[u32, str] = local_import_storage_size(0x1FFFFFFF);
-    val overflow: R.Result[u32, str] = local_import_storage_size(0x20000000);
+    val max_size: res[u32, fail.Fail] = local_import_storage_size(0x1FFFFFFF);
+    val overflow: res[u32, fail.Fail] = local_import_storage_size(0x20000000);
     session.dnit(?s);
-    if (R.is_err[bool, str](malformed)
-        || R.unwrap_ok[bool, str](malformed)
-        || !R.is_err[R.Void, str](diagnosed)
-        || R.is_err[u32, str](max_size)
-        || R.unwrap_ok[u32, str](max_size) != 0xFFFFFFF8
-        || !R.is_err[u32, str](overflow)) { ret 1; }
+    if (sel malformed.err) { ret 1; }
+    if (malformed.ok) { ret 1; }
+    if (!sel diagnosed.err) { ret 1; }
+    if (sel max_size.err) { ret 1; }
+    if (max_size.ok != 0xFFFFFFF8) { ret 1; }
+    if (!sel overflow.err) { ret 1; }
     ret 0;
 }
 
@@ -9873,27 +9977,27 @@ test "mach.lang.be.linker.synthesize_local_imports:dead_weak_comdat" {
     var sec_base: [3]u32;
     var atoms: AtomPlan;
     init_atom_plan(?atoms);
-    val planned: R.Result[R.Void, str] = build_atom_plan(
+    val planned: err[fail.Fail] = build_atom_plan(
         ?s, ?modules[0], 3, 0, ?sec_base[0], 3, true, tgt.isa, ?atoms);
     var synth: of.ObjectImage;
-    val dead: R.Result[bool, str] = synthesize_local_imports(
+    val dead: res[bool, fail.Fail] = synthesize_local_imports(
         ?s, "__imp_", ?modules[0], 3, LINK_EXE,
         ?sec_base[0], ?atoms, ?synth);
     var control: of.ObjectImage;
-    val inert: R.Result[bool, str] = synthesize_local_imports(
+    val inert: res[bool, fail.Fail] = synthesize_local_imports(
         ?s, "__imp_", ?modules[0], 3, LINK_EXE,
         nil::*u32, nil::*AtomPlan, ?control);
-    if (R.is_ok[bool, str](inert) && R.unwrap_ok[bool, str](inert)) {
+    if (sel inert.ok && inert.ok) {
         obj.dnit(?control);
     }
     val discarded: bool = atoms.active;
     free_atom_plan(?alloc, ?atoms);
     session.dnit(?s);
-    if (R.is_err[R.Void, str](planned) || !discarded
-        || R.is_err[bool, str](dead) || R.unwrap_ok[bool, str](dead)
-        || R.is_err[bool, str](inert) || !R.unwrap_ok[bool, str](inert)) {
-        ret 1;
-    }
+    if (sel planned.err || !discarded) { ret 1; }
+    if (sel dead.err) { ret 1; }
+    if (dead.ok) { ret 1; }
+    if (sel inert.err) { ret 1; }
+    if (!inert.ok) { ret 1; }
     ret 0;
 }
 
@@ -9924,11 +10028,13 @@ test "mach.lang.be.linker.build_dynamic_info:partial_import_cleanup" {
     var dyn: DynState;
     init_dynstate(?dyn);
 
-    val built: R.Result[R.Void, str] = build_dynamic_info(
+    val built: err[fail.Fail] = build_dynamic_info(
         ?s, ?tgt, ?dyn, ?module, 1, ?locs,
         nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
-    if (!R.is_err[R.Void, str](built) || dyn.info.imports == nil
-        || dyn.info.import_count != 0 || dyn.import_cap != 1) { ret 1; }
+    if (!sel built.err) { ret 1; }
+    if (dyn.info.imports == nil) { ret 1; }
+    if (dyn.info.import_count != 0) { ret 1; }
+    if (dyn.import_cap != 1) { ret 1; }
     free_dynstate(?alloc, ?dyn);
     if (dyn.info.imports != nil || dyn.import_cap != 0) { ret 1; }
 
@@ -9966,10 +10072,10 @@ test "mach.lang.be.linker.build_dynamic_info:implicit_platform_identity" {
     var collision_dyn: DynState;
     init_dynstate(?collision_dyn);
     collision_dyn.info.pie = true;
-    val collision: R.Result[R.Void, str] =
+    val collision: err[fail.Fail] =
         build_dynamic_info(?s, ?tgt, ?collision_dyn, nil::*of.ObjectImage, 0,
                            ?locs, ?explicit[0], 1, nil::*u32, nil::*AtomPlan);
-    if (!R.is_err[R.Void, str](collision)) { ret 1; }
+    if (!sel collision.err) { ret 1; }
     free_dynstate(?alloc, ?collision_dyn);
 
     var sym: of.Symbol;
@@ -9988,10 +10094,10 @@ test "mach.lang.be.linker.build_dynamic_info:implicit_platform_identity" {
     var dyn: DynState;
     init_dynstate(?dyn);
     dyn.info.pie = true;
-    val built: R.Result[R.Void, str] =
+    val built: err[fail.Fail] =
         build_dynamic_info(?s, ?tgt, ?dyn, ?module, 1, ?locs,
                            nil::*of.DynLib, 0, nil::*u32, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](built)) { ret 1; }
+    if (sel built.err) { ret 1; }
     if (dyn.info.lib_count != 1 || dyn.info.libs[0].name != platform
         || dyn.info.libs[0].soname != platform || dyn.info.import_count != 1
         || dyn.info.imports[0].lib_index != 0) { ret 1; }
@@ -10098,10 +10204,10 @@ test "mach.lang.be.linker.plan_atom_coalescing:only_matching_embed_atoms" {
     sec_base[0] = 0;
     sec_base[1] = 1;
 
-    val dr: R.Result[*u32, str] =
+    val dr: res[*u32, fail.Fail] =
         plan_atom_coalescing(?alloc, ?mods[0], 2, ?sec_base[0], 7, nil::*AtomPlan);
-    if (R.is_err[*u32, str](dr)) { ret 1; }
-    val dup: *u32 = R.unwrap_ok[*u32, str](dr);
+    if (sel dr.err) { ret 1; }
+    val dup: *u32 = dr.ok;
 
     if (dup[0] != ATOM_OWNS) { ret 1; }
     if (dup[1] != 0)          { ret 1; }
@@ -10120,10 +10226,10 @@ test "mach.lang.be.linker.plan_atom_coalescing:only_matching_embed_atoms" {
     mods3[2] = lt_image(?s, lt_name(?s, "m2"), ?secs2[0], 1, nil::*of.Symbol, 0, nil::*of.Relocation, 0);
     var base3: [3]u32;
     base3[0] = 0; base3[1] = 1; base3[2] = 7;
-    val dr3: R.Result[*u32, str] =
+    val dr3: res[*u32, fail.Fail] =
         plan_atom_coalescing(?alloc, ?mods3[0], 3, ?base3[0], 8, nil::*AtomPlan);
-    if (R.is_err[*u32, str](dr3)) { ret 1; }
-    val dup3: *u32 = R.unwrap_ok[*u32, str](dr3);
+    if (sel dr3.err) { ret 1; }
+    val dup3: *u32 = dr3.ok;
     if (dup3[7] != 0) { ret 1; }
     A.deallocate[u32](?alloc, dup3, 8::usize);
 
@@ -10135,10 +10241,10 @@ test "mach.lang.be.linker.plan_atom_coalescing:only_matching_embed_atoms" {
     mods_r[1] = lt_image(?s, lt_name(?s, "m1r"), ?secs1[0], 1, nil::*of.Symbol, 0, ?relocs[0], 1);
     var base_r: [2]u32;
     base_r[0] = 0; base_r[1] = 1;
-    val drr: R.Result[*u32, str] =
+    val drr: res[*u32, fail.Fail] =
         plan_atom_coalescing(?alloc, ?mods_r[0], 2, ?base_r[0], 2, nil::*AtomPlan);
-    if (R.is_err[*u32, str](drr)) { ret 1; }
-    val dupr: *u32 = R.unwrap_ok[*u32, str](drr);
+    if (sel drr.err) { ret 1; }
+    val dupr: *u32 = drr.ok;
     if (dupr[1] != ATOM_OWNS) { ret 1; }
     A.deallocate[u32](?alloc, dupr, 2::usize);
 
@@ -10203,15 +10309,15 @@ test "mach.lang.be.linker.link_modules:input_section_names_survive" {
     fin { output.dnit(?tf); }
     val tpath: str = output.path(?tf);
 
-    val lr: R.Result[R.Void, str] =
+    val lr: err[fail.Fail] =
         t_planned_link_modules_nocapture(?s, ?tgt, ?mods[0], 2, 2, nil::*of.DynLib, 0, tpath::*u8,
                      "macho_names"::*u8, LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
-    if (R.is_err[R.Void, str](lr)) { ret 1; }
+    if (sel lr.err) { ret 1; }
 
-    val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
+    val rr: res[Vector[u8], fs.FsError] = fs.read_bytes(?alloc, tpath);
 
-    if (R.is_err[Vector[u8], str](rr)) { ret 1; }
-    var b: Vector[u8] = R.unwrap_ok[Vector[u8], str](rr);
+    if (sel rr.err) { ret 1; }
+    var b: Vector[u8] = rr.ok;
 
     val cls: usize = lt_macho_section(b.data, "__DATA", "__objc_classlist");
     if (cls == 0)                                       { vector.dnit[u8](?b); ret 1; }
@@ -10289,14 +10395,14 @@ test "mach.lang.be.linker.link_modules:flat_entry_leads_regardless_of_order" {
     fin { output.dnit(?tf); }
     val tpath: str = output.path(?tf);
 
-    val lr: R.Result[R.Void, str] =
+    val lr: err[fail.Fail] =
         t_planned_link_modules_nocapture(?s, ?tgt, ?mods[0], 2, 2, nil::*of.DynLib, 0, tpath::*u8, "flat_entry"::*u8, LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
-    if (R.is_err[R.Void, str](lr)) { ret 1; }
+    if (sel lr.err) { ret 1; }
 
-    val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
+    val rr: res[Vector[u8], fs.FsError] = fs.read_bytes(?alloc, tpath);
 
-    if (R.is_err[Vector[u8], str](rr)) { ret 1; }
-    var b: Vector[u8] = R.unwrap_ok[Vector[u8], str](rr);
+    if (sel rr.err) { ret 1; }
+    var b: Vector[u8] = rr.ok;
 
     if (b.len != 48)        { vector.dnit[u8](?b); ret 1; }
     if (b.data[0]  != 0xCC) { vector.dnit[u8](?b); ret 1; }
@@ -10337,21 +10443,21 @@ fun lt_loader_link(s: *session.Session, tgt: *target.Target, mode: LinkMode, pie
     fin { output.dnit(?tf); }
     val tpath: str = output.path(?tf);
 
-    val lr: R.Result[R.Void, str] =
+    val lr: err[fail.Fail] =
         t_planned_link_modules_nocapture(s, tgt, ?mods[0], 1, 1, dynlibs, dynlib_count, tpath::*u8,
                      "loader_req"::*u8, mode, pie,
                      of.image_options_default(of.SUBSYSTEM_CONSOLE));
-    if (R.is_err[R.Void, str](lr)) {
+    if (sel lr.err) {
 
-        ret R.unwrap_err[R.Void, str](lr);
+        ret fail.describe(lr.err);
     }
     if (out != nil) {
-        val rr: R.Result[Vector[u8], str] = fs.read_bytes(s.alloc, tpath);
-        if (R.is_err[Vector[u8], str](rr)) {
+        val rr: res[Vector[u8], fs.FsError] = fs.read_bytes(s.alloc, tpath);
+        if (sel rr.err) {
 
             ret "lt: read failed";
         }
-        @out = R.unwrap_ok[Vector[u8], str](rr);
+        @out = rr.ok;
     }
 
     ret "";
@@ -10466,11 +10572,11 @@ fun lt_attributed_link(s: *session.Session, tgt: *target.Target, attributes: *u8
     if (R.is_err[output.Output, str](tf_r)) { ret "lt: temp failed"; }
     var tf: output.Output = R.unwrap_ok[output.Output, str](tf_r);
     fin { output.dnit(?tf); }
-    val lr: R.Result[R.Void, str] =
+    val lr: err[fail.Fail] =
         t_planned_link_modules_nocapture(s, tgt, ?mods[0], 1, 1, nil::*of.DynLib, 0, output.path(?tf)::*u8,
                      "attributed"::*u8, LINK_EXE, false,
                      of.image_options_default(of.SUBSYSTEM_CONSOLE));
-    if (R.is_err[R.Void, str](lr)) { ret R.unwrap_err[R.Void, str](lr); }
+    if (sel lr.err) { ret fail.describe(lr.err); }
     ret "";
 }
 
@@ -10584,16 +10690,16 @@ test "mach.lang.be.linker.patch_relocations:anonymous_section_symbols_stay_disti
     var otf: output.Output = R.unwrap_ok[output.Output, str](otf_r);
     fin { output.dnit(?otf); }
     val opath: str = output.path(?otf);
-    val olr: R.Result[R.Void, str] =
+    val olr: err[fail.Fail] =
         t_planned_link_modules_nocapture(?s, ?etgt, ?mods[0], 1, 0, nil::*of.DynLib, 0, opath::*u8,
                      "anon_section_obj"::*u8, LINK_RELOCATABLE, false,
                      of.image_options_default(of.SUBSYSTEM_CONSOLE));
-    if (R.is_err[R.Void, str](olr)) { ret 1; }
+    if (sel olr.err) { ret 1; }
 
-    val orb: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, opath);
+    val orb: res[Vector[u8], fs.FsError] = fs.read_bytes(?alloc, opath);
 
-    if (R.is_err[Vector[u8], str](orb)) { ret 1; }
-    var ob: Vector[u8] = R.unwrap_ok[Vector[u8], str](orb);
+    if (sel orb.err) { ret 1; }
+    var ob: Vector[u8] = orb.ok;
     var carried: of.ObjectImage;
     val opr: R.Result[R.Void, str] =
         etgt.of.parse_object(?alloc, ?s.interner, ob.data, ob.len, ?carried);
@@ -10624,14 +10730,14 @@ test "mach.lang.be.linker.patch_relocations:anonymous_section_symbols_stay_disti
     fin { output.dnit(?tf); }
     val tpath: str = output.path(?tf);
 
-    val lr: R.Result[R.Void, str] =
+    val lr: err[fail.Fail] =
         t_planned_link_modules_nocapture(?s, ?tgt, ?mods[0], 1, 1, nil::*of.DynLib, 0, tpath::*u8, "anon_section_syms"::*u8, LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
-    if (R.is_err[R.Void, str](lr)) { ret 1; }
+    if (sel lr.err) { ret 1; }
 
-    val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
+    val rr: res[Vector[u8], fs.FsError] = fs.read_bytes(?alloc, tpath);
 
-    if (R.is_err[Vector[u8], str](rr)) { ret 1; }
-    var b: Vector[u8] = R.unwrap_ok[Vector[u8], str](rr);
+    if (sel rr.err) { ret 1; }
+    var b: Vector[u8] = rr.ok;
 
     if (b.len < 24) { vector.dnit[u8](?b); ret 1; }
     var site: usize = b.len;
@@ -10737,15 +10843,15 @@ test "mach.lang.be.linker.patch_relocations:duplicate_coff_section_symbols_stay_
     fin { output.dnit(?tf); }
     val tpath: str = output.path(?tf);
 
-    val lr: R.Result[R.Void, str] =
+    val lr: err[fail.Fail] =
         t_planned_link_modules_nocapture(?s, ?tgt, ?mods[0], 1, 0, nil::*of.DynLib, 0, tpath::*u8,
                      "coff_section_syms"::*u8, LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
-    if (R.is_err[R.Void, str](lr)) { ret 1; }
+    if (sel lr.err) { ret 1; }
 
-    val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, tpath);
+    val rr: res[Vector[u8], fs.FsError] = fs.read_bytes(?alloc, tpath);
 
-    if (R.is_err[Vector[u8], str](rr)) { ret 1; }
-    var b: Vector[u8] = R.unwrap_ok[Vector[u8], str](rr);
+    if (sel rr.err) { ret 1; }
+    var b: Vector[u8] = rr.ok;
 
     var site: usize = b.len;
     var scan: usize = 0;
@@ -10796,16 +10902,16 @@ test "mach.lang.be.linker.collect_symbols:weak_strong_order_independent" {
     strong2.name = nm; strong2.section = of.section_id(0); strong2.offset = 0; strong2.size = 0;
     strong2.flags = of.SYM_OBJ_FLAG_GLOBAL;
 
-    val r1: R.Result[u64, str] = lt_link(?s, nm, ?weak, ?strong);
-    if (R.is_err[u64, str](r1))              { ret 1; }
-    if (R.unwrap_ok[u64, str](r1) != 0x2000) { ret 1; }
+    val r1: res[u64, fail.Fail] = lt_link(?s, nm, ?weak, ?strong);
+    if (sel r1.err)              { ret 1; }
+    if (r1.ok != 0x2000) { ret 1; }
 
-    val r2: R.Result[u64, str] = lt_link(?s, nm, ?strong, ?weak);
-    if (R.is_err[u64, str](r2))              { ret 1; }
-    if (R.unwrap_ok[u64, str](r2) != 0x1000) { ret 1; }
+    val r2: res[u64, fail.Fail] = lt_link(?s, nm, ?strong, ?weak);
+    if (sel r2.err)              { ret 1; }
+    if (r2.ok != 0x1000) { ret 1; }
 
-    val r3: R.Result[u64, str] = lt_link(?s, nm, ?strong, ?strong2);
-    if (!R.is_err[u64, str](r3)) { ret 1; }
+    val r3: res[u64, fail.Fail] = lt_link(?s, nm, ?strong, ?strong2);
+    if (!sel r3.err) { ret 1; }
     ret 0;
 }
 
@@ -10837,12 +10943,12 @@ test "mach.lang.be.linker.collect_symbols:winning_section_metadata" {
     var locs: map.Map[intern.StrId, SymbolLoc] =
         map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
 
-    val cr: R.Result[R.Void, str] = collect_symbols(?s, ?modules[0], 2,
+    val cr: err[fail.Fail] = collect_symbols(?s, ?modules[0], 2,
         ?placements[0], ?sec_base[0], ?locs, true, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](cr)) { map.dnit[intern.StrId, SymbolLoc](?locs); ret 1; }
-    val lr: R.Result[*SymbolLoc, str] = map.get[intern.StrId, SymbolLoc](?locs, ?name);
-    if (R.is_err[*SymbolLoc, str](lr)) { map.dnit[intern.StrId, SymbolLoc](?locs); ret 1; }
-    val loc: *SymbolLoc = R.unwrap_ok[*SymbolLoc, str](lr);
+    if (sel cr.err) { map.dnit[intern.StrId, SymbolLoc](?locs); ret 1; }
+    val lr: opt[*SymbolLoc] = map.get[intern.StrId, SymbolLoc](?locs, ?name);
+    if (sel lr.none) { map.dnit[intern.StrId, SymbolLoc](?locs); ret 1; }
+    val loc: *SymbolLoc = lr.some;
     if (loc.vaddr != 0x2430 || loc.section_vaddr != 0x2000
         || loc.merged_index != 1 || loc.weak) {
         map.dnit[intern.StrId, SymbolLoc](?locs);
@@ -10935,13 +11041,16 @@ test "mach.lang.be.linker.atom_plan:resolution_and_inert_gate" {
 
     var plan: AtomPlan;
     init_atom_plan(?plan);
-    val disabled: R.Result[R.Void, str] =
+    val disabled: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, false, nil::*isa.IsaVTable, ?plan);
-    if (R.is_err[R.Void, str](disabled) || plan.active) { ret 1; }
+    if (sel disabled.err) { ret 1; }
+    if (plan.active) { ret 1; }
 
-    val ww: R.Result[R.Void, str] =
+    val ww: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
-    if (R.is_err[R.Void, str](ww) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (sel ww.err) { ret 1; }
+    if (!plan.active) { ret 1; }
+    if (plan.drop_count != 1) { ret 1; }
     if (plan.drops[0].section != 1 || plan.drops[0].start != 0
         || plan.drops[0].end != 8 || plan.removed_bytes != 8) { ret 1; }
     if (module_weak_function_ref_is_dead(?mods[0], 0, dup, 0, ?bases[0], ?plan)
@@ -10949,33 +11058,38 @@ test "mach.lang.be.linker.atom_plan:resolution_and_inert_gate" {
     free_atom_plan(?alloc, ?plan);
 
     syms1[0].flags = strong_flags;
-    val ws: R.Result[R.Void, str] =
+    val ws: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
-    if (R.is_err[R.Void, str](ws) || !plan.active || plan.drops[0].section != 0) { ret 1; }
+    if (sel ws.err) { ret 1; }
+    if (!plan.active) { ret 1; }
+    if (plan.drops[0].section != 0) { ret 1; }
     if (!module_weak_function_ref_is_dead(?mods[0], 0, dup, 0, ?bases[0], ?plan)
         || module_weak_function_ref_is_dead(?mods[0], 1, dup, 0, ?bases[0], ?plan)) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
     syms0[0].flags = strong_flags;
     syms1[0].flags = weak_flags;
-    val sw: R.Result[R.Void, str] =
+    val sw: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
-    if (R.is_err[R.Void, str](sw) || !plan.active || plan.drops[0].section != 1) { ret 1; }
+    if (sel sw.err) { ret 1; }
+    if (!plan.active) { ret 1; }
+    if (plan.drops[0].section != 1) { ret 1; }
     if (module_weak_function_ref_is_dead(?mods[0], 0, dup, 0, ?bases[0], ?plan)
         || !module_weak_function_ref_is_dead(?mods[0], 1, dup, 0, ?bases[0], ?plan)) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
     syms1[0].flags = strong_flags;
-    val ss: R.Result[R.Void, str] =
+    val ss: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
-    if (!R.is_err[R.Void, str](ss)) { ret 1; }
+    if (!sel ss.err) { ret 1; }
 
     syms0[0].flags = weak_flags;
     syms1[0].flags = weak_flags;
     syms1[0].name = other;
-    val unique: R.Result[R.Void, str] =
+    val unique: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, nil::*isa.IsaVTable, ?plan);
-    if (R.is_err[R.Void, str](unique) || plan.active) { ret 1; }
+    if (sel unique.err) { ret 1; }
+    if (plan.active) { ret 1; }
     ret 0;
 }
 
@@ -11055,9 +11169,11 @@ test "mach.lang.be.linker.atom_plan:copy_remap_and_reloc_liveness" {
     var bases: [2]u32;
     var plan: AtomPlan;
     init_atom_plan(?plan);
-    val pr: R.Result[R.Void, str] =
+    val pr: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
-    if (R.is_err[R.Void, str](pr) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (sel pr.err) { ret 1; }
+    if (!plan.active) { ret 1; }
+    if (plan.drop_count != 1) { ret 1; }
 
     if (plan.drops[0].section != 1 || plan.drops[0].start != 8
         || plan.drops[0].end != 24 || plan.drops[0].resume != 8
@@ -11129,17 +11245,21 @@ test "mach.lang.be.linker.atom_plan:shared_symbol_retains_loser" {
     var bases: [2]u32;
     var plan: AtomPlan;
     init_atom_plan(?plan);
-    val pr: R.Result[R.Void, str] =
+    val pr: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
-    if (R.is_err[R.Void, str](pr) || plan.active || plan.drop_count != 0) { ret 1; }
+    if (sel pr.err) { ret 1; }
+    if (plan.active) { ret 1; }
+    if (plan.drop_count != 0) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
     init_atom_plan(?plan);
     mods[1] = lt_image(?s, lt_name(?s, "b"), ?b_sec[0], 1, ?b_syms[0], 2,
                        nil::*of.Relocation, 0);
-    val ur: R.Result[R.Void, str] =
+    val ur: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
-    if (R.is_err[R.Void, str](ur) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (sel ur.err) { ret 1; }
+    if (!plan.active) { ret 1; }
+    if (plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
     ret 0;
 }
@@ -11192,26 +11312,26 @@ test "mach.lang.be.linker.atom_plan:undescribed_kind_is_rejected_not_defaulted" 
     var bases: [2]u32;
     var plan: AtomPlan;
     init_atom_plan(?plan);
-    val described: R.Result[R.Void, str] =
+    val described: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
-    if (R.is_err[R.Void, str](described)) { ret 4; }
+    if (sel described.err) { ret 4; }
     free_atom_plan(?alloc, ?plan);
 
     relocation[0].kind = of.RK_PAGE21;
     init_atom_plan(?plan);
-    val undescribed: R.Result[R.Void, str] =
+    val undescribed: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
-    if (!R.is_err[R.Void, str](undescribed)) { ret 5; }
-    if (!str_contains(R.unwrap_err[R.Void, str](undescribed), "catalog does not describe")) { ret 6; }
+    if (!sel undescribed.err) { ret 5; }
+    if (!str_contains(fail.describe(undescribed.err), "catalog does not describe")) { ret 6; }
     free_atom_plan(?alloc, ?plan);
 
     relocation[0].kind = of.RK_ABS64;
     relocation[0].section = of.section_id(9);
     init_atom_plan(?plan);
-    val stray: R.Result[R.Void, str] =
+    val stray: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
-    if (!R.is_err[R.Void, str](stray)) { ret 7; }
-    if (!str_contains(R.unwrap_err[R.Void, str](stray), "does not carry")) { ret 8; }
+    if (!sel stray.err) { ret 7; }
+    if (!str_contains(fail.describe(stray.err), "does not carry")) { ret 8; }
     free_atom_plan(?alloc, ?plan);
     ret 0;
 }
@@ -11270,15 +11390,18 @@ test "mach.lang.be.linker.atom_plan:difference_subtrahend_retains_loser" {
     var bases: [2]u32;
     var plan: AtomPlan;
     init_atom_plan(?plan);
-    val difference: R.Result[R.Void, str] =
+    val difference: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
-    if (R.is_err[R.Void, str](difference) || plan.active) { ret 1; }
+    if (sel difference.err) { ret 1; }
+    if (plan.active) { ret 1; }
 
     relocation[0].kind = of.RK_ABS32;
     if (!unreferenced_local(?mods[1], 1)) { ret 1; }
-    val ordinary: R.Result[R.Void, str] =
+    val ordinary: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
-    if (R.is_err[R.Void, str](ordinary) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (sel ordinary.err) { ret 1; }
+    if (!plan.active) { ret 1; }
+    if (plan.drop_count != 1) { ret 1; }
     if (plan.drops[0].section != 1 || plan.drops[0].start != 0
         || plan.drops[0].end != 8) { ret 1; }
     free_atom_plan(?alloc, ?plan);
@@ -11336,9 +11459,11 @@ test "mach.lang.be.linker.atom_plan:sized_extent_and_covering_symbol" {
     var bases: [2]u32;
     var plan: AtomPlan;
     init_atom_plan(?plan);
-    val sized: R.Result[R.Void, str] =
+    val sized: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
-    if (R.is_err[R.Void, str](sized) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (sel sized.err) { ret 1; }
+    if (!plan.active) { ret 1; }
+    if (plan.drop_count != 1) { ret 1; }
     if (plan.drops[0].start != 0 || plan.drops[0].end != 8
         || plan.sections[1].live_len != 8) { ret 1; }
     var copied: [8]u8;
@@ -11354,9 +11479,10 @@ test "mach.lang.be.linker.atom_plan:sized_extent_and_covering_symbol" {
     b_syms[0].size = 8;
     b_syms[1].offset = 0;
     b_syms[1].size = 16;
-    val covered: R.Result[R.Void, str] =
+    val covered: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
-    if (R.is_err[R.Void, str](covered) || plan.active) { ret 1; }
+    if (sel covered.err) { ret 1; }
+    if (plan.active) { ret 1; }
     ret 0;
 }
 
@@ -11421,10 +11547,12 @@ test "mach.lang.be.linker.atom_plan:suffix_alignment_grid" {
     var bases: [2]u32;
     var plan: AtomPlan;
     init_atom_plan(?plan);
-    val pr: R.Result[R.Void, str] =
+    val pr: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true,
                         nil::*isa.IsaVTable, ?plan);
-    if (R.is_err[R.Void, str](pr) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (sel pr.err) { ret 1; }
+    if (!plan.active) { ret 1; }
+    if (plan.drop_count != 1) { ret 1; }
     if (plan.drops[0].start != 16 || plan.drops[0].end != 37
         || plan.drops[0].resume != 21 || plan.sections[1].live_len != 48
         || plan.removed_bytes != 16) { ret 1; }
@@ -11483,17 +11611,20 @@ test "mach.lang.be.linker.atom_plan:coff_carrier_anchor" {
     var bases: [2]u32;
     var plan: AtomPlan;
     init_atom_plan(?plan);
-    val inert_anchor: R.Result[R.Void, str] =
+    val inert_anchor: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
-    if (R.is_err[R.Void, str](inert_anchor) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (sel inert_anchor.err) { ret 1; }
+    if (!plan.active) { ret 1; }
+    if (plan.drop_count != 1) { ret 1; }
     if (plan.drops[0].section != 1 || plan.drops[0].start != 0
         || plan.drops[0].end != 8) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
     mods[1].reloc_count = 1;
-    val referenced_anchor: R.Result[R.Void, str] =
+    val referenced_anchor: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
-    if (R.is_err[R.Void, str](referenced_anchor) || plan.active) { ret 1; }
+    if (sel referenced_anchor.err) { ret 1; }
+    if (plan.active) { ret 1; }
     ret 0;
 }
 
@@ -11551,15 +11682,18 @@ test "mach.lang.be.linker.atom_plan:debug_crossing_does_not_retain_loser" {
     var bases: [2]u32;
     var plan: AtomPlan;
     init_atom_plan(?plan);
-    val from_debug: R.Result[R.Void, str] =
+    val from_debug: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
-    if (R.is_err[R.Void, str](from_debug) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (sel from_debug.err) { ret 1; }
+    if (!plan.active) { ret 1; }
+    if (plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
     b_secs[1].kind = of.SK_TEXT;
-    val from_text: R.Result[R.Void, str] =
+    val from_text: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
-    if (R.is_err[R.Void, str](from_text) || plan.active) { ret 1; }
+    if (sel from_text.err) { ret 1; }
+    if (plan.active) { ret 1; }
     ret 0;
 }
 
@@ -11618,54 +11752,64 @@ test "mach.lang.be.linker.atom_plan:anchor_addend_crossing_retains_loser" {
     var bases: [2]u32;
     var plan: AtomPlan;
     init_atom_plan(?plan);
-    val crossing: R.Result[R.Void, str] =
+    val crossing: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
-    if (R.is_err[R.Void, str](crossing) || plan.active) { ret 1; }
+    if (sel crossing.err) { ret 1; }
+    if (plan.active) { ret 1; }
 
     reloc[0].addend = 4;
-    val same_side: R.Result[R.Void, str] =
+    val same_side: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
-    if (R.is_err[R.Void, str](same_side) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (sel same_side.err) { ret 1; }
+    if (!plan.active) { ret 1; }
+    if (plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
     b_bytes[3] = 0xE8;
     reloc[0].offset = 4;
     reloc[0].kind = of.RK_PC32;
     reloc[0].addend = -4;
-    val pc_local: R.Result[R.Void, str] =
+    val pc_local: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 3, true, x64, ?plan);
-    if (R.is_err[R.Void, str](pc_local) || plan.active) { ret 1; }
+    if (sel pc_local.err) { ret 1; }
+    if (plan.active) { ret 1; }
     reloc[0].sym = 2;
     reloc[0].kind = of.RK_PLT32;
 
-    val parsed_plt_data: R.Result[R.Void, str] =
+    val parsed_plt_data: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 1, ?bases[0], 3, true, x64, ?plan);
-    if (R.is_err[R.Void, str](parsed_plt_data) || plan.active) { ret 1; }
+    if (sel parsed_plt_data.err) { ret 1; }
+    if (plan.active) { ret 1; }
 
     reloc[0].sym = 0;
     reloc[0].addend = 3;
-    val parsed_plt_trailing: R.Result[R.Void, str] =
+    val parsed_plt_trailing: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 1, ?bases[0], 3, true, x64, ?plan);
-    if (R.is_err[R.Void, str](parsed_plt_trailing) || plan.active) { ret 1; }
+    if (sel parsed_plt_trailing.err) { ret 1; }
+    if (plan.active) { ret 1; }
 
     reloc[0].sym = 2;
     reloc[0].addend = -4;
     reloc[0].kind = of.RK_PC32;
-    val codegen_pc: R.Result[R.Void, str] =
+    val codegen_pc: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 2, ?bases[0], 3, true, x64, ?plan);
-    if (R.is_err[R.Void, str](codegen_pc) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (sel codegen_pc.err) { ret 1; }
+    if (!plan.active) { ret 1; }
+    if (plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
-    val arm_global: R.Result[R.Void, str] =
+    val arm_global: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 2, ?bases[0], 3, true, arm64, ?plan);
-    if (R.is_err[R.Void, str](arm_global) || plan.active) { ret 1; }
+    if (sel arm_global.err) { ret 1; }
+    if (plan.active) { ret 1; }
 
     reloc[0].section = of.section_id(1);
     reloc[0].offset = 0;
     reloc[0].kind = of.RK_PC32;
-    val data_pc: R.Result[R.Void, str] =
+    val data_pc: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 2, ?bases[0], 3, true, x64, ?plan);
-    if (R.is_err[R.Void, str](data_pc) || plan.active) { ret 1; }
+    if (sel data_pc.err) { ret 1; }
+    if (plan.active) { ret 1; }
     ret 0;
 }
 
@@ -11719,19 +11863,24 @@ test "mach.lang.be.linker.atom_plan:rv64_plt_pair_boundary" {
     var plan: AtomPlan;
     init_atom_plan(?plan);
 
-    val x: R.Result[R.Void, str] =
+    val x: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, x64, ?plan);
-    if (R.is_err[R.Void, str](x) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (sel x.err) { ret 1; }
+    if (!plan.active) { ret 1; }
+    if (plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
-    val arm: R.Result[R.Void, str] =
+    val arm: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, arm64, ?plan);
-    if (R.is_err[R.Void, str](arm) || !plan.active || plan.drop_count != 1) { ret 1; }
+    if (sel arm.err) { ret 1; }
+    if (!plan.active) { ret 1; }
+    if (plan.drop_count != 1) { ret 1; }
     free_atom_plan(?alloc, ?plan);
 
-    val rv: R.Result[R.Void, str] =
+    val rv: err[fail.Fail] =
         build_atom_plan(?s, ?mods[0], 2, 0, ?bases[0], 2, true, rv64, ?plan);
-    if (R.is_err[R.Void, str](rv) || plan.active) { ret 1; }
+    if (sel rv.err) { ret 1; }
+    if (plan.active) { ret 1; }
     ret 0;
 }
 
@@ -11797,16 +11946,16 @@ test "mach.lang.be.linker.dynstate_add_import_addr_fixup:preserves_addend" {
     var dyn: DynState;
     init_dynstate(?dyn);
 
-    val added: R.Result[R.Void, str] = dynstate_add_import_addr_fixup(
+    val added: err[fail.Fail] = dynstate_add_import_addr_fixup(
         ?s, ?dyn, 2, 8, 3, 0x1234, of.RK_PC32, -4);
-    if (R.is_err[R.Void, str](added)
-        || dyn.info.import_addr_fixup_count != 1
-        || dyn.info.import_addr_fixups[0].seg_index != 2
-        || dyn.info.import_addr_fixups[0].seg_offset != 8
-        || dyn.info.import_addr_fixups[0].import_index != 3
-        || dyn.info.import_addr_fixups[0].patch_vaddr != 0x1234
-        || dyn.info.import_addr_fixups[0].kind != of.RK_PC32
-        || dyn.info.import_addr_fixups[0].addend != -4) { ret 1; }
+    if (sel added.err) { ret 1; }
+    if (dyn.info.import_addr_fixup_count != 1) { ret 1; }
+    if (dyn.info.import_addr_fixups[0].seg_index != 2) { ret 1; }
+    if (dyn.info.import_addr_fixups[0].seg_offset != 8) { ret 1; }
+    if (dyn.info.import_addr_fixups[0].import_index != 3) { ret 1; }
+    if (dyn.info.import_addr_fixups[0].patch_vaddr != 0x1234) { ret 1; }
+    if (dyn.info.import_addr_fixups[0].kind != of.RK_PC32) { ret 1; }
+    if (dyn.info.import_addr_fixups[0].addend != -4) { ret 1; }
 
     free_dynstate(?alloc, ?dyn);
     session.dnit(?s);
@@ -11863,8 +12012,9 @@ test "mach.lang.be.linker.local_got_plan:deduplicates_effective_target" {
     loc.merged_index = of.SK_DATA::u32;
     loc.weak = false;
     loc.fallback = intern.STR_NIL;
-    if (R.is_err[bool, str](map.insert[intern.StrId, SymbolLoc](
-        ?locs, target_name, loc))) { ret 1; }
+    val insert_r: res[bool, A.Error] = map.insert[intern.StrId, SymbolLoc](
+        ?locs, target_name, loc);
+    if (sel insert_r.err) { ret 1; }
 
     var merged: [7]MergedSection;
     merged[of.SK_RELRO::u32].len = 3;
@@ -11876,20 +12026,22 @@ test "mach.lang.be.linker.local_got_plan:deduplicates_effective_target" {
     init_section_groups(?groups);
     var undeclared: LocalGotPlan;
     init_local_got_plan(?undeclared);
-    val skipped: R.Result[R.Void, str] = build_local_got_plan(
+    val skipped: err[fail.Fail] = build_local_got_plan(
         ?s, arm64, ?module, 1, ?locs, ?sec_base[0], nil::*AtomPlan,
         ?merged[0], ?groups, ?undeclared);
-    if (R.is_err[R.Void, str](skipped) || undeclared.count != 0) { ret 1; }
+    if (sel skipped.err) { ret 1; }
+    if (undeclared.count != 0) { ret 1; }
     free_local_got_plan(?alloc, ?undeclared);
 
-    val built: R.Result[R.Void, str] = build_local_got_plan(
+    val built: err[fail.Fail] = build_local_got_plan(
         ?s, x64, ?module, 1, ?locs, ?sec_base[0], nil::*AtomPlan,
         ?merged[0], ?groups, ?plan);
-    if (R.is_err[R.Void, str](built) || plan.count != 1
-        || plan.slots[0].offset != 8
-        || merged[of.SK_RELRO::u32].len != 16
-        || merged[of.SK_RELRO::u32].align != 8
-        || !merged[of.SK_RELRO::u32].used) { ret 1; }
+    if (sel built.err) { ret 1; }
+    if (plan.count != 1) { ret 1; }
+    if (plan.slots[0].offset != 8) { ret 1; }
+    if (merged[of.SK_RELRO::u32].len != 16) { ret 1; }
+    if (merged[of.SK_RELRO::u32].align != 8) { ret 1; }
+    if (!merged[of.SK_RELRO::u32].used) { ret 1; }
 
     merged[of.SK_RELRO::u32].vaddr = 0x5000;
     finalize_local_got_vaddrs(?merged[0], ?plan);
@@ -11905,8 +12057,9 @@ fun lt_common_module(s: *session.Session, mod_name: str, name: str, size: u32, a
     val alloc: *A.Allocator = s.alloc;
     val mn: R.Result[intern.StrId, str] = intern.intern(?s.interner, mod_name);
     val sn: R.Result[intern.StrId, str] = intern.intern(?s.interner, name);
-    var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](
-        obj.init(alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](mn)));
+    val img_r: res[of.ObjectImage, fail.Fail] = obj.image_init(alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](mn));
+    var img: of.ObjectImage;
+    if (sel img_r.ok) { img = img_r.ok; }
     var sym: of.Symbol;
     sym.name    = R.unwrap_ok[intern.StrId, str](sn);
     sym.section = of.external_section();
@@ -11914,7 +12067,7 @@ fun lt_common_module(s: *session.Session, mod_name: str, name: str, size: u32, a
     sym.size    = size;
     sym.align   = align;
     sym.flags   = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_EXTERN | of.SYM_OBJ_FLAG_COMMON;
-    obj.add_symbol(?img, sym);
+    obj.symbol_add(?img, sym);
     ret img;
 }
 
@@ -11931,9 +12084,9 @@ test "mach.lang.be.linker.synthesize_common_storage:coalesces_to_the_largest_req
 
     var bad: i32 = 0;
     var out: of.ObjectImage;
-    val cr: R.Result[bool, str] = synthesize_common_storage(?s, ?mods[0], 2, LINK_EXE, ?out);
-    if (R.is_err[bool, str](cr)) { bad = 2; }
-    or (!R.unwrap_ok[bool, str](cr)) { bad = 3; }
+    val cr: res[bool, fail.Fail] = synthesize_common_storage(?s, ?mods[0], 2, LINK_EXE, ?out);
+    if (sel cr.err) { bad = 2; }
+    or (sel cr.ok && !cr.ok) { bad = 3; }
     or {
         if (out.symbol_count != 1                      && bad == 0) { bad = 4; }
         or (out.section_count != 1                     && bad == 0) { bad = 5; }
@@ -11968,41 +12121,44 @@ test "mach.lang.be.linker.synthesize_common_storage:a_real_definition_wins" {
     val mn: R.Result[intern.StrId, str] = intern.intern(?s.interner, "b.o");
     val dn: R.Result[intern.StrId, str] = intern.intern(?s.interner, ".data");
     val sn: R.Result[intern.StrId, str] = intern.intern(?s.interner, "_shared");
-    mods[1] = R.unwrap_ok[of.ObjectImage, str](
-        obj.init(?alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](mn)));
-    val bytes_r: R.Result[*u8, str] = A.zallocate[u8](?alloc, 8::usize);
+    val mod_r: res[of.ObjectImage, fail.Fail] = obj.image_init(?alloc, ?s.interner, R.unwrap_ok[intern.StrId, str](mn));
+    if (sel mod_r.err) { ret 1; }
+    mods[1] = mod_r.ok;
+    val bytes_r: res[*u8, A.Error] = A.zallocate[u8](?alloc, 8::usize);
+    if (sel bytes_r.err) { ret 1; }
     var sec: of.Section;
     sec.name = R.unwrap_ok[intern.StrId, str](dn);
     sec.kind = of.SK_DATA;
-    sec.bytes = R.unwrap_ok[*u8, str](bytes_r);
+    sec.bytes = bytes_r.ok;
     sec.len = 8;
     sec.align = 8;
     sec.flags = 0;
-    val si: R.Result[u32, str] = obj.install_section(?mods[1], ?sec);
+    val si: res[u32, fail.Fail] = obj.section_install(?mods[1], ?sec);
+    if (sel si.err) { ret 1; }
     var dsym: of.Symbol;
     dsym.name    = R.unwrap_ok[intern.StrId, str](sn);
-    dsym.section = of.section_id(R.unwrap_ok[u32, str](si));
+    dsym.section = of.section_id(si.ok);
     dsym.offset  = 0;
     dsym.size    = 8;
     dsym.flags   = of.SYM_OBJ_FLAG_GLOBAL | of.SYM_OBJ_FLAG_OBJECT;
     dsym.fallback = of.SYMBOL_NONE;
     dsym.align    = 8;
-    obj.add_symbol(?mods[1], dsym);
+    obj.symbol_add(?mods[1], dsym);
 
     var bad: i32 = 0;
     var out: of.ObjectImage;
-    val cr: R.Result[bool, str] = synthesize_common_storage(?s, ?mods[0], 2, LINK_EXE, ?out);
-    if (R.is_err[bool, str](cr)) { bad = 2; }
-    or (R.unwrap_ok[bool, str](cr)) {
+    val cr: res[bool, fail.Fail] = synthesize_common_storage(?s, ?mods[0], 2, LINK_EXE, ?out);
+    if (sel cr.err) { bad = 2; }
+    or (sel cr.ok && cr.ok) {
         bad = 3;
         obj.dnit(?out);
     }
 
     if (bad == 0) {
         var out2: of.ObjectImage;
-        val rr: R.Result[bool, str] = synthesize_common_storage(?s, ?mods[0], 1, LINK_RELOCATABLE, ?out2);
-        if (R.is_err[bool, str](rr)) { bad = 4; }
-        or (R.unwrap_ok[bool, str](rr)) { bad = 5; obj.dnit(?out2); }
+        val rr: res[bool, fail.Fail] = synthesize_common_storage(?s, ?mods[0], 1, LINK_RELOCATABLE, ?out2);
+        if (sel rr.err) { bad = 4; }
+        or (sel rr.ok && rr.ok) { bad = 5; obj.dnit(?out2); }
     }
 
     obj.dnit(?mods[0]);
@@ -12023,9 +12179,9 @@ test "mach.lang.be.linker.synthesize_common_storage:refuses_layout_exceeding_2gi
     mods[1] = lt_common_module(?s, "b.o", "_second", 1, 1);
 
     var out: of.ObjectImage;
-    val cr: R.Result[bool, str] = synthesize_common_storage(?s, ?mods[0], 2, LINK_EXE, ?out);
+    val cr: res[bool, fail.Fail] = synthesize_common_storage(?s, ?mods[0], 2, LINK_EXE, ?out);
     var bad: i32 = 0;
-    if (R.is_ok[bool, str](cr)) { bad = 1; obj.dnit(?out); }
+    if (sel cr.ok) { bad = 1; obj.dnit(?out); }
 
     obj.dnit(?mods[0]);
     obj.dnit(?mods[1]);
@@ -12037,8 +12193,8 @@ test "mach.lang.be.linker.total_sections:refuses_flattened_count_overflow" {
     var mods: [2]of.ObjectImage;
     mods[0].section_count = 0xFFFFFFFF;
     mods[1].section_count = 1;
-    val r: R.Result[u32, str] = total_sections(?mods[0], 2);
-    if (R.is_ok[u32, str](r)) { ret 1; }
+    val r: res[u32, fail.Fail] = total_sections(?mods[0], 2);
+    if (sel r.ok) { ret 1; }
     ret 0;
 }
 
@@ -12046,28 +12202,28 @@ test "mach.lang.be.linker.total_symbols:refuses_flattened_count_overflow" {
     var mods: [2]of.ObjectImage;
     mods[0].symbol_count = 0xFFFFFFFF;
     mods[1].symbol_count = 1;
-    val r: R.Result[u32, str] = total_symbols(?mods[0], 2);
-    if (R.is_ok[u32, str](r)) { ret 1; }
+    val r: res[u32, fail.Fail] = total_symbols(?mods[0], 2);
+    if (sel r.ok) { ret 1; }
     ret 0;
 }
 
 test "mach.lang.be.linker.combined_image_count:refuses_input_count_overflow" {
-    val overflow_r: R.Result[u32, str] = combined_image_count(0xFFFFFFFF, 1);
-    if (R.is_ok[u32, str](overflow_r)) { ret 1; }
+    val overflow_r: res[u32, fail.Fail] = combined_image_count(0xFFFFFFFF, 1);
+    if (sel overflow_r.ok) { ret 1; }
 
-    val normal_r: R.Result[u32, str] = combined_image_count(2, 3);
-    if (R.is_err[u32, str](normal_r)) { ret 2; }
-    if (R.unwrap_ok[u32, str](normal_r) != 5) { ret 3; }
+    val normal_r: res[u32, fail.Fail] = combined_image_count(2, 3);
+    if (sel normal_r.err) { ret 2; }
+    if (normal_r.ok != 5) { ret 3; }
     ret 0;
 }
 
 test "mach.lang.be.linker.merged_section_count:refuses_debug_count_overflow" {
-    val overflow_r: R.Result[u32, str] = merged_section_count(0xFFFFFFFF);
-    if (R.is_ok[u32, str](overflow_r)) { ret 1; }
+    val overflow_r: res[u32, fail.Fail] = merged_section_count(0xFFFFFFFF);
+    if (sel overflow_r.ok) { ret 1; }
 
-    val normal_r: R.Result[u32, str] = merged_section_count(2);
-    if (R.is_err[u32, str](normal_r)) { ret 2; }
-    if (R.unwrap_ok[u32, str](normal_r) != MERGED_KIND_COUNT + 2) { ret 3; }
+    val normal_r: res[u32, fail.Fail] = merged_section_count(2);
+    if (sel normal_r.err) { ret 2; }
+    if (normal_r.ok != MERGED_KIND_COUNT + 2) { ret 3; }
     ret 0;
 }
 
@@ -12075,14 +12231,14 @@ test "mach.lang.be.linker.total_frames:refuses_flattened_count_overflow" {
     var mods: [2]of.ObjectImage;
     mods[0].frame_count = 0xFFFFFFFF;
     mods[1].frame_count = 1;
-    val overflow_r: R.Result[u32, str] = total_frames(?mods[0], 2);
-    if (R.is_ok[u32, str](overflow_r)) { ret 1; }
+    val overflow_r: res[u32, fail.Fail] = total_frames(?mods[0], 2);
+    if (sel overflow_r.ok) { ret 1; }
 
     mods[0].frame_count = 2;
     mods[1].frame_count = 3;
-    val normal_r: R.Result[u32, str] = total_frames(?mods[0], 2);
-    if (R.is_err[u32, str](normal_r)) { ret 2; }
-    if (R.unwrap_ok[u32, str](normal_r) != 5) { ret 3; }
+    val normal_r: res[u32, fail.Fail] = total_frames(?mods[0], 2);
+    if (sel normal_r.err) { ret 2; }
+    if (normal_r.ok != 5) { ret 3; }
     ret 0;
 }
 
@@ -12092,9 +12248,9 @@ test "mach.lang.be.linker.fill_section_bases:refuses_rather_than_wrapping_a_base
     mods[1].section_count = 1;
     mods[2].section_count = 0;
     var sec_base: [3]u32;
-    val r: R.Result[R.Void, str] = fill_section_bases(?mods[0], 3, ?sec_base[0]);
+    val r: err[fail.Fail] = fill_section_bases(?mods[0], 3, ?sec_base[0]);
     var bad: i32 = 0;
-    if (R.is_ok[R.Void, str](r))     { bad = 1; }
+    if (sel r.ok)     { bad = 1; }
     if (sec_base[0] != 0)          { bad = 2; }
     if (sec_base[1] != 0xFFFFFFFF) { bad = 3; }
     ret bad;
@@ -12106,9 +12262,9 @@ test "mach.lang.be.linker.fill_symbol_bases:refuses_rather_than_wrapping_a_base_
     mods[1].symbol_count = 1;
     mods[2].symbol_count = 0;
     var sym_base: [3]u32;
-    val r: R.Result[R.Void, str] = fill_symbol_bases(?mods[0], 3, ?sym_base[0]);
+    val r: err[fail.Fail] = fill_symbol_bases(?mods[0], 3, ?sym_base[0]);
     var bad: i32 = 0;
-    if (R.is_ok[R.Void, str](r))     { bad = 1; }
+    if (sel r.ok)     { bad = 1; }
     if (sym_base[0] != 0)          { bad = 2; }
     if (sym_base[1] != 0xFFFFFFFF) { bad = 3; }
     ret bad;
@@ -12145,10 +12301,10 @@ test "mach.lang.be.linker.grow_modules:refuses_capacity_overflow_before_realloca
     var modules: *of.ObjectImage = nil;
     var count: u32 = 0xFFFFFFFF;
     var cap:   u32 = 0xFFFFFFFF;
-    val r: R.Result[u32, str] = grow_modules(?alloc, ?modules, ?count, ?cap);
+    val r: res[u32, fail.Fail] = grow_modules(?alloc, ?modules, ?count, ?cap);
 
     var bad: i32 = 0;
-    if (R.is_ok[u32, str](r))        { bad = 1; }
+    if (sel r.ok)        { bad = 1; }
     if (probe.reallocate_calls != 0) { bad = 2; }
     if (cap != 0xFFFFFFFF)           { bad = 3; }
     ret bad;
@@ -12175,11 +12331,11 @@ test "mach.lang.be.linker.build_str_merge:refuses_unterminated_debug_str_section
     var mods: [1]of.ObjectImage;
     mods[0] = lt_image(?s, lt_name(?s, "m.o"), ?sec, 1, nil, 0, nil, 0);
 
-    val r: R.Result[StrMerge, str] = build_str_merge(?s, ?mods[0], 1, true);
+    val r: res[StrMerge, fail.Fail] = build_str_merge(?s, ?mods[0], 1, true);
     var bad: i32 = 0;
-    if (R.is_ok[StrMerge, str](r)) {
+    if (sel r.ok) {
         bad = 1;
-        var sm: StrMerge = R.unwrap_ok[StrMerge, str](r);
+        var sm: StrMerge = r.ok;
         free_str_merge(?sm);
     }
 
@@ -12247,22 +12403,23 @@ test "mach.lang.be.linker.resolve_strp:uses_symbol_offset_and_collects_suffix" {
         ?s, lt_name(?s, "strings.o"), ?sections[0], 2,
         ?symbol, 1, ?relocation, 1);
 
-    val merge_r: R.Result[StrMerge, str] = build_str_merge(?s, ?module, 1, true);
-    if (R.is_err[StrMerge, str](merge_r)) {
+    val merge_r: res[StrMerge, fail.Fail] = build_str_merge(?s, ?module, 1, true);
+    if (sel merge_r.err) {
         session.dnit(?s);
         target.registry_dnit(?reg);
         ret 4;
     }
-    var strm: StrMerge = R.unwrap_ok[StrMerge, str](merge_r);
+    var strm: StrMerge = merge_r.ok;
     var destination: [4]u8;
 
-    val resolved_r: R.Result[R.Void, str] = resolve_strp(
+    val resolved_r: err[fail.Fail] = resolve_strp(
         ?s, ?module, 0, 0, ?symbol, ?relocation, ?strm,
         ?destination[0], 0, 4, 0, selected.isa, 0);
     var bad: i32 = 0;
-    if (R.is_err[R.Void, str](resolved_r))                  { bad = 5; }
+    val debug_str_source_offset_r: res[u32, fail.Fail] = debug_str_source_offset(0xFFFFFFFF, 1, 0xFFFFFFFF);
+    if (sel resolved_r.err)                  { bad = 5; }
     or (bin.read_u32_le(?destination[0], 0) != 13)        { bad = 6; }
-    or (R.is_ok[u32, str](debug_str_source_offset(0xFFFFFFFF, 1, 0xFFFFFFFF))) {
+    or (sel debug_str_source_offset_r.ok) {
         bad = 7;
     }
 
@@ -12303,10 +12460,10 @@ test "mach.lang.be.linker.grow_cap:refuses_a_u32_capacity_that_cannot_double_bef
     var dummy: u8;
     var data: *u8 = ?dummy;
     var cap: u32 = 0xFFFFFFFF;
-    val res: R.Result[R.Void, str] = grow_cap[u8](?a, ?data, ?cap, 16);
+    val result: err[fail.Fail] = grow_cap[u8](?a, ?data, ?cap, 16);
 
     var bad: i32 = 0;
-    if (!R.is_err[R.Void, str](res))   { bad = 1; }
+    if (!sel result.err)   { bad = 1; }
     if (probe.reallocate_calls != 0) { bad = 2; }
     if (cap != 0xFFFFFFFF)           { bad = 3; }
     ret bad;
@@ -12352,9 +12509,9 @@ test "mach.lang.be.linker.reorder_flat_entry_first:refuses_u32_layout_overflow" 
     var sec_base: [1]u32;
     sec_base[0] = 0;
 
-    val r: R.Result[R.Void, str] = reorder_flat_entry_first(
+    val r: err[fail.Fail] = reorder_flat_entry_first(
         ?image, 1, ?merged[0], ?placements[0], ?sec_base[0], nil::*AtomPlan, entry.name);
-    if (R.is_ok[R.Void, str](r)) { ret 1; }
+    if (sel r.ok) { ret 1; }
     ret 0;
 }
 
@@ -12368,14 +12525,17 @@ test "mach.lang.be.linker.assign_section_vaddrs:checks_page_and_address_ranges" 
     merged[of.SK_TEXT::u32].align = 16;
     merged[of.SK_TEXT::u32].len   = 32;
     merged[of.SK_TEXT::u32].used  = true;
-    if (R.is_ok[R.Void, str](assign_section_vaddrs(?tgt, ?merged[0], 0))) { ret 1; }
+    val assign_section_vaddrs_r: err[fail.Fail] = assign_section_vaddrs(?tgt, ?merged[0], 0);
+    if (sel assign_section_vaddrs_r.ok) { ret 1; }
 
     tgt.base = 0x1000;
     tgt.page_size = 3;
-    if (R.is_ok[R.Void, str](assign_section_vaddrs(?tgt, ?merged[0], 0))) { ret 2; }
+    val assign_section_vaddrs_r2: err[fail.Fail] = assign_section_vaddrs(?tgt, ?merged[0], 0);
+    if (sel assign_section_vaddrs_r2.ok) { ret 2; }
 
     tgt.page_size = 0x1000;
-    if (R.is_err[R.Void, str](assign_section_vaddrs(?tgt, ?merged[0], 0))) { ret 3; }
+    val assign_section_vaddrs_r3: err[fail.Fail] = assign_section_vaddrs(?tgt, ?merged[0], 0);
+    if (sel assign_section_vaddrs_r3.err) { ret 3; }
     if (merged[of.SK_TEXT::u32].vaddr != 0x1000) { ret 4; }
     ret 0;
 }
@@ -12389,8 +12549,8 @@ test "mach.lang.be.linker.section_group_add:refuses_a_group_count_at_the_u32_sen
     g.count = 0xFFFFFFFF;
     g.cap   = 0xFFFFFFFF;
 
-    val res: R.Result[u32, str] = section_group_add(?alloc, ?g, 0, 0::intern.StrId, 0);
-    if (!R.is_err[u32, str](res)) { g.items = nil; g.count = 0; g.cap = 0; ret 1; }
+    val result: res[u32, fail.Fail] = section_group_add(?alloc, ?g, 0, 0::intern.StrId, 0);
+    if (!sel result.err) { g.items = nil; g.count = 0; g.cap = 0; ret 1; }
     if (g.count != 0xFFFFFFFF)    { ret 1; }
     ret 0;
 }
@@ -12431,9 +12591,9 @@ test "mach.lang.be.linker.build_symtab_entries:trustworthy_size_wins_over_a_synt
     segs[0] = seg;
 
     var count: u32 = 0;
-    val er: R.Result[*of.SymtabEntry, str] = build_symtab_entries(?alloc, ?image, ?segs[0], 1, ?count);
-    if (R.is_err[*of.SymtabEntry, str](er)) { ret 1; }
-    val entries: *of.SymtabEntry = R.unwrap_ok[*of.SymtabEntry, str](er);
+    val er: res[*of.SymtabEntry, fail.Fail] = build_symtab_entries(?alloc, ?image, ?segs[0], 1, ?count);
+    if (sel er.err) { ret 1; }
+    val entries: *of.SymtabEntry = er.ok;
 
     if (count != 2) { ret 1; }
     var bad: i32 = 0;
@@ -12475,46 +12635,46 @@ test "mach.lang.be.linker.build_symtab_entries:a_trustworthy_zero_size_function_
     segs[0] = seg;
 
     var count: u32 = 0;
-    val er: R.Result[*of.SymtabEntry, str] = build_symtab_entries(?alloc, ?image, ?segs[0], 1, ?count);
-    if (R.is_err[*of.SymtabEntry, str](er)) { ret 1; }
+    val er: res[*of.SymtabEntry, fail.Fail] = build_symtab_entries(?alloc, ?image, ?segs[0], 1, ?count);
+    if (sel er.err) { ret 1; }
     if (count != 0) { ret 1; }
     ret 0;
 }
 
 test "mach.lang.be.linker.relocation_arithmetic:rejects_wraparound" {
-    val diff_min: R.Result[i64, str] =
+    val diff_min: res[i64, fail.Fail] =
         difference_relocation_addend(9223372036854775807, 0xFFFFFFFFFFFFFFFF);
-    val diff_under: R.Result[i64, str] =
+    val diff_under: res[i64, fail.Fail] =
         difference_relocation_addend(-9223372036854775807 - 1, 1);
-    val base_zero: R.Result[u64, str] = base_relocation_target(4, -4);
-    val base_under: R.Result[u64, str] = base_relocation_target(0, -1);
-    val base_over: R.Result[u64, str] = base_relocation_target(0xFFFFFFFFFFFFFFFF, 1);
+    val base_zero: res[u64, fail.Fail] = base_relocation_target(4, -4);
+    val base_under: res[u64, fail.Fail] = base_relocation_target(0, -1);
+    val base_over: res[u64, fail.Fail] = base_relocation_target(0xFFFFFFFFFFFFFFFF, 1);
 
-    if (R.is_err[i64, str](diff_min)
-        || R.unwrap_ok[i64, str](diff_min) != -9223372036854775807 - 1
-        || !R.is_err[i64, str](diff_under)
-        || R.is_err[u64, str](base_zero)
-        || R.unwrap_ok[u64, str](base_zero) != 0
-        || !R.is_err[u64, str](base_under)
-        || !R.is_err[u64, str](base_over)) { ret 1; }
+    if (sel diff_min.err) { ret 1; }
+    if (diff_min.ok != -9223372036854775807 - 1) { ret 1; }
+    if (!sel diff_under.err) { ret 1; }
+    if (sel base_zero.err) { ret 1; }
+    if (base_zero.ok != 0) { ret 1; }
+    if (!sel base_under.err) { ret 1; }
+    if (!sel base_over.err) { ret 1; }
     ret 0;
 }
 
 
-fun t_publication_open(operation: *publication.Plan, alloc: *A.Allocator, name: str) R.Result[*publication.Destination, str] {
+fun t_publication_open(operation: *publication.Plan, alloc: *A.Allocator, name: str) res[*publication.Destination, fail.Fail] {
     val initialized: O.Option[txn.Error] = publication.plan_init(operation, alloc);
-    if (O.is_some[txn.Error](initialized)) { ret R.err[*publication.Destination, str](txn.error_message(O.unwrap[txn.Error](initialized))); }
+    if (O.is_some[txn.Error](initialized)) { ret res[*publication.Destination, fail.Fail].err{fail.message(txn.error_message(O.unwrap[txn.Error](initialized)))}; }
     val destination: R.Result[*publication.Destination, str] = publication.plan_add(operation, name, false);
-    if (R.is_err[*publication.Destination, str](destination)) { ret destination; }
+    if (R.is_err[*publication.Destination, str](destination)) { ret fail.lift_res[*publication.Destination](destination); }
     val sealed: O.Option[txn.Error] = publication.plan_seal(operation);
-    if (O.is_some[txn.Error](sealed)) { ret R.err[*publication.Destination, str](txn.error_message(O.unwrap[txn.Error](sealed))); }
-    ret destination;
+    if (O.is_some[txn.Error](sealed)) { ret res[*publication.Destination, fail.Fail].err{fail.message(txn.error_message(O.unwrap[txn.Error](sealed)))}; }
+    ret fail.lift_res[*publication.Destination](destination);
 }
 
-fun t_publication_close(operation: *publication.Plan, result: R.Result[R.Void, str]) R.Result[R.Void, str] {
+fun t_publication_close(operation: *publication.Plan, result: err[fail.Fail]) err[fail.Fail] {
     val closed: O.Option[txn.Error] = publication.plan_dnit(operation);
-    if (R.is_ok[R.Void, str](result) && O.is_some[txn.Error](closed)) {
-        ret R.err[R.Void, str](txn.error_message(O.unwrap[txn.Error](closed)));
+    if (sel result.ok && O.is_some[txn.Error](closed)) {
+        ret err[fail.Fail].err{fail.message(txn.error_message(O.unwrap[txn.Error](closed)))};
     }
     ret result;
 }
@@ -12522,23 +12682,23 @@ fun t_publication_close(operation: *publication.Plan, result: R.Result[R.Void, s
 fun t_planned_link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
              obj_count: u32, dynlibs: *of.DynLib, dynlib_count: u32,
              out_path: *u8, name: *u8, mode: LinkMode, pie: bool,
-             image_options: of.ImageOptions) R.Result[R.Void, str] {
-    if (out_path == nil || str_len(out_path::str) == 0) { ret link(s, tgt, obj_paths, obj_count, dynlibs, dynlib_count, nil::*publication.Destination, name, mode, pie, image_options); }
+             image_options: of.ImageOptions) err[fail.Fail] {
+    if (out_path == nil || str_len(out_path::str) == 0) { ret fail.lift_err(link(s, tgt, obj_paths, obj_count, dynlibs, dynlib_count, nil::*publication.Destination, name, mode, pie, image_options)); }
     var operation: publication.Plan;
-    val opened: R.Result[*publication.Destination, str] = t_publication_open(?operation, s.alloc, out_path::str);
-    if (R.is_err[*publication.Destination, str](opened)) { ret t_publication_close(?operation, R.err[R.Void, str](R.unwrap_err[*publication.Destination, str](opened))); }
-    ret t_publication_close(?operation, link(s, tgt, obj_paths, obj_count, dynlibs, dynlib_count, R.unwrap_ok[*publication.Destination, str](opened), name, mode, pie, image_options));
+    val opened: res[*publication.Destination, fail.Fail] = t_publication_open(?operation, s.alloc, out_path::str);
+    if (sel opened.err) { ret t_publication_close(?operation, err[fail.Fail].err{opened.err}); }
+    ret t_publication_close(?operation, fail.lift_err(link(s, tgt, obj_paths, obj_count, dynlibs, dynlib_count, opened.ok, name, mode, pie, image_options)));
 }
 
 fun t_planned_link_images(s: *session.Session, tgt: *target.Target, images: *of.ObjectImage,
                     image_count: u32, dynlibs: *of.DynLib, dynlib_count: u32,
                     out_path: *u8, name: *u8, mode: LinkMode, pie: bool,
-                    image_options: of.ImageOptions) R.Result[R.Void, str] {
-    if (out_path == nil || str_len(out_path::str) == 0) { ret link_images(s, tgt, images, image_count, dynlibs, dynlib_count, nil::*publication.Destination, name, mode, pie, image_options); }
+                    image_options: of.ImageOptions) err[fail.Fail] {
+    if (out_path == nil || str_len(out_path::str) == 0) { ret fail.lift_err(link_images(s, tgt, images, image_count, dynlibs, dynlib_count, nil::*publication.Destination, name, mode, pie, image_options)); }
     var operation: publication.Plan;
-    val opened: R.Result[*publication.Destination, str] = t_publication_open(?operation, s.alloc, out_path::str);
-    if (R.is_err[*publication.Destination, str](opened)) { ret t_publication_close(?operation, R.err[R.Void, str](R.unwrap_err[*publication.Destination, str](opened))); }
-    ret t_publication_close(?operation, link_images(s, tgt, images, image_count, dynlibs, dynlib_count, R.unwrap_ok[*publication.Destination, str](opened), name, mode, pie, image_options));
+    val opened: res[*publication.Destination, fail.Fail] = t_publication_open(?operation, s.alloc, out_path::str);
+    if (sel opened.err) { ret t_publication_close(?operation, err[fail.Fail].err{opened.err}); }
+    ret t_publication_close(?operation, fail.lift_err(link_images(s, tgt, images, image_count, dynlibs, dynlib_count, opened.ok, name, mode, pie, image_options)));
 }
 
 fun t_planned_link_mixed(s: *session.Session, tgt: *target.Target,
@@ -12546,41 +12706,41 @@ fun t_planned_link_mixed(s: *session.Session, tgt: *target.Target,
                    obj_paths: **u8, obj_count: u32,
                    dynlibs: *of.DynLib, dynlib_count: u32,
                    out_path: *u8, name: *u8, mode: LinkMode, pie: bool,
-                   image_options: of.ImageOptions) R.Result[R.Void, str] {
-    if (out_path == nil || str_len(out_path::str) == 0) { ret link_mixed(s, tgt, images, image_count, obj_paths, obj_count, dynlibs, dynlib_count, nil::*publication.Destination, name, mode, pie, image_options); }
+                   image_options: of.ImageOptions) err[fail.Fail] {
+    if (out_path == nil || str_len(out_path::str) == 0) { ret fail.lift_err(link_mixed(s, tgt, images, image_count, obj_paths, obj_count, dynlibs, dynlib_count, nil::*publication.Destination, name, mode, pie, image_options)); }
     var operation: publication.Plan;
-    val opened: R.Result[*publication.Destination, str] = t_publication_open(?operation, s.alloc, out_path::str);
-    if (R.is_err[*publication.Destination, str](opened)) { ret t_publication_close(?operation, R.err[R.Void, str](R.unwrap_err[*publication.Destination, str](opened))); }
-    ret t_publication_close(?operation, link_mixed(s, tgt, images, image_count, obj_paths, obj_count, dynlibs, dynlib_count, R.unwrap_ok[*publication.Destination, str](opened), name, mode, pie, image_options));
+    val opened: res[*publication.Destination, fail.Fail] = t_publication_open(?operation, s.alloc, out_path::str);
+    if (sel opened.err) { ret t_publication_close(?operation, err[fail.Fail].err{opened.err}); }
+    ret t_publication_close(?operation, fail.lift_err(link_mixed(s, tgt, images, image_count, obj_paths, obj_count, dynlibs, dynlib_count, opened.ok, name, mode, pie, image_options)));
 }
 
 fun t_planned_link_modules_nocapture(s: *session.Session, tgt: *target.Target, modules: *of.ObjectImage,
                            module_count: u32, codegen_count: u32,
                            dynlibs: *of.DynLib, dynlib_count: u32,
                            out_path: *u8, name: *u8, mode: LinkMode, pie_opt_in: bool,
-                           image_options: of.ImageOptions) R.Result[R.Void, str] {
+                           image_options: of.ImageOptions) err[fail.Fail] {
     if (out_path == nil || str_len(out_path::str) == 0) { ret link_modules_nocapture(s, tgt, modules, module_count, codegen_count, dynlibs, dynlib_count, nil::*publication.Destination, name, mode, pie_opt_in, image_options); }
     var operation: publication.Plan;
-    val opened: R.Result[*publication.Destination, str] = t_publication_open(?operation, s.alloc, out_path::str);
-    if (R.is_err[*publication.Destination, str](opened)) { ret t_publication_close(?operation, R.err[R.Void, str](R.unwrap_err[*publication.Destination, str](opened))); }
-    ret t_publication_close(?operation, link_modules_nocapture(s, tgt, modules, module_count, codegen_count, dynlibs, dynlib_count, R.unwrap_ok[*publication.Destination, str](opened), name, mode, pie_opt_in, image_options));
+    val opened: res[*publication.Destination, fail.Fail] = t_publication_open(?operation, s.alloc, out_path::str);
+    if (sel opened.err) { ret t_publication_close(?operation, err[fail.Fail].err{opened.err}); }
+    ret t_publication_close(?operation, link_modules_nocapture(s, tgt, modules, module_count, codegen_count, dynlibs, dynlib_count, opened.ok, name, mode, pie_opt_in, image_options));
 }
 
-fun t_planned_object(tgt: *target.Target, image: *of.ObjectImage, name: *u8) R.Result[R.Void, str] {
+fun t_planned_object(tgt: *target.Target, image: *of.ObjectImage, name: *u8) err[fail.Fail] {
     var operation: publication.Plan;
-    val opened: R.Result[*publication.Destination, str] = t_publication_open(?operation, image.alloc, name::str);
-    if (R.is_err[*publication.Destination, str](opened)) { ret t_publication_close(?operation, R.err[R.Void, str](R.unwrap_err[*publication.Destination, str](opened))); }
-    ret t_publication_close(?operation, tgt.of.emit_object(?tgt.object, image, R.unwrap_ok[*publication.Destination, str](opened)));
+    val opened: res[*publication.Destination, fail.Fail] = t_publication_open(?operation, image.alloc, name::str);
+    if (sel opened.err) { ret t_publication_close(?operation, err[fail.Fail].err{opened.err}); }
+    ret t_publication_close(?operation, fail.lift_err(tgt.of.emit_object(?tgt.object, image, opened.ok)));
 }
 
-fun t_planned_archive(alloc: *A.Allocator, members: *ar.ArMember, count: u32, name: str) R.Result[R.Void, str] {
+fun t_planned_archive(alloc: *A.Allocator, members: *ar.ArMember, count: u32, name: str) err[fail.Fail] {
     var operation: publication.Plan;
-    val opened: R.Result[*publication.Destination, str] = t_publication_open(?operation, alloc, name);
-    if (R.is_err[*publication.Destination, str](opened)) {
-        ret t_publication_close(?operation, R.err[R.Void, str](R.unwrap_err[*publication.Destination, str](opened)));
+    val opened: res[*publication.Destination, fail.Fail] = t_publication_open(?operation, alloc, name);
+    if (sel opened.err) {
+        ret t_publication_close(?operation, err[fail.Fail].err{opened.err});
     }
-    ret t_publication_close(?operation, ar.write_archive(alloc, members, count,
-        R.unwrap_ok[*publication.Destination, str](opened)));
+    ret t_publication_close(?operation, fail.lift_err(ar.write_archive(alloc, members, count,
+        opened.ok)));
 }
 
 test "mach.lang.be.linker.link_modules:arm64_import_tail_branch" {
@@ -12633,13 +12793,13 @@ test "mach.lang.be.linker.link_modules:arm64_import_tail_branch" {
     var count: u32 = 1;
     for (count <= 2) {
         module.reloc_count = count;
-        val linked: R.Result[R.Void, str] = t_planned_link_modules_nocapture(?s, ?tgt,
+        val linked: err[fail.Fail] = t_planned_link_modules_nocapture(?s, ?tgt,
             ?module, 1, 1, ?provider, 1, path::*u8, "tail_import"::*u8,
             LINK_EXE, true, of.image_options_default(of.SUBSYSTEM_CONSOLE));
-        if (R.is_err[R.Void, str](linked)) { ret 6; }
-        val rr: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, path);
-        if (R.is_err[Vector[u8], str](rr)) { ret 7; }
-        var image: Vector[u8] = R.unwrap_ok[Vector[u8], str](rr);
+        if (sel linked.err) { ret 6; }
+        val rr: res[Vector[u8], fs.FsError] = fs.read_bytes(?alloc, path);
+        if (sel rr.err) { ret 7; }
+        var image: Vector[u8] = rr.ok;
         fin { vector.dnit[u8](?image); }
         val text: usize = lt_macho_section(image.data, "__TEXT", "__text");
         val stubs: usize = lt_macho_section(image.data, "__STUBS", "__stubs");
@@ -12660,18 +12820,19 @@ test "mach.lang.be.linker.link_modules:arm64_import_tail_branch" {
         }
         count = count + 1;
     }
-    val refused: R.Result[R.Void, str] = t_planned_link_modules_nocapture(?s, ?tgt,
+    val refused: err[fail.Fail] = t_planned_link_modules_nocapture(?s, ?tgt,
         ?module, 1, 1, nil::*of.DynLib, 0, path::*u8, "tail_import"::*u8,
         LINK_EXE, true, of.image_options_default(of.SUBSYSTEM_CONSOLE));
-    if (!R.is_err[R.Void, str](refused)
-        || !str_contains(R.unwrap_err[R.Void, str](refused), "not among the link's dependencies")) { ret 12; }
+    if (!sel refused.err) { ret 12; }
+    if (!str_contains(fail.describe(refused.err), "not among the link's dependencies")) { ret 12; }
     ret 0;
 }
 
 
 test "mach.lang.be.linker.publication_fixtures:independent_owners" {
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     val first: R.Result[output.Output, str] = output.create(?alloc, "linker_owner_first");
     if (R.is_err[output.Output, str](first)) { ret 1; }
     var a: output.Output = R.unwrap_ok[output.Output, str](first);
@@ -12684,12 +12845,12 @@ test "mach.lang.be.linker.publication_fixtures:independent_owners" {
 
     var one: publication.Plan;
     fin { publication.plan_dnit(?one); }
-    val opened_one: R.Result[*publication.Destination, str] = t_publication_open(?one, ?alloc, output.path(?a));
-    if (R.is_err[*publication.Destination, str](opened_one)) { ret 3; }
+    val opened_one: res[*publication.Destination, fail.Fail] = t_publication_open(?one, ?alloc, output.path(?a));
+    if (sel opened_one.err) { ret 3; }
     var two: publication.Plan;
     fin { publication.plan_dnit(?two); }
-    val opened_two: R.Result[*publication.Destination, str] = t_publication_open(?two, ?alloc, output.path(?b));
-    if (R.is_err[*publication.Destination, str](opened_two)) { ret 4; }
+    val opened_two: res[*publication.Destination, fail.Fail] = t_publication_open(?two, ?alloc, output.path(?b));
+    if (sel opened_two.err) { ret 4; }
     if (O.is_some[txn.Error](publication.plan_dnit(?two))) { ret 5; }
     if (O.is_some[txn.Error](publication.plan_dnit(?one))) { ret 6; }
     ret 0;
@@ -12737,13 +12898,13 @@ test "mach.lang.be.linker.local_got_plan:arm64_function_pointer_slot" {
     var file: output.Output = R.unwrap_ok[output.Output, str](created);
     fin { output.dnit(?file); }
 
-    val linked: R.Result[R.Void, str] = t_planned_link_modules_nocapture(?s, ?tgt,
+    val linked: err[fail.Fail] = t_planned_link_modules_nocapture(?s, ?tgt,
         ?module, 1, 0, nil::*of.DynLib, 0, output.path(?file)::*u8, "arm-got"::*u8,
         LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
-    if (R.is_err[R.Void, str](linked)) { ret 5; }
-    val read: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, output.path(?file));
-    if (R.is_err[Vector[u8], str](read)) { ret 6; }
-    var image: Vector[u8] = R.unwrap_ok[Vector[u8], str](read);
+    if (sel linked.err) { ret 5; }
+    val read: res[Vector[u8], fs.FsError] = fs.read_bytes(?alloc, output.path(?file));
+    if (sel read.err) { ret 6; }
+    var image: Vector[u8] = read.ok;
     fin { vector.dnit[u8](?image); }
     if (image.len < 64) { ret 7; }
     val entry: u64 = bin.read_u64_le(image.data, 24);
@@ -12797,8 +12958,8 @@ rec TestElfLoad {
     remaining: u64;
 }
 
-fun t_elf_load(image: *Vector[u8], address: u64, width: u64) R.Result[TestElfLoad, str] {
-    if (image.len < 64) { ret R.err[TestElfLoad, str]("short ELF header"); }
+fun t_elf_load(image: *Vector[u8], address: u64, width: u64) res[TestElfLoad, fail.Fail] {
+    if (image.len < 64) { ret res[TestElfLoad, fail.Fail].err{fail.message("short ELF header")}; }
     var phoff: u64 = bin.read_u64_le(image.data, 32);
     var phnum: u32 = bin.read_u16_le(image.data, 56)::u32;
     var stride: u32 = 56;
@@ -12806,12 +12967,12 @@ fun t_elf_load(image: *Vector[u8], address: u64, width: u64) R.Result[TestElfLoa
         phoff = bin.read_u32_le(image.data, 28)::u64;
         phnum = bin.read_u16_le(image.data, 44)::u32;
         stride = 32;
-        if (bin.read_u16_le(image.data, 42) != 32) { ret R.err[TestElfLoad, str]("invalid ELF32 program header"); }
+        if (bin.read_u16_le(image.data, 42) != 32) { ret res[TestElfLoad, fail.Fail].err{fail.message("invalid ELF32 program header")}; }
     } or {
-        if (image.data[4] != 2 || bin.read_u16_le(image.data, 54) != 56) { ret R.err[TestElfLoad, str]("invalid ELF64 program header"); }
+        if (image.data[4] != 2 || bin.read_u16_le(image.data, 54) != 56) { ret res[TestElfLoad, fail.Fail].err{fail.message("invalid ELF64 program header")}; }
     }
     if (phoff > image.len::u64 || phnum::u64 > (image.len::u64 - phoff) / stride::u64) {
-        ret R.err[TestElfLoad, str]("program headers exceed ELF image");
+        ret res[TestElfLoad, fail.Fail].err{fail.message("program headers exceed ELF image")};
     }
     var i: u32 = 0;
     for (i < phnum) {
@@ -12830,13 +12991,13 @@ fun t_elf_load(image: *Vector[u8], address: u64, width: u64) R.Result[TestElfLoa
         }
         if (bin.read_u32_le(image.data, ph) == 1 && address >= va && address - va < size) {
             if (off > image.len::u64 || size > image.len::u64 - off || size - (address - va) < width) {
-                ret R.err[TestElfLoad, str]("load range exceeds ELF image");
+                ret res[TestElfLoad, fail.Fail].err{fail.message("load range exceeds ELF image")};
             }
-            ret R.ok[TestElfLoad, str](TestElfLoad{offset: (off + address - va)::usize, remaining: size - (address - va)});
+            ret res[TestElfLoad, fail.Fail].ok{TestElfLoad{offset: (off + address - va)::usize, remaining: size - (address - va)}};
         }
         i = i + 1;
     }
-    ret R.err[TestElfLoad, str]("ELF address is not file backed");
+    ret res[TestElfLoad, fail.Fail].err{fail.message("ELF address is not file backed")};
 }
 
 fun t_riscv_got_pointer(arch: str, abi: str, width: u32) i32 {
@@ -12886,24 +13047,24 @@ fun t_riscv_got_pointer(arch: str, abi: str, width: u32) i32 {
     var file: output.Output = R.unwrap_ok[output.Output, str](created);
     fin { output.dnit(?file); }
 
-    val linked: R.Result[R.Void, str] = t_planned_link_modules_nocapture(?s, ?tgt,
+    val linked: err[fail.Fail] = t_planned_link_modules_nocapture(?s, ?tgt,
         ?module, 1, 0, nil::*of.DynLib, 0, output.path(?file)::*u8, "riscv-got"::*u8,
         LINK_EXE, false, of.image_options_default(of.SUBSYSTEM_CONSOLE));
-    if (R.is_err[R.Void, str](linked)) {
-        val message: str = R.unwrap_err[R.Void, str](linked);
+    if (sel linked.err) {
+        val message: str = fail.describe(linked.err);
         os.write(2, message::*u8, str_len(message));
         ret 6;
     }
-    val read: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, output.path(?file));
-    if (R.is_err[Vector[u8], str](read)) { ret 7; }
-    var image: Vector[u8] = R.unwrap_ok[Vector[u8], str](read);
+    val read: res[Vector[u8], fs.FsError] = fs.read_bytes(?alloc, output.path(?file));
+    if (sel read.err) { ret 7; }
+    var image: Vector[u8] = read.ok;
     fin { vector.dnit[u8](?image); }
     if (image.len < 64) { ret 8; }
     var entry: u64 = bin.read_u64_le(image.data, 24);
     if (width == 4) { entry = bin.read_u32_le(image.data, 24)::u64; }
-    val code: R.Result[TestElfLoad, str] = t_elf_load(?image, entry, 16);
-    if (R.is_err[TestElfLoad, str](code)) { ret 8; }
-    val off: usize = R.unwrap_ok[TestElfLoad, str](code).offset;
+    val code: res[TestElfLoad, fail.Fail] = t_elf_load(?image, entry, 16);
+    if (sel code.err) { ret 8; }
+    val off: usize = code.ok.offset;
     val high: u32 = bin.read_u32_le(image.data, off);
     val low: u32 = bin.read_u32_le(image.data, off + 4);
     val call_high: u32 = bin.read_u32_le(image.data, off + 8);
@@ -12913,9 +13074,9 @@ fun t_riscv_got_pointer(arch: str, abi: str, width: u32) i32 {
     val slot: u64 = (entry::i64 + (high & 0xFFFFF000)::i32::i64 + (low::i32 >> 20)::i64)::u64;
     val function: u64 = (entry::i64 + 8 + (call_high & 0xFFFFF000)::i32::i64 + (call_low::i32 >> 20)::i64)::u64;
     if (function != entry + 20 || slot == function || slot % width::u64 != 0) { ret 10; }
-    val pointer: R.Result[TestElfLoad, str] = t_elf_load(?image, slot, width::u64);
-    if (R.is_err[TestElfLoad, str](pointer)) { ret 11; }
-    val found: TestElfLoad = R.unwrap_ok[TestElfLoad, str](pointer);
+    val pointer: res[TestElfLoad, fail.Fail] = t_elf_load(?image, slot, width::u64);
+    if (sel pointer.err) { ret 11; }
+    val found: TestElfLoad = pointer.ok;
     if (found.remaining != width::u64) { ret 12; }
     var stored: u64 = 0;
     if (width == 4) { stored = bin.read_u32_le(image.data, found.offset)::u64; }
@@ -12947,19 +13108,20 @@ test "mach.lang.be.linker:local_and_global_absolute_definitions_resolve_without_
         ?symbols[0], 2, nil::*of.Relocation, 0);
     var locs: map.Map[intern.StrId, SymbolLoc] = map.init[intern.StrId, SymbolLoc](?alloc, map.hash_u32, map.eq_u32);
     fin { map.dnit[intern.StrId, SymbolLoc](?locs); }
-    val collected: R.Result[R.Void, str] = collect_symbols(?s, ?image, 1,
+    val collected: err[fail.Fail] = collect_symbols(?s, ?image, 1,
         nil::*Placement, nil::*u32, ?locs, true, nil::*AtomPlan);
-    if (R.is_err[R.Void, str](collected)) { ret 2; }
-    val location: R.Result[*SymbolLoc, str] = map.get[intern.StrId, SymbolLoc](?locs, ?symbols[1].name);
-    if (R.is_err[*SymbolLoc, str](location)) { ret 3; }
-    val found: *SymbolLoc = R.unwrap_ok[*SymbolLoc, str](location);
+    if (sel collected.err) { ret 2; }
+    val location: opt[*SymbolLoc] = map.get[intern.StrId, SymbolLoc](?locs, ?symbols[1].name);
+    if (sel location.none) { ret 3; }
+    val found: *SymbolLoc = location.some;
     if (found.vaddr != symbols[1].absolute_value || found.merged_index != of.SECTION_ABSOLUTE) { ret 4; }
     var local: rel.RelocTarget = rel.target(0, 0, 0);
     if (!local_symbol_target(?image, 0, 0, nil::*Placement, nil::*u32, nil::*u32,
         nil::*of.ObjectImage, nil::*of.OfVTable, 0, nil::*AtomPlan, ?local) || local.vaddr != 0x123) { ret 5; }
-    val sub: R.Result[u64, str] = difference_subtrahend_vaddr(?s, ?image, 0, 1,
+    val sub: res[u64, fail.Fail] = difference_subtrahend_vaddr(?s, ?image, 0, 1,
         nil::*Placement, nil::*u32, nil::*u32, nil::*of.ObjectImage, nil::*of.OfVTable,
         0, nil::*AtomPlan, ?locs);
-    if (R.is_err[u64, str](sub) || R.unwrap_ok[u64, str](sub) != symbols[1].absolute_value) { ret 6; }
+    if (sel sub.err) { ret 6; }
+    if (sub.ok != symbols[1].absolute_value) { ret 6; }
     ret 0;
 }

--- a/src/lang/be/linker/relocatable.mach
+++ b/src/lang/be/linker/relocatable.mach
@@ -1,10 +1,12 @@
-use A: mach.lang.legacy.allocator;
+use A: std.allocator;
+use std.types.canonical.res;
+use mach.lang.fail;
 use R: std.types.result;
 use O: std.types.option;
-use page: mach.lang.legacy.page;
-use fs: mach.lang.legacy.filesystem;
-use txn: mach.lang.legacy.transaction;
-use mach.lang.legacy.vector.Vector;
+use page: std.allocator.page;
+use fs: std.filesystem;
+use txn: std.filesystem.transaction;
+use std.collections.vector.Vector;
 use std.memory;
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -21,10 +23,10 @@ use output: mach.lang.publication.testing;
 
 pub fun combine(alloc: *A.Allocator, itn: *intern.Interner,
                 inputs: *of.ObjectImage, count: u32, machine_flags: u32,
-                attributes: *u8, attributes_len: u32) R.Result[of.ObjectImage, str] {
+                attributes: *u8, attributes_len: u32) res[of.ObjectImage, fail.Fail] {
     if (alloc == nil || itn == nil || inputs == nil || count == 0
         || (attributes_len != 0 && attributes == nil)) {
-        ret R.err[of.ObjectImage, str]("relocatable: incomplete input ownership");
+        ret res[of.ObjectImage, fail.Fail].err{fail.message("relocatable: incomplete input ownership")};
     }
     var sections: u32 = 0;
     var symbols: u32 = 0;
@@ -36,15 +38,15 @@ pub fun combine(alloc: *A.Allocator, itn: *intern.Interner,
     for (i < count) {
         val input: *of.ObjectImage = ?inputs[i];
         val valid: R.Result[R.Void, str] = of.validate_object_view(input);
-        if (R.is_err[R.Void, str](valid)) { ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](valid)); }
-        if (input.interner != itn) { ret R.err[of.ObjectImage, str]("relocatable: input names have a different owner"); }
+        if (R.is_err[R.Void, str](valid)) { ret res[of.ObjectImage, fail.Fail].err{fail.message(R.unwrap_err[R.Void, str](valid))}; }
+        if (input.interner != itn) { ret res[of.ObjectImage, fail.Fail].err{fail.message("relocatable: input names have a different owner")}; }
         if (input.section_count > 0xFFFFFFFF - sections
             || input.symbol_count > 0xFFFFFFFF - symbols
             || input.reloc_count > 0xFFFFFFFF - relocations
             || input.frame_count > 0xFFFFFFFF - frames
             || input.import_count > 0xFFFFFFFF - imports
             || input.indirect_count > 0xFFFFFFFF - indirects) {
-            ret R.err[of.ObjectImage, str]("relocatable: combined table exceeds its index range");
+            ret res[of.ObjectImage, fail.Fail].err{fail.message("relocatable: combined table exceeds its index range")};
         }
         sections = sections + input.section_count;
         symbols = symbols + input.symbol_count;
@@ -58,45 +60,45 @@ pub fun combine(alloc: *A.Allocator, itn: *intern.Interner,
     var complete: bool = false;
     fin { if (!complete) { of.object_image_dnit(?output); } }
     if (sections > 0) {
-        val storage: R.Result[*of.Section, str] = A.allocate[of.Section](alloc, sections::usize);
-        if (R.is_err[*of.Section, str](storage)) { ret R.err[of.ObjectImage, str](R.unwrap_err[*of.Section, str](storage)); }
-        output.sections = R.unwrap_ok[*of.Section, str](storage);
+        val storage: res[*of.Section, A.Error] = A.allocate[of.Section](alloc, sections::usize);
+        if (sel storage.err) { ret res[of.ObjectImage, fail.Fail].err{fail.refused(storage.err)}; }
+        output.sections = storage.ok;
         output.section_cap = sections;
     }
     if (symbols > 0) {
-        val storage: R.Result[*of.Symbol, str] = A.allocate[of.Symbol](alloc, symbols::usize);
-        if (R.is_err[*of.Symbol, str](storage)) { ret R.err[of.ObjectImage, str](R.unwrap_err[*of.Symbol, str](storage)); }
-        output.symbols = R.unwrap_ok[*of.Symbol, str](storage);
+        val storage: res[*of.Symbol, A.Error] = A.allocate[of.Symbol](alloc, symbols::usize);
+        if (sel storage.err) { ret res[of.ObjectImage, fail.Fail].err{fail.refused(storage.err)}; }
+        output.symbols = storage.ok;
         output.symbol_cap = symbols;
     }
     if (relocations > 0) {
-        val storage: R.Result[*of.Relocation, str] = A.allocate[of.Relocation](alloc, relocations::usize);
-        if (R.is_err[*of.Relocation, str](storage)) { ret R.err[of.ObjectImage, str](R.unwrap_err[*of.Relocation, str](storage)); }
-        output.relocations = R.unwrap_ok[*of.Relocation, str](storage);
+        val storage: res[*of.Relocation, A.Error] = A.allocate[of.Relocation](alloc, relocations::usize);
+        if (sel storage.err) { ret res[of.ObjectImage, fail.Fail].err{fail.refused(storage.err)}; }
+        output.relocations = storage.ok;
         output.reloc_cap = relocations;
     }
     if (frames > 0) {
-        val storage: R.Result[*of.FrameUnwind, str] = A.allocate[of.FrameUnwind](alloc, frames::usize);
-        if (R.is_err[*of.FrameUnwind, str](storage)) { ret R.err[of.ObjectImage, str](R.unwrap_err[*of.FrameUnwind, str](storage)); }
-        output.frames = R.unwrap_ok[*of.FrameUnwind, str](storage);
+        val storage: res[*of.FrameUnwind, A.Error] = A.allocate[of.FrameUnwind](alloc, frames::usize);
+        if (sel storage.err) { ret res[of.ObjectImage, fail.Fail].err{fail.refused(storage.err)}; }
+        output.frames = storage.ok;
         output.frame_cap = frames;
     }
     if (imports > 0) {
-        val storage: R.Result[*of.ImportDecl, str] = A.allocate[of.ImportDecl](alloc, imports::usize);
-        if (R.is_err[*of.ImportDecl, str](storage)) { ret R.err[of.ObjectImage, str](R.unwrap_err[*of.ImportDecl, str](storage)); }
-        output.imports = R.unwrap_ok[*of.ImportDecl, str](storage);
+        val storage: res[*of.ImportDecl, A.Error] = A.allocate[of.ImportDecl](alloc, imports::usize);
+        if (sel storage.err) { ret res[of.ObjectImage, fail.Fail].err{fail.refused(storage.err)}; }
+        output.imports = storage.ok;
         output.import_cap = imports;
     }
     if (indirects > 0) {
-        val storage: R.Result[*of.NativeIndirect, str] = A.allocate[of.NativeIndirect](alloc, indirects::usize);
-        if (R.is_err[*of.NativeIndirect, str](storage)) { ret R.err[of.ObjectImage, str](R.unwrap_err[*of.NativeIndirect, str](storage)); }
-        output.indirects = R.unwrap_ok[*of.NativeIndirect, str](storage);
+        val storage: res[*of.NativeIndirect, A.Error] = A.allocate[of.NativeIndirect](alloc, indirects::usize);
+        if (sel storage.err) { ret res[of.ObjectImage, fail.Fail].err{fail.refused(storage.err)}; }
+        output.indirects = storage.ok;
         output.indirect_cap = indirects;
     }
     if (attributes_len > 0) {
-        val storage: R.Result[*u8, str] = A.allocate[u8](alloc, attributes_len::usize);
-        if (R.is_err[*u8, str](storage)) { ret R.err[of.ObjectImage, str](R.unwrap_err[*u8, str](storage)); }
-        output.attributes = R.unwrap_ok[*u8, str](storage);
+        val storage: res[*u8, A.Error] = A.allocate[u8](alloc, attributes_len::usize);
+        if (sel storage.err) { ret res[of.ObjectImage, fail.Fail].err{fail.refused(storage.err)}; }
+        output.attributes = storage.ok;
         output.attributes_len = attributes_len;
         memory.copy[u8](output.attributes, attributes, attributes_len::usize);
     }
@@ -112,9 +114,9 @@ pub fun combine(alloc: *A.Allocator, itn: *intern.Interner,
             var section: of.Section = input.sections[j];
             section.bytes = nil;
             if (section.kind != of.SK_BSS && section.len > 0) {
-                val storage: R.Result[*u8, str] = A.allocate[u8](alloc, section.len::usize);
-                if (R.is_err[*u8, str](storage)) { ret R.err[of.ObjectImage, str](R.unwrap_err[*u8, str](storage)); }
-                section.bytes = R.unwrap_ok[*u8, str](storage);
+                val storage: res[*u8, A.Error] = A.allocate[u8](alloc, section.len::usize);
+                if (sel storage.err) { ret res[of.ObjectImage, fail.Fail].err{fail.refused(storage.err)}; }
+                section.bytes = storage.ok;
                 memory.copy[u8](section.bytes, input.sections[j].bytes, section.len::usize);
             }
             if (section.native.link_section != 0) { section.native.link_section = section_base + section.native.link_section; }
@@ -176,9 +178,9 @@ pub fun combine(alloc: *A.Allocator, itn: *intern.Interner,
         i = i + 1;
     }
     val valid: R.Result[R.Void, str] = of.validate_owned_object(?output);
-    if (R.is_err[R.Void, str](valid)) { ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](valid)); }
+    if (R.is_err[R.Void, str](valid)) { ret res[of.ObjectImage, fail.Fail].err{fail.message(R.unwrap_err[R.Void, str](valid))}; }
     complete = true;
-    ret R.ok[of.ObjectImage, str](output);
+    ret res[of.ObjectImage, fail.Fail].ok{output};
 }
 
 test "mach.lang.be.linker.relocatable:combined_native_elf_preserves_group_and_relocation_targets" {
@@ -231,9 +233,9 @@ test "mach.lang.be.linker.relocatable:combined_native_elf_preserves_group_and_re
     inputs[1].sections = ?second_sections[0]; inputs[1].section_count = 2;
     inputs[1].symbols = ?second_symbols[0]; inputs[1].symbol_count = 2;
     inputs[1].relocations = ?relocations[0]; inputs[1].reloc_count = 2;
-    val combined: R.Result[of.ObjectImage, str] = combine(?alloc, ?itn, ?inputs[0], 2, 0, nil, 0);
-    if (R.is_err[of.ObjectImage, str](combined)) { ret 2; }
-    var image: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](combined);
+    val combined: res[of.ObjectImage, fail.Fail] = combine(?alloc, ?itn, ?inputs[0], 2, 0, nil, 0);
+    if (sel combined.err) { ret 2; }
+    var image: of.ObjectImage = combined.ok;
     fin { of.object_image_dnit(?image); }
     if (image.section_count != 3 || image.symbol_count != 3 || image.reloc_count != 2
         || image.sections[2].native.link_symbol != 2 || bin.read_u32_le(image.sections[2].bytes, 4) != 2
@@ -263,9 +265,9 @@ test "mach.lang.be.linker.relocatable:combined_native_elf_preserves_group_and_re
     if (R.is_err[R.Void, str](emitted)) { ret 7; }
     closed = true;
     if (O.is_some[txn.Error](publication.plan_dnit(?operation))) { ret 7; }
-    val read: R.Result[Vector[u8], str] = fs.read_bytes(?alloc, output.path(?file));
-    if (R.is_err[Vector[u8], str](read)) { ret 8; }
-    var bytes: Vector[u8] = R.unwrap_ok[Vector[u8], str](read);
+    val read: res[Vector[u8], fs.FsError] = fs.read_bytes(?alloc, output.path(?file));
+    if (sel read.err) { ret 8; }
+    var bytes: Vector[u8] = read.ok;
     fin { if (bytes.data != nil) { A.deallocate[u8](?alloc, bytes.data, bytes.cap); } }
     var parsed: of.ObjectImage;
     if (R.is_err[R.Void, str](tgt.of.parse_object(?alloc, ?itn, bytes.data, bytes.len, ?parsed))) { ret 9; }

--- a/src/lang/be/obj.mach
+++ b/src/lang/be/obj.mach
@@ -1,4 +1,7 @@
 use std.types.canonical.opt;
+use std.types.canonical.res;
+use std.types.canonical.err;
+use mach.lang.fail;
 use mach.lang.publication;
 use std.types.bool.bool;
 use std.types.bool.false;
@@ -7,10 +10,10 @@ use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_equals;
 
-use page: mach.lang.legacy.page;
+use page: std.allocator.page;
 use std.memory;
 
-use A: mach.lang.legacy.allocator;
+use A: std.allocator;
 use O: std.types.option;
 use R: std.types.result;
 
@@ -22,75 +25,75 @@ use target_testing: mach.lang.target.testing;
 use mach.lang.target.of;
 use rel: mach.lang.target.of.reloc;
 
-pub fun init(a: *A.Allocator, interner: *intern.Interner, name: intern.StrId) R.Result[of.ObjectImage, str] {
-    ret R.ok[of.ObjectImage, str](of.object_image_init(a, interner, name));
+pub fun image_init(a: *A.Allocator, interner: *intern.Interner, name: intern.StrId) res[of.ObjectImage, fail.Fail] {
+    ret res[of.ObjectImage, fail.Fail].ok{of.object_image_init(a, interner, name)};
 }
 
 pub fun dnit(o: *of.ObjectImage) {
     of.object_image_dnit(o);
 }
 
-pub fun install_section(o: *of.ObjectImage, s: *of.Section) R.Result[u32, str] {
+pub fun section_install(o: *of.ObjectImage, s: *of.Section) res[u32, fail.Fail] {
     if (o == nil || o.alloc == nil || s == nil) {
-        ret R.err[u32, str]("obj: cannot install a section without complete ownership");
+        ret res[u32, fail.Fail].err{fail.message("obj: cannot install a section without complete ownership")};
     }
     if (s.bytes != nil && s.len == 0) {
-        ret R.err[u32, str]("obj: section byte allocation has no release extent");
+        ret res[u32, fail.Fail].err{fail.message("obj: section byte allocation has no release extent")};
     }
     val section: of.Section = @s;
     s.bytes = nil;
     s.len   = 0;
 
-    val res_grow: R.Result[R.Void, str] = array_reserve_one[of.Section](
+    val res_grow: err[fail.Fail] = array_reserve_one[of.Section](
         o.alloc, ?o.sections, o.section_count, ?o.section_cap);
-    if (R.is_err[R.Void, str](res_grow)) {
+    if (sel res_grow.err) {
         if (section.bytes != nil && section.len > 0) {
             A.deallocate[u8](o.alloc, section.bytes, section.len::usize);
         }
-        ret R.err[u32, str](R.unwrap_err[R.Void, str](res_grow));
+        ret res[u32, fail.Fail].err{res_grow.err};
     }
 
     val ix: u32 = o.section_count;
     o.sections[ix]  = section;
     o.section_count = o.section_count + 1;
-    ret R.ok[u32, str](ix);
+    ret res[u32, fail.Fail].ok{ix};
 }
 
-pub fun add_symbol(o: *of.ObjectImage, sym: of.Symbol) R.Result[u32, str] {
-    val res_grow: R.Result[R.Void, str] = array_reserve_one[of.Symbol](
+pub fun symbol_add(o: *of.ObjectImage, sym: of.Symbol) res[u32, fail.Fail] {
+    val res_grow: err[fail.Fail] = array_reserve_one[of.Symbol](
         o.alloc, ?o.symbols, o.symbol_count, ?o.symbol_cap);
-    if (R.is_err[R.Void, str](res_grow)) {
-        ret R.err[u32, str](R.unwrap_err[R.Void, str](res_grow));
+    if (sel res_grow.err) {
+        ret res[u32, fail.Fail].err{res_grow.err};
     }
 
     val ix: u32 = o.symbol_count;
     o.symbols[ix]  = sym;
     o.symbol_count = o.symbol_count + 1;
-    ret R.ok[u32, str](ix);
+    ret res[u32, fail.Fail].ok{ix};
 }
 
-pub fun add_frame(o: *of.ObjectImage, fr: *of.FrameUnwind) R.Result[R.Void, str] {
-    val res_grow: R.Result[R.Void, str] = array_reserve_one[of.FrameUnwind](
+pub fun add_frame(o: *of.ObjectImage, fr: *of.FrameUnwind) err[fail.Fail] {
+    val res_grow: err[fail.Fail] = array_reserve_one[of.FrameUnwind](
         o.alloc, ?o.frames, o.frame_count, ?o.frame_cap);
-    if (R.is_err[R.Void, str](res_grow)) {
+    if (sel res_grow.err) {
         ret res_grow;
     }
 
     o.frames[o.frame_count] = @fr;
     o.frame_count = o.frame_count + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
-pub fun add_relocation(o: *of.ObjectImage, rel: of.Relocation) R.Result[R.Void, str] {
-    val res_grow: R.Result[R.Void, str] = array_reserve_one[of.Relocation](
+pub fun add_relocation(o: *of.ObjectImage, rel: of.Relocation) err[fail.Fail] {
+    val res_grow: err[fail.Fail] = array_reserve_one[of.Relocation](
         o.alloc, ?o.relocations, o.reloc_count, ?o.reloc_cap);
-    if (R.is_err[R.Void, str](res_grow)) {
+    if (sel res_grow.err) {
         ret res_grow;
     }
 
     o.relocations[o.reloc_count] = rel;
     o.reloc_count = o.reloc_count + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 pub fun symbol_index(o: *of.ObjectImage, name: intern.StrId) u32 {
@@ -138,53 +141,53 @@ pub fun deferred_dnit(d: *DeferredRelocs) {
     d.cap   = 0;
 }
 
-pub fun defer_relocation(d: *DeferredRelocs, rec: DeferredReloc) R.Result[R.Void, str] {
+pub fun defer_relocation(d: *DeferredRelocs, rec: DeferredReloc) err[fail.Fail] {
     if (d.count == d.cap) {
         var next: u32 = 8;
         if (d.cap > 0) {
             val doubled: R.Result[layout.CheckedCount[DeferredReloc], layout.CheckCause] =
                 layout.count_mul[DeferredReloc](layout.count[DeferredReloc](d.cap::usize), 2::usize);
             if (R.is_err[layout.CheckedCount[DeferredReloc], layout.CheckCause](doubled)) {
-                ret R.err[R.Void, str]("obj: deferred relocation queue growth count overflow");
+                ret err[fail.Fail].err{fail.message("obj: deferred relocation queue growth count overflow")};
             }
             val fits: R.Result[u32, layout.CheckCause] =
                 layout.usize_to_u32(R.unwrap_ok[layout.CheckedCount[DeferredReloc], layout.CheckCause](doubled).value);
             if (R.is_err[u32, layout.CheckCause](fits)) {
-                ret R.err[R.Void, str]("obj: deferred relocation queue capacity exceeds the u32 limit");
+                ret err[fail.Fail].err{fail.message("obj: deferred relocation queue capacity exceeds the u32 limit")};
             }
             next = R.unwrap_ok[u32, layout.CheckCause](fits);
         }
         var grown: *DeferredReloc = nil;
         if (d.items == nil) {
-            val ar: R.Result[*DeferredReloc, str] = A.allocate[DeferredReloc](d.alloc, next::usize);
-            if (R.is_err[*DeferredReloc, str](ar)) { ret R.err[R.Void, str](R.unwrap_err[*DeferredReloc, str](ar)); }
-            grown = R.unwrap_ok[*DeferredReloc, str](ar);
+            val ar: res[*DeferredReloc, A.Error] = A.allocate[DeferredReloc](d.alloc, next::usize);
+            if (sel ar.err) { ret err[fail.Fail].err{fail.refused(ar.err)}; }
+            grown = ar.ok;
         }
         or {
-            val rr: R.Result[*DeferredReloc, str] =
+            val rr: res[*DeferredReloc, A.Error] =
                 A.reallocate[DeferredReloc](d.alloc, d.items, d.cap::usize, next::usize);
-            if (R.is_err[*DeferredReloc, str](rr)) { ret R.err[R.Void, str](R.unwrap_err[*DeferredReloc, str](rr)); }
-            grown = R.unwrap_ok[*DeferredReloc, str](rr);
+            if (sel rr.err) { ret err[fail.Fail].err{fail.refused(rr.err)}; }
+            grown = rr.ok;
         }
         d.items = grown;
         d.cap   = next;
     }
     d.items[d.count] = rec;
     d.count = d.count + 1;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 pub fun defer_relocation_for_target(d: *DeferredRelocs, rec: DeferredReloc,
                                     tgt: *target.Target, section_kind: of.SectionKind,
-                                    codegen_image: bool) R.Result[R.Void, str] {
+                                    codegen_image: bool) err[fail.Fail] {
     if (tgt == nil || tgt.isa == nil || tgt.isa.reloc == nil
         || tgt.isa.reloc.traits == nil) {
-        ret R.err[R.Void, str]("codegen: target cannot describe relocations");
+        ret err[fail.Fail].err{fail.message("codegen: target cannot describe relocations")};
     }
     val tr: R.Result[rel.RelocTraits, rel.RelocError] =
         tgt.isa.reloc.traits(rec.kind, section_kind, codegen_image);
     if (R.is_err[rel.RelocTraits, rel.RelocError](tr)) {
-        ret R.err[R.Void, str]("codegen: relocation kind is not supported by the selected target");
+        ret err[fail.Fail].err{fail.message("codegen: relocation kind is not supported by the selected target")};
     }
     ret defer_relocation(d, rec);
 }
@@ -199,14 +202,14 @@ fun flush_deferred_consume(d: *DeferredRelocs, flushed: u32) {
     d.count = d.count - flushed;
 }
 
-pub fun flush_deferred(o: *of.ObjectImage, d: *DeferredRelocs) R.Result[R.Void, str] {
+pub fun flush_deferred(o: *of.ObjectImage, d: *DeferredRelocs) err[fail.Fail] {
     val image_base: u32 = o.reloc_count;
     var i: u32 = 0;
     for (i < d.count) {
         val pend: *DeferredReloc = ?d.items[i];
         if (pend.name == intern.STR_NIL) {
             flush_deferred_consume(d, i);
-            ret R.err[R.Void, str]("codegen: relocation has no target symbol");
+            ret err[fail.Fail].err{fail.message("codegen: relocation has no target symbol")};
         }
 
         var sym_ix: u32 = symbol_index(o, pend.name);
@@ -219,12 +222,12 @@ pub fun flush_deferred(o: *of.ObjectImage, d: *DeferredRelocs) R.Result[R.Void, 
             ext.flags   = pend.extern_flags;
             ext.fallback = of.SYMBOL_NONE;
             ext.align    = 1;
-            val sa: R.Result[u32, str] = add_symbol(o, ext);
-            if (R.is_err[u32, str](sa)) {
+            val sa: res[u32, fail.Fail] = symbol_add(o, ext);
+            if (sel sa.err) {
                 flush_deferred_consume(d, i);
-                ret R.err[R.Void, str](R.unwrap_err[u32, str](sa));
+                ret err[fail.Fail].err{sa.err};
             }
-            sym_ix = R.unwrap_ok[u32, str](sa);
+            sym_ix = sa.ok;
         }
 
         var rel: of.Relocation;
@@ -238,12 +241,12 @@ pub fun flush_deferred(o: *of.ObjectImage, d: *DeferredRelocs) R.Result[R.Void, 
         if (pend.pair != 0) {
             if (pend.pair > d.count) {
                 flush_deferred_consume(d, i);
-                ret R.err[R.Void, str]("codegen: relocation pair index is outside the deferred batch");
+                ret err[fail.Fail].err{fail.message("codegen: relocation pair index is outside the deferred batch")};
             }
             rel.pair = image_base + pend.pair;
         }
-        val ar: R.Result[R.Void, str] = add_relocation(o, rel);
-        if (R.is_err[R.Void, str](ar)) {
+        val ar: err[fail.Fail] = add_relocation(o, rel);
+        if (sel ar.err) {
             flush_deferred_consume(d, i);
             ret ar;
         }
@@ -251,7 +254,7 @@ pub fun flush_deferred(o: *of.ObjectImage, d: *DeferredRelocs) R.Result[R.Void, 
         i = i + 1;
     }
     d.count = 0;
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun remap_name(id: intern.StrId, remap: intern.ReinternMap) intern.StrId {
@@ -311,50 +314,50 @@ fun rehome_names_valid(src: *of.ObjectImage, dst_interner: *intern.Interner,
     ret true;
 }
 
-pub fun rehome_remap(dst_alloc: *A.Allocator, dst_interner: *intern.Interner,
-                     src: *of.ObjectImage, remap: intern.ReinternMap) R.Result[of.ObjectImage, str] {
+pub fun rehome(dst_alloc: *A.Allocator, dst_interner: *intern.Interner,
+                     src: *of.ObjectImage, remap: intern.ReinternMap) res[of.ObjectImage, fail.Fail] {
     if (dst_alloc == nil || dst_interner == nil) {
-        ret R.err[of.ObjectImage, str]("obj.rehome_remap: destination ownership is incomplete");
+        ret res[of.ObjectImage, fail.Fail].err{fail.message("obj.rehome_remap: destination ownership is incomplete")};
     }
     val source_valid: R.Result[R.Void, str] = of.validate_object_view(src);
     if (R.is_err[R.Void, str](source_valid)) {
-        ret R.err[of.ObjectImage, str](R.unwrap_err[R.Void, str](source_valid));
+        ret res[of.ObjectImage, fail.Fail].err{fail.message(R.unwrap_err[R.Void, str](source_valid))};
     }
     if (!rehome_names_valid(src, dst_interner, remap)) {
-        ret R.err[of.ObjectImage, str]("obj.rehome_remap: intern remap does not cover the source image");
+        ret res[of.ObjectImage, fail.Fail].err{fail.message("obj.rehome_remap: intern remap does not cover the source image")};
     }
-    val res_img: R.Result[of.ObjectImage, str] = init(dst_alloc, dst_interner, remap_name(src.name, remap));
-    if (R.is_err[of.ObjectImage, str](res_img)) { ret res_img; }
-    var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](res_img);
+    val res_img: res[of.ObjectImage, fail.Fail] = image_init(dst_alloc, dst_interner, remap_name(src.name, remap));
+    if (sel res_img.err) { ret res_img; }
+    var img: of.ObjectImage = res_img.ok;
     img.machine_flags = src.machine_flags;
     img.attributes = nil;
     img.attributes_len = 0;
     if (src.attributes != nil && src.attributes_len > 0) {
-        val ab: R.Result[*u8, str] = A.allocate[u8](dst_alloc, src.attributes_len::usize);
-        if (R.is_err[*u8, str](ab)) { ret R.err[of.ObjectImage, str](R.unwrap_err[*u8, str](ab)); }
-        val abuf: *u8 = R.unwrap_ok[*u8, str](ab);
+        val ab: res[*u8, A.Error] = A.allocate[u8](dst_alloc, src.attributes_len::usize);
+        if (sel ab.err) { ret res[of.ObjectImage, fail.Fail].err{fail.refused(ab.err)}; }
+        val abuf: *u8 = ab.ok;
         memory.raw_copy(abuf::ptr, src.attributes::ptr, src.attributes_len::usize);
         img.attributes = abuf;
         img.attributes_len = src.attributes_len;
     }
 
     if (src.section_count > 0) {
-        val rs: R.Result[*of.Section, str] = A.allocate[of.Section](dst_alloc, src.section_count::usize);
-        if (R.is_err[*of.Section, str](rs)) { dnit(?img); ret R.err[of.ObjectImage, str](R.unwrap_err[*of.Section, str](rs)); }
-        img.sections = R.unwrap_ok[*of.Section, str](rs);
+        val rs: res[*of.Section, A.Error] = A.allocate[of.Section](dst_alloc, src.section_count::usize);
+        if (sel rs.err) { dnit(?img); ret res[of.ObjectImage, fail.Fail].err{fail.refused(rs.err)}; }
+        img.sections = rs.ok;
         img.section_cap = src.section_count;
         var i: u32 = 0;
         for (i < src.section_count) {
             var sec: of.Section = src.sections[i];
             sec.name = remap_name(src.sections[i].name, remap);
             if (src.sections[i].bytes != nil && src.sections[i].len > 0) {
-                val rb: R.Result[*u8, str] = A.allocate[u8](dst_alloc, src.sections[i].len::usize);
-                if (R.is_err[*u8, str](rb)) {
+                val rb: res[*u8, A.Error] = A.allocate[u8](dst_alloc, src.sections[i].len::usize);
+                if (sel rb.err) {
                     img.section_count = i;
                     dnit(?img);
-                    ret R.err[of.ObjectImage, str](R.unwrap_err[*u8, str](rb));
+                    ret res[of.ObjectImage, fail.Fail].err{fail.refused(rb.err)};
                 }
-                sec.bytes = R.unwrap_ok[*u8, str](rb);
+                sec.bytes = rb.ok;
                 memory.copy[u8](sec.bytes, src.sections[i].bytes, src.sections[i].len::usize);
             }
             img.sections[i] = sec;
@@ -364,9 +367,9 @@ pub fun rehome_remap(dst_alloc: *A.Allocator, dst_interner: *intern.Interner,
     }
 
     if (src.symbol_count > 0) {
-        val ry: R.Result[*of.Symbol, str] = A.allocate[of.Symbol](dst_alloc, src.symbol_count::usize);
-        if (R.is_err[*of.Symbol, str](ry)) { dnit(?img); ret R.err[of.ObjectImage, str](R.unwrap_err[*of.Symbol, str](ry)); }
-        img.symbols = R.unwrap_ok[*of.Symbol, str](ry);
+        val ry: res[*of.Symbol, A.Error] = A.allocate[of.Symbol](dst_alloc, src.symbol_count::usize);
+        if (sel ry.err) { dnit(?img); ret res[of.ObjectImage, fail.Fail].err{fail.refused(ry.err)}; }
+        img.symbols = ry.ok;
         img.symbol_cap = src.symbol_count;
         var i: u32 = 0;
         for (i < src.symbol_count) {
@@ -379,36 +382,36 @@ pub fun rehome_remap(dst_alloc: *A.Allocator, dst_interner: *intern.Interner,
     }
 
     if (src.reloc_count > 0) {
-        val rr: R.Result[*of.Relocation, str] = A.allocate[of.Relocation](dst_alloc, src.reloc_count::usize);
-        if (R.is_err[*of.Relocation, str](rr)) { dnit(?img); ret R.err[of.ObjectImage, str](R.unwrap_err[*of.Relocation, str](rr)); }
-        img.relocations = R.unwrap_ok[*of.Relocation, str](rr);
+        val rr: res[*of.Relocation, A.Error] = A.allocate[of.Relocation](dst_alloc, src.reloc_count::usize);
+        if (sel rr.err) { dnit(?img); ret res[of.ObjectImage, fail.Fail].err{fail.refused(rr.err)}; }
+        img.relocations = rr.ok;
         img.reloc_cap = src.reloc_count;
         memory.copy[of.Relocation](img.relocations, src.relocations, src.reloc_count::usize);
         img.reloc_count = src.reloc_count;
     }
 
     if (src.frame_count > 0) {
-        val rf: R.Result[*of.FrameUnwind, str] = A.allocate[of.FrameUnwind](dst_alloc, src.frame_count::usize);
-        if (R.is_err[*of.FrameUnwind, str](rf)) { dnit(?img); ret R.err[of.ObjectImage, str](R.unwrap_err[*of.FrameUnwind, str](rf)); }
-        img.frames = R.unwrap_ok[*of.FrameUnwind, str](rf);
+        val rf: res[*of.FrameUnwind, A.Error] = A.allocate[of.FrameUnwind](dst_alloc, src.frame_count::usize);
+        if (sel rf.err) { dnit(?img); ret res[of.ObjectImage, fail.Fail].err{fail.refused(rf.err)}; }
+        img.frames = rf.ok;
         img.frame_cap = src.frame_count;
         memory.copy[of.FrameUnwind](img.frames, src.frames, src.frame_count::usize);
         img.frame_count = src.frame_count;
     }
 
     if (src.indirect_count > 0) {
-        val copied: R.Result[*of.NativeIndirect, str] = A.allocate[of.NativeIndirect](dst_alloc, src.indirect_count::usize);
-        if (R.is_err[*of.NativeIndirect, str](copied)) { dnit(?img); ret R.err[of.ObjectImage, str](R.unwrap_err[*of.NativeIndirect, str](copied)); }
-        img.indirects = R.unwrap_ok[*of.NativeIndirect, str](copied);
+        val copied: res[*of.NativeIndirect, A.Error] = A.allocate[of.NativeIndirect](dst_alloc, src.indirect_count::usize);
+        if (sel copied.err) { dnit(?img); ret res[of.ObjectImage, fail.Fail].err{fail.refused(copied.err)}; }
+        img.indirects = copied.ok;
         img.indirect_cap = src.indirect_count;
         img.indirect_count = src.indirect_count;
         memory.copy[of.NativeIndirect](img.indirects, src.indirects, src.indirect_count::usize);
     }
 
     if (src.import_count > 0) {
-        val ri: R.Result[*of.ImportDecl, str] = A.allocate[of.ImportDecl](dst_alloc, src.import_count::usize);
-        if (R.is_err[*of.ImportDecl, str](ri)) { dnit(?img); ret R.err[of.ObjectImage, str](R.unwrap_err[*of.ImportDecl, str](ri)); }
-        img.imports = R.unwrap_ok[*of.ImportDecl, str](ri);
+        val ri: res[*of.ImportDecl, A.Error] = A.allocate[of.ImportDecl](dst_alloc, src.import_count::usize);
+        if (sel ri.err) { dnit(?img); ret res[of.ObjectImage, fail.Fail].err{fail.refused(ri.err)}; }
+        img.imports = ri.ok;
         img.import_cap = src.import_count;
         var i: u32 = 0;
         for (i < src.import_count) {
@@ -426,60 +429,60 @@ pub fun rehome_remap(dst_alloc: *A.Allocator, dst_interner: *intern.Interner,
     if (R.is_err[R.Void, str](image_valid)) {
         val reason: str = R.unwrap_err[R.Void, str](image_valid);
         dnit(?img);
-        ret R.err[of.ObjectImage, str](reason);
+        ret res[of.ObjectImage, fail.Fail].err{fail.message(reason)};
     }
-    ret R.ok[of.ObjectImage, str](img);
+    ret res[of.ObjectImage, fail.Fail].ok{img};
 }
 
-pub fun emit(o: *of.ObjectImage, tgt: *target.Target, destination: *publication.Destination) R.Result[R.Void, str] {
-    if (tgt == nil)                { ret R.err[R.Void, str]("emit: nil target"); }
-    if (tgt.of == nil)             { ret R.err[R.Void, str]("emit: target has no object-format vtable"); }
-    if (tgt.of.emit_object == nil) { ret R.err[R.Void, str]("emit: object format has no writer"); }
+pub fun emit_image(o: *of.ObjectImage, tgt: *target.Target, destination: *publication.Destination) err[fail.Fail] {
+    if (tgt == nil)                { ret err[fail.Fail].err{fail.message("emit: nil target")}; }
+    if (tgt.of == nil)             { ret err[fail.Fail].err{fail.message("emit: target has no object-format vtable")}; }
+    if (tgt.of.emit_object == nil) { ret err[fail.Fail].err{fail.message("emit: object format has no writer")}; }
     val image_valid: R.Result[R.Void, str] = of.validate_object_view(o);
-    if (R.is_err[R.Void, str](image_valid)) { ret image_valid; }
-    ret tgt.of.emit_object(?tgt.object, o, destination);
+    if (R.is_err[R.Void, str](image_valid)) { ret fail.lift_err(image_valid); }
+    ret fail.lift_err(tgt.of.emit_object(?tgt.object, o, destination));
 }
 
 
-fun array_reserve_one[T](a: *A.Allocator, arr: **T, len: u32, cap: *u32) R.Result[R.Void, str] {
+fun array_reserve_one[T](a: *A.Allocator, arr: **T, len: u32, cap: *u32) err[fail.Fail] {
     if (a == nil || arr == nil || cap == nil) {
-        ret R.err[R.Void, str]("obj: array growth requires initialized ownership");
+        ret err[fail.Fail].err{fail.message("obj: array growth requires initialized ownership")};
     }
     if (len > @cap || ((@arr == nil) != (@cap == 0))) {
-        ret R.err[R.Void, str]("obj: array count, capacity, and storage are inconsistent");
+        ret err[fail.Fail].err{fail.message("obj: array count, capacity, and storage are inconsistent")};
     }
-    if (len < @cap) { ret R.ok_void[str](); }
+    if (len < @cap) { ret err[fail.Fail].ok{}; }
 
     var grown: usize = 8;
     if (@cap > 0) {
         val next: R.Result[layout.CheckedCount[T], layout.CheckCause] =
             layout.count_mul[T](layout.count[T]((@cap)::usize), 2::usize);
         if (R.is_err[layout.CheckedCount[T], layout.CheckCause](next)) {
-            ret R.err[R.Void, str]("obj: array growth count overflow");
+            ret err[fail.Fail].err{fail.message("obj: array growth count overflow")};
         }
         grown = R.unwrap_ok[layout.CheckedCount[T], layout.CheckCause](next).value;
     }
     val fits: R.Result[u32, layout.CheckCause] = layout.usize_to_u32(grown);
     if (R.is_err[u32, layout.CheckCause](fits)) {
-        ret R.err[R.Void, str]("obj: array capacity exceeds the u32 limit");
+        ret err[fail.Fail].err{fail.message("obj: array capacity exceeds the u32 limit")};
     }
     var storage: *T = nil;
     if (@cap == 0) {
-        val allocated: R.Result[*T, str] = A.allocate[T](a, grown);
-        if (R.is_err[*T, str](allocated)) {
-            ret R.err[R.Void, str](R.unwrap_err[*T, str](allocated));
+        val allocated: res[*T, A.Error] = A.allocate[T](a, grown);
+        if (sel allocated.err) {
+            ret err[fail.Fail].err{fail.refused(allocated.err)};
         }
-        storage = R.unwrap_ok[*T, str](allocated);
+        storage = allocated.ok;
     } or {
-        val reallocated: R.Result[*T, str] = A.reallocate[T](a, @arr, (@cap)::usize, grown);
-        if (R.is_err[*T, str](reallocated)) {
-            ret R.err[R.Void, str](R.unwrap_err[*T, str](reallocated));
+        val reallocated: res[*T, A.Error] = A.reallocate[T](a, @arr, (@cap)::usize, grown);
+        if (sel reallocated.err) {
+            ret err[fail.Fail].err{fail.refused(reallocated.err)};
         }
-        storage = R.unwrap_ok[*T, str](reallocated);
+        storage = reallocated.ok;
     }
     @arr = storage;
     @cap = R.unwrap_ok[u32, layout.CheckCause](fits);
-    ret R.ok_void[str]();
+    ret err[fail.Fail].ok{};
 }
 
 fun t_obj_intern(itn: *intern.Interner, s: str) intern.StrId {
@@ -489,22 +492,26 @@ fun t_obj_intern(itn: *intern.Interner, s: str) intern.StrId {
 }
 
 fun t_debug_produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
+    ret fail.lower_unit(t_debug_produce_typed(req));
+}
+
+fun t_debug_produce_typed(req: *of.DebugProduceRequest) err[fail.Fail] {
     val img: *of.ObjectImage = req.image;
-    val br: R.Result[*u8, str] = A.allocate[u8](img.alloc, 4::usize);
-    if (R.is_err[*u8, str](br)) { ret R.err[R.Void, str](R.unwrap_err[*u8, str](br)); }
+    val br: res[*u8, A.Error] = A.allocate[u8](img.alloc, 4::usize);
+    if (sel br.err) { ret err[fail.Fail].err{fail.refused(br.err)}; }
 
     var sec: of.Section;
     sec.name  = t_obj_intern(img.interner, ".debug_info");
     sec.kind  = of.SK_DEBUG;
-    sec.bytes = R.unwrap_ok[*u8, str](br);
+    sec.bytes = br.ok;
     sec.len   = 4;
     sec.align = 1;
     sec.flags = 0;
-    val sr: R.Result[u32, str] = install_section(img, ?sec);
-    if (R.is_err[u32, str](sr)) {
-        ret R.err[R.Void, str](R.unwrap_err[u32, str](sr));
+    val sr: res[u32, fail.Fail] = section_install(img, ?sec);
+    if (sel sr.err) {
+        ret err[fail.Fail].err{sr.err};
     }
-    val sec_idx: u32 = R.unwrap_ok[u32, str](sr);
+    val sec_idx: u32 = sr.ok;
 
     var sym: of.Symbol;
     sym.name    = t_obj_intern(img.interner, ".Ldebug_info0");
@@ -514,23 +521,56 @@ fun t_debug_produce(req: *of.DebugProduceRequest) R.Result[R.Void, str] {
     sym.flags   = 0;
     sym.fallback = of.SYMBOL_NONE;
     sym.align    = 1;
-    val yr: R.Result[u32, str] = add_symbol(img, sym);
-    if (R.is_err[u32, str](yr)) { ret R.err[R.Void, str](R.unwrap_err[u32, str](yr)); }
+    val yr: res[u32, fail.Fail] = symbol_add(img, sym);
+    if (sel yr.err) { ret err[fail.Fail].err{yr.err}; }
 
     var rel: of.Relocation;
     rel.section = of.section_id(sec_idx);
     rel.offset  = 0;
     rel.kind    = of.RK_ABS32;
-    rel.sym     = R.unwrap_ok[u32, str](yr);
+    rel.sym     = yr.ok;
     rel.addend  = 0;
     rel.sym2    = of.SYMBOL_NONE;
-    val added: R.Result[R.Void, str] = add_relocation(img, rel);
-    if (R.is_err[R.Void, str](added)) { ret added; }
-    ret R.ok_void[str]();
+    val added: err[fail.Fail] = add_relocation(img, rel);
+    if (sel added.err) { ret added; }
+    ret err[fail.Fail].ok{};
 }
 
 fun t_debug_supports(tgt: *debug_input.DebugTarget) bool {
     ret tgt != nil;
+}
+
+# translation shims (#3226): the legacy carriers the build, driver and fuzz
+# lanes read until their call sites migrate to the typed twins above
+pub fun init(a: *A.Allocator, interner: *intern.Interner, name: intern.StrId) R.Result[of.ObjectImage, str] {
+    val r: res[of.ObjectImage, fail.Fail] = image_init(a, interner, name);
+    if (sel r.err) { ret R.err[of.ObjectImage, str](fail.describe(r.err)); }
+    ret R.ok[of.ObjectImage, str](r.ok);
+}
+
+pub fun install_section(o: *of.ObjectImage, s: *of.Section) R.Result[u32, str] {
+    val r: res[u32, fail.Fail] = section_install(o, s);
+    if (sel r.err) { ret R.err[u32, str](fail.describe(r.err)); }
+    ret R.ok[u32, str](r.ok);
+}
+
+pub fun add_symbol(o: *of.ObjectImage, sym: of.Symbol) R.Result[u32, str] {
+    val r: res[u32, fail.Fail] = symbol_add(o, sym);
+    if (sel r.err) { ret R.err[u32, str](fail.describe(r.err)); }
+    ret R.ok[u32, str](r.ok);
+}
+
+pub fun rehome_remap(dst_alloc: *A.Allocator, dst_interner: *intern.Interner,
+                     src: *of.ObjectImage, remap: intern.ReinternMap) R.Result[of.ObjectImage, str] {
+    val r: res[of.ObjectImage, fail.Fail] = rehome(dst_alloc, dst_interner, src, remap);
+    if (sel r.err) { ret R.err[of.ObjectImage, str](fail.describe(r.err)); }
+    ret R.ok[of.ObjectImage, str](r.ok);
+}
+
+pub fun emit(o: *of.ObjectImage, tgt: *target.Target, destination: *publication.Destination) R.Result[R.Void, str] {
+    val r: err[fail.Fail] = emit_image(o, tgt, destination);
+    if (sel r.err) { ret R.err[R.Void, str](fail.describe(r.err)); }
+    ret R.ok_void[str]();
 }
 
 test "mach.lang.be.obj.debug_seam:producer_writes_into_image" {
@@ -538,9 +578,9 @@ test "mach.lang.be.obj.debug_seam:producer_writes_into_image" {
     page.make(?alloc);
     var itn: intern.Interner = intern.init(?alloc);
 
-    val ir: R.Result[of.ObjectImage, str] = init(?alloc, ?itn, t_obj_intern(?itn, "m"));
-    if (R.is_err[of.ObjectImage, str](ir)) { ret 1; }
-    var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](ir);
+    val ir: res[of.ObjectImage, fail.Fail] = image_init(?alloc, ?itn, t_obj_intern(?itn, "m"));
+    if (sel ir.err) { ret 1; }
+    var img: of.ObjectImage = ir.ok;
 
     var reg: of.DebugRegistry = of.debug_registry_init();
     fin { of.debug_registry_dnit(?reg); }
@@ -622,7 +662,8 @@ fun obj_probe_deallocate(ctx: ptr, item: ptr, size: usize, align: usize) i64 {
 }
 
 fun obj_probe_make(p: *ObjProbe, fail_at: u32) bool {
-    if (O.is_some[str](page.make(?p.backing))) { ret false; }
+    val make_r: err[A.Error] = page.make(?p.backing);
+    if (sel make_r.err) { ret false; }
     p.live     = 0;
     p.calls    = 0;
     p.fail_at  = fail_at;
@@ -643,13 +684,13 @@ test "mach.lang.be.obj.dnit:frees_attributes" {
     alloc.fn_deallocate = obj_probe_deallocate;
     var itn: intern.Interner = intern.init(?alloc);
 
-    val ir: R.Result[of.ObjectImage, str] = init(?alloc, ?itn, t_obj_intern(?itn, "m"));
-    if (R.is_err[of.ObjectImage, str](ir)) { ret 1; }
-    var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](ir);
+    val ir: res[of.ObjectImage, fail.Fail] = image_init(?alloc, ?itn, t_obj_intern(?itn, "m"));
+    if (sel ir.err) { ret 1; }
+    var img: of.ObjectImage = ir.ok;
 
-    val ab: R.Result[*u8, str] = A.allocate[u8](?alloc, 8::usize);
-    if (R.is_err[*u8, str](ab)) { ret 1; }
-    img.attributes     = R.unwrap_ok[*u8, str](ab);
+    val ab: res[*u8, A.Error] = A.allocate[u8](?alloc, 8::usize);
+    if (sel ab.err) { ret 1; }
+    img.attributes     = ab.ok;
     img.attributes_len = 8;
 
     dnit(?img);
@@ -671,35 +712,35 @@ test "mach.lang.be.obj.install_section:consumes_payload_on_success_and_failure" 
     alloc.fn_deallocate = obj_probe_deallocate;
     var itn: intern.Interner = intern.init(?alloc);
 
-    val ir: R.Result[of.ObjectImage, str] = init(?alloc, ?itn, t_obj_intern(?itn, "m"));
-    if (R.is_err[of.ObjectImage, str](ir)) { intern.dnit(?itn); ret 1; }
-    var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](ir);
+    val ir: res[of.ObjectImage, fail.Fail] = image_init(?alloc, ?itn, t_obj_intern(?itn, "m"));
+    if (sel ir.err) { intern.dnit(?itn); ret 1; }
+    var img: of.ObjectImage = ir.ok;
 
-    val br: R.Result[*u8, str] = A.allocate[u8](?alloc, 16::usize);
-    if (R.is_err[*u8, str](br)) { dnit(?img); intern.dnit(?itn); ret 1; }
+    val br: res[*u8, A.Error] = A.allocate[u8](?alloc, 16::usize);
+    if (sel br.err) { dnit(?img); intern.dnit(?itn); ret 1; }
     var sec: of.Section;
     sec.name  = t_obj_intern(?itn, ".data");
     sec.kind  = of.SK_DATA;
-    sec.bytes = R.unwrap_ok[*u8, str](br);
+    sec.bytes = br.ok;
     sec.len   = 16;
     sec.align = 8;
     sec.flags = 0;
 
     probe.fail_at = probe.calls + 1;
-    val installed: R.Result[u32, str] = install_section(?img, ?sec);
+    val installed: res[u32, fail.Fail] = section_install(?img, ?sec);
     probe.fail_at = 0;
 
     var bad: i32 = 0;
-    if (R.is_ok[u32, str](installed)) { bad = 1; }
+    if (sel installed.ok) { bad = 1; }
     if (img.section_count != 0)       { bad = 2; }
     if (sec.bytes != nil || sec.len != 0) { bad = 3; }
 
-    val br2: R.Result[*u8, str] = A.allocate[u8](?alloc, 16::usize);
-    if (R.is_err[*u8, str](br2)) { dnit(?img); intern.dnit(?itn); ret 1; }
-    sec.bytes = R.unwrap_ok[*u8, str](br2);
+    val br2: res[*u8, A.Error] = A.allocate[u8](?alloc, 16::usize);
+    if (sel br2.err) { dnit(?img); intern.dnit(?itn); ret 1; }
+    sec.bytes = br2.ok;
     sec.len   = 16;
-    val installed2: R.Result[u32, str] = install_section(?img, ?sec);
-    if (R.is_err[u32, str](installed2))     { bad = 4; }
+    val installed2: res[u32, fail.Fail] = section_install(?img, ?sec);
+    if (sel installed2.err)     { bad = 4; }
     if (img.section_count != 1)             { bad = 5; }
     if (sec.bytes != nil || sec.len != 0)   { bad = 6; }
     dnit(?img);
@@ -723,13 +764,13 @@ test "mach.lang.be.obj.rehome_remap:copies_imports" {
     val base_len: usize = intern.count(?base);
     var child: intern.Interner = intern.make_child(?base, ?alloc);
 
-    val ir: R.Result[of.ObjectImage, str] = init(?alloc, ?child, t_obj_intern(?child, "src"));
-    if (R.is_err[of.ObjectImage, str](ir)) { ret 1; }
-    var src: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](ir);
+    val ir: res[of.ObjectImage, fail.Fail] = image_init(?alloc, ?child, t_obj_intern(?child, "src"));
+    if (sel ir.err) { ret 1; }
+    var src: of.ObjectImage = ir.ok;
 
-    val ri: R.Result[*of.ImportDecl, str] = A.allocate[of.ImportDecl](?alloc, 1::usize);
-    if (R.is_err[*of.ImportDecl, str](ri)) { ret 1; }
-    src.imports = R.unwrap_ok[*of.ImportDecl, str](ri);
+    val ri: res[*of.ImportDecl, A.Error] = A.allocate[of.ImportDecl](?alloc, 1::usize);
+    if (sel ri.err) { ret 1; }
+    src.imports = ri.ok;
     src.import_cap = 1;
     src.imports[0].symbol      = t_obj_intern(?child, "sym");
     src.imports[0].import_name = t_obj_intern(?child, "sym@0");
@@ -745,27 +786,27 @@ test "mach.lang.be.obj.rehome_remap:copies_imports" {
 
     var short_map: intern.ReinternMap = remap;
     short_map.len = 1;
-    val short: R.Result[of.ObjectImage, str] =
-        rehome_remap(?alloc, ?base, ?src, short_map);
-    if (R.is_ok[of.ObjectImage, str](short)) {
-        var escaped: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](short);
+    val short: res[of.ObjectImage, fail.Fail] =
+        rehome(?alloc, ?base, ?src, short_map);
+    if (sel short.ok) {
+        var escaped: of.ObjectImage = short.ok;
         dnit(?escaped); dnit(?src); ret 1;
     }
 
     val original: intern.StrId = remap.ids[0];
     remap.ids[0] = base_name;
-    val wrong: R.Result[of.ObjectImage, str] =
-        rehome_remap(?alloc, ?base, ?src, remap);
+    val wrong: res[of.ObjectImage, fail.Fail] =
+        rehome(?alloc, ?base, ?src, remap);
     remap.ids[0] = original;
-    if (R.is_ok[of.ObjectImage, str](wrong)) {
-        var escaped: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](wrong);
+    if (sel wrong.ok) {
+        var escaped: of.ObjectImage = wrong.ok;
         dnit(?escaped); dnit(?src); ret 1;
     }
 
-    val rr: R.Result[of.ObjectImage, str] =
-        rehome_remap(?alloc, ?base, ?src, remap);
-    if (R.is_err[of.ObjectImage, str](rr)) { dnit(?src); ret 1; }
-    var dst: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](rr);
+    val rr: res[of.ObjectImage, fail.Fail] =
+        rehome(?alloc, ?base, ?src, remap);
+    if (sel rr.err) { dnit(?src); ret 1; }
+    var dst: of.ObjectImage = rr.ok;
 
     if (dst.import_count != 1)         { dnit(?src); dnit(?dst); ret 1; }
     if (dst.imports == src.imports)    { dnit(?src); dnit(?dst); ret 1; }
@@ -797,41 +838,45 @@ test "mach.lang.be.obj.flush_deferred:sym2_set_and_retry_consumes_flushed_prefix
     alloc.fn_deallocate = obj_probe_deallocate;
     var itn: intern.Interner = intern.init(?alloc);
 
-    val ir: R.Result[of.ObjectImage, str] = init(?alloc, ?itn, t_obj_intern(?itn, "m"));
-    if (R.is_err[of.ObjectImage, str](ir)) { ret 1; }
-    var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](ir);
+    val ir: res[of.ObjectImage, fail.Fail] = image_init(?alloc, ?itn, t_obj_intern(?itn, "m"));
+    if (sel ir.err) { ret 1; }
+    var img: of.ObjectImage = ir.ok;
 
     val name_a: intern.StrId = t_obj_intern(?itn, "sym_a");
     val name_b: intern.StrId = t_obj_intern(?itn, "sym_b");
 
     var sym_a: of.Symbol;
     sym_a.name = name_a; sym_a.section = of.section_id(0); sym_a.offset = 0; sym_a.size = 0; sym_a.flags = 0;
-    if (R.is_err[u32, str](add_symbol(?img, sym_a))) { dnit(?img); ret 1; }
+    val symbol_add_r: res[u32, fail.Fail] = symbol_add(?img, sym_a);
+    if (sel symbol_add_r.err) { dnit(?img); ret 1; }
     var filler: of.Symbol = sym_a;
     filler.name = intern.STR_NIL;
     var fill_i: u32 = 1;
     for (fill_i < 8) {
-        if (R.is_err[u32, str](add_symbol(?img, filler))) { dnit(?img); ret 1; }
+        val symbol_add_r2: res[u32, fail.Fail] = symbol_add(?img, filler);
+        if (sel symbol_add_r2.err) { dnit(?img); ret 1; }
         fill_i = fill_i + 1;
     }
 
     var deferred: DeferredRelocs = deferred_init(?alloc);
     var rec_a: DeferredReloc;
     rec_a.section = of.section_id(0); rec_a.offset = 0; rec_a.kind = of.RK_ABS64; rec_a.name = name_a; rec_a.addend = 0; rec_a.extern_flags = 0;
-    if (R.is_err[R.Void, str](defer_relocation(?deferred, rec_a))) { deferred_dnit(?deferred); dnit(?img); ret 1; }
+    val defer_relocation_r: err[fail.Fail] = defer_relocation(?deferred, rec_a);
+    if (sel defer_relocation_r.err) { deferred_dnit(?deferred); dnit(?img); ret 1; }
     var rec_b: DeferredReloc;
     rec_b.section = of.section_id(0); rec_b.offset = 4; rec_b.kind = of.RK_ABS64; rec_b.name = name_b; rec_b.addend = 0; rec_b.extern_flags = 0;
-    if (R.is_err[R.Void, str](defer_relocation(?deferred, rec_b))) { deferred_dnit(?deferred); dnit(?img); ret 1; }
+    val defer_relocation_r2: err[fail.Fail] = defer_relocation(?deferred, rec_b);
+    if (sel defer_relocation_r2.err) { deferred_dnit(?deferred); dnit(?img); ret 1; }
 
     probe.fail_at = probe.calls + 2;
-    val r1: R.Result[R.Void, str] = flush_deferred(?img, ?deferred);
-    if (R.is_ok[R.Void, str](r1)) { deferred_dnit(?deferred); dnit(?img); ret 1; }
+    val r1: err[fail.Fail] = flush_deferred(?img, ?deferred);
+    if (sel r1.ok) { deferred_dnit(?deferred); dnit(?img); ret 1; }
     if (deferred.count != 1)     { deferred_dnit(?deferred); dnit(?img); ret 1; }
     if (img.reloc_count != 1)    { deferred_dnit(?deferred); dnit(?img); ret 1; }
 
     probe.fail_at = 0;
-    val r2: R.Result[R.Void, str] = flush_deferred(?img, ?deferred);
-    if (R.is_err[R.Void, str](r2)) { deferred_dnit(?deferred); dnit(?img); ret 1; }
+    val r2: err[fail.Fail] = flush_deferred(?img, ?deferred);
+    if (sel r2.err) { deferred_dnit(?deferred); dnit(?img); ret 1; }
     if (deferred.count != 0)     { deferred_dnit(?deferred); dnit(?img); ret 1; }
     if (img.reloc_count != 2)    { deferred_dnit(?deferred); dnit(?img); ret 1; }
     if (img.relocations[0].sym2 != of.SYMBOL_NONE) { deferred_dnit(?deferred); dnit(?img); ret 1; }
@@ -857,9 +902,9 @@ test "mach.lang.be.obj.add_symbol:grows_geometrically_and_releases_capacity" {
     alloc.fn_deallocate = obj_probe_deallocate;
     var itn: intern.Interner = intern.init(?alloc);
 
-    val ir: R.Result[of.ObjectImage, str] = init(?alloc, ?itn, intern.STR_NIL);
-    if (R.is_err[of.ObjectImage, str](ir)) { ret 1; }
-    var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](ir);
+    val ir: res[of.ObjectImage, fail.Fail] = image_init(?alloc, ?itn, intern.STR_NIL);
+    if (sel ir.err) { ret 1; }
+    var img: of.ObjectImage = ir.ok;
 
     var sym: of.Symbol;
     sym.name     = intern.STR_NIL;
@@ -873,7 +918,8 @@ test "mach.lang.be.obj.add_symbol:grows_geometrically_and_releases_capacity" {
     val calls_before: u32 = probe.calls;
     var i: u32 = 0;
     for (i < 4096) {
-        if (R.is_err[u32, str](add_symbol(?img, sym))) {
+        val symbol_add_r: res[u32, fail.Fail] = symbol_add(?img, sym);
+        if (sel symbol_add_r.err) {
             dnit(?img);
             intern.dnit(?itn);
             ret 1;
@@ -927,9 +973,9 @@ test "mach.lang.be.obj.install_section:refuses_count_overflow_before_reallocatin
     alloc.fn_deallocate = growth_probe_deallocate;
     var itn: intern.Interner = intern.init(?alloc);
 
-    val ir: R.Result[of.ObjectImage, str] = init(?alloc, ?itn, t_obj_intern(?itn, "m"));
-    if (R.is_err[of.ObjectImage, str](ir)) { ret 1; }
-    var img: of.ObjectImage = R.unwrap_ok[of.ObjectImage, str](ir);
+    val ir: res[of.ObjectImage, fail.Fail] = image_init(?alloc, ?itn, t_obj_intern(?itn, "m"));
+    if (sel ir.err) { ret 1; }
+    var img: of.ObjectImage = ir.ok;
     var dummy: of.Section;
     img.sections      = ?dummy;
     img.section_count = 0x80000000;
@@ -943,10 +989,10 @@ test "mach.lang.be.obj.install_section:refuses_count_overflow_before_reallocatin
     sec.align = 1;
     probe.allocate_calls = 0;
     probe.reallocate_calls = 0;
-    val r: R.Result[u32, str] = install_section(?img, ?sec);
+    val r: res[u32, fail.Fail] = section_install(?img, ?sec);
 
     var bad: i32 = 0;
-    if (R.is_ok[u32, str](r))            { bad = 1; }
+    if (sel r.ok)            { bad = 1; }
     if (probe.reallocate_calls != 0)     { bad = 2; }
     if (probe.allocate_calls != 0)       { bad = 3; }
     if (img.section_count != 0x80000000) { bad = 4; }
@@ -975,10 +1021,10 @@ test "mach.lang.be.obj.defer_relocation:refuses_capacity_overflow_before_realloc
     var drec: DeferredReloc;
     drec.section = of.section_id(0); drec.offset = 0; drec.kind = of.RK_ABS64;
     drec.name = intern.STR_NIL; drec.addend = 0; drec.extern_flags = 0;
-    val r: R.Result[R.Void, str] = defer_relocation(?d, drec);
+    val r: err[fail.Fail] = defer_relocation(?d, drec);
 
     var bad: i32 = 0;
-    if (R.is_ok[R.Void, str](r))       { bad = 1; }
+    if (sel r.ok)       { bad = 1; }
     if (probe.reallocate_calls != 0) { bad = 2; }
     if (d.cap != 0xFFFFFFFF)         { bad = 3; }
     ret bad;
@@ -1000,16 +1046,17 @@ test "mach.lang.be.obj.defer_relocation_for_target:refuses_a_kind_the_target_can
     if (!t_x64_target(?reg, ?t)) { ret 1; }
 
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var d: DeferredRelocs = deferred_init(?alloc);
 
     var rec: DeferredReloc;
     rec.section = of.section_id(0); rec.offset = 0; rec.kind = of.RK_PAGE21;
     rec.name = intern.STR_NIL; rec.addend = 0; rec.extern_flags = 0;
 
-    val r: R.Result[R.Void, str] = defer_relocation_for_target(?d, rec, ?t, of.SK_TEXT, true);
+    val r: err[fail.Fail] = defer_relocation_for_target(?d, rec, ?t, of.SK_TEXT, true);
     var bad: i32 = 0;
-    if (R.is_ok[R.Void, str](r)) { bad = 1; }
+    if (sel r.ok) { bad = 1; }
     if (d.count != 0)          { bad = 2; }
 
     deferred_dnit(?d);
@@ -1023,16 +1070,17 @@ test "mach.lang.be.obj.defer_relocation_for_target:admits_a_kind_the_target_can_
     if (!t_x64_target(?reg, ?t)) { ret 1; }
 
     var alloc: A.Allocator;
-    if (O.is_some[str](page.make(?alloc))) { ret 1; }
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
     var d: DeferredRelocs = deferred_init(?alloc);
 
     var rec: DeferredReloc;
     rec.section = of.section_id(0); rec.offset = 0; rec.kind = of.RK_PLT32;
     rec.name = intern.STR_NIL; rec.addend = 0; rec.extern_flags = 0;
 
-    val r: R.Result[R.Void, str] = defer_relocation_for_target(?d, rec, ?t, of.SK_TEXT, true);
+    val r: err[fail.Fail] = defer_relocation_for_target(?d, rec, ?t, of.SK_TEXT, true);
     var bad: i32 = 0;
-    if (R.is_err[R.Void, str](r)) { bad = 1; }
+    if (sel r.err) { bad = 1; }
     if (d.count != 1)           { bad = 2; }
 
     deferred_dnit(?d);

--- a/src/lang/fail.mach
+++ b/src/lang/fail.mach
@@ -5,6 +5,7 @@ use std.types.bool.false;
 use std.types.string.str;
 use std.types.string.str_equals;
 use std.types.string.str_len;
+use std.types.string.StrError;
 use std.types.canonical.res;
 use std.types.canonical.opt;
 use std.types.canonical.err;
@@ -15,7 +16,12 @@ use O: std.types.option;
 use R: std.types.result;
 use T: std.allocator.testing;
 use format: std.format;
+use fs: std.filesystem;
+use io_error: std.io.error;
 use page: std.allocator.page;
+use reader: std.io.reader;
+use removal: std.filesystem.removal;
+use writer: std.io.writer;
 
 use mach.lang.alloc;
 use mach.lang.intern;
@@ -36,6 +42,51 @@ pub fun reported() Fail { ret Fail.reported{}; }
 pub fun message(text: str) Fail { ret Fail.message{text}; }
 
 pub fun refused(e: A.Error) Fail { ret Fail.message{alloc.text(e)}; }
+
+# a refused write met by the compiler (an assembly or diagnostic sink): the
+# compiler recovers from none of them either, the text names the cause once
+pub fun write_refused(e: writer.WriteError) Fail {
+    if (sel e.stalled)     { ret Fail.message{"short write"}; }
+    or (sel e.would_block) { ret Fail.message{"write would block"}; }
+    ret Fail.message{io_error.message(e.native.error)};
+}
+
+# a refused string operation: the allocator's refusal or a slice outside its
+# string, which is a compiler defect
+pub fun str_refused(e: StrError) Fail {
+    if (sel e.alloc) { ret refused(e.alloc); }
+    ret Fail.message{"string slice out of bounds"};
+}
+
+# a refused read met by the compiler (an object or archive it was handed)
+pub fun read_refused(e: reader.ReadError) Fail {
+    if (sel e.eof)         { ret Fail.message{"unexpected end of input"}; }
+    or (sel e.would_block) { ret Fail.message{"read would block"}; }
+    or (sel e.native)      { ret Fail.message{io_error.message(e.native.error)}; }
+    ret refused(e.alloc);
+}
+
+# a refused filesystem operation met by the compiler: the step that refused
+# names its own cause
+pub fun fs_refused(e: fs.FsError) Fail {
+    if (sel e.io)        { ret Fail.message{io_error.message(e.io)}; }
+    or (sel e.alloc)     { ret refused(e.alloc); }
+    or (sel e.read)      { ret read_refused(e.read); }
+    or (sel e.write)     { ret write_refused(e.write); }
+    or (sel e.removal)   { ret Fail.message{removal.message(e.removal)}; }
+    or (sel e.exhausted) { ret Fail.message{"temp file: max attempts exceeded"}; }
+    ret Fail.message{io_error.message(e.published)};
+}
+
+# a refused format: a malformed literal is a compiler defect, the rest is the
+# sink's or the allocator's refusal
+pub fun format_refused(e: format.FormatError) Fail {
+    if (sel e.syntax)     { ret Fail.message{"format: malformed format string"}; }
+    or (sel e.few_holes)  { ret Fail.message{"format: too few arguments"}; }
+    or (sel e.many_holes) { ret Fail.message{"format: too many arguments"}; }
+    or (sel e.write)      { ret write_refused(e.write); }
+    ret refused(e.alloc);
+}
 
 pub fun is_reported(f: Fail) bool { ret sel f.reported; }
 pub fun is_message(f: Fail) bool  { ret sel f.message; }
@@ -60,6 +111,31 @@ pub fun describe(f: Fail) str {
 pub fun lift[T](r: R.Result[T, str]) R.Result[T, Fail] {
     if (R.is_err[T, str](r)) { ret R.err[T, Fail](message(R.unwrap_err[T, str](r))); }
     ret R.ok[T, Fail](R.unwrap_ok[T, str](r));
+}
+
+# the same lift onto the canonical carriers, for a migrated consumer reading
+# a neighbour that still produces the legacy message result
+pub fun lift_res[T](r: R.Result[T, str]) res[T, Fail] {
+    if (R.is_err[T, str](r)) { ret res[T, Fail].err{message(R.unwrap_err[T, str](r))}; }
+    ret res[T, Fail].ok{R.unwrap_ok[T, str](r)};
+}
+
+pub fun lift_err(r: R.Result[R.Void, str]) err[Fail] {
+    if (R.is_err[R.Void, str](r)) { ret err[Fail].err{message(R.unwrap_err[R.Void, str](r))}; }
+    ret err[Fail].ok{};
+}
+
+# translation shims (#3226), the other direction: a typed outcome spelled as
+# the legacy message carrier for a consumer that has not migrated. removed by
+# C5 once no R.Result[T, str] consumer remains
+pub fun lower[T](r: res[T, Fail]) R.Result[T, str] {
+    if (sel r.err) { ret R.err[T, str](describe(r.err)); }
+    ret R.ok[T, str](r.ok);
+}
+
+pub fun lower_unit(r: err[Fail]) R.Result[R.Void, str] {
+    if (sel r.err) { ret R.err[R.Void, str](describe(r.err)); }
+    ret R.ok_void[str]();
 }
 
 # phase status is independent of diagnostic storage and rendering: accepted,

--- a/test/census.sh
+++ b/test/census.sh
@@ -225,7 +225,8 @@ fi
 if want real-bools; then
     # B-DIAG-3: a Result[bool, E] is a declared real outcome, never a success
     # that is always true. every declaration whose return type is
-    # R.Result[bool, str] or R.Result[bool, outcome.Fail] is listed in
+    # R.Result[bool, str], R.Result[bool, outcome.Fail] or, once migrated
+    # (#3226), res[bool, fail.Fail] or res[bool, outcome.Fail] is listed in
     # test/census/real-bools.txt as path:function; a declaration off the list,
     # or a list entry with no declaration, fails. no function-pointer type
     # returns a bool Result, and no error is an empty string standing in for a
@@ -244,14 +245,14 @@ if want real-bools; then
                 name = substr($0, RSTART + 4, RLENGTH - 4)
                 sub(/^[ \t]+/, "", name)
             }
-            /\) R\.Result\[bool, (str|outcome\.Fail)\][ \t]*\{/ { print rel ":" name }
+            /\) (R\.Result\[bool, (str|outcome\.Fail)\]|res\[bool, (fail|outcome)\.Fail\])[ \t]*\{/ { print rel ":" name }
         ' "$f"
     done | sort > "$found"
     awk '{ sub(/\r$/, ""); print }' "$list" | sort > "$listed"
     : > "$tmp"
     comm -23 "$found" "$listed" | sed 's|^|  declared, not listed: |' >> "$tmp"
     comm -13 "$found" "$listed" | sed 's|^|  listed, not declared: |' >> "$tmp"
-    grep -rnE 'fun\([^)]*\) R\.Result\[bool, (str|outcome\.Fail)\]|^[ \t]*[^(]*\) R\.Result\[bool, (str|outcome\.Fail)\];' "$root/src" \
+    grep -rnE 'fun\([^)]*\) (R\.Result\[bool, (str|outcome\.Fail)\]|res\[bool, (fail|outcome)\.Fail\])|^[ \t]*[^(]*\) (R\.Result\[bool, (str|outcome\.Fail)\]|res\[bool, (fail|outcome)\.Fail\]);' "$root/src" \
         | sed "s|^$root/||; s|^|  bool-result function type: |" >> "$tmp"
     grep -rnE 'R\.err\[[^]]*\]\(""\)' "$root/src" \
         | sed "s|^$root/||; s|^|  empty-string error: |" >> "$tmp"


### PR DESCRIPTION
Lane C3b of #3226: every outcome the backend owns (codegen and its mir, regalloc, legalize, encode, rules, ctvalidate, frame subtrees; the linker and its relocatable helper; obj) is `res[T, fail.Fail]`, `err[fail.Fail]` or `opt[T]`, per the type set in `doc/design/compiler-migration-3226.md`. Allocation refusals lift through `fail.refused`, std refusals met by the backend through the new `fail.write_refused`, `format_refused`, `fs_refused`, `read_refused` and `str_refused`. Every `mach.lang.legacy` façade import under `src/lang/be` is replaced by the std module it fronted and the sites read the frozen signatures. `src/lang/ct.mach` is unchanged (its two `O.Option` sites are the `ct_cap` boundary below).

Behaviour-preserving: no golden moved, no code generation changed (fixpoint below). Merged with origin/dev at 6adcf4db0 (N5 phase 2b): `ctwalk.mach` is migrated with `Refusal` as its own domain (`walk` is the typed entry, `run` the legacy shim its per-ISA encoder tests read), `notes.mach` swept.

## Counts (`src/lang/be` + `src/lang/ct.mach`, origin/dev 6adcf4db0 -> this head)

| | before | after |
| --- | ---: | ---: |
| `R.Result[` | 2,459 | 553 |
| `R.Result[T, str]` | 2,359 | 489 |
| `O.Option[` | 205 | 136 |
| `ok_void` / `void_of` | 319 | 35 |
| `use ... mach.lang.legacy` | 72 (21 files) | 0 |

What remains is the translation shim at the two boundaries, listed here so the neighbouring lanes remove it.

## Shim: exports kept on the legacy carrier for unmigrated consumers

Each is a thin wrapper (`fail.lower`, `fail.lower_unit`, or the `R.Result[T, fail.Fail]` carrier) over the typed twin named beside it. The consumer lane replaces its call with the twin and deletes the wrapper.

| kept export | typed twin | consumers |
| --- | --- | --- |
| `codegen.codegen_module` (`R.Result[of.ObjectImage, fail.Fail]`) | `codegen.codegen_unit` | build/emit, build/engine, build/testing, driver/passes, driver/tests (C4) |
| `codegen.prepare_debug_types` | `codegen.prepare_debug` | driver/passes, driver/tests (C4) |
| `linker.link`, `link_images`, `link_mixed`, `link_images_captured` | `linker.link_modules`, `link_modules_nocapture` (the same signatures with `err[fail.Fail]`, after the input reads) | build/emit, build/testing, driver/tests (C4) |
| `obj.init`, `install_section`, `add_symbol`, `rehome_remap`, `emit` | `obj.image_init`, `section_install`, `symbol_add`, `rehome`, `emit_image` | build/emit, build/engine, build/testing, fuzz/dwarf (C4) |
| `mir.lower.lower_ir` | `mir.lower.lower_module` | driver/tests (C4) |
| `ctvalidate.run` | `ctvalidate.validate` | fuzz/mir (C4) |
| `ctwalk.run` (`R.Result[R.Void, ctwalk.Refusal]`) | `ctwalk.walk` (`err[Refusal]`) | target/isa/{x64,riscv}/encode tests (C3a) |
| `dwarf.produce` (the `of.DebugProduceFn` vtable entry) | `dwarf.produce_debug` | target/of vtable typedef (C3a) |
| `rules.select`, `rules.emit` | `rules.select_function`, `rules.emit_instr` | target/isa/{x64,arm64,riscv,mos6502}/rules (C3a) |
| `rules.ExpandFn`, `encode.EncodeFunctionFn`, `encode.PatchBranchFn` (typedefs) | none yet: implemented by target/isa | target/isa/* (C3a) |
| `mir.validate_operand_banks` | `mir.check_operand_banks` | target/isa (C3a) |
| `encode.encode_driver`, `encode_driver_asm` | `encode.encode_module`, `encode_module_asm` | target/isa/*/encode (C3a) |
| `encode.push_symbol`, `push_reloc`, `push_fixup`, `push_block`, `push_row`, `push_frame`, `push_frame_step`, `push_inline_pc`, `emit_var_bindings`, `note_push`, `note_barrier`, `note_insert_after`, `insert_text`, `render_bytes_text`, `render_bytes_directive`, `bind_reloc_pair`, `bind_reloc_pair_site`, `reloc_pair_site`, `block_offset`, `intern_const`, `intern_float_const`, `intern_local_label`, `opcode_failure` | none: their bodies are typed internally and render at the return (carrier-only hunks, N5 is editing this file) | target/isa/*/encode, target/isa/*/printer (C3a) |
| `frame.slot_offset`, `frame.slot_sp_offset` (`O.Option[i64]`) | none | target/isa/*/encode (C3a) |
| `ct.ct_cap` (`O.Option[CtCap]`) | none | fe/sema/infer (C2), target/isa/asm (C3a) |

## Shim: legacy carriers read from unmigrated neighbours

The backend reads these as `R.Result[T, str]` / `O.Option[T]` and lifts the text with `fail.message` (or `fail.lift_res` / `fail.lift_err`). Binding counts by producer, to be flipped when the producer's lane lands: `intern` 121, `session` 85, `me.ir.type` 64 + 20 (`ir_type`), `target` 42 + 11 (`treg`), `me.ir` 34, `publication.testing` 32, `target.of` 20 (+6 vtable calls: `parse_object`, `emit_object`, `emit_exec`, `emit_dyn_exec`, `emit_shared`, `emit_exec_image`), `layout` 17 (`layout.CheckCause`, a typed domain already), `type` 15, `target.abi` 11, `target.isa` 9 (+3 vtable calls: `select`, `encode`, `assembly.emit`, `emitter.emit_module`, `debug.produce`), `publication` 6, `me.ir.builder` 5, `source` 4, `target.of.reloc` 3 (`rel.RelocError`, typed), `fe.sema.generics` 1, and the `EncodeHooks` / `Rule.expand` / `AsmCtScanFn` callbacks. After C3a lands (typed exports under the canonical names) I re-resolve the `me.ir`, `me.ir.type`, `target`, `target.of` and `layout` reads against my migration.

## `fail` additions (shared adapter)

`write_refused`, `format_refused`, `fs_refused`, `read_refused`, `str_refused` are final API (a std refusal met by a phase, rendered once, like `refused`). `lift_res`, `lift_err`, `lower`, `lower_unit` are translation shims owed to C5 with `lift`.

## Verification

- unit suite through the from-source compiler (built by the v5 stage): 2996 passed, 0 failed (2996 at origin/dev 6adcf4db0 with the stage; per-module counts identical, no test added or removed)
- `sh test/census.sh` all ok (the real-bools census now reads the canonical `res[bool, fail.Fail]` / `res[bool, outcome.Fail]` spelling; the list is unchanged)
- corpus layer B: x86_64-linux 102 pass / 0 fail / 0 skip, spirv 94 pass / 0 fail / 8 skip (the declared limitations), unchanged goldens
- link leg x86_64-linux: 140 pass / 0 fail / 0 skip
- three-generation fixpoint from the v5 stage: A by the stage, B by A, C by B, A = B = C `88131af8`
- cross-builds for darwin-aarch64, darwin-x86_64, windows-x86_64

#3226
