### PR TITLE
subprocess: make the runaway-capture bound independent of scheduler timing (#3260)

### DIFF
--- a/src/subprocess.mach
+++ b/src/subprocess.mach
@@ -1395,11 +1395,12 @@ test "mach.subprocess:wait_any_bounds_a_runaway_capture" {
         or {
             if (p.state != STATE_REAPED || p.requested != REQUEST_CANCELLED) { bad = true; }
 
+            # the reaper polls the file size, so only the overrun is guaranteed, not its extent
             val disk_r: R.Result[filesystem.Metadata, str] = filesystem.metadata(identity);
             if (R.is_err[filesystem.Metadata, str](disk_r)) { bad = true; }
             or {
                 val disk_size: usize = R.unwrap_ok[filesystem.Metadata, str](disk_r).size;
-                if (disk_size < 64 || disk_size >= 1048576) { bad = true; }
+                if (disk_size <= 64) { bad = true; }
             }
 
             val cr: R.Result[CaptureIoResult, str] = finish_capture(?alloc, ?p, true);


### PR DESCRIPTION
Closes #3260

## Diagnosis

`wait_any` polls the capture file size once a millisecond and cancels the child on the first poll that sees it over the limit. The child writes the file directly, so how far the file runs past the limit before that poll is a scheduler quantity, not something the module bounds. `finalize_capture_file` then truncates the retained bytes to exactly the limit.

The test asserted both the contract (`truncated`, `bytes == 64`, `capture_bytes` length 64) and a 1 MiB ceiling on the on-disk file. The ceiling is a race between the writer and the reaper: a parent stalled for 250 ms behind the tight `sh` echo loop lands at about 1.2 MiB. There is no race in the bounding path itself; the retained capture was exactly 64 bytes in every failing run.

## Change

`src/subprocess.mach`, test body only: the disk assertion becomes `disk_size > 64` (the reaper only fires on `size > limit` and the file only grows, so the overrun is guaranteed; its extent is not). The retained-byte assertions are unchanged and are the bound.

## Measured

Reproduction that isolates the mechanism: run the test process, SIGSTOP it 0.5 ms after launch so the child keeps writing, SIGCONT after the stall.

| condition | old assertion | new assertion |
|---|---|---|
| 250 ms parent stall, 20 runs | 20/20 fail, all at the disk ceiling (disk 1.10 to 1.28 MiB, retained 64 bytes every run) | 0/20 |
| 1 s parent stall, 20 runs | not run | 0/20 |
| 200 runs beside a full `mach test .` on a 16-core host | 0/200 (max disk 10 KB) | 0/200 |
| 200 runs pinned to 2 cores with 8 CPU hogs | 0/200 (max disk 15 KB) | not run |

This host's scheduler never starves the parent long enough to hit the ceiling; the CI runners do (four unrelated PRs, most recently release aarch64-linux on #3285).

## Verification

- full suite: 2996 passed, 0 failed, same count and no test-name delta against origin/dev b6c458898
- `sh test/census.sh`: all ok
- `wait_any` is not modified
