### PR TITLE
chore(dep): pin std 2.0.0 (#3226, #617)

### DIFF
--- a/mach.toml
+++ b/mach.toml
@@ -71,4 +71,4 @@ need = []
 
 [dep.std]
 git = "https://github.com/briar-systems/mach-std"
-ref = "commit/e204cb81f39fb31ed3bb33802ce9f2331626a640"
+ref = "commit/e6fc41251e442eb736d4d15de677903a4ba52461"


### PR DESCRIPTION
Pairs the compiler with mach-std at e6fc41251 (std PR #637: types.result and types.option deleted, version 2.0.0). The compiler consumed nothing of those modules since PR #3290; C5c proved 2997/0 against this std, this PR pins it. Suite, census and the x86_64 link leg verified with the v5 stage. References #3226 and mach-std #617.