### PR TITLE
test(link): the std atomic wrappers inline across modules on every native target (#3110)

### DIFF
--- a/doc/design/inline-acceptance-3110.md
+++ b/doc/design/inline-acceptance-3110.md
@@ -1,11 +1,17 @@
 # Inlining acceptance inventory for #3110
 
-Roadmap item N6, phase 1. One row per acceptance bullet of #3110: what `dev`
-does at the start of this lane (`853d4c17`) with the test that shows it, what
-the three candidate commits on `archive/3218-candidate-era` add, and a verdict.
-The compiler policy is covered here with local fixtures shaped like the eight
-`std.sync.atomic` wrappers (short asm bodies with volatile memory effects); the
-std-side annotations are Track C's S4 and are not part of this lane.
+Roadmap item N6. One row per acceptance bullet of #3110: what `dev` does at the
+start of the phase 1 lane (`853d4c17`) with the test that shows it, what the
+three candidate commits on `archive/3218-candidate-era` add, and a verdict.
+Phase 1 (#3270) covered the compiler policy with local fixtures shaped like the
+eight `std.sync.atomic` wrappers (short asm bodies with volatile memory
+effects). Phase 2, recorded in the `Phase 2` paragraphs below, asserts the same
+claims on the wrappers std ships: `dev` at `83d3c1c9d` pins std 2.0.0
+(`e6fc41251`), whose `std.sync.atomic` carries the eight `#[inline]`
+annotations (S4a, std PR #633), and the evidence is a link-suite case that
+links and runs them on the three native ELF targets with the call counts read
+from the linked image, plus three driver tests that read the pinned
+`dep/std/src/sync/atomic.mach` itself.
 
 Candidate commits, in the order they are ported:
 
@@ -125,6 +131,19 @@ Candidate: `Q_INLINE_BODIES` plus `body.Available` as described above. Shown by
 Verdict: gap on `dev`, closed by the port. Phase 1 adds the machine-text
 check `driver:inline_cross_module_helper_leaves_no_call_in_x86_64_text`.
 
+Phase 2: `test/link/cases/3110-atomic-inline` builds a program that calls each
+of the eight wrappers from the pinned std across the module boundary and reads
+the linked image with `llvm-objdump`: the release cell's
+`calls from case text:` line is `load=0 store=0 cas=0 fetch_add=0 fetch_sub=0
+exchange=0 fence=0 spin_hint=0` over every function the case defines (`main`
+and `case.*`), on `x86_64-linux`, `aarch64-linux` and `riscv64-linux`; the
+debug cell is the control with `load=4 store=4 cas=3 fetch_add=3 fetch_sub=2
+exchange=2 fence=2 spin_hint=5`, the counts the source has. Mutation control:
+`#[noinline]` on `fetch_add` in the case's std copy reads `fetch_add=3` and
+`call std.sync.atomic.fetch_add` in the probe sequence. At the IR level
+`driver:inline_std_atomic_wrappers_lose_their_calls_and_keep_their_asm_in_order`
+counts zero `OP_CALL` and eight `OP_ASM` in the importer.
+
 ### Bounded growth
 
 `dev`: `INLINE_BUDGET` (1024) counts inlining events per caller, not
@@ -195,6 +214,26 @@ release pipeline, store/fence/store keep their order in IR and at MIR, and each
 MIR asm keeps its `MirAsm` payload with both `{name}` bindings. The `naked`
 refusal is the `nkd` leg of the rule test.
 
+Phase 2: the same case's `probe:` block lists the atomic instructions of
+`case.main.probe` in text order, which is the order the eight wrappers were
+called in. The goldens (`expect.<target>.release.txt`) record, per ISA:
+
+| ISA | sequence the importer's text carries |
+| --- | --- |
+| x86_64 | `xchgq` (store), `lock cmpxchgq` (cas), `lock xaddq` (fetch_add), `lock xaddq` after `neg` (fetch_sub), `xchgq` (exchange), `mfence`, `pause`; the load is a plain aligned `mov` |
+| aarch64 | `ldar` (load), `stlr` (store), then `ldaxr`/`stlxr`/`dmb ish` for cas, fetch_add, fetch_sub and exchange, `dmb ish` (fence), `yield` |
+| riscv64 | `fence`/`ld`/`fence` (load), `amoswap.d.aqrl zero` (store), `lr.d.aqrl`/`sc.d.aqrl` (cas), `amoadd.d.aqrl` twice, `amoswap.d.aqrl` (exchange), `fence`, `fence w, 0` (the `pause` hint) |
+
+The program the case runs uses every wrapper from two threads in shapes whose
+correctness depends on the atomicity and the ordering the wrappers promise (a
+fetch_add counter, a cas loop counter, a fetch_sub countdown, a spinlock from
+exchange and store, and a producer/consumer handshake through store/load with
+a fence), and its `added=40000 swapped=40000 remaining=0 guarded=40000 torn=0`
+line is part of the golden. In IR,
+`driver:inline_std_atomic_wrappers_lose_their_calls_and_keep_their_asm_in_order`
+checks each of the eight inlined `OP_ASM` payloads in call order for its own
+x86-64 instruction.
+
 ### Secrecy
 
 `dev`: `secret` on values and instructions survives cloning
@@ -239,6 +278,11 @@ adds a `dbg_value` per local, is inlined at both call sites with and without
 `OP_DBG_VALUE` in `body.counted()` keeps the calls under `-g` and the texts
 differ.
 
+Phase 2:
+`driver:release_text_is_byte_identical_with_and_without_g_for_the_std_atomic_wrappers`
+runs the same comparison over an importer of the pinned std's eight wrappers:
+zero calls in both builds and identical `.text` bytes.
+
 ### Cache and query dependency invalidation
 
 `dev`: an `#[inline]` body is part of `Q_LOWERED_SURFACE`, so its edit
@@ -259,6 +303,14 @@ adds `driver:inline_body_product_stops_propagation_when_extracted_bodies_are_equ
 an edit to a `noinline` provider function moves the provider's `Q_LOWER` and
 not the importer's, and an edit to the extracted helper moves both.
 
+Phase 2: `driver:std_atomic_wrapper_body_edit_relowers_the_importer` runs three
+rounds over the pinned `atomic.mach` as the std dependency: the shipped text,
+then `fence`'s `mfence` edited to `lfence`, then an edit to a `noinline`
+function appended beside the wrappers. The importer's `Q_LOWER` revision moves
+on the body edit while the provider's `Q_LOWERED_SURFACE` does not, and the
+importer's seventh inlined asm carries `lfence`; the edit beside the wrappers
+moves the provider's `Q_LOWER` and leaves the importer's.
+
 ### Pure versus atomic controls
 
 `dev`: there is no purity model in the inliner or the pipeline; an inlining
@@ -272,19 +324,56 @@ Verdict: accepted on `dev`. The controls are the effect legs above: an inlined
 atomic-shaped wrapper whose result is unused is not removed and two identical
 ones are not merged.
 
+Phase 2: the link case's `contend` calls `fetch_add` and `fetch_sub` for their
+effect only, and its counts come out right on all three targets; the release
+goldens show the `lock xaddq` / `ldaxr`+`stlxr` / `amoadd.d.aqrl` still in the
+importer's text, not dropped as a pure call with an unused result.
+
 ### The eight atomic wrappers
 
-`std.sync.atomic` at the pinned std (`168a9f76`, 1.0.1) defines `load`,
+`std.sync.atomic` at the std phase 1 pinned (`168a9f76`, 1.0.1) defined `load`,
 `store`, `cas`, `fetch_add`, `fetch_sub`, `exchange`, `fence` and `spin_hint`
 as unannotated `pub fun` bodies of one `asm` block under `$if` on the build
 arch, each well under 25 live instructions after `mem2reg`. Under the ported
 policy every one is extracted into `Q_INLINE_BODIES` and inlined at its
-importers with no std-side annotation; `#[inline]` would only override the
-size bar, which they clear. The local fixtures in the phase 1 tests mirror
-their shape (a `{ptr}`/`{result}` binding pair around one memory instruction).
+importers with no std-side annotation; `#[inline]` only overrides the size
+bar, which they clear. The local fixtures in the phase 1 tests mirror their
+shape (a `{ptr}`/`{result}` binding pair around one memory instruction).
 
-Verdict: compiler policy covered by the effect legs above; the std-side
-annotations remain Track C's S4 and are not needed for elimination.
+Phase 1 verdict: compiler policy covered by the effect legs above; the
+std-side annotations were Track C's S4 and not needed for elimination.
+
+Phase 2: std 2.0.0 (`e6fc41251`, pinned by `dev` at `83d3c1c9d`) carries the
+eight `#[inline]` annotations (S4a, std PR #633; its MIGRATION.md records that
+the release policy already inlines them unannotated and the annotations pin
+the decision). The wrappers themselves are now the subject:
+
+| evidence | where | what it shows |
+| --- | --- | --- |
+| link case `3110-atomic-inline`, release cells | `test/link/cases/3110-atomic-inline/expect.{x86_64,aarch64,riscv64}-linux.release.txt` | zero direct calls to any `std.sync.atomic.*` symbol from the case's text; the ISA's atomic instruction sequence in call order in `probe`; the program's single-thread results and two-thread counts |
+| link case, debug cells | `expect.<target>.debug.txt` | the control: eight `call std.sync.atomic.*` in `probe`, per-wrapper call counts matching the source |
+| link case, `by-address=100` | the goldens | a call through a function value the optimizer cannot see through (`pick` is `noinline`) reaches the provider's one strong definition, which no inlined copy replaces |
+| `driver:inline_std_atomic_wrappers_lose_their_calls_and_keep_their_asm_in_order` | `src/lang/driver/tests.mach` | zero `OP_CALL`, eight `OP_ASM` in call order, each payload the wrapper's own x86-64 instruction |
+| `driver:release_text_is_byte_identical_with_and_without_g_for_the_std_atomic_wrappers` | same | `-g` moves no inlining decision on the real wrappers |
+| `driver:std_atomic_wrapper_body_edit_relowers_the_importer` | same | an edit to `atomic.mach`'s body re-lowers the importer and reaches its text; an edit beside the wrappers does not |
+
+The three driver tests read `dep/std/src/sync/atomic.mach` and
+`dep/std/src/types/bool.mach` from the repository at test time and place them
+verbatim in a `std` path dependency of the scaffold, so they measure the file
+std ships at the pin rather than a restatement of it. Mutation control for
+all four: `#[noinline]` on one wrapper in the pinned std fails the release
+goldens (`fetch_add=3`, `call std.sync.atomic.fetch_add` in the sequence) and
+the three driver tests (calls present).
+
+The link case's `aarch64-linux` goldens were blessed from a `qemu-aarch64` run
+of the producer on the x86-64 host (the observable is the instruction text
+and the program's deterministic output); the leg itself executes natively on
+CI's arm runner. `riscv64-linux` executes under qemu on both, which
+`test/engines.conf` marks as compute evidence only: the ordering claim on that
+ISA rests on the instruction sequence the case reads from the image.
+
+Verdict: every #3110 bullet is demonstrated on the wrappers std ships, on the
+three native ELF targets.
 
 ## Corpus goldens moved by this change
 

--- a/doc/design/inline-acceptance-3110.md
+++ b/doc/design/inline-acceptance-3110.md
@@ -360,10 +360,11 @@ the decision). The wrappers themselves are now the subject:
 The three driver tests read `dep/std/src/sync/atomic.mach` and
 `dep/std/src/types/bool.mach` from the repository at test time and place them
 verbatim in a `std` path dependency of the scaffold, so they measure the file
-std ships at the pin rather than a restatement of it. Mutation control for
-all four: `#[noinline]` on one wrapper in the pinned std fails the release
-goldens (`fetch_add=3`, `call std.sync.atomic.fetch_add` in the sequence) and
-the three driver tests (calls present).
+std ships at the pin rather than a restatement of it. Mutation controls:
+`#[noinline]` on `fetch_add` in the case's std copy fails the release goldens
+(`fetch_add=3`, `call std.sync.atomic.fetch_add` in the sequence), and
+`#[noinline]` on `cas` in the pinned `dep/std` fails the three driver tests
+(exits 8, 50 and 10: calls present).
 
 The link case's `aarch64-linux` goldens were blessed from a `qemu-aarch64` run
 of the producer on the x86-64 host (the observable is the instruction text

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -8250,7 +8250,7 @@ test "mach.lang.driver:inline_oblivious_callee_stays_a_call_in_a_public_caller" 
     ret 0;
 }
 
-fun ut_inline_text_bytes(alloc: *A.Allocator, root: str, debug: bool, out: *u8, cap: usize, out_len: *usize, out_calls: *u32) i32 {
+fun ut_inline_text_bytes(alloc: *A.Allocator, root: str, fn: str, debug: bool, out: *u8, cap: usize, out_len: *usize, out_calls: *u32) i32 {
     val initialized: res[session.Session, fail.Fail] = session.init(alloc);
     if (sel initialized.err) { ret 1; }
     var s: session.Session = initialized.ok;
@@ -8272,7 +8272,7 @@ fun ut_inline_text_bytes(alloc: *A.Allocator, root: str, debug: bool, out: *u8, 
     if (sel run_codegen_pass_r.err) { ret 6; }
     val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
     if (mid == session.MODULE_NIL) { ret 7; }
-    @out_calls = ut_inline_calls_of(?s, p.modules[mid::u32].ir_module, "uniontest.main.pair");
+    @out_calls = ut_inline_calls_of(?s, p.modules[mid::u32].ir_module, fn);
     val image: *of.ObjectImage = p.modules[mid::u32].object_image;
     if (image == nil) { ret 8; }
     var i: u32 = 0;
@@ -8312,9 +8312,9 @@ test "mach.lang.driver:release_text_is_byte_identical_with_and_without_g_at_the_
     var annotated_len: usize = 0;
     var plain_calls: u32 = 0;
     var annotated_calls: u32 = 0;
-    val a: i32 = ut_inline_text_bytes(?alloc, root, false, ?plain[0], 65536, ?plain_len, ?plain_calls);
+    val a: i32 = ut_inline_text_bytes(?alloc, root, "uniontest.main.pair", false, ?plain[0], 65536, ?plain_len, ?plain_calls);
     if (a != 0) { ret 10 + a; }
-    val b: i32 = ut_inline_text_bytes(?alloc, root, true, ?annotated[0], 65536, ?annotated_len, ?annotated_calls);
+    val b: i32 = ut_inline_text_bytes(?alloc, root, "uniontest.main.pair", true, ?annotated[0], 65536, ?annotated_len, ?annotated_calls);
     if (b != 0) { ret 30 + b; }
     if (plain_calls != 0 || annotated_calls != 0) { ret 50; }
     if (plain_len == 0 || plain_len != annotated_len) { ret 51; }
@@ -8375,6 +8375,226 @@ test "mach.lang.driver:inline_body_product_stops_propagation_when_extracted_bodi
         if (round == 2 && (current_main == main_rev || current_leaf == leaf_rev)) { ret 12; }
         main_rev = current_main;
         leaf_rev = current_leaf;
+        round = round + 1;
+    }
+    ret 0;
+}
+
+# the repository root, found from the working directory the way the format tree test
+# finds it: the directory holding src/cli/args.mach
+fun ut_repo_root(alloc: *A.Allocator) opt[str] {
+    var prefix: str = ".";
+    var depth: usize = 0;
+    for (depth < 8) {
+        val probe: res[str, A.Error] = path.join(alloc, prefix, "src/cli/args.mach");
+        if (sel probe.err) { ret opt[str].none{}; }
+        val is_file: res[bool, io_error.Error] = fs.is_file(probe.ok);
+        if (sel is_file.ok && is_file.ok) { ret opt[str].some{prefix}; }
+        val up: res[str, A.Error] = path.join(alloc, prefix, "..");
+        if (sel up.err) { ret opt[str].none{}; }
+        prefix = up.ok;
+        depth = depth + 1;
+    }
+    ret opt[str].none{};
+}
+
+# the text of a file under the repository root
+fun ut_repo_file(alloc: *A.Allocator, root: str, rel: str) opt[str] {
+    val joined: res[str, A.Error] = path.join(alloc, root, rel);
+    if (sel joined.err) { ret opt[str].none{}; }
+    val bytes_r: res[Vector[u8], fs.FsError] = fs.read_bytes(alloc, joined.ok);
+    if (sel bytes_r.err) { ret opt[str].none{}; }
+    var bytes: Vector[u8] = bytes_r.ok;
+    val buf_r: res[*u8, A.Error] = A.allocate[u8](alloc, bytes.len + 1);
+    if (sel buf_r.err) { vector.dnit[u8](?bytes); ret opt[str].none{}; }
+    val buf: *u8 = buf_r.ok;
+    var i: usize = 0;
+    for (i < bytes.len) { buf[i] = bytes.data[i]; i = i + 1; }
+    buf[bytes.len] = 0;
+    vector.dnit[u8](?bytes);
+    ret opt[str].some{buf::str};
+}
+
+# one call to each of the eight std.sync.atomic wrappers, in the order atomic.mach
+# documents them, from a module in another project
+fun ut_atomic_probe_text() str {
+    ret "use std.sync.atomic;\nuse std.types.bool.bool;\npub fun probe(cell: *i64, expected: *i64) i64 { val a: i64 = atomic.load(cell); atomic.store(cell, a + 1); val swapped: bool = atomic.cas(cell, expected, 10); val b: i64 = atomic.fetch_add(cell, 5); val c: i64 = atomic.fetch_sub(cell, 3); val d: i64 = atomic.exchange(cell, 100); atomic.fence(); atomic.spin_hint(); var s: i64 = 0; if (swapped) { s = 1; } ret a + b * 10 + c * 100 + d * 1000 + s * 10000; }\nfun main() i32 { ret 0; }\n";
+}
+
+fun ut_atomic_std_manifest() str {
+    ret "[project]\nid = \"std\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[profile.debug]\ndefault = true\nopt = 0\ndebug = true\nsimd = \"scalarize\"\nvectorize = false\nfloat_reassoc = false\n[profile.release]\nopt = 2\ndebug = false\nsimd = \"scalarize\"\nvectorize = true\nfloat_reassoc = false\n";
+}
+
+# a project importing std.sync.atomic from a `std` dependency that holds the real
+# wrappers: `dep/std/src/sync/atomic.mach` and the `std.types.bool` it uses are read
+# from the repository's own pinned std, not restated here, so the test measures the
+# wrappers std ships. returns the scaffold root; `atomic_path` receives the path of
+# the dependency's copy of atomic.mach so a test can edit it between rounds.
+fun ut_atomic_scaffold(alloc: *A.Allocator, atomic_path: *str) res[str, fail.Fail] {
+    val repo: opt[str] = ut_repo_root(alloc);
+    if (sel repo.none) { ret res[str, fail.Fail].err{fail.message("cannot locate the repository root from the working directory")}; }
+    val atomic_src_r: opt[str] = ut_repo_file(alloc, repo.some, "dep/std/src/sync/atomic.mach");
+    val bool_src_r: opt[str] = ut_repo_file(alloc, repo.some, "dep/std/src/types/bool.mach");
+    if (sel atomic_src_r.none) { ret res[str, fail.Fail].err{fail.message("cannot read the pinned std atomic.mach")}; }
+    if (sel bool_src_r.none) { ret res[str, fail.Fail].err{fail.message("cannot read the pinned std bool.mach")}; }
+    val atomic_src: str = atomic_src_r.some;
+    val bool_src: str = bool_src_r.some;
+    var names: [1]str = [1]str{"main.mach"};
+    var texts: [1]str = [1]str{ut_atomic_probe_text()};
+    val manifest_text: str = ut_cc3(alloc, ut_manifest(), "\n[dep.std]\npath = \"dep/std\"\n", "");
+    val scaffold: res[str, fail.Fail] = ut_scaffold_m(alloc, manifest_text, ?names[0], ?texts[0], 1);
+    if (sel scaffold.err) { ret scaffold; }
+    val root: str = scaffold.ok;
+    val dep_root: str = ut_cc3(alloc, root, "/", "dep/std");
+    val sync_dir: str = ut_cc3(alloc, dep_root, "/", "src/sync");
+    val types_dir: str = ut_cc3(alloc, dep_root, "/", "src/types");
+    val d1: err[fs.FsError] = fs.create_dir_all(alloc, sync_dir, 493);
+    if (sel d1.err) { ret res[str, fail.Fail].err{fail.fs_refused(d1.err)}; }
+    val d2: err[fs.FsError] = fs.create_dir_all(alloc, types_dir, 493);
+    if (sel d2.err) { ret res[str, fail.Fail].err{fail.fs_refused(d2.err)}; }
+    val mf: str = ut_cc3(alloc, dep_root, "/", manifest.MANIFEST_FILE);
+    val w0: err[fs.FsError] = fs.write_bytes(mf, ut_atomic_std_manifest(), str_len(ut_atomic_std_manifest()), 420);
+    if (sel w0.err) { ret res[str, fail.Fail].err{fail.fs_refused(w0.err)}; }
+    val ap: str = ut_cc3(alloc, sync_dir, "/", "atomic.mach");
+    val w1: err[fs.FsError] = fs.write_bytes(ap, atomic_src, str_len(atomic_src), 420);
+    if (sel w1.err) { ret res[str, fail.Fail].err{fail.fs_refused(w1.err)}; }
+    val bp: str = ut_cc3(alloc, types_dir, "/", "bool.mach");
+    val w2: err[fs.FsError] = fs.write_bytes(bp, bool_src, str_len(bool_src), 420);
+    if (sel w2.err) { ret res[str, fail.Fail].err{fail.fs_refused(w2.err)}; }
+    @atomic_path = ap;
+    ret res[str, fail.Fail].ok{root};
+}
+
+# the eight wrappers std ships, as pinned under dep/std, lose every call in an importer
+# in another project and leave their asm blocks in call order, each with its own
+# x86-64 instruction: the effect and order claims of #3110 on the real wrappers
+test "mach.lang.driver:inline_std_atomic_wrappers_lose_their_calls_and_keep_their_asm_in_order" {
+    var alloc: A.Allocator;
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
+    val initialized: res[session.Session, fail.Fail] = session.init(?alloc);
+    if (sel initialized.err) { ret 2; }
+    var s: session.Session = initialized.ok;
+    fin { session.dnit(?s); }
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    if (sel setup_registry_r.err) { ret 3; }
+    var atomic_path: str = "";
+    val scaffold: res[str, fail.Fail] = ut_atomic_scaffold(?alloc, ?atomic_path);
+    if (sel scaffold.err) { ret 4; }
+    val root: str = scaffold.ok;
+    fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+    val lowered: res[project.Project, outcome.Fail] = ut_inline_prepare(?s, root, 0);
+    if (sel lowered.err) { ret 5; }
+    var p: project.Project = lowered.ok;
+    fin { project.dnit_project(?p); }
+    val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+    if (mid == session.MODULE_NIL) { ret 6; }
+    val m: *ir.Module = p.modules[mid::u32].ir_module;
+    val probe: *ir.Function = ut_inline_function(?s, m, "uniontest.main.probe");
+    if (probe == nil) { ret 7; }
+    if (ut_inline_ops(probe, instruction.OP_CALL) != 0) { ret 8; }
+    if (ut_inline_ops(probe, instruction.OP_ASM) != 8) { ret 9; }
+    var needles: [8]str = [8]str{"mov rax, [rcx]", "xchg [rcx], rax", "lock cmpxchg [rcx], rdx", "lock xadd [rcx], rax", "neg rax", "xchg [rcx], rax", "mfence", "pause"};
+    var i: u32 = 0;
+    for (i < 8) {
+        if (!ut_inline_asm_body_has(?s, probe, i, needles[i])) { ret 10 + i::i32; }
+        i = i + 1;
+    }
+    if (ut_inline_asm_body_has(?s, probe, 2, "xadd") || ut_inline_asm_body_has(?s, probe, 6, "xchg")) { ret 20; }
+    ret 0;
+}
+
+# the debug mapping claim on the real wrappers: the importer's release text with the
+# eight wrappers inlined is byte-identical with and without -g
+test "mach.lang.driver:release_text_is_byte_identical_with_and_without_g_for_the_std_atomic_wrappers" {
+    var alloc: A.Allocator;
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
+    var atomic_path: str = "";
+    val scaffold: res[str, fail.Fail] = ut_atomic_scaffold(?alloc, ?atomic_path);
+    if (sel scaffold.err) { ret 2; }
+    val root: str = scaffold.ok;
+    fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+    var plain: [65536]u8;
+    var annotated: [65536]u8;
+    var plain_len: usize = 0;
+    var annotated_len: usize = 0;
+    var plain_calls: u32 = 0;
+    var annotated_calls: u32 = 0;
+    val a: i32 = ut_inline_text_bytes(?alloc, root, "uniontest.main.probe", false, ?plain[0], 65536, ?plain_len, ?plain_calls);
+    if (a != 0) { ret 10 + a; }
+    val b: i32 = ut_inline_text_bytes(?alloc, root, "uniontest.main.probe", true, ?annotated[0], 65536, ?annotated_len, ?annotated_calls);
+    if (b != 0) { ret 30 + b; }
+    if (plain_calls != 0 || annotated_calls != 0) { ret 50; }
+    if (plain_len == 0 || plain_len != annotated_len) { ret 51; }
+    var i: usize = 0;
+    for (i < plain_len) {
+        if (plain[i] != annotated[i]) { ret 52; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# the dependency claim on the real wrappers: an edit to a wrapper's body in atomic.mach
+# re-lowers the importer (its Q_LOWER revision moves, the provider's surface does not)
+# and the importer carries the edited instruction; an edit beside the wrappers that
+# leaves every extracted body equal moves the provider's lowering and not the importer's
+test "mach.lang.driver:std_atomic_wrapper_body_edit_relowers_the_importer" {
+    var alloc: A.Allocator;
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
+    val initialized: res[session.Session, fail.Fail] = session.init(?alloc);
+    if (sel initialized.err) { ret 2; }
+    var s: session.Session = initialized.ok;
+    fin { session.dnit(?s); }
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    if (sel setup_registry_r.err) { ret 3; }
+    var atomic_path: str = "";
+    val scaffold: res[str, fail.Fail] = ut_atomic_scaffold(?alloc, ?atomic_path);
+    if (sel scaffold.err) { ret 4; }
+    val root: str = scaffold.ok;
+    fin { fs.remove_all(?alloc, root); str_free(?alloc, root); }
+    val repo: opt[str] = ut_repo_root(?alloc);
+    if (sel repo.none) { ret 5; }
+    val shipped_r: opt[str] = ut_repo_file(?alloc, repo.some, "dep/std/src/sync/atomic.mach");
+    if (sel shipped_r.none) { ret 5; }
+    val shipped: str = shipped_r.some;
+    val beside: str = "\n#[noinline] pub fun beside() i64 { ret 1; }\n";
+    val edited_r: res[str, string.StrError] = str_replace(?alloc, shipped, "mfence", "lfence");
+    if (sel edited_r.err) { ret 6; }
+    val edited: str = edited_r.ok;
+    var versions: [3]str = [3]str{
+        ut_cc3(?alloc, shipped, beside, ""),
+        ut_cc3(?alloc, edited, beside, ""),
+        ut_cc3(?alloc, edited, "\n#[noinline] pub fun beside() i64 { ret 2; }\n", "")
+    };
+    var main_rev: query.Revision = 0;
+    var std_rev: query.Revision = 0;
+    var surface: query.Revision = 0;
+    var round: u32 = 0;
+    for (round < 3) {
+        val write_bytes_r: err[fs.FsError] = fs.write_bytes(atomic_path, versions[round], str_len(versions[round]), 420);
+        if (sel write_bytes_r.err) { ret 7; }
+        val built: res[project.Project, outcome.Fail] = ut_inline_prepare(?s, root, 0);
+        if (sel built.err) { ret 8; }
+        var p: project.Project = built.ok;
+        fin { project.dnit_project(?p); }
+        val mid: session.ModuleId = ut_mid(?p, ?s, "uniontest.main");
+        val provider: session.StableModuleId = ut_stable(?p, ?s, "std.sync.atomic");
+        if (mid == session.MODULE_NIL || provider == session.STABLE_MODULE_NIL) { ret 9; }
+        val probe: *ir.Function = ut_inline_function(?s, p.modules[mid::u32].ir_module, "uniontest.main.probe");
+        if (probe == nil || ut_inline_ops(probe, instruction.OP_CALL) != 0 || ut_inline_ops(probe, instruction.OP_ASM) != 8) { ret 10; }
+        if (round == 0 && !ut_inline_asm_body_has(?s, probe, 6, "mfence")) { ret 11; }
+        if (round > 0 && !ut_inline_asm_body_has(?s, probe, 6, "lfence")) { ret 12; }
+        val current_main: query.Revision = ut_lower_lc(?s, p.modules[mid::u32].stable_id);
+        val current_std: query.Revision = ut_lower_lc(?s, provider);
+        val current_surface: query.Revision = ut_surface_lc(?s, provider);
+        if (current_main == 0 || current_main == ~(0::query.Revision)) { ret 13; }
+        if (round == 1 && (current_main == main_rev || current_std == std_rev || current_surface != surface)) { ret 14; }
+        if (round == 2 && (current_main != main_rev || current_std == std_rev)) { ret 15; }
+        main_rev = current_main;
+        std_rev = current_std;
+        surface = current_surface;
         round = round + 1;
     }
     ret 0;

--- a/test/link/README.md
+++ b/test/link/README.md
@@ -109,6 +109,10 @@ depends on what its producer observes:
   structural producer.
 - `expect.<profile>.txt` — the observable is a real function of the active
   profile's own codegen. Only `gdb-session` is, and only since #2779.
+- `expect.<target>.<profile>.txt` — the observable is a function of both: an ISA's
+  instruction vocabulary under a profile's inlining policy. Only `atomic-inline` is
+  (#3110), where the release cell's zero calls are the claim and the debug cell's
+  eight calls are the control.
 
 `run.sh --bless` rewrites them and prints the diff, and refuses to run when `CI` is
 set: a golden nobody read is not a golden.

--- a/test/link/cases/3110-atomic-inline/case.conf
+++ b/test/link/cases/3110-atomic-inline/case.conf
@@ -1,0 +1,35 @@
+# the std.sync.atomic wrappers inline across the module boundary (#3110), phase 2
+# of roadmap item N6: the eight wrappers themselves, from the pinned std, linked and
+# run on every native ELF target, with the call counts read from the linked image.
+#
+# Phase 1 (#3270) settled the compiler policy against fixtures shaped like the
+# wrappers, inside the driver's own tests. What only a linked image can say:
+#
+#   - that the wrappers std actually ships (an `asm` block under `$if` on the
+#     build arch, `#[inline]` since std 2.0.0) are extracted and expanded into an
+#     importer std's own module graph sits between, and that no call to any
+#     `std.sync.atomic.*` symbol is left in the importer's text. the producer counts
+#     the DIRECT calls from every function the case defines, per wrapper.
+#   - that the instruction each wrapper documents for the ISA is what the importer's
+#     text carries, in the order the wrappers were called: `xchg` / `lock cmpxchg` /
+#     `lock xadd` / `mfence` / `pause` on x86-64, `ldar` / `stlr` / `ldaxr`+`stlxr`
+#     with `dmb ish` / `yield` on aarch64, `fence` / `amoswap` / `lr`+`sc` / `amoadd`
+#     and the `fence w, 0` spelling of `pause` on riscv64. x86-64's atomic load is a
+#     plain aligned `mov` and is not listed; its `store` is the first `xchg`.
+#   - that the program still computes what the wrappers promise from two threads:
+#     the counts in the last output line depend on every wrapper's atomicity and on
+#     the ordering between the payload write and the flag store, so an inlined copy
+#     that dropped a prefix or a fence is wrong here and not only in the text.
+#
+# The debug cell is the control: the same text with the eight calls present, one per
+# wrapper in `probe`, and every case function's calls counted. Nothing about the
+# case decides which cell is which; the profile does, which is the claim.
+#
+# The goldens are per target and per profile (`expect.<target>.<profile>.txt`): the
+# instruction vocabulary is the ISA's and the call counts are the profile's.
+#
+# riscv64 executes under qemu, which is compute evidence only (test/engines.conf):
+# the ordering claim on that ISA rests on the instruction sequence, which is the
+# fact this case reads from the image, and the run proves the sequence is live code.
+run: atomic-inline
+legs: x86_64-linux aarch64-linux riscv64-linux

--- a/test/link/cases/3110-atomic-inline/expect.aarch64-linux.debug.txt
+++ b/test/link/cases/3110-atomic-inline/expect.aarch64-linux.debug.txt
@@ -1,0 +1,17 @@
+probe=23605
+cell=100 expected=6
+cas-miss=0
+cell=100 expected=100
+by-address=100
+cell=101
+added=40000 swapped=40000 remaining=0 guarded=40000 torn=0
+calls from case text: load=4 store=4 cas=3 fetch_add=3 fetch_sub=2 exchange=2 fence=2 spin_hint=5
+probe:
+  call std.sync.atomic.load
+  call std.sync.atomic.store
+  call std.sync.atomic.cas
+  call std.sync.atomic.fetch_add
+  call std.sync.atomic.fetch_sub
+  call std.sync.atomic.exchange
+  call std.sync.atomic.fence
+  call std.sync.atomic.spin_hint

--- a/test/link/cases/3110-atomic-inline/expect.aarch64-linux.release.txt
+++ b/test/link/cases/3110-atomic-inline/expect.aarch64-linux.release.txt
@@ -1,0 +1,25 @@
+probe=23605
+cell=100 expected=6
+cas-miss=0
+cell=100 expected=100
+by-address=100
+cell=101
+added=40000 swapped=40000 remaining=0 guarded=40000 torn=0
+calls from case text: load=0 store=0 cas=0 fetch_add=0 fetch_sub=0 exchange=0 fence=0 spin_hint=0
+probe:
+  ldar x9, [x12]
+  stlr x9, [x12]
+  ldaxr x10, [x12]
+  stlxr w11, x13, [x12]
+  dmb ish
+  ldaxr x9, [x12]
+  stlxr w11, x10, [x12]
+  dmb ish
+  ldaxr x9, [x12]
+  stlxr w11, x10, [x12]
+  dmb ish
+  ldaxr x9, [x12]
+  stlxr w11, x14, [x12]
+  dmb ish
+  dmb ish
+  yield

--- a/test/link/cases/3110-atomic-inline/expect.riscv64-linux.debug.txt
+++ b/test/link/cases/3110-atomic-inline/expect.riscv64-linux.debug.txt
@@ -1,0 +1,17 @@
+probe=23605
+cell=100 expected=6
+cas-miss=0
+cell=100 expected=100
+by-address=100
+cell=101
+added=40000 swapped=40000 remaining=0 guarded=40000 torn=0
+calls from case text: load=4 store=4 cas=3 fetch_add=3 fetch_sub=2 exchange=2 fence=2 spin_hint=5
+probe:
+  call std.sync.atomic.load
+  call std.sync.atomic.store
+  call std.sync.atomic.cas
+  call std.sync.atomic.fetch_add
+  call std.sync.atomic.fetch_sub
+  call std.sync.atomic.exchange
+  call std.sync.atomic.fence
+  call std.sync.atomic.spin_hint

--- a/test/link/cases/3110-atomic-inline/expect.riscv64-linux.release.txt
+++ b/test/link/cases/3110-atomic-inline/expect.riscv64-linux.release.txt
@@ -1,0 +1,19 @@
+probe=23605
+cell=100 expected=6
+cas-miss=0
+cell=100 expected=100
+by-address=100
+cell=101
+added=40000 swapped=40000 remaining=0 guarded=40000 torn=0
+calls from case text: load=0 store=0 cas=0 fetch_add=0 fetch_sub=0 exchange=0 fence=0 spin_hint=0
+probe:
+  fence
+  fence
+  amoswap.d.aqrl zero, a1, (a0)
+  lr.d.aqrl a3, (a0)
+  sc.d.aqrl a4, a2, (a0)
+  amoadd.d.aqrl a2, a1, (a0)
+  amoadd.d.aqrl a2, a1, (a0)
+  amoswap.d.aqrl a2, a1, (a0)
+  fence
+  fence w, 0

--- a/test/link/cases/3110-atomic-inline/expect.x86_64-linux.debug.txt
+++ b/test/link/cases/3110-atomic-inline/expect.x86_64-linux.debug.txt
@@ -1,0 +1,17 @@
+probe=23605
+cell=100 expected=6
+cas-miss=0
+cell=100 expected=100
+by-address=100
+cell=101
+added=40000 swapped=40000 remaining=0 guarded=40000 torn=0
+calls from case text: load=4 store=4 cas=3 fetch_add=3 fetch_sub=2 exchange=2 fence=2 spin_hint=5
+probe:
+  call std.sync.atomic.load
+  call std.sync.atomic.store
+  call std.sync.atomic.cas
+  call std.sync.atomic.fetch_add
+  call std.sync.atomic.fetch_sub
+  call std.sync.atomic.exchange
+  call std.sync.atomic.fence
+  call std.sync.atomic.spin_hint

--- a/test/link/cases/3110-atomic-inline/expect.x86_64-linux.release.txt
+++ b/test/link/cases/3110-atomic-inline/expect.x86_64-linux.release.txt
@@ -1,0 +1,16 @@
+probe=23605
+cell=100 expected=6
+cas-miss=0
+cell=100 expected=100
+by-address=100
+cell=101
+added=40000 swapped=40000 remaining=0 guarded=40000 torn=0
+calls from case text: load=0 store=0 cas=0 fetch_add=0 fetch_sub=0 exchange=0 fence=0 spin_hint=0
+probe:
+  xchgq %rax, (%rcx)
+  lock cmpxchgq %rdx, (%rcx)
+  lock xaddq %rax, (%rcx)
+  lock xaddq %rax, (%rcx)
+  xchgq %rax, (%rcx)
+  mfence
+  pause

--- a/test/link/cases/3110-atomic-inline/mach.toml
+++ b/test/link/cases/3110-atomic-inline/mach.toml
@@ -1,0 +1,47 @@
+[project]
+id = "case"
+version = "0.0.0"
+src = "src"
+out = "out/{target.name}/{profile.name}"
+
+[target.x86_64-linux]
+isa = "x86_64"
+os  = "linux"
+abi = "sysv64"
+
+[target.aarch64-linux]
+isa = "aarch64"
+os  = "linux"
+abi = "aapcs64"
+
+[target.riscv64-linux]
+isa = "riscv64"
+os  = "linux"
+abi = "lp64d"
+
+[profile.debug]
+default = true
+opt = 0
+debug = false
+simd = "scalarize"
+vectorize = true
+float_reassoc = false
+
+[profile.release]
+opt = 2
+debug = false
+simd = "scalarize"
+vectorize = true
+float_reassoc = false
+
+[artifact.case]
+kind = "bin"
+entry = "main.mach"
+out = "bin/case"
+targets = ["*"]
+link = []
+need = []
+
+[dep.std]
+git = "https://github.com/briar-systems/mach-std"
+ref = "branch/main"

--- a/test/link/cases/3110-atomic-inline/src/main.mach
+++ b/test/link/cases/3110-atomic-inline/src/main.mach
@@ -1,0 +1,121 @@
+# the eight std.sync.atomic wrappers, called across the module boundary (#3110).
+#
+# `probe` makes one call to each wrapper in the order atomic.mach documents them,
+# straight-line, in a function that stays a symbol (`noinline`) so the producer can
+# read its text: in release the eight calls become the ISA's atomic instruction
+# sequence in that order, in debug they stay eight calls. its result folds every
+# returned value with a distinct weight, so a wrapper that returned the wrong value
+# changes the number.
+#
+# the threads use every wrapper in a shape whose correctness depends on the
+# atomicity and the ordering the wrappers promise: two threads sharing one
+# fetch_add counter, one cas counter, one fetch_sub countdown and one spinlock built
+# from exchange and store around a plain increment, and a producer/consumer
+# handshake where the payload is written before a store to the flag and read after a
+# load of it. an inlined copy that kept the value but lost its LOCK prefix, its
+# DMB or its FENCE would be right in `probe` and wrong in these counts.
+#
+# `pick` hides the wrapper's address from the optimizer so `by_address` is a real
+# call through a function value: the address taken is the provider's one strong
+# definition, which an inlined copy never replaces.
+
+use std.runtime;
+use std.types.size.usize;
+use std.types.bool.bool;
+use p: std.print;
+use atomic: std.sync.atomic;
+use thread: std.sync.thread;
+
+val ROUNDS: i64 = 20000;
+
+#[noinline]
+fun probe(cell: *i64, expected: *i64) i64 {
+    val a: i64 = atomic.load(cell);
+    atomic.store(cell, a + 1);
+    val swapped: bool = atomic.cas(cell, expected, 10);
+    val b: i64 = atomic.fetch_add(cell, 5);
+    val c: i64 = atomic.fetch_sub(cell, 3);
+    val d: i64 = atomic.exchange(cell, 100);
+    atomic.fence();
+    atomic.spin_hint();
+    var s: i64 = 0;
+    if (swapped) { s = 1; }
+    ret a + b * 10 + c * 100 + d * 1000 + s * 10000;
+}
+
+#[noinline]
+fun pick(f: fun(*i64, i64) i64) fun(*i64, i64) i64 { ret f; }
+
+rec Shared {
+    added:     i64;
+    swapped:   i64;
+    remaining: i64;
+    lock:      i64;
+    guarded:   i64;
+    flag:      i64;
+    ack:       i64;
+    data:      i64;
+    torn:      i64;
+}
+
+# the contended half every thread runs: fetch_add, a cas loop, fetch_sub, and a
+# spinlock from exchange and store around a plain increment
+fun contend(s: *Shared) {
+    var i: i64 = 0;
+    for (i < ROUNDS) {
+        atomic.fetch_add(?s.added, 1);
+        var seen: i64 = atomic.load(?s.swapped);
+        for (!atomic.cas(?s.swapped, ?seen, seen + 1)) { atomic.spin_hint(); }
+        atomic.fetch_sub(?s.remaining, 1);
+        for (atomic.exchange(?s.lock, 1) != 0) { atomic.spin_hint(); }
+        s.guarded = s.guarded + 1;
+        atomic.store(?s.lock, 0);
+        i = i + 1;
+    }
+}
+
+# the consumer: wait for each round's flag, read the payload written before it, ack
+fun consume(arg: *u8) {
+    val s: *Shared = arg::*Shared;
+    contend(s);
+    var round: i64 = 1;
+    for (round <= ROUNDS) {
+        for (atomic.load(?s.flag) != round) { atomic.spin_hint(); }
+        atomic.fence();
+        if (s.data != round * 7) { atomic.fetch_add(?s.torn, 1); }
+        atomic.store(?s.ack, round);
+        round = round + 1;
+    }
+}
+
+#[symbol("main")]
+fun main(argc: usize, argv: **u8) i64 {
+    var cell: i64 = 5;
+    var expected: i64 = 6;
+    p.printlnf("probe={}", probe(?cell, ?expected));
+    p.printlnf("cell={} expected={}", cell, expected);
+    expected = 0;
+    p.printlnf("cas-miss={}", atomic.cas(?cell, ?expected, 1));
+    p.printlnf("cell={} expected={}", cell, expected);
+
+    val by_address: fun(*i64, i64) i64 = pick(atomic.fetch_add);
+    p.printlnf("by-address={}", by_address(?cell, 1));
+    p.printlnf("cell={}", cell);
+
+    var s: Shared = Shared{added: 0, swapped: 0, remaining: 2 * ROUNDS, lock: 0, guarded: 0, flag: 0, ack: 0, data: 0, torn: 0};
+    var t: thread.Thread;
+    val spawned: thread.Operation = thread.spawn_with(consume, (?s)::*u8, ?t);
+    if (sel spawned.err) { p.println("spawn failed"); ret 1; }
+    contend(?s);
+    var round: i64 = 1;
+    for (round <= ROUNDS) {
+        s.data = round * 7;
+        atomic.store(?s.flag, round);
+        for (atomic.load(?s.ack) != round) { atomic.spin_hint(); }
+        round = round + 1;
+    }
+    val joined: thread.Operation = thread.join(?t);
+    if (sel joined.err) { p.println("join failed"); ret 1; }
+    p.printlnf("added={} swapped={} remaining={} guarded={} torn={}", s.added, s.swapped, s.remaining, s.guarded, s.torn);
+    ret 0;
+}

--- a/test/link/lib/produce.sh
+++ b/test/link/lib/produce.sh
@@ -102,6 +102,16 @@
 #                 the offset alone cannot see #2759, because a producer that derives
 #                 it a second way is self-consistent under the bug. requires
 #                 llvm-dwarfdump and llvm-objdump.
+#   atomic-inline — run the program, then read the linked image (#3110): count the
+#                 DIRECT calls the case's own functions make to `std.sync.atomic.*`
+#                 (a per-wrapper count, so the release cell's zeros are eight facts
+#                 and the debug cell's counts are the control), and list the atomic
+#                 instructions of `case.main.probe` in text order, which is the
+#                 order the wrappers were called in. what a run alone cannot see:
+#                 an inlined wrapper that kept the right value while losing its
+#                 LOCK prefix, its DMB or its FENCE is correct on one thread and
+#                 wrong under contention that a test cannot reliably provoke.
+#                 requires llvm-objdump.
 #   readobj     — parse the linked image and every relocatable object with
 #                 llvm-readobj --all and fail on any reader diagnostic; then name the
 #                 image's sections, alignments and segments (#3113). requires
@@ -3094,6 +3104,109 @@ PY_FBREG
 }
 
 
+# produce_atomic_inline <engine> <leg> <binary>
+# the CROSS-MODULE INLINING observable for the std atomic wrappers (#3110): the
+# program's own output first (its counts depend on the atomicity and the ordering the
+# wrappers promise, from two threads), then two facts read from the linked image.
+#
+#   calls from case text   per wrapper, the direct calls (`call`/`bl`/`jal`/`jalr`
+#                          naming the symbol) made from every function the case
+#                          itself defines: `main` and `case.*`. std's own callers of
+#                          the wrappers are deliberately outside this count; the
+#                          question is what the IMPORTER's text does.
+#   probe                  the atomic instructions of `case.main.probe`, one per
+#                          line, in text order, with a direct wrapper call listed as
+#                          `call <symbol>` so the debug cell's sequence is the eight
+#                          calls and the release cell's is the instruction sequence
+#                          those calls became. the x86-64 `lock` prefix, which
+#                          llvm-objdump decodes as its own line, is joined onto the
+#                          instruction it prefixes.
+#
+# the golden is per target and per profile: the instruction vocabulary is the ISA's
+# and the counts are the profile's.
+produce_atomic_inline() {
+    engine=$1
+    target=$2
+    bin=$3
+    out=$(mktemp)
+    err=$(mktemp)
+    run_captured "$engine" "$target" "$bin" "$out" "$err" || { rm -f "$out" "$err"; return 1; }
+    if [ "$run_status" -ne 0 ]; then
+        report_run_failure "atomic-inline" "$run_status" "$run_out"
+        [ -s "$err" ] && sed 's/^/    /' "$err" >&2
+        rm -f "$out" "$err"
+        return "$run_status"
+    fi
+    cat "$err" >&2
+    cat "$out"
+    rm -f "$out" "$err"
+
+    tool=$(resolve_objdump) || {
+        echo "link: atomic-inline: llvm-objdump not found (install the 'llvm' package)" >&2
+        return 2
+    }
+    case "$target" in
+        x86_64-*)  atomic='^(lock|xchg|cmpxchg|xadd|mfence|lfence|sfence|pause)' ;;
+        aarch64-*) atomic='^(ldar|stlr|ldaxr|stlxr|ldxr|stxr|dmb|dsb|isb|yield|cas|ldadd|swp)' ;;
+        riscv64-*) atomic='^(fence|lr[.]|sc[.]|amo|pause)' ;;
+        *) echo "link: atomic-inline: no atomic vocabulary for '$target'" >&2; return 2 ;;
+    esac
+    "$tool" -d --no-show-raw-insn "$bin" | atomic_inline_scan "$atomic"
+}
+
+# atomic_inline_scan <mnemonic-regex> — read a linked-image disassembly and report
+# the two facts above. the wrapper list is spelled out so a wrapper with no call
+# reads as 0 rather than being absent, and any other `std.sync.atomic.*` symbol a
+# case function calls is appended after the eight.
+atomic_inline_scan() {
+    awk -v atomic="$1" '
+    BEGIN {
+        n = split("load store cas fetch_add fetch_sub exchange fence spin_hint", names, " ")
+        for (i = 1; i <= n; i++) { calls[names[i]] = 0; known[names[i]] = 1 }
+        probe = 0; incase = 0; pending = ""
+    }
+    /^[0-9a-f]+ <.*>:$/ {
+        fn = $0; sub(/^[0-9a-f]+ </, "", fn); sub(/>:$/, "", fn)
+        incase = (fn == "main" || fn ~ /^case\./)
+        probe = (fn == "case.main.probe")
+        pending = ""
+        next
+    }
+    /^[[:space:]]*[0-9a-f]+:/ {
+        if (!incase) { next }
+        text = $0
+        sub(/^[[:space:]]*[0-9a-f]+:[[:space:]]*/, "", text)
+        sub(/[[:space:]]*#.*$/, "", text)
+        gsub(/[[:space:]]+/, " ", text)
+        sub(/ $/, "", text)
+        mnemonic = text; sub(/ .*$/, "", mnemonic)
+        if (match(text, /<std\.sync\.atomic\.[a-z_]+>/)) {
+            sym = substr(text, RSTART + 1, RLENGTH - 2)
+            if (mnemonic ~ /^(call|bl|jal|jalr)/) {
+                short = sym; sub(/^std\.sync\.atomic\./, "", short)
+                if (!(short in known)) { names[++n] = short; known[short] = 1 }
+                calls[short]++
+                if (probe) { seq[++nseq] = "call " sym }
+            }
+            next
+        }
+        if (mnemonic == "lock") { pending = "lock "; next }
+        if (mnemonic ~ atomic) {
+            if (probe) { seq[++nseq] = pending text }
+        }
+        pending = ""
+        next
+    }
+    END {
+        line = "calls from case text:"
+        for (i = 1; i <= n; i++) { line = line " " names[i] "=" calls[names[i]] }
+        print line
+        print "probe:"
+        for (i = 1; i <= nseq; i++) { print "  " seq[i] }
+    }
+    '
+}
+
 # produce <run> <engine> <leg> <binary> [<g_binary>] [<profile>]
 # dispatches to the producer named by <run>, forwarding the remaining arguments. the
 # debuginfo producer takes an extra `-g` artifact path run.sh built alongside the
@@ -3136,6 +3249,7 @@ produce() {
         varloc-fbreg) produce_varloc_fbreg "$@" ;;
         riscv-pcrel) produce_riscv_pcrel "$@" ;;
         readobj)     produce_readobj "$@" ;;
+        atomic-inline) produce_atomic_inline "$@" ;;
         *) echo "link: unknown run mode '$run'" >&2; return 2 ;;
     esac
 }

--- a/test/link/run.sh
+++ b/test/link/run.sh
@@ -367,11 +367,14 @@ for dir in "$here"/cases/*/; do
             # observables (exec, the relro-fault guard, and debuginfo / varloc-fbreg
             # / symtab, whose facts hold identically on every ELF ISA), per-profile
             # for gdb-session (its stop/frame/value facts are a real function of the
-            # active profile's own codegen, #2779), and per-build-target for
-            # structural producers, whose fact is format-specific.
+            # active profile's own codegen, #2779), per-build-target and per-profile
+            # for atomic-inline (an ISA's instruction vocabulary under a profile's
+            # inlining policy, #3110), and per-build-target for structural
+            # producers, whose fact is format-specific.
             case "$case_run" in
                 exec|relro-fault|debuginfo|varloc-fbreg|symtab) golden="$dir/expect.txt" ;;
                 gdb-session) golden="$dir/expect.$profile.txt" ;;
+                atomic-inline) golden="$dir/expect.$build_target.$profile.txt" ;;
                 *)           golden="$dir/expect.$build_target.txt" ;;
             esac
 


### PR DESCRIPTION
Roadmap item N6, phase 2. Phase 1 (#3270) landed the cross-module inlining policy against fixtures shaped like the eight `std.sync.atomic` wrappers. This lane asserts the same claims on the wrappers std ships: `dev` pins std 2.0.0 (`e6fc41251`), whose `atomic.mach` carries the eight `#[inline]` annotations (S4a, std PR #633). No compiler change.

## What is added

- `test/link/cases/3110-atomic-inline`: a program that calls each of `load`, `store`, `cas`, `fetch_add`, `fetch_sub`, `exchange`, `fence` and `spin_hint` across the module boundary, on `x86_64-linux`, `aarch64-linux` and `riscv64-linux`, both profiles. A `noinline` `probe` makes one call per wrapper in atomic.mach's order; two threads share the wrappers in ordering-dependent shapes (a fetch_add counter, a cas loop counter, a fetch_sub countdown, a spinlock from exchange and store, a producer/consumer handshake through store/load with a fence); `pick` hides the wrapper's address so `by_address` is a real call through a function value.
- The `atomic-inline` producer (`test/link/lib/produce.sh`): runs the program, then reads the linked image with `llvm-objdump`: the direct calls to `std.sync.atomic.*` from every function the case defines, per wrapper, and the atomic instructions of `probe` in text order. Its golden is per target and per profile (`expect.<target>.<profile>.txt`, one new line in `run.sh`'s golden rule and the README).
- Three driver tests that read the pinned `dep/std/src/sync/atomic.mach` and `bool.mach` from the repository at test time and place them verbatim in a `std` path dependency of the scaffold.
- `doc/design/inline-acceptance-3110.md`: phase 2 paragraphs per bullet and the evidence table under "The eight atomic wrappers".

## Every #3110 acceptance bullet, mapped to a test

| bullet | test |
| --- | --- |
| eligible helpers lose the relevant calls, same-module | `driver:inline_same_module_helper_leaves_no_call_in_x86_64_text` (phase 1) |
| cross-module, on the std wrappers | link case release cells: `calls from case text: load=0 store=0 cas=0 fetch_add=0 fetch_sub=0 exchange=0 fence=0 spin_hint=0` on all three targets; debug control: `load=4 store=4 cas=3 fetch_add=3 fetch_sub=2 exchange=2 fence=2 spin_hint=5` and eight `call std.sync.atomic.*` in `probe`; `driver:inline_std_atomic_wrappers_lose_their_calls_and_keep_their_asm_in_order` (zero `OP_CALL`, eight `OP_ASM`) |
| bounded code growth | `inline.run:helper_at_the_size_bar_keeps_its_call`, `body.Budget` (phase 1) |
| recursion, indirect calls, `noinline`, unsupported asm follow a documented rule | `driver:inline_rule_keeps_recursive_indirect_noinline_naked_and_large_calls` (phase 1); the link case's `by-address=100` is the indirect call reaching the provider's one strong definition |
| effects and order | link case `probe:` sequences per ISA: `xchgq`, `lock cmpxchgq`, `lock xaddq`, `lock xaddq`, `xchgq`, `mfence`, `pause`; `ldar`, `stlr`, four `ldaxr`/`stlxr`/`dmb ish` groups, `dmb ish`, `yield`; `fence`/`fence`, `amoswap.d.aqrl zero`, `lr.d.aqrl`/`sc.d.aqrl`, two `amoadd.d.aqrl`, `amoswap.d.aqrl`, `fence`, `fence w, 0`; plus the two-thread counts `added=40000 swapped=40000 remaining=0 guarded=40000 torn=0`; in IR, the driver test above checks each inlined asm payload in call order |
| secrecy | `inline.run:oblivious_callee_inlines_only_into_an_oblivious_caller`, `driver:inline_oblivious_callee_stays_a_call_in_a_public_caller` (phase 1) |
| debug mapping | `driver:release_text_is_byte_identical_with_and_without_g_for_the_std_atomic_wrappers` (new), `driver:release_text_is_byte_identical_with_and_without_g_at_the_inline_bar`, `body:debug_annotation_does_not_move_a_bodys_cost` (phase 1) |
| cache and query dependency invalidation | `driver:std_atomic_wrapper_body_edit_relowers_the_importer` (new: `mfence` to `lfence` in `fence` moves the importer's `Q_LOWER` and reaches its seventh inlined asm while the provider's surface holds; an edit beside the wrappers moves the provider only), plus the phase 1 pair |
| pure/atomic controls semantically correct on native targets | the link case's program output on x86_64 (native), aarch64 (native on CI's arm runner) and riscv64 (qemu, compute evidence per engines.conf); `fetch_add`/`fetch_sub` called for effect only keep their `lock xadd` / `ldaxr`+`stlxr` / `amoadd` in the release text |
| function-address identity | `driver:inline_bodies_cross_modules_preserve_identity_effects_and_owned_metadata` (phase 1); link case `by-address=100` |

Mutation controls: `#[noinline]` on `fetch_add` in the case's std copy fails the release goldens (`fetch_add=3`, `call std.sync.atomic.fetch_add` in the sequence); `#[noinline]` on `cas` in the pinned `dep/std` fails the three driver tests (exits 8, 50, 10).

## Verification

- Link leg `x86_64-linux`, `--deps pin`, from-source compiler: 142 pass / 0 fail / 0 skip over 142 cells (140 baseline + the two new cells).
- `riscv64-linux` leg for the new case under the host's qemu-riscv64: 2 pass. The whole riscv64 leg needs the cross libc headers the host lacks; CI's runner executes it.
- `aarch64-linux`: the goldens were blessed from a `qemu-aarch64` run of the producer (the observable is instruction text and deterministic program output); the leg itself executes only on CI's arm runner.
- Full suite through the from-source compiler: 3006 passed, 0 failed (baseline 3003 at 83d3c1c9d, three added). `sh test/census.sh`: all ok.

Pre-existing and outside this lane: the PR lane's link suite floats std to `branch/main` (4917c2a), which predates v5's `:^` removal, so every std-using link case already fails to build there on `dev` (run 34706006615). The pinned lanes are the ones this case's goldens were produced under.

Closes #3110
