### PR TITLE
test: report a test's full result instead of its 8-bit exit status (#3241)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -171,6 +171,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- A test whose result was `256` or more, or negative, was reported as passing
+  on linux and darwin: the dispatcher exited with the raw `i32` and the kernel
+  kept its low eight bits, so `256` read as `0`. The test result is now a
+  status in `0..255` at both ends of the protocol. A literal-shaped `ret`
+  outside the range in a test body is a compile error at the `ret` naming the
+  value (`test result 256 is outside the status range 0..255`), and the
+  dispatcher folds a run-time result outside the range to `255` before it
+  exits, so it is a failure on every host with the same status reported. Four
+  tests in the tree that accumulated more than eight failure bits now return
+  the ordinal of the first failing check. The decision is recorded in
+  `doc/design/test-status-range.md`. (#3241)
 - A comment that shares its line with code is no longer taken as the doc run
   of the declaration on the next line, and never joins the comment on the
   following line into one run. (#3225)

--- a/doc/design/test-status-range.md
+++ b/doc/design/test-status-range.md
@@ -1,0 +1,86 @@
+# The test status range
+
+A test reports its result as the exit status of the process that ran it, and
+a process exit status is eight bits. This page records why the test protocol
+was closed over the range `0..255` at both ends instead of growing a wider
+result channel, and what that decision cost.
+
+## The defect it closes
+
+A test that returned `256` was reported as passing on linux and darwin and as
+failing on windows (#3241). The dispatcher returned the test's `i32` result
+from `main` unchanged, the POSIX kernel kept the low eight bits, and `mach
+test` classified an exit status of `0` as a pass. Windows preserves the full
+32-bit code, so the same test failed there. A RISC-V constant-time regression
+sat behind a bit mask that had grown to nine bits and was invisible on POSIX
+for the life of its branch; the tree carried three more nine-plus-bit masks
+and one `ret 1000 + op` that would have hidden the same way.
+
+The rule from the windows migration, judge success from the full preserved
+status, holds in the other direction too: POSIX must not fabricate success
+from a truncated one.
+
+## The alternatives
+
+**A result channel other than the exit code.** The dispatcher would write the
+`i32` to a pipe, a status line on the captured output, or a result file, and
+the runner would read it back. The runner has no pipe to the child: it
+redirects the child's stdout and stderr into a capture file and reads the
+exit status, nothing else. Any of those channels needs the dispatcher to
+perform I/O, and the dispatcher is synthesized as target-agnostic IR with no
+runtime behind it. Writing bytes from it means a per-OS `write` in the
+compiler (a linux syscall, a darwin libSystem import, a kernel32 import), a
+second copy of what `std.runtime` exists to own. Calling into `std` by
+linkage name from the synthesized module was rejected too: a std module is
+compiled only when something uses it, so the symbol is not guaranteed to be
+linked, and it ties the compiler's test protocol to a std release. The
+channel was not built.
+
+**Keep the exit code and reserve nothing.** Fold a wide result to its low
+eight bits unless that would read as a pass. That preserves more digits in
+some cases (`257` would arrive as `1`) at the cost of a rule nobody can
+apply while reading a failure line. Rejected for the simpler rule below.
+
+**Trap on a wide result.** A `ud2`/`brk` in the dispatcher turns `256` into a
+signal. Loud, but it reports as a crash on every host and as an exception
+code on windows, and says nothing about the value. Rejected.
+
+## The rule
+
+The status range `0..255` is part of the protocol, and it is enforced where
+each kind of value can be seen:
+
+- **At the `ret`, at compile time.** A `ret` in a test body whose value is
+  literal-shaped (a literal, a negated literal, or arithmetic over literals,
+  the same shapes literal coercion already folds) outside `0..255` is refused
+  with a located diagnostic naming the value. The check reuses the literal
+  range probe against the `u8` range without retyping the expression, so an
+  ordinary `i32` function returning `256` is untouched. A suffixed literal
+  (`256i32`) is typed, not literal-shaped, and is left to the run-time fold.
+- **At the dispatcher, at run time.** The synthesized entry compares the
+  result against `255` unsigned, which puts every negative value past the
+  range in one instruction, and exits `255` for anything outside it. The
+  fold is one shared block; the compare is one per test. The value is lost,
+  the failure is not, and the same status is reported on every host.
+- **In the readout.** `(exit 255)` is the top of the range and the fold
+  target both; `code` in the JSON stream is documented as `1..255`.
+
+The dispatcher's own statuses are unchanged: `2` for a missing, malformed, or
+out-of-range index.
+
+## What it cost
+
+Nine-plus-bit masks in the tree were rewritten to return the ordinal of the
+first failing check, which keeps every check distinguishable and loses the
+"all failures at once" reading of a mask. A test that wants that reading
+has eight bits to spend. The compile-time check cannot see a mask that grows
+past eight bits at run time; that case reaches the fold and reads as `255`,
+which is the documented signal to look for a wide result.
+
+The guards are covered by an IR-level test that reads the synthesized module
+(every branch on a `255 <u result` compare takes its true edge to a block
+whose only instruction is `ret 255`), a driver test that runs the built
+dispatcher on results of `256`, `300`, `-1`, `3`, `0` and `255`, and a driver
+test that the three literal shapes are refused at the `ret` with the value in
+the message. Each guard was mutated once: unwiring the fold's true edge fails
+the first two, disabling the sema check fails the third.

--- a/doc/language/test.md
+++ b/doc/language/test.md
@@ -63,26 +63,37 @@ point so the runner can iterate it. The label is interned and becomes the lowere
 function's name. Ordinary builds omit test bodies from IR and object files.
 
 The body is checked against an `i32` return type. A test reports its result
-through that return value, treated as a process-style status:
+through that return value, treated as a process-style status in the range
+`0..255`:
 
 - `ret 0` — pass.
-- any non-zero `ret N` — fail.
+- any `ret N` with `N` in `1..255` — fail, reported as `(exit N)`.
 - falling off the end of the body returns `0` (the default terminator for
   a non-void function is a zero return), so a body that never returns
   explicitly is treated as a pass.
 
-The return value is an ordinary integer status; the compiler does not
-attach any special pass/fail meaning to particular non-zero codes, nor does
-it provide built-in assertion intrinsics. A test signals failure by
-returning non-zero — typically by returning early from a failed check, as
-in the example above.
+The result is the test process's exit status, and a process exit status is
+eight bits wide on every host (`mach test` reads the same eight bits on
+windows). The range is therefore part of the protocol, enforced at both
+ends:
 
-> **Note.** The convention above (`0` = pass, non-zero = fail) is the
-> interpretation the test runner applies to each test's exit status; it is
-> not enforced by the type system. Existing standard-library tests are not
-> all consistent about which non-zero codes they use, and some return `1`
-> on the success path. When writing new tests, prefer `ret 0` for pass and
-> a non-zero `ret` for failure.
+- A `ret` in a test body whose value is a literal (or a literal-shaped
+  expression: a negated literal, or an arithmetic expression over literals)
+  outside `0..255` is a compile error located at the `ret`, naming the value:
+  `test result 256 is outside the status range 0..255`. An ordinary function
+  returning the same value is unaffected; only test bodies carry the range.
+- A result computed at run time that lands outside `0..255` — a bit mask that
+  has grown past eight bits, a negative code — is folded by the dispatcher to
+  `255` before the process exits. It is reported as `(exit 255)` and is
+  always a failure. The low eight bits are never used on their own, so a
+  result of `256` cannot read as a pass.
+
+Within the range the compiler attaches no special pass/fail meaning to
+particular non-zero codes, nor does it provide built-in assertion
+intrinsics. A test signals failure by returning non-zero — typically by
+returning early from a failed check, as in the example above. A test that
+accumulates a bit mask must keep it within eight bits; past that, return
+the ordinal of the first failing check instead.
 
 ### Collection across modules
 
@@ -179,6 +190,11 @@ one dispatcher object whose entry selects a test by its index argument. That
 object links with the project's objects into a single executable, even for a
 library artifact; in a test build the project's own entry is neutralised so
 the dispatcher is the sole program entry.
+
+The dispatcher's entry calls the selected test and exits with its result:
+as is when the result is in `0..255`, and `255` otherwise (see
+[Semantics](#semantics)). A missing, malformed, or out-of-range index exits
+`2`.
 
 `mach test` then keeps up to `--jobs` children in flight, each spawned as
 `<exe> <index>`, captures each child's stdout and stderr to a per-test file

--- a/doc/tooling/test-json.md
+++ b/doc/tooling/test-json.md
@@ -79,7 +79,7 @@ order as the human readout), regardless of completion order.
 | `file`        | string        | source file path of the declaring module |
 | `line`        | int           | 1-based source line of the `test` keyword |
 | `kind`        | string        | outcome (see below) |
-| `code`        | int           | exit code (`kind` = `exit`) or signal number (`kind` = `signal`); `0` otherwise |
+| `code`        | int           | exit code in `1..255` (`kind` = `exit`; a test result outside `0..255` arrives as `255`) or signal number (`kind` = `signal`); `0` otherwise |
 | `timeout_seconds` | int       | the bound the test exceeded (`kind` = `timeout`); `0` otherwise |
 | `duration_ns` | int           | wall time of the test process, in nanoseconds |
 | `index`       | int           | the test's collection-order dispatch index (`<exe> <index>` reruns exactly this test; sort by it for declaration order) |

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -698,6 +698,164 @@ test "mach.lang.driver:test_reachable_error_still_fatal" {
     ret bad;
 }
 
+fun ut_sema_rejects_at(src: str, needle: str, want_offset: usize, want_len: usize) bool {
+    var alloc: A.Allocator;
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret false; }
+    val sr: res[session.Session, fail.Fail] = session.init(?alloc);
+    if (sel sr.err) { ret false; }
+    var s: session.Session = sr.ok;
+    fin { session.dnit(?s); }
+
+    var names: [1]str;
+    names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = src;
+    val pr: res[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (sel pr.err) { ret false; }
+    var p: project.Project = pr.ok;
+    fin { project.dnit_project(?p); }
+
+    val se: err[outcome.Fail] = driver.run_sema_pass(?p);
+    if (!(sel se.err && outcome.is_reported(se.err))) { ret false; }
+    var i: usize = 0;
+    for (i < diagnostic.len(?s.diags)) {
+        val d: *diagnostic.Diagnostic = ?s.diags.items.data[i];
+        if (d.severity == diagnostic.SEVERITY_ERROR
+         && ut_str_contains(d.message, needle)
+         && d.loc.span.offset == want_offset
+         && d.loc.span.len    == want_len) { ret true; }
+        i = i + 1;
+    }
+    ret false;
+}
+
+# a test body's literal `ret` is refused at the ret when it is outside 0..255, with
+# the value in the message; an ordinary function returning the same value is not
+test "mach.lang.driver:test_result_outside_the_status_range_is_refused_at_the_ret" {
+    val src: str = "fun main() i32 { ret 0; }\nfun wide() i32 { ret 256; }\ntest \"a\" { ret 256; }\ntest \"b\" { ret 300; }\ntest \"c\" { ret -1; }\n";
+    if (!ut_sema_rejects_at(src, "test result 256 is outside the status range 0..255", 65, 8))  { ret 1; }
+    if (!ut_sema_rejects_at(src, "test result 300 is outside the status range 0..255", 87, 8))  { ret 2; }
+    if (!ut_sema_rejects_at(src, "test result -1 is outside the status range 0..255", 109, 7))  { ret 3; }
+
+    var alloc: A.Allocator;
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 4; }
+    val sr: res[session.Session, fail.Fail] = session.init(?alloc);
+    if (sel sr.err) { ret 4; }
+    var s: session.Session = sr.ok;
+    fin { session.dnit(?s); }
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str; texts[0] = src;
+    val pr: res[project.Project, outcome.Fail] = ut_build(?s, ?alloc, ?names[0], ?texts[0], 1);
+    if (sel pr.err) { ret 4; }
+    var p: project.Project = pr.ok;
+    fin { project.dnit_project(?p); }
+    driver.run_sema_pass(?p);
+    # exactly the three test rets, not `wide`
+    if (ut_diag_count(?s.diags, "outside the status range 0..255") != 3) { ret 5; }
+    if (!ut_diag_note_has(?s.diags, "eight bits on every host"))          { ret 6; }
+
+    # the range itself, and a run-time value, are the dispatcher's business
+    if (!ut_sema_clean("fun main() i32 { ret 0; }\nfun wide() i32 { ret 256; }\ntest \"d\" { ret 255; }\ntest \"e\" { ret 0; }\ntest \"f\" { ret wide(); }\ntest \"g\" { ret 200 + 55; }\n")) { ret 7; }
+    ret 0;
+}
+
+fun ut_dispatcher_start_stub() str {
+    ret "\n#[symbol(\"_start\")]\npub fun start() {\n    asm x86_64 {\n        mov rax, rsp\n        mov rdi, [rax]\n        lea rsi, [rax+8]\n        and rsp, -16\n        call main\n        mov rdi, rax\n        mov rax, 60\n        syscall\n    }\n}\n";
+}
+
+# runs the built dispatcher on one test index and returns its exit code, or -1
+fun ut_dispatch_status(exe: str, idx: u32) i32 {
+    var ibuf: [16]u8;
+    var len: usize = 0;
+    var v: u32 = idx;
+    if (v == 0) { ibuf[0] = 48; len = 1; }
+    for (v > 0) { ibuf[len] = 48 + (v % 10)::u8; v = v / 10; len = len + 1; }
+    # the digits were written least significant first
+    var lo: usize = 0;
+    var hi: usize = len;
+    for (lo + 1 < hi) { val t: u8 = ibuf[lo]; ibuf[lo] = ibuf[hi - 1]; ibuf[hi - 1] = t; lo = lo + 1; hi = hi - 1; }
+    ibuf[len] = 0;
+    var argv: [3]*u8;
+    argv[0] = exe::*u8;
+    argv[1] = ?ibuf[0];
+    argv[2] = nil;
+    val spawned: res[exec.Child, exec.Error] = exec.spawn(exe, ?argv[0], env.environ());
+    if (sel spawned.err) { ret -1; }
+    val rr: res[exec.ExitStatus, exec.Error] = exec.wait(spawned.ok);
+    if (sel rr.err) { ret -1; }
+    if (!exec.exited(rr.ok)) { ret -1; }
+    ret exec.code(rr.ok)::i32;
+}
+
+# a run-time result outside 0..255 exits 255 instead of its low eight bits, so it
+# can never read as a pass; a result inside the range is the exit code as is
+test "mach.lang.driver:dispatcher_folds_a_wide_run_time_result_to_255" {
+    $if ($mach.build.os != $mach.os.linux || $mach.build.arch != $mach.arch.x86_64) { ret 0; }
+    var alloc: A.Allocator;
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
+    val sr: res[session.Session, fail.Fail] = session.init(?alloc);
+    if (sel sr.err) { ret 1; }
+    var s: session.Session = sr.ok;
+    fin { session.dnit(?s); }
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    if (sel setup_registry_r.err) { ret 1; }
+
+    var names: [1]str; names[0] = "main.mach";
+    var texts: [1]str;
+    texts[0] = ut_cc3(?alloc,
+        "#[noinline]\nfun wide(v: i32) i32 { ret v; }\n",
+        "test \"r256\" { ret wide(256); }\ntest \"r300\" { ret wide(300); }\ntest \"rneg1\" { ret wide(-1); }\ntest \"r3\" { ret 3; }\ntest \"r0\" { ret 0; }\ntest \"r255\" { ret 255; }\n",
+        ut_dispatcher_start_stub());
+    val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
+    if (sel root_r.err) { ret 1; }
+    val root: str = root_r.ok;
+    fin { fs.remove_all(?alloc, root); }
+
+    val mr: res[manifest.Manifest, outcome.Fail] = driver.load_manifest(?s, root);
+    if (sel mr.err) { ret 1; }
+    var m: manifest.Manifest = mr.ok;
+    var rq: request.BuildRequest = request.defaults();
+    rq.project_root = root;
+    rq.target       = "linux";
+    rq.goal         = request.GOAL_TESTS;
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    if (sel pr.err) { ret 1; }
+    var bp: bplan.BuildPlan = pr.ok;
+    val r: res[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, ?alloc, nil);
+    if (sel r.err) { print.eprintln(outcome.describe(r.err)); ret 1; }
+    var bo: outcome.BuildOutcome = r.ok;
+    if (bo.severity != outcome.BUILD_OK) { ret 2; }
+    if (bo.tests.len != 6) { ret 3; }
+
+    var labels: [6]str;
+    labels[0] = "r256"; labels[1] = "r300"; labels[2] = "rneg1"; labels[3] = "r3"; labels[4] = "r0"; labels[5] = "r255";
+    var want: [6]i32;
+    want[0] = 255; want[1] = 255; want[2] = 255; want[3] = 3; want[4] = 0; want[5] = 255;
+    var i: usize = 0;
+    for (i < 6) {
+        var found: bool = false;
+        var t: usize = 0;
+        for (t < bo.tests.len) {
+            val art: *outcome.TestArtifact = ?bo.tests.data[t];
+            if (str_equals(art.label::str, labels[i])) {
+                found = true;
+                val got: i32 = ut_dispatch_status(art.exe::str, art.idx);
+                if (got != want[i]) {
+                    print.eprintlnf("{}: exit {} (want {})", labels[i], got::i64, want[i]::i64);
+                    ret 10 + i::i32;
+                }
+            }
+            t = t + 1;
+        }
+        if (!found) { ret 4; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
 fun ut_has(p: *project.Project, s: *session.Session, fqn: str) bool {
     val idr: res[intern.StrId, A.Error] = intern.intern(?s.interner, fqn);
     if (sel idr.err) { ret false; }

--- a/src/lang/fe/sema.mach
+++ b/src/lang/fe/sema.mach
@@ -32,6 +32,7 @@ use np: mach.lang.fe.path;
 use mach.lang.fe.resolve;
 use mach.lang.float;
 use mach.lang.fe.sema.check;
+use mach.lang.fe.sema.coerce;
 use mach.lang.fe.sema.context;
 use mach.lang.fe.sema.embed;
 use mach.lang.fe.sema.generics;
@@ -272,6 +273,7 @@ pub fun reinfer_pack_each_body(
     sc.inst_site_set    = false;
     sc.in_fin           = false;
     sc.fin_loop_depth   = 0;
+    sc.in_test          = false;
     sc.guards           = nil;
     sc.subst            = subst;
     sc.subst_len        = subst_len;
@@ -333,6 +335,7 @@ pub fun reinfer_instance_body(
     sc.inst_site_set    = false;
     sc.in_fin           = false;
     sc.fin_loop_depth   = 0;
+    sc.in_test          = false;
     sc.guards           = nil;
     sc.subst            = subst;
     sc.subst_len        = subst_len;
@@ -487,6 +490,7 @@ fun revalidate_one(sc: *context.SemaContext, deps: *context.SemaDeps, origin: se
     tsc.inst_site_set    = false;
     tsc.in_fin           = false;
     tsc.fin_loop_depth   = 0;
+    tsc.in_test          = false;
     tsc.guards           = nil;
     tsc.subst            = args;
     tsc.subst_len        = arg_len;
@@ -585,6 +589,7 @@ fun init_context(
     sc.inst_site_set    = false;
     sc.in_fin           = false;
     sc.fin_loop_depth   = 0;
+    sc.in_test          = false;
     sc.guards           = nil;
     sc.subst            = nil;
     sc.subst_len        = 0;
@@ -1164,7 +1169,10 @@ fun infer_one_body(sc: *context.SemaContext, did: id.DeclId) err[fail.Fail] {
     if (d.kind == decl.DECL_KIND_TEST) {
         if (d.data.test_.body != id.STMT_NIL) {
             val ret_ty: type.TypeId = test_return_type(sc);
-            ret infer_stmt(sc, d.data.test_.body, ret_ty);
+            sc.in_test = true;
+            val res_body: err[fail.Fail] = infer_stmt(sc, d.data.test_.body, ret_ty);
+            sc.in_test = false;
+            ret res_body;
         }
         ret err[fail.Fail].ok{};
     }
@@ -1997,6 +2005,30 @@ fun test_return_type(sc: *context.SemaContext) type.TypeId {
     ret opt_i32.some;
 }
 
+# a test result is a process status: the u8 range is the status range, so a
+# literal-shaped `ret` value outside it is refused here, at the ret, instead of
+# being folded by the dispatcher at run time
+fun check_test_status(sc: *context.SemaContext, value: id.ExprId, span: token.Span) {
+    if (value == id.EXPR_NIL) { ret; }
+    val opt_u8: opt[type.TypeId] = type.prim(?sc.s.types, type.TYPE_U8);
+    if (!sel opt_u8.some) { ret; }
+    val cr: coerce.CoerceResult = coerce.probe_literal_range(sc, value, opt_u8.some);
+    if (cr.kind != coerce.COERCE_OUT_OF_RANGE) { ret; }
+    var sign: str = "";
+    if (cr.negated) { sign = "-"; }
+    val res_msg: res[str, format.FormatError] = format.sprint(sc.s.alloc,
+        "test result {}{} is outside the status range 0..255", sign, cr.value::usize);
+    if (sel res_msg.err) {
+        fail.internal(?sc.status, fail.describe(fail.format_refused(res_msg.err)));
+        context.report(sc, span, "test result is outside the status range 0..255");
+        ret;
+    }
+    val msg: str = res_msg.ok;
+    context.report_note(sc, span, msg,
+        "a test reports its result as the process exit status, which is eight bits on every host; 0 passes and 1..255 fail");
+    str_free(sc.s.alloc, msg);
+}
+
 fun infer_binding_init(sc: *context.SemaContext, did: id.DeclId, d: *decl.Decl) err[fail.Fail] {
     if (d.data.bind.init == id.EXPR_NIL) { ret err[fail.Fail].ok{}; }
     if (d.data.bind.ty   == id.TYPE_NIL) { ret err[fail.Fail].ok{}; }
@@ -2133,6 +2165,7 @@ fun infer_stmt(sc: *context.SemaContext, sid: id.StmtId, fn_ret: type.TypeId) er
             context.report(sc, st.span, "`ret` cannot appear inside a `fin` body");
         }
         check_return_stmt(sc, fn_ret, st.data.ret_.value, st.span);
+        if (sc.in_test) { check_test_status(sc, st.data.ret_.value, st.span); }
         ret err[fail.Fail].ok{};
     }
     if (st.kind == stmt.STMT_KIND_BRK) {
@@ -2398,6 +2431,7 @@ fun infer_const_array_each_imported(sc: *context.SemaContext, ce: *stmt.StmtComp
     tsc.inst_site_set    = false;
     tsc.in_fin           = false;
     tsc.fin_loop_depth   = 0;
+    tsc.in_test          = false;
     tsc.guards           = nil;
     tsc.subst            = nil;
     tsc.subst_len        = 0;

--- a/src/lang/fe/sema/coerce.mach
+++ b/src/lang/fe/sema/coerce.mach
@@ -88,6 +88,19 @@ pub fun try_coerce_literal(sc: *context.SemaContext, eid: id.ExprId, to: type.Ty
     ret r;
 }
 
+# ask whether a literal-shaped expression fits the integer range of `to` without
+# retyping anything: `COERCE_OUT_OF_RANGE` carries the offending leaf's value and
+# sign, and any other kind means the shape is not a literal or it fits
+# ---
+# sc: the semantic context
+# eid: the expression to probe
+# to: the integer type whose range is asked about
+# ret: the probe result; never commits an expression type
+pub fun probe_literal_range(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId) CoerceResult {
+    if (to == type.TYPE_NIL || to == type.TYPE_ERROR) { ret not_applicable(); }
+    ret coerce_to(sc, eid, type.strip_secret(?sc.s.types, to), false, true);
+}
+
 fun coerce_to(sc: *context.SemaContext, eid: id.ExprId, to: type.TypeId, negated: bool, probe: bool) CoerceResult {
     if (eid == id.EXPR_NIL) { ret not_applicable(); }
 

--- a/src/lang/fe/sema/context.mach
+++ b/src/lang/fe/sema/context.mach
@@ -357,6 +357,9 @@ pub rec SemaContext {
     in_fin:         bool;
     fin_loop_depth: u32;
 
+    # inside a `test` body, where a `ret` value is a status in 0..255
+    in_test:        bool;
+
     guards: *Guard;
 
     subst:     *type.TypeId;

--- a/src/lang/me/lower/constagg.mach
+++ b/src/lang/me/lower/constagg.mach
@@ -473,29 +473,28 @@ fun constagg_probe_runtime() ConstAggProbe {
 }
 
 test "mach.lang.me.lower.constagg:static_and_runtime_agree_on_omitted_fields" {
-    var bad: i32 = 0;
 
-    if (constagg_probe_dirty() != 0xAAAAAAAAAAAAAAAA) { bad = bad + 1; }
+    if (constagg_probe_dirty() != 0xAAAAAAAAAAAAAAAA) { ret 1; }
 
     val r: ConstAggProbe = constagg_probe_runtime();
 
-    if (r.a != 7)                                  { bad = bad + 2; }
-    if (constagg_probe_static.a != 7)              { bad = bad + 4; }
+    if (r.a != 7)                                  { ret 2; }
+    if (constagg_probe_static.a != 7)              { ret 3; }
 
-    if (r.b != 0)                                  { bad = bad + 8; }
-    if (r.c != 0)                                  { bad = bad + 16; }
-    if (r.inner.x != 0 || r.inner.y != 0)          { bad = bad + 32; }
-    if (r.arr[0] != 0 || r.arr[1] != 0 || r.arr[2] != 0) { bad = bad + 64; }
+    if (r.b != 0)                                  { ret 4; }
+    if (r.c != 0)                                  { ret 5; }
+    if (r.inner.x != 0 || r.inner.y != 0)          { ret 6; }
+    if (r.arr[0] != 0 || r.arr[1] != 0 || r.arr[2] != 0) { ret 7; }
 
-    if (constagg_probe_static.b != r.b)                     { bad = bad + 128; }
-    if (constagg_probe_static.c != r.c)                     { bad = bad + 256; }
+    if (constagg_probe_static.b != r.b)                     { ret 8; }
+    if (constagg_probe_static.c != r.c)                     { ret 9; }
     val st: ConstAggProbe = constagg_probe_static;
-    if (st.inner.x != r.inner.x)                            { bad = bad + 512; }
-    if (st.inner.y != r.inner.y)                            { bad = bad + 1024; }
-    if (st.arr[0] != r.arr[0])                              { bad = bad + 2048; }
-    if (st.arr[2] != r.arr[2])                              { bad = bad + 4096; }
+    if (st.inner.x != r.inner.x)                            { ret 10; }
+    if (st.inner.y != r.inner.y)                            { ret 11; }
+    if (st.arr[0] != r.arr[0])                              { ret 12; }
+    if (st.arr[2] != r.arr[2])                              { ret 13; }
 
-    ret bad;
+    ret 0;
 }
 
 test "mach.lang.me.lower.constagg:comptime_constant_and_runtime_agree_on_omitted_fields" {

--- a/src/lang/me/lower/testrunner.mach
+++ b/src/lang/me/lower/testrunner.mach
@@ -1,5 +1,6 @@
 use std.types.canonical.res;
 use std.types.canonical.err;
+use std.types.canonical.opt;
 use std.types.bool.bool;
 use std.types.bool.false;
 use std.types.bool.true;
@@ -7,11 +8,13 @@ use std.types.size.usize;
 use std.types.string.str;
 
 use A: std.allocator;
+use page: std.allocator.page;
 
 use mach.lang.intern;
 use mach.lang.me.ir;
 use mach.lang.me.ir.builder;
 use mach.lang.me.ir.id;
+use mach.lang.me.ir.instruction;
 use mach.lang.me.ir.type;
 use mach.lang.me.ir.value;
 use mach.lang.session;
@@ -102,6 +105,21 @@ pub fun neutralize_main(main_id: intern.StrId, mod: *ir.Module) {
     }
 }
 
+# the status a test result outside 0..255 exits with: the process exit code is
+# eight bits on posix, so a wider result is folded to this value rather than
+# truncated, and it can never read as a pass
+pub val TEST_STATUS_WIDE: u64 = 255;
+
+# synthesize the test dispatcher module: a `main(argc, argv)` that parses argv[1]
+# as a decimal test index, calls that test, and exits with its result folded to the
+# status protocol. a result in 0..255 is the exit code as is; any other result
+# exits `TEST_STATUS_WIDE`; a missing or malformed index, or one past `count`,
+# exits 2
+# ---
+# s: the session whose interner names the dispatcher and `main`
+# tests: the collected tests in dispatch order, indexed by argv[1]
+# count: how many tests there are, at least one
+# ret: the dispatcher module, owned by the caller, or why it could not be built
 pub fun synthesize_dispatcher(s: *session.Session, tests: *Test, count: u32) res[ir.Module, fail.Fail] {
     if (count == 0) { ret res[ir.Module, fail.Fail].err{fail.message("test dispatcher: no tests to dispatch")}; }
 
@@ -235,6 +253,10 @@ fun build_dispatcher(s: *session.Session, m: *ir.Module, tests: *Test, count: u3
     if (sel res_body.err) { ret err[fail.Fail].err{res_body.err}; }
     val b_body: id.BlockId = res_body.ok;
 
+    val res_wide: res[id.BlockId, fail.Fail] = builder.new_block(?b);
+    if (sel res_wide.err) { ret err[fail.Fail].err{res_wide.err}; }
+    val b_wide: id.BlockId = res_wide.ok;
+
     val res_dblocks: res[*id.BlockId, A.Error] = A.allocate[id.BlockId](m.alloc, count::usize);
     if (sel res_dblocks.err) { ret err[fail.Fail].err{fail.refused(res_dblocks.err)}; }
     val dblocks: *id.BlockId = res_dblocks.ok;
@@ -353,12 +375,28 @@ fun build_dispatcher(s: *session.Session, m: *ir.Module, tests: *Test, count: u3
         builder.set_block(?b, cblocks[k]);
         val res_call: res[value.Value, fail.Fail] = builder.emit_call(?b, callees[k], nil, 0, i32t);
         if (sel res_call.err) { ret err[fail.Fail].err{res_call.err}; }
-        val res_r64: res[value.Value, fail.Fail] = builder.emit_sext(?b, res_call.ok, i64t);
+        val result: value.Value = res_call.ok;
+
+        # an unsigned compare puts every negative result past 255 as well
+        val res_over: res[value.Value, fail.Fail] = builder.emit_cmp_lt_u(?b, value.const_int(TEST_STATUS_WIDE, i32t), result);
+        if (sel res_over.err) { ret err[fail.Fail].err{res_over.err}; }
+        val res_narrow: res[id.BlockId, fail.Fail] = builder.new_block(?b);
+        if (sel res_narrow.err) { ret err[fail.Fail].err{res_narrow.err}; }
+        val b_narrow: id.BlockId = res_narrow.ok;
+        val res_cbrw: err[fail.Fail] = builder.emit_cbr(?b, res_over.ok, b_wide, b_narrow);
+        if (sel res_cbrw.err) { ret res_cbrw; }
+
+        builder.set_block(?b, b_narrow);
+        val res_r64: res[value.Value, fail.Fail] = builder.emit_sext(?b, result, i64t);
         if (sel res_r64.err) { ret err[fail.Fail].err{res_r64.err}; }
         val res_retk: err[fail.Fail] = builder.emit_ret(?b, res_r64.ok);
         if (sel res_retk.err) { ret res_retk; }
         k = k + 1;
     }
+
+    builder.set_block(?b, b_wide);
+    val res_retw: err[fail.Fail] = builder.emit_ret(?b, value.const_int(TEST_STATUS_WIDE, i64t));
+    if (sel res_retw.err) { ret res_retw; }
 
     ret err[fail.Fail].ok{};
 }
@@ -376,4 +414,66 @@ fun append_function(m: *ir.Module, name: intern.StrId, sig: type.IrTypeId, flags
     }
 
     ret res[u32, fail.Fail].ok{idx};
+}
+
+# the synthesized dispatcher folds every result outside 0..255 to `TEST_STATUS_WIDE`:
+# the entry compares each test's result against 255 unsigned, and one block returns
+# the fold. this reads the module, so it holds on every host the compiler runs on
+test "mach.lang.me.lower.testrunner.synthesize_dispatcher:folds_a_wide_result_to_the_status_range" {
+    var alloc: A.Allocator;
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
+    val sr: res[session.Session, fail.Fail] = session.init(?alloc);
+    if (sel sr.err) { ret 1; }
+    var s: session.Session = sr.ok;
+    fin { session.dnit(?s); }
+
+    var tests: [2]Test;
+    var k: u32 = 0;
+    for (k < 2) {
+        val name_r: res[intern.StrId, A.Error] = intern.intern(?s.interner, "t_probe");
+        if (sel name_r.err) { ret 1; }
+        tests[k].linkage = name_r.ok;
+        tests[k].label   = name_r.ok;
+        tests[k].line    = k + 1;
+        tests[k].mod_idx = 0;
+        k = k + 1;
+    }
+    val mr: res[ir.Module, fail.Fail] = synthesize_dispatcher(?s, ?tests[0], 2);
+    if (sel mr.err) { ret 1; }
+    var m: ir.Module = mr.ok;
+    fin { ir.dnit(?m); }
+
+    val main_r: res[intern.StrId, A.Error] = intern.intern(?s.interner, "main");
+    if (sel main_r.err) { ret 1; }
+    val main_ix: opt[u32] = ir.function_lookup(?m, main_r.ok);
+    if (sel main_ix.none) { ret 2; }
+    val fn: *ir.Function = ?m.functions[main_ix.some];
+
+    # every branch on a `255 <u result` compare must take the true edge to a block
+    # that does nothing but `ret 255`
+    var guarded: u32 = 0;
+    var i: u32 = 0;
+    for (i < fn.instr_len) {
+        val ins: *instruction.Instruction = ?fn.instrs[i];
+        if (ins.kind != instruction.OP_CBR || ins.operand_count != 3) { i = i + 1; cnt; }
+        if (ins.operands[0].kind != value.VAL_INSTR) { i = i + 1; cnt; }
+        val cond: *instruction.Instruction = ?fn.instrs[ins.operands[0].data.instr::u32];
+        if (cond.kind != instruction.OP_CMP_LT_U || cond.operand_count != 2
+            || cond.operands[0].kind != value.VAL_CONST_INT
+            || cond.operands[0].data.int_lit != TEST_STATUS_WIDE) { i = i + 1; cnt; }
+        guarded = guarded + 1;
+        val target: u32 = ins.operands[1].data.int_lit::u32;
+        if (target >= fn.block_count) { ret 3; }
+        val blk: *ir.Block = ?fn.blocks[target];
+        if (blk.instr_count != 0 || blk.phi_count != 0) { ret 4; }
+        val fold: *instruction.Instruction = ?fn.instrs[blk.terminator::u32];
+        if (fold.kind != instruction.OP_RET || fold.operand_count != 1
+            || fold.operands[0].kind != value.VAL_CONST_INT
+            || fold.operands[0].data.int_lit != TEST_STATUS_WIDE) { ret 5; }
+        i = i + 1;
+    }
+    # one guard per test
+    if (guarded != 2) { ret 6; }
+    ret 0;
 }

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -7698,50 +7698,49 @@ test "mach.lang.target.isa.arm64.encode.asm_ct_class:indirect_transfers_are_regi
 test "mach.lang.target.isa.arm64.encode.asm_ct_scan:register_indirect_transfer_on_secret_refused" {
     var alloc: A.Allocator;
     page.make(?alloc);
-    var bad: i32 = 0;
 
     var names: [1]str;
     names[0] = "r";
 
     val brt: str = "ldr x9, {r}\nbr x9";
     val r_7573: err[fail.Fail] = asm_ct_scan(brt, ?names[0], 1, false, false, ?alloc);
-    if (!sel r_7573.err) { bad = bad + 1; }
+    if (!sel r_7573.err) { ret 1; }
     val r_7574: err[fail.Fail] = asm_ct_scan(brt, ?names[0], 0, false, false, ?alloc);
-    if (sel r_7574.err) { bad = bad + 2; }
+    if (sel r_7574.err) { ret 2; }
 
     val blrt: str = "ldr x9, {r}\nblr x9";
     val r_7577: err[fail.Fail] = asm_ct_scan(blrt, ?names[0], 1, false, false, ?alloc);
-    if (!sel r_7577.err) { bad = bad + 4; }
+    if (!sel r_7577.err) { ret 3; }
     val r_7578: err[fail.Fail] = asm_ct_scan(blrt, ?names[0], 0, false, false, ?alloc);
-    if (sel r_7578.err) { bad = bad + 8; }
+    if (sel r_7578.err) { ret 4; }
 
     val rett: str = "ldr x30, {r}\nret";
     val r_7581: err[fail.Fail] = asm_ct_scan(rett, ?names[0], 1, false, false, ?alloc);
-    if (!sel r_7581.err) { bad = bad + 16; }
+    if (!sel r_7581.err) { ret 5; }
     val r_7582: err[fail.Fail] = asm_ct_scan(rett, ?names[0], 0, false, false, ?alloc);
-    if (sel r_7582.err) { bad = bad + 32; }
+    if (sel r_7582.err) { ret 6; }
 
     val retreg: str = "ldr x9, {r}\nret x9";
     val r_7585: err[fail.Fail] = asm_ct_scan(retreg, ?names[0], 1, false, false, ?alloc);
-    if (!sel r_7585.err) { bad = bad + 64; }
+    if (!sel r_7585.err) { ret 7; }
 
     val pubbr: str = "mov x9, 5\nbr x9";
     val r_7588: err[fail.Fail] = asm_ct_scan(pubbr, ?names[0], 1, false, false, ?alloc);
-    if (sel r_7588.err) { bad = bad + 128; }
+    if (sel r_7588.err) { ret 8; }
 
     val pubret: str = "mov x30, 5\nret";
     val r_7591: err[fail.Fail] = asm_ct_scan(pubret, ?names[0], 1, false, false, ?alloc);
-    if (sel r_7591.err) { bad = bad + 256; }
+    if (sel r_7591.err) { ret 9; }
 
     val ordinaryret: str = "ldr x0, {r}\nret";
     val r_7594: err[fail.Fail] = asm_ct_scan(ordinaryret, ?names[0], 1, false, false, ?alloc);
-    if (sel r_7594.err) { bad = bad + 512; }
+    if (sel r_7594.err) { ret 10; }
 
     val direct: str = "b some_symbol";
     val r_7597: err[fail.Fail] = asm_ct_scan(direct, ?names[0], 1, false, false, ?alloc);
-    if (sel r_7597.err) { bad = bad + 1024; }
+    if (sel r_7597.err) { ret 11; }
 
-    ret bad;
+    ret 0;
 }
 
 test "mach.lang.target.isa.arm64.encode.asm_ct_scan:cset_flags_taint_reaches_destination_register" {

--- a/src/lang/target/isa/arm64/inst.mach
+++ b/src/lang/target/isa/arm64/inst.mach
@@ -293,15 +293,17 @@ pub fun with_elem_bytes(flags: u16, eb: u8) u16 {
 }
 
 test "mach.lang.target.isa.arm64.inst.mnemonic:every_member_is_named_and_the_catalog_is_closed" {
+    # the status carries the op: 1..127 unnamed, 128..254 unknown
+    if (MOP_LAST::i32 > 127) { ret 255; }
     var op: MachOp = 1;
     for (op <= MOP_LAST) {
         if (mnemonic(op) == nil) { ret op::i32; }
-        if (!known(op))          { ret 1000 + op::i32; }
+        if (!known(op))          { ret 128 + op::i32; }
         op = op + 1;
     }
-    if (mnemonic(MOP_NONE) != nil)     { ret 2001; }
-    if (mnemonic(MOP_LAST + 1) != nil) { ret 2002; }
-    if (known(MOP_NONE) || known(MOP_LAST + 1)) { ret 2003; }
+    if (mnemonic(MOP_NONE) != nil)     { ret 251; }
+    if (mnemonic(MOP_LAST + 1) != nil) { ret 252; }
+    if (known(MOP_NONE) || known(MOP_LAST + 1)) { ret 253; }
     ret 0;
 }
 

--- a/src/lang/target/isa/riscv/encode.mach
+++ b/src/lang/target/isa/riscv/encode.mach
@@ -6242,42 +6242,41 @@ test "mach.lang.target.isa.riscv.encode.asm_ct_class:indirect_transfers_are_regi
 test "mach.lang.target.isa.riscv.encode.asm_ct_scan:register_indirect_transfer_on_secret_refused" {
     var alloc: A.Allocator;
     page.make(?alloc);
-    var bad: i32 = 0;
 
     var names: [1]str;
     names[0] = "r";
 
     val jrt: str = "ld a1, {r}\njr a1";
     val r_6188: err[fail.Fail] = asm_ct_scan(jrt, ?names[0], 1, false, false, ?alloc);
-    if (!sel r_6188.err) { bad = bad + 1; }
+    if (!sel r_6188.err) { ret 1; }
     val r_6189: err[fail.Fail] = asm_ct_scan(jrt, ?names[0], 0, false, false, ?alloc);
-    if (sel r_6189.err) { bad = bad + 2; }
+    if (sel r_6189.err) { ret 2; }
 
     val jalrt: str = "ld a1, {r}\njalr ra, a1, 0";
     val r_6192: err[fail.Fail] = asm_ct_scan(jalrt, ?names[0], 1, false, false, ?alloc);
-    if (!sel r_6192.err) { bad = bad + 4; }
+    if (!sel r_6192.err) { ret 3; }
     val r_6193: err[fail.Fail] = asm_ct_scan(jalrt, ?names[0], 0, false, false, ?alloc);
-    if (sel r_6193.err) { bad = bad + 8; }
+    if (sel r_6193.err) { ret 4; }
 
     val rett: str = "ld ra, {r}\nret";
     val r_6196: err[fail.Fail] = asm_ct_scan(rett, ?names[0], 1, false, false, ?alloc);
-    if (!sel r_6196.err) { bad = bad + 16; }
+    if (!sel r_6196.err) { ret 5; }
     val r_6197: err[fail.Fail] = asm_ct_scan(rett, ?names[0], 0, false, false, ?alloc);
-    if (sel r_6197.err) { bad = bad + 32; }
+    if (sel r_6197.err) { ret 6; }
 
     val pubjr: str = "li a1, 5\njr a1";
     val r_6200: err[fail.Fail] = asm_ct_scan(pubjr, ?names[0], 1, false, false, ?alloc);
-    if (sel r_6200.err) { bad = bad + 64; }
+    if (sel r_6200.err) { ret 7; }
 
     val ordinaryret: str = "ld a0, {r}\nret";
     val r_6203: err[fail.Fail] = asm_ct_scan(ordinaryret, ?names[0], 1, false, false, ?alloc);
-    if (sel r_6203.err) { bad = bad + 128; }
+    if (sel r_6203.err) { ret 8; }
 
     val direct: str = "j 1f\n1:";
     val r_6206: err[fail.Fail] = asm_ct_scan(direct, ?names[0], 1, false, false, ?alloc);
-    if (sel r_6206.err) { bad = bad + 256; }
+    if (sel r_6206.err) { ret 9; }
 
-    ret bad;
+    ret 0;
 }
 
 test "mach.lang.target.isa.riscv.encode.asm_ct_class:every_grammar_row_is_classified" {


### PR DESCRIPTION
Closes #3241

## What was wrong

The dispatcher returned the test's `i32` from `main` unchanged. A POSIX kernel keeps the low eight bits of an exit status, so a test returning `256` exited `0` and `mach test` reported it as passing on linux and darwin, while windows preserved the full code and reported `(exit 256)`. The tree carried four tests whose accumulated result could grow past eight bits.

## The contract

The test result is a process status in `0..255`, enforced at both ends (recorded in `doc/design/test-status-range.md`, stated in `doc/language/test.md` and the `synthesize_dispatcher` docstring):

- **At the `ret`, at compile time.** A literal-shaped `ret` (literal, negated literal, arithmetic over literals) outside `0..255` in a test body is a located error naming the value: `test result 256 is outside the status range 0..255`, with a note. The check probes the literal range against `u8` without retyping anything; ordinary `i32` functions are untouched.
- **At the dispatcher, at run time.** The synthesized entry compares the result against `255` unsigned (one compare per test) and exits `255` for anything outside the range (one shared fold block). The value is lost, the failure is not, and every host reports the same status.

A result channel other than the exit code was not built: the runner has no pipe to the child (it redirects stdout/stderr into a capture file and reads the exit status), and the dispatcher is target-agnostic IR with no runtime behind it, so any channel would mean a per-OS `write` in the compiler or a by-name dependence on a std symbol that is only linked when used. The design page records the alternatives.

## Fixtures

`riscv/encode.mach` (the bit-256 mask the issue names), `arm64/encode.mach` (bit 1024), `me/lower/constagg.mach` (bit 4096) and `arm64/inst.mach` (`ret 1000 + op`) now return the ordinal of the first failing check.

## Verification

- Full suite through the from-source compiler: 3009 passed, 0 failed (baseline 3006 at be058d846; +3 by name: `testrunner.synthesize_dispatcher:folds_a_wide_result_to_the_status_range`, `driver:test_result_outside_the_status_range_is_refused_at_the_ret`, `driver:dispatcher_folds_a_wide_run_time_result_to_255`; 0 removed).
- `sh test/census.sh`: all ok. `doc-agreement.py`, `doc-examples.py`, `check-changelog.sh`: ok.
- Cross-builds of the compiler for `windows-x86_64` and `darwin-aarch64` succeed. The runner side is unchanged (windows still reads the full preserved status). A scratch suite cross-compiled for windows and run under wine reports the same statuses as linux (`256`, `300`, `-1`, `-256` as `(exit 255)`, `3` as `(exit 3)`).
- Mutation controls: unwiring the fold's true edge (`cbr` to `b_narrow, b_narrow`) makes the IR test fail (exit 4) and the driver test fail with `r256: exit 0 (want 255)`, and a scratch test returning `256` passes wrongly again; disabling the sema check makes the refusal test fail (exit 6). Both restored.
