### PR TITLE
refactor(comptime): delete the unreachable manifest defines table (#3131)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -492,6 +492,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   4 is reserved as `MOS6502_WITHDRAWN`. The width legalization pass the target
   drove stays as shared infrastructure, exercised by its unit tests and the
   riscv32 column (#3226, #3112).
+- The comptime manifest defines table. `$mach.build.<name>` was documented as
+  a lookup of a manifest `defines` key, but no manifest key ever populated the
+  driver's define list, so the comptime environment's define table, its
+  binding step and its slot in the build fingerprint were unreachable. The
+  known `$mach.build.*` members are unchanged; a name outside them is refused
+  at the use site as `` unknown `$mach.*` path `` (#3131).
 
 ## [4.30.0] - 2026-09-07
 

--- a/doc/language/comptime-mach.md
+++ b/doc/language/comptime-mach.md
@@ -6,7 +6,7 @@ constants. The tags `$mach.{os,arch,abi,mode}.*` exist for path-value
 comparison against the resolved-build facts.
 
 > **Live and reserved paths.** The resolved-build facts (`$mach.build.{os,arch,
-> abi,pointer_width,mode,pie}`), the tag tables (`$mach.{os,arch,abi,mode}.*`),
+> abi,pointer_width,mode,pie,platform}`), the tag tables (`$mach.{os,arch,abi,mode}.*`),
 > the compiler version (`$mach.version` and `$mach.version.{major,minor,patch}`),
 > and `$mach.compiler.{name,version}` are live. The `$mach.build.{timestamp,
 > host}`, `$mach.build.git.*`, `$mach.project.*`, and `$mach.source.*` paths are
@@ -29,19 +29,19 @@ $mach.build.abi                 # live; compared against $mach.abi.* tags
 $mach.build.pointer_width       # live; integer count of bytes
 $mach.build.mode                # live; compared against $mach.mode.* tags
 $mach.build.pie                 # live; 1 when building position-independent, else 0
+$mach.build.platform            # live; the target's open platform tag as a string, "" when unset
 $mach.build.timestamp           # stub — not yet available
 $mach.build.host                # stub — not yet available
 $mach.build.git.commit          # stub — not yet available
 $mach.build.git.dirty           # stub — not yet available
 ```
 
-A bare `$mach.build.<name>` that names none of the facts above is a compile
-error (`` no manifest define named in `$mach.build.<name>` ``). The manifest
-schema has no key that declares such a define, so today every other name is
-refused; a project's own configuration constants are ordinary `val`s selected
-with `$if` over the facts above.
+The members above are the whole subtree, and no manifest key adds one. A
+`$mach.build.<name>` that names none of them is a compile error at the use site
+(`` unknown `$mach.*` path ``). A project's own configuration constants are
+ordinary `val`s selected with `$if` over the facts above.
 
-```mach reject "no manifest define named"
+```mach reject "unknown `$mach.*` path"
 val TRACING: u64 = $mach.build.TRACING;
 ```
 

--- a/src/lang/driver/load.mach
+++ b/src/lang/driver/load.mach
@@ -370,13 +370,6 @@ fun module_context(p: *project.Project, req: *request.BuildRequest) res[comptime
         p.target_entry.os_name, p.target_entry.isa_name, p.target_entry.abi_name,
         p.target_entry.platform_name,
         p.config.bin_name);
-
-    val bd_r: err[fail.Fail] = bind_defines(p, ?ctx);
-    if (sel bd_r.err) {
-        val message: str = fail.describe(bd_r.err);
-        comptime.dnit(?ctx);
-        ret res[comptime.ComptimeCtx, fail.Fail].err{fail.message(message)};
-    }
     ret res[comptime.ComptimeCtx, fail.Fail].ok{ctx};
 }
 
@@ -463,105 +456,6 @@ fun register_module_slot(p: *project.Project, fqn: intern.StrId) res[session.Mod
     p.module_len = p.module_len + 1;
     p.load_status[mid::u32] = project.LOAD_LOADING;
     ret res[session.ModuleId, fail.Fail].ok{mid};
-}
-
-fun bind_defines(p: *project.Project, ctx: *comptime.ComptimeCtx) err[fail.Fail] {
-    if (p.config.define_count == 0) { ret err[fail.Fail].ok{}; }
-    var i: u32 = 0;
-    for (i < p.config.define_count) {
-        val s_opt: opt[str] = intern.lookup(?p.s.interner, p.config.defines[i]);
-        if (sel s_opt.none) { ret err[fail.Fail].err{fail.message("define StrId not interned")}; }
-        val r: err[fail.Fail] = bind_one_define(p, ctx, s_opt.some);
-        if (sel r.err) { ret r; }
-        i = i + 1;
-    }
-    ret err[fail.Fail].ok{};
-}
-
-fun bind_one_define(p: *project.Project, ctx: *comptime.ComptimeCtx, s: str) err[fail.Fail] {
-    val n: usize = str_len(s);
-    var eq: usize = n;
-    var k: usize = 0;
-    for (k < n) {
-        if (s[k] == '=') { eq = k; brk; }
-        k = k + 1;
-    }
-    if (eq == 0) { ret err[fail.Fail].err{fail.message(diag_join3(p.s, "mach.toml: define '", s, "' has an empty name", "mach.toml: a define has an empty name"))}; }
-
-    val name_r: res[intern.StrId, A.Error] = intern.intern_bytes(?p.s.interner, s, eq);
-    if (sel name_r.err) { ret err[fail.Fail].err{fail.refused(name_r.err)}; }
-    val name_id: intern.StrId = name_r.ok;
-
-    var v: comptime.CTValue;
-    v.int_unsigned = false;
-    v.int_width    = 0;
-
-    if (eq == n) {
-        v = comptime.ct_u8(1);
-    }
-    or {
-        val vstart: usize = eq + 1;
-        val vlen:   usize = n - vstart;
-        var iv: i64 = 0;
-        if (parse_define_int(s, vstart, vlen, ?iv)) {
-            if (iv == 0 || iv == 1) { v = comptime.ct_u8(iv::u8); }
-            or { v.kind = comptime.CT_KIND_INT; v.data.i = iv; }
-        }
-        or {
-            val vr: res[intern.StrId, A.Error] = intern.intern_bytes(?p.s.interner, (s::usize + vstart)::str, vlen);
-            if (sel vr.err) { ret err[fail.Fail].err{fail.refused(vr.err)}; }
-            v.kind = comptime.CT_KIND_STR; v.data.s = vr.ok;
-        }
-    }
-
-    ret comptime.bind_define(ctx, name_id, v);
-}
-
-fun parse_define_int(s: str, start: usize, len: usize, out: *i64) bool {
-    if (len == 0) { ret false; }
-    var i: usize = 0;
-    var neg: bool = false;
-    if (s[start] == '-') {
-        if (len == 1) { ret false; }
-        neg = true;
-        i = 1;
-    }
-    var base: u64 = 10;
-    if (len - i >= 2 && s[start + i] == '0') {
-        val c1: u8 = s[start + i + 1];
-        if (c1 == 'x') { base = 16; i = i + 2; }
-        or (c1 == 'b') { base = 2;  i = i + 2; }
-        or (c1 == 'o') { base = 8;  i = i + 2; }
-    }
-
-    var value:     u64 = 0;
-    var saw_digit: bool = false;
-    val u64_max:   u64 = 0xFFFFFFFFFFFFFFFF;
-    for (i < len) {
-        val c: u8 = s[start + i];
-        if (c == '_') { i = i + 1; cnt; }
-        var digit: i64 = 0 - 1;
-        if      (c >= '0' && c <= '9')       { digit = (c - '0')::i64; }
-        or      (c >= 'a' && c <= 'f')       { digit = (c - 'a')::i64 + 10; }
-        or      (c >= 'A' && c <= 'F')       { digit = (c - 'A')::i64 + 10; }
-        if (digit < 0 || digit::u64 >= base) { ret false; }
-        val d: u64 = digit::u64;
-        if (value > (u64_max - d) / base) { ret false; }
-        value = value * base + d;
-        saw_digit = true;
-        i = i + 1;
-    }
-    if (!saw_digit) { ret false; }
-
-    val signed_max: u64 = 0x7FFFFFFFFFFFFFFF;
-    if (neg) {
-        if (value > signed_max + 1) { ret false; }
-        @out = 0 - value::i64;
-        ret true;
-    }
-    if (value > signed_max) { ret false; }
-    @out = value::i64;
-    ret true;
 }
 
 fun parse_module(p: *project.Project, mid: session.ModuleId, fqn: intern.StrId) err[fail.Fail] {

--- a/src/lang/driver/passes.mach
+++ b/src/lang/driver/passes.mach
@@ -2550,15 +2550,6 @@ fun write_configuration_identity(fb: *dq.FpBuf, p: *project.Project) err[fail.Fa
     if (sel a9.err) { ret a9; }
     val ab: err[fail.Fail] = dq.fp_name(fb, ?p.s.interner, p.config.bin_name);
     if (sel ab.err) { ret ab; }
-
-    val ac: err[fail.Fail] = dq.fp_u32(fb, p.config.define_count);
-    if (sel ac.err) { ret ac; }
-    var i: u32 = 0;
-    for (i < p.config.define_count) {
-        val ad: err[fail.Fail] = dq.fp_name(fb, ?p.s.interner, p.config.defines[i]);
-        if (sel ad.err) { ret ad; }
-        i = i + 1;
-    }
     ret write_step_declarations(fb, p);
 }
 
@@ -2937,8 +2928,8 @@ test "mach.lang.driver.passes.write_build_config:every_tuple_field_moves_the_fin
     base.target_entry = ?te;
     base.config       = cfg;
 
-    val N: usize = 11;
-    var digests: [11][32]u8;
+    val N: usize = 10;
+    var digests: [10][32]u8;
     if (!ut_fp_digest(?alloc, ?base, ?digests[0][0])) { ret 1; }
 
     var v: project.Project = base;
@@ -2966,15 +2957,6 @@ test "mach.lang.driver.passes.write_build_config:every_tuple_field_moves_the_fin
     v = base; v.req.profile = "release";
     if (!ut_fp_digest(?alloc, ?v, ?digests[8][0])) { ret 1; }
 
-    var define_ids: [1]intern.StrId;
-    val intern_r: res[intern.StrId, A.Error] = intern.intern(?s.interner, "TRACE");
-    if (sel intern_r.err) { ret 99; }
-    define_ids[0] = intern_r.ok;
-    v = base;
-    v.config.defines      = ?define_ids[0];
-    v.config.define_count = 1;
-    if (!ut_fp_digest(?alloc, ?v, ?digests[9][0])) { ret 1; }
-
     var env_keys:   [1]intern.StrId;
     var env_values: [1]intern.StrId;
     val intern_r2: res[intern.StrId, A.Error] = intern.intern(?s.interner, "MODE");
@@ -2993,7 +2975,7 @@ test "mach.lang.driver.passes.write_build_config:every_tuple_field_moves_the_fin
     v = base;
     v.config.steps      = ?steps[0];
     v.config.step_count = 1;
-    if (!ut_fp_digest(?alloc, ?v, ?digests[10][0])) { ret 1; }
+    if (!ut_fp_digest(?alloc, ?v, ?digests[9][0])) { ret 1; }
 
     var i: usize = 0;
     for (i < N) {

--- a/src/lang/driver/project.mach
+++ b/src/lang/driver/project.mach
@@ -114,8 +114,6 @@ pub rec ProjectConfig {
     target_count: u32;
     deps:         *DepEntry;
     dep_count:    u32;
-    defines:      *intern.StrId;
-    define_count: u32;
     cascade_libs:      *manifest.LinkRequirement;
     cascade_lib_count: u32;
     profile:      intern.StrId;
@@ -625,8 +623,6 @@ pub fun init_project(p: *Project, s: *session.Session) {
     p.config.target_count = 0;
     p.config.deps         = nil;
     p.config.dep_count    = 0;
-    p.config.defines       = nil;
-    p.config.define_count  = 0;
     p.config.cascade_libs      = nil;
     p.config.cascade_lib_count = 0;
     p.config.art_reqs      = nil;
@@ -668,9 +664,6 @@ fun deallocate_config(c: *ProjectConfig, alloc: *A.Allocator) {
     }
     if (c.deps != nil && c.dep_count > 0) {
         free_dep_entries(alloc, c.deps, c.dep_count, c.dep_count::usize);
-    }
-    if (c.defines != nil && c.define_count > 0) {
-        A.deallocate[intern.StrId](alloc, c.defines, c.define_count::usize);
     }
     if (c.cascade_libs != nil && c.cascade_lib_count > 0) {
         manifest.free_link_claims(alloc, c.cascade_libs, c.cascade_lib_count);
@@ -719,8 +712,6 @@ fun deallocate_config(c: *ProjectConfig, alloc: *A.Allocator) {
     c.target_count = 0;
     c.deps         = nil;
     c.dep_count    = 0;
-    c.defines       = nil;
-    c.define_count  = 0;
     c.cascade_libs      = nil;
     c.cascade_lib_count = 0;
     c.steps = nil;

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -12533,6 +12533,16 @@ test "mach.lang.driver:project_name_and_description_paths_are_refused_naming_the
     ret 0;
 }
 
+# `$mach.build.*` has no manifest-defined members (#3131): a name outside the
+# known set is refused at the use site as an unknown path, and a known member
+# on the line before it still resolves
+test "mach.lang.driver:unknown_mach_build_member_is_refused_at_the_use_site" {
+    val src: str = "val w: u64 = $mach.build.pointer_width;\nval n: u64 = $mach.build.nosuch;\nfun main() i32 { ret 0; }\n";
+    if (!ut_sema_rejects_at(src, "unknown `$mach.*` path", 53, 18)) { ret 1; }
+    if (!ut_sema_clean("val w: u64 = $mach.build.pointer_width;\nfun main() i32 { ret 0; }\n")) { ret 2; }
+    ret 0;
+}
+
 # with the untyped `:^` gone, a generic body names the public type it expects and
 # the template defers the equality to each instance
 test "mach.lang.driver:generic_strip_target_is_checked_per_instance" {

--- a/src/lang/fe/comptime.mach
+++ b/src/lang/fe/comptime.mach
@@ -681,9 +681,6 @@ pub rec ComptimeEnv {
     va_list_align:  u32;
     compiler_name:  intern.StrId;
     compiler_ver:   intern.StrId;
-    defines:        *NamedConst;
-    define_len:     u32;
-    define_cap:     u32;
     project_id:     intern.StrId;
     project_ver:    intern.StrId;
     target_os:      intern.StrId;
@@ -748,9 +745,6 @@ pub fun init(
     c.env.va_list_align   = 0;
     c.env.compiler_name   = compiler_name;
     c.env.compiler_ver    = compiler_ver;
-    c.env.defines         = nil;
-    c.env.define_len      = 0;
-    c.env.define_cap      = 0;
     c.env.project_id      = intern.STR_NIL;
     c.env.project_ver     = intern.STR_NIL;
     c.env.target_os       = intern.STR_NIL;
@@ -812,9 +806,6 @@ pub fun dnit(c: *ComptimeCtx) {
     if (c.entries != nil && c.entries_cap > 0) {
         A.deallocate[NamedConst](c.env.alloc, c.entries, c.entries_cap::usize);
     }
-    if (c.env.defines != nil && c.env.define_cap > 0) {
-        A.deallocate[NamedConst](c.env.alloc, c.env.defines, c.env.define_cap::usize);
-    }
     c.entries     = nil;
     c.entries_len = 0;
     c.entries_cap = 0;
@@ -827,9 +818,6 @@ pub fun dnit(c: *ComptimeCtx) {
     if (c.load_walked != nil && c.gate_decl_count > 0) {
         A.deallocate[bool](c.env.alloc, c.load_walked, c.gate_decl_count::usize);
     }
-    c.env.defines     = nil;
-    c.env.define_len  = 0;
-    c.env.define_cap  = 0;
     c.deferred    = nil;
     c.deferred_len = 0;
     c.deferred_cap = 0;
@@ -981,32 +969,6 @@ pub fun field_type_of_binding[T](c: *ComptimeCtx, cap_ctx: *T, caps: PhaseCapabi
     val v: CTValue = o.some;
     if (v.kind != CT_KIND_TYPE) { ret res[opt[u32], EvalFail].ok{opt[u32].none{}}; }
     ret res[opt[u32], EvalFail].ok{opt[u32].some{v.data.t}};
-}
-
-pub fun bind_define(c: *ComptimeCtx, name: intern.StrId, value: CTValue) err[fail.Fail] {
-    var i: u32 = 0;
-    for (i < c.env.define_len) {
-        if (c.env.defines[i].name == name) {
-            c.env.defines[i].value = value;
-            ret err[fail.Fail].ok{};
-        }
-        i = i + 1;
-    }
-
-    var nc: NamedConst;
-    nc.name  = name;
-    nc.value = value;
-    nc.gated = false;
-    ret consts_push(c.env.alloc, ?c.env.defines, ?c.env.define_len, ?c.env.define_cap, nc);
-}
-
-pub fun lookup_define(c: *ComptimeCtx, name: intern.StrId) opt[NamedConst] {
-    var i: u32 = 0;
-    for (i < c.env.define_len) {
-        if (c.env.defines[i].name == name) { ret opt[NamedConst].some{c.env.defines[i]}; }
-        i = i + 1;
-    }
-    ret opt[NamedConst].none{};
 }
 
 fun consts_push(a: *A.Allocator, arr: **NamedConst, len: *u32, cap: *u32, nc: NamedConst) err[fail.Fail] {
@@ -2098,9 +2060,7 @@ fun gate_name_probe_node[T](g: *GateNameProbe[T], eid: id.ExprId, e: *expr.Expr)
     if (sel r.err) { g.failure = err[fail.Fail].err{fail.refused(r.err)}; ret GATE_NODE_PRUNE; }
     val name: intern.StrId = r.ok;
     val bound: opt[NamedConst] = lookup(g.c, name);
-    if (sel bound.some)        { ret GATE_NODE_NO; }
-    val defined: opt[NamedConst] = lookup_define(g.c, name);
-    if (sel defined.some) { ret GATE_NODE_NO; }
+    if (sel bound.some) { ret GATE_NODE_NO; }
     g.found = name;
     ret GATE_NODE_PRUNE;
 }
@@ -3514,13 +3474,6 @@ fun resolve_mach_path(c: *ComptimeCtx, source: str, stack: *token.Span, depth: u
     if (depth == 4 && seg_is(source, stack, 2, "build") && seg_is(source, stack, 1, "git")
      && (seg_is(source, stack, 0, "commit") || seg_is(source, stack, 0, "dirty"))) {
         ret reject("`$mach.build.git.*` is not yet available");
-    }
-    if (depth == 3 && seg_is(source, stack, 1, "build")) {
-        val nr: res[intern.StrId, A.Error] = intern.intern_span(interner, source, stack[0]);
-        if (sel nr.err) { ret internal_failure(alloc.text(nr.err)); }
-        val d_opt: opt[NamedConst] = lookup_define(c, nr.ok);
-        if (sel d_opt.some) { ret res[CTValue, EvalFail].ok{d_opt.some.value}; }
-        ret reject("no manifest define named in `$mach.build.<name>`");
     }
 
     if (depth == 3 && seg_is(source, stack, 1, "source")


### PR DESCRIPTION
Refs #3131. Owner ruling 2026-09-12 following D1's finding in #3293: `$mach.build.<name>` was documented as a manifest `defines` lookup, but no manifest key ever populated the driver's define list. Its only writer was the fingerprint unit test.

Removed end to end:

- `ComptimeEnv.defines/define_len/define_cap`, `bind_define`, `lookup_define`, the gate-name probe's consult of the table and the `$mach.build.<name>` fallthrough arm that read it (`src/lang/fe/comptime.mach`)
- `ProjectConfig.defines/define_count` and their init/free (`src/lang/driver/project.mach`)
- `bind_defines`, `bind_one_define`, `parse_define_int` and the call in comptime context construction (`src/lang/driver/load.mach`)
- the define count/name slot in `write_configuration_identity` and the test digest that was its only writer (`src/lang/driver/passes.mach`)
- the doc paragraph and reject example that described the table; `platform` is now listed with the other live members (`doc/language/comptime-mach.md`); changelog entry under Unreleased/Removed

Every known `$mach.build.*` member and its tests are untouched. A name outside the set now falls through to `` unknown `$mach.*` path `` at the use site; a new driver test pins that diagnostic and its span (`mach.lang.driver:unknown_mach_build_member_is_refused_at_the_use_site`).

Verification (compiler built from this tree by the v5 stage, 4.30 seed cannot build dev):

- `mach test .`: 3010 passed, 0 failed (baseline 3009, delta is the one added test)
- `sh test/census.sh`: all ok
- `test/doc-agreement.py` ok; `test/doc-examples.py` 99 exercised ok, the rewritten `comptime-mach.md` reject fence included
- fixpoint: A (stage) == B (A) == C (B), byte-identical, so the fingerprint slot removal changed no emitted bytes
- corpus layer B, x86_64-linux: 102 pass, 0 fail, 0 skip
