### PR TITLE
codegen: sparse liveness, linear verifier and DWARF indexes, a running cache inventory (#2299)

### DIFF
--- a/doc/design/r2-measurements.md
+++ b/doc/design/r2-measurements.md
@@ -291,7 +291,7 @@ today, and the 2026-09-06 archive's modules-150 debug serial cell was 52.1
 MiB (CI runner) against 57.9 here and 52.9 for the seed. Wall is linear in
 `modules` (1.57 s at 400) and, at release, in `dense` (1.34 s at 400).
 
-### Two cliffs, reported with their cause (not fixed here)
+### Two cliffs, reported with their cause (addressed below)
 
 **blocks: memory and time quadratic in one function's size.** Peak per
 doubling of N: 2.58x, 3.32x, 3.71x (approaching 4x; 970 MiB for one
@@ -332,6 +332,136 @@ functions of one module. The synthetic profile has `debug = true`; the
 compiler's own profiles do not, which is why the self-build does not show
 it. The fix is one sweep over the offset-sorted symbols and rows per module
 (or a binary search into a function table sorted by offset).
+
+### Cliffs addressed
+
+Branch `fix/2299-cliffs` on dev `278dc07e5` (std `248b6e77a`), 2026-09-12,
+the debug-profile compiler built by the v5 stage (`out/audit/mach`) against
+the same tree built by the dev compiler (`out/base/mach`, the "before"
+column); every cell a fresh process on this host with the other lanes'
+load as given. Every fix is an index or a propagation over the structure
+the scan walked, and none changes an output: corpus layer B goldens on
+x86_64, aarch64 and riscv64 are byte-identical, the compiler's own debug,
+release and release `-g` self-builds by the before and after compilers are
+byte-identical (so the sparse liveness makes the same allocation decisions,
+not fewer spills: no golden moved), the `-g` debuginfo fixture at both
+profiles on the three ISAs is byte-identical, and the x86_64 link leg
+passes its 142 cells.
+
+**1. Dense liveness (`regalloc.extend_liveness`).** The four
+`block_count x vreg_count` matrices are gone; liveness is a backward
+reachability per register over grouped use blocks, definition blocks and
+predecessor edges (`fad388ec5`). The dense equations survive as the test
+oracle for sixteen small graphs.
+
+blocks, peak RSS MiB (wait4) / wall s, jobs 1, uncached, debug:
+
+| N | before | after (sparse liveness only) | after (whole series) |
+|---|---|---|---|
+| 500 | 33.1 / 0.85 | 20.8 / 0.78 | 19.4 / 0.05 |
+| 1000 | 81.9 / 3.31 | 27.8 / 3.00 | 26.2 / 0.09 |
+| 2000 | 262.8 / 12.88 | 41.6 / 11.79 | 41.3 / 0.17 |
+| 4000 | 973.3 / 51.13 | 56.9 / 48.01 (69.4 and 68.7 on repetition, THP `always`) | 70.1 / 0.33 |
+
+The harness's own cells (jobs 1 and 4, off, cold and warm, one
+repetition, `test/out/memory-blocks`) put the largest peak at 18.1 / 24.9
+/ 38.7 / 65.8 MiB debug and 17.9 / 24.3 / 37.2 / 63.0 release at 500 /
+1000 / 2000 / 4000: 1.37x, 1.55x and 1.70x per doubling against 2.58x,
+3.32x and 3.71x, an intercept near the spawner floor and about 13 MiB per
+1000 conditionals. Wall at release: 0.06 / 0.12 / 0.23 / 0.47 s against
+1.59 / 6.48 / 24.77 / 99.49.
+
+**2. Verifier (`verify.check_pred_consistency`).** One successor sweep
+groups the actual edges by target and each block settles its declared
+list against its own group; `check_phi_coverage` had the same
+reset-per-phi shape and settles the same way (`776926442`). A
+declared-only predecessor, which only the declared side of the multiset
+check can see, gains a test.
+
+| workload | before | after |
+|---|---|---|
+| blocks-2000 debug wall (sparse liveness in both) | 11.93 s | 1.24 s |
+
+The remaining 1.24 s was three more quadratic shapes in the same
+function, each addressed at its cause and each output-identical:
+`looprotate` cost a sweep of the function per candidate header
+(confinement of the header's definitions and the in-loop marks are
+indexed once per function, the body walk is bounded to the header's
+strongly connected component, `6262368b8`), `mutate.erase_marked`
+salvaged the dbg_values of each erased instruction by a scan of the
+function (one pass, `7d4370fd8`), `loops.dominates` walked the idom chain
+per query on a dominator tree as deep as the chain (interval numbering,
+`5970ec8de`), and `encode.block_offset` and `mir.lower`'s block lookup
+scanned per branch fixup and per phi predecessor (keyed, `d17b11ac4`).
+
+| blocks-4000 debug wall | 51.13 s (dev) | 4.6 s (verifier fixed) | 1.24 s (looprotate) | 0.43 s (salvage, dominance) | 0.33 s (block keys) |
+|---|---|---|---|---|---|
+
+**3. DWARF (`dwarf.ir_function_at`, `build_line`, `first_row_loc`,
+`gather_vars`).** One `FuncIndex` per module: the text section's function
+symbols by offset (ties by symbol index, the order the stable sort
+produced), a first-per-name mir function table, and the rows, variable
+locations and inline pcs grouped per function in their own order; the
+function holding a pc is a binary search, with the first symbol of an
+offset group for `ir_function_at` and the last for the sized `DwFunc`, as
+the scans answered. The string table carries an open-addressed index and
+the relocation install keys the image's symbols by name once
+(`0d011f987`). The two name lookups left in the profile, codegen's
+`function_defined_get` per emitted symbol and the linker's
+`module_weak_function_ref_is_dead` per debug relocation, go through the
+IR's `fn_by_name` table and a first-defined-per-name map per module
+(`5dd89e7da`). A refused DWARF buffer now fails the section install
+instead of copying a truncated section.
+
+dense at debug (`debug = true`, 16 functions per group), wall s, jobs 1:
+
+| groups (functions) | before | after |
+|---|---|---|
+| 50 (802) | | 0.13 |
+| 150 (2402) | 1.22 | 0.36 |
+| 400 (6402) | 7.25 to 7.34 | 0.97 |
+
+150 to 400 is 2.7x the time for 2.67x the functions (7.8x before). The
+`-g` bytes are identical as stated above.
+
+**4. Store (`store.make_room`).** The store keeps a journal
+(`.mach-store-index`) beside its entries under the lock: an add record
+ahead of every entry write, a remove record behind every unlink, a seal
+with the directory's modification time after each publication. A
+publication reads the journal for the total and the oldest-first order
+and stats only its victims. Every entry write follows its add record and
+every remove record follows its unlink, so an interrupted step can only
+leave the journal listing more than the directory holds, never less: a
+sealed journal whose seal matches the directory's time on arrival (taken
+before the lock's own housekeeping moves it) is taken as is, otherwise
+one listing without stats counts the entries, an equal count settles it,
+and a discrepancy reconciles and rewrites. A missing or malformed journal
+is rebuilt from the directory inventory, a foreign name still refuses the
+directory, and a journal past twice its live entries is compacted
+(`6dbecfba4`). The eviction policy and its tests are unchanged.
+
+Publish build of the compiler's own tree (debug, 280 publications, each
+round a distinct comment in `src/lang/version.mach`), btrfs, the store
+at 6,210 entries and 536,845,552 bytes ("full", evicting on every
+publication) or holding only the previous round ("small"):
+
+| store | before | after |
+|---|---|---|
+| full | 25.9, 26.3, 25.9, 26.3 s | 23.7, 23.9, 23.1, 23.1 s |
+| small | 21.6, 21.7, 21.4, 21.4 s | 20.5, 20.6, 20.4, 20.4 s |
+| full minus small | 4.3 s (1.75 million stats) | 2.7 s |
+
+The store never exceeded its limit in any round (536,845,552 bytes after
+each). Of the remaining 2.7 s, `strace -c` and `perf` put 0.5 s in the
+journal parse (6,210 records per publication through the debug
+compiler) and the rest in the transaction layer's own recovery scan,
+which lists the whole directory on every lock acquisition (`std`,
+`transaction.recover`, ten `getdents64` calls per access at this size);
+that scan is the next cliff and belongs to mach-std.
+
+**Bar.** `blocks` is linear in memory and time, `dense` at debug is
+linear in time, the full-store publication no longer stats the
+directory; the thresholds below carry the new `blocks` ceilings.
 
 ## Storage bounds (#3221)
 
@@ -457,15 +587,18 @@ multiple:
   with more margin.
 - **synthetic families, 1.5x with a 32 MiB minimum**: modules 41 / 88 /
   201 MiB at 50 / 150 / 400, dense 50 / 118 / 279 debug and 48 / 111 / 260
-  release, blocks 47 / 119 / 393 at 500 / 1000 / 2000, and 32 MiB for
-  every cell within a few MiB of the spawner floor (modules-10, dense-10,
-  the aggregate family). The multiple is wider than the self-build's
+  release, and 32 MiB for every cell within a few MiB of the spawner
+  floor (modules-10, dense-10, the aggregate family). The blocks ceilings
+  were 47 / 119 / 393 at 500 / 1000 / 2000 under the dense liveness sets
+  and are from the sparse liveness (above) now: 32 / 37 / 58 / 99 debug
+  and 32 / 36 / 56 / 94 release at 500 / 1000 / 2000 / 4000 for measured
+  peaks of 18.1 / 24.9 / 38.7 / 65.8 and 17.9 / 24.3 / 37.2 / 63.0, and
+  4000 is a default size of the harness. The multiple is wider than the self-build's
   because these peaks are 10 to 200 MiB, where the mapped executable's
   resident share (up to 4 MiB between staging filesystems) and the spawner
   floor are a visible fraction; 1.5x still catches a return of the July
   slope (0.84 against 0.31 MiB/module would be 2.7x at 400 modules) and a
-  doubling of any family. The blocks ceilings describe the dense liveness
-  sets above and come down when they are replaced.
+  doubling of any family.
 - **no wall-time thresholds.** Wall on this host moved up to 20 percent
   with the other lanes' load (the load column is beside every row), and a
   CI runner is a different machine; time is recorded per cell and read

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -1582,7 +1582,14 @@ fun rebased_text_offset(placements: *SectionPlacement, count: u32, offset: u32) 
     ret offset - shift;
 }
 
+# the module's name table answers first; the scan remains for a module whose
+# table names an extern declaration while a definition of the same name exists
 fun function_defined_get(irmod: *ir.Module, name: intern.StrId) opt[*ir.Function] {
+    val known: opt[u32] = ir.function_lookup(irmod, name);
+    if (sel known.some) {
+        val kf: *ir.Function = ?irmod.functions[known.some];
+        if (kf.name == name && (kf.flags & ir.FN_FLAG_EXTERN) == 0) { ret opt[*ir.Function].some{kf}; }
+    }
     var i: u32 = 0;
     for (i < irmod.function_len) {
         val fn: *ir.Function = ?irmod.functions[i];

--- a/src/lang/be/codegen/dwarf.mach
+++ b/src/lang/be/codegen/dwarf.mach
@@ -30,6 +30,8 @@ use mach.lang.target.of;
 use mach.lang.target.of.bin;
 
 use page: std.allocator.page;
+use sort: std.collections.sort;
+use format: std.format;
 
 val DW_TAG_compile_unit:     u8 = 0x11;
 val DW_TAG_base_type:        u8 = 0x24;
@@ -411,20 +413,88 @@ fun memb_reserve(tc: *TypeCtx) bool {
     ret true;
 }
 
+# the string table with its own open-addressed index of (hash, offset), so
+# a string is found or appended without a scan of the table; an index
+# refusal is recorded on the buffer, which the section install renders
 rec StrTab {
-    buf: enc.ByteBuf;
+    buf:   enc.ByteBuf;
+    slots: *StrSlot;
+    cap:   u32;
+    len:   u32;
+}
+
+rec StrSlot {
+    hash: u64;
+    off:  u32;
+    used: bool;
+}
+
+fun strtab_init(alloc: *A.Allocator) StrTab {
+    var st: StrTab;
+    st.buf   = enc.buf_init(alloc);
+    st.slots = nil;
+    st.cap   = 0;
+    st.len   = 0;
+    ret st;
+}
+
+fun strtab_dnit(st: *StrTab) {
+    if (st.slots != nil && st.cap > 0) { A.deallocate[StrSlot](st.buf.alloc, st.slots, st.cap::usize); }
+    st.slots = nil;
+    st.cap   = 0;
+    st.len   = 0;
+    enc.buf_dnit(?st.buf);
+}
+
+fun str_hash(s: str) u64 {
+    val n: usize = str_len(s);
+    var h: u64 = 0xcbf29ce484222325;
+    var i: usize = 0;
+    for (i < n) { h = (h ^ (s[i]::u64)) * 0x100000001b3; i = i + 1; }
+    ret h;
+}
+
+fun strtab_grow(st: *StrTab) bool {
+    var new_cap: u32 = 64;
+    if (st.cap > 0) { new_cap = st.cap * 2; }
+    val r: res[*StrSlot, A.Error] = A.allocate[StrSlot](st.buf.alloc, new_cap::usize);
+    if (sel r.err) { st.buf.failed = true; st.buf.fail_err = r.err; ret false; }
+    val slots: *StrSlot = r.ok;
+    var i: u32 = 0;
+    for (i < new_cap) { slots[i].used = false; i = i + 1; }
+    i = 0;
+    for (i < st.cap) {
+        if (st.slots[i].used) {
+            var j: u32 = (st.slots[i].hash::u32) & (new_cap - 1);
+            for (slots[j].used) { j = (j + 1) & (new_cap - 1); }
+            slots[j] = st.slots[i];
+        }
+        i = i + 1;
+    }
+    if (st.slots != nil && st.cap > 0) { A.deallocate[StrSlot](st.buf.alloc, st.slots, st.cap::usize); }
+    st.slots = slots;
+    st.cap   = new_cap;
+    ret true;
 }
 
 fun str_off(st: *StrTab, s: str) u32 {
-    var i: usize = 0;
-    for (i < st.buf.len) {
-        val start: usize = i;
-        for (i < st.buf.len && st.buf.data[i] != 0) { i = i + 1; }
-        if (bytes_eq_str(?st.buf, start, i, s)) { ret start::u32; }
-        i = i + 1;
+    if (st.buf.failed) { ret 0; }
+    if ((st.len + 1) * 2 > st.cap && !strtab_grow(st)) { ret 0; }
+    val h: u64 = str_hash(s);
+    val n: usize = str_len(s);
+    var j: u32 = (h::u32) & (st.cap - 1);
+    for (st.slots[j].used) {
+        val slot: *StrSlot = ?st.slots[j];
+        if (slot.hash == h && bytes_eq_str(?st.buf, slot.off::usize, slot.off::usize + n, s)) { ret slot.off; }
+        j = (j + 1) & (st.cap - 1);
     }
     val off: u32 = st.buf.len::u32;
     emit_cstr(?st.buf, s);
+    if (st.buf.failed) { ret 0; }
+    st.slots[j].hash = h;
+    st.slots[j].off  = off;
+    st.slots[j].used = true;
+    st.len = st.len + 1;
     ret off;
 }
 
@@ -670,6 +740,7 @@ fun copy_exact(alloc: *A.Allocator, b: *enc.ByteBuf) res[*u8, fail.Fail] {
 }
 
 fun add_debug_section(image: *of.ObjectImage, name: intern.StrId, b: *enc.ByteBuf) res[u32, fail.Fail] {
+    if (b.failed) { ret res[u32, fail.Fail].err{fail.refused(b.fail_err)}; }
     val rb: res[*u8, fail.Fail] = copy_exact(image.alloc, b);
     if (sel rb.err) { ret res[u32, fail.Fail].err{rb.err}; }
     var sec: of.Section;
@@ -1490,7 +1561,9 @@ fun emit_row(b: *enc.ByteBuf, addr_delta: u32, line_delta: i32) {
     enc.emit_byte(b, DW_LNS_copy);
 }
 
-fun build_line(s: *debug_input.DebugProgram, funcs: *DwFunc, nfuncs: u32, rows: *enc.LineRow, row_count: u32,
+# row_start and row_items group the rows by function in row order (FuncIndex)
+fun build_line(s: *debug_input.DebugProgram, funcs: *DwFunc, nfuncs: u32, rows: *enc.LineRow,
+               row_start: *u32, row_items: *u32,
                text_sec: u32, address_size: u8, comp_dir: str, name: str, ft: *FileTable,
                b: *enc.ByteBuf, addr_off: *u32) {
     val len_pos: usize = b.len;
@@ -1547,9 +1620,9 @@ fun build_line(s: *debug_input.DebugProgram, funcs: *DwFunc, nfuncs: u32, rows: 
         var cur_file: i64 = -1;
         var first_row: bool = true;
 
-        var r: u32 = 0;
-        for (r < row_count) {
-            val row: *enc.LineRow = ?rows[r];
+        var r: u32 = row_start[f];
+        for (r < row_start[f + 1]) {
+            val row: *enc.LineRow = ?rows[row_items[r]];
             if (row.sec == text_sec && row.text_offset >= fn.offset && row.text_offset < fn.offset + fn.size) {
                 val pl: PosLine = pos_of(s, row.loc, ft);
                 if (pl.file::i64 != cur_file) {
@@ -1615,6 +1688,218 @@ fun emit_addr(b: *enc.ByteBuf, address_size: u8) {
     or                          { enc.emit_u32(b, 0); }
 }
 
+val FUNC_NONE: u32 = 0xFFFFFFFF;
+
+# one index per module: the text section's function symbols by offset (ties
+# by symbol index, the order the emitter's stable sort produced), so the
+# function holding a pc is a binary search, and the line rows, variable
+# locations and inline pcs grouped per function in their own order, so each
+# function walks its own spans rather than every span of the module. the
+# mir table maps a function name to its first mir function
+rec FuncIndex {
+    alloc:     *A.Allocator;
+    sec:       u32;
+    text_len:  u32;
+    count:     u32;
+    syms:      *u32;
+    offsets:   *u32;
+    row_start: *u32;
+    rows:      *u32;
+    row_total: u32;
+    var_start: *u32;
+    vars:      *u32;
+    var_total: u32;
+    pc_start:  *u32;
+    pcs:       *u32;
+    pc_total:  u32;
+    mir:       map.Map[u32, u32];
+}
+
+rec SymOrder {
+    offset: u32;
+    sym:    u32;
+}
+
+fun sym_order_cmp(a: *SymOrder, b: *SymOrder) i64 {
+    if (a.offset != b.offset) { ret (a.offset::i64) - (b.offset::i64); }
+    ret (a.sym::i64) - (b.sym::i64);
+}
+
+fun func_index_release(fi: *FuncIndex, arr: **u32, n: u32) {
+    if (@arr != nil && n > 0) { A.deallocate[u32](fi.alloc, @arr, n::usize); }
+    @arr = nil;
+}
+
+fun func_index_dnit(fi: *FuncIndex) {
+    map.dnit[u32, u32](?fi.mir);
+    func_index_release(fi, ?fi.pcs, fi.pc_total);
+    func_index_release(fi, ?fi.pc_start, fi.count + 1);
+    func_index_release(fi, ?fi.vars, fi.var_total);
+    func_index_release(fi, ?fi.var_start, fi.count + 1);
+    func_index_release(fi, ?fi.rows, fi.row_total);
+    func_index_release(fi, ?fi.row_start, fi.count + 1);
+    func_index_release(fi, ?fi.offsets, fi.count);
+    func_index_release(fi, ?fi.syms, fi.count);
+}
+
+fun func_index_init(fi: *FuncIndex, alloc: *A.Allocator, image: *of.ObjectImage, mirmod: *mir.MirModule, sec: u32) err[fail.Fail] {
+    fi.alloc     = alloc;
+    fi.sec       = sec;
+    fi.text_len  = image.sections[sec].len;
+    fi.count     = count_funcs(image, sec);
+    fi.syms      = nil;
+    fi.offsets   = nil;
+    fi.row_start = nil;
+    fi.rows      = nil;
+    fi.row_total = 0;
+    fi.var_start = nil;
+    fi.vars      = nil;
+    fi.var_total = 0;
+    fi.pc_start  = nil;
+    fi.pcs       = nil;
+    fi.pc_total  = 0;
+    fi.mir       = map.init[u32, u32](alloc, map.hash_u32, map.eq_u32);
+    if (mirmod != nil) {
+        var mi: u32 = 0;
+        for (mi < mirmod.function_len) {
+            val name: u32 = mirmod.functions[mi].name::u32;
+            if (!map.contains[u32, u32](?fi.mir, ?name)) {
+                val inserted: res[bool, A.Error] = map.insert[u32, u32](?fi.mir, name, mi);
+                if (sel inserted.err) { func_index_dnit(fi); ret err[fail.Fail].err{fail.refused(inserted.err)}; }
+            }
+            mi = mi + 1;
+        }
+    }
+    if (fi.count == 0) { ret err[fail.Fail].ok{}; }
+    val ro: res[*SymOrder, A.Error] = A.allocate[SymOrder](alloc, fi.count::usize);
+    if (sel ro.err) { func_index_dnit(fi); ret err[fail.Fail].err{fail.refused(ro.err)}; }
+    val order: *SymOrder = ro.ok;
+    fin { A.deallocate[SymOrder](alloc, order, fi.count::usize); }
+    var n: u32 = 0;
+    var i: u32 = 0;
+    for (i < image.symbol_count) {
+        val sym: *of.Symbol = ?image.symbols[i];
+        if ((sym.flags & of.SYM_OBJ_FLAG_FUNCTION) != 0 && of.section_index(sym.section) == sec) {
+            order[n].offset = sym.offset;
+            order[n].sym    = i;
+            n = n + 1;
+        }
+        i = i + 1;
+    }
+    sort.sort[SymOrder](order, fi.count::usize, sym_order_cmp);
+    val rs: res[*u32, A.Error] = A.allocate[u32](alloc, fi.count::usize);
+    if (sel rs.err) { func_index_dnit(fi); ret err[fail.Fail].err{fail.refused(rs.err)}; }
+    fi.syms = rs.ok;
+    val rf: res[*u32, A.Error] = A.allocate[u32](alloc, fi.count::usize);
+    if (sel rf.err) { func_index_dnit(fi); ret err[fail.Fail].err{fail.refused(rf.err)}; }
+    fi.offsets = rf.ok;
+    i = 0;
+    for (i < fi.count) { fi.syms[i] = order[i].sym; fi.offsets[i] = order[i].offset; i = i + 1; }
+    ret err[fail.Fail].ok{};
+}
+
+# the position of the function whose span holds pc: the last function at
+# or before pc, when pc precedes the next function's offset (or the text
+# end); FUNC_NONE otherwise. equal offsets make the earlier functions empty
+fun func_index_holding(fi: *FuncIndex, sec: u32, pc: u32) u32 {
+    if (sec != fi.sec || fi.count == 0 || pc < fi.offsets[0]) { ret FUNC_NONE; }
+    var lo: u32 = 0;
+    var hi: u32 = fi.count;
+    for (hi - lo > 1) {
+        val mid: u32 = lo + (hi - lo) / 2;
+        if (fi.offsets[mid] <= pc) { lo = mid; } or { hi = mid; }
+    }
+    var end: u32 = fi.text_len;
+    if (lo + 1 < fi.count) { end = fi.offsets[lo + 1]; }
+    if (pc >= end) { ret FUNC_NONE; }
+    ret lo;
+}
+
+# the first symbol of an offset group, which is the one a symbol scan meets
+fun func_index_first_at(fi: *FuncIndex, pos: u32) u32 {
+    var p: u32 = pos;
+    for (p > 0 && fi.offsets[p - 1] == fi.offsets[p]) { p = p - 1; }
+    ret p;
+}
+
+fun func_index_mir(fi: *FuncIndex, mirmod: *mir.MirModule, name: intern.StrId) *mir.MirFunction {
+    val key: u32 = name::u32;
+    val found: opt[*u32] = map.get[u32, u32](?fi.mir, ?key);
+    if (sel found.none) { ret nil; }
+    ret ?mirmod.functions[@found.some];
+}
+
+# spans grouped by the function holding them, in their own order: two
+# passes, a count and a fill, over the caller's position function
+fun bucket_spans(fi: *FuncIndex, n: u32, ctx: ptr, position: fun(ptr, u32) u32,
+                 out_start: **u32, out_items: **u32, out_total: *u32) err[fail.Fail] {
+    val slots: u32 = fi.count + 1;
+    val rs: res[*u32, A.Error] = A.allocate[u32](fi.alloc, slots::usize);
+    if (sel rs.err) { ret err[fail.Fail].err{fail.refused(rs.err)}; }
+    val start: *u32 = rs.ok;
+    @out_start = start;
+    var z: u32 = 0;
+    for (z < slots) { start[z] = 0; z = z + 1; }
+    var i: u32 = 0;
+    for (i < n) {
+        val pos: u32 = position(ctx, i);
+        if (pos != FUNC_NONE) { start[pos + 1] = start[pos + 1] + 1; }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < fi.count) { start[i + 1] = start[i + 1] + start[i]; i = i + 1; }
+    val total: u32 = start[fi.count];
+    @out_total = total;
+    @out_items = nil;
+    if (total == 0) { ret err[fail.Fail].ok{}; }
+    val ri: res[*u32, A.Error] = A.allocate[u32](fi.alloc, total::usize);
+    if (sel ri.err) { ret err[fail.Fail].err{fail.refused(ri.err)}; }
+    val items: *u32 = ri.ok;
+    @out_items = items;
+    i = 0;
+    for (i < n) {
+        val pos: u32 = position(ctx, i);
+        if (pos != FUNC_NONE) { items[start[pos]] = i; start[pos] = start[pos] + 1; }
+        i = i + 1;
+    }
+    i = fi.count;
+    for (i > 0) { start[i] = start[i - 1]; i = i - 1; }
+    start[0] = 0;
+    ret err[fail.Fail].ok{};
+}
+
+rec RowSpans  { fi: *FuncIndex; rows: *enc.LineRow; }
+rec VarSpans  { fi: *FuncIndex; varlocs: *enc.VarLoc; }
+rec PcSpans   { fi: *FuncIndex; pcs: *enc.InlinePc; }
+
+fun row_position(ctx: ptr, i: u32) u32 {
+    val c: *RowSpans = ctx::*RowSpans;
+    ret func_index_holding(c.fi, c.rows[i].sec, c.rows[i].text_offset);
+}
+
+fun var_position(ctx: ptr, i: u32) u32 {
+    val c: *VarSpans = ctx::*VarSpans;
+    ret func_index_holding(c.fi, c.varlocs[i].sec, c.varlocs[i].text_offset);
+}
+
+fun pc_position(ctx: ptr, i: u32) u32 {
+    val c: *PcSpans = ctx::*PcSpans;
+    ret func_index_holding(c.fi, c.pcs[i].sec, c.pcs[i].text_offset);
+}
+
+fun func_index_spans(fi: *FuncIndex, rows: *enc.LineRow, row_count: u32,
+                     varlocs: *enc.VarLoc, varloc_count: u32,
+                     pcs: *enc.InlinePc, pc_count: u32) err[fail.Fail] {
+    var rc: RowSpans; rc.fi = fi; rc.rows = rows;
+    val r0: err[fail.Fail] = bucket_spans(fi, row_count, (?rc)::ptr, row_position, ?fi.row_start, ?fi.rows, ?fi.row_total);
+    if (sel r0.err) { ret r0; }
+    var vc: VarSpans; vc.fi = fi; vc.varlocs = varlocs;
+    val r1: err[fail.Fail] = bucket_spans(fi, varloc_count, (?vc)::ptr, var_position, ?fi.var_start, ?fi.vars, ?fi.var_total);
+    if (sel r1.err) { ret r1; }
+    var pc: PcSpans; pc.fi = fi; pc.pcs = pcs;
+    ret bucket_spans(fi, pc_count, (?pc)::ptr, pc_position, ?fi.pc_start, ?fi.pcs, ?fi.pc_total);
+}
+
 fun count_funcs(image: *of.ObjectImage, text_sec: u32) u32 {
     var n: u32 = 0;
     var i: u32 = 0;
@@ -1628,63 +1913,27 @@ fun count_funcs(image: *of.ObjectImage, text_sec: u32) u32 {
     ret n;
 }
 
-fun mir_omits_frame(mirmod: *mir.MirModule, name: intern.StrId) bool {
-    if (mirmod == nil) { ret false; }
-    var i: u32 = 0;
-    for (i < mirmod.function_len) {
-        if (mirmod.functions[i].name == name) { ret mirmod.functions[i].frame.omit; }
-        i = i + 1;
-    }
-    ret false;
-}
-
-fun mir_realigns_frame(mirmod: *mir.MirModule, name: intern.StrId) bool {
-    if (mirmod == nil) { ret false; }
-    var i: u32 = 0;
-    for (i < mirmod.function_len) {
-        if (mirmod.functions[i].name == name) { ret mirmod.functions[i].frame.realign != 0; }
-        i = i + 1;
-    }
-    ret false;
-}
-
-fun mir_is_naked(mirmod: *mir.MirModule, name: intern.StrId) bool {
-    if (mirmod == nil) { ret false; }
-    var i: u32 = 0;
-    for (i < mirmod.function_len) {
-        if (mirmod.functions[i].name == name) { ret mirmod.functions[i].naked; }
-        i = i + 1;
-    }
-    ret false;
-}
-
-fun gather_funcs(image: *of.ObjectImage, mirmod: *mir.MirModule, text_sec: u32, out: *DwFunc) {
+# the index already holds the function symbols in offset order
+fun gather_funcs(image: *of.ObjectImage, mirmod: *mir.MirModule, fi: *FuncIndex, out: *DwFunc) {
     var n: u32 = 0;
-    var i: u32 = 0;
-    for (i < image.symbol_count) {
-        val sym: *of.Symbol = ?image.symbols[i];
-        if ((sym.flags & of.SYM_OBJ_FLAG_FUNCTION) != 0 && of.section_index(sym.section) == text_sec) {
-            out[n].name     = sym.name;
-            out[n].offset   = sym.offset;
-            out[n].external = (sym.flags & of.SYM_OBJ_FLAG_GLOBAL) != 0;
-            out[n].weak     = (sym.flags & of.SYM_OBJ_FLAG_WEAK) != 0;
-            out[n].omit     = mir_omits_frame(mirmod, sym.name);
-            out[n].realign  = mir_realigns_frame(mirmod, sym.name);
-            out[n].naked    = mir_is_naked(mirmod, sym.name);
-            n = n + 1;
+    for (n < fi.count) {
+        val sym: *of.Symbol = ?image.symbols[fi.syms[n]];
+        out[n].name     = sym.name;
+        out[n].offset   = sym.offset;
+        out[n].external = (sym.flags & of.SYM_OBJ_FLAG_GLOBAL) != 0;
+        out[n].weak     = (sym.flags & of.SYM_OBJ_FLAG_WEAK) != 0;
+        out[n].omit     = false;
+        out[n].realign  = false;
+        out[n].naked    = false;
+        if (mirmod != nil) {
+            val mf: *mir.MirFunction = func_index_mir(fi, mirmod, sym.name);
+            if (mf != nil) {
+                out[n].omit    = mf.frame.omit;
+                out[n].realign = mf.frame.realign != 0;
+                out[n].naked   = mf.naked;
+            }
         }
-        i = i + 1;
-    }
-    var a: u32 = 1;
-    for (a < n) {
-        val key: DwFunc = out[a];
-        var b: i64 = a::i64 - 1;
-        for (b >= 0 && out[b::u32].offset > key.offset) {
-            out[(b + 1)::u32] = out[b::u32];
-            b = b - 1;
-        }
-        out[(b + 1)::u32] = key;
-        a = a + 1;
+        n = n + 1;
     }
 }
 
@@ -1706,13 +1955,35 @@ fun intern_anchor(itn: *intern.Interner, base: str, suffix: str) res[intern.StrI
     ret res[intern.StrId, fail.Fail].ok{ri.ok};
 }
 
-fun add_reloc(image: *of.ObjectImage, sec: u32, offset: u32, kind: of.RelocKind, sym: intern.StrId) err[fail.Fail] {
-    ret add_reloc_addend(image, sec, offset, kind, sym, 0);
+# the image's first symbol per name, built once after the debug anchors are
+# added so each relocation asks a map rather than a symbol scan
+fun index_symbol_names(image: *of.ObjectImage, alloc: *A.Allocator) res[map.Map[u32, u32], fail.Fail] {
+    var names: map.Map[u32, u32] = map.init[u32, u32](alloc, map.hash_u32, map.eq_u32);
+    var i: u32 = 0;
+    for (i < image.symbol_count) {
+        val name: u32 = image.symbols[i].name::u32;
+        if (name != intern.STR_NIL::u32 && !map.contains[u32, u32](?names, ?name)) {
+            val inserted: res[bool, A.Error] = map.insert[u32, u32](?names, name, i);
+            if (sel inserted.err) {
+                map.dnit[u32, u32](?names);
+                ret res[map.Map[u32, u32], fail.Fail].err{fail.refused(inserted.err)};
+            }
+        }
+        i = i + 1;
+    }
+    ret res[map.Map[u32, u32], fail.Fail].ok{names};
 }
 
-fun add_reloc_addend(image: *of.ObjectImage, sec: u32, offset: u32, kind: of.RelocKind,
+fun add_reloc(image: *of.ObjectImage, names: *map.Map[u32, u32], sec: u32, offset: u32, kind: of.RelocKind, sym: intern.StrId) err[fail.Fail] {
+    ret add_reloc_addend(image, names, sec, offset, kind, sym, 0);
+}
+
+fun add_reloc_addend(image: *of.ObjectImage, names: *map.Map[u32, u32], sec: u32, offset: u32, kind: of.RelocKind,
                      sym: intern.StrId, addend: i64) err[fail.Fail] {
-    val sym_ix: u32 = obj.symbol_index(image, sym);
+    var sym_ix: u32 = of.SYMBOL_NONE;
+    val key: u32 = sym::u32;
+    val found: opt[*u32] = map.get[u32, u32](names, ?key);
+    if (sel found.some) { sym_ix = @found.some; }
     if (sym_ix == of.SYMBOL_NONE) {
         ret err[fail.Fail].err{fail.message("dwarf: relocation target absent from the image symbol table")};
     }
@@ -1727,25 +1998,10 @@ fun add_reloc_addend(image: *of.ObjectImage, sec: u32, offset: u32, kind: of.Rel
     ret obj.add_relocation(image, rel);
 }
 
-fun ir_function_at(image: *of.ObjectImage, irmod: *ir.Module, sec: u32, pc: u32) *ir.Function {
-    var best: *of.Symbol = nil;
-    var end: u32 = image.sections[sec].len;
-    var i: u32 = 0;
-    for (i < image.symbol_count) {
-        val sym: *of.Symbol = ?image.symbols[i];
-        if ((sym.flags & of.SYM_OBJ_FLAG_FUNCTION) != 0 && of.section_index(sym.section) == sec
-            && sym.offset <= pc && (best == nil || sym.offset > best.offset)) { best = sym; }
-        i = i + 1;
-    }
-    if (best == nil) { ret nil; }
-    i = 0;
-    for (i < image.symbol_count) {
-        val next: *of.Symbol = ?image.symbols[i];
-        if ((next.flags & of.SYM_OBJ_FLAG_FUNCTION) != 0 && of.section_index(next.section) == sec
-            && next.offset > best.offset && next.offset < end) { end = next.offset; }
-        i = i + 1;
-    }
-    if (pc >= end) { ret nil; }
+fun ir_function_at(fi: *FuncIndex, image: *of.ObjectImage, irmod: *ir.Module, sec: u32, pc: u32) *ir.Function {
+    val pos: u32 = func_index_holding(fi, sec, pc);
+    if (pos == FUNC_NONE) { ret nil; }
+    val best: *of.Symbol = ?image.symbols[fi.syms[func_index_first_at(fi, pos)]];
     val found: opt[u32] = ir.function_lookup(irmod, best.name);
     if (sel found.none) { ret nil; }
     ret ?irmod.functions[found.some];
@@ -1761,7 +2017,7 @@ fun inline_tree_valid(fn: *ir.Function) bool {
     ret true;
 }
 
-fun validate_request(req: *of.DebugProduceRequest) err[fail.Fail] {
+fun validate_shape(req: *of.DebugProduceRequest) err[fail.Fail] {
     if (req == nil) { ret err[fail.Fail].err{fail.message("dwarf.produce: nil request")}; }
     if (req.image == nil) { ret err[fail.Fail].err{fail.message("dwarf.produce: nil object image")}; }
     val s: *debug_input.DebugProgram = ?req.program;
@@ -1815,6 +2071,15 @@ fun validate_request(req: *of.DebugProduceRequest) err[fail.Fail] {
         }
         row_i = row_i + 1;
     }
+    ret err[fail.Fail].ok{};
+}
+
+# the checks that need the function index: inline pcs and variable
+# locations against the function holding them
+fun validate_spans(req: *of.DebugProduceRequest, fi: *FuncIndex) err[fail.Fail] {
+    val s: *debug_input.DebugProgram = ?req.program;
+    val image: *of.ObjectImage = req.image;
+    val text_len: u32 = image.sections[req.text_section].len;
     var inline_i: u32 = 0;
     for (inline_i < req.inline_pc_count) {
         val pc: *enc.InlinePc = ?req.inline_pcs[inline_i];
@@ -1824,7 +2089,7 @@ fun validate_request(req: *of.DebugProduceRequest) err[fail.Fail] {
         if (inline_i > 0 && req.inline_pcs[inline_i - 1].text_offset > pc.text_offset) {
             ret err[fail.Fail].err{fail.message("dwarf.produce: inline PCs are not monotonic within a section")};
         }
-        val fn: *ir.Function = ir_function_at(image, s.ir_module, pc.sec, pc.text_offset);
+        val fn: *ir.Function = ir_function_at(fi, image, s.ir_module, pc.sec, pc.text_offset);
         if (!inline_tree_valid(fn) || (pc.inline_site != 0 && pc.inline_site > fn.inline_site_len)) {
             ret err[fail.Fail].err{fail.message("dwarf.produce: inline PC refers to an invalid inline site")};
         }
@@ -1838,12 +2103,12 @@ fun validate_request(req: *of.DebugProduceRequest) err[fail.Fail] {
                 && (loc.end_offset < loc.text_offset || loc.end_offset > text_len))) {
             ret err[fail.Fail].err{fail.message("dwarf.produce: variable location range lies outside the selected text section")};
         }
-        val fn: *ir.Function = ir_function_at(image, s.ir_module, loc.sec, loc.text_offset);
+        val fn: *ir.Function = ir_function_at(fi, image, s.ir_module, loc.sec, loc.text_offset);
         if (fn == nil || loc.iid >= fn.instr_len) {
             ret err[fail.Fail].err{fail.message("dwarf.produce: variable location refers to an invalid instruction")};
         }
         if (loc.end_offset != 0) {
-            val end_fn: *ir.Function = ir_function_at(image, s.ir_module, loc.sec, loc.end_offset - 1);
+            val end_fn: *ir.Function = ir_function_at(fi, image, s.ir_module, loc.sec, loc.end_offset - 1);
             if (end_fn != fn) {
                 ret err[fail.Fail].err{fail.message("dwarf.produce: variable location crosses a function boundary")};
             }
@@ -1853,11 +2118,30 @@ fun validate_request(req: *of.DebugProduceRequest) err[fail.Fail] {
     ret err[fail.Fail].ok{};
 }
 
+fun validate_request(req: *of.DebugProduceRequest) err[fail.Fail] {
+    val shaped: err[fail.Fail] = validate_shape(req);
+    if (sel shaped.err) { ret shaped; }
+    val s: *debug_input.DebugProgram = ?req.program;
+    var fi: FuncIndex;
+    val indexed: err[fail.Fail] = func_index_init(?fi, s.alloc, req.image, nil, req.text_section);
+    if (sel indexed.err) { ret indexed; }
+    fin { func_index_dnit(?fi); }
+    ret validate_spans(req, ?fi);
+}
+
 pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
-    val valid: err[fail.Fail] = validate_request(req);
-    if (sel valid.err) { ret valid; }
+    val shaped: err[fail.Fail] = validate_shape(req);
+    if (sel shaped.err) { ret shaped; }
     val s: *debug_input.DebugProgram = ?req.program;
     val image: *of.ObjectImage = req.image;
+    var fi: FuncIndex;
+    val indexed: err[fail.Fail] = func_index_init(?fi, s.alloc, image, s.mir_module, req.text_section);
+    if (sel indexed.err) { ret indexed; }
+    fin { func_index_dnit(?fi); }
+    val valid: err[fail.Fail] = validate_spans(req, ?fi);
+    if (sel valid.err) { ret valid; }
+    val spanned: err[fail.Fail] = func_index_spans(?fi, req.rows, req.row_count, req.varlocs, req.varloc_count, req.inline_pcs, req.inline_pc_count);
+    if (sel spanned.err) { ret spanned; }
     val irmod: *ir.Module = s.ir_module;
     val mirmod: *mir.MirModule = s.mir_module;
     val rows: *enc.LineRow = req.rows;
@@ -1869,7 +2153,7 @@ pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
     val producer_id: intern.StrId = req.producer;
     val comp_dir_id: intern.StrId = req.comp_dir;
     val text_sec: u32 = req.text_section;
-    val nfuncs: u32 = count_funcs(image, text_sec);
+    val nfuncs: u32 = fi.count;
     if (nfuncs == 0) { ret err[fail.Fail].ok{}; }
 
     val fb_reg:      i32 = frame_base_reg(s);
@@ -1889,7 +2173,7 @@ pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
     val rf: res[*DwFunc, A.Error] = A.allocate[DwFunc](s.alloc, nfuncs::usize);
     if (sel rf.err) { ret err[fail.Fail].err{fail.refused(rf.err)}; }
     val funcs: *DwFunc = rf.ok;
-    gather_funcs(image, mirmod, text_sec, funcs);
+    gather_funcs(image, mirmod, ?fi, funcs);
 
     val text_len: u32 = image.sections[text_sec].len;
     var fi0: u32 = 0;
@@ -1942,20 +2226,19 @@ pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
     val ranges: *LocRange = rgr.ok;
 
     var tc: TypeCtx = type_ctx_init(s.alloc);
-    var strtab: StrTab;
-    strtab.buf = enc.buf_init(s.alloc);
+    var strtab: StrTab = strtab_init(s.alloc);
     var var_count: u32 = 0;
     var range_count: u32 = 0;
 
     var dtypes: ir_type.IrTypeTable;
     val rdt: err[fail.Fail] = ir_type.init(?dtypes, s.alloc);
     if (sel rdt.err) {
-        enc.buf_dnit(?strtab.buf); type_ctx_dnit(?tc);
+        strtab_dnit(?strtab); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
         ret err[fail.Fail].err{rdt.err};
     }
-    gather_subprograms(s, irmod, subs, nsub, rows, row_count, varlocs, varloc_count, text_sec, ?ft, address_size,
+    gather_subprograms(s, irmod, ?fi, subs, nsub, rows, varlocs, text_sec, ?ft, address_size,
                        ?tc, ?strtab, ?dtypes, vars, ?var_count, var_cap, ranges, ?range_count, range_cap);
     ir_type.dnit(?dtypes);
 
@@ -1965,7 +2248,7 @@ pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
 
     val ra: res[*u32, A.Error] = A.allocate[u32](s.alloc, nfuncs::usize);
     if (sel ra.err) {
-        enc.buf_dnit(?strtab.buf); type_ctx_dnit(?tc);
+        strtab_dnit(?strtab); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
         ret err[fail.Fail].err{fail.refused(ra.err)};
@@ -1975,7 +2258,7 @@ pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
     val reloc_cap: u32 = 2 + 2 * nsub + tc.ntypes + tc.nmemb + 2 * var_count + 2 * tot_sites;
     val rr2: res[*InfoReloc, A.Error] = A.allocate[InfoReloc](s.alloc, reloc_cap::usize);
     if (sel rr2.err) {
-        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); enc.buf_dnit(?strtab.buf);
+        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); strtab_dnit(?strtab);
         type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
@@ -1988,7 +2271,7 @@ pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
     val rlr: res[*LocReloc, A.Error] = A.allocate[LocReloc](s.alloc, loc_reloc_cap::usize);
     if (sel rlr.err) {
         A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
-        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); enc.buf_dnit(?strtab.buf);
+        A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); strtab_dnit(?strtab);
         type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
         A.deallocate[DwFunc](s.alloc, subs, nfuncs::usize); A.deallocate[DwFunc](s.alloc, funcs, nfuncs::usize);
@@ -2009,7 +2292,7 @@ pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
     if (ir_cap == 0) { ir_cap = 1; }
     val rinl: res[*DwInline, A.Error] = A.allocate[DwInline](s.alloc, inl_cap::usize);
     if (sel rinl.err) {
-        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
+        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); strtab_dnit(?strtab);
         A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
@@ -2020,7 +2303,7 @@ pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
     val rirng: res[*DwInlineRange, A.Error] = A.allocate[DwInlineRange](s.alloc, ir_cap::usize);
     if (sel rirng.err) {
         A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
-        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
+        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); strtab_dnit(?strtab);
         A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
@@ -2030,10 +2313,10 @@ pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
     val iranges: *DwInlineRange = rirng.ok;
     var ninl: u32 = 0;
     var nir:  u32 = 0;
-    val rgi: err[fail.Fail] = gather_inlines(s, irmod, subs, nsub, inline_pcs, inline_pc_count, text_sec, ?ft, inlines, ?ninl, inl_cap, iranges, ?nir, ir_cap);
+    val rgi: err[fail.Fail] = gather_inlines(s, irmod, ?fi, subs, nsub, inline_pcs, text_sec, ?ft, inlines, ?ninl, inl_cap, iranges, ?nir, ir_cap);
     if (sel rgi.err) {
         A.deallocate[DwInlineRange](s.alloc, iranges, ir_cap::usize); A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
-        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
+        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); strtab_dnit(?strtab);
         A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
@@ -2046,7 +2329,7 @@ pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
     val rrr: res[*RngReloc, A.Error] = A.allocate[RngReloc](s.alloc, rng_reloc_cap::usize);
     if (sel rrr.err) {
         A.deallocate[DwInlineRange](s.alloc, iranges, ir_cap::usize); A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
-        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
+        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); strtab_dnit(?strtab);
         A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
@@ -2061,7 +2344,7 @@ pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
     if (sel rfx.err) {
         A.deallocate[RngReloc](s.alloc, rng_relocs, rng_reloc_cap::usize);
         A.deallocate[DwInlineRange](s.alloc, iranges, ir_cap::usize); A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
-        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); enc.buf_dnit(?strtab.buf);
+        enc.buf_dnit(?b_rnglists); enc.buf_dnit(?b_loclists); enc.buf_dnit(?b_info); enc.buf_dnit(?b_line); enc.buf_dnit(?b_abbrev); strtab_dnit(?strtab);
         A.deallocate[LocReloc](s.alloc, loc_relocs, loc_reloc_cap::usize); A.deallocate[InfoReloc](s.alloc, info_relocs, reloc_cap::usize);
         A.deallocate[u32](s.alloc, addr_off, nfuncs::usize); type_ctx_dnit(?tc);
         A.deallocate[LocRange](s.alloc, ranges, range_cap::usize); A.deallocate[DwVar](s.alloc, vars, var_cap::usize);
@@ -2071,7 +2354,7 @@ pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
     val type_fixups: *TypeFixup = rfx.ok;
 
     build_abbrev(?b_abbrev);
-    build_line(s, funcs, nfuncs, rows, row_count, text_sec, address_size, comp_dir, name, ?ft, ?b_line, addr_off);
+    build_line(s, funcs, nfuncs, rows, fi.row_start, fi.rows, text_sec, address_size, comp_dir, name, ?ft, ?b_line, addr_off);
     if (has_loclists) {
         build_loclists(?b_loclists, subs, nsub, vars, ranges, address_size, loc_relocs, ?loc_reloc_count, loc_reloc_cap);
     }
@@ -2094,7 +2377,7 @@ pub fun produce_debug(req: *of.DebugProduceRequest) err[fail.Fail] {
     enc.buf_dnit(?b_info);
     enc.buf_dnit(?b_loclists);
     enc.buf_dnit(?b_rnglists);
-    enc.buf_dnit(?strtab.buf);
+    strtab_dnit(?strtab);
     A.deallocate[TypeFixup](s.alloc, type_fixups, fixup_cap::usize);
     A.deallocate[DwInlineRange](s.alloc, iranges, ir_cap::usize);
     A.deallocate[DwInline](s.alloc, inlines, inl_cap::usize);
@@ -2124,9 +2407,9 @@ pub fun debug_descriptor() of.DebugVTable {
     ret descriptor;
 }
 
-fun gather_subprograms(s: *debug_input.DebugProgram, irmod: *ir.Module,
-                       funcs: *DwFunc, nfuncs: u32, rows: *enc.LineRow, row_count: u32,
-                       varlocs: *enc.VarLoc, varloc_count: u32, text_sec: u32,
+fun gather_subprograms(s: *debug_input.DebugProgram, irmod: *ir.Module, fi: *FuncIndex,
+                       funcs: *DwFunc, nfuncs: u32, rows: *enc.LineRow,
+                       varlocs: *enc.VarLoc, text_sec: u32,
                        ft: *FileTable, address_size: u8, tc: *TypeCtx, strtab: *StrTab,
                        dtypes: *ir_type.IrTypeTable,
                        vars: *DwVar, var_count: *u32, var_cap: u32,
@@ -2154,7 +2437,7 @@ fun gather_subprograms(s: *debug_input.DebugProgram, irmod: *ir.Module,
         if (fn.disp == intern.STR_NIL) { nm = resolve(s.interner, fn.name); }
         fn.disp_off = str_off(strtab, nm);
 
-        val first: opt[source.SrcLoc] = first_row_loc(rows, row_count, text_sec, fn.offset, fn.offset + fn.size);
+        val first: opt[source.SrcLoc] = first_row_loc(rows, ?fi.rows[fi.row_start[i]], fi.row_start[i + 1] - fi.row_start[i], text_sec, fn.offset, fn.offset + fn.size);
         if (sel first.some) {
             val pl: PosLine = pos_of(s, first.some, ft);
             fn.decl_file = pl.file;
@@ -2164,7 +2447,8 @@ fun gather_subprograms(s: *debug_input.DebugProgram, irmod: *ir.Module,
         fn.ret_ty = type_intern(s, dtypes, tc, strtab, ret_sem, address_size);
 
         if (irfn != nil) {
-            gather_vars(s, irmod, dtypes, irfn, fn.offset, fn.offset + fn.size, varlocs, varloc_count, text_sec,
+            gather_vars(s, irmod, dtypes, irfn, fn.offset, fn.offset + fn.size, varlocs,
+                        ?fi.vars[fi.var_start[i]], fi.var_start[i + 1] - fi.var_start[i], text_sec,
                         address_size, tc, strtab, vars, var_count, var_cap, ranges, range_count, range_cap);
             fn.var_count = @var_count - fn.var_start;
         }
@@ -2203,8 +2487,8 @@ fun inline_caps(irmod: *ir.Module, funcs: *DwFunc, nfuncs: u32, total: *u32, max
     }
 }
 
-fun gather_inlines(s: *debug_input.DebugProgram, irmod: *ir.Module, funcs: *DwFunc, nfuncs: u32,
-                   inline_pcs: *enc.InlinePc, inline_pc_count: u32, text_sec: u32, ft: *FileTable,
+fun gather_inlines(s: *debug_input.DebugProgram, irmod: *ir.Module, fi: *FuncIndex, funcs: *DwFunc, nfuncs: u32,
+                   inline_pcs: *enc.InlinePc, text_sec: u32, ft: *FileTable,
                    out: *DwInline, ninl: *u32, inl_cap: u32,
                    iranges: *DwInlineRange, nir: *u32, ir_cap: u32) err[fail.Fail] {
     var i: u32 = 0;
@@ -2240,14 +2524,13 @@ fun gather_inlines(s: *debug_input.DebugProgram, irmod: *ir.Module, funcs: *DwFu
                 di.call_line = funcs[i].decl_line;
             }
 
-            var j: u32 = 0;
-            for (j < inline_pc_count) {
+            var pj: u32 = fi.pc_start[i];
+            for (pj < fi.pc_start[i + 1]) {
+                val j: u32 = fi.pcs[pj];
                 val o: u32 = inline_pcs[j].text_offset;
                 if (inline_pcs[j].sec == text_sec && o >= lo && o < hi && inline_ancestor_or_self(irfn, k, inline_pcs[j].inline_site)) {
                     var seg_end: u32 = hi;
-                    var jn: u32 = j + 1;
-                    for (jn < inline_pc_count && inline_pcs[jn].sec != text_sec) { jn = jn + 1; }
-                    if (jn < inline_pc_count && inline_pcs[jn].text_offset < hi) { seg_end = inline_pcs[jn].text_offset; }
+                    if (pj + 1 < fi.pc_start[i + 1] && inline_pcs[fi.pcs[pj + 1]].text_offset < hi) { seg_end = inline_pcs[fi.pcs[pj + 1]].text_offset; }
                     if (o < seg_end) {
                         if (@nir >= ir_cap) { ret err[fail.Fail].err{fail.message("dwarf.gather_inlines: inline-range capacity exceeded")}; }
                         iranges[@nir].start = o;
@@ -2256,7 +2539,7 @@ fun gather_inlines(s: *debug_input.DebugProgram, irmod: *ir.Module, funcs: *DwFu
                         di.range_count = di.range_count + 1;
                     }
                 }
-                j = j + 1;
+                pj = pj + 1;
             }
 
             if (di.range_count > 0) { @ninl = @ninl + 1; }
@@ -2267,15 +2550,16 @@ fun gather_inlines(s: *debug_input.DebugProgram, irmod: *ir.Module, funcs: *DwFu
     ret err[fail.Fail].ok{};
 }
 
+# var_items lists the function's variable locations in varloc order (FuncIndex)
 fun gather_vars(s: *debug_input.DebugProgram, irmod: *ir.Module, dtypes: *ir_type.IrTypeTable, irfn: *ir.Function, lo: u32, hi: u32,
-                varlocs: *enc.VarLoc, varloc_count: u32, text_sec: u32, address_size: u8,
+                varlocs: *enc.VarLoc, var_items: *u32, var_item_count: u32, text_sec: u32, address_size: u8,
                 tc: *TypeCtx, strtab: *StrTab, vars: *DwVar, var_count: *u32, var_cap: u32,
                 ranges: *LocRange, range_count: *u32, range_cap: u32) {
     val fn_var_start: u32 = @var_count;
 
     var i: u32 = 0;
-    for (i < varloc_count) {
-        val vl: *enc.VarLoc = ?varlocs[i];
+    for (i < var_item_count) {
+        val vl: *enc.VarLoc = ?varlocs[var_items[i]];
         if (vl.sec != text_sec || vl.text_offset < lo || vl.text_offset >= hi) { i = i + 1; cnt; }
         val obt: opt[u32] = varloc_ident(s, irmod, dtypes, irfn, vl, address_size, tc, strtab);
         if (sel obt.none) { i = i + 1; cnt; }
@@ -2313,8 +2597,8 @@ fun gather_vars(s: *debug_input.DebugProgram, irmod: *ir.Module, dtypes: *ir_typ
         val v: *DwVar = ?vars[vi];
         v.range_start = @range_count;
         var k: u32 = 0;
-        for (k < varloc_count) {
-            val vl: *enc.VarLoc = ?varlocs[k];
+        for (k < var_item_count) {
+            val vl: *enc.VarLoc = ?varlocs[var_items[k]];
             if (vl.sec != text_sec || vl.text_offset < lo || vl.text_offset >= hi) { k = k + 1; cnt; }
             if (@range_count >= range_cap) { k = k + 1; cnt; }
             val oid: opt[u32] = varloc_ident(s, irmod, dtypes, irfn, vl, address_size, tc, strtab);
@@ -2695,13 +2979,14 @@ fun ptr_base_type(address_size: u8) TypeDie {
     ret bt;
 }
 
-fun first_row_loc(rows: *enc.LineRow, row_count: u32, text_sec: u32, start: u32, end: u32) opt[source.SrcLoc] {
+# row_items lists the function's rows in row order (FuncIndex)
+fun first_row_loc(rows: *enc.LineRow, row_items: *u32, row_item_count: u32, text_sec: u32, start: u32, end: u32) opt[source.SrcLoc] {
     var found: bool = false;
     var best_off: u32 = 0;
     var best_loc: source.SrcLoc;
     var r: u32 = 0;
-    for (r < row_count) {
-        val row: *enc.LineRow = ?rows[r];
+    for (r < row_item_count) {
+        val row: *enc.LineRow = ?rows[row_items[r]];
         if (row.sec == text_sec && row.text_offset >= start && row.text_offset < end && source.loc_is_valid(row.loc)) {
             if (!found || row.text_offset < best_off) {
                 found = true; best_off = row.text_offset; best_loc = row.loc;
@@ -2784,7 +3069,12 @@ fun install_into(s: *debug_input.DebugProgram, image: *of.ObjectImage, itn: *int
         if (sel rlar.err) { ret err[fail.Fail].err{rlar.err}; }
     }
 
-    val r2: err[fail.Fail] = add_reloc(image, info_sec, stmt_off, of.RK_ABS32, anchor);
+    val names_r: res[map.Map[u32, u32], fail.Fail] = index_symbol_names(image, s.alloc);
+    if (sel names_r.err) { ret err[fail.Fail].err{names_r.err}; }
+    var names: map.Map[u32, u32] = names_r.ok;
+    fin { map.dnit[u32, u32](?names); }
+
+    val r2: err[fail.Fail] = add_reloc(image, ?names, info_sec, stmt_off, of.RK_ABS32, anchor);
     if (sel r2.err) { ret r2; }
 
     var k: u32 = 0;
@@ -2794,7 +3084,7 @@ fun install_into(s: *debug_input.DebugProgram, image: *of.ObjectImage, itn: *int
         if (ir2.target == IRLT_STR)     { sym = str_anchor; }
         or (ir2.target == IRLT_LOCLIST) { sym = loclists_anchor; }
         or (ir2.target == IRLT_RNGLIST) { sym = rnglists_anchor; }
-        val rk: err[fail.Fail] = add_reloc_addend(image, info_sec, ir2.off, ir2.kind, sym, ir2.addend);
+        val rk: err[fail.Fail] = add_reloc_addend(image, ?names, info_sec, ir2.off, ir2.kind, sym, ir2.addend);
         if (sel rk.err) { ret rk; }
         k = k + 1;
     }
@@ -2802,7 +3092,7 @@ fun install_into(s: *debug_input.DebugProgram, image: *of.ObjectImage, itn: *int
     var li: u32 = 0;
     for (li < loc_reloc_count) {
         val lr: *LocReloc = ?loc_relocs[li];
-        val rlrx: err[fail.Fail] = add_reloc(image, loclists_sec, lr.off, addr_kind, lr.sym);
+        val rlrx: err[fail.Fail] = add_reloc(image, ?names, loclists_sec, lr.off, addr_kind, lr.sym);
         if (sel rlrx.err) { ret rlrx; }
         li = li + 1;
     }
@@ -2810,14 +3100,14 @@ fun install_into(s: *debug_input.DebugProgram, image: *of.ObjectImage, itn: *int
     var ri3: u32 = 0;
     for (ri3 < rng_reloc_count) {
         val rr3: *RngReloc = ?rng_relocs[ri3];
-        val rrx: err[fail.Fail] = add_reloc(image, rnglists_sec, rr3.off, addr_kind, rr3.sym);
+        val rrx: err[fail.Fail] = add_reloc(image, ?names, rnglists_sec, rr3.off, addr_kind, rr3.sym);
         if (sel rrx.err) { ret rrx; }
         ri3 = ri3 + 1;
     }
 
     var i: u32 = 0;
     for (i < nfuncs) {
-        val rr: err[fail.Fail] = add_reloc(image, line_sec, addr_off[i], addr_kind, funcs[i].name);
+        val rr: err[fail.Fail] = add_reloc(image, ?names, line_sec, addr_off[i], addr_kind, funcs[i].name);
         if (sel rr.err) { ret rr; }
         i = i + 1;
     }
@@ -3622,7 +3912,9 @@ test "mach.lang.be.codegen.dwarf.build_line:prologue_end_and_entry_row" {
     var ft: FileTable; ft.count = 0;
     var b: enc.ByteBuf = enc.buf_init(?alloc);
     var addr_off: [1]u32; addr_off[0] = 0;
-    build_line(?program, ?fn, 1, ?row, 1, 0, 8, "/", "/", ?ft, ?b, ?addr_off[0]);
+    var row_start: [2]u32; row_start[0] = 0; row_start[1] = 1;
+    var row_items: [1]u32; row_items[0] = 0;
+    build_line(?program, ?fn, 1, ?row, ?row_start[0], ?row_items[0], 0, 8, "/", "/", ?ft, ?b, ?addr_off[0]);
 
     var pe: u32 = 0;
     var i: usize = (addr_off[0] + 8)::usize;
@@ -3658,7 +3950,9 @@ test "mach.lang.be.codegen.dwarf.build_line:file_table_declares_slot_one" {
 
     var b: enc.ByteBuf = enc.buf_init(?alloc);
     var addr_off: [1]u32; addr_off[0] = 0;
-    build_line(?program, ?fn, 1, ?row, 1, 0, 8, "/", "/", ?ft, ?b, ?addr_off[0]);
+    var row_start: [2]u32; row_start[0] = 0; row_start[1] = 1;
+    var row_items: [1]u32; row_items[0] = 0;
+    build_line(?program, ?fn, 1, ?row, ?row_start[0], ?row_items[0], 0, 8, "/", "/", ?ft, ?b, ?addr_off[0]);
 
     val fc: usize = 30 + 1 + 2 + 1 + 2 + 1 + 4;
     if (b.data[fc] != 2) { code = 1; }
@@ -3676,8 +3970,7 @@ test "mach.lang.be.codegen.dwarf.str_off:dedup" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var code: i32 = 0;
-    var st: StrTab;
-    st.buf = enc.buf_init(?alloc);
+    var st: StrTab = strtab_init(?alloc);
 
     val a0: u32 = str_off(?st, "i32");
     val b0: u32 = str_off(?st, "u32");
@@ -3686,8 +3979,18 @@ test "mach.lang.be.codegen.dwarf.str_off:dedup" {
     if (b0 != 4) { code = 1; }
     if (a1 != a0) { code = 1; }
     if (st.buf.len != 8::usize) { code = 1; }
+    var extra: u32 = 0;
+    for (extra < 200) {
+        val rs: res[str, format.FormatError] = format.sprint(?alloc, "name{}", extra);
+        if (sel rs.err) { code = 1; brk; }
+        val first: u32 = str_off(?st, rs.ok);
+        if (str_off(?st, rs.ok) != first || str_off(?st, "i32") != a0) { code = 1; }
+        A.deallocate[u8](?alloc, rs.ok, str_len(rs.ok) + 1);
+        extra = extra + 1;
+    }
+    if (st.len != 202 || st.buf.failed) { code = 1; }
 
-    enc.buf_dnit(?st.buf);
+    strtab_dnit(?st);
     ret code;
 }
 

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -490,6 +490,7 @@ pub rec EncodeState {
     blocks:      *BlockOffset;
     block_count: u32;
     block_cap:   u32;
+    block_index: map.Map[u64, u32];
     rows:        *LineRow;
     row_count:   u32;
     row_cap:     u32;
@@ -1059,6 +1060,32 @@ pub fun push_block(st: *EncodeState, fn_text_base: u32, block_id: u32, offset: u
     st.blocks[st.block_count].block_id     = block_id;
     st.blocks[st.block_count].offset       = offset;
     st.block_count = st.block_count + 1;
+    ret index_block(st, st.block_count - 1);
+}
+
+fun block_key(fn_text_base: u32, block_id: u32) u64 {
+    ret ((fn_text_base::u64) << 32) | (block_id::u64);
+}
+
+# the first record of a (function base, block id) pair is the one a lookup
+# finds, as the scan it replaces did
+fun index_block(st: *EncodeState, bi: u32) err[fail.Fail] {
+    val key: u64 = block_key(st.blocks[bi].fn_text_base, st.blocks[bi].block_id);
+    if (map.contains[u64, u32](?st.block_index, ?key)) { ret err[fail.Fail].ok{}; }
+    val inserted: res[bool, A.Error] = map.insert[u64, u32](?st.block_index, key, bi);
+    if (sel inserted.err) { ret err[fail.Fail].err{fail.refused(inserted.err)}; }
+    ret err[fail.Fail].ok{};
+}
+
+# a text gap moves function bases, which are part of the key
+fun reindex_blocks(st: *EncodeState) err[fail.Fail] {
+    map.clear[u64, u32](?st.block_index);
+    var bi: u32 = 0;
+    for (bi < st.block_count) {
+        val r: err[fail.Fail] = index_block(st, bi);
+        if (sel r.err) { ret r; }
+        bi = bi + 1;
+    }
     ret err[fail.Fail].ok{};
 }
 
@@ -1277,6 +1304,7 @@ pub fun state_blank(st: *EncodeState, alloc: *A.Allocator, model: *isa.MachineMo
     st.blocks      = nil;
     st.block_count = 0;
     st.block_cap   = 0;
+    st.block_index = map.init[u64, u32](alloc, map.hash_u64, map.eq_u64);
     st.rows        = nil;
     st.row_count   = 0;
     st.row_cap     = 0;
@@ -1371,6 +1399,7 @@ fun scratch_release(st: *EncodeState) {
     st.blocks      = nil;
     st.block_count = 0;
     st.block_cap   = 0;
+    map.dnit[u64, u32](?st.block_index);
 }
 
 fun shrink_text(st: *EncodeState) err[fail.Fail] {
@@ -1584,13 +1613,9 @@ fun patch_branches(st: *EncodeState, hooks: *EncodeHooks) err[fail.Fail] {
 }
 
 pub fun block_offset(st: *EncodeState, fn_base: u32, block_id: u32) res[u32, fail.Fail] {
-    var i: u32 = 0;
-    for (i < st.block_count) {
-        if (st.blocks[i].fn_text_base == fn_base && st.blocks[i].block_id == block_id) {
-            ret res[u32, fail.Fail].ok{st.blocks[i].offset};
-        }
-        i = i + 1;
-    }
+    val key: u64 = block_key(fn_base, block_id);
+    val found: opt[*u32] = map.get[u64, u32](?st.block_index, ?key);
+    if (sel found.some) { ret res[u32, fail.Fail].ok{st.blocks[@found.some].offset}; }
     ret res[u32, fail.Fail].err{fail.message("encode: branch target block was never recorded")};
 }
 
@@ -1639,10 +1664,15 @@ pub fun insert_text(st: *EncodeState, pos: u32, nbytes: u32) err[fail.Fail] {
     st.buf.len = need;
 
     var bi: u32 = 0;
+    var bases_moved: bool = false;
     for (bi < st.block_count) {
         if (st.blocks[bi].offset >= pos)       { st.blocks[bi].offset = st.blocks[bi].offset + nbytes; }
-        if (st.blocks[bi].fn_text_base >= pos) { st.blocks[bi].fn_text_base = st.blocks[bi].fn_text_base + nbytes; }
+        if (st.blocks[bi].fn_text_base >= pos) { st.blocks[bi].fn_text_base = st.blocks[bi].fn_text_base + nbytes; bases_moved = true; }
         bi = bi + 1;
+    }
+    if (bases_moved) {
+        val reindexed: err[fail.Fail] = reindex_blocks(st);
+        if (sel reindexed.err) { ret reindexed; }
     }
     var fi: u32 = 0;
     for (fi < st.fixup_count) {

--- a/src/lang/be/codegen/looprotate.mach
+++ b/src/lang/be/codegen/looprotate.mach
@@ -26,12 +26,27 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) err[fail.Fail] {
     ret err[fail.Fail].ok{};
 }
 
+# component holds each block's strongly connected component over the
+# terminator edges: a header's body is confined to its own component, so
+# mark_loop walks the loop rather than everything the body can reach.
+# loop_mark stamps a block with the epoch of the mark_loop call that reached
+# it, so a candidate header costs the blocks its loop holds rather than a
+# sweep of the function. named_in and named_multi record, per virtual
+# register, the one block naming it or that several do, so a header's
+# definitions are checked for confinement without a sweep of the function.
+# tarjan is the component walk's own scratch, six words per block
 rec LoopScratch {
     id_index:     *u32;
     id_index_cap: u32;
-    in_loop:      *bool;
+    loop_mark:    *u32;
+    epoch:        u32;
     stack:        *u32;
     block_count:  u32;
+    component:    *u32;
+    tarjan:       *u32;
+    named_in:     *u32;
+    named_multi:  *bool;
+    vreg_count:   u32;
 }
 
 fun rotate_function(alloc: *A.Allocator, f: *mir.MirFunction) err[fail.Fail] {
@@ -43,6 +58,9 @@ fun rotate_function(alloc: *A.Allocator, f: *mir.MirFunction) err[fail.Fail] {
 
     val rp: err[fail.Fail] = rebuild_preds(alloc, f, ?sc);
     if (sel rp.err) { scratch_dnit(alloc, ?sc); ret rp; }
+    val rn: err[fail.Fail] = rebuild_naming(alloc, f, ?sc);
+    if (sel rn.err) { scratch_dnit(alloc, ?sc); ret rn; }
+    rebuild_components(f, ?sc);
 
     var bi: u32 = 0;
     for (bi < f.block_count) {
@@ -51,6 +69,9 @@ fun rotate_function(alloc: *A.Allocator, f: *mir.MirFunction) err[fail.Fail] {
         if (rotated_r.ok) {
             val rp2: err[fail.Fail] = rebuild_preds(alloc, f, ?sc);
             if (sel rp2.err) { scratch_dnit(alloc, ?sc); ret rp2; }
+            val rn2: err[fail.Fail] = rebuild_naming(alloc, f, ?sc);
+            if (sel rn2.err) { scratch_dnit(alloc, ?sc); ret rn2; }
+            rebuild_components(f, ?sc);
         }
         bi = bi + 1;
     }
@@ -62,9 +83,15 @@ fun rotate_function(alloc: *A.Allocator, f: *mir.MirFunction) err[fail.Fail] {
 fun scratch_init(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) err[fail.Fail] {
     sc.id_index     = nil;
     sc.id_index_cap = 0;
-    sc.in_loop      = nil;
+    sc.loop_mark    = nil;
+    sc.epoch        = 0;
     sc.stack        = nil;
     sc.block_count  = f.block_count;
+    sc.component    = nil;
+    sc.tarjan       = nil;
+    sc.named_in     = nil;
+    sc.named_multi  = nil;
+    sc.vreg_count   = 0;
 
     var max_id: u32 = 0;
     var i: u32 = 0;
@@ -83,12 +110,14 @@ fun scratch_init(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) err
     k = 0;
     for (k < f.block_count) { sc.id_index[f.blocks[k].id] = k; k = k + 1; }
 
-    val rb: res[*bool, A.Error] = A.allocate[bool](alloc, f.block_count::usize);
+    val rb: res[*u32, A.Error] = A.allocate[u32](alloc, f.block_count::usize);
     if (sel rb.err) {
         scratch_dnit(alloc, sc);
         ret err[fail.Fail].err{fail.refused(rb.err)};
     }
-    sc.in_loop = rb.ok;
+    sc.loop_mark = rb.ok;
+    var mi: u32 = 0;
+    for (mi < f.block_count) { sc.loop_mark[mi] = 0; mi = mi + 1; }
 
     val rs: res[*u32, A.Error] = A.allocate[u32](alloc, f.block_count::usize);
     if (sel rs.err) {
@@ -96,6 +125,20 @@ fun scratch_init(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) err
         ret err[fail.Fail].err{fail.refused(rs.err)};
     }
     sc.stack = rs.ok;
+
+    val rc: res[*u32, A.Error] = A.allocate[u32](alloc, f.block_count::usize);
+    if (sel rc.err) {
+        scratch_dnit(alloc, sc);
+        ret err[fail.Fail].err{fail.refused(rc.err)};
+    }
+    sc.component = rc.ok;
+
+    val rt: res[*u32, A.Error] = A.allocate[u32](alloc, (f.block_count::usize) * 6);
+    if (sel rt.err) {
+        scratch_dnit(alloc, sc);
+        ret err[fail.Fail].err{fail.refused(rt.err)};
+    }
+    sc.tarjan = rt.ok;
 
     ret err[fail.Fail].ok{};
 }
@@ -106,14 +149,153 @@ fun scratch_dnit(alloc: *A.Allocator, sc: *LoopScratch) {
         sc.id_index     = nil;
         sc.id_index_cap = 0;
     }
-    if (sc.in_loop != nil) {
-        A.deallocate[bool](alloc, sc.in_loop, sc.block_count::usize);
-        sc.in_loop = nil;
+    if (sc.loop_mark != nil) {
+        A.deallocate[u32](alloc, sc.loop_mark, sc.block_count::usize);
+        sc.loop_mark = nil;
     }
     if (sc.stack != nil) {
         A.deallocate[u32](alloc, sc.stack, sc.block_count::usize);
         sc.stack = nil;
     }
+    if (sc.component != nil) {
+        A.deallocate[u32](alloc, sc.component, sc.block_count::usize);
+        sc.component = nil;
+    }
+    if (sc.tarjan != nil) {
+        A.deallocate[u32](alloc, sc.tarjan, (sc.block_count::usize) * 6);
+        sc.tarjan = nil;
+    }
+    naming_dnit(alloc, sc);
+}
+
+fun terminator_target(f: *mir.MirFunction, sc: *LoopScratch, bx: u32, k: u32) u32 {
+    val mb: *mir.MirBlock = ?f.blocks[bx];
+    if (mb.instr_count == 0) { ret mir.MIR_VREG_NIL; }
+    val t: *mir.MirInstr = ?mb.instrs[mb.instr_count - 1];
+    if (k >= t.operand_count) { ret mir.MIR_VREG_NIL; }
+    val op: *mir.MirOperand = ?t.operands[k];
+    if (op.kind != mir.MIR_OP_BLOCK) { ret mir.MIR_VREG_NIL; }
+    ret block_index(sc, op.imm::u32);
+}
+
+fun terminator_arity(f: *mir.MirFunction, bx: u32) u32 {
+    val mb: *mir.MirBlock = ?f.blocks[bx];
+    if (mb.instr_count == 0) { ret 0; }
+    ret mb.instrs[mb.instr_count - 1].operand_count;
+}
+
+# strongly connected components over the terminator edges, iterative tarjan;
+# a block on no cycle is its own component
+fun rebuild_components(f: *mir.MirFunction, sc: *LoopScratch) {
+    val n: u32 = sc.block_count;
+    val index: *u32 = sc.tarjan;
+    val low: *u32 = ?sc.tarjan[n];
+    val on_stack: *u32 = ?sc.tarjan[(n::usize) * 2];
+    val stack: *u32 = ?sc.tarjan[(n::usize) * 3];
+    val frame_block: *u32 = ?sc.tarjan[(n::usize) * 4];
+    val frame_next: *u32 = ?sc.tarjan[(n::usize) * 5];
+    var i: u32 = 0;
+    for (i < n) { index[i] = mir.MIR_VREG_NIL; on_stack[i] = 0; sc.component[i] = i; i = i + 1; }
+    var counter: u32 = 0;
+    var sp: u32 = 0;
+    var root: u32 = 0;
+    for (root < n) {
+        if (index[root] != mir.MIR_VREG_NIL) { root = root + 1; cnt; }
+        index[root] = counter; low[root] = counter; counter = counter + 1;
+        stack[sp] = root; sp = sp + 1; on_stack[root] = 1;
+        var depth: u32 = 1;
+        frame_block[0] = root;
+        frame_next[0] = 0;
+        for (depth > 0) {
+            val v: u32 = frame_block[depth - 1];
+            val k: u32 = frame_next[depth - 1];
+            if (k < terminator_arity(f, v)) {
+                frame_next[depth - 1] = k + 1;
+                val w: u32 = terminator_target(f, sc, v, k);
+                if (w == mir.MIR_VREG_NIL) { cnt; }
+                if (index[w] == mir.MIR_VREG_NIL) {
+                    index[w] = counter; low[w] = counter; counter = counter + 1;
+                    stack[sp] = w; sp = sp + 1; on_stack[w] = 1;
+                    frame_block[depth] = w;
+                    frame_next[depth] = 0;
+                    depth = depth + 1;
+                }
+                or (on_stack[w] != 0 && index[w] < low[v]) { low[v] = index[w]; }
+                cnt;
+            }
+            depth = depth - 1;
+            if (low[v] == index[v]) {
+                var member: u32 = mir.MIR_VREG_NIL;
+                for (member != v) {
+                    sp = sp - 1;
+                    member = stack[sp];
+                    on_stack[member] = 0;
+                    sc.component[member] = v;
+                }
+            }
+            if (depth > 0) {
+                val u: u32 = frame_block[depth - 1];
+                if (low[v] < low[u]) { low[u] = low[v]; }
+            }
+        }
+        root = root + 1;
+    }
+}
+
+fun naming_dnit(alloc: *A.Allocator, sc: *LoopScratch) {
+    if (sc.named_in != nil) {
+        A.deallocate[u32](alloc, sc.named_in, sc.vreg_count::usize);
+        sc.named_in = nil;
+    }
+    if (sc.named_multi != nil) {
+        A.deallocate[bool](alloc, sc.named_multi, sc.vreg_count::usize);
+        sc.named_multi = nil;
+    }
+    sc.vreg_count = 0;
+}
+
+fun note_named(sc: *LoopScratch, v: u32, bi: u32) {
+    if (v >= sc.vreg_count) { ret; }
+    if (sc.named_in[v] == mir.MIR_VREG_NIL) { sc.named_in[v] = bi; }
+    or (sc.named_in[v] != bi)               { sc.named_multi[v] = true; }
+}
+
+# one sweep of the function after every change to it: a rotation adds
+# registers and instructions, so the index is rebuilt at the new count
+fun rebuild_naming(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) err[fail.Fail] {
+    naming_dnit(alloc, sc);
+    if (f.vreg_count == 0) { ret err[fail.Fail].ok{}; }
+    val rn: res[*u32, A.Error] = A.allocate[u32](alloc, f.vreg_count::usize);
+    if (sel rn.err) { ret err[fail.Fail].err{fail.refused(rn.err)}; }
+    sc.named_in   = rn.ok;
+    sc.vreg_count = f.vreg_count;
+    val rm: res[*bool, A.Error] = A.allocate[bool](alloc, f.vreg_count::usize);
+    if (sel rm.err) { naming_dnit(alloc, sc); ret err[fail.Fail].err{fail.refused(rm.err)}; }
+    sc.named_multi = rm.ok;
+    var v: u32 = 0;
+    for (v < f.vreg_count) { sc.named_in[v] = mir.MIR_VREG_NIL; sc.named_multi[v] = false; v = v + 1; }
+
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val mb: *mir.MirBlock = ?f.blocks[bi];
+        var k: u32 = 0;
+        for (k < mb.instr_count) {
+            val ins: *mir.MirInstr = ?mb.instrs[k];
+            var o: u32 = 0;
+            for (o < ins.operand_count) {
+                val op: *mir.MirOperand = ?ins.operands[o];
+                if (op.kind == mir.MIR_OP_VREG) { note_named(sc, op.vreg, bi); }
+                if (op.kind == mir.MIR_OP_MEM) {
+                    note_named(sc, op.vreg, bi);
+                    if (!op.index_is_preg) { note_named(sc, op.index, bi); }
+                }
+                o = o + 1;
+            }
+            k = k + 1;
+        }
+        bi = bi + 1;
+    }
+    ret err[fail.Fail].ok{};
 }
 
 fun block_index(sc: *LoopScratch, id: u32) u32 {
@@ -149,7 +331,7 @@ fun try_rotate_header(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch
     if (h.pred_count < 2) { ret res[bool, fail.Fail].ok{false}; }
 
     if (!test_clonable(h, cond_vreg)) { ret res[bool, fail.Fail].ok{false}; }
-    if (!defs_confined(f, h))         { ret res[bool, fail.Fail].ok{false}; }
+    if (!defs_confined(sc, h))        { ret res[bool, fail.Fail].ok{false}; }
 
     if (!mark_loop(f, sc, b_id, h.id, e_id)) { ret res[bool, fail.Fail].ok{false}; }
     var p_id: u32 = mir.MIR_VREG_NIL;
@@ -158,7 +340,7 @@ fun try_rotate_header(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch
     var pi: u32 = 0;
     for (pi < h.pred_count) {
         val px: u32 = block_index(sc, h.preds[pi]);
-        if (px != mir.MIR_VREG_NIL && sc.in_loop[px]) {
+        if (px != mir.MIR_VREG_NIL && sc.loop_mark[px] == sc.epoch) {
             inside = inside + 1;
         } or {
             outside = outside + 1;
@@ -183,14 +365,22 @@ fun try_rotate_header(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch
 }
 
 fun mark_loop(f: *mir.MirFunction, sc: *LoopScratch, b_id: u32, h_id: u32, e_id: u32) bool {
-    var i: u32 = 0;
-    for (i < sc.block_count) { sc.in_loop[i] = false; i = i + 1; }
+    sc.epoch = sc.epoch + 1;
+    if (sc.epoch == 0) {
+        var i: u32 = 0;
+        for (i < sc.block_count) { sc.loop_mark[i] = 0; i = i + 1; }
+        sc.epoch = 1;
+    }
 
     val root: u32 = block_index(sc, b_id);
     if (root == mir.MIR_VREG_NIL) { ret false; }
-    sc.in_loop[root] = true;
+    val hx: u32 = block_index(sc, h_id);
+    var loop: u32 = mir.MIR_VREG_NIL;
+    if (hx != mir.MIR_VREG_NIL) { loop = sc.component[hx]; }
+    sc.loop_mark[root] = sc.epoch;
     sc.stack[0] = root;
     var sp: u32 = 1;
+    if (sc.component[root] != loop) { ret true; }
 
     for (sp > 0) {
         sp = sp - 1;
@@ -205,8 +395,8 @@ fun mark_loop(f: *mir.MirFunction, sc: *LoopScratch, b_id: u32, h_id: u32, e_id:
                     val tid: u32 = op.imm::u32;
                     if (tid != h_id && tid != e_id) {
                         val tx: u32 = block_index(sc, tid);
-                        if (tx != mir.MIR_VREG_NIL && !sc.in_loop[tx]) {
-                            sc.in_loop[tx] = true;
+                        if (tx != mir.MIR_VREG_NIL && sc.loop_mark[tx] != sc.epoch && sc.component[tx] == loop) {
+                            sc.loop_mark[tx] = sc.epoch;
                             sc.stack[sp] = tx;
                             sp = sp + 1;
                         }
@@ -268,46 +458,21 @@ fun test_clonable(h: *mir.MirBlock, cond_vreg: u32) bool {
     ret defines_cond;
 }
 
-fun defs_confined(f: *mir.MirFunction, h: *mir.MirBlock) bool {
-    var bi: u32 = 0;
-    for (bi < f.block_count) {
-        val mb: *mir.MirBlock = ?f.blocks[bi];
-        if (mb.id != h.id) {
-            var k: u32 = 0;
-            for (k < mb.instr_count) {
-                if (names_test_def(h, ?mb.instrs[k])) { ret false; }
-                k = k + 1;
-            }
-        }
-        bi = bi + 1;
-    }
-    ret true;
-}
-
-fun names_test_def(h: *mir.MirBlock, ins: *mir.MirInstr) bool {
-    var k: u32 = 0;
-    for (k < ins.operand_count) {
-        val op: *mir.MirOperand = ?ins.operands[k];
-        if (op.kind == mir.MIR_OP_VREG && test_defines(h, op.vreg)) { ret true; }
-        if (op.kind == mir.MIR_OP_MEM) {
-            if (test_defines(h, op.vreg))                       { ret true; }
-            if (!op.index_is_preg && test_defines(h, op.index)) { ret true; }
-        }
-        k = k + 1;
-    }
-    ret false;
-}
-
-fun test_defines(h: *mir.MirBlock, v: u32) bool {
-    if (v == mir.MIR_VREG_NIL) { ret false; }
+# every register the header's test defines is named by the header alone
+fun defs_confined(sc: *LoopScratch, h: *mir.MirBlock) bool {
+    val hx: u32 = block_index(sc, h.id);
     var i: u32 = 0;
     for (i < h.instr_count - 1) {
         val ins: *mir.MirInstr = ?h.instrs[i];
-        if (ins.operand_count > 0 && ins.operands[0].kind == mir.MIR_OP_VREG &&
-            ins.operands[0].vreg == v) { ret true; }
+        if (ins.operand_count > 0 && ins.operands[0].kind == mir.MIR_OP_VREG) {
+            val v: u32 = ins.operands[0].vreg;
+            if (v < sc.vreg_count && (sc.named_multi[v] || (sc.named_in[v] != mir.MIR_VREG_NIL && sc.named_in[v] != hx))) {
+                ret false;
+            }
+        }
         i = i + 1;
     }
-    ret false;
+    ret true;
 }
 
 fun clonable_opcode(op: mir.MirOpcode) bool {

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -61,6 +61,7 @@ pub rec LowerCtx {
     pending:       *mir.MirDbgBinding;
     pending_count: u32;
     pending_cap:   u32;
+    max_block_id:  u32;
 }
 
 pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) err[fail.Fail] {

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -135,6 +135,7 @@ fun lower_function(tgt: *target.Target, m: *ir.Module, fn: *ir.Function, alloc: 
     ctx.pending        = nil;
     ctx.pending_count  = 0;
     ctx.pending_cap    = 0;
+    ctx.max_block_id   = 0;
 
     val setup: err[fail.Fail] = lctx.ctx_setup(?ctx, tgt, fn);
     if (sel setup.err) {
@@ -186,6 +187,7 @@ fun lower_block(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block, is_entry:
     val f: *mir.MirFunction = ctx.f;
     val mb: *mir.MirBlock = ?f.blocks[f.block_count];
     mb.id          = blk.id::u32;
+    if (mb.id > ctx.max_block_id) { ctx.max_block_id = mb.id; }
     mb.instrs      = nil;
     mb.instr_count = 0;
     mb.instr_cap   = 0;
@@ -345,7 +347,11 @@ fun phi_edge_err(ctx: *lctx.LowerCtx, block_id: u32, pred_id: u32, dst_vreg: u32
     ret rj.ok;
 }
 
+# lowering keeps a block's index equal to its id (IR blocks in order, then
+# fresh ids past the largest), so the direct slot is checked first and the
+# scan covers any function shaped otherwise
 fun mir_block_by_id(f: *mir.MirFunction, block_id: u32) *mir.MirBlock {
+    if (block_id < f.block_count && f.blocks[block_id].id == block_id) { ret ?f.blocks[block_id]; }
     var bi: u32 = 0;
     for (bi < f.block_count) {
         if (f.blocks[bi].id == block_id) { ret ?f.blocks[bi]; }
@@ -497,19 +503,14 @@ fun grow_block(ctx: *lctx.LowerCtx) err[fail.Fail] {
     ret err[fail.Fail].ok{};
 }
 
-fun fresh_block_id(f: *mir.MirFunction) u32 {
-    var max_id: u32 = 0;
-    var bi: u32 = 0;
-    for (bi < f.block_count) {
-        if (f.blocks[bi].id > max_id) { max_id = f.blocks[bi].id; }
-        bi = bi + 1;
-    }
-    ret max_id + 1;
+fun fresh_block_id(ctx: *lctx.LowerCtx) u32 {
+    ctx.max_block_id = ctx.max_block_id + 1;
+    ret ctx.max_block_id;
 }
 
 fun split_critical_edge(ctx: *lctx.LowerCtx, pred: *mir.MirBlock, succ_id: u32) res[*mir.MirBlock, fail.Fail] {
     val pred_id: u32 = pred.id;
-    val new_id:  u32 = fresh_block_id(ctx.f);
+    val new_id:  u32 = fresh_block_id(ctx);
 
     val gr: err[fail.Fail] = grow_block(ctx);
     if (sel gr.err) { ret res[*mir.MirBlock, fail.Fail].err{gr.err}; }

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -16,6 +16,7 @@ use std.types.string.str_len;
 use std.types.string.str_contains;
 
 use A: std.allocator;
+use T: std.allocator.testing;
 
 use mach.lang.be.codegen.mir;
 use mach.lang.be.codegen.rules;
@@ -1222,91 +1223,255 @@ fun maybe_reverse_hint(ctx: *AllocCtx, mi: *mir.MirInstr, pos: u32, nv: u32) {
     ctx.hints[sv].dst_copy_pos = p;
 }
 
-fun extend_liveness(ctx: *AllocCtx) err[fail.Fail] {
+# liveness scratch: per-register use and definition blocks and per-block
+# predecessors, each grouped as offset ranges, so the propagation touches
+# only the blocks a register reaches instead of a block-by-register matrix
+rec LiveScratch {
+    alloc:      *A.Allocator;
+    nb:         u32;
+    nv:         u32;
+    use_start:  *u32;
+    def_start:  *u32;
+    pred_start: *u32;
+    use_mark:   *u32;
+    def_mark:   *u32;
+    def_of:     *u32;
+    visited:    *u32;
+    pending:    *u32;
+    use_count:  u32;
+    def_count:  u32;
+    edge_count: u32;
+    use_blocks: *u32;
+    def_blocks: *u32;
+    preds:      *u32;
+    fill:       bool;
+}
+
+fun live_scratch_array(l: *LiveScratch, out: **u32, n: u32, value: u32) err[fail.Fail] {
+    if (n == 0) { @out = nil; ret err[fail.Fail].ok{}; }
+    val r: res[*u32, A.Error] = A.allocate[u32](l.alloc, n::usize);
+    if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
+    @out = r.ok;
+    var i: u32 = 0;
+    for (i < n) { r.ok[i] = value; i = i + 1; }
+    ret err[fail.Fail].ok{};
+}
+
+fun live_scratch_release(l: *LiveScratch, arr: **u32, n: u32) {
+    if (@arr != nil && n > 0) { A.deallocate[u32](l.alloc, @arr, n::usize); }
+    @arr = nil;
+}
+
+fun live_scratch_dnit(l: *LiveScratch) {
+    live_scratch_release(l, ?l.preds, l.edge_count);
+    live_scratch_release(l, ?l.def_blocks, l.def_count);
+    live_scratch_release(l, ?l.use_blocks, l.use_count);
+    live_scratch_release(l, ?l.pending, l.nb);
+    live_scratch_release(l, ?l.visited, l.nb);
+    live_scratch_release(l, ?l.def_of, l.nb);
+    live_scratch_release(l, ?l.def_mark, l.nv);
+    live_scratch_release(l, ?l.use_mark, l.nv);
+    live_scratch_release(l, ?l.pred_start, l.nb + 1);
+    live_scratch_release(l, ?l.def_start, l.nv + 1);
+    live_scratch_release(l, ?l.use_start, l.nv + 1);
+}
+
+fun live_scratch_init(l: *LiveScratch, alloc: *A.Allocator, nb: u32, nv: u32) err[fail.Fail] {
+    l.alloc      = alloc;
+    l.nb         = nb;
+    l.nv         = nv;
+    l.use_start  = nil;
+    l.def_start  = nil;
+    l.pred_start = nil;
+    l.use_mark   = nil;
+    l.def_mark   = nil;
+    l.def_of     = nil;
+    l.visited    = nil;
+    l.pending    = nil;
+    l.use_count  = 0;
+    l.def_count  = 0;
+    l.edge_count = 0;
+    l.use_blocks = nil;
+    l.def_blocks = nil;
+    l.preds      = nil;
+    l.fill       = false;
+    val r0: err[fail.Fail] = live_scratch_array(l, ?l.use_start, nv + 1, 0);
+    if (sel r0.err) { ret r0; }
+    val r1: err[fail.Fail] = live_scratch_array(l, ?l.def_start, nv + 1, 0);
+    if (sel r1.err) { live_scratch_dnit(l); ret r1; }
+    val r2: err[fail.Fail] = live_scratch_array(l, ?l.pred_start, nb + 1, 0);
+    if (sel r2.err) { live_scratch_dnit(l); ret r2; }
+    val r3: err[fail.Fail] = live_scratch_array(l, ?l.use_mark, nv, RANGE_NIL);
+    if (sel r3.err) { live_scratch_dnit(l); ret r3; }
+    val r4: err[fail.Fail] = live_scratch_array(l, ?l.def_mark, nv, RANGE_NIL);
+    if (sel r4.err) { live_scratch_dnit(l); ret r4; }
+    val r5: err[fail.Fail] = live_scratch_array(l, ?l.def_of, nb, RANGE_NIL);
+    if (sel r5.err) { live_scratch_dnit(l); ret r5; }
+    val r6: err[fail.Fail] = live_scratch_array(l, ?l.visited, nb, RANGE_NIL);
+    if (sel r6.err) { live_scratch_dnit(l); ret r6; }
+    val r7: err[fail.Fail] = live_scratch_array(l, ?l.pending, nb, RANGE_NIL);
+    if (sel r7.err) { live_scratch_dnit(l); ret r7; }
+    ret err[fail.Fail].ok{};
+}
+
+# a use counts once per block and only before the block's first definition
+fun note_use(l: *LiveScratch, reg: u32, block: u32) {
+    if (reg >= l.nv || l.def_mark[reg] == block || l.use_mark[reg] == block) { ret; }
+    l.use_mark[reg] = block;
+    if (l.fill) { l.use_blocks[l.use_start[reg]] = block; l.use_start[reg] = l.use_start[reg] + 1; }
+    or          { l.use_start[reg + 1] = l.use_start[reg + 1] + 1; }
+}
+
+fun note_def(l: *LiveScratch, reg: u32, block: u32) {
+    if (reg >= l.nv || l.def_mark[reg] == block) { ret; }
+    l.def_mark[reg] = block;
+    if (l.fill) { l.def_blocks[l.def_start[reg]] = block; l.def_start[reg] = l.def_start[reg] + 1; }
+    or          { l.def_start[reg + 1] = l.def_start[reg + 1] + 1; }
+}
+
+fun note_edge(l: *LiveScratch, pred: u32, succ: u32) {
+    if (l.fill) { l.preds[l.pred_start[succ]] = pred; l.pred_start[succ] = l.pred_start[succ] + 1; }
+    or          { l.pred_start[succ + 1] = l.pred_start[succ + 1] + 1; }
+}
+
+# the same walk counts on the first pass and fills on the second; the start
+# arrays hold counts per index + 1 after the first pass, prefix sums after
+# exclusive_offsets, and each fill advances its own start, which
+# restore_offsets shifts back
+fun collect_references(ctx: *AllocCtx, l: *LiveScratch) {
     val f: *mir.MirFunction = ctx.f;
-    val nb: u32 = f.block_count;
-    val nv: u32 = f.vreg_count;
-    if (nb == 0 || nv == 0) { ret err[fail.Fail].ok{}; }
-
-    val total: usize = (nb::usize) * (nv::usize);
-    val use_set: res[*bool, A.Error] = A.allocate[bool](ctx.alloc, total);
-    if (sel use_set.err) { ret err[fail.Fail].err{fail.refused(use_set.err)}; }
-    val uses: *bool = use_set.ok;
-    val def_set: res[*bool, A.Error] = A.allocate[bool](ctx.alloc, total);
-    if (sel def_set.err) { A.deallocate[bool](ctx.alloc, uses, total); ret err[fail.Fail].err{fail.refused(def_set.err)}; }
-    val defs: *bool = def_set.ok;
-    val in_set: res[*bool, A.Error] = A.allocate[bool](ctx.alloc, total);
-    if (sel in_set.err) {
-        A.deallocate[bool](ctx.alloc, uses, total);
-        A.deallocate[bool](ctx.alloc, defs, total);
-        ret err[fail.Fail].err{fail.refused(in_set.err)};
-    }
-    val live_in: *bool = in_set.ok;
-    val out_set: res[*bool, A.Error] = A.allocate[bool](ctx.alloc, total);
-    if (sel out_set.err) {
-        A.deallocate[bool](ctx.alloc, uses, total);
-        A.deallocate[bool](ctx.alloc, defs, total);
-        A.deallocate[bool](ctx.alloc, live_in, total);
-        ret err[fail.Fail].err{fail.refused(out_set.err)};
-    }
-    val live_out: *bool = out_set.ok;
-
-    var z: usize = 0;
-    for (z < total) {
-        uses[z] = false;
-        defs[z] = false;
-        live_in[z] = false;
-        live_out[z] = false;
-        z = z + 1;
-    }
-
-    compute_use_def(ctx, uses, defs, nv);
-
-    var changed: bool = true;
-    for (changed) {
-        changed = false;
-        var ri: i64 = nb::i64 - 1;
-        for (ri >= 0) {
-            val b: u32 = ri::u32;
-            val base: usize = (b::usize) * (nv::usize);
-
-            var v: u32 = 0;
-            for (v < nv) { live_out[base + v::usize] = false; v = v + 1; }
-            union_succ_live_in(ctx, b, live_out, live_in, nv);
-
-            v = 0;
-            for (v < nv) {
-                val idx: usize = base + v::usize;
-                var new_in: bool = uses[idx];
-                if (live_out[idx] && !defs[idx]) { new_in = true; }
-                if (new_in && !live_in[idx]) {
-                    live_in[idx] = true;
-                    changed = true;
-                }
-                v = v + 1;
-            }
-            ri = ri - 1;
-        }
-    }
-
+    var i: u32 = 0;
+    for (i < l.nv) { l.use_mark[i] = RANGE_NIL; l.def_mark[i] = RANGE_NIL; i = i + 1; }
     var bi: u32 = 0;
-    for (bi < nb) {
-        val span: BlockSpan = ctx.block_spans[bi];
-        val base: usize = (bi::usize) * (nv::usize);
-        var v: u32 = 0;
-        for (v < nv) {
-            val idx: usize = base + v::usize;
-            extend_range_for_block(?ctx.ranges[v], span, live_in[idx], live_out[idx]);
-            v = v + 1;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            val has_def: bool = instr_defines(mi);
+            var k: u32 = 0;
+            for (k < mi.operand_count) {
+                val op: *mir.MirOperand = ?mi.operands[k];
+                if (op.kind == mir.MIR_OP_VREG || op.kind == mir.MIR_OP_MEM) {
+                    val is_dst: bool = has_def && k == 0 && op.kind == mir.MIR_OP_VREG;
+                    if (!is_dst) { note_use(l, op.vreg, bi); }
+                }
+                if (op.kind == mir.MIR_OP_MEM && !op.index_is_preg) { note_use(l, op.index, bi); }
+                k = k + 1;
+            }
+            if (has_def) { note_def(l, mi.operands[0].vreg, bi); }
+            ii = ii + 1;
         }
         bi = bi + 1;
     }
+}
 
-    A.deallocate[bool](ctx.alloc, uses, total);
-    A.deallocate[bool](ctx.alloc, defs, total);
-    A.deallocate[bool](ctx.alloc, live_in, total);
-    A.deallocate[bool](ctx.alloc, live_out, total);
+fun collect_edges(ctx: *AllocCtx, l: *LiveScratch) {
+    val f: *mir.MirFunction = ctx.f;
+    var bi: u32 = 0;
+    for (bi < f.block_count) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        if (blk.instr_count > 0) {
+            val term: *mir.MirInstr = ?blk.instrs[blk.instr_count - 1];
+            var k: u32 = 0;
+            for (k < term.operand_count) {
+                val op: *mir.MirOperand = ?term.operands[k];
+                if (op.kind == mir.MIR_OP_BLOCK) {
+                    val si: u32 = block_index_of(ctx, op.imm::u32);
+                    if (si != RANGE_NIL) { note_edge(l, bi, si); }
+                }
+                k = k + 1;
+            }
+        }
+        if (bi + 1 < f.block_count && block_lists_pred(?f.blocks[bi + 1], blk.id)) {
+            note_edge(l, bi, bi + 1);
+        }
+        bi = bi + 1;
+    }
+}
+
+fun exclusive_offsets(start: *u32, n: u32) u32 {
+    var i: u32 = 0;
+    for (i < n) { start[i + 1] = start[i + 1] + start[i]; i = i + 1; }
+    ret start[n];
+}
+
+fun restore_offsets(start: *u32, n: u32) {
+    var i: u32 = n;
+    for (i > 0) { start[i] = start[i - 1]; i = i - 1; }
+    start[0] = 0;
+}
+
+fun extend_liveness(ctx: *AllocCtx) err[fail.Fail] {
+    val nb: u32 = ctx.f.block_count;
+    val nv: u32 = ctx.f.vreg_count;
+    if (nb == 0 || nv == 0) { ret err[fail.Fail].ok{}; }
+    var l: LiveScratch;
+    val li: err[fail.Fail] = live_scratch_init(?l, ctx.alloc, nb, nv);
+    if (sel li.err) { ret li; }
+    fin { live_scratch_dnit(?l); }
+
+    collect_references(ctx, ?l);
+    collect_edges(ctx, ?l);
+    l.use_count  = exclusive_offsets(l.use_start, nv);
+    l.def_count  = exclusive_offsets(l.def_start, nv);
+    l.edge_count = exclusive_offsets(l.pred_start, nb);
+    val ru: err[fail.Fail] = live_scratch_array(?l, ?l.use_blocks, l.use_count, RANGE_NIL);
+    if (sel ru.err) { ret ru; }
+    val rd: err[fail.Fail] = live_scratch_array(?l, ?l.def_blocks, l.def_count, RANGE_NIL);
+    if (sel rd.err) { ret rd; }
+    val rp: err[fail.Fail] = live_scratch_array(?l, ?l.preds, l.edge_count, RANGE_NIL);
+    if (sel rp.err) { ret rp; }
+    l.fill = true;
+    collect_references(ctx, ?l);
+    collect_edges(ctx, ?l);
+    restore_offsets(l.use_start, nv);
+    restore_offsets(l.def_start, nv);
+    restore_offsets(l.pred_start, nb);
+
+    propagate_liveness(ctx, ?l);
     ret err[fail.Fail].ok{};
+}
+
+# backward reachability per register: every block with an upward-exposed use
+# is live-in, every predecessor of a live-in block is live-out, and a
+# predecessor without a definition of the register is live-in in turn
+fun propagate_liveness(ctx: *AllocCtx, l: *LiveScratch) {
+    var reg: u32 = 0;
+    for (reg < l.nv) {
+        val lr: *LiveRange = ?ctx.ranges[reg];
+        var d: u32 = l.def_start[reg];
+        for (d < l.def_start[reg + 1]) { l.def_of[l.def_blocks[d]] = reg; d = d + 1; }
+        var count: u32 = 0;
+        var u: u32 = l.use_start[reg];
+        for (u < l.use_start[reg + 1]) {
+            val b: u32 = l.use_blocks[u];
+            if (l.visited[b] != reg) {
+                l.visited[b] = reg;
+                l.pending[count] = b;
+                count = count + 1;
+                extend_range_for_block(lr, ctx.block_spans[b], true, false);
+            }
+            u = u + 1;
+        }
+        for (count > 0) {
+            count = count - 1;
+            val b: u32 = l.pending[count];
+            var e: u32 = l.pred_start[b];
+            for (e < l.pred_start[b + 1]) {
+                val p: u32 = l.preds[e];
+                extend_range_for_block(lr, ctx.block_spans[p], false, true);
+                if (l.def_of[p] != reg && l.visited[p] != reg) {
+                    l.visited[p] = reg;
+                    l.pending[count] = p;
+                    count = count + 1;
+                    extend_range_for_block(lr, ctx.block_spans[p], true, false);
+                }
+                e = e + 1;
+            }
+        }
+        reg = reg + 1;
+    }
 }
 
 fun extend_range_for_block(lr: *LiveRange, span: BlockSpan, live_in: bool, live_out: bool) {
@@ -1335,74 +1500,9 @@ fun build_block_spans(ctx: *AllocCtx) err[fail.Fail] {
     ret err[fail.Fail].ok{};
 }
 
-fun compute_use_def(ctx: *AllocCtx, uses: *bool, defs: *bool, nv: u32) {
-    val f: *mir.MirFunction = ctx.f;
-    var bi: u32 = 0;
-    for (bi < f.block_count) {
-        val blk: *mir.MirBlock = ?f.blocks[bi];
-        val base: usize = (bi::usize) * (nv::usize);
-        var ii: u32 = 0;
-        for (ii < blk.instr_count) {
-            val mi: *mir.MirInstr = ?blk.instrs[ii];
-            val has_def: bool = instr_defines(mi);
-
-            var k: u32 = 0;
-            for (k < mi.operand_count) {
-                val op: *mir.MirOperand = ?mi.operands[k];
-                var v: u32 = mir.MIR_VREG_NIL;
-                if (op.kind == mir.MIR_OP_VREG)                               { v = op.vreg; }
-                if (op.kind == mir.MIR_OP_MEM && op.vreg != mir.MIR_VREG_NIL) { v = op.vreg; }
-                if (v != mir.MIR_VREG_NIL && v < nv) {
-                    val is_dst: bool = has_def && k == 0 && op.kind == mir.MIR_OP_VREG;
-                    if (!is_dst) {
-                        if (!defs[base + v::usize]) { uses[base + v::usize] = true; }
-                    }
-                }
-                if (op.kind == mir.MIR_OP_MEM && !op.index_is_preg && op.index != mir.MIR_VREG_NIL && op.index < nv) {
-                    if (!defs[base + op.index::usize]) { uses[base + op.index::usize] = true; }
-                }
-                k = k + 1;
-            }
-            if (has_def) {
-                val d: *mir.MirOperand = ?mi.operands[0];
-                if (d.kind == mir.MIR_OP_VREG && d.vreg < nv) {
-                    defs[base + d.vreg::usize] = true;
-                }
-            }
-            ii = ii + 1;
-        }
-        bi = bi + 1;
-    }
-}
-
 fun instr_defines(mi: *mir.MirInstr) bool {
     if (!mir.instr_defines_shape(mi)) { ret false; }
     ret mi.operands[0].kind == mir.MIR_OP_VREG;
-}
-
-fun union_succ_live_in(ctx: *AllocCtx, b: u32, live_out: *bool, live_in: *bool, nv: u32) {
-    val f: *mir.MirFunction = ctx.f;
-    val blk: *mir.MirBlock = ?f.blocks[b];
-    val ob: usize = (b::usize) * (nv::usize);
-
-    if (blk.instr_count > 0) {
-        val term: *mir.MirInstr = ?blk.instrs[blk.instr_count - 1];
-        var k: u32 = 0;
-        for (k < term.operand_count) {
-            val op: *mir.MirOperand = ?term.operands[k];
-            if (op.kind == mir.MIR_OP_BLOCK) {
-                val si: u32 = block_index_of(ctx, op.imm::u32);
-                if (si != RANGE_NIL) {
-                    or_row(live_out, ob, live_in, (si::usize) * (nv::usize), nv);
-                }
-            }
-            k = k + 1;
-        }
-    }
-
-    if (b + 1 < f.block_count && block_lists_pred(?f.blocks[b + 1], blk.id)) {
-        or_row(live_out, ob, live_in, ((b + 1)::usize) * (nv::usize), nv);
-    }
 }
 
 fun block_lists_pred(blk: *mir.MirBlock, pred_id: u32) bool {
@@ -1412,14 +1512,6 @@ fun block_lists_pred(blk: *mir.MirBlock, pred_id: u32) bool {
         i = i + 1;
     }
     ret false;
-}
-
-fun or_row(dst: *bool, dbase: usize, src: *bool, sbase: usize, nv: u32) {
-    var v: u32 = 0;
-    for (v < nv) {
-        if (src[sbase + v::usize]) { dst[dbase + v::usize] = true; }
-        v = v + 1;
-    }
 }
 
 fun mark_call_crossing(ctx: *AllocCtx) err[fail.Fail] {
@@ -4361,5 +4453,231 @@ test "mach.lang.be.codegen.regalloc:unknown_catalog_inputs_never_use_the_fp_or_n
     val bad_operand: err[fail.Fail] = run(?tgt, ?module);
     if (sel bad_operand.ok) { ret 10; }
     if (!str_contains(fail.describe(bad_operand.err), "unknown MirOperandKind tag 200")) { ret 10; }
+    ret 0;
+}
+
+# the dense block-by-register equations, kept only as the oracle the sparse
+# propagation is checked against on small graphs
+fun t_dense_liveness(ctx: *AllocCtx) err[fail.Fail] {
+    val f: *mir.MirFunction = ctx.f;
+    val nb: u32 = f.block_count;
+    val nv: u32 = f.vreg_count;
+    if (nb == 0 || nv == 0) { ret err[fail.Fail].ok{}; }
+    val total: usize = (nb::usize) * (nv::usize) * 4;
+    val cells: res[*bool, A.Error] = A.allocate[bool](ctx.alloc, total);
+    if (sel cells.err) { ret err[fail.Fail].err{fail.refused(cells.err)}; }
+    fin { A.deallocate[bool](ctx.alloc, cells.ok, total); }
+    val stride: usize = (nb::usize) * (nv::usize);
+    val uses: *bool = cells.ok;
+    val defs: *bool = ?cells.ok[stride];
+    val live_in: *bool = ?cells.ok[stride * 2];
+    val live_out: *bool = ?cells.ok[stride * 3];
+    var z: usize = 0;
+    for (z < total) { cells.ok[z] = false; z = z + 1; }
+
+    var bi: u32 = 0;
+    for (bi < nb) {
+        val blk: *mir.MirBlock = ?f.blocks[bi];
+        val base: usize = (bi::usize) * (nv::usize);
+        var ii: u32 = 0;
+        for (ii < blk.instr_count) {
+            val mi: *mir.MirInstr = ?blk.instrs[ii];
+            val has_def: bool = instr_defines(mi);
+            var k: u32 = 0;
+            for (k < mi.operand_count) {
+                val op: *mir.MirOperand = ?mi.operands[k];
+                var v: u32 = mir.MIR_VREG_NIL;
+                if (op.kind == mir.MIR_OP_VREG || op.kind == mir.MIR_OP_MEM) { v = op.vreg; }
+                if (v < nv && !(has_def && k == 0 && op.kind == mir.MIR_OP_VREG) && !defs[base + v::usize]) {
+                    uses[base + v::usize] = true;
+                }
+                if (op.kind == mir.MIR_OP_MEM && !op.index_is_preg && op.index < nv && !defs[base + op.index::usize]) {
+                    uses[base + op.index::usize] = true;
+                }
+                k = k + 1;
+            }
+            if (has_def && mi.operands[0].vreg < nv) { defs[base + mi.operands[0].vreg::usize] = true; }
+            ii = ii + 1;
+        }
+        bi = bi + 1;
+    }
+
+    var changed: bool = true;
+    for (changed) {
+        changed = false;
+        var ri: i64 = nb::i64 - 1;
+        for (ri >= 0) {
+            val b: u32 = ri::u32;
+            val base: usize = (b::usize) * (nv::usize);
+            var v: u32 = 0;
+            for (v < nv) { live_out[base + v::usize] = false; v = v + 1; }
+            val blk: *mir.MirBlock = ?f.blocks[b];
+            if (blk.instr_count > 0) {
+                val term: *mir.MirInstr = ?blk.instrs[blk.instr_count - 1];
+                var k: u32 = 0;
+                for (k < term.operand_count) {
+                    if (term.operands[k].kind == mir.MIR_OP_BLOCK) {
+                        val si: u32 = block_index_of(ctx, term.operands[k].imm::u32);
+                        if (si != RANGE_NIL) { t_or_row(live_out, base, live_in, (si::usize) * (nv::usize), nv); }
+                    }
+                    k = k + 1;
+                }
+            }
+            if (b + 1 < nb && block_lists_pred(?f.blocks[b + 1], blk.id)) {
+                t_or_row(live_out, base, live_in, ((b + 1)::usize) * (nv::usize), nv);
+            }
+            v = 0;
+            for (v < nv) {
+                val idx: usize = base + v::usize;
+                if ((uses[idx] || (live_out[idx] && !defs[idx])) && !live_in[idx]) { live_in[idx] = true; changed = true; }
+                v = v + 1;
+            }
+            ri = ri - 1;
+        }
+    }
+
+    bi = 0;
+    for (bi < nb) {
+        val base: usize = (bi::usize) * (nv::usize);
+        var v: u32 = 0;
+        for (v < nv) {
+            extend_range_for_block(?ctx.ranges[v], ctx.block_spans[bi], live_in[base + v::usize], live_out[base + v::usize]);
+            v = v + 1;
+        }
+        bi = bi + 1;
+    }
+    ret err[fail.Fail].ok{};
+}
+
+fun t_or_row(dst: *bool, dbase: usize, src: *bool, sbase: usize, nv: u32) {
+    var v: u32 = 0;
+    for (v < nv) { if (src[sbase + v::usize]) { dst[dbase + v::usize] = true; } v = v + 1; }
+}
+
+# eight blocks of four instructions whose uses, definitions, memory operands,
+# fallthroughs, self loops and an empty block vary with the sample bits
+fun t_sparse_liveness_case(sample: u32, ordinal: usize, attempts: *usize) i32 {
+    var track: T.Testing;
+    val made: err[A.Error] = T.make(?track);
+    if (sel made.err) { ret 1; }
+    fin { T.dnit(?track); }
+    var alloc: A.Allocator;
+    val paged: err[A.Error] = page.make(?alloc);
+    if (sel paged.err) { ret 2; }
+    var blocks: [8]mir.MirBlock;
+    var instrs: [8][4]mir.MirInstr;
+    var operands: [8][4][3]mir.MirOperand;
+    var preds: [8]u32;
+    var spans: [8]BlockSpan;
+    var block_map: [64]u32;
+    var sparse: [8]LiveRange;
+    var dense: [8]LiveRange;
+    var bi: u32 = 0;
+    for (bi < 64) { block_map[bi] = RANGE_NIL; bi = bi + 1; }
+    bi = 0;
+    for (bi < 8) {
+        val bid: u32 = 40 - bi * 3;
+        blocks[bi].id = bid;
+        block_map[bid] = bi;
+        blocks[bi].instrs = ?instrs[bi][0];
+        blocks[bi].instr_count = 4;
+        blocks[bi].preds = nil;
+        blocks[bi].pred_count = 0;
+        if (bi > 0 && ((sample + bi) & 1) == 0) {
+            preds[bi] = 40 - (bi - 1) * 3;
+            blocks[bi].preds = ?preds[bi];
+            blocks[bi].pred_count = 1;
+        }
+        var definition: u32 = 0;
+        var use_index: u32 = 1;
+        if ((sample & 2) != 0) { definition = 1; use_index = 0; }
+        operands[bi][definition][0] = mir.op_vreg(bi);
+        operands[bi][definition][1] = mir.op_preg(0);
+        instrs[bi][definition] = mir.instr(mir.MIR_MOV, ?operands[bi][definition][0], 2, 8, 8);
+        operands[bi][use_index][0] = mir.op_preg(0);
+        operands[bi][use_index][1] = mir.op_vreg((bi + sample) % 8);
+        instrs[bi][use_index] = mir.instr(mir.MIR_MOV, ?operands[bi][use_index][0], 2, 8, 8);
+        var destination: u32 = (bi + 1) % 8;
+        if ((sample & 4) != 0) { destination = bi; }
+        if ((sample & 3) == 3) { destination = (bi + 2) % 8; }
+        operands[bi][2][0] = mir.op_vreg(destination);
+        operands[bi][2][1] = mir.op_mem_value((bi + 2) % 8, 0);
+        operands[bi][2][1].index = (bi + 3) % 8;
+        operands[bi][2][1].index_is_preg = (sample & 1) != 0;
+        instrs[bi][2] = mir.instr(mir.MIR_LOAD, ?operands[bi][2][0], 2, 8, 8);
+        operands[bi][3][0] = mir.op_vreg((bi + 4) % 8);
+        operands[bi][3][1] = mir.op_block(40 - ((bi + 1) % 8) * 3);
+        operands[bi][3][2] = mir.op_block(40 - ((bi + sample + 6) % 8) * 3);
+        instrs[bi][3] = mir.instr(mir.MIR_CBR, ?operands[bi][3][0], 3, 8, 8);
+        spans[bi].start = (bi * 4)::i64;
+        spans[bi].end = (bi * 4 + 3)::i64;
+        if (bi == 5 && (sample & 8) != 0) {
+            blocks[bi].instr_count = 0;
+            spans[bi].start = -1;
+            spans[bi].end = -1;
+        }
+        sparse[bi].vreg = bi; sparse[bi].start = POS_MAX; sparse[bi].end_pos = -1;
+        dense[bi] = sparse[bi];
+        bi = bi + 1;
+    }
+    var f: mir.MirFunction;
+    f.blocks = ?blocks[0];
+    f.block_count = 8;
+    f.vreg_count = 8;
+    var ctx: AllocCtx;
+    ctx.alloc = T.allocator_of(?track);
+    ctx.f = ?f;
+    ctx.block_spans = ?spans[0];
+    ctx.block_id_index = ?block_map[0];
+    ctx.block_id_index_cap = 64;
+    ctx.ranges = ?sparse[0];
+    T.fail_at_ordinal(?track, ordinal);
+    val result: err[fail.Fail] = extend_liveness(?ctx);
+    @attempts = T.attempt_count(?track);
+    if (T.leaked(?track) || T.double_free_count(?track) != 0 || T.tracking_exhausted(?track)) { ret 3; }
+    if (ordinal != 0) {
+        if (sel result.ok) { ret 4; }
+        bi = 0;
+        for (bi < 8) {
+            if (sparse[bi].start != POS_MAX || sparse[bi].end_pos != -1) { ret 5; }
+            bi = bi + 1;
+        }
+        ret 0;
+    }
+    if (sel result.err) { ret 6; }
+    ctx.alloc = ?alloc;
+    ctx.ranges = ?dense[0];
+    val oracle: err[fail.Fail] = t_dense_liveness(?ctx);
+    if (sel oracle.err) { ret 7; }
+    bi = 0;
+    for (bi < 8) {
+        if (sparse[bi].start != dense[bi].start || sparse[bi].end_pos != dense[bi].end_pos) { ret 8; }
+        bi = bi + 1;
+    }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.regalloc.extend_liveness:sparse_matches_dense_loops_definitions_and_memory_uses" {
+    var sample: u32 = 0;
+    for (sample < 16) {
+        var attempts: usize = 0;
+        val result: i32 = t_sparse_liveness_case(sample, 0, ?attempts);
+        if (result != 0) { ret result; }
+        sample = sample + 1;
+    }
+    ret 0;
+}
+
+test "mach.lang.be.codegen.regalloc.extend_liveness:allocation_failure_preserves_ranges_and_releases_scratch" {
+    var attempts: usize = 0;
+    val baseline: i32 = t_sparse_liveness_case(9, 0, ?attempts);
+    if (baseline != 0 || attempts == 0) { ret 1; }
+    var ordinal: usize = 1;
+    for (ordinal <= attempts) {
+        var refused_attempts: usize = 0;
+        val result: i32 = t_sparse_liveness_case(9, ordinal, ?refused_attempts);
+        if (result != 0) { ret result; }
+        ordinal = ordinal + 1;
+    }
     ret 0;
 }

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -4715,20 +4715,58 @@ fun local_symbol_target(modules: *of.ObjectImage, m: u32, sy: u32,
 
 fun module_weak_function_ref_is_dead(modules: *of.ObjectImage, m: u32, name: intern.StrId,
                                      addend: i64, sec_base: *u32, atoms: *AtomPlan) bool {
+    ret weak_function_ref_is_dead(modules, m, first_defined_symbol(modules, m, name), addend, sec_base, atoms);
+}
+
+fun symbol_is_defined(modules: *of.ObjectImage, m: u32, sy: u32) bool {
+    val sym: *of.Symbol = ?modules[m].symbols[sy];
+    ret !of.section_is_external(sym.section) && of.section_index(sym.section) < modules[m].section_count;
+}
+
+fun first_defined_symbol(modules: *of.ObjectImage, m: u32, name: intern.StrId) u32 {
     var sy: u32 = 0;
     for (sy < modules[m].symbol_count) {
-        val sym: *of.Symbol = ?modules[m].symbols[sy];
-        if (sym.name == name && !of.section_is_external(sym.section)
-            && of.section_index(sym.section) < modules[m].section_count) {
-            val need: u32 = of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
-            if ((sym.flags & need) != need) { ret false; }
-            val eff: i64 = sym.offset::i64 + addend;
-            if (eff < 0 || eff > 0xFFFFFFFF) { ret false; }
-            ret atom_offset_dead(atoms, sec_base[m] + of.section_index(sym.section), eff::u32);
+        if (modules[m].symbols[sy].name == name && symbol_is_defined(modules, m, sy)) { ret sy; }
+        sy = sy + 1;
+    }
+    ret of.SYMBOL_NONE;
+}
+
+# the module's first defined symbol per name, built once for a module with
+# debug sections so each debug relocation asks a map rather than a scan
+fun index_defined_symbols(alloc: *A.Allocator, modules: *of.ObjectImage, m: u32) res[map.Map[intern.StrId, u32], fail.Fail] {
+    var index: map.Map[intern.StrId, u32] = map.init[intern.StrId, u32](alloc, map.hash_u32, map.eq_u32);
+    var sy: u32 = 0;
+    for (sy < modules[m].symbol_count) {
+        val name: intern.StrId = modules[m].symbols[sy].name;
+        if (symbol_is_defined(modules, m, sy) && !map.contains[intern.StrId, u32](?index, ?name)) {
+            val inserted: res[bool, A.Error] = map.insert[intern.StrId, u32](?index, name, sy);
+            if (sel inserted.err) {
+                map.dnit[intern.StrId, u32](?index);
+                ret res[map.Map[intern.StrId, u32], fail.Fail].err{fail.refused(inserted.err)};
+            }
         }
         sy = sy + 1;
     }
-    ret false;
+    ret res[map.Map[intern.StrId, u32], fail.Fail].ok{index};
+}
+
+fun indexed_defined_symbol(index: *map.Map[intern.StrId, u32], name: intern.StrId) u32 {
+    var key: intern.StrId = name;
+    val found: opt[*u32] = map.get[intern.StrId, u32](index, ?key);
+    if (sel found.some) { ret @found.some; }
+    ret of.SYMBOL_NONE;
+}
+
+fun weak_function_ref_is_dead(modules: *of.ObjectImage, m: u32, sy: u32,
+                              addend: i64, sec_base: *u32, atoms: *AtomPlan) bool {
+    if (sy == of.SYMBOL_NONE) { ret false; }
+    val sym: *of.Symbol = ?modules[m].symbols[sy];
+    val need: u32 = of.SYM_OBJ_FLAG_WEAK | of.SYM_OBJ_FLAG_FUNCTION;
+    if ((sym.flags & need) != need) { ret false; }
+    val eff: i64 = sym.offset::i64 + addend;
+    if (eff < 0 || eff > 0xFFFFFFFF) { ret false; }
+    ret atom_offset_dead(atoms, sec_base[m] + of.section_index(sym.section), eff::u32);
 }
 
 fun is_dwarf_code_address(r: *of.Relocation, info_sec: u32, line_sec: u32,
@@ -4799,6 +4837,14 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
     }
 
     val debug_linkable: bool = module_debug_is_linkable(modules, m);
+    var defined_by_name: map.Map[intern.StrId, u32] = map.init[intern.StrId, u32](s.alloc, map.hash_u32, map.eq_u32);
+    fin { map.dnit[intern.StrId, u32](?defined_by_name); }
+    if (debug_linkable && (info_sec != 0xFFFFFFFF || line_sec != 0xFFFFFFFF
+                           || loclists_sec != 0xFFFFFFFF || rnglists_sec != 0xFFFFFFFF)) {
+        val indexed: res[map.Map[intern.StrId, u32], fail.Fail] = index_defined_symbols(s.alloc, modules, m);
+        if (sel indexed.err) { ret err[fail.Fail].err{indexed.err}; }
+        defined_by_name = indexed.ok;
+    }
 
     var ri: u32 = 0;
     for (ri < modules[m].reloc_count) {
@@ -4907,7 +4953,8 @@ fun patch_module_relocations(s: *session.Session, out_img: *of.ObjectImage,
                 if ((of.section_index(r.section) == info_sec || of.section_index(r.section) == line_sec
                      || of.section_index(r.section) == loclists_sec || of.section_index(r.section) == rnglists_sec)
                     && of.is_pointer_abs_kind(r.kind, arch.pointer_width)
-                    && module_weak_function_ref_is_dead(modules, m, target_name, target_addend, sec_base, atoms)) {
+                    && weak_function_ref_is_dead(modules, m, indexed_defined_symbol(?defined_by_name, target_name),
+                                                 target_addend, sec_base, atoms)) {
                     resolved.vaddr = DWARF_TOMBSTONE_ADDRESS;
                     apply_addend = 0;
                 }

--- a/src/lang/build/cache/store.mach
+++ b/src/lang/build/cache/store.mach
@@ -8,6 +8,7 @@ use std.types.error.err;
 use io_error: std.io.error;
 use A: std.allocator;
 use vector: std.collections.vector;
+use map: std.collections.map;
 use std.crypto.hash.sha256;
 use std.system.os;
 use txn: std.filesystem.transaction;
@@ -53,6 +54,9 @@ pub rec Lookup {
     bytes: vector.Vector[u8];
 }
 
+# entered_* is the directory's modification time as found on arrival, before
+# the lock's own housekeeping moves it: a journal sealed at that time was the
+# directory's last writer
 rec Access {
     alloc: *A.Allocator;
     root: txn.Root;
@@ -61,6 +65,9 @@ rec Access {
     locked: bool;
     failed: bool;
     error: Error;
+    entered: bool;
+    entered_mtime: i64;
+    entered_nsec: i64;
 }
 
 fun internal(e: txn.Error) bool {
@@ -96,6 +103,8 @@ fun begin(a: *Access, alloc: *A.Allocator, directory: str) {
     transaction_error(a, txn.root_open(?a.root, directory, ""));
     if (a.failed) { ret; }
     a.opened = true;
+    a.entered = directory_time(a, ?a.entered_mtime, ?a.entered_nsec);
+    if (a.failed) { ret; }
     transaction_error(a, txn.lock(?a.held, ?a.root));
     if (a.failed) { ret; }
     a.locked = true;
@@ -144,6 +153,7 @@ fun reserved_prefix(name: str, prefix: str) bool {
 
 fun metadata(name: str) bool {
     if (str_equals(name, ".") || str_equals(name, "..")) { ret true; }
+    if (str_equals(name, INDEX_LEAF) || str_equals(name, INDEX_NEXT_LEAF)) { ret true; }
     if (str_len(name) == str_len(txn.LOCK_LEAF) && reserved_prefix(name, txn.LOCK_LEAF)) { ret true; }
     if (str_equals(name, ownership.CLAIMS_LEAF)) { ret true; }
     ret reserved_prefix(name, txn.STAGING_TAG);
@@ -318,9 +328,417 @@ fun sweep(a: *Access, replacing: str) u64 {
     ret inventory(a, ?entries, replacing);
 }
 
-# eviction policy: least recently published first (entry mtime, then name), never
-# an entry this build restored or published, and never past the store limit by
-# leaving the store as it was: a publication that cannot make room is declined
+# the store's own inventory: a journal beside the entries, maintained under the
+# lock, of add records (name and size, oldest publication first) and remove
+# records. an add record goes ahead of every entry write and a remove record
+# behind every unlink, so an interrupted step can only leave an entry the
+# journal still lists: the store then holds less than it accounts for, never
+# more, and the next eviction meets the listed entry, finds it absent and drops
+# it. a publication reads the journal instead of stat'ing every entry. a
+# missing, malformed or truncated journal is rebuilt from a directory
+# inventory, and a journal grown past twice its live entries is compacted
+val INDEX_LEAF: str = ".mach-store-index";
+val INDEX_NEXT_LEAF: str = ".mach-store-index.next";
+val INDEX_MAGIC: u32 = 0x58494D53;
+val INDEX_VERSION: u32 = 1;
+val INDEX_HEADER: usize = 8;
+val INDEX_RECORD: usize = 73;
+val INDEX_ADD: u8 = 1;
+val INDEX_REMOVE: u8 = 2;
+val INDEX_SEAL: u8 = 3;
+val INDEX_SLACK: usize = 64;
+
+# a seal closes a publication: the directory's modification time once every
+# change of that publication is on disk. a journal whose last record is a
+# seal matching the directory's time on arrival was the directory's last
+# writer, so the next publication trusts it without a listing
+rec Inventory {
+    entries: vector.Vector[Entry];
+    total: u64;
+    records: usize;
+    sealed: bool;
+    seal_mtime: i64;
+    seal_nsec: i64;
+}
+
+fun inventory_init(a: *Access, inv: *Inventory) {
+    inv.entries = vector.init[Entry](a.alloc);
+    inv.total = 0;
+    inv.records = 0;
+    inv.sealed = false;
+    inv.seal_mtime = 0;
+    inv.seal_nsec = 0;
+}
+
+fun inventory_dnit(inv: *Inventory) {
+    vector.dnit[Entry](?inv.entries);
+}
+
+fun name_key(name: *u8) u64 {
+    var key: u64 = 0;
+    var i: usize = 0;
+    for (i < 16) {
+        var digit: u64 = 0;
+        val c: u8 = name[i];
+        if (c >= 'a' && c <= 'f') { digit = (c - 'a' + 10)::u64; } or { digit = (c - '0')::u64; }
+        key = (key << 4) | digit;
+        i = i + 1;
+    }
+    ret key;
+}
+
+fun name_equals(a: *u8, b: *u8) bool {
+    var i: usize = 0;
+    for (i < 64) { if (a[i] != b[i]) { ret false; } i = i + 1; }
+    ret true;
+}
+
+fun index_open_flags() i32 {
+    var flags: i32 = 0;
+    $if ($mach.build.os == $mach.os.linux) { flags = native.O_NOFOLLOW; }
+    $or ($mach.build.os == $mach.os.darwin) { flags = native.O_NOFOLLOW; }
+    ret flags;
+}
+
+# the whole file into the vector's own buffer, reserved from the file's size
+fun read_all(a: *Access, fd: i32, bytes: *vector.Vector[u8]) bool {
+    var info: os.stat_t;
+    val observed: i64 = os.stat(fd, ?info);
+    if (observed < 0) { native_error(a, observed, txn.OP_RECOVER); ret false; }
+    if ((os.stat_mode(?info) & os.S_IFMT) != os.S_IFREG || info.st_size < 0) {
+        record(a, txn.error(txn.CONTAINMENT, txn.OP_RECOVER), "cache index is not a regular file"); ret false;
+    }
+    for (true) {
+        val room: res[usize, A.Error] = vector.reserve[u8](bytes, info.st_size::usize - bytes.len + 4096);
+        if (sel room.err) { record(a, txn.error(txn.MEMORY, txn.OP_RECOVER), alloc.text(room.err)); ret false; }
+        val n: i64 = os.read(fd, ?bytes.data[bytes.len], bytes.cap - bytes.len);
+        if (n < 0) { native_error(a, n, txn.OP_RECOVER); ret false; }
+        if (n == 0) { ret true; }
+        bytes.len = bytes.len + n::usize;
+        if (bytes.len > info.st_size::usize) { info.st_size = bytes.len::i64; }
+    }
+    ret true;
+}
+
+# false when the journal is absent or unusable, which is not a failure of
+# the access: the caller rebuilds it
+fun index_load(a: *Access, inv: *Inventory) bool {
+    val dirfd: i32 = txn.root_fd(?a.root);
+    val opened: i64 = os.open(dirfd, INDEX_LEAF, os.O_RDONLY | index_open_flags(), 0);
+    if (opened == os.ENOENT) { ret false; }
+    if (opened < 0) { native_error(a, opened, txn.OP_RECOVER); ret false; }
+    val fd: i32 = opened::i32;
+    var bytes: vector.Vector[u8] = vector.init[u8](a.alloc);
+    fin { vector.dnit[u8](?bytes); }
+    val read_ok: bool = read_all(a, fd, ?bytes);
+    native_error(a, os.close(fd), txn.OP_RECOVER);
+    if (!read_ok || a.failed) { ret false; }
+    if (bytes.len < INDEX_HEADER || get(bytes.data, 0, 4)::u32 != INDEX_MAGIC
+        || get(bytes.data, 4, 4)::u32 != INDEX_VERSION) { ret false; }
+    # a record's name is taken as written: one the directory does not hold is
+    # dropped by the reconciliation, whatever its bytes
+    val records: usize = (bytes.len - INDEX_HEADER) / INDEX_RECORD;
+    var dead: vector.Vector[bool] = vector.init[bool](a.alloc);
+    fin { vector.dnit[bool](?dead); }
+    var slots: map.Map[u64, usize] = map.init[u64, usize](a.alloc, map.hash_u64, map.eq_u64);
+    fin { map.dnit[u64, usize](?slots); }
+    var total: u64 = 0;
+    var dropped: usize = 0;
+    var r: usize = 0;
+    for (r < records) {
+        val at: usize = INDEX_HEADER + r * INDEX_RECORD;
+        val op: u8 = bytes.data[at];
+        val name: *u8 = ?bytes.data[at + 1];
+        if (op == INDEX_SEAL) {
+            inv.sealed = r + 1 == records;
+            inv.seal_mtime = get(bytes.data, at + 1, 8)::i64;
+            inv.seal_nsec = get(bytes.data, at + 9, 8)::i64;
+            r = r + 1;
+            cnt;
+        }
+        if (op != INDEX_ADD && op != INDEX_REMOVE) { ret false; }
+        var key: u64 = name_key(name);
+        val found: opt[*usize] = map.get[u64, usize](?slots, ?key);
+        if (sel found.some) {
+            val prior: usize = @found.some;
+            if (!dead.data[prior] && name_equals(?inv.entries.data[prior].name[0], name)) {
+                dead.data[prior] = true;
+                total = total - inv.entries.data[prior].size;
+                dropped = dropped + 1;
+            }
+        }
+        if (op == INDEX_ADD) {
+            val size: u64 = get(bytes.data, at + 65, 8);
+            if (size > 18446744073709551615 - total) { ret false; }
+            var entry: Entry = Entry{size: size, mtime: 0, mtime_nsec: 0};
+            var c: usize = 0;
+            for (c < 64) { entry.name[c] = name[c]; c = c + 1; }
+            entry.name[64] = 0;
+            val pushed: res[usize, A.Error] = vector.push[Entry](?inv.entries, entry);
+            if (sel pushed.err) { record(a, txn.error(txn.MEMORY, txn.OP_RECOVER), alloc.text(pushed.err)); ret false; }
+            val marked: res[usize, A.Error] = vector.push[bool](?dead, false);
+            if (sel marked.err) { record(a, txn.error(txn.MEMORY, txn.OP_RECOVER), alloc.text(marked.err)); ret false; }
+            val slotted: res[bool, A.Error] = map.insert[u64, usize](?slots, key, inv.entries.len - 1);
+            if (sel slotted.err) { record(a, txn.error(txn.MEMORY, txn.OP_RECOVER), alloc.text(slotted.err)); ret false; }
+            total = total + size;
+        }
+        r = r + 1;
+    }
+    if (dropped > 0) {
+        var w: usize = 0;
+        var i: usize = 0;
+        for (i < inv.entries.len) {
+            if (!dead.data[i]) { inv.entries.data[w] = inv.entries.data[i]; w = w + 1; }
+            i = i + 1;
+        }
+        inv.entries.len = w;
+    }
+    inv.total = total;
+    inv.records = records;
+    ret true;
+}
+
+fun write_all(a: *Access, fd: i32, bytes: *u8, len: usize) bool {
+    var done: usize = 0;
+    for (done < len) {
+        val n: i64 = os.write(fd, ?bytes[done], len - done);
+        if (n < 0) { native_error(a, n, txn.OP_PREPARE); ret false; }
+        if (n == 0) { record(a, txn.error(txn.REJECTED, txn.OP_PREPARE), "cache index write made no progress"); ret false; }
+        done = done + n::usize;
+    }
+    ret true;
+}
+
+fun index_record(bytes: *u8, op: u8, name: *u8, size: u64) {
+    bytes[0] = op;
+    var i: usize = 0;
+    for (i < 64) { bytes[1 + i] = name[i]; i = i + 1; }
+    put(bytes, 65, size, 8);
+}
+
+fun directory_time(a: *Access, mtime: *i64, nsec: *i64) bool {
+    var info: os.stat_t;
+    val observed: i64 = os.stat(txn.root_fd(?a.root), ?info);
+    if (observed < 0) { native_error(a, observed, txn.OP_PREPARE); ret false; }
+    @mtime = info.st_mtime;
+    @nsec = info.st_mtime_nsec;
+    ret true;
+}
+
+fun index_seal(a: *Access) {
+    if (a.failed) { ret; }
+    var mtime: i64 = 0;
+    var nsec: i64 = 0;
+    if (!directory_time(a, ?mtime, ?nsec)) { ret; }
+    var stamp: [64]u8;
+    var i: usize = 0;
+    for (i < 64) { stamp[i] = 0; i = i + 1; }
+    put(?stamp[0], 0, mtime::u64, 8);
+    put(?stamp[0], 8, nsec::u64, 8);
+    index_append(a, INDEX_SEAL, ?stamp[0], 0);
+}
+
+fun index_append(a: *Access, op: u8, name: *u8, size: u64) {
+    if (a.failed) { ret; }
+    val dirfd: i32 = txn.root_fd(?a.root);
+    val opened: i64 = os.open(dirfd, INDEX_LEAF, os.O_WRONLY | os.O_APPEND | os.O_CREAT | index_open_flags(), 0o600);
+    if (opened < 0) { native_error(a, opened, txn.OP_PREPARE); ret; }
+    val fd: i32 = opened::i32;
+    var bytes: [INDEX_RECORD]u8;
+    index_record(?bytes[0], op, name, size);
+    write_all(a, fd, ?bytes[0], INDEX_RECORD);
+    native_error(a, os.close(fd), txn.OP_PREPARE);
+}
+
+# the whole journal from the live inventory, written beside it and renamed over
+fun index_write(a: *Access, inv: *Inventory) {
+    if (a.failed) { ret; }
+    val dirfd: i32 = txn.root_fd(?a.root);
+    val opened: i64 = os.open(dirfd, INDEX_NEXT_LEAF, os.O_WRONLY | os.O_CREAT | os.O_TRUNC | index_open_flags(), 0o600);
+    if (opened < 0) { native_error(a, opened, txn.OP_PREPARE); ret; }
+    val fd: i32 = opened::i32;
+    var header: [INDEX_HEADER]u8;
+    put(?header[0], 0, INDEX_MAGIC::u64, 4);
+    put(?header[0], 4, INDEX_VERSION::u64, 4);
+    var written: bool = write_all(a, fd, ?header[0], INDEX_HEADER);
+    var i: usize = 0;
+    for (written && i < inv.entries.len) {
+        var bytes: [INDEX_RECORD]u8;
+        index_record(?bytes[0], INDEX_ADD, ?inv.entries.data[i].name[0], inv.entries.data[i].size);
+        written = write_all(a, fd, ?bytes[0], INDEX_RECORD);
+        i = i + 1;
+    }
+    native_error(a, os.close(fd), txn.OP_PREPARE);
+    if (a.failed) { ret; }
+    native_error(a, os.rename(dirfd, INDEX_NEXT_LEAF, dirfd, INDEX_LEAF), txn.OP_PREPARE);
+    if (!a.failed) { inv.records = inv.entries.len; }
+}
+
+# the directory's own entries, counted (one listing, no stat); a name outside
+# the private namespace refuses the directory as foreign
+fun count_entries(a: *Access) usize {
+    val dirfd: i32 = txn.root_fd(?a.root);
+    native_error(a, os.seek(dirfd, 0, os.SEEK_SET), txn.OP_RECOVER);
+    if (a.failed) { ret 0; }
+    var cursor: os.DirectoryCursor = os.DirectoryCursor{};
+    val opened: os.DirectoryInitResult = os.directory_init(?cursor, dirfd);
+    if (opened.code < 0) { native_error(a, opened.code, txn.OP_RECOVER); ret 0; }
+    var count: usize = 0;
+    for (!a.failed) {
+        var entry: os.DirectoryEntry;
+        val got: i64 = os.directory_next(?cursor, ?entry);
+        if (got < 0) { native_error(a, got, txn.OP_RECOVER); brk; }
+        if (got == 0) { brk; }
+        val name: str = entry.name;
+        if (metadata(name)) { cnt; }
+        if (!entry_name(name)) { record(a, txn.error(txn.CONTAINMENT, txn.OP_RECOVER), "cache directory contains an unrelated entry"); brk; }
+        count = count + 1;
+    }
+    val closed: i64 = os.directory_close(?cursor);
+    if (closed < 0 && !a.failed) { native_error(a, closed, txn.OP_RECOVER); }
+    ret count;
+}
+
+# the journal checked against the directory's names (a listing, no stat).
+# every entry write follows its add record and every remove record follows
+# its unlink, so the journal lists at least what the directory holds and an
+# equal count settles it. otherwise a listed entry the directory lacks is
+# dropped, an entry the journal lacks is stat'ed and placed ahead of the rest
+# (nothing is known of its publication), and the journal is rewritten
+fun reconcile(a: *Access, inv: *Inventory) {
+    if (inv.sealed && a.entered && a.entered_mtime == inv.seal_mtime && a.entered_nsec == inv.seal_nsec) { ret; }
+    val held: usize = count_entries(a);
+    if (a.failed || held == inv.entries.len) { ret; }
+    val dirfd: i32 = txn.root_fd(?a.root);
+    var slots: map.Map[u64, usize] = map.init[u64, usize](a.alloc, map.hash_u64, map.eq_u64);
+    fin { map.dnit[u64, usize](?slots); }
+    var seen: vector.Vector[bool] = vector.init[bool](a.alloc);
+    fin { vector.dnit[bool](?seen); }
+    var extra: vector.Vector[Entry] = vector.init[Entry](a.alloc);
+    fin { vector.dnit[Entry](?extra); }
+    var i: usize = 0;
+    for (i < inv.entries.len) {
+        val key: u64 = name_key(?inv.entries.data[i].name[0]);
+        val slotted: res[bool, A.Error] = map.insert[u64, usize](?slots, key, i);
+        if (sel slotted.err) { record(a, txn.error(txn.MEMORY, txn.OP_RECOVER), alloc.text(slotted.err)); ret; }
+        val marked: res[usize, A.Error] = vector.push[bool](?seen, false);
+        if (sel marked.err) { record(a, txn.error(txn.MEMORY, txn.OP_RECOVER), alloc.text(marked.err)); ret; }
+        i = i + 1;
+    }
+    native_error(a, os.seek(dirfd, 0, os.SEEK_SET), txn.OP_RECOVER);
+    if (a.failed) { ret; }
+    var cursor: os.DirectoryCursor = os.DirectoryCursor{};
+    val opened: os.DirectoryInitResult = os.directory_init(?cursor, dirfd);
+    if (opened.code < 0) { native_error(a, opened.code, txn.OP_RECOVER); ret; }
+    var matched: usize = 0;
+    for (!a.failed) {
+        var entry: os.DirectoryEntry;
+        val got: i64 = os.directory_next(?cursor, ?entry);
+        if (got < 0) { native_error(a, got, txn.OP_RECOVER); brk; }
+        if (got == 0) { brk; }
+        val name: str = entry.name;
+        if (metadata(name)) { cnt; }
+        if (!entry_name(name)) { record(a, txn.error(txn.CONTAINMENT, txn.OP_RECOVER), "cache directory contains an unrelated entry"); brk; }
+        var key: u64 = name_key(name);
+        val found: opt[*usize] = map.get[u64, usize](?slots, ?key);
+        var known: usize = 0;
+        var listed_here: bool = false;
+        if (sel found.some) {
+            known = @found.some;
+            listed_here = !seen.data[known] && name_equals(?inv.entries.data[known].name[0], name);
+        }
+        if (listed_here) {
+            seen.data[known] = true;
+            matched = matched + 1;
+            cnt;
+        }
+        var info: os.stat_t;
+        val observed: i64 = os.stat_path(dirfd, name, ?info, os.AT_SYMLINK_NOFOLLOW);
+        if (observed < 0) { native_error(a, observed, txn.OP_RECOVER); brk; }
+        if ((os.stat_mode(?info) & os.S_IFMT) != os.S_IFREG || info.st_size < 0) {
+            record(a, txn.error(txn.CONTAINMENT, txn.OP_RECOVER), "cache hash entry is not a regular file"); brk;
+        }
+        var listed: Entry = Entry{size: info.st_size::u64, mtime: info.st_mtime, mtime_nsec: info.st_mtime_nsec};
+        var c: usize = 0;
+        for (c < 64) { listed.name[c] = name[c]; c = c + 1; }
+        listed.name[64] = 0;
+        val pushed: res[usize, A.Error] = vector.push[Entry](?extra, listed);
+        if (sel pushed.err) { record(a, txn.error(txn.MEMORY, txn.OP_RECOVER), alloc.text(pushed.err)); brk; }
+    }
+    val closed: i64 = os.directory_close(?cursor);
+    if (closed < 0 && !a.failed) { native_error(a, closed, txn.OP_RECOVER); }
+    if (a.failed) { ret; }
+    if (extra.len == 0 && matched == inv.entries.len) { ret; }
+    sort.sort[Entry](extra.data, extra.len, older);
+    var merged: vector.Vector[Entry] = vector.init[Entry](a.alloc);
+    var total: u64 = 0;
+    i = 0;
+    for (i < extra.len + inv.entries.len) {
+        var next: Entry;
+        if (i < extra.len) { next = extra.data[i]; }
+        or {
+            if (!seen.data[i - extra.len]) { i = i + 1; cnt; }
+            next = inv.entries.data[i - extra.len];
+        }
+        if (next.size > 18446744073709551615 - total) {
+            vector.dnit[Entry](?merged);
+            record(a, txn.error(txn.REJECTED, txn.OP_RECOVER), "cache size accounting overflow"); ret;
+        }
+        total = total + next.size;
+        val pushed: res[usize, A.Error] = vector.push[Entry](?merged, next);
+        if (sel pushed.err) {
+            vector.dnit[Entry](?merged);
+            record(a, txn.error(txn.MEMORY, txn.OP_RECOVER), alloc.text(pushed.err)); ret;
+        }
+        i = i + 1;
+    }
+    vector.dnit[Entry](?inv.entries);
+    inv.entries = merged;
+    inv.total = total;
+    index_write(a, inv);
+}
+
+# the journal's word on the store checked against the directory, or the
+# directory's word when the journal cannot be read, in which case the
+# directory's order and sizes become the journal
+fun load_inventory(a: *Access, inv: *Inventory) {
+    inventory_init(a, inv);
+    if (index_load(a, inv)) { reconcile(a, inv); ret; }
+    if (a.failed) { ret; }
+    vector.clear[Entry](?inv.entries);
+    inv.total = inventory(a, ?inv.entries, nil);
+    if (a.failed) { ret; }
+    index_write(a, inv);
+}
+
+# the entry's real size after a write that may or may not have replaced it
+fun index_settle(a: *Access, name: *u8) {
+    if (a.failed) { ret; }
+    var info: os.stat_t;
+    val observed: i64 = os.stat_path(txn.root_fd(?a.root), name, ?info, os.AT_SYMLINK_NOFOLLOW);
+    if (observed == os.ENOENT) { index_append(a, INDEX_REMOVE, name, 0); ret; }
+    if (observed < 0) { native_error(a, observed, txn.OP_PREPARE); ret; }
+    if ((os.stat_mode(?info) & os.S_IFMT) != os.S_IFREG || info.st_size < 0) {
+        record(a, txn.error(txn.CONTAINMENT, txn.OP_PREPARE), "cache entry is not a regular file"); ret;
+    }
+    index_append(a, INDEX_ADD, name, info.st_size::u64);
+}
+
+# an eviction that the journal records; a listed entry that is already absent
+# is dropped from the journal and counts as freed
+fun evict_entry(a: *Access, name: *u8) {
+    var info: os.stat_t;
+    val observed: i64 = os.stat_path(txn.root_fd(?a.root), name, ?info, os.AT_SYMLINK_NOFOLLOW);
+    if (observed < 0 && observed != os.ENOENT) { native_error(a, observed, txn.OP_REMOVE); ret; }
+    if (observed >= 0) { remove_entry(a, name::str); }
+    index_append(a, INDEX_REMOVE, name, 0);
+}
+
+# eviction policy: least recently published first, never an entry this build
+# restored or published, and never past the store limit by leaving the store
+# as it was: a publication that cannot make room is declined. the order is
+# the journal's (publication order; the directory's mtime-then-name order when
+# it was rebuilt from one), and only the victims are stat'ed
 fun make_room(a: *Access, incoming: usize, replacing: str, limit: u64, keys: *[32]u8, key_count: usize) {
     var prior: u64 = 0;
     if (replacing != nil) {
@@ -342,20 +760,34 @@ fun make_room(a: *Access, incoming: usize, replacing: str, limit: u64, keys: *[3
     if (prior > charged) { charged = prior; }
     if (charged > limit) { record(a, txn.error(txn.REJECTED, txn.OP_PREPARE), "cache entry exceeds the store byte limit"); ret; }
     val available: u64 = limit - charged;
-    var entries: vector.Vector[Entry] = vector.init[Entry](a.alloc);
-    fin { vector.dnit[Entry](?entries); }
-    var total: u64 = inventory(a, ?entries, replacing);
-    if (a.failed || total <= available) { ret; }
+    var inv: Inventory;
+    load_inventory(a, ?inv);
+    fin { inventory_dnit(?inv); }
+    if (a.failed) { ret; }
+    var total: u64 = inv.total;
     var i: usize = 0;
-    for (i < entries.len && total > available && !a.failed) {
-        val victim: *Entry = ?entries.data[i];
+    for (i < inv.entries.len) {
+        if (replacing != nil && str_equals(?inv.entries.data[i].name[0], replacing)) { total = total - inv.entries.data[i].size; }
         i = i + 1;
+    }
+    var evicted: usize = 0;
+    i = 0;
+    for (i < inv.entries.len && total > available && !a.failed) {
+        val victim: *Entry = ?inv.entries.data[i];
+        i = i + 1;
+        if (replacing != nil && str_equals(?victim.name[0], replacing)) { cnt; }
         if (protected(?victim.name[0], keys, key_count)) { cnt; }
-        remove_entry(a, ?victim.name[0]);
-        if (!a.failed) { total = total - victim.size; }
+        evict_entry(a, ?victim.name[0]);
+        if (!a.failed) { total = total - victim.size; evicted = evicted + 1; }
     }
     if (a.failed) { ret; }
     if (total > available) { record(a, txn.error(txn.REJECTED, txn.OP_REMOVE), "cache eviction would remove an entry this build restored or published"); ret; }
+    if (inv.records + evicted > 2 * (inv.entries.len - evicted) + INDEX_SLACK) {
+        var compacted: Inventory;
+        load_inventory(a, ?compacted);
+        fin { inventory_dnit(?compacted); }
+        if (!a.failed) { index_write(a, ?compacted); }
+    }
 }
 
 # publication may report unavailable after replacement or partial eviction
@@ -383,6 +815,7 @@ pub fun publish(alloc: *A.Allocator, directory: str, key: *[32]u8, payload: *u8,
     var name: [65]u8;
     leaf(key, ?name);
     if (!access.failed) { make_room(?access, size, ?name[0], MAX_STORE_BYTES, keys, key_count); }
+    if (!access.failed) { index_append(?access, INDEX_ADD, ?name[0], size::u64); }
     if (!access.failed) {
         var claim: txn.Claim = txn.Claim{};
         transaction_error(?access, txn.claim(?claim, alloc, ?access.held, ?name[0]));
@@ -394,6 +827,15 @@ pub fun publish(alloc: *A.Allocator, directory: str, key: *[32]u8, payload: *u8,
             }
             transaction_error(?access, txn.release_claim(?claim));
         }
+        # a refused write leaves the entry as it was or replaced: the journal
+        # takes the entry's real state, and the refusal stays the reported one
+        if (access.failed && !internal(access.error.native)) {
+            val refusal: Error = access.error;
+            access.failed = false;
+            index_settle(?access, ?name[0]);
+            if (!access.failed || !internal(access.error.native)) { access.failed = true; access.error = refusal; }
+        }
+        index_seal(?access);
     }
     finish(?access);
     if (access.failed) {
@@ -618,6 +1060,160 @@ test "mach.lang.build.cache.store:eviction_is_oldest_publication_first_under_the
     ret 0;
 }
 
+rec Loaded {
+    count: usize;
+    total: u64;
+    records: usize;
+    sealed: bool;
+    first: [65]u8;
+    failed: bool;
+    kind: u8;
+}
+
+fun t_load(alloc: *A.Allocator, directory: str) Loaded {
+    var out: Loaded = Loaded{count: 0, total: 0, records: 0, sealed: false, failed: false, kind: 0};
+    var access: Access = Access{};
+    begin(?access, alloc, directory);
+    var inv: Inventory;
+    if (!access.failed) {
+        load_inventory(?access, ?inv);
+        if (!access.failed) {
+            out.count = inv.entries.len;
+            out.total = inv.total;
+            out.records = inv.records;
+            out.sealed = inv.sealed;
+            if (inv.entries.len > 0) { out.first = inv.entries.data[0].name; }
+        }
+        inventory_dnit(?inv);
+    }
+    finish(?access);
+    out.failed = access.failed;
+    if (access.failed) { out.kind = access.error.native.kind; }
+    ret out;
+}
+
+fun t_journal_size(directory: str) i64 {
+    val dirfd: i64 = os.open(os.AT_FDCWD, directory, os.O_RDONLY | os.O_DIRECTORY, 0);
+    if (dirfd < 0) { ret -1; }
+    var info: os.stat_t;
+    val observed: i64 = os.stat_path(dirfd::i32, INDEX_LEAF, ?info, os.AT_SYMLINK_NOFOLLOW);
+    os.close(dirfd::i32);
+    if (observed < 0) { ret -1; }
+    ret info.st_size;
+}
+
+fun t_journal_op(alloc: *A.Allocator, directory: str, op: u8, name: *u8, size: u64, unlink_journal: bool, rewrite_first: bool) bool {
+    var access: Access = Access{};
+    begin(?access, alloc, directory);
+    if (!access.failed) {
+        if (unlink_journal) { native_error(?access, os.unlink(txn.root_fd(?access.root), INDEX_LEAF, 0), txn.OP_REMOVE); }
+        or (rewrite_first) {
+            var inv: Inventory;
+            load_inventory(?access, ?inv);
+            if (!access.failed && inv.entries.len > 1) { inv.entries.len = 1; index_write(?access, ?inv); }
+            inventory_dnit(?inv);
+        }
+        or { index_append(?access, op, name, size); }
+    }
+    finish(?access);
+    ret !access.failed;
+}
+
+# the journal is the inventory a publication reads: it lists publications in
+# order with their sizes and seals each, is rebuilt when absent, drops an
+# entry the directory lacks, adopts an entry it did not list ahead of the
+# rest, and still refuses a directory holding a foreign name; the eviction
+# path compacts it
+test "mach.lang.build.cache.store:journal_tracks_publications_and_reconciles_with_the_directory" {
+    var alloc: A.Allocator;
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
+    val temporary: res[fs.TempFile, fs.FsError] = fs.temp_create(?alloc, "mach-cache-journal");
+    if (sel temporary.err) { ret 2; }
+    var temp: fs.TempFile = temporary.ok;
+    fin { str_free(?alloc, temp.path); }
+    val temp_close_and_remove_r: err[io_error.Error] = fs.temp_close_and_remove(?temp);
+    if (sel temp_close_and_remove_r.err) { ret 3; }
+    if (os.make_dir(os.AT_FDCWD, temp.path, 0o700) < 0) { ret 3; }
+    fin { fs.remove_all(?alloc, temp.path); }
+    val entry: u64 = HEADER_BYTES::u64 + 4;
+    var keys: [3][32]u8;
+    t_key("first", ?keys[0]); t_key("second", ?keys[1]); t_key("third", ?keys[2]);
+    var names: [3][65]u8;
+    leaf(?keys[0], ?names[0]); leaf(?keys[1], ?names[1]); leaf(?keys[2], ?names[2]);
+    if (!t_status(publish(?alloc, temp.path, ?keys[0], "aaaa", 4, nil, 0), STORED)) { ret 4; }
+    if (!t_status(publish(?alloc, temp.path, ?keys[1], "bbbb", 4, nil, 0), STORED)) { ret 4; }
+    if (!t_status(publish(?alloc, temp.path, ?keys[2], "cccc", 4, nil, 0), STORED)) { ret 4; }
+    var loaded: Loaded = t_load(?alloc, temp.path);
+    if (loaded.failed || loaded.count != 3 || loaded.total != 3 * entry || loaded.records != 6 || !loaded.sealed) { ret 5; }
+    if (!str_equals(?loaded.first[0], ?names[0][0])) { ret 5; }
+    # a replacement keeps one live record for the name, at the tail
+    if (!t_status(publish(?alloc, temp.path, ?keys[0], "aaaaaa", 6, nil, 0), STORED)) { ret 6; }
+    loaded = t_load(?alloc, temp.path);
+    if (loaded.failed || loaded.count != 3 || loaded.total != 3 * entry + 2 || loaded.records != 8 || !loaded.sealed) { ret 6; }
+    if (!str_equals(?loaded.first[0], ?names[1][0])) { ret 6; }
+    # absent journal: rebuilt from the directory in mtime order
+    if (!t_journal_op(?alloc, temp.path, 0, nil, 0, true, false)) { ret 7; }
+    if (t_journal_size(temp.path) >= 0) { ret 7; }
+    loaded = t_load(?alloc, temp.path);
+    if (loaded.failed || loaded.count != 3 || loaded.total != 3 * entry + 2 || loaded.records != 3 || loaded.sealed) { ret 8; }
+    if (t_journal_size(temp.path) != (INDEX_HEADER + 3 * INDEX_RECORD)::i64) { ret 8; }
+    # a listed entry the directory lacks is dropped and the journal rewritten
+    var ghost_key: [32]u8;
+    t_key("ghost", ?ghost_key);
+    var ghost: [65]u8;
+    leaf(?ghost_key, ?ghost);
+    if (!t_journal_op(?alloc, temp.path, INDEX_ADD, ?ghost[0], 1000, false, false)) { ret 9; }
+    loaded = t_load(?alloc, temp.path);
+    if (loaded.failed || loaded.count != 3 || loaded.total != 3 * entry + 2 || loaded.records != 3) { ret 10; }
+    # an entry the journal does not list is adopted ahead of the listed ones
+    if (!t_journal_op(?alloc, temp.path, 0, nil, 0, false, true)) { ret 11; }
+    loaded = t_load(?alloc, temp.path);
+    if (loaded.failed || loaded.count != 3 || loaded.total != 3 * entry + 2 || loaded.records != 3) { ret 12; }
+    if (str_equals(?loaded.first[0], ?names[1][0])) { ret 12; }
+    # a foreign name still refuses the directory
+    val foreign_r: res[path.Path, A.Error] = path.join(?alloc, temp.path, "user-note");
+    if (sel foreign_r.err) { ret 13; }
+    val foreign: str = foreign_r.ok;
+    fin { str_free(?alloc, foreign); }
+    val write_bytes_r: err[fs.FsError] = fs.write_bytes(foreign, "retained", 8, 0o600);
+    if (sel write_bytes_r.err) { ret 13; }
+    loaded = t_load(?alloc, temp.path);
+    if (!loaded.failed || loaded.kind != txn.CONTAINMENT) { ret 14; }
+    if (os.unlink(os.AT_FDCWD, foreign, 0) < 0) { ret 14; }
+    # publications at a two-entry limit append an add and a remove record each,
+    # and the journal is compacted once it grows past twice its live entries
+    var round: u32 = 0;
+    var peak: i64 = 0;
+    for (round < 80) {
+        var fresh: [32]u8;
+        var text: [8]u8 = [8]u8{'r', 'o', 'u', 'n', 'd', ('0' + (round % 10)::u8), ('0' + (round / 10)::u8), 0};
+        t_key(?text[0], ?fresh);
+        val room: res[u64, Error] = t_make_room(?alloc, temp.path, entry::usize, nil, 2 * entry + 2, nil, 0);
+        if (sel room.err) { print.eprintln(room.err.message); ret 15; }
+        if (room.ok > entry + 2) { ret 15; }
+        if (!t_status(publish(?alloc, temp.path, ?fresh, "rrrr", 4, nil, 0), STORED)) { ret 16; }
+        val size: i64 = t_journal_size(temp.path);
+        if (size > peak) { peak = size; }
+        round = round + 1;
+    }
+    loaded = t_load(?alloc, temp.path);
+    if (loaded.failed || loaded.count != 2 || loaded.total != 2 * entry) { ret 17; }
+    if (peak > (INDEX_HEADER + (2 * 2 + INDEX_SLACK + 6) * INDEX_RECORD)::i64) { ret 18; }
+    if (loaded.records > 2 * 2 + INDEX_SLACK) { ret 18; }
+    if (t_inventory(?alloc, temp.path) != 2 * entry) { ret 19; }
+    # the last publication sealed the journal; a foreign file written after it
+    # moves the directory's time, so the sealed journal is not taken on trust
+    loaded = t_load(?alloc, temp.path);
+    if (loaded.failed || !loaded.sealed) { ret 20; }
+    t_settle();
+    val late_r: err[fs.FsError] = fs.write_bytes(foreign, "late", 4, 0o600);
+    if (sel late_r.err) { ret 21; }
+    loaded = t_load(?alloc, temp.path);
+    if (!loaded.failed || loaded.kind != txn.CONTAINMENT) { ret 22; }
+    ret 0;
+}
+
 test "mach.lang.build.cache.store:byte_eviction_preserves_unrelated_entries_and_reports_invalid_owners" {
     var alloc: A.Allocator;
     val make_r: err[A.Error] = page.make(?alloc);
@@ -645,7 +1241,7 @@ test "mach.lang.build.cache.store:byte_eviction_preserves_unrelated_entries_and_
         if (!replacement.failed && sweep(?replacement, nil) != 2 * (HEADER_BYTES::u64 + 4)) {
             record(?replacement, txn.error(txn.INVALID, txn.OP_RECOVER), "same-size replacement evicted a current cache entry");
         }
-        if (!replacement.failed) { leaf(?peer, ?name); remove_entry(?replacement, ?name[0]); }
+        if (!replacement.failed) { leaf(?peer, ?name); evict_entry(?replacement, ?name[0]); }
     }
     finish(?replacement);
     if (replacement.failed || !t_read(?alloc, temp.path, ?key, HIT, "keep")) { ret 13; }

--- a/src/lang/me/analysis/loops.mach
+++ b/src/lang/me/analysis/loops.mach
@@ -56,6 +56,8 @@ pub rec Loop {
     counted:    CountedInfo;
 }
 
+# dom_pre and dom_post number the dominator tree in one depth-first walk, so
+# a dominance query is an interval test rather than a walk up the idom chain
 pub rec LoopAnalysis {
     alloc:       *A.Allocator;
     block_count: u32;
@@ -64,6 +66,8 @@ pub rec LoopAnalysis {
     rpo_len:     u32;
     rpo_index:   *u32;
     idom:        *id.BlockId;
+    dom_pre:     *u32;
+    dom_post:    *u32;
 
     instr_block: *id.BlockId;
     instr_count: u32;
@@ -81,6 +85,8 @@ pub fun analyze(fn: *ir.Function, alloc: *A.Allocator) res[LoopAnalysis, fail.Fa
     la.rpo_len     = 0;
     la.rpo_index   = nil;
     la.idom        = nil;
+    la.dom_pre     = nil;
+    la.dom_post    = nil;
     la.instr_block = nil;
     la.instr_count = 0;
     la.loops       = nil;
@@ -133,6 +139,8 @@ pub fun dnit(la: *LoopAnalysis) {
     if (la.rpo != nil)         { A.deallocate[id.BlockId](la.alloc, la.rpo, n::usize); la.rpo = nil; }
     if (la.rpo_index != nil)   { A.deallocate[u32](la.alloc, la.rpo_index, n::usize); la.rpo_index = nil; }
     if (la.idom != nil)        { A.deallocate[id.BlockId](la.alloc, la.idom, n::usize); la.idom = nil; }
+    if (la.dom_pre != nil)     { A.deallocate[u32](la.alloc, la.dom_pre, n::usize); la.dom_pre = nil; }
+    if (la.dom_post != nil)    { A.deallocate[u32](la.alloc, la.dom_post, n::usize); la.dom_post = nil; }
     if (la.instr_block != nil) { A.deallocate[id.BlockId](la.alloc, la.instr_block, la.instr_count::usize); la.instr_block = nil; }
     if (la.loops != nil) {
         var i: u32 = 0;
@@ -155,18 +163,8 @@ pub fun dominates(la: *LoopAnalysis, a: id.BlockId, b: id.BlockId) bool {
     if (a::u32 >= n || b::u32 >= n) { ret false; }
     if (a == b)                     { ret true; }
     if (la.rpo_index[b::u32] == NONE_U32) { ret false; }
-    var x: u32 = b::u32;
-    var steps: u32 = 0;
-    for (true) {
-        if (x == a::u32) { ret true; }
-        val nx: id.BlockId = la.idom[x];
-        if (nx == id.BLOCK_NIL) { panic("mach.lang.me.analysis.loops: dominator chain reached an unset idom\n"); }
-        if (nx::u32 == x) { ret false; }
-        x = nx::u32;
-        steps = steps + 1;
-        if (steps > n) { panic("mach.lang.me.analysis.loops: cyclic dominator chain\n"); }
-    }
-    ret false;
+    if (la.dom_pre == nil) { panic("mach.lang.me.analysis.loops: dominance queried before the dominator tree was numbered\n"); }
+    ret la.dom_pre[a::u32] <= la.dom_pre[b::u32] && la.dom_post[b::u32] <= la.dom_post[a::u32];
 }
 
 pub fun loop_contains(la: *LoopAnalysis, loop_ix: u32, b: id.BlockId) bool {
@@ -309,6 +307,75 @@ fun build_dom(la: *LoopAnalysis, fn: *ir.Function, pred_start: *u32, pred_len: *
     if (sel rb.err) { ret rb; }
 
     build_idom(la, pred_start, pred_len, pred_flat);
+    ret build_dom_intervals(la);
+}
+
+# children lists from idom, then one depth-first walk from the entry; a
+# block outside the tree (unreachable) gets an empty interval that no query
+# can satisfy
+fun build_dom_intervals(la: *LoopAnalysis) err[fail.Fail] {
+    val n: u32 = la.block_count;
+    val rp: res[*u32, A.Error] = A.allocate[u32](la.alloc, n::usize);
+    if (sel rp.err) { ret err[fail.Fail].err{fail.refused(rp.err)}; }
+    la.dom_pre = rp.ok;
+    val rq: res[*u32, A.Error] = A.allocate[u32](la.alloc, n::usize);
+    if (sel rq.err) { ret err[fail.Fail].err{fail.refused(rq.err)}; }
+    la.dom_post = rq.ok;
+    val scratch_len: usize = (n::usize) * 4 + 1;
+    val rs: res[*u32, A.Error] = A.allocate[u32](la.alloc, scratch_len);
+    if (sel rs.err) { ret err[fail.Fail].err{fail.refused(rs.err)}; }
+    fin { A.deallocate[u32](la.alloc, rs.ok, scratch_len); }
+    val child_start: *u32 = rs.ok;
+    val children: *u32 = ?rs.ok[(n::usize) + 1];
+    val frame_block: *u32 = ?rs.ok[(n::usize) * 2 + 1];
+    val frame_next: *u32 = ?rs.ok[(n::usize) * 3 + 1];
+    var i: u32 = 0;
+    for (i < n) { la.dom_pre[i] = NONE_U32; la.dom_post[i] = 0; child_start[i + 1] = 0; i = i + 1; }
+    child_start[0] = 0;
+    i = 0;
+    for (i < n) {
+        if (la.rpo_index[i] != NONE_U32 && i != 0 && la.idom[i] != id.BLOCK_NIL) {
+            val parent: u32 = la.idom[i]::u32;
+            child_start[parent + 1] = child_start[parent + 1] + 1;
+        }
+        i = i + 1;
+    }
+    i = 0;
+    for (i < n) { child_start[i + 1] = child_start[i + 1] + child_start[i]; i = i + 1; }
+    i = 0;
+    for (i < n) {
+        if (la.rpo_index[i] != NONE_U32 && i != 0 && la.idom[i] != id.BLOCK_NIL) {
+            val parent: u32 = la.idom[i]::u32;
+            children[child_start[parent]] = i;
+            child_start[parent] = child_start[parent] + 1;
+        }
+        i = i + 1;
+    }
+    i = n;
+    for (i > 0) { child_start[i] = child_start[i - 1]; i = i - 1; }
+    child_start[0] = 0;
+
+    if (la.rpo_index[0] == NONE_U32) { ret err[fail.Fail].ok{}; }
+    var counter: u32 = 0;
+    var depth: u32 = 1;
+    frame_block[0] = 0;
+    frame_next[0] = child_start[0];
+    la.dom_pre[0] = counter; counter = counter + 1;
+    for (depth > 0) {
+        val v: u32 = frame_block[depth - 1];
+        val k: u32 = frame_next[depth - 1];
+        if (k < child_start[v + 1]) {
+            frame_next[depth - 1] = k + 1;
+            val c: u32 = children[k];
+            la.dom_pre[c] = counter; counter = counter + 1;
+            frame_block[depth] = c;
+            frame_next[depth] = child_start[c];
+            depth = depth + 1;
+            cnt;
+        }
+        la.dom_post[v] = counter; counter = counter + 1;
+        depth = depth - 1;
+    }
     ret err[fail.Fail].ok{};
 }
 

--- a/src/lang/me/ir/mutate.mach
+++ b/src/lang/me/ir/mutate.mach
@@ -124,34 +124,16 @@ pub fun replace_uses(fn: *ir.Function, old_id: id.InstructionId, replacement: va
 # every allocation the erasure needs happens in the salvage phase, before a
 # list is compacted: a refusal leaves the function with its dead instructions
 # still listed and some `dbg_value`s already rebased onto their salvage
-# expression, which is a valid function, never a list mid-compaction
-pub fun erase_marked[T](m: *ir.Module, fn: *ir.Function, ctx: *T,
+# expression, which is a valid function, never a list mid-compaction. `alloc`
+# holds the salvage's own scratch (the set of listed, erased instructions)
+pub fun erase_marked[T](m: *ir.Module, fn: *ir.Function, alloc: *A.Allocator, ctx: *T,
                         test: fun(*T, id.InstructionId) bool) res[bool, fail.Fail] {
     if (ctx == nil || test == nil) {
         ret res[bool, fail.Fail].err{fail.message("instruction erasure predicate is incomplete")};
     }
     if (has_dbg_values(fn)) {
-        var b: u32 = 0;
-        for (b < fn.block_count) {
-            val blk: *ir.Block = ?fn.blocks[b];
-            var r: u32 = 0;
-            for (r < blk.phi_count) {
-                if (test(ctx, blk.phis[r])) {
-                    val res_: err[fail.Fail] = salvage_dbg_values[T](m, fn, ctx, test, blk.phis[r]);
-                    if (sel res_.err) { ret res[bool, fail.Fail].err{res_.err}; }
-                }
-                r = r + 1;
-            }
-            r = 0;
-            for (r < blk.instr_count) {
-                if (test(ctx, blk.instructions[r])) {
-                    val res_: err[fail.Fail] = salvage_dbg_values[T](m, fn, ctx, test, blk.instructions[r]);
-                    if (sel res_.err) { ret res[bool, fail.Fail].err{res_.err}; }
-                }
-                r = r + 1;
-            }
-            b = b + 1;
-        }
+        val salvaged: err[fail.Fail] = salvage_dbg_values[T](m, fn, alloc, ctx, test);
+        if (sel salvaged.err) { ret res[bool, fail.Fail].err{salvaged.err}; }
     }
 
     var changed: bool = false;
@@ -198,32 +180,59 @@ fun has_dbg_values(fn: *ir.Function) bool {
     ret false;
 }
 
-fun salvage_dbg_values[T](m: *ir.Module, fn: *ir.Function, ctx: *T,
-                          test: fun(*T, id.InstructionId) bool,
-                          dropped: id.InstructionId) err[fail.Fail] {
-    var base:        value.Value;
-    var op:          ir.DbgOp;
-    var recoverable: bool = false;
-    salvage_decode(fn, dropped, ?base, ?op, ?recoverable);
-
-    var base_live: bool = false;
-    if (recoverable) {
-        if (base.kind != value.VAL_INSTR) { base_live = true; }
-        or { base_live = test(ctx, base.data.instr) == false; }
+# one pass over the `dbg_value`s: each whose operand is a listed, erased
+# instruction is rebased onto that instruction's live base through a salvage
+# expression when it has one, and nulled otherwise
+fun salvage_dbg_values[T](m: *ir.Module, fn: *ir.Function, alloc: *A.Allocator, ctx: *T,
+                          test: fun(*T, id.InstructionId) bool) err[fail.Fail] {
+    if (fn.instr_len == 0) { ret err[fail.Fail].ok{}; }
+    val res_listed: res[*bool, A.Error] = A.allocate[bool](alloc, fn.instr_len::usize);
+    if (sel res_listed.err) { ret err[fail.Fail].err{fail.refused(res_listed.err)}; }
+    val listed: *bool = res_listed.ok;
+    fin { A.deallocate[bool](alloc, listed, fn.instr_len::usize); }
+    var z: u32 = 0;
+    for (z < fn.instr_len) { listed[z] = false; z = z + 1; }
+    var b: u32 = 0;
+    for (b < fn.block_count) {
+        val blk: *ir.Block = ?fn.blocks[b];
+        var r: u32 = 0;
+        for (r < blk.phi_count) {
+            val iid: id.InstructionId = blk.phis[r];
+            if (iid::u32 < fn.instr_len && test(ctx, iid)) { listed[iid::u32] = true; }
+            r = r + 1;
+        }
+        r = 0;
+        for (r < blk.instr_count) {
+            val iid: id.InstructionId = blk.instructions[r];
+            if (iid::u32 < fn.instr_len && test(ctx, iid)) { listed[iid::u32] = true; }
+            r = r + 1;
+        }
+        b = b + 1;
     }
 
     var i: u32 = 0;
     for (i < fn.instr_len) {
         val d: *instruction.Instruction = ?fn.instrs[i];
-        if (d.kind == instruction.OP_DBG_VALUE && d.operand_count == 1
-            && d.operands[0].kind == value.VAL_INSTR && d.operands[0].data.instr == dropped) {
-            if (recoverable && base_live) {
-                val res_: err[fail.Fail] = salvage_rebase(m, fn, i::id.InstructionId, d, base, op);
-                if (sel res_.err) { ret res_; }
-            }
-            or {
-                d.operands[0] = value.const_null(d.operands[0].ty);
-            }
+        if (d.kind != instruction.OP_DBG_VALUE || d.operand_count != 1
+            || d.operands[0].kind != value.VAL_INSTR) { i = i + 1; cnt; }
+        val dropped: id.InstructionId = d.operands[0].data.instr;
+        if (dropped::u32 >= fn.instr_len || !listed[dropped::u32]) { i = i + 1; cnt; }
+
+        var base:        value.Value;
+        var op:          ir.DbgOp;
+        var recoverable: bool = false;
+        salvage_decode(fn, dropped, ?base, ?op, ?recoverable);
+        var base_live: bool = false;
+        if (recoverable) {
+            if (base.kind != value.VAL_INSTR) { base_live = true; }
+            or { base_live = test(ctx, base.data.instr) == false; }
+        }
+        if (recoverable && base_live) {
+            val res_: err[fail.Fail] = salvage_rebase(m, fn, i::id.InstructionId, d, base, op);
+            if (sel res_.err) { ret res_; }
+        }
+        or {
+            d.operands[0] = value.const_null(d.operands[0].ty);
         }
         i = i + 1;
     }
@@ -450,7 +459,7 @@ test "mach.lang.me.ir.mutate.erase_marked:reports_no_change_when_nothing_is_mark
     var target: id.InstructionId = id.INSTR_NIL;
     val target_ptr: *id.InstructionId = ?target;
     val res_: res[bool, fail.Fail] =
-        erase_marked[id.InstructionId](?m, fn, target_ptr, t_erase_none);
+        erase_marked[id.InstructionId](?m, fn, ?alloc, target_ptr, t_erase_none);
     if (sel res_.err) { ir.dnit(?m); ret 1; }
     val changed: bool = res_.ok;
     ir.dnit(?m);
@@ -498,7 +507,7 @@ test "mach.lang.me.ir.mutate.erase_marked:reports_change_when_the_marked_instruc
     var target: id.InstructionId = x_id;
     val target_ptr: *id.InstructionId = ?target;
     val res_: res[bool, fail.Fail] =
-        erase_marked[id.InstructionId](?m, fn, target_ptr, t_erase_target);
+        erase_marked[id.InstructionId](?m, fn, ?alloc, target_ptr, t_erase_target);
     if (sel res_.err) { ir.dnit(?m); ret 1; }
     val changed: bool = res_.ok;
     val after: u32 = blk.instr_count;

--- a/src/lang/me/ir/verify.mach
+++ b/src/lang/me/ir/verify.mach
@@ -798,63 +798,89 @@ fun agg_value_is_address_producing(fn: *ir.Function, op: *value.Value) bool {
     ret false;
 }
 
+# every block's declared predecessor list must equal, as a multiset, the
+# blocks whose terminators target it; one successor sweep groups the actual
+# edges by target so each block is settled by its own two lists
 fun check_pred_consistency(fn: *ir.Function, fi: u32, r: *VerifyReport) err[fail.Fail] {
     val n: u32 = fn.block_count;
     if (n == 0) { ret err[fail.Fail].ok{}; }
-    val res_count: res[*u32, A.Error] = A.allocate[u32](r.alloc, n::usize);
-    if (sel res_count.err) { ret err[fail.Fail].err{fail.refused(res_count.err)}; }
-    val count: *u32 = res_count.ok;
+    val scratch_len: usize = (n::usize) * 4 + 1;
+    val res_scratch: res[*u32, A.Error] = A.allocate[u32](r.alloc, scratch_len);
+    if (sel res_scratch.err) { ret err[fail.Fail].err{fail.refused(res_scratch.err)}; }
+    val count: *u32 = res_scratch.ok;
+    val edge_start: *u32 = ?res_scratch.ok[n::usize];
+    val edges: *u32 = ?res_scratch.ok[(n::usize) * 2 + 1];
+    fin { A.deallocate[u32](r.alloc, res_scratch.ok, scratch_len); }
+    var z: usize = 0;
+    for (z < scratch_len) { count[z] = 0; z = z + 1; }
+
+    var s: u32 = 0;
+    for (s < n) {
+        var s0: id.BlockId = id.BLOCK_NIL;
+        var s1: id.BlockId = id.BLOCK_NIL;
+        val sc: u32 = ir.block_successors(fn, ?fn.blocks[s], ?s0, ?s1);
+        if (sc >= 1 && s0::u32 < n) { edge_start[s0::u32 + 1] = edge_start[s0::u32 + 1] + 1; }
+        if (sc >= 2 && s1::u32 < n) { edge_start[s1::u32 + 1] = edge_start[s1::u32 + 1] + 1; }
+        s = s + 1;
+    }
+    var t: u32 = 0;
+    for (t < n) { edge_start[t + 1] = edge_start[t + 1] + edge_start[t]; t = t + 1; }
+    s = 0;
+    for (s < n) {
+        var s0: id.BlockId = id.BLOCK_NIL;
+        var s1: id.BlockId = id.BLOCK_NIL;
+        val sc: u32 = ir.block_successors(fn, ?fn.blocks[s], ?s0, ?s1);
+        if (sc >= 1 && s0::u32 < n) { edges[edge_start[s0::u32]] = s; edge_start[s0::u32] = edge_start[s0::u32] + 1; }
+        if (sc >= 2 && s1::u32 < n) { edges[edge_start[s1::u32]] = s; edge_start[s1::u32] = edge_start[s1::u32] + 1; }
+        s = s + 1;
+    }
+    t = n;
+    for (t > 0) { edge_start[t] = edge_start[t - 1]; t = t - 1; }
+    edge_start[0] = 0;
 
     var ti: u32 = 0;
     for (ti < n) {
-        var z: u32 = 0;
-        for (z < n) { count[z] = 0; z = z + 1; }
-
         val blk: *ir.Block = ?fn.blocks[ti];
         var bad: bool = false;
         var pi: u32 = 0;
         for (pi < blk.pred_count) {
             val p: id.BlockId = blk.preds[pi];
-            if (p < n) {
-                count[p] = count[p] + 1;
-            }
-            or {
-                bad = true;
-            }
+            if (p < n) { count[p] = count[p] + 1; }
+            or         { bad = true; }
             pi = pi + 1;
         }
-        var s: u32 = 0;
-        for (s < n) {
-            var s0: id.BlockId = id.BLOCK_NIL;
-            var s1: id.BlockId = id.BLOCK_NIL;
-            val sc: u32 = ir.block_successors(fn, ?fn.blocks[s], ?s0, ?s1);
-            if (sc >= 1 && s0 == ti::id.BlockId) { count[s] = count[s] - 1; }
-            if (sc >= 2 && s1 == ti::id.BlockId) { count[s] = count[s] - 1; }
-            s = s + 1;
+        var e: u32 = edge_start[ti];
+        for (e < edge_start[ti + 1]) { count[edges[e]] = count[edges[e]] - 1; e = e + 1; }
+        pi = 0;
+        for (pi < blk.pred_count) {
+            val p: id.BlockId = blk.preds[pi];
+            if (p < n) { if (count[p] != 0) { bad = true; } count[p] = 0; }
+            pi = pi + 1;
         }
-        if (!bad) {
-            var k: u32 = 0;
-            for (k < n) {
-                if (count[k] != 0) { bad = true; }
-                k = k + 1;
-            }
-        }
+        e = edge_start[ti];
+        for (e < edge_start[ti + 1]) { if (count[edges[e]] != 0) { bad = true; } count[edges[e]] = 0; e = e + 1; }
         if (bad) {
             val rr: err[fail.Fail] = push(r, fi, ti::id.BlockId, id.INSTR_NIL, VC_PRED_CONSISTENT);
-            if (sel rr.err) { A.deallocate[u32](r.alloc, count, n::usize); ret rr; }
+            if (sel rr.err) { ret rr; }
         }
         ti = ti + 1;
     }
-    A.deallocate[u32](r.alloc, count, n::usize);
     ret err[fail.Fail].ok{};
 }
 
+# a phi's incoming blocks must equal its block's predecessor list as a
+# multiset; the balance array is settled and cleared through the two lists
+# themselves, so a phi costs its own operands and predecessors, not a block
+# sweep
 fun check_phi_coverage(fn: *ir.Function, fi: u32, r: *VerifyReport) err[fail.Fail] {
     val n: u32 = fn.block_count;
     if (n == 0) { ret err[fail.Fail].ok{}; }
     val res_count: res[*u32, A.Error] = A.allocate[u32](r.alloc, n::usize);
     if (sel res_count.err) { ret err[fail.Fail].err{fail.refused(res_count.err)}; }
     val count: *u32 = res_count.ok;
+    fin { A.deallocate[u32](r.alloc, count, n::usize); }
+    var z: u32 = 0;
+    for (z < n) { count[z] = 0; z = z + 1; }
 
     var bi: u32 = 0;
     for (bi < n) {
@@ -864,19 +890,13 @@ fun check_phi_coverage(fn: *ir.Function, fi: u32, r: *VerifyReport) err[fail.Fai
             val iid: id.InstructionId = blk.phis[p];
             if (iid < fn.instr_len) {
                 val ins: *instruction.Instruction = ?fn.instrs[iid];
-                var z: u32 = 0;
-                for (z < n) { count[z] = 0; z = z + 1; }
                 var bad: bool = false;
                 if ((ins.operand_count % 2) != 0) { bad = true; }
                 var o: u32 = 0;
                 for (o + 1 < ins.operand_count) {
                     val src: id.BlockId = ir.block_target(ins.operands[o]);
-                    if (src < n) {
-                        count[src] = count[src] + 1;
-                    }
-                    or {
-                        bad = true;
-                    }
+                    if (src < n) { count[src] = count[src] + 1; }
+                    or           { bad = true; }
                     o = o + 2;
                 }
                 var pp: u32 = 0;
@@ -885,23 +905,27 @@ fun check_phi_coverage(fn: *ir.Function, fi: u32, r: *VerifyReport) err[fail.Fai
                     if (pb < n) { count[pb] = count[pb] - 1; }
                     pp = pp + 1;
                 }
-                if (!bad) {
-                    var k: u32 = 0;
-                    for (k < n) {
-                        if (count[k] != 0) { bad = true; }
-                        k = k + 1;
-                    }
+                o = 0;
+                for (o + 1 < ins.operand_count) {
+                    val src: id.BlockId = ir.block_target(ins.operands[o]);
+                    if (src < n) { if (count[src] != 0) { bad = true; } count[src] = 0; }
+                    o = o + 2;
+                }
+                pp = 0;
+                for (pp < blk.pred_count) {
+                    val pb: id.BlockId = blk.preds[pp];
+                    if (pb < n) { if (count[pb] != 0) { bad = true; } count[pb] = 0; }
+                    pp = pp + 1;
                 }
                 if (bad) {
                     val rr: err[fail.Fail] = push(r, fi, blk.id, iid, VC_PHI_COVERAGE);
-                    if (sel rr.err) { A.deallocate[u32](r.alloc, count, n::usize); ret rr; }
+                    if (sel rr.err) { ret rr; }
                 }
             }
             p = p + 1;
         }
         bi = bi + 1;
     }
-    A.deallocate[u32](r.alloc, count, n::usize);
     ret err[fail.Fail].ok{};
 }
 
@@ -1619,6 +1643,38 @@ test "mach.lang.me.ir.verify.check_pred_consistency:wrong_member" {
     if (sel r_1579.err) { ret 1; }
 
     env.m.functions[0].blocks[3].preds[1] = 1::id.BlockId;
+    if (t_count(?env, false, false, VC_PRED_CONSISTENT) < 1) { ret 1; }
+    ret 0;
+}
+
+# a declared predecessor that targets nothing balances on the edge side, so
+# only the declared side of the multiset check can see it
+test "mach.lang.me.ir.verify.check_pred_consistency:declared_pred_without_an_edge" {
+    var env: TEnv;
+    fin { target.registry_dnit(?env.registry); }
+    if (!t_env(?env)) { ret 1; }
+    val b0: id.BlockId = t_block(?env);
+    val b1: id.BlockId = t_block(?env);
+    val b2: id.BlockId = t_block(?env);
+    val b3: id.BlockId = t_block(?env);
+    if (b3 != 3) { ret 1; }
+
+    builder.set_block(?env.bld, b0);
+    val r_cbr: err[fail.Fail] = builder.emit_cbr(?env.bld, t_ci(?env, 1), b1, b2);
+    if (sel r_cbr.err) { ret 1; }
+    builder.set_block(?env.bld, b1);
+    val r_br1: err[fail.Fail] = builder.emit_br(?env.bld, b3);
+    if (sel r_br1.err) { ret 1; }
+    builder.set_block(?env.bld, b2);
+    val r_br2: err[fail.Fail] = builder.emit_br(?env.bld, b3);
+    if (sel r_br2.err) { ret 1; }
+    builder.set_block(?env.bld, b3);
+    val r_ret: err[fail.Fail] = builder.emit_ret_void(?env.bld);
+    if (sel r_ret.err) { ret 1; }
+    if (t_count(?env, false, false, VC_PRED_CONSISTENT) != 0) { ret 1; }
+
+    val r_extra: err[fail.Fail] = ir.block_append_pred(?env.m, ?env.m.functions[0].blocks[3], b0);
+    if (sel r_extra.err) { ret 1; }
     if (t_count(?env, false, false, VC_PRED_CONSISTENT) < 1) { ret 1; }
     ret 0;
 }

--- a/src/lang/me/pass/dce.mach
+++ b/src/lang/me/pass/dce.mach
@@ -144,7 +144,7 @@ fun value_dce(request: *scratch.Function, alloc: *A.Allocator) res[bool, fail.Fa
     marks.dead = dead;
     marks.ilen = ilen;
     val erased_r: res[bool, fail.Fail] =
-        mutate.erase_marked[DceMarks](m, fn, ?marks, dce_marked);
+        mutate.erase_marked[DceMarks](m, fn, alloc, ?marks, dce_marked);
 
     A.deallocate[bool](alloc, live, ilen::usize);
     A.deallocate[bool](alloc, dead, ilen::usize);

--- a/src/lang/me/pass/mem2reg.mach
+++ b/src/lang/me/pass/mem2reg.mach
@@ -1195,7 +1195,7 @@ fun add_phi_incomings(rc: *RenameCtx, pred: id.BlockId, succ: id.BlockId) err[fa
 }
 
 fun strip_promoted(st: *State) err[fail.Fail] {
-    val changed_r: res[bool, fail.Fail] = mutate.erase_marked[State](st.m, st.fn, st, strip_test);
+    val changed_r: res[bool, fail.Fail] = mutate.erase_marked[State](st.m, st.fn, st.alloc, st, strip_test);
     if (sel changed_r.err) { ret err[fail.Fail].err{changed_r.err}; }
     ret err[fail.Fail].ok{};
 }

--- a/src/lang/me/transform/sroa.mach
+++ b/src/lang/me/transform/sroa.mach
@@ -933,7 +933,7 @@ fun rewrite(st: *State) err[fail.Fail] {
     mutate.rewrite_apply(st.fn, ?rw);
     mutate.rewrite_dnit(?rw, st.alloc);
 
-    val changed_r: res[bool, fail.Fail] = mutate.erase_marked[State](st.m, st.fn, st, erase_test);
+    val changed_r: res[bool, fail.Fail] = mutate.erase_marked[State](st.m, st.fn, st.alloc, st, erase_test);
     if (sel changed_r.err) { ret err[fail.Fail].err{changed_r.err}; }
     ret err[fail.Fail].ok{};
 }

--- a/test/memory.py
+++ b/test/memory.py
@@ -171,8 +171,9 @@ BUILT = re.compile(rb'^built .*?(\d+) modules?\b', re.M)
 # there: 1.25 for the self-build, where the two 2026-09-06 scratch fixes were
 # each worth more and the spread with THP disabled is under 3 percent, and 1.5
 # for the synthetic families with a 32 MiB minimum for cells that sit within a
-# few MiB of the spawner floor. the blocks ceilings describe the dense
-# block-by-register liveness sets and come down when that is fixed.
+# few MiB of the spawner floor. the blocks ceilings follow the sparse liveness
+# (doc/design/r2-measurements.md, "cliffs addressed"): 18.1 / 24.9 / 38.7 /
+# 65.8 MiB measured at 500 / 1000 / 2000 / 4000, linear.
 THRESHOLDS = {
     'self-debug': 2867,
     'self-release': 3601,
@@ -200,14 +201,14 @@ THRESHOLDS = {
     'aggregate-65536-release': 32,
     'aggregate-262144-debug': 32,
     'aggregate-262144-release': 32,
-    'blocks-500-debug': 47,
-    'blocks-500-release': 47,
-    'blocks-1000-debug': 119,
-    'blocks-1000-release': 119,
-    'blocks-2000-debug': 393,
-    'blocks-2000-release': 393,
-    'blocks-4000-debug': 1456,
-    'blocks-4000-release': 1454,
+    'blocks-500-debug': 32,
+    'blocks-500-release': 32,
+    'blocks-1000-debug': 37,
+    'blocks-1000-release': 36,
+    'blocks-2000-debug': 58,
+    'blocks-2000-release': 56,
+    'blocks-4000-debug': 99,
+    'blocks-4000-release': 94,
 }
 
 
@@ -572,8 +573,8 @@ def main():
                         help='the tree the control self-builds when it cannot build this checkout')
     parser.add_argument('--repetitions', type=int, default=1, help='measurements per cell and variant (default 1)')
     parser.add_argument('--families', default='modules,dense,aggregate,blocks', help='synthetic families to run; empty for none')
-    parser.add_argument('--sizes', default='modules=10,50,150,400;dense=10,50,150,400;aggregate=4096,16384,65536,262144;blocks=500,1000,2000',
-                        help='per-family size lists (blocks=4000 is measured in the design note and takes 100 s a cell)')
+    parser.add_argument('--sizes', default='modules=10,50,150,400;dense=10,50,150,400;aggregate=4096,16384,65536,262144;blocks=500,1000,2000,4000',
+                        help='per-family size lists')
     parser.add_argument('--profiles', default='debug,release')
     parser.add_argument('--jobs', default='1,4', help='codegen worker counts to compare on the synthetic families')
     parser.add_argument('--cache-modes', default='off,cold,warm', help='off (uncached), cold (publishing), warm (restoring)')


### PR DESCRIPTION
Closes #2299. References #3221 (the persistent store's inventory is the fourth item here).

The last acceptance gap of #2299: "dense block-by-vreg structures and any remaining scaling cliffs are addressed at their cause." R2 (#3302) named the structure and three cliffs; this branch addresses them and the further quadratic shapes the profile exposed behind them, one commit each, every one output-identical.

## Identity bar

- corpus layer B goldens on x86_64-linux, aarch64-linux and riscv64-linux: 306 cells, byte-identical (run once, with the fixpoint compiler); no golden moved, so the sparse liveness makes the same allocation decisions
- the compiler's own debug, release and release `-g` self-builds by the dev compiler and by this branch's compiler: byte-identical
- the `debuginfo` link fixture with `-g` at debug and release on the three ISAs: byte-identical
- x86_64 link leg: 142 pass / 0 fail
- fixpoint: A by the v5 stage, B by A, C by B, `cmp B C` identical
- suite through the from-source compiler: 3037 passed, 0 failed (3033 at `278dc07e5`, +4: `regalloc.extend_liveness` x2, `verify.check_pred_consistency:declared_pred_without_an_edge`, `cache.store:journal_tracks_publications_and_reconciles_with_the_directory`); `sh test/census.sh` 10 of 10 ok
- `python3 test/memory.py --families blocks` green under the new ceilings; the enforcement control (one ceiling lowered to 8 MiB) fails as it should

## Before and after

**1. Sparse liveness** (`fad388ec5`). `blocks` peak RSS MiB, debug, uncached: 33.1 / 81.9 / 262.8 / 973.3 at 500 / 1000 / 2000 / 4000 before; the harness's largest cells after: 18.1 / 24.9 / 38.7 / 65.8 debug, 17.9 / 24.3 / 37.2 / 63.0 release. Linear (1.37x, 1.55x, 1.70x per doubling against 2.58x, 3.32x, 3.71x).

**2. Verifier** (`776926442`), plus the shapes behind it (`6262368b8` loop rotation bounded by the header's component, `7d4370fd8` one-pass dbg_value salvage, `5970ec8de` dominance as an interval test, `d17b11ac4` keyed branch targets and lowered blocks). blocks-2000 debug wall 12.9 s to 1.24 s with the verifier alone; blocks-4000 debug 51.1 s to 0.33 s and release 99.5 s to 0.42 s over the series, linear from 500 to 4000.

**3. DWARF** (`0d011f987`, `5dd89e7da`). dense-400 at debug (6,402 functions in one module, `-g`): 7.3 s to 0.97 s; 150 to 400 groups is 2.7x the time for 2.67x the functions (7.8x before).

**4. Store** (`6dbecfba4`). A journal beside the entries under the lock replaces the per-publication directory inventory. Full-store publish build of the compiler's own tree (280 publications at 6,210 entries, 536,845,552 bytes, btrfs): 25.9 to 26.3 s before against 21.4 to 21.7 s at a small store, 23.1 to 23.9 s after against 20.4 to 20.6 s; the store never exceeded its limit. The remainder is the transaction layer's own recovery scan on every lock acquisition (`std`), reported in the design note as the next cliff.

**5.** `test/memory.py` blocks ceilings 47 / 119 / 393 / 1456 to 32 / 37 / 58 / 99 (1.5x rule, 32 MiB minimum), 4000 joins the default sizes, and `doc/design/r2-measurements.md` gains "cliffs addressed" with the tables (`1f4283442`).

## Outside the named scope, fixed on the way

- `dwarf.add_debug_section` copied a refused (truncated) buffer into the image with no check; it now fails the install.
- `dwarf.str_off` and the relocation install's symbol lookup, codegen's `function_defined_get` and the linker's `module_weak_function_ref_is_dead` were further O(F^2) scans on the same workload; indexed in the DWARF and `be` commits.
