### PR TITLE
target: one heap-owned immutable registry held by pointer (#2212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -336,6 +336,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- The target registry is one heap-owned immutable object. `Session` creates
+  it through `target.registry_new` over its own allocator, holds it by
+  pointer and releases it once in `dnit`; the parallel codegen workers' session
+  copies borrow that pointer instead of aliasing an inline registry. A
+  registry is published once by `register_all` and released once by
+  `registry_dnit`, which is terminal: a released registry refuses
+  `register_all` and `resolve`. A resolved target records the registry it was
+  resolved against, and `isel`, the encoder, `codegen_unit` and every link
+  entry refuse a target whose registry has been released as a typed error
+  rather than following a dead vtable. A fail-at-N probe walk over
+  build/publish/resolve/release proves the registry releases everything at
+  every refusal ordinal. (#2212)
+
 - The compiler builds against std 2.0 (std dev `e204cb81f`) and CI
   bootstraps it through the v5 migration stage (mach `2a2918b23` with std
   1.0.1) after the audited 4.30 fixpoint (#3226, lane C1). The language

--- a/doc/design/backend-census-2212.md
+++ b/doc/design/backend-census-2212.md
@@ -384,6 +384,22 @@ Which of "immutable ownership" or "a generation stamp" closes item 1 is the
 owner's call named in #2212 ("choose immutable ownership rather than a redundant
 version scheme where sufficient"); section 9 records it as non-mechanical.
 
+Landed 2026-09-12 (section 10 item 5, immutable ownership, no stamp): the
+registry is `mach.lang.target.registry.TargetRegistry`, born by `registry_new`
+(heap, one allocator for the block and every entry) or `registry_init` (in
+place, fixtures), published once by `register_all`, released once by
+`registry_dnit`, which is terminal: a released registry refuses `register_all`
+and `resolve`, so re-initialization under a borrower cannot happen. `Session`
+holds it by pointer and `pcg_worker_init`'s session copy borrows that pointer,
+which closes item 2 by construction and makes item 3 moot. `resolved.Target`
+records `registry`, `resolved.live` refuses a borrow whose registry is released,
+and `isel.run`, `encode.run`, `codegen_unit` and the four link entries run it
+before following a vtable (`backend_target` panics rather than follow a dead
+borrow). Item 4 stands as written: the fixture form is in place because the
+lane-locked `regalloc.mach`/`verify.mach` fixtures hold it, and a copy of an
+in-place registry is still expressible; retiring `registry_init` for
+`registry_new` at every fixture is the follow-up that removes that.
+
 ## 8. Gap tally per ISA
 
 Counts are of distinct sites or site families named in sections 2 to 7.
@@ -455,6 +471,7 @@ owner decision or a proven bar beyond "goldens unchanged".
    the by-value copy at `engine.mach:1181` becomes impossible. #2212 prefers the
    second where sufficient; it is sufficient here. Bar: the fail-at-N allocator
    leak check and a fail-closed test for a target used after `registry_dnit`.
+   Landed 2026-09-12 as the second form; section 7.3 records the shape.
 6. **riscv admission on the codegen path.** `inst.admits` guards only inline
    asm; the MIR path relies on width arithmetic. One admission point, and the
    `has_compressed` claim (`EF_RISCV_RVC`, `c2p0`) removed until an emitter

--- a/src/cli/cmd/build.mach
+++ b/src/cli/cmd/build.mach
@@ -66,7 +66,7 @@ pub fun plan_invocation(a: *A.Allocator, root: str, cli: *args.CliArgs, goal: re
     }
     @ps = res_session.ok;
 
-    val res_register: err[outcome.Fail] = driver.setup_registry(?ps.registry);
+    val res_register: err[outcome.Fail] = driver.setup_registry(ps.registry);
     if (sel res_register.err) {
         ret plan_failure(a, ps, res_register.err);
     }
@@ -88,7 +88,7 @@ pub fun plan_invocation(a: *A.Allocator, root: str, cli: *args.CliArgs, goal: re
         ret plan_failure(a, ps, res_req.err);
     }
 
-    val plan_r: res[plan.BuildPlan, outcome.Fail] = plan.plan(ps.alloc, ?ps.interner, ?ps.registry, ?m,
+    val plan_r: res[plan.BuildPlan, outcome.Fail] = plan.plan(ps.alloc, ?ps.interner, ps.registry, ?m,
         res_req.ok);
     if (sel plan_r.err) {
         ret plan_failure(a, ps, plan_r.err);

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -1869,7 +1869,7 @@ fun t_session_and_mode(a: *A.Allocator, root: str, s: *session.Session, mode: *u
 }
 
 fun t_build_ok(s: *session.Session, root: str) bool {
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret false; }
     var pick: manifest.Selection;
     pick.target = ""; pick.profile = ""; pick.artifact = ""; pick.want_lib = false; pick.has_artifact = false;
@@ -2138,7 +2138,7 @@ test "mach.cli.cmd.dep.add:a_discovered_clash_retains_native_changes_and_release
 
 # the build refusal text of a dependency-shaped failure, or "" when the build succeeds
 fun t_build_refusal(s: *session.Session, root: str) str {
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret ""; }
     var pick: manifest.Selection;
     pick.target = ""; pick.profile = ""; pick.artifact = ""; pick.want_lib = false; pick.has_artifact = false;

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -515,7 +515,7 @@ pub fun run(argv: **u8, inv: *args.ParsedInvocation) i64 {
     }
     var s: session.Session = res_session.ok;
 
-    val res_register: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val res_register: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel res_register.err) {
         print.eprint("error: failed to register targets\n");
         session.dnit(?s);
@@ -854,7 +854,7 @@ test "mach.cli.cmd.doc.build_project:several_artifacts_without_a_default_are_ref
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { fs.remove_all(?alloc, ?root[0]); ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) {
         session.dnit(?s); fs.remove_all(?alloc, ?root[0]); ret 1;
     }
@@ -944,7 +944,7 @@ test "mach.cli.cmd.doc.generate:creates_missing_output_dirs" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { fs.remove_all(?alloc, ?root[0]); ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) {
         session.dnit(?s); fs.remove_all(?alloc, ?root[0]); ret 1;
     }
@@ -1134,7 +1134,7 @@ test "mach.cli.cmd.doc.generate:documents_public_generic_tag" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { fs.remove_all(?alloc, ?root[0]); ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) {
         session.dnit(?s); fs.remove_all(?alloc, ?root[0]); ret 1;
     }

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -106,6 +106,8 @@ fun codegen_with_backing(s: *session.Session, tgt: *target.Target,
                         placement_policy: u32, dbg: DebugInfo,
                         backing: *A.Allocator) res[of.ObjectImage, fail.Fail] {
     if (s == nil) { ret res[of.ObjectImage, fail.Fail].err{fail.message("codegen: nil session")}; }
+    val borrow: err[fail.Fail] = resolved.live(tgt);
+    if (sel borrow.err) { ret res[of.ObjectImage, fail.Fail].err{borrow.err}; }
     var scratch: arena.Arena;
     val initialized: err[A.Error] = arena.init(?scratch, backing, 0);
     if (sel initialized.err) { ret res[of.ObjectImage, fail.Fail].err{fail.refused(initialized.err)}; }
@@ -2434,9 +2436,9 @@ test "mach.lang.be.codegen.scratch:module_images_survive_reclaimed_working_stora
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
     fin { session.dnit(?s); }
-    val r_2451: err[fail.Fail] = target.register_all(?s.registry, target_testing.debug_descriptor);
+    val r_2451: err[fail.Fail] = target.register_all(s.registry, target_testing.debug_descriptor);
     if (sel r_2451.err) { ret 2; }
-    val selected: res[target.Target, fail.Fail] = target.select(?s.registry, "x86_64", "linux", "sysv64");
+    val selected: res[target.Target, fail.Fail] = target.select(s.registry, "x86_64", "linux", "sysv64");
     if (sel selected.err) { ret 2; }
     var tgt: target.Target = selected.ok;
     val named: res[intern.StrId, A.Error] = intern.intern(?s.interner, "scratch_probe");

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -66,6 +66,8 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule,
             asm_out: *writer.Writer) res[EncoderOutput, fail.Fail] {
     if (tgt == nil) { ret res[EncoderOutput, fail.Fail].err{fail.message("encode: nil target")}; }
     if (m == nil)   { ret res[EncoderOutput, fail.Fail].err{fail.message("encode: nil mir module")}; }
+    val borrow: err[fail.Fail] = target.live(tgt);
+    if (sel borrow.err) { ret res[EncoderOutput, fail.Fail].err{borrow.err}; }
     if (tgt.arch == nil) {
         ret res[EncoderOutput, fail.Fail].err{fail.message("encode: target has no ISA vtable")};
     }

--- a/src/lang/be/codegen/isel.mach
+++ b/src/lang/be/codegen/isel.mach
@@ -15,6 +15,8 @@ use target_view: mach.lang.target.resolved;
 pub fun run(tgt: *target.Target, m: *mir.MirModule) err[fail.Fail] {
     if (tgt == nil) { ret err[fail.Fail].err{fail.message("isel: nil target")}; }
     if (m == nil)   { ret err[fail.Fail].err{fail.message("isel: nil mir module")}; }
+    val borrow: err[fail.Fail] = target_view.live(tgt);
+    if (sel borrow.err) { ret borrow; }
     if (tgt.arch == nil) {
         ret err[fail.Fail].err{fail.message("isel: target has no ISA vtable")};
     }
@@ -104,5 +106,36 @@ test "mach.lang.be.codegen.isel:catalog_validation_brackets_the_selector_callbac
     if (sel refused.ok) { ret 11; }
     if (!str_contains(fail.describe(refused.err), "out of memory")) { ret 11; }
     if (function.callee_mask != 0 || T.leaked(?testing) || T.double_free_count(?testing) != 0) { ret 12; }
+    ret 0;
+}
+
+# the borrow gate: a target whose registry was released is refused before
+# any vtable is followed
+test "mach.lang.be.codegen.isel:target_outliving_its_registry_is_refused" {
+    var alloc: A.Allocator;
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
+    var interner: intern.Interner = intern.init(?alloc);
+    fin { intern.dnit(?interner); }
+    var registry: target.TargetRegistry = target.registry_init();
+    fin { target.registry_dnit(?registry); }
+    val r_reg: err[fail.Fail] = target.register_all(?registry, target_testing.debug_descriptor);
+    if (sel r_reg.err) { ret 2; }
+    val selected: res[target.Target, fail.Fail] = target.select(?registry, "x86_64", "linux", "sysv64");
+    if (sel selected.err) { ret 3; }
+    var tgt: target.Target = selected.ok;
+    var operand: mir.MirOperand = mir.op_imm(7);
+    var instruction: mir.MirInstr = mir.instr(mir.MIR_ASM, ?operand, 0, 8, 8);
+    var block: mir.MirBlock = mir.MirBlock{instrs: ?instruction, instr_count: 1};
+    var function: mir.MirFunction = mir.MirFunction{blocks: ?block, block_count: 1};
+    var module: mir.MirModule = mir.MirModule{alloc: ?alloc, interner: ?interner, functions: ?function, function_len: 1};
+    val live_r: err[fail.Fail] = run(?tgt, ?module);
+    if (sel live_r.err) { ret 4; }
+    target.registry_dnit(?registry);
+    instruction.opcode = mir.MIR_ASM;
+    val refused: err[fail.Fail] = run(?tgt, ?module);
+    if (sel refused.ok) { ret 5; }
+    if (!str_contains(fail.describe(refused.err), "outlived the registry")) { ret 6; }
+    if (instruction.opcode != mir.MIR_ASM) { ret 7; }
     ret 0;
 }

--- a/src/lang/be/linker.mach
+++ b/src/lang/be/linker.mach
@@ -214,6 +214,8 @@ pub fun link(s: *session.Session, tgt: *target.Target, obj_paths: **u8,
              image_options: of.ImageOptions) err[fail.Fail] {
     if (s == nil)      { ret err[fail.Fail].err{fail.message("link: nil session")}; }
     if (tgt == nil)    { ret err[fail.Fail].err{fail.message("link: nil target")}; }
+    val borrow: err[fail.Fail] = target.live(tgt);
+    if (sel borrow.err) { ret borrow; }
     if (tgt.of == nil) { ret err[fail.Fail].err{fail.message("link: target has no object-format vtable")}; }
     if (tgt.os == nil) { ret err[fail.Fail].err{fail.message("link: target has no OS vtable")}; }
     if (!link_mode_valid(mode)) { ret err[fail.Fail].err{fail.message("link: invalid link mode")}; }
@@ -298,6 +300,8 @@ pub fun link_images_captured(s: *session.Session, tgt: *target.Target, images: *
 
     if (s == nil)      { ret err[fail.Fail].err{fail.message("link: nil session")}; }
     if (tgt == nil)    { ret err[fail.Fail].err{fail.message("link: nil target")}; }
+    val borrow: err[fail.Fail] = target.live(tgt);
+    if (sel borrow.err) { ret borrow; }
     if (tgt.of == nil) { ret err[fail.Fail].err{fail.message("link: target has no object-format vtable")}; }
     if (tgt.os == nil) { ret err[fail.Fail].err{fail.message("link: target has no OS vtable")}; }
     if (images == nil || image_count == 0) {
@@ -340,6 +344,8 @@ pub fun link_images(s: *session.Session, tgt: *target.Target, images: *of.Object
                     image_options: of.ImageOptions) err[fail.Fail] {
     if (s == nil)      { ret err[fail.Fail].err{fail.message("link: nil session")}; }
     if (tgt == nil)    { ret err[fail.Fail].err{fail.message("link: nil target")}; }
+    val borrow: err[fail.Fail] = target.live(tgt);
+    if (sel borrow.err) { ret borrow; }
     if (tgt.of == nil) { ret err[fail.Fail].err{fail.message("link: target has no object-format vtable")}; }
     if (tgt.os == nil) { ret err[fail.Fail].err{fail.message("link: target has no OS vtable")}; }
     if (!link_mode_valid(mode)) { ret err[fail.Fail].err{fail.message("link: invalid link mode")}; }
@@ -358,6 +364,8 @@ pub fun link_mixed(s: *session.Session, tgt: *target.Target,
                    image_options: of.ImageOptions) err[fail.Fail] {
     if (s == nil)      { ret err[fail.Fail].err{fail.message("link: nil session")}; }
     if (tgt == nil)    { ret err[fail.Fail].err{fail.message("link: nil target")}; }
+    val borrow: err[fail.Fail] = target.live(tgt);
+    if (sel borrow.err) { ret borrow; }
     if (tgt.of == nil) { ret err[fail.Fail].err{fail.message("link: target has no object-format vtable")}; }
     if (tgt.os == nil) { ret err[fail.Fail].err{fail.message("link: target has no OS vtable")}; }
     if (!link_mode_valid(mode)) { ret err[fail.Fail].err{fail.message("link: invalid link mode")}; }

--- a/src/lang/build/engine.mach
+++ b/src/lang/build/engine.mach
@@ -319,7 +319,7 @@ pub fun execute_warm(bp: *plan.BuildPlan, unit_index: usize, s: *session.Session
         arena.dnit(?call_ar);
     }
 
-    val res_register: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val res_register: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel res_register.err) {
         val r: res[outcome.BuildOutcome, outcome.Fail] = warm_fail(?bo, res_register.err);
         ret r;
@@ -336,7 +336,7 @@ pub fun execute_warm(bp: *plan.BuildPlan, unit_index: usize, s: *session.Session
         request.for_cell(?bp.request, planned.sel_target, planned.sel_artifact, planned.want_lib,
                          planned.subsystem, planned.goal);
 
-    val replan_r: res[plan.BuildUnit, outcome.Fail] = plan.replan_unit(?call_alloc, ?s.interner, ?s.registry, ?m, ?req, planned);
+    val replan_r: res[plan.BuildUnit, outcome.Fail] = plan.replan_unit(?call_alloc, ?s.interner, s.registry, ?m, ?req, planned);
     if (sel replan_r.err) {
         val r: res[outcome.BuildOutcome, outcome.Fail] = warm_fail(?bo, replan_r.err);
         ret r;
@@ -1323,6 +1323,8 @@ fun pcg_worker_init(w: *PcgWorker, p: *driver.Project) err[outcome.Fail] {
     val make_r2: err[A.Error] = arena.make(?w.alloc, ?w.ar);
     if (sel make_r2.err)     { arena.dnit(?w.ar); ret err[outcome.Fail].err{outcome.internal("parallel codegen: worker arena bind failed")}; }
 
+    # the worker's session view borrows the project's registry by pointer;
+    # the project session is its one owner and outlives every worker
     w.sess          = @p.s;
     w.sess.alloc    = ?w.alloc;
     w.sess.interner = intern.make_child(?p.s.interner, ?w.alloc);

--- a/src/lang/driver.mach
+++ b/src/lang/driver.mach
@@ -336,7 +336,7 @@ pub fun analyze_project_until(s: *session.Session, m: *manifest.Manifest, req: *
     diagnostic.store_dnit(?s.diags);
     s.diags = diagnostic.store_init(s.alloc);
 
-    val reg_r: err[outcome.Fail] = setup_registry(?s.registry);
+    val reg_r: err[outcome.Fail] = setup_registry(s.registry);
     if (sel reg_r.err) {
         ret res[project.Project, outcome.Fail].err{reg_r.err};
     }
@@ -752,10 +752,10 @@ fun check_stack_keys(s: *session.Session, m: *manifest.Manifest) err[outcome.Fai
         val td: *manifest.TargetDef = ?m.targets[i];
         if (td.stack_reserve == 0 && td.stack_commit == 0) { i = i + 1; cnt; }
 
-        val reg_r: err[outcome.Fail] = setup_registry(?s.registry);
+        val reg_r: err[outcome.Fail] = setup_registry(s.registry);
         if (sel reg_r.err) { ret reg_r; }
 
-        val tr: res[target.Target, fail.Fail] = target.select_of(?s.registry,
+        val tr: res[target.Target, fail.Fail] = target.select_of(s.registry,
             intern_or_empty(s, td.isa), intern_or_empty(s, td.os),
             intern_or_empty(s, td.abi), intern_or_empty(s, td.of));
         if (sel tr.err) { i = i + 1; cnt; }

--- a/src/lang/driver/config.mach
+++ b/src/lang/driver/config.mach
@@ -318,7 +318,7 @@ pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifes
         }
     }
 
-    val ur: res[manifest.BuildUnit, outcome.Fail] = manifest.resolve_build_unit(p.alloc, ?p.s.interner, ?p.s.registry, m, eff_sel);
+    val ur: res[manifest.BuildUnit, outcome.Fail] = manifest.resolve_build_unit(p.alloc, ?p.s.interner, p.s.registry, m, eff_sel);
     if (sel ur.err) {
         ret err[outcome.Fail].err{ur.err};
     }
@@ -329,7 +329,7 @@ pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifes
     val cell_profile: str = lookup_r.some;
     p.config.art_reqs      = nil;
     p.config.art_req_count = 0;
-    val rqr: err[outcome.Fail] = manifest.resolve_artifact_reqs(p.alloc, ?p.s.interner, ?p.s.registry, m,
+    val rqr: err[outcome.Fail] = manifest.resolve_artifact_reqs(p.alloc, ?p.s.interner, p.s.registry, m,
         bu.artifact, bu.target, cell_profile, is_test, ?p.config.art_reqs, ?p.config.art_req_count);
     if (sel rqr.err) { ret err[outcome.Fail].err{rqr.err}; }
 
@@ -337,7 +337,7 @@ pub fun load_config_manifest(p: *project.Project, project_root: str, m: *manifes
         cell_profile, p.config.art_reqs, p.config.art_req_count);
     embed.set_path_env(?p.s.embeds, project_root, p.config.art_reqs, p.config.art_req_count);
 
-    val cr: err[outcome.Fail] = manifest.check_collisions(p.alloc, ?p.s.interner, ?p.s.registry, m, ?cell_v);
+    val cr: err[outcome.Fail] = manifest.check_collisions(p.alloc, ?p.s.interner, p.s.registry, m, ?cell_v);
     if (sel cr.err) {
         ret cr;
     }
@@ -734,7 +734,7 @@ pub fun select_target(p: *project.Project, t: *project.TargetEntry) err[outcome.
     val label_opt: opt[str] = intern.lookup(?p.s.interner, t.name);
     if (sel label_opt.some) { label = label_opt.some; }
     target.with_env(?req, env_name, label);
-    val tr: res[target.Target, fail.Fail] = target.resolve(?p.s.registry, ?req);
+    val tr: res[target.Target, fail.Fail] = target.resolve(p.s.registry, ?req);
     if (sel tr.err) { ret err[outcome.Fail].err{outcome.user_fail(tr.err)}; }
     p.target = tr.ok;
 

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -471,7 +471,7 @@ fun ut_build(s: *session.Session, alloc: *A.Allocator, names: *str, texts: *str,
     val root_r: res[str, fail.Fail] = ut_scaffold(alloc, names, texts, n);
     if (sel root_r.err) { ret res[project.Project, outcome.Fail].err{outcome.from_fail(root_r.err)}; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(alloc, root); ret res[project.Project, outcome.Fail].err{rr.err}; }
     val pr: res[project.Project, outcome.Fail] = driver.build_project_union(s, root);
     fs.remove_all(alloc, root);
@@ -482,7 +482,7 @@ fun ut_build_multi(s: *session.Session, alloc: *A.Allocator, names: *str, texts:
     val root_r: res[str, fail.Fail] = ut_scaffold_m(alloc, ut_manifest_multi(), names, texts, n);
     if (sel root_r.err) { ret res[project.Project, outcome.Fail].err{outcome.from_fail(root_r.err)}; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(alloc, root); ret res[project.Project, outcome.Fail].err{rr.err}; }
     val pr: res[project.Project, outcome.Fail] = driver.build_project_union(s, root);
     fs.remove_all(alloc, root);
@@ -493,7 +493,7 @@ fun ut_build_test(s: *session.Session, alloc: *A.Allocator, names: *str, texts: 
     val root_r: res[str, fail.Fail] = ut_scaffold(alloc, names, texts, n);
     if (sel root_r.err) { ret res[project.Project, outcome.Fail].err{outcome.from_fail(root_r.err)}; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(alloc, root); ret res[project.Project, outcome.Fail].err{rr.err}; }
     var pick: manifest.Selection;
     pick.target       = "";
@@ -800,7 +800,7 @@ test "mach.lang.driver:dispatcher_folds_a_wide_run_time_result_to_255" {
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -821,7 +821,7 @@ test "mach.lang.driver:dispatcher_folds_a_wide_run_time_result_to_255" {
     rq.project_root = root;
     rq.target       = "linux";
     rq.goal         = request.GOAL_TESTS;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
     val r: res[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, ?alloc, nil);
@@ -1388,7 +1388,7 @@ test "mach.lang.driver:load_module_registration_fail_at_n_no_leak" {
         val sr: res[session.Session, fail.Fail] = session.init(?alloc);
         if (sel sr.err) { bad = 1; brk; }
         var s: session.Session = sr.ok;
-        val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+        val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
         if (sel rr.err) { session.dnit(?s); bad = 1; brk; }
 
         val pr: res[project.Project, outcome.Fail] = driver.build_project_union(?s, root);
@@ -1440,7 +1440,7 @@ test "mach.lang.driver:load_module_registration_fail_at_n_no_leak" {
         if (sel sr.err) { bad = 5; }
         if (sel sr.ok) {
             var s: session.Session = sr.ok;
-            val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+            val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
             if (sel rr.err) { session.dnit(?s); bad = 5; }
             if (sel rr.ok) {
                 val pr: res[project.Project, outcome.Fail] = driver.build_project_union(?s, root);
@@ -1555,7 +1555,7 @@ fun ut_single_sema_n(s: *session.Session, alloc: *A.Allocator, names: *str, text
     val root_r: res[str, fail.Fail] = ut_scaffold(alloc, names, texts, n);
     if (sel root_r.err) { ret res[project.Project, outcome.Fail].err{outcome.from_fail(root_r.err)}; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(alloc, root); ret res[project.Project, outcome.Fail].err{rr.err}; }
     var tsel_1294: manifest.Selection = ut_target_sel("linux");
     val pr: res[project.Project, outcome.Fail] = driver.build_project(s, root, ?tsel_1294);
@@ -2031,7 +2031,7 @@ fun ut_codegen_target_ok(src: str, target_name: str) i32 {
     val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var tsel_1773: manifest.Selection = ut_target_sel(target_name);
     val pr: res[project.Project, outcome.Fail] = driver.build_project(?s, root, ?tsel_1773);
@@ -2082,7 +2082,7 @@ fun ut_codegen_target_rejects(src: str, target_name: str, needle: str) i32 {
     val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var tsel_1821: manifest.Selection = ut_target_sel(target_name);
     val pr: res[project.Project, outcome.Fail] = driver.build_project(?s, root, ?tsel_1821);
@@ -2250,7 +2250,7 @@ fun ut_vec_lower(s: *session.Session, alloc: *A.Allocator, src: str, target_name
     val root_r: res[str, fail.Fail] = ut_scaffold_m(alloc, ut_manifest_spirv(), ?names[0], ?texts[0], 1);
     if (sel root_r.err) { ret res[project.Project, outcome.Fail].err{outcome.from_fail(root_r.err)}; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(alloc, root); ret res[project.Project, outcome.Fail].err{rr.err}; }
     var tsel_1984: manifest.Selection = ut_target_sel(target_name);
     val pr: res[project.Project, outcome.Fail] = driver.build_project(s, root, ?tsel_1984);
@@ -2273,7 +2273,7 @@ fun ut_vec_lower_opt(s: *session.Session, alloc: *A.Allocator, src: str, target_
     val root_r: res[str, fail.Fail] = ut_scaffold_m(alloc, ut_manifest_spirv(), ?names[0], ?texts[0], 1);
     if (sel root_r.err) { ret res[project.Project, outcome.Fail].err{outcome.from_fail(root_r.err)}; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(alloc, root); ret res[project.Project, outcome.Fail].err{rr.err}; }
     var tsel: manifest.Selection = ut_target_sel(target_name);
     val pr: res[project.Project, outcome.Fail] = driver.build_project(s, root, ?tsel);
@@ -3261,7 +3261,7 @@ fun ut_union_gate_result_n(names: *str, texts: *str, count: u32, want_diag: str,
     val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, names, texts, count);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     val pr: res[project.Project, outcome.Fail] = driver.build_project_union(?s, root);
     fs.remove_all(?alloc, root);
@@ -3320,7 +3320,7 @@ test "mach.lang.driver:unresolved_union_gate_preserves_independent_diagnostics" 
     val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
     if (sel root_r.err) { session.dnit(?s); ret 2; }
     val root: str = root_r.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) {
         fs.remove_all(?alloc, root); session.dnit(?s); ret 3;
     }
@@ -3356,7 +3356,7 @@ test "mach.lang.driver:union_gate_fixpoint_gives_up_despite_const_import_progres
     val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) {
         fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
     }
@@ -3392,7 +3392,7 @@ test "mach.lang.driver:union_tuple_dependent_dependency_const_fails_closed" {
     val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) {
         fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
     }
@@ -3431,7 +3431,7 @@ test "mach.lang.driver:union_tuple_dependent_dependency_const_via_bare_member_fa
     val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) {
         fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
     }
@@ -3475,7 +3475,7 @@ test "mach.lang.driver:union_gated_walk_does_not_taint_freshly_loaded_dependency
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
     fin { str_free(?alloc, root); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) {
         fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
     }
@@ -3554,7 +3554,7 @@ test "mach.lang.driver:union_tuple_reach_propagates_transitively" {
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
     fin { str_free(?alloc, root); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) {
         fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
     }
@@ -3596,7 +3596,7 @@ test "mach.lang.driver:same_alias_distinct_failures_per_tuple_both_visible" {
     val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
     if (sel root_r.err) { session.dnit(?s); ret 2; }
     val root: str = root_r.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) {
         fs.remove_all(?alloc, root); session.dnit(?s); ret 3;
     }
@@ -4146,7 +4146,7 @@ test "mach.lang.driver:union_skips_uncoverable_target" {
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
 
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
 
     val pur: res[project.Project, outcome.Fail] = driver.build_project_union(?s, root);
@@ -4212,7 +4212,7 @@ test "mach.lang.driver:union_gate_selection_uses_tuple_abi_and_platform" {
     val root_r: res[str, fail.Fail] = ut_scaffold_m(?alloc, mf, ?names[0], ?texts[0], 5);
     if (sel root_r.err) { session.dnit(?s); ret 2; }
     val root: str = root_r.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) {
         fs.remove_all(?alloc, root); session.dnit(?s); ret 3;
     }
@@ -4356,7 +4356,7 @@ test "mach.lang.driver:union_malformed_condition_reported_once" {
     val root1_r: res[str, fail.Fail] = ut_scaffold(?a1, ?names[0], ?texts[0], 1);
     if (sel root1_r.err) { session.dnit(?s1); ret 1; }
     val root1: str = root1_r.ok;
-    val rr1: err[outcome.Fail] = driver.setup_registry(?s1.registry);
+    val rr1: err[outcome.Fail] = driver.setup_registry(s1.registry);
     if (sel rr1.err) { fs.remove_all(?a1, root1); session.dnit(?s1); ret 1; }
     var pick: manifest.Selection;
     pick.target = ""; pick.profile = ""; pick.artifact = ""; pick.want_lib = false; pick.has_artifact = false;
@@ -4493,7 +4493,7 @@ test "mach.lang.driver:union_ambiguous_multi_artifact_default" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [4]str;
@@ -4547,7 +4547,7 @@ test "mach.lang.driver:validate_local_links_skips_filtered_cross_target" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -4576,7 +4576,7 @@ test "mach.lang.driver:step_out_in_module_obj_tree_rejected" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str; names[0] = "main.mach";      names[1] = "window.mach";
@@ -4614,7 +4614,7 @@ test "mach.lang.driver:step_out_in_stage_tree_rejected" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str; names[0] = "main.mach";      names[1] = "window.mach";
@@ -4652,7 +4652,7 @@ test "mach.lang.driver:step_out_in_stamp_tree_rejected" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str; names[0] = "main.mach";      names[1] = "window.mach";
@@ -4690,7 +4690,7 @@ test "mach.lang.driver:step_out_beside_module_obj_tree_allowed" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str; names[0] = "main.mach";      names[1] = "window.mach";
@@ -4721,7 +4721,7 @@ test "mach.lang.driver:build_steps_repeat_cache_hit_skips_reexecution" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -4766,7 +4766,7 @@ test "mach.lang.driver:build_steps_repeat_no_cache_reexecutes_a_stamped_step" {
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -4813,7 +4813,7 @@ test "mach.lang.driver:build_steps_repeat_reexecutes_on_stale_input" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -4874,7 +4874,7 @@ test "mach.lang.driver:build_steps_stale_staging_discarded_before_run" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str; names[0] = "main.mach";      names[1] = "window.mach";
@@ -4993,7 +4993,7 @@ test "mach.lang.driver:test_primary_artifact_matches_target" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -5027,7 +5027,7 @@ test "mach.lang.driver:selected_root_artifact_sets_project_module" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str; names[0] = "alpha.mach"; names[1] = "beta.mach";
@@ -5060,7 +5060,7 @@ test "mach.lang.driver:dep_closure_refuses_an_alias_key_before_any_conflict" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -5111,7 +5111,7 @@ test "mach.lang.driver:dep_git_checkout_uses_parent_gitlink_authority" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     val origin: str = "https://example.invalid/verified.git";
@@ -5370,7 +5370,7 @@ test "mach.lang.driver:path_dependency_verifies_filesystem_content_without_chang
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var root_names: [1]str; root_names[0] = "main.mach";
@@ -5557,7 +5557,7 @@ test "mach.lang.driver:path_package_resolves_nested_git_dependency" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     val source: str = "https://example.invalid/b.git";
@@ -5613,7 +5613,7 @@ test "mach.lang.driver:dep_transitive_gitlink_resolves_flat_and_the_nested_place
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
     val a_source: str = "https://example.invalid/a.git";
     val b_source: str = "https://example.invalid/b.git";
@@ -5688,7 +5688,7 @@ fun ut_dep_root_override(nested: bool, root_git: bool, child_git: bool, root_fir
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 1; }
 
     val a_decl: str = "\n[dep.a]\npath = \"./vendor/a\"\n";
@@ -5809,7 +5809,7 @@ test "mach.lang.driver:dep_transitive_manifest_failures_are_not_leaves" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -5859,7 +5859,7 @@ test "mach.lang.driver:empty_target_table_synthesizes_native" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -5890,7 +5890,7 @@ test "mach.lang.driver:undeclared_use_root_names_the_missing_dep" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -5935,7 +5935,7 @@ test "mach.lang.driver:dep_closure_registers_transitive" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -6015,7 +6015,7 @@ test "mach.lang.driver:cascade_libs_fail_at_n_releases_scratch" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -6104,7 +6104,7 @@ test "mach.lang.driver:dep_unresolved_names_dep_and_fix" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -6142,7 +6142,7 @@ test "mach.lang.driver:reload_rebuild_dedup_sources_by_path" {
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
 
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str;
@@ -6195,7 +6195,7 @@ test "mach.lang.driver:incremental_qparse_ast_reuse_and_reparse" {
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
 
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str;
@@ -6291,7 +6291,7 @@ test "mach.lang.driver:incremental_reused_phase_replays_diagnostics" {
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
 
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str;
@@ -6345,7 +6345,7 @@ test "mach.lang.driver:incremental_overlay_reparses_exactly_overlaid_module" {
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
 
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str;
@@ -6417,7 +6417,7 @@ test "mach.lang.driver:incremental_stable_identity_across_reshape" {
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
 
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [3]str;
@@ -6479,7 +6479,7 @@ test "mach.lang.driver:incremental_qexports_firewalls_body_edit" {
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
 
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str;
@@ -6617,7 +6617,7 @@ test "mach.lang.driver:incremental_resolve_firewall_body_edit_equals_scratch" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [2]str;
@@ -6659,7 +6659,7 @@ test "mach.lang.driver:incremental_resolve_firewall_body_edit_equals_scratch" {
     val sr2: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr2.err) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = sr2.ok;
-    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(?sB.registry);
+    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(sB.registry);
     if (sel setup_registry_r2.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: res[project.Project, outcome.Fail] = driver.build_project_union(?sB, root);
     if (sel pBr.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
@@ -6683,7 +6683,7 @@ test "mach.lang.driver:incremental_resolve_pub_surface_change_equals_scratch" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [2]str;
@@ -6751,7 +6751,7 @@ test "mach.lang.driver:incremental_resolve_pub_surface_change_equals_scratch" {
     val sr2: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr2.err) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = sr2.ok;
-    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(?sB.registry);
+    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(sB.registry);
     if (sel setup_registry_r2.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: res[project.Project, outcome.Fail] = driver.build_project_union(?sB, root);
     if (sel pBr.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
@@ -6775,7 +6775,7 @@ test "mach.lang.driver:incremental_resolve_const_value_change_equals_scratch" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [2]str;
@@ -6814,7 +6814,7 @@ test "mach.lang.driver:incremental_resolve_const_value_change_equals_scratch" {
     val sr2: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr2.err) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = sr2.ok;
-    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(?sB.registry);
+    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(sB.registry);
     if (sel setup_registry_r2.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: res[project.Project, outcome.Fail] = driver.build_project_union(?sB, root);
     if (sel pBr.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
@@ -6838,7 +6838,7 @@ test "mach.lang.driver:incremental_resolve_reexport_two_hop_propagation" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [3]str;
@@ -6887,7 +6887,7 @@ test "mach.lang.driver:incremental_resolve_reexport_two_hop_propagation" {
     val sr2: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr2.err) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = sr2.ok;
-    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(?sB.registry);
+    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(sB.registry);
     if (sel setup_registry_r2.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: res[project.Project, outcome.Fail] = driver.build_project_union(?sB, root);
     if (sel pBr.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
@@ -6929,7 +6929,7 @@ test "mach.lang.driver:dotted_path_missing_root_rejection_ignores_trivia" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -7003,7 +7003,7 @@ test "mach.lang.driver:resolve_fwd_renamed_reexport_links_across_module_boundary
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [3]str;
@@ -7039,7 +7039,7 @@ test "mach.lang.driver:resolve_fwd_renamed_reexport_link_name_independent_of_imp
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [3]str;
@@ -7301,7 +7301,7 @@ test "mach.lang.driver:incremental_sema_firewall_body_edit_equals_scratch" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [2]str;
@@ -7347,7 +7347,7 @@ test "mach.lang.driver:incremental_sema_firewall_body_edit_equals_scratch" {
     val sr2: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr2.err) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = sr2.ok;
-    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(?sB.registry);
+    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(sB.registry);
     if (sel setup_registry_r2.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: res[project.Project, outcome.Fail] = driver.build_project_union(?sB, root);
     if (sel pBr.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
@@ -7373,7 +7373,7 @@ test "mach.lang.driver:incremental_sema_return_type_change_equals_scratch" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [2]str;
@@ -7414,7 +7414,7 @@ test "mach.lang.driver:incremental_sema_return_type_change_equals_scratch" {
     val sr2: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr2.err) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = sr2.ok;
-    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(?sB.registry);
+    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(sB.registry);
     if (sel setup_registry_r2.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: res[project.Project, outcome.Fail] = driver.build_project_union(?sB, root);
     if (sel pBr.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
@@ -7440,7 +7440,7 @@ test "mach.lang.driver:incremental_sema_field_type_change_equals_scratch" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [2]str;
@@ -7483,7 +7483,7 @@ test "mach.lang.driver:incremental_sema_field_type_change_equals_scratch" {
     val sr2: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr2.err) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = sr2.ok;
-    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(?sB.registry);
+    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(sB.registry);
     if (sel setup_registry_r2.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: res[project.Project, outcome.Fail] = driver.build_project_union(?sB, root);
     if (sel pBr.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
@@ -7509,7 +7509,7 @@ test "mach.lang.driver:incremental_sema_reshape_renumber_recheck" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [3]str;
@@ -7556,7 +7556,7 @@ test "mach.lang.driver:incremental_sema_reshape_renumber_recheck" {
     val sr2: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr2.err) { project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     var sB: session.Session = sr2.ok;
-    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(?sB.registry);
+    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(sB.registry);
     if (sel setup_registry_r2.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
     val pBr: res[project.Project, outcome.Fail] = driver.build_project_union(?sB, root);
     if (sel pBr.err) { session.dnit(?sB); project.dnit_project(?pA2); fs.remove_all(?alloc, root); session.dnit(?sA); ret 1; }
@@ -7582,7 +7582,7 @@ test "mach.lang.driver:incremental_lower_reuse_no_change" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [2]str;
@@ -7863,7 +7863,7 @@ test "mach.lang.driver:inline_bodies_cross_modules_preserve_identity_effects_and
         if (sel initialized.err) { ret 3; }
         var s: session.Session = initialized.ok;
         fin { session.dnit(?s); }
-        val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+        val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
         if (sel setup_registry_r.err) { ret 4; }
         val lowered: res[project.Project, outcome.Fail] = ut_inline_prepare(?s, root, round * 2);
         if (sel lowered.err) { ret 5; }
@@ -7942,7 +7942,7 @@ test "mach.lang.driver:inline_body_availability_refreshes_after_unannotated_prov
     if (sel initialized.err) { ret 2; }
     var s: session.Session = initialized.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 3; }
     var names: [2]str = [2]str{"main.mach", "leaf.mach"};
     var versions: [3]str = [3]str{
@@ -8009,7 +8009,7 @@ test "mach.lang.driver:inline_shared_specializations_keep_an_actual_provider_for
     if (sel initialized.err) { ret 2; }
     var s: session.Session = initialized.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 3; }
     var names: [4]str = [4]str{"main.mach", "a.mach", "b.mach", "generic.mach"};
     var texts: [4]str;
@@ -8087,7 +8087,7 @@ fun ut_inline_module_calls(s: *session.Session, root: str, out: *u8, cap: usize)
     if (sel initialized.err) { ret -1; }
     var fresh: session.Session = initialized.ok;
     fin { session.dnit(?fresh); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?fresh.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(fresh.registry);
     if (sel setup_registry_r.err) { ret -1; }
     val lowered: res[project.Project, outcome.Fail] = ut_inline_prepare(?fresh, root, 0);
     if (sel lowered.err) { ret -1; }
@@ -8223,7 +8223,7 @@ test "mach.lang.driver:inline_rule_keeps_recursive_indirect_noinline_naked_and_l
     if (sel initialized.err) { ret 2; }
     var s: session.Session = initialized.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 3; }
     var names: [2]str = [2]str{"main.mach", "helper.mach"};
     var texts: [2]str;
@@ -8306,7 +8306,7 @@ test "mach.lang.driver:inline_effectful_asm_wrapper_keeps_its_effects_and_order"
     if (sel initialized.err) { ret 2; }
     var s: session.Session = initialized.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 3; }
     var names: [2]str = [2]str{"main.mach", "helper.mach"};
     var texts: [2]str;
@@ -8378,7 +8378,7 @@ test "mach.lang.driver:inline_oblivious_callee_stays_a_call_in_a_public_caller" 
     if (sel initialized.err) { ret 2; }
     var s: session.Session = initialized.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 3; }
     var names: [2]str = [2]str{"main.mach", "helper.mach"};
     var texts: [2]str;
@@ -8413,7 +8413,7 @@ fun ut_inline_text_bytes(alloc: *A.Allocator, root: str, fn: str, debug: bool, o
     if (sel initialized.err) { ret 1; }
     var s: session.Session = initialized.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 2; }
     var selection: manifest.Selection = ut_target_sel("linux");
     selection.profile = "release";
@@ -8495,7 +8495,7 @@ test "mach.lang.driver:inline_body_product_stops_propagation_when_extracted_bodi
     if (sel initialized.err) { ret 2; }
     var s: session.Session = initialized.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 3; }
     var names: [2]str = [2]str{"main.mach", "leaf.mach"};
     var versions: [3]str = [3]str{
@@ -8634,7 +8634,7 @@ test "mach.lang.driver:inline_std_atomic_wrappers_lose_their_calls_and_keep_thei
     if (sel initialized.err) { ret 2; }
     var s: session.Session = initialized.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 3; }
     var atomic_path: str = "";
     val scaffold: res[str, fail.Fail] = ut_atomic_scaffold(?alloc, ?atomic_path);
@@ -8705,7 +8705,7 @@ test "mach.lang.driver:std_atomic_wrapper_body_edit_relowers_the_importer" {
     if (sel initialized.err) { ret 2; }
     var s: session.Session = initialized.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 3; }
     var atomic_path: str = "";
     val scaffold: res[str, fail.Fail] = ut_atomic_scaffold(?alloc, ?atomic_path);
@@ -8815,7 +8815,7 @@ fun ut_noinline_survives_object(target_name: str) i32 {
     val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var tsel_6836: manifest.Selection = ut_target_sel(target_name);
     val pr: res[project.Project, outcome.Fail] = driver.build_project(?s, root, ?tsel_6836);
@@ -8948,7 +8948,7 @@ fun ut_naked_spans(target_name: str, src: str, naked_out: *i64, bare_out: *i64) 
     val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var tsel_6966: manifest.Selection = ut_target_sel(target_name);
     val pr: res[project.Project, outcome.Fail] = driver.build_project(?s, root, ?tsel_6966);
@@ -9022,7 +9022,7 @@ test "mach.lang.driver:naked_propagates_to_a_generic_instance" {
     val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var tsel_7035: manifest.Selection = ut_target_sel("linux");
     val pr: res[project.Project, outcome.Fail] = driver.build_project(?s, root, ?tsel_7035);
@@ -9094,7 +9094,7 @@ test "mach.lang.driver:incremental_lower_isolated_edit_reuses_sibling" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [3]str;
@@ -9159,7 +9159,7 @@ test "mach.lang.driver:incremental_lower_entry_edit_reuses_dep" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [2]str;
@@ -9218,7 +9218,7 @@ test "mach.lang.driver:incremental_lower_surface_firewall" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [2]str;
@@ -9286,7 +9286,7 @@ test "mach.lang.driver:incremental_lower_surface_excludes_test_body" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [2]str;
@@ -9340,7 +9340,7 @@ test "mach.lang.driver:incremental_lower_surface_comptime_value_invalidates" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [2]str;
@@ -9390,7 +9390,7 @@ test "mach.lang.driver:incremental_lower_inline_body_invalidates_importers" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [2]str;
@@ -9443,7 +9443,7 @@ test "mach.lang.driver:incremental_codegen_reuse_and_recompute" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [3]str;
@@ -9564,7 +9564,7 @@ test "mach.lang.driver.cache:repeated_project_operations_publish_under_current_s
         if (sel initialized.err) { ret 5; }
         var s: session.Session = initialized.ok;
         fin { session.dnit(?s); }
-        val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+        val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
         if (sel setup_registry_r.err) { ret 6; }
         val built: res[project.Project, outcome.Fail] = driver.build_project_union(?s, root);
         if (sel built.err) { ret 7; }
@@ -9708,7 +9708,7 @@ test "mach.lang.driver.cache:restored_product_is_invalidated_by_each_keyed_input
     val first_r: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel first_r.err) { ret 2; }
     var first: session.Session = first_r.ok;
-    val registered: err[outcome.Fail] = driver.setup_registry(?first.registry);
+    val registered: err[outcome.Fail] = driver.setup_registry(first.registry);
     if (sel registered.err) { session.dnit(?first); ret 2; }
     val published: UtCachedRound = ut_cached_round(?first, root, false);
     session.dnit(?first);
@@ -9719,7 +9719,7 @@ test "mach.lang.driver.cache:restored_product_is_invalidated_by_each_keyed_input
     if (sel sr.err) { ret 4; }
     var s: session.Session = sr.ok;
     fin { session.dnit(?s); }
-    val registered2: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val registered2: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel registered2.err) { ret 4; }
     val restored: UtCachedRound = ut_cached_round(?s, root, false);
     if (!restored.ok || restored.hits != 2 || restored.misses != 0 || restored.lowered_main || restored.lowered_leaf) { ret 5; }
@@ -9754,7 +9754,7 @@ test "mach.lang.driver.cache:restored_product_is_invalidated_by_each_keyed_input
     if (sel third_r.err) { ret 15; }
     var third: session.Session = third_r.ok;
     fin { session.dnit(?third); }
-    val registered3: err[outcome.Fail] = driver.setup_registry(?third.registry);
+    val registered3: err[outcome.Fail] = driver.setup_registry(third.registry);
     if (sel registered3.err) { ret 15; }
     val final: UtCachedRound = ut_cached_round(?third, root, true);
     if (!final.ok || final.hits != 2 || final.misses != 0 || final.lowered_main || final.lowered_leaf) { ret 16; }
@@ -9768,7 +9768,7 @@ test "mach.lang.driver:incremental_link_reuse_and_fingerprint" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [3]str;
@@ -9900,7 +9900,7 @@ test "mach.lang.driver:incremental_link_external_content_fingerprint" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [3]str;
@@ -10016,7 +10016,7 @@ test "mach.lang.driver:incremental_test_mode_neutralization_variant" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var sA: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?sA.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(sA.registry);
     if (sel setup_registry_r.err) { session.dnit(?sA); ret 1; }
 
     var names: [2]str;
@@ -10742,7 +10742,7 @@ test "mach.lang.driver:bracket_interpretation_changes_without_rewriting_reused_s
     if (sel initialized.err) { ret 2; }
     var s: session.Session = initialized.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 3; }
     var names: [2]str = [2]str{"main.mach", "lib.mach"};
     var versions: [2]str = [2]str{
@@ -11118,7 +11118,7 @@ fun ut_volatile_counts_release(src: str, vol_loads: *u32, vol_stores: *u32,
     if (sel root_r.err) { session.dnit(?s); ret false; }
     val root: str = root_r.ok;
 
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret false; }
 
     var pick: manifest.Selection;
@@ -11537,7 +11537,7 @@ fun ut_ct_edge_project(s: *session.Session, alloc: *A.Allocator, src: str, targe
     val root_r: res[str, fail.Fail] = ut_scaffold_m(alloc, ut_ct_edge_manifest(), ?names[0], ?texts[0], 1);
     if (sel root_r.err) { ret res[project.Project, outcome.Fail].err{outcome.from_fail(root_r.err)}; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(alloc, root); ret res[project.Project, outcome.Fail].err{rr.err}; }
     var tsel_9040: manifest.Selection = ut_target_sel(target_name);
     val pr: res[project.Project, outcome.Fail] = driver.build_project(s, root, ?tsel_9040);
@@ -11553,7 +11553,7 @@ test "mach.lang.driver.setup_registry:idempotent_across_repeated_calls_on_one_se
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
 
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
     val isa_count: u32 = isa.registered_count(?s.registry.isa);
     val abi_count: u32 = abi.registered_count(?s.registry.abi);
@@ -11561,9 +11561,9 @@ test "mach.lang.driver.setup_registry:idempotent_across_repeated_calls_on_one_se
     val os_count:  u32 = os.registered_count(?s.registry.os);
     if (isa_count == 0) { session.dnit(?s); ret 1; }
 
-    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r2: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r2.err) { session.dnit(?s); ret 1; }
-    val setup_registry_r3: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r3: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r3.err) { session.dnit(?s); ret 1; }
     if (isa.registered_count(?s.registry.isa) != isa_count) { session.dnit(?s); ret 1; }
     if (abi.registered_count(?s.registry.abi) != abi_count) { session.dnit(?s); ret 1; }
@@ -11694,7 +11694,7 @@ test "mach.lang.driver:mos6502_target_is_refused_as_withdrawn" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -11763,7 +11763,7 @@ test "mach.lang.driver:float_gated_out_of_a_freestanding_tuple" {
     val root_r: res[str, fail.Fail] = ut_scaffold_m(?alloc, ut_float_union_manifest(), ?names[0], ?texts[0], 1);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     val pr: res[project.Project, outcome.Fail] = driver.build_project_union(?s, root);
     fs.remove_all(?alloc, root);
@@ -11818,7 +11818,7 @@ test "mach.lang.driver:union_ctx_has_float_restored_across_divergent_tuple" {
     val root_r: res[str, fail.Fail] = ut_scaffold_m(?alloc, ut_float_union_manifest(), ?names[0], ?texts[0], 1);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     val pr: res[project.Project, outcome.Fail] = driver.build_project_union(?s, root);
     fs.remove_all(?alloc, root);
@@ -12241,7 +12241,7 @@ fun ut_engine_build_fails(src: str) i32 {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str;
@@ -12257,7 +12257,7 @@ fun ut_engine_build_fails(src: str) i32 {
     var m: manifest.Manifest = mr.ok;
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -13069,7 +13069,7 @@ test "mach.lang.build.engine.execute:artifact_build_roots_at_reachable_modules" 
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [3]str;
@@ -13089,7 +13089,7 @@ test "mach.lang.build.engine.execute:artifact_build_roots_at_reachable_modules" 
     rq.project_root = root;
     rq.target       = "spirv";
     rq.artifact     = "probe_frag";
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -13119,7 +13119,7 @@ test "mach.lang.build.engine.execute_warm:blocked_output_directory_is_environmen
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str;
@@ -13139,7 +13139,7 @@ test "mach.lang.build.engine.execute_warm:blocked_output_directory_is_environmen
     var m: manifest.Manifest = mr.ok;
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -13163,7 +13163,7 @@ test "mach.lang.build.engine.execute_warm:unchanged_rebuild_reuses_and_stays_bou
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [3]str;
@@ -13181,7 +13181,7 @@ test "mach.lang.build.engine.execute_warm:unchanged_rebuild_reuses_and_stays_bou
     var m: manifest.Manifest = mr.ok;
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -13263,7 +13263,7 @@ test "mach.lang.build.engine.execute_warm:tampered_artifact_forces_relink_not_si
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [3]str;
@@ -13281,7 +13281,7 @@ test "mach.lang.build.engine.execute_warm:tampered_artifact_forces_relink_not_si
     var m: manifest.Manifest = mr.ok;
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -13344,7 +13344,7 @@ test "mach.lang.build.engine.execute_warm:failed_link_retries_at_unchanged_revis
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str;
@@ -13361,7 +13361,7 @@ test "mach.lang.build.engine.execute_warm:failed_link_retries_at_unchanged_revis
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
     rq.goal         = request.GOAL_TESTS;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -13406,7 +13406,7 @@ test "mach.lang.build.engine.execute_warm:jobs_flip_holds_all_revisions" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [3]str;
@@ -13425,7 +13425,7 @@ test "mach.lang.build.engine.execute_warm:jobs_flip_holds_all_revisions" {
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
     rq.jobs         = 1;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -13484,7 +13484,7 @@ test "mach.lang.build.engine.execute_warm:parallel_pool_rebuilds_only_stale_modu
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [4]str;
@@ -13504,7 +13504,7 @@ test "mach.lang.build.engine.execute_warm:parallel_pool_rebuilds_only_stale_modu
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
     rq.jobs         = 2;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -13616,7 +13616,7 @@ fun ut_build_scale(alloc: *A.Allocator, root: str, jobs: u32, out_bytes: *Vector
     val sr: res[session.Session, fail.Fail] = session.init(alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     val mr: res[manifest.Manifest, outcome.Fail] = driver.load_manifest(?s, root);
@@ -13627,7 +13627,7 @@ fun ut_build_scale(alloc: *A.Allocator, root: str, jobs: u32, out_bytes: *Vector
     rq.jobs          = jobs;
     rq.opt            = pipeline.OPT_RELEASE;
     rq.debug          = true;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -13687,7 +13687,7 @@ test "mach.lang.build.engine.execute_warm:replaced_image_owns_section_bytes" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     val LIT: str = "warm-owned-section-bytes";
@@ -13707,7 +13707,7 @@ test "mach.lang.build.engine.execute_warm:replaced_image_owns_section_bytes" {
     var m: manifest.Manifest = mr.ok;
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -13787,7 +13787,7 @@ test "mach.lang.build.engine.execute_warm_all:two_artifacts_both_link" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str;
@@ -13805,7 +13805,7 @@ test "mach.lang.build.engine.execute_warm_all:two_artifacts_both_link" {
 
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -13842,7 +13842,7 @@ test "mach.lang.build.engine.execute_warm:bin_name_keys_the_artifact_cache" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [3]str;
@@ -13860,7 +13860,7 @@ test "mach.lang.build.engine.execute_warm:bin_name_keys_the_artifact_cache" {
     var m: manifest.Manifest = mr.ok;
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -13907,7 +13907,7 @@ test "mach.lang.build.engine.execute_warm:unit_failure_is_owned_after_teardown" 
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str;
@@ -13923,7 +13923,7 @@ test "mach.lang.build.engine.execute_warm:unit_failure_is_owned_after_teardown" 
     var m: manifest.Manifest = mr.ok;
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -13968,7 +13968,7 @@ test "mach.lang.build.engine.execute_warm:pool_error_message_survives_teardown" 
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [4]str;
@@ -13988,7 +13988,7 @@ test "mach.lang.build.engine.execute_warm:pool_error_message_survives_teardown" 
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
     rq.jobs         = 2;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -14046,7 +14046,7 @@ fun ut_readout_rows_case(jobs: u32) i32 {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [17]str;
@@ -14063,7 +14063,7 @@ fun ut_readout_rows_case(jobs: u32) i32 {
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
     rq.jobs         = jobs;
-    val pr_r: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr_r: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr_r.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr_r.ok;
 
@@ -14153,7 +14153,7 @@ test "mach.lang.build.engine.execute_warm:sema_phase_diagnostic_fails_build" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str;
@@ -14169,7 +14169,7 @@ test "mach.lang.build.engine.execute_warm:sema_phase_diagnostic_fails_build" {
     var m: manifest.Manifest = mr.ok;
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -14191,7 +14191,7 @@ fun ut_lower_n(s: *session.Session, alloc: *A.Allocator, names: *str, texts: *st
     val root_r: res[str, fail.Fail] = ut_scaffold(alloc, names, texts, n);
     if (sel root_r.err) { ret res[project.Project, outcome.Fail].err{outcome.from_fail(root_r.err)}; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(alloc, root); ret res[project.Project, outcome.Fail].err{rr.err}; }
     var tsel_11572: manifest.Selection = ut_target_sel("linux");
     val pr: res[project.Project, outcome.Fail] = driver.build_project(s, root, ?tsel_11572);
@@ -14460,7 +14460,7 @@ test "mach.lang.driver:rejected_global_has_no_lower_query_product" {
     if (sel rooted.err) { ret 2; }
     val root: str = rooted.ok;
     fin { fs.remove_all(?alloc, root); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 3; }
     var selection: manifest.Selection = ut_target_sel("linux");
     val built: res[project.Project, outcome.Fail] = driver.build_project(?s, root, ?selection);
@@ -15116,7 +15116,7 @@ test "mach.lang.driver:test_decl_linkage_name" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str;
@@ -15703,7 +15703,7 @@ fun ut_rv32_build_linked(s: *session.Session, alloc: *A.Allocator, src: str, tgt
     val root: str = root_r.ok;
 
     var ok: bool = false;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.ok) {
         var tsel_12976: manifest.Selection = ut_target_sel(tgt);
         val pr: res[project.Project, outcome.Fail] = driver.build_project(s, root, ?tsel_12976);
@@ -16034,7 +16034,7 @@ test "mach.lang.driver:setup_registry_publishes_only_complete_debug_descriptors"
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
 
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
     if (of.debug_registered_count(?s.registry.debug) == 0)       { session.dnit(?s); ret 1; }
     session.dnit(?s);
@@ -16253,7 +16253,7 @@ fun ut_embed_unreadable_diag() i32 {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str;
@@ -16326,7 +16326,7 @@ fun ut_embed_escape_arm(alloc: *A.Allocator, escaped: bool) i32 {
     val sr: res[session.Session, fail.Fail] = session.init(alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str; names[0] = "main.mach"; names[1] = "asset.bin";
@@ -16393,7 +16393,7 @@ test "mach.lang.driver:debug_info_on_a_target_without_a_debug_model_fails_the_ar
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -16463,7 +16463,7 @@ fun ut_divide_trap_target(alloc: *A.Allocator, target_name: str, runner_name: st
     val sr: res[session.Session, fail.Fail] = session.init(alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -16479,7 +16479,7 @@ fun ut_divide_trap_target(alloc: *A.Allocator, target_name: str, runner_name: st
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
     rq.target = target_name;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
     val br: res[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, alloc, nil);
@@ -16534,7 +16534,7 @@ fun ut_native_fixture_case(alloc: *A.Allocator, target_name: str, runner_name: s
     val sr: res[session.Session, fail.Fail] = session.init(alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -16551,7 +16551,7 @@ fun ut_native_fixture_case(alloc: *A.Allocator, target_name: str, runner_name: s
     rq.project_root = root;
     rq.target = target_name;
     if (release) { rq.profile = "release"; rq.opt = pipeline.OPT_RELEASE; }
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
     val br: res[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, alloc, nil);
@@ -16618,7 +16618,7 @@ fun ut_pipeline_verdict(alloc: *A.Allocator, text: str, found: pipeline.OptLevel
     if (sel sr.err) { ret -1; }
     var s: session.Session = sr.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret -1; }
     var names: [1]str; names[0] = "main.mach";
     var texts: [1]str; texts[0] = text;
@@ -16814,7 +16814,7 @@ fun ut_tag_guard_target(alloc: *A.Allocator, target_name: str, runner_name: str,
     val sr: res[session.Session, fail.Fail] = session.init(alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -16831,7 +16831,7 @@ fun ut_tag_guard_target(alloc: *A.Allocator, target_name: str, runner_name: str,
     rq.project_root = root;
     rq.target = target_name;
     if (release) { rq.profile = "release"; rq.opt = pipeline.OPT_RELEASE; }
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
     val br: res[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, alloc, nil);
@@ -16958,7 +16958,7 @@ fun ut_tag_native_case_files(alloc: *A.Allocator, manifest_text: str, root_names
     val sr: res[session.Session, fail.Fail] = session.init(alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -16983,7 +16983,7 @@ fun ut_tag_native_case_files(alloc: *A.Allocator, manifest_text: str, root_names
     rq.project_root = root;
     rq.target = target_name;
     if (release) { rq.profile = "release"; rq.opt = pipeline.OPT_RELEASE; }
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
     val br: res[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, alloc, nil);
@@ -17285,7 +17285,7 @@ fun ut_pipeline_rejects_with(alloc: *A.Allocator, text: str, needle: str) bool {
     if (sel sr.err) { ret false; }
     var s: session.Session = sr.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret false; }
     var names: [1]str; names[0] = "main.mach";
     var texts: [1]str; texts[0] = text;
@@ -17344,7 +17344,7 @@ fun ut_unreachable_count(alloc: *A.Allocator, text: str, found: pipeline.OptLeve
     if (sel sr.err) { ret -1; }
     var s: session.Session = sr.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret -1; }
     var names: [1]str; names[0] = "main.mach";
     var texts: [1]str; texts[0] = text;
@@ -17493,7 +17493,7 @@ fun ut_l8_trap_target(alloc: *A.Allocator, target_name: str, runner_name: str, r
     val sr: res[session.Session, fail.Fail] = session.init(alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -17510,7 +17510,7 @@ fun ut_l8_trap_target(alloc: *A.Allocator, target_name: str, runner_name: str, r
     rq.project_root = root;
     rq.target = target_name;
     if (release) { rq.profile = "release"; rq.opt = pipeline.OPT_RELEASE; }
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
     val br: res[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, alloc, nil);
@@ -17569,7 +17569,7 @@ fun ut_spirv_env_build(alloc: *A.Allocator, env_line: str, needle: str, want_ver
     val sr: res[session.Session, fail.Fail] = session.init(alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "k.mach";
@@ -17682,7 +17682,7 @@ test "mach.lang.driver:embed_asset_edit_invalidates_sema" {
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
 
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [3]str;
@@ -17788,7 +17788,7 @@ test "mach.lang.driver:embed_buffer_is_stable_across_warm_rebuilds" {
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
 
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str;
@@ -17858,7 +17858,7 @@ fun ut_attr_probe(s: *session.Session, alloc: *A.Allocator, names: *str, texts: 
         ret res[str, outcome.Fail].err{outcome.from_fail(root_r.err)};
     }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) {
         fs.remove_all(alloc, root);
         ret res[str, outcome.Fail].err{rr.err};
@@ -17902,7 +17902,7 @@ fun ut_attr_probe_allsrc(s: *session.Session, alloc: *A.Allocator, names: *str, 
         ret res[str, outcome.Fail].err{outcome.from_fail(root_r.err)};
     }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) {
         fs.remove_all(alloc, root);
         ret res[str, outcome.Fail].err{rr.err};
@@ -18474,7 +18474,7 @@ fun ut_spv_lower(s: *session.Session, alloc: *A.Allocator,
         }
     }
 
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(alloc, root); ret res[project.Project, outcome.Fail].err{rr.err}; }
     var tsel_14660: manifest.Selection = ut_target_sel("spirv");
     val pr: res[project.Project, outcome.Fail] = driver.build_project(s, root, ?tsel_14660);
@@ -18738,7 +18738,7 @@ fun ut_va_diag(target_name: str, src: str, needle: str) bool {
     if (sel root_r.err) { session.dnit(?s); ret false; }
     val root: str = root_r.ok;
 
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret false; }
     var tsel_14921: manifest.Selection = ut_target_sel(target_name);
     val pr: res[project.Project, outcome.Fail] = driver.build_project(?s, root, ?tsel_14921);
@@ -19728,7 +19728,7 @@ test "mach.lang.driver.readout:a_phase_counts_what_it_processed" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [3]str;
@@ -19747,7 +19747,7 @@ test "mach.lang.driver.readout:a_phase_counts_what_it_processed" {
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
     rq.goal         = request.GOAL_TEST_LIST;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -19802,7 +19802,7 @@ test "mach.lang.driver.readout:a_deferred_gate_resolves_each_module_once" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [3]str;
@@ -19825,7 +19825,7 @@ test "mach.lang.driver.readout:a_deferred_gate_resolves_each_module_once" {
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
     rq.goal         = request.GOAL_OBJECTS;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -20123,7 +20123,7 @@ fun ut_dwarf_addr_reloc_width(target_name: str, section: str) u32 {
     val root_r: res[str, fail.Fail] = ut_scaffold_m(?alloc, ut_manifest_riscv_pair(), ?names[0], ?texts[0], 1);
     if (sel root_r.err) { session.dnit(?s); ret 0; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 0; }
     var tsel_16211: manifest.Selection = ut_target_sel(target_name);
     val pr: res[project.Project, outcome.Fail] = driver.build_project(?s, root, ?tsel_16211);
@@ -20201,7 +20201,7 @@ fun ut_dwarf_nested_inline_debug_build() bool {
     val root_r: res[str, fail.Fail] = ut_scaffold_m(?alloc, ut_manifest_x64_linux(), ?names[0], ?texts[0], 1);
     if (sel root_r.err) { session.dnit(?s); ret false; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret false; }
     var tsel_16282: manifest.Selection = ut_target_sel("lx64");
     val pr: res[project.Project, outcome.Fail] = driver.build_project(?s, root, ?tsel_16282);
@@ -20300,7 +20300,7 @@ test "mach.lang.be.codegen.pack_symbols:emitted_function_symbol_carries_its_real
     val root_r: res[str, fail.Fail] = ut_scaffold_m(?alloc, ut_manifest_x64_linux(), ?names[0], ?texts[0], 1);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var tsel_16374: manifest.Selection = ut_target_sel("lx64");
     val pr: res[project.Project, outcome.Fail] = driver.build_project(?s, root, ?tsel_16374);
@@ -20453,7 +20453,7 @@ fun ut_fs_elf_image(alloc: *A.Allocator, target_name: str, out: *Vector[u8]) boo
     val root: str = root_r.ok;
 
     var ok: bool = false;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.ok) {
         var tsel_16525: manifest.Selection = ut_target_sel(target_name);
         val pr: res[project.Project, outcome.Fail] = driver.build_project(?s, root, ?tsel_16525);
@@ -21613,7 +21613,7 @@ fun ut_o2_lower(s: *session.Session, alloc: *A.Allocator, src: str, target_name:
     val root_r: res[str, fail.Fail] = ut_scaffold_m(alloc, ut_manifest_o2(), ?names[0], ?texts[0], 1);
     if (sel root_r.err) { ret res[project.Project, outcome.Fail].err{outcome.from_fail(root_r.err)}; }
     val root: str = root_r.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(alloc, root); ret res[project.Project, outcome.Fail].err{rr.err}; }
     var tsel_17664: manifest.Selection = ut_target_sel(target_name);
     val pr: res[project.Project, outcome.Fail] = driver.build_project(s, root, ?tsel_17664);
@@ -22493,7 +22493,7 @@ test "mach.lang.driver:a_manifest_stack_reserve_reaches_the_linked_pe" {
     val root: str = root_r.ok;
 
     var bad: i32 = 0;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { bad = 3; }
     if (sel rr.ok) {
         var tsel_18542: manifest.Selection = ut_target_sel("win");
@@ -22595,7 +22595,7 @@ test "mach.lang.driver:a_frame_larger_than_the_stack_reserve_is_refused" {
     val root: str = root_r.ok;
 
     var bad: i32 = 0;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { bad = 3; }
     if (sel rr.ok) {
         if (!ut_build_names_frame_refusal(?s, root, "small") && bad == 0) { bad = 4; }
@@ -22661,7 +22661,7 @@ fun ut_w64uw_image(alloc: *A.Allocator, out: *Vector[u8]) bool {
     val root: str = root_r.ok;
 
     var ok: bool = false;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.ok) {
         var tsel_18705: manifest.Selection = ut_target_sel("win");
         val pr: res[project.Project, outcome.Fail] = driver.build_project(?s, root, ?tsel_18705);
@@ -22895,7 +22895,7 @@ fun ut_w64realign_image(alloc: *A.Allocator, out: *Vector[u8]) bool {
     val root: str = root_r.ok;
 
     var ok: bool = false;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.ok) {
         var tsel_18936: manifest.Selection = ut_target_sel("win");
         val pr: res[project.Project, outcome.Fail] = driver.build_project(?s, root, ?tsel_18936);
@@ -22996,7 +22996,7 @@ fun ut_w64xmmscratch_image(alloc: *A.Allocator, out: *Vector[u8]) bool {
     val root: str = root_r.ok;
 
     var ok: bool = false;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.ok) {
         var tsel_19035: manifest.Selection = ut_target_sel("win");
         val pr: res[project.Project, outcome.Fail] = driver.build_project(?s, root, ?tsel_19035);
@@ -23073,7 +23073,7 @@ test "mach.lang.driver.passes.q_link:records_the_test_qualified_codegen_key" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str;
@@ -23091,7 +23091,7 @@ test "mach.lang.driver.passes.q_link:records_the_test_qualified_codegen_key" {
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
     rq.goal         = request.GOAL_TESTS;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -23129,7 +23129,7 @@ test "mach.lang.build.engine.artifact_reusable:a_tampered_test_dispatcher_is_rel
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str;
@@ -23145,7 +23145,7 @@ test "mach.lang.build.engine.artifact_reusable:a_tampered_test_dispatcher_is_rel
     var m: manifest.Manifest = mr.ok;
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -23202,7 +23202,7 @@ test "mach.lang.build.engine.execute_warm:refuses_a_manifest_that_changed_after_
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str;
@@ -23218,7 +23218,7 @@ test "mach.lang.build.engine.execute_warm:refuses_a_manifest_that_changed_after_
     var m: manifest.Manifest = mr.ok;
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -23255,7 +23255,7 @@ test "mach.lang.driver:step_target_environment_replaces_a_declared_override" {
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -23374,7 +23374,7 @@ fun ut_orphan_goal(target_name: str, entry_symbol: str, expected_count: usize, e
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str;
@@ -23394,7 +23394,7 @@ fun ut_orphan_goal(target_name: str, entry_symbol: str, expected_count: usize, e
     rq.target       = target_name;
     rq.debug        = false;
     rq.goal         = request.GOAL_TESTS;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) {
         print.eprintlnf("orphan target {} planning failed: {}", target_name, outcome.describe(pr.err));
         fs.remove_all(?alloc, root); session.dnit(?s); ret 1;
@@ -23464,7 +23464,7 @@ test "mach.lang.driver:test_goal_reports_a_compile_error_and_collects_no_tests" 
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [2]str;
@@ -23482,7 +23482,7 @@ test "mach.lang.driver:test_goal_reports_a_compile_error_and_collects_no_tests" 
     var rq: request.BuildRequest = request.defaults();
     rq.project_root = root;
     rq.goal         = request.GOAL_TESTS;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(?alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { fs.remove_all(?alloc, root); session.dnit(?s); ret 1; }
     var bp: bplan.BuildPlan = pr.ok;
 
@@ -23546,7 +23546,7 @@ test "mach.lang.driver:one_gate_decides_the_same_in_every_phase" {
     val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, ?names[0], ?texts[0], 2);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) {
         fs.remove_all(?alloc, root); session.dnit(?s); ret 2;
     }
@@ -23603,7 +23603,7 @@ fun ut_gate_diag_located(text: str, needle: str, want_file: str, want_line: usiz
     val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) {
         fs.remove_all(?alloc, root); session.dnit(?s); ret 2;
     }
@@ -23660,7 +23660,7 @@ test "mach.lang.driver:a_stalled_gate_fixpoint_fails_as_reported_with_no_unlocat
     val root_r: res[str, fail.Fail] = ut_scaffold(?alloc, ?names[0], ?texts[0], 1);
     if (sel root_r.err) { session.dnit(?s); ret 1; }
     val root: str = root_r.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) {
         fs.remove_all(?alloc, root); session.dnit(?s); ret 2;
     }
@@ -23698,7 +23698,7 @@ test "mach.lang.driver:bare_import_of_a_dependency_whose_artifacts_name_differen
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     val origin: str = "https://example.invalid/split.git";
@@ -23759,7 +23759,7 @@ test "mach.lang.driver:bare_import_of_an_artifact_less_dependency_names_the_remo
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     val origin: str = "https://example.invalid/bare.git";
@@ -23830,7 +23830,7 @@ test "mach.lang.driver:a_test_build_over_several_artifacts_without_a_default_is_
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     var names: [1]str; names[0] = "main.mach";
@@ -23854,7 +23854,7 @@ test "mach.lang.driver:a_test_build_over_several_artifacts_without_a_default_is_
         val rr: res[request.BuildRequest, outcome.Fail] = request.compose(?alloc, ?s.interner, ?m, ?cli, root, request.GOAL_TESTS, ?pick);
         if (sel rr.err) { bad = 2; }
         if (sel rr.ok) {
-            val br: res[plan.BuildPlan, outcome.Fail] = plan.plan(?alloc, ?s.interner, ?s.registry, ?m, rr.ok);
+            val br: res[plan.BuildPlan, outcome.Fail] = plan.plan(?alloc, ?s.interner, s.registry, ?m, rr.ok);
             if (sel br.ok) { bad = 3; }
             if (sel br.err) {
                 if (!outcome.is_user(br.err)) { bad = 4; }
@@ -23878,7 +23878,7 @@ test "mach.lang.driver:removed_manifest_keys_are_refused_for_the_root_and_each_d
     val sr: res[session.Session, fail.Fail] = session.init(?alloc);
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret 1; }
 
     val origin: str = "https://example.invalid/old.git";
@@ -23979,7 +23979,7 @@ fun ut_float_zero_profile(alloc: *A.Allocator, root: str, profile_name: str) i32
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 2; }
     val mr: res[manifest.Manifest, outcome.Fail] = driver.load_manifest(?s, root);
     if (sel mr.err) { ret 3; }
@@ -23988,7 +23988,7 @@ fun ut_float_zero_profile(alloc: *A.Allocator, root: str, profile_name: str) i32
     rq.project_root = root;
     rq.target = "native";
     rq.profile = profile_name;
-    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, ?s.registry, ?m, rq);
+    val pr: res[bplan.BuildPlan, outcome.Fail] = bplan.plan(alloc, ?s.interner, s.registry, ?m, rq);
     if (sel pr.err) { ret 4; }
     var bp: bplan.BuildPlan = pr.ok;
     val br: res[outcome.BuildOutcome, outcome.Fail] = bengine.execute_warm(?bp, 0, ?s, alloc, nil);
@@ -24821,7 +24821,7 @@ test "mach.lang.driver:tag_discriminator_edit_advances_the_typed_surface_and_rep
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 1; }
     var names: [2]str = [2]str{"main.mach", "api.mach"};
     var texts: [2]str;
@@ -24863,7 +24863,7 @@ test "mach.lang.driver:tag_case_list_edit_and_revert_replay_the_typed_surface_an
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 1; }
     var names: [2]str = [2]str{"main.mach", "api.mach"};
     var texts: [2]str;
@@ -24911,7 +24911,7 @@ test "mach.lang.driver:deprecation_message_edit_and_revert_replay_the_public_sur
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 1; }
     var names: [2]str = [2]str{"main.mach", "api.mach"};
     var texts: [2]str;
@@ -25077,7 +25077,7 @@ fun ut_l6_project(s: *session.Session, alloc: *A.Allocator, src: str, release: b
     var texts: [1]str = [1]str{src};
     val wr: err[fail.Fail] = ut_write_node_multi(alloc, root, ut_spv_manifest(alloc, ""), ?names[0], ?texts[0], 1);
     if (sel wr.err) { fs.remove_all(alloc, root); ret res[project.Project, outcome.Fail].err{outcome.from_fail(wr.err)}; }
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) { fs.remove_all(alloc, root); ret res[project.Project, outcome.Fail].err{rr.err}; }
     var tsel: manifest.Selection = ut_target_sel("spirv");
     val pr: res[project.Project, outcome.Fail] = driver.build_project(s, root, ?tsel);
@@ -25527,7 +25527,7 @@ fun ut_l6_env(alloc: *A.Allocator, src: str, env_line: str, target_env: str, nee
     if (sel sr.err) { ret 1; }
     var s: session.Session = sr.ok;
     fin { session.dnit(?s); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 1; }
     var names: [1]str; names[0] = "k.mach";
     var texts: [1]str; texts[0] = src;

--- a/src/lang/driver/union.mach
+++ b/src/lang/driver/union.mach
@@ -208,7 +208,7 @@ pub fun populate_union_tuples(p: *project.Project, m: *manifest.Manifest) err[fa
         var of_name: str = "";
         val of_opt: opt[str] = intern.lookup(?p.s.interner, td.of);
         if (sel of_opt.some) { of_name = of_opt.some; }
-        val sr: res[target.Target, fail.Fail] = target.select_of(?p.s.registry, isa_name, os_name, abi_name, of_name);
+        val sr: res[target.Target, fail.Fail] = target.select_of(p.s.registry, isa_name, os_name, abi_name, of_name);
         if (sel sr.err) {
             warn_union_target_skipped(p, os_name, isa_name, fail.describe(sr.err));
         }

--- a/src/lang/editor.mach
+++ b/src/lang/editor.mach
@@ -968,7 +968,7 @@ pub fun build(es: *EditorSession, req: *request.BuildRequest) res[outcome.BuildO
     es.proj_dirty = true;
     val s: *session.Session = es.s;
 
-    val reg_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val reg_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel reg_r.err) {
         val f: outcome.Fail = fail_owned(es, reg_r.err);
         ret res[outcome.BuildOutcome, outcome.Fail].err{f};
@@ -1007,7 +1007,7 @@ pub fun build(es: *EditorSession, req: *request.BuildRequest) res[outcome.BuildO
     }
     var m: manifest.Manifest = m_r.ok;
 
-    val p_r: res[plan.BuildPlan, outcome.Fail] = plan.plan(?al, ?s.interner, ?s.registry, ?m, @req);
+    val p_r: res[plan.BuildPlan, outcome.Fail] = plan.plan(?al, ?s.interner, s.registry, ?m, @req);
     if (sel p_r.err) {
         val f: outcome.Fail = fail_owned(es, p_r.err);
         ret res[outcome.BuildOutcome, outcome.Fail].err{f};
@@ -1537,14 +1537,14 @@ fun ctx_seed(es: *EditorSession, b: *Buffer) err[fail.Fail] {
         es.operation_failure = opt[outcome.Fail].some{outcome.user("a standalone buffer requires a resolved target, not a project target name")};
         ret err[fail.Fail].err{fail.message("a standalone buffer requires a resolved target, not a project target name")};
     }
-    val registry: err[outcome.Fail] = driver.setup_registry(?es.s.registry);
+    val registry: err[outcome.Fail] = driver.setup_registry(es.s.registry);
     if (sel registry.err) { ret err[fail.Fail].err{fail.message(outcome.describe(registry.err))}; }
     var host_request: target.TargetRequest = target.target_request(
         isa.arch_name_for(target.host_arch_id()), os.os_name_for(target.host_os_id()), abi.abi_name_for(target.host_abi_id()));
     var host: target.Target;
     var selected: *target.Target = req.standalone_target;
     if (selected == nil) {
-        val resolved: res[target.Target, fail.Fail] = target.resolve(?es.s.registry, ?host_request);
+        val resolved: res[target.Target, fail.Fail] = target.resolve(es.s.registry, ?host_request);
         if (sel resolved.err) { ret err[fail.Fail].err{resolved.err}; }
         host = resolved.ok;
         selected = ?host;
@@ -3929,7 +3929,7 @@ fun t_driver_parse_outcome(alloc: *A.Allocator, root: str, diags_out: *diagnosti
     val sr: res[session.Session, fail.Fail] = session.init(alloc);
     if (sel sr.err) { ret opt[outcome.Fail].some{outcome.internal("session")}; }
     var s: session.Session = sr.ok;
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { session.dnit(?s); ret opt[outcome.Fail].some{outcome.internal("registry")}; }
     var pick: manifest.Selection;
     pick.target = ""; pick.profile = ""; pick.artifact = ""; pick.want_lib = false; pick.has_artifact = false;
@@ -4227,13 +4227,13 @@ test "mach.lang.editor.analyze:explicit_target_changes_context_and_expires_previ
     fin { session.dnit(?s); }
     var es: EditorSession = init(?s);
     fin { t_dnit(?es); }
-    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val setup_registry_r: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel setup_registry_r.err) { ret 99; }
     var tr32: target.TargetRequest = target.target_request("rv32imafdc", "freestanding", "ilp32d");
     var tr64: target.TargetRequest = target.target_request("riscv64", "linux", "lp64d");
-    val selected32: res[target.Target, fail.Fail] = target.resolve(?s.registry, ?tr32);
+    val selected32: res[target.Target, fail.Fail] = target.resolve(s.registry, ?tr32);
     if (sel selected32.err) { ret 6; }
-    val selected64: res[target.Target, fail.Fail] = target.resolve(?s.registry, ?tr64);
+    val selected64: res[target.Target, fail.Fail] = target.resolve(s.registry, ?tr64);
     if (sel selected64.err) { ret 7; }
     var t32: target.Target = selected32.ok;
     var t64: target.Target = selected64.ok;

--- a/src/lang/fe/sema/tests.mach
+++ b/src/lang/fe/sema/tests.mach
@@ -106,7 +106,7 @@ fun ut_build(alloc: *A.Allocator, root: str, s: *session.Session) res[project.Pr
         ret res[project.Project, outcome.Fail].err{outcome.from_fail(sr.err)};
     }
     @s = sr.ok;
-    val rr: err[outcome.Fail] = driver.setup_registry(?s.registry);
+    val rr: err[outcome.Fail] = driver.setup_registry(s.registry);
     if (sel rr.err) {
         session.dnit(s);
         ret res[project.Project, outcome.Fail].err{rr.err};

--- a/src/lang/session.mach
+++ b/src/lang/session.mach
@@ -94,7 +94,8 @@ pub rec Session {
 
     stable_to_mid: map.Map[module.StableModuleId, module.ModuleId];
 
-    registry: target.TargetRegistry;
+    # the one owner of the target registry; workers borrow it by pointer
+    registry: *target.TargetRegistry;
 
     overlays:    *Overlay;
     overlay_len: u32;
@@ -141,7 +142,15 @@ pub fun init(alloc: *A.Allocator) res[Session, fail.Fail] {
     s.stable_ids       = map.init[intern.StrId, module.StableModuleId](alloc, map.hash_u32, map.eq_u32);
     s.stable_id_next   = 0;
     s.stable_to_mid    = map.init[module.StableModuleId, module.ModuleId](alloc, map.hash_u32, map.eq_u32);
-    s.registry         = target.registry_init();
+    val res_registry: res[*target.TargetRegistry, fail.Fail] = target.registry_new(alloc);
+    if (sel res_registry.err) {
+        intern.dnit(?s.interner);
+
+        diagnostic.store_dnit(?s.diags);
+        source.dnit(?s.sources);
+        ret res[Session, fail.Fail].err{res_registry.err};
+    }
+    s.registry         = res_registry.ok;
     s.overlays         = nil;
     s.overlay_len      = 0;
     s.overlay_cap      = 0;
@@ -149,6 +158,7 @@ pub fun init(alloc: *A.Allocator) res[Session, fail.Fail] {
 
     val opt_types: err[fail.Fail] = type.init(?s.types, alloc);
     if (sel opt_types.err) {
+        target.registry_dnit(s.registry);
         intern.dnit(?s.interner);
 
         diagnostic.store_dnit(?s.diags);
@@ -158,6 +168,7 @@ pub fun init(alloc: *A.Allocator) res[Session, fail.Fail] {
 
     val res_queries: res[query.QueryDb, fail.Fail] = query.init(alloc);
     if (sel res_queries.err) {
+        target.registry_dnit(s.registry);
         type.dnit(?s.types);
         intern.dnit(?s.interner);
 
@@ -169,6 +180,7 @@ pub fun init(alloc: *A.Allocator) res[Session, fail.Fail] {
 
     val res_catalog: err[fail.Fail] = register_catalog(?s.queries);
     if (sel res_catalog.err) {
+        target.registry_dnit(s.registry);
         query.dnit(?s.queries);
         type.dnit(?s.types);
         intern.dnit(?s.interner);
@@ -212,7 +224,8 @@ fun register_catalog(db: *query.QueryDb) err[fail.Fail] {
 pub fun dnit(s: *Session) {
     if (s == nil) { ret; }
 
-    target.registry_dnit(?s.registry);
+    target.registry_dnit(s.registry);
+    s.registry = nil;
 
     if (s.overlays != nil && s.overlay_cap > 0) {
         var oi: u32 = 0;

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -27,6 +27,9 @@ use std.types.string.str_join;
 use std.types.string.str_len;
 
 use A: std.allocator;
+use std.text.string.str_free;
+use mach.lang.alloc;
+use probe: mach.lang.alloc.probe;
 
 use fp: mach.lang.build.fingerprint;
 use mach.lang.be.codegen.debug_input;
@@ -51,6 +54,7 @@ use mach.lang.target.of.macho;
 use mach.lang.target.of.raw;
 use mach.lang.target.of.spv;
 use mach.lang.target.os;
+use treg: mach.lang.target.registry;
 use mach.lang.target.os.darwin;
 use mach.lang.target.os.freestanding;
 use mach.lang.target.os.linux;
@@ -62,6 +66,13 @@ fwd isa.ENDIAN_LITTLE;
 fwd isa.ENDIAN_BIG;
 
 fwd resolved.Target;
+fwd resolved.live;
+
+fwd treg.TargetRegistry;
+fwd treg.registry_init;
+fwd treg.registry_new;
+fwd treg.registry_dnit;
+fwd treg.registry_published;
 
 pub fun host_os_id() u32 {
     $if ($mach.build.os == $mach.os.linux)   { ret os.OS_LINUX; }
@@ -92,50 +103,7 @@ pub fun host_abi_id() u32 {
     ret ($mach.build.abi)::u32;
 }
 
-pub rec TargetRegistry {
-    isa:   isa.IsaRegistry;
-    os:    os.OsRegistry;
-    abi:   abi.AbiRegistry;
-    of:    of.OfRegistry;
-    debug: of.DebugRegistry;
-    state: u8;
-    version: u32;
-}
-
 pub def DebugDescriptorProvider: fun() res[of.DebugVTable, fail.Fail];
-
-val REGISTRY_FRESH:    u8 = 0;
-val REGISTRY_BUILDING: u8 = 1;
-val REGISTRY_READY:    u8 = 2;
-val REGISTRY_VERSION: u32 = 1;
-
-pub fun registry_init() TargetRegistry {
-    var reg: TargetRegistry;
-    reg.isa   = isa.registry_init();
-    reg.os    = os.registry_init();
-    reg.abi   = abi.registry_init();
-    reg.of    = of.registry_init();
-    reg.debug = of.debug_registry_init();
-    reg.state = REGISTRY_FRESH;
-    reg.version = 0;
-    ret reg;
-}
-
-pub fun registry_dnit(reg: *TargetRegistry) {
-    if (reg == nil) { ret; }
-    isa.registry_dnit(?reg.isa);
-    os.registry_dnit(?reg.os);
-    abi.registry_dnit(?reg.abi);
-    of.registry_dnit(?reg.of);
-    of.debug_registry_dnit(?reg.debug);
-    reg.state = REGISTRY_FRESH;
-    reg.version = 0;
-}
-
-fun registry_empty(reg: *TargetRegistry) bool {
-    ret reg != nil && reg.isa.count == 0 && reg.os.count == 0 && reg.abi.count == 0
-        && reg.of.count == 0 && reg.debug.count == 0;
-}
 
 fun isa_identity(reg: *TargetRegistry, name: str, id: u32) bool {
     val found: opt[*isa.IsaVTable] = isa.lookup(?reg.isa, name);
@@ -221,76 +189,79 @@ pub fun register_all(reg: *TargetRegistry, debug_provider: DebugDescriptorProvid
     if (reg == nil || debug_provider == nil) {
         ret err[fail.Fail].err{fail.message("target: register_all requires a registry and debug descriptor provider")};
     }
-    if (reg.state == REGISTRY_READY) {
-        if (reg.version == REGISTRY_VERSION && production_registry_complete(reg)) {
+    if (reg.state == treg.REGISTRY_READY) {
+        if (reg.version == treg.REGISTRY_VERSION && production_registry_complete(reg)) {
             ret err[fail.Fail].ok{};
         }
         ret err[fail.Fail].err{fail.message("target: published registry invariants do not match this catalog version")};
     }
-    if (reg.state != REGISTRY_FRESH || !registry_empty(reg)) {
+    if (reg.state == treg.REGISTRY_RELEASED) {
+        ret err[fail.Fail].err{fail.message("target: register_all refuses a released registry; a registry is published once")};
+    }
+    if (reg.state != treg.REGISTRY_FRESH || !treg.registry_empty(reg)) {
         ret err[fail.Fail].err{fail.message("target: register_all refuses a partial or foreign registry")};
     }
-    reg.state = REGISTRY_BUILDING;
+    reg.state = treg.REGISTRY_BUILDING;
     var res_: err[fail.Fail] = x64.register_x64(?reg.isa);
-    if (sel res_.err) { registry_dnit(reg); ret res_; }
+    if (sel res_.err) { treg.registry_rollback(reg); ret res_; }
     val res__1: err[fail.Fail] = arm64.register_arm64(?reg.isa);
-    if (sel res__1.err) { registry_dnit(reg); ret res__1; }
+    if (sel res__1.err) { treg.registry_rollback(reg); ret res__1; }
     val res__2: err[fail.Fail] = riscv.register_riscv64(?reg.isa);
-    if (sel res__2.err) { registry_dnit(reg); ret res__2; }
+    if (sel res__2.err) { treg.registry_rollback(reg); ret res__2; }
     val res__3: err[fail.Fail] = riscv.register_riscv32(?reg.isa);
-    if (sel res__3.err) { registry_dnit(reg); ret res__3; }
+    if (sel res__3.err) { treg.registry_rollback(reg); ret res__3; }
     val res__4: err[fail.Fail] = spirv.register_spirv(?reg.isa);
-    if (sel res__4.err) { registry_dnit(reg); ret res__4; }
+    if (sel res__4.err) { treg.registry_rollback(reg); ret res__4; }
 
     val res__6: err[fail.Fail] = sysv.register(?reg.abi);
-    if (sel res__6.err) { registry_dnit(reg); ret res__6; }
+    if (sel res__6.err) { treg.registry_rollback(reg); ret res__6; }
     val res__7: err[fail.Fail] = win64.register_win64(?reg.abi);
-    if (sel res__7.err) { registry_dnit(reg); ret res__7; }
+    if (sel res__7.err) { treg.registry_rollback(reg); ret res__7; }
     val res__8: err[fail.Fail] = aapcs64.register(?reg.abi);
-    if (sel res__8.err) { registry_dnit(reg); ret res__8; }
+    if (sel res__8.err) { treg.registry_rollback(reg); ret res__8; }
     val res__9: err[fail.Fail] = rvabi.register(?reg.abi);
-    if (sel res__9.err) { registry_dnit(reg); ret res__9; }
+    if (sel res__9.err) { treg.registry_rollback(reg); ret res__9; }
     val res__10: err[fail.Fail] = sabi.register(?reg.abi);
-    if (sel res__10.err) { registry_dnit(reg); ret res__10; }
+    if (sel res__10.err) { treg.registry_rollback(reg); ret res__10; }
 
     val res__12: err[fail.Fail] = elf.register(?reg.of);
-    if (sel res__12.err) { registry_dnit(reg); ret res__12; }
+    if (sel res__12.err) { treg.registry_rollback(reg); ret res__12; }
     val res__13: err[fail.Fail] = coff.register_coff(?reg.of);
-    if (sel res__13.err) { registry_dnit(reg); ret res__13; }
+    if (sel res__13.err) { treg.registry_rollback(reg); ret res__13; }
     val res__14: err[fail.Fail] = macho.register_macho(?reg.of);
-    if (sel res__14.err) { registry_dnit(reg); ret res__14; }
+    if (sel res__14.err) { treg.registry_rollback(reg); ret res__14; }
     val res__15: err[fail.Fail] = raw.register(?reg.of);
-    if (sel res__15.err) { registry_dnit(reg); ret res__15; }
+    if (sel res__15.err) { treg.registry_rollback(reg); ret res__15; }
     val res__16: err[fail.Fail] = spv.register(?reg.of);
-    if (sel res__16.err) { registry_dnit(reg); ret res__16; }
+    if (sel res__16.err) { treg.registry_rollback(reg); ret res__16; }
 
     val res__17: err[fail.Fail] = linux.register_linux(?reg.os);
-    if (sel res__17.err) { registry_dnit(reg); ret res__17; }
+    if (sel res__17.err) { treg.registry_rollback(reg); ret res__17; }
     val res__18: err[fail.Fail] = darwin.register_darwin(?reg.os);
-    if (sel res__18.err) { registry_dnit(reg); ret res__18; }
+    if (sel res__18.err) { treg.registry_rollback(reg); ret res__18; }
     val res__19: err[fail.Fail] = windows.register_windows(?reg.os);
-    if (sel res__19.err) { registry_dnit(reg); ret res__19; }
+    if (sel res__19.err) { treg.registry_rollback(reg); ret res__19; }
     val res__20: err[fail.Fail] = freestanding.register_freestanding(?reg.os);
-    if (sel res__20.err) { registry_dnit(reg); ret res__20; }
+    if (sel res__20.err) { treg.registry_rollback(reg); ret res__20; }
 
     val debug_r: res[of.DebugVTable, fail.Fail] = debug_provider();
     if (sel debug_r.err) {
         val debug_err: str = fail.describe(debug_r.err);
-        registry_dnit(reg);
+        treg.registry_rollback(reg);
         ret err[fail.Fail].err{fail.message(debug_err)};
     }
     var debug_descriptor: of.DebugVTable = debug_r.ok;
     val res__21: err[fail.Fail] = of.debug_register(?reg.debug, ?debug_descriptor);
-    if (sel res__21.err) { registry_dnit(reg); ret res__21; }
+    if (sel res__21.err) { treg.registry_rollback(reg); ret res__21; }
     val res__22: err[fail.Fail] = of.debug_hooks_complete(?reg.debug);
-    if (sel res__22.err) { registry_dnit(reg); ret res__22; }
+    if (sel res__22.err) { treg.registry_rollback(reg); ret res__22; }
     if (!production_registry_complete(reg)) {
-        registry_dnit(reg);
+        treg.registry_rollback(reg);
         ret err[fail.Fail].err{fail.message("target: registrar did not construct the complete production registry")};
     }
 
-    reg.version = REGISTRY_VERSION;
-    reg.state = REGISTRY_READY;
+    reg.version = treg.REGISTRY_VERSION;
+    reg.state = treg.REGISTRY_READY;
 
     ret err[fail.Fail].ok{};
 }
@@ -349,8 +320,7 @@ pub fun resolve(reg: *TargetRegistry, req: *TargetRequest) res[resolved.Target, 
     if (reg == nil || req == nil) {
         ret res[resolved.Target, fail.Fail].err{fail.message("target: resolve requires a registry and target request")};
     }
-    if (reg.state != REGISTRY_READY || reg.version != REGISTRY_VERSION
-        || !production_registry_complete(reg)) {
+    if (!treg.registry_published(reg) || !production_registry_complete(reg)) {
         ret res[resolved.Target, fail.Fail].err{fail.message("target: resolve requires a published registry at the current catalog version")};
     }
     val isa_name: str = req.isa_name;
@@ -424,6 +394,7 @@ pub fun resolve(reg: *TargetRegistry, req: *TargetRequest) res[resolved.Target, 
     }
 
     var t: resolved.Target;
+    t.registry = reg;
     t.os      = os_vt;
     val env_r: res[u32, fail.Fail] = resolve_environment(arch_vt, req);
     if (sel env_r.err) { ret res[resolved.Target, fail.Fail].err{env_r.err}; }
@@ -826,7 +797,7 @@ test "mach.lang.target.register_all:publishes_once_and_is_idempotent" {
     fin { registry_dnit(?reg); }
     val r_818: err[fail.Fail] = register_all(?reg, target_testing.debug_descriptor);
     if (sel r_818.err) { ret 1; }
-    if (reg.state != REGISTRY_READY || reg.version != REGISTRY_VERSION) { ret 1; }
+    if (reg.state != treg.REGISTRY_READY || reg.version != treg.REGISTRY_VERSION) { ret 1; }
 
     val isa_count: u32 = reg.isa.count;
     val os_count: u32 = reg.os.count;
@@ -848,7 +819,7 @@ test "mach.lang.target.register_all:rejects_partial_state_without_destroying_it"
     val count: u32 = reg.isa.count;
     val r_837: err[fail.Fail] = register_all(?reg, target_testing.debug_descriptor);
     if (sel r_837.ok) { ret 1; }
-    if (reg.state != REGISTRY_FRESH || reg.version != 0 || reg.isa.count != count) { ret 1; }
+    if (reg.state != treg.REGISTRY_FRESH || reg.version != 0 || reg.isa.count != count) { ret 1; }
     val r_839: opt[*isa.IsaVTable] = isa.lookup(?reg.isa, "x86_64");
     if (sel r_839.none) { ret 1; }
     ret 0;
@@ -859,7 +830,7 @@ test "mach.lang.target.register_all:provider_failure_rolls_back_and_allows_retry
     fin { registry_dnit(?reg); }
     val r_846: err[fail.Fail] = register_all(?reg, t_debug_provider_failure);
     if (sel r_846.ok) { ret 1; }
-    if (reg.state != REGISTRY_FRESH || reg.version != 0 || !registry_empty(?reg)) { ret 1; }
+    if (reg.state != treg.REGISTRY_FRESH || reg.version != 0 || !treg.registry_empty(?reg)) { ret 1; }
     val r_848: err[fail.Fail] = register_all(?reg, target_testing.debug_descriptor);
     if (sel r_848.err) { ret 1; }
     ret 0;
@@ -870,7 +841,7 @@ test "mach.lang.target.register_all:incomplete_descriptor_rolls_back_and_allows_
     fin { registry_dnit(?reg); }
     val r_855: err[fail.Fail] = register_all(?reg, t_incomplete_debug_provider);
     if (sel r_855.ok) { ret 1; }
-    if (reg.state != REGISTRY_FRESH || reg.version != 0 || !registry_empty(?reg)) { ret 1; }
+    if (reg.state != treg.REGISTRY_FRESH || reg.version != 0 || !treg.registry_empty(?reg)) { ret 1; }
     val r_857: err[fail.Fail] = register_all(?reg, target_testing.debug_descriptor);
     if (sel r_857.err) { ret 1; }
     ret 0;
@@ -2709,4 +2680,119 @@ fun t_publication_close(operation: *publication.Plan, result: err[fail.Fail]) er
         if (sel result.ok) { ret err[fail.Fail].err{fail.message(txn.error_message(closed.err))}; }
     }
     ret result;
+}
+
+rec Walk {
+    depth: u32;
+}
+
+# the operation under the probe: one heap registry born, published and
+# borrowed; the registry comes back through `out` for the attempt to release
+# whichever way the operation ended. a nonzero `bad` is the fixture's own
+# contract failure, not a refusal
+fun t_registry_build(owner: *A.Allocator, out: **TargetRegistry, bad: *i32) err[fail.Fail] {
+    val made: res[*TargetRegistry, fail.Fail] = registry_new(owner);
+    if (sel made.err) { ret err[fail.Fail].err{made.err}; }
+    val reg: *TargetRegistry = made.ok;
+    @out = reg;
+    if (reg.owner != owner || reg.state != treg.REGISTRY_FRESH) { @bad = 20; ret err[fail.Fail].ok{}; }
+    val published: err[fail.Fail] = register_all(reg, target_testing.debug_descriptor);
+    if (sel published.err) {
+        if (reg.state != treg.REGISTRY_FRESH || !treg.registry_empty(reg)) { @bad = 24; }
+        ret published;
+    }
+    if (!registry_published(reg)) { @bad = 21; ret err[fail.Fail].ok{}; }
+    val selected: res[resolved.Target, fail.Fail] = select(reg, "x86_64", "linux", "sysv64");
+    if (sel selected.err) { ret err[fail.Fail].err{selected.err}; }
+    var t: resolved.Target = selected.ok;
+    if (t.registry != reg) { @bad = 22; ret err[fail.Fail].ok{}; }
+    val borrow: err[fail.Fail] = resolved.live(?t);
+    if (sel borrow.err) { @bad = 23; }
+    ret err[fail.Fail].ok{};
+}
+
+# at ordinal zero everything succeeds; at every other ordinal the refusal
+# comes back typed as the allocation layer's text, and either way the probe
+# ends clean, which is the leak check
+fun t_registry_attempt(w: *Walk, p: *probe.Probe) i32 {
+    val owner: *A.Allocator = probe.allocator_of(p);
+    probe.arm(p);
+    var reg: *TargetRegistry = nil;
+    var bad: i32 = 0;
+    val outcome: err[fail.Fail] = t_registry_build(owner, ?reg, ?bad);
+    registry_dnit(reg);
+    probe.clear_failure(p);
+    if (bad != 0) { ret bad; }
+    if (p.ordinal == 0) {
+        if (sel outcome.err) { ret 3; }
+        ret 0;
+    }
+    if (sel outcome.ok) { ret 4; }
+    val text: str = fail.describe(outcome.err);
+    val expected: bool = str_equals(text, alloc.text(A.Error.exhausted{}));
+    if (probe.owns(p, text::ptr)) { str_free(owner, text); }
+    if (!expected) { print.eprintlnf("refusal text: {}", text); ret 5; }
+    ret 0;
+}
+
+test "mach.lang.target.registry:heap_registry_fail_at_n_releases_everything" {
+    var w: Walk = Walk{depth: 0};
+    val out: probe.Outcome = probe.walk[Walk](?w, t_registry_attempt);
+    if (out.code != 0) {
+        print.eprintlnf("fail-at-N: code {} at ordinal {} of {} requests", out.code, out.ordinal, out.attempts);
+    }
+    ret out.code;
+}
+
+# a target borrowed from a released registry is refused, not followed; the
+# in-place form keeps the storage alive so the refusal reads a released
+# state and never a freed block
+test "mach.lang.target.registry:target_used_after_dnit_is_refused_and_release_is_terminal" {
+    var reg: TargetRegistry = registry_init();
+    fin { registry_dnit(?reg); }
+    val published: err[fail.Fail] = register_all(?reg, target_testing.debug_descriptor);
+    if (sel published.err) { ret 1; }
+    val selected: res[resolved.Target, fail.Fail] = select(?reg, "x86_64", "linux", "sysv64");
+    if (sel selected.err) { ret 2; }
+    var t: resolved.Target = selected.ok;
+    if (t.registry != ?reg) { ret 3; }
+    val before: err[fail.Fail] = resolved.live(?t);
+    if (sel before.err) { ret 4; }
+
+    registry_dnit(?reg);
+    if (reg.state != treg.REGISTRY_RELEASED) { ret 5; }
+    val after: err[fail.Fail] = resolved.live(?t);
+    if (sel after.ok) { ret 6; }
+    if (!str_contains(fail.describe(after.err), "outlived the registry")) { ret 7; }
+
+    val again: err[fail.Fail] = register_all(?reg, target_testing.debug_descriptor);
+    if (sel again.ok) { ret 8; }
+    if (!str_contains(fail.describe(again.err), "released registry")) { ret 9; }
+    val resolve_again: res[resolved.Target, fail.Fail] = select(?reg, "x86_64", "linux", "sysv64");
+    if (sel resolve_again.ok) { ret 10; }
+    registry_dnit(?reg);
+    if (reg.state != treg.REGISTRY_RELEASED) { ret 11; }
+    ret 0;
+}
+
+# a publication that fails part way rolls back to fresh, and a fresh
+# registry publishes; a copy of a resolved target keeps the same borrow
+test "mach.lang.target.registry:heap_registry_is_owned_once_and_borrowed_by_copies" {
+    var backing: A.Allocator;
+    val made_backing: err[A.Error] = page.make(?backing);
+    if (sel made_backing.err) { ret 1; }
+    val made: res[*TargetRegistry, fail.Fail] = registry_new(?backing);
+    if (sel made.err) { ret 2; }
+    val reg: *TargetRegistry = made.ok;
+    val published: err[fail.Fail] = register_all(reg, target_testing.debug_descriptor);
+    if (sel published.err) { registry_dnit(reg); ret 3; }
+    val selected: res[resolved.Target, fail.Fail] = select(reg, "aarch64", "darwin", "aapcs64");
+    if (sel selected.err) { registry_dnit(reg); ret 4; }
+    val first: resolved.Target = selected.ok;
+    val copy: resolved.Target = first;
+    if (copy.registry != reg || copy.isa != first.isa || copy.os != first.os) { registry_dnit(reg); ret 5; }
+    val borrow: err[fail.Fail] = resolved.live(?copy);
+    if (sel borrow.err) { registry_dnit(reg); ret 6; }
+    registry_dnit(reg);
+    ret 0;
 }

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -353,10 +353,10 @@ test "mach.lang.target.abi.variadic_float_in_fp_bank:is_the_declared_width" {
     ret 0;
 }
 
-pub fun registry_init() AbiRegistry {
+pub fun registry_init_with_allocator(alloc: *A.Allocator) AbiRegistry {
     var r: AbiRegistry;
-    val r_355: err[A.Error] = page.make(?r.alloc);
-    r.alloc_ready = sel r_355.ok;
+    r.alloc_ready = alloc != nil;
+    if (alloc != nil) { r.alloc = @alloc; }
     var i: u32 = 0;
     for (i < ABI_REGISTRY_CAP) {
         r.entries[i].id = ABI_UNKNOWN;
@@ -365,6 +365,13 @@ pub fun registry_init() AbiRegistry {
     }
     r.count = 0;
     ret r;
+}
+
+pub fun registry_init() AbiRegistry {
+    var alloc: A.Allocator;
+    val r_355: err[A.Error] = page.make(?alloc);
+    if (sel r_355.err) { ret registry_init_with_allocator(nil); }
+    ret registry_init_with_allocator(?alloc);
 }
 
 pub fun registry_dnit(reg: *AbiRegistry) {

--- a/src/lang/target/of.mach
+++ b/src/lang/target/of.mach
@@ -1662,10 +1662,10 @@ pub rec OfRegistry {
     alloc_ready: bool;
 }
 
-pub fun registry_init() OfRegistry {
+pub fun registry_init_with_allocator(alloc: *A.Allocator) OfRegistry {
     var reg: OfRegistry;
-    val r_1623: err[A.Error] = page.make(?reg.alloc);
-    reg.alloc_ready = sel r_1623.ok;
+    reg.alloc_ready = alloc != nil;
+    if (alloc != nil) { reg.alloc = @alloc; }
     var i:   u32 = 0;
     for (i < OF_REGISTRY_CAP) {
         reg.entries[i].id = OF_UNKNOWN;
@@ -1713,6 +1713,13 @@ fun release_of_entry(reg: *OfRegistry, vt: *OfVTable) {
                          str_len(vt.import_address_prefix) + 1);
         vt.import_address_prefix = nil;
     }
+}
+
+pub fun registry_init() OfRegistry {
+    var alloc: A.Allocator;
+    val r_1623: err[A.Error] = page.make(?alloc);
+    if (sel r_1623.err) { ret registry_init_with_allocator(nil); }
+    ret registry_init_with_allocator(?alloc);
 }
 
 pub fun registry_dnit(reg: *OfRegistry) {
@@ -1966,10 +1973,10 @@ pub rec DebugRegistry {
     alloc_ready: bool;
 }
 
-pub fun debug_registry_init() DebugRegistry {
+pub fun debug_registry_init_with_allocator(alloc: *A.Allocator) DebugRegistry {
     var reg: DebugRegistry;
-    val r_1912: err[A.Error] = page.make(?reg.alloc);
-    reg.alloc_ready = sel r_1912.ok;
+    reg.alloc_ready = alloc != nil;
+    if (alloc != nil) { reg.alloc = @alloc; }
     var i:   u32 = 0;
     for (i < DEBUG_REGISTRY_CAP) {
         reg.entries[i].id = DBG_UNKNOWN;
@@ -1980,6 +1987,13 @@ pub fun debug_registry_init() DebugRegistry {
     }
     reg.count = 0;
     ret reg;
+}
+
+pub fun debug_registry_init() DebugRegistry {
+    var alloc: A.Allocator;
+    val r_1912: err[A.Error] = page.make(?alloc);
+    if (sel r_1912.err) { ret debug_registry_init_with_allocator(nil); }
+    ret debug_registry_init_with_allocator(?alloc);
 }
 
 pub fun debug_registry_dnit(reg: *DebugRegistry) {

--- a/src/lang/target/registry.mach
+++ b/src/lang/target/registry.mach
@@ -1,0 +1,116 @@
+# the target registry as one owned object
+#
+# a registry is born fresh, published once by `target.register_all`, and
+# released once by `registry_dnit`; release is terminal, so a registry is
+# never re-initialized under a target that borrowed from it (a publication
+# that fails part way rolls back to fresh, nothing has borrowed yet).
+# `registry_new` is the heap form the session owns and every worker borrows
+# by pointer; `registry_init` is the in-place form a fixture owns on its own
+# stack. a `resolved.Target` borrows the registry it was resolved against and
+# `resolved.live` refuses the borrow once the registry is released.
+use std.types.result.res;
+use std.types.error.err;
+use std.types.bool.bool;
+use std.types.size.usize;
+
+use A: std.allocator;
+
+use mach.lang.fail;
+use mach.lang.target.abi;
+use mach.lang.target.isa;
+use mach.lang.target.of;
+use mach.lang.target.os;
+
+pub rec TargetRegistry {
+    isa:   isa.IsaRegistry;
+    os:    os.OsRegistry;
+    abi:   abi.AbiRegistry;
+    of:    of.OfRegistry;
+    debug: of.DebugRegistry;
+    state: u8;
+    version: u32;
+    # the allocator that owns this object's block, nil for an in-place registry
+    owner: *A.Allocator;
+}
+
+pub val REGISTRY_FRESH:    u8 = 0;
+pub val REGISTRY_BUILDING: u8 = 1;
+pub val REGISTRY_READY:    u8 = 2;
+pub val REGISTRY_RELEASED: u8 = 3;
+pub val REGISTRY_VERSION: u32 = 1;
+
+fun fill(reg: *TargetRegistry) {
+    reg.state = REGISTRY_FRESH;
+    reg.version = 0;
+    reg.owner = nil;
+}
+
+# an in-place registry over the sub-registries' own page allocators
+pub fun registry_init() TargetRegistry {
+    var reg: TargetRegistry;
+    reg.isa   = isa.registry_init();
+    reg.os    = os.registry_init();
+    reg.abi   = abi.registry_init();
+    reg.of    = of.registry_init();
+    reg.debug = of.debug_registry_init();
+    fill(?reg);
+    ret reg;
+}
+
+# a heap registry whose block and every entry come from `alloc`
+pub fun registry_new(alloc: *A.Allocator) res[*TargetRegistry, fail.Fail] {
+    if (alloc == nil) {
+        ret res[*TargetRegistry, fail.Fail].err{fail.message("target: registry_new requires an allocator")};
+    }
+    val block: res[*TargetRegistry, A.Error] = A.allocate[TargetRegistry](alloc, 1::usize);
+    if (sel block.err) { ret res[*TargetRegistry, fail.Fail].err{fail.refused(block.err)}; }
+    val reg: *TargetRegistry = block.ok;
+    reg.isa   = isa.registry_init_with_allocator(alloc);
+    reg.os    = os.registry_init_with_allocator(alloc);
+    reg.abi   = abi.registry_init_with_allocator(alloc);
+    reg.of    = of.registry_init_with_allocator(alloc);
+    reg.debug = of.debug_registry_init_with_allocator(alloc);
+    fill(reg);
+    reg.owner = alloc;
+    ret res[*TargetRegistry, fail.Fail].ok{reg};
+}
+
+fun release_entries(reg: *TargetRegistry) {
+    isa.registry_dnit(?reg.isa);
+    os.registry_dnit(?reg.os);
+    abi.registry_dnit(?reg.abi);
+    of.registry_dnit(?reg.of);
+    of.debug_registry_dnit(?reg.debug);
+    reg.version = 0;
+}
+
+# a publication that failed part way releases what it registered and hands
+# back a fresh registry; nothing borrowed from it yet, so a retry is sound
+pub fun registry_rollback(reg: *TargetRegistry) {
+    if (reg == nil || reg.state != REGISTRY_BUILDING) { ret; }
+    release_entries(reg);
+    reg.state = REGISTRY_FRESH;
+}
+
+# release the entries and, for a heap registry, return the block to its
+# owner; release is terminal, a second call on an in-place registry is a
+# no-op, and a second call on a heap registry is a call on a dead pointer
+pub fun registry_dnit(reg: *TargetRegistry) {
+    if (reg == nil) { ret; }
+    release_entries(reg);
+    reg.state = REGISTRY_RELEASED;
+    val owner: *A.Allocator = reg.owner;
+    if (owner != nil) {
+        reg.owner = nil;
+        A.deallocate[TargetRegistry](owner, reg, 1::usize);
+    }
+}
+
+pub fun registry_published(reg: *TargetRegistry) bool {
+    ret reg != nil && reg.state == REGISTRY_READY && reg.version == REGISTRY_VERSION;
+}
+
+pub fun registry_empty(reg: *TargetRegistry) bool {
+    ret reg != nil && reg.isa.count == 0 && reg.os.count == 0 && reg.abi.count == 0
+        && reg.of.count == 0 && reg.debug.count == 0;
+}

--- a/src/lang/target/resolved.mach
+++ b/src/lang/target/resolved.mach
@@ -1,14 +1,20 @@
 use std.types.bool.bool;
+use std.types.error.err;
 use std.types.string.str;
 use std.system.panic.panic;
 
+use mach.lang.fail;
 use mach.lang.layout;
 use mach.lang.target.abi;
 use mach.lang.target.isa;
 use mach.lang.target.of;
 use mach.lang.target.os;
+use treg: mach.lang.target.registry;
 
+# a resolved target borrows every vtable from the registry it was resolved
+# against; the borrow is live exactly while that registry stays published
 pub rec Target {
+    registry: *treg.TargetRegistry;
     os_id:    u32;
     arch_id:  u32;
     abi_id:   u32;
@@ -35,6 +41,16 @@ pub rec Target {
     env_name:      str;
 }
 
+# the borrow check every backend entry runs before following a vtable:
+# a target resolved from a registry that has since been released is refused
+pub fun live(tgt: *Target) err[fail.Fail] {
+    if (tgt == nil) { ret err[fail.Fail].err{fail.message("target: nil resolved target")}; }
+    if (!treg.registry_published(tgt.registry)) {
+        ret err[fail.Fail].err{fail.message("target: resolved target outlived the registry it was resolved against")};
+    }
+    ret err[fail.Fail].ok{};
+}
+
 pub fun layout_machine(tgt: *Target) layout.Machine {
     if (tgt == nil || tgt.isa == nil) {
         panic("target.resolved: layout query needs a resolved target with an instruction set\n");
@@ -43,6 +59,8 @@ pub fun layout_machine(tgt: *Target) layout.Machine {
 }
 
 pub fun backend_target(tgt: *Target) isa.BackendTarget {
+    val borrow: err[fail.Fail] = live(tgt);
+    if (sel borrow.err) { panic(fail.describe(borrow.err)); }
     var view: isa.BackendTarget;
     view.identity.arch_id   = tgt.arch_id;
     view.identity.os_id     = tgt.os_id;


### PR DESCRIPTION
Part of #2212 (census section 10 item 5, the section 7.3 BLU rows). No Closes: the coordinator closes #2212 when every remainder lane lands.

## What

The target registry becomes one heap-owned immutable object held by pointer, so the by-value session copy the census found at `pcg_worker_init` (`w.sess = @p.s`, formerly `engine.mach:1181`) borrows the one owner instead of aliasing an inline registry. Immutable ownership was chosen over a generation stamp, as #2212 prefers; no stamp exists anywhere.

- `mach.lang.target.registry` (new) owns `TargetRegistry`: `registry_new(alloc)` is the heap form whose block and every entry come from one allocator (the sub-registries gained `registry_init_with_allocator` for abi/of/debug); `registry_init` stays the in-place fixture form; `registry_dnit` is the single terminal release and returns a heap block to its owner. A publication that fails part way rolls back to fresh (nothing has borrowed yet). A released registry refuses `register_all` and `resolve`, so a registry is never re-initialized under a borrower. `target.mach` re-exports the names, so the ~200 fixture sites are untouched.
- `Session.registry` is `*TargetRegistry`, created in `session.init` over the session allocator and released once in `dnit`. Every `?s.registry` caller now passes `s.registry`.
- `resolved.Target.registry` records the borrow; `resolved.live` refuses a target whose registry is released. `isel.run`, `encode.run`, `codegen_unit` and the four link entries run it before following a vtable; `backend_target` (signature frozen for N4, and called from the lane-locked `regalloc.mach`) panics rather than follow a dead borrow.

## Bar

- Fail-at-N: `mach.lang.target.registry:heap_registry_fail_at_n_releases_everything` walks the shared probe (`src/lang/alloc/probe.mach`) over `registry_new` / `register_all` / `select` / `live` / `registry_dnit`: 186 ordinals, every refusal is the allocation layer's text, the probe ends clean at each. Mutation control: skipping the block free reports `code -2 (leak) at ordinal 0`.
- Fail-closed: `target_used_after_dnit_is_refused_and_release_is_terminal` (in-place storage, so the refusal reads a released state and never a freed block) and `isel:target_outliving_its_registry_is_refused`. Mutation control: weakening `live` to a nil check fails both.
- Identity: x86_64-linux layer B corpus 102/102 pass against the blessed goldens (run once, at the end, through the self-built compiler), x86_64-linux link leg 142/142, `sh test/census.sh` all ok, suite 3045 = 3041 + the 4 tests above (through both the stage-built and the self-built compiler), fixpoint A (stage) -> B -> C with B == C byte-identical.

## Not in this PR

Census item 7.3.4 stands: the in-place fixture form remains because `regalloc.mach` and `verify.mach` are lane-locked and hold it, so a copy of an in-place registry is still expressible. Retiring `registry_init` at every fixture in favour of `registry_new` is the follow-up that removes that last by-value path.
