### PR TITLE
isa(x64): one per-opcode description table for form, flags and memory (#2212)

### DIFF
--- a/doc/design/backend-census-2212.md
+++ b/doc/design/backend-census-2212.md
@@ -138,13 +138,13 @@ Files: `src/lang/target/isa/x64.mach`, `x64/{encode,printer,register,reloc,rules
 | aspect | authoritative site | duplicates / derived | gap |
 |---|---|---|---|
 | opcode set | `x64.mach:54 def Opcode: u16`, `:56-194` 135 constants (`^pub val [A-Z0-9_]*: *Opcode`) | `x64/printer.mach:257 mnemonic_of` (134 arms), `x64/encode.mach:1616 encode_inst_one` (49 arms), `x64/encode.mach:4096 X64_MNEMONICS` (60 rows, asm parser only) | DUP x3 |
-| instruction form / operand shape | none as data; only the 33 per-opcode encoder functions `(mi: *isa.Inst, buf)` in `x64/encode.mach` | range predicates `x64.mach:205 is_fp_opcode`, `x64/encode.mach:362 is_jcc`, `:366 is_setcc`, `:381 is_sse_mov`, `:385 is_sse_alu` depend on hand-assigned contiguity (`SETP/SETNP` already break it, `:367`) | ADM |
+| instruction form / operand shape | `x64.mach` `rec OpDesc { form; shape; arity; mem; cls }` and `describe(op)`, one row per opcode (134 rows, `FORM_NONE` for `ASM_BLOCK` and anything outside the catalog); `Form` is the encoder family with its operand shape stated per constant, `Shape` the role pattern, `arity` the positions taken (closed 2026-09-12, #2212 remainder item 2) | the family predicates `x64/encode.mach is_jcc`, `is_setcc`, `is_alu`, `is_sse_mov`, `is_sse_alu`, `is_cvt` and `x64.is_fp_opcode` read `describe(op).form`; `encode_inst_one` refuses a `FORM_NONE` row and a memory operand on a row without `MEM_OPERAND`/`MEM_ADDR`; census `asm_ct_class:every_notifiable_opcode_has_a_row` fails the build for an opcode without a complete, self-consistent row | ok |
 | instruction value | `isa.Inst` consumed by encoder and printer alike (`x64/printer.mach:45 note_inst(buf, mi: *isa.Inst)`) | none | ok |
 | encoding | 66 `fun encode_*` + 41 `fun emit_*` in `x64/encode.mach`; entry `:2169 encode_x64` → `:2198 encode_function` → `:3981 mir_to_inst` → `:1581 encode_inst` | SSE opcode-byte selection stated 4 ways: `:1431 sse_alu_opcode`+`:1439 sse_alu_prefix`, `:2530 float_alu_opcode`, `:3230 packed_prefix66`+`:3236 packed_opbyte`, `:3425 packed_arith_opcode` | DUP |
 | width ladder | none | `x64/encode.mach:93 size_to_w`, `:3969 effective_width`+`:3974 width_flags`, `:4917 width_flags_for`, `:4250 x64_size_keyword`, `x64/printer.mach:248 size_prefix` (five copies; the last two disagree on the 16-byte row) | DUP |
 | condition codes | none | `x64/encode.mach:346 cc_to_x86`, `:2449 mir_setcc_opcode`, `:3135 float_setcc_opcode`, `:3519 i64_ordering_setcc`, `:3911 fused_jcc_opcode`, `x64/printer.mach:279-300` (six copies) | DUP |
-| flags effect (codegen path) | none; `x64/encode.mach:2458 emit_flag_cmp` / `:2490 encode_compare` / `:3859 encode_cbr` / `:3920 encode_fused_cbr` assume the adjacent CMP set the flags | asm path: `x64/encode.mach:6910 asm_ct_class` (53 opcodes), `:7073 probed_rows` (26 measured rows), `x64/probe.mach:28 run` (26 asm bodies) | ADM (codegen), DUP x3 (asm) |
-| memory effect | none anywhere in the x64 tree (`is_load`/`is_store`/`MIRF_MEMORY`: 0 hits); inferred from `Operand.kind == OPK_MEM` at `x64/encode.mach:113` | asm: `Mnemonic.implicit_mem` on 4 rows (`push/pop/pushfq/popfq`) only | ADM |
+| flags effect (codegen path) | `x64.describe(op).cls` (the `ct.AsmClass` column of the one row); `asm_ct_class(code, flags)` is its reader. every producer/consumer pair the codegen path emits (`emit_flag_cmp` → `encode_compare`/`encode_fused_cbr`, `encode_cbr`, `emit_stack_probe`, `emit_u64_to_fp`, the fp→u64 bound check, `encode_float_cmp` with its parity `setcc`) passes `flags_pair(producer, consumer)` and `flags_kept(between)`, table reads that refuse before the consumer is emitted | asm: `probed_rows` (26 measured rows), `x64/probe.mach run` (26 asm bodies) remain the independent control | ok (codegen), DUP x2 (asm control) |
+| memory effect | `x64.describe(op).mem` (`MEM_OPERAND`, `MEM_ADDR`, `MEM_STACK`, `MEM_STRING` as bits): the direction of an operand access is that position's role from `shape`; `inst_effects` derives `implicit_mem` from `MEM_STACK` and `implicit_addr` from `MEM_STRING`; the mem-mem staging in `encode_inst` reads `MEM_OPERAND`/`FORM_SHIFT`/`SHAPE_SWAP` instead of an opcode list | asm: `Mnemonic.implicit_mem` on 4 rows, pinned to the table's `MEM_STACK` rows by `describe:grammar_implicit_mem_matches_stack_rows` | ok |
 | sub-register aliasing | none as data; width rides `Operand.size` (`x64/encode.mach:108 needs_rex_for_byte_reg`, `:242 emit_prefix_reg`) and the allocator sees one 16-entry GP file (`x64/register.mach:119`) | naming only: `x64.mach:212 reg_name` (64 rows) vs `x64/encode.mach:4166 x64_reg_region` (56 rows) | ADM, DUP |
 | clobbers | `Inst.clobbers` never written (see 1.1); asm: `x64/encode.mach:4900 asm_clobbers` over `Mnemonic.implicit` | — | ADM |
 | latency provenance | codegen: catalog `ct_class` (1.2); asm: `asm_ct_class` | — | ok |
@@ -434,7 +434,8 @@ owner decision or a proven bar beyond "goldens unchanged".
    that is #2212's open question 1 (per-ISA shape vs one generic type) and needs
    the owner's ruling before code.
 2. **Per-opcode description tables where none exist** (ADM rows above):
-   x86_64 form/flags/memory for the codegen path; a riscv `inst.mach` table
+   x86_64 form/flags/memory for the codegen path (landed 2026-09-12:
+   `x64.describe`, section 2); a riscv `inst.mach` table
    (format, opcode7, funct3, funct7, xlen mask, mnemonic, load/store) that
    `rv_fields`, `classify_*`, `shape_of`, `printer.mnemonic` and `RV_MNEMONICS.code`
    all read; an aarch64 base-word table. The #2766 access rows are the template.
@@ -572,6 +573,16 @@ link admission any other way without a second capability channel.
   (`isa.mach:283-287`), `asm.Grammar.ct_class: CtClassFn`, `asm.Mnemonic`
   (`writes`, `implicit`, `implicit_mem`), and each ISA's `asm_ct_class(code,
   flags)`: the closed per-instruction effect description inline asm uses.
+  Amended 2026-09-12 (#2212 remainder item 2, x86_64): the x86_64 row behind
+  `asm_ct_class` is `x64.OpDesc { form; shape; arity; mem; cls }` from
+  `x64.describe(op)`; `asm_ct_class` returns its `cls` column and
+  `inst_effects` projects the whole row onto the operands present. The
+  encoder's family predicates and the codegen flags pairing read the same row.
+  `ct.InstEffects` is unchanged: form, shape and memory class are ISA vocabulary
+  and stay on the ISA's row, and the walk keeps reading roles and the implicit
+  sets. A second x86_64 opcode-keyed table is a census failure by construction
+  (`asm_ct_class:every_notifiable_opcode_has_a_row` pins every notifiable opcode
+  to one complete, self-consistent row).
 - `isa.Inst`, `isa.Operand`, `isa.inst_blank`, `regid_make/class/index`: the
   physical-register stream after allocation; the `clobbers` field is frozen as
   **unpopulated** until item 10.3 rules. Amended 2026-09-12 (#3126, accepted as

--- a/src/lang/target/isa/x64.mach
+++ b/src/lang/target/isa/x64.mach
@@ -3,6 +3,7 @@ use std.types.bool.false;
 use std.types.bool.true;
 use std.types.string.str;
 
+use mach.lang.ct;
 use mach.lang.target.abi;
 use mach.lang.target.isa;
 
@@ -204,11 +205,302 @@ pub val FLAG_LOCAL_FWD: EncFlag = 32;
 
 pub val MEM_BASE_ABS: i32 = -2;
 
+# the instruction form of an opcode: the operand shape the encoder admits and
+# the encoder family that emits it. every opcode the stream can carry has
+# exactly one; FORM_NONE is the absence of a row and every reader refuses it
+pub def Form: u8;
+
+pub val FORM_NONE:     Form = 0;
+# fixed bytes, no explicit operand
+pub val FORM_BARE:     Form = 1;
+# mov: dst r/m, src r/m, imm or sym
+pub val FORM_MOV:      Form = 2;
+# lea: dst r, src m taken as an address
+pub val FORM_LEA:      Form = 3;
+# push: src r or imm, through the stack
+pub val FORM_PUSH:     Form = 4;
+# pop: dst r, through the stack
+pub val FORM_POP:      Form = 5;
+# add sub and or xor cmp: dst r/m, src r/m or imm
+pub val FORM_ALU:      Form = 6;
+# test: dst r/m, src r or imm
+pub val FORM_TEST:     Form = 7;
+# imul: src r/m into rdx:rax, dst r with src r/m, or dst r with src r/m and imm
+pub val FORM_IMUL:     Form = 8;
+# idiv div: src r/m over rdx:rax
+pub val FORM_DIV:      Form = 9;
+# shl shr sar: dst r/m, count imm or cl
+pub val FORM_SHIFT:    Form = 10;
+# jcc: a label
+pub val FORM_JCC:      Form = 11;
+# jmp: a label, a sym, or r/m
+pub val FORM_JMP:      Form = 12;
+# call: a sym or r/m, through the stack
+pub val FORM_CALL:     Form = 13;
+# ret iretq: through the stack
+pub val FORM_RET:      Form = 14;
+# setcc: dst r8
+pub val FORM_SETCC:    Form = 15;
+# movzx movsx movsxd: dst r, src r/m
+pub val FORM_MOVX:     Form = 16;
+# movabs: dst r, imm64 or sym
+pub val FORM_MOVABS:   Form = 17;
+# movq: r to xmm or xmm to r
+pub val FORM_MOVQ:     Form = 18;
+# movss movsd: xmm to xmm or m, m to xmm
+pub val FORM_SSE_MOV:  Form = 19;
+# movaps movups: xmm to xmm or m128, m128 to xmm
+pub val FORM_SSE_MOVA: Form = 20;
+# scalar sse arithmetic: dst xmm, src xmm or m
+pub val FORM_SSE_ALU:  Form = 21;
+# ucomiss ucomisd: xmm, xmm or m
+pub val FORM_UCOMIS:   Form = 22;
+# scalar conversions between r and xmm
+pub val FORM_CVT:      Form = 23;
+# xorps: dst xmm, src xmm or m128
+pub val FORM_XORPS:    Form = 24;
+# packed sse2 arithmetic, logic and compare: dst xmm, src xmm or m128
+pub val FORM_PACKED:   Form = 25;
+# pshufd: dst xmm, src xmm, imm8
+pub val FORM_PSHUF:    Form = 26;
+# pslld: dst xmm, imm8
+pub val FORM_PSLL:     Form = 27;
+# neg not: r/m
+pub val FORM_GRP3:     Form = 28;
+# inc dec: r/m
+pub val FORM_GRP5:     Form = 29;
+# xchg: r, r/m
+pub val FORM_XCHG:     Form = 30;
+# xadd cmpxchg: r/m, r
+pub val FORM_XADD:     Form = 31;
+# in out: al ax eax with dx or imm8
+pub val FORM_PORTIO:   Form = 32;
+# lidt: m
+pub val FORM_LIDT:     Form = 33;
+# mov to or from a control register
+pub val FORM_MOV_CR:   Form = 34;
+# mov to or from a segment register
+pub val FORM_MOV_SEG:  Form = 35;
+# movsb: rsi to rdi, rcx under rep
+pub val FORM_STRING:   Form = 36;
+# ud2 hlt: never continues
+pub val FORM_TRAP:     Form = 37;
+# a data byte in the stream (raw_byte), not an instruction
+pub val FORM_DATA:     Form = 38;
+
+pub val FORM_COUNT: u32 = 39;
+
+# the role pattern of the explicit operands, in intel order
+pub def Shape: u8;
+
+pub val SHAPE_NONE: Shape = 0;
+# the first operand is written, the second read
+pub val SHAPE_DEF:  Shape = 1;
+# the first operand is read and written, the second read
+pub val SHAPE_RW:   Shape = 2;
+# every operand is read
+pub val SHAPE_USE:  Shape = 3;
+# every operand is read and written
+pub val SHAPE_SWAP: Shape = 4;
+# the operand is a transfer target
+pub val SHAPE_XFER: Shape = 5;
+
+pub val SHAPE_COUNT: u32 = 6;
+
+# how the instruction reaches memory, as bits
+pub def MemEffect: u8;
+
+pub val MEM_NONE:    MemEffect = 0;
+# through an r/m operand, read or written as that position's role says
+pub val MEM_OPERAND: MemEffect = 1;
+# a memory operand read as an address only, never accessed
+pub val MEM_ADDR:    MemEffect = 2;
+# through rsp with no explicit address
+pub val MEM_STACK:   MemEffect = 4;
+# through rsi and rdi with no explicit address
+pub val MEM_STRING:  MemEffect = 8;
+
+pub val MEM_ALL: MemEffect = 15;
+
+# the description of one opcode: its form and operand shape, the flags it
+# reads and writes with its latency class, and how it reaches memory. the
+# encoder, the effect walk, the inline-asm scan and the range predicates
+# all read this row and nothing else describes an opcode
+pub rec OpDesc {
+    form:  Form;
+    shape: Shape;
+    # explicit operand positions the form takes, in intel order
+    arity: u8;
+    mem:   MemEffect;
+    cls:   ct.AsmClass;
+}
+
+fun row(form: Form, shape: Shape, arity: u8, mem: MemEffect, cls: ct.AsmClass) OpDesc {
+    var d: OpDesc;
+    d.form  = form;
+    d.shape = shape;
+    d.arity = arity;
+    d.mem   = mem;
+    d.cls   = cls;
+    ret d;
+}
+
+fun keep(op: ct.CtOp) ct.AsmClass    { ret ct.flags_untouched(ct.asm_op(op)); }
+fun defined(op: ct.CtOp) ct.AsmClass { ret ct.flags_defined(ct.asm_op(op)); }
+fun written(op: ct.CtOp) ct.AsmClass { ret ct.flags_written(ct.asm_op(op)); }
+fun read(op: ct.CtOp) ct.AsmClass    { ret ct.flags_read(ct.asm_op(op)); }
+fun opaque(op: ct.CtOp) ct.AsmClass  { ret ct.flags_opaque(ct.asm_op(op)); }
+
+# the row of an opcode; the two pseudo entries and anything outside the
+# catalog describe as FORM_NONE with an unknown class
+pub fun describe(op: u16) OpDesc {
+    val none: ct.CtOp = ct.CT_OP_NONE;
+    if (op == NOP)       { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == MOV)       { ret row(FORM_MOV, SHAPE_DEF, 2, MEM_OPERAND, keep(none)); }
+    if (op == LEA)       { ret row(FORM_LEA, SHAPE_DEF, 2, MEM_ADDR, keep(none)); }
+    if (op == PUSH)      { ret row(FORM_PUSH, SHAPE_USE, 1, MEM_STACK, keep(none)); }
+    if (op == POP)       { ret row(FORM_POP, SHAPE_DEF, 1, MEM_STACK, keep(none)); }
+    if (op == ADD)       { ret row(FORM_ALU, SHAPE_RW, 2, MEM_OPERAND, defined(none)); }
+    if (op == SUB)       { ret row(FORM_ALU, SHAPE_RW, 2, MEM_OPERAND, defined(none)); }
+    if (op == IMUL)      { ret row(FORM_IMUL, SHAPE_RW, 3, MEM_OPERAND, written(ct.CT_OP_INT_MUL)); }
+    if (op == IDIV)      { ret row(FORM_DIV, SHAPE_USE, 1, MEM_OPERAND, written(ct.CT_OP_INT_DIVMOD)); }
+    if (op == DIV)       { ret row(FORM_DIV, SHAPE_USE, 1, MEM_OPERAND, written(ct.CT_OP_INT_DIVMOD)); }
+    if (op == AND)       { ret row(FORM_ALU, SHAPE_RW, 2, MEM_OPERAND, defined(none)); }
+    if (op == OR)        { ret row(FORM_ALU, SHAPE_RW, 2, MEM_OPERAND, defined(none)); }
+    if (op == XOR)       { ret row(FORM_ALU, SHAPE_RW, 2, MEM_OPERAND, defined(none)); }
+    if (op == SHL)       { ret row(FORM_SHIFT, SHAPE_RW, 2, MEM_OPERAND, written(ct.CT_OP_VAR_SHIFT)); }
+    if (op == SHR)       { ret row(FORM_SHIFT, SHAPE_RW, 2, MEM_OPERAND, written(ct.CT_OP_VAR_SHIFT)); }
+    if (op == SAR)       { ret row(FORM_SHIFT, SHAPE_RW, 2, MEM_OPERAND, written(ct.CT_OP_VAR_SHIFT)); }
+    if (op == CMP)       { ret row(FORM_ALU, SHAPE_USE, 2, MEM_OPERAND, defined(none)); }
+    if (op == TEST)      { ret row(FORM_TEST, SHAPE_USE, 2, MEM_OPERAND, defined(none)); }
+    if (op == JMP)       { ret row(FORM_JMP, SHAPE_XFER, 1, MEM_OPERAND, ct.untouched_branch_reg()); }
+    if (op == CALL)      { ret row(FORM_CALL, SHAPE_XFER, 1, MEM_OPERAND | MEM_STACK, ct.untouched_branch_reg()); }
+    if (op == RET)       { ret row(FORM_RET, SHAPE_NONE, 0, MEM_STACK, keep(none)); }
+    if (op == JE)        { ret row(FORM_JCC, SHAPE_XFER, 1, MEM_NONE, ct.asm_branch_flags()); }
+    if (op == JNE)       { ret row(FORM_JCC, SHAPE_XFER, 1, MEM_NONE, ct.asm_branch_flags()); }
+    if (op == JL)        { ret row(FORM_JCC, SHAPE_XFER, 1, MEM_NONE, ct.asm_branch_flags()); }
+    if (op == JLE)       { ret row(FORM_JCC, SHAPE_XFER, 1, MEM_NONE, ct.asm_branch_flags()); }
+    if (op == JG)        { ret row(FORM_JCC, SHAPE_XFER, 1, MEM_NONE, ct.asm_branch_flags()); }
+    if (op == JGE)       { ret row(FORM_JCC, SHAPE_XFER, 1, MEM_NONE, ct.asm_branch_flags()); }
+    if (op == JB)        { ret row(FORM_JCC, SHAPE_XFER, 1, MEM_NONE, ct.asm_branch_flags()); }
+    if (op == JBE)       { ret row(FORM_JCC, SHAPE_XFER, 1, MEM_NONE, ct.asm_branch_flags()); }
+    if (op == JA)        { ret row(FORM_JCC, SHAPE_XFER, 1, MEM_NONE, ct.asm_branch_flags()); }
+    if (op == JAE)       { ret row(FORM_JCC, SHAPE_XFER, 1, MEM_NONE, ct.asm_branch_flags()); }
+    if (op == SETE)      { ret row(FORM_SETCC, SHAPE_DEF, 1, MEM_NONE, read(none)); }
+    if (op == SETNE)     { ret row(FORM_SETCC, SHAPE_DEF, 1, MEM_NONE, read(none)); }
+    if (op == SETL)      { ret row(FORM_SETCC, SHAPE_DEF, 1, MEM_NONE, read(none)); }
+    if (op == SETLE)     { ret row(FORM_SETCC, SHAPE_DEF, 1, MEM_NONE, read(none)); }
+    if (op == SETG)      { ret row(FORM_SETCC, SHAPE_DEF, 1, MEM_NONE, read(none)); }
+    if (op == SETGE)     { ret row(FORM_SETCC, SHAPE_DEF, 1, MEM_NONE, read(none)); }
+    if (op == SETB)      { ret row(FORM_SETCC, SHAPE_DEF, 1, MEM_NONE, read(none)); }
+    if (op == SETBE)     { ret row(FORM_SETCC, SHAPE_DEF, 1, MEM_NONE, read(none)); }
+    if (op == SETA)      { ret row(FORM_SETCC, SHAPE_DEF, 1, MEM_NONE, read(none)); }
+    if (op == SETAE)     { ret row(FORM_SETCC, SHAPE_DEF, 1, MEM_NONE, read(none)); }
+    if (op == MOVSS)     { ret row(FORM_SSE_MOV, SHAPE_DEF, 2, MEM_OPERAND, keep(none)); }
+    if (op == MOVSD)     { ret row(FORM_SSE_MOV, SHAPE_DEF, 2, MEM_OPERAND, keep(none)); }
+    if (op == ADDSS)     { ret row(FORM_SSE_ALU, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == ADDSD)     { ret row(FORM_SSE_ALU, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == SUBSS)     { ret row(FORM_SSE_ALU, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == SUBSD)     { ret row(FORM_SSE_ALU, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == MULSS)     { ret row(FORM_SSE_ALU, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == MULSD)     { ret row(FORM_SSE_ALU, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == DIVSS)     { ret row(FORM_SSE_ALU, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == DIVSD)     { ret row(FORM_SSE_ALU, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == SYSCALL)   { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, opaque(none)); }
+    if (op == MOVABS)    { ret row(FORM_MOVABS, SHAPE_DEF, 2, MEM_NONE, keep(none)); }
+    if (op == UD2)       { ret row(FORM_TRAP, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == PAUSE)     { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == CDQ)       { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == CQO)       { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == MOVSX)     { ret row(FORM_MOVX, SHAPE_DEF, 2, MEM_OPERAND, keep(none)); }
+    if (op == MOVZX)     { ret row(FORM_MOVX, SHAPE_DEF, 2, MEM_OPERAND, keep(none)); }
+    if (op == MOVSXD)    { ret row(FORM_MOVX, SHAPE_DEF, 2, MEM_OPERAND, keep(none)); }
+    if (op == CVTSI2SS)  { ret row(FORM_CVT, SHAPE_RW, 2, MEM_NONE, keep(ct.CT_OP_FLOAT)); }
+    if (op == CVTSI2SD)  { ret row(FORM_CVT, SHAPE_RW, 2, MEM_NONE, keep(ct.CT_OP_FLOAT)); }
+    if (op == CVTSS2SD)  { ret row(FORM_CVT, SHAPE_RW, 2, MEM_NONE, keep(ct.CT_OP_FLOAT)); }
+    if (op == CVTSD2SS)  { ret row(FORM_CVT, SHAPE_RW, 2, MEM_NONE, keep(ct.CT_OP_FLOAT)); }
+    if (op == CVTTSS2SI) { ret row(FORM_CVT, SHAPE_DEF, 2, MEM_NONE, keep(ct.CT_OP_FLOAT)); }
+    if (op == CVTTSD2SI) { ret row(FORM_CVT, SHAPE_DEF, 2, MEM_NONE, keep(ct.CT_OP_FLOAT)); }
+    if (op == UCOMISS)   { ret row(FORM_UCOMIS, SHAPE_USE, 2, MEM_OPERAND, defined(ct.CT_OP_FLOAT)); }
+    if (op == UCOMISD)   { ret row(FORM_UCOMIS, SHAPE_USE, 2, MEM_OPERAND, defined(ct.CT_OP_FLOAT)); }
+    if (op == MOVSB)     { ret row(FORM_STRING, SHAPE_NONE, 0, MEM_STRING, keep(none)); }
+    if (op == MFENCE)    { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == CBW)       { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == CWD)       { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == MOVQ)      { ret row(FORM_MOVQ, SHAPE_DEF, 2, MEM_NONE, keep(none)); }
+    if (op == XORPS)     { ret row(FORM_XORPS, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == NEG)       { ret row(FORM_GRP3, SHAPE_RW, 1, MEM_OPERAND, defined(none)); }
+    if (op == NOT)       { ret row(FORM_GRP3, SHAPE_RW, 1, MEM_OPERAND, keep(none)); }
+    if (op == INC)       { ret row(FORM_GRP5, SHAPE_RW, 1, MEM_OPERAND, written(none)); }
+    if (op == DEC)       { ret row(FORM_GRP5, SHAPE_RW, 1, MEM_OPERAND, written(none)); }
+    if (op == HLT)       { ret row(FORM_TRAP, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == XCHG)      { ret row(FORM_XCHG, SHAPE_SWAP, 2, MEM_OPERAND, keep(none)); }
+    if (op == XADD)      { ret row(FORM_XADD, SHAPE_SWAP, 2, MEM_OPERAND, defined(none)); }
+    if (op == CMPXCHG)   { ret row(FORM_XADD, SHAPE_SWAP, 2, MEM_OPERAND, defined(none)); }
+    if (op == RAW_BYTE)  { ret row(FORM_DATA, SHAPE_NONE, 1, MEM_NONE, ct.asm_unknown()); }
+    if (op == MOVAPS)    { ret row(FORM_SSE_MOVA, SHAPE_DEF, 2, MEM_OPERAND, keep(none)); }
+    if (op == SETP)      { ret row(FORM_SETCC, SHAPE_DEF, 1, MEM_NONE, read(none)); }
+    if (op == SETNP)     { ret row(FORM_SETCC, SHAPE_DEF, 1, MEM_NONE, read(none)); }
+    if (op == ADDPS)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == SUBPS)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == MULPS)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == DIVPS)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == ADDPD)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == SUBPD)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == MULPD)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == DIVPD)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == PADDB)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PADDW)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PADDD)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PADDQ)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PSUBB)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PSUBW)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PSUBD)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PSUBQ)     { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PMULLW)    { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(ct.CT_OP_INT_MUL)); }
+    if (op == PAND)      { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == POR)       { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PXOR)      { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == CMPPS)     { ret row(FORM_PACKED, SHAPE_RW, 3, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == CMPPD)     { ret row(FORM_PACKED, SHAPE_RW, 3, MEM_OPERAND, keep(ct.CT_OP_FLOAT)); }
+    if (op == PCMPEQB)   { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PCMPEQW)   { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PCMPEQD)   { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PCMPGTB)   { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PCMPGTW)   { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PCMPGTD)   { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == MOVUPS)    { ret row(FORM_SSE_MOVA, SHAPE_DEF, 2, MEM_OPERAND, keep(none)); }
+    if (op == PSHUFD)    { ret row(FORM_PSHUF, SHAPE_DEF, 3, MEM_NONE, keep(none)); }
+    if (op == PSLLD)     { ret row(FORM_PSLL, SHAPE_RW, 2, MEM_NONE, keep(none)); }
+    if (op == PSUBUSB)   { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == PSUBUSW)   { ret row(FORM_PACKED, SHAPE_RW, 2, MEM_OPERAND, keep(none)); }
+    if (op == IN)        { ret row(FORM_PORTIO, SHAPE_DEF, 2, MEM_NONE, keep(none)); }
+    if (op == OUT)       { ret row(FORM_PORTIO, SHAPE_USE, 2, MEM_NONE, keep(none)); }
+    if (op == CLI)       { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == STI)       { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == LIDT)      { ret row(FORM_LIDT, SHAPE_USE, 1, MEM_OPERAND, keep(none)); }
+    if (op == RDTSC)     { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == RDMSR)     { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == WRMSR)     { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == CLD)       { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == PUSHFQ)    { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_STACK, read(none)); }
+    if (op == POPFQ)     { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_STACK, opaque(none)); }
+    if (op == IRETQ)     { ret row(FORM_RET, SHAPE_NONE, 0, MEM_STACK, opaque(none)); }
+    if (op == SWAPGS)    { ret row(FORM_BARE, SHAPE_NONE, 0, MEM_NONE, keep(none)); }
+    if (op == MOV_CR)    { ret row(FORM_MOV_CR, SHAPE_DEF, 2, MEM_NONE, keep(none)); }
+    if (op == MOV_SEG)   { ret row(FORM_MOV_SEG, SHAPE_DEF, 2, MEM_NONE, keep(none)); }
+    ret row(FORM_NONE, SHAPE_NONE, 0, MEM_NONE, ct.asm_unknown());
+}
+
+# the forms whose operands live in the xmm file, wholly or on one side
+pub fun form_is_float(form: Form) bool {
+    ret form == FORM_MOVQ || form == FORM_SSE_MOV || form == FORM_SSE_MOVA ||
+        form == FORM_SSE_ALU || form == FORM_UCOMIS || form == FORM_CVT ||
+        form == FORM_XORPS || form == FORM_PACKED || form == FORM_PSHUF || form == FORM_PSLL;
+}
+
 pub fun is_fp_opcode(op: u16) bool {
-    if (op >= MOVSS && op <= DIVSD)      { ret true; }
-    if (op >= CVTSI2SS && op <= UCOMISD) { ret true; }
-    if (op == MOVQ || op == XORPS)       { ret true; }
-    ret false;
+    ret form_is_float(describe(op).form);
 }
 
 pub fun reg_name(ctx: ptr, id: i32, size: u8) str {

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -362,31 +362,30 @@ fun cc_to_x86(opcode: u16) u8 {
     ret 0x04;
 }
 
+# the family predicates read the opcode's row; no reader depends on how the
+# opcode numbers were assigned
 fun is_jcc(opcode: u16) bool {
-    ret opcode >= x64.JE && opcode <= x64.JAE;
+    ret x64.describe(opcode).form == x64.FORM_JCC;
 }
 
 fun is_setcc(opcode: u16) bool {
-    if (opcode == x64.SETP || opcode == x64.SETNP) { ret true; }
-    ret opcode >= x64.SETE && opcode <= x64.SETAE;
+    ret x64.describe(opcode).form == x64.FORM_SETCC;
 }
 
 fun is_alu(opcode: u16) bool {
-    if (opcode == x64.ADD) { ret true; }
-    if (opcode == x64.SUB) { ret true; }
-    if (opcode == x64.AND) { ret true; }
-    if (opcode == x64.OR)  { ret true; }
-    if (opcode == x64.XOR) { ret true; }
-    if (opcode == x64.CMP) { ret true; }
-    ret false;
+    ret x64.describe(opcode).form == x64.FORM_ALU;
 }
 
 fun is_sse_mov(opcode: u16) bool {
-    ret opcode == x64.MOVSS || opcode == x64.MOVSD;
+    ret x64.describe(opcode).form == x64.FORM_SSE_MOV;
 }
 
 fun is_sse_alu(opcode: u16) bool {
-    ret opcode >= x64.ADDSS && opcode <= x64.DIVSD;
+    ret x64.describe(opcode).form == x64.FORM_SSE_ALU;
+}
+
+fun is_cvt(opcode: u16) bool {
+    ret x64.describe(opcode).form == x64.FORM_CVT;
 }
 
 fun is_float_width(w: u8) bool {
@@ -1587,12 +1586,13 @@ fun encode_inst(mi: *isa.Inst, buf: *enc.ByteBuf) i32 {
 
     if (opcode == isa.ISA_PCOPY || opcode == isa.ISA_PCOPY_FENCE) { ret 0; }
 
+    # a memory source beside a memory destination is staged through a
+    # scratch register where the row admits one r/m operand: a shift's
+    # count and a swap's second operand are never staged
+    val desc: x64.OpDesc = x64.describe(opcode);
     if (mi.src1.kind == isa.OPK_MEM && mi.dst.kind == isa.OPK_MEM &&
-        opcode != x64.NOP && opcode != x64.RET && opcode != x64.SYSCALL &&
-        opcode != x64.UD2 && opcode != x64.PAUSE && opcode != x64.CDQ &&
-        opcode != x64.CQO && opcode != x64.MFENCE &&
-        opcode != x64.SHL && opcode != x64.SHR && opcode != x64.SAR &&
-        opcode != x64.XCHG && opcode != x64.XADD && opcode != x64.CMPXCHG) {
+        (desc.mem & x64.MEM_OPERAND) != 0 &&
+        desc.form != x64.FORM_SHIFT && desc.shape != x64.SHAPE_SWAP) {
         var scratch: i32 = float_scratch0();
         if (mi.size != 16) {
             scratch = pick_stage_scratch(?mi.dst, ?mi.src1);
@@ -1618,8 +1618,19 @@ fun encode_inst(mi: *isa.Inst, buf: *enc.ByteBuf) i32 {
     ret n;
 }
 
+fun has_mem_operand(mi: *isa.Inst) bool {
+    ret mi.dst.kind == isa.OPK_MEM || mi.src1.kind == isa.OPK_MEM ||
+        mi.src2.kind == isa.OPK_MEM || mi.src3.kind == isa.OPK_MEM;
+}
+
 fun encode_inst_one(mi: *isa.Inst, buf: *enc.ByteBuf) i32 {
     val opcode: u16 = mi.opcode;
+
+    # an opcode without a row, or a memory operand on a row that reaches
+    # memory only implicitly or not at all, is refused before any byte
+    val desc: x64.OpDesc = x64.describe(opcode);
+    if (desc.form == x64.FORM_NONE) { ret 0; }
+    if (has_mem_operand(mi) && (desc.mem & (x64.MEM_OPERAND | x64.MEM_ADDR)) == 0) { ret 0; }
 
     if (opcode == x64.NOP) {
         enc.emit_byte(buf, 0x90);
@@ -1730,7 +1741,7 @@ fun encode_inst_one(mi: *isa.Inst, buf: *enc.ByteBuf) i32 {
         ret encode_ucomiss(mi, buf);
     }
 
-    if (opcode >= x64.CVTSI2SS && opcode <= x64.CVTTSD2SI) {
+    if (is_cvt(opcode)) {
         ret encode_cvt(mi, buf);
     }
 
@@ -7005,105 +7016,11 @@ test "mach.lang.target.isa.x64.encode:float_width_refusals_emit_nothing" {
     ret bad;
 }
 
+# the flags and latency row of an opcode, as the inline-asm scan and the
+# effect walk read it: the class column of the one description table
 pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {
-    if (code == x64.MOV::u32 || code == x64.MOVZX::u32 || code == x64.MOVSX::u32 ||
-        code == x64.LEA::u32 || code == x64.PUSH::u32  || code == x64.POP::u32 ||
-        code == x64.XCHG::u32) {
-        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
-    }
-    if (code == x64.ADD::u32 || code == x64.SUB::u32 || code == x64.AND::u32 ||
-        code == x64.OR::u32  || code == x64.XOR::u32 || code == x64.CMP::u32 ||
-        code == x64.TEST::u32 || code == x64.NEG::u32) {
-        ret ct.flags_defined(ct.asm_op(ct.CT_OP_NONE));
-    }
-    if (code == x64.INC::u32 || code == x64.DEC::u32) {
-        ret ct.flags_written(ct.asm_op(ct.CT_OP_NONE));
-    }
-    if (code == x64.NOT::u32) {
-        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
-    }
-    if (code == x64.SETB::u32 || code == x64.SETAE::u32) {
-        ret ct.flags_read(ct.asm_op(ct.CT_OP_NONE));
-    }
-    if (code == x64.SHL::u32 || code == x64.SHR::u32 || code == x64.SAR::u32) {
-        ret ct.flags_written(ct.asm_op(ct.CT_OP_VAR_SHIFT));
-    }
-    if (code == x64.CMPXCHG::u32 || code == x64.XADD::u32) {
-        ret ct.flags_defined(ct.asm_op(ct.CT_OP_NONE));
-    }
-    if (code == x64.MFENCE::u32 || code == x64.PAUSE::u32) {
-        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
-    }
-    if (code == x64.IN::u32    || code == x64.OUT::u32   || code == x64.CLI::u32 ||
-        code == x64.STI::u32   || code == x64.LIDT::u32  || code == x64.RDTSC::u32 ||
-        code == x64.RDMSR::u32 || code == x64.WRMSR::u32 || code == x64.CLD::u32 ||
-        code == x64.SWAPGS::u32 || code == x64.MOV_CR::u32 || code == x64.MOV_SEG::u32) {
-        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
-    }
-    if (code == x64.POPFQ::u32 || code == x64.IRETQ::u32 || code == x64.SYSCALL::u32) {
-        ret ct.flags_opaque(ct.asm_op(ct.CT_OP_NONE));
-    }
-    if (code == x64.PUSHFQ::u32) {
-        ret ct.flags_read(ct.asm_op(ct.CT_OP_NONE));
-    }
-
-    if (code == x64.JMP::u32 || code == x64.CALL::u32) {
-        ret ct.untouched_branch_reg();
-    }
-    if (code == x64.RET::u32 ||
-        code == x64.NOP::u32 || code == x64.HLT::u32 || code == x64.UD2::u32) {
-        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
-    }
-    if (code == x64.JE::u32  || code == x64.JNE::u32 || code == x64.JB::u32 ||
-        code == x64.JAE::u32) {
-        ret ct.asm_branch_flags();
-    }
-
-    # rows for the opcodes the encoder emits that the inline-asm grammar has
-    # no spelling for: the same closed table, extended, not paralleled
-    if (code == x64.JL::u32  || code == x64.JLE::u32 || code == x64.JG::u32 ||
-        code == x64.JGE::u32 || code == x64.JBE::u32 || code == x64.JA::u32) {
-        ret ct.asm_branch_flags();
-    }
-    if (code == x64.SETE::u32  || code == x64.SETNE::u32 || code == x64.SETL::u32 ||
-        code == x64.SETLE::u32 || code == x64.SETG::u32  || code == x64.SETGE::u32 ||
-        code == x64.SETBE::u32 || code == x64.SETA::u32  || code == x64.SETP::u32 ||
-        code == x64.SETNP::u32) {
-        ret ct.flags_read(ct.asm_op(ct.CT_OP_NONE));
-    }
-    if (code == x64.IMUL::u32 || code == x64.PMULLW::u32) {
-        if (code == x64.IMUL::u32) { ret ct.flags_written(ct.asm_op(ct.CT_OP_INT_MUL)); }
-        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_INT_MUL));
-    }
-    if (code == x64.IDIV::u32 || code == x64.DIV::u32) {
-        ret ct.flags_written(ct.asm_op(ct.CT_OP_INT_DIVMOD));
-    }
-    if (code == x64.CDQ::u32 || code == x64.CQO::u32 || code == x64.CWD::u32 || code == x64.CBW::u32 ||
-        code == x64.MOVABS::u32 || code == x64.MOVSXD::u32 || code == x64.MOVSB::u32 ||
-        code == x64.MOVQ::u32 || code == x64.MOVAPS::u32 || code == x64.MOVUPS::u32 ||
-        code == x64.MOVSS::u32 || code == x64.MOVSD::u32 || code == x64.PSHUFD::u32 ||
-        code == x64.PSLLD::u32 || code == x64.XORPS::u32 || code == x64.PAND::u32 ||
-        code == x64.POR::u32 || code == x64.PXOR::u32 ||
-        code == x64.PADDB::u32 || code == x64.PADDW::u32 || code == x64.PADDD::u32 || code == x64.PADDQ::u32 ||
-        code == x64.PSUBB::u32 || code == x64.PSUBW::u32 || code == x64.PSUBD::u32 || code == x64.PSUBQ::u32 ||
-        code == x64.PSUBUSB::u32 || code == x64.PSUBUSW::u32 ||
-        code == x64.PCMPEQB::u32 || code == x64.PCMPEQW::u32 || code == x64.PCMPEQD::u32 ||
-        code == x64.PCMPGTB::u32 || code == x64.PCMPGTW::u32 || code == x64.PCMPGTD::u32) {
-        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
-    }
-    if (code == x64.ADDSS::u32 || code == x64.ADDSD::u32 || code == x64.SUBSS::u32 || code == x64.SUBSD::u32 ||
-        code == x64.MULSS::u32 || code == x64.MULSD::u32 || code == x64.DIVSS::u32 || code == x64.DIVSD::u32 ||
-        code == x64.ADDPS::u32 || code == x64.ADDPD::u32 || code == x64.SUBPS::u32 || code == x64.SUBPD::u32 ||
-        code == x64.MULPS::u32 || code == x64.MULPD::u32 || code == x64.DIVPS::u32 || code == x64.DIVPD::u32 ||
-        code == x64.CMPPS::u32 || code == x64.CMPPD::u32 ||
-        code == x64.CVTSI2SS::u32 || code == x64.CVTSI2SD::u32 || code == x64.CVTSS2SD::u32 ||
-        code == x64.CVTSD2SS::u32 || code == x64.CVTTSS2SI::u32 || code == x64.CVTTSD2SI::u32) {
-        ret ct.flags_untouched(ct.asm_op(ct.CT_OP_FLOAT));
-    }
-    if (code == x64.UCOMISS::u32 || code == x64.UCOMISD::u32) {
-        ret ct.flags_defined(ct.asm_op(ct.CT_OP_FLOAT));
-    }
-    ret ct.asm_unknown();
+    if (code > 0xFFFF) { ret ct.asm_unknown(); }
+    ret x64.describe(code::u16).cls;
 }
 
 # the machine opcodes a notification can carry: every x64.Opcode except the
@@ -7143,56 +7060,26 @@ fun x64_slot(mi: *isa.Inst, pos: u32) *isa.Operand {
     ret ?mi.src3;
 }
 
-fun x64_grammar_implicit(code: u32, mem: *bool) u32 {
+fun x64_grammar_implicit(code: u32) u32 {
     var i: usize = 0;
     for (i < X64_MNEMONIC_COUNT) {
-        if (X64_MNEMONICS[i].code == code) {
-            @mem = X64_MNEMONICS[i].implicit_mem;
-            ret X64_MNEMONICS[i].implicit;
-        }
+        if (X64_MNEMONICS[i].code == code) { ret X64_MNEMONICS[i].implicit; }
         i = i + 1;
     }
-    @mem = false;
     ret 0;
 }
 
-fun x64_is_setcc(op: u16) bool {
-    ret op == x64.SETE || op == x64.SETNE || op == x64.SETL  || op == x64.SETLE ||
-        op == x64.SETG || op == x64.SETGE || op == x64.SETB  || op == x64.SETBE ||
-        op == x64.SETA || op == x64.SETAE || op == x64.SETP  || op == x64.SETNP;
-}
-
-fun x64_is_jcc(op: u16) bool {
-    ret op == x64.JE || op == x64.JNE || op == x64.JL || op == x64.JLE || op == x64.JG ||
-        op == x64.JGE || op == x64.JB || op == x64.JBE || op == x64.JA || op == x64.JAE;
-}
-
-fun x64_two_address(op: u16) bool {
-    ret op == x64.ADD || op == x64.SUB || op == x64.AND || op == x64.OR || op == x64.XOR ||
-        op == x64.SHL || op == x64.SHR || op == x64.SAR ||
-        op == x64.ADDSS || op == x64.ADDSD || op == x64.SUBSS || op == x64.SUBSD ||
-        op == x64.MULSS || op == x64.MULSD || op == x64.DIVSS || op == x64.DIVSD ||
-        op == x64.ADDPS || op == x64.ADDPD || op == x64.SUBPS || op == x64.SUBPD ||
-        op == x64.MULPS || op == x64.MULPD || op == x64.DIVPS || op == x64.DIVPD ||
-        op == x64.PADDB || op == x64.PADDW || op == x64.PADDD || op == x64.PADDQ ||
-        op == x64.PSUBB || op == x64.PSUBW || op == x64.PSUBD || op == x64.PSUBQ ||
-        op == x64.PSUBUSB || op == x64.PSUBUSW || op == x64.PMULLW ||
-        op == x64.PAND || op == x64.POR || op == x64.PXOR || op == x64.XORPS ||
-        op == x64.CMPPS || op == x64.CMPPD ||
-        op == x64.PCMPEQB || op == x64.PCMPEQW || op == x64.PCMPEQD ||
-        op == x64.PCMPGTB || op == x64.PCMPGTW || op == x64.PCMPGTD || op == x64.PSLLD ||
-        op == x64.CVTSI2SS || op == x64.CVTSI2SD || op == x64.CVTSS2SD || op == x64.CVTSD2SS;
-}
-
-fun x64_pure_def(op: u16) bool {
-    ret op == x64.MOV || op == x64.MOVZX || op == x64.MOVSX || op == x64.MOVSXD || op == x64.MOVABS ||
-        op == x64.MOVQ || op == x64.MOVAPS || op == x64.MOVUPS || op == x64.PSHUFD ||
-        op == x64.CVTTSS2SI || op == x64.CVTTSD2SI || op == x64.IN || op == x64.MOV_CR || op == x64.MOV_SEG;
-}
-
-fun x64_compare(op: u16) bool {
-    ret op == x64.CMP || op == x64.TEST || op == x64.UCOMISS || op == x64.UCOMISD || op == x64.OUT ||
-        op == x64.LIDT || op == x64.WRMSR;
+# the roles a shape gives the first two present operands the form takes; a
+# third position is an immediate on every form that has one
+fun x64_shape_roles(e: *ct.InstEffects, d: *x64.OpDesc, shape: x64.Shape, n: u32, pos: *u32) {
+    if (n == 0 || d.arity == 0 || shape == x64.SHAPE_NONE || shape == x64.SHAPE_XFER) { ret; }
+    var first: ct.OperandRole = ct.ROLE_READ;
+    var second: ct.OperandRole = ct.ROLE_READ;
+    if (shape == x64.SHAPE_DEF)  { first = ct.ROLE_WRITE; }
+    if (shape == x64.SHAPE_RW)   { first = ct.ROLE_RW; }
+    if (shape == x64.SHAPE_SWAP) { first = ct.ROLE_RW; second = ct.ROLE_RW; }
+    e.roles[pos[0]] = first;
+    if (n >= 2 && d.arity >= 2) { e.roles[pos[1]] = second; }
 }
 
 val X64_RAX: u64 = 0x1;
@@ -7202,152 +7089,74 @@ val X64_RSP: u64 = 0x10;
 val X64_RSI: u64 = 0x40;
 val X64_RDI: u64 = 0x80;
 
-# the effect description of one emitted x86-64 instruction: the closed class
-# row plus the operand roles in Intel order and the implicit effects. every
-# opcode notifiable_opcode admits has a known row; the two pseudo entries and
-# anything outside the catalog describe as unknown
+# the effect description of one emitted x86-64 instruction: the opcode's
+# row (form, shape, memory, class) projected onto the operands present, in
+# intel order, plus the implicit effects the form carries. every opcode
+# notifiable_opcode admits has a row; the two pseudo entries and anything
+# outside the catalog describe as unknown
 pub fun inst_effects(mi: *isa.Inst, e: *ct.InstEffects) {
     @e = ct.inst_effects_unknown();
     val op: u16 = mi.opcode;
     if (!notifiable_opcode(op)) { ret; }
-    e.cls = asm_ct_class(op::u32, 0);
+    val d: x64.OpDesc = x64.describe(op);
+    e.cls = d.cls;
 
     var pos: [4]u32;
     val n: u32 = x64_present(mi, ?pos[0]);
-    var mem: bool = false;
-    val implicit: u32 = x64_grammar_implicit(op::u32, ?mem);
-    e.implicit_reads  = implicit::u64;
-    e.implicit_writes = implicit::u64;
-    e.implicit_mem    = mem;
+    e.implicit_reads  = x64_grammar_implicit(op::u32)::u64;
+    e.implicit_writes = e.implicit_reads;
+    e.implicit_mem    = (d.mem & x64.MEM_STACK) != 0;
+    if ((d.mem & x64.MEM_STRING) != 0) { e.implicit_addr = X64_RSI | X64_RDI; }
 
-    if (n >= 1 && x64_pure_def(op)) {
-        e.roles[pos[0]] = ct.ROLE_WRITE;
-        if (n >= 2) { e.roles[pos[1]] = ct.ROLE_READ; }
-        ret;
-    }
-    if (op == x64.LEA) {
-        if (n >= 1) { e.roles[pos[0]] = ct.ROLE_WRITE; }
-        if (n >= 2) { e.roles[pos[1]] = ct.ROLE_ADDR; }
-        ret;
-    }
-    if (n >= 1 && (op == x64.MOVSS || op == x64.MOVSD)) {
+    var shape: x64.Shape = d.shape;
+    # the three-operand imul writes a register the sources do not name
+    if (d.form == x64.FORM_IMUL && n == 3) { shape = x64.SHAPE_DEF; }
+    x64_shape_roles(e, ?d, shape, n, ?pos[0]);
+    if ((d.mem & x64.MEM_ADDR) != 0 && n >= 2) { e.roles[pos[1]] = ct.ROLE_ADDR; }
+
+    if (d.form == x64.FORM_SSE_MOV && n >= 2) {
         # a register source merges into the upper lanes; a memory source zeroes them
-        e.roles[pos[0]] = ct.ROLE_WRITE;
-        if (n >= 2) {
-            e.roles[pos[1]] = ct.ROLE_READ;
-            if (x64_slot(mi, pos[1]).kind == isa.OPK_REG && x64_slot(mi, pos[0]).kind == isa.OPK_REG) {
-                e.roles[pos[0]] = ct.ROLE_RW;
-            }
+        if (x64_slot(mi, pos[1]).kind == isa.OPK_REG && x64_slot(mi, pos[0]).kind == isa.OPK_REG) {
+            e.roles[pos[0]] = ct.ROLE_RW;
         }
-        ret;
     }
-    if (x64_two_address(op)) {
-        if (n >= 1) { e.roles[pos[0]] = ct.ROLE_RW; }
-        if (n >= 2) { e.roles[pos[1]] = ct.ROLE_READ; }
-        if (op == x64.SHL || op == x64.SHR || op == x64.SAR) {
-            if (n >= 2) { e.count_pos = pos[1]::i8; }
-            or { e.implicit_reads = e.implicit_reads | X64_RCX; e.count_pos = -1; }
-        }
-        if ((op == x64.XOR || op == x64.SUB || op == x64.PXOR || op == x64.XORPS) && n == 2) {
-            val a: *isa.Operand = x64_slot(mi, pos[0]);
-            val b: *isa.Operand = x64_slot(mi, pos[1]);
-            if (a.kind == isa.OPK_REG && b.kind == isa.OPK_REG && a.reg == b.reg) { e.zero_idiom = true; }
-        }
-        ret;
+    if (d.form == x64.FORM_SHIFT) {
+        if (n >= 2) { e.count_pos = pos[1]::i8; }
+        or { e.implicit_reads = e.implicit_reads | X64_RCX; e.count_pos = -1; }
     }
-    if (op == x64.IMUL) {
-        if (n == 3) {
-            e.roles[pos[0]] = ct.ROLE_WRITE;
-            e.roles[pos[1]] = ct.ROLE_READ;
-        } or {
-            if (n >= 1) { e.roles[pos[0]] = ct.ROLE_RW; }
-            if (n >= 2) { e.roles[pos[1]] = ct.ROLE_READ; }
-            if (n == 1) { e.implicit_reads = X64_RAX; e.implicit_writes = X64_RAX | X64_RDX; }
-        }
-        ret;
+    if ((op == x64.XOR || op == x64.SUB || op == x64.PXOR || op == x64.XORPS) && n == 2) {
+        val a: *isa.Operand = x64_slot(mi, pos[0]);
+        val b: *isa.Operand = x64_slot(mi, pos[1]);
+        if (a.kind == isa.OPK_REG && b.kind == isa.OPK_REG && a.reg == b.reg) { e.zero_idiom = true; }
     }
-    if (x64_compare(op)) {
-        if (n >= 1) { e.roles[pos[0]] = ct.ROLE_READ; }
-        if (n >= 2) { e.roles[pos[1]] = ct.ROLE_READ; }
-        ret;
-    }
-    if (op == x64.NEG || op == x64.NOT || op == x64.INC || op == x64.DEC) {
-        if (n >= 1) { e.roles[pos[0]] = ct.ROLE_RW; }
-        ret;
-    }
-    if (op == x64.XCHG || op == x64.XADD || op == x64.CMPXCHG) {
-        if (n >= 1) { e.roles[pos[0]] = ct.ROLE_RW; }
-        if (n >= 2) { e.roles[pos[1]] = ct.ROLE_RW; }
-        if (op == x64.CMPXCHG) { e.implicit_reads = X64_RAX; e.implicit_writes = X64_RAX; }
-        ret;
-    }
-    if (x64_is_setcc(op)) {
-        if (n >= 1) { e.roles[pos[0]] = ct.ROLE_WRITE; }
-        ret;
-    }
-    if (op == x64.IDIV || op == x64.DIV) {
-        if (n >= 1) { e.roles[pos[0]] = ct.ROLE_READ; }
+    if (d.form == x64.FORM_IMUL && n == 1) { e.implicit_reads = X64_RAX; e.implicit_writes = X64_RAX | X64_RDX; }
+    if (op == x64.CMPXCHG) { e.implicit_reads = X64_RAX; e.implicit_writes = X64_RAX; }
+    if (d.form == x64.FORM_DIV) {
         e.implicit_reads  = X64_RAX | X64_RDX;
         e.implicit_writes = X64_RAX | X64_RDX;
-        ret;
     }
     if (op == x64.CDQ || op == x64.CQO || op == x64.CWD) {
         e.implicit_reads  = X64_RAX;
         e.implicit_writes = X64_RDX;
-        ret;
     }
     if (op == x64.CBW) {
         e.implicit_reads  = X64_RAX;
         e.implicit_writes = X64_RAX;
-        ret;
     }
-    if (op == x64.MOVSB) {
+    if (d.form == x64.FORM_STRING) {
         e.implicit_reads  = X64_RSI | X64_RDI | X64_RCX;
         e.implicit_writes = X64_RSI | X64_RDI | X64_RCX;
-        e.implicit_addr   = X64_RSI | X64_RDI;
-        ret;
     }
-    if (op == x64.PUSH) {
-        if (n >= 1) { e.roles[pos[0]] = ct.ROLE_READ; }
+    if (d.form == x64.FORM_PUSH || d.form == x64.FORM_POP || op == x64.PUSHFQ || op == x64.POPFQ) {
         e.implicit_reads  = X64_RSP;
         e.implicit_writes = X64_RSP;
-        e.implicit_mem    = true;
-        ret;
     }
-    if (op == x64.POP) {
-        if (n >= 1) { e.roles[pos[0]] = ct.ROLE_WRITE; }
-        e.implicit_reads  = X64_RSP;
-        e.implicit_writes = X64_RSP;
-        e.implicit_mem    = true;
-        ret;
-    }
-    if (op == x64.PUSHFQ || op == x64.POPFQ) {
-        e.implicit_reads  = X64_RSP;
-        e.implicit_writes = X64_RSP;
-        e.implicit_mem    = true;
-        ret;
-    }
-    if (op == x64.JMP || op == x64.CALL) {
-        e.xfer = ct.XFER_JUMP;
-        if (op == x64.CALL) { e.xfer = ct.XFER_CALL; e.implicit_mem = true; }
-        x64_transfer_target(mi, n, ?pos[0], e);
-        ret;
-    }
-    if (x64_is_jcc(op)) {
-        e.xfer = ct.XFER_BRANCH;
-        x64_transfer_target(mi, n, ?pos[0], e);
-        ret;
-    }
-    if (op == x64.RET || op == x64.IRETQ) {
-        e.xfer = ct.XFER_RET;
-        e.implicit_mem = true;
-        ret;
-    }
-    if (op == x64.UD2 || op == x64.HLT) {
-        e.xfer = ct.XFER_TRAP;
-        ret;
-    }
-    # the remaining operand-less system instructions carry only their grammar row's implicit set
+
+    if (d.form == x64.FORM_JMP)  { e.xfer = ct.XFER_JUMP;   x64_transfer_target(mi, n, ?pos[0], e); }
+    if (d.form == x64.FORM_CALL) { e.xfer = ct.XFER_CALL;   x64_transfer_target(mi, n, ?pos[0], e); }
+    if (d.form == x64.FORM_JCC)  { e.xfer = ct.XFER_BRANCH; x64_transfer_target(mi, n, ?pos[0], e); }
+    if (d.form == x64.FORM_RET)  { e.xfer = ct.XFER_RET; }
+    if (d.form == x64.FORM_TRAP) { e.xfer = ct.XFER_TRAP; }
 }
 
 fun x64_transfer_target(mi: *isa.Inst, n: u32, pos: *u32, e: *ct.InstEffects) {
@@ -8089,22 +7898,148 @@ test "mach.lang.target.isa.x64.encode.stream:notes_name_their_instruction_and_ca
 # the census the walk depends on: every machine opcode a notification can
 # carry has a row in the closed table, with its flags stated. the pseudo
 # entries are outside the notifiable space by definition, not exceptions
+# the census over the opcode space: every notifiable opcode has a complete
+# row (a form, a shape, a memory effect and a stated flags class) and a
+# mnemonic, and the row's columns agree with each other. an opcode added
+# without a row fails here before it can reach a stream
 test "mach.lang.target.isa.x64.encode.asm_ct_class:every_notifiable_opcode_has_a_row" {
     var missing: u32 = 0;
     var op: u32 = 0;
     for (op < X64_OPCODE_COUNT) {
         if (notifiable_opcode(op::u16)) {
+            val d: x64.OpDesc = x64.describe(op::u16);
             val cls: ct.AsmClass = asm_ct_class(op, 0);
             if (!cls.known || !cls.flags_stated) { missing = missing + 1; }
+            if (d.form == x64.FORM_NONE || d.form::u32 >= x64.FORM_COUNT) { missing = missing + 1; }
+            if (d.shape::u32 >= x64.SHAPE_COUNT) { missing = missing + 1; }
+            if (d.mem > x64.MEM_ALL) { missing = missing + 1; }
             if (printer.mnemonic(op::u16) == nil) { missing = missing + 1; }
+            if (!ut_row_consistent(?d)) { missing = missing + 1; }
         }
         op = op + 1;
     }
     if (notifiable_opcode(x64.ASM_BLOCK) || notifiable_opcode(x64.RAW_BYTE)) { ret 2; }
     if (notifiable_opcode(X64_OPCODE_COUNT::u16)) { ret 3; }
     if (printer.mnemonic(X64_OPCODE_COUNT::u16) != nil) { ret 4; }
+    if (x64.describe(x64.ASM_BLOCK).form != x64.FORM_NONE) { ret 5; }
+    if (x64.describe(x64.RAW_BYTE).form != x64.FORM_DATA || x64.describe(x64.RAW_BYTE).cls.known) { ret 6; }
+    if (x64.describe(X64_OPCODE_COUNT::u16).form != x64.FORM_NONE) { ret 7; }
     if (missing != 0) { ret 1; }
     ret 0;
+}
+
+# the columns of one row agree: a transfer form has a transfer shape and
+# nothing else does, a flags branch is a jcc, a flags reader with a
+# destination is a setcc, the stack forms reach the stack, a memory address
+# is only taken by lea, and a compare defines flags
+fun ut_row_consistent(d: *x64.OpDesc) bool {
+    val xfer_form: bool = d.form == x64.FORM_JMP || d.form == x64.FORM_CALL || d.form == x64.FORM_JCC;
+    if (xfer_form != (d.shape == x64.SHAPE_XFER)) { ret false; }
+    if (d.cls.cond_flags != (d.form == x64.FORM_JCC)) { ret false; }
+    if (d.cls.cond_reg != (d.form == x64.FORM_JMP || d.form == x64.FORM_CALL)) { ret false; }
+    if ((d.form == x64.FORM_SETCC) != (d.cls.reads_flags && d.shape == x64.SHAPE_DEF)) { ret false; }
+    if (d.form == x64.FORM_SETCC && d.mem != x64.MEM_NONE) { ret false; }
+    val stack_form: bool = d.form == x64.FORM_PUSH || d.form == x64.FORM_POP ||
+                           d.form == x64.FORM_CALL || d.form == x64.FORM_RET;
+    if (stack_form && (d.mem & x64.MEM_STACK) == 0) { ret false; }
+    if (((d.mem & x64.MEM_ADDR) != 0) != (d.form == x64.FORM_LEA)) { ret false; }
+    if (((d.mem & x64.MEM_STRING) != 0) != (d.form == x64.FORM_STRING)) { ret false; }
+    if ((d.form == x64.FORM_UCOMIS || d.form == x64.FORM_TEST) && !d.cls.defines_flags) { ret false; }
+    if (d.form == x64.FORM_ALU && !d.cls.defines_flags) { ret false; }
+    if ((d.arity == 0) != (d.shape == x64.SHAPE_NONE && d.form != x64.FORM_DATA)) { ret false; }
+    if (d.arity > 3) { ret false; }
+    if (d.shape == x64.SHAPE_XFER && d.arity != 1) { ret false; }
+    if (d.shape == x64.SHAPE_NONE && d.form != x64.FORM_BARE && d.form != x64.FORM_RET &&
+        d.form != x64.FORM_TRAP && d.form != x64.FORM_STRING && d.form != x64.FORM_DATA) { ret false; }
+    if (d.shape != x64.SHAPE_NONE && (d.form == x64.FORM_BARE || d.form == x64.FORM_RET ||
+        d.form == x64.FORM_TRAP || d.form == x64.FORM_STRING || d.form == x64.FORM_DATA)) { ret false; }
+    if (x64.form_is_float(d.form) && d.cls.op == ct.CT_OP_INT_DIVMOD) { ret false; }
+    if (d.cls.op == ct.CT_OP_FLOAT && !x64.form_is_float(d.form)) { ret false; }
+    if (d.cls.op == ct.CT_OP_VAR_SHIFT && d.form != x64.FORM_SHIFT) { ret false; }
+    if (d.cls.op == ct.CT_OP_INT_DIVMOD && d.form != x64.FORM_DIV) { ret false; }
+    ret true;
+}
+
+# the family predicates are exact over the whole opcode space, including
+# the two setcc rows assigned outside the setcc run
+test "mach.lang.target.isa.x64.encode.describe:family_predicates_read_the_table" {
+    var jcc: u32 = 0;
+    var setcc: u32 = 0;
+    var sse_mov: u32 = 0;
+    var sse_alu: u32 = 0;
+    var alu: u32 = 0;
+    var cvt: u32 = 0;
+    var fp: u32 = 0;
+    var op: u32 = 0;
+    for (op < X64_OPCODE_COUNT) {
+        val o: u16 = op::u16;
+        if (is_jcc(o))     { jcc = jcc + 1; }
+        if (is_setcc(o))   { setcc = setcc + 1; }
+        if (is_sse_mov(o)) { sse_mov = sse_mov + 1; }
+        if (is_sse_alu(o)) { sse_alu = sse_alu + 1; }
+        if (is_alu(o))     { alu = alu + 1; }
+        if (is_cvt(o))     { cvt = cvt + 1; }
+        if (x64.is_fp_opcode(o)) { fp = fp + 1; }
+        op = op + 1;
+    }
+    if (jcc != 10 || setcc != 12 || sse_mov != 2 || sse_alu != 8 || alu != 6 || cvt != 6) { ret 1; }
+    if (!is_setcc(x64.SETP) || !is_setcc(x64.SETNP)) { ret 2; }
+    if (is_jcc(x64.JMP) || is_jcc(x64.SETE) || is_setcc(x64.JE) || is_setcc(x64.PUSHFQ)) { ret 3; }
+    if (is_sse_alu(x64.ADDPS) || is_sse_mov(x64.MOVAPS) || is_alu(x64.TEST) || is_cvt(x64.MOVQ)) { ret 4; }
+    if (!x64.is_fp_opcode(x64.MOVQ) || !x64.is_fp_opcode(x64.PADDB) || !x64.is_fp_opcode(x64.MOVUPS)) { ret 5; }
+    if (x64.is_fp_opcode(x64.MOV) || x64.is_fp_opcode(x64.MOVABS) || x64.is_fp_opcode(x64.MOVSB)) { ret 6; }
+    # movq, movss/movsd, movaps/movups, 8 scalar alu, 2 ucomis, 6 cvt, xorps, 30 packed, pshufd, pslld
+    if (fp != 1 + 2 + 2 + 8 + 2 + 6 + 1 + 30 + 1 + 1) { ret 7; }
+    if (is_jcc(X64_OPCODE_COUNT::u16) || is_setcc(x64.ASM_BLOCK)) { ret 8; }
+    ret 0;
+}
+
+# the inline-asm grammar's implicit-memory rows are the table's stack rows
+test "mach.lang.target.isa.x64.encode.describe:grammar_implicit_mem_matches_stack_rows" {
+    var i: usize = 0;
+    for (i < X64_MNEMONIC_COUNT) {
+        val d: x64.OpDesc = x64.describe(X64_MNEMONICS[i].code::u16);
+        if (X64_MNEMONICS[i].implicit_mem && (d.mem & x64.MEM_STACK) == 0) { ret 1; }
+        i = i + 1;
+    }
+    ret 0;
+}
+
+# the codegen flags pairing is a table read: a consumer that does not read
+# the flags, or a producer that does not define them, is refused; a mov
+# between the two is refused as a flags writer would be
+# an opcode with no row, and a memory operand on a row that never reaches
+# memory through an operand, are refused with the buffer untouched
+test "mach.lang.target.isa.x64.encode.encode_inst:rowless_and_memoryless_forms_emit_nothing" {
+    var alloc: A.Allocator;
+    page.make(?alloc);
+    var buf: enc.ByteBuf = enc.buf_init(?alloc);
+    var bad: i32 = 0;
+
+    var mi: isa.Inst = isa.inst_blank();
+    mi.opcode = X64_OPCODE_COUNT::u16;
+    if (encode_inst(?mi, ?buf) != 0 || buf.len != 0) { bad = 1; }
+    mi.opcode = x64.ASM_BLOCK;
+    if (encode_inst(?mi, ?buf) != 0 || buf.len != 0) { bad = 2; }
+
+    mi = isa.inst_blank();
+    mi.opcode = x64.SETE;
+    mi.dst    = isa.make_mem(x64.RBP, -8, -1, 0, 1);
+    mi.size   = 1;
+    if (encode_inst(?mi, ?buf) != 0 || buf.len != 0) { bad = 3; }
+    mi.dst = isa.make_reg(x64.RAX, 1);
+    if (encode_inst(?mi, ?buf) <= 0 || buf.len == 0) { bad = 4; }
+
+    buf.len = 0;
+    mi = isa.inst_blank();
+    mi.opcode = x64.MOVQ;
+    mi.dst    = isa.make_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, x64.XMM0), 16);
+    mi.src1   = isa.make_mem(x64.RBP, -8, -1, 0, 8);
+    mi.size   = 8;
+    if (encode_inst(?mi, ?buf) != 0 || buf.len != 0) { bad = 5; }
+
+    enc.buf_dnit(?buf);
+    ret bad;
 }
 
 # an opcode outside the notifiable space describes as unknown, so a stream

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -1940,7 +1940,7 @@ fun needs_stack_probe(stack_probe: bool, page_size: u64, total: usize) bool {
     ret stack_probe && total > page_size::usize;
 }
 
-fun emit_stack_probe(st: *enc.EncodeState, total: usize, page_bytes: usize) {
+fun emit_stack_probe(st: *enc.EncodeState, total: usize, page_bytes: usize) err[fail.Fail] {
     var mov_cnt: isa.Inst = isa.inst_blank();
     mov_cnt.opcode = x64.MOV;
     mov_cnt.dst    = isa.make_reg(x64.SCRATCH_REG, 8);
@@ -1987,6 +1987,8 @@ fun emit_stack_probe(st: *enc.EncodeState, total: usize, page_bytes: usize) {
     ja.opcode = x64.JA;
     ja.dst    = isa.make_local_label(false);
     ja.size   = DEFAULT_OPERAND_SIZE;
+    val fp: err[fail.Fail] = flags_pair(cmp_cnt.opcode, ja.opcode);
+    if (sel fp.err) { ret fp; }
     emit_inst(st, ?ja);
     val ja_patch: usize = st.buf.len - 4;
     patch_rel32(?st.buf, ja_patch, (loop_top::i64 - st.buf.len::i64)::i32);
@@ -1998,6 +2000,7 @@ fun emit_stack_probe(st: *enc.EncodeState, total: usize, page_bytes: usize) {
     sub_rem.size   = 8;
     sub_rem.flags  = x64.FLAG_REX_W;
     emit_inst(st, ?sub_rem);
+    ret err[fail.Fail].ok{};
 }
 
 fun emit_prologue(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32) err[fail.Fail] {
@@ -2045,7 +2048,8 @@ fun emit_prologue(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32) err[f
     val total: usize = f.frame.base_dist::usize;
     if (total > 0) {
         if (needs_stack_probe(st.stack_probe, st.page_size, total)) {
-            emit_stack_probe(st, total, st.page_size::usize);
+            val pr: err[fail.Fail] = emit_stack_probe(st, total, st.page_size::usize);
+            if (sel pr.err) { ret pr; }
         } or {
             var sub_rsp: isa.Inst = isa.inst_blank();
             sub_rsp.opcode = x64.SUB;
@@ -2487,14 +2491,40 @@ fun mir_setcc_opcode(op: mir.MirOpcode) u16 {
     ret x64.SETBE;
 }
 
+# a flags consumer emitted directly after its producer: both rows are read
+# from the table, so the pairing is a stated fact and not an assumption
+# about adjacency
+fun flags_pair(producer: u16, consumer: u16) err[fail.Fail] {
+    val p: ct.AsmClass = x64.describe(producer).cls;
+    val c: ct.AsmClass = x64.describe(consumer).cls;
+    if (!p.known || !p.defines_flags) {
+        ret err[fail.Fail].err{fail.message("internal compiler error: x86-64 flags producer does not define the flags its consumer reads")};
+    }
+    if (!c.known || !(c.reads_flags || c.cond_flags)) {
+        ret err[fail.Fail].err{fail.message("internal compiler error: x86-64 flags consumer does not read the flags its producer defines")};
+    }
+    ret err[fail.Fail].ok{};
+}
+
+# an instruction emitted between a flags producer and its consumer must
+# leave the flags alone, by its row
+fun flags_kept(op: u16) err[fail.Fail] {
+    val c: ct.AsmClass = x64.describe(op).cls;
+    if (!c.known || !c.flags_stated || c.writes_flags) {
+        ret err[fail.Fail].err{fail.message("internal compiler error: x86-64 instruction between a flags producer and its consumer writes the flags")};
+    }
+    ret err[fail.Fail].ok{};
+}
+
+# emits the compare and answers the opcode that defined the flags
 fun emit_flag_cmp(f: *mir.MirFunction, lhs_op: *mir.MirOperand, rhs_op: *mir.MirOperand,
-                  width: u8, buf: *enc.ByteBuf) err[fail.Fail] {
+                  width: u8, buf: *enc.ByteBuf) res[u16, fail.Fail] {
     val cwidth: u8 = effective_width(width);
     val rl: res[isa.Operand, fail.Fail] = mir_to_operand(f, lhs_op, cwidth);
-    if (sel rl.err) { ret err[fail.Fail].err{rl.err}; }
+    if (sel rl.err) { ret res[u16, fail.Fail].err{rl.err}; }
     val lhs: isa.Operand = rl.ok;
     val rr: res[isa.Operand, fail.Fail] = mir_to_operand(f, rhs_op, cwidth);
-    if (sel rr.err) { ret err[fail.Fail].err{rr.err}; }
+    if (sel rr.err) { ret res[u16, fail.Fail].err{rr.err}; }
     val rhs: isa.Operand = rr.ok;
 
     var cmp_lhs: isa.Operand = lhs;
@@ -2516,7 +2546,7 @@ fun emit_flag_cmp(f: *mir.MirFunction, lhs_op: *mir.MirOperand, rhs_op: *mir.Mir
     cmp.size   = cwidth;
     cmp.flags  = width_flags(width);
     encode_inst(?cmp, buf);
-    ret err[fail.Fail].ok{};
+    ret res[u16, fail.Fail].ok{cmp.opcode};
 }
 
 fun encode_compare(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) err[fail.Fail] {
@@ -2528,11 +2558,13 @@ fun encode_compare(f: *mir.MirFunction, mi: *mir.MirInstr, buf: *enc.ByteBuf) er
     if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
     val dst: isa.Operand = rd.ok;
 
-    val rc: err[fail.Fail] = emit_flag_cmp(f, ?mi.operands[1], ?mi.operands[2], mi.width, buf);
-    if (sel rc.err) { ret rc; }
+    val rc: res[u16, fail.Fail] = emit_flag_cmp(f, ?mi.operands[1], ?mi.operands[2], mi.width, buf);
+    if (sel rc.err) { ret err[fail.Fail].err{rc.err}; }
 
     var setcc: isa.Inst = isa.inst_blank();
     setcc.opcode  = mir_setcc_opcode(mi.opcode);
+    val fp: err[fail.Fail] = flags_pair(rc.ok, setcc.opcode);
+    if (sel fp.err) { ret fp; }
     setcc.dst     = dst;
     setcc.dst.size = 1;
     setcc.size    = 1;
@@ -2980,6 +3012,8 @@ fun emit_u64_to_fp(dst: isa.Operand, work: i32, dst_w: u8, cvt_op: u16, buf: *en
     jl.opcode = x64.JL;
     jl.dst    = isa.make_local_label(true);
     jl.size   = DEFAULT_OPERAND_SIZE;
+    val fp: err[fail.Fail] = flags_pair(test_inst.opcode, jl.opcode);
+    if (sel fp.err) { ret fp; }
     encode_inst(?jl, buf);
     val jl_patch: usize = buf.len - 4;
     val after_jl: usize = buf.len;
@@ -3030,6 +3064,8 @@ fun emit_fp_to_u64(st: *enc.EncodeState, src_reg: i32, src_w: u8, cvt_op: u16) e
     jb.opcode = x64.JB;
     jb.dst    = isa.make_local_label(true);
     jb.size   = DEFAULT_OPERAND_SIZE;
+    val fp: err[fail.Fail] = flags_pair(ucom.opcode, jb.opcode);
+    if (sel fp.err) { ret fp; }
     encode_inst(?jb, buf);
     val jb_patch: usize = buf.len - 4;
     val after_jb: usize = buf.len;
@@ -3227,6 +3263,8 @@ fun encode_float_cmp(st: *enc.EncodeState, f: *mir.MirFunction, mi: *mir.MirInst
     setcc.dst      = dst;
     setcc.dst.size = 1;
     setcc.size     = 1;
+    val fp: err[fail.Fail] = flags_pair(ucom.opcode, setcc.opcode);
+    if (sel fp.err) { ret fp; }
     encode_inst(?setcc, buf);
 
     if (cc == mir.FCC_EQ || cc == mir.FCC_NE) {
@@ -3236,6 +3274,11 @@ fun encode_float_cmp(st: *enc.EncodeState, f: *mir.MirFunction, mi: *mir.MirInst
         par.dst      = isa.make_reg(x64.R11, 1);
         par.dst.size = 1;
         par.size     = 1;
+        # the parity read follows the first setcc, which keeps the flags
+        val fk: err[fail.Fail] = flags_kept(setcc.opcode);
+        if (sel fk.err) { ret fk; }
+        val fp2: err[fail.Fail] = flags_pair(ucom.opcode, par.opcode);
+        if (sel fp2.err) { ret fp2; }
         encode_inst(?par, buf);
 
         var comb: isa.Inst = isa.inst_blank();
@@ -3937,6 +3980,8 @@ fun encode_cbr(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi: *mir
     val jne_start: usize = st.buf.len;
     var jne: isa.Inst = isa.inst_blank();
     jne.opcode = x64.JNE;
+    val fp: err[fail.Fail] = flags_pair(test_inst.opcode, jne.opcode);
+    if (sel fp.err) { ret fp; }
     jne.dst    = isa.make_block_label(then_block);
     jne.size   = DEFAULT_OPERAND_SIZE;
     val jne_size: i32 = encode_inst(?jne, ?st.buf);
@@ -3981,12 +4026,14 @@ fun encode_fused_cbr(st: *enc.EncodeState, f: *mir.MirFunction, fn_base: u32, mi
     val else_block: u32 = mi.operands[3].imm::u32;
     val instr_start: u32 = st.buf.len::u32;
 
-    val rc: err[fail.Fail] = emit_flag_cmp(f, ?mi.operands[0], ?mi.operands[1], mi.width, ?st.buf);
-    if (sel rc.err) { ret rc; }
+    val rc: res[u16, fail.Fail] = emit_flag_cmp(f, ?mi.operands[0], ?mi.operands[1], mi.width, ?st.buf);
+    if (sel rc.err) { ret err[fail.Fail].err{rc.err}; }
 
     val jcc_start: usize = st.buf.len;
     var jcc: isa.Inst = isa.inst_blank();
     jcc.opcode = fused_jcc_opcode(mi.opcode);
+    val fp: err[fail.Fail] = flags_pair(rc.ok, jcc.opcode);
+    if (sel fp.err) { ret fp; }
     jcc.dst    = isa.make_block_label(then_block);
     jcc.size   = DEFAULT_OPERAND_SIZE;
     val jcc_size: i32 = encode_inst(?jcc, ?st.buf);
@@ -6046,7 +6093,8 @@ test "mach.lang.target.isa.x64.encode.emit_stack_probe:chkstk_body" {
     var st: enc.EncodeState;
     st.buf = enc.buf_init(?alloc);
 
-    emit_stack_probe(?st, 12288, 4096);
+    val pr: err[fail.Fail] = emit_stack_probe(?st, 12288, 4096);
+    if (sel pr.err) { ret 9; }
 
     var want: [41]u8;
     want[0]  = 0x49; want[1]  = 0xc7; want[2]  = 0xc3; want[3]  = 0x00; want[4]  = 0x30; want[5]  = 0x00; want[6]  = 0x00;
@@ -8008,6 +8056,31 @@ test "mach.lang.target.isa.x64.encode.describe:grammar_implicit_mem_matches_stac
 # the codegen flags pairing is a table read: a consumer that does not read
 # the flags, or a producer that does not define them, is refused; a mov
 # between the two is refused as a flags writer would be
+fun ut_pair_ok(producer: u16, consumer: u16) bool {
+    val r: err[fail.Fail] = flags_pair(producer, consumer);
+    ret !sel r.err;
+}
+
+fun ut_kept_ok(op: u16) bool {
+    val r: err[fail.Fail] = flags_kept(op);
+    ret !sel r.err;
+}
+
+test "mach.lang.target.isa.x64.encode.flags_pair:reads_the_table" {
+    if (!ut_pair_ok(x64.CMP, x64.SETE))      { ret 1; }
+    if (!ut_pair_ok(x64.TEST, x64.JNE))      { ret 2; }
+    if (!ut_pair_ok(x64.UCOMISD, x64.JB))    { ret 3; }
+    if (!ut_pair_ok(x64.UCOMISS, x64.SETNP)) { ret 4; }
+    if (ut_pair_ok(x64.MOV, x64.SETE))       { ret 5; }
+    if (ut_pair_ok(x64.CMP, x64.JMP))        { ret 6; }
+    if (ut_pair_ok(x64.INC, x64.JE))         { ret 7; }
+    if (ut_pair_ok(x64.CMP, x64.MOVZX))      { ret 8; }
+    if (ut_pair_ok(x64.ASM_BLOCK, x64.JE))   { ret 9; }
+    if (!ut_kept_ok(x64.SETE) || !ut_kept_ok(x64.MOV))  { ret 10; }
+    if (ut_kept_ok(x64.ADD) || ut_kept_ok(x64.SYSCALL)) { ret 11; }
+    ret 0;
+}
+
 # an opcode with no row, and a memory operand on a row that never reaches
 # memory through an operand, are refused with the buffer untouched
 test "mach.lang.target.isa.x64.encode.encode_inst:rowless_and_memoryless_forms_emit_nothing" {


### PR DESCRIPTION
Roadmap N1 remainder, `doc/design/backend-census-2212.md` section 10 item 2 for x86_64 (#2212). Closes the three ADM rows of section 2: instruction form and operand shape, the flags effect on the codegen path, and the memory effect.

## The table

`x64.describe(op)` (`src/lang/target/isa/x64.mach`) answers one `OpDesc` row per opcode:

- `form`: the encoder family with its operand shape stated on the constant (`FORM_ALU` is "dst r/m, src r/m or imm"; 38 forms over 134 opcodes; `FORM_NONE` for `ASM_BLOCK` and anything outside the catalog)
- `shape`: the role pattern (`DEF`, `RW`, `USE`, `SWAP`, `XFER`, `NONE`) and `arity`: the positions the form takes
- `mem`: `MEM_OPERAND`, `MEM_ADDR`, `MEM_STACK`, `MEM_STRING` as bits; the direction of an operand access is that position's role
- `cls`: the `ct.AsmClass` flags and latency column, exactly the rows `asm_ct_class` carried

This extends N5's row rather than adding a second table: `asm_ct_class(code, flags)` returns the `cls` column, and `inst_effects` projects the row onto the operands present. The opcode sets `inst_effects` used to restate (`x64_pure_def`, `x64_two_address`, `x64_compare`, `x64_is_setcc`, `x64_is_jcc`) are gone. `ct.InstEffects` is unchanged: form, shape and memory class are ISA vocabulary and stay on the ISA's row. Section 11 records the amendment.

## Readers

- The family predicates `is_jcc`, `is_setcc`, `is_alu`, `is_sse_mov`, `is_sse_alu`, the `cvt` range in `encode_inst_one` and `x64.is_fp_opcode` read `describe(op).form`. `SETP`/`SETNP` and the packed rows no longer depend on where their numbers landed (`is_fp_opcode` had no callers and excluded `movaps`/`movups`/every packed op; it now answers from the row).
- `encode_inst_one` refuses an opcode without a row and a memory operand on a row that never reaches memory through an operand, before any byte. The mem-mem staging in `encode_inst` reads `MEM_OPERAND`/`FORM_SHIFT`/`SHAPE_SWAP` instead of a thirteen-opcode exclusion list.
- The codegen flags pairing is a table read at every site: `emit_flag_cmp` answers the opcode that defined the flags, and `flags_pair(producer, consumer)` / `flags_kept(between)` refuse before the consumer is emitted in `encode_compare`, `encode_fused_cbr`, `encode_cbr`, and the three sites outside the brief that had the same adjacency assumption (`emit_stack_probe` cmp/ja, the u64-to-float test/jl, the float-to-u64 ucomis/jb, and `encode_float_cmp`'s ucomis/setcc with its parity setcc). `emit_stack_probe` gains the error channel.
- The census test `asm_ct_class:every_notifiable_opcode_has_a_row` now requires a complete, self-consistent row (form, shape, arity, memory bits, stated class, mnemonic; a transfer form has a transfer shape and nothing else does; a flags branch is a jcc; the stack forms reach the stack; only lea takes an address) for every notifiable opcode, so an opcode added without a row is a build failure. Mutation control: removing the `pslld` row fails the census and the predicate count test.

## Verification

Built through the v5 stage compiler (A), then B by A from this tree, C by B:

- full suite through B: 3045 passed, 0 failed (3041 baseline at 61484755b, +4 by name: `describe:family_predicates_read_the_table`, `describe:grammar_implicit_mem_matches_stack_rows`, `flags_pair:reads_the_table`, `encode_inst:rowless_and_memoryless_forms_emit_nothing`)
- `sh test/census.sh`: all ok
- corpus layer B, x86_64-linux, compiler B: 102 cells pass, 0 fail, goldens byte-identical (no bytes change; the llvm-mc conformance the encoder unit tests pin is unchanged with them)
- link leg: x86_64-linux 142 pass / 0 fail (the 14 riscv64-linux failures are the missing riscv64 cross libc headers on this host, same before the change)
- fixpoint: B == C byte-identical
- shadow equivalence: a temporary harness ran the old `inst_effects` beside the new over every opcode x sixteen operand configurations; the rows are identical on every reachable configuration. The only divergences are on impossible instances (a second operand on a one-operand form such as `push`, `pop`, `setcc`, `lidt`, `div`; operands on the operand-less `wrmsr`), where the old code assigned roles to positions the form does not have and the new row does not.
