### PR TITLE
isa(riscv): one instruction table read by fields, classification, shape and printing (#2212)

### DIFF
--- a/src/lang/target/isa/riscv/encode.mach
+++ b/src/lang/target/isa/riscv/encode.mach
@@ -36,102 +36,91 @@ use mach.lang.target.isa.riscv.printer;
 use mach.lang.target.isa.riscv.inst;
 use mach.lang.target.of;
 
-val OPC_OP:        u32 = 0x33;
-val OPC_OP_IMM:    u32 = 0x13;
-val OPC_OP_32:     u32 = 0x3B;
-val OPC_OP_IMM_32: u32 = 0x1B;
-val OPC_LOAD:      u32 = 0x03;
-val OPC_STORE:     u32 = 0x23;
-val OPC_BRANCH:    u32 = 0x63;
-val OPC_JAL:       u32 = 0x6F;
-val OPC_JALR:      u32 = 0x67;
-val OPC_LUI:       u32 = 0x37;
-val OPC_AUIPC:     u32 = 0x17;
-val OPC_SYSTEM:    u32 = 0x73;
-val OPC_MISC_MEM:  u32 = 0x0F;
-val OPC_AMO:       u32 = 0x2F;
+# the encoding vocabulary is the table's (inst.mach); these are the local
+# spellings the field-passing emit sites use until they emit by opcode
+val OPC_OP:        u32 = inst.OPC_OP;
+val OPC_OP_IMM:    u32 = inst.OPC_OP_IMM;
+val OPC_OP_32:     u32 = inst.OPC_OP_32;
+val OPC_OP_IMM_32: u32 = inst.OPC_OP_IMM_32;
+val OPC_LOAD:      u32 = inst.OPC_LOAD;
+val OPC_STORE:     u32 = inst.OPC_STORE;
+val OPC_BRANCH:    u32 = inst.OPC_BRANCH;
+val OPC_JAL:       u32 = inst.OPC_JAL;
+val OPC_JALR:      u32 = inst.OPC_JALR;
+val OPC_LUI:       u32 = inst.OPC_LUI;
+val OPC_AUIPC:     u32 = inst.OPC_AUIPC;
+val OPC_SYSTEM:    u32 = inst.OPC_SYSTEM;
+val OPC_MISC_MEM:  u32 = inst.OPC_MISC_MEM;
+val OPC_AMO:       u32 = inst.OPC_AMO;
+val OPC_OP_FP:     u32 = inst.OPC_OP_FP;
+val OPC_LOAD_FP:   u32 = inst.OPC_LOAD_FP;
+val OPC_STORE_FP:  u32 = inst.OPC_STORE_FP;
 
-val F3_ADD:  u32 = 0x0;
-val F3_SLL:  u32 = 0x1;
-val F3_SLT:  u32 = 0x2;
-val F3_SLTU: u32 = 0x3;
-val F3_XOR:  u32 = 0x4;
-val F3_SRL:  u32 = 0x5;
-val F3_OR:   u32 = 0x6;
-val F3_AND:  u32 = 0x7;
+val F3_ADD:  u32 = inst.F3_ADD;
+val F3_SLL:  u32 = inst.F3_SLL;
+val F3_SLT:  u32 = inst.F3_SLT;
+val F3_SLTU: u32 = inst.F3_SLTU;
+val F3_XOR:  u32 = inst.F3_XOR;
+val F3_SRL:  u32 = inst.F3_SRL;
+val F3_OR:   u32 = inst.F3_OR;
+val F3_AND:  u32 = inst.F3_AND;
 
-val F3_CSRRW:  u32 = 0x1;
-val F3_CSRRS:  u32 = 0x2;
-val F3_CSRRC:  u32 = 0x3;
-val F3_CSRRWI: u32 = 0x5;
-val F3_CSRRSI: u32 = 0x6;
-val F3_CSRRCI: u32 = 0x7;
+val F3_CSRRW:  u32 = inst.F3_CSRRW;
+val F3_CSRRS:  u32 = inst.F3_CSRRS;
+val F3_CSRRC:  u32 = inst.F3_CSRRC;
+val F3_CSRRWI: u32 = inst.F3_CSRRWI;
+val F3_CSRRSI: u32 = inst.F3_CSRRSI;
+val F3_CSRRCI: u32 = inst.F3_CSRRCI;
 
-val F7_ZERO:   u32 = 0x00;
-val F7_SUB:    u32 = 0x20;
-val F7_MULDIV: u32 = 0x01;
+val F7_ZERO:   u32 = inst.F7_ZERO;
+val F7_SUB:    u32 = inst.F7_SUB;
+val F7_MULDIV: u32 = inst.F7_MULDIV;
 
-val F3_BEQ:  u32 = 0x0;
-val F3_BNE:  u32 = 0x1;
-val F3_BLT:  u32 = 0x4;
-val F3_BGE:  u32 = 0x5;
-val F3_BLTU: u32 = 0x6;
-val F3_BGEU: u32 = 0x7;
+val F3_BEQ:  u32 = inst.F3_BEQ;
+val F3_BNE:  u32 = inst.F3_BNE;
+val F3_BLT:  u32 = inst.F3_BLT;
+val F3_BGE:  u32 = inst.F3_BGE;
+val F3_BLTU: u32 = inst.F3_BLTU;
+val F3_BGEU: u32 = inst.F3_BGEU;
 
-val F3_DIV:  u32 = 0x4;
-val F3_DIVU: u32 = 0x5;
-val F3_REM:  u32 = 0x6;
-val F3_REMU: u32 = 0x7;
+val F3_DIV:  u32 = inst.F3_DIV;
+val F3_DIVU: u32 = inst.F3_DIVU;
+val F3_REM:  u32 = inst.F3_REM;
+val F3_REMU: u32 = inst.F3_REMU;
 
-val OPC_OP_FP:    u32 = 0x53;
-val OPC_LOAD_FP:  u32 = 0x07;
-val OPC_STORE_FP: u32 = 0x27;
+val F7_FADD:     u32 = inst.F7_FADD;
+val F7_FSUB:     u32 = inst.F7_FSUB;
+val F7_FMUL:     u32 = inst.F7_FMUL;
+val F7_FDIV:     u32 = inst.F7_FDIV;
+val F7_FSGNJ:    u32 = inst.F7_FSGNJ;
+val F7_FCMP:     u32 = inst.F7_FCMP;
+val F7_FCVT_F2F: u32 = inst.F7_FCVT_F2F;
+val F7_FCVT_F2I: u32 = inst.F7_FCVT_F2I;
+val F7_FCVT_I2F: u32 = inst.F7_FCVT_I2F;
+val F7_FMV_F2I:  u32 = inst.F7_FMV_F2I;
+val F7_FMV_I2F:  u32 = inst.F7_FMV_I2F;
 
-val F7_FADD:    u32 = 0x00;
-val F7_FSUB:    u32 = 0x04;
-val F7_FMUL:    u32 = 0x08;
-val F7_FDIV:    u32 = 0x0C;
-val F7_FSGNJ:   u32 = 0x10;
-val F7_FCMP:    u32 = 0x50;
-val F7_FCVT_F2F: u32 = 0x20;
-val F7_FCVT_F2I: u32 = 0x60;
-val F7_FCVT_I2F: u32 = 0x68;
-val F7_FMV_F2I:  u32 = 0x70;
-val F7_FMV_I2F:  u32 = 0x78;
+val F3_FLE: u32 = inst.F3_FLE;
+val F3_FLT: u32 = inst.F3_FLT;
+val F3_FEQ: u32 = inst.F3_FEQ;
 
-val F3_FLE: u32 = 0x0;
-val F3_FLT: u32 = 0x1;
-val F3_FEQ: u32 = 0x2;
+val RM_RNE: u32 = inst.RM_RNE;
+val RM_RTZ: u32 = inst.RM_RTZ;
+val RM_DYN: u32 = inst.RM_DYN;
 
-val RM_RNE: u32 = 0x0;
-val RM_RTZ: u32 = 0x1;
-val RM_DYN: u32 = 0x7;
+val FCVT_W:  u32 = inst.FCVT_W;
+val FCVT_WU: u32 = inst.FCVT_WU;
+val FCVT_L:  u32 = inst.FCVT_L;
+val FCVT_LU: u32 = inst.FCVT_LU;
 
-val FCVT_W:  u32 = 0x0;
-val FCVT_WU: u32 = 0x1;
-val FCVT_L:  u32 = 0x2;
-val FCVT_LU: u32 = 0x3;
-
-val FMT_S: u32 = 0x0;
-val FMT_D: u32 = 0x1;
+val FMT_S: u32 = inst.FMT_S_BIT;
+val FMT_D: u32 = inst.FMT_D_BIT;
 
 val FP_SCRATCH:  u32 = riscv.F31::u32;
 val FP_SCRATCH2: u32 = riscv.F30::u32;
 
-val F3_AMO_W: u32 = 0x2;
-val F3_AMO_D: u32 = 0x3;
-
-val A5_LR:      u32 = 0x02;
-val A5_SC:      u32 = 0x03;
-val A5_AMOSWAP: u32 = 0x01;
-val A5_AMOADD:  u32 = 0x00;
-val A5_AMOXOR:  u32 = 0x04;
-val A5_AMOAND:  u32 = 0x0C;
-val A5_AMOOR:   u32 = 0x08;
-val A5_AMOMIN:  u32 = 0x10;
-val A5_AMOMAX:  u32 = 0x14;
-val A5_AMOMINU: u32 = 0x18;
-val A5_AMOMAXU: u32 = 0x1C;
+val F3_AMO_W: u32 = inst.F3_AMO_W;
+val F3_AMO_D: u32 = inst.F3_AMO_D;
 
 val RZERO:    u32 = riscv.ZERO::u32;
 val RRA:      u32 = riscv.RA::u32;
@@ -189,26 +178,6 @@ fun emit_word(st: *encode.EncodeState, word: u32) {
 
 val WORD_SIZE: u32 = 4;
 
-val SH_NONE:    u8 = 0;
-val SH_RRR:     u8 = 1;
-val SH_RRI:     u8 = 2;
-val SH_RU:      u8 = 3;
-val SH_LOAD:    u8 = 4;
-val SH_FLOAD:   u8 = 5;
-val SH_STORE:   u8 = 6;
-val SH_FSTORE:  u8 = 7;
-val SH_BRANCH:  u8 = 8;
-val SH_JUMP:    u8 = 9;
-val SH_FFF:     u8 = 10;
-val SH_FF:      u8 = 11;
-val SH_GFF:     u8 = 12;
-val SH_GF:      u8 = 13;
-val SH_FG:      u8 = 14;
-val SH_AMO:     u8 = 15;
-val SH_AMO_LR:  u8 = 16;
-val SH_CSR:     u8 = 17;
-val SH_CSR_I:   u8 = 18;
-
 fun gpr(idx: u32) isa.Operand {
     ret isa.make_reg(idx::i32, 8);
 }
@@ -222,104 +191,84 @@ fun build_inst(op: inst.MachOp, rd: u32, rs1: u32, rs2: u32, imm: i64) isa.Inst 
     mi.opcode = op::u16;
     mi.size   = WORD_SIZE::u8;
 
-    val shape: u8 = shape_of(op);
-    if (shape == SH_RRR) { mi.dst = gpr(rd); mi.src1 = gpr(rs1); mi.src2 = gpr(rs2); ret mi; }
-    if (shape == SH_RRI) { mi.dst = gpr(rd); mi.src1 = gpr(rs1); mi.src2 = isa.make_imm(imm, 8); ret mi; }
-    if (shape == SH_RU)  { mi.dst = gpr(rd); mi.src1 = isa.make_imm(imm, 8); ret mi; }
-    if (shape == SH_LOAD)   { mi.dst = gpr(rd); mi.src1 = isa.make_mem(rs1::i32, imm::i32, -1, 0, 8); ret mi; }
-    if (shape == SH_FLOAD)  { mi.dst = fpr(rd); mi.src1 = isa.make_mem(rs1::i32, imm::i32, -1, 0, 8); ret mi; }
-    if (shape == SH_STORE)  { mi.dst = isa.make_mem(rs1::i32, imm::i32, -1, 0, 8); mi.src1 = gpr(rs2); ret mi; }
-    if (shape == SH_FSTORE) { mi.dst = isa.make_mem(rs1::i32, imm::i32, -1, 0, 8); mi.src1 = fpr(rs2); ret mi; }
-    if (shape == SH_BRANCH) { mi.dst = gpr(rs1); mi.src1 = gpr(rs2); mi.src2 = isa.make_block_label(0); ret mi; }
-    if (shape == SH_JUMP)   { mi.dst = gpr(rd); mi.src1 = isa.make_block_label(0); ret mi; }
-    if (shape == SH_FFF) { mi.dst = fpr(rd); mi.src1 = fpr(rs1); mi.src2 = fpr(rs2); ret mi; }
-    if (shape == SH_FF)  { mi.dst = fpr(rd); mi.src1 = fpr(rs1); ret mi; }
-    if (shape == SH_GFF) { mi.dst = gpr(rd); mi.src1 = fpr(rs1); mi.src2 = fpr(rs2); ret mi; }
-    if (shape == SH_GF)  { mi.dst = gpr(rd); mi.src1 = fpr(rs1); ret mi; }
-    if (shape == SH_FG)  { mi.dst = fpr(rd); mi.src1 = gpr(rs1); ret mi; }
-    if (shape == SH_AMO) {
+    val shape: u8 = inst.shape_of(op);
+    if (shape == inst.SH_RRR) { mi.dst = gpr(rd); mi.src1 = gpr(rs1); mi.src2 = gpr(rs2); ret mi; }
+    if (shape == inst.SH_RRI) { mi.dst = gpr(rd); mi.src1 = gpr(rs1); mi.src2 = isa.make_imm(imm, 8); ret mi; }
+    if (shape == inst.SH_RU)  { mi.dst = gpr(rd); mi.src1 = isa.make_imm(imm, 8); ret mi; }
+    if (shape == inst.SH_LOAD)   { mi.dst = gpr(rd); mi.src1 = isa.make_mem(rs1::i32, imm::i32, -1, 0, 8); ret mi; }
+    if (shape == inst.SH_FLOAD)  { mi.dst = fpr(rd); mi.src1 = isa.make_mem(rs1::i32, imm::i32, -1, 0, 8); ret mi; }
+    if (shape == inst.SH_STORE)  { mi.dst = isa.make_mem(rs1::i32, imm::i32, -1, 0, 8); mi.src1 = gpr(rs2); ret mi; }
+    if (shape == inst.SH_FSTORE) { mi.dst = isa.make_mem(rs1::i32, imm::i32, -1, 0, 8); mi.src1 = fpr(rs2); ret mi; }
+    if (shape == inst.SH_BRANCH) { mi.dst = gpr(rs1); mi.src1 = gpr(rs2); mi.src2 = isa.make_block_label(0); ret mi; }
+    if (shape == inst.SH_JUMP)   { mi.dst = gpr(rd); mi.src1 = isa.make_block_label(0); ret mi; }
+    if (shape == inst.SH_FFF) { mi.dst = fpr(rd); mi.src1 = fpr(rs1); mi.src2 = fpr(rs2); ret mi; }
+    if (shape == inst.SH_FF)  { mi.dst = fpr(rd); mi.src1 = fpr(rs1); ret mi; }
+    if (shape == inst.SH_GFF) { mi.dst = gpr(rd); mi.src1 = fpr(rs1); mi.src2 = fpr(rs2); ret mi; }
+    if (shape == inst.SH_GF)  { mi.dst = gpr(rd); mi.src1 = fpr(rs1); ret mi; }
+    if (shape == inst.SH_FG)  { mi.dst = fpr(rd); mi.src1 = gpr(rs1); ret mi; }
+    if (shape == inst.SH_AMO) {
         mi.dst  = gpr(rd);
         mi.src1 = gpr(rs2);
         mi.src2 = isa.make_mem(rs1::i32, 0, -1, 0, 8);
         ret mi;
     }
-    if (shape == SH_AMO_LR) { mi.dst = gpr(rd); mi.src1 = isa.make_mem(rs1::i32, 0, -1, 0, 8); ret mi; }
-    if (shape == SH_CSR)   { mi.dst = gpr(rd); mi.src1 = isa.make_imm(imm, 8); mi.src2 = gpr(rs1); ret mi; }
-    if (shape == SH_CSR_I) { mi.dst = gpr(rd); mi.src1 = isa.make_imm(imm, 8); mi.src2 = isa.make_imm(rs1::i64, 8); ret mi; }
+    if (shape == inst.SH_AMO_LR) { mi.dst = gpr(rd); mi.src1 = isa.make_mem(rs1::i32, 0, -1, 0, 8); ret mi; }
+    if (shape == inst.SH_CSR)   { mi.dst = gpr(rd); mi.src1 = isa.make_imm(imm, 8); mi.src2 = gpr(rs1); ret mi; }
+    if (shape == inst.SH_CSR_I) { mi.dst = gpr(rd); mi.src1 = isa.make_imm(imm, 8); mi.src2 = isa.make_imm(rs1::i64, 8); ret mi; }
     ret mi;
 }
 
-fun shape_of(op: inst.MachOp) u8 {
-    if (op >= inst.ADD && op <= inst.REMUW) { ret SH_RRR; }
-    if (op >= inst.ADDI && op <= inst.SRAIW) { ret SH_RRI; }
-    if (op >= inst.LB && op <= inst.LWU) { ret SH_LOAD; }
-    if (op >= inst.SB && op <= inst.SD) { ret SH_STORE; }
-    if (op >= inst.BEQ && op <= inst.BGEU) { ret SH_BRANCH; }
-    if (op == inst.JAL)  { ret SH_JUMP; }
-    if (op == inst.JALR) { ret SH_LOAD; }
-    if (op == inst.LUI || op == inst.AUIPC) { ret SH_RU; }
-    if (op >= inst.ECALL && op <= inst.PAUSE) { ret SH_NONE; }
-    if (op == inst.FLW || op == inst.FLD) { ret SH_FLOAD; }
-    if (op == inst.FSW || op == inst.FSD) { ret SH_FSTORE; }
-    if (op >= inst.FADD_S && op <= inst.FSGNJX_D) { ret SH_FFF; }
-    if (op >= inst.FEQ_S && op <= inst.FLE_D) { ret SH_GFF; }
-    if (op == inst.FCVT_S_D || op == inst.FCVT_D_S) { ret SH_FF; }
-    if (op >= inst.FCVT_W_S && op <= inst.FCVT_LU_D) { ret SH_GF; }
-    if (op >= inst.FCVT_S_W && op <= inst.FCVT_D_LU) { ret SH_FG; }
-    if (op == inst.FMV_X_W || op == inst.FMV_X_D) { ret SH_GF; }
-    if (op == inst.FMV_W_X || op == inst.FMV_D_X) { ret SH_FG; }
-    if (op == inst.LR_W || op == inst.LR_D) { ret SH_AMO_LR; }
-    if (op >= inst.SC_W && op <= inst.AMOMAXU_D) { ret SH_AMO; }
-    if (op >= inst.CSRRW && op <= inst.CSRRC)   { ret SH_CSR; }
-    if (op >= inst.CSRRWI && op <= inst.CSRRCI) { ret SH_CSR_I; }
-    ret SH_NONE;
-}
-
 fun emit_r(st: *encode.EncodeState, opcode: u32, funct3: u32, funct7: u32, rd: u32, rs1: u32, rs2: u32) {
-    emit_word(st, pack_r(opcode, funct3, funct7, rd, rs1, rs2));
+    val word: u32 = pack_r(opcode, funct3, funct7, rd, rs1, rs2);
+    emit_word(st, word);
     if (!encode.sink_active(?st.buf)) { ret; }
-    val op: inst.MachOp = classify_r(opcode, funct3, funct7, rs2);
+    val op: inst.MachOp = inst.classify(word);
     var mi: isa.Inst = build_inst(op, rd, rs1, rs2, 0);
     if (opcode == OPC_AMO) { mi.flags = amo_ordering_flags(funct7); }
     note(st, op, ?mi, "R", opcode);
 }
 
 fun emit_i(st: *encode.EncodeState, opcode: u32, funct3: u32, rd: u32, rs1: u32, imm12: u32) {
-    emit_word(st, pack_i(opcode, funct3, rd, rs1, imm12));
+    val word: u32 = pack_i(opcode, funct3, rd, rs1, imm12);
+    emit_word(st, word);
     if (!encode.sink_active(?st.buf)) { ret; }
-    val op: inst.MachOp = classify_i(opcode, funct3, imm12);
+    val op: inst.MachOp = inst.classify(word);
     var mi: isa.Inst = build_inst(op, rd, rs1, 0, imm_of_i(op, imm12));
     note(st, op, ?mi, "I", opcode);
 }
 
 fun emit_s(st: *encode.EncodeState, opcode: u32, funct3: u32, rs1: u32, rs2: u32, imm12: u32) {
-    emit_word(st, pack_s(opcode, funct3, rs1, rs2, imm12));
+    val word: u32 = pack_s(opcode, funct3, rs1, rs2, imm12);
+    emit_word(st, word);
     if (!encode.sink_active(?st.buf)) { ret; }
-    val op: inst.MachOp = classify_s(opcode, funct3);
+    val op: inst.MachOp = inst.classify(word);
     var mi: isa.Inst = build_inst(op, 0, rs1, rs2, sext12(imm12::i64));
     note(st, op, ?mi, "S", opcode);
 }
 
 fun emit_b(st: *encode.EncodeState, opcode: u32, funct3: u32, rs1: u32, rs2: u32, imm: u32) {
-    emit_word(st, pack_b(opcode, funct3, rs1, rs2, imm));
+    val word: u32 = pack_b(opcode, funct3, rs1, rs2, imm);
+    emit_word(st, word);
     if (!encode.sink_active(?st.buf)) { ret; }
-    val op: inst.MachOp = classify_b(opcode, funct3);
+    val op: inst.MachOp = inst.classify(word);
     var mi: isa.Inst = build_inst(op, 0, rs1, rs2, 0);
     note(st, op, ?mi, "B", opcode);
 }
 
 fun emit_u(st: *encode.EncodeState, opcode: u32, rd: u32, imm20: u32) {
-    emit_word(st, pack_u(opcode, rd, imm20));
+    val word: u32 = pack_u(opcode, rd, imm20);
+    emit_word(st, word);
     if (!encode.sink_active(?st.buf)) { ret; }
-    val op: inst.MachOp = classify_u(opcode);
+    val op: inst.MachOp = inst.classify(word);
     var mi: isa.Inst = build_inst(op, rd, 0, 0, (imm20 & 0xFFFFF)::i64);
     note(st, op, ?mi, "U", opcode);
 }
 
 fun emit_j(st: *encode.EncodeState, opcode: u32, rd: u32, imm: u32) {
-    emit_word(st, pack_j(opcode, rd, imm));
+    val word: u32 = pack_j(opcode, rd, imm);
+    emit_word(st, word);
     if (!encode.sink_active(?st.buf)) { ret; }
-    val op: inst.MachOp = classify_j(opcode);
+    val op: inst.MachOp = inst.classify(word);
     var mi: isa.Inst = build_inst(op, rd, 0, 0, 0);
     note(st, op, ?mi, "J", opcode);
 }
@@ -385,190 +334,6 @@ fun imm_of_i(op: inst.MachOp, imm12: u32) i64 {
     ret sext12(imm12::i64);
 }
 
-fun classify_r(opcode: u32, funct3: u32, funct7: u32, rs2: u32) inst.MachOp {
-    if (opcode == OPC_OP_FP) { ret classify_fp(funct3, funct7, rs2); }
-    if (opcode == OPC_AMO)   { ret classify_amo(funct3, funct7); }
-    if (opcode != OPC_OP && opcode != OPC_OP_32) { ret inst.MOP_NONE; }
-    val word: bool = opcode == OPC_OP_32;
-
-    if (funct7 == F7_MULDIV) {
-        if (funct3 == F3_ADD)  { if (word) { ret inst.MULW; }  ret inst.MUL; }
-        if (funct3 == F3_DIV)  { if (word) { ret inst.DIVW; }  ret inst.DIV; }
-        if (funct3 == F3_DIVU) { if (word) { ret inst.DIVUW; } ret inst.DIVU; }
-        if (funct3 == F3_REM)  { if (word) { ret inst.REMW; }  ret inst.REM; }
-        if (funct3 == F3_REMU) { if (word) { ret inst.REMUW; } ret inst.REMU; }
-        if (word) { ret inst.MOP_NONE; }
-        if (funct3 == F3_SLL)  { ret inst.MULH; }
-        if (funct3 == F3_SLT)  { ret inst.MULHSU; }
-        if (funct3 == F3_SLTU) { ret inst.MULHU; }
-        ret inst.MOP_NONE;
-    }
-    if (funct7 == F7_SUB) {
-        if (funct3 == F3_ADD) { if (word) { ret inst.SUBW; } ret inst.SUB; }
-        if (funct3 == F3_SRL) { if (word) { ret inst.SRAW; } ret inst.SRA; }
-        ret inst.MOP_NONE;
-    }
-    if (funct7 != F7_ZERO) { ret inst.MOP_NONE; }
-    if (funct3 == F3_ADD) { if (word) { ret inst.ADDW; } ret inst.ADD; }
-    if (funct3 == F3_SLL) { if (word) { ret inst.SLLW; } ret inst.SLL; }
-    if (funct3 == F3_SRL) { if (word) { ret inst.SRLW; } ret inst.SRL; }
-    if (word) { ret inst.MOP_NONE; }
-    if (funct3 == F3_SLT)  { ret inst.SLT; }
-    if (funct3 == F3_SLTU) { ret inst.SLTU; }
-    if (funct3 == F3_XOR)  { ret inst.XOR; }
-    if (funct3 == F3_OR)   { ret inst.OR; }
-    if (funct3 == F3_AND)  { ret inst.AND; }
-    ret inst.MOP_NONE;
-}
-
-fun classify_fp(funct3: u32, funct7: u32, rs2: u32) inst.MachOp {
-    val dbl: bool = (funct7 & 1) != 0;
-    val base: u32 = funct7 & 0xFE;
-
-    if (base == F7_FADD) { if (dbl) { ret inst.FADD_D; } ret inst.FADD_S; }
-    if (base == F7_FSUB) { if (dbl) { ret inst.FSUB_D; } ret inst.FSUB_S; }
-    if (base == F7_FMUL) { if (dbl) { ret inst.FMUL_D; } ret inst.FMUL_S; }
-    if (base == F7_FDIV) { if (dbl) { ret inst.FDIV_D; } ret inst.FDIV_S; }
-    if (base == F7_FSGNJ) {
-        if (funct3 == 0) { if (dbl) { ret inst.FSGNJ_D; }  ret inst.FSGNJ_S; }
-        if (funct3 == 1) { if (dbl) { ret inst.FSGNJN_D; } ret inst.FSGNJN_S; }
-        if (funct3 == 2) { if (dbl) { ret inst.FSGNJX_D; } ret inst.FSGNJX_S; }
-        ret inst.MOP_NONE;
-    }
-    if (base == F7_FCMP) {
-        if (funct3 == F3_FLE) { if (dbl) { ret inst.FLE_D; } ret inst.FLE_S; }
-        if (funct3 == F3_FLT) { if (dbl) { ret inst.FLT_D; } ret inst.FLT_S; }
-        if (funct3 == F3_FEQ) { if (dbl) { ret inst.FEQ_D; } ret inst.FEQ_S; }
-        ret inst.MOP_NONE;
-    }
-    if (base == F7_FCVT_F2F) { if (dbl) { ret inst.FCVT_D_S; } ret inst.FCVT_S_D; }
-    if (base == F7_FCVT_F2I) {
-        if (rs2 == FCVT_W)  { if (dbl) { ret inst.FCVT_W_D; }  ret inst.FCVT_W_S; }
-        if (rs2 == FCVT_WU) { if (dbl) { ret inst.FCVT_WU_D; } ret inst.FCVT_WU_S; }
-        if (rs2 == FCVT_L)  { if (dbl) { ret inst.FCVT_L_D; }  ret inst.FCVT_L_S; }
-        if (rs2 == FCVT_LU) { if (dbl) { ret inst.FCVT_LU_D; } ret inst.FCVT_LU_S; }
-        ret inst.MOP_NONE;
-    }
-    if (base == F7_FCVT_I2F) {
-        if (rs2 == FCVT_W)  { if (dbl) { ret inst.FCVT_D_W; }  ret inst.FCVT_S_W; }
-        if (rs2 == FCVT_WU) { if (dbl) { ret inst.FCVT_D_WU; } ret inst.FCVT_S_WU; }
-        if (rs2 == FCVT_L)  { if (dbl) { ret inst.FCVT_D_L; }  ret inst.FCVT_S_L; }
-        if (rs2 == FCVT_LU) { if (dbl) { ret inst.FCVT_D_LU; } ret inst.FCVT_S_LU; }
-        ret inst.MOP_NONE;
-    }
-    if (base == F7_FMV_F2I) { if (dbl) { ret inst.FMV_X_D; } ret inst.FMV_X_W; }
-    if (base == F7_FMV_I2F) { if (dbl) { ret inst.FMV_D_X; } ret inst.FMV_W_X; }
-    ret inst.MOP_NONE;
-}
-
-fun classify_amo(funct3: u32, funct7: u32) inst.MachOp {
-    if (funct3 != F3_AMO_W && funct3 != F3_AMO_D) { ret inst.MOP_NONE; }
-    val word: bool = funct3 == F3_AMO_W;
-    val funct5: u32 = (funct7 >> 2) & 0x1F;
-
-    if (funct5 == A5_LR)      { if (word) { ret inst.LR_W; }      ret inst.LR_D; }
-    if (funct5 == A5_SC)      { if (word) { ret inst.SC_W; }      ret inst.SC_D; }
-    if (funct5 == A5_AMOSWAP) { if (word) { ret inst.AMOSWAP_W; } ret inst.AMOSWAP_D; }
-    if (funct5 == A5_AMOADD)  { if (word) { ret inst.AMOADD_W; }  ret inst.AMOADD_D; }
-    if (funct5 == A5_AMOXOR)  { if (word) { ret inst.AMOXOR_W; }  ret inst.AMOXOR_D; }
-    if (funct5 == A5_AMOAND)  { if (word) { ret inst.AMOAND_W; }  ret inst.AMOAND_D; }
-    if (funct5 == A5_AMOOR)   { if (word) { ret inst.AMOOR_W; }   ret inst.AMOOR_D; }
-    if (funct5 == A5_AMOMIN)  { if (word) { ret inst.AMOMIN_W; }  ret inst.AMOMIN_D; }
-    if (funct5 == A5_AMOMAX)  { if (word) { ret inst.AMOMAX_W; }  ret inst.AMOMAX_D; }
-    if (funct5 == A5_AMOMINU) { if (word) { ret inst.AMOMINU_W; } ret inst.AMOMINU_D; }
-    if (funct5 == A5_AMOMAXU) { if (word) { ret inst.AMOMAXU_W; } ret inst.AMOMAXU_D; }
-    ret inst.MOP_NONE;
-}
-
-fun classify_i(opcode: u32, funct3: u32, imm12: u32) inst.MachOp {
-    if (opcode == OPC_LOAD) {
-        if (funct3 == 0x0) { ret inst.LB; }
-        if (funct3 == 0x1) { ret inst.LH; }
-        if (funct3 == 0x2) { ret inst.LW; }
-        if (funct3 == 0x3) { ret inst.LD; }
-        if (funct3 == 0x4) { ret inst.LBU; }
-        if (funct3 == 0x5) { ret inst.LHU; }
-        if (funct3 == 0x6) { ret inst.LWU; }
-        ret inst.MOP_NONE;
-    }
-    if (opcode == OPC_LOAD_FP) {
-        if (funct3 == 0x2) { ret inst.FLW; }
-        if (funct3 == 0x3) { ret inst.FLD; }
-        ret inst.MOP_NONE;
-    }
-    if (opcode == OPC_JALR)   { ret inst.JALR; }
-    if (opcode == OPC_SYSTEM) {
-        if (funct3 == F3_CSRRW)  { ret inst.CSRRW; }
-        if (funct3 == F3_CSRRS)  { ret inst.CSRRS; }
-        if (funct3 == F3_CSRRC)  { ret inst.CSRRC; }
-        if (funct3 == F3_CSRRWI) { ret inst.CSRRWI; }
-        if (funct3 == F3_CSRRSI) { ret inst.CSRRSI; }
-        if (funct3 == F3_CSRRCI) { ret inst.CSRRCI; }
-        if (imm12 == 0) { ret inst.ECALL; }
-        if (imm12 == 1) { ret inst.EBREAK; }
-        ret inst.MOP_NONE;
-    }
-    if (opcode == OPC_MISC_MEM) {
-        if (imm12 == 0x010) { ret inst.PAUSE; }
-        ret inst.FENCE;
-    }
-    if (opcode != OPC_OP_IMM && opcode != OPC_OP_IMM_32) { ret inst.MOP_NONE; }
-    val word: bool = opcode == OPC_OP_IMM_32;
-
-    if (funct3 == F3_SLL) { if (word) { ret inst.SLLIW; } ret inst.SLLI; }
-    if (funct3 == F3_SRL) {
-        if ((imm12 & 0x400) != 0) { if (word) { ret inst.SRAIW; } ret inst.SRAI; }
-        if (word) { ret inst.SRLIW; }
-        ret inst.SRLI;
-    }
-    if (funct3 == F3_ADD) { if (word) { ret inst.ADDIW; } ret inst.ADDI; }
-    if (word) { ret inst.MOP_NONE; }
-    if (funct3 == F3_SLT)  { ret inst.SLTI; }
-    if (funct3 == F3_SLTU) { ret inst.SLTIU; }
-    if (funct3 == F3_XOR)  { ret inst.XORI; }
-    if (funct3 == F3_OR)   { ret inst.ORI; }
-    if (funct3 == F3_AND)  { ret inst.ANDI; }
-    ret inst.MOP_NONE;
-}
-
-fun classify_s(opcode: u32, funct3: u32) inst.MachOp {
-    if (opcode == OPC_STORE) {
-        if (funct3 == 0x0) { ret inst.SB; }
-        if (funct3 == 0x1) { ret inst.SH; }
-        if (funct3 == 0x2) { ret inst.SW; }
-        if (funct3 == 0x3) { ret inst.SD; }
-        ret inst.MOP_NONE;
-    }
-    if (opcode == OPC_STORE_FP) {
-        if (funct3 == 0x2) { ret inst.FSW; }
-        if (funct3 == 0x3) { ret inst.FSD; }
-        ret inst.MOP_NONE;
-    }
-    ret inst.MOP_NONE;
-}
-
-fun classify_b(opcode: u32, funct3: u32) inst.MachOp {
-    if (opcode != OPC_BRANCH) { ret inst.MOP_NONE; }
-    if (funct3 == F3_BEQ)  { ret inst.BEQ; }
-    if (funct3 == F3_BNE)  { ret inst.BNE; }
-    if (funct3 == F3_BLT)  { ret inst.BLT; }
-    if (funct3 == F3_BGE)  { ret inst.BGE; }
-    if (funct3 == F3_BLTU) { ret inst.BLTU; }
-    if (funct3 == F3_BGEU) { ret inst.BGEU; }
-    ret inst.MOP_NONE;
-}
-
-fun classify_u(opcode: u32) inst.MachOp {
-    if (opcode == OPC_LUI)   { ret inst.LUI; }
-    if (opcode == OPC_AUIPC) { ret inst.AUIPC; }
-    ret inst.MOP_NONE;
-}
-
-fun classify_j(opcode: u32) inst.MachOp {
-    if (opcode != OPC_JAL) { ret inst.MOP_NONE; }
-    ret inst.JAL;
-}
-
 fun last_inst(st: *encode.EncodeState) *isa.Inst {
     val count: u32 = encode.note_count(?st.buf);
     if (count == 0) { ret nil; }
@@ -578,10 +343,10 @@ fun last_inst(st: *encode.EncodeState) *isa.Inst {
 }
 
 fun target_operand(mi: *isa.Inst) *isa.Operand {
-    val shape: u8 = shape_of(mi.opcode::inst.MachOp);
-    if (shape == SH_RRI || shape == SH_BRANCH) { ret ?mi.src2; }
-    if (shape == SH_RU || shape == SH_JUMP || shape == SH_LOAD || shape == SH_FLOAD) { ret ?mi.src1; }
-    if (shape == SH_STORE || shape == SH_FSTORE) { ret ?mi.dst; }
+    val shape: u8 = inst.shape_of(mi.opcode::inst.MachOp);
+    if (shape == inst.SH_RRI || shape == inst.SH_BRANCH) { ret ?mi.src2; }
+    if (shape == inst.SH_RU || shape == inst.SH_JUMP || shape == inst.SH_LOAD || shape == inst.SH_FLOAD) { ret ?mi.src1; }
+    if (shape == inst.SH_STORE || shape == inst.SH_FSTORE) { ret ?mi.dst; }
     ret nil;
 }
 
@@ -666,11 +431,11 @@ fun int_mem_funct3(width: u8, is_load: bool, xl: u8) res[u32, fail.Fail] {
     if (width > xl) {
         ret res[u32, fail.Fail].err{fail.message("internal compiler error: this RISC-V machine has no integer memory access wider than its registers")};
     }
-    if (width == 1) { if (is_load) { ret res[u32, fail.Fail].ok{0x4}; } ret res[u32, fail.Fail].ok{0x0}; }
-    if (width == 2) { if (is_load) { ret res[u32, fail.Fail].ok{0x5}; } ret res[u32, fail.Fail].ok{0x1}; }
-    if (width == 4) { if (is_load) { ret res[u32, fail.Fail].ok{0x2}; } ret res[u32, fail.Fail].ok{0x2}; }
-    if (width == 8) { if (is_load) { ret res[u32, fail.Fail].ok{0x3}; } ret res[u32, fail.Fail].ok{0x3}; }
-    ret res[u32, fail.Fail].err{fail.message("internal compiler error: riscv has no integer memory access form for this width (expected 1, 2, 4, or 8)")};
+    val op: inst.MachOp = inst.int_access(width, is_load);
+    if (op == inst.MOP_NONE) {
+        ret res[u32, fail.Fail].err{fail.message("internal compiler error: riscv has no integer memory access form for this width (expected 1, 2, 4, or 8)")};
+    }
+    ret res[u32, fail.Fail].ok{inst.row(op).funct3};
 }
 
 fun req_gpr(op: *mir.MirOperand) res[i32, fail.Fail] {
@@ -1538,9 +1303,11 @@ fun reg_is_fp(op: *mir.MirOperand) bool {
 }
 
 fun fp_mem_funct3(width: u8, is_load: bool) res[u32, fail.Fail] {
-    if (width == 4) { ret res[u32, fail.Fail].ok{0x2}; }
-    if (width == 8) { ret res[u32, fail.Fail].ok{0x3}; }
-    ret res[u32, fail.Fail].err{fail.message("internal compiler error: riscv64 has no float memory access form for this width (expected 4 or 8)")};
+    val op: inst.MachOp = inst.fp_access(width, is_load);
+    if (op == inst.MOP_NONE) {
+        ret res[u32, fail.Fail].err{fail.message("internal compiler error: riscv64 has no float memory access form for this width (expected 4 or 8)")};
+    }
+    ret res[u32, fail.Fail].ok{inst.row(op).funct3};
 }
 
 fun emit_fp_mem(st: *encode.EncodeState, rt: u32, base: u32, off: i64, width: u8, is_load: bool) err[fail.Fail] {
@@ -2375,24 +2142,8 @@ fun extension_admission(bits: u32, op: inst.MachOp) err[fail.Fail] {
     ret err[fail.Fail].err{fail.message("internal compiler error: RISC-V extension declaration is invalid")};
 }
 
-# re-decodes an emitted word through the inverse tables so the admission check does
+# re-decodes every emitted word through the table so the admission check does
 # not trust the emitter's own opcode bookkeeping
-fun generated_word_op(word: u32) inst.MachOp {
-    val opcode: u32 = word & 0x7F;
-    val f3: u32 = (word >> 12) & 7;
-    if (opcode == OPC_OP || opcode == OPC_OP_32 || opcode == OPC_OP_FP || opcode == OPC_AMO) {
-        ret classify_r(opcode, f3, word >> 25, (word >> 20) & 31);
-    }
-    if (opcode == OPC_LOAD || opcode == OPC_LOAD_FP || opcode == OPC_OP_IMM
-        || opcode == OPC_OP_IMM_32 || opcode == OPC_JALR || opcode == OPC_SYSTEM
-        || opcode == OPC_MISC_MEM) { ret classify_i(opcode, f3, word >> 20); }
-    if (opcode == OPC_STORE || opcode == OPC_STORE_FP) { ret classify_s(opcode, f3); }
-    if (opcode == OPC_BRANCH) { ret classify_b(opcode, f3); }
-    if (opcode == OPC_LUI || opcode == OPC_AUIPC) { ret classify_u(opcode); }
-    if (opcode == OPC_JAL) { ret classify_j(opcode); }
-    ret inst.MOP_NONE;
-}
-
 fun check_generated_extensions(st: *encode.EncodeState, start: usize) err[fail.Fail] {
     if (start > st.buf.len || (st.buf.len - start) % 4 != 0) {
         ret err[fail.Fail].err{fail.message("internal compiler error: generated RISC-V instructions are not word aligned")};
@@ -2400,7 +2151,7 @@ fun check_generated_extensions(st: *encode.EncodeState, start: usize) err[fail.F
     var at: usize = start;
     for (at < st.buf.len) {
         val r: err[fail.Fail] = extension_admission(st.model.riscv_extensions,
-            generated_word_op(read_word(?st.buf, at)));
+            inst.classify(read_word(?st.buf, at)));
         if (sel r.err) { ret r; }
         at = at + 4;
     }
@@ -2550,7 +2301,7 @@ fun riscv64_hooks() encode.EncodeHooks {
 }
 
 fun rv_mnemonic(op: u16) str {
-    ret printer.mnemonic(op::inst.MachOp);
+    ret inst.mnemonic(op::inst.MachOp);
 }
 
 fun rv_reg_name(id: i32, size: u8) str {
@@ -2805,27 +2556,19 @@ fun rv_decode_amo(body: str, lo: usize, hi: usize, m: *iasm.Mnemonic, n_out: *us
     or (len >= 3 && str_region_equals(body, lo + len - 3, 3, ".rl"))   { order = RVF_RL;           len = len - 3; }
     if (len < 4) { ret false; }
 
-    var word: bool = false;
-    if (str_region_equals(body, lo + len - 2, 2, ".w"))      { word = true; }
-    or (str_region_equals(body, lo + len - 2, 2, ".d"))      { word = false; }
-    or { ret false; }
-    val blen: usize = len - 2;
-
+    # the stem with its width suffix is the table's spelling; the .w and .d
+    # rows of one operation are adjacent, .w first
+    var op: inst.MachOp = inst.LR_W;
+    if (str_region_equals(body, lo + len - 2, 2, ".d")) { op = inst.LR_D; }
+    or (!str_region_equals(body, lo + len - 2, 2, ".w")) { ret false; }
     var code: u32 = 0;
+    for (op <= inst.AMOMAXU_D && code == 0) {
+        if (str_region_equals(body, lo, len, inst.ROWS[op::usize].name)) { code = op::u32; }
+        op = op + 2;
+    }
+    if (code == 0) { ret false; }
     var pat: u16 = RVP_AMO;
-    if (str_region_equals(body, lo, blen, "lr"))           { code = inst.LR_W::u32; pat = RVP_AMO_LR; }
-    or (str_region_equals(body, lo, blen, "sc"))           { code = inst.SC_W::u32; }
-    or (str_region_equals(body, lo, blen, "amoswap"))      { code = inst.AMOSWAP_W::u32; }
-    or (str_region_equals(body, lo, blen, "amoadd"))       { code = inst.AMOADD_W::u32; }
-    or (str_region_equals(body, lo, blen, "amoxor"))       { code = inst.AMOXOR_W::u32; }
-    or (str_region_equals(body, lo, blen, "amoand"))       { code = inst.AMOAND_W::u32; }
-    or (str_region_equals(body, lo, blen, "amoor"))        { code = inst.AMOOR_W::u32; }
-    or (str_region_equals(body, lo, blen, "amominu"))      { code = inst.AMOMINU_W::u32; }
-    or (str_region_equals(body, lo, blen, "amomaxu"))      { code = inst.AMOMAXU_W::u32; }
-    or (str_region_equals(body, lo, blen, "amomin"))       { code = inst.AMOMIN_W::u32; }
-    or (str_region_equals(body, lo, blen, "amomax"))       { code = inst.AMOMAX_W::u32; }
-    or { ret false; }
-    if (!word) { code = code + 1; }
+    if (code == inst.LR_W::u32 || code == inst.LR_D::u32) { pat = RVP_AMO_LR; }
 
     m.name     = nil;
     m.code     = code;
@@ -2836,121 +2579,6 @@ fun rv_decode_amo(body: str, lo: usize, hi: usize, m: *iasm.Mnemonic, n_out: *us
     m.words    = 1;
     @n_out     = end - lo;
     ret true;
-}
-
-val RVFMT_R: u8 = 0;
-val RVFMT_I: u8 = 1;
-val RVFMT_S: u8 = 2;
-val RVFMT_B: u8 = 3;
-val RVFMT_U: u8 = 4;
-val RVFMT_J: u8 = 5;
-
-fun rv_fields(op: inst.MachOp, fmt: *u8, opcode: *u32, f3: *u32, f7: *u32) bool {
-    @fmt = RVFMT_R; @opcode = 0; @f3 = 0; @f7 = F7_ZERO;
-
-    if (op == inst.ADD)  { @opcode = OPC_OP; @f3 = F3_ADD;  ret true; }
-    if (op == inst.SLL)  { @opcode = OPC_OP; @f3 = F3_SLL;  ret true; }
-    if (op == inst.SLT)  { @opcode = OPC_OP; @f3 = F3_SLT;  ret true; }
-    if (op == inst.SLTU) { @opcode = OPC_OP; @f3 = F3_SLTU; ret true; }
-    if (op == inst.XOR)  { @opcode = OPC_OP; @f3 = F3_XOR;  ret true; }
-    if (op == inst.SRL)  { @opcode = OPC_OP; @f3 = F3_SRL;  ret true; }
-    if (op == inst.OR)   { @opcode = OPC_OP; @f3 = F3_OR;   ret true; }
-    if (op == inst.AND)  { @opcode = OPC_OP; @f3 = F3_AND;  ret true; }
-    if (op == inst.SUB)  { @opcode = OPC_OP; @f3 = F3_ADD; @f7 = F7_SUB; ret true; }
-    if (op == inst.SRA)  { @opcode = OPC_OP; @f3 = F3_SRL; @f7 = F7_SUB; ret true; }
-    if (op == inst.ADDW) { @opcode = OPC_OP_32; @f3 = F3_ADD; ret true; }
-    if (op == inst.SLLW) { @opcode = OPC_OP_32; @f3 = F3_SLL; ret true; }
-    if (op == inst.SRLW) { @opcode = OPC_OP_32; @f3 = F3_SRL; ret true; }
-    if (op == inst.SUBW) { @opcode = OPC_OP_32; @f3 = F3_ADD; @f7 = F7_SUB; ret true; }
-    if (op == inst.SRAW) { @opcode = OPC_OP_32; @f3 = F3_SRL; @f7 = F7_SUB; ret true; }
-
-    if (op == inst.MUL)    { @opcode = OPC_OP; @f3 = F3_ADD;  @f7 = F7_MULDIV; ret true; }
-    if (op == inst.MULH)   { @opcode = OPC_OP; @f3 = F3_SLL;  @f7 = F7_MULDIV; ret true; }
-    if (op == inst.MULHSU) { @opcode = OPC_OP; @f3 = F3_SLT;  @f7 = F7_MULDIV; ret true; }
-    if (op == inst.MULHU)  { @opcode = OPC_OP; @f3 = F3_SLTU; @f7 = F7_MULDIV; ret true; }
-    if (op == inst.DIV)    { @opcode = OPC_OP; @f3 = F3_DIV;  @f7 = F7_MULDIV; ret true; }
-    if (op == inst.DIVU)   { @opcode = OPC_OP; @f3 = F3_DIVU; @f7 = F7_MULDIV; ret true; }
-    if (op == inst.REM)    { @opcode = OPC_OP; @f3 = F3_REM;  @f7 = F7_MULDIV; ret true; }
-    if (op == inst.REMU)   { @opcode = OPC_OP; @f3 = F3_REMU; @f7 = F7_MULDIV; ret true; }
-    if (op == inst.MULW)   { @opcode = OPC_OP_32; @f3 = F3_ADD;  @f7 = F7_MULDIV; ret true; }
-    if (op == inst.DIVW)   { @opcode = OPC_OP_32; @f3 = F3_DIV;  @f7 = F7_MULDIV; ret true; }
-    if (op == inst.DIVUW)  { @opcode = OPC_OP_32; @f3 = F3_DIVU; @f7 = F7_MULDIV; ret true; }
-    if (op == inst.REMW)   { @opcode = OPC_OP_32; @f3 = F3_REM;  @f7 = F7_MULDIV; ret true; }
-    if (op == inst.REMUW)  { @opcode = OPC_OP_32; @f3 = F3_REMU; @f7 = F7_MULDIV; ret true; }
-
-    if (op == inst.ADDI)  { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_ADD;  ret true; }
-    if (op == inst.SLTI)  { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_SLT;  ret true; }
-    if (op == inst.SLTIU) { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_SLTU; ret true; }
-    if (op == inst.XORI)  { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_XOR;  ret true; }
-    if (op == inst.ORI)   { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_OR;   ret true; }
-    if (op == inst.ANDI)  { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_AND;  ret true; }
-    if (op == inst.SLLI)  { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_SLL;  ret true; }
-    if (op == inst.SRLI)  { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_SRL;  ret true; }
-    if (op == inst.SRAI)  { @fmt = RVFMT_I; @opcode = OPC_OP_IMM; @f3 = F3_SRL;  ret true; }
-    if (op == inst.ADDIW) { @fmt = RVFMT_I; @opcode = OPC_OP_IMM_32; @f3 = F3_ADD; ret true; }
-    if (op == inst.SLLIW) { @fmt = RVFMT_I; @opcode = OPC_OP_IMM_32; @f3 = F3_SLL; ret true; }
-    if (op == inst.SRLIW) { @fmt = RVFMT_I; @opcode = OPC_OP_IMM_32; @f3 = F3_SRL; ret true; }
-    if (op == inst.SRAIW) { @fmt = RVFMT_I; @opcode = OPC_OP_IMM_32; @f3 = F3_SRL; ret true; }
-
-    if (op == inst.LB)   { @fmt = RVFMT_I; @opcode = OPC_LOAD; @f3 = 0x0; ret true; }
-    if (op == inst.LH)   { @fmt = RVFMT_I; @opcode = OPC_LOAD; @f3 = 0x1; ret true; }
-    if (op == inst.LW)   { @fmt = RVFMT_I; @opcode = OPC_LOAD; @f3 = 0x2; ret true; }
-    if (op == inst.LD)   { @fmt = RVFMT_I; @opcode = OPC_LOAD; @f3 = 0x3; ret true; }
-    if (op == inst.LBU)  { @fmt = RVFMT_I; @opcode = OPC_LOAD; @f3 = 0x4; ret true; }
-    if (op == inst.LHU)  { @fmt = RVFMT_I; @opcode = OPC_LOAD; @f3 = 0x5; ret true; }
-    if (op == inst.LWU)  { @fmt = RVFMT_I; @opcode = OPC_LOAD; @f3 = 0x6; ret true; }
-    if (op == inst.JALR) { @fmt = RVFMT_I; @opcode = OPC_JALR; @f3 = F3_ADD; ret true; }
-    if (op == inst.SB) { @fmt = RVFMT_S; @opcode = OPC_STORE; @f3 = 0x0; ret true; }
-    if (op == inst.SH) { @fmt = RVFMT_S; @opcode = OPC_STORE; @f3 = 0x1; ret true; }
-    if (op == inst.SW) { @fmt = RVFMT_S; @opcode = OPC_STORE; @f3 = 0x2; ret true; }
-    if (op == inst.SD) { @fmt = RVFMT_S; @opcode = OPC_STORE; @f3 = 0x3; ret true; }
-
-    if (op == inst.ECALL || op == inst.EBREAK) { @fmt = RVFMT_I; @opcode = OPC_SYSTEM;   @f3 = F3_ADD; ret true; }
-    if (op == inst.FENCE || op == inst.PAUSE)  { @fmt = RVFMT_I; @opcode = OPC_MISC_MEM; @f3 = F3_ADD; ret true; }
-
-    if (op == inst.CSRRW)  { @fmt = RVFMT_I; @opcode = OPC_SYSTEM; @f3 = F3_CSRRW;  ret true; }
-    if (op == inst.CSRRS)  { @fmt = RVFMT_I; @opcode = OPC_SYSTEM; @f3 = F3_CSRRS;  ret true; }
-    if (op == inst.CSRRC)  { @fmt = RVFMT_I; @opcode = OPC_SYSTEM; @f3 = F3_CSRRC;  ret true; }
-    if (op == inst.CSRRWI) { @fmt = RVFMT_I; @opcode = OPC_SYSTEM; @f3 = F3_CSRRWI; ret true; }
-    if (op == inst.CSRRSI) { @fmt = RVFMT_I; @opcode = OPC_SYSTEM; @f3 = F3_CSRRSI; ret true; }
-    if (op == inst.CSRRCI) { @fmt = RVFMT_I; @opcode = OPC_SYSTEM; @f3 = F3_CSRRCI; ret true; }
-
-    if (op == inst.BEQ)  { @fmt = RVFMT_B; @opcode = OPC_BRANCH; @f3 = F3_BEQ;  ret true; }
-    if (op == inst.BNE)  { @fmt = RVFMT_B; @opcode = OPC_BRANCH; @f3 = F3_BNE;  ret true; }
-    if (op == inst.BLT)  { @fmt = RVFMT_B; @opcode = OPC_BRANCH; @f3 = F3_BLT;  ret true; }
-    if (op == inst.BGE)  { @fmt = RVFMT_B; @opcode = OPC_BRANCH; @f3 = F3_BGE;  ret true; }
-    if (op == inst.BLTU) { @fmt = RVFMT_B; @opcode = OPC_BRANCH; @f3 = F3_BLTU; ret true; }
-    if (op == inst.BGEU) { @fmt = RVFMT_B; @opcode = OPC_BRANCH; @f3 = F3_BGEU; ret true; }
-    if (op == inst.LUI)   { @fmt = RVFMT_U; @opcode = OPC_LUI;   ret true; }
-    if (op == inst.AUIPC) { @fmt = RVFMT_U; @opcode = OPC_AUIPC; ret true; }
-    if (op == inst.JAL)   { @fmt = RVFMT_J; @opcode = OPC_JAL;   ret true; }
-
-    if (op >= inst.LR_W && op <= inst.AMOMAXU_D) {
-        @opcode = OPC_AMO;
-        @f3     = F3_AMO_D;
-        if (rv_amo_is_word(op)) { @f3 = F3_AMO_W; }
-        @f7 = rv_amo_funct5(op) << 2;
-        ret true;
-    }
-    ret false;
-}
-
-fun rv_amo_is_word(op: inst.MachOp) bool {
-    ret ((op - inst.LR_W) & 1) == 0;
-}
-
-fun rv_amo_funct5(op: inst.MachOp) u32 {
-    if (op == inst.LR_W || op == inst.LR_D)             { ret A5_LR; }
-    if (op == inst.SC_W || op == inst.SC_D)             { ret A5_SC; }
-    if (op == inst.AMOSWAP_W || op == inst.AMOSWAP_D)   { ret A5_AMOSWAP; }
-    if (op == inst.AMOADD_W || op == inst.AMOADD_D)     { ret A5_AMOADD; }
-    if (op == inst.AMOXOR_W || op == inst.AMOXOR_D)     { ret A5_AMOXOR; }
-    if (op == inst.AMOAND_W || op == inst.AMOAND_D)     { ret A5_AMOAND; }
-    if (op == inst.AMOOR_W || op == inst.AMOOR_D)       { ret A5_AMOOR; }
-    if (op == inst.AMOMIN_W || op == inst.AMOMIN_D)     { ret A5_AMOMIN; }
-    if (op == inst.AMOMAX_W || op == inst.AMOMAX_D)     { ret A5_AMOMAX; }
-    if (op == inst.AMOMINU_W || op == inst.AMOMINU_D)   { ret A5_AMOMINU; }
-    ret A5_AMOMAXU;
 }
 
 fun rv_operand(c: *iasm.Cursor, lo: usize, hi: usize, op: *iasm.Operand) err[fail.Fail] {
@@ -3324,22 +2952,17 @@ fun rv_emit(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, item: *ia
     val admitted: err[fail.Fail] = extension_admission(st.model.riscv_extensions, op);
     if (sel admitted.err) { ret admitted; }
 
-    var fmt: u8 = 0;
-    var opcode: u32 = 0;
-    var f3: u32 = 0;
-    var f7: u32 = 0;
-    if (pat != RVP_LI && pat != RVP_LA && pat != RVP_CALL && pat != RVP_TAIL) {
-        if (!rv_fields(op, ?fmt, ?opcode, ?f3, ?f7)) {
-            ret err[fail.Fail].err{fail.message("internal compiler error: inline-asm riscv64 instruction has no encoding")};
-        }
-    }
+    val row: *inst.Row = inst.row(op);
+    val opcode: u32 = row.opcode7;
+    val f3: u32 = row.funct3;
+    val f7: u32 = row.funct7;
 
-    if (pat == RVP_ECALL)  { emit_i(st, OPC_SYSTEM, F3_ADD, RZERO, RZERO, 0); ret err[fail.Fail].ok{}; }
-    if (pat == RVP_EBREAK) { emit_i(st, OPC_SYSTEM, F3_ADD, RZERO, RZERO, 1); ret err[fail.Fail].ok{}; }
-    if (pat == RVP_NOP)    { emit_i(st, OPC_OP_IMM, F3_ADD, RZERO, RZERO, 0); ret err[fail.Fail].ok{}; }
-    if (pat == RVP_RET)    { emit_i(st, OPC_JALR, F3_ADD, RZERO, RRA, 0); ret err[fail.Fail].ok{}; }
-    if (pat == RVP_FENCE)  { emit_i(st, OPC_MISC_MEM, F3_ADD, RZERO, RZERO, 0xFF); ret err[fail.Fail].ok{}; }
-    if (pat == RVP_PAUSE)  { emit_i(st, OPC_MISC_MEM, F3_ADD, RZERO, RZERO, 0x010); ret err[fail.Fail].ok{}; }
+    if (pat == RVP_ECALL || pat == RVP_EBREAK || pat == RVP_FENCE || pat == RVP_PAUSE) {
+        emit_i(st, opcode, f3, RZERO, RZERO, row.sel);
+        ret err[fail.Fail].ok{};
+    }
+    if (pat == RVP_NOP)    { emit_i(st, opcode, f3, RZERO, RZERO, 0); ret err[fail.Fail].ok{}; }
+    if (pat == RVP_RET)    { emit_i(st, opcode, f3, RZERO, RRA, 0); ret err[fail.Fail].ok{}; }
 
     if (pat == RVP_RRR) {
         emit_r(st, opcode, f3, f7, rv_reg(?item.ops[0]), rv_reg(?item.ops[1]), rv_reg(?item.ops[2]));
@@ -5374,45 +4997,33 @@ test "mach.lang.target.isa.riscv.encode:emit_asm_renders_csr" {
     ret bad;
 }
 
-test "mach.lang.target.isa.riscv.encode:asm_fields_classify_round_trip" {
+test "mach.lang.target.isa.riscv.encode:grammar_rows_read_the_table" {
     var bad: i32 = 0;
     var i: usize = 0;
     for (i < RV_MNEMONIC_COUNT) {
-        val op: inst.MachOp = RV_MNEMONICS[i].code::inst.MachOp;
-        var fmt: u8 = 0;
-        var opcode: u32 = 0;
-        var f3: u32 = 0;
-        var f7: u32 = 0;
-        if (!rv_fields(op, ?fmt, ?opcode, ?f3, ?f7)) { bad = 1; }
-        or {
-            var imm: u32 = 0;
-            if (op == inst.SRAI || op == inst.SRAIW) { imm = 0x400; }
-            or (op == inst.EBREAK)                   { imm = 1; }
-            or (op == inst.PAUSE)                    { imm = 0x010; }
-            or (op == inst.FENCE)                    { imm = 0xFF; }
-
-            var back: inst.MachOp = inst.MOP_NONE;
-            if (fmt == RVFMT_R)      { back = classify_r(opcode, f3, f7, 0); }
-            or (fmt == RVFMT_I)      { back = classify_i(opcode, f3, imm); }
-            or (fmt == RVFMT_S)      { back = classify_s(opcode, f3); }
-            or (fmt == RVFMT_B)      { back = classify_b(opcode, f3); }
-            or (fmt == RVFMT_U)      { back = classify_u(opcode); }
-            or                       { back = classify_j(opcode); }
-            if (back != op) { bad = 1; }
+        val m: *iasm.Mnemonic = ?RV_MNEMONICS[i];
+        val op: inst.MachOp = m.code::inst.MachOp;
+        if (!inst.in_catalog(op)) { bad = 1; }
+        # a row that is the instruction itself carries the table's spelling
+        val pat: u16 = rv_pattern(m.flags);
+        if (pat == RVP_RRR || pat == RVP_RRI || pat == RVP_SHIFT || pat == RVP_LOAD || pat == RVP_STORE
+            || pat == RVP_UIMM || pat == RVP_BRANCH || pat == RVP_JAL || pat == RVP_JALR
+            || pat == RVP_CSR || pat == RVP_CSR_I || pat == RVP_ECALL || pat == RVP_EBREAK
+            || pat == RVP_FENCE || pat == RVP_PAUSE) {
+            if (!str_equals(m.name, inst.mnemonic(op))) { bad = 2; }
         }
         i = i + 1;
     }
 
-    var op2: inst.MachOp = inst.LR_W;
-    for (op2 <= inst.AMOMAXU_D) {
-        var fmt: u8 = 0;
-        var opcode: u32 = 0;
-        var f3: u32 = 0;
-        var f7: u32 = 0;
-        if (!rv_fields(op2, ?fmt, ?opcode, ?f3, ?f7)) { bad = 1; }
-        or { if (classify_r(opcode, f3, f7 | 0x3, 0) != op2) { bad = 1; } }
-        op2 = op2 + 1;
-    }
+    # the amo decoder reads the same spellings, with the ordering suffix split off
+    var m: iasm.Mnemonic;
+    var n: usize = 0;
+    if (!rv_decode_amo("amoadd.w.aqrl a0, a1, (a2)", 0, 26, ?m, ?n) || m.code != inst.AMOADD_W::u32
+        || rv_pattern(m.flags) != RVP_AMO || (m.flags & (RVF_AQ | RVF_RL)) != (RVF_AQ | RVF_RL) || n != 13) { bad = 3; }
+    if (!rv_decode_amo("lr.d a0, (a2)", 0, 13, ?m, ?n) || m.code != inst.LR_D::u32 || rv_pattern(m.flags) != RVP_AMO_LR) { bad = 4; }
+    if (!rv_decode_amo("sc.w.rl a0, a1, (a2)", 0, 20, ?m, ?n) || m.code != inst.SC_W::u32 || m.flags != (RVP_AMO | RVF_RL)) { bad = 5; }
+    if (rv_decode_amo("amoadd.x a0, a1, (a2)", 0, 21, ?m, ?n)) { bad = 6; }
+    if (rv_decode_amo("amonot.w a0, a1, (a2)", 0, 21, ?m, ?n)) { bad = 7; }
     ret bad;
 }
 
@@ -6129,7 +5740,7 @@ pub fun inst_effects(mi: *isa.Inst, e: *ct.InstEffects) {
     val op: inst.MachOp = mi.opcode::inst.MachOp;
     if (op == inst.MOP_NONE || op > inst.MOP_LAST) { ret; }
     e.cls = asm_ct_class(op::u32, 0);
-    val shape: u8 = shape_of(op);
+    val shape: u8 = inst.shape_of(op);
 
     if (op == inst.JALR) {
         # the target register rides in the load-shaped memory operand; it is
@@ -6156,7 +5767,7 @@ pub fun inst_effects(mi: *isa.Inst, e: *ct.InstEffects) {
         rv_target(mi, ?mi.src1, e);
         ret;
     }
-    if (shape == SH_BRANCH) {
+    if (shape == inst.SH_BRANCH) {
         e.roles[0] = ct.ROLE_READ;
         e.roles[1] = ct.ROLE_READ;
         e.xfer     = ct.XFER_BRANCH;
@@ -6170,25 +5781,25 @@ pub fun inst_effects(mi: *isa.Inst, e: *ct.InstEffects) {
         e.implicit_writes = implicit;
         ret;
     }
-    if (shape == SH_NONE) { ret; }
-    if (shape == SH_STORE || shape == SH_FSTORE) {
+    if (shape == inst.SH_NONE) { ret; }
+    if (shape == inst.SH_STORE || shape == inst.SH_FSTORE) {
         e.roles[0] = ct.ROLE_WRITE;
         e.roles[1] = ct.ROLE_READ;
         ret;
     }
-    if (shape == SH_AMO) {
+    if (shape == inst.SH_AMO) {
         e.roles[0] = ct.ROLE_WRITE;
         e.roles[1] = ct.ROLE_READ;
         e.roles[2] = ct.ROLE_RW;
         if (op == inst.SC_W || op == inst.SC_D) { e.roles[2] = ct.ROLE_WRITE; }
         ret;
     }
-    if (shape == SH_CSR) {
+    if (shape == inst.SH_CSR) {
         e.roles[0] = ct.ROLE_WRITE;
         e.roles[2] = ct.ROLE_READ;
         ret;
     }
-    if (shape == SH_CSR_I) { e.roles[0] = ct.ROLE_WRITE; ret; }
+    if (shape == inst.SH_CSR_I) { e.roles[0] = ct.ROLE_WRITE; ret; }
     if (op == inst.SLL || op == inst.SRL || op == inst.SRA || op == inst.SLLW || op == inst.SRLW || op == inst.SRAW) {
         e.count_pos = 2;
     }

--- a/src/lang/target/isa/riscv/encode.mach
+++ b/src/lang/target/isa/riscv/encode.mach
@@ -427,10 +427,9 @@ fun alu_imm_opcode(width: u8, xl: u8) u32 {
     ret OPC_OP_IMM;
 }
 
-fun int_mem_funct3(width: u8, is_load: bool, xl: u8) res[u32, fail.Fail] {
-    if (width > xl) {
-        ret res[u32, fail.Fail].err{fail.message("internal compiler error: this RISC-V machine has no integer memory access wider than its registers")};
-    }
+# the funct3 of a memory access row; the machine that admits the row is the
+# admission seam's question after the word is emitted
+fun int_mem_funct3(width: u8, is_load: bool) res[u32, fail.Fail] {
     val op: inst.MachOp = inst.int_access(width, is_load);
     if (op == inst.MOP_NONE) {
         ret res[u32, fail.Fail].err{fail.message("internal compiler error: riscv has no integer memory access form for this width (expected 1, 2, 4, or 8)")};
@@ -505,7 +504,7 @@ fun emit_addi(st: *encode.EncodeState, rd: u32, rs1: u32, off: i64) {
 }
 
 fun emit_mem_access(st: *encode.EncodeState, rt: u32, base: u32, off: i64, width: u8, is_load: bool) err[fail.Fail] {
-    val f3r: res[u32, fail.Fail] = int_mem_funct3(width, is_load, xlen(st));
+    val f3r: res[u32, fail.Fail] = int_mem_funct3(width, is_load);
     if (sel f3r.err) { ret err[fail.Fail].err{f3r.err}; }
     val f3: u32 = f3r.ok;
     var b: u32 = base;
@@ -835,7 +834,7 @@ fun emit_global_load(st: *encode.EncodeState, rt: u32, symop: *mir.MirOperand, w
     if (symop.sym == intern.STR_NIL) {
         ret err[fail.Fail].err{fail.message("encode: folded-global load has no resolved symbol name")};
     }
-    val f3r: res[u32, fail.Fail] = int_mem_funct3(width, true, xlen(st));
+    val f3r: res[u32, fail.Fail] = int_mem_funct3(width, true);
     if (sel f3r.err) { ret err[fail.Fail].err{f3r.err}; }
     val hr: err[fail.Fail] = emit_pcrel_hi(st, SCRATCH, symop.sym, symop.sym_off);
     if (sel hr.err) { ret hr; }
@@ -849,7 +848,7 @@ fun emit_global_store(st: *encode.EncodeState, symop: *mir.MirOperand, val_op: *
     if (symop.sym == intern.STR_NIL) {
         ret err[fail.Fail].err{fail.message("encode: folded-global store has no resolved symbol name")};
     }
-    val f3r: res[u32, fail.Fail] = int_mem_funct3(width, false, xlen(st));
+    val f3r: res[u32, fail.Fail] = int_mem_funct3(width, false);
     if (sel f3r.err) { ret err[fail.Fail].err{f3r.err}; }
     var rt: u32 = RZERO;
     if (val_op.kind == mir.MIR_OP_IMM) {
@@ -2128,9 +2127,15 @@ fun encode_function_riscv64(st: *encode.EncodeState, f: *mir.MirFunction) err[fa
     ret printer.render_notes(?st.buf);
 }
 
-fun extension_admission(bits: u32, op: inst.MachOp) err[fail.Fail] {
+# the one admission point: the table's xlen mask and extension bits against
+# the selected machine
+fun admission(bits: u32, xl: u8, op: inst.MachOp) err[fail.Fail] {
+    if (!inst.in_catalog(op)) { ret err[fail.Fail].err{fail.message("internal compiler error: emitted RISC-V word spells no catalogued instruction")}; }
+    if (!inst.admits(op, xl)) {
+        if (xl == 4) { ret err[fail.Fail].err{fail.message("encode: RISC-V instruction is not admitted on riscv32")}; }
+        ret err[fail.Fail].err{fail.message("encode: RISC-V instruction is not admitted on riscv64")};
+    }
     val required: u32 = inst.required_extensions(op);
-    if (required == 0) { ret err[fail.Fail].err{fail.message("internal compiler error: emitted RISC-V instruction has no extension declaration")}; }
     val missing: u32 = required & ~bits;
     if (missing == 0) { ret err[fail.Fail].ok{}; }
     if ((missing & features.I) != 0) { ret err[fail.Fail].err{fail.message("encode: RISC-V instruction requires the I extension")}; }
@@ -2144,13 +2149,13 @@ fun extension_admission(bits: u32, op: inst.MachOp) err[fail.Fail] {
 
 # re-decodes every emitted word through the table so the admission check does
 # not trust the emitter's own opcode bookkeeping
-fun check_generated_extensions(st: *encode.EncodeState, start: usize) err[fail.Fail] {
+fun check_generated_admission(st: *encode.EncodeState, start: usize) err[fail.Fail] {
     if (start > st.buf.len || (st.buf.len - start) % 4 != 0) {
         ret err[fail.Fail].err{fail.message("internal compiler error: generated RISC-V instructions are not word aligned")};
     }
     var at: usize = start;
     for (at < st.buf.len) {
-        val r: err[fail.Fail] = extension_admission(st.model.riscv_extensions,
+        val r: err[fail.Fail] = admission(st.model.riscv_extensions, xlen(st),
             inst.classify(read_word(?st.buf, at)));
         if (sel r.err) { ret r; }
         at = at + 4;
@@ -2168,7 +2173,7 @@ fun encode_function_body(st: *encode.EncodeState, f: *mir.MirFunction) err[fail.
     val naked: bool = f.frame.omit;
     val total: u32 = f.frame.base_dist + f.frame.fp_dist;
     if (!naked) { emit_prologue(st, f, total); }
-    val admitted: err[fail.Fail] = check_generated_extensions(st, fn_base::usize);
+    val admitted: err[fail.Fail] = check_generated_admission(st, fn_base::usize);
     if (sel admitted.err) { ret admitted; }
     val rp: err[fail.Fail] = check_accounted(st, fn_base, PROLOGUE_REGION);
     if (sel rp.err) { ret rp; }
@@ -2208,7 +2213,7 @@ fun encode_function_body(st: *encode.EncodeState, f: *mir.MirFunction) err[fail.
             if (sel ei.err) { ret ei; }
             if (sel eb.err) { ret err[fail.Fail].err{eb.err}; }
             if (mi.opcode != mir.MIR_ASM) {
-                val ar: err[fail.Fail] = check_generated_extensions(st, generated_start);
+                val ar: err[fail.Fail] = check_generated_admission(st, generated_start);
                 if (sel ar.err) { ret ar; }
             }
             val ra: err[fail.Fail] = check_accounted(st, fn_base, mi.opcode::u16);
@@ -2949,7 +2954,7 @@ fun rv_emit(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, item: *ia
     val op: inst.MachOp = item.code::inst.MachOp;
 
     if (!inst.admits(op, xlen(st))) { ret err[fail.Fail].err{fail.message(rv_absent_message(c, item, xlen(st)))}; }
-    val admitted: err[fail.Fail] = extension_admission(st.model.riscv_extensions, op);
+    val admitted: err[fail.Fail] = admission(st.model.riscv_extensions, xlen(st), op);
     if (sel admitted.err) { ret admitted; }
 
     val row: *inst.Row = inst.row(op);
@@ -4055,7 +4060,7 @@ test "mach.lang.target.isa.riscv.encode:pcrel_pair_sites_are_indexed" {
         || label_at(?st, latest_label, first_off)) { bad = 14; }
     val symbols_after_first_low: u32 = st.sym_count;
     val second_low_off: u32 = st.buf.len::u32;
-    val store_f3_r: res[u32, fail.Fail] = int_mem_funct3(8, false, 8);
+    val store_f3_r: res[u32, fail.Fail] = int_mem_funct3(8, false);
     if (sel store_f3_r.err) { ret 1; }
     val store_f3: u32 = store_f3_r.ok;
     emit_s(?st, OPC_STORE, store_f3, SCRATCH, SCRATCH, 0);
@@ -6176,27 +6181,27 @@ test "mach.lang.target.isa.riscv.encode:selected_extensions_bound_generated_and_
         i = i + 1;
     }
     emit_r(?st, OPC_OP, F3_ADD, F7_MULDIV, 10, 11, 12);
-    val mul: err[fail.Fail] = check_generated_extensions(?st, 0);
+    val mul: err[fail.Fail] = check_generated_admission(?st, 0);
     if (sel mul.ok) { ret 3; }
     if (!str_contains(fail.describe(mul.err), "M extension")) { ret 3; }
     selected.riscv_extensions = features.I | features.M;
-    val r_6498: err[fail.Fail] = check_generated_extensions(?st, 0);
+    val r_6498: err[fail.Fail] = check_generated_admission(?st, 0);
     if (sel r_6498.err) { ret 4; }
     st.buf.len = 0;
     emit_r(?st, OPC_OP_FP, 0, 0, 10, 11, 12);
-    val fp: err[fail.Fail] = check_generated_extensions(?st, 0);
+    val fp: err[fail.Fail] = check_generated_admission(?st, 0);
     if (sel fp.ok) { ret 5; }
     if (!str_contains(fail.describe(fp.err), "F extension")) { ret 5; }
     selected.riscv_extensions = features.I | features.F | features.ZICSR;
-    val r_6505: err[fail.Fail] = check_generated_extensions(?st, 0);
+    val r_6505: err[fail.Fail] = check_generated_admission(?st, 0);
     if (sel r_6505.err) { ret 6; }
     st.buf.len = 0;
     emit_r(?st, OPC_OP_FP, 0, 1, 10, 11, 12);
-    val dp: err[fail.Fail] = check_generated_extensions(?st, 0);
+    val dp: err[fail.Fail] = check_generated_admission(?st, 0);
     if (sel dp.ok) { ret 7; }
     if (!str_contains(fail.describe(dp.err), "D extension")) { ret 7; }
     selected.riscv_extensions = features.ALL;
-    val r_6512: err[fail.Fail] = check_generated_extensions(?st, 0);
+    val r_6512: err[fail.Fail] = check_generated_admission(?st, 0);
     if (sel r_6512.err) { ret 8; }
     selected.riscv_extensions = features.I;
     st.buf.len = 0;
@@ -6209,6 +6214,43 @@ test "mach.lang.target.isa.riscv.encode:selected_extensions_bound_generated_and_
         op = op + 1;
     }
     if (inst.required_extensions(inst.MOP_NONE) != 0 || inst.required_extensions(inst.MOP_LAST + 1) != 0) { ret 12; }
+    ret 0;
+}
+
+# the codegen path admits by the table's xlen mask at the same seam as the
+# extension bits: a 64-bit access the width arithmetic selects on rv32 is
+# refused after emission, and a word no row claims is refused as such
+test "mach.lang.target.isa.riscv.encode:generated_words_admit_by_the_tables_xlen_mask" {
+    var st: encode.EncodeState;
+    var alloc: A.Allocator;
+    var interner: intern.Interner;
+    tasm32(?st, ?alloc, ?interner);
+    fin { intern.dnit(?interner); encode.buf_dnit(?st.buf); }
+
+    val ld: err[fail.Fail] = emit_mem_access(?st, 10, 11, 0, 8, true);
+    if (sel ld.err) { ret 1; }
+    if (st.buf.len != 4 || inst.classify(read_word(?st.buf, 0)) != inst.LD) { ret 2; }
+    val r32: err[fail.Fail] = check_generated_admission(?st, 0);
+    if (sel r32.ok) { ret 3; }
+    if (!str_contains(fail.describe(r32.err), "not admitted on riscv32")) { ret 4; }
+
+    var rv64: isa.MachineModel = @st.model;
+    rv64.gpr_width = 8;
+    st.model = ?rv64;
+    val r64: err[fail.Fail] = check_generated_admission(?st, 0);
+    if (sel r64.err) { ret 5; }
+
+    st.buf.len = 0;
+    emit_mem_access(?st, 10, 11, 0, 4, true);
+    st.model = rv32_machine();
+    val lw: err[fail.Fail] = check_generated_admission(?st, 0);
+    if (sel lw.err) { ret 6; }
+
+    st.buf.len = 0;
+    emit_word(?st, inst.key_word(inst.FENCE) ^ (0x0F0 << 20));
+    val unnamed: err[fail.Fail] = check_generated_admission(?st, 0);
+    if (sel unnamed.ok) { ret 7; }
+    if (!str_contains(fail.describe(unnamed.err), "spells no catalogued instruction")) { ret 8; }
     ret 0;
 }
 

--- a/src/lang/target/isa/riscv/inst.mach
+++ b/src/lang/target/isa/riscv/inst.mach
@@ -1,4 +1,10 @@
 use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.string.str;
+use std.types.size.usize;
+use std.types.string.str_equals;
+use std.types.string.str_len;
 use mach.lang.target.isa.riscv.features;
 
 pub def MachOp: u16;
@@ -170,6 +176,10 @@ pub val CSRRCI: MachOp = 140;
 
 pub val MOP_LAST: MachOp = CSRRCI;
 
+# ROW_COUNT is MOP_LAST + 1 spelled as a literal so the array length is
+# comptime; the catalog test holds the two together
+pub val ROW_COUNT: usize = 141;
+
 pub val XL32:   u8 = 0x01;
 pub val XL64:   u8 = 0x02;
 pub val XL_ANY: u8 = 0x03;
@@ -180,26 +190,364 @@ pub fun xlen_bit(xlen_bytes: u8) u8 {
     ret 0;
 }
 
+# base opcodes, bits 6:0 of every word
+pub val OPC_LOAD:      u32 = 0x03;
+pub val OPC_LOAD_FP:   u32 = 0x07;
+pub val OPC_MISC_MEM:  u32 = 0x0F;
+pub val OPC_OP_IMM:    u32 = 0x13;
+pub val OPC_AUIPC:     u32 = 0x17;
+pub val OPC_OP_IMM_32: u32 = 0x1B;
+pub val OPC_STORE:     u32 = 0x23;
+pub val OPC_STORE_FP:  u32 = 0x27;
+pub val OPC_AMO:       u32 = 0x2F;
+pub val OPC_OP:        u32 = 0x33;
+pub val OPC_LUI:       u32 = 0x37;
+pub val OPC_OP_32:     u32 = 0x3B;
+pub val OPC_OP_FP:     u32 = 0x53;
+pub val OPC_BRANCH:    u32 = 0x63;
+pub val OPC_JALR:      u32 = 0x67;
+pub val OPC_JAL:       u32 = 0x6F;
+pub val OPC_SYSTEM:    u32 = 0x73;
+
+# funct3 of the integer operate forms
+pub val F3_ADD:  u32 = 0x0;
+pub val F3_SLL:  u32 = 0x1;
+pub val F3_SLT:  u32 = 0x2;
+pub val F3_SLTU: u32 = 0x3;
+pub val F3_XOR:  u32 = 0x4;
+pub val F3_SRL:  u32 = 0x5;
+pub val F3_OR:   u32 = 0x6;
+pub val F3_AND:  u32 = 0x7;
+
+pub val F3_DIV:  u32 = 0x4;
+pub val F3_DIVU: u32 = 0x5;
+pub val F3_REM:  u32 = 0x6;
+pub val F3_REMU: u32 = 0x7;
+
+# funct3 of the memory forms: the access width, unsigned loads at bit 2
+pub val F3_MEM_B:  u32 = 0x0;
+pub val F3_MEM_H:  u32 = 0x1;
+pub val F3_MEM_W:  u32 = 0x2;
+pub val F3_MEM_D:  u32 = 0x3;
+pub val F3_MEM_BU: u32 = 0x4;
+pub val F3_MEM_HU: u32 = 0x5;
+pub val F3_MEM_WU: u32 = 0x6;
+
+pub val F3_BEQ:  u32 = 0x0;
+pub val F3_BNE:  u32 = 0x1;
+pub val F3_BLT:  u32 = 0x4;
+pub val F3_BGE:  u32 = 0x5;
+pub val F3_BLTU: u32 = 0x6;
+pub val F3_BGEU: u32 = 0x7;
+
+pub val F3_CSRRW:  u32 = 0x1;
+pub val F3_CSRRS:  u32 = 0x2;
+pub val F3_CSRRC:  u32 = 0x3;
+pub val F3_CSRRWI: u32 = 0x5;
+pub val F3_CSRRSI: u32 = 0x6;
+pub val F3_CSRRCI: u32 = 0x7;
+
+pub val F3_AMO_W: u32 = 0x2;
+pub val F3_AMO_D: u32 = 0x3;
+
+# funct3 of the sign-injection and compare forms
+pub val F3_FSGNJ:  u32 = 0x0;
+pub val F3_FSGNJN: u32 = 0x1;
+pub val F3_FSGNJX: u32 = 0x2;
+pub val F3_FLE:    u32 = 0x0;
+pub val F3_FLT:    u32 = 0x1;
+pub val F3_FEQ:    u32 = 0x2;
+
+# funct3 of the rounding-mode forms: the mode the encoder emits
+pub val RM_RNE: u32 = 0x0;
+pub val RM_RTZ: u32 = 0x1;
+pub val RM_DYN: u32 = 0x7;
+
+pub val F7_ZERO:   u32 = 0x00;
+pub val F7_MULDIV: u32 = 0x01;
+pub val F7_SUB:    u32 = 0x20;
+
+# funct7 of the F forms; bit 0 selects the D format
+pub val F7_FADD:     u32 = 0x00;
+pub val F7_FSUB:     u32 = 0x04;
+pub val F7_FMUL:     u32 = 0x08;
+pub val F7_FDIV:     u32 = 0x0C;
+pub val F7_FSGNJ:    u32 = 0x10;
+pub val F7_FCVT_F2F: u32 = 0x20;
+pub val F7_FCMP:     u32 = 0x50;
+pub val F7_FCVT_F2I: u32 = 0x60;
+pub val F7_FCVT_I2F: u32 = 0x68;
+pub val F7_FMV_F2I:  u32 = 0x70;
+pub val F7_FMV_I2F:  u32 = 0x78;
+
+pub val FMT_S_BIT: u32 = 0x0;
+pub val FMT_D_BIT: u32 = 0x1;
+
+# the rs2 selector of a conversion: the integer width, or the source format
+pub val FCVT_W:  u32 = 0x0;
+pub val FCVT_WU: u32 = 0x1;
+pub val FCVT_L:  u32 = 0x2;
+pub val FCVT_LU: u32 = 0x3;
+
+# funct5 (funct7 bits 6:2) of the A forms; bits 1:0 carry aq and rl
+pub val A5_AMOADD:  u32 = 0x00;
+pub val A5_AMOSWAP: u32 = 0x01;
+pub val A5_LR:      u32 = 0x02;
+pub val A5_SC:      u32 = 0x03;
+pub val A5_AMOXOR:  u32 = 0x04;
+pub val A5_AMOOR:   u32 = 0x08;
+pub val A5_AMOAND:  u32 = 0x0C;
+pub val A5_AMOMIN:  u32 = 0x10;
+pub val A5_AMOMAX:  u32 = 0x14;
+pub val A5_AMOMINU: u32 = 0x18;
+pub val A5_AMOMAXU: u32 = 0x1C;
+
+# the fixed imm12 of the system and fence forms
+pub val IMM_ECALL:      u32 = 0x000;
+pub val IMM_EBREAK:     u32 = 0x001;
+pub val IMM_FENCE_IORW: u32 = 0x0FF;
+pub val IMM_PAUSE:      u32 = 0x010;
+
+# the instruction format: how the fields pack into the word
+pub val FMT_R: u8 = 0;
+pub val FMT_I: u8 = 1;
+pub val FMT_S: u8 = 2;
+pub val FMT_B: u8 = 3;
+pub val FMT_U: u8 = 4;
+pub val FMT_J: u8 = 5;
+
+# the operand shape of the notification the encoder builds for an
+# instruction: which register banks and operand kinds sit in dst/src1/src2
+pub val SH_NONE:   u8 = 0;
+pub val SH_RRR:    u8 = 1;
+pub val SH_RRI:    u8 = 2;
+pub val SH_RU:     u8 = 3;
+pub val SH_LOAD:   u8 = 4;
+pub val SH_FLOAD:  u8 = 5;
+pub val SH_STORE:  u8 = 6;
+pub val SH_FSTORE: u8 = 7;
+pub val SH_BRANCH: u8 = 8;
+pub val SH_JUMP:   u8 = 9;
+pub val SH_FFF:    u8 = 10;
+pub val SH_FF:     u8 = 11;
+pub val SH_GFF:    u8 = 12;
+pub val SH_GF:     u8 = 13;
+pub val SH_FG:     u8 = 14;
+pub val SH_AMO:    u8 = 15;
+pub val SH_AMO_LR: u8 = 16;
+pub val SH_CSR:    u8 = 17;
+pub val SH_CSR_I:  u8 = 18;
+
+# the memory role of an instruction
+pub val MEM_NONE:   u8 = 0;
+pub val MEM_LOAD:   u8 = 1;
+pub val MEM_STORE:  u8 = 2;
+pub val MEM_ATOMIC: u8 = 3;
+
+# which fields beyond the base opcode name the instruction when a word is
+# classified; a field a row does not key on is free (a rounding mode, a
+# shift amount, an ordering bit)
+pub val KEY_F3:     u8 = 0x01;
+pub val KEY_F7:     u8 = 0x02;
+# funct7 bits 6:1; bit 0 is shamt[5] on rv64 (the shift immediates)
+pub val KEY_F7_HI6: u8 = 0x04;
+# funct7 bits 6:2 (the A forms)
+pub val KEY_F5:     u8 = 0x08;
+# rs2 == sel (the conversions)
+pub val KEY_RS2:    u8 = 0x10;
+# imm12 == sel (the system and fence forms)
+pub val KEY_IMM12:  u8 = 0x20;
+
+# one row per machine opcode: the encoding fields, the classification key,
+# the machines and extensions that admit it, its spelling and its shape.
+# every reader of a per-opcode fact reads this table; an opcode without a
+# row does not compile, and a row out of order fails the catalog test
+pub rec Row {
+    op:      MachOp;
+    name:    str;
+    fmt:     u8;
+    opcode7: u32;
+    # on a rounding-mode form this is the mode the encoder emits
+    funct3:  u32;
+    # on an A form the funct5 shifted into place, the ordering bits clear
+    funct7:  u32;
+    key:     u8;
+    # the fixed field a KEY_RS2 or KEY_IMM12 row names
+    sel:     u32;
+    xlens:   u8;
+    exts:    u32;
+    shape:   u8;
+    mem:     u8;
+}
+
+pub val ROWS: [ROW_COUNT]Row = [ROW_COUNT]Row{
+    Row{ op: MOP_NONE, name: "", fmt: FMT_I, opcode7: 0, funct3: 0, funct7: 0, key: 0, sel: 0, xlens: 0, exts: 0, shape: SH_NONE, mem: MEM_NONE },
+    Row{ op: ADD, name: "add", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_ADD, funct7: F7_ZERO, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: SUB, name: "sub", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_ADD, funct7: F7_SUB, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: SLL, name: "sll", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_SLL, funct7: F7_ZERO, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: SLT, name: "slt", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_SLT, funct7: F7_ZERO, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: SLTU, name: "sltu", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_SLTU, funct7: F7_ZERO, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: XOR, name: "xor", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_XOR, funct7: F7_ZERO, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: SRL, name: "srl", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_SRL, funct7: F7_ZERO, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: SRA, name: "sra", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_SRL, funct7: F7_SUB, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: OR, name: "or", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_OR, funct7: F7_ZERO, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: AND, name: "and", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_AND, funct7: F7_ZERO, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: ADDW, name: "addw", fmt: FMT_R, opcode7: OPC_OP_32, funct3: F3_ADD, funct7: F7_ZERO, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL64, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: SUBW, name: "subw", fmt: FMT_R, opcode7: OPC_OP_32, funct3: F3_ADD, funct7: F7_SUB, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL64, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: SLLW, name: "sllw", fmt: FMT_R, opcode7: OPC_OP_32, funct3: F3_SLL, funct7: F7_ZERO, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL64, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: SRLW, name: "srlw", fmt: FMT_R, opcode7: OPC_OP_32, funct3: F3_SRL, funct7: F7_ZERO, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL64, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: SRAW, name: "sraw", fmt: FMT_R, opcode7: OPC_OP_32, funct3: F3_SRL, funct7: F7_SUB, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL64, exts: features.I, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: MUL, name: "mul", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_ADD, funct7: F7_MULDIV, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.M, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: MULH, name: "mulh", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_SLL, funct7: F7_MULDIV, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.M, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: MULHSU, name: "mulhsu", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_SLT, funct7: F7_MULDIV, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.M, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: MULHU, name: "mulhu", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_SLTU, funct7: F7_MULDIV, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.M, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: DIV, name: "div", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_DIV, funct7: F7_MULDIV, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.M, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: DIVU, name: "divu", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_DIVU, funct7: F7_MULDIV, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.M, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: REM, name: "rem", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_REM, funct7: F7_MULDIV, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.M, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: REMU, name: "remu", fmt: FMT_R, opcode7: OPC_OP, funct3: F3_REMU, funct7: F7_MULDIV, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.M, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: MULW, name: "mulw", fmt: FMT_R, opcode7: OPC_OP_32, funct3: F3_ADD, funct7: F7_MULDIV, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL64, exts: features.I | features.M, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: DIVW, name: "divw", fmt: FMT_R, opcode7: OPC_OP_32, funct3: F3_DIV, funct7: F7_MULDIV, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL64, exts: features.I | features.M, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: DIVUW, name: "divuw", fmt: FMT_R, opcode7: OPC_OP_32, funct3: F3_DIVU, funct7: F7_MULDIV, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL64, exts: features.I | features.M, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: REMW, name: "remw", fmt: FMT_R, opcode7: OPC_OP_32, funct3: F3_REM, funct7: F7_MULDIV, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL64, exts: features.I | features.M, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: REMUW, name: "remuw", fmt: FMT_R, opcode7: OPC_OP_32, funct3: F3_REMU, funct7: F7_MULDIV, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL64, exts: features.I | features.M, shape: SH_RRR, mem: MEM_NONE },
+    Row{ op: ADDI, name: "addi", fmt: FMT_I, opcode7: OPC_OP_IMM, funct3: F3_ADD, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRI, mem: MEM_NONE },
+    Row{ op: SLTI, name: "slti", fmt: FMT_I, opcode7: OPC_OP_IMM, funct3: F3_SLT, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRI, mem: MEM_NONE },
+    Row{ op: SLTIU, name: "sltiu", fmt: FMT_I, opcode7: OPC_OP_IMM, funct3: F3_SLTU, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRI, mem: MEM_NONE },
+    Row{ op: XORI, name: "xori", fmt: FMT_I, opcode7: OPC_OP_IMM, funct3: F3_XOR, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRI, mem: MEM_NONE },
+    Row{ op: ORI, name: "ori", fmt: FMT_I, opcode7: OPC_OP_IMM, funct3: F3_OR, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRI, mem: MEM_NONE },
+    Row{ op: ANDI, name: "andi", fmt: FMT_I, opcode7: OPC_OP_IMM, funct3: F3_AND, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRI, mem: MEM_NONE },
+    Row{ op: SLLI, name: "slli", fmt: FMT_I, opcode7: OPC_OP_IMM, funct3: F3_SLL, funct7: F7_ZERO, key: KEY_F3 | KEY_F7_HI6, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRI, mem: MEM_NONE },
+    Row{ op: SRLI, name: "srli", fmt: FMT_I, opcode7: OPC_OP_IMM, funct3: F3_SRL, funct7: F7_ZERO, key: KEY_F3 | KEY_F7_HI6, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRI, mem: MEM_NONE },
+    Row{ op: SRAI, name: "srai", fmt: FMT_I, opcode7: OPC_OP_IMM, funct3: F3_SRL, funct7: F7_SUB, key: KEY_F3 | KEY_F7_HI6, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RRI, mem: MEM_NONE },
+    Row{ op: ADDIW, name: "addiw", fmt: FMT_I, opcode7: OPC_OP_IMM_32, funct3: F3_ADD, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL64, exts: features.I, shape: SH_RRI, mem: MEM_NONE },
+    Row{ op: SLLIW, name: "slliw", fmt: FMT_I, opcode7: OPC_OP_IMM_32, funct3: F3_SLL, funct7: F7_ZERO, key: KEY_F3 | KEY_F7_HI6, sel: 0, xlens: XL64, exts: features.I, shape: SH_RRI, mem: MEM_NONE },
+    Row{ op: SRLIW, name: "srliw", fmt: FMT_I, opcode7: OPC_OP_IMM_32, funct3: F3_SRL, funct7: F7_ZERO, key: KEY_F3 | KEY_F7_HI6, sel: 0, xlens: XL64, exts: features.I, shape: SH_RRI, mem: MEM_NONE },
+    Row{ op: SRAIW, name: "sraiw", fmt: FMT_I, opcode7: OPC_OP_IMM_32, funct3: F3_SRL, funct7: F7_SUB, key: KEY_F3 | KEY_F7_HI6, sel: 0, xlens: XL64, exts: features.I, shape: SH_RRI, mem: MEM_NONE },
+    Row{ op: LB, name: "lb", fmt: FMT_I, opcode7: OPC_LOAD, funct3: F3_MEM_B, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_LOAD, mem: MEM_LOAD },
+    Row{ op: LH, name: "lh", fmt: FMT_I, opcode7: OPC_LOAD, funct3: F3_MEM_H, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_LOAD, mem: MEM_LOAD },
+    Row{ op: LW, name: "lw", fmt: FMT_I, opcode7: OPC_LOAD, funct3: F3_MEM_W, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_LOAD, mem: MEM_LOAD },
+    Row{ op: LD, name: "ld", fmt: FMT_I, opcode7: OPC_LOAD, funct3: F3_MEM_D, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL64, exts: features.I, shape: SH_LOAD, mem: MEM_LOAD },
+    Row{ op: LBU, name: "lbu", fmt: FMT_I, opcode7: OPC_LOAD, funct3: F3_MEM_BU, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_LOAD, mem: MEM_LOAD },
+    Row{ op: LHU, name: "lhu", fmt: FMT_I, opcode7: OPC_LOAD, funct3: F3_MEM_HU, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_LOAD, mem: MEM_LOAD },
+    Row{ op: LWU, name: "lwu", fmt: FMT_I, opcode7: OPC_LOAD, funct3: F3_MEM_WU, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL64, exts: features.I, shape: SH_LOAD, mem: MEM_LOAD },
+    Row{ op: SB, name: "sb", fmt: FMT_S, opcode7: OPC_STORE, funct3: F3_MEM_B, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_STORE, mem: MEM_STORE },
+    Row{ op: SH, name: "sh", fmt: FMT_S, opcode7: OPC_STORE, funct3: F3_MEM_H, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_STORE, mem: MEM_STORE },
+    Row{ op: SW, name: "sw", fmt: FMT_S, opcode7: OPC_STORE, funct3: F3_MEM_W, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_STORE, mem: MEM_STORE },
+    Row{ op: SD, name: "sd", fmt: FMT_S, opcode7: OPC_STORE, funct3: F3_MEM_D, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL64, exts: features.I, shape: SH_STORE, mem: MEM_STORE },
+    Row{ op: BEQ, name: "beq", fmt: FMT_B, opcode7: OPC_BRANCH, funct3: F3_BEQ, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_BRANCH, mem: MEM_NONE },
+    Row{ op: BNE, name: "bne", fmt: FMT_B, opcode7: OPC_BRANCH, funct3: F3_BNE, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_BRANCH, mem: MEM_NONE },
+    Row{ op: BLT, name: "blt", fmt: FMT_B, opcode7: OPC_BRANCH, funct3: F3_BLT, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_BRANCH, mem: MEM_NONE },
+    Row{ op: BGE, name: "bge", fmt: FMT_B, opcode7: OPC_BRANCH, funct3: F3_BGE, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_BRANCH, mem: MEM_NONE },
+    Row{ op: BLTU, name: "bltu", fmt: FMT_B, opcode7: OPC_BRANCH, funct3: F3_BLTU, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_BRANCH, mem: MEM_NONE },
+    Row{ op: BGEU, name: "bgeu", fmt: FMT_B, opcode7: OPC_BRANCH, funct3: F3_BGEU, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_BRANCH, mem: MEM_NONE },
+    Row{ op: JAL, name: "jal", fmt: FMT_J, opcode7: OPC_JAL, funct3: F3_ADD, funct7: F7_ZERO, key: 0, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_JUMP, mem: MEM_NONE },
+    Row{ op: JALR, name: "jalr", fmt: FMT_I, opcode7: OPC_JALR, funct3: F3_ADD, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_LOAD, mem: MEM_NONE },
+    Row{ op: LUI, name: "lui", fmt: FMT_U, opcode7: OPC_LUI, funct3: F3_ADD, funct7: F7_ZERO, key: 0, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RU, mem: MEM_NONE },
+    Row{ op: AUIPC, name: "auipc", fmt: FMT_U, opcode7: OPC_AUIPC, funct3: F3_ADD, funct7: F7_ZERO, key: 0, sel: 0, xlens: XL_ANY, exts: features.I, shape: SH_RU, mem: MEM_NONE },
+    Row{ op: ECALL, name: "ecall", fmt: FMT_I, opcode7: OPC_SYSTEM, funct3: F3_ADD, funct7: F7_ZERO, key: KEY_F3 | KEY_IMM12, sel: IMM_ECALL, xlens: XL_ANY, exts: features.I, shape: SH_NONE, mem: MEM_NONE },
+    Row{ op: EBREAK, name: "ebreak", fmt: FMT_I, opcode7: OPC_SYSTEM, funct3: F3_ADD, funct7: F7_ZERO, key: KEY_F3 | KEY_IMM12, sel: IMM_EBREAK, xlens: XL_ANY, exts: features.I, shape: SH_NONE, mem: MEM_NONE },
+    Row{ op: FENCE, name: "fence", fmt: FMT_I, opcode7: OPC_MISC_MEM, funct3: F3_ADD, funct7: F7_ZERO, key: KEY_F3 | KEY_IMM12, sel: IMM_FENCE_IORW, xlens: XL_ANY, exts: features.I, shape: SH_NONE, mem: MEM_NONE },
+    Row{ op: PAUSE, name: "pause", fmt: FMT_I, opcode7: OPC_MISC_MEM, funct3: F3_ADD, funct7: F7_ZERO, key: KEY_F3 | KEY_IMM12, sel: IMM_PAUSE, xlens: XL_ANY, exts: features.I, shape: SH_NONE, mem: MEM_NONE },
+    Row{ op: FLW, name: "flw", fmt: FMT_I, opcode7: OPC_LOAD_FP, funct3: F3_MEM_W, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_FLOAD, mem: MEM_LOAD },
+    Row{ op: FLD, name: "fld", fmt: FMT_I, opcode7: OPC_LOAD_FP, funct3: F3_MEM_D, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FLOAD, mem: MEM_LOAD },
+    Row{ op: FSW, name: "fsw", fmt: FMT_S, opcode7: OPC_STORE_FP, funct3: F3_MEM_W, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_FSTORE, mem: MEM_STORE },
+    Row{ op: FSD, name: "fsd", fmt: FMT_S, opcode7: OPC_STORE_FP, funct3: F3_MEM_D, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FSTORE, mem: MEM_STORE },
+    Row{ op: FADD_S, name: "fadd.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FADD, key: KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_FFF, mem: MEM_NONE },
+    Row{ op: FADD_D, name: "fadd.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FADD | FMT_D_BIT, key: KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FFF, mem: MEM_NONE },
+    Row{ op: FSUB_S, name: "fsub.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FSUB, key: KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_FFF, mem: MEM_NONE },
+    Row{ op: FSUB_D, name: "fsub.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FSUB | FMT_D_BIT, key: KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FFF, mem: MEM_NONE },
+    Row{ op: FMUL_S, name: "fmul.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FMUL, key: KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_FFF, mem: MEM_NONE },
+    Row{ op: FMUL_D, name: "fmul.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FMUL | FMT_D_BIT, key: KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FFF, mem: MEM_NONE },
+    Row{ op: FDIV_S, name: "fdiv.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FDIV, key: KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_FFF, mem: MEM_NONE },
+    Row{ op: FDIV_D, name: "fdiv.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FDIV | FMT_D_BIT, key: KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FFF, mem: MEM_NONE },
+    Row{ op: FSGNJ_S, name: "fsgnj.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: F3_FSGNJ, funct7: F7_FSGNJ, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_FFF, mem: MEM_NONE },
+    Row{ op: FSGNJ_D, name: "fsgnj.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: F3_FSGNJ, funct7: F7_FSGNJ | FMT_D_BIT, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FFF, mem: MEM_NONE },
+    Row{ op: FSGNJN_S, name: "fsgnjn.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: F3_FSGNJN, funct7: F7_FSGNJ, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_FFF, mem: MEM_NONE },
+    Row{ op: FSGNJN_D, name: "fsgnjn.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: F3_FSGNJN, funct7: F7_FSGNJ | FMT_D_BIT, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FFF, mem: MEM_NONE },
+    Row{ op: FSGNJX_S, name: "fsgnjx.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: F3_FSGNJX, funct7: F7_FSGNJ, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_FFF, mem: MEM_NONE },
+    Row{ op: FSGNJX_D, name: "fsgnjx.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: F3_FSGNJX, funct7: F7_FSGNJ | FMT_D_BIT, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FFF, mem: MEM_NONE },
+    Row{ op: FEQ_S, name: "feq.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: F3_FEQ, funct7: F7_FCMP, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_GFF, mem: MEM_NONE },
+    Row{ op: FEQ_D, name: "feq.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: F3_FEQ, funct7: F7_FCMP | FMT_D_BIT, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_GFF, mem: MEM_NONE },
+    Row{ op: FLT_S, name: "flt.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: F3_FLT, funct7: F7_FCMP, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_GFF, mem: MEM_NONE },
+    Row{ op: FLT_D, name: "flt.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: F3_FLT, funct7: F7_FCMP | FMT_D_BIT, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_GFF, mem: MEM_NONE },
+    Row{ op: FLE_S, name: "fle.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: F3_FLE, funct7: F7_FCMP, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_GFF, mem: MEM_NONE },
+    Row{ op: FLE_D, name: "fle.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: F3_FLE, funct7: F7_FCMP | FMT_D_BIT, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_GFF, mem: MEM_NONE },
+    Row{ op: FCVT_S_D, name: "fcvt.s.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FCVT_F2F, key: KEY_F7 | KEY_RS2, sel: FMT_D_BIT, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FF, mem: MEM_NONE },
+    Row{ op: FCVT_D_S, name: "fcvt.d.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_RNE, funct7: F7_FCVT_F2F | FMT_D_BIT, key: KEY_F7 | KEY_RS2, sel: FMT_S_BIT, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FF, mem: MEM_NONE },
+    Row{ op: FCVT_W_S, name: "fcvt.w.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_RTZ, funct7: F7_FCVT_F2I, key: KEY_F7 | KEY_RS2, sel: FCVT_W, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_GF, mem: MEM_NONE },
+    Row{ op: FCVT_WU_S, name: "fcvt.wu.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_RTZ, funct7: F7_FCVT_F2I, key: KEY_F7 | KEY_RS2, sel: FCVT_WU, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_GF, mem: MEM_NONE },
+    Row{ op: FCVT_L_S, name: "fcvt.l.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_RTZ, funct7: F7_FCVT_F2I, key: KEY_F7 | KEY_RS2, sel: FCVT_L, xlens: XL64, exts: features.I | features.F | features.ZICSR, shape: SH_GF, mem: MEM_NONE },
+    Row{ op: FCVT_LU_S, name: "fcvt.lu.s", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_RTZ, funct7: F7_FCVT_F2I, key: KEY_F7 | KEY_RS2, sel: FCVT_LU, xlens: XL64, exts: features.I | features.F | features.ZICSR, shape: SH_GF, mem: MEM_NONE },
+    Row{ op: FCVT_W_D, name: "fcvt.w.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_RTZ, funct7: F7_FCVT_F2I | FMT_D_BIT, key: KEY_F7 | KEY_RS2, sel: FCVT_W, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_GF, mem: MEM_NONE },
+    Row{ op: FCVT_WU_D, name: "fcvt.wu.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_RTZ, funct7: F7_FCVT_F2I | FMT_D_BIT, key: KEY_F7 | KEY_RS2, sel: FCVT_WU, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_GF, mem: MEM_NONE },
+    Row{ op: FCVT_L_D, name: "fcvt.l.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_RTZ, funct7: F7_FCVT_F2I | FMT_D_BIT, key: KEY_F7 | KEY_RS2, sel: FCVT_L, xlens: XL64, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_GF, mem: MEM_NONE },
+    Row{ op: FCVT_LU_D, name: "fcvt.lu.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_RTZ, funct7: F7_FCVT_F2I | FMT_D_BIT, key: KEY_F7 | KEY_RS2, sel: FCVT_LU, xlens: XL64, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_GF, mem: MEM_NONE },
+    Row{ op: FCVT_S_W, name: "fcvt.s.w", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FCVT_I2F, key: KEY_F7 | KEY_RS2, sel: FCVT_W, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_FG, mem: MEM_NONE },
+    Row{ op: FCVT_S_WU, name: "fcvt.s.wu", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FCVT_I2F, key: KEY_F7 | KEY_RS2, sel: FCVT_WU, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_FG, mem: MEM_NONE },
+    Row{ op: FCVT_S_L, name: "fcvt.s.l", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FCVT_I2F, key: KEY_F7 | KEY_RS2, sel: FCVT_L, xlens: XL64, exts: features.I | features.F | features.ZICSR, shape: SH_FG, mem: MEM_NONE },
+    Row{ op: FCVT_S_LU, name: "fcvt.s.lu", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FCVT_I2F, key: KEY_F7 | KEY_RS2, sel: FCVT_LU, xlens: XL64, exts: features.I | features.F | features.ZICSR, shape: SH_FG, mem: MEM_NONE },
+    Row{ op: FCVT_D_W, name: "fcvt.d.w", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FCVT_I2F | FMT_D_BIT, key: KEY_F7 | KEY_RS2, sel: FCVT_W, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FG, mem: MEM_NONE },
+    Row{ op: FCVT_D_WU, name: "fcvt.d.wu", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FCVT_I2F | FMT_D_BIT, key: KEY_F7 | KEY_RS2, sel: FCVT_WU, xlens: XL_ANY, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FG, mem: MEM_NONE },
+    Row{ op: FCVT_D_L, name: "fcvt.d.l", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FCVT_I2F | FMT_D_BIT, key: KEY_F7 | KEY_RS2, sel: FCVT_L, xlens: XL64, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FG, mem: MEM_NONE },
+    Row{ op: FCVT_D_LU, name: "fcvt.d.lu", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_DYN, funct7: F7_FCVT_I2F | FMT_D_BIT, key: KEY_F7 | KEY_RS2, sel: FCVT_LU, xlens: XL64, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FG, mem: MEM_NONE },
+    Row{ op: FMV_X_W, name: "fmv.x.w", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_RNE, funct7: F7_FMV_F2I, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_GF, mem: MEM_NONE },
+    Row{ op: FMV_X_D, name: "fmv.x.d", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_RNE, funct7: F7_FMV_F2I | FMT_D_BIT, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL64, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_GF, mem: MEM_NONE },
+    Row{ op: FMV_W_X, name: "fmv.w.x", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_RNE, funct7: F7_FMV_I2F, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL_ANY, exts: features.I | features.F | features.ZICSR, shape: SH_FG, mem: MEM_NONE },
+    Row{ op: FMV_D_X, name: "fmv.d.x", fmt: FMT_R, opcode7: OPC_OP_FP, funct3: RM_RNE, funct7: F7_FMV_I2F | FMT_D_BIT, key: KEY_F3 | KEY_F7, sel: 0, xlens: XL64, exts: features.I | features.F | features.D | features.ZICSR, shape: SH_FG, mem: MEM_NONE },
+    Row{ op: LR_W, name: "lr.w", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_W, funct7: A5_LR << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL_ANY, exts: features.I | features.A, shape: SH_AMO_LR, mem: MEM_ATOMIC },
+    Row{ op: LR_D, name: "lr.d", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_D, funct7: A5_LR << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL64, exts: features.I | features.A, shape: SH_AMO_LR, mem: MEM_ATOMIC },
+    Row{ op: SC_W, name: "sc.w", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_W, funct7: A5_SC << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL_ANY, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: SC_D, name: "sc.d", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_D, funct7: A5_SC << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL64, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOSWAP_W, name: "amoswap.w", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_W, funct7: A5_AMOSWAP << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL_ANY, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOSWAP_D, name: "amoswap.d", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_D, funct7: A5_AMOSWAP << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL64, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOADD_W, name: "amoadd.w", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_W, funct7: A5_AMOADD << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL_ANY, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOADD_D, name: "amoadd.d", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_D, funct7: A5_AMOADD << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL64, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOXOR_W, name: "amoxor.w", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_W, funct7: A5_AMOXOR << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL_ANY, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOXOR_D, name: "amoxor.d", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_D, funct7: A5_AMOXOR << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL64, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOAND_W, name: "amoand.w", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_W, funct7: A5_AMOAND << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL_ANY, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOAND_D, name: "amoand.d", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_D, funct7: A5_AMOAND << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL64, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOOR_W, name: "amoor.w", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_W, funct7: A5_AMOOR << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL_ANY, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOOR_D, name: "amoor.d", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_D, funct7: A5_AMOOR << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL64, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOMIN_W, name: "amomin.w", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_W, funct7: A5_AMOMIN << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL_ANY, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOMIN_D, name: "amomin.d", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_D, funct7: A5_AMOMIN << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL64, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOMAX_W, name: "amomax.w", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_W, funct7: A5_AMOMAX << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL_ANY, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOMAX_D, name: "amomax.d", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_D, funct7: A5_AMOMAX << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL64, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOMINU_W, name: "amominu.w", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_W, funct7: A5_AMOMINU << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL_ANY, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOMINU_D, name: "amominu.d", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_D, funct7: A5_AMOMINU << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL64, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOMAXU_W, name: "amomaxu.w", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_W, funct7: A5_AMOMAXU << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL_ANY, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: AMOMAXU_D, name: "amomaxu.d", fmt: FMT_R, opcode7: OPC_AMO, funct3: F3_AMO_D, funct7: A5_AMOMAXU << 2, key: KEY_F3 | KEY_F5, sel: 0, xlens: XL64, exts: features.I | features.A, shape: SH_AMO, mem: MEM_ATOMIC },
+    Row{ op: CSRRW, name: "csrrw", fmt: FMT_I, opcode7: OPC_SYSTEM, funct3: F3_CSRRW, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I | features.ZICSR, shape: SH_CSR, mem: MEM_NONE },
+    Row{ op: CSRRS, name: "csrrs", fmt: FMT_I, opcode7: OPC_SYSTEM, funct3: F3_CSRRS, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I | features.ZICSR, shape: SH_CSR, mem: MEM_NONE },
+    Row{ op: CSRRC, name: "csrrc", fmt: FMT_I, opcode7: OPC_SYSTEM, funct3: F3_CSRRC, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I | features.ZICSR, shape: SH_CSR, mem: MEM_NONE },
+    Row{ op: CSRRWI, name: "csrrwi", fmt: FMT_I, opcode7: OPC_SYSTEM, funct3: F3_CSRRWI, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I | features.ZICSR, shape: SH_CSR_I, mem: MEM_NONE },
+    Row{ op: CSRRSI, name: "csrrsi", fmt: FMT_I, opcode7: OPC_SYSTEM, funct3: F3_CSRRSI, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I | features.ZICSR, shape: SH_CSR_I, mem: MEM_NONE },
+    Row{ op: CSRRCI, name: "csrrci", fmt: FMT_I, opcode7: OPC_SYSTEM, funct3: F3_CSRRCI, funct7: F7_ZERO, key: KEY_F3, sel: 0, xlens: XL_ANY, exts: features.I | features.ZICSR, shape: SH_CSR_I, mem: MEM_NONE },
+};
+
+pub fun in_catalog(op: MachOp) bool {
+    ret op != MOP_NONE && op <= MOP_LAST;
+}
+
+pub fun row(op: MachOp) *Row {
+    if (!in_catalog(op)) { ret ?ROWS[0]; }
+    ret ?ROWS[op::usize];
+}
+
+pub fun mnemonic(op: MachOp) str {
+    if (!in_catalog(op)) { ret nil; }
+    ret ROWS[op::usize].name;
+}
+
+pub fun shape_of(op: MachOp) u8 {
+    ret row(op).shape;
+}
+
+pub fun mem_role(op: MachOp) u8 {
+    ret row(op).mem;
+}
+
 pub fun xlens(op: MachOp) u8 {
-    if (op == MOP_NONE || op > MOP_LAST) { ret 0; }
-
-    if (op >= ADDW  && op <= SRAW)  { ret XL64; }
-    if (op >= MULW  && op <= REMUW) { ret XL64; }
-    if (op >= ADDIW && op <= SRAIW) { ret XL64; }
-
-    if (op == LD || op == LWU || op == SD) { ret XL64; }
-
-    if (op == FCVT_L_S || op == FCVT_LU_S || op == FCVT_L_D || op == FCVT_LU_D) { ret XL64; }
-    if (op == FCVT_S_L || op == FCVT_S_LU || op == FCVT_D_L || op == FCVT_D_LU) { ret XL64; }
-
-    if (op == FMV_X_D || op == FMV_D_X) { ret XL64; }
-
-    if (op == LR_D || op == SC_D) { ret XL64; }
-    if (op == AMOSWAP_D || op == AMOADD_D || op == AMOXOR_D || op == AMOAND_D
-        || op == AMOOR_D || op == AMOMIN_D || op == AMOMAX_D
-        || op == AMOMINU_D || op == AMOMAXU_D) { ret XL64; }
-
-    ret XL_ANY;
+    ret row(op).xlens;
 }
 
 pub fun admits(op: MachOp, xlen_bytes: u8) bool {
@@ -208,21 +556,67 @@ pub fun admits(op: MachOp, xlen_bytes: u8) bool {
 
 # the selection bits an opcode needs; 0 only for an opcode outside the catalog
 pub fun required_extensions(op: MachOp) u32 {
-    if (op == MOP_NONE || op > MOP_LAST) { ret 0; }
-    if (op >= MUL && op <= REMUW) { ret features.I | features.M; }
-    if (op >= LR_W && op <= AMOMAXU_D) { ret features.I | features.A; }
-    if (op >= CSRRW && op <= CSRRCI) { ret features.I | features.ZICSR; }
-    if (op >= FLW && op <= FMV_D_X) {
-        var bits: u32 = features.I | features.F | features.ZICSR;
-        if (op == FLD || op == FSD || op == FADD_D || op == FSUB_D || op == FMUL_D
-            || op == FDIV_D || op == FSGNJ_D || op == FSGNJN_D || op == FSGNJX_D
-            || op == FEQ_D || op == FLT_D || op == FLE_D || op == FCVT_S_D || op == FCVT_D_S
-            || (op >= FCVT_W_D && op <= FCVT_LU_D) || (op >= FCVT_D_W && op <= FCVT_D_LU)
-            || op == FMV_X_D || op == FMV_D_X) { bits = bits | features.D; }
-        ret bits;
+    ret row(op).exts;
+}
+
+# the integer memory access of a width: a subword load zero-extends, the
+# word load sign-extends. the machine that admits the row is the admission
+# seam's question, not this one's
+pub fun int_access(width: u8, is_load: bool) MachOp {
+    if (width == 1) { if (is_load) { ret LBU; } ret SB; }
+    if (width == 2) { if (is_load) { ret LHU; } ret SH; }
+    if (width == 4) { if (is_load) { ret LW; } ret SW; }
+    if (width == 8) { if (is_load) { ret LD; } ret SD; }
+    ret MOP_NONE;
+}
+
+pub fun fp_access(width: u8, is_load: bool) MachOp {
+    if (width == 4) { if (is_load) { ret FLW; } ret FSW; }
+    if (width == 8) { if (is_load) { ret FLD; } ret FSD; }
+    ret MOP_NONE;
+}
+
+fun key_matches(r: *Row, f3: u32, f7: u32, rs2: u32, imm12: u32) bool {
+    if ((r.key & KEY_F3) != 0 && f3 != r.funct3) { ret false; }
+    if ((r.key & KEY_F7) != 0 && f7 != r.funct7) { ret false; }
+    if ((r.key & KEY_F7_HI6) != 0 && (f7 >> 1) != (r.funct7 >> 1)) { ret false; }
+    if ((r.key & KEY_F5) != 0 && (f7 >> 2) != (r.funct7 >> 2)) { ret false; }
+    if ((r.key & KEY_RS2) != 0 && rs2 != r.sel) { ret false; }
+    if ((r.key & KEY_IMM12) != 0 && imm12 != r.sel) { ret false; }
+    ret true;
+}
+
+# the opcode an emitted word spells, MOP_NONE when no row claims it
+pub fun classify(word: u32) MachOp {
+    val opcode7: u32 = word & 0x7F;
+    val f3: u32 = (word >> 12) & 0x7;
+    val f7: u32 = word >> 25;
+    val rs2: u32 = (word >> 20) & 0x1F;
+    val imm12: u32 = word >> 20;
+    var op: MachOp = 1;
+    for (op <= MOP_LAST) {
+        val r: *Row = ?ROWS[op::usize];
+        if (r.opcode7 == opcode7 && key_matches(r, f3, f7, rs2, imm12)) { ret op; }
+        op = op + 1;
     }
-    if ((op >= ADD && op <= SRAW) || (op >= ADDI && op <= PAUSE)) { ret features.I; }
-    ret 0;
+    ret MOP_NONE;
+}
+
+# the word an opcode's row spells with every register field zero: the
+# keyed fields set, every free field zero
+pub fun key_word(op: MachOp) u32 {
+    val r: *Row = row(op);
+    var word: u32 = r.opcode7;
+    if (r.fmt != FMT_U && r.fmt != FMT_J) { word = word | (r.funct3 << 12); }
+    if (r.fmt == FMT_R) {
+        word = word | (r.funct7 << 25);
+        if ((r.key & KEY_RS2) != 0) { word = word | (r.sel << 20); }
+    }
+    if (r.fmt == FMT_I) {
+        if ((r.key & KEY_IMM12) != 0) { word = word | (r.sel << 20); }
+        or { word = word | (r.funct7 << 25); }
+    }
+    ret word;
 }
 
 pub val FLAG_AQ: u16 = 0x0001;
@@ -233,3 +627,74 @@ pub val FLAG_LABEL_FWD:   u16 = 0x0008;
 pub val FLAG_LABEL_SKIP:  u16 = 0x0010;
 
 pub val FLAG_TARGET_BLOCK: u16 = 0x0020;
+
+test "mach.lang.target.isa.riscv.inst.ROWS:every_opcode_has_its_row_in_order" {
+    var op: MachOp = 1;
+    for (op <= MOP_LAST) {
+        val r: *Row = ?ROWS[op::usize];
+        if (r.op != op) { ret 1; }
+        if (r.name == nil || str_len(r.name) == 0) { ret 2; }
+        if (r.fmt > FMT_J) { ret 3; }
+        if (r.xlens == 0 || (r.xlens & ~XL_ANY) != 0) { ret 4; }
+        if (r.exts == 0 || (r.exts & features.I) == 0) { ret 5; }
+        if (r.mem != MEM_NONE && r.shape != SH_LOAD && r.shape != SH_FLOAD && r.shape != SH_STORE
+            && r.shape != SH_FSTORE && r.shape != SH_AMO && r.shape != SH_AMO_LR) { ret 6; }
+        op = op + 1;
+    }
+    if (ROWS[0].op != MOP_NONE || ROWS[0].xlens != 0 || ROWS[0].exts != 0) { ret 7; }
+    if (ROW_COUNT != MOP_LAST::usize + 1) { ret 12; }
+    if (mnemonic(MOP_NONE) != nil || mnemonic(MOP_LAST + 1) != nil) { ret 8; }
+    if (!str_equals(mnemonic(ADDIW), "addiw") || !str_equals(mnemonic(FCVT_W_D), "fcvt.w.d")
+        || !str_equals(mnemonic(FSGNJN_S), "fsgnjn.s") || !str_equals(mnemonic(AMOADD_D), "amoadd.d")
+        || !str_equals(mnemonic(LR_W), "lr.w") || !str_equals(mnemonic(CSRRCI), "csrrci")) { ret 13; }
+    if (xlens(MOP_NONE) != 0 || xlens(MOP_LAST + 1) != 0) { ret 9; }
+    if (required_extensions(MOP_NONE) != 0 || required_extensions(MOP_LAST + 1) != 0) { ret 10; }
+    if (shape_of(MOP_LAST + 1) != SH_NONE) { ret 11; }
+    ret 0;
+}
+
+test "mach.lang.target.isa.riscv.inst.classify:every_key_word_names_exactly_its_row" {
+    var op: MachOp = 1;
+    for (op <= MOP_LAST) {
+        val word: u32 = key_word(op);
+        if (classify(word) != op) { ret 1; }
+        var claims: u32 = 0;
+        var other: MachOp = 1;
+        for (other <= MOP_LAST) {
+            val r: *Row = ?ROWS[other::usize];
+            if (r.opcode7 == (word & 0x7F)
+                && key_matches(r, (word >> 12) & 0x7, word >> 25, (word >> 20) & 0x1F, word >> 20)) {
+                claims = claims + 1;
+            }
+            other = other + 1;
+        }
+        if (claims != 1) { ret 2; }
+        op = op + 1;
+    }
+    # a free field does not change the answer: rounding, shift amount, ordering
+    if (classify(key_word(FADD_D) | (RM_RTZ << 12)) != FADD_D) { ret 3; }
+    if (classify(key_word(SRAI) | (0x3F << 20)) != SRAI) { ret 4; }
+    if (classify(key_word(SLLI) | (0x3F << 20)) != SLLI) { ret 5; }
+    if (classify(key_word(AMOADD_W) | (0x3 << 25)) != AMOADD_W) { ret 6; }
+    # a keyed field does: an unnamed fence set, a foreign rs2 selector
+    if (classify(key_word(FENCE) ^ (0x0F0 << 20)) != MOP_NONE) { ret 7; }
+    if (classify(key_word(FCVT_W_S) | (0x4 << 20)) != MOP_NONE) { ret 8; }
+    if (classify(0) != MOP_NONE) { ret 9; }
+    ret 0;
+}
+
+test "mach.lang.target.isa.riscv.inst.admits:xlen_and_extension_columns" {
+    if (xlens(LD) != XL64 || xlens(LW) != XL_ANY) { ret 1; }
+    if (admits(LD, 4) || !admits(LD, 8) || !admits(LW, 4) || !admits(LW, 8)) { ret 2; }
+    if (admits(ADD, 0)) { ret 3; }
+    if (required_extensions(MUL) != (features.I | features.M)) { ret 4; }
+    if (required_extensions(FLD) != (features.I | features.F | features.D | features.ZICSR)) { ret 5; }
+    if (required_extensions(CSRRW) != (features.I | features.ZICSR)) { ret 6; }
+    if (required_extensions(LR_W) != (features.I | features.A)) { ret 7; }
+    if (int_access(8, true) != LD || int_access(1, true) != LBU || int_access(2, true) != LHU || int_access(4, true) != LW
+        || int_access(1, false) != SB || int_access(3, true) != MOP_NONE) { ret 8; }
+    if (fp_access(4, false) != FSW || fp_access(8, true) != FLD || fp_access(2, true) != MOP_NONE) { ret 9; }
+    if (mem_role(SD) != MEM_STORE || mem_role(FLW) != MEM_LOAD || mem_role(SC_W) != MEM_ATOMIC
+        || mem_role(JALR) != MEM_NONE) { ret 10; }
+    ret 0;
+}

--- a/src/lang/target/isa/riscv/printer.mach
+++ b/src/lang/target/isa/riscv/printer.mach
@@ -59,7 +59,7 @@ fun render_inst(out: *writer.Writer, interner: *intern.Interner, mi: *isa.Inst) 
     val res_indent: err[fail.Fail] = emit_str(out, "  ");
     if (sel res_indent.err) { ret res_indent; }
 
-    val mnem: str = mnemonic(mi.opcode::inst.MachOp);
+    val mnem: str = inst.mnemonic(mi.opcode::inst.MachOp);
     if (mnem == nil) {
         ret err[fail.Fail].err{fail.message("--emit-asm: no riscv64 mnemonic for the emitted opcode")};
     }
@@ -81,7 +81,8 @@ fun rounding_operand(op: inst.MachOp) str {
 }
 
 fun render_operands(out: *writer.Writer, interner: *intern.Interner, mi: *isa.Inst) err[fail.Fail] {
-    if (mi.dst.kind == isa.OPK_MEM) {
+    # a store spells its value before its address
+    if (inst.mem_role(mi.opcode::inst.MachOp) == inst.MEM_STORE) {
         var printed: u32 = 0;
         val res_src: res[u32, fail.Fail] = render_operand(out, interner, mi, ?mi.src1, printed);
         if (sel res_src.err) { ret err[fail.Fail].err{res_src.err}; }
@@ -296,172 +297,6 @@ pub fun fp_name(idx: u32) str {
     ret "f?";
 }
 
-pub fun mnemonic(op: inst.MachOp) str {
-    if (op == inst.ADD)  { ret "add"; }
-    if (op == inst.SUB)  { ret "sub"; }
-    if (op == inst.SLL)  { ret "sll"; }
-    if (op == inst.SLT)  { ret "slt"; }
-    if (op == inst.SLTU) { ret "sltu"; }
-    if (op == inst.XOR)  { ret "xor"; }
-    if (op == inst.SRL)  { ret "srl"; }
-    if (op == inst.SRA)  { ret "sra"; }
-    if (op == inst.OR)   { ret "or"; }
-    if (op == inst.AND)  { ret "and"; }
-
-    if (op == inst.ADDW) { ret "addw"; }
-    if (op == inst.SUBW) { ret "subw"; }
-    if (op == inst.SLLW) { ret "sllw"; }
-    if (op == inst.SRLW) { ret "srlw"; }
-    if (op == inst.SRAW) { ret "sraw"; }
-
-    if (op == inst.MUL)    { ret "mul"; }
-    if (op == inst.MULH)   { ret "mulh"; }
-    if (op == inst.MULHSU) { ret "mulhsu"; }
-    if (op == inst.MULHU)  { ret "mulhu"; }
-    if (op == inst.DIV)    { ret "div"; }
-    if (op == inst.DIVU)   { ret "divu"; }
-    if (op == inst.REM)    { ret "rem"; }
-    if (op == inst.REMU)   { ret "remu"; }
-
-    if (op == inst.MULW)  { ret "mulw"; }
-    if (op == inst.DIVW)  { ret "divw"; }
-    if (op == inst.DIVUW) { ret "divuw"; }
-    if (op == inst.REMW)  { ret "remw"; }
-    if (op == inst.REMUW) { ret "remuw"; }
-
-    if (op == inst.ADDI)  { ret "addi"; }
-    if (op == inst.SLTI)  { ret "slti"; }
-    if (op == inst.SLTIU) { ret "sltiu"; }
-    if (op == inst.XORI)  { ret "xori"; }
-    if (op == inst.ORI)   { ret "ori"; }
-    if (op == inst.ANDI)  { ret "andi"; }
-    if (op == inst.SLLI)  { ret "slli"; }
-    if (op == inst.SRLI)  { ret "srli"; }
-    if (op == inst.SRAI)  { ret "srai"; }
-
-    if (op == inst.ADDIW) { ret "addiw"; }
-    if (op == inst.SLLIW) { ret "slliw"; }
-    if (op == inst.SRLIW) { ret "srliw"; }
-    if (op == inst.SRAIW) { ret "sraiw"; }
-
-    if (op == inst.LB)  { ret "lb"; }
-    if (op == inst.LH)  { ret "lh"; }
-    if (op == inst.LW)  { ret "lw"; }
-    if (op == inst.LD)  { ret "ld"; }
-    if (op == inst.LBU) { ret "lbu"; }
-    if (op == inst.LHU) { ret "lhu"; }
-    if (op == inst.LWU) { ret "lwu"; }
-
-    if (op == inst.SB) { ret "sb"; }
-    if (op == inst.SH) { ret "sh"; }
-    if (op == inst.SW) { ret "sw"; }
-    if (op == inst.SD) { ret "sd"; }
-
-    if (op == inst.BEQ)  { ret "beq"; }
-    if (op == inst.BNE)  { ret "bne"; }
-    if (op == inst.BLT)  { ret "blt"; }
-    if (op == inst.BGE)  { ret "bge"; }
-    if (op == inst.BLTU) { ret "bltu"; }
-    if (op == inst.BGEU) { ret "bgeu"; }
-
-    if (op == inst.JAL)  { ret "jal"; }
-    if (op == inst.JALR) { ret "jalr"; }
-
-    if (op == inst.LUI)   { ret "lui"; }
-    if (op == inst.AUIPC) { ret "auipc"; }
-
-    if (op == inst.ECALL)  { ret "ecall"; }
-    if (op == inst.EBREAK) { ret "ebreak"; }
-    if (op == inst.FENCE)  { ret "fence"; }
-    if (op == inst.PAUSE)  { ret "pause"; }
-
-    if (op == inst.FLW) { ret "flw"; }
-    if (op == inst.FLD) { ret "fld"; }
-    if (op == inst.FSW) { ret "fsw"; }
-    if (op == inst.FSD) { ret "fsd"; }
-
-    if (op == inst.FADD_S) { ret "fadd.s"; }
-    if (op == inst.FADD_D) { ret "fadd.d"; }
-    if (op == inst.FSUB_S) { ret "fsub.s"; }
-    if (op == inst.FSUB_D) { ret "fsub.d"; }
-    if (op == inst.FMUL_S) { ret "fmul.s"; }
-    if (op == inst.FMUL_D) { ret "fmul.d"; }
-    if (op == inst.FDIV_S) { ret "fdiv.s"; }
-    if (op == inst.FDIV_D) { ret "fdiv.d"; }
-
-    if (op == inst.FSGNJ_S)  { ret "fsgnj.s"; }
-    if (op == inst.FSGNJ_D)  { ret "fsgnj.d"; }
-    if (op == inst.FSGNJN_S) { ret "fsgnjn.s"; }
-    if (op == inst.FSGNJN_D) { ret "fsgnjn.d"; }
-    if (op == inst.FSGNJX_S) { ret "fsgnjx.s"; }
-    if (op == inst.FSGNJX_D) { ret "fsgnjx.d"; }
-
-    if (op == inst.FEQ_S) { ret "feq.s"; }
-    if (op == inst.FEQ_D) { ret "feq.d"; }
-    if (op == inst.FLT_S) { ret "flt.s"; }
-    if (op == inst.FLT_D) { ret "flt.d"; }
-    if (op == inst.FLE_S) { ret "fle.s"; }
-    if (op == inst.FLE_D) { ret "fle.d"; }
-
-    if (op == inst.FCVT_S_D) { ret "fcvt.s.d"; }
-    if (op == inst.FCVT_D_S) { ret "fcvt.d.s"; }
-
-    if (op == inst.FCVT_W_S)  { ret "fcvt.w.s"; }
-    if (op == inst.FCVT_WU_S) { ret "fcvt.wu.s"; }
-    if (op == inst.FCVT_L_S)  { ret "fcvt.l.s"; }
-    if (op == inst.FCVT_LU_S) { ret "fcvt.lu.s"; }
-    if (op == inst.FCVT_W_D)  { ret "fcvt.w.d"; }
-    if (op == inst.FCVT_WU_D) { ret "fcvt.wu.d"; }
-    if (op == inst.FCVT_L_D)  { ret "fcvt.l.d"; }
-    if (op == inst.FCVT_LU_D) { ret "fcvt.lu.d"; }
-
-    if (op == inst.FCVT_S_W)  { ret "fcvt.s.w"; }
-    if (op == inst.FCVT_S_WU) { ret "fcvt.s.wu"; }
-    if (op == inst.FCVT_S_L)  { ret "fcvt.s.l"; }
-    if (op == inst.FCVT_S_LU) { ret "fcvt.s.lu"; }
-    if (op == inst.FCVT_D_W)  { ret "fcvt.d.w"; }
-    if (op == inst.FCVT_D_WU) { ret "fcvt.d.wu"; }
-    if (op == inst.FCVT_D_L)  { ret "fcvt.d.l"; }
-    if (op == inst.FCVT_D_LU) { ret "fcvt.d.lu"; }
-
-    if (op == inst.FMV_X_W) { ret "fmv.x.w"; }
-    if (op == inst.FMV_X_D) { ret "fmv.x.d"; }
-    if (op == inst.FMV_W_X) { ret "fmv.w.x"; }
-    if (op == inst.FMV_D_X) { ret "fmv.d.x"; }
-
-    if (op == inst.LR_W) { ret "lr.w"; }
-    if (op == inst.LR_D) { ret "lr.d"; }
-    if (op == inst.SC_W) { ret "sc.w"; }
-    if (op == inst.SC_D) { ret "sc.d"; }
-
-    if (op == inst.AMOSWAP_W) { ret "amoswap.w"; }
-    if (op == inst.AMOSWAP_D) { ret "amoswap.d"; }
-    if (op == inst.AMOADD_W)  { ret "amoadd.w"; }
-    if (op == inst.AMOADD_D)  { ret "amoadd.d"; }
-    if (op == inst.AMOXOR_W)  { ret "amoxor.w"; }
-    if (op == inst.AMOXOR_D)  { ret "amoxor.d"; }
-    if (op == inst.AMOAND_W)  { ret "amoand.w"; }
-    if (op == inst.AMOAND_D)  { ret "amoand.d"; }
-    if (op == inst.AMOOR_W)   { ret "amoor.w"; }
-    if (op == inst.AMOOR_D)   { ret "amoor.d"; }
-    if (op == inst.AMOMIN_W)  { ret "amomin.w"; }
-    if (op == inst.AMOMIN_D)  { ret "amomin.d"; }
-    if (op == inst.AMOMAX_W)  { ret "amomax.w"; }
-    if (op == inst.AMOMAX_D)  { ret "amomax.d"; }
-    if (op == inst.AMOMINU_W) { ret "amominu.w"; }
-    if (op == inst.AMOMINU_D) { ret "amominu.d"; }
-    if (op == inst.AMOMAXU_W) { ret "amomaxu.w"; }
-    if (op == inst.AMOMAXU_D) { ret "amomaxu.d"; }
-
-    if (op == inst.CSRRW)  { ret "csrrw"; }
-    if (op == inst.CSRRS)  { ret "csrrs"; }
-    if (op == inst.CSRRC)  { ret "csrrc"; }
-    if (op == inst.CSRRWI) { ret "csrrwi"; }
-    if (op == inst.CSRRSI) { ret "csrrsi"; }
-    if (op == inst.CSRRCI) { ret "csrrci"; }
-    ret nil;
-}
-
 fun emit_str(out: *writer.Writer, s: str) err[fail.Fail] {
     val res_write: res[usize, writer.WriteError] = format.write_str(out, s);
     if (sel res_write.err) { ret err[fail.Fail].err{fail.write_refused(res_write.err)}; }
@@ -567,30 +402,11 @@ test "mach.lang.target.isa.riscv.printer.render_inst:rounding_mode_is_named" {
     ret 0;
 }
 
-test "mach.lang.target.isa.riscv.printer.mnemonic:opcode_names" {
-    if (!str_equals(mnemonic(inst.ADD), "add"))     { ret 1; }
-    if (!str_equals(mnemonic(inst.ADDW), "addw"))   { ret 1; }
-    if (!str_equals(mnemonic(inst.ADDI), "addi"))   { ret 1; }
-    if (!str_equals(mnemonic(inst.ADDIW), "addiw")) { ret 1; }
-
-    if (!str_equals(mnemonic(inst.JAL), "jal"))   { ret 1; }
-    if (!str_equals(mnemonic(inst.JALR), "jalr")) { ret 1; }
-    if (!str_equals(mnemonic(inst.BLT), "blt"))   { ret 1; }
-    if (!str_equals(mnemonic(inst.SD), "sd"))     { ret 1; }
-    if (!str_equals(mnemonic(inst.LD), "ld"))     { ret 1; }
-
-    if (!str_equals(mnemonic(inst.FADD_D), "fadd.d"))     { ret 1; }
-    if (!str_equals(mnemonic(inst.FSGNJN_S), "fsgnjn.s")) { ret 1; }
-    if (!str_equals(mnemonic(inst.FCVT_W_D), "fcvt.w.d")) { ret 1; }
-    if (!str_equals(mnemonic(inst.FMV_X_W), "fmv.x.w"))   { ret 1; }
-
-    if (!str_equals(mnemonic(inst.AMOADD_D), "amoadd.d")) { ret 1; }
-    if (!str_equals(mnemonic(inst.LR_W), "lr.w"))         { ret 1; }
+test "mach.lang.target.isa.riscv.printer.ordering_suffix:aq_rl_spellings" {
     if (!str_equals(ordering_suffix(inst.FLAG_AQ), ".aq")) { ret 1; }
+    if (!str_equals(ordering_suffix(inst.FLAG_RL), ".rl")) { ret 1; }
     if (!str_equals(ordering_suffix(inst.FLAG_AQ | inst.FLAG_RL), ".aqrl")) { ret 1; }
     if (!str_equals(ordering_suffix(0), "")) { ret 1; }
-
-    if (mnemonic(inst.MOP_NONE) != nil) { ret 1; }
     ret 0;
 }
 


### PR DESCRIPTION
Census #2212 section 10 item 2, the riscv half: one instruction table in `riscv/inst.mach` that every per-opcode reader reads. Refs #2212 (the coordinator closes it when the remainder lanes land).

## The table

`inst.Row`, one per `MachOp`, indexed by opcode: `fmt`, `opcode7`, `funct3`, `funct7`, `key` (which fields classify a word), `sel` (the fixed rs2 or imm12 a keyed row names), `xlens`, `exts`, `name`, `shape`, `mem`. An opcode without a row is a compile error (array length); a row out of order fails the catalog test; every row's key word classifies back to exactly that row (uniqueness is asserted over the whole catalog, and free fields such as a rounding mode, a shift amount or an aq/rl bit are shown not to change the answer).

Readers, replacing what each re-derived (the DUP/ADM rows the census cites at `riscv/inst.mach:182` and `encode.mach:383-571, 2746, 3221`):

- `rv_fields` (deleted) and the eight `classify_*` inverses (deleted): `emit_[risbuj]` classify the packed word through `inst.classify`; `rv_emit` reads the row's fields, and the fixed fence/pause/ecall/ebreak immediates are the row's `sel` (the fence sets are now modelled, `IMM_FENCE_IORW`).
- `shape_of` (deleted from encode): the row's `shape`; `SH_*` live with the table.
- `printer.mnemonic` (deleted): `inst.mnemonic`; the printer orders a store's operands by the row's `mem` role instead of re-deriving store-ness from `dst.kind == OPK_MEM`.
- `rv_decode_amo` matches the table's spellings instead of restating the eleven stems; a test pins that every canonical grammar row (`RVP_RRR/RRI/SHIFT/LOAD/STORE/UIMM/BRANCH/JAL/JALR/CSR*/ECALL/EBREAK/FENCE/PAUSE`) spells the table's name.
- `xlens`, `admits`, `required_extensions` (N3's frozen names, unchanged signatures) read their column.
- The #2766 access rows: `inst.int_access` / `inst.fp_access` name the load or store of a width; `int_mem_funct3` / `fp_mem_funct3` read the row's funct3.

## The admission seam (census item 6, the codegen half)

`inst.admits` guarded only inline asm while the MIR path enforced xlen by width arithmetic inside `int_mem_funct3`. N3's seam (`check_generated_extensions`, now `check_generated_admission`) re-decodes every generated word through `inst.classify` and asks the row for its xlen mask before its extension bits: a 64-bit access selected on rv32 is refused where a missing extension is, and a word no row claims is refused as such. The inline-asm pre-check keeps its span-bearing message and then goes through the same `admission`. Three mutation controls were run: the xlen check disabled (seam test fails at 3), a key flag dropped from `srai` (uniqueness test fails), two rows swapped (catalog test fails).

Effect facts stay where N5 put them (`inst_effects`, `asm_ct_class`); `inst_effects` reads the shape from the table and gains no parallel column.

## Not done here, on purpose

- The 111 `emit_[risbuj](st, OPC_*, F3_*, ...)` MIR sites still pass raw fields; the encoder's field constants are now aliases of the table's (`val OPC_OP: u32 = inst.OPC_OP`) rather than a third spelling. Emitting by opcode at those sites is the follow-up that deletes the aliases; it was kept out to keep this diff mechanical under the identity bar and ahead of the `mach fmt` commit.
- `RV_MNEMONICS` rows keep literal names: a static initializer cannot read `inst.ROWS[...]` across a module boundary (`array literals are not comptime-evaluable`, reproduced in a two-module scratch project; same-module folds fine). The grammar test above holds them to the table instead.
- The printer's `rounding_operand` range test (census's rounding-mode DUP row) is untouched; the row's `funct3` records the mode the encoder emits, but the emit sites do not yet read it.

## Bar

- Corpus once, at the end, with the HEAD-built compiler: riscv64-linux, riscv32 (rv32imafdc) and x86_64-linux, layers A+B: 816 pass / 0 fail / 204 declared skip, goldens byte-identical (this is a refactor; no golden moved).
- llvm-mc 22.1.8 conformance (the tree has no harness; run as a scratch check): all 140 rows assembled by name and compared field by field against the row's key, including the rounding mode, the fcvt rs2 selectors, the amo funct5 and the CSR funct3: 140/140 agree.
- Suite through the HEAD-built compiler: 3045 passed / 0 failed (baseline 3041 at 61484755b; +6: `inst.ROWS:every_opcode_has_its_row_in_order`, `inst.classify:every_key_word_names_exactly_its_row`, `inst.admits:xlen_and_extension_columns`, `encode:grammar_rows_read_the_table`, `encode:generated_words_admit_by_the_tables_xlen_mask`, `printer.ordering_suffix:aq_rl_spellings`; −2: `encode:asm_fields_classify_round_trip`, `printer.mnemonic:opcode_names`, both subsumed).
- `sh test/census.sh`: all ok.
- Link: x86_64-linux leg 142/142; `3110-atomic-inline` on riscv64-linux under qemu, debug and release, pass.
- Fixpoint: A (stage) builds B, B builds C, `cmp B C` identical.
