### PR TITLE
isa(arm64, spirv): one instruction representation and one form table per ISA (#2212)

### DIFF
--- a/doc/design/backend-census-2212.md
+++ b/doc/design/backend-census-2212.md
@@ -433,12 +433,29 @@ owner decision or a proven bar beyond "goldens unchanged".
    word only if `isa.Inst` grows a fourth operand or aarch64 keeps a form byte;
    that is #2212's open question 1 (per-ISA shape vs one generic type) and needs
    the owner's ruling before code.
+   *Landed 2026-09-12 (#2212, "one instruction representation").* Ruled as one
+   generic `isa.Inst` (`src3` from N5). The private record, its 22 form bytes and
+   the `to_inst` translation are gone: `arm64/inst.mach:Form` is one row per
+   `MachOp` (spelling, `Layout`, base word and immediate-form base, `WidthRule`,
+   `LaneClass`, alias flag); `inst.assemble(*isa.Inst)` packs the word from the row
+   and the operands, `inst.spell` renames an encoding to the alias an assembler
+   reads back (the notification carries the spelled form), and `arm64/printer.mach`
+   renders from `isa.Inst` alone. The layout is the old form byte as a row column;
+   `FLAG_SP`, `FLAG_LABEL_LOCAL/FWD/SKIP` carry what the record's `target`/`sym_mod`
+   fields did (the symbol modifier is now `isa.Operand.sym_mod`). Three members
+   were added for encodings that shared a spelling: `FMOV_GEN`, `FMOV_IMM`,
+   `INS_EL`. `inst.form:every_member_has_a_complete_row` is the opcode-space
+   census; an instruction the table cannot hold emits nothing and refuses the
+   buffer (`encode.buf_refuse`, reported at the function boundary).
 2. **Per-opcode description tables where none exist** (ADM rows above):
    x86_64 form/flags/memory for the codegen path; a riscv `inst.mach` table
    (format, opcode7, funct3, funct7, xlen mask, mnemonic, load/store) that
    `rv_fields`, `classify_*`, `shape_of`, `printer.mnemonic` and `RV_MNEMONICS.code`
    all read; an aarch64 base-word table. The #2766 access rows are the template.
    Bar: byte-identical corpus plus `llvm-mc` conformance per #2118's acceptance.
+   *aarch64 landed 2026-09-12* with item 1: the base-word table is the `Form` row,
+   the access rows (`encode.mach:A64Access`) now name members instead of words,
+   and the packer unit tests state their expectations through `inst.assemble`.
 3. **`isa.Inst.clobbers`.** Either delete the field or make every encoder
    populate it and add a reader; leaving a zero-filled effect field for N5 to
    discover is the fail-open shape #2212 forbids. N5 should rule.
@@ -462,6 +479,11 @@ owner decision or a proven bar beyond "goldens unchanged".
 7. **SPIR-V opcode table.** An `OpDef`-shaped row (opcode, arity, result-type)
    for the ~60 `emit_instr` arms, so word counts and the int/float pairing are
    data. Sequenced after N4 so the value ABI is not rebuilt twice.
+   *Landed 2026-09-12.* `spirv/ops.mach`: `CoreOp` (opcode, name, arity; every
+   row typed) and `MirMap` (MIR opcode, emitter shape, int/float opcode, source
+   class). `emit_instr` dispatches by the mapping row; `emit_binary`/`unary`/
+   `compare`/`convert` size the word from the core row and refuse an opcode whose
+   arity is not the shape's. The N4 value ABI is untouched.
 
 ## 11. Frozen interfaces for N3 to N6
 

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -98,6 +98,9 @@ pub rec ByteBuf {
     # typed outcome. a failed buffer stops appending and stays releasable
     failed:   bool;
     fail_err: A.Error;
+    # an encoder's own refusal of an instruction it cannot assemble, recorded
+    # the same way and reported at the boundary; nil when none
+    refusal:  str;
 }
 
 pub rec AsmSink {
@@ -404,7 +407,16 @@ pub fun buf_init(alloc: *A.Allocator) ByteBuf {
     buf.asm   = nil;
     buf.failed   = false;
     buf.fail_err = A.Error.exhausted{};
+    buf.refusal  = nil;
     ret buf;
+}
+
+# an encoder records that an instruction had no encoding for its operands;
+# the first refusal is kept and the emission is reported failed at the
+# function boundary, so the bytes a partial expansion left never ship
+pub fun buf_refuse(buf: *ByteBuf, msg: str) {
+    if (buf == nil || buf.refusal != nil) { ret; }
+    buf.refusal = msg;
 }
 
 pub fun buf_dnit(buf: *ByteBuf) {
@@ -698,6 +710,12 @@ pub fun encode_module_asm(alloc: *A.Allocator, tgt: *isa.BackendTarget, m: *mir.
             notes_free(?st.buf);
             state_dnit(?st);
             ret res[EncoderOutput, fail.Fail].err{fail.refused(e)};
+        }
+        if (st.buf.refusal != nil) {
+            val msg: str = st.buf.refusal;
+            notes_free(?st.buf);
+            state_dnit(?st);
+            ret res[EncoderOutput, fail.Fail].err{fail.message(msg)};
         }
         if (st.sym_count > pre_sym_count) {
             st.syms[pre_sym_count].size = st.buf.len::u32 - st.syms[pre_sym_count].offset;

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -31,66 +31,6 @@ use mach.lang.target.isa.arm64.printer;
 use mop: mach.lang.target.isa.arm64.inst;
 use mach.lang.target.of;
 
-val ADD_X: u32 = 0x8B000000; val ADD_W: u32 = 0x0B000000;
-val SUB_X: u32 = 0xCB000000; val SUB_W: u32 = 0x4B000000;
-val AND_X: u32 = 0x8A000000; val AND_W: u32 = 0x0A000000;
-val ORR_X: u32 = 0xAA000000; val ORR_W: u32 = 0x2A000000;
-val EOR_X: u32 = 0xCA000000; val EOR_W: u32 = 0x4A000000;
-val ORN_X: u32 = 0xAA200000; val ORN_W: u32 = 0x2A200000;
-val MUL_X: u32 = 0x9B007C00; val MUL_W: u32 = 0x1B007C00;
-val LSLV_X: u32 = 0x9AC02000; val LSLV_W: u32 = 0x1AC02000;
-val LSRV_X: u32 = 0x9AC02400; val LSRV_W: u32 = 0x1AC02400;
-val ASRV_X: u32 = 0x9AC02800; val ASRV_W: u32 = 0x1AC02800;
-val SDIV_X: u32 = 0x9AC00C00; val SDIV_W: u32 = 0x1AC00C00;
-val UDIV_X: u32 = 0x9AC00800; val UDIV_W: u32 = 0x1AC00800;
-val MSUB_X: u32 = 0x9B008000; val MSUB_W: u32 = 0x1B008000;
-val ADDI_X: u32 = 0x91000000; val ADDI_W: u32 = 0x11000000;
-val SUBI_X: u32 = 0xD1000000; val SUBI_W: u32 = 0x51000000;
-val UBFM_X: u32 = 0xD3400000; val UBFM_W: u32 = 0x53000000;
-val SBFM_X: u32 = 0x93400000; val SBFM_W: u32 = 0x13000000;
-val MOVZ_X: u32 = 0xD2800000; val MOVZ_W: u32 = 0x52800000;
-val MOVK_X: u32 = 0xF2800000; val MOVK_W: u32 = 0x72800000;
-val SUBS_REG_X: u32 = 0xEB000000; val SUBS_REG_W: u32 = 0x6B000000;
-val SUBS_IMM_X: u32 = 0xF1000000; val SUBS_IMM_W: u32 = 0x71000000;
-val ADDS_IMM_X: u32 = 0xB1000000; val ADDS_IMM_W: u32 = 0x31000000;
-val CSINC_X: u32 = 0x9A800400; val CSINC_W: u32 = 0x1A800400;
-val STP_PRE_X:  u32 = 0xA9800000;
-val LDP_POST_X: u32 = 0xA8C00000;
-val STP_OFF_X:  u32 = 0xA9000000;
-val LDP_OFF_X:  u32 = 0xA9400000;
-val STP_OFF_D:  u32 = 0x6D000000;
-val LDP_OFF_D:  u32 = 0x6D400000;
-val STR_OFF_X:  u32 = 0xF9000000;
-val LDR_OFF_X:  u32 = 0xF9400000;
-val STRB_OFF: u32 = 0x39000000; val LDRB_OFF: u32 = 0x39400000;
-val STRH_OFF: u32 = 0x79000000; val LDRH_OFF: u32 = 0x79400000;
-val STRW_OFF: u32 = 0xB9000000; val LDRW_OFF: u32 = 0xB9400000;
-val STURB: u32 = 0x38000000; val LDURB: u32 = 0x38400000;
-val STURH: u32 = 0x78000000; val LDURH: u32 = 0x78400000;
-val STURW: u32 = 0xB8000000; val LDURW: u32 = 0xB8400000;
-val STUR_X: u32 = 0xF8000000; val LDUR_X: u32 = 0xF8400000;
-val STRB_REG: u32 = 0x38206800; val LDRB_REG: u32 = 0x38606800;
-val STRH_REG: u32 = 0x78206800; val LDRH_REG: u32 = 0x78606800;
-val STRW_REG: u32 = 0xB8206800; val LDRW_REG: u32 = 0xB8606800;
-val STR_REG_X: u32 = 0xF8206800; val LDR_REG_X: u32 = 0xF8606800;
-val B_BASE:    u32 = 0x14000000;
-val BCOND:     u32 = 0x54000000;
-val CBNZ_X:    u32 = 0xB5000000; val CBNZ_W: u32 = 0x35000000;
-val CBZ_X:     u32 = 0xB4000000; val CBZ_W: u32 = 0x34000000;
-val RET_WORD:  u32 = 0xD65F03C0;
-val RET_BASE:  u32 = 0xD65F0000;
-val BRK_BASE:  u32 = 0xD4200000;
-val NOP_WORD:  u32 = 0xD503201F;
-val BR_BASE:   u32 = 0xD61F0000;
-val SVC_BASE:  u32 = 0xD4000001;
-val HVC_BASE:  u32 = 0xD4000002;
-val SMC_BASE:  u32 = 0xD4000003;
-val STP_POST_X: u32 = 0xA8800000;
-val LDP_PRE_X:  u32 = 0xA9C00000;
-val BL_BASE:   u32 = 0x94000000;
-val BLR_BASE:  u32 = 0xD63F0000;
-val ADRP_BASE: u32 = 0x90000000;
-val SUB_SP_REG_X: u32 = 0xCB2063FF;
 
 val ZR: u32 = arm64.SP::u32;
 val SP_REG: u32 = arm64.SP::u32;
@@ -121,70 +61,11 @@ val CC_AL: u32 = 14;
 val FP_SCRATCH0: u32 = arm64.V31::u32;
 val FP_SCRATCH1: u32 = arm64.V30::u32;
 
-val FADD_S: u32 = 0x1E202800; val FADD_D: u32 = 0x1E602800;
-val FSUB_S: u32 = 0x1E203800; val FSUB_D: u32 = 0x1E603800;
-val FMUL_S: u32 = 0x1E200800; val FMUL_D: u32 = 0x1E600800;
-val FDIV_S: u32 = 0x1E201800; val FDIV_D: u32 = 0x1E601800;
-val FNEG_S: u32 = 0x1E214000; val FNEG_D: u32 = 0x1E614000;
-val FMOV_S: u32 = 0x1E204000; val FMOV_D: u32 = 0x1E604000;
-val FCVT_S2D: u32 = 0x1E22C000; val FCVT_D2S: u32 = 0x1E624000;
-val FCMP_S: u32 = 0x1E202000; val FCMP_D: u32 = 0x1E602000;
-val SCVTF_S_W: u32 = 0x1E220000; val SCVTF_D_W: u32 = 0x1E620000;
-val SCVTF_S_X: u32 = 0x9E220000; val SCVTF_D_X: u32 = 0x9E620000;
-val UCVTF_S_W: u32 = 0x1E230000; val UCVTF_D_W: u32 = 0x1E630000;
-val UCVTF_S_X: u32 = 0x9E230000; val UCVTF_D_X: u32 = 0x9E630000;
-val FCVTZS_W_S: u32 = 0x1E380000; val FCVTZS_X_S: u32 = 0x9E380000;
-val FCVTZS_W_D: u32 = 0x1E780000; val FCVTZS_X_D: u32 = 0x9E780000;
-val FCVTZU_W_S: u32 = 0x1E390000; val FCVTZU_X_S: u32 = 0x9E390000;
-val FCVTZU_W_D: u32 = 0x1E790000; val FCVTZU_X_D: u32 = 0x9E790000;
-val FMOV_S_FROM_W: u32 = 0x1E270000; val FMOV_D_FROM_X: u32 = 0x9E670000;
-val FMOV_S_IMM:    u32 = 0x1E201000; val FMOV_D_IMM:    u32 = 0x1E601000;
-val FMOV_W_FROM_S: u32 = 0x1E260000; val FMOV_X_FROM_D: u32 = 0x9E660000;
 
-val LDR_D_OFF: u32 = 0xFD400000; val STR_D_OFF: u32 = 0xFD000000;
-val LDR_S_OFF: u32 = 0xBD400000; val STR_S_OFF: u32 = 0xBD000000;
-val LDUR_D_FP: u32 = 0xFC400000; val STUR_D_FP: u32 = 0xFC000000;
-val LDUR_S_FP: u32 = 0xBC400000; val STUR_S_FP: u32 = 0xBC000000;
-val LDR_D_REG: u32 = 0xFC606800; val STR_D_REG: u32 = 0xFC206800;
-val LDR_S_REG: u32 = 0xBC606800; val STR_S_REG: u32 = 0xBC206800;
 
-val LDR_B_OFF: u32 = 0x3D400000; val STR_B_OFF: u32 = 0x3D000000;
-val LDR_H_OFF: u32 = 0x7D400000; val STR_H_OFF: u32 = 0x7D000000;
-val LDUR_B_FP: u32 = 0x3C400000; val STUR_B_FP: u32 = 0x3C000000;
-val LDUR_H_FP: u32 = 0x7C400000; val STUR_H_FP: u32 = 0x7C000000;
-val LDR_B_REG: u32 = 0x3C606800; val STR_B_REG: u32 = 0x3C206800;
-val LDR_H_REG: u32 = 0x7C606800; val STR_H_REG: u32 = 0x7C206800;
 
-val VFADD:   u32 = 0x4E20D400; val VFSUB:   u32 = 0x4EA0D400;
-val VFMUL:   u32 = 0x6E20DC00; val VFDIV:   u32 = 0x6E20FC00;
-val VADD:    u32 = 0x4E208400; val VSUB:    u32 = 0x6E208400;
-val VMUL:    u32 = 0x4E209C00;
-val VAND:    u32 = 0x4E201C00; val VORR:    u32 = 0x4EA01C00; val VEOR: u32 = 0x6E201C00;
-val VCMEQ:   u32 = 0x6E208C00;
-val VCMGT_S: u32 = 0x4E203400; val VCMGE_S: u32 = 0x4E203C00;
-val VCMHI_U: u32 = 0x6E203400; val VCMHS_U: u32 = 0x6E203C00;
-val VFCMEQ:  u32 = 0x4E20E400; val VFCMGT:  u32 = 0x6EA0E400; val VFCMGE: u32 = 0x6E20E400;
-val VNOT:    u32 = 0x6E205800;
-val LDR_Q_OFF: u32 = 0x3DC00000; val STR_Q_OFF: u32 = 0x3D800000;
-val LDUR_Q_FP: u32 = 0x3CC00000; val STUR_Q_FP: u32 = 0x3C800000;
-val LDR_Q_REG: u32 = 0x3CE06800; val STR_Q_REG: u32 = 0x3CA06800;
-val VUMOV_W: u32 = 0x0E003C00; val VUMOV_X: u32 = 0x4E003C00;
-val VSMOV_W: u32 = 0x0E002C00; val VSMOV_X: u32 = 0x4E002C00;
-val VINS_GP: u32 = 0x4E001C00; val VINS_EL: u32 = 0x6E000400;
-val VDUP_EL: u32 = 0x5E000400;
 
-val LDAR_X:  u32 = 0xC8DFFC00; val LDAR_W:  u32 = 0x88DFFC00;
-val STLR_X:  u32 = 0xC89FFC00; val STLR_W:  u32 = 0x889FFC00;
-val LDAXR_X: u32 = 0xC85FFC00; val LDAXR_W: u32 = 0x885FFC00;
-val STLXR_X: u32 = 0xC800FC00; val STLXR_W: u32 = 0x8800FC00;
-val YIELD_WORD: u32 = 0xD503203F;
-val WFE_WORD:   u32 = 0xD503205F;
-val WFI_WORD:   u32 = 0xD503207F;
-val DMB_BASE:   u32 = 0xD50330BF;
 
-val MSR_IMM_BASE: u32 = 0xD500401F;
-val MSR_REG_BASE: u32 = 0xD5100000;
-val MRS_BASE:     u32 = 0xD5300000;
 
 val A64_SYSREG_NAME_MAX: usize = 32;
 
@@ -324,121 +205,25 @@ fun a64_sysreg(name: str, op0_out: *u32, op1_out: *u32, crn_out: *u32, crm_out: 
     ret a64_sysreg_numeric(name, op0_out, op1_out, crn_out, crm_out, op2_out);
 }
 
-fun pack_alu3(base: u32, rd: u32, rn: u32, rm: u32) u32 {
-    ret base | ((rm & 0x1F) << 16) | ((rn & 0x1F) << 5) | (rd & 0x1F);
-}
-
-fun pack_addsub_imm(base: u32, rd: u32, rn: u32, imm12: u32, sh: u32) u32 {
-    ret base | ((sh & 0x1) << 22) | ((imm12 & 0xFFF) << 10) | ((rn & 0x1F) << 5) | (rd & 0x1F);
-}
-
-fun pack_bitfield(base: u32, rd: u32, rn: u32, immr: u32, imms: u32) u32 {
-    ret base | ((immr & 0x3F) << 16) | ((imms & 0x3F) << 10) | ((rn & 0x1F) << 5) | (rd & 0x1F);
-}
-
-fun pack_movewide(base: u32, rd: u32, hw: u32, imm16: u32) u32 {
-    ret base | ((hw & 0x3) << 21) | ((imm16 & 0xFFFF) << 5) | (rd & 0x1F);
-}
-
-fun pack_neon_3same(base: u32, size: u32, rd: u32, rn: u32, rm: u32) u32 {
-    ret base | ((size & 0x3) << 22) | ((rm & 0x1F) << 16) | ((rn & 0x1F) << 5) | (rd & 0x1F);
-}
-
-fun pack_neon_2misc(base: u32, rd: u32, rn: u32) u32 {
-    ret base | ((rn & 0x1F) << 5) | (rd & 0x1F);
-}
-
-fun neon_imm5(size: u32, index: u32) u32 {
-    ret (index << (size + 1)) | (1 << size);
-}
-
-fun pack_neon_lane_read(base: u32, size: u32, index: u32, rd: u32, rn: u32) u32 {
-    ret base | ((neon_imm5(size, index) & 0x1F) << 16) | ((rn & 0x1F) << 5) | (rd & 0x1F);
-}
-
-fun pack_neon_ins_gp(size: u32, index: u32, rd: u32, rn: u32) u32 {
-    ret VINS_GP | ((neon_imm5(size, index) & 0x1F) << 16) | ((rn & 0x1F) << 5) | (rd & 0x1F);
-}
-
-fun pack_neon_ins_el(size: u32, index: u32, src_index: u32, rd: u32, rn: u32) u32 {
-    ret VINS_EL | ((neon_imm5(size, index) & 0x1F) << 16) | (((src_index << size) & 0xF) << 11)
-        | ((rn & 0x1F) << 5) | (rd & 0x1F);
-}
-
-fun pack_neon_dup_el(size: u32, index: u32, rd: u32, rn: u32) u32 {
-    ret VDUP_EL | ((neon_imm5(size, index) & 0x1F) << 16) | ((rn & 0x1F) << 5) | (rd & 0x1F);
-}
-
-fun pack_cmp_reg(base: u32, rn: u32, rm: u32) u32 {
-    ret base | ((rm & 0x1F) << 16) | ((rn & 0x1F) << 5) | ZR;
-}
-
-fun pack_cmp_imm(base: u32, rn: u32, imm12: u32) u32 {
-    ret base | ((imm12 & 0xFFF) << 10) | ((rn & 0x1F) << 5) | ZR;
-}
-
-fun pack_cset(base: u32, rd: u32, cc: u32) u32 {
-    val inv: u32 = cc ^ 1;
-    ret base | (ZR << 16) | ((inv & 0xF) << 12) | (ZR << 5) | (rd & 0x1F);
-}
-
-fun pack_ldstp(base: u32, rt: u32, rt2: u32, rn: u32, imm7: u32) u32 {
-    ret base | ((imm7 & 0x7F) << 15) | ((rt2 & 0x1F) << 10) | ((rn & 0x1F) << 5) | (rt & 0x1F);
-}
-
-fun pack_ldst(base: u32, rt: u32, rn: u32, imm12: u32) u32 {
-    ret base | ((imm12 & 0xFFF) << 10) | ((rn & 0x1F) << 5) | (rt & 0x1F);
-}
-
-fun pack_cbnz(base: u32, rt: u32) u32 {
-    ret base | (rt & 0x1F);
-}
-
-fun pack_cbnz_off(base: u32, rt: u32, imm19: u32) u32 {
-    ret base | ((imm19 & 0x7FFFF) << 5) | (rt & 0x1F);
-}
-
-fun pack_bcond(imm19: u32, cond: u32) u32 {
-    ret BCOND | ((imm19 & 0x7FFFF) << 5) | (cond & 0xF);
-}
-
-fun pack_madd(base: u32, rd: u32, rn: u32, rm: u32, ra: u32) u32 {
-    ret base | ((rm & 0x1F) << 16) | ((ra & 0x1F) << 10) | ((rn & 0x1F) << 5) | (rd & 0x1F);
-}
-
-fun pack_alu3_sh(base: u32, rd: u32, rn: u32, rm: u32, sh: u32) u32 {
-    ret base | ((rm & 0x1F) << 16) | ((sh & 0x3F) << 10) | ((rn & 0x1F) << 5) | (rd & 0x1F);
-}
-
-fun pack_ldur(base: u32, rt: u32, rn: u32, imm9: u32) u32 {
-    ret base | ((imm9 & 0x1FF) << 12) | ((rn & 0x1F) << 5) | (rt & 0x1F);
-}
-
-fun pack_ldst_reg(base: u32, rt: u32, rn: u32, rm: u32) u32 {
-    ret base | ((rm & 0x1F) << 16) | ((rn & 0x1F) << 5) | (rt & 0x1F);
-}
-
-fun pack_blr(rn: u32) u32 {
-    ret BLR_BASE | ((rn & 0x1F) << 5);
-}
-
-fun pack_adrp(rd: u32) u32 {
-    ret ADRP_BASE | (rd & 0x1F);
-}
-
+# the access row of an integer or float load/store at one width: the
+# member for each addressing form, the register the data travels in and the
+# immediate scale, together with the `:lo12:` relocation kind. a width with no
+# row is refused
 rec A64Access {
-    scaled:   u32;
-    unscaled: u32;
-    reg:      u32;
+    op:       mop.MachOp;
+    unscaled: mop.MachOp;
+    fp:       bool;
+    width:    u8;
     shift:    u32;
     lo12:     of.RelocKind;
 }
 
-fun acc(scaled: u32, unscaled: u32, reg: u32, shift: u32, lo12: of.RelocKind) res[A64Access, fail.Fail] {
+fun acc(op: mop.MachOp, unscaled: mop.MachOp, fp: bool, width: u8, shift: u32, lo12: of.RelocKind) res[A64Access, fail.Fail] {
     var a: A64Access;
-    a.scaled   = scaled;
+    a.op       = op;
     a.unscaled = unscaled;
-    a.reg      = reg;
+    a.fp       = fp;
+    a.width    = width;
     a.shift    = shift;
     a.lo12     = lo12;
     ret res[A64Access, fail.Fail].ok{a};
@@ -446,551 +231,388 @@ fun acc(scaled: u32, unscaled: u32, reg: u32, shift: u32, lo12: of.RelocKind) re
 
 fun int_access(w: u8, is_load: bool) res[A64Access, fail.Fail] {
     if (w == 1) {
-        if (is_load) { ret acc(LDRB_OFF, LDURB, LDRB_REG, 0, of.RK_LDST8_LO12); }
-        ret acc(STRB_OFF, STURB, STRB_REG, 0, of.RK_LDST8_LO12);
+        if (is_load) { ret acc(mop.LDRB, mop.LDURB, false, 4, 0, of.RK_LDST8_LO12); }
+        ret acc(mop.STRB, mop.STURB, false, 4, 0, of.RK_LDST8_LO12);
     }
     if (w == 2) {
-        if (is_load) { ret acc(LDRH_OFF, LDURH, LDRH_REG, 1, of.RK_LDST16_LO12); }
-        ret acc(STRH_OFF, STURH, STRH_REG, 1, of.RK_LDST16_LO12);
+        if (is_load) { ret acc(mop.LDRH, mop.LDURH, false, 4, 1, of.RK_LDST16_LO12); }
+        ret acc(mop.STRH, mop.STURH, false, 4, 1, of.RK_LDST16_LO12);
     }
     if (w == 4) {
-        if (is_load) { ret acc(LDRW_OFF, LDURW, LDRW_REG, 2, of.RK_LDST32_LO12); }
-        ret acc(STRW_OFF, STURW, STRW_REG, 2, of.RK_LDST32_LO12);
+        if (is_load) { ret acc(mop.LDR, mop.LDUR, false, 4, 2, of.RK_LDST32_LO12); }
+        ret acc(mop.STR, mop.STUR, false, 4, 2, of.RK_LDST32_LO12);
     }
     if (w == 8) {
-        if (is_load) { ret acc(LDR_OFF_X, LDUR_X, LDR_REG_X, 3, of.RK_LDST64_LO12); }
-        ret acc(STR_OFF_X, STUR_X, STR_REG_X, 3, of.RK_LDST64_LO12);
+        if (is_load) { ret acc(mop.LDR, mop.LDUR, false, 8, 3, of.RK_LDST64_LO12); }
+        ret acc(mop.STR, mop.STUR, false, 8, 3, of.RK_LDST64_LO12);
     }
     ret res[A64Access, fail.Fail].err{fail.message("internal compiler error: aarch64 has no integer memory access form for this width (expected 1, 2, 4, or 8)")};
 }
 
 fun fp_access(w: u8, is_load: bool) res[A64Access, fail.Fail] {
-    if (w == 1) {
-        if (is_load) { ret acc(LDR_B_OFF, LDUR_B_FP, LDR_B_REG, 0, of.RK_LDST8_LO12); }
-        ret acc(STR_B_OFF, STUR_B_FP, STR_B_REG, 0, of.RK_LDST8_LO12);
+    var lo12: of.RelocKind = of.RK_LDST8_LO12;
+    var shift: u32 = 0;
+    if (w == 2)       { lo12 = of.RK_LDST16_LO12;  shift = 1; }
+    or (w == 4)       { lo12 = of.RK_LDST32_LO12;  shift = 2; }
+    or (w == 8)       { lo12 = of.RK_LDST64_LO12;  shift = 3; }
+    or (w == 16)      { lo12 = of.RK_LDST128_LO12; shift = 4; }
+    or (w != 1) {
+        ret res[A64Access, fail.Fail].err{fail.message("internal compiler error: aarch64 has no float memory access form for this width (expected 1, 2, 4, 8, or 16)")};
     }
-    if (w == 2) {
-        if (is_load) { ret acc(LDR_H_OFF, LDUR_H_FP, LDR_H_REG, 1, of.RK_LDST16_LO12); }
-        ret acc(STR_H_OFF, STUR_H_FP, STR_H_REG, 1, of.RK_LDST16_LO12);
-    }
-    if (w == 4) {
-        if (is_load) { ret acc(LDR_S_OFF, LDUR_S_FP, LDR_S_REG, 2, of.RK_LDST32_LO12); }
-        ret acc(STR_S_OFF, STUR_S_FP, STR_S_REG, 2, of.RK_LDST32_LO12);
-    }
-    if (w == 8) {
-        if (is_load) { ret acc(LDR_D_OFF, LDUR_D_FP, LDR_D_REG, 3, of.RK_LDST64_LO12); }
-        ret acc(STR_D_OFF, STUR_D_FP, STR_D_REG, 3, of.RK_LDST64_LO12);
-    }
-    if (w == 16) {
-        if (is_load) { ret acc(LDR_Q_OFF, LDUR_Q_FP, LDR_Q_REG, 4, of.RK_LDST128_LO12); }
-        ret acc(STR_Q_OFF, STUR_Q_FP, STR_Q_REG, 4, of.RK_LDST128_LO12);
-    }
-    ret res[A64Access, fail.Fail].err{fail.message("internal compiler error: aarch64 has no float memory access form for this width (expected 1, 2, 4, 8, or 16)")};
+    if (is_load) { ret acc(mop.LDR, mop.LDUR, true, w, shift, lo12); }
+    ret acc(mop.STR, mop.STUR, true, w, shift, lo12);
 }
 
 fun emit_word(st: *encode.EncodeState, word: u32) {
     encode.emit_u32(?st.buf, word);
 }
 
-rec Alu3Shape {
-    dst_fp: bool;
-    dst_w:  u8;
-    src_fp: bool;
-    src_w:  u8;
-    arity:  u8;
-}
-
-fun a3(dst_fp: bool, dst_w: u8, src_fp: bool, src_w: u8, arity: u8) Alu3Shape {
-    var s: Alu3Shape;
-    s.dst_fp = dst_fp;
-    s.dst_w  = dst_w;
-    s.src_fp = src_fp;
-    s.src_w  = src_w;
-    s.arity  = arity;
-    ret s;
-}
-
-fun alu3_shape(base: u32) Alu3Shape {
-    if (base == ADD_X || base == SUB_X || base == AND_X || base == ORR_X ||
-        base == EOR_X || base == ORN_X || base == MUL_X || base == LSLV_X ||
-        base == LSRV_X || base == ASRV_X || base == SDIV_X || base == UDIV_X ||
-        base == SUBS_REG_X || base == SUB_SP_REG_X) { ret a3(false, 8, false, 8, 3); }
-    if (base == ADD_W || base == SUB_W || base == AND_W || base == ORR_W ||
-        base == EOR_W || base == ORN_W || base == MUL_W || base == LSLV_W ||
-        base == LSRV_W || base == ASRV_W || base == SDIV_W || base == UDIV_W ||
-        base == SUBS_REG_W)                         { ret a3(false, 4, false, 4, 3); }
-
-    if (base == FADD_S || base == FSUB_S || base == FMUL_S || base == FDIV_S) { ret a3(true, 4, true, 4, 3); }
-    if (base == FADD_D || base == FSUB_D || base == FMUL_D || base == FDIV_D) { ret a3(true, 8, true, 8, 3); }
-    if (base == FNEG_S || base == FMOV_S) { ret a3(true, 4, true, 4, 2); }
-    if (base == FNEG_D || base == FMOV_D) { ret a3(true, 8, true, 8, 2); }
-    if (base == FCVT_S2D)                 { ret a3(true, 8, true, 4, 2); }
-    if (base == FCVT_D2S)                 { ret a3(true, 4, true, 8, 2); }
-    if (base == FCMP_S)                   { ret a3(true, 4, true, 4, 0); }
-    if (base == FCMP_D)                   { ret a3(true, 8, true, 8, 0); }
-
-    if (base == SCVTF_S_W || base == UCVTF_S_W) { ret a3(true, 4, false, 4, 2); }
-    if (base == SCVTF_D_W || base == UCVTF_D_W) { ret a3(true, 8, false, 4, 2); }
-    if (base == SCVTF_S_X || base == UCVTF_S_X) { ret a3(true, 4, false, 8, 2); }
-    if (base == SCVTF_D_X || base == UCVTF_D_X) { ret a3(true, 8, false, 8, 2); }
-
-    if (base == FCVTZS_W_S || base == FCVTZU_W_S) { ret a3(false, 4, true, 4, 2); }
-    if (base == FCVTZS_X_S || base == FCVTZU_X_S) { ret a3(false, 8, true, 4, 2); }
-    if (base == FCVTZS_W_D || base == FCVTZU_W_D) { ret a3(false, 4, true, 8, 2); }
-    if (base == FCVTZS_X_D || base == FCVTZU_X_D) { ret a3(false, 8, true, 8, 2); }
-
-    if (base == FMOV_S_FROM_W) { ret a3(true,  4, false, 4, 2); }
-    if (base == FMOV_D_FROM_X) { ret a3(true,  8, false, 8, 2); }
-    if (base == FMOV_W_FROM_S) { ret a3(false, 4, true,  4, 2); }
-    if (base == FMOV_X_FROM_D) { ret a3(false, 8, true,  8, 2); }
-    ret a3(false, 0, false, 0, 255);
-}
-
 fun shaped_reg(fp: bool, n: u32, bytes: u8) isa.Operand {
-    if (fp) { ret printer.vec(n, bytes); }
-    ret printer.gp(n, bytes);
+    if (fp) { ret mop.vec(n, bytes); }
+    ret mop.gp(n, bytes);
+}
+
+fun width_bytes(use64: bool) u8 {
+    if (use64) { ret 8; }
+    ret 4;
 }
 
 fun noting(st: *encode.EncodeState) bool {
     ret encode.sink_active(?st.buf);
 }
 
-fun emit_alu3(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, rm: u32) {
-    emit_word(st, pack_alu3(base, rd, rn, rm));
-    note_alu3(st, base, rd, rn, rm, 0, false);
+fun inst_of(op: mop.MachOp, dst: isa.Operand, src1: isa.Operand, src2: isa.Operand) isa.Inst {
+    var mi: isa.Inst = isa.inst_blank();
+    mi.opcode = op::u16;
+    mi.dst    = dst;
+    mi.src1   = src1;
+    mi.src2   = src2;
+    ret mi;
 }
 
-fun emit_alu3_sh(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, rm: u32, sh: u32) {
-    emit_word(st, pack_alu3_sh(base, rd, rn, rm, sh));
-    note_alu3(st, base, rd, rn, rm, sh, sh != 0);
+fun operation_width(mi: *isa.Inst) u8 {
+    if (mi.dst.kind == isa.OPK_REG)  { ret mi.dst.size; }
+    if (mi.src1.kind == isa.OPK_REG) { ret mi.src1.size; }
+    if (mi.src2.kind == isa.OPK_REG) { ret mi.src2.size; }
+    if (mi.dst.kind == isa.OPK_MEM)  { ret mi.dst.size; }
+    if (mi.src1.kind == isa.OPK_MEM) { ret mi.src1.size; }
+    ret 0;
 }
 
-fun note_alu3(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, rm: u32, sh: u32, shifted: bool) {
-    if (!noting(st)) { ret; }
-    val s: Alu3Shape = alu3_shape(base);
-    if (s.arity == 255) {
-        encode.sink_fail(?st.buf, "--emit-asm: no aarch64 operand shape for an emitted three-register base word");
+# every instruction word leaves through here: the row assembles the word
+# from the instruction, the word is emitted, and the same instruction, spelled
+# as an assembler reads it back, is what the stream is notified with. a member
+# whose row cannot hold what it was given emits nothing and refuses the buffer
+fun emit_inst(st: *encode.EncodeState, mi: *isa.Inst) {
+    val word: u32 = mop.assemble(mi);
+    if (word == 0) {
+        encode.buf_refuse(?st.buf, "internal compiler error: an aarch64 instruction has no encoding row for its operands");
         ret;
     }
-    var i: printer.Inst = printer.inst(printer.FORM_ALU3, base);
-    if (s.arity != 0) { i.dst = shaped_reg(s.dst_fp, rd, s.dst_w); }
-    i.src1 = shaped_reg(s.src_fp, rn, s.src_w);
-    if (s.arity != 2) { i.src2 = shaped_reg(s.src_fp, rm, s.src_w); }
-    if (shifted)      { i.src3 = isa.make_imm(sh::i64, 1); }
-    printer.note_inst(?st.buf, ?i);
-}
-
-fun emit_addsub_imm(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, imm12: u32, sh: u32) {
-    emit_word(st, pack_addsub_imm(base, rd, rn, imm12, sh));
+    emit_word(st, word);
     if (!noting(st)) { ret; }
-    var w: u8 = 4;
-    if ((base & 0x80000000) != 0) { w = 8; }
-    var i: printer.Inst = printer.inst(printer.FORM_ADDSUB_IMM, base);
-    i.dst  = printer.gp(rd, w);
-    i.src1 = printer.gp(rn, w);
-    i.src2 = isa.make_imm(imm12::i64, w);
-    if (sh != 0) { i.src3 = isa.make_imm(12, 1); }
-    printer.note_inst(?st.buf, ?i);
+    mi.size = operation_width(mi);
+    mop.spell(mi);
+    printer.note_inst(?st.buf, mi);
 }
 
-fun emit_addsub_imm_sym(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, sym: intern.StrId, mod: u8, addend: i32) {
-    emit_word(st, pack_addsub_imm(base, rd, rn, 0, 0));
-    if (!noting(st)) { ret; }
-    var w: u8 = 4;
-    if ((base & 0x80000000) != 0) { w = 8; }
-    var i: printer.Inst = printer.inst(printer.FORM_ADDSUB_IMM, base);
-    i.dst     = printer.gp(rd, w);
-    i.src1    = printer.gp(rn, w);
-    i.src2    = isa.make_sym(sym::u32, w);
-    i.src2.sym_addend = addend;
-    i.sym_mod = mod;
-    printer.note_inst(?st.buf, ?i);
+fun emit_alu3(st: *encode.EncodeState, op: mop.MachOp, use64: bool, rd: u32, rn: u32, rm: u32) {
+    val w: u8 = width_bytes(use64);
+    var mi: isa.Inst = inst_of(op, mop.gp(rd, w), mop.gp(rn, w), mop.gp(rm, w));
+    # add/sub writing index 31 writes the stack pointer, which is the
+    # extended-register form; in every other position of the shifted form
+    # index 31 is the zero register (neg is sub from it)
+    if ((op == mop.ADD || op == mop.SUB) && rd == SP_REG) { mi.flags = mop.FLAG_SP; }
+    emit_inst(st, ?mi);
 }
 
-fun emit_bitfield(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, immr: u32, imms: u32) {
-    emit_word(st, pack_bitfield(base, rd, rn, immr, imms));
-    if (!noting(st)) { ret; }
-    var w: u8 = 4;
-    if (base == UBFM_X || base == SBFM_X) { w = 8; }
-    var i: printer.Inst = printer.inst(printer.FORM_BITFIELD, base);
-    i.dst  = printer.gp(rd, w);
-    i.src1 = printer.gp(rn, w);
-    i.src2 = isa.make_imm(immr::i64, 1);
-    i.src3 = isa.make_imm(imms::i64, 1);
-    printer.note_inst(?st.buf, ?i);
+fun emit_alu3_sh(st: *encode.EncodeState, op: mop.MachOp, use64: bool, rd: u32, rn: u32, rm: u32, sh: u32) {
+    val w: u8 = width_bytes(use64);
+    var mi: isa.Inst = inst_of(op, mop.gp(rd, w), mop.gp(rn, w), mop.gp(rm, w));
+    if (sh != 0) { mi.src3 = isa.make_imm(sh::i64, 1); }
+    emit_inst(st, ?mi);
 }
 
-fun emit_movewide(st: *encode.EncodeState, base: u32, rd: u32, hw: u32, imm16: u32) {
-    emit_word(st, pack_movewide(base, rd, hw, imm16));
-    if (!noting(st)) { ret; }
-    var w: u8 = 4;
-    if (base == MOVZ_X || base == MOVK_X) { w = 8; }
-    var i: printer.Inst = printer.inst(printer.FORM_MOVEWIDE, base);
-    i.dst  = printer.gp(rd, w);
-    i.src2 = isa.make_imm(imm16::i64, w);
-    if (hw != 0) { i.src3 = isa.make_imm((hw * 16)::i64, 1); }
-    printer.note_inst(?st.buf, ?i);
+fun emit_fp3(st: *encode.EncodeState, op: mop.MachOp, dbl: bool, rd: u32, rn: u32, rm: u32) {
+    val w: u8 = width_bytes(dbl);
+    var mi: isa.Inst = inst_of(op, mop.vec(rd, w), mop.vec(rn, w), mop.vec(rm, w));
+    emit_inst(st, ?mi);
 }
 
-fun emit_madd(st: *encode.EncodeState, base: u32, rd: u32, rn: u32, rm: u32, ra: u32) {
-    emit_word(st, pack_madd(base, rd, rn, rm, ra));
-    if (!noting(st)) { ret; }
-    var w: u8 = 4;
-    if (base == MSUB_X) { w = 8; }
-    var i: printer.Inst = printer.inst(printer.FORM_MADD, base);
-    i.dst  = printer.gp(rd, w);
-    i.src1 = printer.gp(rn, w);
-    i.src2 = printer.gp(rm, w);
-    i.src3 = printer.gp(ra, w);
-    printer.note_inst(?st.buf, ?i);
+fun emit_fp2(st: *encode.EncodeState, op: mop.MachOp, dbl: bool, rd: u32, rn: u32) {
+    val w: u8 = width_bytes(dbl);
+    var mi: isa.Inst = inst_of(op, mop.vec(rd, w), mop.vec(rn, w), isa.make_none());
+    emit_inst(st, ?mi);
 }
 
-fun emit_cset(st: *encode.EncodeState, base: u32, rd: u32, cc: u32) {
-    emit_word(st, pack_cset(base, rd, cc));
-    if (!noting(st)) { ret; }
-    var w: u8 = 4;
-    if (base == CSINC_X) { w = 8; }
-    var i: printer.Inst = printer.inst(printer.FORM_CSET, base);
-    i.dst   = printer.gp(rd, w);
-    i.flags = ((cc ^ 1) & 0xF)::u16;
-    printer.note_inst(?st.buf, ?i);
+fun emit_fcmp(st: *encode.EncodeState, dbl: bool, rn: u32, rm: u32) {
+    val w: u8 = width_bytes(dbl);
+    var mi: isa.Inst = inst_of(mop.FCMP, isa.make_none(), mop.vec(rn, w), mop.vec(rm, w));
+    emit_inst(st, ?mi);
 }
 
-rec LdStShape {
-    fp:    bool;
-    w:     u8;
-    scale: u32;
+fun emit_fcvt(st: *encode.EncodeState, to_dbl: bool, rd: u32, rn: u32) {
+    var mi: isa.Inst = inst_of(mop.FCVT, mop.vec(rd, width_bytes(to_dbl)), mop.vec(rn, width_bytes(!to_dbl)), isa.make_none());
+    emit_inst(st, ?mi);
 }
 
-fun ls(fp: bool, w: u8, scale: u32) LdStShape {
-    var s: LdStShape;
-    s.fp    = fp;
-    s.w     = w;
-    s.scale = scale;
-    ret s;
+# a conversion between the banks: the operands carry the bank and width of
+# each side, the row's rule places them in the word
+fun emit_cvt(st: *encode.EncodeState, op: mop.MachOp, dst: isa.Operand, src: isa.Operand) {
+    var mi: isa.Inst = inst_of(op, dst, src, isa.make_none());
+    emit_inst(st, ?mi);
 }
 
-fun ldst_shape(base: u32) LdStShape {
-    if (base == LDRB_OFF || base == STRB_OFF) { ret ls(false, 4, 1); }
-    if (base == LDRH_OFF || base == STRH_OFF) { ret ls(false, 4, 2); }
-    if (base == LDRW_OFF || base == STRW_OFF) { ret ls(false, 4, 4); }
-    if (base == LDR_OFF_X || base == STR_OFF_X) { ret ls(false, 8, 8); }
-    if (base == LDR_D_OFF || base == STR_D_OFF) { ret ls(true, 8, 8); }
-    if (base == LDR_S_OFF || base == STR_S_OFF) { ret ls(true, 4, 4); }
-    if (base == LDR_H_OFF || base == STR_H_OFF) { ret ls(true, 2, 2); }
-    if (base == LDR_B_OFF || base == STR_B_OFF) { ret ls(true, 1, 1); }
-    if (base == LDR_Q_OFF || base == STR_Q_OFF) { ret ls(true, 16, 16); }
-    if (base == LDAR_X || base == STLR_X || base == LDAXR_X) { ret ls(false, 8, 0); }
-    if (base == LDAR_W || base == STLR_W || base == LDAXR_W) { ret ls(false, 4, 0); }
-    ret ls(false, 0, 255);
+fun emit_addsub_imm(st: *encode.EncodeState, op: mop.MachOp, use64: bool, rd: u32, rn: u32, imm12: u32, sh: u32) {
+    val w: u8 = width_bytes(use64);
+    var mi: isa.Inst = inst_of(op, mop.gp(rd, w), mop.gp(rn, w), isa.make_imm(imm12::i64, w));
+    if (sh != 0) { mi.src3 = isa.make_imm(12, 1); }
+    mi.flags = mop.FLAG_SP;
+    emit_inst(st, ?mi);
 }
 
-fun ldur_shape(base: u32) LdStShape {
-    if (base == LDURB || base == STURB || base == LDURH || base == STURH ||
-        base == LDURW || base == STURW) { ret ls(false, 4, 1); }
-    if (base == LDUR_X || base == STUR_X)       { ret ls(false, 8, 1); }
-    if (base == LDUR_D_FP || base == STUR_D_FP) { ret ls(true, 8, 1); }
-    if (base == LDUR_S_FP || base == STUR_S_FP) { ret ls(true, 4, 1); }
-    if (base == LDUR_H_FP || base == STUR_H_FP) { ret ls(true, 2, 1); }
-    if (base == LDUR_B_FP || base == STUR_B_FP) { ret ls(true, 1, 1); }
-    if (base == LDUR_Q_FP || base == STUR_Q_FP) { ret ls(true, 16, 1); }
-    ret ls(false, 0, 255);
+fun emit_addsub_imm_sym(st: *encode.EncodeState, op: mop.MachOp, use64: bool, rd: u32, rn: u32, sym: intern.StrId, mod: isa.SymModifier, addend: i32) {
+    val w: u8 = width_bytes(use64);
+    var mi: isa.Inst = inst_of(op, mop.gp(rd, w), mop.gp(rn, w), isa.make_sym_addend(sym::u32, w, mod, addend));
+    mi.flags = mop.FLAG_SP;
+    emit_inst(st, ?mi);
 }
 
-fun ldst_reg_shape(base: u32) LdStShape {
-    if (base == LDRB_REG || base == STRB_REG || base == LDRH_REG || base == STRH_REG ||
-        base == LDRW_REG || base == STRW_REG)     { ret ls(false, 4, 1); }
-    if (base == LDR_REG_X || base == STR_REG_X)   { ret ls(false, 8, 1); }
-    if (base == LDR_D_REG || base == STR_D_REG)   { ret ls(true, 8, 1); }
-    if (base == LDR_S_REG || base == STR_S_REG)   { ret ls(true, 4, 1); }
-    if (base == LDR_H_REG || base == STR_H_REG)   { ret ls(true, 2, 1); }
-    if (base == LDR_B_REG || base == STR_B_REG)   { ret ls(true, 1, 1); }
-    if (base == LDR_Q_REG || base == STR_Q_REG)   { ret ls(true, 16, 1); }
-    ret ls(false, 0, 255);
-}
-
-fun ldst_loads(base: u32) bool {
-    ret base == LDRB_OFF || base == LDRH_OFF || base == LDRW_OFF || base == LDR_OFF_X ||
-        base == LDR_D_OFF || base == LDR_S_OFF || base == LDR_Q_OFF ||
-        base == LDR_B_OFF || base == LDR_H_OFF ||
-        base == LDUR_B_FP || base == LDUR_H_FP ||
-        base == LDR_B_REG || base == LDR_H_REG ||
-        base == LDAR_X || base == LDAR_W || base == LDAXR_X || base == LDAXR_W ||
-        base == LDURB || base == LDURH || base == LDURW || base == LDUR_X ||
-        base == LDUR_D_FP || base == LDUR_S_FP || base == LDUR_Q_FP ||
-        base == LDRB_REG || base == LDRH_REG || base == LDRW_REG || base == LDR_REG_X ||
-        base == LDR_D_REG || base == LDR_S_REG || base == LDR_Q_REG;
-}
-
-fun note_ldst(st: *encode.EncodeState, base: u32, s: *LdStShape, rt: u32, mem: isa.Operand) {
-    if (s.scale == 255) {
-        encode.sink_fail(?st.buf, "--emit-asm: no aarch64 operand shape for an emitted load/store base word");
-        ret;
+# a bitfield alias with its own immediates: a shift count for lsl/lsr/asr,
+# a position and a width for the extract and insert forms, none for the
+# extends (whose source is always the 32-bit register)
+fun emit_bitfield(st: *encode.EncodeState, op: mop.MachOp, use64: bool, rd: u32, rn: u32, a: u32, b: u32) {
+    val w: u8 = width_bytes(use64);
+    var src_w: u8 = w;
+    val extend: bool = op == mop.UXTB || op == mop.UXTH || op == mop.SXTB || op == mop.SXTH || op == mop.SXTW;
+    if (extend) { src_w = 4; }
+    var mi: isa.Inst = inst_of(op, mop.gp(rd, w), mop.gp(rn, src_w), isa.make_none());
+    if (!extend) {
+        mi.src2 = isa.make_imm(a::i64, 1);
+        if (op == mop.UBFX || op == mop.UBFIZ || op == mop.SBFX || op == mop.SBFIZ) { mi.src3 = isa.make_imm(b::i64, 1); }
     }
-    var i: printer.Inst = printer.inst(printer.FORM_LDST, base);
-    val reg: isa.Operand = shaped_reg(s.fp, rt, s.w);
-    if (ldst_loads(base)) { i.dst = reg; i.src1 = mem; }
-    or                    { i.dst = mem; i.src1 = reg; }
-    printer.note_inst(?st.buf, ?i);
+    emit_inst(st, ?mi);
 }
 
-fun emit_ldst(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, imm12: u32) {
-    emit_word(st, pack_ldst(base, rt, rn, imm12));
-    if (!noting(st)) { ret; }
-    val s: LdStShape = ldst_shape(base);
-    var disp: i32 = 0;
-    if (s.scale != 0 && s.scale != 255) { disp = (imm12 * s.scale)::i32; }
-    note_ldst(st, base, ?s, rt, isa.make_mem(printer.gp_id(rn), disp, -1, 0, s.w));
+fun emit_movewide(st: *encode.EncodeState, op: mop.MachOp, use64: bool, rd: u32, hw: u32, imm16: u32) {
+    val w: u8 = width_bytes(use64);
+    var mi: isa.Inst = inst_of(op, mop.gp(rd, w), isa.make_none(), isa.make_imm(imm16::i64, w));
+    if (hw != 0) { mi.src3 = isa.make_imm((hw * 16)::i64, 1); }
+    emit_inst(st, ?mi);
 }
 
-fun emit_ldst_sym(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, sym: intern.StrId, mod: u8, addend: i32) {
-    emit_word(st, pack_ldst(base, rt, rn, 0));
-    if (!noting(st)) { ret; }
-    val s: LdStShape = ldst_shape(base);
-    if (s.scale == 255) {
-        encode.sink_fail(?st.buf, "--emit-asm: no aarch64 operand shape for an emitted load/store base word");
-        ret;
-    }
-    var mem: isa.Operand = isa.make_mem(printer.gp_id(rn), 0, -1, 0, s.w);
+fun emit_madd(st: *encode.EncodeState, op: mop.MachOp, use64: bool, rd: u32, rn: u32, rm: u32, ra: u32) {
+    val w: u8 = width_bytes(use64);
+    var mi: isa.Inst = inst_of(op, mop.gp(rd, w), mop.gp(rn, w), mop.gp(rm, w));
+    mi.src3 = mop.gp(ra, w);
+    emit_inst(st, ?mi);
+}
+
+fun emit_cset(st: *encode.EncodeState, use64: bool, rd: u32, cc: u32) {
+    var mi: isa.Inst = inst_of(mop.CSET, mop.gp(rd, width_bytes(use64)), isa.make_none(), isa.make_none());
+    mi.flags = mop.with_cond(0, cc);
+    emit_inst(st, ?mi);
+}
+
+fun access_bytes(op: mop.MachOp, width: u8) u8 {
+    if (op == mop.LDRB || op == mop.STRB || op == mop.LDURB || op == mop.STURB) { ret 1; }
+    if (op == mop.LDRH || op == mop.STRH || op == mop.LDURH || op == mop.STURH) { ret 2; }
+    ret width;
+}
+
+fun ldst_inst(op: mop.MachOp, reg: isa.Operand, mem: isa.Operand) isa.Inst {
+    val load: bool = op == mop.LDR || op == mop.LDRB || op == mop.LDRH || op == mop.LDUR ||
+                     op == mop.LDURB || op == mop.LDURH || op == mop.LDAR || op == mop.LDAXR;
+    if (load) { ret inst_of(op, reg, mem, isa.make_none()); }
+    ret inst_of(op, mem, reg, isa.make_none());
+}
+
+fun emit_ldst(st: *encode.EncodeState, op: mop.MachOp, fp: bool, width: u8, rt: u32, rn: u32, imm12: u32) {
+    val bytes: u8 = access_bytes(op, width);
+    val mem: isa.Operand = isa.make_mem(mop.gp_id(rn), (imm12 * bytes::u32)::i32, -1, 0, bytes);
+    var mi: isa.Inst = ldst_inst(op, shaped_reg(fp, rt, width), mem);
+    emit_inst(st, ?mi);
+}
+
+fun emit_ldst_sym(st: *encode.EncodeState, op: mop.MachOp, fp: bool, width: u8, rt: u32, rn: u32, sym: intern.StrId, mod: isa.SymModifier, addend: i32) {
+    val bytes: u8 = access_bytes(op, width);
+    var mem: isa.Operand = isa.make_mem(mop.gp_id(rn), 0, -1, 0, bytes);
     mem.sym_id     = sym::u32;
+    mem.sym_mod    = mod;
     mem.sym_addend = addend;
-    var i: printer.Inst = printer.inst(printer.FORM_LDST, base);
-    i.sym_mod = mod;
-    val reg: isa.Operand = shaped_reg(s.fp, rt, s.w);
-    if (ldst_loads(base)) { i.dst = reg; i.src1 = mem; }
-    or                    { i.dst = mem; i.src1 = reg; }
-    printer.note_inst(?st.buf, ?i);
+    var mi: isa.Inst = ldst_inst(op, shaped_reg(fp, rt, width), mem);
+    emit_inst(st, ?mi);
 }
 
-fun emit_ldur(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, imm9: u32) {
-    emit_word(st, pack_ldur(base, rt, rn, imm9));
-    if (!noting(st)) { ret; }
-    val s: LdStShape = ldur_shape(base);
-    note_ldst(st, base, ?s, rt, isa.make_mem(printer.gp_id(rn), sign_extend_field(imm9, 9)::i32, -1, 0, s.w));
+fun emit_ldur(st: *encode.EncodeState, op: mop.MachOp, fp: bool, width: u8, rt: u32, rn: u32, imm9: u32) {
+    val bytes: u8 = access_bytes(op, width);
+    val mem: isa.Operand = isa.make_mem(mop.gp_id(rn), sign_extend_field(imm9, 9)::i32, -1, 0, bytes);
+    var mi: isa.Inst = ldst_inst(op, shaped_reg(fp, rt, width), mem);
+    emit_inst(st, ?mi);
 }
 
-fun emit_ldst_reg(st: *encode.EncodeState, base: u32, rt: u32, rn: u32, rm: u32) {
-    emit_word(st, pack_ldst_reg(base, rt, rn, rm));
-    if (!noting(st)) { ret; }
-    val s: LdStShape = ldst_reg_shape(base);
-    note_ldst(st, base, ?s, rt, isa.make_mem(printer.gp_id(rn), 0, printer.gp_id(rm), 1, s.w));
+fun emit_ldst_reg(st: *encode.EncodeState, op: mop.MachOp, fp: bool, width: u8, rt: u32, rn: u32, rm: u32) {
+    val bytes: u8 = access_bytes(op, width);
+    val mem: isa.Operand = isa.make_mem(mop.gp_id(rn), 0, mop.gp_id(rm), 1, bytes);
+    var mi: isa.Inst = ldst_inst(op, shaped_reg(fp, rt, width), mem);
+    emit_inst(st, ?mi);
 }
 
-fun emit_ldstp(st: *encode.EncodeState, base: u32, rt: u32, rt2: u32, rn: u32, imm7: u32) {
-    emit_word(st, pack_ldstp(base, rt, rt2, rn, imm7));
-    if (!noting(st)) { ret; }
-    val fp: bool = base == STP_OFF_D || base == LDP_OFF_D;
-    val load: bool = base == LDP_OFF_X || base == LDP_PRE_X || base == LDP_POST_X || base == LDP_OFF_D;
-    var i: printer.Inst = printer.inst(printer.FORM_LDSTP, base);
-    if (base == STP_PRE_X || base == LDP_PRE_X)   { i.flags = printer.FLAG_WB_PRE; }
-    if (base == STP_POST_X || base == LDP_POST_X) { i.flags = printer.FLAG_WB_POST; }
+fun emit_ldord(st: *encode.EncodeState, op: mop.MachOp, use64: bool, rt: u32, rn: u32) {
+    val w: u8 = width_bytes(use64);
+    var mi: isa.Inst = ldst_inst(op, mop.gp(rt, w), isa.make_mem(mop.gp_id(rn), 0, -1, 0, w));
+    emit_inst(st, ?mi);
+}
 
-    val mem: isa.Operand = isa.make_mem(printer.gp_id(rn), (sign_extend_field(imm7, 7) * 8)::i32, -1, 0, 8);
+fun emit_ldstp(st: *encode.EncodeState, op: mop.MachOp, fp: bool, rt: u32, rt2: u32, rn: u32, imm7: u32, wb: u16) {
+    val mem: isa.Operand = isa.make_mem(mop.gp_id(rn), (sign_extend_field(imm7, 7) * 8)::i32, -1, 0, 8);
     val ra: isa.Operand = shaped_reg(fp, rt, 8);
     val rb: isa.Operand = shaped_reg(fp, rt2, 8);
-    if (load) { i.dst = ra; i.src1 = rb; i.src2 = mem; }
-    or        { i.dst = mem; i.src1 = ra; i.src2 = rb; }
-    printer.note_inst(?st.buf, ?i);
+    var mi: isa.Inst = inst_of(op, mem, ra, rb);
+    if (op == mop.LDP) { mi = inst_of(op, ra, rb, mem); }
+    mi.flags = wb;
+    emit_inst(st, ?mi);
 }
 
-fun emit_neon_3same(st: *encode.EncodeState, base: u32, size: u32, rd: u32, rn: u32, rm: u32, lane: u32) {
-    emit_word(st, pack_neon_3same(base, size, rd, rn, rm));
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_NEON_3SAME, base);
-    i.dst      = printer.vec(rd, 16);
-    i.src1     = printer.vec(rn, 16);
-    i.src2     = printer.vec(rm, 16);
-    i.vec_lane = lane;
-    printer.note_inst(?st.buf, ?i);
+fun lane_flags(lane: u32) u16 {
+    ret mop.with_elem_bytes(0, mir.vec_lane_elem_bytes(lane));
 }
 
-fun emit_neon_2misc(st: *encode.EncodeState, base: u32, rd: u32, rn: u32) {
-    emit_word(st, pack_neon_2misc(base, rd, rn));
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_NEON_2MISC, base);
-    i.dst  = printer.vec(rd, 16);
-    i.src1 = printer.vec(rn, 16);
-    printer.note_inst(?st.buf, ?i);
+fun emit_neon_3same(st: *encode.EncodeState, op: mop.MachOp, rd: u32, rn: u32, rm: u32, lane: u32) {
+    var mi: isa.Inst = inst_of(op, mop.vec(rd, 16), mop.vec(rn, 16), mop.vec(rm, 16));
+    mi.flags = lane_flags(lane);
+    emit_inst(st, ?mi);
 }
 
-fun emit_neon_umov(st: *encode.EncodeState, base: u32, size: u32, index: u32, rd: u32, rn: u32, lane: u32) {
-    emit_word(st, pack_neon_lane_read(base, size, index, rd, rn));
-    if (!noting(st)) { ret; }
+fun emit_neon_2misc(st: *encode.EncodeState, op: mop.MachOp, rd: u32, rn: u32) {
+    var mi: isa.Inst = inst_of(op, mop.vec(rd, 16), mop.vec(rn, 16), isa.make_none());
+    mi.flags = mop.with_elem_bytes(0, 1);
+    emit_inst(st, ?mi);
+}
+
+fun emit_neon_umov(st: *encode.EncodeState, index: u32, rd: u32, rn: u32, lane: u32) {
     var dst_bytes: u8 = 4;
-    if (base == VUMOV_X) { dst_bytes = 8; }
-    var i: printer.Inst = printer.inst(printer.FORM_NEON_LANE_RD, base);
-    i.dst      = printer.gp(rd, dst_bytes);
-    i.src1     = printer.vec(rn, 16);
-    i.src2     = isa.make_imm(index::i64, 1);
-    i.vec_lane = lane;
-    printer.note_inst(?st.buf, ?i);
+    if (mir.vec_lane_elem_bytes(lane) == 8) { dst_bytes = 8; }
+    var mi: isa.Inst = inst_of(mop.UMOV, mop.gp(rd, dst_bytes), mop.vec(rn, 16), isa.make_imm(index::i64, 1));
+    mi.flags = lane_flags(lane);
+    emit_inst(st, ?mi);
 }
 
-fun emit_neon_dup_el(st: *encode.EncodeState, size: u32, index: u32, rd: u32, rn: u32, lane: u32) {
-    emit_word(st, pack_neon_dup_el(size, index, rd, rn));
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_NEON_LANE_RD, VDUP_EL);
-    i.dst      = printer.vec(rd, mir.vec_lane_elem_bytes(lane));
-    i.src1     = printer.vec(rn, 16);
-    i.src2     = isa.make_imm(index::i64, 1);
-    i.vec_lane = lane;
-    printer.note_inst(?st.buf, ?i);
+fun emit_neon_dup_el(st: *encode.EncodeState, index: u32, rd: u32, rn: u32, lane: u32) {
+    var mi: isa.Inst = inst_of(mop.DUP, mop.vec(rd, mir.vec_lane_elem_bytes(lane)), mop.vec(rn, 16), isa.make_imm(index::i64, 1));
+    mi.flags = lane_flags(lane);
+    emit_inst(st, ?mi);
 }
 
-fun emit_neon_ins_gp(st: *encode.EncodeState, size: u32, index: u32, rd: u32, rn: u32, lane: u32, src_bytes: u8) {
-    emit_word(st, pack_neon_ins_gp(size, index, rd, rn));
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_NEON_LANE_WR, VINS_GP);
-    i.dst      = printer.vec(rd, 16);
-    i.src1     = printer.gp(rn, src_bytes);
-    i.src2     = isa.make_imm(index::i64, 1);
-    i.vec_lane = lane;
-    printer.note_inst(?st.buf, ?i);
+fun emit_neon_ins_gp(st: *encode.EncodeState, index: u32, rd: u32, rn: u32, lane: u32, src_bytes: u8) {
+    var mi: isa.Inst = inst_of(mop.INS, mop.vec(rd, 16), mop.gp(rn, src_bytes), isa.make_imm(index::i64, 1));
+    mi.flags = lane_flags(lane);
+    emit_inst(st, ?mi);
 }
 
-fun emit_neon_ins_el(st: *encode.EncodeState, size: u32, index: u32, src_index: u32, rd: u32, rn: u32, lane: u32) {
-    emit_word(st, pack_neon_ins_el(size, index, src_index, rd, rn));
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_NEON_LANE_WR, VINS_EL);
-    i.dst      = printer.vec(rd, 16);
-    i.src1     = printer.vec(rn, 16);
-    i.src2     = isa.make_imm(index::i64, 1);
-    i.src3     = isa.make_imm(src_index::i64, 1);
-    i.vec_lane = lane;
-    printer.note_inst(?st.buf, ?i);
+fun emit_neon_ins_el(st: *encode.EncodeState, index: u32, src_index: u32, rd: u32, rn: u32, lane: u32) {
+    var mi: isa.Inst = inst_of(mop.INS_EL, mop.vec(rd, 16), mop.vec(rn, 16), isa.make_imm(index::i64, 1));
+    mi.src3  = isa.make_imm(src_index::i64, 1);
+    mi.flags = lane_flags(lane);
+    emit_inst(st, ?mi);
 }
 
-fun branch_reg_operand(base: u32, rt: u32, has_rt: bool) isa.Operand {
-    if (!has_rt) { ret printer.none_operand(); }
-    if (base == CBNZ_X || base == CBZ_X) { ret printer.gp(rt, 8); }
-    ret printer.gp(rt, 4);
+# a compare-and-branch names its register in src1; the other branches none
+fun branch_inst(op: mop.MachOp, cc: u32, use64: bool, rt: u32, target: isa.Operand) isa.Inst {
+    var reg: isa.Operand = isa.make_none();
+    if (op == mop.CBZ || op == mop.CBNZ) { reg = mop.gp(rt, width_bytes(use64)); }
+    var mi: isa.Inst = inst_of(op, isa.make_none(), reg, target);
+    if (op == mop.BCOND) { mi.flags = mop.with_cond(0, cc); }
+    ret mi;
 }
 
-fun emit_branch_block(st: *encode.EncodeState, base: u32, rt: u32, has_rt: bool, block: u32) {
-    var word: u32 = base;
-    if (has_rt) { word = base | (rt & 0x1F); }
-    emit_word(st, word);
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_BRANCH, base);
-    i.src1   = branch_reg_operand(base, rt, has_rt);
-    i.target = printer.TGT_BLOCK;
-    i.block  = block;
-    printer.note_inst(?st.buf, ?i);
+fun emit_branch_block(st: *encode.EncodeState, op: mop.MachOp, cc: u32, use64: bool, rt: u32, block: u32) {
+    var mi: isa.Inst = branch_inst(op, cc, use64, rt, isa.make_block_label(block));
+    mi.flags = mi.flags | mop.FLAG_TARGET_BLOCK;
+    emit_inst(st, ?mi);
 }
 
-fun emit_branch_sym(st: *encode.EncodeState, base: u32, sym: intern.StrId, addend: i32) {
-    emit_word(st, base);
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_BRANCH, base);
-    i.src2   = isa.make_sym(sym::u32, 0);
-    i.src2.sym_addend = addend;
-    i.target = printer.TGT_SYM;
-    printer.note_inst(?st.buf, ?i);
+fun emit_branch_sym(st: *encode.EncodeState, op: mop.MachOp, sym: intern.StrId, addend: i32) {
+    var mi: isa.Inst = branch_inst(op, 0, false, 0, isa.make_sym_addend(sym::u32, 0, isa.SYM_MOD_NONE, addend));
+    emit_inst(st, ?mi);
 }
 
-fun emit_branch_pcrel(st: *encode.EncodeState, base: u32, rt: u32, has_rt: bool, imm19: u32) {
-    var word: u32 = base | ((imm19 & 0x7FFFF) << 5);
-    if (has_rt) { word = word | (rt & 0x1F); }
-    emit_word(st, word);
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_BRANCH, base);
-    i.src1   = branch_reg_operand(base, rt, has_rt);
-    i.src2   = isa.make_imm(imm19::i64, 4);
-    i.target = printer.TGT_PCREL;
-    printer.note_inst(?st.buf, ?i);
+# a pc-relative skip inside the same expansion: the target travels as a
+# local label whose displacement is the bytes skipped
+fun emit_branch_pcrel(st: *encode.EncodeState, op: mop.MachOp, cc: u32, use64: bool, rt: u32, imm19: u32) {
+    val disp: i64 = sign_extend_field(imm19, 19) * 4;
+    var target: isa.Operand = isa.make_local_label(disp > 0);
+    target.disp = disp::i32;
+    var mi: isa.Inst = branch_inst(op, cc, use64, rt, target);
+    mi.flags = mi.flags | mop.FLAG_LABEL_SKIP;
+    emit_inst(st, ?mi);
 }
 
-fun emit_branch_local(st: *encode.EncodeState, word: u32, base: u32, rt: u32, has_rt: bool, number: u64, fwd: bool) {
-    emit_word(st, word);
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_BRANCH, base);
-    i.src1   = branch_reg_operand(base, rt, has_rt);
-    i.src2   = isa.make_imm(number::i64, 8);
-    i.target = printer.TGT_LOCAL_BACK;
-    if (fwd) { i.target = printer.TGT_LOCAL_FWD; }
-    printer.note_inst(?st.buf, ?i);
+# a numbered inline-asm local: the number travels in the label's sym_id
+fun emit_branch_local(st: *encode.EncodeState, op: mop.MachOp, cc: u32, use64: bool, rt: u32, number: u64, fwd: bool) {
+    var target: isa.Operand = isa.make_local_label(fwd);
+    target.sym_id = number::u32;
+    var mi: isa.Inst = branch_inst(op, cc, use64, rt, target);
+    mi.flags = mi.flags | mop.FLAG_LABEL_LOCAL;
+    if (fwd) { mi.flags = mi.flags | mop.FLAG_LABEL_FWD; }
+    emit_inst(st, ?mi);
 }
 
-fun emit_branch_reg(st: *encode.EncodeState, base: u32, rn: u32) {
-    emit_word(st, base | ((rn & 0x1F) << 5));
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_BRANCH_REG, base);
-    i.src1 = printer.gp(rn, 8);
-    printer.note_inst(?st.buf, ?i);
+fun emit_branch_reg(st: *encode.EncodeState, op: mop.MachOp, rn: u32) {
+    var mi: isa.Inst = inst_of(op, isa.make_none(), mop.gp(rn, 8), isa.make_none());
+    emit_inst(st, ?mi);
 }
 
-fun emit_adrp(st: *encode.EncodeState, rd: u32, sym: intern.StrId, mod: u8, addend: i32) {
-    emit_word(st, pack_adrp(rd));
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_ADRP, ADRP_BASE);
-    i.dst     = printer.gp(rd, 8);
-    i.src1    = isa.make_sym(sym::u32, 0);
-    i.src1.sym_addend = addend;
-    i.sym_mod = mod;
-    printer.note_inst(?st.buf, ?i);
+fun emit_ret(st: *encode.EncodeState) {
+    var mi: isa.Inst = inst_of(mop.RET, isa.make_none(), isa.make_none(), isa.make_none());
+    emit_inst(st, ?mi);
 }
 
-fun emit_nullary(st: *encode.EncodeState, word: u32) {
-    emit_word(st, word);
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_NULLARY, word);
-    printer.note_inst(?st.buf, ?i);
+fun emit_adrp(st: *encode.EncodeState, rd: u32, sym: intern.StrId, mod: isa.SymModifier, addend: i32) {
+    var mi: isa.Inst = inst_of(mop.ADRP, mop.gp(rd, 8), isa.make_sym_addend(sym::u32, 0, mod, addend), isa.make_none());
+    emit_inst(st, ?mi);
 }
 
-fun emit_imm16(st: *encode.EncodeState, base: u32, imm16: u32) {
-    emit_word(st, base | ((imm16 & 0xFFFF) << 5));
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_IMM16, base);
-    i.src1 = isa.make_imm(imm16::i64, 2);
-    printer.note_inst(?st.buf, ?i);
+fun emit_nullary(st: *encode.EncodeState, op: mop.MachOp) {
+    var mi: isa.Inst = inst_of(op, isa.make_none(), isa.make_none(), isa.make_none());
+    emit_inst(st, ?mi);
+}
+
+fun emit_imm16(st: *encode.EncodeState, op: mop.MachOp, imm16: u32) {
+    var mi: isa.Inst = inst_of(op, isa.make_none(), isa.make_imm(imm16::i64, 2), isa.make_none());
+    emit_inst(st, ?mi);
 }
 
 fun emit_barrier(st: *encode.EncodeState, crm: u32) {
-    emit_word(st, DMB_BASE | ((crm & 0xF) << 8));
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_BARRIER, DMB_BASE);
-    i.src1 = isa.make_imm(crm::i64, 1);
-    printer.note_inst(?st.buf, ?i);
+    var mi: isa.Inst = inst_of(mop.DMB, isa.make_none(), isa.make_imm(crm::i64, 1), isa.make_none());
+    emit_inst(st, ?mi);
 }
 
 fun emit_msr_imm(st: *encode.EncodeState, op1: u32, op2: u32, imm: u32) {
-    emit_word(st, MSR_IMM_BASE | ((op1 & 0x7) << 16) | ((imm & 0xF) << 8) | ((op2 & 0x7) << 5));
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_SYSREG_IMM, MSR_IMM_BASE);
-    i.src1 = isa.make_imm((((op1 & 0x7) << 3) | (op2 & 0x7))::i64, 1);
-    i.src2 = isa.make_imm(imm::i64, 1);
-    printer.note_inst(?st.buf, ?i);
+    var mi: isa.Inst = inst_of(mop.MSR, isa.make_none(),
+                               isa.make_imm((((op1 & 0x7) << 3) | (op2 & 0x7))::i64, 1),
+                               isa.make_imm(imm::i64, 1));
+    emit_inst(st, ?mi);
 }
 
 fun a64_sysreg_pack(op0: u32, op1: u32, crn: u32, crm: u32, op2: u32) u32 {
     ret ((op0 & 0x3) << 16) | ((op1 & 0x7) << 12) | ((crn & 0xF) << 8) | ((crm & 0xF) << 4) | (op2 & 0x7);
 }
 
-fun a64_emit_sysreg(st: *encode.EncodeState, base: u32, packed: u32, rt: u32) {
-    val op0: u32 = (packed >> 16) & 0x3;
-    val op1: u32 = (packed >> 12) & 0x7;
-    val crn: u32 = (packed >> 8) & 0xF;
-    val crm: u32 = (packed >> 4) & 0xF;
-    val op2: u32 = packed & 0x7;
-    emit_word(st, base | ((op0 & 0x1) << 19) | (op1 << 16)
-                       | (crn << 12) | (crm << 8) | (op2 << 5) | (rt & 0x1F));
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_SYSREG, base);
-    i.dst  = printer.gp(rt, 8);
-    i.src1 = isa.make_imm(packed::i64, 4);
-    printer.note_inst(?st.buf, ?i);
+fun emit_mrs(st: *encode.EncodeState, packed: u32, rt: u32) {
+    var mi: isa.Inst = inst_of(mop.MRS, mop.gp(rt, 8), isa.make_imm(packed::i64, 4), isa.make_none());
+    emit_inst(st, ?mi);
 }
 
-fun emit_stxr(st: *encode.EncodeState, base: u32, rs: u32, rt: u32, rn: u32) {
-    emit_word(st, pack_ldst(base, rt, rn, 0) | ((rs & 0x1F) << 16));
-    if (!noting(st)) { ret; }
-    var w: u8 = 4;
-    if (base == STLXR_X) { w = 8; }
-    var i: printer.Inst = printer.inst(printer.FORM_STXR, base);
-    i.dst  = printer.gp(rs, 4);
-    i.src1 = printer.gp(rt, w);
-    i.src2 = isa.make_mem(printer.gp_id(rn), 0, -1, 0, w);
-    printer.note_inst(?st.buf, ?i);
+fun emit_msr_reg(st: *encode.EncodeState, packed: u32, rt: u32) {
+    var mi: isa.Inst = inst_of(mop.MSR, isa.make_none(), isa.make_imm(packed::i64, 4), mop.gp(rt, 8));
+    emit_inst(st, ?mi);
+}
+
+fun emit_stxr(st: *encode.EncodeState, use64: bool, rs: u32, rt: u32, rn: u32) {
+    val w: u8 = width_bytes(use64);
+    var mi: isa.Inst = inst_of(mop.STLXR, mop.gp(rs, 4), mop.gp(rt, w), isa.make_mem(mop.gp_id(rn), 0, -1, 0, w));
+    emit_inst(st, ?mi);
 }
 
 fun sign_extend_field(v: u32, bits: u32) i64 {
@@ -1014,26 +636,19 @@ fun write_word(buf: *encode.ByteBuf, pos: usize, word: u32) {
     buf.data[pos + 3] = ((word >> 24) & 0xFF)::u8;
 }
 
-fun pick(use64: bool, base_x: u32, base_w: u32) u32 {
-    if (use64) { ret base_x; }
-    ret base_w;
-}
-
 fun is64(width: u8) bool {
     if (width == 0) { ret true; }
     ret width >= 8;
 }
 
 fun emit_movewide_seq(st: *encode.EncodeState, rd: u32, value: u64, use64: bool) {
-    val base_z: u32 = pick(use64, MOVZ_X, MOVZ_W);
-    val base_k: u32 = pick(use64, MOVK_X, MOVK_W);
     var chunks: u32 = 2;
     if (use64) { chunks = 4; }
     var v: u64 = value;
     if (!use64) { v = value & 0xFFFFFFFF; }
 
     if (v == 0) {
-        emit_movewide(st, base_z, rd, 0, 0);
+        emit_movewide(st, mop.MOVZ, use64, rd, 0, 0);
         ret;
     }
 
@@ -1043,10 +658,10 @@ fun emit_movewide_seq(st: *encode.EncodeState, rd: u32, value: u64, use64: bool)
         val chunk: u32 = ((v >> (16::u64 * i::u64)) & 0xFFFF)::u32;
         if (chunk != 0) {
             if (first) {
-                emit_movewide(st, base_z, rd, i, chunk);
+                emit_movewide(st, mop.MOVZ, use64, rd, i, chunk);
                 first = false;
             } or {
-                emit_movewide(st, base_k, rd, i, chunk);
+                emit_movewide(st, mop.MOVK, use64, rd, i, chunk);
             }
         }
         i = i + 1;
@@ -1153,43 +768,43 @@ fun emit_mem_access(st: *encode.EncodeState, rt: u32, base: u32, off: i64, width
     if (off >= 0) {
         val mask: i64 = (1::i64 << sh::i64) - 1;
         if ((off & mask) == 0 && (off >> sh::i64) <= 4095) {
-            emit_ldst(st, a.scaled, rt, base, (off >> sh::i64)::u32);
+            emit_ldst(st, a.op, a.fp, a.width, rt, base, (off >> sh::i64)::u32);
             ret err[fail.Fail].ok{};
         }
     }
     if (off >= -256 && off <= 255) {
-        emit_ldur(st, a.unscaled, rt, base, off::u32 & 0x1FF);
+        emit_ldur(st, a.unscaled, a.fp, a.width, rt, base, off::u32 & 0x1FF);
         ret err[fail.Fail].ok{};
     }
     emit_movewide_seq(st, SCRATCH0, off::u64, true);
-    emit_ldst_reg(st, a.reg, rt, base, SCRATCH0);
+    emit_ldst_reg(st, a.op, a.fp, a.width, rt, base, SCRATCH0);
     ret err[fail.Fail].ok{};
 }
 
 fun emit_add_imm(st: *encode.EncodeState, rd: u32, rn: u32, off: i64) {
     if (off >= 0 && off <= 4095) {
-        emit_addsub_imm(st, ADDI_X, rd, rn, off::u32, 0);
+        emit_addsub_imm(st, mop.ADD, true, rd, rn, off::u32, 0);
         ret;
     }
     if (off < 0 && off >= -4095) {
-        emit_addsub_imm(st, SUBI_X, rd, rn, (-off)::u32, 0);
+        emit_addsub_imm(st, mop.SUB, true, rd, rn, (-off)::u32, 0);
         ret;
     }
     if (off > 0 && (off & 0xFFF) == 0 && (off >> 12) <= 4095) {
-        emit_addsub_imm(st, ADDI_X, rd, rn, (off >> 12)::u32, 1);
+        emit_addsub_imm(st, mop.ADD, true, rd, rn, (off >> 12)::u32, 1);
         ret;
     }
     if (off < 0 && ((-off) & 0xFFF) == 0 && ((-off) >> 12) <= 4095) {
-        emit_addsub_imm(st, SUBI_X, rd, rn, ((-off) >> 12)::u32, 1);
+        emit_addsub_imm(st, mop.SUB, true, rd, rn, ((-off) >> 12)::u32, 1);
         ret;
     }
     emit_movewide_seq(st, SCRATCH0, off::u64, true);
     if (rn == ZR) {
-        emit_addsub_imm(st, ADDI_X, SCRATCH1, ZR, 0, 0);
-        emit_alu3(st, ADD_X, rd, SCRATCH1, SCRATCH0);
+        emit_addsub_imm(st, mop.ADD, true, SCRATCH1, ZR, 0, 0);
+        emit_alu3(st, mop.ADD, true, rd, SCRATCH1, SCRATCH0);
         ret;
     }
-    emit_alu3(st, ADD_X, rd, rn, SCRATCH0);
+    emit_alu3(st, mop.ADD, true, rd, rn, SCRATCH0);
 }
 
 fun scale_shift(scale: u8) res[u32, fail.Fail] {
@@ -1202,7 +817,7 @@ fun scale_shift(scale: u8) res[u32, fail.Fail] {
 
 fun emit_adrp_reloc(st: *encode.EncodeState, rd: u32, sym: intern.StrId, addend: i32) err[fail.Fail] {
     val pos: u32 = st.buf.len::u32;
-    emit_adrp(st, rd, sym, printer.MOD_PCREL_HI, addend);
+    emit_adrp(st, rd, sym, isa.SYM_MOD_PCREL_HI, addend);
     val r_1198: err[fail.Fail] = encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PAGE21, sym, addend);
     if (sel r_1198.err) { ret err[fail.Fail].err{r_1198.err}; }
     ret err[fail.Fail].ok{};
@@ -1215,7 +830,7 @@ fun emit_global_addr(st: *encode.EncodeState, rd: u32, symop: *mir.MirOperand) e
     val ar: err[fail.Fail] = emit_adrp_reloc(st, rd, symop.sym, symop.sym_off);
     if (sel ar.err) { ret ar; }
     val pos: u32 = st.buf.len::u32;
-    emit_addsub_imm_sym(st, ADDI_X, rd, rd, symop.sym, printer.MOD_PCREL_LO, symop.sym_off);
+    emit_addsub_imm_sym(st, mop.ADD, true, rd, rd, symop.sym, isa.SYM_MOD_PCREL_LO, symop.sym_off);
     val r_1209: err[fail.Fail] = encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_ADD_LO12, symop.sym, symop.sym_off);
     if (sel r_1209.err) { ret err[fail.Fail].err{r_1209.err}; }
     ret err[fail.Fail].ok{};
@@ -1232,7 +847,7 @@ fun emit_global_load(st: *encode.EncodeState, rt: u32, symop: *mir.MirOperand, w
     val ar: err[fail.Fail] = emit_adrp_reloc(st, SCRATCH0, symop.sym, symop.sym_off);
     if (sel ar.err) { ret ar; }
     val pos: u32 = st.buf.len::u32;
-    emit_ldst_sym(st, a.scaled, rt, SCRATCH0, symop.sym, printer.MOD_PCREL_LO, symop.sym_off);
+    emit_ldst_sym(st, a.op, a.fp, a.width, rt, SCRATCH0, symop.sym, isa.SYM_MOD_PCREL_LO, symop.sym_off);
     val r_1224: err[fail.Fail] = encode.push_reloc(st, arm64_reloc_offset(pos), a.lo12, symop.sym, symop.sym_off);
     if (sel r_1224.err) { ret err[fail.Fail].err{r_1224.err}; }
     ret err[fail.Fail].ok{};
@@ -1273,7 +888,7 @@ fun emit_global_store(st: *encode.EncodeState, f: *mir.MirFunction, symop: *mir.
     val ar: err[fail.Fail] = emit_adrp_reloc(st, SCRATCH0, symop.sym, symop.sym_off);
     if (sel ar.err) { ret ar; }
     val pos: u32 = st.buf.len::u32;
-    emit_ldst_sym(st, a.scaled, rt, SCRATCH0, symop.sym, printer.MOD_PCREL_LO, symop.sym_off);
+    emit_ldst_sym(st, a.op, a.fp, a.width, rt, SCRATCH0, symop.sym, isa.SYM_MOD_PCREL_LO, symop.sym_off);
     val r_1263: err[fail.Fail] = encode.push_reloc(st, arm64_reloc_offset(pos), a.lo12, symop.sym, symop.sym_off);
     if (sel r_1263.err) { ret err[fail.Fail].err{r_1263.err}; }
     ret err[fail.Fail].ok{};
@@ -1281,7 +896,7 @@ fun emit_global_store(st: *encode.EncodeState, f: *mir.MirFunction, symop: *mir.
 
 fun emit_adrp_got_reloc(st: *encode.EncodeState, rd: u32, sym: intern.StrId) err[fail.Fail] {
     val pos: u32 = st.buf.len::u32;
-    emit_adrp(st, rd, sym, printer.MOD_GOT_HI, 0);
+    emit_adrp(st, rd, sym, isa.SYM_MOD_GOT_HI, 0);
     val r_1269: err[fail.Fail] = encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_GOT_PAGE21, sym, 0);
     if (sel r_1269.err) { ret err[fail.Fail].err{r_1269.err}; }
     ret err[fail.Fail].ok{};
@@ -1294,7 +909,7 @@ fun emit_global_addr_got(st: *encode.EncodeState, rd: u32, symop: *mir.MirOperan
     val ar: err[fail.Fail] = emit_adrp_got_reloc(st, rd, symop.sym);
     if (sel ar.err) { ret ar; }
     val pos: u32 = st.buf.len::u32;
-    emit_ldst_sym(st, LDR_OFF_X, rd, rd, symop.sym, printer.MOD_GOT_LO, 0);
+    emit_ldst_sym(st, mop.LDR, false, 8, rd, rd, symop.sym, isa.SYM_MOD_GOT_LO, 0);
     val pr: err[fail.Fail] = encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_GOT_LO12, symop.sym, 0);
     if (sel pr.err) { ret err[fail.Fail].err{pr.err}; }
     if (symop.sym_off != 0) { emit_add_imm(st, rd, rd, symop.sym_off::i64); }
@@ -1360,18 +975,18 @@ fun encode_call(st: *encode.EncodeState, mi: *mir.MirInstr) err[fail.Fail] {
             ret err[fail.Fail].err{fail.message("encode: direct call has no resolved symbol name")};
         }
         val pos: u32 = st.buf.len::u32;
-        emit_branch_sym(st, BL_BASE, callee.sym, callee.sym_off);
+        emit_branch_sym(st, mop.BL, callee.sym, callee.sym_off);
         val r_1346: err[fail.Fail] = encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PLT32, callee.sym, callee.sym_off);
         if (sel r_1346.err) { ret err[fail.Fail].err{r_1346.err}; }
         ret err[fail.Fail].ok{};
     }
     val rr: res[i32, fail.Fail] = req_gpr(callee);
     if (sel rr.err) { ret err[fail.Fail].err{rr.err}; }
-    emit_branch_reg(st, BLR_BASE, rr.ok::u32);
+    emit_branch_reg(st, mop.BLR, rr.ok::u32);
     ret err[fail.Fail].ok{};
 }
 
-fun encode_alu3(st: *encode.EncodeState, mi: *mir.MirInstr, base_x: u32, base_w: u32) err[fail.Fail] {
+fun encode_alu3(st: *encode.EncodeState, mi: *mir.MirInstr, op: mop.MachOp) err[fail.Fail] {
     if (mi.operand_count < 3) { ret err[fail.Fail].err{fail.message("encode: ALU op missing operands")}; }
     val use64: bool = is64(mi.width);
 
@@ -1387,7 +1002,7 @@ fun encode_alu3(st: *encode.EncodeState, mi: *mir.MirInstr, base_x: u32, base_w:
     if (sel rmr.err) { ret err[fail.Fail].err{rmr.err}; }
     val rm: u32 = rmr.ok::u32;
 
-    emit_alu3(st, pick(use64, base_x, base_w), rd, rn, rm);
+    emit_alu3(st, op, use64, rd, rn, rm);
     ret err[fail.Fail].ok{};
 }
 
@@ -1406,16 +1021,14 @@ fun encode_addsub(st: *encode.EncodeState, mi: *mir.MirInstr, is_sub: bool) err[
     val rhs: *mir.MirOperand = ?mi.operands[2];
     if (rhs.kind == mir.MIR_OP_IMM) {
         val v: i64 = rhs.imm;
+        var op_i: mop.MachOp = mop.ADD;
+        if (is_sub) { op_i = mop.SUB; }
         if (v >= 0 && v <= 4095) {
-            var base_i: u32 = pick(use64, ADDI_X, ADDI_W);
-            if (is_sub) { base_i = pick(use64, SUBI_X, SUBI_W); }
-            emit_addsub_imm(st, base_i, rd, rn, v::u32, 0);
+            emit_addsub_imm(st, op_i, use64, rd, rn, v::u32, 0);
             ret err[fail.Fail].ok{};
         }
         if (v > 0 && (v & 0xFFF) == 0 && (v >> 12) <= 4095) {
-            var base_i: u32 = pick(use64, ADDI_X, ADDI_W);
-            if (is_sub) { base_i = pick(use64, SUBI_X, SUBI_W); }
-            emit_addsub_imm(st, base_i, rd, rn, (v >> 12)::u32, 1);
+            emit_addsub_imm(st, op_i, use64, rd, rn, (v >> 12)::u32, 1);
             ret err[fail.Fail].ok{};
         }
     }
@@ -1423,9 +1036,9 @@ fun encode_addsub(st: *encode.EncodeState, mi: *mir.MirInstr, is_sub: bool) err[
     val rmr: res[i32, fail.Fail] = resolve_source(st, rhs, SCRATCH0, use64);
     if (sel rmr.err) { ret err[fail.Fail].err{rmr.err}; }
     val rm: u32 = rmr.ok::u32;
-    var base_r: u32 = pick(use64, ADD_X, ADD_W);
-    if (is_sub) { base_r = pick(use64, SUB_X, SUB_W); }
-    emit_alu3(st, base_r, rd, rn, rm);
+    var op_r: mop.MachOp = mop.ADD;
+    if (is_sub) { op_r = mop.SUB; }
+    emit_alu3(st, op_r, use64, rd, rn, rm);
     ret err[fail.Fail].ok{};
 }
 
@@ -1446,32 +1059,24 @@ fun encode_shift(st: *encode.EncodeState, mi: *mir.MirInstr, kind: u32) err[fail
         var width_bits: u32 = 32;
         if (use64) { width_bits = 64; }
         val sh: u32 = cnt.imm::u32 & (width_bits - 1);
-        if (kind == arm64.LSL::u32) {
-            val immr: u32 = (width_bits - sh) & (width_bits - 1);
-            val imms: u32 = (width_bits - 1) - sh;
-            emit_bitfield(st, pick(use64, UBFM_X, UBFM_W), rd, rn, immr, imms);
-            ret err[fail.Fail].ok{};
-        }
-        if (kind == arm64.LSR::u32) {
-            emit_bitfield(st, pick(use64, UBFM_X, UBFM_W), rd, rn, sh, width_bits - 1);
-            ret err[fail.Fail].ok{};
-        }
-        emit_bitfield(st, pick(use64, SBFM_X, SBFM_W), rd, rn, sh, width_bits - 1);
+        var op_i: mop.MachOp = mop.LSL;
+        if (kind == arm64.LSR::u32) { op_i = mop.LSR; }
+        or (kind == arm64.ASR::u32) { op_i = mop.ASR; }
+        emit_bitfield(st, op_i, use64, rd, rn, sh, 0);
         ret err[fail.Fail].ok{};
     }
 
     val rmr: res[i32, fail.Fail] = req_gpr(cnt);
     if (sel rmr.err) { ret err[fail.Fail].err{rmr.err}; }
     val rm: u32 = rmr.ok::u32;
-    var base_x: u32 = LSLV_X;
-    var base_w: u32 = LSLV_W;
-    if (kind == arm64.LSR::u32) { base_x = LSRV_X; base_w = LSRV_W; }
-    or (kind == arm64.ASR::u32) { base_x = ASRV_X; base_w = ASRV_W; }
-    emit_alu3(st, pick(use64, base_x, base_w), rd, rn, rm);
+    var op_v: mop.MachOp = mop.LSLV;
+    if (kind == arm64.LSR::u32) { op_v = mop.LSRV; }
+    or (kind == arm64.ASR::u32) { op_v = mop.ASRV; }
+    emit_alu3(st, op_v, use64, rd, rn, rm);
     ret err[fail.Fail].ok{};
 }
 
-fun encode_neg_mvn(st: *encode.EncodeState, mi: *mir.MirInstr, base_x: u32, base_w: u32) err[fail.Fail] {
+fun encode_neg_mvn(st: *encode.EncodeState, mi: *mir.MirInstr, op: mop.MachOp) err[fail.Fail] {
     if (mi.operand_count < 2) { ret err[fail.Fail].err{fail.message("encode: neg/not missing operands")}; }
     val use64: bool = is64(mi.width);
 
@@ -1483,7 +1088,7 @@ fun encode_neg_mvn(st: *encode.EncodeState, mi: *mir.MirInstr, base_x: u32, base
     if (sel rmr.err) { ret err[fail.Fail].err{rmr.err}; }
     val rm: u32 = rmr.ok::u32;
 
-    emit_alu3(st, pick(use64, base_x, base_w), rd, ZR, rm);
+    emit_alu3(st, op, use64, rd, ZR, rm);
     ret err[fail.Fail].ok{};
 }
 
@@ -1517,7 +1122,7 @@ fun encode_mov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) 
     val rmr: res[i32, fail.Fail] = req_gpr(src);
     if (sel rmr.err) { ret err[fail.Fail].err{rmr.err}; }
     val rm: u32 = rmr.ok::u32;
-    emit_alu3(st, pick(use64, ORR_X, ORR_W), rd, ZR, rm);
+    emit_alu3(st, mop.ORR, use64, rd, ZR, rm);
     ret err[fail.Fail].ok{};
 }
 
@@ -1628,15 +1233,15 @@ fun encode_addr(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
     val sh: u32 = shr.ok;
     var ibase: u32 = m.base;
     if (ibase == ZR) {
-        emit_addsub_imm(st, ADDI_X, SCRATCH0, ZR, 0, 0);
+        emit_addsub_imm(st, mop.ADD, true, SCRATCH0, ZR, 0, 0);
         ibase = SCRATCH0;
     }
     if (m.off == 0) {
-        emit_alu3_sh(st, ADD_X, rd, ibase, m.index, sh);
+        emit_alu3_sh(st, mop.ADD, true, rd, ibase, m.index, sh);
         ret err[fail.Fail].ok{};
     }
     emit_add_imm(st, rd, ibase, m.off);
-    emit_alu3_sh(st, ADD_X, rd, rd, m.index, sh);
+    emit_alu3_sh(st, mop.ADD, true, rd, rd, m.index, sh);
     ret err[fail.Fail].ok{};
 }
 
@@ -1653,29 +1258,38 @@ fun encode_convert(st: *encode.EncodeState, mi: *mir.MirInstr) err[fail.Fail] {
     val rs: u32 = rsr.ok::u32;
 
     if (mi.opcode == mir.MIR_TRUNC) {
-        emit_alu3(st, ORR_W, rd, ZR, rs);
+        emit_alu3(st, mop.ORR, false, rd, ZR, rs);
         ret err[fail.Fail].ok{};
     }
     if (mi.opcode == mir.MIR_BITCAST) {
-        emit_alu3(st, pick(is64(dw), ORR_X, ORR_W), rd, ZR, rs);
+        emit_alu3(st, mop.ORR, is64(dw), rd, ZR, rs);
         ret err[fail.Fail].ok{};
     }
     if (mi.opcode == mir.MIR_SEXT) {
         if (sw >= 8) {
-            emit_alu3(st, ORR_X, rd, ZR, rs);
+            emit_alu3(st, mop.ORR, true, rd, ZR, rs);
             ret err[fail.Fail].ok{};
         }
-        val imms: u32 = (sw::u32 * 8) - 1;
-        emit_bitfield(st, pick(is64(dw), SBFM_X, SBFM_W), rd, rs, 0, imms);
+        emit_bitfield(st, extend_op(true, sw), is64(dw), rd, rs, 0, 0);
         ret err[fail.Fail].ok{};
     }
     if (sw >= 4) {
-        emit_alu3(st, ORR_W, rd, ZR, rs);
+        emit_alu3(st, mop.ORR, false, rd, ZR, rs);
         ret err[fail.Fail].ok{};
     }
-    val imms: u32 = (sw::u32 * 8) - 1;
-    emit_bitfield(st, UBFM_W, rd, rs, 0, imms);
+    emit_bitfield(st, extend_op(false, sw), false, rd, rs, 0, 0);
     ret err[fail.Fail].ok{};
+}
+
+# the extend alias that widens a narrow source: sxtb/sxth/sxtw or uxtb/uxth
+fun extend_op(signed: bool, sw: u8) mop.MachOp {
+    if (signed) {
+        if (sw == 1) { ret mop.SXTB; }
+        if (sw == 2) { ret mop.SXTH; }
+        ret mop.SXTW;
+    }
+    if (sw == 1) { ret mop.UXTB; }
+    ret mop.UXTH;
 }
 
 fun is_float_width(w: u8) bool {
@@ -1707,16 +1321,16 @@ fun emit_fp_mem(st: *encode.EncodeState, rt: u32, base: u32, off: i64, width: u8
     if (off >= 0) {
         val mask: i64 = (1::i64 << sh::i64) - 1;
         if ((off & mask) == 0 && (off >> sh::i64) <= 4095) {
-            emit_ldst(st, a.scaled, rt, base, (off >> sh::i64)::u32);
+            emit_ldst(st, a.op, a.fp, a.width, rt, base, (off >> sh::i64)::u32);
             ret err[fail.Fail].ok{};
         }
     }
     if (off >= -256 && off <= 255) {
-        emit_ldur(st, a.unscaled, rt, base, off::u32 & 0x1FF);
+        emit_ldur(st, a.unscaled, a.fp, a.width, rt, base, off::u32 & 0x1FF);
         ret err[fail.Fail].ok{};
     }
     emit_movewide_seq(st, SCRATCH0, off::u64, true);
-    emit_ldst_reg(st, a.reg, rt, base, SCRATCH0);
+    emit_ldst_reg(st, a.op, a.fp, a.width, rt, base, SCRATCH0);
     ret err[fail.Fail].ok{};
 }
 
@@ -1770,20 +1384,9 @@ fun fmov_imm8(bits: u64, use64: bool) opt[u32] {
     ret opt[u32].some{(sign << 7) | (b << 6) | ((exp & 0x3) << 4) | frac};
 }
 
-fun pack_fmov_imm(base: u32, rd: u32, imm8: u32) u32 {
-    ret base | ((imm8 & 0xFF) << 13) | (rd & 0x1F);
-}
-
 fun emit_fmov_imm(st: *encode.EncodeState, rd: u32, imm8: u32, use64: bool) {
-    var base: u32 = FMOV_S_IMM;
-    var w: u8 = 4;
-    if (use64) { base = FMOV_D_IMM; w = 8; }
-    emit_word(st, pack_fmov_imm(base, rd, imm8));
-    if (!noting(st)) { ret; }
-    var i: printer.Inst = printer.inst(printer.FORM_FMOV_IMM, base);
-    i.dst  = printer.vec(rd, w);
-    i.src2 = isa.make_imm(imm8::i64, 1);
-    printer.note_inst(?st.buf, ?i);
+    var mi: isa.Inst = inst_of(mop.FMOV_IMM, mop.vec(rd, width_bytes(use64)), isa.make_none(), isa.make_imm(imm8::i64, 1));
+    emit_inst(st, ?mi);
 }
 
 fun movewide_words(bits: u64, use64: bool) u32 {
@@ -1809,11 +1412,10 @@ fun emit_fp_const(st: *encode.EncodeState, vd: u32, bits: u64, width: u8) err[fa
     var pattern: u64 = bits;
     if (!use64) { pattern = bits & 0xFFFFFFFF; }
 
-    var fmov_base: u32 = FMOV_S_FROM_W;
-    if (use64) { fmov_base = FMOV_D_FROM_X; }
+    val w: u8 = width_bytes(use64);
 
     if (pattern == 0) {
-        emit_alu3(st, fmov_base, vd, ZR, 0);
+        emit_cvt(st, mop.FMOV_GEN, mop.vec(vd, w), mop.gp(ZR, w));
         ret err[fail.Fail].ok{};
     }
     val i8: opt[u32] = fmov_imm8(pattern, use64);
@@ -1823,7 +1425,7 @@ fun emit_fp_const(st: *encode.EncodeState, vd: u32, bits: u64, width: u8) err[fa
     }
     if (movewide_words(pattern, use64) <= 1) {
         emit_movewide_seq(st, SCRATCH0, pattern, use64);
-        emit_alu3(st, fmov_base, vd, SCRATCH0, 0);
+        emit_cvt(st, mop.FMOV_GEN, mop.vec(vd, w), mop.gp(SCRATCH0, w));
         ret err[fail.Fail].ok{};
     }
 
@@ -1837,7 +1439,7 @@ fun emit_fp_const(st: *encode.EncodeState, vd: u32, bits: u64, width: u8) err[fa
     val ar: err[fail.Fail] = emit_adrp_reloc(st, SCRATCH0, sym, 0);
     if (sel ar.err) { ret ar; }
     val pos: u32 = st.buf.len::u32;
-    emit_ldst_sym(st, a.scaled, vd, SCRATCH0, sym, printer.MOD_PCREL_LO, 0);
+    emit_ldst_sym(st, a.op, a.fp, a.width, vd, SCRATCH0, sym, isa.SYM_MOD_PCREL_LO, 0);
     val r_1820: err[fail.Fail] = encode.push_reloc(st, arm64_reloc_offset(pos), a.lo12, sym, 0);
     if (sel r_1820.err) { ret err[fail.Fail].err{r_1820.err}; }
     ret err[fail.Fail].ok{};
@@ -1861,12 +1463,12 @@ fun resolve_fp_source(st: *encode.EncodeState, f: *mir.MirFunction, op: *mir.Mir
     ret req_vec(op);
 }
 
-fun fp_arith_base(op: mir.MirOpcode, dbl: bool) res[u32, fail.Fail] {
-    if (op == mir.MIR_FADD) { if (dbl) { ret res[u32, fail.Fail].ok{FADD_D}; } ret res[u32, fail.Fail].ok{FADD_S}; }
-    if (op == mir.MIR_FSUB) { if (dbl) { ret res[u32, fail.Fail].ok{FSUB_D}; } ret res[u32, fail.Fail].ok{FSUB_S}; }
-    if (op == mir.MIR_FMUL) { if (dbl) { ret res[u32, fail.Fail].ok{FMUL_D}; } ret res[u32, fail.Fail].ok{FMUL_S}; }
-    if (op == mir.MIR_FDIV) { if (dbl) { ret res[u32, fail.Fail].ok{FDIV_D}; } ret res[u32, fail.Fail].ok{FDIV_S}; }
-    ret res[u32, fail.Fail].err{fail.message("encode: aarch64 has no float arithmetic form for this opcode")};
+fun fp_arith_op(op: mir.MirOpcode) res[mop.MachOp, fail.Fail] {
+    if (op == mir.MIR_FADD) { ret res[mop.MachOp, fail.Fail].ok{mop.FADD}; }
+    if (op == mir.MIR_FSUB) { ret res[mop.MachOp, fail.Fail].ok{mop.FSUB}; }
+    if (op == mir.MIR_FMUL) { ret res[mop.MachOp, fail.Fail].ok{mop.FMUL}; }
+    if (op == mir.MIR_FDIV) { ret res[mop.MachOp, fail.Fail].ok{mop.FDIV}; }
+    ret res[mop.MachOp, fail.Fail].err{fail.message("encode: aarch64 has no float arithmetic form for this opcode")};
 }
 
 fun fp_cond(cc: u8) res[u32, fail.Fail] {
@@ -1906,17 +1508,17 @@ fun encode_fp_arith(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIn
     if (sel rmr.err) { ret err[fail.Fail].err{rmr.err}; }
     val rm: u32 = rmr.ok::u32;
 
-    val baser: res[u32, fail.Fail] = fp_arith_base(mi.opcode, dbl);
-    if (sel baser.err) { ret err[fail.Fail].err{baser.err}; }
-    val base: u32 = baser.ok;
+    val opr: res[mop.MachOp, fail.Fail] = fp_arith_op(mi.opcode);
+    if (sel opr.err) { ret err[fail.Fail].err{opr.err}; }
+    val fop: mop.MachOp = opr.ok;
     val dst: *mir.MirOperand = ?mi.operands[0];
     if (dst.kind == mir.MIR_OP_MEM) {
-        emit_alu3(st, base, FP_SCRATCH0, rn, rm);
+        emit_fp3(st, fop, dbl, FP_SCRATCH0, rn, rm);
         ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, w);
     }
     val rdr: res[i32, fail.Fail] = req_vec(dst);
     if (sel rdr.err) { ret err[fail.Fail].err{rdr.err}; }
-    emit_alu3(st, base, rdr.ok::u32, rn, rm);
+    emit_fp3(st, fop, dbl, rdr.ok::u32, rn, rm);
     ret err[fail.Fail].ok{};
 }
 
@@ -1932,14 +1534,6 @@ fun neon_size(vl: u32) u32 {
     ret 0;
 }
 
-fun neon_lane_size(vl: u32) u32 {
-    val eb: u8 = mir.vec_lane_elem_bytes(vl);
-    if (eb == 2) { ret 1; }
-    if (eb == 4) { ret 2; }
-    if (eb == 8) { ret 3; }
-    ret 0;
-}
-
 fun encode_vec_lane_read(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) err[fail.Fail] {
     if (mi.operand_count < 3) { ret err[fail.Fail].err{fail.message("encode: vector lane read missing operands")}; }
     val vl: u32 = mi.vec_lane;
@@ -1948,7 +1542,6 @@ fun encode_vec_lane_read(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.
     if (lane_op.kind != mir.MIR_OP_IMM) { ret err[fail.Fail].err{fail.message("encode: vector lane index is not an immediate")}; }
     val index: u32 = lane_op.imm::u32;
     if (index >= mir.vec_lane_count(vl)) { ret err[fail.Fail].err{fail.message("encode: vector lane index out of range for lane arrangement")}; }
-    val size:  u32 = neon_lane_size(vl);
 
     val rnr: res[i32, fail.Fail] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, 16);
     if (sel rnr.err) { ret err[fail.Fail].err{rnr.err}; }
@@ -1959,20 +1552,17 @@ fun encode_vec_lane_read(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.
 
     if (is_float) {
         if (dst.kind == mir.MIR_OP_MEM) {
-            emit_neon_dup_el(st, size, index, FP_SCRATCH1, rn, vl);
+            emit_neon_dup_el(st, index, FP_SCRATCH1, rn, vl);
             ret emit_fp_slot_store(st, f, dst, FP_SCRATCH1, mi.width);
         }
         val rdr: res[i32, fail.Fail] = req_vec(dst);
         if (sel rdr.err) { ret err[fail.Fail].err{rdr.err}; }
-        emit_neon_dup_el(st, size, index, rdr.ok::u32, rn, vl);
+        emit_neon_dup_el(st, index, rdr.ok::u32, rn, vl);
         ret err[fail.Fail].ok{};
     }
 
-    var base: u32 = VUMOV_W;
-    if (mir.vec_lane_elem_bytes(vl) == 8) { base = VUMOV_X; }
-
     if (dst.kind == mir.MIR_OP_MEM) {
-        emit_neon_umov(st, base, size, index, SCRATCH0, rn, vl);
+        emit_neon_umov(st, index, SCRATCH0, rn, vl);
         val mr: res[A64Mem, fail.Fail] = resolve_mem(f, dst);
         if (sel mr.err) { ret err[fail.Fail].err{mr.err}; }
         val m: A64Mem = mr.ok;
@@ -1981,7 +1571,7 @@ fun encode_vec_lane_read(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.
     }
     val rdr: res[i32, fail.Fail] = req_gpr(dst);
     if (sel rdr.err) { ret err[fail.Fail].err{rdr.err}; }
-    emit_neon_umov(st, base, size, index, rdr.ok::u32, rn, vl);
+    emit_neon_umov(st, index, rdr.ok::u32, rn, vl);
     ret err[fail.Fail].ok{};
 }
 
@@ -1993,7 +1583,6 @@ fun encode_vec_lane_write(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir
     if (lane_op.kind != mir.MIR_OP_IMM) { ret err[fail.Fail].err{fail.message("encode: vector lane index is not an immediate")}; }
     val index: u32 = lane_op.imm::u32;
     if (index >= mir.vec_lane_count(vl)) { ret err[fail.Fail].err{fail.message("encode: vector lane index out of range for lane arrangement")}; }
-    val size:  u32 = neon_lane_size(vl);
 
     val rnr: res[i32, fail.Fail] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, 16);
     if (sel rnr.err) { ret err[fail.Fail].err{rnr.err}; }
@@ -2011,48 +1600,48 @@ fun encode_vec_lane_write(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir
         rd = rdr.ok::u32;
     }
 
-    if (rd != rn) { emit_neon_3same(st, VORR, 0, rd, rn, rn, mir.vec_lane_make(mir.VEC_LANE_INT, 1, 16)); }
+    if (rd != rn) { emit_neon_3same(st, mop.V_ORR, rd, rn, rn, mir.vec_lane_make(mir.VEC_LANE_INT, 1, 16)); }
 
     if (mir.vec_lane_kind(vl) == mir.VEC_LANE_FLOAT) {
         val rvr: res[i32, fail.Fail] = resolve_fp_source(st, f, ?mi.operands[3], FP_SCRATCH0, mi.src_width);
         if (sel rvr.err) { ret err[fail.Fail].err{rvr.err}; }
-        emit_neon_ins_el(st, size, index, 0, rd, rvr.ok::u32, vl);
+        emit_neon_ins_el(st, index, 0, rd, rvr.ok::u32, vl);
     }
     or {
         val rvr: res[i32, fail.Fail] = resolve_source(st, ?mi.operands[3], SCRATCH0, mir.vec_lane_elem_bytes(vl) == 8);
         if (sel rvr.err) { ret err[fail.Fail].err{rvr.err}; }
         var src_bytes: u8 = 4;
         if (mir.vec_lane_elem_bytes(vl) == 8) { src_bytes = 8; }
-        emit_neon_ins_gp(st, size, index, rd, rvr.ok::u32, vl, src_bytes);
+        emit_neon_ins_gp(st, index, rd, rvr.ok::u32, vl, src_bytes);
     }
 
     if (to_slot) { ret emit_fp_slot_store(st, f, dst, rd, 16); }
     ret err[fail.Fail].ok{};
 }
 
-fun neon_base(opcode: u32, is_float: bool) u32 {
-    if (opcode == arm64.VEC_ADD::u32)  { if (is_float) { ret VFADD; } ret VADD; }
-    if (opcode == arm64.VEC_SUB::u32)  { if (is_float) { ret VFSUB; } ret VSUB; }
-    if (opcode == arm64.VEC_MUL::u32)  { if (is_float) { ret VFMUL; } ret VMUL; }
-    if (opcode == arm64.VEC_DIV::u32)  { ret VFDIV; }
-    if (opcode == arm64.VEC_AND::u32)  { ret VAND; }
-    if (opcode == arm64.VEC_ORR::u32)  { ret VORR; }
-    if (opcode == arm64.VEC_EOR::u32)  { ret VEOR; }
-    if (opcode == arm64.VEC_CMEQ::u32) { if (is_float) { ret VFCMEQ; } ret VCMEQ; }
-    if (opcode == arm64.VEC_CMGT::u32) { if (is_float) { ret VFCMGT; } ret VCMGT_S; }
-    if (opcode == arm64.VEC_CMGE::u32) { if (is_float) { ret VFCMGE; } ret VCMGE_S; }
-    if (opcode == arm64.VEC_CMHI::u32) { ret VCMHI_U; }
-    if (opcode == arm64.VEC_CMHS::u32) { ret VCMHS_U; }
-    ret 0;
+fun neon_op(opcode: u32, is_float: bool) mop.MachOp {
+    if (opcode == arm64.VEC_ADD::u32)  { if (is_float) { ret mop.V_FADD; } ret mop.V_ADD; }
+    if (opcode == arm64.VEC_SUB::u32)  { if (is_float) { ret mop.V_FSUB; } ret mop.V_SUB; }
+    if (opcode == arm64.VEC_MUL::u32)  { if (is_float) { ret mop.V_FMUL; } ret mop.V_MUL; }
+    if (opcode == arm64.VEC_DIV::u32)  { ret mop.V_FDIV; }
+    if (opcode == arm64.VEC_AND::u32)  { ret mop.V_AND; }
+    if (opcode == arm64.VEC_ORR::u32)  { ret mop.V_ORR; }
+    if (opcode == arm64.VEC_EOR::u32)  { ret mop.V_EOR; }
+    if (opcode == arm64.VEC_CMEQ::u32) { if (is_float) { ret mop.V_FCMEQ; } ret mop.V_CMEQ; }
+    if (opcode == arm64.VEC_CMGT::u32) { if (is_float) { ret mop.V_FCMGT; } ret mop.V_CMGT; }
+    if (opcode == arm64.VEC_CMGE::u32) { if (is_float) { ret mop.V_FCMGE; } ret mop.V_CMGE; }
+    if (opcode == arm64.VEC_CMHI::u32) { ret mop.V_CMHI; }
+    if (opcode == arm64.VEC_CMHS::u32) { ret mop.V_CMHS; }
+    ret mop.MOP_NONE;
 }
 
-fun neon_3same_size_ok(base: u32, size: u32) bool {
-    if (base == VMUL) { ret size != 3; }
+fun neon_3same_size_ok(op: mop.MachOp, size: u32) bool {
+    if (op == mop.V_MUL) { ret size != 3; }
     ret true;
 }
 
-fun neon_arrangement_err(base: u32, size: u32) str {
-    if (base == VMUL) { ret "encode: NEON integer multiply has no 64-bit lane arrangement (MUL (vector) leaves size 3 unallocated)"; }
+fun neon_arrangement_err(op: mop.MachOp, size: u32) str {
+    if (op == mop.V_MUL) { ret "encode: NEON integer multiply has no 64-bit lane arrangement (MUL (vector) leaves size 3 unallocated)"; }
     ret "encode: NEON three-register-same word has no encoding at this arrangement";
 }
 
@@ -2069,12 +1658,12 @@ fun encode_neon(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
         val rn: u32 = rnr.ok::u32;
         val ndst: *mir.MirOperand = ?mi.operands[0];
         if (ndst.kind == mir.MIR_OP_MEM) {
-            emit_neon_2misc(st, VNOT, FP_SCRATCH0, rn);
+            emit_neon_2misc(st, mop.V_MVN, FP_SCRATCH0, rn);
             ret emit_fp_slot_store(st, f, ndst, FP_SCRATCH0, 16);
         }
         val rdr: res[i32, fail.Fail] = req_vec(ndst);
         if (sel rdr.err) { ret err[fail.Fail].err{rdr.err}; }
-        emit_neon_2misc(st, VNOT, rdr.ok::u32, rn);
+        emit_neon_2misc(st, mop.V_MVN, rdr.ok::u32, rn);
         ret err[fail.Fail].ok{};
     }
 
@@ -2099,18 +1688,18 @@ fun encode_neon(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
     }
 
     if (op == arm64.VEC_CMNE::u32) {
-        var eqbase: u32 = VCMEQ;
-        if (is_float) { eqbase = VFCMEQ; }
-        if (!neon_3same_size_ok(eqbase, size)) { ret err[fail.Fail].err{fail.message(neon_arrangement_err(eqbase, size))}; }
-        emit_neon_3same(st, eqbase, size, rd, rn, rm, vl);
-        emit_neon_2misc(st, VNOT, rd, rd);
+        var eqop: mop.MachOp = mop.V_CMEQ;
+        if (is_float) { eqop = mop.V_FCMEQ; }
+        if (!neon_3same_size_ok(eqop, size)) { ret err[fail.Fail].err{fail.message(neon_arrangement_err(eqop, size))}; }
+        emit_neon_3same(st, eqop, rd, rn, rm, vl);
+        emit_neon_2misc(st, mop.V_MVN, rd, rd);
     }
     or {
         var eff_size: u32 = size;
         if (op == arm64.VEC_AND::u32 || op == arm64.VEC_ORR::u32 || op == arm64.VEC_EOR::u32) { eff_size = 0; }
-        val base: u32 = neon_base(op, is_float);
-        if (!neon_3same_size_ok(base, eff_size)) { ret err[fail.Fail].err{fail.message(neon_arrangement_err(base, eff_size))}; }
-        emit_neon_3same(st, base, eff_size, rd, rn, rm, vl);
+        val vop: mop.MachOp = neon_op(op, is_float);
+        if (!neon_3same_size_ok(vop, eff_size)) { ret err[fail.Fail].err{fail.message(neon_arrangement_err(vop, eff_size))}; }
+        emit_neon_3same(st, vop, rd, rn, rm, vl);
     }
 
     if (to_slot) { ret emit_fp_slot_store(st, f, dst, rd, 16); }
@@ -2127,16 +1716,14 @@ fun encode_fp_neg(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInst
     if (sel rnr.err) { ret err[fail.Fail].err{rnr.err}; }
     val rn: u32 = rnr.ok::u32;
 
-    var base: u32 = FNEG_S;
-    if (w == 8) { base = FNEG_D; }
     val dst: *mir.MirOperand = ?mi.operands[0];
     if (dst.kind == mir.MIR_OP_MEM) {
-        emit_alu3(st, base, FP_SCRATCH0, rn, 0);
+        emit_fp2(st, mop.FNEG, w == 8, FP_SCRATCH0, rn);
         ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, w);
     }
     val rdr: res[i32, fail.Fail] = req_vec(dst);
     if (sel rdr.err) { ret err[fail.Fail].err{rdr.err}; }
-    emit_alu3(st, base, rdr.ok::u32, rn, 0);
+    emit_fp2(st, mop.FNEG, w == 8, rdr.ok::u32, rn);
     ret err[fail.Fail].ok{};
 }
 
@@ -2160,35 +1747,11 @@ fun encode_fp_cmp(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInst
     if (sel rdr.err) { ret err[fail.Fail].err{rdr.err}; }
     val rd: u32 = rdr.ok::u32;
 
-    var base: u32 = FCMP_S;
-    if (w == 8) { base = FCMP_D; }
-    emit_alu3(st, base, 0, rn, rm);
+    emit_fcmp(st, w == 8, rn, rm);
     val ccr: res[u32, fail.Fail] = fp_cond(cc);
     if (sel ccr.err) { ret err[fail.Fail].err{ccr.err}; }
-    emit_cset(st, CSINC_W, rd, ccr.ok);
+    emit_cset(st, false, rd, ccr.ok);
     ret err[fail.Fail].ok{};
-}
-
-fun cvt_int_to_fp_base(signed: bool, dbl: bool, src_x: bool) u32 {
-    if (signed) {
-        if (dbl) { if (src_x) { ret SCVTF_D_X; } ret SCVTF_D_W; }
-        if (src_x)            { ret SCVTF_S_X; }
-        ret SCVTF_S_W;
-    }
-    if (dbl) { if (src_x) { ret UCVTF_D_X; } ret UCVTF_D_W; }
-    if (src_x)            { ret UCVTF_S_X; }
-    ret UCVTF_S_W;
-}
-
-fun cvt_fp_to_int_base(signed: bool, dst_x: bool, src_d: bool) u32 {
-    if (signed) {
-        if (dst_x) { if (src_d) { ret FCVTZS_X_D; } ret FCVTZS_X_S; }
-        if (src_d)              { ret FCVTZS_W_D; }
-        ret FCVTZS_W_S;
-    }
-    if (dst_x) { if (src_d) { ret FCVTZU_X_D; } ret FCVTZU_X_S; }
-    if (src_d)              { ret FCVTZU_W_D; }
-    ret FCVTZU_W_S;
 }
 
 fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) err[fail.Fail] {
@@ -2204,16 +1767,15 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
         val rnr: res[i32, fail.Fail] = resolve_fp_source(st, f, ?mi.operands[1], FP_SCRATCH0, sw);
         if (sel rnr.err) { ret err[fail.Fail].err{rnr.err}; }
         val rn: u32 = rnr.ok::u32;
-        var base: u32 = FCVT_D2S;
-        if (op == mir.MIR_FP_EXT) { base = FCVT_S2D; }
+        val to_dbl: bool = op == mir.MIR_FP_EXT;
         val dst: *mir.MirOperand = ?mi.operands[0];
         if (dst.kind == mir.MIR_OP_MEM) {
-            emit_alu3(st, base, FP_SCRATCH0, rn, 0);
+            emit_fcvt(st, to_dbl, FP_SCRATCH0, rn);
             ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, dw);
         }
         val rdr: res[i32, fail.Fail] = req_vec(dst);
         if (sel rdr.err) { ret err[fail.Fail].err{rdr.err}; }
-        emit_alu3(st, base, rdr.ok::u32, rn, 0);
+        emit_fcvt(st, to_dbl, rdr.ok::u32, rn);
         ret err[fail.Fail].ok{};
     }
 
@@ -2227,22 +1789,21 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
         var gp: u32 = gpr.ok::u32;
         var src_x: bool = sw >= 8;
         if (sw < 4) {
-            val imms: u32 = (sw::u32 * 8) - 1;
-            if (signed) { emit_bitfield(st, SBFM_W, SCRATCH0, gp, 0, imms); }
-            or          { emit_bitfield(st, UBFM_W, SCRATCH0, gp, 0, imms); }
+            emit_bitfield(st, extend_op(signed, sw), false, SCRATCH0, gp, 0, 0);
             gp = SCRATCH0;
             src_x = false;
         }
-        val dbl: bool = dw == 8;
-        val base: u32 = cvt_int_to_fp_base(signed, dbl, src_x);
+        var cop: mop.MachOp = mop.UCVTF;
+        if (signed) { cop = mop.SCVTF; }
+        val src: isa.Operand = mop.gp(gp, width_bytes(src_x));
         val dst: *mir.MirOperand = ?mi.operands[0];
         if (dst.kind == mir.MIR_OP_MEM) {
-            emit_alu3(st, base, FP_SCRATCH0, gp, 0);
+            emit_cvt(st, cop, mop.vec(FP_SCRATCH0, dw), src);
             ret emit_fp_slot_store(st, f, dst, FP_SCRATCH0, dw);
         }
         val rdr: res[i32, fail.Fail] = req_vec(dst);
         if (sel rdr.err) { ret err[fail.Fail].err{rdr.err}; }
-        emit_alu3(st, base, rdr.ok::u32, gp, 0);
+        emit_cvt(st, cop, mop.vec(rdr.ok::u32, dw), src);
         ret err[fail.Fail].ok{};
     }
 
@@ -2256,8 +1817,9 @@ fun encode_fp_conv(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirIns
     val rdr: res[i32, fail.Fail] = req_gpr(?mi.operands[0]);
     if (sel rdr.err) { ret err[fail.Fail].err{rdr.err}; }
     val rd: u32 = rdr.ok::u32;
-    val base: u32 = cvt_fp_to_int_base(signed, dw >= 8, sw == 8);
-    emit_alu3(st, base, rd, rn, 0);
+    var cop: mop.MachOp = mop.FCVTZU;
+    if (signed) { cop = mop.FCVTZS; }
+    emit_cvt(st, cop, mop.gp(rd, width_bytes(dw >= 8)), mop.vec(rn, sw));
     ret err[fail.Fail].ok{};
 }
 
@@ -2281,7 +1843,7 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
         val rnr: res[i32, fail.Fail] = req_vec(src);
         if (sel rnr.err) { ret err[fail.Fail].err{rnr.err}; }
         val rn: u32 = rnr.ok::u32;
-        emit_neon_3same(st, VORR, 0, rd, rn, rn, mir.vec_lane_make(mir.VEC_LANE_INT, 1, 16));
+        emit_neon_3same(st, mop.V_ORR, rd, rn, rn, mir.vec_lane_make(mir.VEC_LANE_INT, 1, 16));
         ret err[fail.Fail].ok{};
     }
 
@@ -2310,9 +1872,7 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
             if (sel rdr.err) { ret err[fail.Fail].err{rdr.err}; }
             val rnr: res[i32, fail.Fail] = req_vec(src);
             if (sel rnr.err) { ret err[fail.Fail].err{rnr.err}; }
-            var base: u32 = FMOV_S;
-            if (dbl) { base = FMOV_D; }
-            emit_alu3(st, base, rdr.ok::u32, rnr.ok::u32, 0);
+            emit_fp2(st, mop.FMOV, dbl, rdr.ok::u32, rnr.ok::u32);
             ret err[fail.Fail].ok{};
         }
         if (dvec) {
@@ -2320,9 +1880,7 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
             if (sel rdr.err) { ret err[fail.Fail].err{rdr.err}; }
             val rnr: res[i32, fail.Fail] = req_gpr(src);
             if (sel rnr.err) { ret err[fail.Fail].err{rnr.err}; }
-            var base: u32 = FMOV_S_FROM_W;
-            if (dbl) { base = FMOV_D_FROM_X; }
-            emit_alu3(st, base, rdr.ok::u32, rnr.ok::u32, 0);
+            emit_cvt(st, mop.FMOV_GEN, mop.vec(rdr.ok::u32, w), mop.gp(rnr.ok::u32, w));
             ret err[fail.Fail].ok{};
         }
         if (svec) {
@@ -2330,9 +1888,7 @@ fun encode_fmov(st: *encode.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr)
             if (sel rdr.err) { ret err[fail.Fail].err{rdr.err}; }
             val rnr: res[i32, fail.Fail] = req_vec(src);
             if (sel rnr.err) { ret err[fail.Fail].err{rnr.err}; }
-            var base: u32 = FMOV_W_FROM_S;
-            if (dbl) { base = FMOV_X_FROM_D; }
-            emit_alu3(st, base, rdr.ok::u32, rnr.ok::u32, 0);
+            emit_cvt(st, mop.FMOV_GEN, mop.gp(rdr.ok::u32, w), mop.vec(rnr.ok::u32, w));
             ret err[fail.Fail].ok{};
         }
         ret err[fail.Fail].err{fail.message("encode: fmov names two general-purpose registers")};
@@ -2392,9 +1948,7 @@ fun is_mir_compare(op: mir.MirOpcode) bool {
 
 fun narrow_cmp_source(st: *encode.EncodeState, reg: u32, scratch: u32, width: u8, signed: bool) u32 {
     if (width == 0 || width >= 4) { ret reg; }
-    val imms: u32 = (width::u32 * 8) - 1;
-    if (signed) { emit_bitfield(st, SBFM_W, scratch, reg, 0, imms); }
-    or          { emit_bitfield(st, UBFM_W, scratch, reg, 0, imms); }
+    emit_bitfield(st, extend_op(signed, width), false, scratch, reg, 0, 0);
     ret scratch;
 }
 
@@ -2423,13 +1977,13 @@ fun emit_flag_cmp(st: *encode.EncodeState, lhs_op: *mir.MirOperand, rhs_op: *mir
 
     val rhs_val: i64 = cmp_imm_value(rhs_op.imm, width, signed);
     if (rhs_op.kind == mir.MIR_OP_IMM && rhs_val >= 0 && rhs_val <= 4095) {
-        emit_addsub_imm(st, pick(use64, SUBS_IMM_X, SUBS_IMM_W), ZR, rn, rhs_val::u32, 0);
+        emit_addsub_imm(st, mop.SUBS, use64, ZR, rn, rhs_val::u32, 0);
     } or {
         val rmr: res[i32, fail.Fail] = resolve_source(st, rhs_op, SCRATCH0, use64);
         if (sel rmr.err) { ret err[fail.Fail].err{rmr.err}; }
         var rm: u32 = rmr.ok::u32;
         rm = narrow_cmp_source(st, rm, SCRATCH0, width, signed);
-        emit_alu3(st, pick(use64, SUBS_REG_X, SUBS_REG_W), ZR, rn, rm);
+        emit_alu3(st, mop.SUBS, use64, ZR, rn, rm);
     }
     ret err[fail.Fail].ok{};
 }
@@ -2446,7 +2000,7 @@ fun encode_compare(st: *encode.EncodeState, mi: *mir.MirInstr) err[fail.Fail] {
 
     val ccr: res[u32, fail.Fail] = cmp_cond(mi.opcode);
     if (sel ccr.err) { ret err[fail.Fail].err{ccr.err}; }
-    emit_cset(st, CSINC_W, rd, ccr.ok);
+    emit_cset(st, false, rd, ccr.ok);
     ret err[fail.Fail].ok{};
 }
 
@@ -2457,7 +2011,7 @@ fun encode_branch(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) err[
     val target_block: u32 = mi.operands[0].imm::u32;
     if (encode.branch_falls_through(st, target_block)) { ret err[fail.Fail].ok{}; }
     val patch_pos: u32 = st.buf.len::u32;
-    emit_branch_block(st, B_BASE, 0, false, target_block);
+    emit_branch_block(st, mop.B, 0, false, 0, target_block);
     val next_ip: u32 = st.buf.len::u32;
     val r_2439: err[fail.Fail] = encode.push_fixup(st, patch_pos, next_ip, target_block, fn_base);
     if (sel r_2439.err) { ret err[fail.Fail].err{r_2439.err}; }
@@ -2478,14 +2032,14 @@ fun encode_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) err[fai
     val cond: u32 = rcr.ok::u32;
 
     val cbnz_pos: u32 = st.buf.len::u32;
-    emit_branch_block(st, pick(use64, CBNZ_X, CBNZ_W), cond, true, then_block);
+    emit_branch_block(st, mop.CBNZ, 0, use64, cond, then_block);
     val cbnz_next: u32 = st.buf.len::u32;
     val f1: err[fail.Fail] = encode.push_fixup(st, cbnz_pos, cbnz_next, then_block, fn_base);
     if (sel f1.err) { ret err[fail.Fail].err{f1.err}; }
 
     if (encode.branch_falls_through(st, else_block)) { ret err[fail.Fail].ok{}; }
     val b_pos: u32 = st.buf.len::u32;
-    emit_branch_block(st, B_BASE, 0, false, else_block);
+    emit_branch_block(st, mop.B, 0, false, 0, else_block);
     val b_next: u32 = st.buf.len::u32;
     val r_2465: err[fail.Fail] = encode.push_fixup(st, b_pos, b_next, else_block, fn_base);
     if (sel r_2465.err) { ret err[fail.Fail].err{r_2465.err}; }
@@ -2519,7 +2073,7 @@ fun encode_fused_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) e
     val bcc_pos: u32 = st.buf.len::u32;
     val ccr: res[u32, fail.Fail] = fused_cbr_cond(mi.opcode);
     if (sel ccr.err) { ret err[fail.Fail].err{ccr.err}; }
-    emit_branch_block(st, BCOND | (ccr.ok & 0xF), 0, false, then_block);
+    emit_branch_block(st, mop.BCOND, ccr.ok, false, 0, then_block);
     val bcc_next: u32 = st.buf.len::u32;
     val f1: err[fail.Fail] = encode.push_fixup(st, bcc_pos, bcc_next, then_block, fn_base);
     if (sel f1.err) { ret err[fail.Fail].err{f1.err}; }
@@ -2529,7 +2083,7 @@ fun encode_fused_cbr(st: *encode.EncodeState, fn_base: u32, mi: *mir.MirInstr) e
         ret err[fail.Fail].ok{};
     }
     val b_pos: u32 = st.buf.len::u32;
-    emit_branch_block(st, B_BASE, 0, false, else_block);
+    emit_branch_block(st, mop.B, 0, false, 0, else_block);
     val b_next: u32 = st.buf.len::u32;
     encode.close_cmp_varlocs(st, instr_start, st.buf.len::u32);
     val r_2508: err[fail.Fail] = encode.push_fixup(st, b_pos, b_next, else_block, fn_base);
@@ -2562,30 +2116,29 @@ fun encode_divide(st: *encode.EncodeState, mi: *mir.MirInstr) err[fail.Fail] {
     val signed: bool = op == mir.MIR_SEL_DIV_S || op == mir.MIR_SEL_REM_S;
     val rem:    bool = op == mir.MIR_SEL_REM_S || op == mir.MIR_SEL_REM_U;
 
-    emit_branch_pcrel(st, pick(use64, CBNZ_X, CBNZ_W), rm, true, 2);
-    emit_imm16(st, BRK_BASE, 0);
+    emit_branch_pcrel(st, mop.CBNZ, 0, use64, rm, 2);
+    emit_imm16(st, mop.BRK, 0);
 
     if (signed) {
-        emit_addsub_imm(st, pick(use64, ADDS_IMM_X, ADDS_IMM_W), ZR, rm, 1, 0);
-        emit_branch_pcrel(st, BCOND | CC_NE, 0, false, 5);
+        emit_addsub_imm(st, mop.ADDS, use64, ZR, rm, 1, 0);
+        emit_branch_pcrel(st, mop.BCOND, CC_NE, false, 0, 5);
         var hw: u32 = 1;
         if (use64) { hw = 3; }
-        emit_movewide(st, pick(use64, MOVZ_X, MOVZ_W), SCRATCH1, hw, 0x8000);
-        emit_alu3(st, pick(use64, SUBS_REG_X, SUBS_REG_W), ZR, rn, SCRATCH1);
-        emit_branch_pcrel(st, BCOND | CC_NE, 0, false, 2);
-        emit_imm16(st, BRK_BASE, 0);
+        emit_movewide(st, mop.MOVZ, use64, SCRATCH1, hw, 0x8000);
+        emit_alu3(st, mop.SUBS, use64, ZR, rn, SCRATCH1);
+        emit_branch_pcrel(st, mop.BCOND, CC_NE, false, 0, 2);
+        emit_imm16(st, mop.BRK, 0);
     }
 
-    var dbase_x: u32 = SDIV_X;
-    var dbase_w: u32 = SDIV_W;
-    if (!signed) { dbase_x = UDIV_X; dbase_w = UDIV_W; }
+    var dop: mop.MachOp = mop.SDIV;
+    if (!signed) { dop = mop.UDIV; }
 
     if (rem) {
-        emit_alu3(st, pick(use64, dbase_x, dbase_w), SCRATCH0, rn, rm);
-        emit_madd(st, pick(use64, MSUB_X, MSUB_W), rd, SCRATCH0, rm, rn);
+        emit_alu3(st, dop, use64, SCRATCH0, rn, rm);
+        emit_madd(st, mop.MSUB, use64, rd, SCRATCH0, rm, rn);
         ret err[fail.Fail].ok{};
     }
-    emit_alu3(st, pick(use64, dbase_x, dbase_w), rd, rn, rm);
+    emit_alu3(st, dop, use64, rd, rn, rm);
     ret err[fail.Fail].ok{};
 }
 
@@ -2616,23 +2169,23 @@ fun frame_subsize(f: *mir.MirFunction) u32 {
 
 fun emit_sp_sub(st: *encode.EncodeState, subsize: u32) {
     if (subsize <= 0xFFF) {
-        emit_addsub_imm(st, SUBI_X, ZR, ZR, subsize, 0);
+        emit_addsub_imm(st, mop.SUB, true, ZR, ZR, subsize, 0);
         ret;
     }
     if (subsize <= MAX_FRAME_SUB) {
         val hi: u32 = subsize >> 12;
         val lo: u32 = subsize & 0xFFF;
-        emit_addsub_imm(st, SUBI_X, ZR, ZR, hi, 1);
-        if (lo != 0) { emit_addsub_imm(st, SUBI_X, ZR, ZR, lo, 0); }
+        emit_addsub_imm(st, mop.SUB, true, ZR, ZR, hi, 1);
+        if (lo != 0) { emit_addsub_imm(st, mop.SUB, true, ZR, ZR, lo, 0); }
         ret;
     }
     emit_movewide_seq(st, SCRATCH0, subsize::u64, true);
-    emit_alu3(st, SUB_SP_REG_X, ZR, ZR, SCRATCH0);
+    emit_alu3(st, mop.SUB, true, SP_REG, SP_REG, SCRATCH0);
 }
 
 fun emit_prologue(st: *encode.EncodeState, f: *mir.MirFunction, subsize: u32) {
-    emit_ldstp(st, STP_PRE_X, FP_REG, LR_REG, ZR, (0::u32 - 2) & 0x7F);
-    emit_addsub_imm(st, ADDI_X, FP_REG, ZR, 0, 0);
+    emit_ldstp(st, mop.STP, false, FP_REG, LR_REG, SP_REG, (0::u32 - 2) & 0x7F, mop.FLAG_WB_PRE);
+    emit_addsub_imm(st, mop.ADD, true, FP_REG, ZR, 0, 0);
     emit_sp_realign(st, f.frame.realign);
     if (subsize > 0) { emit_sp_sub(st, subsize); }
     save_callee_gp(st, f, true);
@@ -2642,10 +2195,10 @@ fun emit_prologue(st: *encode.EncodeState, f: *mir.MirFunction, subsize: u32) {
 fun emit_sp_realign(st: *encode.EncodeState, realign: u32) {
     if (realign == 0) { ret; }
     val k: u32 = log2_u32(realign);
-    emit_addsub_imm(st, ADDI_X, SCRATCH0, ZR, 0, 0);
-    emit_bitfield(st, UBFM_X, SCRATCH0, SCRATCH0, k, 63);
-    emit_bitfield(st, UBFM_X, SCRATCH0, SCRATCH0, (64 - k) & 63, 63 - k);
-    emit_addsub_imm(st, ADDI_X, ZR, SCRATCH0, 0, 0);
+    emit_addsub_imm(st, mop.ADD, true, SCRATCH0, ZR, 0, 0);
+    emit_bitfield(st, mop.LSR, true, SCRATCH0, SCRATCH0, k, 0);
+    emit_bitfield(st, mop.LSL, true, SCRATCH0, SCRATCH0, k, 0);
+    emit_addsub_imm(st, mop.ADD, true, ZR, SCRATCH0, 0, 0);
 }
 
 fun log2_u32(n: u32) u32 {
@@ -2659,9 +2212,9 @@ fun emit_epilogue(st: *encode.EncodeState, f: *mir.MirFunction, subsize: u32) {
     save_callee_fp(st, f, false);
     save_callee_gp(st, f, false);
     if (subsize > 0) {
-        emit_addsub_imm(st, ADDI_X, ZR, FP_REG, 0, 0);
+        emit_addsub_imm(st, mop.ADD, true, ZR, FP_REG, 0, 0);
     }
-    emit_ldstp(st, LDP_POST_X, FP_REG, LR_REG, ZR, 2);
+    emit_ldstp(st, mop.LDP, false, FP_REG, LR_REG, SP_REG, 2, mop.FLAG_WB_POST);
 }
 
 fun save_callee_gp(st: *encode.EncodeState, f: *mir.MirFunction, store: bool) {
@@ -2694,8 +2247,8 @@ fun save_callee_gp(st: *encode.EncodeState, f: *mir.MirFunction, store: bool) {
     for (p < num_pairs) {
         val base_off: i32 = 0 - (anchor + (16 * p)::i32);
         val imm7: u32 = (base_off / 8)::u32 & 0x7F;
-        if (store) { emit_ldstp(st, STP_OFF_X, regs[2 * p], regs[2 * p + 1], base_reg, imm7); }
-        or         { emit_ldstp(st, LDP_OFF_X, regs[2 * p], regs[2 * p + 1], base_reg, imm7); }
+        if (store) { emit_ldstp(st, mop.STP, false, regs[2 * p], regs[2 * p + 1], base_reg, imm7, 0); }
+        or         { emit_ldstp(st, mop.LDP, false, regs[2 * p], regs[2 * p + 1], base_reg, imm7, 0); }
         p = p + 1;
     }
     if ((n & 1) == 1) {
@@ -2735,8 +2288,8 @@ fun save_callee_fp(st: *encode.EncodeState, f: *mir.MirFunction, store: bool) {
     for (p < num_pairs) {
         val base_off: i32 = 0 - (anchor + (16 * p)::i32);
         val imm7: u32 = (base_off / 8)::u32 & 0x7F;
-        if (store) { emit_ldstp(st, STP_OFF_D, regs[2 * p], regs[2 * p + 1], base_reg, imm7); }
-        or         { emit_ldstp(st, LDP_OFF_D, regs[2 * p], regs[2 * p + 1], base_reg, imm7); }
+        if (store) { emit_ldstp(st, mop.STP, true, regs[2 * p], regs[2 * p + 1], base_reg, imm7, 0); }
+        or         { emit_ldstp(st, mop.LDP, true, regs[2 * p], regs[2 * p + 1], base_reg, imm7, 0); }
         p = p + 1;
     }
     if ((n & 1) == 1) {
@@ -2799,21 +2352,21 @@ fun encode_mir_instr(st: *encode.EncodeState, f: *mir.MirFunction, fn_base: u32,
     if (op >= arm64.VEC_ADD::u32 && op <= arm64.VEC_CMHS::u32) { ret encode_neon(st, f, mi); }
     if (op == arm64.ADD::u32)  { ret encode_addsub(st, mi, false); }
     if (op == arm64.SUB::u32)  { ret encode_addsub(st, mi, true); }
-    if (op == arm64.MUL::u32)  { ret encode_alu3(st, mi, MUL_X, MUL_W); }
-    if (op == arm64.AND::u32)  { ret encode_alu3(st, mi, AND_X, AND_W); }
-    if (op == arm64.ORR::u32)  { ret encode_alu3(st, mi, ORR_X, ORR_W); }
-    if (op == arm64.EOR::u32)  { ret encode_alu3(st, mi, EOR_X, EOR_W); }
+    if (op == arm64.MUL::u32)  { ret encode_alu3(st, mi, mop.MUL); }
+    if (op == arm64.AND::u32)  { ret encode_alu3(st, mi, mop.AND); }
+    if (op == arm64.ORR::u32)  { ret encode_alu3(st, mi, mop.ORR); }
+    if (op == arm64.EOR::u32)  { ret encode_alu3(st, mi, mop.EOR); }
     if (op == arm64.LSL::u32)  { ret encode_shift(st, mi, arm64.LSL::u32); }
     if (op == arm64.LSR::u32)  { ret encode_shift(st, mi, arm64.LSR::u32); }
     if (op == arm64.ASR::u32)  { ret encode_shift(st, mi, arm64.ASR::u32); }
-    if (op == arm64.NEG::u32)  { ret encode_neg_mvn(st, mi, SUB_X, SUB_W); }
-    if (op == arm64.MVN::u32)  { ret encode_neg_mvn(st, mi, ORN_X, ORN_W); }
+    if (op == arm64.NEG::u32)  { ret encode_neg_mvn(st, mi, mop.SUB); }
+    if (op == arm64.MVN::u32)  { ret encode_neg_mvn(st, mi, mop.ORN); }
     if (op == arm64.MOV::u32)  { ret encode_mov(st, f, mi); }
     if (op == arm64.FMOV::u32) { ret encode_fmov(st, f, mi); }
     if (op == arm64.B::u32)    { ret encode_branch(st, fn_base, mi); }
-    if (op == arm64.RET::u32)  { emit_nullary(st, RET_WORD); ret err[fail.Fail].ok{}; }
-    if (op == arm64.BRK::u32)  { emit_imm16(st, BRK_BASE, 0); ret err[fail.Fail].ok{}; }
-    if (op == arm64.NOP::u32)  { emit_nullary(st, NOP_WORD); ret err[fail.Fail].ok{}; }
+    if (op == arm64.RET::u32)  { emit_ret(st); ret err[fail.Fail].ok{}; }
+    if (op == arm64.BRK::u32)  { emit_imm16(st, mop.BRK, 0); ret err[fail.Fail].ok{}; }
+    if (op == arm64.NOP::u32)  { emit_nullary(st, mop.NOP); ret err[fail.Fail].ok{}; }
 
     val r_2788: err[fail.Fail] = encode.opcode_failure(st, f, "arm64", mi.opcode);
     if (sel r_2788.err) { ret err[fail.Fail].err{r_2788.err}; }
@@ -2890,7 +2443,7 @@ fun patch_branch_arm64(st: *encode.EncodeState, fx: *encode.BranchFixup, target_
     val disp: u32 = target_off - fx.patch_pos;
 
     var patched: u32 = 0;
-    if ((word & 0xFC000000) == B_BASE) {
+    if ((word & 0xFC000000) == mop.form(mop.B).base) {
         if (sdisp < -134217728 || sdisp >= 134217728) {
             ret err[fail.Fail].err{fail.message("encode: aarch64 B displacement exceeds the +-128MB branch range")};
         }
@@ -3026,7 +2579,7 @@ fun emit_asm_mov_imm(st: *encode.EncodeState, rd: u32, value: u64, use64: bool) 
         val sh: u64 = 16::u64 * i::u64;
         val chunk: u64 = (v >> sh) & 0xFFFF;
         if ((chunk << sh) == v) {
-            emit_movewide(st, pick(use64, MOVZ_X, MOVZ_W), rd, i, chunk::u32);
+            emit_movewide(st, mop.MOVZ, use64, rd, i, chunk::u32);
             ret;
         }
         i = i + 1;
@@ -3604,26 +3157,16 @@ fun a64_emit(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, item: *i
     val pat: u16 = a64_pattern(item.flags);
 
     if (pat == A64P_NULLARY) {
-        if (item.code == mop.NOP::u32)   { emit_nullary(st, NOP_WORD);   ret err[fail.Fail].ok{}; }
-        if (item.code == mop.YIELD::u32) { emit_nullary(st, YIELD_WORD); ret err[fail.Fail].ok{}; }
-        if (item.code == mop.WFE::u32)   { emit_nullary(st, WFE_WORD);   ret err[fail.Fail].ok{}; }
-        if (item.code == mop.WFI::u32)   { emit_nullary(st, WFI_WORD);   ret err[fail.Fail].ok{}; }
-        emit_nullary(st, RET_WORD);
+        if (item.code == mop.RET::u32) { emit_ret(st); ret err[fail.Fail].ok{}; }
+        emit_nullary(st, item.code::mop.MachOp);
         ret err[fail.Fail].ok{};
     }
-    if (pat == A64P_RET_REG) { emit_branch_reg(st, RET_BASE, item.ops[0].reg::u32); ret err[fail.Fail].ok{}; }
-    if (pat == A64P_BR_REG) {
-        var base: u32 = BR_BASE;
-        if (item.code == mop.BLR::u32) { base = BLR_BASE; }
-        emit_branch_reg(st, base, item.ops[0].reg::u32);
+    if (pat == A64P_RET_REG || pat == A64P_BR_REG) {
+        emit_branch_reg(st, item.code::mop.MachOp, item.ops[0].reg::u32);
         ret err[fail.Fail].ok{};
     }
     if (pat == A64P_IMM16) {
-        var base: u32 = BRK_BASE;
-        if (item.code == mop.SVC::u32) { base = SVC_BASE; }
-        or (item.code == mop.HVC::u32) { base = HVC_BASE; }
-        or (item.code == mop.SMC::u32) { base = SMC_BASE; }
-        emit_imm16(st, base, item.ops[0].imm::u32);
+        emit_imm16(st, item.code::mop.MachOp, item.ops[0].imm::u32);
         ret err[fail.Fail].ok{};
     }
     if (pat == A64P_MOV)      { ret a64_emit_mov(st, item); }
@@ -3633,7 +3176,7 @@ fun a64_emit(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, item: *i
     if (pat == A64P_CMP)      { ret a64_emit_cmp(st, item); }
     if (pat == A64P_CSET) {
         val use64: bool = a64_is64(?item.ops[0]);
-        emit_cset(st, pick(use64, CSINC_X, CSINC_W), item.ops[0].reg::u32, a64_cond(item.flags));
+        emit_cset(st, use64, item.ops[0].reg::u32, a64_cond(item.flags));
         ret err[fail.Fail].ok{};
     }
     if (pat == A64P_ADRP)  { ret a64_emit_adrp(st, c, item); }
@@ -3648,17 +3191,16 @@ fun a64_emit(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, item: *i
             emit_msr_imm(st, (f >> 8) & 0x7, f & 0x7, item.ops[1].imm::u32);
             ret err[fail.Fail].ok{};
         }
-        a64_emit_sysreg(st, MSR_REG_BASE, item.ops[0].imm::u32, item.ops[1].reg::u32);
+        emit_msr_reg(st, item.ops[0].imm::u32, item.ops[1].reg::u32);
         ret err[fail.Fail].ok{};
     }
     if (pat == A64P_MRS) {
-        a64_emit_sysreg(st, MRS_BASE, item.ops[1].imm::u32, item.ops[0].reg::u32);
+        emit_mrs(st, item.ops[1].imm::u32, item.ops[0].reg::u32);
         ret err[fail.Fail].ok{};
     }
     if (pat == A64P_LDORD) { ret a64_emit_ldord(st, item); }
     if (pat == A64P_STLXR) {
-        val base: u32 = pick(a64_is64(?item.ops[1]), STLXR_X, STLXR_W);
-        emit_stxr(st, base, item.ops[0].reg::u32, item.ops[1].reg::u32, item.ops[2].reg::u32);
+        emit_stxr(st, a64_is64(?item.ops[1]), item.ops[0].reg::u32, item.ops[1].reg::u32, item.ops[2].reg::u32);
         ret err[fail.Fail].ok{};
     }
     if (pat == A64P_SHIFT) { ret a64_emit_shift(st, item); }
@@ -3671,9 +3213,9 @@ fun a64_emit_mov(st: *encode.EncodeState, item: *iasm.Item) err[fail.Fail] {
     val use64: bool = a64_is64(dst);
     if (src.kind == iasm.AOP_REG) {
         if (a64_is_sp(dst) || a64_is_sp(src)) {
-            emit_addsub_imm(st, pick(use64, ADDI_X, ADDI_W), dst.reg::u32, src.reg::u32, 0, 0);
+            emit_addsub_imm(st, mop.ADD, use64, dst.reg::u32, src.reg::u32, 0, 0);
         } or {
-            emit_alu3(st, pick(use64, ORR_X, ORR_W), dst.reg::u32, ZR, src.reg::u32);
+            emit_alu3(st, mop.ORR, use64, dst.reg::u32, ZR, src.reg::u32);
         }
         ret err[fail.Fail].ok{};
     }
@@ -3685,9 +3227,7 @@ fun a64_emit_movewide(st: *encode.EncodeState, item: *iasm.Item) err[fail.Fail] 
     val use64: bool = a64_is64(?item.ops[0]);
     var hw: u32 = 0;
     if (item.nops == 3) { hw = item.ops[2].imm::u32; }
-    var base: u32 = pick(use64, MOVZ_X, MOVZ_W);
-    if (item.code == mop.MOVK::u32) { base = pick(use64, MOVK_X, MOVK_W); }
-    emit_movewide(st, base, item.ops[0].reg::u32, hw, item.ops[1].imm::u32);
+    emit_movewide(st, item.code::mop.MachOp, use64, item.ops[0].reg::u32, hw, item.ops[1].imm::u32);
     ret err[fail.Fail].ok{};
 }
 
@@ -3698,16 +3238,15 @@ fun a64_emit_addsub(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) 
     val use64: bool = a64_is64(rd);
     val is_sub: bool = item.code == mop.SUB::u32;
 
+    val aop: mop.MachOp = item.code::mop.MachOp;
     if (op3.kind == iasm.AOP_IMM) {
-        var base: u32 = pick(use64, ADDI_X, ADDI_W);
-        if (is_sub) { base = pick(use64, SUBI_X, SUBI_W); }
         val v: i64 = op3.imm;
         if (v >= 0 && v <= 4095) {
-            emit_addsub_imm(st, base, rd.reg::u32, rn.reg::u32, v::u32, 0);
+            emit_addsub_imm(st, aop, use64, rd.reg::u32, rn.reg::u32, v::u32, 0);
             ret err[fail.Fail].ok{};
         }
         if (v > 0 && (v & 0xFFF) == 0 && (v >> 12) <= 4095) {
-            emit_addsub_imm(st, base, rd.reg::u32, rn.reg::u32, (v >> 12)::u32, 1);
+            emit_addsub_imm(st, aop, use64, rd.reg::u32, rn.reg::u32, (v >> 12)::u32, 1);
             ret err[fail.Fail].ok{};
         }
         ret err[fail.Fail].err{fail.message("encode: inline-asm add/sub immediate is out of imm12 range")};
@@ -3719,7 +3258,7 @@ fun a64_emit_addsub(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) 
         if (sel sr.err) { ret err[fail.Fail].err{sr.err}; }
         val sid: intern.StrId = sr.ok;
         val pos: u32 = st.buf.len::u32;
-        emit_addsub_imm_sym(st, pick(use64, ADDI_X, ADDI_W), rd.reg::u32, rn.reg::u32, sid, printer.MOD_PCREL_LO, 0);
+        emit_addsub_imm_sym(st, mop.ADD, use64, rd.reg::u32, rn.reg::u32, sid, isa.SYM_MOD_PCREL_LO, 0);
         val r_3680: err[fail.Fail] = encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_ADD_LO12, sid, 0);
         if (sel r_3680.err) { ret err[fail.Fail].err{r_3680.err}; }
         ret err[fail.Fail].ok{};
@@ -3727,9 +3266,7 @@ fun a64_emit_addsub(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) 
     if (a64_is_sp(rd) || a64_is_sp(rn) || a64_is_sp(op3)) {
         ret err[fail.Fail].err{fail.message("encode: inline-asm add/sub with SP and a register operand requires the extended-register form (unsupported)")};
     }
-    var base_r: u32 = pick(use64, ADD_X, ADD_W);
-    if (is_sub) { base_r = pick(use64, SUB_X, SUB_W); }
-    emit_alu3(st, base_r, rd.reg::u32, rn.reg::u32, op3.reg::u32);
+    emit_alu3(st, aop, use64, rd.reg::u32, rn.reg::u32, op3.reg::u32);
     ret err[fail.Fail].ok{};
 }
 
@@ -3738,11 +3275,7 @@ fun a64_emit_logical(st: *encode.EncodeState, item: *iasm.Item) err[fail.Fail] {
         ret err[fail.Fail].err{fail.message("encode: inline-asm logical (shifted register) has no sp operand form; register 31 there is always xzr")};
     }
     val use64: bool = a64_is64(?item.ops[0]);
-    var bx: u32 = AND_X;
-    var bw: u32 = AND_W;
-    if (item.code == mop.ORR::u32)      { bx = ORR_X; bw = ORR_W; }
-    or (item.code == mop.EOR::u32)      { bx = EOR_X; bw = EOR_W; }
-    emit_alu3(st, pick(use64, bx, bw), item.ops[0].reg::u32, item.ops[1].reg::u32, item.ops[2].reg::u32);
+    emit_alu3(st, item.code::mop.MachOp, use64, item.ops[0].reg::u32, item.ops[1].reg::u32, item.ops[2].reg::u32);
     ret err[fail.Fail].ok{};
 }
 
@@ -3752,13 +3285,13 @@ fun a64_emit_cmp(st: *encode.EncodeState, item: *iasm.Item) err[fail.Fail] {
     val use64: bool = a64_is64(rn);
     if (op2.kind == iasm.AOP_IMM) {
         if (op2.imm < 0 || op2.imm > 4095) { ret err[fail.Fail].err{fail.message("encode: inline-asm 'cmp' second operand must be a register or imm12")}; }
-        emit_addsub_imm(st, pick(use64, SUBS_IMM_X, SUBS_IMM_W), ZR, rn.reg::u32, op2.imm::u32, 0);
+        emit_addsub_imm(st, mop.SUBS, use64, ZR, rn.reg::u32, op2.imm::u32, 0);
         ret err[fail.Fail].ok{};
     }
     if (a64_is_sp(rn) || a64_is_sp(op2)) {
         ret err[fail.Fail].err{fail.message("encode: inline-asm 'cmp' with sp and a register operand requires the extended-register form (unsupported)")};
     }
-    emit_alu3(st, pick(use64, SUBS_REG_X, SUBS_REG_W), ZR, rn.reg::u32, op2.reg::u32);
+    emit_alu3(st, mop.SUBS, use64, ZR, rn.reg::u32, op2.reg::u32);
     ret err[fail.Fail].ok{};
 }
 
@@ -3779,7 +3312,7 @@ fun a64_emit_call(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) er
     if (sel sr.err) { ret err[fail.Fail].err{sr.err}; }
     val sid: intern.StrId = sr.ok;
     val pos: u32 = st.buf.len::u32;
-    emit_branch_sym(st, BL_BASE, sid, 0);
+    emit_branch_sym(st, mop.BL, sid, 0);
     val r_3738: err[fail.Fail] = encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_PLT32, sid, 0);
     if (sel r_3738.err) { ret err[fail.Fail].err{r_3738.err}; }
     ret err[fail.Fail].ok{};
@@ -3794,31 +3327,28 @@ fun a64_emit_branch(st: *encode.EncodeState, c: *iasm.Cursor, l: *iasm.Labels, i
         if (sel sr.err) { ret err[fail.Fail].err{fail.refused(sr.err)}; }
         val sid: intern.StrId = sr.ok;
         val pos: u32 = st.buf.len::u32;
-        emit_branch_sym(st, B_BASE, sid, 0);
+        emit_branch_sym(st, mop.B, sid, 0);
         val r_3751: err[fail.Fail] = encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_JUMP26, sid, 0);
         if (sel r_3751.err) { ret err[fail.Fail].err{r_3751.err}; }
         ret err[fail.Fail].ok{};
     }
 
-    var base: u32 = B_BASE;
-    var word: u32 = B_BASE;
+    var bop: mop.MachOp = mop.B;
+    var cc: u32 = 0;
     var rt: u32 = 0;
-    var has_rt: bool = false;
+    var use64: bool = false;
     if (pat == A64P_BCOND) {
-        base = BCOND | (a64_cond(item.flags) & 0xF);
-        word = base;
+        bop = mop.BCOND;
+        cc  = a64_cond(item.flags) & 0xF;
     }
     or (pat == A64P_CBR) {
-        val use64: bool = a64_is64(?item.ops[0]);
-        base = pick(use64, CBZ_X, CBZ_W);
-        if (item.code == mop.CBNZ::u32) { base = pick(use64, CBNZ_X, CBNZ_W); }
-        rt     = item.ops[0].reg::u32;
-        has_rt = true;
-        word   = pack_cbnz(base, rt);
+        bop   = item.code::mop.MachOp;
+        use64 = a64_is64(?item.ops[0]);
+        rt    = item.ops[0].reg::u32;
     }
 
     val pos: u32 = st.buf.len::u32;
-    emit_branch_local(st, word, base, rt, has_rt, item.ref_num, item.ref_fwd);
+    emit_branch_local(st, bop, cc, use64, rt, item.ref_num, item.ref_fwd);
     ret iasm.resolve_local(st, c.g, l, pos, item.ref_num, item.ref_fwd);
 }
 
@@ -3845,18 +3375,18 @@ fun a64_emit_ldst(st: *encode.EncodeState, c: *iasm.Cursor, item: *iasm.Item) er
         val pos: u32 = st.buf.len::u32;
         if (mem.mod == isa.SYM_MOD_GOT_LO) {
             if (!is_load || w != 8) { ret err[fail.Fail].err{fail.message("encode: inline-asm ':got_lo12:' offset takes a 64-bit load")}; }
-            emit_ldst_sym(st, LDR_OFF_X, rt.reg::u32, mem.reg::u32, sid, printer.MOD_GOT_LO, 0);
+            emit_ldst_sym(st, mop.LDR, false, 8, rt.reg::u32, mem.reg::u32, sid, isa.SYM_MOD_GOT_LO, 0);
             val r_3800: err[fail.Fail] = encode.push_reloc(st, arm64_reloc_offset(pos), of.RK_GOT_LO12, sid, 0);
             if (sel r_3800.err) { ret err[fail.Fail].err{r_3800.err}; }
             ret err[fail.Fail].ok{};
         }
-        emit_ldst_sym(st, acf.scaled, rt.reg::u32, mem.reg::u32, sid, printer.MOD_PCREL_LO, 0);
+        emit_ldst_sym(st, acf.op, acf.fp, acf.width, rt.reg::u32, mem.reg::u32, sid, isa.SYM_MOD_PCREL_LO, 0);
         val r_3803: err[fail.Fail] = encode.push_reloc(st, arm64_reloc_offset(pos), acf.lo12, sid, 0);
         if (sel r_3803.err) { ret err[fail.Fail].err{r_3803.err}; }
         ret err[fail.Fail].ok{};
     }
     if ((mem.flags & iasm.AOF_HAS_INDEX) != 0) {
-        emit_ldst_reg(st, acf.reg, rt.reg::u32, mem.reg::u32, mem.index::u32);
+        emit_ldst_reg(st, acf.op, acf.fp, acf.width, rt.reg::u32, mem.reg::u32, mem.index::u32);
         ret err[fail.Fail].ok{};
     }
     val no_scratch_r: res[bool, fail.Fail] = mem_access_needs_no_scratch(mem.imm, w);
@@ -3886,27 +3416,26 @@ fun a64_emit_ldstp(st: *encode.EncodeState, item: *iasm.Item) err[fail.Fail] {
     val mem: *iasm.Operand = ?item.ops[2];
     val is_load: bool = item.code == mop.LDP::u32;
     var disp: i64 = 0;
-    var base_word: u32 = pick(is_load, LDP_OFF_X, STP_OFF_X);
+    var wb: u16 = 0;
     if (item.nops == 4) {
-        disp      = item.ops[3].imm;
-        base_word = pick(is_load, LDP_POST_X, STP_POST_X);
+        disp = item.ops[3].imm;
+        wb   = mop.FLAG_WB_POST;
     } or {
         disp = mem.imm;
-        if ((mem.flags & iasm.AOF_WRITEBACK) != 0) { base_word = pick(is_load, LDP_PRE_X, STP_PRE_X); }
+        if ((mem.flags & iasm.AOF_WRITEBACK) != 0) { wb = mop.FLAG_WB_PRE; }
     }
     if ((disp & 7) != 0)   { ret err[fail.Fail].err{fail.message("encode: inline-asm stp/ldp offset must be a multiple of 8")}; }
     val q: i64 = disp / 8;
     if (q < -64 || q > 63) { ret err[fail.Fail].err{fail.message("encode: inline-asm stp/ldp offset is out of the imm7 range")}; }
-    emit_ldstp(st, base_word, item.ops[0].reg::u32, item.ops[1].reg::u32, mem.reg::u32, q::u32 & 0x7F);
+    var pop: mop.MachOp = mop.STP;
+    if (is_load) { pop = mop.LDP; }
+    emit_ldstp(st, pop, false, item.ops[0].reg::u32, item.ops[1].reg::u32, mem.reg::u32, q::u32 & 0x7F, wb);
     ret err[fail.Fail].ok{};
 }
 
 fun a64_emit_ldord(st: *encode.EncodeState, item: *iasm.Item) err[fail.Fail] {
     val use64: bool = a64_is64(?item.ops[0]);
-    var base: u32 = pick(use64, LDAXR_X, LDAXR_W);
-    if (item.code == mop.LDAR::u32)      { base = pick(use64, LDAR_X, LDAR_W); }
-    or (item.code == mop.STLR::u32)      { base = pick(use64, STLR_X, STLR_W); }
-    emit_ldst(st, base, item.ops[0].reg::u32, item.ops[1].reg::u32, 0);
+    emit_ldord(st, item.code::mop.MachOp, use64, item.ops[0].reg::u32, item.ops[1].reg::u32);
     ret err[fail.Fail].ok{};
 }
 
@@ -3927,23 +3456,17 @@ fun a64_emit_shift(st: *encode.EncodeState, item: *iasm.Item) err[fail.Fail] {
 
     if (cnt.kind == iasm.AOP_IMM && !vform) {
         val sh: u32 = cnt.imm::u32 & (width - 1);
-        if (is_asr) {
-            emit_bitfield(st, pick(use64, SBFM_X, SBFM_W), rd.reg::u32, rn.reg::u32, sh, width - 1);
-        } or (is_lsr) {
-            emit_bitfield(st, pick(use64, UBFM_X, UBFM_W), rd.reg::u32, rn.reg::u32, sh, width - 1);
-        } or {
-            val immr: u32 = (width - sh) & (width - 1);
-            val imms: u32 = (width - 1) - sh;
-            emit_bitfield(st, pick(use64, UBFM_X, UBFM_W), rd.reg::u32, rn.reg::u32, immr, imms);
-        }
+        var sop: mop.MachOp = mop.LSL;
+        if (is_asr)     { sop = mop.ASR; }
+        or (is_lsr)     { sop = mop.LSR; }
+        emit_bitfield(st, sop, use64, rd.reg::u32, rn.reg::u32, sh, 0);
         ret err[fail.Fail].ok{};
     }
     if (cnt.kind != iasm.AOP_REG) { ret err[fail.Fail].err{fail.message("encode: inline-asm shift count must be a register or immediate")}; }
-    var bx: u32 = LSLV_X;
-    var bw: u32 = LSLV_W;
-    if (is_lsr)      { bx = LSRV_X; bw = LSRV_W; }
-    or (is_asr)      { bx = ASRV_X; bw = ASRV_W; }
-    emit_alu3(st, pick(use64, bx, bw), rd.reg::u32, rn.reg::u32, cnt.reg::u32);
+    var vop: mop.MachOp = mop.LSLV;
+    if (is_lsr)      { vop = mop.LSRV; }
+    or (is_asr)      { vop = mop.ASRV; }
+    emit_alu3(st, vop, use64, rd.reg::u32, rn.reg::u32, cnt.reg::u32);
     ret err[fail.Fail].ok{};
 }
 
@@ -4097,31 +3620,147 @@ fun tvec(n: i32) mir.MirOperand {
     ret mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, n)::u32);
 }
 
+# the words the assembler produces for a spelled instruction: the packer
+# tests state each expectation against `llvm-mc` output through these
+fun t_asm(op: mop.MachOp, dst: isa.Operand, src1: isa.Operand, src2: isa.Operand) u32 {
+    var mi: isa.Inst = inst_of(op, dst, src1, src2);
+    ret mop.assemble(?mi);
+}
+
+fun t_alu(op: mop.MachOp, w: u8, rd: u32, rn: u32, rm: u32) u32 {
+    ret t_asm(op, mop.gp(rd, w), mop.gp(rn, w), mop.gp(rm, w));
+}
+
+fun t_alu_sp(op: mop.MachOp, w: u8, rd: u32, rn: u32, rm: u32) u32 {
+    var mi: isa.Inst = inst_of(op, mop.gp(rd, w), mop.gp(rn, w), mop.gp(rm, w));
+    mi.flags = mop.FLAG_SP;
+    ret mop.assemble(?mi);
+}
+
+fun t_fp3(op: mop.MachOp, w: u8, rd: u32, rn: u32, rm: u32) u32 {
+    ret t_asm(op, mop.vec(rd, w), mop.vec(rn, w), mop.vec(rm, w));
+}
+
+fun t_imm(op: mop.MachOp, w: u8, rd: u32, rn: u32, imm12: u32, sh: u32) u32 {
+    var mi: isa.Inst = inst_of(op, mop.gp(rd, w), mop.gp(rn, w), isa.make_imm(imm12::i64, w));
+    if (sh != 0) { mi.src3 = isa.make_imm(12, 1); }
+    mi.flags = mop.FLAG_SP;
+    ret mop.assemble(?mi);
+}
+
+fun t_mw(op: mop.MachOp, w: u8, rd: u32, hw: u32, imm16: u32) u32 {
+    var mi: isa.Inst = inst_of(op, mop.gp(rd, w), isa.make_none(), isa.make_imm(imm16::i64, w));
+    if (hw != 0) { mi.src3 = isa.make_imm((hw * 16)::i64, 1); }
+    ret mop.assemble(?mi);
+}
+
+fun t_cset(w: u8, rd: u32, cc: u32) u32 {
+    var mi: isa.Inst = inst_of(mop.CSET, mop.gp(rd, w), isa.make_none(), isa.make_none());
+    mi.flags = mop.with_cond(0, cc);
+    ret mop.assemble(?mi);
+}
+
+fun t_madd(op: mop.MachOp, w: u8, rd: u32, rn: u32, rm: u32, ra: u32) u32 {
+    var mi: isa.Inst = inst_of(op, mop.gp(rd, w), mop.gp(rn, w), mop.gp(rm, w));
+    mi.src3 = mop.gp(ra, w);
+    ret mop.assemble(?mi);
+}
+
+fun t_skip(op: mop.MachOp, cc: u32, w: u8, rt: u32, imm19: u32) u32 {
+    var target: isa.Operand = isa.make_local_label(true);
+    target.disp = (imm19 * 4)::i32;
+    var mi: isa.Inst = branch_inst(op, cc, w == 8, rt, target);
+    mi.flags = mi.flags | mop.FLAG_LABEL_SKIP;
+    ret mop.assemble(?mi);
+}
+
+fun t_ldst(op: mop.MachOp, fp: bool, w: u8, rt: u32, rn: u32, imm12: u32) u32 {
+    val bytes: u8 = access_bytes(op, w);
+    var mi: isa.Inst = ldst_inst(op, shaped_reg(fp, rt, w), isa.make_mem(mop.gp_id(rn), (imm12 * bytes::u32)::i32, -1, 0, bytes));
+    ret mop.assemble(?mi);
+}
+
+fun t_ldur(op: mop.MachOp, fp: bool, w: u8, rt: u32, rn: u32, imm9: u32) u32 {
+    val bytes: u8 = access_bytes(op, w);
+    var mi: isa.Inst = ldst_inst(op, shaped_reg(fp, rt, w), isa.make_mem(mop.gp_id(rn), sign_extend_field(imm9, 9)::i32, -1, 0, bytes));
+    ret mop.assemble(?mi);
+}
+
+fun t_ldst_reg(op: mop.MachOp, fp: bool, w: u8, rt: u32, rn: u32, rm: u32) u32 {
+    val bytes: u8 = access_bytes(op, w);
+    var mi: isa.Inst = ldst_inst(op, shaped_reg(fp, rt, w), isa.make_mem(mop.gp_id(rn), 0, mop.gp_id(rm), 1, bytes));
+    ret mop.assemble(?mi);
+}
+
+fun t_ldstp(op: mop.MachOp, fp: bool, rt: u32, rt2: u32, rn: u32, imm7: u32) u32 {
+    val mem: isa.Operand = isa.make_mem(mop.gp_id(rn), (sign_extend_field(imm7, 7) * 8)::i32, -1, 0, 8);
+    var mi: isa.Inst = inst_of(op, mem, shaped_reg(fp, rt, 8), shaped_reg(fp, rt2, 8));
+    if (op == mop.LDP) { mi = inst_of(op, shaped_reg(fp, rt, 8), shaped_reg(fp, rt2, 8), mem); }
+    ret mop.assemble(?mi);
+}
+
+fun t_neon3(op: mop.MachOp, eb: u8, rd: u32, rn: u32, rm: u32) u32 {
+    var mi: isa.Inst = inst_of(op, mop.vec(rd, 16), mop.vec(rn, 16), mop.vec(rm, 16));
+    mi.flags = mop.with_elem_bytes(0, eb);
+    ret mop.assemble(?mi);
+}
+
+fun t_neon2(op: mop.MachOp, rd: u32, rn: u32) u32 {
+    var mi: isa.Inst = inst_of(op, mop.vec(rd, 16), mop.vec(rn, 16), isa.make_none());
+    mi.flags = mop.with_elem_bytes(0, 1);
+    ret mop.assemble(?mi);
+}
+
+fun t_lane_rd(op: mop.MachOp, dst: isa.Operand, eb: u8, index: u32, rn: u32) u32 {
+    var mi: isa.Inst = inst_of(op, dst, mop.vec(rn, 16), isa.make_imm(index::i64, 1));
+    mi.flags = mop.with_elem_bytes(0, eb);
+    ret mop.assemble(?mi);
+}
+
+fun t_ins_gp(eb: u8, index: u32, rd: u32, rn: u32) u32 {
+    var src_w: u8 = 4;
+    if (eb == 8) { src_w = 8; }
+    var mi: isa.Inst = inst_of(mop.INS, mop.vec(rd, 16), mop.gp(rn, src_w), isa.make_imm(index::i64, 1));
+    mi.flags = mop.with_elem_bytes(0, eb);
+    ret mop.assemble(?mi);
+}
+
+fun t_ins_el(eb: u8, index: u32, src_index: u32, rd: u32, rn: u32) u32 {
+    var mi: isa.Inst = inst_of(mop.INS_EL, mop.vec(rd, 16), mop.vec(rn, 16), isa.make_imm(index::i64, 1));
+    mi.src3  = isa.make_imm(src_index::i64, 1);
+    mi.flags = mop.with_elem_bytes(0, eb);
+    ret mop.assemble(?mi);
+}
+
+fun t_reg1(op: mop.MachOp, rn: u32) u32 {
+    ret t_asm(op, isa.make_none(), mop.gp(rn, 8), isa.make_none());
+}
+
 test "mach.lang.target.isa.arm64.encode:three_address_alu_register_forms" {
     var bad: i32 = 0;
-    if (pack_alu3(ADD_X, 0, 1, 2) != 0x8B020020) { bad = 1; }
-    if (pack_alu3(ADD_W, 0, 1, 2) != 0x0B020020) { bad = 1; }
-    if (pack_alu3(SUB_X, 0, 1, 2) != 0xCB020020) { bad = 1; }
-    if (pack_alu3(SUB_W, 0, 1, 2) != 0x4B020020) { bad = 1; }
-    if (pack_alu3(MUL_X, 0, 1, 2) != 0x9B027C20) { bad = 1; }
-    if (pack_alu3(MUL_W, 0, 1, 2) != 0x1B027C20) { bad = 1; }
-    if (pack_alu3(AND_X, 0, 1, 2) != 0x8A020020) { bad = 1; }
-    if (pack_alu3(ORR_X, 0, 1, 2) != 0xAA020020) { bad = 1; }
-    if (pack_alu3(EOR_X, 0, 1, 2) != 0xCA020020) { bad = 1; }
-    if (pack_alu3(AND_W, 0, 1, 2) != 0x0A020020) { bad = 1; }
-    if (pack_alu3(ORR_W, 0, 1, 2) != 0x2A020020) { bad = 1; }
-    if (pack_alu3(EOR_W, 0, 1, 2) != 0x4A020020) { bad = 1; }
+    if (t_alu(mop.ADD, 8, 0, 1, 2) != 0x8B020020) { bad = 1; }
+    if (t_alu(mop.ADD, 4, 0, 1, 2) != 0x0B020020) { bad = 1; }
+    if (t_alu(mop.SUB, 8, 0, 1, 2) != 0xCB020020) { bad = 1; }
+    if (t_alu(mop.SUB, 4, 0, 1, 2) != 0x4B020020) { bad = 1; }
+    if (t_alu(mop.MUL, 8, 0, 1, 2) != 0x9B027C20) { bad = 1; }
+    if (t_alu(mop.MUL, 4, 0, 1, 2) != 0x1B027C20) { bad = 1; }
+    if (t_alu(mop.AND, 8, 0, 1, 2) != 0x8A020020) { bad = 1; }
+    if (t_alu(mop.ORR, 8, 0, 1, 2) != 0xAA020020) { bad = 1; }
+    if (t_alu(mop.EOR, 8, 0, 1, 2) != 0xCA020020) { bad = 1; }
+    if (t_alu(mop.AND, 4, 0, 1, 2) != 0x0A020020) { bad = 1; }
+    if (t_alu(mop.ORR, 4, 0, 1, 2) != 0x2A020020) { bad = 1; }
+    if (t_alu(mop.EOR, 4, 0, 1, 2) != 0x4A020020) { bad = 1; }
     ret bad;
 }
 
 test "mach.lang.target.isa.arm64.encode:register_shifts" {
     var bad: i32 = 0;
-    if (pack_alu3(LSLV_X, 0, 1, 2) != 0x9AC22020) { bad = 1; }
-    if (pack_alu3(LSLV_W, 0, 1, 2) != 0x1AC22020) { bad = 1; }
-    if (pack_alu3(LSRV_X, 0, 1, 2) != 0x9AC22420) { bad = 1; }
-    if (pack_alu3(LSRV_W, 0, 1, 2) != 0x1AC22420) { bad = 1; }
-    if (pack_alu3(ASRV_X, 0, 1, 2) != 0x9AC22820) { bad = 1; }
-    if (pack_alu3(ASRV_W, 0, 1, 2) != 0x1AC22820) { bad = 1; }
+    if (t_alu(mop.LSLV, 8, 0, 1, 2) != 0x9AC22020) { bad = 1; }
+    if (t_alu(mop.LSLV, 4, 0, 1, 2) != 0x1AC22020) { bad = 1; }
+    if (t_alu(mop.LSRV, 8, 0, 1, 2) != 0x9AC22420) { bad = 1; }
+    if (t_alu(mop.LSRV, 4, 0, 1, 2) != 0x1AC22420) { bad = 1; }
+    if (t_alu(mop.ASRV, 8, 0, 1, 2) != 0x9AC22820) { bad = 1; }
+    if (t_alu(mop.ASRV, 4, 0, 1, 2) != 0x1AC22820) { bad = 1; }
     ret bad;
 }
 
@@ -4157,25 +3796,25 @@ test "mach.lang.target.isa.arm64.encode:immediate_shifts" {
 
 test "mach.lang.target.isa.arm64.encode:neg_mvn_mov_register_forms" {
     var bad: i32 = 0;
-    if (pack_alu3(SUB_X, 0, ZR, 1) != 0xCB0103E0) { bad = 1; }
-    if (pack_alu3(SUB_W, 0, ZR, 1) != 0x4B0103E0) { bad = 1; }
-    if (pack_alu3(ORN_X, 0, ZR, 1) != 0xAA2103E0) { bad = 1; }
-    if (pack_alu3(ORN_W, 0, ZR, 1) != 0x2A2103E0) { bad = 1; }
-    if (pack_alu3(ORR_X, 0, ZR, 1) != 0xAA0103E0) { bad = 1; }
-    if (pack_alu3(ORR_W, 0, ZR, 1) != 0x2A0103E0) { bad = 1; }
+    if (t_alu(mop.SUB, 8, 0, ZR, 1) != 0xCB0103E0) { bad = 1; }
+    if (t_alu(mop.SUB, 4, 0, ZR, 1) != 0x4B0103E0) { bad = 1; }
+    if (t_alu(mop.ORN, 8, 0, ZR, 1) != 0xAA2103E0) { bad = 1; }
+    if (t_alu(mop.ORN, 4, 0, ZR, 1) != 0x2A2103E0) { bad = 1; }
+    if (t_alu(mop.ORR, 8, 0, ZR, 1) != 0xAA0103E0) { bad = 1; }
+    if (t_alu(mop.ORR, 4, 0, ZR, 1) != 0x2A0103E0) { bad = 1; }
     ret bad;
 }
 
 test "mach.lang.target.isa.arm64.encode:movz_movk_materialization" {
     var bad: i32 = 0;
-    if (pack_movewide(MOVZ_X, 0, 0, 0x1234) != 0xD2824680) { bad = 1; }
-    if (pack_movewide(MOVZ_X, 0, 1, 0x1234) != 0xD2A24680) { bad = 1; }
-    if (pack_movewide(MOVZ_X, 0, 2, 0x1234) != 0xD2C24680) { bad = 1; }
-    if (pack_movewide(MOVZ_X, 0, 3, 0x1234) != 0xD2E24680) { bad = 1; }
-    if (pack_movewide(MOVK_X, 0, 0, 0x5678) != 0xF28ACF00) { bad = 1; }
-    if (pack_movewide(MOVK_X, 0, 1, 0x5678) != 0xF2AACF00) { bad = 1; }
-    if (pack_movewide(MOVZ_W, 0, 0, 0x1234) != 0x52824680) { bad = 1; }
-    if (pack_movewide(MOVK_W, 0, 1, 0x5678) != 0x72AACF00) { bad = 1; }
+    if (t_mw(mop.MOVZ, 8, 0, 0, 0x1234) != 0xD2824680) { bad = 1; }
+    if (t_mw(mop.MOVZ, 8, 0, 1, 0x1234) != 0xD2A24680) { bad = 1; }
+    if (t_mw(mop.MOVZ, 8, 0, 2, 0x1234) != 0xD2C24680) { bad = 1; }
+    if (t_mw(mop.MOVZ, 8, 0, 3, 0x1234) != 0xD2E24680) { bad = 1; }
+    if (t_mw(mop.MOVK, 8, 0, 0, 0x5678) != 0xF28ACF00) { bad = 1; }
+    if (t_mw(mop.MOVK, 8, 0, 1, 0x5678) != 0xF2AACF00) { bad = 1; }
+    if (t_mw(mop.MOVZ, 4, 0, 0, 0x1234) != 0x52824680) { bad = 1; }
+    if (t_mw(mop.MOVK, 4, 0, 1, 0x5678) != 0x72AACF00) { bad = 1; }
 
     var st: encode.EncodeState;
     var alloc: A.Allocator;
@@ -4183,8 +3822,8 @@ test "mach.lang.target.isa.arm64.encode:movz_movk_materialization" {
     emit_movewide_seq(?st, 0, 0x12345678, false);
     if (st.buf.len != 8) { bad = 1; }
     or {
-        if (read_word(?st.buf, 0) != pack_movewide(MOVZ_W, 0, 0, 0x5678)) { bad = 1; }
-        if (read_word(?st.buf, 4) != pack_movewide(MOVK_W, 0, 1, 0x1234)) { bad = 1; }
+        if (read_word(?st.buf, 0) != t_mw(mop.MOVZ, 4, 0, 0, 0x5678)) { bad = 1; }
+        if (read_word(?st.buf, 4) != t_mw(mop.MOVK, 4, 0, 1, 0x1234)) { bad = 1; }
     }
     encode.buf_dnit(?st.buf);
     ret bad;
@@ -4192,31 +3831,31 @@ test "mach.lang.target.isa.arm64.encode:movz_movk_materialization" {
 
 test "mach.lang.target.isa.arm64.encode:add_sub_immediate_forms" {
     var bad: i32 = 0;
-    if (pack_addsub_imm(ADDI_X, 0, 1, 5, 0) != 0x91001420) { bad = 1; }
-    if (pack_addsub_imm(SUBI_X, 0, 1, 5, 0) != 0xD1001420) { bad = 1; }
-    if (pack_addsub_imm(ADDI_W, 0, 1, 5, 0) != 0x11001420) { bad = 1; }
-    if (pack_addsub_imm(SUBI_W, 0, 1, 5, 0) != 0x51001420) { bad = 1; }
-    if (pack_addsub_imm(ADDI_X, 0, 1, 5, 1) != 0x91401420) { bad = 1; }
-    if (pack_addsub_imm(ADDI_W, 0, 1, 5, 1) != 0x11401420) { bad = 1; }
-    if (pack_addsub_imm(ADDI_X, ZR, ZR, 16, 0) != 0x910043FF) { bad = 1; }
-    if (pack_addsub_imm(SUBI_X, ZR, ZR, 16, 0) != 0xD10043FF) { bad = 1; }
-    if (pack_addsub_imm(ADDI_X, 29, ZR, 0, 0) != 0x910003FD)  { bad = 1; }
+    if (t_imm(mop.ADD, 8, 0, 1, 5, 0) != 0x91001420) { bad = 1; }
+    if (t_imm(mop.SUB, 8, 0, 1, 5, 0) != 0xD1001420) { bad = 1; }
+    if (t_imm(mop.ADD, 4, 0, 1, 5, 0) != 0x11001420) { bad = 1; }
+    if (t_imm(mop.SUB, 4, 0, 1, 5, 0) != 0x51001420) { bad = 1; }
+    if (t_imm(mop.ADD, 8, 0, 1, 5, 1) != 0x91401420) { bad = 1; }
+    if (t_imm(mop.ADD, 4, 0, 1, 5, 1) != 0x11401420) { bad = 1; }
+    if (t_imm(mop.ADD, 8, ZR, ZR, 16, 0) != 0x910043FF) { bad = 1; }
+    if (t_imm(mop.SUB, 8, ZR, ZR, 16, 0) != 0xD10043FF) { bad = 1; }
+    if (t_imm(mop.ADD, 8, 29, ZR, 0, 0) != 0x910003FD)  { bad = 1; }
     ret bad;
 }
 
 test "mach.lang.target.isa.arm64.encode:cmp_plus_cset" {
     var bad: i32 = 0;
-    if (pack_cmp_reg(SUBS_REG_X, 0, 1) != 0xEB01001F) { bad = 1; }
-    if (pack_cmp_reg(SUBS_REG_W, 0, 1) != 0x6B01001F) { bad = 1; }
-    if (pack_cmp_imm(SUBS_IMM_X, 0, 5) != 0xF100141F) { bad = 1; }
-    if (pack_cmp_imm(SUBS_IMM_W, 0, 5) != 0x7100141F) { bad = 1; }
-    if (pack_cset(CSINC_W, 0, CC_EQ) != 0x1A9F17E0) { bad = 1; }
-    if (pack_cset(CSINC_W, 0, CC_NE) != 0x1A9F07E0) { bad = 1; }
-    if (pack_cset(CSINC_W, 0, CC_LT) != 0x1A9FA7E0) { bad = 1; }
-    if (pack_cset(CSINC_W, 0, CC_LE) != 0x1A9FC7E0) { bad = 1; }
-    if (pack_cset(CSINC_W, 0, CC_CC) != 0x1A9F27E0) { bad = 1; }
-    if (pack_cset(CSINC_W, 0, CC_LS) != 0x1A9F87E0) { bad = 1; }
-    if (pack_cset(CSINC_X, 0, CC_EQ) != 0x9A9F17E0) { bad = 1; }
+    if (t_alu(mop.SUBS, 8, ZR, 0, 1) != 0xEB01001F) { bad = 1; }
+    if (t_alu(mop.SUBS, 4, ZR, 0, 1) != 0x6B01001F) { bad = 1; }
+    if (t_imm(mop.SUBS, 8, ZR, 0, 5, 0) != 0xF100141F) { bad = 1; }
+    if (t_imm(mop.SUBS, 4, ZR, 0, 5, 0) != 0x7100141F) { bad = 1; }
+    if (t_cset(4, 0, CC_EQ) != 0x1A9F17E0) { bad = 1; }
+    if (t_cset(4, 0, CC_NE) != 0x1A9F07E0) { bad = 1; }
+    if (t_cset(4, 0, CC_LT) != 0x1A9FA7E0) { bad = 1; }
+    if (t_cset(4, 0, CC_LE) != 0x1A9FC7E0) { bad = 1; }
+    if (t_cset(4, 0, CC_CC) != 0x1A9F27E0) { bad = 1; }
+    if (t_cset(4, 0, CC_LS) != 0x1A9F87E0) { bad = 1; }
+    if (t_cset(8, 0, CC_EQ) != 0x9A9F17E0) { bad = 1; }
     ret bad;
 }
 
@@ -4247,20 +3886,20 @@ test "mach.lang.target.isa.arm64.encode:compare_with_an_immediate_lhs_materializ
 
 test "mach.lang.target.isa.arm64.encode:sdiv_udiv_msub_plus_divide_trap_packers" {
     var bad: i32 = 0;
-    if (pack_alu3(SDIV_W, 0, 1, 2) != 0x1AC20C20) { bad = 1; }
-    if (pack_alu3(SDIV_X, 0, 1, 2) != 0x9AC20C20) { bad = 1; }
-    if (pack_alu3(UDIV_W, 0, 1, 2) != 0x1AC20820) { bad = 1; }
-    if (pack_alu3(UDIV_X, 0, 1, 2) != 0x9AC20820) { bad = 1; }
-    if (pack_madd(MSUB_W, 0, 16, 2, 1) != 0x1B028600) { bad = 1; }
-    if (pack_madd(MSUB_X, 0, 16, 2, 1) != 0x9B028600) { bad = 1; }
-    if (pack_cbnz_off(CBNZ_W, 2, 2) != 0x35000042) { bad = 1; }
-    if (pack_cbnz_off(CBNZ_X, 2, 2) != 0xB5000042) { bad = 1; }
-    if (pack_addsub_imm(ADDS_IMM_W, ZR, 2, 1, 0) != 0x3100045F) { bad = 1; }
-    if (pack_addsub_imm(ADDS_IMM_X, ZR, 2, 1, 0) != 0xB100045F) { bad = 1; }
-    if (pack_bcond(5, CC_NE) != 0x540000A1) { bad = 1; }
-    if (pack_bcond(2, CC_NE) != 0x54000041) { bad = 1; }
-    if (pack_movewide(MOVZ_W, 17, 1, 0x8000) != 0x52B00011) { bad = 1; }
-    if (pack_movewide(MOVZ_X, 17, 3, 0x8000) != 0xD2F00011) { bad = 1; }
+    if (t_alu(mop.SDIV, 4, 0, 1, 2) != 0x1AC20C20) { bad = 1; }
+    if (t_alu(mop.SDIV, 8, 0, 1, 2) != 0x9AC20C20) { bad = 1; }
+    if (t_alu(mop.UDIV, 4, 0, 1, 2) != 0x1AC20820) { bad = 1; }
+    if (t_alu(mop.UDIV, 8, 0, 1, 2) != 0x9AC20820) { bad = 1; }
+    if (t_madd(mop.MSUB, 4, 0, 16, 2, 1) != 0x1B028600) { bad = 1; }
+    if (t_madd(mop.MSUB, 8, 0, 16, 2, 1) != 0x9B028600) { bad = 1; }
+    if (t_skip(mop.CBNZ, 0, 4, 2, 2) != 0x35000042) { bad = 1; }
+    if (t_skip(mop.CBNZ, 0, 8, 2, 2) != 0xB5000042) { bad = 1; }
+    if (t_imm(mop.ADDS, 4, ZR, 2, 1, 0) != 0x3100045F) { bad = 1; }
+    if (t_imm(mop.ADDS, 8, ZR, 2, 1, 0) != 0xB100045F) { bad = 1; }
+    if (t_skip(mop.BCOND, CC_NE, 8, 0, 5) != 0x540000A1) { bad = 1; }
+    if (t_skip(mop.BCOND, CC_NE, 8, 0, 2) != 0x54000041) { bad = 1; }
+    if (t_mw(mop.MOVZ, 4, 17, 1, 0x8000) != 0x52B00011) { bad = 1; }
+    if (t_mw(mop.MOVZ, 8, 17, 3, 0x8000) != 0xD2F00011) { bad = 1; }
     ret bad;
 }
 
@@ -4372,10 +4011,10 @@ test "mach.lang.target.isa.arm64.encode:unsigned_remainder_plus_div_by_zero_trap
 
 test "mach.lang.target.isa.arm64.encode:ret_brk_nop_b_base" {
     var bad: i32 = 0;
-    if (RET_WORD != 0xD65F03C0) { bad = 1; }
-    if (BRK_BASE != 0xD4200000) { bad = 1; }
-    if (NOP_WORD != 0xD503201F) { bad = 1; }
-    if (B_BASE   != 0x14000000) { bad = 1; }
+    if (t_asm(mop.RET, isa.make_none(), isa.make_none(), isa.make_none()) != 0xD65F03C0) { bad = 1; }
+    if (t_asm(mop.BRK, isa.make_none(), isa.make_imm(0, 2), isa.make_none()) != 0xD4200000) { bad = 1; }
+    if (t_asm(mop.NOP, isa.make_none(), isa.make_none(), isa.make_none()) != 0xD503201F) { bad = 1; }
+    if (mop.form(mop.B).base != 0x14000000) { bad = 1; }
     ret bad;
 }
 
@@ -4483,15 +4122,15 @@ test "mach.lang.target.isa.arm64.encode:callee_save_fp_stp_ldp_stur_d_register_p
 
 test "mach.lang.target.isa.arm64.encode:callee_save_stp_ldp_stur_pair_words" {
     var bad: i32 = 0;
-    if (pack_ldstp(STP_OFF_X, 19, 20, 29, (0::u32 - 2) & 0x7F) != 0xA93F53B3) { bad = 1; }
-    if (pack_ldstp(LDP_OFF_X, 19, 20, 29, (0::u32 - 2) & 0x7F) != 0xA97F53B3) { bad = 1; }
-    if (pack_ldstp(STP_OFF_X, 21, 22, 29, (0::u32 - 4) & 0x7F) != 0xA93E5BB5) { bad = 1; }
-    if (pack_ldur(STUR_X, 21, 29, (0::u32 - 40) & 0x1FF) != 0xF81D83B5) { bad = 1; }
-    if (pack_ldur(LDUR_X, 21, 29, (0::u32 - 40) & 0x1FF) != 0xF85D83B5) { bad = 1; }
-    if (pack_ldstp(STP_OFF_D, 8, 9, 29, (0::u32 - 2) & 0x7F) != 0x6D3F27A8) { bad = 1; }
-    if (pack_ldstp(LDP_OFF_D, 8, 9, 29, (0::u32 - 2) & 0x7F) != 0x6D7F27A8) { bad = 1; }
-    if (pack_ldur(STUR_D_FP, 10, 29, (0::u32 - 40) & 0x1FF) != 0xFC1D83AA) { bad = 1; }
-    if (pack_ldur(LDUR_D_FP, 10, 29, (0::u32 - 40) & 0x1FF) != 0xFC5D83AA) { bad = 1; }
+    if (t_ldstp(mop.STP, false, 19, 20, 29, (0::u32 - 2) & 0x7F) != 0xA93F53B3) { bad = 1; }
+    if (t_ldstp(mop.LDP, false, 19, 20, 29, (0::u32 - 2) & 0x7F) != 0xA97F53B3) { bad = 1; }
+    if (t_ldstp(mop.STP, false, 21, 22, 29, (0::u32 - 4) & 0x7F) != 0xA93E5BB5) { bad = 1; }
+    if (t_ldur(mop.STUR, false, 8, 21, 29, (0::u32 - 40) & 0x1FF) != 0xF81D83B5) { bad = 1; }
+    if (t_ldur(mop.LDUR, false, 8, 21, 29, (0::u32 - 40) & 0x1FF) != 0xF85D83B5) { bad = 1; }
+    if (t_ldstp(mop.STP, true, 8, 9, 29, (0::u32 - 2) & 0x7F) != 0x6D3F27A8) { bad = 1; }
+    if (t_ldstp(mop.LDP, true, 8, 9, 29, (0::u32 - 2) & 0x7F) != 0x6D7F27A8) { bad = 1; }
+    if (t_ldur(mop.STUR, true, 8, 10, 29, (0::u32 - 40) & 0x1FF) != 0xFC1D83AA) { bad = 1; }
+    if (t_ldur(mop.LDUR, true, 8, 10, 29, (0::u32 - 40) & 0x1FF) != 0xFC5D83AA) { bad = 1; }
     ret bad;
 }
 
@@ -5342,10 +4981,10 @@ test "mach.lang.target.isa.arm64.encode:branch_fixups_insert_imm26_imm19" {
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    emit_word(?st, B_BASE);
-    emit_word(?st, BCOND | CC_EQ);
-    emit_word(?st, pack_cbnz(0xB4000000, 0));
-    emit_word(?st, pack_cbnz(CBNZ_X, 1));
+    emit_word(?st, mop.form(mop.B).base);
+    emit_word(?st, mop.form(mop.BCOND).base | CC_EQ);
+    emit_word(?st, 0xB4000000);
+    emit_word(?st, 0xB5000001);
 
     var fx: encode.BranchFixup;
     fx.patch_pos = 0; fx.next_ip = 4;
@@ -5363,11 +5002,11 @@ test "mach.lang.target.isa.arm64.encode:branch_fixups_insert_imm26_imm19" {
 
     st.buf.len = 0;
     var k: u32 = 0;
-    for (k < 8) { emit_word(?st, B_BASE); k = k + 1; }
+    for (k < 8) { emit_word(?st, mop.form(mop.B).base); k = k + 1; }
     fx.patch_pos = 28; fx.next_ip = 32;
     patch_branch_arm64(?st, ?fx, 0);
     if (read_word(?st.buf, 28) != 0x17FFFFF9) { bad = 1; }
-    emit_word(?st, BCOND | CC_EQ);
+    emit_word(?st, mop.form(mop.BCOND).base | CC_EQ);
     fx.patch_pos = 32; fx.next_ip = 36;
     patch_branch_arm64(?st, ?fx, 0);
     if (read_word(?st.buf, 32) != 0x54FFFF00) { bad = 1; }
@@ -5441,20 +5080,20 @@ test "mach.lang.target.isa.arm64.encode:branch_fixups_reject_out_of_range_displa
     var alloc: A.Allocator;
     tbuf(?st, ?alloc);
 
-    emit_word(?st, BCOND | CC_EQ);
+    emit_word(?st, mop.form(mop.BCOND).base | CC_EQ);
     var fx: encode.BranchFixup;
     fx.patch_pos = 0; fx.next_ip = 4;
     val r1: err[fail.Fail] = patch_branch_arm64(?st, ?fx, 2000000);
     if (!sel r1.err) { bad = 1; }
 
     st.buf.len = 0;
-    emit_word(?st, B_BASE);
+    emit_word(?st, mop.form(mop.B).base);
     fx.patch_pos = 0; fx.next_ip = 4;
     val r2: err[fail.Fail] = patch_branch_arm64(?st, ?fx, 200000000);
     if (!sel r2.err) { bad = 1; }
 
     st.buf.len = 0;
-    emit_word(?st, BCOND | CC_EQ);
+    emit_word(?st, mop.form(mop.BCOND).base | CC_EQ);
     fx.patch_pos = 0; fx.next_ip = 4;
     val r3: err[fail.Fail] = patch_branch_arm64(?st, ?fx, 1048572);
     if (sel r3.err) { bad = 1; }
@@ -5485,14 +5124,14 @@ test "mach.lang.target.isa.arm64.encode:end_to_end_leaf_add_body" {
 
 test "mach.lang.target.isa.arm64.encode:call_plus_symbol_reloc_base_words" {
     var bad: i32 = 0;
-    if (BL_BASE != 0x94000000)      { bad = 1; }
-    if (pack_blr(0)  != 0xD63F0000) { bad = 1; }
-    if (pack_blr(9)  != 0xD63F0120) { bad = 1; }
-    if (pack_blr(16) != 0xD63F0200) { bad = 1; }
-    if (pack_adrp(0)  != 0x90000000) { bad = 1; }
-    if (pack_adrp(16) != 0x90000010) { bad = 1; }
-    if (pack_addsub_imm(ADDI_X, 0, 0, 0, 0)   != 0x91000000) { bad = 1; }
-    if (pack_addsub_imm(ADDI_X, 16, 16, 0, 0) != 0x91000210) { bad = 1; }
+    if (mop.form(mop.BL).base != 0x94000000) { bad = 1; }
+    if (t_reg1(mop.BLR, 0)  != 0xD63F0000) { bad = 1; }
+    if (t_reg1(mop.BLR, 9)  != 0xD63F0120) { bad = 1; }
+    if (t_reg1(mop.BLR, 16) != 0xD63F0200) { bad = 1; }
+    if (t_asm(mop.ADRP, mop.gp(0, 8), isa.make_sym(0, 0), isa.make_none())  != 0x90000000) { bad = 1; }
+    if (t_asm(mop.ADRP, mop.gp(16, 8), isa.make_sym(0, 0), isa.make_none()) != 0x90000010) { bad = 1; }
+    if (t_imm(mop.ADD, 8, 0, 0, 0, 0)   != 0x91000000) { bad = 1; }
+    if (t_imm(mop.ADD, 8, 16, 16, 0, 0) != 0x91000210) { bad = 1; }
     if (t_int_row(1, 0x39400200, 0x39000200, of.RK_LDST8_LO12)  != 0) { bad = 1; }
     if (t_int_row(2, 0x79400200, 0x79000200, of.RK_LDST16_LO12) != 0) { bad = 1; }
     if (t_int_row(4, 0xB9400200, 0xB9000200, of.RK_LDST32_LO12) != 0) { bad = 1; }
@@ -5507,8 +5146,8 @@ fun t_int_row(w: u8, ldw: u32, stw: u32, kind: of.RelocKind) i32 {
     if (sel sr.err) { ret 1; }
     val l: A64Access = lr.ok;
     val s: A64Access = sr.ok;
-    if (pack_ldst(l.scaled, 0, 16, 0) != ldw) { ret 1; }
-    if (pack_ldst(s.scaled, 0, 16, 0) != stw) { ret 1; }
+    if (t_ldst(l.op, l.fp, l.width, 0, 16, 0) != ldw) { ret 1; }
+    if (t_ldst(s.op, s.fp, s.width, 0, 16, 0) != stw) { ret 1; }
     if (l.lo12 != kind || s.lo12 != kind)     { ret 1; }
     ret 0;
 }
@@ -5682,8 +5321,8 @@ test "mach.lang.target.isa.arm64.encode:oversized_sub_sp_uses_the_register_form"
     tbuf(?st, ?alloc);
 
     emit_sp_sub(?st, 0x1000000);
-    if (read_word(?st.buf, 0) != pack_movewide(MOVZ_X, 16, 1, 0x100)) { bad = 1; }
-    if (read_word(?st.buf, 4) != (SUB_SP_REG_X | (16 << 16)))         { bad = 1; }
+    if (read_word(?st.buf, 0) != t_mw(mop.MOVZ, 8, 16, 1, 0x100)) { bad = 1; }
+    if (read_word(?st.buf, 4) != 0xCB3063FF)         { bad = 1; }
 
     encode.buf_dnit(?st.buf);
     ret bad;
@@ -7016,59 +6655,58 @@ test "mach.lang.target.isa.arm64.encode:asm_relocation_modifiers" {
 test "mach.lang.target.isa.arm64.encode:neon_vector_base_words" {
     var bad: i32 = 0;
 
-    if (pack_neon_3same(VFADD, 0, 0, 0, 1) != 0x4E21D400) { bad = 1; }
-    if (pack_neon_3same(VFADD, 1, 0, 0, 1) != 0x4E61D400) { bad = 1; }
-    if (pack_neon_3same(VFSUB, 0, 0, 0, 1) != 0x4EA1D400) { bad = 1; }
-    if (pack_neon_3same(VFSUB, 1, 0, 0, 1) != 0x4EE1D400) { bad = 1; }
-    if (pack_neon_3same(VFMUL, 0, 0, 0, 1) != 0x6E21DC00) { bad = 1; }
-    if (pack_neon_3same(VFDIV, 0, 0, 0, 1) != 0x6E21FC00) { bad = 1; }
+    if (t_neon3(mop.V_FADD, 4, 0, 0, 1) != 0x4E21D400) { bad = 1; }
+    if (t_neon3(mop.V_FADD, 8, 0, 0, 1) != 0x4E61D400) { bad = 1; }
+    if (t_neon3(mop.V_FSUB, 4, 0, 0, 1) != 0x4EA1D400) { bad = 1; }
+    if (t_neon3(mop.V_FSUB, 8, 0, 0, 1) != 0x4EE1D400) { bad = 1; }
+    if (t_neon3(mop.V_FMUL, 4, 0, 0, 1) != 0x6E21DC00) { bad = 1; }
+    if (t_neon3(mop.V_FDIV, 4, 0, 0, 1) != 0x6E21FC00) { bad = 1; }
 
-    if (pack_neon_3same(VADD, 0, 0, 0, 1) != 0x4E218400) { bad = 1; }
-    if (pack_neon_3same(VADD, 1, 0, 0, 1) != 0x4E618400) { bad = 1; }
-    if (pack_neon_3same(VADD, 2, 0, 0, 1) != 0x4EA18400) { bad = 1; }
-    if (pack_neon_3same(VADD, 3, 0, 0, 1) != 0x4EE18400) { bad = 1; }
-    if (pack_neon_3same(VSUB, 0, 0, 0, 1) != 0x6E218400) { bad = 1; }
+    if (t_neon3(mop.V_ADD, 1, 0, 0, 1) != 0x4E218400) { bad = 1; }
+    if (t_neon3(mop.V_ADD, 2, 0, 0, 1) != 0x4E618400) { bad = 1; }
+    if (t_neon3(mop.V_ADD, 4, 0, 0, 1) != 0x4EA18400) { bad = 1; }
+    if (t_neon3(mop.V_ADD, 8, 0, 0, 1) != 0x4EE18400) { bad = 1; }
+    if (t_neon3(mop.V_SUB, 1, 0, 0, 1) != 0x6E218400) { bad = 1; }
 
-    if (pack_neon_3same(VAND, 0, 0, 0, 1) != 0x4E211C00) { bad = 1; }
-    if (pack_neon_3same(VORR, 0, 0, 0, 1) != 0x4EA11C00) { bad = 1; }
-    if (pack_neon_3same(VEOR, 0, 0, 0, 1) != 0x6E211C00) { bad = 1; }
-    if (pack_neon_3same(VORR, 0, 0, 1, 1) != 0x4EA11C20) { bad = 1; }
-    if (pack_neon_2misc(VNOT, 0, 1)       != 0x6E205820) { bad = 1; }
+    if (t_neon3(mop.V_AND, 1, 0, 0, 1) != 0x4E211C00) { bad = 1; }
+    if (t_neon3(mop.V_ORR, 1, 0, 0, 1) != 0x4EA11C00) { bad = 1; }
+    if (t_neon3(mop.V_EOR, 1, 0, 0, 1) != 0x6E211C00) { bad = 1; }
+    if (t_neon3(mop.V_ORR, 1, 0, 1, 1) != 0x4EA11C20) { bad = 1; }
+    if (t_neon2(mop.V_MVN, 0, 1)       != 0x6E205820) { bad = 1; }
 
-    if (pack_neon_3same(VCMEQ,  0, 0, 0, 1) != 0x6E218C00) { bad = 1; }
-    if (pack_neon_3same(VCMGT_S, 0, 0, 0, 1) != 0x4E213400) { bad = 1; }
-    if (pack_neon_3same(VCMGE_S, 0, 0, 0, 1) != 0x4E213C00) { bad = 1; }
-    if (pack_neon_3same(VCMHI_U, 0, 0, 0, 1) != 0x6E213400) { bad = 1; }
-    if (pack_neon_3same(VCMHS_U, 0, 0, 0, 1) != 0x6E213C00) { bad = 1; }
-    if (pack_neon_3same(VFCMEQ, 0, 0, 0, 1) != 0x4E21E400) { bad = 1; }
-    if (pack_neon_3same(VFCMGT, 0, 0, 0, 1) != 0x6EA1E400) { bad = 1; }
-    if (pack_neon_3same(VFCMGE, 0, 0, 0, 1) != 0x6E21E400) { bad = 1; }
+    if (t_neon3(mop.V_CMEQ, 1, 0, 0, 1) != 0x6E218C00) { bad = 1; }
+    if (t_neon3(mop.V_CMGT, 1, 0, 0, 1) != 0x4E213400) { bad = 1; }
+    if (t_neon3(mop.V_CMGE, 1, 0, 0, 1) != 0x4E213C00) { bad = 1; }
+    if (t_neon3(mop.V_CMHI, 1, 0, 0, 1) != 0x6E213400) { bad = 1; }
+    if (t_neon3(mop.V_CMHS, 1, 0, 0, 1) != 0x6E213C00) { bad = 1; }
+    if (t_neon3(mop.V_FCMEQ, 4, 0, 0, 1) != 0x4E21E400) { bad = 1; }
+    if (t_neon3(mop.V_FCMGT, 4, 0, 0, 1) != 0x6EA1E400) { bad = 1; }
+    if (t_neon3(mop.V_FCMGE, 4, 0, 0, 1) != 0x6E21E400) { bad = 1; }
 
-    if (pack_neon_lane_read(VUMOV_W, 0, 0, 0, 1) != 0x0E013C20) { bad = 1; }
-    if (pack_neon_lane_read(VUMOV_W, 1, 3, 0, 1) != 0x0E0E3C20) { bad = 1; }
-    if (pack_neon_lane_read(VUMOV_W, 2, 2, 0, 1) != 0x0E143C20) { bad = 1; }
-    if (pack_neon_lane_read(VUMOV_X, 3, 1, 0, 1) != 0x4E183C20) { bad = 1; }
-    if (pack_neon_lane_read(VSMOV_X, 0, 0, 0, 1) != 0x4E012C20) { bad = 1; }
-    if (pack_neon_ins_gp(0, 0, 0, 1) != 0x4E011C20) { bad = 1; }
-    if (pack_neon_ins_gp(2, 2, 0, 1) != 0x4E141C20) { bad = 1; }
-    if (pack_neon_ins_gp(3, 1, 0, 1) != 0x4E181C20) { bad = 1; }
+    if (t_lane_rd(mop.UMOV, mop.gp(0, 4), 1, 0, 1) != 0x0E013C20) { bad = 1; }
+    if (t_lane_rd(mop.UMOV, mop.gp(0, 4), 2, 3, 1) != 0x0E0E3C20) { bad = 1; }
+    if (t_lane_rd(mop.UMOV, mop.gp(0, 4), 4, 2, 1) != 0x0E143C20) { bad = 1; }
+    if (t_lane_rd(mop.UMOV, mop.gp(0, 8), 8, 1, 1) != 0x4E183C20) { bad = 1; }
+    if (t_ins_gp(1, 0, 0, 1) != 0x4E011C20) { bad = 1; }
+    if (t_ins_gp(4, 2, 0, 1) != 0x4E141C20) { bad = 1; }
+    if (t_ins_gp(8, 1, 0, 1) != 0x4E181C20) { bad = 1; }
 
-    if (pack_neon_dup_el(2, 1, 0, 2) != 0x5E0C0440) { bad = 1; }
-    if (pack_neon_dup_el(3, 1, 0, 2) != 0x5E180440) { bad = 1; }
-    if (pack_neon_dup_el(2, 0, 1, 0) != 0x5E040401) { bad = 1; }
-    if (pack_neon_ins_el(2, 3, 0, 0, 1) != 0x6E1C0420) { bad = 1; }
-    if (pack_neon_ins_el(3, 1, 0, 0, 1) != 0x6E180420) { bad = 1; }
-    if (pack_neon_ins_el(2, 3, 2, 0, 1) != 0x6E1C4420) { bad = 1; }
-    if (pack_neon_ins_el(3, 1, 1, 0, 1) != 0x6E184420) { bad = 1; }
-    if (pack_neon_ins_el(0, 5, 3, 0, 1) != 0x6E0B1C20) { bad = 1; }
-    if (pack_neon_ins_el(1, 2, 7, 0, 1) != 0x6E0A7420) { bad = 1; }
+    if (t_lane_rd(mop.DUP, mop.vec(0, 4), 4, 1, 2) != 0x5E0C0440) { bad = 1; }
+    if (t_lane_rd(mop.DUP, mop.vec(0, 8), 8, 1, 2) != 0x5E180440) { bad = 1; }
+    if (t_lane_rd(mop.DUP, mop.vec(1, 4), 4, 0, 0) != 0x5E040401) { bad = 1; }
+    if (t_ins_el(4, 3, 0, 0, 1) != 0x6E1C0420) { bad = 1; }
+    if (t_ins_el(8, 1, 0, 0, 1) != 0x6E180420) { bad = 1; }
+    if (t_ins_el(4, 3, 2, 0, 1) != 0x6E1C4420) { bad = 1; }
+    if (t_ins_el(8, 1, 1, 0, 1) != 0x6E184420) { bad = 1; }
+    if (t_ins_el(1, 5, 3, 0, 1) != 0x6E0B1C20) { bad = 1; }
+    if (t_ins_el(2, 2, 7, 0, 1) != 0x6E0A7420) { bad = 1; }
 
-    if (pack_ldst(LDR_Q_OFF, 0, 0, 0) != 0x3DC00000) { bad = 1; }
-    if (pack_ldst(STR_Q_OFF, 0, 0, 0) != 0x3D800000) { bad = 1; }
-    if (pack_ldst(LDR_Q_OFF, 0, 1, 1) != 0x3DC00420) { bad = 1; }
-    if (pack_ldst(STR_Q_OFF, 2, 3, 2) != 0x3D800862) { bad = 1; }
-    if (pack_ldur(LDUR_Q_FP, 0, 0, 0x1F8::u32) != 0x3CDF8000) { bad = 1; }
-    if (pack_ldst_reg(LDR_Q_REG, 0, 0, 1) != 0x3CE16800) { bad = 1; }
+    if (t_ldst(mop.LDR, true, 16, 0, 0, 0) != 0x3DC00000) { bad = 1; }
+    if (t_ldst(mop.STR, true, 16, 0, 0, 0) != 0x3D800000) { bad = 1; }
+    if (t_ldst(mop.LDR, true, 16, 0, 1, 1) != 0x3DC00420) { bad = 1; }
+    if (t_ldst(mop.STR, true, 16, 2, 3, 2) != 0x3D800862) { bad = 1; }
+    if (t_ldur(mop.LDUR, true, 16, 0, 0, 0x1F8::u32) != 0x3CDF8000) { bad = 1; }
+    if (t_ldst_reg(mop.LDR, true, 16, 0, 0, 1) != 0x3CE16800) { bad = 1; }
 
     ret bad;
 }
@@ -7076,18 +6714,18 @@ test "mach.lang.target.isa.arm64.encode:neon_vector_base_words" {
 test "mach.lang.target.isa.arm64.encode:neon_integer_multiply_arrangements" {
     var bad: i32 = 0;
 
-    if (pack_neon_3same(VMUL, 0, 3, 5, 7) != 0x4E279CA3) { bad = 1; }
-    if (pack_neon_3same(VMUL, 1, 3, 5, 7) != 0x4E679CA3) { bad = 2; }
-    if (pack_neon_3same(VMUL, 2, 3, 5, 7) != 0x4EA79CA3) { bad = 3; }
+    if (t_neon3(mop.V_MUL, 1, 3, 5, 7) != 0x4E279CA3) { bad = 1; }
+    if (t_neon3(mop.V_MUL, 2, 3, 5, 7) != 0x4E679CA3) { bad = 2; }
+    if (t_neon3(mop.V_MUL, 4, 3, 5, 7) != 0x4EA79CA3) { bad = 3; }
 
-    if (!neon_3same_size_ok(VMUL, 0)) { bad = 4; }
-    if (!neon_3same_size_ok(VMUL, 1)) { bad = 5; }
-    if (!neon_3same_size_ok(VMUL, 2)) { bad = 6; }
-    if (neon_3same_size_ok(VMUL, 3))  { bad = 7; }
+    if (!neon_3same_size_ok(mop.V_MUL, 0)) { bad = 4; }
+    if (!neon_3same_size_ok(mop.V_MUL, 1)) { bad = 5; }
+    if (!neon_3same_size_ok(mop.V_MUL, 2)) { bad = 6; }
+    if (neon_3same_size_ok(mop.V_MUL, 3))  { bad = 7; }
 
-    if (!neon_3same_size_ok(VADD, 3)) { bad = 8; }
-    if (!neon_3same_size_ok(VSUB, 3)) { bad = 9; }
-    if (!neon_3same_size_ok(VCMEQ, 3)) { bad = 10; }
+    if (!neon_3same_size_ok(mop.V_ADD, 3)) { bad = 8; }
+    if (!neon_3same_size_ok(mop.V_SUB, 3)) { bad = 9; }
+    if (!neon_3same_size_ok(mop.V_CMEQ, 3)) { bad = 10; }
 
     ret bad;
 }
@@ -7245,7 +6883,7 @@ test "mach.lang.target.isa.arm64.encode.check_accounted:rejects_unrendered_bytes
     val r_7136: err[fail.Fail] = check_accounted(?st, arm64.NOP::u16);
     if (sel r_7136.err) { bad = 1; }
 
-    encode.emit_u32(?st.buf, NOP_WORD);
+    encode.emit_u32(?st.buf, mop.form(mop.NOP).base);
     val r_7139: err[fail.Fail] = check_accounted(?st, arm64.NOP::u16);
     if (!sel r_7139.err) { bad = 1; }
 
@@ -7253,14 +6891,14 @@ test "mach.lang.target.isa.arm64.encode.check_accounted:rejects_unrendered_bytes
     val r_7142: err[fail.Fail] = check_accounted(?st, arm64.NOP::u16);
     if (sel r_7142.err) { bad = 1; }
 
-    encode.emit_u32(?st.buf, NOP_WORD);
-    encode.emit_u32(?st.buf, NOP_WORD);
+    encode.emit_u32(?st.buf, mop.form(mop.NOP).base);
+    encode.emit_u32(?st.buf, mop.form(mop.NOP).base);
     encode.sink_claim(?st.buf, 8);
     val r_7147: err[fail.Fail] = check_accounted(?st, arm64.NOP::u16);
     if (!sel r_7147.err) { bad = 1; }
 
     st.buf.asm = nil;
-    encode.emit_u32(?st.buf, NOP_WORD);
+    encode.emit_u32(?st.buf, mop.form(mop.NOP).base);
     val r_7151: err[fail.Fail] = check_accounted(?st, arm64.NOP::u16);
     if (sel r_7151.err) { bad = 1; }
 
@@ -7301,6 +6939,11 @@ fun t_cc(r: res[u32, fail.Fail]) u32 {
     ret r.ok;
 }
 
+fun t_fop(r: res[mop.MachOp, fail.Fail]) mop.MachOp {
+    if (sel r.err) { ret mop.MOP_NONE; }
+    ret r.ok;
+}
+
 test "mach.lang.target.isa.arm64.encode:classifiers_are_total_over_named_forms" {
     var bad: i32 = 0;
 
@@ -7325,14 +6968,10 @@ test "mach.lang.target.isa.arm64.encode:classifiers_are_total_over_named_forms" 
     if (t_cc(fp_cond(mir.FCC_GT)) != CC_GT) { bad = 1; }
     if (t_cc(fp_cond(mir.FCC_GE)) != CC_GE) { bad = 1; }
 
-    if (t_cc(fp_arith_base(mir.MIR_FADD, false)) != FADD_S) { bad = 1; }
-    if (t_cc(fp_arith_base(mir.MIR_FADD, true))  != FADD_D) { bad = 1; }
-    if (t_cc(fp_arith_base(mir.MIR_FSUB, false)) != FSUB_S) { bad = 1; }
-    if (t_cc(fp_arith_base(mir.MIR_FSUB, true))  != FSUB_D) { bad = 1; }
-    if (t_cc(fp_arith_base(mir.MIR_FMUL, false)) != FMUL_S) { bad = 1; }
-    if (t_cc(fp_arith_base(mir.MIR_FMUL, true))  != FMUL_D) { bad = 1; }
-    if (t_cc(fp_arith_base(mir.MIR_FDIV, false)) != FDIV_S) { bad = 1; }
-    if (t_cc(fp_arith_base(mir.MIR_FDIV, true))  != FDIV_D) { bad = 1; }
+    if (t_fop(fp_arith_op(mir.MIR_FADD)) != mop.FADD) { bad = 1; }
+    if (t_fop(fp_arith_op(mir.MIR_FSUB)) != mop.FSUB) { bad = 1; }
+    if (t_fop(fp_arith_op(mir.MIR_FMUL)) != mop.FMUL) { bad = 1; }
+    if (t_fop(fp_arith_op(mir.MIR_FDIV)) != mop.FDIV) { bad = 1; }
 
     if (t_cc(scale_shift(1)) != 0) { bad = 1; }
     if (t_cc(scale_shift(2)) != 1) { bad = 1; }
@@ -7353,9 +6992,9 @@ test "mach.lang.target.isa.arm64.encode:unnamed_forms_are_refused" {
     if (!sel r_7236.err) { bad = 1; }
     val r_7237: res[u32, fail.Fail] = fused_cbr_cond(mir.MIR_SEL_CBR_LE_U + 1);
     if (!sel r_7237.err) { bad = 1; }
-    val r_7238: res[u32, fail.Fail] = fp_arith_base(mir.MIR_ADD, false);
+    val r_7238: res[mop.MachOp, fail.Fail] = fp_arith_op(mir.MIR_ADD);
     if (!sel r_7238.err) { bad = 1; }
-    val r_7239: res[u32, fail.Fail] = fp_arith_base(mir.MIR_FNEG, true);
+    val r_7239: res[mop.MachOp, fail.Fail] = fp_arith_op(mir.MIR_FNEG);
     if (!sel r_7239.err) { bad = 1; }
 
     val r_7241: res[u32, fail.Fail] = fp_cond(mir.FCC_GE + 1);
@@ -7434,12 +7073,13 @@ pub fun asm_ct_class(code: u32, flags: u16) ct.AsmClass {
         code == mop.SXTW::u32 ||
         code == mop.LDUR::u32 || code == mop.STUR::u32  || code == mop.LDURB::u32 || code == mop.STURB::u32 ||
         code == mop.LDURH::u32 || code == mop.STURH::u32 ||
-        code == mop.FMOV::u32 ||
+        code == mop.FMOV::u32 || code == mop.FMOV_GEN::u32 || code == mop.FMOV_IMM::u32 ||
         code == mop.V_ADD::u32  || code == mop.V_SUB::u32  || code == mop.V_AND::u32 || code == mop.V_ORR::u32 ||
         code == mop.V_EOR::u32  || code == mop.V_MVN::u32  || code == mop.V_MOV::u32 ||
         code == mop.V_CMEQ::u32 || code == mop.V_CMGT::u32 || code == mop.V_CMGE::u32 ||
         code == mop.V_CMHI::u32 || code == mop.V_CMHS::u32 ||
-        code == mop.UMOV::u32 || code == mop.MOV_LANE::u32 || code == mop.INS::u32 || code == mop.DUP::u32) {
+        code == mop.UMOV::u32 || code == mop.MOV_LANE::u32 || code == mop.INS::u32 || code == mop.DUP::u32 ||
+        code == mop.INS_EL::u32) {
         ret ct.flags_untouched(ct.asm_op(ct.CT_OP_NONE));
     }
     if (code == mop.FADD::u32  || code == mop.FSUB::u32  || code == mop.FMUL::u32   || code == mop.FDIV::u32 ||
@@ -7575,7 +7215,7 @@ pub fun inst_effects(mi: *isa.Inst, e: *ct.InstEffects) {
         ret;
     }
 
-    if (op == mop.MOVK || op == mop.INS || op == mop.MOV_LANE) {
+    if (op == mop.MOVK || op == mop.INS || op == mop.INS_EL || op == mop.MOV_LANE) {
         e.roles[0] = ct.ROLE_RW;
         a64_reads_rest(e, mi, 1);
         ret;
@@ -8104,134 +7744,165 @@ test "mach.lang.target.isa.arm64.encode.stream:translation_round_trips_against_t
     var sink: encode.AsmSink = encode.sink_init(?w, ?interner);
     st.buf.asm = ?sink;
 
-    val alu: [52]u32 = [52]u32{
-        ADD_X, ADD_W, SUB_X, SUB_W, AND_X, AND_W, ORR_X, ORR_W, EOR_X, EOR_W, ORN_X, ORN_W,
-        MUL_X, MUL_W, LSLV_X, LSLV_W, LSRV_X, LSRV_W, ASRV_X, ASRV_W, SDIV_X, SDIV_W, UDIV_X, UDIV_W,
-        SUBS_REG_X, SUBS_REG_W,
-        FADD_S, FADD_D, FSUB_S, FSUB_D, FMUL_S, FMUL_D, FDIV_S, FDIV_D, FNEG_S, FNEG_D,
-        FMOV_S, FMOV_D, FCVT_S2D, FCVT_D2S, FCMP_S, FCMP_D,
-        SCVTF_S_W, SCVTF_D_X, UCVTF_S_W, UCVTF_D_X, FCVTZS_W_S, FCVTZS_X_D, FCVTZU_W_S, FCVTZU_X_D,
-        FMOV_S_FROM_W, FMOV_X_FROM_D };
+    val alu: [26]mop.MachOp = [26]mop.MachOp{
+        mop.ADD, mop.SUB, mop.AND, mop.ORR, mop.EOR, mop.ORN, mop.MUL, mop.MNEG, mop.LSLV, mop.LSRV, mop.ASRV,
+        mop.SDIV, mop.UDIV, mop.SUBS, mop.ADDS,
+        mop.ADD, mop.SUB, mop.AND, mop.ORR, mop.EOR, mop.ORN, mop.MUL, mop.LSLV, mop.SDIV, mop.UDIV, mop.SUBS };
     var i: u32 = 0;
-    for (i < 52) { emit_alu3(?st, alu[i], 1, 2, 3); i = i + 1; }
-    # the aliases: mov, neg, mvn, cmp, and the sp-relative sub
-    emit_alu3(?st, ORR_X, 1, ZR, 3);
-    emit_alu3(?st, SUB_X, 1, ZR, 3);
-    emit_alu3(?st, ORN_X, 1, ZR, 3);
-    emit_alu3(?st, SUBS_REG_X, ZR, 2, 3);
-    emit_alu3(?st, SUB_SP_REG_X, ZR, ZR, 16);
-    emit_alu3_sh(?st, ADD_X, 1, 2, 3, 4);
-
-    val asi: [8]u32 = [8]u32{ ADDI_X, ADDI_W, SUBI_X, SUBI_W, ADDS_IMM_X, ADDS_IMM_W, SUBS_IMM_X, SUBS_IMM_W };
+    for (i < 26) { emit_alu3(?st, alu[i], i < 15, 1, 2, 3); i = i + 1; }
+    val fp3: [4]mop.MachOp = [4]mop.MachOp{ mop.FADD, mop.FSUB, mop.FMUL, mop.FDIV };
     i = 0;
-    for (i < 8) { emit_addsub_imm(?st, asi[i], 1, 2, 5, 0); i = i + 1; }
-    emit_addsub_imm(?st, ADDI_X, 29, ZR, 0, 0);
-    emit_addsub_imm(?st, ADDS_IMM_X, ZR, 2, 1, 0);
-    emit_addsub_imm(?st, SUBS_IMM_X, ZR, 2, 1, 0);
-    emit_addsub_imm(?st, SUBI_X, ZR, ZR, 2, 1);
-    emit_addsub_imm_sym(?st, ADDI_X, 0, 0, g, printer.MOD_PCREL_LO, 0);
+    for (i < 4) { emit_fp3(?st, fp3[i], false, 1, 2, 3); emit_fp3(?st, fp3[i], true, 1, 2, 3); i = i + 1; }
+    emit_fp2(?st, mop.FNEG, false, 1, 2);
+    emit_fp2(?st, mop.FNEG, true, 1, 2);
+    emit_fp2(?st, mop.FMOV, false, 1, 2);
+    emit_fp2(?st, mop.FMOV, true, 1, 2);
+    emit_fcvt(?st, true, 1, 2);
+    emit_fcvt(?st, false, 1, 2);
+    emit_fcmp(?st, false, 2, 3);
+    emit_fcmp(?st, true, 2, 3);
+    emit_cvt(?st, mop.SCVTF, mop.vec(1, 4), mop.gp(2, 4));
+    emit_cvt(?st, mop.SCVTF, mop.vec(1, 8), mop.gp(2, 8));
+    emit_cvt(?st, mop.UCVTF, mop.vec(1, 4), mop.gp(2, 4));
+    emit_cvt(?st, mop.UCVTF, mop.vec(1, 8), mop.gp(2, 8));
+    emit_cvt(?st, mop.FCVTZS, mop.gp(1, 4), mop.vec(2, 4));
+    emit_cvt(?st, mop.FCVTZS, mop.gp(1, 8), mop.vec(2, 8));
+    emit_cvt(?st, mop.FCVTZU, mop.gp(1, 4), mop.vec(2, 4));
+    emit_cvt(?st, mop.FCVTZU, mop.gp(1, 8), mop.vec(2, 8));
+    emit_cvt(?st, mop.FMOV_GEN, mop.vec(1, 4), mop.gp(2, 4));
+    emit_cvt(?st, mop.FMOV_GEN, mop.gp(1, 8), mop.vec(2, 8));
+    # the aliases: mov, neg, mvn, cmp, and the sp-relative sub
+    emit_alu3(?st, mop.ORR, true, 1, ZR, 3);
+    emit_alu3(?st, mop.SUB, true, 1, ZR, 3);
+    emit_alu3(?st, mop.ORN, true, 1, ZR, 3);
+    emit_alu3(?st, mop.SUBS, true, ZR, 2, 3);
+    emit_alu3(?st, mop.SUB, true, SP_REG, SP_REG, 16);
+    emit_alu3_sh(?st, mop.ADD, true, 1, 2, 3, 4);
+
+    val asi: [4]mop.MachOp = [4]mop.MachOp{ mop.ADD, mop.SUB, mop.ADDS, mop.SUBS };
+    i = 0;
+    for (i < 4) { emit_addsub_imm(?st, asi[i], true, 1, 2, 5, 0); emit_addsub_imm(?st, asi[i], false, 1, 2, 5, 0); i = i + 1; }
+    emit_addsub_imm(?st, mop.ADD, true, 29, ZR, 0, 0);
+    emit_addsub_imm(?st, mop.ADDS, true, ZR, 2, 1, 0);
+    emit_addsub_imm(?st, mop.SUBS, true, ZR, 2, 1, 0);
+    emit_addsub_imm(?st, mop.SUB, true, ZR, ZR, 2, 1);
+    emit_addsub_imm_sym(?st, mop.ADD, true, 0, 0, g, isa.SYM_MOD_PCREL_LO, 0);
 
     # bitfield aliases: uxtb, uxth, sxtb, sxth, sxtw, lsr, asr, lsl, ubfx, ubfiz, sbfx, sbfiz
-    emit_bitfield(?st, UBFM_W, 0, 1, 0, 7);
-    emit_bitfield(?st, UBFM_W, 0, 1, 0, 15);
-    emit_bitfield(?st, SBFM_W, 0, 1, 0, 7);
-    emit_bitfield(?st, SBFM_X, 0, 1, 0, 15);
-    emit_bitfield(?st, SBFM_X, 0, 1, 0, 31);
-    emit_bitfield(?st, UBFM_X, 4, 5, 4, 63);
-    emit_bitfield(?st, SBFM_X, 4, 5, 4, 63);
-    emit_bitfield(?st, UBFM_X, 0, 3, 32, 31);
-    emit_bitfield(?st, UBFM_X, 0, 1, 3, 10);
-    emit_bitfield(?st, UBFM_X, 0, 1, 60, 3);
-    emit_bitfield(?st, SBFM_X, 0, 1, 3, 10);
-    emit_bitfield(?st, SBFM_X, 0, 1, 60, 3);
+    emit_bitfield(?st, mop.UXTB, false, 0, 1, 0, 0);
+    emit_bitfield(?st, mop.UXTH, false, 0, 1, 0, 0);
+    emit_bitfield(?st, mop.SXTB, false, 0, 1, 0, 0);
+    emit_bitfield(?st, mop.SXTH, true, 0, 1, 0, 0);
+    emit_bitfield(?st, mop.SXTW, true, 0, 1, 0, 0);
+    emit_bitfield(?st, mop.LSR, true, 4, 5, 4, 0);
+    emit_bitfield(?st, mop.ASR, true, 4, 5, 4, 0);
+    emit_bitfield(?st, mop.LSL, true, 0, 3, 32, 0);
+    emit_bitfield(?st, mop.UBFX, true, 0, 1, 3, 8);
+    emit_bitfield(?st, mop.UBFIZ, true, 0, 1, 4, 4);
+    emit_bitfield(?st, mop.SBFX, true, 0, 1, 3, 8);
+    emit_bitfield(?st, mop.SBFIZ, true, 0, 1, 4, 4);
 
-    emit_movewide(?st, MOVZ_X, 17, 3, 0x8000);
-    emit_movewide(?st, MOVZ_W, 17, 0, 0);
-    emit_movewide(?st, MOVZ_X, 17, 1, 0);
-    emit_movewide(?st, MOVK_X, 16, 1, 0xFFFF);
-    emit_movewide(?st, MOVK_W, 16, 0, 1);
+    emit_movewide(?st, mop.MOVZ, true, 17, 3, 0x8000);
+    emit_movewide(?st, mop.MOVZ, false, 17, 0, 0);
+    emit_movewide(?st, mop.MOVZ, true, 17, 1, 0);
+    emit_movewide(?st, mop.MOVK, true, 16, 1, 0xFFFF);
+    emit_movewide(?st, mop.MOVK, false, 16, 0, 1);
     emit_fmov_imm(?st, 0, 0x70, true);
     emit_fmov_imm(?st, 0, 0x70, false);
 
-    emit_madd(?st, MSUB_X, 0, 1, 2, 3);
-    emit_madd(?st, MSUB_W, 0, 1, 2, ZR);
-    emit_madd(?st, 0x9B000000, 0, 1, 2, 3);
-    emit_madd(?st, 0x1B000000, 0, 1, 2, ZR);
-    emit_cset(?st, CSINC_X, 0, CC_EQ);
-    emit_cset(?st, CSINC_W, 0, CC_NE);
+    emit_madd(?st, mop.MSUB, true, 0, 1, 2, 3);
+    emit_madd(?st, mop.MSUB, false, 0, 1, 2, ZR);
+    emit_madd(?st, mop.MADD, true, 0, 1, 2, 3);
+    emit_madd(?st, mop.MADD, false, 0, 1, 2, ZR);
+    emit_cset(?st, true, 0, CC_EQ);
+    emit_cset(?st, false, 0, CC_NE);
 
-    val lds: [32]u32 = [32]u32{
-        STRB_OFF, LDRB_OFF, STRH_OFF, LDRH_OFF, STRW_OFF, LDRW_OFF, STR_OFF_X, LDR_OFF_X,
-        LDR_D_OFF, STR_D_OFF, LDR_S_OFF, STR_S_OFF, LDR_H_OFF, STR_H_OFF, LDR_B_OFF, STR_B_OFF,
-        LDR_Q_OFF, STR_Q_OFF, LDAR_X, LDAR_W, STLR_X, STLR_W, LDAXR_X, LDAXR_W,
-        STRB_OFF, LDRB_OFF, STRH_OFF, LDRH_OFF, STRW_OFF, LDRW_OFF, STR_OFF_X, LDR_OFF_X };
+    val lds: [6]mop.MachOp = [6]mop.MachOp{ mop.STRB, mop.LDRB, mop.STRH, mop.LDRH, mop.STR, mop.LDR };
     i = 0;
-    for (i < 24) { emit_ldst(?st, lds[i], 1, 2, 1); i = i + 1; }
-    emit_ldst_sym(?st, LDR_OFF_X, 1, 2, g, printer.MOD_PCREL_LO, 0);
-    val ldu: [18]u32 = [18]u32{
-        STURB, LDURB, STURH, LDURH, STURW, LDURW, STUR_X, LDUR_X,
-        LDUR_D_FP, STUR_D_FP, LDUR_S_FP, STUR_S_FP, LDUR_H_FP, STUR_H_FP, LDUR_B_FP, STUR_B_FP,
-        LDUR_Q_FP, STUR_Q_FP };
+    for (i < 6) { emit_ldst(?st, lds[i], false, 4, 1, 2, 1); i = i + 1; }
+    emit_ldst(?st, mop.STR, false, 8, 1, 2, 1);
+    emit_ldst(?st, mop.LDR, false, 8, 1, 2, 1);
+    val fw: [5]u8 = [5]u8{ 1, 2, 4, 8, 16 };
     i = 0;
-    for (i < 18) { emit_ldur(?st, ldu[i], 1, 2, 0x1FF); i = i + 1; }
-    val ldr: [18]u32 = [18]u32{
-        STRB_REG, LDRB_REG, STRH_REG, LDRH_REG, STRW_REG, LDRW_REG, STR_REG_X, LDR_REG_X,
-        LDR_D_REG, STR_D_REG, LDR_S_REG, STR_S_REG, LDR_H_REG, STR_H_REG, LDR_B_REG, STR_B_REG,
-        LDR_Q_REG, STR_Q_REG };
+    for (i < 5) {
+        emit_ldst(?st, mop.LDR, true, fw[i], 1, 2, 1);
+        emit_ldst(?st, mop.STR, true, fw[i], 1, 2, 1);
+        emit_ldur(?st, mop.LDUR, true, fw[i], 1, 2, 0x1FF);
+        emit_ldur(?st, mop.STUR, true, fw[i], 1, 2, 0x1FF);
+        emit_ldst_reg(?st, mop.LDR, true, fw[i], 1, 2, 3);
+        emit_ldst_reg(?st, mop.STR, true, fw[i], 1, 2, 3);
+        i = i + 1;
+    }
+    val ord: [3]mop.MachOp = [3]mop.MachOp{ mop.LDAR, mop.STLR, mop.LDAXR };
     i = 0;
-    for (i < 18) { emit_ldst_reg(?st, ldr[i], 1, 2, 3); i = i + 1; }
-    val ldp: [8]u32 = [8]u32{ STP_PRE_X, LDP_POST_X, STP_OFF_X, LDP_OFF_X, STP_OFF_D, LDP_OFF_D, STP_POST_X, LDP_PRE_X };
+    for (i < 3) { emit_ldord(?st, ord[i], true, 1, 2); emit_ldord(?st, ord[i], false, 1, 2); i = i + 1; }
+    emit_ldst_sym(?st, mop.LDR, false, 8, 1, 2, g, isa.SYM_MOD_PCREL_LO, 0);
+    val ldu: [6]mop.MachOp = [6]mop.MachOp{ mop.STURB, mop.LDURB, mop.STURH, mop.LDURH, mop.STUR, mop.LDUR };
     i = 0;
-    for (i < 8) { emit_ldstp(?st, ldp[i], 29, 30, 31, 2); i = i + 1; }
+    for (i < 6) { emit_ldur(?st, ldu[i], false, 4, 1, 2, 0x1FF); i = i + 1; }
+    emit_ldur(?st, mop.STUR, false, 8, 1, 2, 0x1FF);
+    emit_ldur(?st, mop.LDUR, false, 8, 1, 2, 0x1FF);
+    i = 0;
+    for (i < 6) { emit_ldst_reg(?st, lds[i], false, 4, 1, 2, 3); i = i + 1; }
+    emit_ldst_reg(?st, mop.STR, false, 8, 1, 2, 3);
+    emit_ldst_reg(?st, mop.LDR, false, 8, 1, 2, 3);
+    emit_ldstp(?st, mop.STP, false, 29, 30, 31, 2, mop.FLAG_WB_PRE);
+    emit_ldstp(?st, mop.LDP, false, 29, 30, 31, 2, mop.FLAG_WB_POST);
+    emit_ldstp(?st, mop.STP, false, 29, 30, 31, 2, 0);
+    emit_ldstp(?st, mop.LDP, false, 29, 30, 31, 2, 0);
+    emit_ldstp(?st, mop.STP, true, 29, 30, 31, 2, 0);
+    emit_ldstp(?st, mop.LDP, true, 29, 30, 31, 2, 0);
+    emit_ldstp(?st, mop.STP, false, 29, 30, 31, 2, mop.FLAG_WB_POST);
+    emit_ldstp(?st, mop.LDP, false, 29, 30, 31, 2, mop.FLAG_WB_PRE);
 
     val lane: u32 = mir.vec_lane_make(mir.VEC_LANE_INT, 4, 4);
     val flane: u32 = mir.vec_lane_make(mir.VEC_LANE_FLOAT, 4, 4);
-    val neon: [18]u32 = [18]u32{
-        VFADD, VFSUB, VFMUL, VFDIV, VADD, VSUB, VMUL, VAND, VORR, VEOR,
-        VCMEQ, VCMGT_S, VCMGE_S, VCMHI_U, VCMHS_U, VFCMEQ, VFCMGT, VFCMGE };
+    val neon: [18]mop.MachOp = [18]mop.MachOp{
+        mop.V_FADD, mop.V_FSUB, mop.V_FMUL, mop.V_FDIV, mop.V_ADD, mop.V_SUB, mop.V_MUL, mop.V_AND, mop.V_ORR, mop.V_EOR,
+        mop.V_CMEQ, mop.V_CMGT, mop.V_CMGE, mop.V_CMHI, mop.V_CMHS, mop.V_FCMEQ, mop.V_FCMGT, mop.V_FCMGE };
     i = 0;
     for (i < 18) {
         var l: u32 = lane;
         if (i < 4 || i >= 15) { l = flane; }
-        emit_neon_3same(?st, neon[i], 2, 2, 0, 1, l);
+        emit_neon_3same(?st, neon[i], 2, 0, 1, l);
         i = i + 1;
     }
-    emit_neon_3same(?st, VORR, 0, 5, 6, 6, mir.vec_lane_make(mir.VEC_LANE_INT, 1, 16));
-    emit_neon_2misc(?st, VNOT, 0, 1);
-    emit_neon_umov(?st, VUMOV_W, 0, 1, 0, 1, mir.vec_lane_make(mir.VEC_LANE_INT, 1, 16));
-    emit_neon_umov(?st, VUMOV_W, 2, 1, 0, 1, lane);
-    emit_neon_umov(?st, VUMOV_X, 3, 1, 0, 1, mir.vec_lane_make(mir.VEC_LANE_INT, 8, 2));
-    emit_neon_dup_el(?st, 2, 1, 0, 1, lane);
-    emit_neon_ins_gp(?st, 2, 1, 0, 1, lane, 4);
-    emit_neon_ins_el(?st, 2, 1, 2, 0, 1, lane);
+    emit_neon_3same(?st, mop.V_ORR, 5, 6, 6, mir.vec_lane_make(mir.VEC_LANE_INT, 1, 16));
+    emit_neon_2misc(?st, mop.V_MVN, 0, 1);
+    emit_neon_umov(?st, 1, 0, 1, mir.vec_lane_make(mir.VEC_LANE_INT, 1, 16));
+    emit_neon_umov(?st, 1, 0, 1, lane);
+    emit_neon_umov(?st, 1, 0, 1, mir.vec_lane_make(mir.VEC_LANE_INT, 8, 2));
+    emit_neon_dup_el(?st, 1, 0, 1, lane);
+    emit_neon_ins_gp(?st, 1, 0, 1, lane, 4);
+    emit_neon_ins_el(?st, 1, 2, 0, 1, lane);
 
-    emit_branch_block(?st, B_BASE, 0, false, 3);
-    emit_branch_block(?st, CBNZ_X, 1, true, 3);
-    emit_branch_block(?st, CBZ_W, 1, true, 3);
-    emit_branch_block(?st, BCOND | CC_EQ, 0, false, 3);
-    emit_branch_block(?st, BCOND | CC_LT, 0, false, 3);
-    emit_branch_sym(?st, BL_BASE, g, 0);
-    emit_branch_pcrel(?st, CBNZ_W, 1, true, 2);
-    emit_branch_local(?st, B_BASE, B_BASE, 0, false, 1, true);
-    emit_branch_reg(?st, BLR_BASE, 1);
-    emit_branch_reg(?st, BR_BASE, 1);
-    emit_branch_reg(?st, RET_BASE, 30);
-    emit_adrp(?st, 0, g, printer.MOD_PCREL_HI, 0);
-    emit_nullary(?st, RET_WORD);
-    emit_nullary(?st, NOP_WORD);
-    emit_nullary(?st, YIELD_WORD);
-    emit_nullary(?st, WFE_WORD);
-    emit_nullary(?st, WFI_WORD);
-    emit_imm16(?st, BRK_BASE, 0);
-    emit_imm16(?st, SVC_BASE, 0);
-    emit_imm16(?st, HVC_BASE, 0);
-    emit_imm16(?st, SMC_BASE, 1);
+    emit_branch_block(?st, mop.B, 0, false, 0, 3);
+    emit_branch_block(?st, mop.CBNZ, 0, true, 1, 3);
+    emit_branch_block(?st, mop.CBZ, 0, false, 1, 3);
+    emit_branch_block(?st, mop.BCOND, CC_EQ, false, 0, 3);
+    emit_branch_block(?st, mop.BCOND, CC_LT, false, 0, 3);
+    emit_branch_sym(?st, mop.BL, g, 0);
+    emit_branch_pcrel(?st, mop.CBNZ, 0, false, 1, 2);
+    emit_branch_local(?st, mop.B, 0, false, 0, 1, true);
+    emit_branch_reg(?st, mop.BLR, 1);
+    emit_branch_reg(?st, mop.BR, 1);
+    emit_branch_reg(?st, mop.RET, 30);
+    emit_adrp(?st, 0, g, isa.SYM_MOD_PCREL_HI, 0);
+    emit_ret(?st);
+    emit_nullary(?st, mop.NOP);
+    emit_nullary(?st, mop.YIELD);
+    emit_nullary(?st, mop.WFE);
+    emit_nullary(?st, mop.WFI);
+    emit_imm16(?st, mop.BRK, 0);
+    emit_imm16(?st, mop.SVC, 0);
+    emit_imm16(?st, mop.HVC, 0);
+    emit_imm16(?st, mop.SMC, 1);
     emit_barrier(?st, 15);
     emit_msr_imm(?st, 3, 6, 1);
-    a64_emit_sysreg(?st, MRS_BASE, a64_sysreg_pack(3, 3, 14, 0, 2), 0);
-    a64_emit_sysreg(?st, MSR_REG_BASE, a64_sysreg_pack(3, 3, 14, 3, 1), 1);
-    emit_stxr(?st, STLXR_X, 0, 1, 2);
-    emit_stxr(?st, STLXR_W, 0, 1, 2);
+    emit_mrs(?st, a64_sysreg_pack(3, 3, 14, 0, 2), 0);
+    emit_msr_reg(?st, a64_sysreg_pack(3, 3, 14, 3, 1), 1);
+    emit_stxr(?st, true, 0, 1, 2);
+    emit_stxr(?st, false, 0, 1, 2);
 
     if (sink.failed) { ret 2; }
     if (sink.refused != 0 || encode.sink_unaccounted(?st.buf) != 0) { ret 3; }
@@ -8267,7 +7938,7 @@ test "mach.lang.target.isa.arm64.encode.inst_effects:roles_follow_the_translated
     var e: ct.InstEffects;
     var mi: isa.Inst = isa.inst_blank();
 
-    mi.opcode = mop.SUBS::u16; mi.dst = printer.gp(31, 8); mi.src1 = printer.gp(1, 8); mi.src2 = printer.gp(2, 8);
+    mi.opcode = mop.SUBS::u16; mi.dst = mop.gp(31, 8); mi.src1 = mop.gp(1, 8); mi.src2 = mop.gp(2, 8);
     mi.opcode = mop.CMP::u16;
     inst_effects(?mi, ?e);
     if (!e.cls.known || !e.cls.defines_flags || e.roles[0] != ct.ROLE_NONE || e.roles[1] != ct.ROLE_READ || e.roles[2] != ct.ROLE_READ) { ret 1; }
@@ -8276,34 +7947,34 @@ test "mach.lang.target.isa.arm64.encode.inst_effects:roles_follow_the_translated
     inst_effects(?mi, ?e);
     if (!e.cls.cond_flags || e.xfer != ct.XFER_BRANCH || e.target != ct.TARGET_BLOCK || e.target_block != 4) { ret 2; }
 
-    mi = isa.inst_blank(); mi.opcode = mop.CBNZ::u16; mi.src1 = printer.gp(3, 8); mi.src2 = isa.make_local_label(true);
+    mi = isa.inst_blank(); mi.opcode = mop.CBNZ::u16; mi.src1 = mop.gp(3, 8); mi.src2 = isa.make_local_label(true);
     inst_effects(?mi, ?e);
     if (!e.cls.cond_reg || e.roles[1] != ct.ROLE_READ || e.target != ct.TARGET_LOCAL_FWD) { ret 3; }
     mi.src2 = isa.make_local_label(false);
     inst_effects(?mi, ?e);
     if (e.target != ct.TARGET_LOCAL) { ret 14; }
 
-    mi = isa.inst_blank(); mi.opcode = mop.SDIV::u16; mi.dst = printer.gp(0, 8); mi.src1 = printer.gp(1, 8); mi.src2 = printer.gp(2, 8);
+    mi = isa.inst_blank(); mi.opcode = mop.SDIV::u16; mi.dst = mop.gp(0, 8); mi.src1 = mop.gp(1, 8); mi.src2 = mop.gp(2, 8);
     inst_effects(?mi, ?e);
     if (e.cls.op != ct.CT_OP_INT_DIVMOD || e.roles[0] != ct.ROLE_WRITE || e.roles[2] != ct.ROLE_READ) { ret 4; }
 
-    mi = isa.inst_blank(); mi.opcode = mop.MSUB::u16; mi.dst = printer.gp(0, 8); mi.src1 = printer.gp(1, 8); mi.src2 = printer.gp(2, 8); mi.src3 = printer.gp(3, 8);
+    mi = isa.inst_blank(); mi.opcode = mop.MSUB::u16; mi.dst = mop.gp(0, 8); mi.src1 = mop.gp(1, 8); mi.src2 = mop.gp(2, 8); mi.src3 = mop.gp(3, 8);
     inst_effects(?mi, ?e);
     if (e.cls.op != ct.CT_OP_INT_MUL || e.roles[3] != ct.ROLE_READ) { ret 5; }
 
-    mi = isa.inst_blank(); mi.opcode = mop.STR::u16; mi.dst = isa.make_mem(printer.gp_id(29), -16, -1, 0, 8); mi.src1 = printer.gp(5, 8);
+    mi = isa.inst_blank(); mi.opcode = mop.STR::u16; mi.dst = isa.make_mem(mop.gp_id(29), -16, -1, 0, 8); mi.src1 = mop.gp(5, 8);
     inst_effects(?mi, ?e);
     if (e.roles[0] != ct.ROLE_WRITE || e.roles[1] != ct.ROLE_READ) { ret 6; }
 
-    mi = isa.inst_blank(); mi.opcode = mop.LDP::u16; mi.dst = printer.gp(29, 8); mi.src1 = printer.gp(30, 8); mi.src2 = isa.make_mem(printer.gp_id(31), 0, -1, 0, 8);
+    mi = isa.inst_blank(); mi.opcode = mop.LDP::u16; mi.dst = mop.gp(29, 8); mi.src1 = mop.gp(30, 8); mi.src2 = isa.make_mem(mop.gp_id(31), 0, -1, 0, 8);
     inst_effects(?mi, ?e);
     if (e.roles[0] != ct.ROLE_WRITE || e.roles[1] != ct.ROLE_WRITE || e.roles[2] != ct.ROLE_READ || e.mem_bytes != 16) { ret 7; }
 
-    mi = isa.inst_blank(); mi.opcode = mop.MOVK::u16; mi.dst = printer.gp(16, 8); mi.src1 = isa.make_imm(1, 2);
+    mi = isa.inst_blank(); mi.opcode = mop.MOVK::u16; mi.dst = mop.gp(16, 8); mi.src1 = isa.make_imm(1, 2);
     inst_effects(?mi, ?e);
     if (e.roles[0] != ct.ROLE_RW) { ret 8; }
 
-    mi = isa.inst_blank(); mi.opcode = mop.LSLV::u16; mi.dst = printer.gp(0, 8); mi.src1 = printer.gp(1, 8); mi.src2 = printer.gp(2, 8);
+    mi = isa.inst_blank(); mi.opcode = mop.LSLV::u16; mi.dst = mop.gp(0, 8); mi.src1 = mop.gp(1, 8); mi.src2 = mop.gp(2, 8);
     inst_effects(?mi, ?e);
     if (e.cls.op != ct.CT_OP_VAR_SHIFT || e.count_pos != 2) { ret 9; }
 
@@ -8315,7 +7986,7 @@ test "mach.lang.target.isa.arm64.encode.inst_effects:roles_follow_the_translated
     inst_effects(?mi, ?e);
     if (e.xfer != ct.XFER_CALL || e.target != ct.TARGET_EXTERNAL || e.implicit_writes != A64_X30) { ret 11; }
 
-    mi = isa.inst_blank(); mi.opcode = mop.BLR::u16; mi.src1 = printer.gp(9, 8);
+    mi = isa.inst_blank(); mi.opcode = mop.BLR::u16; mi.src1 = mop.gp(9, 8);
     inst_effects(?mi, ?e);
     if (e.xfer != ct.XFER_CALL || e.target != ct.TARGET_REGISTER || e.roles[1] != ct.ROLE_READ) { ret 12; }
 

--- a/src/lang/target/isa/arm64/inst.mach
+++ b/src/lang/target/isa/arm64/inst.mach
@@ -1,12 +1,20 @@
 use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
 use std.types.string.str;
 use std.types.string.str_equals;
+
+use mach.lang.target.isa;
 
 # the aarch64 machine-opcode space: one member per instruction the encoder
 # emits or the inline-asm grammar accepts, named by the assembler spelling the
 # printer renders. `arm64.Opcode` is the selection space (a MIR row alias);
 # this is what an instruction notification carries, the same split riscv makes
-# between `riscv.Opcode` and `riscv.inst.MachOp`.
+# between `riscv.Opcode` and `riscv.inst.MachOp`. members that share a
+# spelling are distinct instructions (the NEON `mov` aliases, the three `fmov`
+# pages); an alias member is a spelling the notification produces for another
+# member's encoding and is never assembled itself
 pub def MachOp: u16;
 
 pub val MOP_NONE: MachOp = 0;
@@ -139,148 +147,290 @@ pub val MOV_LANE: MachOp = 109;
 pub val INS:      MachOp = 110;
 pub val DUP:      MachOp = 111;
 
-pub val MOP_LAST: MachOp = DUP;
+# the other `fmov` pages: FMOV (general) between the banks, in either
+# direction, and FMOV (scalar, immediate); INS (element) beside INS (general)
+pub val FMOV_GEN: MachOp = 112;
+pub val FMOV_IMM: MachOp = 113;
+pub val INS_EL:   MachOp = 114;
+
+pub val MOP_LAST: MachOp = INS_EL;
+val MOP_COUNT: usize = 115;
 
 pub fun known(op: MachOp) bool {
     ret op != MOP_NONE && op <= MOP_LAST;
 }
 
+# the operand layout of a member: what its operands are, how they pack into
+# the word and how the printer lays the line out. this is the form byte the
+# printer-private record used to carry, now a column of the member's row
+pub def Layout: u8;
+
+pub val L_NONE:         Layout = 0;
+# dst, src1, src2 registers, an optional src3 shift immediate; a row with an
+# immediate form takes a src2 immediate instead (add/sub/adds/subs)
+pub val L_ALU3:         Layout = 1;
+# the bitfield aliases: dst, src1 and the alias's own immediates
+pub val L_BITFIELD:     Layout = 2;
+# dst, #imm16, optional src3 `lsl #hw*16`
+pub val L_MOVEWIDE:     Layout = 3;
+# dst, src1, src2, src3 (the accumulator)
+pub val L_MADD:         Layout = 4;
+# dst and the condition in the flags
+pub val L_CSET:         Layout = 5;
+# a load names dst, [src1]; a store names [dst], src1. a memory operand with
+# an index is the register-offset form, otherwise the scaled unsigned offset
+pub val L_LDST:         Layout = 6;
+# the unscaled signed-offset forms
+pub val L_LDUR:         Layout = 7;
+# the ordered loads and stores: [base] only
+pub val L_LDORD:        Layout = 8;
+# status dst, data src1, [src2]
+pub val L_STXR:         Layout = 9;
+# a load names dst, src1, [src2]; a store names [dst], src1, src2; the
+# writeback in the flags
+pub val L_LDSTP:        Layout = 10;
+# dst, src1, src2 vectors at the arrangement the element width names
+pub val L_NEON_3SAME:   Layout = 11;
+# dst, src1 vectors, always .16b
+pub val L_NEON_2MISC:   Layout = 12;
+# dst, src1.elem[src2]
+pub val L_NEON_LANE_RD: Layout = 13;
+# dst.elem[src2], src1 or dst.elem[src2], src1.elem[src3]
+pub val L_NEON_LANE_WR: Layout = 14;
+# optional src1 register (cbz/cbnz), the target in src2
+pub val L_BRANCH:       Layout = 15;
+# src1 register, or none for the plain `ret`
+pub val L_BRANCH_REG:   Layout = 16;
+# dst, a page symbol in src1
+pub val L_ADRP:         Layout = 17;
+pub val L_NULLARY:      Layout = 18;
+# a src1 immediate
+pub val L_IMM16:        Layout = 19;
+# the barrier domain in src1
+pub val L_BARRIER:      Layout = 20;
+# mrs dst, src1(sysreg); msr src1(sysreg), src2 register; msr src1(pstate
+# field), src2 immediate
+pub val L_SYSREG:       Layout = 21;
+# dst, the imm8 in src2
+pub val L_FMOV_IMM:     Layout = 22;
+
+# how the operand widths reach the base word
+pub def WidthRule: u8;
+
+pub val W_NONE:     WidthRule = 0;
+# bit 31 set for a 64-bit general-purpose operation
+pub val W_SF:       WidthRule = 1;
+# sf and the bitfield N bit
+pub val W_SF_N:     WidthRule = 2;
+# bit 22 set for a double-precision float operation
+pub val W_FTYPE:    WidthRule = 3;
+# sf from the general-purpose operand, ftype from the float operand
+pub val W_SF_FTYPE: WidthRule = 4;
+# ftype from the source float width, opc from the destination float width
+pub val W_FCVT:     WidthRule = 5;
+# the load/store size field from the data register, with the vector bank bit
+# and the quadword opc
+pub val W_SIZE:     WidthRule = 6;
+# bit 30 set for a 64-bit data register
+pub val W_SIZE30:   WidthRule = 7;
+# the pair opc from the data register's bank and width
+pub val W_LDP:      WidthRule = 8;
+# FMOV (general): sf and ftype as W_SF_FTYPE, the direction from the banks
+pub val W_FMOV_GEN: WidthRule = 9;
+
+# the lane class of a NEON member: how the element width reaches the size
+# field and which arrangement the printer renders
+pub def LaneClass: u8;
+
+pub val LANE_NONE:  LaneClass = 0;
+pub val LANE_INT:   LaneClass = 1;
+pub val LANE_FLOAT: LaneClass = 2;
+# the bitwise members: always the byte arrangement
+pub val LANE_BITS:  LaneClass = 3;
+
+# one member's row: the spelling, the operand layout, the base word of its
+# encoding (and of its immediate form when the instruction has one), and how
+# the operand widths reach the word. an alias row has no base word: the
+# encoder assembles the member it aliases and the notification renames it
+pub rec Form {
+    mnemonic: str;
+    layout:   Layout;
+    base:     u32;
+    base_imm: u32;
+    width:    WidthRule;
+    lane:     LaneClass;
+    alias:    bool;
+}
+
+val FORMS: [MOP_COUNT]Form = [MOP_COUNT]Form{
+    Form{ mnemonic: nil,      layout: L_NONE,       base: 0,          base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "nop",    layout: L_NULLARY,    base: 0xD503201F, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "yield",  layout: L_NULLARY,    base: 0xD503203F, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "wfe",    layout: L_NULLARY,    base: 0xD503205F, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "wfi",    layout: L_NULLARY,    base: 0xD503207F, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "ret",    layout: L_BRANCH_REG, base: 0xD65F0000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "svc",    layout: L_IMM16,      base: 0xD4000001, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "brk",    layout: L_IMM16,      base: 0xD4200000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "hvc",    layout: L_IMM16,      base: 0xD4000002, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "smc",    layout: L_IMM16,      base: 0xD4000003, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+
+    Form{ mnemonic: "mov",    layout: L_ALU3,       base: 0,          base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: true },
+    Form{ mnemonic: "movz",   layout: L_MOVEWIDE,   base: 0x52800000, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "movk",   layout: L_MOVEWIDE,   base: 0x72800000, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "mvn",    layout: L_ALU3,       base: 0,          base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: true },
+    Form{ mnemonic: "neg",    layout: L_ALU3,       base: 0,          base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: true },
+
+    Form{ mnemonic: "add",    layout: L_ALU3,       base: 0x0B000000, base_imm: 0x11000000, width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "adds",   layout: L_ALU3,       base: 0x2B000000, base_imm: 0x31000000, width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "sub",    layout: L_ALU3,       base: 0x4B000000, base_imm: 0x51000000, width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "subs",   layout: L_ALU3,       base: 0x6B000000, base_imm: 0x71000000, width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "cmp",    layout: L_ALU3,       base: 0,          base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: true },
+    Form{ mnemonic: "cmn",    layout: L_ALU3,       base: 0,          base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: true },
+    Form{ mnemonic: "and",    layout: L_ALU3,       base: 0x0A000000, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "orr",    layout: L_ALU3,       base: 0x2A000000, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "orn",    layout: L_ALU3,       base: 0x2A200000, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "eor",    layout: L_ALU3,       base: 0x4A000000, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+
+    Form{ mnemonic: "mul",    layout: L_ALU3,       base: 0x1B007C00, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "mneg",   layout: L_ALU3,       base: 0x1B00FC00, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "madd",   layout: L_MADD,       base: 0x1B000000, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "msub",   layout: L_MADD,       base: 0x1B008000, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "sdiv",   layout: L_ALU3,       base: 0x1AC00C00, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "udiv",   layout: L_ALU3,       base: 0x1AC00800, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+
+    Form{ mnemonic: "lsl",    layout: L_BITFIELD,   base: 0x53000000, base_imm: 0,          width: W_SF_N,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "lsr",    layout: L_BITFIELD,   base: 0x53000000, base_imm: 0,          width: W_SF_N,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "asr",    layout: L_BITFIELD,   base: 0x13000000, base_imm: 0,          width: W_SF_N,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "lsl",    layout: L_ALU3,       base: 0x1AC02000, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "lsr",    layout: L_ALU3,       base: 0x1AC02400, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "asr",    layout: L_ALU3,       base: 0x1AC02800, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+
+    Form{ mnemonic: "ubfx",   layout: L_BITFIELD,   base: 0x53000000, base_imm: 0,          width: W_SF_N,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "ubfiz",  layout: L_BITFIELD,   base: 0x53000000, base_imm: 0,          width: W_SF_N,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "sbfx",   layout: L_BITFIELD,   base: 0x13000000, base_imm: 0,          width: W_SF_N,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "sbfiz",  layout: L_BITFIELD,   base: 0x13000000, base_imm: 0,          width: W_SF_N,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "uxtb",   layout: L_BITFIELD,   base: 0x53000000, base_imm: 0,          width: W_SF_N,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "uxth",   layout: L_BITFIELD,   base: 0x53000000, base_imm: 0,          width: W_SF_N,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "sxtb",   layout: L_BITFIELD,   base: 0x13000000, base_imm: 0,          width: W_SF_N,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "sxth",   layout: L_BITFIELD,   base: 0x13000000, base_imm: 0,          width: W_SF_N,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "sxtw",   layout: L_BITFIELD,   base: 0x13000000, base_imm: 0,          width: W_SF_N,     lane: LANE_NONE, alias: false },
+
+    Form{ mnemonic: "cset",   layout: L_CSET,       base: 0x1A9F07E0, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "adrp",   layout: L_ADRP,       base: 0x90000000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+
+    Form{ mnemonic: "b",      layout: L_BRANCH,     base: 0x14000000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "b.",     layout: L_BRANCH,     base: 0x54000000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "bl",     layout: L_BRANCH,     base: 0x94000000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "blr",    layout: L_BRANCH_REG, base: 0xD63F0000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "br",     layout: L_BRANCH_REG, base: 0xD61F0000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "cbz",    layout: L_BRANCH,     base: 0x34000000, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "cbnz",   layout: L_BRANCH,     base: 0x35000000, base_imm: 0,          width: W_SF,       lane: LANE_NONE, alias: false },
+
+    Form{ mnemonic: "ldr",    layout: L_LDST,       base: 0x38400000, base_imm: 0,          width: W_SIZE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "str",    layout: L_LDST,       base: 0x38000000, base_imm: 0,          width: W_SIZE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "ldrb",   layout: L_LDST,       base: 0x38400000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "strb",   layout: L_LDST,       base: 0x38000000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "ldrh",   layout: L_LDST,       base: 0x78400000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "strh",   layout: L_LDST,       base: 0x78000000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "ldur",   layout: L_LDUR,       base: 0x38400000, base_imm: 0,          width: W_SIZE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "stur",   layout: L_LDUR,       base: 0x38000000, base_imm: 0,          width: W_SIZE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "ldurb",  layout: L_LDUR,       base: 0x38400000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "sturb",  layout: L_LDUR,       base: 0x38000000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "ldurh",  layout: L_LDUR,       base: 0x78400000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "sturh",  layout: L_LDUR,       base: 0x78000000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "ldp",    layout: L_LDSTP,      base: 0x28400000, base_imm: 0,          width: W_LDP,      lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "stp",    layout: L_LDSTP,      base: 0x28000000, base_imm: 0,          width: W_LDP,      lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "ldar",   layout: L_LDORD,      base: 0x88DFFC00, base_imm: 0,          width: W_SIZE30,   lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "stlr",   layout: L_LDORD,      base: 0x889FFC00, base_imm: 0,          width: W_SIZE30,   lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "ldaxr",  layout: L_LDORD,      base: 0x885FFC00, base_imm: 0,          width: W_SIZE30,   lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "stlxr",  layout: L_STXR,       base: 0x8800FC00, base_imm: 0,          width: W_SIZE30,   lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "dmb",    layout: L_BARRIER,    base: 0xD50330BF, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "msr",    layout: L_SYSREG,     base: 0xD5100000, base_imm: 0xD500401F, width: W_NONE,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "mrs",    layout: L_SYSREG,     base: 0xD5300000, base_imm: 0,          width: W_NONE,     lane: LANE_NONE, alias: false },
+
+    Form{ mnemonic: "fadd",   layout: L_ALU3,       base: 0x1E202800, base_imm: 0,          width: W_FTYPE,    lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "fsub",   layout: L_ALU3,       base: 0x1E203800, base_imm: 0,          width: W_FTYPE,    lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "fmul",   layout: L_ALU3,       base: 0x1E200800, base_imm: 0,          width: W_FTYPE,    lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "fdiv",   layout: L_ALU3,       base: 0x1E201800, base_imm: 0,          width: W_FTYPE,    lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "fneg",   layout: L_ALU3,       base: 0x1E214000, base_imm: 0,          width: W_FTYPE,    lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "fmov",   layout: L_ALU3,       base: 0x1E204000, base_imm: 0,          width: W_FTYPE,    lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "fcvt",   layout: L_ALU3,       base: 0x1E224000, base_imm: 0,          width: W_FCVT,     lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "fcmp",   layout: L_ALU3,       base: 0x1E202000, base_imm: 0,          width: W_FTYPE,    lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "scvtf",  layout: L_ALU3,       base: 0x1E220000, base_imm: 0,          width: W_SF_FTYPE, lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "ucvtf",  layout: L_ALU3,       base: 0x1E230000, base_imm: 0,          width: W_SF_FTYPE, lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "fcvtzs", layout: L_ALU3,       base: 0x1E380000, base_imm: 0,          width: W_SF_FTYPE, lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "fcvtzu", layout: L_ALU3,       base: 0x1E390000, base_imm: 0,          width: W_SF_FTYPE, lane: LANE_NONE, alias: false },
+
+    Form{ mnemonic: "fadd",   layout: L_NEON_3SAME, base: 0x4E20D400, base_imm: 0,          width: W_NONE,     lane: LANE_FLOAT, alias: false },
+    Form{ mnemonic: "fsub",   layout: L_NEON_3SAME, base: 0x4EA0D400, base_imm: 0,          width: W_NONE,     lane: LANE_FLOAT, alias: false },
+    Form{ mnemonic: "fmul",   layout: L_NEON_3SAME, base: 0x6E20DC00, base_imm: 0,          width: W_NONE,     lane: LANE_FLOAT, alias: false },
+    Form{ mnemonic: "fdiv",   layout: L_NEON_3SAME, base: 0x6E20FC00, base_imm: 0,          width: W_NONE,     lane: LANE_FLOAT, alias: false },
+    Form{ mnemonic: "add",    layout: L_NEON_3SAME, base: 0x4E208400, base_imm: 0,          width: W_NONE,     lane: LANE_INT,   alias: false },
+    Form{ mnemonic: "sub",    layout: L_NEON_3SAME, base: 0x6E208400, base_imm: 0,          width: W_NONE,     lane: LANE_INT,   alias: false },
+    Form{ mnemonic: "mul",    layout: L_NEON_3SAME, base: 0x4E209C00, base_imm: 0,          width: W_NONE,     lane: LANE_INT,   alias: false },
+    Form{ mnemonic: "and",    layout: L_NEON_3SAME, base: 0x4E201C00, base_imm: 0,          width: W_NONE,     lane: LANE_BITS,  alias: false },
+    Form{ mnemonic: "orr",    layout: L_NEON_3SAME, base: 0x4EA01C00, base_imm: 0,          width: W_NONE,     lane: LANE_BITS,  alias: false },
+    Form{ mnemonic: "eor",    layout: L_NEON_3SAME, base: 0x6E201C00, base_imm: 0,          width: W_NONE,     lane: LANE_BITS,  alias: false },
+    Form{ mnemonic: "mvn",    layout: L_NEON_2MISC, base: 0x6E205800, base_imm: 0,          width: W_NONE,     lane: LANE_BITS,  alias: false },
+    Form{ mnemonic: "mov",    layout: L_NEON_3SAME, base: 0,          base_imm: 0,          width: W_NONE,     lane: LANE_BITS,  alias: true },
+    Form{ mnemonic: "cmeq",   layout: L_NEON_3SAME, base: 0x6E208C00, base_imm: 0,          width: W_NONE,     lane: LANE_INT,   alias: false },
+    Form{ mnemonic: "cmgt",   layout: L_NEON_3SAME, base: 0x4E203400, base_imm: 0,          width: W_NONE,     lane: LANE_INT,   alias: false },
+    Form{ mnemonic: "cmge",   layout: L_NEON_3SAME, base: 0x4E203C00, base_imm: 0,          width: W_NONE,     lane: LANE_INT,   alias: false },
+    Form{ mnemonic: "cmhi",   layout: L_NEON_3SAME, base: 0x6E203400, base_imm: 0,          width: W_NONE,     lane: LANE_INT,   alias: false },
+    Form{ mnemonic: "cmhs",   layout: L_NEON_3SAME, base: 0x6E203C00, base_imm: 0,          width: W_NONE,     lane: LANE_INT,   alias: false },
+    Form{ mnemonic: "fcmeq",  layout: L_NEON_3SAME, base: 0x4E20E400, base_imm: 0,          width: W_NONE,     lane: LANE_FLOAT, alias: false },
+    Form{ mnemonic: "fcmgt",  layout: L_NEON_3SAME, base: 0x6EA0E400, base_imm: 0,          width: W_NONE,     lane: LANE_FLOAT, alias: false },
+    Form{ mnemonic: "fcmge",  layout: L_NEON_3SAME, base: 0x6E20E400, base_imm: 0,          width: W_NONE,     lane: LANE_FLOAT, alias: false },
+
+    Form{ mnemonic: "umov",   layout: L_NEON_LANE_RD, base: 0x0E003C00, base_imm: 0,        width: W_SIZE30,   lane: LANE_INT,   alias: false },
+    Form{ mnemonic: "mov",    layout: L_NEON_LANE_RD, base: 0,          base_imm: 0,        width: W_SIZE30,   lane: LANE_INT,   alias: true },
+    Form{ mnemonic: "mov",    layout: L_NEON_LANE_WR, base: 0x4E001C00, base_imm: 0,        width: W_NONE,     lane: LANE_INT,   alias: false },
+    Form{ mnemonic: "mov",    layout: L_NEON_LANE_RD, base: 0x5E000400, base_imm: 0,        width: W_NONE,     lane: LANE_FLOAT, alias: false },
+
+    Form{ mnemonic: "fmov",   layout: L_ALU3,       base: 0x1E260000, base_imm: 0,          width: W_FMOV_GEN, lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "fmov",   layout: L_FMOV_IMM,   base: 0x1E201000, base_imm: 0,          width: W_FTYPE,    lane: LANE_NONE, alias: false },
+    Form{ mnemonic: "mov",    layout: L_NEON_LANE_WR, base: 0x6E000400, base_imm: 0,        width: W_NONE,     lane: LANE_INT,   alias: false },
+};
+
+# the row of a member; the blank row outside the catalog
+pub fun form(op: MachOp) *Form {
+    if (!known(op)) { ret ?FORMS[0]; }
+    ret ?FORMS[op::usize];
+}
+
 # the assembler spelling the printer renders; nil outside the catalog
 pub fun mnemonic(op: MachOp) str {
-    if (op == NOP)   { ret "nop"; }
-    if (op == YIELD) { ret "yield"; }
-    if (op == WFE)   { ret "wfe"; }
-    if (op == WFI)   { ret "wfi"; }
-    if (op == RET)   { ret "ret"; }
-    if (op == SVC)   { ret "svc"; }
-    if (op == BRK)   { ret "brk"; }
-    if (op == HVC)   { ret "hvc"; }
-    if (op == SMC)   { ret "smc"; }
+    ret form(op).mnemonic;
+}
 
-    if (op == MOV)  { ret "mov"; }
-    if (op == MOVZ) { ret "movz"; }
-    if (op == MOVK) { ret "movk"; }
-    if (op == MVN)  { ret "mvn"; }
-    if (op == NEG)  { ret "neg"; }
-
-    if (op == ADD)  { ret "add"; }
-    if (op == ADDS) { ret "adds"; }
-    if (op == SUB)  { ret "sub"; }
-    if (op == SUBS) { ret "subs"; }
-    if (op == CMP)  { ret "cmp"; }
-    if (op == CMN)  { ret "cmn"; }
-    if (op == AND)  { ret "and"; }
-    if (op == ORR)  { ret "orr"; }
-    if (op == ORN)  { ret "orn"; }
-    if (op == EOR)  { ret "eor"; }
-
-    if (op == MUL)  { ret "mul"; }
-    if (op == MNEG) { ret "mneg"; }
-    if (op == MADD) { ret "madd"; }
-    if (op == MSUB) { ret "msub"; }
-    if (op == SDIV) { ret "sdiv"; }
-    if (op == UDIV) { ret "udiv"; }
-
-    if (op == LSL || op == LSLV) { ret "lsl"; }
-    if (op == LSR || op == LSRV) { ret "lsr"; }
-    if (op == ASR || op == ASRV) { ret "asr"; }
-
-    if (op == UBFX)  { ret "ubfx"; }
-    if (op == UBFIZ) { ret "ubfiz"; }
-    if (op == SBFX)  { ret "sbfx"; }
-    if (op == SBFIZ) { ret "sbfiz"; }
-    if (op == UXTB)  { ret "uxtb"; }
-    if (op == UXTH)  { ret "uxth"; }
-    if (op == SXTB)  { ret "sxtb"; }
-    if (op == SXTH)  { ret "sxth"; }
-    if (op == SXTW)  { ret "sxtw"; }
-
-    if (op == CSET) { ret "cset"; }
-    if (op == ADRP) { ret "adrp"; }
-
-    if (op == B)     { ret "b"; }
-    if (op == BCOND) { ret "b."; }
-    if (op == BL)    { ret "bl"; }
-    if (op == BLR)   { ret "blr"; }
-    if (op == BR)    { ret "br"; }
-    if (op == CBZ)   { ret "cbz"; }
-    if (op == CBNZ)  { ret "cbnz"; }
-
-    if (op == LDR)   { ret "ldr"; }
-    if (op == STR)   { ret "str"; }
-    if (op == LDRB)  { ret "ldrb"; }
-    if (op == STRB)  { ret "strb"; }
-    if (op == LDRH)  { ret "ldrh"; }
-    if (op == STRH)  { ret "strh"; }
-    if (op == LDUR)  { ret "ldur"; }
-    if (op == STUR)  { ret "stur"; }
-    if (op == LDURB) { ret "ldurb"; }
-    if (op == STURB) { ret "sturb"; }
-    if (op == LDURH) { ret "ldurh"; }
-    if (op == STURH) { ret "sturh"; }
-    if (op == LDP)   { ret "ldp"; }
-    if (op == STP)   { ret "stp"; }
-    if (op == LDAR)  { ret "ldar"; }
-    if (op == STLR)  { ret "stlr"; }
-    if (op == LDAXR) { ret "ldaxr"; }
-    if (op == STLXR) { ret "stlxr"; }
-    if (op == DMB)   { ret "dmb"; }
-    if (op == MSR)   { ret "msr"; }
-    if (op == MRS)   { ret "mrs"; }
-
-    if (op == FADD)   { ret "fadd"; }
-    if (op == FSUB)   { ret "fsub"; }
-    if (op == FMUL)   { ret "fmul"; }
-    if (op == FDIV)   { ret "fdiv"; }
-    if (op == FNEG)   { ret "fneg"; }
-    if (op == FMOV)   { ret "fmov"; }
-    if (op == FCVT)   { ret "fcvt"; }
-    if (op == FCMP)   { ret "fcmp"; }
-    if (op == SCVTF)  { ret "scvtf"; }
-    if (op == UCVTF)  { ret "ucvtf"; }
-    if (op == FCVTZS) { ret "fcvtzs"; }
-    if (op == FCVTZU) { ret "fcvtzu"; }
-
-    if (op == V_FADD)  { ret "fadd"; }
-    if (op == V_FSUB)  { ret "fsub"; }
-    if (op == V_FMUL)  { ret "fmul"; }
-    if (op == V_FDIV)  { ret "fdiv"; }
-    if (op == V_ADD)   { ret "add"; }
-    if (op == V_SUB)   { ret "sub"; }
-    if (op == V_MUL)   { ret "mul"; }
-    if (op == V_AND)   { ret "and"; }
-    if (op == V_ORR)   { ret "orr"; }
-    if (op == V_EOR)   { ret "eor"; }
-    if (op == V_MVN)   { ret "mvn"; }
-    if (op == V_MOV)   { ret "mov"; }
-    if (op == V_CMEQ)  { ret "cmeq"; }
-    if (op == V_CMGT)  { ret "cmgt"; }
-    if (op == V_CMGE)  { ret "cmge"; }
-    if (op == V_CMHI)  { ret "cmhi"; }
-    if (op == V_CMHS)  { ret "cmhs"; }
-    if (op == V_FCMEQ) { ret "fcmeq"; }
-    if (op == V_FCMGT) { ret "fcmgt"; }
-    if (op == V_FCMGE) { ret "fcmge"; }
-
-    if (op == UMOV)     { ret "umov"; }
-    if (op == MOV_LANE) { ret "mov"; }
-    if (op == INS)      { ret "mov"; }
-    if (op == DUP)      { ret "mov"; }
-    ret nil;
+pub fun layout(op: MachOp) Layout {
+    ret form(op).layout;
 }
 
 # `isa.Inst.flags` layout for an aarch64 notification
 pub val FLAG_COND:    u16 = 0x000F;
 pub val FLAG_WB_PRE:  u16 = 0x0010;
 pub val FLAG_WB_POST: u16 = 0x0020;
-pub val FLAG_ELEM:    u16 = 0x0F00;
-val FLAG_ELEM_SHIFT:  u16 = 8;
 # the branch target in src2 is a block of the function (a block label);
 # without it a src2 label is an offset inside the same expansion
 pub val FLAG_TARGET_BLOCK: u16 = 0x0040;
+# index 31 in a general-purpose register operand names the stack pointer;
+# without it index 31 is the zero register
+pub val FLAG_SP:      u16 = 0x0080;
+pub val FLAG_ELEM:    u16 = 0x0F00;
+val FLAG_ELEM_SHIFT:  u16 = 8;
+# the src2 label is a numbered inline-asm local (`sym_id` holds the number,
+# FLAG_LABEL_FWD its direction) or a pc-relative skip (`disp` holds the bytes)
+pub val FLAG_LABEL_LOCAL: u16 = 0x1000;
+pub val FLAG_LABEL_FWD:   u16 = 0x2000;
+pub val FLAG_LABEL_SKIP:  u16 = 0x4000;
 
 pub fun cond_of(flags: u16) u32 {
     ret (flags & FLAG_COND)::u32;
+}
+
+pub fun with_cond(flags: u16, cc: u32) u16 {
+    ret (flags & ~FLAG_COND) | (cc & 0xF)::u16;
 }
 
 # the vector element width in bytes, 0 for a scalar instruction
@@ -290,6 +440,366 @@ pub fun elem_bytes(flags: u16) u8 {
 
 pub fun with_elem_bytes(flags: u16, eb: u8) u16 {
     ret (flags & ~FLAG_ELEM) | ((eb::u16 << FLAG_ELEM_SHIFT) & FLAG_ELEM);
+}
+
+pub fun gp_id(n: u32) i32 {
+    ret isa.regid_make(isa.REG_CLASS_ID_GP, (n & 0x1F)::i32);
+}
+
+pub fun vec_id(n: u32) i32 {
+    ret isa.regid_make(isa.REG_CLASS_ID_XMM, (n & 0x1F)::i32);
+}
+
+pub fun gp(n: u32, bytes: u8) isa.Operand {
+    ret isa.make_reg(gp_id(n), bytes);
+}
+
+pub fun vec(n: u32, bytes: u8) isa.Operand {
+    ret isa.make_reg(vec_id(n), bytes);
+}
+
+pub fun is_gp(op: *isa.Operand) bool {
+    ret op.kind == isa.OPK_REG && isa.regid_class(op.reg) == isa.REG_CLASS_ID_GP;
+}
+
+pub fun is_vec(op: *isa.Operand) bool {
+    ret op.kind == isa.OPK_REG && isa.regid_class(op.reg) == isa.REG_CLASS_ID_XMM;
+}
+
+# index 31 in a data position with the stack pointer not named
+pub fun is_zero_reg(mi: *isa.Inst, op: *isa.Operand) bool {
+    ret is_gp(op) && isa.regid_index(op.reg) == 31 && (mi.flags & FLAG_SP) == 0;
+}
+
+fun reg_n(op: *isa.Operand) u32 {
+    if (op.kind != isa.OPK_REG) { ret 0; }
+    ret isa.regid_index(op.reg)::u32 & 0x1F;
+}
+
+fun mem_base_n(op: *isa.Operand) u32 {
+    if (op.kind != isa.OPK_MEM || op.base < 0) { ret 0; }
+    ret isa.regid_index(op.base)::u32 & 0x1F;
+}
+
+fun mem_index_n(op: *isa.Operand) u32 {
+    if (op.kind != isa.OPK_MEM || op.index < 0) { ret 0; }
+    ret isa.regid_index(op.index)::u32 & 0x1F;
+}
+
+# the first general-purpose register operand's width, 0 when none
+fun gp_width(mi: *isa.Inst) u8 {
+    if (is_gp(?mi.dst))  { ret mi.dst.size; }
+    if (is_gp(?mi.src1)) { ret mi.src1.size; }
+    if (is_gp(?mi.src2)) { ret mi.src2.size; }
+    if (is_gp(?mi.src3)) { ret mi.src3.size; }
+    ret 0;
+}
+
+# the first vector-bank register operand's width, 0 when none
+fun fp_width(mi: *isa.Inst) u8 {
+    if (is_vec(?mi.dst))  { ret mi.dst.size; }
+    if (is_vec(?mi.src1)) { ret mi.src1.size; }
+    if (is_vec(?mi.src2)) { ret mi.src2.size; }
+    ret 0;
+}
+
+# the register a load or store moves: dst for a load, src1 for a store
+fun data_operand(mi: *isa.Inst) *isa.Operand {
+    if (layout(mi.opcode::MachOp) == L_STXR) { ret ?mi.src1; }
+    if (mi.dst.kind == isa.OPK_REG) { ret ?mi.dst; }
+    ret ?mi.src1;
+}
+
+fun log2_bytes(w: u8) u32 {
+    if (w == 2)  { ret 1; }
+    if (w == 4)  { ret 2; }
+    if (w == 8)  { ret 3; }
+    if (w == 16) { ret 4; }
+    ret 0;
+}
+
+val SF:      u32 = 0x80000000;
+val BFM_N:   u32 = 0x00400000;
+val FTYPE_D: u32 = 0x00400000;
+val FCVT_TO_D: u32 = 0x00008000;
+val LDST_V:  u32 = 0x04000000;
+val LDST_Q_OPC: u32 = 0x00800000;
+val LDP_X:   u32 = 0x80000000;
+val LDP_D:   u32 = 0x44000000;
+val FMOV_GEN_TO_FP: u32 = 0x00010000;
+
+# the base word with the operand widths applied: the row's rule names which
+# operands the size bits come from
+pub fun base_word(mi: *isa.Inst) u32 {
+    val f: *Form = form(mi.opcode::MachOp);
+    var w: u32 = f.base;
+    val rule: WidthRule = f.width;
+    if (rule == W_SF || rule == W_SF_N) {
+        if (gp_width(mi) == 8) { w = w | SF; }
+        if (rule == W_SF_N && gp_width(mi) == 8) { w = w | BFM_N; }
+        ret w;
+    }
+    if (rule == W_FTYPE) {
+        if (fp_width(mi) == 8) { w = w | FTYPE_D; }
+        ret w;
+    }
+    if (rule == W_SF_FTYPE || rule == W_FMOV_GEN) {
+        if (gp_width(mi) == 8) { w = w | SF; }
+        if (fp_width(mi) == 8) { w = w | FTYPE_D; }
+        if (rule == W_FMOV_GEN && is_vec(?mi.dst)) { w = w | FMOV_GEN_TO_FP; }
+        ret w;
+    }
+    if (rule == W_FCVT) {
+        if (mi.src1.size == 8) { w = w | FTYPE_D; }
+        if (mi.dst.size == 8)  { w = w | FCVT_TO_D; }
+        ret w;
+    }
+    if (rule == W_SIZE) {
+        val d: *isa.Operand = data_operand(mi);
+        w = w | ((log2_bytes(d.size) & 3) << 30);
+        if (d.size == 16) { w = w | LDST_Q_OPC; }
+        if (is_vec(d))    { w = w | LDST_V; }
+        ret w;
+    }
+    if (rule == W_SIZE30) {
+        if (data_operand(mi).size == 8) { w = w | 0x40000000; }
+        ret w;
+    }
+    if (rule == W_LDP) {
+        val d: *isa.Operand = data_operand(mi);
+        if (d.size == 8) {
+            if (is_vec(d)) { w = w | LDP_D; }
+            or             { w = w | LDP_X; }
+        }
+        ret w;
+    }
+    ret w;
+}
+
+val LDST_OFF_MODE: u32 = 0x01000000;
+val LDST_REG_MODE: u32 = 0x00206800;
+val LDP_OFF_MODE:  u32 = 0x01000000;
+val LDP_PRE_MODE:  u32 = 0x01800000;
+val LDP_POST_MODE: u32 = 0x00800000;
+val ALU_EXT_SP:    u32 = 0x00206000;
+
+# the bytes a load/store's immediate offset is scaled by
+fun access_bytes(op: MachOp, data: *isa.Operand) u32 {
+    if (op == LDRB || op == STRB) { ret 1; }
+    if (op == LDRH || op == STRH) { ret 2; }
+    ret data.size::u32;
+}
+
+fun neon_size(f: *Form, flags: u16) u32 {
+    val eb: u8 = elem_bytes(flags);
+    if (f.lane == LANE_BITS) { ret 0; }
+    if (f.lane == LANE_FLOAT) {
+        if (eb == 8) { ret 1; }
+        ret 0;
+    }
+    ret log2_bytes(eb);
+}
+
+fun neon_imm5(size: u32, index: u32) u32 {
+    ret (index << (size + 1)) | (1 << size);
+}
+
+fun bitfield_fields(op: MachOp, wbits: u32, a: u32, b: u32, immr: *u32, imms: *u32) {
+    if (op == LSL)                { @immr = (wbits - a) & (wbits - 1); @imms = wbits - 1 - a; ret; }
+    if (op == LSR || op == ASR)   { @immr = a; @imms = wbits - 1; ret; }
+    if (op == UXTB || op == SXTB) { @immr = 0; @imms = 7; ret; }
+    if (op == UXTH || op == SXTH) { @immr = 0; @imms = 15; ret; }
+    if (op == SXTW)               { @immr = 0; @imms = 31; ret; }
+    if (op == UBFIZ || op == SBFIZ) { @immr = (wbits - a) & (wbits - 1); @imms = b - 1; ret; }
+    @immr = a;
+    @imms = a + b - 1;
+}
+
+# the instruction word of a notification-shaped instruction: the row's base
+# word with the widths applied and the operands packed by the layout. the
+# operands are the assembler's, so an alias member (never assembled) and a
+# member whose row cannot hold the operands it was given assemble to none
+pub fun assemble(mi: *isa.Inst) u32 {
+    val op: MachOp = mi.opcode::MachOp;
+    val f: *Form = form(op);
+    if (f.alias || f.base == 0) { ret 0; }
+    val lay: Layout = f.layout;
+    val rd: u32 = reg_n(?mi.dst);
+    val rn: u32 = reg_n(?mi.src1);
+    val rm: u32 = reg_n(?mi.src2);
+
+    if (lay == L_ALU3) {
+        if (mi.src2.kind == isa.OPK_IMM || mi.src2.kind == isa.OPK_SYM) {
+            if (f.base_imm == 0) { ret 0; }
+            var imm12: u32 = 0;
+            if (mi.src2.kind == isa.OPK_IMM) { imm12 = mi.src2.imm::u32 & 0xFFF; }
+            var sh: u32 = 0;
+            if (mi.src3.kind == isa.OPK_IMM && mi.src3.imm == 12) { sh = 1; }
+            var w: u32 = f.base_imm;
+            if (gp_width(mi) == 8) { w = w | SF; }
+            ret w | (sh << 22) | (imm12 << 10) | (rn << 5) | rd;
+        }
+        var w: u32 = base_word(mi);
+        if ((mi.flags & FLAG_SP) != 0 && (op == ADD || op == SUB)) { w = w | ALU_EXT_SP; }
+        or (mi.src3.kind == isa.OPK_IMM) { w = w | ((mi.src3.imm::u32 & 0x3F) << 10); }
+        ret w | (rm << 16) | (rn << 5) | rd;
+    }
+    if (lay == L_BITFIELD) {
+        var wbits: u32 = 32;
+        if (mi.dst.size == 8) { wbits = 64; }
+        var immr: u32 = 0;
+        var imms: u32 = 0;
+        bitfield_fields(op, wbits, mi.src2.imm::u32, mi.src3.imm::u32, ?immr, ?imms);
+        ret base_word(mi) | ((immr & 0x3F) << 16) | ((imms & 0x3F) << 10) | (rn << 5) | rd;
+    }
+    if (lay == L_MOVEWIDE) {
+        var hw: u32 = 0;
+        if (mi.src3.kind == isa.OPK_IMM) { hw = (mi.src3.imm::u32 / 16) & 0x3; }
+        ret base_word(mi) | (hw << 21) | ((mi.src2.imm::u32 & 0xFFFF) << 5) | rd;
+    }
+    if (lay == L_FMOV_IMM) {
+        ret base_word(mi) | ((mi.src2.imm::u32 & 0xFF) << 13) | rd;
+    }
+    if (lay == L_MADD) {
+        ret base_word(mi) | (rm << 16) | (reg_n(?mi.src3) << 10) | (rn << 5) | rd;
+    }
+    if (lay == L_CSET) {
+        ret base_word(mi) | (((cond_of(mi.flags) ^ 1) & 0xF) << 12) | rd;
+    }
+    if (lay == L_LDST || lay == L_LDUR || lay == L_LDORD) {
+        val data: *isa.Operand = data_operand(mi);
+        var mem: *isa.Operand = ?mi.src1;
+        if (mi.dst.kind == isa.OPK_MEM) { mem = ?mi.dst; }
+        val rt: u32 = reg_n(data);
+        val base: u32 = mem_base_n(mem);
+        val w: u32 = base_word(mi);
+        if (lay == L_LDORD) { ret w | (base << 5) | rt; }
+        if (lay == L_LDUR)  { ret w | ((mem.disp::u32 & 0x1FF) << 12) | (base << 5) | rt; }
+        if (mem.index >= 0) { ret w | LDST_REG_MODE | (mem_index_n(mem) << 16) | (base << 5) | rt; }
+        var imm12: u32 = 0;
+        if (mem.sym_mod == isa.SYM_MOD_NONE) {
+            val scale: u32 = access_bytes(op, data);
+            if (scale != 0) { imm12 = (mem.disp::u32 / scale) & 0xFFF; }
+        }
+        ret w | LDST_OFF_MODE | (imm12 << 10) | (base << 5) | rt;
+    }
+    if (lay == L_STXR) {
+        ret base_word(mi) | (rd << 16) | (mem_base_n(?mi.src2) << 5) | rn;
+    }
+    if (lay == L_LDSTP) {
+        var mem: *isa.Operand = ?mi.src2;
+        var rt: u32 = rd;
+        var rt2: u32 = rn;
+        if (mi.dst.kind == isa.OPK_MEM) { mem = ?mi.dst; rt = rn; rt2 = rm; }
+        var mode: u32 = LDP_OFF_MODE;
+        if ((mi.flags & FLAG_WB_PRE) != 0)  { mode = LDP_PRE_MODE; }
+        if ((mi.flags & FLAG_WB_POST) != 0) { mode = LDP_POST_MODE; }
+        val imm7: u32 = ((mem.disp / 8)::u32) & 0x7F;
+        ret base_word(mi) | mode | (imm7 << 15) | (rt2 << 10) | (mem_base_n(mem) << 5) | rt;
+    }
+    if (lay == L_NEON_3SAME) {
+        ret f.base | (neon_size(f, mi.flags) << 22) | (rm << 16) | (rn << 5) | rd;
+    }
+    if (lay == L_NEON_2MISC) {
+        ret f.base | (rn << 5) | rd;
+    }
+    if (lay == L_NEON_LANE_RD) {
+        val size: u32 = log2_bytes(elem_bytes(mi.flags));
+        ret base_word(mi) | ((neon_imm5(size, mi.src2.imm::u32) & 0x1F) << 16) | (rn << 5) | rd;
+    }
+    if (lay == L_NEON_LANE_WR) {
+        val size: u32 = log2_bytes(elem_bytes(mi.flags));
+        var w: u32 = f.base | ((neon_imm5(size, mi.src2.imm::u32) & 0x1F) << 16) | (rn << 5) | rd;
+        if (op == INS_EL) { w = w | (((mi.src3.imm::u32 << size) & 0xF) << 11); }
+        ret w;
+    }
+    if (lay == L_BRANCH) {
+        var w: u32 = base_word(mi) | rn;
+        if (op == BCOND) { w = w | cond_of(mi.flags); }
+        if ((mi.flags & FLAG_LABEL_SKIP) != 0) {
+            w = w | ((((mi.src2.disp / 4)::u32) & 0x7FFFF) << 5);
+        }
+        ret w;
+    }
+    if (lay == L_BRANCH_REG) {
+        var target: u32 = rn;
+        if (mi.src1.kind != isa.OPK_REG) { target = 30; }
+        ret f.base | (target << 5);
+    }
+    if (lay == L_ADRP)   { ret f.base | rd; }
+    if (lay == L_NULLARY) { ret f.base; }
+    if (lay == L_IMM16)  { ret f.base | ((mi.src1.imm::u32 & 0xFFFF) << 5); }
+    if (lay == L_BARRIER) { ret f.base | ((mi.src1.imm::u32 & 0xF) << 8); }
+    if (lay == L_SYSREG) {
+        if (mi.src2.kind == isa.OPK_IMM) {
+            val fld: u32 = mi.src1.imm::u32;
+            ret f.base_imm | (((fld >> 3) & 0x7) << 16) | ((mi.src2.imm::u32 & 0xF) << 8) | ((fld & 0x7) << 5);
+        }
+        val packed: u32 = mi.src1.imm::u32;
+        var rt: u32 = rd;
+        if (mi.src2.kind == isa.OPK_REG) { rt = rm; }
+        ret f.base | (((packed >> 16) & 0x1) << 19) | (((packed >> 12) & 0x7) << 16)
+                   | (((packed >> 8) & 0xF) << 12) | (((packed >> 4) & 0xF) << 8)
+                   | ((packed & 0x7) << 5) | rt;
+    }
+    ret 0;
+}
+
+# the value of a move-wide fold as the register holds it: a 32-bit pattern
+# with its top bit set is negative at that width
+pub fun signed_at_width(v: u64, wide: bool) i64 {
+    if (wide) { ret v::i64; }
+    if ((v & 0x80000000) != 0) { ret (v::i64) - 0x100000000; }
+    ret v::i64;
+}
+
+# the spelling an assembler reads back for an encoded member: the alias the
+# preferred disassembly uses, with the operands laid out as the alias names
+# them. the encoding member is what `assemble` packs; the notification
+# carries the result of this
+pub fun spell(mi: *isa.Inst) {
+    val op: MachOp = mi.opcode::MachOp;
+    if (op == ORR && is_zero_reg(mi, ?mi.src1) && mi.src2.kind == isa.OPK_REG) {
+        mi.opcode = MOV::u16; mi.src1 = mi.src2; mi.src2 = isa.make_none(); ret;
+    }
+    if (op == SUB && is_zero_reg(mi, ?mi.src1) && mi.src2.kind == isa.OPK_REG) {
+        mi.opcode = NEG::u16; mi.src1 = mi.src2; mi.src2 = isa.make_none(); ret;
+    }
+    if (op == ORN && is_zero_reg(mi, ?mi.src1) && mi.src2.kind == isa.OPK_REG) {
+        mi.opcode = MVN::u16; mi.src1 = mi.src2; mi.src2 = isa.make_none(); ret;
+    }
+    # a flag-setting operation cannot write the stack pointer: index 31 in
+    # its destination is the zero register in both the register and the
+    # immediate form, whatever the flag says about the base position
+    if (op == SUBS && is_gp(?mi.dst) && reg_n(?mi.dst) == 31) {
+        mi.opcode = CMP::u16; mi.dst = isa.make_none(); ret;
+    }
+    if (op == ADDS && is_gp(?mi.dst) && reg_n(?mi.dst) == 31) {
+        mi.opcode = CMN::u16; mi.dst = isa.make_none(); ret;
+    }
+    if (op == ADD && mi.src2.kind == isa.OPK_IMM && mi.src2.imm == 0 && mi.src3.kind == isa.OPK_NONE &&
+        (mi.flags & FLAG_SP) != 0 && (reg_n(?mi.dst) == 31 || reg_n(?mi.src1) == 31)) {
+        mi.opcode = MOV::u16; mi.src2 = isa.make_none(); ret;
+    }
+    if (op == MOVZ) {
+        var sh: i64 = 0;
+        if (mi.src3.kind == isa.OPK_IMM) { sh = mi.src3.imm; }
+        if (mi.src2.imm != 0 || sh == 0) {
+            var v: u64 = mi.src2.imm::u64 << sh::u64;
+            if (mi.dst.size != 8) { v = v & 0xFFFFFFFF; }
+            mi.opcode = MOV::u16;
+            mi.src1   = isa.make_imm(signed_at_width(v, mi.dst.size == 8), mi.dst.size);
+            mi.src2   = isa.make_none();
+            mi.src3   = isa.make_none();
+        }
+        ret;
+    }
+    if (op == MADD && is_zero_reg(mi, ?mi.src3)) { mi.opcode = MUL::u16;  mi.src3 = isa.make_none(); ret; }
+    if (op == MSUB && is_zero_reg(mi, ?mi.src3)) { mi.opcode = MNEG::u16; mi.src3 = isa.make_none(); ret; }
+    if (op == V_ORR && mi.src1.reg == mi.src2.reg) {
+        mi.opcode = V_MOV::u16; mi.src2 = isa.make_none(); ret;
+    }
+    if (op == UMOV && elem_bytes(mi.flags) >= 4) { mi.opcode = MOV_LANE::u16; ret; }
 }
 
 test "mach.lang.target.isa.arm64.inst.mnemonic:every_member_is_named_and_the_catalog_is_closed" {
@@ -304,6 +814,38 @@ test "mach.lang.target.isa.arm64.inst.mnemonic:every_member_is_named_and_the_cat
     if (mnemonic(MOP_NONE) != nil)     { ret 251; }
     if (mnemonic(MOP_LAST + 1) != nil) { ret 252; }
     if (known(MOP_NONE) || known(MOP_LAST + 1)) { ret 253; }
+    if (MOP_COUNT != MOP_LAST::usize + 1) { ret 254; }
+    ret 0;
+}
+
+# a row's completeness: an encoded member has a layout and a base word; an
+# alias member has a layout and no base word, and every alias is one `spell`
+# produces. 0 when complete, otherwise the check that failed
+fun t_row_gap(op: MachOp) i32 {
+    val f: *Form = form(op);
+    if (f.layout == L_NONE)                { ret 1; }
+    if (f.alias && f.base != 0)            { ret 2; }
+    if (!f.alias && f.base == 0)           { ret 3; }
+    if (f.alias && f.base_imm != 0)        { ret 4; }
+    val spelled: bool = op == MOV || op == NEG || op == MVN || op == CMP || op == CMN ||
+                        op == V_MOV || op == MOV_LANE;
+    if (f.alias != spelled)                { ret 5; }
+    if (f.base_imm != 0 && f.layout != L_ALU3 && f.layout != L_SYSREG) { ret 6; }
+    if ((f.layout == L_NEON_3SAME || f.layout == L_NEON_2MISC) && f.lane == LANE_NONE) { ret 7; }
+    ret 0;
+}
+
+# the census of the opcode space: every member has a complete row. a member
+# the table forgot fails here by number (the status is the member, offset
+# past the harness codes), not silently at emission
+test "mach.lang.target.isa.arm64.inst.form:every_member_has_a_complete_row" {
+    var op: MachOp = 1;
+    for (op <= MOP_LAST) {
+        if (t_row_gap(op) != 0) { ret 100 + op::i32; }
+        op = op + 1;
+    }
+    if (form(MOP_NONE).layout != L_NONE)     { ret 1; }
+    if (form(MOP_LAST + 1).layout != L_NONE) { ret 2; }
     ret 0;
 }
 
@@ -314,6 +856,99 @@ test "mach.lang.target.isa.arm64.inst.flags:element_width_shares_the_word_with_c
     if ((f & FLAG_WB_PRE) == 0)        { ret 3; }
     if (elem_bytes(with_elem_bytes(f, 0)) != 0) { ret 4; }
     if (elem_bytes(0) != 0)            { ret 5; }
+    if (cond_of(with_cond(f, 13)) != 13 || elem_bytes(with_cond(f, 13)) != 8) { ret 6; }
+    ret 0;
+}
+
+fun t_inst(op: MachOp, dst: isa.Operand, src1: isa.Operand, src2: isa.Operand) isa.Inst {
+    var mi: isa.Inst = isa.inst_blank();
+    mi.opcode = op::u16;
+    mi.dst  = dst;
+    mi.src1 = src1;
+    mi.src2 = src2;
+    ret mi;
+}
+
+# the width rules against the words an assembler produces
+test "mach.lang.target.isa.arm64.inst.assemble:width_rules_reach_the_word" {
+    var mi: isa.Inst = t_inst(ADD, gp(0, 8), gp(1, 8), gp(2, 8));
+    if (assemble(?mi) != 0x8B020020) { ret 1; }
+    mi = t_inst(ADD, gp(0, 4), gp(1, 4), gp(2, 4));
+    if (assemble(?mi) != 0x0B020020) { ret 2; }
+    mi = t_inst(FADD, vec(0, 8), vec(1, 8), vec(2, 8));
+    if (assemble(?mi) != 0x1E622820) { ret 3; }
+    mi = t_inst(FADD, vec(0, 4), vec(1, 4), vec(2, 4));
+    if (assemble(?mi) != 0x1E222820) { ret 4; }
+    mi = t_inst(SCVTF, vec(0, 8), gp(1, 4), isa.make_none());
+    if (assemble(?mi) != 0x1E620020) { ret 5; }
+    mi = t_inst(FCVTZS, gp(0, 8), vec(1, 4), isa.make_none());
+    if (assemble(?mi) != 0x9E380020) { ret 6; }
+    mi = t_inst(FCVT, vec(0, 8), vec(1, 4), isa.make_none());
+    if (assemble(?mi) != 0x1E22C020) { ret 7; }
+    mi = t_inst(FCVT, vec(0, 4), vec(1, 8), isa.make_none());
+    if (assemble(?mi) != 0x1E624020) { ret 8; }
+    mi = t_inst(FMOV_GEN, vec(0, 8), gp(1, 8), isa.make_none());
+    if (assemble(?mi) != 0x9E670020) { ret 9; }
+    mi = t_inst(FMOV_GEN, gp(0, 4), vec(1, 4), isa.make_none());
+    if (assemble(?mi) != 0x1E260020) { ret 10; }
+    mi = t_inst(LDR, vec(0, 16), isa.make_mem(gp_id(1), 32, -1, 0, 16), isa.make_none());
+    if (assemble(?mi) != 0x3DC00820) { ret 11; }
+    mi = t_inst(STR, isa.make_mem(gp_id(1), 8, -1, 0, 8), gp(0, 8), isa.make_none());
+    if (assemble(?mi) != 0xF9000420) { ret 12; }
+    mi = t_inst(LDRB, gp(0, 4), isa.make_mem(gp_id(1), 3, -1, 0, 1), isa.make_none());
+    if (assemble(?mi) != 0x39400C20) { ret 13; }
+    mi = t_inst(LDAR, gp(0, 8), isa.make_mem(gp_id(1), 0, -1, 0, 8), isa.make_none());
+    if (assemble(?mi) != 0xC8DFFC20) { ret 14; }
+    mi = t_inst(STP, isa.make_mem(gp_id(31), -16, -1, 0, 8), gp(29, 8), gp(30, 8));
+    mi.flags = FLAG_WB_PRE;
+    if (assemble(?mi) != 0xA9BF7BFD) { ret 15; }
+    mi = t_inst(STP, isa.make_mem(gp_id(29), -32, -1, 0, 8), vec(8, 8), vec(9, 8));
+    if (assemble(?mi) != 0x6D3E27A8) { ret 16; }
+    mi = t_inst(UMOV, gp(3, 8), vec(1, 16), isa.make_imm(1, 1));
+    mi.flags = with_elem_bytes(0, 8);
+    if (assemble(?mi) != 0x4E183C23) { ret 17; }
+    mi = t_inst(LSL, gp(0, 8), gp(3, 8), isa.make_imm(32, 1));
+    if (assemble(?mi) != 0xD3607C60) { ret 18; }
+    mi = t_inst(MOV, gp(0, 8), gp(1, 8), isa.make_none());
+    if (assemble(?mi) != 0) { ret 19; }
+    ret 0;
+}
+
+test "mach.lang.target.isa.arm64.inst.spell:aliases_take_the_assembler_operand_order" {
+    var mi: isa.Inst = t_inst(ORR, gp(3, 8), gp(31, 8), gp(4, 8));
+    spell(?mi);
+    if (mi.opcode != MOV::u16 || mi.src1.reg != gp_id(4) || mi.src2.kind != isa.OPK_NONE) { ret 1; }
+    mi = t_inst(SUBS, gp(31, 8), gp(1, 8), gp(2, 8));
+    spell(?mi);
+    if (mi.opcode != CMP::u16 || mi.dst.kind != isa.OPK_NONE || mi.src1.reg != gp_id(1)) { ret 2; }
+    # the stack pointer is not the zero register: the sp-relative sub stays a sub
+    mi = t_inst(SUB, gp(31, 8), gp(31, 8), gp(16, 8));
+    mi.flags = FLAG_SP;
+    spell(?mi);
+    if (mi.opcode != SUB::u16) { ret 3; }
+    mi = t_inst(ADD, gp(29, 8), gp(31, 8), isa.make_imm(0, 8));
+    mi.flags = FLAG_SP;
+    spell(?mi);
+    if (mi.opcode != MOV::u16 || mi.src2.kind != isa.OPK_NONE) { ret 4; }
+    mi = t_inst(MOVZ, gp(17, 8), isa.make_none(), isa.make_imm(0x8000, 8));
+    mi.src3 = isa.make_imm(48, 1);
+    spell(?mi);
+    if (mi.opcode != MOV::u16 || mi.src1.imm::u64 != 0x8000000000000000 || mi.src2.kind != isa.OPK_NONE) { ret 5; }
+    mi = t_inst(MOVZ, gp(17, 8), isa.make_none(), isa.make_imm(0, 8));
+    mi.src3 = isa.make_imm(16, 1);
+    spell(?mi);
+    if (mi.opcode != MOVZ::u16) { ret 6; }
+    mi = t_inst(MADD, gp(0, 8), gp(1, 8), gp(2, 8));
+    mi.src3 = gp(31, 8);
+    spell(?mi);
+    if (mi.opcode != MUL::u16 || mi.src3.kind != isa.OPK_NONE) { ret 7; }
+    mi = t_inst(UMOV, gp(0, 4), vec(1, 16), isa.make_imm(0, 1));
+    mi.flags = with_elem_bytes(0, 2);
+    spell(?mi);
+    if (mi.opcode != UMOV::u16) { ret 8; }
+    mi.flags = with_elem_bytes(0, 4);
+    spell(?mi);
+    if (mi.opcode != MOV_LANE::u16) { ret 9; }
     ret 0;
 }
 
@@ -432,5 +1067,8 @@ test "mach.lang.target.isa.arm64.inst.mnemonic:spellings_are_the_assembler_mnemo
     if (!str_equals(mnemonic(MOV_LANE), "mov")) { ret 109; }
     if (!str_equals(mnemonic(INS), "mov")) { ret 110; }
     if (!str_equals(mnemonic(DUP), "mov")) { ret 111; }
+    if (!str_equals(mnemonic(FMOV_GEN), "fmov")) { ret 112; }
+    if (!str_equals(mnemonic(FMOV_IMM), "fmov")) { ret 113; }
+    if (!str_equals(mnemonic(INS_EL), "mov")) { ret 114; }
     ret 0;
 }

--- a/src/lang/target/isa/arm64/printer.mach
+++ b/src/lang/target/isa/arm64/printer.mach
@@ -25,92 +25,6 @@ use mach.lang.intern;
 use mach.lang.target.isa;
 use mop: mach.lang.target.isa.arm64.inst;
 
-pub val FORM_ALU3: u8 = 1;
-pub val FORM_ADDSUB_IMM: u8 = 2;
-pub val FORM_BITFIELD: u8 = 3;
-pub val FORM_MOVEWIDE: u8 = 4;
-pub val FORM_MADD: u8 = 5;
-pub val FORM_CSET: u8 = 6;
-pub val FORM_LDST: u8 = 7;
-pub val FORM_LDSTP: u8 = 8;
-pub val FORM_NEON_3SAME: u8 = 9;
-pub val FORM_NEON_2MISC: u8 = 10;
-pub val FORM_BRANCH: u8 = 11;
-pub val FORM_BRANCH_REG: u8 = 12;
-pub val FORM_ADRP: u8 = 13;
-pub val FORM_NULLARY: u8 = 14;
-pub val FORM_IMM16: u8 = 15;
-pub val FORM_BARRIER: u8 = 16;
-pub val FORM_STXR: u8 = 17;
-pub val FORM_NEON_LANE_RD: u8 = 18;
-pub val FORM_NEON_LANE_WR: u8 = 19;
-pub val FORM_SYSREG_IMM: u8 = 20;
-pub val FORM_SYSREG: u8 = 21;
-pub val FORM_FMOV_IMM: u8 = 22;
-
-pub val MOD_NONE: u8 = 0;
-pub val MOD_PCREL_HI: u8 = 1;
-pub val MOD_PCREL_LO: u8 = 2;
-pub val MOD_GOT_HI: u8 = 3;
-pub val MOD_GOT_LO: u8 = 4;
-
-pub val FLAG_COND: u16 = 0x000F;
-pub val FLAG_WB_PRE: u16 = 0x0010;
-pub val FLAG_WB_POST: u16 = 0x0020;
-
-pub val TGT_NONE: u8 = 0;
-pub val TGT_BLOCK: u8 = 1;
-pub val TGT_SYM: u8 = 2;
-pub val TGT_PCREL: u8 = 3;
-pub val TGT_LOCAL_FWD: u8 = 4;
-pub val TGT_LOCAL_BACK: u8 = 5;
-
-pub rec Inst {
-    base:     u32;
-    form:     u8;
-    dst:      isa.Operand;
-    src1:     isa.Operand;
-    src2:     isa.Operand;
-    src3:     isa.Operand;
-    flags:    u16;
-    vec_lane: u32;
-    sym_mod:  u8;
-    target:   u8;
-    block:    u32;
-}
-
-pub fun inst(form: u8, base: u32) Inst {
-    var i: Inst;
-    i.base     = base;
-    i.form     = form;
-    i.dst      = isa.make_none();
-    i.src1     = isa.make_none();
-    i.src2     = isa.make_none();
-    i.src3     = isa.make_none();
-    i.flags    = 0;
-    i.vec_lane = 0;
-    i.sym_mod  = MOD_NONE;
-    i.target   = TGT_NONE;
-    i.block    = 0;
-    ret i;
-}
-
-pub fun none_operand() isa.Operand {
-    ret isa.make_none();
-}
-
-pub fun gp(n: u32, bytes: u8) isa.Operand {
-    ret isa.make_reg(gp_id(n), bytes);
-}
-
-pub fun gp_id(n: u32) i32 {
-    ret isa.regid_make(isa.REG_CLASS_ID_GP, (n & 0x1F)::i32);
-}
-
-pub fun vec(n: u32, bytes: u8) isa.Operand {
-    ret isa.make_reg(isa.regid_make(isa.REG_CLASS_ID_XMM, (n & 0x1F)::i32), bytes);
-}
-
 pub fun note_function(buf: *enc.ByteBuf, interner: *intern.Interner, f: *mir.MirFunction) err[fail.Fail] {
     var note: enc.AsmNote = enc.note_blank();
     note.kind = enc.ASM_NOTE_FUNC;
@@ -145,640 +59,128 @@ pub fun note_block(buf: *enc.ByteBuf, id: u32) err[fail.Fail] {
 
 val INST_BYTES: usize = 4;
 
-# the notification carries the form record translated to an `isa.Inst` in the
-# machine-opcode space; rendering is a separate step that needs a writer
-pub fun note_inst(buf: *enc.ByteBuf, i: *Inst) {
-    val mi: isa.Inst = to_inst(i);
-    if (mi.opcode == mop.MOP_NONE::u16) {
+# the notification carries the instruction the encoder assembled, already
+# spelled as an assembler reads it back; rendering is a separate step that
+# needs a writer
+pub fun note_inst(buf: *enc.ByteBuf, mi: *isa.Inst) {
+    if (!mop.known(mi.opcode::mop.MachOp)) {
         enc.sink_fail(buf, "--emit-asm: an emitted aarch64 instruction has no machine opcode");
         ret;
     }
     var note: enc.AsmNote = enc.note_blank();
     note.off  = (buf.len - INST_BYTES)::u32;
-    note.inst = mi;
+    note.inst = @mi;
     val kept: err[fail.Fail] = enc.note_push(buf, ?note);
     if (sel kept.err) {
         enc.sink_fail(buf, fail.describe(kept.err));
         ret;
     }
     if (!enc.sink_renders(buf)) { ret; }
-    val res_: err[fail.Fail] = render_inst(buf, i);
+    val res_: err[fail.Fail] = render_inst(buf, mi);
     if (sel res_.err) { enc.sink_fail(buf, fail.describe(res_.err)); }
 }
 
-# the machine opcode of a form record: the alias the printer renders, so the
-# opcode names the same instruction an assembler would read back
-pub fun classify(i: *Inst) mop.MachOp {
-    if (i.form == FORM_ALU3)         { ret classify_alu3(i); }
-    if (i.form == FORM_ADDSUB_IMM)   { ret classify_addsub_imm(i); }
-    if (i.form == FORM_BITFIELD)     { ret classify_bitfield(i); }
-    if (i.form == FORM_MOVEWIDE)     { ret classify_movewide(i); }
-    if (i.form == FORM_FMOV_IMM)     { ret mop.FMOV; }
-    if (i.form == FORM_MADD)         { ret classify_madd(i); }
-    if (i.form == FORM_CSET)         { ret classify_cset(i); }
-    if (i.form == FORM_LDST)         { ret classify_ldst(i.base); }
-    if (i.form == FORM_LDSTP)        { ret classify_ldstp(i.base); }
-    if (i.form == FORM_NEON_3SAME)   { ret classify_neon_3same(i); }
-    if (i.form == FORM_NEON_2MISC)   { ret classify_neon_2misc(i.base); }
-    if (i.form == FORM_NEON_LANE_RD) { ret classify_neon_lane_read(i); }
-    if (i.form == FORM_NEON_LANE_WR) { ret mop.INS; }
-    if (i.form == FORM_BRANCH)       { ret classify_branch(i.base); }
-    if (i.form == FORM_BRANCH_REG)   { ret classify_branch_reg(i.base); }
-    if (i.form == FORM_ADRP)         { ret mop.ADRP; }
-    if (i.form == FORM_NULLARY)      { ret classify_nullary(i.base); }
-    if (i.form == FORM_IMM16)        { ret classify_imm16(i.base); }
-    if (i.form == FORM_BARRIER)      { ret classify_barrier(i.base); }
-    if (i.form == FORM_STXR)         { ret classify_stxr(i.base); }
-    if (i.form == FORM_SYSREG_IMM)   { ret classify_sysreg_imm(i.base); }
-    if (i.form == FORM_SYSREG)       { ret classify_sysreg(i.base); }
-    ret mop.MOP_NONE;
-}
-
-# registers are already regids and memory is base/index/disp in the form
-# record; the translation adds the opcode, the operation width and the
-# vector element width, and keeps the fourth register a madd/msub reads
-pub fun to_inst(i: *Inst) isa.Inst {
-    var mi: isa.Inst = isa.inst_blank();
-    mi.opcode = classify(i)::u16;
-    mi.dst    = i.dst;
-    mi.src1   = i.src1;
-    mi.src2   = i.src2;
-    mi.src3   = i.src3;
-    mi.size   = operation_width(i);
-    mi.flags  = i.flags & (mop.FLAG_COND | mop.FLAG_WB_PRE | mop.FLAG_WB_POST);
-    if (i.form == FORM_BRANCH && (i.base & 0xFF000000) == 0x54000000) {
-        mi.flags = (mi.flags & ~mop.FLAG_COND) | ((i.base & 0xF)::u16);
-    }
-    # the target travels with the notification: a block label, or a local
-    # offset (a pcrel skip, a numbered inline-asm label) the walk cannot name
-    if (i.form == FORM_BRANCH) {
-        if (i.target == TGT_BLOCK) {
-            mi.src2  = isa.make_block_label(i.block);
-            mi.flags = mi.flags | mop.FLAG_TARGET_BLOCK;
-        }
-        or (i.target == TGT_PCREL || i.target == TGT_LOCAL_FWD || i.target == TGT_LOCAL_BACK) {
-            val forward: bool = i.target == TGT_LOCAL_FWD || (i.target == TGT_PCREL && i.src2.imm > 0);
-            mi.src2 = isa.make_local_label(forward);
-            if (i.target == TGT_PCREL) { mi.src2.disp = (i.src2.imm * 4)::i32; }
-        }
-    }
-    if (i.vec_lane != 0) {
-        mi.flags = mop.with_elem_bytes(mi.flags, mir.vec_lane_elem_bytes(i.vec_lane));
-    }
-    ret mi;
-}
-
-fun operation_width(i: *Inst) u8 {
-    if (i.dst.kind == isa.OPK_REG)  { ret i.dst.size; }
-    if (i.src1.kind == isa.OPK_REG) { ret i.src1.size; }
-    if (i.src2.kind == isa.OPK_REG) { ret i.src2.size; }
-    if (i.dst.kind == isa.OPK_MEM)  { ret i.dst.size; }
-    if (i.src1.kind == isa.OPK_MEM) { ret i.src1.size; }
-    ret 0;
-}
-
-fun classify_alu3(i: *Inst) mop.MachOp {
-    val base: u32 = i.base;
-    val zero_rn: bool = is_zero_reg(?i.src1) && i.src2.kind == isa.OPK_REG;
-    if (base == 0x8B000000 || base == 0x0B000000) { ret mop.ADD; }
-    if (base == 0xCB000000 || base == 0x4B000000) { if (zero_rn) { ret mop.NEG; } ret mop.SUB; }
-    if (base == 0x8A000000 || base == 0x0A000000) { ret mop.AND; }
-    if (base == 0xAA000000 || base == 0x2A000000) { if (zero_rn) { ret mop.MOV; } ret mop.ORR; }
-    if (base == 0xCA000000 || base == 0x4A000000) { ret mop.EOR; }
-    if (base == 0xAA200000 || base == 0x2A200000) { if (zero_rn) { ret mop.MVN; } ret mop.ORN; }
-    if (base == 0x9B007C00 || base == 0x1B007C00) { ret mop.MUL; }
-    if (base == 0x9AC02000 || base == 0x1AC02000) { ret mop.LSLV; }
-    if (base == 0x9AC02400 || base == 0x1AC02400) { ret mop.LSRV; }
-    if (base == 0x9AC02800 || base == 0x1AC02800) { ret mop.ASRV; }
-    if (base == 0x9AC00C00 || base == 0x1AC00C00) { ret mop.SDIV; }
-    if (base == 0x9AC00800 || base == 0x1AC00800) { ret mop.UDIV; }
-    if (base == 0xEB000000 || base == 0x6B000000) { if (is_zero_reg(?i.dst)) { ret mop.CMP; } ret mop.SUBS; }
-    if (base == 0xCB2063FF)                       { ret mop.SUB; }
-
-    if (base == 0x1E202800 || base == 0x1E602800) { ret mop.FADD; }
-    if (base == 0x1E203800 || base == 0x1E603800) { ret mop.FSUB; }
-    if (base == 0x1E200800 || base == 0x1E600800) { ret mop.FMUL; }
-    if (base == 0x1E201800 || base == 0x1E601800) { ret mop.FDIV; }
-    if (base == 0x1E214000 || base == 0x1E614000) { ret mop.FNEG; }
-    if (base == 0x1E204000 || base == 0x1E604000) { ret mop.FMOV; }
-    if (base == 0x1E22C000 || base == 0x1E624000) { ret mop.FCVT; }
-    if (base == 0x1E202000 || base == 0x1E602000) { ret mop.FCMP; }
-
-    if (base == 0x1E220000 || base == 0x1E620000 ||
-        base == 0x9E220000 || base == 0x9E620000) { ret mop.SCVTF; }
-    if (base == 0x1E230000 || base == 0x1E630000 ||
-        base == 0x9E230000 || base == 0x9E630000) { ret mop.UCVTF; }
-    if (base == 0x1E380000 || base == 0x9E380000 ||
-        base == 0x1E780000 || base == 0x9E780000) { ret mop.FCVTZS; }
-    if (base == 0x1E390000 || base == 0x9E390000 ||
-        base == 0x1E790000 || base == 0x9E790000) { ret mop.FCVTZU; }
-
-    if (base == 0x1E270000 || base == 0x9E670000 ||
-        base == 0x1E260000 || base == 0x9E660000) { ret mop.FMOV; }
-    ret mop.MOP_NONE;
-}
-
-fun classify_addsub_imm(i: *Inst) mop.MachOp {
-    val base: u32 = i.base;
-    val plain_add: bool = base == 0x91000000 || base == 0x11000000;
-    if (plain_add && i.src2.kind == isa.OPK_IMM && i.src2.imm == 0 &&
-        i.src3.kind == isa.OPK_NONE && (is_reg31(?i.dst) || is_reg31(?i.src1))) { ret mop.MOV; }
-    if (plain_add)                                { ret mop.ADD; }
-    if (base == 0xD1000000 || base == 0x51000000) { ret mop.SUB; }
-    if (base == 0xB1000000 || base == 0x31000000) { if (is_zero_reg(?i.dst)) { ret mop.CMN; } ret mop.ADDS; }
-    if (base == 0xF1000000 || base == 0x71000000) { if (is_zero_reg(?i.dst)) { ret mop.CMP; } ret mop.SUBS; }
-    ret mop.MOP_NONE;
-}
-
-fun classify_bitfield(i: *Inst) mop.MachOp {
-    var signed: bool = false;
-    var wide:   bool = false;
-    if (i.base == 0xD3400000)      { wide = true; }
-    or (i.base == 0x53000000)      { }
-    or (i.base == 0x93400000)      { wide = true; signed = true; }
-    or (i.base == 0x13000000)      { signed = true; }
-    or                             { ret mop.MOP_NONE; }
-
-    var width: u32 = 32;
-    if (wide) { width = 64; }
-    val immr: u32 = i.src2.imm::u32;
-    val imms: u32 = i.src3.imm::u32;
-
-    val extend: bool = immr == 0 && (imms == 7 || imms == 15 || (imms == 31 && wide));
-    if (extend && (signed || !wide)) {
-        if (signed) {
-            if (imms == 15) { ret mop.SXTH; }
-            if (imms == 31) { ret mop.SXTW; }
-            ret mop.SXTB;
-        }
-        if (imms == 15) { ret mop.UXTH; }
-        ret mop.UXTB;
-    }
-    if (imms == width - 1) {
-        if (signed) { ret mop.ASR; }
-        ret mop.LSR;
-    }
-    if (!signed && imms + 1 == immr) { ret mop.LSL; }
-    if (signed) {
-        if (imms < immr) { ret mop.SBFIZ; }
-        ret mop.SBFX;
-    }
-    if (imms < immr) { ret mop.UBFIZ; }
-    ret mop.UBFX;
-}
-
-fun movewide_folds(i: *Inst) bool {
-    val keep: bool = i.base == 0xF2800000 || i.base == 0x72800000;
-    val imm16: u64 = i.src2.imm::u64;
-    var sh: u64 = 0;
-    if (i.src3.kind != isa.OPK_NONE) { sh = i.src3.imm::u64; }
-    ret !keep && (imm16 != 0 || sh == 0);
-}
-
-fun classify_movewide(i: *Inst) mop.MachOp {
-    if (i.base == 0xD2800000 || i.base == 0x52800000) {
-        if (movewide_folds(i)) { ret mop.MOV; }
-        ret mop.MOVZ;
-    }
-    if (i.base == 0xF2800000 || i.base == 0x72800000) { ret mop.MOVK; }
-    ret mop.MOP_NONE;
-}
-
-fun classify_madd(i: *Inst) mop.MachOp {
-    val degenerate: bool = is_zero_reg(?i.src3);
-    if (i.base == 0x9B000000 || i.base == 0x1B000000) { if (degenerate) { ret mop.MUL; } ret mop.MADD; }
-    if (i.base == 0x9B008000 || i.base == 0x1B008000) { if (degenerate) { ret mop.MNEG; } ret mop.MSUB; }
-    ret mop.MOP_NONE;
-}
-
-fun classify_cset(i: *Inst) mop.MachOp {
-    if (i.base != 0x9A800400 && i.base != 0x1A800400) { ret mop.MOP_NONE; }
-    if (cond_name((i.flags & FLAG_COND)::u32 ^ 1) == nil) { ret mop.MOP_NONE; }
-    ret mop.CSET;
-}
-
-fun classify_ldst(base: u32) mop.MachOp {
-    if (base == 0x39400000 || base == 0x38606800) { ret mop.LDRB; }
-    if (base == 0x39000000 || base == 0x38206800) { ret mop.STRB; }
-    if (base == 0x79400000 || base == 0x78606800) { ret mop.LDRH; }
-    if (base == 0x79000000 || base == 0x78206800) { ret mop.STRH; }
-    if (base == 0xB9400000 || base == 0xF9400000 || base == 0xFD400000 ||
-        base == 0xBD400000 || base == 0x3DC00000 || base == 0xB8606800 ||
-        base == 0xF8606800 || base == 0xFC606800 || base == 0xBC606800 ||
-        base == 0x3CE06800 ||
-        base == 0x3D400000 || base == 0x7D400000 ||
-        base == 0x3C606800 || base == 0x7C606800) { ret mop.LDR; }
-    if (base == 0xB9000000 || base == 0xF9000000 || base == 0xFD000000 ||
-        base == 0xBD000000 || base == 0x3D800000 || base == 0xB8206800 ||
-        base == 0xF8206800 || base == 0xFC206800 || base == 0xBC206800 ||
-        base == 0x3CA06800 ||
-        base == 0x3D000000 || base == 0x7D000000 ||
-        base == 0x3C206800 || base == 0x7C206800) { ret mop.STR; }
-    if (base == 0x38400000)                       { ret mop.LDURB; }
-    if (base == 0x38000000)                       { ret mop.STURB; }
-    if (base == 0x78400000)                       { ret mop.LDURH; }
-    if (base == 0x78000000)                       { ret mop.STURH; }
-    if (base == 0xB8400000 || base == 0xF8400000 || base == 0xFC400000 ||
-        base == 0xBC400000 || base == 0x3CC00000 ||
-        base == 0x3C400000 || base == 0x7C400000) { ret mop.LDUR; }
-    if (base == 0xB8000000 || base == 0xF8000000 || base == 0xFC000000 ||
-        base == 0xBC000000 || base == 0x3C800000 ||
-        base == 0x3C000000 || base == 0x7C000000) { ret mop.STUR; }
-    if (base == 0xC8DFFC00 || base == 0x88DFFC00) { ret mop.LDAR; }
-    if (base == 0xC89FFC00 || base == 0x889FFC00) { ret mop.STLR; }
-    if (base == 0xC85FFC00 || base == 0x885FFC00) { ret mop.LDAXR; }
-    ret mop.MOP_NONE;
-}
-
-pub fun ldst_loads(op: mop.MachOp) bool {
-    ret op == mop.LDR || op == mop.LDRB || op == mop.LDRH || op == mop.LDUR ||
-        op == mop.LDURB || op == mop.LDURH || op == mop.LDAR || op == mop.LDAXR || op == mop.LDP;
-}
-
-fun classify_ldstp(base: u32) mop.MachOp {
-    if (base == 0xA9800000 || base == 0xA8800000 ||
-        base == 0xA9000000 || base == 0x6D000000) { ret mop.STP; }
-    if (base == 0xA9C00000 || base == 0xA8C00000 ||
-        base == 0xA9400000 || base == 0x6D400000) { ret mop.LDP; }
-    ret mop.MOP_NONE;
-}
-
-fun classify_neon_3same(i: *Inst) mop.MachOp {
-    val base: u32 = i.base;
-    if (base == 0x4E20D400) { ret mop.V_FADD; }
-    if (base == 0x4EA0D400) { ret mop.V_FSUB; }
-    if (base == 0x6E20DC00) { ret mop.V_FMUL; }
-    if (base == 0x6E20FC00) { ret mop.V_FDIV; }
-    if (base == 0x4E208400) { ret mop.V_ADD; }
-    if (base == 0x6E208400) { ret mop.V_SUB; }
-    if (base == 0x4E209C00) { ret mop.V_MUL; }
-    if (base == 0x4E201C00) { ret mop.V_AND; }
-    if (base == 0x4EA01C00) { if (i.src1.reg == i.src2.reg) { ret mop.V_MOV; } ret mop.V_ORR; }
-    if (base == 0x6E201C00) { ret mop.V_EOR; }
-    if (base == 0x6E208C00) { ret mop.V_CMEQ; }
-    if (base == 0x4E203400) { ret mop.V_CMGT; }
-    if (base == 0x4E203C00) { ret mop.V_CMGE; }
-    if (base == 0x6E203400) { ret mop.V_CMHI; }
-    if (base == 0x6E203C00) { ret mop.V_CMHS; }
-    if (base == 0x4E20E400) { ret mop.V_FCMEQ; }
-    if (base == 0x6EA0E400) { ret mop.V_FCMGT; }
-    if (base == 0x6E20E400) { ret mop.V_FCMGE; }
-    ret mop.MOP_NONE;
-}
-
-fun classify_neon_2misc(base: u32) mop.MachOp {
-    if (base == 0x6E205800) { ret mop.V_MVN; }
-    ret mop.MOP_NONE;
-}
-
-fun classify_neon_lane_read(i: *Inst) mop.MachOp {
-    if (isa.regid_class(i.dst.reg) == isa.REG_CLASS_ID_XMM) { ret mop.DUP; }
-    if (mir.vec_lane_elem_bytes(i.vec_lane) < 4) { ret mop.UMOV; }
-    ret mop.MOV_LANE;
-}
-
-fun classify_branch(base: u32) mop.MachOp {
-    if (base == 0x14000000) { ret mop.B; }
-    if (base == 0x94000000) { ret mop.BL; }
-    if (base == 0xB5000000 || base == 0x35000000) { ret mop.CBNZ; }
-    if (base == 0xB4000000 || base == 0x34000000) { ret mop.CBZ; }
-    if ((base & 0xFF000000) == 0x54000000) {
-        if (cond_name(base & 0xF) == nil) { ret mop.MOP_NONE; }
-        ret mop.BCOND;
-    }
-    ret mop.MOP_NONE;
-}
-
-fun classify_branch_reg(base: u32) mop.MachOp {
-    if (base == 0xD63F0000) { ret mop.BLR; }
-    if (base == 0xD61F0000) { ret mop.BR; }
-    if (base == 0xD65F0000) { ret mop.RET; }
-    ret mop.MOP_NONE;
-}
-
-fun classify_nullary(base: u32) mop.MachOp {
-    if (base == 0xD65F03C0) { ret mop.RET; }
-    if (base == 0xD503201F) { ret mop.NOP; }
-    if (base == 0xD503203F) { ret mop.YIELD; }
-    if (base == 0xD503205F) { ret mop.WFE; }
-    if (base == 0xD503207F) { ret mop.WFI; }
-    ret mop.MOP_NONE;
-}
-
-fun classify_imm16(base: u32) mop.MachOp {
-    if (base == 0xD4200000) { ret mop.BRK; }
-    if (base == 0xD4000001) { ret mop.SVC; }
-    if (base == 0xD4000002) { ret mop.HVC; }
-    if (base == 0xD4000003) { ret mop.SMC; }
-    ret mop.MOP_NONE;
-}
-
-fun classify_barrier(base: u32) mop.MachOp {
-    if (base == 0xD50330BF) { ret mop.DMB; }
-    ret mop.MOP_NONE;
-}
-
-fun classify_stxr(base: u32) mop.MachOp {
-    if (base == 0xC800FC00 || base == 0x8800FC00) { ret mop.STLXR; }
-    ret mop.MOP_NONE;
-}
-
-fun classify_sysreg_imm(base: u32) mop.MachOp {
-    if (base == 0xD500401F) { ret mop.MSR; }
-    ret mop.MOP_NONE;
-}
-
-fun classify_sysreg(base: u32) mop.MachOp {
-    if (base == 0xD5300000) { ret mop.MRS; }
-    if (base == 0xD5100000) { ret mop.MSR; }
-    ret mop.MOP_NONE;
-}
-
-fun render_inst(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
+fun render_inst(buf: *enc.ByteBuf, mi: *isa.Inst) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
     val res_indent: err[fail.Fail] = emit_str(out, "  ");
     if (sel res_indent.err) { ret res_indent; }
-    val res_body: err[fail.Fail] = render_body(buf, i);
+    val res_body: err[fail.Fail] = render_body(buf, mi);
     if (sel res_body.err) { ret res_body; }
     ret emit_str(out, "\n");
 }
 
-fun render_body(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
+# the line is the member's spelling and its operands in the layout the
+# member's row names
+fun render_body(buf: *enc.ByteBuf, mi: *isa.Inst) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
-    if (i.form == FORM_ALU3)        { ret render_alu3(buf, i); }
-    if (i.form == FORM_ADDSUB_IMM)  { ret render_addsub_imm(buf, i); }
-    if (i.form == FORM_BITFIELD)    { ret render_bitfield(buf, i); }
-    if (i.form == FORM_MOVEWIDE)    { ret render_movewide(buf, i); }
-    if (i.form == FORM_FMOV_IMM)    { ret render_fmov_imm(buf, i); }
-    if (i.form == FORM_MADD)        { ret render_madd(buf, i); }
-    if (i.form == FORM_CSET)        { ret render_cset(buf, i); }
-    if (i.form == FORM_LDST)        { ret render_ldst(buf, i); }
-    if (i.form == FORM_LDSTP)       { ret render_ldstp(buf, i); }
-    if (i.form == FORM_NEON_3SAME)  { ret render_neon_3same(buf, i); }
-    if (i.form == FORM_NEON_2MISC)  { ret render_neon_2misc(buf, i); }
-    if (i.form == FORM_NEON_LANE_RD) { ret render_neon_lane_read(buf, i); }
-    if (i.form == FORM_NEON_LANE_WR) { ret render_neon_lane_write(buf, i); }
-    if (i.form == FORM_BRANCH)      { ret render_branch(buf, i); }
-    if (i.form == FORM_BRANCH_REG)  { ret render_branch_reg(buf, i); }
-    if (i.form == FORM_ADRP)        { ret render_adrp(buf, i); }
-    if (i.form == FORM_NULLARY)     { ret render_nullary(out, i); }
-    if (i.form == FORM_IMM16)       { ret render_imm16(buf, i); }
-    if (i.form == FORM_BARRIER)     { ret render_barrier(out, i); }
-    if (i.form == FORM_STXR)        { ret render_stxr(buf, i); }
-    if (i.form == FORM_SYSREG_IMM)  { ret render_sysreg_imm(out, i); }
-    if (i.form == FORM_SYSREG)      { ret render_sysreg(out, i); }
+    val op: mop.MachOp = mi.opcode::mop.MachOp;
+    val lay: mop.Layout = mop.layout(op);
+    if (lay == mop.L_ALU3 || lay == mop.L_MADD || lay == mop.L_BITFIELD || lay == mop.L_ADRP ||
+        lay == mop.L_BRANCH_REG || lay == mop.L_STXR || lay == mop.L_LDST || lay == mop.L_LDUR ||
+        lay == mop.L_LDORD || lay == mop.L_LDSTP) {
+        ret render_operands(buf, mi);
+    }
+    if (lay == mop.L_MOVEWIDE)     { ret render_movewide(buf, mi); }
+    if (lay == mop.L_FMOV_IMM)     { ret render_fmov_imm(buf, mi); }
+    if (lay == mop.L_CSET)         { ret render_cset(buf, mi); }
+    if (lay == mop.L_NEON_3SAME)   { ret render_neon_3same(buf, mi); }
+    if (lay == mop.L_NEON_2MISC)   { ret render_neon_2misc(buf, mi); }
+    if (lay == mop.L_NEON_LANE_RD) { ret render_neon_lane_read(buf, mi); }
+    if (lay == mop.L_NEON_LANE_WR) { ret render_neon_lane_write(buf, mi); }
+    if (lay == mop.L_BRANCH)       { ret render_branch(buf, mi); }
+    if (lay == mop.L_NULLARY)      { ret emit_str(out, mop.mnemonic(op)); }
+    if (lay == mop.L_IMM16)        { ret render_imm16(buf, mi); }
+    if (lay == mop.L_BARRIER)      { ret render_barrier(out, mi); }
+    if (lay == mop.L_SYSREG)       { ret render_sysreg(out, mi); }
     ret err[fail.Fail].err{fail.message("--emit-asm: an emitted aarch64 instruction has no renderable form")};
 }
 
-fun render_alu3(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
+# the mnemonic and every present operand in position order, a shift
+# immediate in src3 as its `lsl` suffix and the bitfield immediates in decimal
+fun render_operands(buf: *enc.ByteBuf, mi: *isa.Inst) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
-    val op: mop.MachOp = classify_alu3(i);
-    if (op == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted three-register base word")};
-    }
-    val drop_rn:  bool = op == mop.MOV || op == mop.NEG || op == mop.MVN;
-    val drop_dst: bool = op == mop.CMP;
-
+    val op: mop.MachOp = mi.opcode::mop.MachOp;
+    val lay: mop.Layout = mop.layout(op);
     val rw: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
     if (sel rw.err) { ret rw; }
-
-    val sp: bool = i.base == 0xCB2063FF;
-
+    # a store names the memory it writes last, after the data it stores
+    val store: bool = mi.dst.kind == isa.OPK_MEM;
     var n: u32 = 0;
-    if (!drop_dst) {
-        val rd: res[u32, fail.Fail] = render_slot(buf, i, ?i.dst, n, sp);
+    if (!store) {
+        val rd: res[u32, fail.Fail] = render_slot(buf, mi, ?mi.dst, n);
         if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
         n = rd.ok;
     }
-    if (!drop_rn) {
-        val rn: res[u32, fail.Fail] = render_slot(buf, i, ?i.src1, n, sp);
-        if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
-        n = rn.ok;
-    }
-    val rm: res[u32, fail.Fail] = render_slot(buf, i, ?i.src2, n, false);
+    val rn: res[u32, fail.Fail] = render_slot(buf, mi, ?mi.src1, n);
+    if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
+    n = rn.ok;
+    val rm: res[u32, fail.Fail] = render_slot(buf, mi, ?mi.src2, n);
     if (sel rm.err) { ret err[fail.Fail].err{rm.err}; }
-
-    if (i.src3.kind == isa.OPK_NONE) { ret err[fail.Fail].ok{}; }
-    ret emit_shift(out, ?i.src3);
-}
-
-fun render_addsub_imm(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
-    val out: *writer.Writer = buf.asm.out;
-    val op: mop.MachOp = classify_addsub_imm(i);
-    if (op == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted add/sub-immediate base word")};
+    n = rm.ok;
+    if (mi.src3.kind != isa.OPK_NONE) {
+        if (lay == mop.L_ALU3 && mi.src3.kind == isa.OPK_IMM) { ret emit_shift(out, ?mi.src3); }
+        val r3: res[u32, fail.Fail] = render_slot(buf, mi, ?mi.src3, n);
+        if (sel r3.err) { ret err[fail.Fail].err{r3.err}; }
+        n = r3.ok;
     }
-    val flags: bool = op == mop.ADDS || op == mop.SUBS || op == mop.CMN || op == mop.CMP;
-
-    if (op == mop.MOV) {
-        val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
-        if (sel rm.err) { ret rm; }
-        val rd: res[u32, fail.Fail] = render_slot(buf, i, ?i.dst, 0, true);
-        if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
-        val rn: res[u32, fail.Fail] = render_slot(buf, i, ?i.src1, 1, true);
-        if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
-        ret err[fail.Fail].ok{};
-    }
-
-    val drop_dst: bool = op == mop.CMP || op == mop.CMN;
-    val rw: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
-    if (sel rw.err) { ret rw; }
-    var n: u32 = 0;
-    if (!drop_dst) {
-        val rd: res[u32, fail.Fail] = render_slot(buf, i, ?i.dst, n, !flags);
-        if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
-        n = rd.ok;
-    }
-    val rn: res[u32, fail.Fail] = render_slot(buf, i, ?i.src1, n, true);
-    if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
-    n = rn.ok;
-    val ri: res[u32, fail.Fail] = render_slot(buf, i, ?i.src2, n, false);
-    if (sel ri.err) { ret err[fail.Fail].err{ri.err}; }
-
-    if (i.src3.kind == isa.OPK_NONE) { ret err[fail.Fail].ok{}; }
-    ret emit_shift(out, ?i.src3);
-}
-
-fun render_bitfield(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
-    val out: *writer.Writer = buf.asm.out;
-    val op: mop.MachOp = classify_bitfield(i);
-    if (op == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted bitfield base word")};
-    }
-    val wide: bool = i.base == 0xD3400000 || i.base == 0x93400000;
-    var width: u32 = 32;
-    if (wide) { width = 64; }
-    val immr: u32 = i.src2.imm::u32;
-    val imms: u32 = i.src3.imm::u32;
-
-    if (op == mop.UXTB || op == mop.UXTH || op == mop.SXTB || op == mop.SXTH || op == mop.SXTW) {
-        val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
-        if (sel rm.err) { ret rm; }
-        val rd: res[u32, fail.Fail] = render_slot(buf, i, ?i.dst, 0, false);
-        if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
-        var src: isa.Operand = i.src1;
-        src.size = 4;
-        ret emit_sep_operand(buf, i, ?src, 1, false);
-    }
-    if (op == mop.LSR || op == mop.ASR) { ret render_shift_alias(buf, i, mop.mnemonic(op), immr); }
-    if (op == mop.LSL)                  { ret render_shift_alias(buf, i, mop.mnemonic(op), width - 1 - imms); }
-
-    var lsb: u32 = immr;
-    var len: u32 = imms - immr + 1;
-    if (op == mop.UBFIZ || op == mop.SBFIZ) {
-        lsb = width - immr;
-        len = imms + 1;
-    }
-
-    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
-    if (sel rm.err) { ret rm; }
-    val rd: res[u32, fail.Fail] = render_slot(buf, i, ?i.dst, 0, false);
+    if (!store) { ret err[fail.Fail].ok{}; }
+    val rd: res[u32, fail.Fail] = render_slot(buf, mi, ?mi.dst, n);
     if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
-    val rn: res[u32, fail.Fail] = render_slot(buf, i, ?i.src1, 1, false);
-    if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
-    val rl: err[fail.Fail] = emit_str(out, ", ");
-    if (sel rl.err) { ret rl; }
-    val rv: err[fail.Fail] = emit_dec_imm(out, lsb::i64);
-    if (sel rv.err) { ret rv; }
-    val rc: err[fail.Fail] = emit_str(out, ", ");
-    if (sel rc.err) { ret rc; }
-    ret emit_dec_imm(out, len::i64);
-}
-
-fun render_shift_alias(buf: *enc.ByteBuf, i: *Inst, mnem: str, sh: u32) err[fail.Fail] {
-    val out: *writer.Writer = buf.asm.out;
-    val rm: err[fail.Fail] = emit_str(out, mnem);
-    if (sel rm.err) { ret rm; }
-    val rd: res[u32, fail.Fail] = render_slot(buf, i, ?i.dst, 0, false);
-    if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
-    val rn: res[u32, fail.Fail] = render_slot(buf, i, ?i.src1, 1, false);
-    if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
-    val rc: err[fail.Fail] = emit_str(out, ", ");
-    if (sel rc.err) { ret rc; }
-    ret emit_dec_imm(out, sh::i64);
-}
-
-fun render_movewide(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
-    val out: *writer.Writer = buf.asm.out;
-    val op: mop.MachOp = classify_movewide(i);
-    if (op == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted move-wide base word")};
-    }
-    val wide: bool = i.base == 0xD2800000 || i.base == 0xF2800000;
-    val imm16: u64 = i.src2.imm::u64;
-    var sh: u64 = 0;
-    if (i.src3.kind != isa.OPK_NONE) { sh = i.src3.imm::u64; }
-
-    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
-    if (sel rm.err) { ret rm; }
-    val rd: res[u32, fail.Fail] = render_slot(buf, i, ?i.dst, 0, false);
-    if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
-    val rc: err[fail.Fail] = emit_str(out, ", ");
-    if (sel rc.err) { ret rc; }
-
-    if (op == mop.MOV) {
-        var v: u64 = imm16 << sh;
-        if (!wide) { v = v & 0xFFFFFFFF; }
-        ret emit_hex_imm(out, signed_at_width(v, wide));
-    }
-    val ri: err[fail.Fail] = emit_hex_u64_imm(out, imm16);
-    if (sel ri.err) { ret ri; }
-    if (sh == 0) { ret err[fail.Fail].ok{}; }
-    ret emit_shift(out, ?i.src3);
-}
-
-fun render_madd(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
-    val out: *writer.Writer = buf.asm.out;
-    val op: mop.MachOp = classify_madd(i);
-    if (op == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted multiply-accumulate base word")};
-    }
-    val degenerate: bool = op == mop.MUL || op == mop.MNEG;
-    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
-    if (sel rm.err) { ret rm; }
-    var n: u32 = 0;
-    val rd: res[u32, fail.Fail] = render_slot(buf, i, ?i.dst, n, false);
-    if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
-    n = rd.ok;
-    val rn: res[u32, fail.Fail] = render_slot(buf, i, ?i.src1, n, false);
-    if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
-    n = rn.ok;
-    val r2: res[u32, fail.Fail] = render_slot(buf, i, ?i.src2, n, false);
-    if (sel r2.err) { ret err[fail.Fail].err{r2.err}; }
-    n = r2.ok;
-    if (degenerate) { ret err[fail.Fail].ok{}; }
-    val r3: res[u32, fail.Fail] = render_slot(buf, i, ?i.src3, n, false);
-    if (sel r3.err) { ret err[fail.Fail].err{r3.err}; }
     ret err[fail.Fail].ok{};
 }
 
-fun render_cset(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
+fun render_movewide(buf: *enc.ByteBuf, mi: *isa.Inst) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
-    if (i.base != 0x9A800400 && i.base != 0x1A800400) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted conditional-select base word")};
-    }
-    val cc: str = cond_name((i.flags & FLAG_COND)::u32 ^ 1);
+    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(mi.opcode::mop.MachOp));
+    if (sel rm.err) { ret rm; }
+    val rd: res[u32, fail.Fail] = render_slot(buf, mi, ?mi.dst, 0);
+    if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
+    val rc: err[fail.Fail] = emit_str(out, ", ");
+    if (sel rc.err) { ret rc; }
+    val ri: err[fail.Fail] = emit_hex_u64_imm(out, mi.src2.imm::u64);
+    if (sel ri.err) { ret ri; }
+    if (mi.src3.kind != isa.OPK_IMM || mi.src3.imm == 0) { ret err[fail.Fail].ok{}; }
+    ret emit_shift(out, ?mi.src3);
+}
+
+fun render_cset(buf: *enc.ByteBuf, mi: *isa.Inst) err[fail.Fail] {
+    val out: *writer.Writer = buf.asm.out;
+    val cc: str = cond_name(mop.cond_of(mi.flags));
     if (cc == nil) {
         ret err[fail.Fail].err{fail.message("--emit-asm: an emitted aarch64 cset names no condition")};
     }
     val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(mop.CSET));
     if (sel rm.err) { ret rm; }
-    val rd: res[u32, fail.Fail] = render_slot(buf, i, ?i.dst, 0, false);
+    val rd: res[u32, fail.Fail] = render_slot(buf, mi, ?mi.dst, 0);
     if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
     val rc: err[fail.Fail] = emit_str(out, ", ");
     if (sel rc.err) { ret rc; }
     ret emit_str(out, cc);
 }
 
-fun render_ldst(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
-    val out: *writer.Writer = buf.asm.out;
-    val op: mop.MachOp = classify_ldst(i.base);
-    if (op == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted load/store base word")};
-    }
-    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
-    if (sel rm.err) { ret rm; }
-
-    if (ldst_loads(op)) {
-        val rd: res[u32, fail.Fail] = render_slot(buf, i, ?i.dst, 0, false);
-        if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
-        ret emit_sep_operand(buf, i, ?i.src1, 1, false);
-    }
-    val rv: res[u32, fail.Fail] = render_slot(buf, i, ?i.src1, 0, false);
-    if (sel rv.err) { ret err[fail.Fail].err{rv.err}; }
-    ret emit_sep_operand(buf, i, ?i.dst, 1, false);
-}
-
-fun render_ldstp(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
-    val out: *writer.Writer = buf.asm.out;
-    val op: mop.MachOp = classify_ldstp(i.base);
-    if (op == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted load/store-pair base word")};
-    }
-    val load: bool = op == mop.LDP;
-
-    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
-    if (sel rm.err) { ret rm; }
-
-    var ra: *isa.Operand = ?i.src1;
-    var rb: *isa.Operand = ?i.src2;
-    var mem: *isa.Operand = ?i.dst;
-    if (load) { ra = ?i.dst; rb = ?i.src1; mem = ?i.src2; }
-
-    val r1: res[u32, fail.Fail] = render_slot(buf, i, ra, 0, false);
-    if (sel r1.err) { ret err[fail.Fail].err{r1.err}; }
-    val r2: res[u32, fail.Fail] = render_slot(buf, i, rb, 1, false);
-    if (sel r2.err) { ret err[fail.Fail].err{r2.err}; }
-    ret emit_sep_operand(buf, i, mem, 2, false);
-}
-
-fun neon_is_bitwise(base: u32) bool {
-    ret base == 0x4E201C00 || base == 0x4EA01C00 || base == 0x6E201C00;
-}
-
-fun neon_arrangement(base: u32, lane: u32) str {
-    if (neon_is_bitwise(base)) { ret ".16b"; }
-    val eb: u8 = mir.vec_lane_elem_bytes(lane);
+fun neon_arrangement(op: mop.MachOp, flags: u16) str {
+    if (mop.form(op).lane == mop.LANE_BITS) { ret ".16b"; }
+    val eb: u8 = mop.elem_bytes(flags);
     if (eb == 1) { ret ".16b"; }
     if (eb == 2) { ret ".8h"; }
     if (eb == 4) { ret ".4s"; }
@@ -786,42 +188,34 @@ fun neon_arrangement(base: u32, lane: u32) str {
     ret nil;
 }
 
-fun render_neon_3same(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
+fun render_neon_3same(buf: *enc.ByteBuf, mi: *isa.Inst) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
-    val op: mop.MachOp = classify_neon_3same(i);
-    if (op == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted NEON three-register base word")};
-    }
-    val arr: str = neon_arrangement(i.base, i.vec_lane);
+    val op: mop.MachOp = mi.opcode::mop.MachOp;
+    val arr: str = neon_arrangement(op, mi.flags);
     if (arr == nil) {
         ret err[fail.Fail].err{fail.message("--emit-asm: an emitted NEON instruction has no lane arrangement")};
     }
-
     val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
     if (sel rm.err) { ret rm; }
-    val rd: err[fail.Fail] = emit_sep_vec(out, " ", ?i.dst, arr);
+    val rd: err[fail.Fail] = emit_sep_vec(out, " ", ?mi.dst, arr);
     if (sel rd.err) { ret rd; }
-    val rn: err[fail.Fail] = emit_sep_vec(out, ", ", ?i.src1, arr);
+    val rn: err[fail.Fail] = emit_sep_vec(out, ", ", ?mi.src1, arr);
     if (sel rn.err) { ret rn; }
-    if (op == mop.V_MOV) { ret err[fail.Fail].ok{}; }
-    ret emit_sep_vec(out, ", ", ?i.src2, arr);
+    if (mi.src2.kind == isa.OPK_NONE) { ret err[fail.Fail].ok{}; }
+    ret emit_sep_vec(out, ", ", ?mi.src2, arr);
 }
 
-fun render_neon_2misc(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
+fun render_neon_2misc(buf: *enc.ByteBuf, mi: *isa.Inst) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
-    val op: mop.MachOp = classify_neon_2misc(i.base);
-    if (op == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted NEON two-register base word")};
-    }
-    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
+    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(mi.opcode::mop.MachOp));
     if (sel rm.err) { ret rm; }
-    val rd: err[fail.Fail] = emit_sep_vec(out, " ", ?i.dst, ".16b");
+    val rd: err[fail.Fail] = emit_sep_vec(out, " ", ?mi.dst, ".16b");
     if (sel rd.err) { ret rd; }
-    ret emit_sep_vec(out, ", ", ?i.src1, ".16b");
+    ret emit_sep_vec(out, ", ", ?mi.src1, ".16b");
 }
 
-fun neon_element(lane: u32) str {
-    val eb: u8 = mir.vec_lane_elem_bytes(lane);
+fun neon_element(flags: u16) str {
+    val eb: u8 = mop.elem_bytes(flags);
     if (eb == 1) { ret ".b"; }
     if (eb == 2) { ret ".h"; }
     if (eb == 4) { ret ".s"; }
@@ -843,154 +237,112 @@ fun emit_sep_lane(out: *writer.Writer, sep: str, op: *isa.Operand, elem: str, la
     ret emit_str(out, "]");
 }
 
-fun render_neon_lane_read(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
+fun render_neon_lane_read(buf: *enc.ByteBuf, mi: *isa.Inst) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
-    val elem: str = neon_element(i.vec_lane);
+    val elem: str = neon_element(mi.flags);
     if (elem == nil) {
         ret err[fail.Fail].err{fail.message("--emit-asm: an emitted NEON lane read has no element width")};
     }
-    if (i.src2.kind != isa.OPK_IMM) {
+    if (mi.src2.kind != isa.OPK_IMM) {
         ret err[fail.Fail].err{fail.message("--emit-asm: an emitted NEON lane read carries no lane index")};
     }
-
-    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(classify_neon_lane_read(i)));
+    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(mi.opcode::mop.MachOp));
     if (sel rm.err) { ret rm; }
     val rs: err[fail.Fail] = emit_str(out, " ");
     if (sel rs.err) { ret rs; }
-    val rd: err[fail.Fail] = emit_reg(out, ?i.dst, false);
+    val rd: err[fail.Fail] = emit_reg(out, ?mi.dst, false);
     if (sel rd.err) { ret rd; }
-    ret emit_sep_lane(out, ", ", ?i.src1, elem, i.src2.imm);
+    ret emit_sep_lane(out, ", ", ?mi.src1, elem, mi.src2.imm);
 }
 
-fun render_neon_lane_write(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
+fun render_neon_lane_write(buf: *enc.ByteBuf, mi: *isa.Inst) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
-    val elem: str = neon_element(i.vec_lane);
+    val elem: str = neon_element(mi.flags);
     if (elem == nil) {
         ret err[fail.Fail].err{fail.message("--emit-asm: an emitted NEON lane write has no element width")};
     }
-    if (i.src2.kind != isa.OPK_IMM) {
+    if (mi.src2.kind != isa.OPK_IMM) {
         ret err[fail.Fail].err{fail.message("--emit-asm: an emitted NEON lane write carries no lane index")};
     }
-
-    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(mop.INS));
+    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(mi.opcode::mop.MachOp));
     if (sel rm.err) { ret rm; }
-    val rd: err[fail.Fail] = emit_sep_lane(out, " ", ?i.dst, elem, i.src2.imm);
+    val rd: err[fail.Fail] = emit_sep_lane(out, " ", ?mi.dst, elem, mi.src2.imm);
     if (sel rd.err) { ret rd; }
 
-    if (isa.regid_class(i.src1.reg) != isa.REG_CLASS_ID_XMM) {
+    if (mi.opcode == mop.INS::u16) {
         val rc: err[fail.Fail] = emit_str(out, ", ");
         if (sel rc.err) { ret rc; }
-        ret emit_reg(out, ?i.src1, false);
+        ret emit_reg(out, ?mi.src1, false);
     }
-    if (i.src3.kind != isa.OPK_IMM) {
+    if (mi.src3.kind != isa.OPK_IMM) {
         ret err[fail.Fail].err{fail.message("--emit-asm: an emitted NEON element insert carries no source lane")};
     }
-    ret emit_sep_lane(out, ", ", ?i.src1, elem, i.src3.imm);
+    ret emit_sep_lane(out, ", ", ?mi.src1, elem, mi.src3.imm);
 }
 
-fun render_branch(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
+fun render_branch(buf: *enc.ByteBuf, mi: *isa.Inst) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
-    val op: mop.MachOp = classify_branch(i.base);
-    if (op == mop.MOP_NONE) {
-        if ((i.base & 0xFF000000) == 0x54000000) {
-            ret err[fail.Fail].err{fail.message("--emit-asm: an emitted aarch64 conditional branch names no condition")};
-        }
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted branch base word")};
-    }
-    if (op == mop.BCOND) {
-        val rb: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
-        if (sel rb.err) { ret rb; }
-        val rc: err[fail.Fail] = emit_str(out, cond_name(i.base & 0xF));
-        if (sel rc.err) { ret rc; }
-        val rs: err[fail.Fail] = emit_str(out, " ");
-        if (sel rs.err) { ret rs; }
-        ret render_target(buf, i);
-    }
-
+    val op: mop.MachOp = mi.opcode::mop.MachOp;
     val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
     if (sel rm.err) { ret rm; }
-    if (op == mop.CBZ || op == mop.CBNZ) {
-        val rt: res[u32, fail.Fail] = render_slot(buf, i, ?i.src1, 0, false);
-        if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
-        val rc: err[fail.Fail] = emit_str(out, ", ");
+    if (op == mop.BCOND) {
+        val cc: str = cond_name(mop.cond_of(mi.flags));
+        if (cc == nil) {
+            ret err[fail.Fail].err{fail.message("--emit-asm: an emitted aarch64 conditional branch names no condition")};
+        }
+        val rc: err[fail.Fail] = emit_str(out, cc);
         if (sel rc.err) { ret rc; }
-        ret render_target(buf, i);
     }
-    val rs: err[fail.Fail] = emit_str(out, " ");
+    var n: u32 = 0;
+    if (mi.src1.kind != isa.OPK_NONE) {
+        val rt: res[u32, fail.Fail] = render_slot(buf, mi, ?mi.src1, 0);
+        if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
+        n = rt.ok;
+    }
+    var sep: str = " ";
+    if (n != 0) { sep = ", "; }
+    val rs: err[fail.Fail] = emit_str(out, sep);
     if (sel rs.err) { ret rs; }
-    ret render_target(buf, i);
+    ret render_target(buf, mi);
 }
 
-fun render_target(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
+fun render_target(buf: *enc.ByteBuf, mi: *isa.Inst) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
-    if (i.target == TGT_BLOCK) {
+    val t: *isa.Operand = ?mi.src2;
+    if (t.kind == isa.OPK_SYM) { ret emit_sym(out, buf.asm.interner, t); }
+    if (t.kind != isa.OPK_LABEL) {
+        ret err[fail.Fail].err{fail.message("--emit-asm: an emitted aarch64 branch names no destination")};
+    }
+    if ((mi.flags & mop.FLAG_TARGET_BLOCK) != 0 && isa.label_is_block(t)) {
         val rd: err[fail.Fail] = emit_str(out, ".");
         if (sel rd.err) { ret rd; }
-        ret emit_u64(out, i.block::u64);
+        ret emit_u64(out, t.imm::u64);
     }
-    if (i.target == TGT_SYM) { ret emit_sym(out, buf.asm.interner, ?i.src2); }
-    if (i.target == TGT_PCREL) {
+    if ((mi.flags & mop.FLAG_LABEL_SKIP) != 0) {
         val rd: err[fail.Fail] = emit_str(out, ".+");
         if (sel rd.err) { ret rd; }
-        ret emit_u64(out, (i.src2.imm * 4)::u64);
+        ret emit_u64(out, t.disp::u64);
     }
-    if (i.target == TGT_LOCAL_FWD || i.target == TGT_LOCAL_BACK) {
-        val rn: err[fail.Fail] = emit_u64(out, i.src2.imm::u64);
+    if ((mi.flags & mop.FLAG_LABEL_LOCAL) != 0) {
+        val rn: err[fail.Fail] = emit_u64(out, t.sym_id::u64);
         if (sel rn.err) { ret rn; }
-        if (i.target == TGT_LOCAL_FWD) { ret emit_str(out, "f"); }
+        if ((mi.flags & mop.FLAG_LABEL_FWD) != 0) { ret emit_str(out, "f"); }
         ret emit_str(out, "b");
     }
     ret err[fail.Fail].err{fail.message("--emit-asm: an emitted aarch64 branch names no destination")};
 }
 
-fun render_branch_reg(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
+fun render_imm16(buf: *enc.ByteBuf, mi: *isa.Inst) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
-    val op: mop.MachOp = classify_branch_reg(i.base);
-    if (op == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted register-branch base word")};
-    }
-    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
-    if (sel rm.err) { ret rm; }
-    val rn: res[u32, fail.Fail] = render_slot(buf, i, ?i.src1, 0, false);
-    if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
-    ret err[fail.Fail].ok{};
-}
-
-fun render_adrp(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
-    val out: *writer.Writer = buf.asm.out;
-    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(mop.ADRP));
-    if (sel rm.err) { ret rm; }
-    val rd: res[u32, fail.Fail] = render_slot(buf, i, ?i.dst, 0, false);
-    if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
-    ret emit_sep_operand(buf, i, ?i.src1, 1, false);
-}
-
-fun render_nullary(out: *writer.Writer, i: *Inst) err[fail.Fail] {
-    val op: mop.MachOp = classify_nullary(i.base);
-    if (op == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted operand-less instruction word")};
-    }
-    ret emit_str(out, mop.mnemonic(op));
-}
-
-fun render_imm16(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
-    val out: *writer.Writer = buf.asm.out;
-    val op: mop.MachOp = classify_imm16(i.base);
-    if (op == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted immediate-only base word")};
-    }
-    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
+    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(mi.opcode::mop.MachOp));
     if (sel rm.err) { ret rm; }
     val rs: err[fail.Fail] = emit_str(out, " ");
     if (sel rs.err) { ret rs; }
-    ret emit_trap_imm(out, i.src1.imm);
+    ret emit_trap_imm(out, mi.src1.imm);
 }
 
-fun render_barrier(out: *writer.Writer, i: *Inst) err[fail.Fail] {
-    if (classify_barrier(i.base) == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted barrier base word")};
-    }
-    val name: str = barrier_name(i.src1.imm::u32);
+fun render_barrier(out: *writer.Writer, mi: *isa.Inst) err[fail.Fail] {
+    val name: str = barrier_name(mi.src1.imm::u32);
     if (name == nil) {
         ret err[fail.Fail].err{fail.message("--emit-asm: an emitted aarch64 barrier names no domain")};
     }
@@ -1017,40 +369,6 @@ fun barrier_name(crm: u32) str {
     ret nil;
 }
 
-fun render_stxr(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
-    val out: *writer.Writer = buf.asm.out;
-    if (classify_stxr(i.base) == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted exclusive-store base word")};
-    }
-    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(mop.STLXR));
-    if (sel rm.err) { ret rm; }
-    val rs: res[u32, fail.Fail] = render_slot(buf, i, ?i.dst, 0, false);
-    if (sel rs.err) { ret err[fail.Fail].err{rs.err}; }
-    val rt: res[u32, fail.Fail] = render_slot(buf, i, ?i.src1, 1, false);
-    if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
-    ret emit_sep_operand(buf, i, ?i.src2, 2, false);
-}
-
-fun render_sysreg_imm(out: *writer.Writer, i: *Inst) err[fail.Fail] {
-    if (classify_sysreg_imm(i.base) == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted PSTATE-field base word")};
-    }
-    val packed: u32 = i.src1.imm::u32;
-    val name: str = pstate_field_name((packed >> 3) & 0x7, packed & 0x7);
-    if (name == nil) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: an emitted aarch64 msr-immediate names no PSTATE field")};
-    }
-    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(mop.MSR));
-    if (sel rm.err) { ret rm; }
-    val rs: err[fail.Fail] = emit_str(out, " ");
-    if (sel rs.err) { ret rs; }
-    val rn: err[fail.Fail] = emit_str(out, name);
-    if (sel rn.err) { ret rn; }
-    val rc: err[fail.Fail] = emit_str(out, ", ");
-    if (sel rc.err) { ret rc; }
-    ret emit_dec_imm(out, i.src2.imm);
-}
-
 fun pstate_field_name(op1: u32, op2: u32) str {
     if (op1 == 3 && op2 == 6) { ret "daifset"; }
     if (op1 == 3 && op2 == 7) { ret "daifclr"; }
@@ -1063,27 +381,37 @@ fun pstate_field_name(op1: u32, op2: u32) str {
     ret nil;
 }
 
-fun render_sysreg(out: *writer.Writer, i: *Inst) err[fail.Fail] {
-    val op: mop.MachOp = classify_sysreg(i.base);
-    if (op == mop.MOP_NONE) {
-        ret err[fail.Fail].err{fail.message("--emit-asm: no aarch64 mnemonic for an emitted system-register base word")};
-    }
+# mrs dst, sysreg; msr sysreg, src2; msr pstate-field, #imm
+fun render_sysreg(out: *writer.Writer, mi: *isa.Inst) err[fail.Fail] {
+    val op: mop.MachOp = mi.opcode::mop.MachOp;
     val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(op));
     if (sel rm.err) { ret rm; }
     val rs: err[fail.Fail] = emit_str(out, " ");
     if (sel rs.err) { ret rs; }
     if (op == mop.MRS) {
-        val rr: err[fail.Fail] = emit_reg(out, ?i.dst, false);
+        val rr: err[fail.Fail] = emit_reg(out, ?mi.dst, false);
         if (sel rr.err) { ret rr; }
         val rc: err[fail.Fail] = emit_str(out, ", ");
         if (sel rc.err) { ret rc; }
-        ret emit_sysreg_numeric(out, i.src1.imm::u32);
+        ret emit_sysreg_numeric(out, mi.src1.imm::u32);
     }
-    val rn: err[fail.Fail] = emit_sysreg_numeric(out, i.src1.imm::u32);
+    if (mi.src2.kind == isa.OPK_IMM) {
+        val packed: u32 = mi.src1.imm::u32;
+        val name: str = pstate_field_name((packed >> 3) & 0x7, packed & 0x7);
+        if (name == nil) {
+            ret err[fail.Fail].err{fail.message("--emit-asm: an emitted aarch64 msr-immediate names no PSTATE field")};
+        }
+        val rn: err[fail.Fail] = emit_str(out, name);
+        if (sel rn.err) { ret rn; }
+        val rc: err[fail.Fail] = emit_str(out, ", ");
+        if (sel rc.err) { ret rc; }
+        ret emit_dec_imm(out, mi.src2.imm);
+    }
+    val rn: err[fail.Fail] = emit_sysreg_numeric(out, mi.src1.imm::u32);
     if (sel rn.err) { ret rn; }
     val rc: err[fail.Fail] = emit_str(out, ", ");
     if (sel rc.err) { ret rc; }
-    ret emit_reg(out, ?i.dst, false);
+    ret emit_reg(out, ?mi.src2, false);
 }
 
 fun emit_sysreg_numeric(out: *writer.Writer, packed: u32) err[fail.Fail] {
@@ -1104,41 +432,43 @@ fun emit_sysreg_numeric(out: *writer.Writer, packed: u32) err[fail.Fail] {
     ret emit_indexed(out, "_", op2);
 }
 
-fun render_slot(buf: *enc.ByteBuf, i: *Inst, op: *isa.Operand, n: u32, sp: bool) res[u32, fail.Fail] {
+fun render_slot(buf: *enc.ByteBuf, mi: *isa.Inst, op: *isa.Operand, n: u32) res[u32, fail.Fail] {
     if (op.kind == isa.OPK_NONE) { ret res[u32, fail.Fail].ok{n}; }
-    val res_: err[fail.Fail] = emit_sep_operand(buf, i, op, n, sp);
+    var sep: str = ", ";
+    if (n == 0) { sep = " "; }
+    val rs: err[fail.Fail] = emit_str(buf.asm.out, sep);
+    if (sel rs.err) { ret res[u32, fail.Fail].err{rs.err}; }
+    val res_: err[fail.Fail] = emit_operand(buf, mi, op);
     if (sel res_.err) { ret res[u32, fail.Fail].err{res_.err}; }
     ret res[u32, fail.Fail].ok{n + 1};
 }
 
-fun emit_sep_operand(buf: *enc.ByteBuf, i: *Inst, op: *isa.Operand, n: u32, sp: bool) err[fail.Fail] {
-    var sep: str = ", ";
-    if (n == 0) { sep = " "; }
-    val rs: err[fail.Fail] = emit_str(buf.asm.out, sep);
-    if (sel rs.err) { ret rs; }
-    ret emit_operand(buf, i, op, sp);
-}
-
-fun emit_operand(buf: *enc.ByteBuf, i: *Inst, op: *isa.Operand, sp: bool) err[fail.Fail] {
+# an immediate renders in hex except where the assembler syntax reads a
+# count: the bitfield aliases take decimal positions and widths
+fun emit_operand(buf: *enc.ByteBuf, mi: *isa.Inst, op: *isa.Operand) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
+    val sp: bool = (mi.flags & mop.FLAG_SP) != 0;
     if (op.kind == isa.OPK_REG) { ret emit_reg(out, op, sp); }
-    if (op.kind == isa.OPK_IMM) { ret emit_hex_imm(out, op.imm); }
-    if (op.kind == isa.OPK_MEM) { ret emit_mem(buf, i, op); }
-    if (op.kind == isa.OPK_SYM) { ret emit_modified_sym(buf, i, op); }
+    if (op.kind == isa.OPK_IMM) {
+        if (mop.layout(mi.opcode::mop.MachOp) == mop.L_BITFIELD) { ret emit_dec_imm(out, op.imm); }
+        ret emit_hex_imm(out, op.imm);
+    }
+    if (op.kind == isa.OPK_MEM) { ret emit_mem(buf, mi, op); }
+    if (op.kind == isa.OPK_SYM) { ret emit_modified_sym(buf, op); }
     ret err[fail.Fail].err{fail.message("--emit-asm: an emitted aarch64 operand has no renderable kind")};
 }
 
-fun emit_mem(buf: *enc.ByteBuf, i: *Inst, op: *isa.Operand) err[fail.Fail] {
+fun emit_mem(buf: *enc.ByteBuf, mi: *isa.Inst, op: *isa.Operand) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
     val ro: err[fail.Fail] = emit_str(out, "[");
     if (sel ro.err) { ret ro; }
     val rb: err[fail.Fail] = emit_reg_id(out, op.base, 8, true);
     if (sel rb.err) { ret rb; }
 
-    if (i.sym_mod != MOD_NONE) {
+    if (op.sym_mod != isa.SYM_MOD_NONE) {
         val rl: err[fail.Fail] = emit_str(out, ", ");
         if (sel rl.err) { ret rl; }
-        val rp: err[fail.Fail] = emit_str(out, sym_mod_prefix(i.sym_mod));
+        val rp: err[fail.Fail] = emit_str(out, sym_mod_prefix(op.sym_mod));
         if (sel rp.err) { ret rp; }
         val rs: err[fail.Fail] = emit_sym(out, buf.asm.interner, op);
         if (sel rs.err) { ret rs; }
@@ -1153,7 +483,7 @@ fun emit_mem(buf: *enc.ByteBuf, i: *Inst, op: *isa.Operand) err[fail.Fail] {
         ret emit_str(out, "]");
     }
 
-    if ((i.flags & FLAG_WB_POST) != 0) {
+    if ((mi.flags & mop.FLAG_WB_POST) != 0) {
         val rc: err[fail.Fail] = emit_str(out, "], ");
         if (sel rc.err) { ret rc; }
         ret emit_hex_imm(out, op.disp::i64);
@@ -1164,21 +494,21 @@ fun emit_mem(buf: *enc.ByteBuf, i: *Inst, op: *isa.Operand) err[fail.Fail] {
         val rd: err[fail.Fail] = emit_hex_imm(out, op.disp::i64);
         if (sel rd.err) { ret rd; }
     }
-    if ((i.flags & FLAG_WB_PRE) != 0) { ret emit_str(out, "]!"); }
+    if ((mi.flags & mop.FLAG_WB_PRE) != 0) { ret emit_str(out, "]!"); }
     ret emit_str(out, "]");
 }
 
-fun emit_modified_sym(buf: *enc.ByteBuf, i: *Inst, op: *isa.Operand) err[fail.Fail] {
+fun emit_modified_sym(buf: *enc.ByteBuf, op: *isa.Operand) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
-    val rp: err[fail.Fail] = emit_str(out, sym_mod_prefix(i.sym_mod));
+    val rp: err[fail.Fail] = emit_str(out, sym_mod_prefix(op.sym_mod));
     if (sel rp.err) { ret rp; }
     ret emit_sym(out, buf.asm.interner, op);
 }
 
-fun sym_mod_prefix(mod: u8) str {
-    if (mod == MOD_PCREL_LO) { ret ":lo12:"; }
-    if (mod == MOD_GOT_HI)   { ret ":got:"; }
-    if (mod == MOD_GOT_LO)   { ret ":got_lo12:"; }
+fun sym_mod_prefix(mod: isa.SymModifier) str {
+    if (mod == isa.SYM_MOD_PCREL_LO) { ret ":lo12:"; }
+    if (mod == isa.SYM_MOD_GOT_HI)   { ret ":got:"; }
+    if (mod == isa.SYM_MOD_GOT_LO)   { ret ":got_lo12:"; }
     ret "";
 }
 
@@ -1188,16 +518,16 @@ fun emit_shift(out: *writer.Writer, op: *isa.Operand) err[fail.Fail] {
     ret emit_dec_imm(out, op.imm);
 }
 
-fun render_fmov_imm(buf: *enc.ByteBuf, i: *Inst) err[fail.Fail] {
+fun render_fmov_imm(buf: *enc.ByteBuf, mi: *isa.Inst) err[fail.Fail] {
     val out: *writer.Writer = buf.asm.out;
-    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(mop.FMOV));
+    val rm: err[fail.Fail] = emit_str(out, mop.mnemonic(mop.FMOV_IMM));
     if (sel rm.err) { ret rm; }
-    val rd: res[u32, fail.Fail] = render_slot(buf, i, ?i.dst, 0, false);
+    val rd: res[u32, fail.Fail] = render_slot(buf, mi, ?mi.dst, 0);
     if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
     val rc: err[fail.Fail] = emit_str(out, ", #");
     if (sel rc.err) { ret rc; }
 
-    val imm8: u32 = i.src2.imm::u32 & 0xFF;
+    val imm8: u32 = mi.src2.imm::u32 & 0xFF;
     if ((imm8 & 0x80) != 0) {
         val rs: err[fail.Fail] = emit_str(out, "-");
         if (sel rs.err) { ret rs; }
@@ -1254,14 +584,6 @@ fun emit_sep_vec(out: *writer.Writer, sep: str, op: *isa.Operand, arr: str) err[
     val rv: err[fail.Fail] = emit_indexed(out, "v", isa.regid_index(op.reg)::u32);
     if (sel rv.err) { ret rv; }
     ret emit_str(out, arr);
-}
-
-fun is_reg31(op: *isa.Operand) bool {
-    ret op.kind == isa.OPK_REG && isa.regid_index(op.reg) == 31;
-}
-
-fun is_zero_reg(op: *isa.Operand) bool {
-    ret is_reg31(op) && isa.regid_class(op.reg) == isa.REG_CLASS_ID_GP;
 }
 
 fun emit_reg(out: *writer.Writer, op: *isa.Operand, sp: bool) err[fail.Fail] {
@@ -1353,12 +675,6 @@ fun emit_hex_imm(out: *writer.Writer, v: i64) err[fail.Fail] {
     ret emit_hex_u64_imm(out, v::u64);
 }
 
-fun signed_at_width(v: u64, wide: bool) i64 {
-    if (wide) { ret v::i64; }
-    if ((v & 0x80000000) != 0) { ret (v::i64) - 0x100000000; }
-    ret v::i64;
-}
-
 fun emit_hex_u64_imm(out: *writer.Writer, v: u64) err[fail.Fail] {
     val rp: err[fail.Fail] = emit_str(out, "#0x");
     if (sel rp.err) { ret rp; }
@@ -1433,16 +749,27 @@ pub fun test_sink_text() str {
     ret (?test_sink_buf[0])::str;
 }
 
-# the fixture emits the word it notifies, so the notification has an extent
-fun rendered_is(buf: *enc.ByteBuf, i: *Inst, want: str) i32 {
+fun t_inst(op: mop.MachOp, dst: isa.Operand, src1: isa.Operand, src2: isa.Operand) isa.Inst {
+    var mi: isa.Inst = isa.inst_blank();
+    mi.opcode = op::u16;
+    mi.dst  = dst;
+    mi.src1 = src1;
+    mi.src2 = src2;
+    ret mi;
+}
+
+# the fixture assembles and emits the word it notifies, so the notification
+# has an extent and the line is what the encoder would have rendered
+fun rendered_is(buf: *enc.ByteBuf, mi: *isa.Inst, want: str) i32 {
     test_sink_reset();
     val before: u32 = enc.note_inst_count(buf);
-    enc.emit_u32(buf, i.base);
-    note_inst(buf, i);
+    enc.emit_u32(buf, mop.assemble(mi));
+    mop.spell(mi);
+    note_inst(buf, mi);
     if (buf.asm.failed) { ret 1; }
     if (enc.note_inst_count(buf) != before + 1) { ret 1; }
     val n: *enc.AsmNote = enc.note_at(buf, enc.note_count(buf) - 1);
-    if (n == nil || n.byte_len != 4 || n.inst.opcode != classify(i)::u16) { ret 1; }
+    if (n == nil || n.byte_len != 4 || n.inst.opcode != mi.opcode) { ret 1; }
     val got: str = test_sink_text();
     if (!str_starts_with(got, "  "))                     { ret 1; }
     if (!str_region_equals(got, 2, str_len(want), want)) { ret 1; }
@@ -1463,163 +790,146 @@ test "mach.lang.target.isa.arm64.printer.render_inst:disassembler_aliases" {
 
     var bad: i32 = 0;
 
-    var i1: Inst = inst(FORM_ALU3, 0xAA000000);
-    i1.dst = gp(3, 8); i1.src1 = gp(31, 8); i1.src2 = gp(4, 8);
+    var i1: isa.Inst = t_inst(mop.ORR, mop.gp(3, 8), mop.gp(31, 8), mop.gp(4, 8));
     bad = bad | rendered_is(?buf, ?i1, "mov x3, x4");
 
-    var i2: Inst = inst(FORM_ALU3, 0xCB000000);
-    i2.dst = gp(0, 8); i2.src1 = gp(31, 8); i2.src2 = gp(1, 8);
+    var i2: isa.Inst = t_inst(mop.SUB, mop.gp(0, 8), mop.gp(31, 8), mop.gp(1, 8));
     bad = bad | rendered_is(?buf, ?i2, "neg x0, x1");
 
-    var i3: Inst = inst(FORM_ALU3, 0xAA200000);
-    i3.dst = gp(0, 8); i3.src1 = gp(31, 8); i3.src2 = gp(1, 8);
+    var i3: isa.Inst = t_inst(mop.ORN, mop.gp(0, 8), mop.gp(31, 8), mop.gp(1, 8));
     bad = bad | rendered_is(?buf, ?i3, "mvn x0, x1");
 
-    var i4: Inst = inst(FORM_ALU3, 0xEB000000);
-    i4.dst = gp(31, 8); i4.src1 = gp(1, 8); i4.src2 = gp(2, 8);
+    var i4: isa.Inst = t_inst(mop.SUBS, mop.gp(31, 8), mop.gp(1, 8), mop.gp(2, 8));
     bad = bad | rendered_is(?buf, ?i4, "cmp x1, x2");
 
-    var i5: Inst = inst(FORM_ADDSUB_IMM, 0x91000000);
-    i5.dst = gp(29, 8); i5.src1 = gp(31, 8); i5.src2 = isa.make_imm(0, 8);
+    var i5: isa.Inst = t_inst(mop.ADD, mop.gp(29, 8), mop.gp(31, 8), isa.make_imm(0, 8));
+    i5.flags = mop.FLAG_SP;
     bad = bad | rendered_is(?buf, ?i5, "mov x29, sp");
 
-    var i6: Inst = inst(FORM_ADDSUB_IMM, 0xB1000000);
-    i6.dst = gp(31, 8); i6.src1 = gp(2, 8); i6.src2 = isa.make_imm(1, 8);
+    var i6: isa.Inst = t_inst(mop.ADDS, mop.gp(31, 8), mop.gp(2, 8), isa.make_imm(1, 8));
+    i6.flags = mop.FLAG_SP;
     bad = bad | rendered_is(?buf, ?i6, "cmn x2, #0x1");
 
-    var i7: Inst = inst(FORM_ADDSUB_IMM, 0xD1000000);
-    i7.dst = gp(31, 8); i7.src1 = gp(31, 8);
-    i7.src2 = isa.make_imm(2, 8); i7.src3 = isa.make_imm(12, 1);
+    var i7: isa.Inst = t_inst(mop.SUB, mop.gp(31, 8), mop.gp(31, 8), isa.make_imm(2, 8));
+    i7.src3 = isa.make_imm(12, 1);
+    i7.flags = mop.FLAG_SP;
     bad = bad | rendered_is(?buf, ?i7, "sub sp, sp, #0x2, lsl #12");
 
-    var i8: Inst = inst(FORM_BITFIELD, 0x53000000);
-    i8.dst = gp(0, 4); i8.src1 = gp(1, 4);
-    i8.src2 = isa.make_imm(0, 1); i8.src3 = isa.make_imm(7, 1);
+    var i8: isa.Inst = t_inst(mop.UXTB, mop.gp(0, 4), mop.gp(1, 4), isa.make_none());
     bad = bad | rendered_is(?buf, ?i8, "uxtb w0, w1");
 
-    var i9: Inst = inst(FORM_BITFIELD, 0x93400000);
-    i9.dst = gp(0, 8); i9.src1 = gp(1, 8);
-    i9.src2 = isa.make_imm(0, 1); i9.src3 = isa.make_imm(31, 1);
+    var i9: isa.Inst = t_inst(mop.SXTW, mop.gp(0, 8), mop.gp(1, 4), isa.make_none());
     bad = bad | rendered_is(?buf, ?i9, "sxtw x0, w1");
 
-    var i10: Inst = inst(FORM_BITFIELD, 0xD3400000);
-    i10.dst = gp(4, 8); i10.src1 = gp(5, 8);
-    i10.src2 = isa.make_imm(4, 1); i10.src3 = isa.make_imm(63, 1);
+    var i10: isa.Inst = t_inst(mop.LSR, mop.gp(4, 8), mop.gp(5, 8), isa.make_imm(4, 1));
     bad = bad | rendered_is(?buf, ?i10, "lsr x4, x5, #4");
 
-    var i11: Inst = inst(FORM_BITFIELD, 0xD3400000);
-    i11.dst = gp(0, 8); i11.src1 = gp(3, 8);
-    i11.src2 = isa.make_imm(32, 1); i11.src3 = isa.make_imm(31, 1);
+    var i11: isa.Inst = t_inst(mop.LSL, mop.gp(0, 8), mop.gp(3, 8), isa.make_imm(32, 1));
     bad = bad | rendered_is(?buf, ?i11, "lsl x0, x3, #32");
 
-    var i12: Inst = inst(FORM_BITFIELD, 0xD3400000);
-    i12.dst = gp(0, 8); i12.src1 = gp(1, 8);
-    i12.src2 = isa.make_imm(3, 1); i12.src3 = isa.make_imm(10, 1);
+    var i12: isa.Inst = t_inst(mop.UBFX, mop.gp(0, 8), mop.gp(1, 8), isa.make_imm(3, 1));
+    i12.src3 = isa.make_imm(8, 1);
     bad = bad | rendered_is(?buf, ?i12, "ubfx x0, x1, #3, #8");
 
-    var i13: Inst = inst(FORM_MOVEWIDE, 0xD2800000);
-    i13.dst = gp(17, 8); i13.src2 = isa.make_imm(0x8000, 8); i13.src3 = isa.make_imm(48, 1);
+    var i13: isa.Inst = t_inst(mop.MOVZ, mop.gp(17, 8), isa.make_none(), isa.make_imm(0x8000, 8));
+    i13.src3 = isa.make_imm(48, 1);
     bad = bad | rendered_is(?buf, ?i13, "mov x17, #-0x8000000000000000");
 
-    var i14: Inst = inst(FORM_MOVEWIDE, 0xF2800000);
-    i14.dst = gp(16, 8); i14.src2 = isa.make_imm(0xFFFF, 8); i14.src3 = isa.make_imm(16, 1);
+    var i14: isa.Inst = t_inst(mop.MOVK, mop.gp(16, 8), isa.make_none(), isa.make_imm(0xFFFF, 8));
+    i14.src3 = isa.make_imm(16, 1);
     bad = bad | rendered_is(?buf, ?i14, "movk x16, #0xffff, lsl #16");
 
-    var f1: Inst = inst(FORM_FMOV_IMM, 0x1E601000);
-    f1.dst = vec(0, 8); f1.src2 = isa.make_imm(0x70, 1);
+    var f1: isa.Inst = t_inst(mop.FMOV_IMM, mop.vec(0, 8), isa.make_none(), isa.make_imm(0x70, 1));
     bad = bad | rendered_is(?buf, ?f1, "fmov d0, #1");
 
-    var f2: Inst = inst(FORM_FMOV_IMM, 0x1E201000);
-    f2.dst = vec(0, 4); f2.src2 = isa.make_imm(0xF8, 1);
+    var f2: isa.Inst = t_inst(mop.FMOV_IMM, mop.vec(0, 4), isa.make_none(), isa.make_imm(0xF8, 1));
     bad = bad | rendered_is(?buf, ?f2, "fmov s0, #-1.5");
 
-    var f3: Inst = inst(FORM_FMOV_IMM, 0x1E601000);
-    f3.dst = vec(30, 8); f3.src2 = isa.make_imm(0x60, 1);
+    var f3: isa.Inst = t_inst(mop.FMOV_IMM, mop.vec(30, 8), isa.make_none(), isa.make_imm(0x60, 1));
     bad = bad | rendered_is(?buf, ?f3, "fmov d30, #0.5");
 
-    var f4: Inst = inst(FORM_FMOV_IMM, 0x1E601000);
-    f4.dst = vec(0, 8); f4.src2 = isa.make_imm(0xC0, 1);
+    var f4: isa.Inst = t_inst(mop.FMOV_IMM, mop.vec(0, 8), isa.make_none(), isa.make_imm(0xC0, 1));
     bad = bad | rendered_is(?buf, ?f4, "fmov d0, #-0.125");
 
-    var f5: Inst = inst(FORM_FMOV_IMM, 0x1E601000);
-    f5.dst = vec(0, 8); f5.src2 = isa.make_imm(0x3F, 1);
+    var f5: isa.Inst = t_inst(mop.FMOV_IMM, mop.vec(0, 8), isa.make_none(), isa.make_imm(0x3F, 1));
     bad = bad | rendered_is(?buf, ?f5, "fmov d0, #31");
 
-    var f6: Inst = inst(FORM_FMOV_IMM, 0x1E601000);
-    f6.dst = vec(5, 8); f6.src2 = isa.make_imm(0xFF, 1);
+    var f6: isa.Inst = t_inst(mop.FMOV_IMM, mop.vec(5, 8), isa.make_none(), isa.make_imm(0xFF, 1));
     bad = bad | rendered_is(?buf, ?f6, "fmov d5, #-1.9375");
 
-    var i15: Inst = inst(FORM_CSET, 0x1A800400);
-    i15.dst = gp(0, 4); i15.flags = 1;
+    var i15: isa.Inst = t_inst(mop.CSET, mop.gp(0, 4), isa.make_none(), isa.make_none());
+    i15.flags = mop.with_cond(0, 0);
     bad = bad | rendered_is(?buf, ?i15, "cset w0, eq");
 
-    var i16: Inst = inst(FORM_MADD, 0x9B008000);
-    i16.dst = gp(0, 8); i16.src1 = gp(1, 8); i16.src2 = gp(2, 8); i16.src3 = gp(3, 8);
+    var i16: isa.Inst = t_inst(mop.MSUB, mop.gp(0, 8), mop.gp(1, 8), mop.gp(2, 8));
+    i16.src3 = mop.gp(3, 8);
     bad = bad | rendered_is(?buf, ?i16, "msub x0, x1, x2, x3");
 
-    var i17: Inst = inst(FORM_LDSTP, 0xA9800000);
-    i17.flags = FLAG_WB_PRE;
-    i17.dst = isa.make_mem(gp_id(31), -16, -1, 0, 8);
-    i17.src1 = gp(29, 8); i17.src2 = gp(30, 8);
+    var i17: isa.Inst = t_inst(mop.STP, isa.make_mem(mop.gp_id(31), -16, -1, 0, 8), mop.gp(29, 8), mop.gp(30, 8));
+    i17.flags = mop.FLAG_WB_PRE;
     bad = bad | rendered_is(?buf, ?i17, "stp x29, x30, [sp, #-0x10]!");
 
-    var i18: Inst = inst(FORM_LDSTP, 0xA8C00000);
-    i18.flags = FLAG_WB_POST;
-    i18.dst = gp(29, 8); i18.src1 = gp(30, 8);
-    i18.src2 = isa.make_mem(gp_id(31), 16, -1, 0, 8);
+    var i18: isa.Inst = t_inst(mop.LDP, mop.gp(29, 8), mop.gp(30, 8), isa.make_mem(mop.gp_id(31), 16, -1, 0, 8));
+    i18.flags = mop.FLAG_WB_POST;
     bad = bad | rendered_is(?buf, ?i18, "ldp x29, x30, [sp], #0x10");
 
-    var i19: Inst = inst(FORM_LDST, 0xF9000000);
-    i19.dst = isa.make_mem(gp_id(1), 8, -1, 0, 8);
-    i19.src1 = gp(0, 8);
+    var i19: isa.Inst = t_inst(mop.STR, isa.make_mem(mop.gp_id(1), 8, -1, 0, 8), mop.gp(0, 8), isa.make_none());
     bad = bad | rendered_is(?buf, ?i19, "str x0, [x1, #0x8]");
 
-    var i20: Inst = inst(FORM_NEON_3SAME, 0x4E20D400);
-    i20.dst = vec(2, 16); i20.src1 = vec(0, 16); i20.src2 = vec(1, 16);
-    i20.vec_lane = mir.vec_lane_make(mir.VEC_LANE_FLOAT, 4, 4);
+    var i20: isa.Inst = t_inst(mop.V_FADD, mop.vec(2, 16), mop.vec(0, 16), mop.vec(1, 16));
+    i20.flags = mop.with_elem_bytes(0, 4);
     bad = bad | rendered_is(?buf, ?i20, "fadd v2.4s, v0.4s, v1.4s");
 
-    var i21: Inst = inst(FORM_NEON_3SAME, 0x4E208400);
-    i21.dst = vec(2, 16); i21.src1 = vec(0, 16); i21.src2 = vec(1, 16);
-    i21.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 2, 8);
+    var i21: isa.Inst = t_inst(mop.V_ADD, mop.vec(2, 16), mop.vec(0, 16), mop.vec(1, 16));
+    i21.flags = mop.with_elem_bytes(0, 2);
     bad = bad | rendered_is(?buf, ?i21, "add v2.8h, v0.8h, v1.8h");
 
-    var i22: Inst = inst(FORM_NEON_3SAME, 0x4EA01C00);
-    i22.dst = vec(5, 16); i22.src1 = vec(6, 16); i22.src2 = vec(6, 16);
-    i22.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 1, 16);
+    var i22: isa.Inst = t_inst(mop.V_ORR, mop.vec(5, 16), mop.vec(6, 16), mop.vec(6, 16));
+    i22.flags = mop.with_elem_bytes(0, 1);
     bad = bad | rendered_is(?buf, ?i22, "mov v5.16b, v6.16b");
 
-    var i24: Inst = inst(FORM_ALU3, 0xCB2063FF);
-    i24.dst = gp(31, 8); i24.src1 = gp(31, 8); i24.src2 = gp(16, 8);
+    var i24: isa.Inst = t_inst(mop.SUB, mop.gp(31, 8), mop.gp(31, 8), mop.gp(16, 8));
+    i24.flags = mop.FLAG_SP;
     bad = bad | rendered_is(?buf, ?i24, "sub sp, sp, x16");
 
-    var i23: Inst = inst(FORM_IMM16, 0xD4200000);
-    i23.src1 = isa.make_imm(0, 2);
+    var i23: isa.Inst = t_inst(mop.BRK, isa.make_none(), isa.make_imm(0, 2), isa.make_none());
     bad = bad | rendered_is(?buf, ?i23, "brk #0");
 
-    var i25: Inst = inst(FORM_IMM16, 0xD4000001);
-    i25.src1 = isa.make_imm(0, 2);
+    var i25: isa.Inst = t_inst(mop.SVC, isa.make_none(), isa.make_imm(0, 2), isa.make_none());
     bad = bad | rendered_is(?buf, ?i25, "svc #0");
 
-    var i26: Inst = inst(FORM_IMM16, 0xD4000002);
-    i26.src1 = isa.make_imm(0, 2);
+    var i26: isa.Inst = t_inst(mop.HVC, isa.make_none(), isa.make_imm(0, 2), isa.make_none());
     bad = bad | rendered_is(?buf, ?i26, "hvc #0");
 
-    var i27: Inst = inst(FORM_IMM16, 0xD4000003);
-    i27.src1 = isa.make_imm(0x1234, 2);
+    var i27: isa.Inst = t_inst(mop.SMC, isa.make_none(), isa.make_imm(0x1234, 2), isa.make_none());
     bad = bad | rendered_is(?buf, ?i27, "smc #0x1234");
 
-    var i28: Inst = inst(FORM_NULLARY, 0xD503207F);
+    var i28: isa.Inst = t_inst(mop.WFI, isa.make_none(), isa.make_none(), isa.make_none());
     bad = bad | rendered_is(?buf, ?i28, "wfi");
 
-    var i29: Inst = inst(FORM_NULLARY, 0xD503205F);
+    var i29: isa.Inst = t_inst(mop.WFE, isa.make_none(), isa.make_none(), isa.make_none());
     bad = bad | rendered_is(?buf, ?i29, "wfe");
+
+    var i30: isa.Inst = t_inst(mop.RET, isa.make_none(), isa.make_none(), isa.make_none());
+    bad = bad | rendered_is(?buf, ?i30, "ret");
+
+    var i31: isa.Inst = t_inst(mop.MSR, isa.make_none(), isa.make_imm(0x33E31, 4), mop.gp(1, 8));
+    bad = bad | rendered_is(?buf, ?i31, "msr s3_3_c14_c3_1, x1");
+
+    var i32: isa.Inst = t_inst(mop.UMOV, mop.gp(0, 4), mop.vec(1, 16), isa.make_imm(2, 1));
+    i32.flags = mop.with_elem_bytes(0, 2);
+    bad = bad | rendered_is(?buf, ?i32, "umov w0, v1.h[2]");
+
+    var i33: isa.Inst = t_inst(mop.INS_EL, mop.vec(0, 16), mop.vec(1, 16), isa.make_imm(1, 1));
+    i33.src3 = isa.make_imm(2, 1);
+    i33.flags = mop.with_elem_bytes(0, 4);
+    bad = bad | rendered_is(?buf, ?i33, "mov v0.s[1], v1.s[2]");
 
     enc.buf_dnit(?buf);
     ret bad;
 }
 
-test "mach.lang.target.isa.arm64.printer.render_inst:unmapped_base_is_an_error" {
+test "mach.lang.target.isa.arm64.printer.render_inst:unknown_opcode_is_an_error" {
     var alloc: A.Allocator;
     page.make(?alloc);
     var buf: enc.ByteBuf = enc.buf_init(?alloc);
@@ -1633,8 +943,8 @@ test "mach.lang.target.isa.arm64.printer.render_inst:unmapped_base_is_an_error" 
     var bad: i32 = 0;
     test_sink_reset();
 
-    var i: Inst = inst(FORM_ALU3, 0x00000000);
-    i.dst = gp(0, 8); i.src1 = gp(1, 8); i.src2 = gp(2, 8);
+    var i: isa.Inst = t_inst(mop.MOP_LAST + 1, mop.gp(0, 8), mop.gp(1, 8), mop.gp(2, 8));
+    enc.emit_u32(?buf, 0);
     note_inst(?buf, ?i);
     if (!buf.asm.failed) { bad = 1; }
 
@@ -1660,35 +970,26 @@ test "mach.lang.target.isa.arm64.printer.render_inst:a_symbol_addend_is_part_of_
 
     var bad: i32 = 0;
 
-    var adrp_lo: Inst = inst(FORM_ADRP, 0x90000000);
-    adrp_lo.dst     = gp(0, 8);
-    adrp_lo.src1    = isa.make_sym(g::u32, 0);
-    adrp_lo.sym_mod = MOD_PCREL_HI;
+    var adrp_lo: isa.Inst = t_inst(mop.ADRP, mop.gp(0, 8), isa.make_sym_mod(g::u32, 0, isa.SYM_MOD_PCREL_HI), isa.make_none());
     bad = bad | rendered_is(?buf, ?adrp_lo, "adrp x0, g");
 
-    var adrp_hi: Inst = adrp_lo;
+    var adrp_hi: isa.Inst = adrp_lo;
     adrp_hi.src1.sym_addend = 8;
     bad = bad | rendered_is(?buf, ?adrp_hi, "adrp x0, g+8");
 
-    var adrp_neg: Inst = adrp_lo;
+    var adrp_neg: isa.Inst = adrp_lo;
     adrp_neg.src1.sym_addend = 0 - 8;
     bad = bad | rendered_is(?buf, ?adrp_neg, "adrp x0, g-8");
 
-    var add_lo: Inst = inst(FORM_ADDSUB_IMM, 0x91000000);
-    add_lo.dst     = gp(0, 8);
-    add_lo.src1    = gp(0, 8);
-    add_lo.src2    = isa.make_sym(g::u32, 8);
-    add_lo.sym_mod = MOD_PCREL_LO;
+    var add_lo: isa.Inst = t_inst(mop.ADD, mop.gp(0, 8), mop.gp(0, 8), isa.make_sym_mod(g::u32, 8, isa.SYM_MOD_PCREL_LO));
+    add_lo.flags = mop.FLAG_SP;
     bad = bad | rendered_is(?buf, ?add_lo, "add x0, x0, :lo12:g");
 
-    var add_hi: Inst = add_lo;
+    var add_hi: isa.Inst = add_lo;
     add_hi.src2.sym_addend = 8;
     bad = bad | rendered_is(?buf, ?add_hi, "add x0, x0, :lo12:g+8");
 
-    var got: Inst = inst(FORM_ADRP, 0x90000000);
-    got.dst     = gp(0, 8);
-    got.src1    = isa.make_sym(g::u32, 0);
-    got.sym_mod = MOD_GOT_HI;
+    var got: isa.Inst = t_inst(mop.ADRP, mop.gp(0, 8), isa.make_sym_mod(g::u32, 0, isa.SYM_MOD_GOT_HI), isa.make_none());
     bad = bad | rendered_is(?buf, ?got, "adrp x0, :got:g");
 
     intern.dnit(?itn);

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -28,6 +28,7 @@ use mach.lang.be.codegen.mir;
 use mach.lang.be.codegen.unit;
 use mach.lang.target.isa.spirv;
 use mach.lang.target.isa.spirv.cfg;
+use mach.lang.target.isa.spirv.ops;
 use mach.lang.target.isa.spirv.types;
 use semtype: mach.lang.type;
 
@@ -2899,11 +2900,6 @@ fun emit_param(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr,
                     ir_value_spv_type(e, fn.params[index].ty), mi.memory_flags);
 }
 
-fun by_class(lane_float: bool, int_op: u32, float_op: u32) u32 {
-    if (lane_float) { ret float_op; }
-    ret int_op;
-}
-
 fun unsupported(e: *Emit, msg: str) err[fail.Fail] {
     ret emit_fail(e, msg);
 }
@@ -2929,54 +2925,22 @@ fun emit_instr(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr, pa
     val lf: bool = mir.vec_lane_is_vector(mi.vec_lane)
                 && mir.vec_lane_kind(mi.vec_lane) == mir.VEC_LANE_FLOAT;
 
-    if (op == mir.MIR_ADD)   { ret emit_binary(e, vm, mi, by_class(lf, spirv.OP_I_ADD, spirv.OP_F_ADD)); }
-    if (op == mir.MIR_SUB)   { ret emit_binary(e, vm, mi, by_class(lf, spirv.OP_I_SUB, spirv.OP_F_SUB)); }
-    if (op == mir.MIR_MUL)   { ret emit_binary(e, vm, mi, by_class(lf, spirv.OP_I_MUL, spirv.OP_F_MUL)); }
-    if (op == mir.MIR_DIV_S) { ret emit_binary(e, vm, mi, by_class(lf, spirv.OP_S_DIV, spirv.OP_F_DIV)); }
-    if (op == mir.MIR_DIV_U) { ret emit_binary(e, vm, mi, by_class(lf, spirv.OP_U_DIV, spirv.OP_F_DIV)); }
-    if (op == mir.MIR_REM_S) { ret emit_binary(e, vm, mi, by_class(lf, spirv.OP_S_REM, spirv.OP_F_REM)); }
-    if (op == mir.MIR_REM_U) { ret emit_binary(e, vm, mi, by_class(lf, spirv.OP_U_MOD, spirv.OP_F_REM)); }
-    if (op == mir.MIR_AND)   { ret emit_binary(e, vm, mi, spirv.OP_BITWISE_AND); }
-    if (op == mir.MIR_OR)    { ret emit_binary(e, vm, mi, spirv.OP_BITWISE_OR); }
-    if (op == mir.MIR_XOR)   { ret emit_binary(e, vm, mi, spirv.OP_BITWISE_XOR); }
-    if (op == mir.MIR_SHL)   { ret emit_binary(e, vm, mi, spirv.OP_SHIFT_LEFT_LOGICAL); }
-    if (op == mir.MIR_SHR_U) { ret emit_binary(e, vm, mi, spirv.OP_SHIFT_RIGHT_LOGICAL); }
-    if (op == mir.MIR_SHR_S) { ret emit_binary(e, vm, mi, spirv.OP_SHIFT_RIGHT_ARITHMETIC); }
-
-    if (op == mir.MIR_FADD) { ret emit_binary(e, vm, mi, spirv.OP_F_ADD); }
-    if (op == mir.MIR_FSUB) { ret emit_binary(e, vm, mi, spirv.OP_F_SUB); }
-    if (op == mir.MIR_FMUL) { ret emit_binary(e, vm, mi, spirv.OP_F_MUL); }
-    if (op == mir.MIR_FDIV) { ret emit_binary(e, vm, mi, spirv.OP_F_DIV); }
-
-    if (op == mir.MIR_NEG)  { ret emit_unary(e, vm, mi, by_class(lf, spirv.OP_S_NEGATE, spirv.OP_F_NEGATE)); }
-    if (op == mir.MIR_NOT)  { ret emit_unary(e, vm, mi, spirv.OP_NOT); }
-    if (op == mir.MIR_FNEG) { ret emit_unary(e, vm, mi, spirv.OP_F_NEGATE); }
-
-    if (op == mir.MIR_CMP_EQ)   { ret emit_compare(e, vm, mi, by_class(lf, spirv.OP_I_EQUAL, spirv.OP_F_ORD_EQUAL)); }
-    if (op == mir.MIR_CMP_NE)   { ret emit_compare(e, vm, mi, by_class(lf, spirv.OP_I_NOT_EQUAL, spirv.OP_F_UNORD_NOT_EQUAL)); }
-    if (op == mir.MIR_CMP_LT_S) { ret emit_compare(e, vm, mi, by_class(lf, spirv.OP_S_LESS_THAN, spirv.OP_F_ORD_LESS_THAN)); }
-    if (op == mir.MIR_CMP_LT_U) { ret emit_compare(e, vm, mi, by_class(lf, spirv.OP_U_LESS_THAN, spirv.OP_F_ORD_LESS_THAN)); }
-    if (op == mir.MIR_CMP_LE_S) { ret emit_compare(e, vm, mi, by_class(lf, spirv.OP_S_LESS_THAN_EQUAL, spirv.OP_F_ORD_LESS_THAN_EQUAL)); }
-    if (op == mir.MIR_CMP_LE_U) { ret emit_compare(e, vm, mi, by_class(lf, spirv.OP_U_LESS_THAN_EQUAL, spirv.OP_F_ORD_LESS_THAN_EQUAL)); }
+    # the value instructions: the mapping row names the emitter shape and
+    # the opcode for the lane class; the opcode's core row sizes the word
+    val m: *ops.MirMap = ops.map_of(op);
+    if (m != nil) {
+        val code: u32 = ops.select(m, lf);
+        if (m.shape == ops.SH_BINARY)  { ret emit_binary(e, vm, mi, code); }
+        if (m.shape == ops.SH_UNARY)   { ret emit_unary(e, vm, mi, code); }
+        if (m.shape == ops.SH_COMPARE) { ret emit_compare(e, vm, mi, code); }
+        ret emit_convert(e, vm, mi, code, m.src_float);
+    }
 
     if (op == mir.MIR_FCMP) { ret emit_float_compare(e, vm, mi); }
 
     if (op == mir.MIR_VEC_EXTRACT) { ret emit_vec_extract(e, vm, mi); }
     if (op == mir.MIR_VEC_INSERT)  { ret emit_vec_insert(e, vm, mi); }
     if (op == mir.MIR_VEC_BUILD)   { ret emit_vec_build(e, vm, mi); }
-
-    if (op == mir.MIR_TRUNC) { ret emit_convert(e, vm, mi, spirv.OP_U_CONVERT, false); }
-    if (op == mir.MIR_ZEXT)  { ret emit_convert(e, vm, mi, spirv.OP_U_CONVERT, false); }
-    if (op == mir.MIR_SEXT)  { ret emit_convert(e, vm, mi, spirv.OP_S_CONVERT, false); }
-
-    if (op == mir.MIR_FP_TRUNC) { ret emit_convert(e, vm, mi, spirv.OP_F_CONVERT, true); }
-    if (op == mir.MIR_FP_EXT)   { ret emit_convert(e, vm, mi, spirv.OP_F_CONVERT, true); }
-    if (op == mir.MIR_FP_TO_SI) { ret emit_convert(e, vm, mi, spirv.OP_CONVERT_F_TO_S, true); }
-    if (op == mir.MIR_FP_TO_UI) { ret emit_convert(e, vm, mi, spirv.OP_CONVERT_F_TO_U, true); }
-    if (op == mir.MIR_SI_TO_FP) { ret emit_convert(e, vm, mi, spirv.OP_CONVERT_S_TO_F, false); }
-    if (op == mir.MIR_UI_TO_FP) { ret emit_convert(e, vm, mi, spirv.OP_CONVERT_U_TO_F, false); }
-
-    if (op == mir.MIR_BITCAST) { ret emit_convert(e, vm, mi, spirv.OP_BITCAST, false); }
 
     if (op == mir.MIR_MOV) { ret emit_mov(e, vm, mi); }
     if (op == mir.MIR_DECLASSIFY) { ret emit_mov(e, vm, mi); }
@@ -3239,10 +3203,12 @@ fun emit_binary(e: *Emit, vm: *VMaps, mi: *mir.MirInstr, op_code: u32) err[fail.
     val a: u32 = read_operand(e, vm, ?mi.operands[1], ty);
     val b: u32 = read_operand(e, vm, ?mi.operands[2], ty);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in binary instruction"); }
+    val row: *ops.CoreOp = ops.core(op_code);
+    if (row.arity != 2) { ret emit_fail(e, "spirv.emit: a binary instruction was mapped to an opcode whose row is not two operands"); }
     val result: u32 = spirv.alloc_id(e.b);
-    var ops: [4]u32;
-    ops[0] = vm.type_id[dst]; ops[1] = result; ops[2] = a; ops[3] = b;
-    spirv.inst(e.b, ?e.b.functions, op_code, ?ops[0], 4);
+    var words: [4]u32;
+    words[0] = vm.type_id[dst]; words[1] = result; words[2] = a; words[3] = b;
+    spirv.inst(e.b, ?e.b.functions, op_code, ?words[0], ops.operand_words(row));
     ret store_vreg(e, vm, dst, result);
 }
 
@@ -3254,10 +3220,12 @@ fun emit_unary(e: *Emit, vm: *VMaps, mi: *mir.MirInstr, op_code: u32) err[fail.F
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: unary result vreg out of range"); }
     val a: u32 = read_operand(e, vm, ?mi.operands[1], vm.type_id[dst]);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in unary instruction"); }
+    val row: *ops.CoreOp = ops.core(op_code);
+    if (row.arity != 1) { ret emit_fail(e, "spirv.emit: a unary instruction was mapped to an opcode whose row is not one operand"); }
     val result: u32 = spirv.alloc_id(e.b);
-    var ops: [3]u32;
-    ops[0] = vm.type_id[dst]; ops[1] = result; ops[2] = a;
-    spirv.inst(e.b, ?e.b.functions, op_code, ?ops[0], 3);
+    var words: [3]u32;
+    words[0] = vm.type_id[dst]; words[1] = result; words[2] = a;
+    spirv.inst(e.b, ?e.b.functions, op_code, ?words[0], ops.operand_words(row));
     ret store_vreg(e, vm, dst, result);
 }
 
@@ -3293,10 +3261,12 @@ fun emit_vector_compare(e: *Emit, vm: *VMaps, mi: *mir.MirInstr, op_code: u32) e
     val b: u32 = read_operand(e, vm, ?mi.operands[2], operand_ty);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in vector comparison"); }
 
+    val row: *ops.CoreOp = ops.core(op_code);
+    if (row.arity != 2) { ret emit_fail(e, "spirv.emit: a comparison was mapped to an opcode whose row is not two operands"); }
     val bvec: u32 = spirv.alloc_id(e.b);
     var cops: [4]u32;
     cops[0] = bvec_ty; cops[1] = bvec; cops[2] = a; cops[3] = b;
-    spirv.inst(e.b, ?e.b.functions, op_code, ?cops[0], 4);
+    spirv.inst(e.b, ?e.b.functions, op_code, ?cops[0], ops.operand_words(row));
 
     val ones: u32 = mask_splat(e, mask_ty, lanes, 0xFFFFFFFF, 0xFFFFFFFF);
     val zeros: u32 = mask_splat(e, mask_ty, lanes, 0, 0);
@@ -3419,14 +3389,8 @@ fun emit_float_compare(e: *Emit, vm: *VMaps, mi: *mir.MirInstr) err[fail.Fail] {
     if (fbits != 32 && fbits != 64) {
         ret unsupported(e, "unsupported float comparison width in the SPIR-V target");
     }
-    val cc: u8 = mi.src_width;
-    var op_code: u32 = spirv.OP_F_ORD_GREATER_THAN_EQUAL;
-    if (cc == mir.FCC_EQ)      { op_code = spirv.OP_F_ORD_EQUAL; }
-    or (cc == mir.FCC_NE)      { op_code = spirv.OP_F_UNORD_NOT_EQUAL; }
-    or (cc == mir.FCC_LT)      { op_code = spirv.OP_F_ORD_LESS_THAN; }
-    or (cc == mir.FCC_LE)      { op_code = spirv.OP_F_ORD_LESS_THAN_EQUAL; }
-    or (cc == mir.FCC_GT)      { op_code = spirv.OP_F_ORD_GREATER_THAN; }
-    or (cc != mir.FCC_GE)      { ret unsupported(e, "unknown float comparison condition in the SPIR-V target"); }
+    val op_code: u32 = ops.float_compare(mi.src_width);
+    if (op_code == 0) { ret unsupported(e, "unknown float comparison condition in the SPIR-V target"); }
     ret emit_compare_typed(e, vm, mi, op_code, types.type_float(e.tt, fbits));
 }
 
@@ -3444,11 +3408,13 @@ fun emit_compare_typed(e: *Emit, vm: *VMaps, mi: *mir.MirInstr,
     val a: u32 = read_operand(e, vm, ?mi.operands[1], operand_ty);
     val b: u32 = read_operand(e, vm, ?mi.operands[2], operand_ty);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in comparison"); }
+    val row: *ops.CoreOp = ops.core(op_code);
+    if (row.arity != 2) { ret emit_fail(e, "spirv.emit: a comparison was mapped to an opcode whose row is not two operands"); }
     val bool_ty: u32 = types.type_bool(e.tt);
     val result: u32 = spirv.alloc_id(e.b);
-    var ops: [4]u32;
-    ops[0] = bool_ty; ops[1] = result; ops[2] = a; ops[3] = b;
-    spirv.inst(e.b, ?e.b.functions, op_code, ?ops[0], 4);
+    var words: [4]u32;
+    words[0] = bool_ty; words[1] = result; words[2] = a; words[3] = b;
+    spirv.inst(e.b, ?e.b.functions, op_code, ?words[0], ops.operand_words(row));
     ret store_vreg(e, vm, dst, result);
 }
 
@@ -3471,10 +3437,12 @@ fun emit_convert(e: *Emit, vm: *VMaps, mi: *mir.MirInstr,
     }
     val a: u32 = read_operand(e, vm, ?mi.operands[1], src_ty);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in conversion"); }
+    val row: *ops.CoreOp = ops.core(op_code);
+    if (row.arity != 1) { ret emit_fail(e, "spirv.emit: a conversion was mapped to an opcode whose row is not one operand"); }
     val result: u32 = spirv.alloc_id(e.b);
-    var ops: [3]u32;
-    ops[0] = vm.type_id[dst]; ops[1] = result; ops[2] = a;
-    spirv.inst(e.b, ?e.b.functions, op_code, ?ops[0], 3);
+    var words: [3]u32;
+    words[0] = vm.type_id[dst]; words[1] = result; words[2] = a;
+    spirv.inst(e.b, ?e.b.functions, op_code, ?words[0], ops.operand_words(row));
     ret store_vreg(e, vm, dst, result);
 }
 

--- a/src/lang/target/isa/spirv/ops.mach
+++ b/src/lang/target/isa/spirv/ops.mach
@@ -1,0 +1,237 @@
+use std.types.bool.bool;
+use std.types.bool.false;
+use std.types.bool.true;
+use std.types.size.usize;
+use std.types.string.str;
+
+use mach.lang.be.codegen.mir;
+use mach.lang.target.isa.spirv;
+
+# the core value instructions the emitter forms from a MIR opcode: one row
+# per SPIR-V opcode with the id operands it takes after `<result type>
+# <result id>`. every row carries a result type and a result id, so an
+# instruction's word count is a table read and never a literal beside a
+# call. the structural instructions (loads, stores, composites, control
+# flow) take variable or context-shaped operands and are formed where their
+# shape is decided
+pub rec CoreOp {
+    opcode: u32;
+    name:   str;
+    arity:  u8;
+}
+
+val CORE_COUNT: usize = 41;
+
+val CORE: [CORE_COUNT]CoreOp = [CORE_COUNT]CoreOp{
+    CoreOp{ opcode: spirv.OP_I_ADD,                    name: "OpIAdd",                 arity: 2 },
+    CoreOp{ opcode: spirv.OP_F_ADD,                    name: "OpFAdd",                 arity: 2 },
+    CoreOp{ opcode: spirv.OP_I_SUB,                    name: "OpISub",                 arity: 2 },
+    CoreOp{ opcode: spirv.OP_F_SUB,                    name: "OpFSub",                 arity: 2 },
+    CoreOp{ opcode: spirv.OP_I_MUL,                    name: "OpIMul",                 arity: 2 },
+    CoreOp{ opcode: spirv.OP_F_MUL,                    name: "OpFMul",                 arity: 2 },
+    CoreOp{ opcode: spirv.OP_U_DIV,                    name: "OpUDiv",                 arity: 2 },
+    CoreOp{ opcode: spirv.OP_S_DIV,                    name: "OpSDiv",                 arity: 2 },
+    CoreOp{ opcode: spirv.OP_F_DIV,                    name: "OpFDiv",                 arity: 2 },
+    CoreOp{ opcode: spirv.OP_U_MOD,                    name: "OpUMod",                 arity: 2 },
+    CoreOp{ opcode: spirv.OP_S_REM,                    name: "OpSRem",                 arity: 2 },
+    CoreOp{ opcode: spirv.OP_F_REM,                    name: "OpFRem",                 arity: 2 },
+    CoreOp{ opcode: spirv.OP_BITWISE_AND,              name: "OpBitwiseAnd",           arity: 2 },
+    CoreOp{ opcode: spirv.OP_BITWISE_OR,               name: "OpBitwiseOr",            arity: 2 },
+    CoreOp{ opcode: spirv.OP_BITWISE_XOR,              name: "OpBitwiseXor",           arity: 2 },
+    CoreOp{ opcode: spirv.OP_SHIFT_LEFT_LOGICAL,       name: "OpShiftLeftLogical",     arity: 2 },
+    CoreOp{ opcode: spirv.OP_SHIFT_RIGHT_LOGICAL,      name: "OpShiftRightLogical",    arity: 2 },
+    CoreOp{ opcode: spirv.OP_SHIFT_RIGHT_ARITHMETIC,   name: "OpShiftRightArithmetic", arity: 2 },
+    CoreOp{ opcode: spirv.OP_S_NEGATE,                 name: "OpSNegate",              arity: 1 },
+    CoreOp{ opcode: spirv.OP_F_NEGATE,                 name: "OpFNegate",              arity: 1 },
+    CoreOp{ opcode: spirv.OP_NOT,                      name: "OpNot",                  arity: 1 },
+    CoreOp{ opcode: spirv.OP_I_EQUAL,                  name: "OpIEqual",               arity: 2 },
+    CoreOp{ opcode: spirv.OP_I_NOT_EQUAL,              name: "OpINotEqual",            arity: 2 },
+    CoreOp{ opcode: spirv.OP_U_LESS_THAN,              name: "OpULessThan",            arity: 2 },
+    CoreOp{ opcode: spirv.OP_S_LESS_THAN,              name: "OpSLessThan",            arity: 2 },
+    CoreOp{ opcode: spirv.OP_U_LESS_THAN_EQUAL,        name: "OpULessThanEqual",       arity: 2 },
+    CoreOp{ opcode: spirv.OP_S_LESS_THAN_EQUAL,        name: "OpSLessThanEqual",       arity: 2 },
+    CoreOp{ opcode: spirv.OP_F_ORD_EQUAL,              name: "OpFOrdEqual",            arity: 2 },
+    CoreOp{ opcode: spirv.OP_F_UNORD_NOT_EQUAL,        name: "OpFUnordNotEqual",       arity: 2 },
+    CoreOp{ opcode: spirv.OP_F_ORD_LESS_THAN,          name: "OpFOrdLessThan",         arity: 2 },
+    CoreOp{ opcode: spirv.OP_F_ORD_GREATER_THAN,       name: "OpFOrdGreaterThan",      arity: 2 },
+    CoreOp{ opcode: spirv.OP_F_ORD_LESS_THAN_EQUAL,    name: "OpFOrdLessThanEqual",    arity: 2 },
+    CoreOp{ opcode: spirv.OP_F_ORD_GREATER_THAN_EQUAL, name: "OpFOrdGreaterThanEqual", arity: 2 },
+    CoreOp{ opcode: spirv.OP_U_CONVERT,                name: "OpUConvert",             arity: 1 },
+    CoreOp{ opcode: spirv.OP_S_CONVERT,                name: "OpSConvert",             arity: 1 },
+    CoreOp{ opcode: spirv.OP_F_CONVERT,                name: "OpFConvert",             arity: 1 },
+    CoreOp{ opcode: spirv.OP_CONVERT_F_TO_S,           name: "OpConvertFToS",          arity: 1 },
+    CoreOp{ opcode: spirv.OP_CONVERT_F_TO_U,           name: "OpConvertFToU",          arity: 1 },
+    CoreOp{ opcode: spirv.OP_CONVERT_S_TO_F,           name: "OpConvertSToF",          arity: 1 },
+    CoreOp{ opcode: spirv.OP_CONVERT_U_TO_F,           name: "OpConvertUToF",          arity: 1 },
+    CoreOp{ opcode: spirv.OP_BITCAST,                  name: "OpBitcast",              arity: 1 },
+};
+
+val CORE_NONE: CoreOp = CoreOp{ opcode: 0, name: nil, arity: 0 };
+
+# the row of a core value opcode; the blank row for an opcode outside the
+# table, whose arity of 0 no emitter shape accepts
+pub fun core(opcode: u32) *CoreOp {
+    var i: usize = 0;
+    for (i < CORE_COUNT) {
+        if (CORE[i].opcode == opcode) { ret ?CORE[i]; }
+        i = i + 1;
+    }
+    ret ?CORE_NONE;
+}
+
+# the operand words of a core value instruction: result type, result id and
+# the row's operands. the encoded word count is one more
+pub fun operand_words(row: *CoreOp) u32 {
+    ret 2 + row.arity::u32;
+}
+
+# how a MIR opcode reaches SPIR-V: the emitter shape that forms the
+# instruction and the opcode for each lane class. an opcode with no float
+# pairing names the same opcode in both columns
+pub def Shape: u8;
+
+pub val SH_NONE:    Shape = 0;
+# <type> <result> a b, result typed as the destination
+pub val SH_BINARY:  Shape = 1;
+# <type> <result> a, result typed as the destination
+pub val SH_UNARY:   Shape = 2;
+# <bool> <result> a b, operands at the comparison width
+pub val SH_COMPARE: Shape = 3;
+# <type> <result> a, the source typed from `src_float` when its operand
+# carries no type of its own
+pub val SH_CONVERT: Shape = 4;
+
+pub rec MirMap {
+    mir:       mir.MirOpcode;
+    shape:     Shape;
+    int_op:    u32;
+    float_op:  u32;
+    src_float: bool;
+}
+
+val MAP_COUNT: usize = 36;
+
+val MAP: [MAP_COUNT]MirMap = [MAP_COUNT]MirMap{
+    MirMap{ mir: mir.MIR_ADD,   shape: SH_BINARY, int_op: spirv.OP_I_ADD, float_op: spirv.OP_F_ADD, src_float: false },
+    MirMap{ mir: mir.MIR_SUB,   shape: SH_BINARY, int_op: spirv.OP_I_SUB, float_op: spirv.OP_F_SUB, src_float: false },
+    MirMap{ mir: mir.MIR_MUL,   shape: SH_BINARY, int_op: spirv.OP_I_MUL, float_op: spirv.OP_F_MUL, src_float: false },
+    MirMap{ mir: mir.MIR_DIV_S, shape: SH_BINARY, int_op: spirv.OP_S_DIV, float_op: spirv.OP_F_DIV, src_float: false },
+    MirMap{ mir: mir.MIR_DIV_U, shape: SH_BINARY, int_op: spirv.OP_U_DIV, float_op: spirv.OP_F_DIV, src_float: false },
+    MirMap{ mir: mir.MIR_REM_S, shape: SH_BINARY, int_op: spirv.OP_S_REM, float_op: spirv.OP_F_REM, src_float: false },
+    MirMap{ mir: mir.MIR_REM_U, shape: SH_BINARY, int_op: spirv.OP_U_MOD, float_op: spirv.OP_F_REM, src_float: false },
+    MirMap{ mir: mir.MIR_AND,   shape: SH_BINARY, int_op: spirv.OP_BITWISE_AND, float_op: spirv.OP_BITWISE_AND, src_float: false },
+    MirMap{ mir: mir.MIR_OR,    shape: SH_BINARY, int_op: spirv.OP_BITWISE_OR,  float_op: spirv.OP_BITWISE_OR,  src_float: false },
+    MirMap{ mir: mir.MIR_XOR,   shape: SH_BINARY, int_op: spirv.OP_BITWISE_XOR, float_op: spirv.OP_BITWISE_XOR, src_float: false },
+    MirMap{ mir: mir.MIR_SHL,   shape: SH_BINARY, int_op: spirv.OP_SHIFT_LEFT_LOGICAL,     float_op: spirv.OP_SHIFT_LEFT_LOGICAL,     src_float: false },
+    MirMap{ mir: mir.MIR_SHR_U, shape: SH_BINARY, int_op: spirv.OP_SHIFT_RIGHT_LOGICAL,    float_op: spirv.OP_SHIFT_RIGHT_LOGICAL,    src_float: false },
+    MirMap{ mir: mir.MIR_SHR_S, shape: SH_BINARY, int_op: spirv.OP_SHIFT_RIGHT_ARITHMETIC, float_op: spirv.OP_SHIFT_RIGHT_ARITHMETIC, src_float: false },
+
+    MirMap{ mir: mir.MIR_FADD, shape: SH_BINARY, int_op: spirv.OP_F_ADD, float_op: spirv.OP_F_ADD, src_float: false },
+    MirMap{ mir: mir.MIR_FSUB, shape: SH_BINARY, int_op: spirv.OP_F_SUB, float_op: spirv.OP_F_SUB, src_float: false },
+    MirMap{ mir: mir.MIR_FMUL, shape: SH_BINARY, int_op: spirv.OP_F_MUL, float_op: spirv.OP_F_MUL, src_float: false },
+    MirMap{ mir: mir.MIR_FDIV, shape: SH_BINARY, int_op: spirv.OP_F_DIV, float_op: spirv.OP_F_DIV, src_float: false },
+
+    MirMap{ mir: mir.MIR_NEG,  shape: SH_UNARY, int_op: spirv.OP_S_NEGATE, float_op: spirv.OP_F_NEGATE, src_float: false },
+    MirMap{ mir: mir.MIR_NOT,  shape: SH_UNARY, int_op: spirv.OP_NOT,      float_op: spirv.OP_NOT,      src_float: false },
+    MirMap{ mir: mir.MIR_FNEG, shape: SH_UNARY, int_op: spirv.OP_F_NEGATE, float_op: spirv.OP_F_NEGATE, src_float: false },
+
+    MirMap{ mir: mir.MIR_CMP_EQ,   shape: SH_COMPARE, int_op: spirv.OP_I_EQUAL,             float_op: spirv.OP_F_ORD_EQUAL,           src_float: false },
+    MirMap{ mir: mir.MIR_CMP_NE,   shape: SH_COMPARE, int_op: spirv.OP_I_NOT_EQUAL,         float_op: spirv.OP_F_UNORD_NOT_EQUAL,     src_float: false },
+    MirMap{ mir: mir.MIR_CMP_LT_S, shape: SH_COMPARE, int_op: spirv.OP_S_LESS_THAN,         float_op: spirv.OP_F_ORD_LESS_THAN,       src_float: false },
+    MirMap{ mir: mir.MIR_CMP_LT_U, shape: SH_COMPARE, int_op: spirv.OP_U_LESS_THAN,         float_op: spirv.OP_F_ORD_LESS_THAN,       src_float: false },
+    MirMap{ mir: mir.MIR_CMP_LE_S, shape: SH_COMPARE, int_op: spirv.OP_S_LESS_THAN_EQUAL,   float_op: spirv.OP_F_ORD_LESS_THAN_EQUAL, src_float: false },
+    MirMap{ mir: mir.MIR_CMP_LE_U, shape: SH_COMPARE, int_op: spirv.OP_U_LESS_THAN_EQUAL,   float_op: spirv.OP_F_ORD_LESS_THAN_EQUAL, src_float: false },
+
+    MirMap{ mir: mir.MIR_TRUNC,    shape: SH_CONVERT, int_op: spirv.OP_U_CONVERT,      float_op: spirv.OP_U_CONVERT,      src_float: false },
+    MirMap{ mir: mir.MIR_ZEXT,     shape: SH_CONVERT, int_op: spirv.OP_U_CONVERT,      float_op: spirv.OP_U_CONVERT,      src_float: false },
+    MirMap{ mir: mir.MIR_SEXT,     shape: SH_CONVERT, int_op: spirv.OP_S_CONVERT,      float_op: spirv.OP_S_CONVERT,      src_float: false },
+    MirMap{ mir: mir.MIR_FP_TRUNC, shape: SH_CONVERT, int_op: spirv.OP_F_CONVERT,      float_op: spirv.OP_F_CONVERT,      src_float: true },
+    MirMap{ mir: mir.MIR_FP_EXT,   shape: SH_CONVERT, int_op: spirv.OP_F_CONVERT,      float_op: spirv.OP_F_CONVERT,      src_float: true },
+    MirMap{ mir: mir.MIR_FP_TO_SI, shape: SH_CONVERT, int_op: spirv.OP_CONVERT_F_TO_S, float_op: spirv.OP_CONVERT_F_TO_S, src_float: true },
+    MirMap{ mir: mir.MIR_FP_TO_UI, shape: SH_CONVERT, int_op: spirv.OP_CONVERT_F_TO_U, float_op: spirv.OP_CONVERT_F_TO_U, src_float: true },
+    MirMap{ mir: mir.MIR_SI_TO_FP, shape: SH_CONVERT, int_op: spirv.OP_CONVERT_S_TO_F, float_op: spirv.OP_CONVERT_S_TO_F, src_float: false },
+    MirMap{ mir: mir.MIR_UI_TO_FP, shape: SH_CONVERT, int_op: spirv.OP_CONVERT_U_TO_F, float_op: spirv.OP_CONVERT_U_TO_F, src_float: false },
+    MirMap{ mir: mir.MIR_BITCAST,  shape: SH_CONVERT, int_op: spirv.OP_BITCAST,        float_op: spirv.OP_BITCAST,        src_float: false },
+};
+
+# the mapping row of a MIR opcode, nil when the value emitter has none (the
+# structural instructions are formed by their own emitters)
+pub fun map_of(op: mir.MirOpcode) *MirMap {
+    var i: usize = 0;
+    for (i < MAP_COUNT) {
+        if (MAP[i].mir == op) { ret ?MAP[i]; }
+        i = i + 1;
+    }
+    ret nil;
+}
+
+# the opcode of a mapped MIR instruction for its lane class
+pub fun select(row: *MirMap, lane_float: bool) u32 {
+    if (lane_float) { ret row.float_op; }
+    ret row.int_op;
+}
+
+# the ordered float comparisons the FCMP condition codes name
+pub fun float_compare(cc: u8) u32 {
+    if (cc == mir.FCC_EQ) { ret spirv.OP_F_ORD_EQUAL; }
+    if (cc == mir.FCC_NE) { ret spirv.OP_F_UNORD_NOT_EQUAL; }
+    if (cc == mir.FCC_LT) { ret spirv.OP_F_ORD_LESS_THAN; }
+    if (cc == mir.FCC_LE) { ret spirv.OP_F_ORD_LESS_THAN_EQUAL; }
+    if (cc == mir.FCC_GT) { ret spirv.OP_F_ORD_GREATER_THAN; }
+    if (cc == mir.FCC_GE) { ret spirv.OP_F_ORD_GREATER_THAN_EQUAL; }
+    ret 0;
+}
+
+# the arity an emitter shape forms
+pub fun shape_arity(shape: Shape) u8 {
+    if (shape == SH_BINARY || shape == SH_COMPARE) { ret 2; }
+    if (shape == SH_UNARY || shape == SH_CONVERT)  { ret 1; }
+    ret 0;
+}
+
+# the census: every mapped opcode has a core row whose arity is the shape's,
+# in both lane classes, and no core row is stated twice. the status names
+# the mapping row that failed, offset past the harness codes
+test "mach.lang.target.isa.spirv.ops:every_mapped_opcode_has_a_core_row_of_the_shape_arity" {
+    var i: usize = 0;
+    for (i < MAP_COUNT) {
+        val m: *MirMap = ?MAP[i];
+        val want: u8 = shape_arity(m.shape);
+        if (want == 0)                      { ret 50 + i::i32; }
+        if (core(m.int_op).arity != want)   { ret 100 + i::i32; }
+        if (core(m.float_op).arity != want) { ret 150 + i::i32; }
+        if (map_of(m.mir) != m)             { ret 200 + i::i32; }
+        i = i + 1;
+    }
+    var a: usize = 0;
+    for (a < CORE_COUNT) {
+        var b: usize = a + 1;
+        for (b < CORE_COUNT) {
+            if (CORE[a].opcode == CORE[b].opcode) { ret 250; }
+            b = b + 1;
+        }
+        if (CORE[a].arity == 0 || CORE[a].name == nil) { ret 251; }
+        a = a + 1;
+    }
+    if (core(0).arity != 0 || core(spirv.OP_LOAD).arity != 0) { ret 252; }
+    if (map_of(mir.MIR_LOAD) != nil || map_of(mir.MIR_FCMP) != nil) { ret 253; }
+    var cc: u8 = mir.FCC_EQ;
+    for (cc <= mir.FCC_GE) {
+        if (core(float_compare(cc)).arity != 2) { ret 254; }
+        cc = cc + 1;
+    }
+    if (float_compare(mir.FCC_GE + 1) != 0) { ret 255; }
+    ret 0;
+}
+
+# the word count is the row's, so an OpIAdd is five words and an OpSNegate
+# four, as the specification lays them out
+test "mach.lang.target.isa.spirv.ops:word_counts_follow_the_row" {
+    if (spirv.inst_word(spirv.OP_I_ADD, operand_words(core(spirv.OP_I_ADD)) + 1) != 0x00050080) { ret 1; }
+    if (spirv.inst_word(spirv.OP_S_NEGATE, operand_words(core(spirv.OP_S_NEGATE)) + 1) != 0x0004007E) { ret 2; }
+    if (spirv.inst_word(spirv.OP_F_ORD_LESS_THAN, operand_words(core(spirv.OP_F_ORD_LESS_THAN)) + 1) != 0x000500B8) { ret 3; }
+    if (spirv.inst_word(spirv.OP_BITCAST, operand_words(core(spirv.OP_BITCAST)) + 1) != 0x0004007C) { ret 4; }
+    if (select(map_of(mir.MIR_ADD), true) != spirv.OP_F_ADD || select(map_of(mir.MIR_ADD), false) != spirv.OP_I_ADD) { ret 5; }
+    if (select(map_of(mir.MIR_REM_U), true) != spirv.OP_F_REM || select(map_of(mir.MIR_AND), true) != spirv.OP_BITWISE_AND) { ret 6; }
+    ret 0;
+}

--- a/src/lang/target/isa/tests.mach
+++ b/src/lang/target/isa/tests.mach
@@ -32,7 +32,7 @@ val CENSUS_HARNESS:     i32 = 1;
 val CENSUS_UNPERMITTED: i32 = 2;
 val CENSUS_COUNT:       i32 = 3;
 
-val ALLOWED_LEN: usize = 13;
+val ALLOWED_LEN: usize = 12;
 
 fun allowed_fun(i: usize) str {
     if (i == 0)  { ret "operand_blank"; }
@@ -41,12 +41,11 @@ fun allowed_fun(i: usize) str {
     if (i == 3)  { ret "reg_machine"; }
     if (i == 4)  { ret "module_emitter"; }
     if (i == 5)  { ret "reloc_seam"; }
-    if (i == 6)  { ret "inst"; }
-    if (i == 7)  { ret "op_none"; }
-    if (i == 8)  { ret "instr"; }
-    if (i == 9)  { ret "abi_vtable"; }
-    if (i == 10) { ret "vreg"; }
-    if (i == 12) { ret "value_abi_vtable"; }
+    if (i == 6)  { ret "op_none"; }
+    if (i == 7)  { ret "instr"; }
+    if (i == 8)  { ret "abi_vtable"; }
+    if (i == 9)  { ret "vreg"; }
+    if (i == 11) { ret "value_abi_vtable"; }
     ret "asm_bind";
 }
 
@@ -57,10 +56,9 @@ fun allowed_file(i: usize) str {
     if (i == 3)  { ret "src/lang/target/isa.mach"; }
     if (i == 4)  { ret "src/lang/target/isa.mach"; }
     if (i == 5)  { ret "src/lang/target/isa.mach"; }
-    if (i == 6)  { ret "src/lang/target/isa/arm64/printer.mach"; }
-    if (i == 7)  { ret "src/lang/target/isa/asm.mach"; }
-    if (i == 8)  { ret "src/lang/be/codegen/mir.mach"; }
-    if (i == 9 || i == 12) { ret "src/lang/target/abi.mach"; }
+    if (i == 6)  { ret "src/lang/target/isa/asm.mach"; }
+    if (i == 7)  { ret "src/lang/be/codegen/mir.mach"; }
+    if (i == 8 || i == 11) { ret "src/lang/target/abi.mach"; }
     ret "src/lang/be/codegen/mir.mach";
 }
 


### PR DESCRIPTION
Part of #2212 (census section 10 items 1, 2 for aarch64, and 7). No `Closes`.

## aarch64: one instruction representation, one form table

- `arm64/printer.mach rec Inst` (the last printer-private representation), its 22 `FORM_*` bytes, the `to_inst` translation at notification and the 201 base-word literals in the printer are gone. The encoder builds an `isa.Inst` (with `src3` for madd/msub), assembles the word from the member's row, emits it, and notifies the same instruction spelled as an assembler reads it back (`inst.spell`: mov/neg/mvn/cmp/cmn/mul/mneg/mov-lane/vector-mov). The printer renders from `isa.Inst` alone.
- `arm64/inst.mach:Form` is one row per `MachOp`: spelling, operand `Layout` (the old form byte as a column), base word and immediate-form base, `WidthRule` (sf / N / ftype / size / pair opc / FMOV-general direction), `LaneClass`, alias flag. `inst.assemble(*isa.Inst)` replaces the encoder's 154 base-word constants and 25 `pack_*` packers; `alu3_shape`, `ldst_shape`, `ldur_shape`, `ldst_reg_shape`, `ldst_loads` and the printer's ten classify ladders are deleted. The #2766 access rows now name members instead of words.
- Three members added for encodings that shared a spelling: `FMOV_GEN`, `FMOV_IMM`, `INS_EL` (effect rows added; the N5 census `every_notifiable_opcode_has_a_row` covers them).
- Opcode-space census: `inst.form:every_member_has_a_complete_row` fails by member number on a row without a layout, or an encoded member without a base word, or an alias with one. An instruction the table cannot hold emits nothing: `encode.buf_refuse` records it on the `ByteBuf` and the encode boundary reports it (a growth refusal's sibling channel).
- Notification carriage: `isa.Operand.sym_mod` replaces the record's `sym_mod`; `FLAG_SP` (index 31 is sp), `FLAG_LABEL_LOCAL/FWD/SKIP` (numbered local in `sym_id`, pc-relative skip in `disp`) replace `target`/`block`. `a64_target` reads the same `label_is_block`/`label_is_forward_local` facts as before.
- Effects: `msr <sysreg>, xt` now carries the register in src2 (a read), where the old form record put it in dst with no role, so the walk sees the read. Memory operands of the byte and halfword loads/stores carry the access size (1, 2) instead of the register width (4); the walk's extents are exact instead of over-approximate.

## SPIR-V: op tables

- `spirv/ops.mach`: `CoreOp` rows (opcode, name, arity; every row typed) for the 41 core value instructions, and `MirMap` rows (MIR opcode, emitter shape, int/float opcode, source class) for the 36 mapped MIR opcodes. `emit_instr` dispatches by the mapping row; `emit_binary`/`unary`/`compare`/`convert` take the word count from the core row and refuse an opcode whose arity is not the shape's. The FCC ladder is `ops.float_compare`. N4's value ABI (doc/design/spirv-abi-2963.md section 6) is untouched.
- Census test: every mapped opcode has a core row of the shape's arity in both lane classes, no core row is stated twice, and the word counts are the specification's (`OpIAdd` five words, `OpSNegate` four).

## Verification (from-source compiler `out/audit/mach2`, built by the v5 stage)

- Corpus, run once at the end: `--target aarch64-linux --target spirv --target x86_64-linux --layer a --layer b`: 1097 pass, 0 fail, 111 skip. Layer B goldens byte-identical on all three (no `--bless`), x86_64-linux as the control.
- Suite: 3046 passed, 0 failed (baseline 3041, +5 by name: `inst.form:every_member_has_a_complete_row`, `inst.assemble:width_rules_reach_the_word`, `inst.spell:aliases_take_the_assembler_operand_order`, `spirv.ops:every_mapped_opcode_has_a_core_row_of_the_shape_arity`, `spirv.ops:word_counts_follow_the_row`; `printer.render_inst:unmapped_base_is_an_error` renamed to `unknown_opcode_is_an_error`). Construction census (`isa.blank`) updated: the printer's `inst` constructor no longer exists.
- `sh test/census.sh`: all ok.
- Link leg `test/link/run.sh`: 167 pass / 14 fail, every failure a riscv64-linux cell refused for missing `libc6-dev-riscv64-cross` headers on this host; every x86_64 cell passes.
- llvm-mc conformance: the encoder's byte-exact packer tests now state their expectations through `inst.assemble`; the new width-rule cases (sp-relative sub, fp pairs, umov, lsl, fmov general, q loads, ldar, fcvt, fcvtzs, scvtf, ins element, cset, msr) were cross-checked against `llvm-mc -triple=aarch64 -show-encoding`.
- Cross-builds: `--target darwin-aarch64` (Mach-O arm64) and `--target linux-arm64` build.
- Fixpoint: A (stage) built B, B built C, `cmp B C` byte-identical.
