### PR TITLE
codegen: nominal VRegId and PRegId, a tagged MIR operand, and the dead clobbers field removed (#2212)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -349,6 +349,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   build/publish/resolve/release proves the registry releases everything at
   every refusal ordinal. (#2212)
 
+- MIR register identities are nominal. `mir.VRegId` and `mir.PRegId` are
+  single-field records, not `def` aliases, so a virtual register cannot be
+  handed where a physical one is meant (or the reverse) and neither indexes a
+  table without naming the unwrap; `MIR_PREG_NIL` joins `MIR_VREG_NIL` so a
+  physical slot never borrows the virtual sentinel. They thread through
+  `MirOperand`, `MirVReg.assigned`, `MirInstr.declassified`, `MirAbiInput.reg`,
+  `abi.ParamSlot.reg` and `ParamPiece.reg`, the lowering context, the
+  allocator and every ISA's operand translation, where `mir.preg_regid` is
+  the one conversion back to an isa regid. A memory operand's index is a tag
+  (`none`, `vreg`, `preg`) in place of `index` plus `index_is_preg`, read under
+  a `sel` guard. Emitted bytes are unchanged on every target. (#2212)
+
 - The compiler builds against std 2.0 (std dev `e204cb81f`) and CI
   bootstraps it through the v5 migration stage (mach `2a2918b23` with std
   1.0.1) after the audited 4.30 fixpoint (#3226, lane C1). The language
@@ -437,6 +449,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Editor analysis returns an owned diagnostic/source snapshot with explicit phase and target selection. Raw products have checked serial-view lifetimes. Closing a buffer retires its overlay, source payload and cached dependents while retaining its FileId. Buffer slots are reused, and checked editor teardown preserves owners on preparation failure (#2999).
 
 ### Removed
+
+- `isa.Inst.clobbers`. The field had one writer (`inst_blank`, `= 0`) and no
+  reader; implicit writes come from `asm.Mnemonic.implicit` and the opcode
+  descriptors, so a future reader can no longer inherit a zero-filled effect
+  that reads as "no clobbers" for every instruction. (#2212)
 
 - The `try` production the parser still carried from the withdrawn
   2026-09-08 design. `try` was never a released form; it is an ordinary

--- a/doc/design/backend-census-2212.md
+++ b/doc/design/backend-census-2212.md
@@ -578,7 +578,11 @@ link admission any other way without a second capability channel.
   additive like N3's): `isa.Inst.src3`, blank by `inst_blank`, because aarch64
   `madd`/`msub` read three registers (Rn, Rm, Ra) and a notification that drops
   the fourth register cannot be walked soundly; no existing reader changes,
-  x86_64 and riscv64 never set it.
+  x86_64 and riscv64 never set it. Amended 2026-09-12 (item 10.3, N5 ruled):
+  `isa.Inst.clobbers` is deleted. Implicit writes come from `asm.Mnemonic.implicit`
+  and the per-opcode `MirOpDescriptor` effect columns; the field had one writer
+  (`inst_blank`, `= 0`) and no reader, so its removal changes no byte and closes
+  the fail-open shape that a future reader would have inherited.
 - `mir.MirInstr.writes_secret`, `memory_flags`, `mir.MirVReg.secret`,
   `mir.MirOperand.required_bank`, `regalloc.verify_rewritten_operands`
   (`regalloc.mach:2322`): the post-rewrite facts N5 validates against.

--- a/doc/design/backend-census-2212.md
+++ b/doc/design/backend-census-2212.md
@@ -549,7 +549,17 @@ link admission any other way without a second capability channel.
   `abi.AggLayout`, `abi.ClassifyFn`/`ArgPassingFn`/`RetPassingFn`
   (`src/lang/target/abi.mach:93-140`) and `abi/spirv.mach` `classify_arg`/
   `classify_return`/`arg_regs`: the contract N4 replaces with a value-oriented
-  one. Register machines keep the `reg: i32` carrier unchanged.
+  one. Register machines keep the `reg: i32` carrier unchanged. Amended
+  2026-09-12 (item 10.4): `ParamSlot.reg` and `ParamPiece.reg` are `mir.PRegId`,
+  the nominal physical register, and `MIR_PREG_NIL` stands where `-1` stood; the
+  constructors (`make_slot`, `make_piece`, `make_slot_pair`, `make_slot_hfa`)
+  still take the isa regid the packs select, so no pack changes, and
+  `mir.preg_regid` is the one way back to the `i32`. Same amendment: the MIR
+  register carriers `mir.VRegId` / `mir.PRegId` (single-field records, not
+  `def` aliases), `mir.MirOperand.index: MirIndex` (a `tag` with `none`, `vreg`
+  and `preg` cases replacing `index` plus `index_is_preg`), `MirVReg.assigned`,
+  `MirInstr.declassified` and `MirAbiInput.reg` typed by them; every ISA reads
+  a physical register through `mir.preg_regid(op.preg)`.
 - `src/lang/be/codegen/mir/abi.mach:45 abi_gp_arg_reg` and `MAX_GP_ARG_REGS`:
   the shared consumer that must stop reading a bank for emitters.
 - `isa.TargetDefs`/`OpDef`/`TypeDef`/`TypeRefuseFn`, `isa.with_defs`,

--- a/src/lang/be/codegen.mach
+++ b/src/lang/be/codegen.mach
@@ -2545,11 +2545,11 @@ fun t_oblivious_fixture(alloc: *A.Allocator, name: intern.StrId, oblivious: bool
             if (sel ro.err) { ret res[mir.MirFunction, fail.Fail].err{fail.refused(ro.err)}; }
             ops = ro.ok;
         }
-        if (k == 0) { ops[0] = mir.op_vreg(0); ops[1] = mir.op_imm(5); instrs[k] = mir.instr(mir.MIR_MOV, ops, 2, 8, 8); }
-        if (k == 1) { ops[0] = mir.op_vreg(1); ops[1] = mir.op_imm(7); instrs[k] = mir.instr(mir.MIR_MOV, ops, 2, 8, 8); }
-        if (k == 2) { ops[0] = mir.op_vreg(2); ops[1] = mir.op_vreg(0); ops[2] = mir.op_vreg(1); instrs[k] = mir.instr(mir.MIR_XOR, ops, 3, 8, 8); }
-        if (k == 3) { ops[0] = mir.op_vreg(3); ops[1] = mir.op_vreg(2); instrs[k] = mir.instr(mir.MIR_DECLASSIFY, ops, 2, 8, 8); }
-        if (k == 4) { ops[0] = mir.op_vreg(4); ops[1] = mir.op_vreg(3); ops[2] = mir.op_vreg(1); instrs[k] = mir.instr(mir.MIR_ADD, ops, 3, 8, 8); }
+        if (k == 0) { ops[0] = mir.op_vreg(mir.vreg_id(0)); ops[1] = mir.op_imm(5); instrs[k] = mir.instr(mir.MIR_MOV, ops, 2, 8, 8); }
+        if (k == 1) { ops[0] = mir.op_vreg(mir.vreg_id(1)); ops[1] = mir.op_imm(7); instrs[k] = mir.instr(mir.MIR_MOV, ops, 2, 8, 8); }
+        if (k == 2) { ops[0] = mir.op_vreg(mir.vreg_id(2)); ops[1] = mir.op_vreg(mir.vreg_id(0)); ops[2] = mir.op_vreg(mir.vreg_id(1)); instrs[k] = mir.instr(mir.MIR_XOR, ops, 3, 8, 8); }
+        if (k == 3) { ops[0] = mir.op_vreg(mir.vreg_id(3)); ops[1] = mir.op_vreg(mir.vreg_id(2)); instrs[k] = mir.instr(mir.MIR_DECLASSIFY, ops, 2, 8, 8); }
+        if (k == 4) { ops[0] = mir.op_vreg(mir.vreg_id(4)); ops[1] = mir.op_vreg(mir.vreg_id(3)); ops[2] = mir.op_vreg(mir.vreg_id(1)); instrs[k] = mir.instr(mir.MIR_ADD, ops, 3, 8, 8); }
         if (k == 5) { instrs[k] = mir.instr(mir.MIR_RET, nil, 0, 0, 0); }
         instrs[k].loc = source.loc_nil();
         k = k + 1;
@@ -2755,8 +2755,8 @@ fun t_seeds_match_walk(arch: str, os_name: str, abi: str) i32 {
                 seen_barrier = seen_barrier + 1;
                 # the coalesced declassify is a zero-byte marker naming the downgraded vreg
                 if (mi.opcode != isa.ISA_USE::mir.MirOpcode || mi.operand_count != 0) { ret 18; }
-                if (seeds.count != 1 || seeds.origin[0] != 2 || seeds.secret[0]) { ret 19; }
-                if (!walk[seeds.origin[0]]) { ret 20; }
+                if (seeds.count != 1 || seeds.origin[0].n != 2 || seeds.secret[0]) { ret 19; }
+                if (!walk[seeds.origin[0].n]) { ret 20; }
                 ii = ii + 1;
                 cnt;
             }
@@ -2767,9 +2767,9 @@ fun t_seeds_match_walk(arch: str, os_name: str, abi: str) i32 {
                 val op: *mir.MirOperand = ?mi.operands[k];
                 if (op.kind == mir.MIR_OP_VREG) { ret 10; }
                 if (op.kind != mir.MIR_OP_PREG) { k = k + 1; cnt; }
-                val origin: u32 = seeds.origin[k];
-                if (origin != mir.operand_origin(op)) { ret 11; }
-                if (origin == mir.MIR_VREG_NIL || origin >= f.vreg_count) { ret 11; }
+                val origin: u32 = seeds.origin[k].n;
+                if (origin != mir.operand_origin(op).n) { ret 11; }
+                if (origin == mir.MIR_VREG_NIL.n || origin >= f.vreg_count) { ret 11; }
                 val listed: bool = seeds.secret[k];
                 if (f.vregs[origin].secret != listed) { ret 12; }
                 if (listed) { seen_seed = seen_seed + 1; }
@@ -2847,14 +2847,14 @@ fun t_walk_fixture(alloc: *A.Allocator, name: intern.StrId, case_id: u32, v0_sec
         val ro: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](alloc, 3::usize);
         if (sel ro.err) { ret res[mir.MirFunction, fail.Fail].err{fail.refused(ro.err)}; }
         val ops: *mir.MirOperand = ro.ok;
-        if (k == 0) { ops[0] = mir.op_vreg(0); ops[1] = mir.op_imm(5);    instrs[n] = mir.instr(mir.MIR_MOV, ops, 2, 8, 8); n = n + 1; }
-        if (k == 1) { ops[0] = mir.op_vreg(1); ops[1] = mir.op_imm(7);    instrs[n] = mir.instr(mir.MIR_MOV, ops, 2, 8, 8); n = n + 1; }
+        if (k == 0) { ops[0] = mir.op_vreg(mir.vreg_id(0)); ops[1] = mir.op_imm(5);    instrs[n] = mir.instr(mir.MIR_MOV, ops, 2, 8, 8); n = n + 1; }
+        if (k == 1) { ops[0] = mir.op_vreg(mir.vreg_id(1)); ops[1] = mir.op_imm(7);    instrs[n] = mir.instr(mir.MIR_MOV, ops, 2, 8, 8); n = n + 1; }
         if (k == 2 && case_id == WALK_CASE_MUL) {
-            ops[0] = mir.op_vreg(2); ops[1] = mir.op_vreg(0); ops[2] = mir.op_vreg(1);
+            ops[0] = mir.op_vreg(mir.vreg_id(2)); ops[1] = mir.op_vreg(mir.vreg_id(0)); ops[2] = mir.op_vreg(mir.vreg_id(1));
             instrs[n] = mir.instr(mir.MIR_MUL, ops, 3, 8, 8); n = n + 1;
         }
         if (k == 2 && case_id == WALK_CASE_DIV && div_reg < 0) {
-            ops[0] = mir.op_vreg(2); ops[1] = mir.op_vreg(0); ops[2] = mir.op_vreg(1);
+            ops[0] = mir.op_vreg(mir.vreg_id(2)); ops[1] = mir.op_vreg(mir.vreg_id(0)); ops[2] = mir.op_vreg(mir.vreg_id(1));
             instrs[n] = mir.instr(mir.MIR_DIV_U, ops, 3, 8, 8); n = n + 1;
         }
         if (k == 2 && case_id == WALK_CASE_DIV && div_reg >= 0) {
@@ -2862,34 +2862,34 @@ fun t_walk_fixture(alloc: *A.Allocator, name: intern.StrId, case_id: u32, v0_sec
             val ra: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](alloc, 2::usize);
             if (sel ra.err) { ret res[mir.MirFunction, fail.Fail].err{fail.refused(ra.err)}; }
             val aops: *mir.MirOperand = ra.ok;
-            aops[0] = mir.op_preg(div_reg::u32); aops[1] = mir.op_vreg(0);
+            aops[0] = mir.op_preg(mir.preg_id(div_reg)); aops[1] = mir.op_vreg(mir.vreg_id(0));
             instrs[n] = mir.instr(mir.MIR_MOV, aops, 2, 8, 8); n = n + 1;
-            ops[0] = mir.op_preg(div_reg::u32); ops[1] = mir.op_vreg(1);
+            ops[0] = mir.op_preg(mir.preg_id(div_reg)); ops[1] = mir.op_vreg(mir.vreg_id(1));
             instrs[n] = mir.instr(mir.MIR_DIV_U, ops, 2, 8, 8); n = n + 1;
             val rr: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](alloc, 2::usize);
             if (sel rr.err) { ret res[mir.MirFunction, fail.Fail].err{fail.refused(rr.err)}; }
             val rops: *mir.MirOperand = rr.ok;
-            rops[0] = mir.op_vreg(2); rops[1] = mir.op_preg(div_reg::u32);
+            rops[0] = mir.op_vreg(mir.vreg_id(2)); rops[1] = mir.op_preg(mir.preg_id(div_reg));
             instrs[n] = mir.instr(mir.MIR_MOV, rops, 2, 8, 8); n = n + 1;
         }
         if (k == 2 && case_id == WALK_CASE_UI_TO_FP) {
-            ops[0] = mir.op_vreg(2); ops[1] = mir.op_vreg(0);
+            ops[0] = mir.op_vreg(mir.vreg_id(2)); ops[1] = mir.op_vreg(mir.vreg_id(0));
             instrs[n] = mir.instr(mir.MIR_UI_TO_FP, ops, 2, 8, 8); n = n + 1;
         }
         if (k == 2 && case_id == WALK_CASE_LOAD) {
-            ops[0] = mir.op_vreg(2); ops[1] = mir.op_imm(4096);
+            ops[0] = mir.op_vreg(mir.vreg_id(2)); ops[1] = mir.op_imm(4096);
             instrs[n] = mir.instr(mir.MIR_MOV, ops, 2, 8, 8); n = n + 1;
         }
         if (k == 3 && case_id == WALK_CASE_LOAD) {
-            ops[0] = mir.op_vreg(3); ops[1] = mir.op_mem_value(2, 0);
+            ops[0] = mir.op_vreg(mir.vreg_id(3)); ops[1] = mir.op_mem_value(mir.vreg_id(2), 0);
             instrs[n] = mir.instr(mir.MIR_LOAD, ops, 2, 8, 8); n = n + 1;
         }
         if (k == 3 && case_id == WALK_CASE_UI_TO_FP) {
-            ops[0] = mir.op_vreg(3); ops[1] = mir.op_vreg(2); ops[2] = mir.op_vreg(2);
+            ops[0] = mir.op_vreg(mir.vreg_id(3)); ops[1] = mir.op_vreg(mir.vreg_id(2)); ops[2] = mir.op_vreg(mir.vreg_id(2));
             instrs[n] = mir.instr(mir.MIR_FADD, ops, 3, 8, 8); n = n + 1;
         }
         if (k == 3 && (case_id == WALK_CASE_MUL || case_id == WALK_CASE_DIV)) {
-            ops[0] = mir.op_vreg(3); ops[1] = mir.op_vreg(2); ops[2] = mir.op_vreg(1);
+            ops[0] = mir.op_vreg(mir.vreg_id(3)); ops[1] = mir.op_vreg(mir.vreg_id(2)); ops[2] = mir.op_vreg(mir.vreg_id(1));
             instrs[n] = mir.instr(mir.MIR_ADD, ops, 3, 8, 8); n = n + 1;
         }
         if (k == 4) { instrs[n] = mir.instr(mir.MIR_RET, nil, 0, 0, 0); n = n + 1; }
@@ -2910,7 +2910,7 @@ fun t_walk_fixture(alloc: *A.Allocator, name: intern.StrId, case_id: u32, v0_sec
 # the register that now aliases the secret
 fun t_walk_alias_reload(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunction) bool {
     if (tgt.arch.reload_scratch_count < 1) { ret false; }
-    val scratch: u32 = tgt.arch.reload_scratch_regs[0].id::u32;
+    val scratch: mir.PRegId = mir.preg_id(tgt.arch.reload_scratch_regs[0].id);
     val blk: *mir.MirBlock = ?f.blocks[0];
     var li: u32 = blk.instr_count;
     var i: u32 = 0;
@@ -2918,7 +2918,7 @@ fun t_walk_alias_reload(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunct
         val mi: *mir.MirInstr = ?blk.instrs[i];
         var k: u32 = 0;
         for (k < mi.operand_count) {
-            if (mi.operands[k].kind == mir.MIR_OP_MEM && mi.operands[k].vreg == mir.MIR_VREG_NIL) { li = i; }
+            if (mi.operands[k].kind == mir.MIR_OP_MEM && mir.vreg_is_nil(mi.operands[k].vreg)) { li = i; }
             k = k + 1;
         }
         i = i + 1;
@@ -2952,9 +2952,9 @@ fun t_walk_alias_reload(tgt: *target.Target, m: *mir.MirModule, f: *mir.MirFunct
     val ro: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](m.alloc, 2::usize);
     if (sel ro.err) { ret false; }
     val ops: *mir.MirOperand = ro.ok;
-    ops[0] = mir.op_preg_of(scratch, 0);
+    ops[0] = mir.op_preg_of(scratch, mir.vreg_id(0));
     ops[0].required_bank = load.operands[0].required_bank;
-    ops[1] = mir.op_mem_slot(0, 0);
+    ops[1] = mir.op_mem_slot(mir.vreg_id(0), 0);
     ops[1].required_bank = load.operands[1].required_bank;
     var reload: mir.MirInstr = @load;
     reload.operands      = ops;

--- a/src/lang/be/codegen/ctvalidate.mach
+++ b/src/lang/be/codegen/ctvalidate.mach
@@ -166,14 +166,14 @@ fun max_preg(f: *mir.MirFunction) u32 {
             for (k < mi.operand_count) {
                 val op: *mir.MirOperand = ?mi.operands[k];
                 if (op.kind == mir.MIR_OP_PREG) {
-                    if (best == NO_PREG || op.preg > best) { best = op.preg; }
+                    if (best == NO_PREG || op.preg.n > best) { best = op.preg.n; }
                 }
                 if (op.kind == mir.MIR_OP_MEM) {
-                    if (op.vreg == mir.MIR_VREG_NIL) {
-                        if (best == NO_PREG || op.preg > best) { best = op.preg; }
+                    if (mir.vreg_is_nil(op.vreg)) {
+                        if (best == NO_PREG || op.preg.n > best) { best = op.preg.n; }
                     }
-                    if (op.index_is_preg && op.index != mir.MIR_VREG_NIL) {
-                        if (best == NO_PREG || op.index > best) { best = op.index; }
+                    if (sel op.index.preg) {
+                        if (best == NO_PREG || op.index.preg.n > best) { best = op.index.preg.n; }
                     }
                 }
                 k = k + 1;
@@ -204,24 +204,28 @@ fun validate_operand_ranges(f: *mir.MirFunction, nv: u32, np: u32, interner: *in
                 if (!operand_kind_known(op.kind)) {
                     ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_OPERAND_KIND_DETAIL))};
                 }
-                if (op.kind == mir.MIR_OP_VREG && op.vreg >= nv) {
+                if (op.kind == mir.MIR_OP_VREG && op.vreg.n >= nv) {
                     ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_VREG_DETAIL))};
                 }
-                if (op.kind == mir.MIR_OP_PREG && op.preg >= np) {
+                if (op.kind == mir.MIR_OP_PREG && op.preg.n >= np) {
                     ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_PREG_DETAIL))};
                 }
                 if (op.kind == mir.MIR_OP_MEM) {
-                    if (op.vreg == mir.MIR_VREG_NIL && op.preg >= np) {
+                    if (mir.vreg_is_nil(op.vreg) && op.preg.n >= np) {
                         ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_MEM_BASE_DETAIL))};
                     }
-                    if (op.vreg != mir.MIR_VREG_NIL && op.vreg >= nv) {
+                    if (!mir.vreg_is_nil(op.vreg) && op.vreg.n >= nv) {
                         ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_MEM_BASE_DETAIL))};
                     }
-                    if (op.index != mir.MIR_VREG_NIL && op.index_is_preg && op.index >= np) {
-                        ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_MEM_INDEX_DETAIL))};
+                    if (sel op.index.preg) {
+                        if (op.index.preg.n >= np) {
+                            ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_MEM_INDEX_DETAIL))};
+                        }
                     }
-                    if (op.index != mir.MIR_VREG_NIL && !op.index_is_preg && op.index >= nv) {
-                        ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_MEM_INDEX_DETAIL))};
+                    if (sel op.index.vreg) {
+                        if (op.index.vreg.n >= nv) {
+                            ret err[fail.Fail].err{fail.message(malformed_msg(alloc, interner, f.name, RANGE_MEM_INDEX_DETAIL))};
+                        }
                     }
                 }
                 k = k + 1;
@@ -234,19 +238,19 @@ fun validate_operand_ranges(f: *mir.MirFunction, nv: u32, np: u32, interner: *in
 }
 
 fun mem_base_secret(op: *mir.MirOperand, vt: *bool, pt: *bool) bool {
-    if (op.vreg == mir.MIR_VREG_NIL) { ret pt[op.preg]; }
-    ret vt[op.vreg];
+    if (mir.vreg_is_nil(op.vreg)) { ret pt[op.preg.n]; }
+    ret vt[op.vreg.n];
 }
 
 fun mem_index_secret(op: *mir.MirOperand, vt: *bool, pt: *bool) bool {
-    if (op.index == mir.MIR_VREG_NIL) { ret false; }
-    if (op.index_is_preg) { ret pt[op.index]; }
-    ret vt[op.index];
+    if (sel op.index.preg) { ret pt[op.index.preg.n]; }
+    if (sel op.index.vreg) { ret vt[op.index.vreg.n]; }
+    ret false;
 }
 
 fun operand_secret(op: *mir.MirOperand, vt: *bool, pt: *bool) bool {
-    if (op.kind == mir.MIR_OP_VREG) { ret vt[op.vreg]; }
-    if (op.kind == mir.MIR_OP_PREG) { ret pt[op.preg]; }
+    if (op.kind == mir.MIR_OP_VREG) { ret vt[op.vreg.n]; }
+    if (op.kind == mir.MIR_OP_PREG) { ret pt[op.preg.n]; }
     if (op.kind == mir.MIR_OP_MEM) {
         ret mem_base_secret(op, vt, pt) || mem_index_secret(op, vt, pt);
     }
@@ -274,10 +278,10 @@ fun apply_instr(mi: *mir.MirInstr, vt: *bool, pt: *bool, np: u32) bool {
     if (!mir.instr_defines_shape(mi)) { ret false; }
     val d: *mir.MirOperand = ?mi.operands[0];
     if (d.kind == mir.MIR_OP_VREG) {
-        if (s && !vt[d.vreg]) { vt[d.vreg] = true; ret true; }
+        if (s && !vt[d.vreg.n]) { vt[d.vreg.n] = true; ret true; }
         ret false;
     }
-    if (d.kind == mir.MIR_OP_PREG) { pt[d.preg] = s; }
+    if (d.kind == mir.MIR_OP_PREG) { pt[d.preg.n] = s; }
     ret false;
 }
 
@@ -530,19 +534,19 @@ test "mach.lang.be.codegen.ctvalidate.rederive:phi_join_branch" {
     vregs[1] = t_vreg(1, false);
     vregs[2] = t_vreg(2, false);
 
-    var b0_mov: [2]mir.MirOperand; b0_mov[0] = mir.op_vreg(1); b0_mov[1] = mir.op_vreg(0);
+    var b0_mov: [2]mir.MirOperand; b0_mov[0] = mir.op_vreg(mir.vreg_id(1)); b0_mov[1] = mir.op_vreg(mir.vreg_id(0));
     var b0_br:  [1]mir.MirOperand; b0_br[0]  = mir.op_block(2);
     var b0i: [2]mir.MirInstr;
     b0i[0] = t_instr(mir.MIR_MOV, ?b0_mov[0], 2);
     b0i[1] = t_instr(mir.MIR_BR,  ?b0_br[0], 1);
 
-    var b1_mov: [2]mir.MirOperand; b1_mov[0] = mir.op_vreg(1); b1_mov[1] = mir.op_vreg(2);
+    var b1_mov: [2]mir.MirOperand; b1_mov[0] = mir.op_vreg(mir.vreg_id(1)); b1_mov[1] = mir.op_vreg(mir.vreg_id(2));
     var b1_br:  [1]mir.MirOperand; b1_br[0]  = mir.op_block(2);
     var b1i: [2]mir.MirInstr;
     b1i[0] = t_instr(mir.MIR_MOV, ?b1_mov[0], 2);
     b1i[1] = t_instr(mir.MIR_BR,  ?b1_br[0], 1);
 
-    var b2_cbr: [3]mir.MirOperand; b2_cbr[0] = mir.op_vreg(1); b2_cbr[1] = mir.op_block(0); b2_cbr[2] = mir.op_block(1);
+    var b2_cbr: [3]mir.MirOperand; b2_cbr[0] = mir.op_vreg(mir.vreg_id(1)); b2_cbr[1] = mir.op_block(0); b2_cbr[2] = mir.op_block(1);
     var b2i: [1]mir.MirInstr;
     b2i[0] = t_instr(mir.MIR_CBR, ?b2_cbr[0], 3);
 
@@ -568,9 +572,9 @@ test "mach.lang.be.codegen.ctvalidate.rederive:inlined_return_address" {
     vregs[2] = t_vreg(2, false);
     vregs[3] = t_vreg(3, false);
 
-    var mov1: [2]mir.MirOperand; mov1[0] = mir.op_vreg(1); mov1[1] = mir.op_vreg(0);
-    var mov2: [2]mir.MirOperand; mov2[0] = mir.op_vreg(2); mov2[1] = mir.op_vreg(1);
-    var load: [2]mir.MirOperand; load[0] = mir.op_vreg(3); load[1] = mir.op_mem_value(2, 0);
+    var mov1: [2]mir.MirOperand; mov1[0] = mir.op_vreg(mir.vreg_id(1)); mov1[1] = mir.op_vreg(mir.vreg_id(0));
+    var mov2: [2]mir.MirOperand; mov2[0] = mir.op_vreg(mir.vreg_id(2)); mov2[1] = mir.op_vreg(mir.vreg_id(1));
+    var load: [2]mir.MirOperand; load[0] = mir.op_vreg(mir.vreg_id(3)); load[1] = mir.op_mem_value(mir.vreg_id(2), 0);
     var b0i: [3]mir.MirInstr;
     b0i[0] = t_instr(mir.MIR_MOV,  ?mov1[0], 2);
     b0i[1] = t_instr(mir.MIR_MOV,  ?mov2[0], 2);
@@ -595,13 +599,13 @@ test "mach.lang.be.codegen.ctvalidate.rederive:rotated_loop_backedge" {
     vregs[2] = t_vreg(2, false);
     vregs[3] = t_vreg(3, false);
 
-    var add: [3]mir.MirOperand; add[0] = mir.op_vreg(3); add[1] = mir.op_vreg(1); add[2] = mir.op_vreg(2);
-    var hbr: [3]mir.MirOperand; hbr[0] = mir.op_vreg(3); hbr[1] = mir.op_block(1); hbr[2] = mir.op_block(2);
+    var add: [3]mir.MirOperand; add[0] = mir.op_vreg(mir.vreg_id(3)); add[1] = mir.op_vreg(mir.vreg_id(1)); add[2] = mir.op_vreg(mir.vreg_id(2));
+    var hbr: [3]mir.MirOperand; hbr[0] = mir.op_vreg(mir.vreg_id(3)); hbr[1] = mir.op_block(1); hbr[2] = mir.op_block(2);
     var b0i: [2]mir.MirInstr;
     b0i[0] = t_instr(mir.MIR_ADD, ?add[0], 3);
     b0i[1] = t_instr(mir.MIR_CBR, ?hbr[0], 3);
 
-    var lmv: [2]mir.MirOperand; lmv[0] = mir.op_vreg(1); lmv[1] = mir.op_vreg(0);
+    var lmv: [2]mir.MirOperand; lmv[0] = mir.op_vreg(mir.vreg_id(1)); lmv[1] = mir.op_vreg(mir.vreg_id(0));
     var lbr: [1]mir.MirOperand; lbr[0] = mir.op_block(0);
     var b1i: [2]mir.MirInstr;
     b1i[0] = t_instr(mir.MIR_MOV, ?lmv[0], 2);
@@ -631,10 +635,10 @@ test "mach.lang.be.codegen.ctvalidate.barrier:declassify_stops_taint" {
     vregs[2] = t_vreg(2, false);
     vregs[3] = t_vreg(3, false);
 
-    var dcl: [2]mir.MirOperand; dcl[0] = mir.op_vreg(1); dcl[1] = mir.op_vreg(0);
-    var mul: [3]mir.MirOperand; mul[0] = mir.op_vreg(2); mul[1] = mir.op_vreg(1); mul[2] = mir.op_vreg(3);
-    var cbr: [3]mir.MirOperand; cbr[0] = mir.op_vreg(1); cbr[1] = mir.op_block(0); cbr[2] = mir.op_block(0);
-    var st:  [2]mir.MirOperand; st[0]  = mir.op_mem_value(1, 0); st[1] = mir.op_vreg(3);
+    var dcl: [2]mir.MirOperand; dcl[0] = mir.op_vreg(mir.vreg_id(1)); dcl[1] = mir.op_vreg(mir.vreg_id(0));
+    var mul: [3]mir.MirOperand; mul[0] = mir.op_vreg(mir.vreg_id(2)); mul[1] = mir.op_vreg(mir.vreg_id(1)); mul[2] = mir.op_vreg(mir.vreg_id(3));
+    var cbr: [3]mir.MirOperand; cbr[0] = mir.op_vreg(mir.vreg_id(1)); cbr[1] = mir.op_block(0); cbr[2] = mir.op_block(0);
+    var st:  [2]mir.MirOperand; st[0]  = mir.op_mem_value(mir.vreg_id(1), 0); st[1] = mir.op_vreg(mir.vreg_id(3));
     var b0i: [4]mir.MirInstr;
     b0i[0] = t_instr(mir.MIR_DECLASSIFY, ?dcl[0], 2);
     b0i[1] = t_instr(mir.MIR_MUL,        ?mul[0], 3);
@@ -658,7 +662,7 @@ test "mach.lang.be.codegen.ctvalidate.varlat:secret_multiply_capability" {
     vregs[1] = t_vreg(1, false);
     vregs[2] = t_vreg(2, false);
 
-    var mul: [3]mir.MirOperand; mul[0] = mir.op_vreg(2); mul[1] = mir.op_vreg(0); mul[2] = mir.op_vreg(1);
+    var mul: [3]mir.MirOperand; mul[0] = mir.op_vreg(mir.vreg_id(2)); mul[1] = mir.op_vreg(mir.vreg_id(0)); mul[2] = mir.op_vreg(mir.vreg_id(1));
     var b0i: [1]mir.MirInstr;
     b0i[0] = t_instr(mir.MIR_MUL, ?mul[0], 3);
     var blocks: [1]mir.MirBlock;
@@ -683,7 +687,7 @@ test "mach.lang.be.codegen.ctvalidate.varlat:secret_shift_count_only" {
     vregs[1] = t_vreg(1, false);
     vregs[2] = t_vreg(2, false);
 
-    var shl: [3]mir.MirOperand; shl[0] = mir.op_vreg(2); shl[1] = mir.op_vreg(1); shl[2] = mir.op_vreg(0);
+    var shl: [3]mir.MirOperand; shl[0] = mir.op_vreg(mir.vreg_id(2)); shl[1] = mir.op_vreg(mir.vreg_id(1)); shl[2] = mir.op_vreg(mir.vreg_id(0));
     var b0i: [1]mir.MirInstr; b0i[0] = t_instr(mir.MIR_SHL, ?shl[0], 3);
     var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?b0i[0], 1);
     var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 3);
@@ -695,7 +699,7 @@ test "mach.lang.be.codegen.ctvalidate.varlat:secret_shift_count_only" {
     val validate_function_r2: err[fail.Fail] = validate_function(?t_yes, ?f, nil, ?alloc);
     if (!sel validate_function_r2.ok) { ret 1; }
 
-    var shl2: [3]mir.MirOperand; shl2[0] = mir.op_vreg(2); shl2[1] = mir.op_vreg(0); shl2[2] = mir.op_imm(3);
+    var shl2: [3]mir.MirOperand; shl2[0] = mir.op_vreg(mir.vreg_id(2)); shl2[1] = mir.op_vreg(mir.vreg_id(0)); shl2[2] = mir.op_imm(3);
     var b0i2: [1]mir.MirInstr; b0i2[0] = t_instr(mir.MIR_SHL, ?shl2[0], 3);
     var blocks2: [1]mir.MirBlock; blocks2[0] = t_block(0, ?b0i2[0], 1);
     var f2: mir.MirFunction = t_fn(true, ?blocks2[0], 1, ?vregs[0], 3);
@@ -713,15 +717,15 @@ test "mach.lang.be.codegen.ctvalidate.varlat:secret_divide_and_precolor" {
     vregs[0] = t_vreg(0, true);
     vregs[1] = t_vreg(1, false);
     vregs[2] = t_vreg(2, false);
-    var dv: [3]mir.MirOperand; dv[0] = mir.op_vreg(2); dv[1] = mir.op_vreg(0); dv[2] = mir.op_vreg(1);
+    var dv: [3]mir.MirOperand; dv[0] = mir.op_vreg(mir.vreg_id(2)); dv[1] = mir.op_vreg(mir.vreg_id(0)); dv[2] = mir.op_vreg(mir.vreg_id(1));
     var b0i: [1]mir.MirInstr; b0i[0] = t_instr(mir.MIR_DIV_S, ?dv[0], 3);
     var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?b0i[0], 1);
     var f: mir.MirFunction = t_fn(true, ?blocks[0], 1, ?vregs[0], 3);
     val validate_function_r: err[fail.Fail] = validate_function(?t, ?f, nil, ?alloc);
     if (!sel validate_function_r.err) { ret 1; }
 
-    var mov: [2]mir.MirOperand; mov[0] = mir.op_preg(0); mov[1] = mir.op_vreg(0);
-    var dv2: [2]mir.MirOperand; dv2[0] = mir.op_preg(0); dv2[1] = mir.op_vreg(1);
+    var mov: [2]mir.MirOperand; mov[0] = mir.op_preg(mir.preg_id(0)); mov[1] = mir.op_vreg(mir.vreg_id(0));
+    var dv2: [2]mir.MirOperand; dv2[0] = mir.op_preg(mir.preg_id(0)); dv2[1] = mir.op_vreg(mir.vreg_id(1));
     var p0i: [2]mir.MirInstr;
     p0i[0] = t_instr(mir.MIR_MOV,   ?mov[0], 2);
     p0i[1] = t_instr(mir.MIR_DIV_S, ?dv2[0], 2);
@@ -743,9 +747,9 @@ test "mach.lang.be.codegen.ctvalidate.clean:valid_oblivious_no_false_positive" {
     vregs[2] = t_vreg(2, false);
     vregs[3] = t_vreg(3, false);
 
-    var mov: [2]mir.MirOperand; mov[0] = mir.op_vreg(2); mov[1] = mir.op_vreg(0);
-    var st:  [2]mir.MirOperand; st[0]  = mir.op_mem_value(1, 0); st[1] = mir.op_vreg(2);
-    var shl: [3]mir.MirOperand; shl[0] = mir.op_vreg(3); shl[1] = mir.op_vreg(2); shl[2] = mir.op_imm(5);
+    var mov: [2]mir.MirOperand; mov[0] = mir.op_vreg(mir.vreg_id(2)); mov[1] = mir.op_vreg(mir.vreg_id(0));
+    var st:  [2]mir.MirOperand; st[0]  = mir.op_mem_value(mir.vreg_id(1), 0); st[1] = mir.op_vreg(mir.vreg_id(2));
+    var shl: [3]mir.MirOperand; shl[0] = mir.op_vreg(mir.vreg_id(3)); shl[1] = mir.op_vreg(mir.vreg_id(2)); shl[2] = mir.op_imm(5);
     var b0i: [4]mir.MirInstr;
     b0i[0] = t_instr(mir.MIR_MOV,   ?mov[0], 2);
     b0i[1] = t_instr(mir.MIR_STORE, ?st[0], 2);
@@ -768,7 +772,7 @@ test "mach.lang.be.codegen.ctvalidate.scope:non_oblivious_unaffected" {
     var vregs: [1]mir.MirVReg;
     vregs[0] = t_vreg(0, true);
 
-    var cbr: [3]mir.MirOperand; cbr[0] = mir.op_vreg(0); cbr[1] = mir.op_block(0); cbr[2] = mir.op_block(0);
+    var cbr: [3]mir.MirOperand; cbr[0] = mir.op_vreg(mir.vreg_id(0)); cbr[1] = mir.op_block(0); cbr[2] = mir.op_block(0);
     var b0i: [1]mir.MirInstr; b0i[0] = t_instr(mir.MIR_CBR, ?cbr[0], 3);
     var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?b0i[0], 1);
 
@@ -793,14 +797,14 @@ test "mach.lang.be.codegen.ctvalidate.control:secret_indirect_call" {
     vregs[0] = t_vreg(0, true);
     vregs[1] = t_vreg(1, false);
 
-    var c_sec: [1]mir.MirOperand; c_sec[0] = mir.op_vreg(0);
+    var c_sec: [1]mir.MirOperand; c_sec[0] = mir.op_vreg(mir.vreg_id(0));
     var si: [1]mir.MirInstr; si[0] = t_instr(mir.MIR_CALL, ?c_sec[0], 1);
     var sblocks: [1]mir.MirBlock; sblocks[0] = t_block(0, ?si[0], 1);
     var sf: mir.MirFunction = t_fn(true, ?sblocks[0], 1, ?vregs[0], 2);
     val validate_function_r: err[fail.Fail] = validate_function(?t, ?sf, nil, ?alloc);
     if (!sel validate_function_r.err) { ret 1; }
 
-    var c_pub: [1]mir.MirOperand; c_pub[0] = mir.op_vreg(1);
+    var c_pub: [1]mir.MirOperand; c_pub[0] = mir.op_vreg(mir.vreg_id(1));
     var pi: [1]mir.MirInstr; pi[0] = t_instr(mir.MIR_CALL, ?c_pub[0], 1);
     var pblocks: [1]mir.MirBlock; pblocks[0] = t_block(0, ?pi[0], 1);
     var pf: mir.MirFunction = t_fn(true, ?pblocks[0], 1, ?vregs[0], 2);
@@ -842,7 +846,7 @@ test "mach.lang.be.codegen.ctvalidate.scope:whole_module_backend_refused" {
     vregs[0] = t_vreg(0, true);
     vregs[1] = t_vreg(1, false);
     vregs[2] = t_vreg(2, false);
-    var add: [3]mir.MirOperand; add[0] = mir.op_vreg(2); add[1] = mir.op_vreg(0); add[2] = mir.op_vreg(1);
+    var add: [3]mir.MirOperand; add[0] = mir.op_vreg(mir.vreg_id(2)); add[1] = mir.op_vreg(mir.vreg_id(0)); add[2] = mir.op_vreg(mir.vreg_id(1));
     var b0i: [2]mir.MirInstr;
     b0i[0] = t_instr(mir.MIR_ADD, ?add[0], 3);
     b0i[1] = t_instr(mir.MIR_RET, nil, 0);
@@ -901,7 +905,7 @@ test "mach.lang.be.codegen.ctvalidate.failclosed:unknown_opcode_rejected" {
 
     var vregs: [1]mir.MirVReg;
     vregs[0] = t_vreg(0, false);
-    var ops: [1]mir.MirOperand; ops[0] = mir.op_vreg(0);
+    var ops: [1]mir.MirOperand; ops[0] = mir.op_vreg(mir.vreg_id(0));
     var b0i: [1]mir.MirInstr;
     b0i[0] = t_instr(0xDEAD, ?ops[0], 1);
     var blocks: [1]mir.MirBlock; blocks[0] = t_block(0, ?b0i[0], 1);
@@ -925,28 +929,28 @@ test "mach.lang.be.codegen.ctvalidate.failclosed:out_of_range_registers_rejected
     vregs[0] = t_vreg(0, true);
     vregs[1] = t_vreg(1, false);
 
-    var good: [2]mir.MirOperand; good[0] = mir.op_vreg(1); good[1] = mir.op_vreg(0);
+    var good: [2]mir.MirOperand; good[0] = mir.op_vreg(mir.vreg_id(1)); good[1] = mir.op_vreg(mir.vreg_id(0));
     var gi: [1]mir.MirInstr; gi[0] = t_instr(mir.MIR_MOV, ?good[0], 2);
     var gb: [1]mir.MirBlock; gb[0] = t_block(0, ?gi[0], 1);
     var gf: mir.MirFunction = t_fn(true, ?gb[0], 1, ?vregs[0], 2);
     val validate_function_r: err[fail.Fail] = validate_function(?t, ?gf, nil, ?alloc);
     if (!sel validate_function_r.ok) { ret 1; }
 
-    var vops: [2]mir.MirOperand; vops[0] = mir.op_vreg(1); vops[1] = mir.op_vreg(7);
+    var vops: [2]mir.MirOperand; vops[0] = mir.op_vreg(mir.vreg_id(1)); vops[1] = mir.op_vreg(mir.vreg_id(7));
     var vi: [1]mir.MirInstr; vi[0] = t_instr(mir.MIR_MOV, ?vops[0], 2);
     var vb: [1]mir.MirBlock; vb[0] = t_block(0, ?vi[0], 1);
     var vf: mir.MirFunction = t_fn(true, ?vb[0], 1, ?vregs[0], 2);
     val validate_function_r2: err[fail.Fail] = validate_function(?t, ?vf, nil, ?alloc);
     if (!sel validate_function_r2.err) { ret 1; }
 
-    var mops: [2]mir.MirOperand; mops[0] = mir.op_vreg(1); mops[1] = mir.op_mem_value(9, 0);
+    var mops: [2]mir.MirOperand; mops[0] = mir.op_vreg(mir.vreg_id(1)); mops[1] = mir.op_mem_value(mir.vreg_id(9), 0);
     var mi2: [1]mir.MirInstr; mi2[0] = t_instr(mir.MIR_LOAD, ?mops[0], 2);
     var mb2: [1]mir.MirBlock; mb2[0] = t_block(0, ?mi2[0], 1);
     var mf: mir.MirFunction = t_fn(true, ?mb2[0], 1, ?vregs[0], 2);
     val validate_function_r3: err[fail.Fail] = validate_function(?t, ?mf, nil, ?alloc);
     if (!sel validate_function_r3.err) { ret 1; }
 
-    var pops: [2]mir.MirOperand; pops[0] = mir.op_vreg(1); pops[1] = mir.op_preg(3);
+    var pops: [2]mir.MirOperand; pops[0] = mir.op_vreg(mir.vreg_id(1)); pops[1] = mir.op_preg(mir.preg_id(3));
     var pi: [2]mir.MirInstr;
     pi[0] = t_instr(mir.MIR_MOV, ?pops[0], 2);
     pi[1] = t_instr(mir.MIR_RET, nil, 0);
@@ -966,8 +970,8 @@ test "mach.lang.be.codegen.ctvalidate.failclosed:secret_memory_base_preg" {
     vregs[0] = t_vreg(0, true);
     vregs[1] = t_vreg(1, false);
 
-    var mk: [2]mir.MirOperand; mk[0] = mir.op_preg(2); mk[1] = mir.op_vreg(0);
-    var ld: [2]mir.MirOperand; ld[0] = mir.op_vreg(1); ld[1] = mir.op_mem_preg(2, 0);
+    var mk: [2]mir.MirOperand; mk[0] = mir.op_preg(mir.preg_id(2)); mk[1] = mir.op_vreg(mir.vreg_id(0));
+    var ld: [2]mir.MirOperand; ld[0] = mir.op_vreg(mir.vreg_id(1)); ld[1] = mir.op_mem_preg(mir.preg_id(2), 0);
     var ins: [2]mir.MirInstr;
     ins[0] = t_instr(mir.MIR_MOV, ?mk[0], 2);
     ins[1] = t_instr(mir.MIR_LOAD, ?ld[0], 2);
@@ -976,7 +980,7 @@ test "mach.lang.be.codegen.ctvalidate.failclosed:secret_memory_base_preg" {
     val validate_function_r: err[fail.Fail] = validate_function(?t, ?f, nil, ?alloc);
     if (!sel validate_function_r.err) { ret 1; }
 
-    var pub_mk: [2]mir.MirOperand; pub_mk[0] = mir.op_preg(2); pub_mk[1] = mir.op_vreg(1);
+    var pub_mk: [2]mir.MirOperand; pub_mk[0] = mir.op_preg(mir.preg_id(2)); pub_mk[1] = mir.op_vreg(mir.vreg_id(1));
     var pub_ins: [2]mir.MirInstr;
     pub_ins[0] = t_instr(mir.MIR_MOV, ?pub_mk[0], 2);
     pub_ins[1] = t_instr(mir.MIR_LOAD, ?ld[0], 2);
@@ -996,7 +1000,7 @@ test "mach.lang.be.codegen.ctvalidate.failclosed:operand_kind_outside_the_catalo
     vregs[0] = t_vreg(0, false);
     vregs[1] = t_vreg(1, false);
 
-    var ops: [2]mir.MirOperand; ops[0] = mir.op_vreg(1); ops[1] = mir.op_vreg(0);
+    var ops: [2]mir.MirOperand; ops[0] = mir.op_vreg(mir.vreg_id(1)); ops[1] = mir.op_vreg(mir.vreg_id(0));
     ops[1].kind = 200::mir.MirOperandKind;
     var ins: [2]mir.MirInstr;
     ins[0] = t_instr(mir.MIR_MOV, ?ops[0], 2);

--- a/src/lang/be/codegen/ctwalk.mach
+++ b/src/lang/be/codegen/ctwalk.mach
@@ -349,7 +349,7 @@ fun seed_read(seeds: *notes.NoteSeeds, mi: *mir.MirInstr, regid: i32) bool {
     for (k < seeds.count && k < mi.operand_count) {
         if (!(k == 0 && defines)) {
             val op: *mir.MirOperand = ?mi.operands[k];
-            if (op.kind == mir.MIR_OP_PREG && op.preg == regid::u32 && seeds.secret[k]) { ret true; }
+            if (op.kind == mir.MIR_OP_PREG && mir.preg_regid(op.preg) == regid && seeds.secret[k]) { ret true; }
         }
         k = k + 1;
     }
@@ -361,7 +361,7 @@ fun seed_read(seeds: *notes.NoteSeeds, mi: *mir.MirInstr, regid: i32) bool {
 fun seed_write(seeds: *notes.NoteSeeds, mi: *mir.MirInstr, regid: i32) bool {
     if (!instr_defines(mi) || seeds.count == 0) { ret false; }
     val op: *mir.MirOperand = ?mi.operands[0];
-    ret op.kind == mir.MIR_OP_PREG && op.preg == regid::u32 && seeds.secret[0];
+    ret op.kind == mir.MIR_OP_PREG && mir.preg_regid(op.preg) == regid && seeds.secret[0];
 }
 
 fun seed_mem_read(seeds: *notes.NoteSeeds, mi: *mir.MirInstr) bool {
@@ -380,14 +380,14 @@ fun seed_mem_write(seeds: *notes.NoteSeeds, mi: *mir.MirInstr) bool {
     ret mi.operands[0].kind == mir.MIR_OP_MEM && seeds.secret[0];
 }
 
-fun clear_vreg_home(w: *Walker, s: *State, v: u32) {
-    if (v == mir.MIR_VREG_NIL || v >= w.f.vreg_count) { ret; }
-    val vr: *mir.MirVReg = ?w.f.vregs[v];
-    if (vr.assigned != mir.MIR_VREG_NIL) { set_reg(w, s, vr.assigned::i32, false, false); }
+fun clear_vreg_home(w: *Walker, s: *State, v: mir.VRegId) {
+    if (mir.vreg_is_nil(v) || v.n >= w.f.vreg_count) { ret; }
+    val vr: *mir.MirVReg = ?w.f.vregs[v.n];
+    if (!mir.preg_is_nil(vr.assigned)) { set_reg(w, s, mir.preg_regid(vr.assigned), false, false); }
     if (vr.spill_slot != -1) {
         var disp: i64 = 0;
         var size: u32 = 0;
-        if (codegen_frame.slot_extent(?w.f.frame, v, ?disp, ?size)) {
+        if (codegen_frame.slot_extent(?w.f.frame, v.n, ?disp, ?size)) {
             var base: i32 = w.fp_reg;
             if (codegen_frame.slots_from_sp(?w.f.frame)) { base = w.sp_reg; }
             extent_clear(s, base, disp, disp + size::i64);
@@ -403,7 +403,7 @@ fun apply_barrier(w: *Walker, s: *State, n: *notes.AsmNote) {
     val mi: *mir.MirInstr = n.mi;
     if (mi.operand_count > 0) {
         val op: *mir.MirOperand = ?mi.operands[0];
-        if (op.kind == mir.MIR_OP_PREG) { set_reg(w, s, op.preg::i32, false, false); ret; }
+        if (op.kind == mir.MIR_OP_PREG) { set_reg(w, s, mir.preg_regid(op.preg), false, false); ret; }
         if (op.kind == mir.MIR_OP_MEM)  { clear_vreg_home(w, s, op.vreg); ret; }
         ret;
     }
@@ -420,7 +420,7 @@ fun initial_state(w: *Walker, s: *State) err[fail.Fail] {
         val in: *mir.MirAbiInput = ?f.abi_inputs[i];
         if (!in.secret) { i = i + 1; cnt; }
         if (in.location == mir.ABI_INPUT_REGISTER) {
-            if (reg_index_ok(in.reg::i32)) { set_reg(w, s, in.reg::i32, true, false); }
+            if (reg_index_ok(mir.preg_regid(in.reg))) { set_reg(w, s, mir.preg_regid(in.reg), true, false); }
         }
         or (in.location == mir.ABI_INPUT_ARG_STACK && !f.frame.omit) {
             val lo: i64 = w.tgt.model.incoming_arg_base + in.offset;

--- a/src/lang/be/codegen/encode.mach
+++ b/src/lang/be/codegen/encode.mach
@@ -1121,11 +1121,11 @@ pub fun push_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction, vr
     var reg:  i32 = 0;
     var off:  i64 = 0;
     var storage: bool = false;
-    if (vreg != mir.MIR_VREG_NIL && vreg < fn.vreg_count) {
+    if (vreg != mir.MIR_VREG_NIL.n && vreg < fn.vreg_count) {
         val vr: *mir.MirVReg = ?fn.vregs[vreg];
-        if (vr.assigned != mir.MIR_VREG_NIL) {
+        if (!mir.preg_is_nil(vr.assigned)) {
             kind = VARLOC_REG;
-            reg  = vr.assigned::i32;
+            reg  = mir.preg_regid(vr.assigned);
         }
         or (vr.spill_slot >= 0) {
             var si: u32 = 0;
@@ -1184,9 +1184,9 @@ fun cmp_operand_home(fn: *mir.MirFunction, is_imm: bool, vreg: u32, imm: i64,
     }
     if (vreg >= fn.vreg_count) { ret; }
     val vr: *mir.MirVReg = ?fn.vregs[vreg];
-    if (vr.assigned != mir.MIR_VREG_NIL) {
+    if (!mir.preg_is_nil(vr.assigned)) {
         @out_kind = VARLOC_REG;
-        @out_reg  = vr.assigned::i32;
+        @out_reg  = mir.preg_regid(vr.assigned);
         ret;
     }
     if (vr.spill_slot >= 0) {
@@ -1211,7 +1211,7 @@ pub fun push_cmp_varloc(st: *EncodeState, text_offset: u32, fn: *mir.MirFunction
     cmp_operand_home(fn, bind.lhs_is_imm, bind.vreg, bind.imm, ?lk, ?lr, ?lo);
     cmp_operand_home(fn, bind.rhs_is_imm, bind.vreg2, bind.imm2, ?rk, ?rr, ?ro);
     if (lk == VARLOC_NONE || rk == VARLOC_NONE) {
-        ret push_varloc(st, text_offset, fn, mir.MIR_VREG_NIL, bind.iid);
+        ret push_varloc(st, text_offset, fn, mir.MIR_VREG_NIL.n, bind.iid);
     }
 
     var rel: u8 = CMPREL_EQ;
@@ -1894,9 +1894,9 @@ test "mach.lang.be.codegen.encode.push_varloc:reg_frame_dead" {
     t_row_state(?alloc, ?st);
 
     var vregs: [3]mir.MirVReg;
-    vregs[0].id = 0; vregs[0].class = 0; vregs[0].spill_slot = -1; vregs[0].assigned = 7;
-    vregs[1].id = 1; vregs[1].class = 0; vregs[1].spill_slot = 0;  vregs[1].assigned = mir.MIR_VREG_NIL;
-    vregs[2].id = 2; vregs[2].class = 0; vregs[2].spill_slot = -1; vregs[2].assigned = mir.MIR_VREG_NIL;
+    vregs[0].id = 0; vregs[0].class = 0; vregs[0].spill_slot = -1; vregs[0].assigned = mir.preg_id(7);
+    vregs[1].id = 1; vregs[1].class = 0; vregs[1].spill_slot = 0;  vregs[1].assigned = mir.MIR_PREG_NIL;
+    vregs[2].id = 2; vregs[2].class = 0; vregs[2].spill_slot = -1; vregs[2].assigned = mir.MIR_PREG_NIL;
 
     var slots: [1]mir.MirSlot;
     slots[0].value = 1; slots[0].kind = mir.SLOT_SPILL; slots[0].offset = -16; slots[0].size = 8; slots[0].align = 8;
@@ -1932,9 +1932,9 @@ test "mach.lang.be.codegen.encode.push_cmp_varloc:homes_digest_and_close" {
     t_row_state(?alloc, ?st);
 
     var vregs: [3]mir.MirVReg;
-    vregs[0].id = 0; vregs[0].class = 0; vregs[0].spill_slot = -1; vregs[0].assigned = 7;
-    vregs[1].id = 1; vregs[1].class = 0; vregs[1].spill_slot = 0;  vregs[1].assigned = mir.MIR_VREG_NIL;
-    vregs[2].id = 2; vregs[2].class = 0; vregs[2].spill_slot = -1; vregs[2].assigned = mir.MIR_VREG_NIL;
+    vregs[0].id = 0; vregs[0].class = 0; vregs[0].spill_slot = -1; vregs[0].assigned = mir.preg_id(7);
+    vregs[1].id = 1; vregs[1].class = 0; vregs[1].spill_slot = 0;  vregs[1].assigned = mir.MIR_PREG_NIL;
+    vregs[2].id = 2; vregs[2].class = 0; vregs[2].spill_slot = -1; vregs[2].assigned = mir.MIR_PREG_NIL;
 
     var slots: [1]mir.MirSlot;
     slots[0].value = 1; slots[0].kind = mir.SLOT_SPILL; slots[0].offset = -16; slots[0].size = 8; slots[0].align = 8;
@@ -1947,7 +1947,7 @@ test "mach.lang.be.codegen.encode.push_cmp_varloc:homes_digest_and_close" {
     var bind: mir.MirDbgBinding;
     bind.iid = 100; bind.cmp_op = mir.MIR_SEL_CBR_LT_U; bind.cmp_width = 2;
     bind.lhs_is_imm = false; bind.vreg = 0; bind.imm = 0;
-    bind.rhs_is_imm = true;  bind.vreg2 = mir.MIR_VREG_NIL; bind.imm2 = 40000;
+    bind.rhs_is_imm = true;  bind.vreg2 = mir.MIR_VREG_NIL.n; bind.imm2 = 40000;
     val ra: err[fail.Fail] = push_cmp_varloc(?st, 12, ?fn, ?bind);
     if (sel ra.err) { code = 1; }
 
@@ -2001,7 +2001,7 @@ test "mach.lang.be.codegen.encode.push_varloc:slot_spill_owner_is_direct_frame" 
     t_row_state(?alloc, ?st);
 
     var vregs: [1]mir.MirVReg;
-    vregs[0].id = 0; vregs[0].class = 0; vregs[0].spill_slot = -1; vregs[0].assigned = mir.MIR_VREG_NIL;
+    vregs[0].id = 0; vregs[0].class = 0; vregs[0].spill_slot = -1; vregs[0].assigned = mir.MIR_PREG_NIL;
 
     var slots: [1]mir.MirSlot;
     slots[0].value = 0; slots[0].kind = mir.SLOT_SPILL; slots[0].offset = -32; slots[0].size = 16; slots[0].align = 8;

--- a/src/lang/be/codegen/frame.mach
+++ b/src/lang/be/codegen/frame.mach
@@ -41,8 +41,8 @@ pub fun run(tgt: *target.Target, m: *mir.MirModule) err[fail.Fail] {
         val func: *mir.MirFunction = ?m.functions[fi];
         val laid_out: err[fail.Fail] = layout_function(func, align);
         if (sel laid_out.err) { ret laid_out; }
-        func.frame.omit = omits_frame(func, tgt.model.frame_ptr_reg::u32,
-                                      tgt.model.stack_ptr_reg::u32);
+        func.frame.omit = omits_frame(func, mir.preg_id(tgt.model.frame_ptr_reg),
+                                      mir.preg_id(tgt.model.stack_ptr_reg));
         val distd: err[fail.Fail] = set_frame_dist(tgt, func);
         if (sel distd.err) { ret distd; }
 
@@ -85,7 +85,7 @@ fun set_frame_dist(tgt: *target.Target, func: *mir.MirFunction) err[fail.Fail] {
     ret err[fail.Fail].ok{};
 }
 
-pub fun omits_frame(func: *mir.MirFunction, fp: u32, sp: u32) bool {
+pub fun omits_frame(func: *mir.MirFunction, fp: mir.PRegId, sp: mir.PRegId) bool {
     if (func.naked) { ret true; }
 
     if (func.frame.size != 0)          { ret false; }
@@ -116,10 +116,12 @@ pub fun omits_frame(func: *mir.MirFunction, fp: u32, sp: u32) bool {
     ret !calls && !frame_ref;
 }
 
-fun operand_is_frame_relative(o: *mir.MirOperand, fp: u32, sp: u32) bool {
+fun operand_is_frame_relative(o: *mir.MirOperand, fp: mir.PRegId, sp: mir.PRegId) bool {
     if (o.kind != mir.MIR_OP_MEM) { ret false; }
-    if (o.vreg == mir.MIR_VREG_NIL && (o.preg == fp || o.preg == sp)) { ret true; }
-    if (o.index_is_preg && (o.index == fp || o.index == sp))          { ret true; }
+    if (mir.vreg_is_nil(o.vreg) && (mir.preg_same(o.preg, fp) || mir.preg_same(o.preg, sp))) { ret true; }
+    if (sel o.index.preg) {
+        if (mir.preg_same(o.index.preg, fp) || mir.preg_same(o.index.preg, sp)) { ret true; }
+    }
     ret false;
 }
 
@@ -586,9 +588,9 @@ test "mach.lang.be.codegen.frame.slot_sp_offset:adds_the_stamped_base_distance" 
     ret 0;
 }
 
-val TEST_FP:    u32 = 5;
-val TEST_SP:    u32 = 4;
-val TEST_OTHER: u32 = 9;
+val TEST_FP:    mir.PRegId = mir.PRegId{n: 5};
+val TEST_SP:    mir.PRegId = mir.PRegId{n: 4};
+val TEST_OTHER: mir.PRegId = mir.PRegId{n: 9};
 
 fun mk_func(blk: *mir.MirBlock, func: *mir.MirFunction, instrs: *mir.MirInstr, n: u32) {
     blk.id          = 0;
@@ -709,8 +711,7 @@ test "mach.lang.be.codegen.frame.omits_frame:frame_relative_operand_keeps_the_fr
 
     var ix_ops: [1]mir.MirOperand;
     ix_ops[0] = mir.op_mem_preg(TEST_OTHER, 0);
-    ix_ops[0].index         = TEST_FP;
-    ix_ops[0].index_is_preg = true;
+    ix_ops[0].index = mir.index_preg(TEST_FP);
     var ix_instrs: [1]mir.MirInstr;
     mk_instr(?ix_instrs[0], mir.MIR_LOAD);
     ix_instrs[0].operands      = ?ix_ops[0];

--- a/src/lang/be/codegen/legalize.mach
+++ b/src/lang/be/codegen/legalize.mach
@@ -111,7 +111,7 @@ fun instr_has_value_base(mi: *mir.MirInstr) bool {
     var k: u32 = 0;
     for (k < mi.operand_count) {
         val op: *mir.MirOperand = ?mi.operands[k];
-        if (op.kind == mir.MIR_OP_MEM && op.vreg != mir.MIR_VREG_NIL) { ret true; }
+        if (op.kind == mir.MIR_OP_MEM && !mir.vreg_is_nil(op.vreg)) { ret true; }
         k = k + 1;
     }
     ret false;
@@ -122,8 +122,8 @@ fun instr_rides_fp_bank(f: *mir.MirFunction, mi: *mir.MirInstr) bool {
     var k: u32 = 0;
     for (k < mi.operand_count) {
         val op: *mir.MirOperand = ?mi.operands[k];
-        if (op.kind == mir.MIR_OP_VREG && op.vreg < f.vreg_count) {
-            if (f.vregs[op.vreg].vector)    { ret true; }
+        if (op.kind == mir.MIR_OP_VREG && op.vreg.n < f.vreg_count) {
+            if (f.vregs[op.vreg.n].vector)    { ret true; }
             if (mir.vreg_is_fp(f, op.vreg)) { ret true; }
         }
         k = k + 1;
@@ -186,7 +186,7 @@ fun plan_lanes(alloc: *A.Allocator, mach: *Machine, f: *mir.MirFunction, out: *L
                 !mir.is_cmp_opcode(mi.opcode) &&
                 mi.width > maw && mi.operand_count > 0 &&
                 mi.operands[0].kind == mir.MIR_OP_VREG) {
-                val dv: u32 = mi.operands[0].vreg;
+                val dv: u32 = mi.operands[0].vreg.n;
                 if (dv < n && out.lane_base[dv] == LANE_NONE) {
                     val nlanes: u32 = (mi.width / maw)::u32;
                     val res_l: res[u32, fail.Fail] = alloc_lanes(alloc, f, dv, nlanes);
@@ -207,12 +207,12 @@ fun plan_lanes(alloc: *A.Allocator, mach: *Machine, f: *mir.MirFunction, out: *L
 
 fun alloc_lanes(alloc: *A.Allocator, f: *mir.MirFunction, wide: u32, nlanes: u32) res[u32, fail.Fail] {
     val cls: u32 = f.vregs[wide].class;
-    var base: u32 = mir.MIR_VREG_NIL;
+    var base: u32 = mir.MIR_VREG_NIL.n;
     var i: u32 = 0;
     for (i < nlanes) {
-        val res_v: res[u32, fail.Fail] = new_vreg(alloc, f, cls);
-        if (sel res_v.err) { ret res_v; }
-        val vid: u32 = res_v.ok;
+        val res_v: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, cls);
+        if (sel res_v.err) { ret res[u32, fail.Fail].err{res_v.err}; }
+        val vid: u32 = res_v.ok.n;
         # a lane is the wide value: the seed the validator and the allocator read must follow it
         f.vregs[vid].secret = f.vregs[wide].secret;
         if (i == 0) { base = vid; }
@@ -221,19 +221,19 @@ fun alloc_lanes(alloc: *A.Allocator, f: *mir.MirFunction, wide: u32, nlanes: u32
     ret res[u32, fail.Fail].ok{base};
 }
 
-fun new_vreg(alloc: *A.Allocator, f: *mir.MirFunction, cls: u32) res[u32, fail.Fail] {
+fun new_vreg(alloc: *A.Allocator, f: *mir.MirFunction, cls: u32) res[mir.VRegId, fail.Fail] {
     if (f.vreg_count >= f.vreg_cap) {
         var new_cap: u32 = f.vreg_cap * 2;
         if (new_cap == 0) { new_cap = mir.INITIAL_VREG_CAP; }
         val res_v: res[*mir.MirVReg, A.Error] = A.reallocate[mir.MirVReg](alloc, f.vregs, f.vreg_cap::usize, new_cap::usize);
-        if (sel res_v.err) { ret res[u32, fail.Fail].err{fail.refused(res_v.err)}; }
+        if (sel res_v.err) { ret res[mir.VRegId, fail.Fail].err{fail.refused(res_v.err)}; }
         f.vregs    = res_v.ok;
         f.vreg_cap = new_cap;
     }
     val vid: u32 = f.vreg_count;
     f.vregs[vid] = mir.vreg(vid, cls, false, false);
     f.vreg_count = f.vreg_count + 1;
-    ret res[u32, fail.Fail].ok{vid};
+    ret res[mir.VRegId, fail.Fail].ok{mir.vreg_id(vid)};
 }
 
 fun free_plan(alloc: *A.Allocator, plan: *LanePlan) {
@@ -398,8 +398,8 @@ fun addr_displaced(base: *mir.MirOperand, off: i64) mir.MirOperand {
 }
 
 fun base_needs_staging(plan: *LanePlan, mem: *mir.MirOperand) bool {
-    ret mem.vreg != mir.MIR_VREG_NIL && mem.vreg < plan.orig_count &&
-        plan.lane_base[mem.vreg] != LANE_NONE;
+    ret !mir.vreg_is_nil(mem.vreg) && mem.vreg.n < plan.orig_count &&
+        plan.lane_base[mem.vreg.n] != LANE_NONE;
 }
 
 fun memory_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) res[u32, fail.Fail] {
@@ -412,7 +412,7 @@ fun memory_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) 
     }
     val mem: *mir.MirOperand = ?mi.operands[mx::u32];
     if (base_needs_staging(plan, mem)) {
-        val pl: u32 = plan.lane_count[mem.vreg]::u32;
+        val pl: u32 = plan.lane_count[mem.vreg.n]::u32;
         if (pl != 2 || plan.mach.stage_lo < 0 || plan.mach.stage_hi < 0) {
             ret res[u32, fail.Fail].err{fail.message("legalize: a runtime pointer needs a two-register address-staging pair this target does not reserve")};
         }
@@ -434,12 +434,12 @@ fun expand_memory(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
 
     var base: mir.MirOperand = mi.operands[mx];
     if (base_needs_staging(plan, ?base)) {
-        val lo: u32 = plan.lane_base[base.vreg];
+        val lo: u32 = plan.lane_base[base.vreg.n];
         val r1: err[fail.Fail] = emit_stage_move(alloc, dst, cursor, mi, plan.mach.stage_lo, lo, lw);
         if (sel r1.err) { ret r1; }
         val r2: err[fail.Fail] = emit_stage_move(alloc, dst, cursor, mi, plan.mach.stage_hi, lo + 1, lw);
         if (sel r2.err) { ret r2; }
-        base = mir.op_mem_preg(plan.mach.stage_lo::u32, base.imm);
+        base = mir.op_mem_preg(mir.preg_id(plan.mach.stage_lo), base.imm);
     }
 
     var i: u32 = 0;
@@ -465,8 +465,8 @@ fun expand_memory(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
 fun emit_stage_move(alloc: *A.Allocator, dst: *mir.MirInstr, cursor: *u32, src: *mir.MirInstr,
                     preg: i32, lane: u32, lw: u8) err[fail.Fail] {
     var ops: [2]mir.MirOperand;
-    ops[0] = mir.op_preg(preg::u32);
-    ops[1] = mir.op_vreg(lane);
+    ops[0] = mir.op_preg(mir.preg_id(preg));
+    ops[1] = mir.op_vreg(mir.vreg_id(lane));
     ret emit_piece(alloc, dst, cursor, src, mir.MIR_MOV, ?ops[0], 2, lw);
 }
 
@@ -545,21 +545,21 @@ fun emit_piece(alloc: *A.Allocator, dst: *mir.MirInstr, cursor: *u32, src: *mir.
 }
 
 fun lane_operand(plan: *LanePlan, op: *mir.MirOperand, i: u32) mir.MirOperand {
-    if (op.kind == mir.MIR_OP_VREG && op.vreg < plan.orig_count && plan.lane_base[op.vreg] != LANE_NONE) {
-        ret mir.op_vreg(plan.lane_base[op.vreg] + i);
+    if (op.kind == mir.MIR_OP_VREG && op.vreg.n < plan.orig_count && plan.lane_base[op.vreg.n] != LANE_NONE) {
+        ret mir.op_vreg(mir.vreg_id(plan.lane_base[op.vreg.n] + i));
     }
     if (op.kind == mir.MIR_OP_IMM) {
         ret mir.op_imm(imm_lane(op.imm, i, plan.lane_width));
     }
     if (op.kind == mir.MIR_OP_PREG) {
-        ret mir.op_preg(op.preg + i);
+        ret mir.op_preg(mir.preg_id(mir.preg_regid(op.preg) + i::i32));
     }
     ret @op;
 }
 
 fun operand_is_lane_ready(plan: *LanePlan, op: *mir.MirOperand, nl: u32) bool {
     if (op.kind == mir.MIR_OP_VREG) {
-        if (op.vreg < plan.orig_count && plan.lane_base[op.vreg] != LANE_NONE) { ret true; }
+        if (op.vreg.n < plan.orig_count && plan.lane_base[op.vreg.n] != LANE_NONE) { ret true; }
         ret nl == 1;
     }
     ret op.kind == mir.MIR_OP_IMM || op.kind == mir.MIR_OP_PREG;
@@ -575,8 +575,8 @@ fun operands_are_lane_ready(plan: *LanePlan, mi: *mir.MirInstr, start: u32) bool
     var k: u32 = start;
     for (k < mi.operand_count) {
         val op: *mir.MirOperand = ?mi.operands[k];
-        val is_wide_vreg: bool = op.kind == mir.MIR_OP_VREG && op.vreg < plan.orig_count &&
-                                 plan.lane_base[op.vreg] != LANE_NONE;
+        val is_wide_vreg: bool = op.kind == mir.MIR_OP_VREG && op.vreg.n < plan.orig_count &&
+                                 plan.lane_base[op.vreg.n] != LANE_NONE;
         if (!is_wide_vreg && op.kind != mir.MIR_OP_IMM) { ret false; }
         k = k + 1;
     }
@@ -648,7 +648,7 @@ fun expand_mov(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
 fun expand_addsub(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
                   dst: *mir.MirInstr, cursor: *u32, is_sub: bool) err[fail.Fail] {
     if (mi.operand_count != 3 || !operands_are_lane_ready(plan, mi, 1) ||
-        mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg] == LANE_NONE) {
+        mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg.n] == LANE_NONE) {
         ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     val nl: u32 = wide_lane_count(plan, mi);
@@ -676,7 +676,7 @@ fun emit_addsub_chain(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirIns
     var op0:  mir.MirOpcode = mir.MIR_ADD;
     if (is_sub) { op0 = mir.MIR_SUB; }
 
-    var carry: u32 = mir.MIR_VREG_NIL;
+    var carry: mir.VRegId = mir.MIR_VREG_NIL;
     var i: u32 = 0;
     for (i < nl) {
         val d: mir.MirOperand = d_ops[i];
@@ -688,7 +688,7 @@ fun emit_addsub_chain(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirIns
         if (is_low) {
             val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, op0, d, a, b, lw);
             if (sel r1.err) { ret r1; }
-            val res_c: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val res_c: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel res_c.err) { ret err[fail.Fail].err{res_c.err}; }
             carry = res_c.ok;
             val cop: mir.MirOperand = mir.op_vreg(carry);
@@ -698,7 +698,7 @@ fun emit_addsub_chain(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirIns
             if (sel rc.err) { ret rc; }
         }
         or (is_top) {
-            val res_t: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val res_t: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel res_t.err) { ret err[fail.Fail].err{res_t.err}; }
             val t: mir.MirOperand = mir.op_vreg(res_t.ok);
             val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, op0, t, a, b, lw);
@@ -707,7 +707,7 @@ fun emit_addsub_chain(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirIns
             if (sel r2.err) { ret r2; }
         }
         or {
-            val res_t: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val res_t: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel res_t.err) { ret err[fail.Fail].err{res_t.err}; }
             val t: mir.MirOperand = mir.op_vreg(res_t.ok);
             val cin: mir.MirOperand = mir.op_vreg(carry);
@@ -715,7 +715,7 @@ fun emit_addsub_chain(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirIns
             val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, op0, t, a, b, lw);
             if (sel r1.err) { ret r1; }
 
-            val res_ct: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val res_ct: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel res_ct.err) { ret err[fail.Fail].err{res_ct.err}; }
             val ct: mir.MirOperand = mir.op_vreg(res_ct.ok);
             var rct: err[fail.Fail];
@@ -726,7 +726,7 @@ fun emit_addsub_chain(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirIns
             val r3: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, op0, d, t, cin, lw);
             if (sel r3.err) { ret r3; }
 
-            val res_cd: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val res_cd: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel res_cd.err) { ret err[fail.Fail].err{res_cd.err}; }
             val cd: mir.MirOperand = mir.op_vreg(res_cd.ok);
             var rcd: err[fail.Fail];
@@ -734,9 +734,9 @@ fun emit_addsub_chain(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirIns
             or          { rcd = emit_bin(alloc, dst, cursor, mi, cmp, cd, d, t, lw); }
             if (sel rcd.err) { ret rcd; }
 
-            val res_co: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val res_co: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel res_co.err) { ret err[fail.Fail].err{res_co.err}; }
-            val co: u32 = res_co.ok;
+            val co: mir.VRegId = res_co.ok;
             val r5: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_OR, mir.op_vreg(co), ct, cd, lw);
             if (sel r5.err) { ret r5; }
             carry = co;
@@ -754,7 +754,7 @@ fun addsub_chain_piece_count(nl: u32) u32 {
 fun expand_neg(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
                dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
     if (mi.operand_count != 2 || !operands_are_lane_ready(plan, mi, 1) ||
-        mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg] == LANE_NONE) {
+        mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg.n] == LANE_NONE) {
         ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     var sub: mir.MirInstr = @mi;
@@ -923,10 +923,10 @@ fun emit_const_shift(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInst
             var nb: mir.MirOperand = fill;
             if (b >= 0) { nb = in_ops[b::u32]; }
 
-            val rt1: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val rt1: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel rt1.err) { ret err[fail.Fail].err{rt1.err}; }
             val t1: mir.MirOperand = mir.op_vreg(rt1.ok);
-            val rt2: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val rt2: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel rt2.err) { ret err[fail.Fail].err{rt2.err}; }
             val t2: mir.MirOperand = mir.op_vreg(rt2.ok);
 
@@ -951,7 +951,7 @@ fun emit_const_shift(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInst
 fun emit_sign_fill(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
                    dst: *mir.MirInstr, cursor: *u32, top: mir.MirOperand, lw: u8,
                    out: *mir.MirOperand) err[fail.Fail] {
-    val rv: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+    val rv: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
     if (sel rv.err) { ret err[fail.Fail].err{rv.err}; }
     @out = mir.op_vreg(rv.ok);
     ret emit_bin(alloc, dst, cursor, src, mir.MIR_SHR_S, @out, top,
@@ -1019,21 +1019,21 @@ fun emit_shift_barrel(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction,
     for (j < stages) {
         var bit_src: mir.MirOperand = cnt;
         if (j > 0) {
-            val rt: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val rt: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
             bit_src = mir.op_vreg(rt.ok);
             val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SHR_U,
                                                    bit_src, cnt, mir.op_imm(j::i64), lw);
             if (sel r1.err) { ret r1; }
         }
-        val rb: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rb: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rb.err) { ret err[fail.Fail].err{rb.err}; }
         val bit: mir.MirOperand = mir.op_vreg(rb.ok);
         val r2: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, bit,
                                                bit_src, mir.op_imm(1), lw);
         if (sel r2.err) { ret r2; }
 
-        val rm: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rm: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rm.err) { ret err[fail.Fail].err{rm.err}; }
         val mask: mir.MirOperand = mir.op_vreg(rm.ok);
         val r3: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SUB, mask,
@@ -1042,7 +1042,7 @@ fun emit_shift_barrel(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction,
 
         i = 0;
         for (i < nl) {
-            val rs: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val rs: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel rs.err) { ret err[fail.Fail].err{rs.err}; }
             sh[i] = mir.op_vreg(rs.ok);
             i = i + 1;
@@ -1059,7 +1059,7 @@ fun emit_shift_barrel(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction,
         or {
             i = 0;
             for (i < nl) {
-                val rn: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                val rn: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
                 if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
                 nxt[i] = mir.op_vreg(rn.ok);
                 i = i + 1;
@@ -1068,13 +1068,13 @@ fun emit_shift_barrel(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction,
 
         i = 0;
         for (i < nl) {
-            val rx: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val rx: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel rx.err) { ret err[fail.Fail].err{rx.err}; }
             val x: mir.MirOperand = mir.op_vreg(rx.ok);
             val r5: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, x, cur[i], sh[i], lw);
             if (sel r5.err) { ret r5; }
 
-            val ry: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val ry: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel ry.err) { ret err[fail.Fail].err{ry.err}; }
             val y: mir.MirOperand = mir.op_vreg(ry.ok);
             val r6: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, y, x, mask, lw);
@@ -1119,7 +1119,7 @@ fun emit_accumulate_lane(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.Mir
                          nl: u32, lw: u8, p: u32, v: mir.MirOperand) err[fail.Fail] {
     if (lane_is_seed_zero(acc[p])) { acc[p] = v; ret err[fail.Fail].ok{}; }
 
-    val rt: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+    val rt: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
     if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
     val t: mir.MirOperand = mir.op_vreg(rt.ok);
     val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_ADD, t, acc[p], v, lw);
@@ -1127,7 +1127,7 @@ fun emit_accumulate_lane(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.Mir
 
     if (p == nl - 1) { acc[p] = t; ret err[fail.Fail].ok{}; }
 
-    val rc: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+    val rc: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
     if (sel rc.err) { ret err[fail.Fail].err{rc.err}; }
     var carry: mir.MirOperand = mir.op_vreg(rc.ok);
     val r2: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_LT_U, carry, t, v, lw);
@@ -1136,7 +1136,7 @@ fun emit_accumulate_lane(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.Mir
 
     var k: u32 = p + 1;
     for (k < nl) {
-        val rn: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rn: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
         val n: mir.MirOperand = mir.op_vreg(rn.ok);
         val r3: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_ADD, n, acc[k], carry, lw);
@@ -1144,7 +1144,7 @@ fun emit_accumulate_lane(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.Mir
         acc[k] = n;
         if (k == nl - 1) { ret err[fail.Fail].ok{}; }
 
-        val rc2: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rc2: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rc2.err) { ret err[fail.Fail].err{rc2.err}; }
         val c2: mir.MirOperand = mir.op_vreg(rc2.ok);
         val r4: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_LT_U, c2, n, carry, lw);
@@ -1267,13 +1267,13 @@ fun expand_mul(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *m
             val p: u32 = i + j;
             val want_hi: bool = p + 1 < nl;
 
-            val rl: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val rl: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel rl.err) { ret err[fail.Fail].err{rl.err}; }
             val lo: mir.MirOperand = mir.op_vreg(rl.ok);
 
             var hi: mir.MirOperand = mir.op_imm(0);
             if (want_hi) {
-                val rh: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                val rh: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
                 if (sel rh.err) { ret err[fail.Fail].err{rh.err}; }
                 hi = mir.op_vreg(rh.ok);
             }
@@ -1325,13 +1325,13 @@ fun emit_double_and_add(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunctio
 
     var j: u32 = 0;
     for (j < stages) {
-        val rb: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rb: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rb.err) { ret err[fail.Fail].err{rb.err}; }
         val bit: mir.MirOperand = mir.op_vreg(rb.ok);
         val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, bit, mplier[0], mir.op_imm(1), lw);
         if (sel r1.err) { ret r1; }
 
-        val rm: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rm: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rm.err) { ret err[fail.Fail].err{rm.err}; }
         val mask: mir.MirOperand = mir.op_vreg(rm.ok);
         val r2: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SUB, mask, mir.op_imm(0), bit, lw);
@@ -1340,7 +1340,7 @@ fun emit_double_and_add(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunctio
         var cand: [MAX_SHIFT_LANES]mir.MirOperand;
         i = 0;
         for (i < nl) {
-            val rc2: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val rc2: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel rc2.err) { ret err[fail.Fail].err{rc2.err}; }
             cand[i] = mir.op_vreg(rc2.ok);
             i = i + 1;
@@ -1354,7 +1354,7 @@ fun emit_double_and_add(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunctio
         for (i < nl) {
             if (is_last) { nxt[i] = out[i]; }
             or {
-                val rn: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                val rn: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
                 if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
                 nxt[i] = mir.op_vreg(rn.ok);
             }
@@ -1362,13 +1362,13 @@ fun emit_double_and_add(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunctio
         }
         i = 0;
         for (i < nl) {
-            val rx: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val rx: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel rx.err) { ret err[fail.Fail].err{rx.err}; }
             val x: mir.MirOperand = mir.op_vreg(rx.ok);
             val r4: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, x, result[i], cand[i], lw);
             if (sel r4.err) { ret r4; }
 
-            val ry: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val ry: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel ry.err) { ret err[fail.Fail].err{ry.err}; }
             val y: mir.MirOperand = mir.op_vreg(ry.ok);
             val r5: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, y, x, mask, lw);
@@ -1385,7 +1385,7 @@ fun emit_double_and_add(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunctio
             var nmc: [MAX_SHIFT_LANES]mir.MirOperand;
             i = 0;
             for (i < nl) {
-                val rmc: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                val rmc: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
                 if (sel rmc.err) { ret err[fail.Fail].err{rmc.err}; }
                 nmc[i] = mir.op_vreg(rmc.ok);
                 i = i + 1;
@@ -1398,7 +1398,7 @@ fun emit_double_and_add(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunctio
             var nmp: [MAX_SHIFT_LANES]mir.MirOperand;
             i = 0;
             for (i < nl) {
-                val rmp: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                val rmp: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
                 if (sel rmp.err) { ret err[fail.Fail].err{rmp.err}; }
                 nmp[i] = mir.op_vreg(rmp.ok);
                 i = i + 1;
@@ -1461,7 +1461,7 @@ fun divmod_piece_count(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr) 
 fun new_lane_temps(alloc: *A.Allocator, f: *mir.MirFunction, out: *mir.MirOperand, n: u32) err[fail.Fail] {
     var i: u32 = 0;
     for (i < n) {
-        val r: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val r: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel r.err) { ret err[fail.Fail].err{r.err}; }
         out[i] = mir.op_vreg(r.ok);
         i = i + 1;
@@ -1474,7 +1474,7 @@ fun emit_wide_abs(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
                   v_ops: *mir.MirOperand, out: *mir.MirOperand, sign: *mir.MirOperand,
                   nl: u32, lw: u8) err[fail.Fail] {
     val lb: u32 = lw::u32 * 8;
-    val rs: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+    val rs: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
     if (sel rs.err) { ret err[fail.Fail].err{rs.err}; }
     val s: mir.MirOperand = mir.op_vreg(rs.ok);
     val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_SHR_S, s,
@@ -1486,7 +1486,7 @@ fun emit_wide_abs(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
     var sb: [MAX_SHIFT_LANES]mir.MirOperand;
     var i: u32 = 0;
     for (i < nl) {
-        val rt: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rt: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
         xr[i] = mir.op_vreg(rt.ok);
         val rx: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_XOR, xr[i], v_ops[i], s, lw);
@@ -1505,7 +1505,7 @@ fun emit_apply_sign(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr
     var sb: [MAX_SHIFT_LANES]mir.MirOperand;
     var i: u32 = 0;
     for (i < nl) {
-        val rt: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rt: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
         xr[i] = mir.op_vreg(rt.ok);
         val rx: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_XOR, xr[i], v_ops[i], s, lw);
@@ -1564,13 +1564,13 @@ fun expand_divmod(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi:
 
     var j: u32 = 0;
     for (j < bits) {
-        val rh: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rh: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rh.err) { ret err[fail.Fail].err{rh.err}; }
         val hs: mir.MirOperand = mir.op_vreg(rh.ok);
         val e1: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SHR_U, hs,
                                                num[nl - 1], mir.op_imm((lb - 1)::i64), lw);
         if (sel e1.err) { ret e1; }
-        val rh2: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rh2: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rh2.err) { ret err[fail.Fail].err{rh2.err}; }
         val hb: mir.MirOperand = mir.op_vreg(rh2.ok);
         val e2: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, hb, hs, mir.op_imm(1), lw);
@@ -1582,7 +1582,7 @@ fun expand_divmod(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi:
         val e3: err[fail.Fail] = emit_const_shift(alloc, f, mi, dst, cursor, ?rem[0], ?rsh[0],
                                                        nl, lw, 0, 1, true, false, mir.op_imm(0));
         if (sel e3.err) { ret e3; }
-        val rl0: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rl0: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rl0.err) { ret err[fail.Fail].err{rl0.err}; }
         val rlo: mir.MirOperand = mir.op_vreg(rl0.ok);
         val e4: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_OR, rlo, rsh[0], hb, lw);
@@ -1596,26 +1596,26 @@ fun expand_divmod(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi:
                                                        nl, lw, 0, 1, true, false, mir.op_imm(0));
         if (sel e5.err) { ret e5; }
 
-        val rlt: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rlt: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rlt.err) { ret err[fail.Fail].err{rlt.err}; }
         val lt: mir.MirOperand = mir.op_vreg(rlt.ok);
         val e6: err[fail.Fail] = emit_wide_rel(alloc, f, mi, dst, cursor, lt, ?rsh[0], ?den[0],
                                                     nl, lw, false, false);
         if (sel e6.err) { ret e6; }
-        val rge: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rge: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rge.err) { ret err[fail.Fail].err{rge.err}; }
         val ge: mir.MirOperand = mir.op_vreg(rge.ok);
         val e7: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, ge, lt, mir.op_imm(1), lw);
         if (sel e7.err) { ret e7; }
 
-        val rq: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rq: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rq.err) { ret err[fail.Fail].err{rq.err}; }
         val qlo: mir.MirOperand = mir.op_vreg(rq.ok);
         val e8: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_OR, qlo, nsh[0], ge, lw);
         if (sel e8.err) { ret e8; }
         nsh[0] = qlo;
 
-        val rm: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rm: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rm.err) { ret err[fail.Fail].err{rm.err}; }
         val mask: mir.MirOperand = mir.op_vreg(rm.ok);
         val e9: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_SUB, mask, mir.op_imm(0), ge, lw);
@@ -1624,7 +1624,7 @@ fun expand_divmod(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi:
         var md: [MAX_SHIFT_LANES]mir.MirOperand;
         i = 0;
         for (i < nl) {
-            val rd: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val rd: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel rd.err) { ret err[fail.Fail].err{rd.err}; }
             md[i] = mir.op_vreg(rd.ok);
             val rx: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, md[i], den[i], mask, lw);
@@ -1658,7 +1658,7 @@ fun expand_divmod(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi:
     if (signed) {
         var s: mir.MirOperand = sa;
         if (!want_rem) {
-            val rq2: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val rq2: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel rq2.err) { ret err[fail.Fail].err{rq2.err}; }
             s = mir.op_vreg(rq2.ok);
             val rs2: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_XOR, s, sa, sb, lw);
@@ -1689,7 +1689,7 @@ fun emit_divmod_zero_fixup(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.M
     var acc: mir.MirOperand = den[0];
     var i: u32 = 1;
     for (i < nl) {
-        val ra: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val ra: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel ra.err) { ret err[fail.Fail].err{ra.err}; }
         val nx: mir.MirOperand = mir.op_vreg(ra.ok);
         val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_OR, nx, acc, den[i], lw);
@@ -1700,12 +1700,12 @@ fun emit_divmod_zero_fixup(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.M
 
     var divisor: mir.MirOperand = acc;
     if (mir.has(src.opcode, mir.MIRF_DIV_SIGNED)) {
-        val rz: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rz: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rz.err) { ret err[fail.Fail].err{rz.err}; }
         val z: mir.MirOperand = mir.op_vreg(rz.ok);
         val r2: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_EQ, z, acc, mir.op_imm(0), lw);
         if (sel r2.err) { ret r2; }
-        val rn: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rn: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rn.err) { ret err[fail.Fail].err{rn.err}; }
         val nonzero: mir.MirOperand = mir.op_vreg(rn.ok);
         val r3: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_SUB, nonzero, mir.op_imm(1), z, lw);
@@ -1716,24 +1716,24 @@ fun emit_divmod_zero_fixup(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.M
         var ov: mir.MirOperand = mir.op_imm(1);
         i = 0;
         for (i < nl) {
-            val rd1: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val rd1: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel rd1.err) { ret err[fail.Fail].err{rd1.err}; }
             val dm: mir.MirOperand = mir.op_vreg(rd1.ok);
             val e1: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_EQ, dm, den[i], mir.op_imm(lane_mask(lw)), lw);
             if (sel e1.err) { ret e1; }
             var want: i64 = 0;
             if (i == nl - 1) { want = lane_min; }
-            val rn1: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val rn1: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel rn1.err) { ret err[fail.Fail].err{rn1.err}; }
             val nm: mir.MirOperand = mir.op_vreg(rn1.ok);
             val e2: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_EQ, nm, num[i], mir.op_imm(want), lw);
             if (sel e2.err) { ret e2; }
-            val ra1: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val ra1: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel ra1.err) { ret err[fail.Fail].err{ra1.err}; }
             val both: mir.MirOperand = mir.op_vreg(ra1.ok);
             val e3: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_AND, both, dm, nm, lw);
             if (sel e3.err) { ret e3; }
-            val ra2: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val ra2: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel ra2.err) { ret err[fail.Fail].err{ra2.err}; }
             val next: mir.MirOperand = mir.op_vreg(ra2.ok);
             val e4: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_AND, next, ov, both, lw);
@@ -1741,14 +1741,14 @@ fun emit_divmod_zero_fixup(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.M
             ov = next;
             i = i + 1;
         }
-        val rd2: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rd2: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rd2.err) { ret err[fail.Fail].err{rd2.err}; }
         divisor = mir.op_vreg(rd2.ok);
         val r4: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_SUB, divisor, nonzero, ov, lw);
         if (sel r4.err) { ret r4; }
     }
 
-    val rp: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+    val rp: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
     if (sel rp.err) { ret err[fail.Fail].err{rp.err}; }
     val probe: mir.MirOperand = mir.op_vreg(rp.ok);
     val r5: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_DIV_U, probe, mir.op_imm(1), divisor, lw);
@@ -1780,7 +1780,7 @@ fun cmp_is_le(op: mir.MirOpcode) bool {
 
 fun cmp_dest_is_native(plan: *LanePlan, d: *mir.MirOperand) bool {
     if (d.kind != mir.MIR_OP_VREG) { ret false; }
-    ret d.vreg >= plan.orig_count || plan.lane_base[d.vreg] == LANE_NONE;
+    ret d.vreg.n >= plan.orig_count || plan.lane_base[d.vreg.n] == LANE_NONE;
 }
 
 fun cmp_rel_pieces(signed: bool, le: bool) u32 {
@@ -1800,13 +1800,13 @@ fun emit_lane_rel(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
 
     if (signed) {
         val bias: mir.MirOperand = mir.op_imm(1::i64 << (lw::i64 * 8 - 1));
-        val rx: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rx: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rx.err) { ret err[fail.Fail].err{rx.err}; }
         val bx: mir.MirOperand = mir.op_vreg(rx.ok);
         val r1: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_XOR, bx, x, bias, lw);
         if (sel r1.err) { ret r1; }
 
-        val ry: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val ry: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel ry.err) { ret err[fail.Fail].err{ry.err}; }
         val by: mir.MirOperand = mir.op_vreg(ry.ok);
         val r2: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_XOR, by, y, bias, lw);
@@ -1818,7 +1818,7 @@ fun emit_lane_rel(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
 
     if (!le) { ret emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_LT_U, d, x, y, lw); }
 
-    val rt: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+    val rt: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
     if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
     val t: mir.MirOperand = mir.op_vreg(rt.ok);
     val r3: err[fail.Fail] = emit_bin(alloc, dst, cursor, src, mir.MIR_CMP_LT_U, t, x, y, lw);
@@ -1875,7 +1875,7 @@ fun expand_cmp_equality(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunctio
     for (i < nl) {
         var out: mir.MirOperand = d;
         if (nl > 1) {
-            val rt: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val rt: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel rt.err) { ret err[fail.Fail].err{rt.err}; }
             out = mir.op_vreg(rt.ok);
         }
@@ -1888,7 +1888,7 @@ fun expand_cmp_equality(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunctio
         or {
             var jd: mir.MirOperand = d;
             if (i < nl - 1) {
-                val rj: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+                val rj: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
                 if (sel rj.err) { ret err[fail.Fail].err{rj.err}; }
                 jd = mir.op_vreg(rj.ok);
             }
@@ -1924,7 +1924,7 @@ fun emit_wide_rel(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
 
     var result: mir.MirOperand = d;
     if (nl > 1) {
-        val r0: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val r0: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel r0.err) { ret err[fail.Fail].err{r0.err}; }
         result = mir.op_vreg(r0.ok);
     }
@@ -1938,20 +1938,20 @@ fun emit_wide_rel(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
         val a: mir.MirOperand = a_ops[i];
         val b: mir.MirOperand = b_ops[i];
 
-        val rl: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rl: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rl.err) { ret err[fail.Fail].err{rl.err}; }
         val lt: mir.MirOperand = mir.op_vreg(rl.ok);
         val r1: err[fail.Fail] = emit_lane_rel(alloc, f, mi, dst, cursor, lt, a, b, lw,
                                                     signed && i == nl - 1, false);
         if (sel r1.err) { ret r1; }
 
-        val re: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val re: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel re.err) { ret err[fail.Fail].err{re.err}; }
         val eq: mir.MirOperand = mir.op_vreg(re.ok);
         val r2: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_CMP_EQ, eq, a, b, lw);
         if (sel r2.err) { ret r2; }
 
-        val rg: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+        val rg: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
         if (sel rg.err) { ret err[fail.Fail].err{rg.err}; }
         val g: mir.MirOperand = mir.op_vreg(rg.ok);
         val r3: err[fail.Fail] = emit_bin(alloc, dst, cursor, mi, mir.MIR_AND, g, eq, result, lw);
@@ -1959,7 +1959,7 @@ fun emit_wide_rel(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
 
         var out: mir.MirOperand = d;
         if (i < nl - 1) {
-            val ro: res[u32, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
+            val ro: res[mir.VRegId, fail.Fail] = new_vreg(alloc, f, mir.REG_CLASS_GP);
             if (sel ro.err) { ret err[fail.Fail].err{ro.err}; }
             out = mir.op_vreg(ro.ok);
         }
@@ -1986,7 +1986,7 @@ fun src_lane_count(plan: *LanePlan, mi: *mir.MirInstr) u32 {
 fun expand_zext(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
                 dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
     if (mi.operand_count != 2 ||
-        mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg] == LANE_NONE) {
+        mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg.n] == LANE_NONE) {
         ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     val dl: u32 = dst_lane_count(plan, mi);
@@ -2008,7 +2008,7 @@ fun expand_zext(alloc: *A.Allocator, plan: *LanePlan, mi: *mir.MirInstr,
 fun expand_sext(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: *mir.MirInstr,
                 dst: *mir.MirInstr, cursor: *u32) err[fail.Fail] {
     if (mi.operand_count != 2 ||
-        mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg] == LANE_NONE) {
+        mi.operands[0].kind != mir.MIR_OP_VREG || plan.lane_base[mi.operands[0].vreg.n] == LANE_NONE) {
         ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
     }
     val dl: u32 = dst_lane_count(plan, mi);
@@ -2101,7 +2101,7 @@ fun cv2(cv: *ConvEmit, opcode: mir.MirOpcode, d: mir.MirOperand, a: mir.MirOpera
 
 fun cv_tmp(cv: *ConvEmit, cls: u32) mir.MirOperand {
     if (cv.dst == nil || cv.fail) { ret mir.op_vreg(mir.MIR_VREG_NIL); }
-    val r: res[u32, fail.Fail] = new_vreg(cv.alloc, cv.f, cls);
+    val r: res[mir.VRegId, fail.Fail] = new_vreg(cv.alloc, cv.f, cls);
     if (sel r.err) { cv.fail = true; ret mir.op_vreg(mir.MIR_VREG_NIL); }
     ret mir.op_vreg(r.ok);
 }
@@ -2380,7 +2380,7 @@ fun conv_prepare(alloc: *A.Allocator, plan: *LanePlan, f: *mir.MirFunction, mi: 
     val ii: u32 = 1 - (conv_float_operand(mi.opcode)::u32);
     if (mi.opcode == mir.MIR_FP_TO_SI || mi.opcode == mir.MIR_FP_TO_UI) {
         val d: *mir.MirOperand = ?mi.operands[0];
-        if (d.kind != mir.MIR_OP_VREG || plan.lane_base[d.vreg] == LANE_NONE) {
+        if (d.kind != mir.MIR_OP_VREG || plan.lane_base[d.vreg.n] == LANE_NONE) {
             ret err[fail.Fail].err{fail.message(unsupported_message(alloc, mi.opcode, mi.width))};
         }
     } or {
@@ -2482,7 +2482,7 @@ fun t_vregs(alloc: *A.Allocator, f: *mir.MirFunction, n: u32) {
         f.vregs[i].id         = i;
         f.vregs[i].class      = mir.REG_CLASS_GP;
         f.vregs[i].spill_slot = -1;
-        f.vregs[i].assigned   = mir.MIR_VREG_NIL;
+        f.vregs[i].assigned   = mir.MIR_PREG_NIL;
         f.vregs[i].vector     = false;
         i = i + 1;
     }
@@ -2537,7 +2537,7 @@ test "mach.lang.be.codegen.legalize:inert_on_native_width" {
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 1);
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_vreg(0); ops[1] = mir.op_vreg(1); ops[2] = mir.op_vreg(2);
+    ops[0] = mir.op_vreg(mir.vreg_id(0)); ops[1] = mir.op_vreg(mir.vreg_id(1)); ops[2] = mir.op_vreg(mir.vreg_id(2));
     t_instr(?alloc, ?b, 0, mir.MIR_ADD, ?ops[0], 3, 8);
     f.blocks = ?b; f.block_count = 1;
 
@@ -2563,13 +2563,13 @@ test "mach.lang.be.codegen.legalize:expands_wide_add_carry_chain" {
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 3);
     var m1: [2]mir.MirOperand;
-    m1[0] = mir.op_vreg(1); m1[1] = mir.op_imm(0x0102);
+    m1[0] = mir.op_vreg(mir.vreg_id(1)); m1[1] = mir.op_imm(0x0102);
     t_instr(?alloc, ?b, 0, mir.MIR_MOV, ?m1[0], 2, 2);
     var m2: [2]mir.MirOperand;
-    m2[0] = mir.op_vreg(2); m2[1] = mir.op_imm(0x0304);
+    m2[0] = mir.op_vreg(mir.vreg_id(2)); m2[1] = mir.op_imm(0x0304);
     t_instr(?alloc, ?b, 1, mir.MIR_MOV, ?m2[0], 2, 2);
     var ad: [3]mir.MirOperand;
-    ad[0] = mir.op_vreg(0); ad[1] = mir.op_vreg(1); ad[2] = mir.op_vreg(2);
+    ad[0] = mir.op_vreg(mir.vreg_id(0)); ad[1] = mir.op_vreg(mir.vreg_id(1)); ad[2] = mir.op_vreg(mir.vreg_id(2));
     t_instr(?alloc, ?b, 2, mir.MIR_ADD, ?ad[0], 3, 2);
     f.blocks = ?b; f.block_count = 1;
 
@@ -2583,11 +2583,11 @@ test "mach.lang.be.codegen.legalize:expands_wide_add_carry_chain" {
 
     if (b.instrs[4].opcode != mir.MIR_ADD)      { ret 1; }
     if (b.instrs[4].width != 1)                 { ret 1; }
-    if (b.instrs[4].operands[0].vreg != 7)      { ret 1; }
+    if (b.instrs[4].operands[0].vreg.n != 7)      { ret 1; }
     if (b.instrs[5].opcode != mir.MIR_CMP_LT_U) { ret 1; }
     if (b.instrs[6].opcode != mir.MIR_ADD)      { ret 1; }
     if (b.instrs[7].opcode != mir.MIR_ADD)      { ret 1; }
-    if (b.instrs[7].operands[0].vreg != 8)      { ret 1; }
+    if (b.instrs[7].operands[0].vreg.n != 8)      { ret 1; }
     ret 0;
 }
 
@@ -2596,13 +2596,13 @@ fun t_divmod_fn(alloc: *A.Allocator, f: *mir.MirFunction, b: *mir.MirBlock,
     t_vregs(alloc, f, 3);
     t_block(alloc, b, 3);
     var ma: [2]mir.MirOperand;
-    ma[0] = mir.op_vreg(1); ma[1] = mir.op_imm(a);
+    ma[0] = mir.op_vreg(mir.vreg_id(1)); ma[1] = mir.op_imm(a);
     t_instr(alloc, b, 0, mir.MIR_MOV, ?ma[0], 2, width);
     var mb: [2]mir.MirOperand;
-    mb[0] = mir.op_vreg(2); mb[1] = mir.op_imm(bv);
+    mb[0] = mir.op_vreg(mir.vreg_id(2)); mb[1] = mir.op_imm(bv);
     t_instr(alloc, b, 1, mir.MIR_MOV, ?mb[0], 2, width);
     var dv: [3]mir.MirOperand;
-    dv[0] = mir.op_vreg(0); dv[1] = mir.op_vreg(1); dv[2] = mir.op_vreg(2);
+    dv[0] = mir.op_vreg(mir.vreg_id(0)); dv[1] = mir.op_vreg(mir.vreg_id(1)); dv[2] = mir.op_vreg(mir.vreg_id(2));
     t_instr(alloc, b, 2, op, ?dv[0], 3, width);
     f.blocks = b; f.block_count = 1;
 }
@@ -2818,7 +2818,7 @@ test "mach.lang.be.codegen.legalize:rejects_unsupported_wide_op" {
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 1);
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_vreg(0); ops[1] = mir.op_vreg(1); ops[2] = mir.op_vreg(2);
+    ops[0] = mir.op_vreg(mir.vreg_id(0)); ops[1] = mir.op_vreg(mir.vreg_id(1)); ops[2] = mir.op_vreg(mir.vreg_id(2));
     t_instr(?alloc, ?b, 0, mir.MIR_DIV_U, ?ops[0], 3, 2);
     f.blocks = ?b; f.block_count = 1;
 
@@ -2837,7 +2837,7 @@ test "mach.lang.be.codegen.legalize:expands_wide_access_at_a_fixed_base" {
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 1);
     var ld: [2]mir.MirOperand;
-    ld[0] = mir.op_vreg(0); ld[1] = mir.op_mem_preg(0, 0);
+    ld[0] = mir.op_vreg(mir.vreg_id(0)); ld[1] = mir.op_mem_preg(mir.preg_id(0), 0);
     t_instr(?alloc, ?b, 0, mir.MIR_MOV, ?ld[0], 2, 4);
     f.blocks = ?b; f.block_count = 1;
 
@@ -2850,9 +2850,9 @@ test "mach.lang.be.codegen.legalize:expands_wide_access_at_a_fixed_base" {
     for (i < 4) {
         if (b.instrs[i].opcode != mir.MIR_LOAD)             { ret 1; }
         if (b.instrs[i].width != 1)                         { ret 1; }
-        if (b.instrs[i].operands[0].vreg != 1 + i)          { ret 1; }
+        if (b.instrs[i].operands[0].vreg.n != 1 + i)          { ret 1; }
         if (b.instrs[i].operands[1].kind != mir.MIR_OP_MEM) { ret 1; }
-        if (b.instrs[i].operands[1].preg != 0)              { ret 1; }
+        if (b.instrs[i].operands[1].preg.n != 0)              { ret 1; }
         if (b.instrs[i].operands[1].imm != i::i64)          { ret 1; }
         i = i + 1;
     }
@@ -2868,7 +2868,7 @@ test "mach.lang.be.codegen.legalize:expands_a_wide_access_at_a_symbol" {
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 1);
     var ld: [2]mir.MirOperand;
-    ld[0] = mir.op_vreg(0); ld[1] = mir.op_sym(7, 0);
+    ld[0] = mir.op_vreg(mir.vreg_id(0)); ld[1] = mir.op_sym(7, 0);
     t_instr(?alloc, ?b, 0, mir.MIR_LOAD, ?ld[0], 2, 4);
     f.blocks = ?b; f.block_count = 1;
     fin { mir.dnit_function(?alloc, ?f); }
@@ -2884,7 +2884,7 @@ test "mach.lang.be.codegen.legalize:expands_a_wide_access_at_a_symbol" {
         if (b.instrs[i].opcode != mir.MIR_LOAD)                { ret 1; }
         if (b.instrs[i].memory_flags != mir.MEMORY_VOLATILE) { ret 2; }
         if (b.instrs[i].width != 2)                            { ret 1; }
-        if (b.instrs[i].operands[0].vreg != 1 + i)             { ret 1; }
+        if (b.instrs[i].operands[0].vreg.n != 1 + i)             { ret 1; }
         if (b.instrs[i].operands[1].kind != mir.MIR_OP_SYM)    { ret 1; }
         if (b.instrs[i].operands[1].sym != 7)                  { ret 1; }
         if (b.instrs[i].operands[1].sym_off != (i * 2)::i32)   { ret 1; }
@@ -2902,7 +2902,7 @@ test "mach.lang.be.codegen.legalize:refuses_a_wide_access_with_no_address_operan
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 1);
     var ld: [2]mir.MirOperand;
-    ld[0] = mir.op_vreg(0); ld[1] = mir.op_vreg(1);
+    ld[0] = mir.op_vreg(mir.vreg_id(0)); ld[1] = mir.op_vreg(mir.vreg_id(1));
     t_instr(?alloc, ?b, 0, mir.MIR_LOAD, ?ld[0], 2, 4);
     f.blocks = ?b; f.block_count = 1;
 
@@ -2921,7 +2921,7 @@ test "mach.lang.be.codegen.legalize:expands_wide_preg_move_onto_consecutive_regs
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 1);
     var mv: [2]mir.MirOperand;
-    mv[0] = mir.op_vreg(0); mv[1] = mir.op_preg(4);
+    mv[0] = mir.op_vreg(mir.vreg_id(0)); mv[1] = mir.op_preg(mir.preg_id(4));
     t_instr(?alloc, ?b, 0, mir.MIR_MOV, ?mv[0], 2, 2);
     f.blocks = ?b; f.block_count = 1;
 
@@ -2929,8 +2929,8 @@ test "mach.lang.be.codegen.legalize:expands_wide_preg_move_onto_consecutive_regs
     val r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
     if (sel r.err) { ret 1; }
     if (b.instr_count != 2)     { ret 1; }
-    if (b.instrs[0].operands[0].vreg != 1 || b.instrs[0].operands[1].preg != 4) { ret 1; }
-    if (b.instrs[1].operands[0].vreg != 2 || b.instrs[1].operands[1].preg != 5) { ret 1; }
+    if (b.instrs[0].operands[0].vreg.n != 1 || b.instrs[0].operands[1].preg.n != 4) { ret 1; }
+    if (b.instrs[1].operands[0].vreg.n != 2 || b.instrs[1].operands[1].preg.n != 5) { ret 1; }
     ret 0;
 }
 
@@ -2945,10 +2945,10 @@ test "mach.lang.be.codegen.legalize:lanes_of_a_secret_wide_value_stay_secret" {
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 2);
     var seed: [2]mir.MirOperand;
-    seed[0] = mir.op_vreg(0); seed[1] = mir.op_imm(0x0102);
+    seed[0] = mir.op_vreg(mir.vreg_id(0)); seed[1] = mir.op_imm(0x0102);
     t_instr(?alloc, ?b, 0, mir.MIR_MOV, ?seed[0], 2, 2);
     var mv: [2]mir.MirOperand;
-    mv[0] = mir.op_vreg(1); mv[1] = mir.op_vreg(0);
+    mv[0] = mir.op_vreg(mir.vreg_id(1)); mv[1] = mir.op_vreg(mir.vreg_id(0));
     t_instr(?alloc, ?b, 1, mir.MIR_MOV, ?mv[0], 2, 2);
     f.blocks = ?b; f.block_count = 1;
 
@@ -2958,8 +2958,8 @@ test "mach.lang.be.codegen.legalize:lanes_of_a_secret_wide_value_stay_secret" {
     if (b.instr_count != 4 || f.vreg_count != 6) { ret 2; }
     var i: u32 = 2;
     for (i < 4) {
-        val dst: u32 = b.instrs[i].operands[0].vreg;
-        val src: u32 = b.instrs[i].operands[1].vreg;
+        val dst: u32 = b.instrs[i].operands[0].vreg.n;
+        val src: u32 = b.instrs[i].operands[1].vreg.n;
         if (dst < 2 || src < 2)     { ret 3; }
         if (!f.vregs[src].secret)   { ret 4; }
         if (f.vregs[dst].secret)    { ret 5; }
@@ -2997,10 +2997,10 @@ test "mach.lang.be.codegen.legalize:a_wide_declassify_keeps_its_barrier_per_lane
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 2);
     var seed: [2]mir.MirOperand;
-    seed[0] = mir.op_vreg(0); seed[1] = mir.op_imm(0x0102);
+    seed[0] = mir.op_vreg(mir.vreg_id(0)); seed[1] = mir.op_imm(0x0102);
     t_instr(?alloc, ?b, 0, mir.MIR_MOV, ?seed[0], 2, 2);
     var dc: [2]mir.MirOperand;
-    dc[0] = mir.op_vreg(1); dc[1] = mir.op_vreg(0);
+    dc[0] = mir.op_vreg(mir.vreg_id(1)); dc[1] = mir.op_vreg(mir.vreg_id(0));
     t_instr(?alloc, ?b, 1, mir.MIR_DECLASSIFY, ?dc[0], 2, 2);
     f.blocks = ?b; f.block_count = 1;
 
@@ -3039,16 +3039,16 @@ test "mach.lang.be.codegen.legalize:stages_runtime_pointer_into_the_address_pair
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 4);
     var p: [2]mir.MirOperand;
-    p[0] = mir.op_vreg(0); p[1] = mir.op_preg(4);
+    p[0] = mir.op_vreg(mir.vreg_id(0)); p[1] = mir.op_preg(mir.preg_id(4));
     t_instr(?alloc, ?b, 0, mir.MIR_MOV, ?p[0], 2, 2);
     var v: [2]mir.MirOperand;
-    v[0] = mir.op_vreg(1); v[1] = mir.op_imm(0x01020304);
+    v[0] = mir.op_vreg(mir.vreg_id(1)); v[1] = mir.op_imm(0x01020304);
     t_instr(?alloc, ?b, 1, mir.MIR_MOV, ?v[0], 2, 4);
     var stv: [2]mir.MirOperand;
-    stv[0] = mir.op_mem_value(0, 0); stv[1] = mir.op_vreg(1);
+    stv[0] = mir.op_mem_value(mir.vreg_id(0), 0); stv[1] = mir.op_vreg(mir.vreg_id(1));
     t_instr(?alloc, ?b, 2, mir.MIR_STORE, ?stv[0], 2, 4);
     var ldv: [2]mir.MirOperand;
-    ldv[0] = mir.op_vreg(2); ldv[1] = mir.op_mem_value(0, 3);
+    ldv[0] = mir.op_vreg(mir.vreg_id(2)); ldv[1] = mir.op_mem_value(mir.vreg_id(0), 3);
     t_instr(?alloc, ?b, 3, mir.MIR_LOAD, ?ldv[0], 2, 1);
     f.blocks = ?b; f.block_count = 1;
 
@@ -3057,23 +3057,23 @@ test "mach.lang.be.codegen.legalize:stages_runtime_pointer_into_the_address_pair
     if (sel r.err) { ret 1; }
     if (b.instr_count != 15) { ret 1; }
 
-    if (b.instrs[6].operands[0].preg != 6) { ret 1; }
-    if (b.instrs[7].operands[0].preg != 7) { ret 1; }
+    if (b.instrs[6].operands[0].preg.n != 6) { ret 1; }
+    if (b.instrs[7].operands[0].preg.n != 7) { ret 1; }
     var i: u32 = 0;
     for (i < 4) {
         val st: *mir.MirInstr = ?b.instrs[8 + i];
         if (st.opcode != mir.MIR_STORE)             { ret 1; }
         if (st.width != 1)                          { ret 1; }
         if (st.operands[0].kind != mir.MIR_OP_MEM)  { ret 1; }
-        if (st.operands[0].vreg != mir.MIR_VREG_NIL){ ret 1; }
-        if (st.operands[0].preg != 6)               { ret 1; }
+        if (!mir.vreg_is_nil(st.operands[0].vreg)){ ret 1; }
+        if (st.operands[0].preg.n != 6)               { ret 1; }
         if (st.operands[0].imm != i::i64)           { ret 1; }
         i = i + 1;
     }
-    if (b.instrs[12].operands[0].preg != 6)          { ret 1; }
-    if (b.instrs[13].operands[0].preg != 7)          { ret 1; }
+    if (b.instrs[12].operands[0].preg.n != 6)          { ret 1; }
+    if (b.instrs[13].operands[0].preg.n != 7)          { ret 1; }
     if (b.instrs[14].opcode != mir.MIR_LOAD)         { ret 1; }
-    if (b.instrs[14].operands[1].preg != 6)          { ret 1; }
+    if (b.instrs[14].operands[1].preg.n != 6)          { ret 1; }
     if (b.instrs[14].operands[1].imm != 3)           { ret 1; }
     ret 0;
 }
@@ -3087,7 +3087,7 @@ test "mach.lang.be.codegen.legalize:value_base_is_inert_on_a_wide_pointer_target
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 1);
     var ops: [2]mir.MirOperand;
-    ops[0] = mir.op_vreg(1); ops[1] = mir.op_mem_value(0, 0);
+    ops[0] = mir.op_vreg(mir.vreg_id(1)); ops[1] = mir.op_mem_value(mir.vreg_id(0), 0);
     t_instr(?alloc, ?b, 0, mir.MIR_LOAD, ?ops[0], 2, 8);
     f.blocks = ?b; f.block_count = 1;
 
@@ -3108,13 +3108,13 @@ fun t_shift_fn(alloc: *A.Allocator, f: *mir.MirFunction, b: *mir.MirBlock,
     t_vregs(alloc, f, 3);
     t_block(alloc, b, 3);
     var mv: [2]mir.MirOperand;
-    mv[0] = mir.op_vreg(1); mv[1] = mir.op_imm(0x01020304);
+    mv[0] = mir.op_vreg(mir.vreg_id(1)); mv[1] = mir.op_imm(0x01020304);
     t_instr(alloc, b, 0, mir.MIR_MOV, ?mv[0], 2, width);
     var mn: [2]mir.MirOperand;
-    mn[0] = mir.op_vreg(2); mn[1] = mir.op_imm(3);
+    mn[0] = mir.op_vreg(mir.vreg_id(2)); mn[1] = mir.op_imm(3);
     t_instr(alloc, b, 1, mir.MIR_MOV, ?mn[0], 2, 1);
     var sh: [3]mir.MirOperand;
-    sh[0] = mir.op_vreg(0); sh[1] = mir.op_vreg(1); sh[2] = count;
+    sh[0] = mir.op_vreg(mir.vreg_id(0)); sh[1] = mir.op_vreg(mir.vreg_id(1)); sh[2] = count;
     t_instr(alloc, b, 2, op, ?sh[0], 3, width);
     f.blocks = b; f.block_count = 1;
 }
@@ -3135,10 +3135,10 @@ test "mach.lang.be.codegen.legalize:expands_constant_wide_shift_as_a_template" {
     if (b.instrs[5].opcode != mir.MIR_SHL)      { ret 1; }
     if (b.instrs[6].opcode != mir.MIR_SHR_U)    { ret 1; }
     if (b.instrs[7].opcode != mir.MIR_OR)       { ret 1; }
-    if (b.instrs[7].operands[0].vreg != 10)     { ret 1; }
+    if (b.instrs[7].operands[0].vreg.n != 10)     { ret 1; }
     if (b.instrs[14].opcode != mir.MIR_SHL)     { ret 1; }
-    if (b.instrs[14].operands[0].vreg != 7)     { ret 1; }
-    if (b.instrs[14].operands[1].vreg != 3)     { ret 1; }
+    if (b.instrs[14].operands[0].vreg.n != 7)     { ret 1; }
+    if (b.instrs[14].operands[1].vreg.n != 3)     { ret 1; }
     if (b.instrs[14].operands[2].imm  != 3)     { ret 1; }
     var i: u32 = 5;
     for (i < 15) {
@@ -3186,7 +3186,7 @@ test "mach.lang.be.codegen.legalize:expands_runtime_shift_as_a_masked_barrel" {
     for (w < 3) {
         var f: mir.MirFunction;
         var b: mir.MirBlock;
-        t_shift_fn(?alloc, ?f, ?b, mir.MIR_SHL, widths[w], mir.op_vreg(2));
+        t_shift_fn(?alloc, ?f, ?b, mir.MIR_SHL, widths[w], mir.op_vreg(mir.vreg_id(2)));
         var mach: Machine = t_mach(1, 2);
         val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
         if (sel legalize_function_r.err) { ret 1; }
@@ -3201,7 +3201,7 @@ test "mach.lang.be.codegen.legalize:expands_runtime_shift_as_a_masked_barrel" {
 
         var f2: mir.MirFunction;
         var b2: mir.MirBlock;
-        t_shift_fn(?alloc, ?f2, ?b2, mir.MIR_SHR_S, widths[w], mir.op_vreg(2));
+        t_shift_fn(?alloc, ?f2, ?b2, mir.MIR_SHR_S, widths[w], mir.op_vreg(mir.vreg_id(2)));
         val legalize_function_r2: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f2);
         if (sel legalize_function_r2.err) { ret 1; }
         if (b2.instr_count != widths[w]::u32 + 1 + shrs[w]) { ret 1; }
@@ -3236,7 +3236,7 @@ test "mach.lang.be.codegen.legalize:normalizes_an_out_of_range_shift_count" {
         for (k < b3.instrs[i].operand_count) {
             if (b19.instrs[i].operands[k].kind != b3.instrs[i].operands[k].kind) { ret 1; }
             if (b19.instrs[i].operands[k].imm  != b3.instrs[i].operands[k].imm)  { ret 1; }
-            if (b19.instrs[i].operands[k].vreg != b3.instrs[i].operands[k].vreg) { ret 1; }
+            if (!mir.vreg_same(b19.instrs[i].operands[k].vreg, b3.instrs[i].operands[k].vreg)) { ret 1; }
             k = k + 1;
         }
         i = i + 1;
@@ -3261,7 +3261,7 @@ test "mach.lang.be.codegen.legalize:shift_is_inert_on_a_variable_shift_machine" 
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 1);
     var sh: [3]mir.MirOperand;
-    sh[0] = mir.op_vreg(0); sh[1] = mir.op_vreg(1); sh[2] = mir.op_vreg(2);
+    sh[0] = mir.op_vreg(mir.vreg_id(0)); sh[1] = mir.op_vreg(mir.vreg_id(1)); sh[2] = mir.op_vreg(mir.vreg_id(2));
     t_instr(?alloc, ?b, 0, mir.MIR_SHL, ?sh[0], 3, 8);
     f.blocks = ?b; f.block_count = 1;
 
@@ -3288,13 +3288,13 @@ fun t_cmp_fn(alloc: *A.Allocator, f: *mir.MirFunction, b: *mir.MirBlock,
     t_vregs(alloc, f, 3);
     t_block(alloc, b, 3);
     var m1: [2]mir.MirOperand;
-    m1[0] = mir.op_vreg(1); m1[1] = mir.op_imm(0x0102030405060708);
+    m1[0] = mir.op_vreg(mir.vreg_id(1)); m1[1] = mir.op_imm(0x0102030405060708);
     t_instr(alloc, b, 0, mir.MIR_MOV, ?m1[0], 2, width);
     var m2: [2]mir.MirOperand;
-    m2[0] = mir.op_vreg(2); m2[1] = mir.op_imm(0x1122334455667788);
+    m2[0] = mir.op_vreg(mir.vreg_id(2)); m2[1] = mir.op_imm(0x1122334455667788);
     t_instr(alloc, b, 1, mir.MIR_MOV, ?m2[0], 2, width);
     var cm: [3]mir.MirOperand;
-    cm[0] = mir.op_vreg(0); cm[1] = mir.op_vreg(1); cm[2] = mir.op_vreg(2);
+    cm[0] = mir.op_vreg(mir.vreg_id(0)); cm[1] = mir.op_vreg(mir.vreg_id(1)); cm[2] = mir.op_vreg(mir.vreg_id(2));
     t_instr(alloc, b, 2, op, ?cm[0], 3, width);
     f.blocks = b; f.block_count = 1;
 }
@@ -3312,13 +3312,13 @@ test "mach.lang.be.codegen.legalize:expands_wide_equality_lane_wise" {
 
     if (b.instr_count != 7) { ret 1; }
     if (b.instrs[4].opcode != mir.MIR_CMP_EQ) { ret 1; }
-    if (b.instrs[4].operands[1].vreg != 3)    { ret 1; }
-    if (b.instrs[4].operands[2].vreg != 5)    { ret 1; }
+    if (b.instrs[4].operands[1].vreg.n != 3)    { ret 1; }
+    if (b.instrs[4].operands[2].vreg.n != 5)    { ret 1; }
     if (b.instrs[5].opcode != mir.MIR_CMP_EQ) { ret 1; }
-    if (b.instrs[5].operands[1].vreg != 4)    { ret 1; }
-    if (b.instrs[5].operands[2].vreg != 6)    { ret 1; }
+    if (b.instrs[5].operands[1].vreg.n != 4)    { ret 1; }
+    if (b.instrs[5].operands[2].vreg.n != 6)    { ret 1; }
     if (b.instrs[6].opcode != mir.MIR_AND)    { ret 1; }
-    if (b.instrs[6].operands[0].vreg != 0)    { ret 1; }
+    if (b.instrs[6].operands[0].vreg.n != 0)    { ret 1; }
 
     var f2: mir.MirFunction;
     var b2: mir.MirBlock;
@@ -3329,7 +3329,7 @@ test "mach.lang.be.codegen.legalize:expands_wide_equality_lane_wise" {
     if (b2.instrs[4].opcode != mir.MIR_CMP_NE)  { ret 1; }
     if (b2.instrs[5].opcode != mir.MIR_CMP_NE)  { ret 1; }
     if (b2.instrs[6].opcode != mir.MIR_OR)      { ret 1; }
-    if (b2.instrs[6].operands[0].vreg != 0)     { ret 1; }
+    if (b2.instrs[6].operands[0].vreg.n != 0)     { ret 1; }
 
     var i: u32 = 4;
     for (i < 7) {
@@ -3356,18 +3356,18 @@ test "mach.lang.be.codegen.legalize:expands_wide_ordered_as_a_lexicographic_walk
     if (b.instr_count != 9) { ret 1; }
 
     if (b.instrs[4].opcode != mir.MIR_CMP_LT_U) { ret 1; }
-    if (b.instrs[4].operands[1].vreg != 3)      { ret 1; }
-    if (b.instrs[4].operands[2].vreg != 5)      { ret 1; }
+    if (b.instrs[4].operands[1].vreg.n != 3)      { ret 1; }
+    if (b.instrs[4].operands[2].vreg.n != 5)      { ret 1; }
     if (b.instrs[5].opcode != mir.MIR_CMP_LT_U) { ret 1; }
-    if (b.instrs[5].operands[1].vreg != 4)      { ret 1; }
+    if (b.instrs[5].operands[1].vreg.n != 4)      { ret 1; }
     if (b.instrs[6].opcode != mir.MIR_CMP_EQ)   { ret 1; }
-    if (b.instrs[6].operands[1].vreg != 4)      { ret 1; }
+    if (b.instrs[6].operands[1].vreg.n != 4)      { ret 1; }
     if (b.instrs[7].opcode != mir.MIR_AND)      { ret 1; }
-    if (b.instrs[7].operands[1].vreg != b.instrs[6].operands[0].vreg) { ret 1; }
-    if (b.instrs[7].operands[2].vreg != b.instrs[4].operands[0].vreg) { ret 1; }
+    if (!mir.vreg_same(b.instrs[7].operands[1].vreg, b.instrs[6].operands[0].vreg)) { ret 1; }
+    if (!mir.vreg_same(b.instrs[7].operands[2].vreg, b.instrs[4].operands[0].vreg)) { ret 1; }
     if (b.instrs[8].opcode != mir.MIR_OR)       { ret 1; }
-    if (b.instrs[8].operands[1].vreg != b.instrs[5].operands[0].vreg) { ret 1; }
-    if (b.instrs[8].operands[0].vreg != 0)      { ret 1; }
+    if (!mir.vreg_same(b.instrs[8].operands[1].vreg, b.instrs[5].operands[0].vreg)) { ret 1; }
+    if (b.instrs[8].operands[0].vreg.n != 0)      { ret 1; }
 
     var fs: mir.MirFunction;
     var bs: mir.MirBlock;
@@ -3376,14 +3376,14 @@ test "mach.lang.be.codegen.legalize:expands_wide_ordered_as_a_lexicographic_walk
     if (sel legalize_function_r2.err) { ret 1; }
     if (bs.instr_count != 11)                     { ret 1; }
     if (bs.instrs[4].opcode != mir.MIR_CMP_LT_U)  { ret 1; }
-    if (bs.instrs[4].operands[1].vreg != 3)       { ret 1; }
+    if (bs.instrs[4].operands[1].vreg.n != 3)       { ret 1; }
     if (bs.instrs[5].opcode != mir.MIR_XOR)       { ret 1; }
-    if (bs.instrs[5].operands[1].vreg != 4)       { ret 1; }
+    if (bs.instrs[5].operands[1].vreg.n != 4)       { ret 1; }
     if (bs.instrs[5].operands[2].imm  != 0x80)    { ret 1; }
     if (bs.instrs[6].opcode != mir.MIR_XOR)       { ret 1; }
     if (bs.instrs[6].operands[2].imm  != 0x80)    { ret 1; }
     if (bs.instrs[7].opcode != mir.MIR_CMP_LT_U)  { ret 1; }
-    if (bs.instrs[10].operands[0].vreg != 0)      { ret 1; }
+    if (bs.instrs[10].operands[0].vreg.n != 0)      { ret 1; }
     var i: u32 = 0;
     for (i < bs.instr_count) {
         if (bs.instrs[i].opcode == mir.MIR_CMP_LT_S) { ret 1; }
@@ -3401,11 +3401,11 @@ test "mach.lang.be.codegen.legalize:expands_wide_ordered_as_a_lexicographic_walk
     if (sel legalize_function_r3.err) { ret 1; }
     if (bl.instr_count != 10)                    { ret 1; }
     if (bl.instrs[4].opcode != mir.MIR_CMP_LT_U) { ret 1; }
-    if (bl.instrs[4].operands[1].vreg != 5)      { ret 1; }
-    if (bl.instrs[4].operands[2].vreg != 3)      { ret 1; }
+    if (bl.instrs[4].operands[1].vreg.n != 5)      { ret 1; }
+    if (bl.instrs[4].operands[2].vreg.n != 3)      { ret 1; }
     if (bl.instrs[5].opcode != mir.MIR_XOR)      { ret 1; }
     if (bl.instrs[5].operands[2].imm != 1)       { ret 1; }
-    if (bl.instrs[9].operands[0].vreg != 0)      { ret 1; }
+    if (bl.instrs[9].operands[0].vreg.n != 0)      { ret 1; }
     ret 0;
 }
 
@@ -3439,7 +3439,7 @@ test "mach.lang.be.codegen.legalize:pins_wide_comparison_piece_counts" {
             if (sel legalize_function_r.err) { ret 1; }
             if (b.instr_count != 2 * widths[c]::u32 + want[r * 3 + c]) { ret 1; }
             if (b.instrs[b.instr_count - 1].operands[0].kind != mir.MIR_OP_VREG) { ret 1; }
-            if (b.instrs[b.instr_count - 1].operands[0].vreg != 0)               { ret 1; }
+            if (b.instrs[b.instr_count - 1].operands[0].vreg.n != 0)               { ret 1; }
             c = c + 1;
         }
         r = r + 1;
@@ -3458,17 +3458,17 @@ test "mach.lang.be.codegen.legalize:leaves_a_comparison_destination_unsplit" {
     val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
     if (sel legalize_function_r.err) { ret 1; }
 
-    if (b.instrs[16].operands[0].vreg != 19) { ret 1; }
+    if (b.instrs[16].operands[0].vreg.n != 19) { ret 1; }
 
     var writes_v0: u32 = 0;
     var i: u32 = 0;
     for (i < b.instr_count) {
         if (b.instrs[i].operands[0].kind == mir.MIR_OP_VREG &&
-            b.instrs[i].operands[0].vreg == 0) { writes_v0 = writes_v0 + 1; }
+            b.instrs[i].operands[0].vreg.n == 0) { writes_v0 = writes_v0 + 1; }
         i = i + 1;
     }
     if (writes_v0 != 1)                                   { ret 1; }
-    if (b.instrs[b.instr_count - 1].operands[0].vreg != 0) { ret 1; }
+    if (b.instrs[b.instr_count - 1].operands[0].vreg.n != 0) { ret 1; }
     if (b.instrs[b.instr_count - 1].width != 1)            { ret 1; }
 
     i = 16;
@@ -3489,13 +3489,13 @@ test "mach.lang.be.codegen.legalize:rejects_a_wide_comparison_of_an_unsupported_
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 3);
     var m1: [2]mir.MirOperand;
-    m1[0] = mir.op_vreg(1); m1[1] = mir.op_imm(0x0102);
+    m1[0] = mir.op_vreg(mir.vreg_id(1)); m1[1] = mir.op_imm(0x0102);
     t_instr(?alloc, ?b, 0, mir.MIR_MOV, ?m1[0], 2, 2);
     var m2: [2]mir.MirOperand;
-    m2[0] = mir.op_vreg(2); m2[1] = mir.op_imm(0x0304);
+    m2[0] = mir.op_vreg(mir.vreg_id(2)); m2[1] = mir.op_imm(0x0304);
     t_instr(?alloc, ?b, 1, mir.MIR_MOV, ?m2[0], 2, 2);
     var cm: [3]mir.MirOperand;
-    cm[0] = mir.op_preg(4); cm[1] = mir.op_vreg(1); cm[2] = mir.op_vreg(2);
+    cm[0] = mir.op_preg(mir.preg_id(4)); cm[1] = mir.op_vreg(mir.vreg_id(1)); cm[2] = mir.op_vreg(mir.vreg_id(2));
     t_instr(?alloc, ?b, 2, mir.MIR_CMP_LT_U, ?cm[0], 3, 2);
     f.blocks = ?b; f.block_count = 1;
 
@@ -3513,7 +3513,7 @@ test "mach.lang.be.codegen.legalize:rejects_a_shift_at_a_non_power_of_two_width"
 
     var f: mir.MirFunction;
     var b: mir.MirBlock;
-    t_shift_fn(?alloc, ?f, ?b, mir.MIR_SHL, 3, mir.op_vreg(2));
+    t_shift_fn(?alloc, ?f, ?b, mir.MIR_SHL, 3, mir.op_vreg(mir.vreg_id(2)));
     var mach: Machine = t_mach(1, 2);
     val legalize_function_r: err[fail.Fail] = legalize_function(?alloc, ?mach, ?f);
     if (!sel legalize_function_r.err) { ret 1; }
@@ -3531,7 +3531,7 @@ test "mach.lang.be.codegen.legalize:a_float_is_not_split_into_integer_lanes" {
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 1);
     var mv: [2]mir.MirOperand;
-    mv[0] = mir.op_vreg(0); mv[1] = mir.op_vreg(1);
+    mv[0] = mir.op_vreg(mir.vreg_id(0)); mv[1] = mir.op_vreg(mir.vreg_id(1));
     t_instr(?alloc, ?b, 0, mir.MIR_MOV, ?mv[0], 2, 8);
     f.blocks = ?b; f.block_count = 1;
 
@@ -3551,7 +3551,7 @@ test "mach.lang.be.codegen.legalize:a_float_is_not_split_into_integer_lanes" {
     var gb: mir.MirBlock;
     t_block(?alloc, ?gb, 1);
     var gi: [2]mir.MirOperand;
-    gi[0] = mir.op_vreg(0); gi[1] = mir.op_imm(0x0102030405060708);
+    gi[0] = mir.op_vreg(mir.vreg_id(0)); gi[1] = mir.op_imm(0x0102030405060708);
     t_instr(?alloc, ?gb, 0, mir.MIR_MOV, ?gi[0], 2, 8);
     gf.blocks = ?gb; gf.block_count = 1;
 
@@ -3593,13 +3593,13 @@ fun t_conv_fn(alloc: *A.Allocator, f: *mir.MirFunction, b: *mir.MirBlock,
     or             { f.vregs[1].class = fp_cls; }
     t_block(alloc, b, 2);
     var mv: [2]mir.MirOperand;
-    mv[0] = mir.op_vreg(2); mv[1] = mir.op_imm(0x0102030405060708);
+    mv[0] = mir.op_vreg(mir.vreg_id(2)); mv[1] = mir.op_imm(0x0102030405060708);
     t_instr(alloc, b, 0, mir.MIR_MOV, ?mv[0], 2, 8);
     var cv: [2]mir.MirOperand;
-    cv[0] = mir.op_vreg(0);
-    cv[1] = mir.op_vreg(1);
-    if (fp_is_dst) { cv[1] = mir.op_vreg(2); }
-    or             { cv[0] = mir.op_vreg(2); }
+    cv[0] = mir.op_vreg(mir.vreg_id(0));
+    cv[1] = mir.op_vreg(mir.vreg_id(1));
+    if (fp_is_dst) { cv[1] = mir.op_vreg(mir.vreg_id(2)); }
+    or             { cv[0] = mir.op_vreg(mir.vreg_id(2)); }
     t_instr(alloc, b, 1, opcode, ?cv[0], 2, dw);
     b.instrs[1].src_width = sw;
     f.blocks = b; f.block_count = 1;

--- a/src/lang/be/codegen/looprotate.mach
+++ b/src/lang/be/codegen/looprotate.mach
@@ -15,6 +15,9 @@ use mach.lang.be.codegen.mir;
 use mach.lang.source;
 use mach.lang.target;
 
+# the absent entry in every scratch table here (block index, vreg number, remap)
+val NONE: u32 = 0xFFFFFFFF;
+
 pub fun run(tgt: *target.Target, m: *mir.MirModule) err[fail.Fail] {
     if (m == nil) { ret err[fail.Fail].err{fail.message("looprotate: nil mir module")}; }
     var fi: u32 = 0;
@@ -106,7 +109,7 @@ fun scratch_init(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) err
     sc.id_index     = ri.ok;
     sc.id_index_cap = cap;
     var k: u32 = 0;
-    for (k < cap) { sc.id_index[k] = mir.MIR_VREG_NIL; k = k + 1; }
+    for (k < cap) { sc.id_index[k] = NONE; k = k + 1; }
     k = 0;
     for (k < f.block_count) { sc.id_index[f.blocks[k].id] = k; k = k + 1; }
 
@@ -170,11 +173,11 @@ fun scratch_dnit(alloc: *A.Allocator, sc: *LoopScratch) {
 
 fun terminator_target(f: *mir.MirFunction, sc: *LoopScratch, bx: u32, k: u32) u32 {
     val mb: *mir.MirBlock = ?f.blocks[bx];
-    if (mb.instr_count == 0) { ret mir.MIR_VREG_NIL; }
+    if (mb.instr_count == 0) { ret NONE; }
     val t: *mir.MirInstr = ?mb.instrs[mb.instr_count - 1];
-    if (k >= t.operand_count) { ret mir.MIR_VREG_NIL; }
+    if (k >= t.operand_count) { ret NONE; }
     val op: *mir.MirOperand = ?t.operands[k];
-    if (op.kind != mir.MIR_OP_BLOCK) { ret mir.MIR_VREG_NIL; }
+    if (op.kind != mir.MIR_OP_BLOCK) { ret NONE; }
     ret block_index(sc, op.imm::u32);
 }
 
@@ -195,12 +198,12 @@ fun rebuild_components(f: *mir.MirFunction, sc: *LoopScratch) {
     val frame_block: *u32 = ?sc.tarjan[(n::usize) * 4];
     val frame_next: *u32 = ?sc.tarjan[(n::usize) * 5];
     var i: u32 = 0;
-    for (i < n) { index[i] = mir.MIR_VREG_NIL; on_stack[i] = 0; sc.component[i] = i; i = i + 1; }
+    for (i < n) { index[i] = NONE; on_stack[i] = 0; sc.component[i] = i; i = i + 1; }
     var counter: u32 = 0;
     var sp: u32 = 0;
     var root: u32 = 0;
     for (root < n) {
-        if (index[root] != mir.MIR_VREG_NIL) { root = root + 1; cnt; }
+        if (index[root] != NONE) { root = root + 1; cnt; }
         index[root] = counter; low[root] = counter; counter = counter + 1;
         stack[sp] = root; sp = sp + 1; on_stack[root] = 1;
         var depth: u32 = 1;
@@ -212,8 +215,8 @@ fun rebuild_components(f: *mir.MirFunction, sc: *LoopScratch) {
             if (k < terminator_arity(f, v)) {
                 frame_next[depth - 1] = k + 1;
                 val w: u32 = terminator_target(f, sc, v, k);
-                if (w == mir.MIR_VREG_NIL) { cnt; }
-                if (index[w] == mir.MIR_VREG_NIL) {
+                if (w == NONE) { cnt; }
+                if (index[w] == NONE) {
                     index[w] = counter; low[w] = counter; counter = counter + 1;
                     stack[sp] = w; sp = sp + 1; on_stack[w] = 1;
                     frame_block[depth] = w;
@@ -225,7 +228,7 @@ fun rebuild_components(f: *mir.MirFunction, sc: *LoopScratch) {
             }
             depth = depth - 1;
             if (low[v] == index[v]) {
-                var member: u32 = mir.MIR_VREG_NIL;
+                var member: u32 = NONE;
                 for (member != v) {
                     sp = sp - 1;
                     member = stack[sp];
@@ -256,7 +259,7 @@ fun naming_dnit(alloc: *A.Allocator, sc: *LoopScratch) {
 
 fun note_named(sc: *LoopScratch, v: u32, bi: u32) {
     if (v >= sc.vreg_count) { ret; }
-    if (sc.named_in[v] == mir.MIR_VREG_NIL) { sc.named_in[v] = bi; }
+    if (sc.named_in[v] == NONE) { sc.named_in[v] = bi; }
     or (sc.named_in[v] != bi)               { sc.named_multi[v] = true; }
 }
 
@@ -273,7 +276,7 @@ fun rebuild_naming(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) e
     if (sel rm.err) { naming_dnit(alloc, sc); ret err[fail.Fail].err{fail.refused(rm.err)}; }
     sc.named_multi = rm.ok;
     var v: u32 = 0;
-    for (v < f.vreg_count) { sc.named_in[v] = mir.MIR_VREG_NIL; sc.named_multi[v] = false; v = v + 1; }
+    for (v < f.vreg_count) { sc.named_in[v] = NONE; sc.named_multi[v] = false; v = v + 1; }
 
     var bi: u32 = 0;
     for (bi < f.block_count) {
@@ -284,10 +287,10 @@ fun rebuild_naming(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) e
             var o: u32 = 0;
             for (o < ins.operand_count) {
                 val op: *mir.MirOperand = ?ins.operands[o];
-                if (op.kind == mir.MIR_OP_VREG) { note_named(sc, op.vreg, bi); }
+                if (op.kind == mir.MIR_OP_VREG) { note_named(sc, op.vreg.n, bi); }
                 if (op.kind == mir.MIR_OP_MEM) {
-                    note_named(sc, op.vreg, bi);
-                    if (!op.index_is_preg) { note_named(sc, op.index, bi); }
+                    note_named(sc, op.vreg.n, bi);
+                    if (sel op.index.vreg) { note_named(sc, op.index.vreg.n, bi); }
                 }
                 o = o + 1;
             }
@@ -299,13 +302,13 @@ fun rebuild_naming(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch) e
 }
 
 fun block_index(sc: *LoopScratch, id: u32) u32 {
-    if (id >= sc.id_index_cap) { ret mir.MIR_VREG_NIL; }
+    if (id >= sc.id_index_cap) { ret NONE; }
     ret sc.id_index[id];
 }
 
 fun find_block(f: *mir.MirFunction, sc: *LoopScratch, id: u32) *mir.MirBlock {
     val ix: u32 = block_index(sc, id);
-    if (ix == mir.MIR_VREG_NIL) { ret nil; }
+    if (ix == NONE) { ret nil; }
     ret ?f.blocks[ix];
 }
 
@@ -321,7 +324,7 @@ fun try_rotate_header(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch
     if (term.operands[1].kind != mir.MIR_OP_BLOCK) { ret res[bool, fail.Fail].ok{false}; }
     if (term.operands[2].kind != mir.MIR_OP_BLOCK) { ret res[bool, fail.Fail].ok{false}; }
 
-    val cond_vreg: u32 = cond_op.vreg;
+    val cond_vreg: u32 = cond_op.vreg.n;
     val b_id: u32 = term.operands[1].imm::u32;
     val e_id: u32 = term.operands[2].imm::u32;
     if (b_id == e_id)  { ret res[bool, fail.Fail].ok{false}; }
@@ -334,13 +337,13 @@ fun try_rotate_header(alloc: *A.Allocator, f: *mir.MirFunction, sc: *LoopScratch
     if (!defs_confined(sc, h))        { ret res[bool, fail.Fail].ok{false}; }
 
     if (!mark_loop(f, sc, b_id, h.id, e_id)) { ret res[bool, fail.Fail].ok{false}; }
-    var p_id: u32 = mir.MIR_VREG_NIL;
+    var p_id: u32 = NONE;
     var outside: u32 = 0;
     var inside: u32 = 0;
     var pi: u32 = 0;
     for (pi < h.pred_count) {
         val px: u32 = block_index(sc, h.preds[pi]);
-        if (px != mir.MIR_VREG_NIL && sc.loop_mark[px] == sc.epoch) {
+        if (px != NONE && sc.loop_mark[px] == sc.epoch) {
             inside = inside + 1;
         } or {
             outside = outside + 1;
@@ -373,10 +376,10 @@ fun mark_loop(f: *mir.MirFunction, sc: *LoopScratch, b_id: u32, h_id: u32, e_id:
     }
 
     val root: u32 = block_index(sc, b_id);
-    if (root == mir.MIR_VREG_NIL) { ret false; }
+    if (root == NONE) { ret false; }
     val hx: u32 = block_index(sc, h_id);
-    var loop: u32 = mir.MIR_VREG_NIL;
-    if (hx != mir.MIR_VREG_NIL) { loop = sc.component[hx]; }
+    var loop: u32 = NONE;
+    if (hx != NONE) { loop = sc.component[hx]; }
     sc.loop_mark[root] = sc.epoch;
     sc.stack[0] = root;
     var sp: u32 = 1;
@@ -395,7 +398,7 @@ fun mark_loop(f: *mir.MirFunction, sc: *LoopScratch, b_id: u32, h_id: u32, e_id:
                     val tid: u32 = op.imm::u32;
                     if (tid != h_id && tid != e_id) {
                         val tx: u32 = block_index(sc, tid);
-                        if (tx != mir.MIR_VREG_NIL && sc.loop_mark[tx] != sc.epoch && sc.component[tx] == loop) {
+                        if (tx != NONE && sc.loop_mark[tx] != sc.epoch && sc.component[tx] == loop) {
                             sc.loop_mark[tx] = sc.epoch;
                             sc.stack[sp] = tx;
                             sp = sp + 1;
@@ -416,7 +419,7 @@ fun rotate(alloc: *A.Allocator, f: *mir.MirFunction, h: *mir.MirBlock, p: *mir.M
     if (sel rr.err) { ret err[fail.Fail].err{fail.refused(rr.err)}; }
     val remap: *u32 = rr.ok;
     var i: u32 = 0;
-    for (i < orig_vregs) { remap[i] = mir.MIR_VREG_NIL; i = i + 1; }
+    for (i < orig_vregs) { remap[i] = NONE; i = i + 1; }
 
     val pt: *mir.MirInstr = ?p.instrs[p.instr_count - 1];
     if (pt.operands != nil && pt.operand_count > 0) {
@@ -452,7 +455,7 @@ fun test_clonable(h: *mir.MirBlock, cond_vreg: u32) bool {
         if (!mir.instr_defines_shape(ins))   { ret false; }
         if (ins.operand_count == 0)          { ret false; }
         if (ins.operands[0].kind != mir.MIR_OP_VREG) { ret false; }
-        if (ins.operands[0].vreg == cond_vreg) { defines_cond = true; }
+        if (ins.operands[0].vreg.n == cond_vreg) { defines_cond = true; }
         i = i + 1;
     }
     ret defines_cond;
@@ -465,8 +468,8 @@ fun defs_confined(sc: *LoopScratch, h: *mir.MirBlock) bool {
     for (i < h.instr_count - 1) {
         val ins: *mir.MirInstr = ?h.instrs[i];
         if (ins.operand_count > 0 && ins.operands[0].kind == mir.MIR_OP_VREG) {
-            val v: u32 = ins.operands[0].vreg;
-            if (v < sc.vreg_count && (sc.named_multi[v] || (sc.named_in[v] != mir.MIR_VREG_NIL && sc.named_in[v] != hx))) {
+            val v: u32 = ins.operands[0].vreg.n;
+            if (v < sc.vreg_count && (sc.named_multi[v] || (sc.named_in[v] != NONE && sc.named_in[v] != hx))) {
                 ret false;
             }
         }
@@ -482,7 +485,7 @@ fun clonable_opcode(op: mir.MirOpcode) bool {
 
 fun clone_compute(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
                   remap: *u32, orig_vregs: u32) res[mir.MirInstr, fail.Fail] {
-    val old_dest: u32 = src.operands[0].vreg;
+    val old_dest: u32 = src.operands[0].vreg.n;
     val nd: res[u32, fail.Fail] = add_vreg_like(alloc, f, old_dest);
     if (sel nd.err) { ret res[mir.MirInstr, fail.Fail].err{nd.err}; }
     val new_dest: u32 = nd.ok;
@@ -497,7 +500,7 @@ fun clone_compute(alloc: *A.Allocator, f: *mir.MirFunction, src: *mir.MirInstr,
         k = k + 1;
     }
     remap[old_dest] = new_dest;
-    ops[0] = mir.op_vreg(new_dest);
+    ops[0] = mir.op_vreg(mir.vreg_id(new_dest));
 
     ret res[mir.MirInstr, fail.Fail].ok{make_instr(src, ops, src.operand_count)};
 }
@@ -508,9 +511,9 @@ fun clone_guard_cbr(alloc: *A.Allocator, src: *mir.MirInstr, remap: *u32, orig_v
     if (sel ro.err) { ret res[mir.MirInstr, fail.Fail].err{fail.refused(ro.err)}; }
     val ops: *mir.MirOperand = ro.ok;
 
-    var cond: mir.MirOperand = mir.op_vreg(cond_vreg);
-    if (cond_vreg < orig_vregs && remap[cond_vreg] != mir.MIR_VREG_NIL) {
-        cond = mir.op_vreg(remap[cond_vreg]);
+    var cond: mir.MirOperand = mir.op_vreg(mir.vreg_id(cond_vreg));
+    if (cond_vreg < orig_vregs && remap[cond_vreg] != NONE) {
+        cond = mir.op_vreg(mir.vreg_id(remap[cond_vreg]));
     }
     ops[0] = cond;
     ops[1] = mir.op_block(b_id);
@@ -521,16 +524,16 @@ fun clone_guard_cbr(alloc: *A.Allocator, src: *mir.MirInstr, remap: *u32, orig_v
 
 fun remap_operand(src: mir.MirOperand, remap: *u32, orig_vregs: u32) mir.MirOperand {
     var o: mir.MirOperand = src;
-    if (o.kind == mir.MIR_OP_VREG && o.vreg < orig_vregs && remap[o.vreg] != mir.MIR_VREG_NIL) {
-        o.vreg = remap[o.vreg];
+    if (o.kind == mir.MIR_OP_VREG && o.vreg.n < orig_vregs && remap[o.vreg.n] != NONE) {
+        o.vreg = mir.vreg_id(remap[o.vreg.n]);
     }
     if (o.kind == mir.MIR_OP_MEM) {
-        if (o.vreg != mir.MIR_VREG_NIL && o.vreg < orig_vregs && remap[o.vreg] != mir.MIR_VREG_NIL) {
-            o.vreg = remap[o.vreg];
+        if (!mir.vreg_is_nil(o.vreg) && o.vreg.n < orig_vregs && remap[o.vreg.n] != NONE) {
+            o.vreg = mir.vreg_id(remap[o.vreg.n]);
         }
-        if (!o.index_is_preg && o.index != mir.MIR_VREG_NIL && o.index < orig_vregs && remap[o.index] != mir.MIR_VREG_NIL) {
-            o.index = remap[o.index];
-        }
+        var ix: u32 = NONE;
+        if (sel o.index.vreg) { ix = o.index.vreg.n; }
+        if (ix < orig_vregs && remap[ix] != NONE) { o.index = mir.index_vreg(mir.vreg_id(remap[ix])); }
     }
     ret o;
 }
@@ -677,7 +680,7 @@ fun t_fn(alloc: *A.Allocator, blocks: *mir.MirBlock, nb: u32, nv: u32) mir.MirFu
         f.vregs[i].id         = i;
         f.vregs[i].class      = mir.REG_CLASS_GP;
         f.vregs[i].spill_slot = -1;
-        f.vregs[i].assigned   = mir.MIR_VREG_NIL;
+        f.vregs[i].assigned   = mir.MIR_PREG_NIL;
         f.vregs[i].vector     = false;
         f.vregs[i].secret     = false;
         i = i + 1;
@@ -699,19 +702,19 @@ test "mach.lang.be.codegen.looprotate.try_rotate_header:multi_block_body" {
     var alloc: A.Allocator;
     page.make(?alloc);
 
-    var mov:  [2]mir.MirOperand; mov[0]  = mir.op_vreg(0); mov[1]  = mir.op_imm(0);
+    var mov:  [2]mir.MirOperand; mov[0]  = mir.op_vreg(mir.vreg_id(0)); mov[1]  = mir.op_imm(0);
     var pbr:  [1]mir.MirOperand; pbr[0]  = mir.op_block(1);
     var b0i:  [2]mir.MirInstr;
     b0i[0] = t_instr(?alloc, mir.MIR_MOV, ?mov[0], 2);
     b0i[1] = t_instr(?alloc, mir.MIR_BR,  ?pbr[0], 1);
 
-    var cmp:  [3]mir.MirOperand; cmp[0]  = mir.op_vreg(2); cmp[1] = mir.op_vreg(0); cmp[2] = mir.op_vreg(1);
-    var hcbr: [3]mir.MirOperand; hcbr[0] = mir.op_vreg(2); hcbr[1] = mir.op_block(2); hcbr[2] = mir.op_block(5);
+    var cmp:  [3]mir.MirOperand; cmp[0]  = mir.op_vreg(mir.vreg_id(2)); cmp[1] = mir.op_vreg(mir.vreg_id(0)); cmp[2] = mir.op_vreg(mir.vreg_id(1));
+    var hcbr: [3]mir.MirOperand; hcbr[0] = mir.op_vreg(mir.vreg_id(2)); hcbr[1] = mir.op_block(2); hcbr[2] = mir.op_block(5);
     var b1i:  [2]mir.MirInstr;
     b1i[0] = t_instr(?alloc, mir.MIR_CMP_LT_S, ?cmp[0], 3);
     b1i[1] = t_instr(?alloc, mir.MIR_CBR,      ?hcbr[0], 3);
 
-    var icbr: [3]mir.MirOperand; icbr[0] = mir.op_vreg(3); icbr[1] = mir.op_block(3); icbr[2] = mir.op_block(4);
+    var icbr: [3]mir.MirOperand; icbr[0] = mir.op_vreg(mir.vreg_id(3)); icbr[1] = mir.op_block(3); icbr[2] = mir.op_block(4);
     var b2i:  [1]mir.MirInstr;
     b2i[0] = t_instr(?alloc, mir.MIR_CBR, ?icbr[0], 3);
 
@@ -719,7 +722,7 @@ test "mach.lang.be.codegen.looprotate.try_rotate_header:multi_block_body" {
     var b3i:  [1]mir.MirInstr;
     b3i[0] = t_instr(?alloc, mir.MIR_BR, ?tbr[0], 1);
 
-    var inc:  [3]mir.MirOperand; inc[0] = mir.op_vreg(0); inc[1] = mir.op_vreg(0); inc[2] = mir.op_imm(1);
+    var inc:  [3]mir.MirOperand; inc[0] = mir.op_vreg(mir.vreg_id(0)); inc[1] = mir.op_vreg(mir.vreg_id(0)); inc[2] = mir.op_imm(1);
     var lbr:  [1]mir.MirOperand; lbr[0] = mir.op_block(1);
     var b4i:  [2]mir.MirInstr;
     b4i[0] = t_instr(?alloc, mir.MIR_ADD, ?inc[0], 3);
@@ -743,8 +746,8 @@ test "mach.lang.be.codegen.looprotate.try_rotate_header:multi_block_body" {
     if (f.blocks[0].instr_count != 3)                       { ret 1; }
     if (f.blocks[0].instrs[1].opcode != mir.MIR_CMP_LT_S)   { ret 1; }
     if (!t_ends_in_cbr_to(?f.blocks[0], 2, 5))              { ret 1; }
-    if (f.blocks[0].instrs[2].operands[0].vreg != 4)        { ret 1; }
-    if (f.blocks[0].instrs[1].operands[0].vreg != 4)        { ret 1; }
+    if (f.blocks[0].instrs[2].operands[0].vreg.n != 4)        { ret 1; }
+    if (f.blocks[0].instrs[1].operands[0].vreg.n != 4)        { ret 1; }
 
     if (f.blocks[1].pred_count != 1) { ret 1; }
     if (f.blocks[1].preds[0] != 4)   { ret 1; }
@@ -756,21 +759,21 @@ test "mach.lang.be.codegen.looprotate.try_rotate_header:memory_bound_test" {
     var alloc: A.Allocator;
     page.make(?alloc);
 
-    var mov:  [2]mir.MirOperand; mov[0]  = mir.op_vreg(0); mov[1]  = mir.op_imm(0);
+    var mov:  [2]mir.MirOperand; mov[0]  = mir.op_vreg(mir.vreg_id(0)); mov[1]  = mir.op_imm(0);
     var pbr:  [1]mir.MirOperand; pbr[0]  = mir.op_block(1);
     var b0i:  [2]mir.MirInstr;
     b0i[0] = t_instr(?alloc, mir.MIR_MOV, ?mov[0], 2);
     b0i[1] = t_instr(?alloc, mir.MIR_BR,  ?pbr[0], 1);
 
-    var ld:   [2]mir.MirOperand; ld[0]   = mir.op_vreg(2); ld[1]  = mir.op_mem_value(1, 0);
-    var cmp:  [3]mir.MirOperand; cmp[0]  = mir.op_vreg(3); cmp[1] = mir.op_vreg(0); cmp[2] = mir.op_vreg(2);
-    var hcbr: [3]mir.MirOperand; hcbr[0] = mir.op_vreg(3); hcbr[1] = mir.op_block(2); hcbr[2] = mir.op_block(3);
+    var ld:   [2]mir.MirOperand; ld[0]   = mir.op_vreg(mir.vreg_id(2)); ld[1]  = mir.op_mem_value(mir.vreg_id(1), 0);
+    var cmp:  [3]mir.MirOperand; cmp[0]  = mir.op_vreg(mir.vreg_id(3)); cmp[1] = mir.op_vreg(mir.vreg_id(0)); cmp[2] = mir.op_vreg(mir.vreg_id(2));
+    var hcbr: [3]mir.MirOperand; hcbr[0] = mir.op_vreg(mir.vreg_id(3)); hcbr[1] = mir.op_block(2); hcbr[2] = mir.op_block(3);
     var b1i:  [3]mir.MirInstr;
     b1i[0] = t_instr(?alloc, mir.MIR_LOAD,     ?ld[0], 2);
     b1i[1] = t_instr(?alloc, mir.MIR_CMP_LT_S, ?cmp[0], 3);
     b1i[2] = t_instr(?alloc, mir.MIR_CBR,      ?hcbr[0], 3);
 
-    var inc:  [3]mir.MirOperand; inc[0] = mir.op_vreg(0); inc[1] = mir.op_vreg(0); inc[2] = mir.op_imm(1);
+    var inc:  [3]mir.MirOperand; inc[0] = mir.op_vreg(mir.vreg_id(0)); inc[1] = mir.op_vreg(mir.vreg_id(0)); inc[2] = mir.op_imm(1);
     var lbr:  [1]mir.MirOperand; lbr[0] = mir.op_block(1);
     var b2i:  [2]mir.MirInstr;
     b2i[0] = t_instr(?alloc, mir.MIR_ADD, ?inc[0], 3);
@@ -793,8 +796,8 @@ test "mach.lang.be.codegen.looprotate.try_rotate_header:memory_bound_test" {
     if (f.blocks[0].instrs[1].opcode != mir.MIR_LOAD)     { ret 1; }
     if (f.blocks[0].instrs[2].opcode != mir.MIR_CMP_LT_S) { ret 1; }
     if (!t_ends_in_cbr_to(?f.blocks[0], 2, 3))            { ret 1; }
-    if (f.blocks[0].instrs[1].operands[0].vreg != 4)      { ret 1; }
-    if (f.blocks[0].instrs[2].operands[2].vreg != 4)      { ret 1; }
+    if (f.blocks[0].instrs[1].operands[0].vreg.n != 4)      { ret 1; }
+    if (f.blocks[0].instrs[2].operands[2].vreg.n != 4)      { ret 1; }
     if (f.blocks[1].pred_count != 1)                      { ret 1; }
     ret 0;
 }
@@ -803,19 +806,19 @@ test "mach.lang.be.codegen.looprotate.try_rotate_header:declines_escaping_test_d
     var alloc: A.Allocator;
     page.make(?alloc);
 
-    var mov:  [2]mir.MirOperand; mov[0]  = mir.op_vreg(0); mov[1]  = mir.op_imm(0);
+    var mov:  [2]mir.MirOperand; mov[0]  = mir.op_vreg(mir.vreg_id(0)); mov[1]  = mir.op_imm(0);
     var pbr:  [1]mir.MirOperand; pbr[0]  = mir.op_block(1);
     var b0i:  [2]mir.MirInstr;
     b0i[0] = t_instr(?alloc, mir.MIR_MOV, ?mov[0], 2);
     b0i[1] = t_instr(?alloc, mir.MIR_BR,  ?pbr[0], 1);
 
-    var cmp:  [3]mir.MirOperand; cmp[0]  = mir.op_vreg(2); cmp[1] = mir.op_vreg(0); cmp[2] = mir.op_vreg(1);
-    var hcbr: [3]mir.MirOperand; hcbr[0] = mir.op_vreg(2); hcbr[1] = mir.op_block(2); hcbr[2] = mir.op_block(3);
+    var cmp:  [3]mir.MirOperand; cmp[0]  = mir.op_vreg(mir.vreg_id(2)); cmp[1] = mir.op_vreg(mir.vreg_id(0)); cmp[2] = mir.op_vreg(mir.vreg_id(1));
+    var hcbr: [3]mir.MirOperand; hcbr[0] = mir.op_vreg(mir.vreg_id(2)); hcbr[1] = mir.op_block(2); hcbr[2] = mir.op_block(3);
     var b1i:  [2]mir.MirInstr;
     b1i[0] = t_instr(?alloc, mir.MIR_CMP_LT_S, ?cmp[0], 3);
     b1i[1] = t_instr(?alloc, mir.MIR_CBR,      ?hcbr[0], 3);
 
-    var use:  [3]mir.MirOperand; use[0] = mir.op_vreg(0); use[1] = mir.op_vreg(0); use[2] = mir.op_vreg(2);
+    var use:  [3]mir.MirOperand; use[0] = mir.op_vreg(mir.vreg_id(0)); use[1] = mir.op_vreg(mir.vreg_id(0)); use[2] = mir.op_vreg(mir.vreg_id(2));
     var lbr:  [1]mir.MirOperand; lbr[0] = mir.op_block(1);
     var b2i:  [2]mir.MirInstr;
     b2i[0] = t_instr(?alloc, mir.MIR_ADD, ?use[0], 3);
@@ -852,13 +855,13 @@ test "mach.lang.be.codegen.looprotate.try_rotate_header:declines_two_entries" {
     var b1i:  [1]mir.MirInstr;
     b1i[0] = t_instr(?alloc, mir.MIR_BR, ?e1br[0], 1);
 
-    var cmp:  [3]mir.MirOperand; cmp[0]  = mir.op_vreg(2); cmp[1] = mir.op_vreg(0); cmp[2] = mir.op_vreg(1);
-    var hcbr: [3]mir.MirOperand; hcbr[0] = mir.op_vreg(2); hcbr[1] = mir.op_block(3); hcbr[2] = mir.op_block(4);
+    var cmp:  [3]mir.MirOperand; cmp[0]  = mir.op_vreg(mir.vreg_id(2)); cmp[1] = mir.op_vreg(mir.vreg_id(0)); cmp[2] = mir.op_vreg(mir.vreg_id(1));
+    var hcbr: [3]mir.MirOperand; hcbr[0] = mir.op_vreg(mir.vreg_id(2)); hcbr[1] = mir.op_block(3); hcbr[2] = mir.op_block(4);
     var b2i:  [2]mir.MirInstr;
     b2i[0] = t_instr(?alloc, mir.MIR_CMP_LT_S, ?cmp[0], 3);
     b2i[1] = t_instr(?alloc, mir.MIR_CBR,      ?hcbr[0], 3);
 
-    var inc:  [3]mir.MirOperand; inc[0] = mir.op_vreg(0); inc[1] = mir.op_vreg(0); inc[2] = mir.op_imm(1);
+    var inc:  [3]mir.MirOperand; inc[0] = mir.op_vreg(mir.vreg_id(0)); inc[1] = mir.op_vreg(mir.vreg_id(0)); inc[2] = mir.op_imm(1);
     var lbr:  [1]mir.MirOperand; lbr[0] = mir.op_block(2);
     var b3i:  [2]mir.MirInstr;
     b3i[0] = t_instr(?alloc, mir.MIR_ADD, ?inc[0], 3);

--- a/src/lang/be/codegen/mir.mach
+++ b/src/lang/be/codegen/mir.mach
@@ -747,7 +747,51 @@ pub val FCC_LE: u8 = 3;
 pub val FCC_GT: u8 = 4;
 pub val FCC_GE: u8 = 5;
 
-pub val MIR_VREG_NIL: u32 = 0xFFFFFFFF;
+# register identities are records, not `def` aliases: a vreg number cannot be
+# handed where a physical register is meant, and neither indexes a table
+# without naming the unwrap. a PRegId carries the class-tagged isa regid.
+pub rec VRegId { n: u32; }
+pub rec PRegId { n: u32; }
+
+pub val MIR_VREG_NIL: VRegId = VRegId{n: 0xFFFFFFFF};
+pub val MIR_PREG_NIL: PRegId = PRegId{n: 0xFFFFFFFF};
+
+pub fun vreg_id(n: u32) VRegId {
+    var v: VRegId;
+    v.n = n;
+    ret v;
+}
+
+pub fun vreg_is_nil(v: VRegId) bool { ret v.n == MIR_VREG_NIL.n; }
+
+pub fun vreg_same(a: VRegId, b: VRegId) bool { ret a.n == b.n; }
+
+# the one way an isa regid becomes a MIR physical register
+pub fun preg_id(regid: i32) PRegId {
+    var p: PRegId;
+    p.n = regid::u32;
+    ret p;
+}
+
+pub fun preg_regid(p: PRegId) i32 { ret p.n::i32; }
+
+pub fun preg_is_nil(p: PRegId) bool { ret p.n == MIR_PREG_NIL.n; }
+
+pub fun preg_same(a: PRegId, b: PRegId) bool { ret a.n == b.n; }
+
+# the index register of a memory operand: absent, a vreg before allocation
+# or a preg after it. a case, not a flag beside a number
+pub tag MirIndex: u8 {
+    none;
+    vreg: VRegId;
+    preg: PRegId;
+}
+
+pub fun index_none() MirIndex { ret MirIndex.none{}; }
+
+pub fun index_vreg(v: VRegId) MirIndex { ret MirIndex.vreg{v}; }
+
+pub fun index_preg(p: PRegId) MirIndex { ret MirIndex.preg{p}; }
 
 pub val REG_CLASS_GP: u32 = 0;
 # every vreg of a values convention: never a bank index
@@ -758,14 +802,13 @@ pub val ALU_MIN_WIDTH: u8 = 4;
 pub rec MirOperand {
     kind:          MirOperandKind;
     required_bank: OperandBank;
-    vreg:          u32;
-    preg:          u32;
+    vreg:          VRegId;
+    preg:          PRegId;
     imm:           i64;
     sym:           intern.StrId;
     sym_off:       i32;
-    index:         u32;
+    index:         MirIndex;
     scale:         u8;
-    index_is_preg: bool;
     sym_got:       bool;
 }
 
@@ -812,7 +855,7 @@ pub rec MirInstr {
     # selection retags MIR_DECLASSIFY to the ISA move; the barrier survives here
     declassifies:      bool;
     # the vreg a dropped declassify self-copy downgraded, once it has no operands
-    declassified:      u32;
+    declassified:      VRegId;
 }
 
 pub fun instr(opcode: MirOpcode, operands: *MirOperand, operand_count: u32,
@@ -830,7 +873,7 @@ pub fun instr(opcode: MirOpcode, operands: *MirOperand, operand_count: u32,
 # a dropped declassify self-copy becomes a zero-byte use that keeps the
 # barrier and names the vreg it downgraded; its carrier is read through
 # MirVReg.assigned and spill_slot
-pub fun declassify_marker(src: *MirInstr, v: u32) MirInstr {
+pub fun declassify_marker(src: *MirInstr, v: VRegId) MirInstr {
     var mi: MirInstr = @src;
     mi.opcode        = ISA_USE_OPCODE;
     mi.operands      = nil;
@@ -898,7 +941,7 @@ pub rec MirVReg {
     id:         u32;
     class:      u32;
     spill_slot: i32;
-    assigned:   u32;
+    assigned:   PRegId;
     ty:         u32;
     vector:     bool;
     secret:     bool;
@@ -911,7 +954,7 @@ pub fun vreg(id: u32, class: u32, vector: bool, secret: bool) MirVReg {
     v.id         = id;
     v.class      = class;
     v.spill_slot = -1;
-    v.assigned   = MIR_VREG_NIL;
+    v.assigned   = MIR_PREG_NIL;
     v.ty         = VREG_TY_NIL;
     v.vector     = vector;
     v.secret     = secret;
@@ -923,7 +966,7 @@ test "mach.lang.be.codegen.mir.vreg:sets_every_field" {
     if (v.id != 7)                  { ret 1; }
     if (v.class != 3)               { ret 1; }
     if (v.spill_slot != -1)         { ret 1; }
-    if (v.assigned != MIR_VREG_NIL) { ret 1; }
+    if (!preg_is_nil(v.assigned)) { ret 1; }
     if (v.ty != VREG_TY_NIL)        { ret 1; }
     if (!v.vector)                  { ret 1; }
     if (!v.secret)                  { ret 1; }
@@ -976,7 +1019,7 @@ pub val ABI_CONTENT_OUTPUT: u8 = 4;
 pub rec MirAbiInput {
     argument: u32;
     location: u8;
-    reg: u32;
+    reg: PRegId;
     # relative to the abi argument area, not entry sp or established fp
     offset: i64;
     width: u64;
@@ -1113,23 +1156,22 @@ pub fun emits_instr(f: *MirFunction, mi: *MirInstr) bool {
     ret mi.asm_block != nil;
 }
 
-pub fun op_vreg(vreg: u32) MirOperand {
+pub fun op_vreg(vreg: VRegId) MirOperand {
     var o: MirOperand;
     o.kind          = MIR_OP_VREG;
     o.required_bank = BANK_UNKNOWN;
     o.vreg          = vreg;
-    o.preg          = 0;
+    o.preg          = MIR_PREG_NIL;
     o.imm           = 0;
     o.sym           = intern.STR_NIL;
     o.sym_off       = 0;
-    o.index         = MIR_VREG_NIL;
+    o.index         = index_none();
     o.scale         = 0;
-    o.index_is_preg = false;
     o.sym_got       = false;
     ret o;
 }
 
-pub fun op_preg(preg: u32) MirOperand {
+pub fun op_preg(preg: PRegId) MirOperand {
     var o: MirOperand;
     o.kind          = MIR_OP_PREG;
     o.required_bank = BANK_UNKNOWN;
@@ -1138,16 +1180,15 @@ pub fun op_preg(preg: u32) MirOperand {
     o.imm           = 0;
     o.sym           = intern.STR_NIL;
     o.sym_off       = 0;
-    o.index         = MIR_VREG_NIL;
+    o.index         = index_none();
     o.scale         = 0;
-    o.index_is_preg = false;
     o.sym_got       = false;
     ret o;
 }
 
 # a physical operand that remembers the vreg it was rewritten from; the seed
 # secrecy of that vreg is what the post-allocation walk reads at this use
-pub fun op_preg_of(preg: u32, origin: u32) MirOperand {
+pub fun op_preg_of(preg: PRegId, origin: VRegId) MirOperand {
     var o: MirOperand = op_preg(preg);
     o.vreg = origin;
     ret o;
@@ -1157,16 +1198,16 @@ pub fun op_preg_of(preg: u32, origin: u32) MirOperand {
 # rewritten register operand, the slot key of a frame-slot memory operand,
 # MIR_VREG_NIL for a precolored register, a preg-based address, an immediate
 # or a symbol
-pub fun operand_origin(op: *MirOperand) u32 {
+pub fun operand_origin(op: *MirOperand) VRegId {
     if (op.kind == MIR_OP_PREG) { ret op.vreg; }
     if (op.kind == MIR_OP_MEM)  { ret op.vreg; }
     ret MIR_VREG_NIL;
 }
 
 pub fun operand_seed_secret(f: *MirFunction, op: *MirOperand) bool {
-    val origin: u32 = operand_origin(op);
-    if (origin == MIR_VREG_NIL || origin >= f.vreg_count) { ret false; }
-    ret f.vregs[origin].secret;
+    val origin: VRegId = operand_origin(op);
+    if (vreg_is_nil(origin) || origin.n >= f.vreg_count) { ret false; }
+    ret f.vregs[origin.n].secret;
 }
 
 pub fun op_imm(imm: i64) MirOperand {
@@ -1174,34 +1215,32 @@ pub fun op_imm(imm: i64) MirOperand {
     o.kind          = MIR_OP_IMM;
     o.required_bank = BANK_UNKNOWN;
     o.vreg          = MIR_VREG_NIL;
-    o.preg          = 0;
+    o.preg          = MIR_PREG_NIL;
     o.imm           = imm;
     o.sym           = intern.STR_NIL;
     o.sym_off       = 0;
-    o.index         = MIR_VREG_NIL;
+    o.index         = index_none();
     o.scale         = 0;
-    o.index_is_preg = false;
     o.sym_got       = false;
     ret o;
 }
 
-pub fun op_mem_slot(slotkey: u32, disp: i64) MirOperand {
+pub fun op_mem_slot(slotkey: VRegId, disp: i64) MirOperand {
     var o: MirOperand;
     o.kind          = MIR_OP_MEM;
     o.required_bank = BANK_UNKNOWN;
     o.vreg          = slotkey;
-    o.preg          = 0;
+    o.preg          = MIR_PREG_NIL;
     o.imm           = disp;
     o.sym           = intern.STR_NIL;
     o.sym_off       = 0;
-    o.index         = MIR_VREG_NIL;
+    o.index         = index_none();
     o.scale         = 0;
-    o.index_is_preg = false;
     o.sym_got       = false;
     ret o;
 }
 
-pub fun op_mem_preg(preg: u32, disp: i64) MirOperand {
+pub fun op_mem_preg(preg: PRegId, disp: i64) MirOperand {
     var o: MirOperand;
     o.kind          = MIR_OP_MEM;
     o.required_bank = BANK_UNKNOWN;
@@ -1210,25 +1249,23 @@ pub fun op_mem_preg(preg: u32, disp: i64) MirOperand {
     o.imm           = disp;
     o.sym           = intern.STR_NIL;
     o.sym_off       = 0;
-    o.index         = MIR_VREG_NIL;
+    o.index         = index_none();
     o.scale         = 0;
-    o.index_is_preg = false;
     o.sym_got       = false;
     ret o;
 }
 
-pub fun op_mem_value(base: u32, disp: i64) MirOperand {
+pub fun op_mem_value(base: VRegId, disp: i64) MirOperand {
     var o: MirOperand;
     o.kind          = MIR_OP_MEM;
     o.required_bank = BANK_UNKNOWN;
     o.vreg          = base;
-    o.preg          = 0;
+    o.preg          = MIR_PREG_NIL;
     o.imm           = disp;
     o.sym           = intern.STR_NIL;
     o.sym_off       = 0;
-    o.index         = MIR_VREG_NIL;
+    o.index         = index_none();
     o.scale         = 0;
-    o.index_is_preg = false;
     o.sym_got       = false;
     ret o;
 }
@@ -1238,13 +1275,12 @@ pub fun op_sym(sym: intern.StrId, sym_off: i32) MirOperand {
     o.kind          = MIR_OP_SYM;
     o.required_bank = BANK_UNKNOWN;
     o.vreg          = MIR_VREG_NIL;
-    o.preg          = 0;
+    o.preg          = MIR_PREG_NIL;
     o.imm           = 0;
     o.sym           = sym;
     o.sym_off       = sym_off;
-    o.index         = MIR_VREG_NIL;
+    o.index         = index_none();
     o.scale         = 0;
-    o.index_is_preg = false;
     o.sym_got       = false;
     ret o;
 }
@@ -1254,20 +1290,19 @@ pub fun op_block(block: u32) MirOperand {
     o.kind          = MIR_OP_BLOCK;
     o.required_bank = BANK_UNKNOWN;
     o.vreg          = MIR_VREG_NIL;
-    o.preg          = 0;
+    o.preg          = MIR_PREG_NIL;
     o.imm           = block::i64;
     o.sym           = intern.STR_NIL;
     o.sym_off       = 0;
-    o.index         = MIR_VREG_NIL;
+    o.index         = index_none();
     o.scale         = 0;
-    o.index_is_preg = false;
     o.sym_got       = false;
     ret o;
 }
 
-pub fun vreg_is_fp(fn: *MirFunction, vreg: u32) bool {
-    if (vreg >= fn.vreg_count) { ret false; }
-    ret fn.vregs[vreg].class != REG_CLASS_GP && fn.vregs[vreg].class != REG_CLASS_VALUE;
+pub fun vreg_is_fp(fn: *MirFunction, vreg: VRegId) bool {
+    if (vreg.n >= fn.vreg_count) { ret false; }
+    ret fn.vregs[vreg.n].class != REG_CLASS_GP && fn.vregs[vreg.n].class != REG_CLASS_VALUE;
 }
 
 pub fun push_function(mm: *MirModule, mf: MirFunction) err[fail.Fail] {
@@ -1317,7 +1352,7 @@ pub fun instr_attach_dbg(a: *A.Allocator, mi: *MirInstr, iid: u32, vreg: u32) er
     mi.dbg_bindings[n].cmp_width  = 0;
     mi.dbg_bindings[n].lhs_is_imm = false;
     mi.dbg_bindings[n].rhs_is_imm = false;
-    mi.dbg_bindings[n].vreg2      = MIR_VREG_NIL;
+    mi.dbg_bindings[n].vreg2      = MIR_VREG_NIL.n;
     mi.dbg_bindings[n].imm        = 0;
     mi.dbg_bindings[n].imm2       = 0;
     mi.dbg_binding_count = n + 1;

--- a/src/lang/be/codegen/mir/abi.mach
+++ b/src/lang/be/codegen/mir/abi.mach
@@ -506,7 +506,7 @@ fun call_ret_type(ctx: *context.LowerCtx, sig: type.IrTypeId, fallback: type.IrT
 }
 
 fun value_slot_valid(slot: *abi.ParamSlot, extent: u64) bool {
-    ret slot.class == abi.CLASS_VALUE && slot.size == extent && slot.reg == -1
+    ret slot.class == abi.CLASS_VALUE && slot.size == extent && mir.preg_is_nil(slot.reg)
         && slot.piece_count == 0 && slot.offset == 0 && slot.indirect_size == 0 && slot.indirect_align == 0;
 }
 
@@ -543,10 +543,10 @@ fun lower_value_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instructi
         }
         i = i + 1;
     }
-    val dst: u32 = context.instr_vreg(ctx, iid);
+    val dst: mir.VRegId = context.instr_vreg(ctx, iid);
     var result: mir.MirOperand = mir.op_vreg(dst);
     if (context.value_is_aggregate(ctx, ret_type)) {
-        if (dst == mir.MIR_VREG_NIL) { ret err[fail.Fail].err{fail.message("mir.abi: logical composite call has no result owner")}; }
+        if (mir.vreg_is_nil(dst)) { ret err[fail.Fail].err{fail.message("mir.abi: logical composite call has no result owner")}; }
         val home: err[fail.Fail] = context.alloc_object_storage(ctx, mb, dst, ret_type);
         if (sel home.err) { ret home; }
         result = mir.op_mem_value(dst, 0);
@@ -573,7 +573,7 @@ fun lower_value_params(ctx: *context.LowerCtx, mb: *mir.MirBlock, slots: *abi.Si
         if (!value_slot_valid(?slots.params[i], type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64)) {
             ret err[fail.Fail].err{fail.message("mir.abi: invalid logical parameter slot")};
         }
-        val dst: u32 = ctx.param_vregs[i];
+        val dst: mir.VRegId = ctx.param_vregs[i];
         var dest: mir.MirOperand = mir.op_vreg(dst);
         if (context.value_is_aggregate(ctx, ty)) {
             val home: err[fail.Fail] = context.alloc_object_storage(ctx, mb, dst, ty);
@@ -641,9 +641,9 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     var fp_used:   i32 = layout.fp_used;
     var stack_off: i64 = layout.stack_off;
 
-    val res_dst: u32 = context.instr_vreg(ctx, iid);
-    var sret_ptr: u32 = mir.MIR_VREG_NIL;
-    if (ret_mem && res_dst != mir.MIR_VREG_NIL) {
+    val res_dst: mir.VRegId = context.instr_vreg(ctx, iid);
+    var sret_ptr: mir.VRegId = mir.MIR_VREG_NIL;
+    if (ret_mem && !mir.vreg_is_nil(res_dst)) {
         var ra: err[fail.Fail] = err[fail.Fail].ok{};
         var owned_size: u64 = ret_size;
         if (rslot.class != abi.CLASS_SRET) {
@@ -669,8 +669,8 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         }
         sret_ptr = res_dst;
     }
-    or (ret_sret_register && res_dst != mir.MIR_VREG_NIL) {
-        val sa: res[u32, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+    or (ret_sret_register && !mir.vreg_is_nil(res_dst)) {
+        val sa: res[mir.VRegId, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
         if (sel sa.err) {
             sig_layout_free(ctx, ?layout);
             ret err[fail.Fail].err{sa.err};
@@ -684,10 +684,10 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     }
 
     if (rslot.class == abi.CLASS_SRET) {
-        if (sret_ptr != mir.MIR_VREG_NIL) {
+        if (!mir.vreg_is_nil(sret_ptr)) {
             val sret_reg: i32 = ctx.tgt.abi.indirect_result_reg;
             val pre: err[fail.Fail] = context.emit_mov_w(ctx, registers,
-                mir.op_preg(sret_reg::u32), mir.op_vreg(sret_ptr), ptr_move_width(ctx));
+                mir.op_preg(mir.preg_id(sret_reg)), mir.op_vreg(sret_ptr), ptr_move_width(ctx));
             if (sel pre.err) {
                 sig_layout_free(ctx, ?layout);
                 ret pre;
@@ -760,7 +760,7 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
                     sig_layout_free(ctx, ?layout);
                     ret dr;
                 }
-                val dm: err[fail.Fail] = emit_call_reg(ctx, mb, registers, mir.op_preg(dup_reg::u32), argop, ctx.tgt.model.gpr_width::u8);
+                val dm: err[fail.Fail] = emit_call_reg(ctx, mb, registers, mir.op_preg(mir.preg_id(dup_reg)), argop, ctx.tgt.model.gpr_width::u8);
                 if (sel dm.err) {
                     sig_layout_free(ctx, ?layout);
                     ret dm;
@@ -792,7 +792,7 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         if (sel vmr.err) { ret vmr; }
         if (vamodel.vector_count_reg >= 0) {
             val al: err[fail.Fail] = context.emit_mov_w(ctx, registers,
-                mir.op_preg(vamodel.vector_count_reg::u32), mir.op_imm(fp_used::i64), 4::u8);
+                mir.op_preg(mir.preg_id(vamodel.vector_count_reg)), mir.op_imm(fp_used::i64), 4::u8);
             if (sel al.err) { ret al; }
         }
     }
@@ -809,14 +809,14 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
     val pc: err[fail.Fail] = context.push_instr(ctx, mb, cmi);
     if (sel pc.err) { ret pc; }
 
-    val dst: u32 = context.instr_vreg(ctx, iid);
-    if (dst != mir.MIR_VREG_NIL && rslot.class != abi.CLASS_SRET) {
+    val dst: mir.VRegId = context.instr_vreg(ctx, iid);
+    if (!mir.vreg_is_nil(dst) && rslot.class != abi.CLASS_SRET) {
         ctx.cur_writes_secret = inst.secret;
         val rr: err[fail.Fail] = emit_ret_slot_to_vreg(ctx, mb, rslot, dst, ret_aggr, ret_type, ret_storage_align);
         ctx.cur_writes_secret = false;
         if (sel rr.err) { ret rr; }
     }
-    if (ret_sret_register && dst != mir.MIR_VREG_NIL) {
+    if (ret_sret_register && !mir.vreg_is_nil(dst)) {
         var lr: err[fail.Fail] = err[fail.Fail].ok{};
         if (ret_vector_register) {
             lr = context.load_subwidth_vector(ctx, mb, mir.op_vreg(dst), mir.op_mem_value(sret_ptr, 0), ret_type);
@@ -825,7 +825,7 @@ pub fun lower_call(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction
         }
         if (sel lr.err) { ret lr; }
     }
-    if (dst != mir.MIR_VREG_NIL) {
+    if (!mir.vreg_is_nil(dst)) {
         val rres: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 1::usize);
         if (sel rres.err) { ret err[fail.Fail].err{fail.refused(rres.err)}; }
         val resops: *mir.MirOperand = rres.ok;
@@ -844,11 +844,11 @@ fun emit_call_reg(ctx: *context.LowerCtx, preparation: *mir.MirBlock, registers:
                   dst: mir.MirOperand, src: mir.MirOperand, width: u8) err[fail.Fail] {
     var value: mir.MirOperand = src;
     if (registers != preparation && src.kind == mir.MIR_OP_MEM) {
-        val class: u32 = isa.regid_class(dst.preg::i32)::u32;
-        val rv: res[u32, fail.Fail] = context.new_vreg_vec(ctx, class, class != mir.REG_CLASS_GP && width > 8);
+        val class: u32 = isa.regid_class(mir.preg_regid(dst.preg))::u32;
+        val rv: res[mir.VRegId, fail.Fail] = context.new_vreg_vec(ctx, class, class != mir.REG_CLASS_GP && width > 8);
         if (sel rv.err) { ret err[fail.Fail].err{rv.err}; }
-        val v: u32 = rv.ok;
-        ctx.f.vregs[v].secret = ctx.cur_writes_secret;
+        val v: mir.VRegId = rv.ok;
+        ctx.f.vregs[v.n].secret = ctx.cur_writes_secret;
         val loaded: err[fail.Fail] = context.emit_mov_w(ctx, preparation, mir.op_vreg(v), src, width);
         if (sel loaded.err) { ret loaded; }
         value = mir.op_vreg(v);
@@ -875,7 +875,7 @@ fun append_deferred(ctx: *context.LowerCtx, mb: *mir.MirBlock, deferred: *mir.Mi
 fun lower_value_addr(ctx: *context.LowerCtx, mb: *mir.MirBlock, v: value.Value) res[mir.MirOperand, fail.Fail] {
     val op: mir.MirOperand = context.lower_value(ctx, v);
     if (op.kind != mir.MIR_OP_SYM || !ctx.tgt.model.flat_addressing) { ret res[mir.MirOperand, fail.Fail].ok{op}; }
-    var addr: u32 = mir.MIR_VREG_NIL;
+    var addr: mir.VRegId = mir.MIR_VREG_NIL;
     val ar: err[fail.Fail] = context.addr_to_vreg(ctx, mb, op, ?addr);
     if (sel ar.err) { ret res[mir.MirOperand, fail.Fail].err{ar.err}; }
     ret res[mir.MirOperand, fail.Fail].ok{mir.op_vreg(addr)};
@@ -884,11 +884,11 @@ fun lower_value_addr(ctx: *context.LowerCtx, mb: *mir.MirBlock, v: value.Value) 
 rec PiecePlan {
     store:      bool;
     registers:  *mir.MirBlock;
-    mem_base:   u32;
+    mem_base:   mir.VRegId;
     mem_slot:   bool;
     mem_align:  u32;
     copies:     *mir.MirBlock;
-    stack_base: u32;
+    stack_base: mir.PRegId;
     stack_off:  i64;
     stack_ok:   bool;
     owned_extent: u64;
@@ -899,14 +899,14 @@ fun carrier_access_legal(ctx: *context.LowerCtx, piece: *abi.ParamPiece, align: 
     ret piece.kind == abi.PIECE_GP && isa.moves_unaligned_gp(?ctx.tgt.model, piece.width::u32);
 }
 
-fun allocate_carrier(ctx: *context.LowerCtx, width: u8) res[u32, fail.Fail] {
-    val kr: res[u32, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+fun allocate_carrier(ctx: *context.LowerCtx, width: u8) res[mir.VRegId, fail.Fail] {
+    val kr: res[mir.VRegId, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
     if (sel kr.err) { ret kr; }
-    val key: u32 = kr.ok;
-    val ar: err[fail.Fail] = context.add_alloca_slot(ctx, key,
+    val key: mir.VRegId = kr.ok;
+    val ar: err[fail.Fail] = context.add_alloca_slot(ctx, key.n,
         width::u64, width::u32, mir.SLOT_TY_NIL);
-    if (sel ar.err) { ret res[u32, fail.Fail].err{ar.err}; }
-    ret res[u32, fail.Fail].ok{key};
+    if (sel ar.err) { ret res[mir.VRegId, fail.Fail].err{ar.err}; }
+    ret res[mir.VRegId, fail.Fail].ok{key};
 }
 
 fun load_piece_carrier(ctx: *context.LowerCtx, mb: *mir.MirBlock, registers: *mir.MirBlock,
@@ -915,9 +915,9 @@ fun load_piece_carrier(ctx: *context.LowerCtx, mb: *mir.MirBlock, registers: *mi
     if (logical_width == carrier_width && direct) {
         ret emit_call_reg(ctx, mb, registers, reg, source, carrier_width);
     }
-    val kr: res[u32, fail.Fail] = allocate_carrier(ctx, carrier_width);
+    val kr: res[mir.VRegId, fail.Fail] = allocate_carrier(ctx, carrier_width);
     if (sel kr.err) { ret err[fail.Fail].err{kr.err}; }
-    val key: u32 = kr.ok;
+    val key: mir.VRegId = kr.ok;
     var off: u64 = 0;
     for (logical_width < carrier_width && off < carrier_width::u64) {
         val width: u8 = context.copy_chunk_width(ctx.tgt, carrier_width::u64 - off);
@@ -1006,14 +1006,14 @@ fun materialize_pieces(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.Para
             val copied: err[fail.Fail] = context.copy_aggregate(ctx, transfers, dst, src, logical_width::u64);
             if (sel copied.err) { ret copied; }
         } or {
-            val reg: mir.MirOperand = mir.op_preg(p.reg::u32);
+            val reg: mir.MirOperand = mir.op_preg(p.reg);
             val direct: bool = carrier_access_legal(ctx, ?p, plan.mem_align);
             if (plan.store) {
                 if (direct) {
                     val st: err[fail.Fail] = context.emit_store_to_w(ctx, mb, mem, reg, p.width);
                     if (sel st.err) { ret st; }
                 } or {
-                    val kr: res[u32, fail.Fail] = allocate_carrier(ctx, p.width);
+                    val kr: res[mir.VRegId, fail.Fail] = allocate_carrier(ctx, p.width);
                     if (sel kr.err) { ret err[fail.Fail].err{kr.err}; }
                     val carrier: mir.MirOperand = mir.op_mem_slot(kr.ok, 0);
                     val st: err[fail.Fail] = context.emit_store_to_w(ctx, mb, carrier, reg, p.width);
@@ -1043,34 +1043,34 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, registers: *mir.Mir
     val size: u64 = type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
 
     if (is_aggr && (slot.class == abi.CLASS_BYREF || slot.class == abi.CLASS_STACK_BYREF)) {
-        var owned: u32 = mir.MIR_VREG_NIL;
+        var owned: mir.VRegId = mir.MIR_VREG_NIL;
         val cr: err[fail.Fail] = copy_aggregate_to_temp(ctx, mb, argop, ty, ?owned);
         if (sel cr.err) { ret cr; }
         if (slot.class == abi.CLASS_STACK_BYREF) {
-            val sp: u32 = ctx.tgt.model.stack_ptr_reg::u32;
+            val sp: mir.PRegId = mir.preg_id(ctx.tgt.model.stack_ptr_reg);
             ret context.emit_store_to(ctx, mb, mir.op_mem_preg(sp, stack_off), mir.op_vreg(owned));
         }
-        ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg::u32), mir.op_vreg(owned), ptr_move_width(ctx));
+        ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg), mir.op_vreg(owned), ptr_move_width(ctx));
     }
     if (slot.class == abi.CLASS_VEC_BYREF || slot.class == abi.CLASS_VEC_STACK_BYREF) {
-        var addr: u32 = mir.MIR_VREG_NIL;
+        var addr: mir.VRegId = mir.MIR_VREG_NIL;
         val sr: err[fail.Fail] = spill_vector_to_temp(ctx, mb, slot, argop, ty, ?addr);
         if (sel sr.err) { ret sr; }
         if (slot.class == abi.CLASS_VEC_STACK_BYREF) {
-            val sp: u32 = ctx.tgt.model.stack_ptr_reg::u32;
+            val sp: mir.PRegId = mir.preg_id(ctx.tgt.model.stack_ptr_reg);
             ret context.emit_store_to(ctx, mb, mir.op_mem_preg(sp, stack_off), mir.op_vreg(addr));
         }
-        ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg::u32), mir.op_vreg(addr), ptr_move_width(ctx));
+        ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg), mir.op_vreg(addr), ptr_move_width(ctx));
     }
     if (slot.class == abi.CLASS_STACK_BYREF) {
-        val sp: u32 = ctx.tgt.model.stack_ptr_reg::u32;
-        var base: u32 = mir.MIR_VREG_NIL;
+        val sp: mir.PRegId = mir.preg_id(ctx.tgt.model.stack_ptr_reg);
+        var base: mir.VRegId = mir.MIR_VREG_NIL;
         val ar: err[fail.Fail] = context.addr_to_vreg(ctx, mb, argop, ?base);
         if (sel ar.err) { ret ar; }
         ret context.emit_store_to(ctx, mb, mir.op_mem_preg(sp, stack_off), mir.op_vreg(base));
     }
     if (slot.class == abi.CLASS_STACK) {
-        val sp: u32 = ctx.tgt.model.stack_ptr_reg::u32;
+        val sp: mir.PRegId = mir.preg_id(ctx.tgt.model.stack_ptr_reg);
         if (is_aggr) {
             ret context.copy_aggregate(ctx, mb, mir.op_mem_preg(sp, stack_off), argop, size);
         }
@@ -1081,14 +1081,14 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, registers: *mir.Mir
                                     scalar_mem_move_width(ctx.tgt.model.gpr_width, size, natural));
     }
     if (slot.class == abi.CLASS_BYREF) {
-        var base: u32 = mir.MIR_VREG_NIL;
+        var base: mir.VRegId = mir.MIR_VREG_NIL;
         val ar: err[fail.Fail] = context.addr_to_vreg(ctx, mb, argop, ?base);
         if (sel ar.err) { ret ar; }
-        ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg::u32), mir.op_vreg(base), ptr_move_width(ctx));
+        ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg), mir.op_vreg(base), ptr_move_width(ctx));
     }
 
     if (is_aggr) {
-        var base: u32 = mir.MIR_VREG_NIL;
+        var base: mir.VRegId = mir.MIR_VREG_NIL;
         val ar: err[fail.Fail] = context.addr_to_vreg(ctx, mb, argop, ?base);
         if (sel ar.err) { ret ar; }
         var plan: PiecePlan;
@@ -1097,7 +1097,7 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, registers: *mir.Mir
         plan.mem_base   = base;
         plan.mem_slot   = false;
         plan.mem_align  = type.byte_align_for_machine(ctx.types, ty, ctx.layout);
-        plan.stack_base = ctx.tgt.model.stack_ptr_reg::u32;
+        plan.stack_base = mir.preg_id(ctx.tgt.model.stack_ptr_reg);
         plan.stack_off  = stack_off;
         plan.stack_ok   = true;
         ret materialize_pieces(ctx, mb, slot, plan);
@@ -1105,20 +1105,20 @@ fun emit_arg_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, registers: *mir.Mir
     if (slot.class == abi.CLASS_FP) {
         val fw: res[u8, fail.Fail] = fp_move_width(ctx, ty);
         if (sel fw.err) { ret err[fail.Fail].err{fw.err}; }
-        ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg::u32), argop, fw.ok);
+        ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg), argop, fw.ok);
     }
-    ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg::u32), argop, scalar_reg_move_width(ctx.tgt.model.gpr_width, size));
+    ret emit_call_reg(ctx, mb, registers, mir.op_preg(slot.reg), argop, scalar_reg_move_width(ctx.tgt.model.gpr_width, size));
 }
 
 fun copy_aggregate_to_temp(ctx: *context.LowerCtx, mb: *mir.MirBlock, src: mir.MirOperand,
-                           ty: type.IrTypeId, out_addr: *u32) err[fail.Fail] {
+                           ty: type.IrTypeId, out_addr: *mir.VRegId) err[fail.Fail] {
     val size:  u64 = type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
     val align: u32 = type.byte_align_for_machine(ctx.types, ty, ctx.layout);
-    val res_key: res[u32, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+    val res_key: res[mir.VRegId, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
     if (sel res_key.err) { ret err[fail.Fail].err{res_key.err}; }
-    val sk: u32 = res_key.ok;
+    val sk: mir.VRegId = res_key.ok;
 
-    val sr: err[fail.Fail] = context.add_spill_slot_aligned(ctx, sk, size, align);
+    val sr: err[fail.Fail] = context.add_spill_slot_aligned(ctx, sk.n, size, align);
     if (sel sr.err) { ret sr; }
 
     val cr: err[fail.Fail] = context.copy_aggregate(ctx, mb, mir.op_mem_slot(sk, 0), src, size);
@@ -1128,18 +1128,18 @@ fun copy_aggregate_to_temp(ctx: *context.LowerCtx, mb: *mir.MirBlock, src: mir.M
 }
 
 fun spill_vector_to_temp(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot,
-                         val_op: mir.MirOperand, ty: type.IrTypeId, out_addr: *u32) err[fail.Fail] {
+                         val_op: mir.MirOperand, ty: type.IrTypeId, out_addr: *mir.VRegId) err[fail.Fail] {
     val logical_size:  u64 = type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
     val size:  u64 = slot.indirect_size;
     val align: u32 = slot.indirect_align;
     if (size < logical_size || align == 0 || (align & (align - 1)) != 0) {
         ret err[fail.Fail].err{fail.message("mir.abi.spill_vector_to_temp: ABI vector placement has invalid indirect storage")};
     }
-    val res_key: res[u32, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+    val res_key: res[mir.VRegId, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
     if (sel res_key.err) { ret err[fail.Fail].err{res_key.err}; }
-    val sk: u32 = res_key.ok;
+    val sk: mir.VRegId = res_key.ok;
 
-    val sr: err[fail.Fail] = context.add_spill_slot_aligned(ctx, sk, size, align);
+    val sr: err[fail.Fail] = context.add_spill_slot_aligned(ctx, sk.n, size, align);
     if (sel sr.err) { ret sr; }
 
     var st: err[fail.Fail] = err[fail.Fail].ok{};
@@ -1167,14 +1167,14 @@ fun fp_move_width(ctx: *context.LowerCtx, ty: type.IrTypeId) res[u8, fail.Fail] 
     ret res[u8, fail.Fail].err{fail.message("mir.abi.fp_move_width: CLASS_FP scalar of unsupported size (expected 4 or 8 bytes)")};
 }
 
-fun capture_slot_reg(ctx: *context.LowerCtx, mb: *mir.MirBlock, dst: u32, slot: abi.ParamSlot, ty: type.IrTypeId) err[fail.Fail] {
+fun capture_slot_reg(ctx: *context.LowerCtx, mb: *mir.MirBlock, dst: mir.VRegId, slot: abi.ParamSlot, ty: type.IrTypeId) err[fail.Fail] {
     if (slot.class == abi.CLASS_FP) {
         val fw: res[u8, fail.Fail] = fp_move_width(ctx, ty);
         if (sel fw.err) { ret err[fail.Fail].err{fw.err}; }
-        ret context.emit_fmov(ctx, mb, mir.op_vreg(dst), mir.op_preg(slot.reg::u32), fw.ok);
+        ret context.emit_fmov(ctx, mb, mir.op_vreg(dst), mir.op_preg(slot.reg), fw.ok);
     }
     val size: u64 = type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
-    ret context.emit_mov_w(ctx, mb, mir.op_vreg(dst), mir.op_preg(slot.reg::u32),
+    ret context.emit_mov_w(ctx, mb, mir.op_vreg(dst), mir.op_preg(slot.reg),
                            scalar_reg_move_width(ctx.tgt.model.gpr_width, size));
 }
 
@@ -1202,7 +1202,7 @@ fun record_outgoing_size(ctx: *context.LowerCtx, bytes: i64) {
     }
 }
 
-fun emit_ret_slot_to_vreg(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, dst: u32, is_aggr: bool, ty: type.IrTypeId, owned_align: u32) err[fail.Fail] {
+fun emit_ret_slot_to_vreg(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.ParamSlot, dst: mir.VRegId, is_aggr: bool, ty: type.IrTypeId, owned_align: u32) err[fail.Fail] {
 
     if (is_aggr) {
         val extent: res[u64, fail.Fail] = abi.carrier_storage_extent(?slot);
@@ -1214,7 +1214,7 @@ fun emit_ret_slot_to_vreg(ctx: *context.LowerCtx, mb: *mir.MirBlock, slot: abi.P
         plan.mem_base   = dst;
         plan.mem_slot   = false;
         plan.mem_align  = owned_align;
-        plan.stack_base = 0;
+        plan.stack_base = mir.MIR_PREG_NIL;
         plan.stack_off  = 0;
         plan.stack_ok   = false;
         ret materialize_pieces(ctx, mb, slot, plan);
@@ -1227,7 +1227,7 @@ fun append_abi_input(inputs: *V.Vector[mir.MirAbiInput], input: mir.MirAbiInput)
         ret err[fail.Fail].err{fail.message("mir.abi: invalid incoming carrier extent")};
     }
     if (input.location == mir.ABI_INPUT_REGISTER) {
-        if (input.reg == mir.MIR_VREG_NIL) {
+        if (mir.preg_is_nil(input.reg)) {
             ret err[fail.Fail].err{fail.message("mir.abi: incoming carrier has no physical register")};
         }
     } or (input.location != mir.ABI_INPUT_ARG_STACK || input.offset < 0) {
@@ -1250,7 +1250,7 @@ fun record_param_input(ctx: *context.LowerCtx, inputs: *V.Vector[mir.MirAbiInput
         || slot.class == abi.CLASS_VEC_BYREF || slot.class == abi.CLASS_VEC_STACK_BYREF;
     var input: mir.MirAbiInput;
     input.argument = index;
-    input.reg = mir.MIR_VREG_NIL;
+    input.reg = mir.MIR_PREG_NIL;
     input.secret = param.secret;
     input.content = mir.ABI_CONTENT_NONE;
     input.content_size = 0;
@@ -1267,8 +1267,8 @@ fun record_param_input(ctx: *context.LowerCtx, inputs: *V.Vector[mir.MirAbiInput
             input.location = mir.ABI_INPUT_ARG_STACK;
             input.offset = slot.offset;
         } or {
-            if (slot.reg < 0) { ret err[fail.Fail].err{fail.message("mir.abi: indirect input has no physical register")}; }
-            input.reg = slot.reg::u32;
+            if (mir.preg_is_nil(slot.reg)) { ret err[fail.Fail].err{fail.message("mir.abi: indirect input has no physical register")}; }
+            input.reg = slot.reg;
         }
         ret append_abi_input(inputs, input);
     }
@@ -1303,12 +1303,12 @@ fun record_param_input(ctx: *context.LowerCtx, inputs: *V.Vector[mir.MirAbiInput
                 ret err[fail.Fail].err{fail.message("mir.abi: incoming stack piece offset overflow")};
             }
             input.location = mir.ABI_INPUT_ARG_STACK;
-            input.reg = mir.MIR_VREG_NIL;
+            input.reg = mir.MIR_PREG_NIL;
             input.offset = slot.offset + piece.stk_off;
             input.width = input.logical_width;
         } or {
-            if (piece.reg < 0) { ret err[fail.Fail].err{fail.message("mir.abi: incoming piece has no physical register")}; }
-            input.reg = piece.reg::u32;
+            if (mir.preg_is_nil(piece.reg)) { ret err[fail.Fail].err{fail.message("mir.abi: incoming piece has no physical register")}; }
+            input.reg = piece.reg;
         }
         if (input.logical_width != 0) {
             val added: err[fail.Fail] = append_abi_input(inputs, input);
@@ -1332,7 +1332,7 @@ fun record_abi_inputs(ctx: *context.LowerCtx, slots: *abi.SigLayout) err[fail.Fa
         if (ctx.tgt.abi.indirect_result_reg < 0) { ret err[fail.Fail].err{fail.message("mir.abi: indirect result has no physical register")}; }
         var result: mir.MirAbiInput;
         result.argument = mir.ABI_INPUT_SRET;
-        result.reg = ctx.tgt.abi.indirect_result_reg::u32;
+        result.reg = mir.preg_id(ctx.tgt.abi.indirect_result_reg);
         result.width = ctx.tgt.model.pointer_width::u64;
         result.logical_width = result.width;
         result.secret = false;
@@ -1380,13 +1380,13 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) err[fail.Fail] {
 
     if (layout.ret_slot.class == abi.CLASS_SRET) {
         val sret_reg: i32 = ctx.tgt.abi.indirect_result_reg;
-        val svr: res[u32, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+        val svr: res[mir.VRegId, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
         if (sel svr.err) {
             sig_layout_free(ctx, ?layout);
             ret err[fail.Fail].err{svr.err};
         }
-        val sv: u32 = svr.ok;
-        val mv: err[fail.Fail] = context.emit_mov_w(ctx, mb, mir.op_vreg(sv), mir.op_preg(sret_reg::u32),
+        val sv: mir.VRegId = svr.ok;
+        val mv: err[fail.Fail] = context.emit_mov_w(ctx, mb, mir.op_vreg(sv), mir.op_preg(mir.preg_id(sret_reg)),
                                                          ptr_move_width(ctx));
         if (sel mv.err) {
             sig_layout_free(ctx, ?layout);
@@ -1399,7 +1399,7 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) err[fail.Fail] {
     if (layout.param_count < bound) { bound = layout.param_count; }
     var i: u32 = 0;
     for (i < bound) {
-        val pv:   u32 = ctx.param_vregs[i];
+        val pv: mir.VRegId = ctx.param_vregs[i];
         val pty:  type.IrTypeId = ctx.fn.params[i].ty;
         val pag:  bool = context.value_is_aggregate(ctx, pty);
         val slot: abi.ParamSlot = layout.params[i];
@@ -1420,14 +1420,14 @@ pub fun lower_params(ctx: *context.LowerCtx, mb: *mir.MirBlock) err[fail.Fail] {
     ret append_deferred(ctx, mb, ?copies);
 }
 
-fun capture_vector_byref(ctx: *context.LowerCtx, mb: *mir.MirBlock, pv: u32,
+fun capture_vector_byref(ctx: *context.LowerCtx, mb: *mir.MirBlock, pv: mir.VRegId,
                          ty: type.IrTypeId, src: mir.MirOperand) err[fail.Fail] {
     if (!context.value_is_vector(ctx, ty)) {
         ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), src, ptr_move_width(ctx));
     }
-    val ar: res[u32, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
+    val ar: res[mir.VRegId, fail.Fail] = context.new_vreg(ctx, mir.REG_CLASS_GP);
     if (sel ar.err) { ret err[fail.Fail].err{ar.err}; }
-    val addr: u32 = ar.ok;
+    val addr: mir.VRegId = ar.ok;
     val mr: err[fail.Fail] = context.emit_mov_w(ctx, mb, mir.op_vreg(addr), src, ptr_move_width(ctx));
     if (sel mr.err) { ret mr; }
     if (context.subwidth_vector_memory(ctx, ty)) {
@@ -1437,24 +1437,24 @@ fun capture_vector_byref(ctx: *context.LowerCtx, mb: *mir.MirBlock, pv: u32,
     ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), mir.op_mem_value(addr, 0), size::u8);
 }
 
-fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, copies: *mir.MirBlock, slot: abi.ParamSlot, pv: u32, ty: type.IrTypeId,
+fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, copies: *mir.MirBlock, slot: abi.ParamSlot, pv: mir.VRegId, ty: type.IrTypeId,
                     stack_off: i64, is_aggr: bool) err[fail.Fail] {
     val size: u64 = type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
     val arg_base: i64 = ctx.tgt.model.incoming_arg_base;
     if (slot.class == abi.CLASS_VEC_STACK_BYREF) {
-        val fp: u32 = ctx.tgt.model.frame_ptr_reg::u32;
+        val fp: mir.PRegId = mir.preg_id(ctx.tgt.model.frame_ptr_reg);
         ret capture_vector_byref(ctx, mb, pv, ty, mir.op_mem_preg(fp, arg_base + stack_off));
     }
     if (slot.class == abi.CLASS_VEC_BYREF) {
-        ret capture_vector_byref(ctx, mb, pv, ty, mir.op_preg(slot.reg::u32));
+        ret capture_vector_byref(ctx, mb, pv, ty, mir.op_preg(slot.reg));
     }
     if (slot.class == abi.CLASS_STACK_BYREF) {
-        val fp: u32 = ctx.tgt.model.frame_ptr_reg::u32;
+        val fp: mir.PRegId = mir.preg_id(ctx.tgt.model.frame_ptr_reg);
         ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), mir.op_mem_preg(fp, arg_base + stack_off),
                                ptr_move_width(ctx));
     }
     if (slot.class == abi.CLASS_STACK) {
-        val fp: u32 = ctx.tgt.model.frame_ptr_reg::u32;
+        val fp: mir.PRegId = mir.preg_id(ctx.tgt.model.frame_ptr_reg);
         if (is_aggr) {
             ret context.emit_lea_preg(ctx, mb, pv, fp, arg_base + stack_off);
         }
@@ -1467,7 +1467,7 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, copies: *mir.MirB
                                                      natural_stack_slot(ctx.tgt, false)));
     }
     if (slot.class == abi.CLASS_BYREF) {
-        ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), mir.op_preg(slot.reg::u32), ptr_move_width(ctx));
+        ret context.emit_mov_w(ctx, mb, mir.op_vreg(pv), mir.op_preg(slot.reg), ptr_move_width(ctx));
     }
 
     if (is_aggr) {
@@ -1478,7 +1478,7 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, copies: *mir.MirB
         var owned_align: u32 = context.ret_align(ctx, ty);
         if (ctx.tgt.model.gpr_width > owned_align) { owned_align = ctx.tgt.model.gpr_width; }
         if (alignment.ok > owned_align) { owned_align = alignment.ok; }
-        val sr: err[fail.Fail] = context.add_spill_slot_aligned(ctx, pv, extent.ok, owned_align);
+        val sr: err[fail.Fail] = context.add_spill_slot_aligned(ctx, pv.n, extent.ok, owned_align);
         if (sel sr.err) { ret sr; }
         var plan: PiecePlan;
         plan.owned_extent = extent.ok;
@@ -1488,7 +1488,7 @@ fun emit_param_slot(ctx: *context.LowerCtx, mb: *mir.MirBlock, copies: *mir.MirB
         plan.mem_slot   = true;
         plan.mem_align  = owned_align;
         plan.copies     = copies;
-        plan.stack_base = ctx.tgt.model.frame_ptr_reg::u32;
+        plan.stack_base = mir.preg_id(ctx.tgt.model.frame_ptr_reg);
         plan.stack_off  = arg_base + stack_off;
         plan.stack_ok   = true;
         ret materialize_pieces(ctx, mb, slot, plan);
@@ -1563,7 +1563,7 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
         ret push_value_instr(ctx, mb, mir.MIR_RET, ops, 1);
     }
     if (slot.class == abi.CLASS_SRET) {
-        if (ctx.sret_vreg == mir.MIR_VREG_NIL) {
+        if (mir.vreg_is_nil(ctx.sret_vreg)) {
             ret err[fail.Fail].err{fail.message("mir.lower_ir: sret return without a captured result-storage pointer")};
         }
         if (context.value_is_vector(ctx, rv.ty)) {
@@ -1576,11 +1576,11 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
             val sr: err[fail.Fail] = context.emit_store_to_w(ctx, mb, mir.op_mem_value(ctx.sret_vreg, 0), rvop, rsz::u8);
             if (sel sr.err) { ret sr; }
         }
-        val mr: err[fail.Fail] = context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32),
+        val mr: err[fail.Fail] = context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg),
                                                          mir.op_vreg(ctx.sret_vreg), ptr_move_width(ctx));
         if (sel mr.err) { ret mr; }
     } or (rag) {
-        var base: u32 = mir.MIR_VREG_NIL;
+        var base: mir.VRegId = mir.MIR_VREG_NIL;
         val ar: err[fail.Fail] = context.addr_to_vreg(ctx, mb, rvop, ?base);
         if (sel ar.err) { ret ar; }
         var plan: PiecePlan;
@@ -1589,7 +1589,7 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
         plan.mem_base   = base;
         plan.mem_slot   = false;
         plan.mem_align  = type.byte_align_for_machine(ctx.types, rt, ctx.layout);
-        plan.stack_base = 0;
+        plan.stack_base = mir.MIR_PREG_NIL;
         plan.stack_off  = 0;
         plan.stack_ok   = false;
         val mr: err[fail.Fail] = materialize_pieces(ctx, mb, slot, plan);
@@ -1597,10 +1597,10 @@ pub fun lower_ret(ctx: *context.LowerCtx, mb: *mir.MirBlock, inst: *instruction.
     } or (slot.class == abi.CLASS_FP) {
         val fw: res[u8, fail.Fail] = fp_move_width(ctx, rt);
         if (sel fw.err) { ret err[fail.Fail].err{fw.err}; }
-        val mr: err[fail.Fail] = context.emit_fmov(ctx, mb, mir.op_preg(slot.reg::u32), rvop, fw.ok);
+        val mr: err[fail.Fail] = context.emit_fmov(ctx, mb, mir.op_preg(slot.reg), rvop, fw.ok);
         if (sel mr.err) { ret mr; }
-    } or (slot.reg >= 0) {
-        val mr: err[fail.Fail] = context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg::u32), rvop, scalar_reg_move_width(ctx.tgt.model.gpr_width, rsz));
+    } or (!mir.preg_is_nil(slot.reg)) {
+        val mr: err[fail.Fail] = context.emit_mov_w(ctx, mb, mir.op_preg(slot.reg), rvop, scalar_reg_move_width(ctx.tgt.model.gpr_width, rsz));
         if (sel mr.err) { ret mr; }
     }
 
@@ -1788,7 +1788,7 @@ test "mach.lang.be.codegen.mir.abi.natural_stack_slot:fixed_diverges_variadic_do
 test "mach.lang.be.codegen.mir.abi.stack_only_tail_slot:moves_placement_not_form" {
     val gp: abi.ParamSlot = stack_only_tail_slot(abi.make_slot(abi.CLASS_GP, 1, 0, 8, 8));
     if (gp.class != abi.CLASS_STACK) { ret 1; }
-    if (gp.reg != -1)                { ret 1; }
+    if (!mir.preg_is_nil(gp.reg))    { ret 1; }
     if (gp.piece_count != 0)         { ret 1; }
     if (gp.size != 8)                { ret 1; }
     val fp: abi.ParamSlot = stack_only_tail_slot(abi.make_slot(abi.CLASS_FP, isa.regid_make(isa.REG_CLASS_ID_XMM, 0), 0, 8, 8));
@@ -1987,7 +1987,7 @@ test "mach.lang.be.codegen.mir.abi.classify_signature:odd_vector_sret_shifts_mix
     if (sel sr.err) { ret 1; }
     fin { sig_layout_free(?ctx, ?slots); }
     if (slots.ret_slot.class != abi.CLASS_SRET || slots.param_count != 5) { ret 2; }
-    if (slots.params[0].reg != 2 || slots.params[1].reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 2) || slots.params[2].reg != 9) { ret 3; }
+    if (mir.preg_regid(slots.params[0].reg) != 2 || mir.preg_regid(slots.params[1].reg) != isa.regid_make(isa.REG_CLASS_ID_XMM, 2) || mir.preg_regid(slots.params[2].reg) != 9) { ret 3; }
     if (slots.params[3].class != abi.CLASS_STACK || slots.params[3].offset != 32) { ret 4; }
     if (slots.params[4].class != abi.CLASS_VEC_STACK_BYREF || slots.params[4].offset != 40 || slots.params[4].indirect_size != 3) { ret 5; }
     ret 0;
@@ -2052,7 +2052,7 @@ test "mach.lang.be.codegen.mir.abi:incoming_security_facts_preserve_carriers_and
     if (sel record_abi_inputs_r.err) { ret 3; }
     if (f.abi_input_count != 8) { ret 4; }
     val inputs: *mir.MirAbiInput = f.abi_inputs;
-    if (inputs[0].argument != mir.ABI_INPUT_SRET || inputs[0].reg != 1
+    if (inputs[0].argument != mir.ABI_INPUT_SRET || inputs[0].reg.n != 1
         || inputs[0].secret || inputs[0].content != mir.ABI_CONTENT_OUTPUT
         || inputs[0].content_size != 24) { ret 5; }
     i = 1;
@@ -2068,9 +2068,9 @@ test "mach.lang.be.codegen.mir.abi:incoming_security_facts_preserve_carriers_and
         if (inputs[i].location != mir.ABI_INPUT_REGISTER) { ret 7; }
         i = i + 1;
     }
-    if (inputs[1].reg != 2 || !inputs[1].secret || inputs[1].content != mir.ABI_CONTENT_NONE
-        || inputs[2].reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 2)::u32 || inputs[2].secret
-        || inputs[3].reg != 9 || inputs[3].secret || inputs[3].content != mir.ABI_CONTENT_UNKNOWN) { ret 7; }
+    if (inputs[1].reg.n != 2 || !inputs[1].secret || inputs[1].content != mir.ABI_CONTENT_NONE
+        || mir.preg_regid(inputs[2].reg) != isa.regid_make(isa.REG_CLASS_ID_XMM, 2) || inputs[2].secret
+        || inputs[3].reg.n != 9 || inputs[3].secret || inputs[3].content != mir.ABI_CONTENT_UNKNOWN) { ret 7; }
     i = 4;
     for (i < 8) {
         if (inputs[i].location != mir.ABI_INPUT_ARG_STACK || inputs[i].offset != 32 + (i - 4)::i64 * 8) { ret 8; }
@@ -2132,8 +2132,8 @@ fun t_call_preparation(indirect: bool, sret: bool) i32 {
     f.vregs[0] = mir.vreg(0, mir.REG_CLASS_GP, false, false);
     f.vregs[1] = mir.vreg(1, mir.REG_CLASS_GP, false, false);
     f.vregs[2] = mir.vreg(2, mir.REG_CLASS_GP, false, false);
-    var pv: [2]u32 = [2]u32{0, 1};
-    var iv: [1]u32 = [1]u32{2};
+    var pv: [2]mir.VRegId = [2]mir.VRegId{mir.vreg_id(0), mir.vreg_id(1)};
+    var iv: [1]mir.VRegId = [1]mir.VRegId{mir.vreg_id(2)};
     var ctx: context.LowerCtx;
     ctx.alloc = ?alloc;
     ctx.tgt = ?tgt;
@@ -2180,7 +2180,7 @@ fun t_call_preparation(indirect: bool, sret: bool) i32 {
         }
         if (mi.opcode == mir.MIR_CALL) {
             calls = calls + 1;
-            if (indirect && (mi.operands[0].kind != mir.MIR_OP_VREG || mi.operands[0].vreg != 1)) { ret 4; }
+            if (indirect && (mi.operands[0].kind != mir.MIR_OP_VREG || mi.operands[0].vreg.n != 1)) { ret 4; }
             if (!indirect && mi.operands[0].kind != mir.MIR_OP_SYM) { ret 5; }
         }
         i = i + 1;
@@ -2259,20 +2259,20 @@ rec CarrierBytes {
 fun t_carrier_address(bytes: *CarrierBytes, operand: mir.MirOperand, width: u32, ordinary: bool) *u8 {
     if (width > 16) { ret nil; }
     if (operand.kind == mir.MIR_OP_VREG) {
-        if (operand.vreg >= 64) { ret nil; }
-        ret ?bytes.virtual[operand.vreg][0];
+        if (operand.vreg.n >= 64) { ret nil; }
+        ret ?bytes.virtual[operand.vreg.n][0];
     }
     if (operand.kind == mir.MIR_OP_PREG) {
         var i: u32 = 0;
         for (i < 4) {
-            if (bytes.registers[i] == operand.preg::i32) { ret ?bytes.physical[i][0]; }
+            if (bytes.registers[i] == mir.preg_regid(operand.preg)) { ret ?bytes.physical[i][0]; }
             i = i + 1;
         }
         ret nil;
     }
     if (operand.kind != mir.MIR_OP_MEM || operand.imm < 0) { ret nil; }
-    var key: u32 = operand.vreg;
-    if (key == mir.MIR_VREG_NIL) { key = 15; }
+    var key: u32 = operand.vreg.n;
+    if (mir.vreg_is_nil(operand.vreg)) { key = 15; }
     if (key >= 16 || operand.imm::u64 + width::u64 > bytes.extent[key]::u64) { ret nil; }
     if (bytes.strict_alignment && ordinary && width > 1 &&
         (bytes.base[key]::u64 + operand.imm::u64) % width::u64 != 0) { ret nil; }
@@ -2332,7 +2332,7 @@ fun t_carrier_materialization(tgt: *target.Target, slot: abi.ParamSlot,
     if (sel vr.err) { ret 2; }
     f.vregs = vr.ok;
     f.vreg_cap = 16;
-    val new_vreg_r: res[u32, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
+    val new_vreg_r: res[mir.VRegId, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
     if (sel new_vreg_r.err) { ret 2; }
     var mb: mir.MirBlock;
     fin { mir.dnit_block(?alloc, ?mb); }
@@ -2344,7 +2344,7 @@ fun t_carrier_materialization(tgt: *target.Target, slot: abi.ParamSlot,
     var plan: PiecePlan;
     plan.store = store;
     plan.mem_slot = true;
-    plan.mem_base = 0;
+    plan.mem_base = mir.vreg_id(0);
     plan.mem_align = align;
     plan.stack_ok = true;
     plan.registers = ?mb;
@@ -2386,7 +2386,7 @@ fun t_carrier_materialization(tgt: *target.Target, slot: abi.ParamSlot,
     i = 0;
     for (i < slot.piece_count) {
         val p: abi.ParamPiece = slot.pieces[i];
-        bytes.registers[i] = p.reg;
+        bytes.registers[i] = mir.preg_regid(p.reg);
         var j: u32 = 0;
         for (j < p.width::u32) {
             var byte: u8 = 0;
@@ -2507,7 +2507,7 @@ test "mach.lang.be.codegen.mir.abi:carrier_memory_requires_legal_base_and_piece_
     if (offset_write != 0) { ret offset_write; }
     tgt.model.gp_unaligned_widths = 2 + 4 + 8;
     offset.pieces[0].kind = abi.PIECE_FP;
-    offset.pieces[0].reg = isa.regid_make(isa.REG_CLASS_ID_XMM, 0);
+    offset.pieces[0].reg = mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 0));
     val fp_read: i32 = t_carrier_materialization(?tgt, offset, false, false, false, 8, 0, true);
     if (fp_read != 0) { ret fp_read; }
     val fp_write: i32 = t_carrier_materialization(?tgt, offset, true, false, false, 8, 0, true);
@@ -2522,8 +2522,8 @@ fun t_incoming_arg(index: i32, size: u64, align: u64, is_float: bool, fp_eightby
     if (index != 0) { ret abi.make_slot(abi.CLASS_GP, 1, 0, size, 8); }
     var slot: abi.ParamSlot = abi.make_slot(abi.CLASS_GP, 0, 0, size, 4);
     slot.piece_count = 3;
-    slot.pieces[1] = abi.ParamPiece{kind: abi.PIECE_FP, reg: isa.regid_make(isa.REG_CLASS_ID_XMM, 0), src_off: 4, width: 8};
-    slot.pieces[2] = abi.ParamPiece{kind: abi.PIECE_STACK, reg: -1, src_off: 12, width: 4};
+    slot.pieces[1] = abi.ParamPiece{kind: abi.PIECE_FP, reg: mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 0)), src_off: 4, width: 8};
+    slot.pieces[2] = abi.ParamPiece{kind: abi.PIECE_STACK, reg: mir.MIR_PREG_NIL, src_off: 12, width: 4};
     ret slot;
 }
 
@@ -2570,7 +2570,7 @@ test "mach.lang.be.codegen.mir.abi:incoming_copies_follow_all_parameter_captures
     if (sel regs.err) { ret 1; }
     f.vregs = regs.ok;
     f.vreg_cap = mir.INITIAL_VREG_CAP;
-    var pv: [3]u32 = [3]u32{0, 1, 2};
+    var pv: [3]mir.VRegId = [3]mir.VRegId{mir.vreg_id(0), mir.vreg_id(1), mir.vreg_id(2)};
     var ctx: context.LowerCtx;
     ctx.alloc = ?alloc;
     ctx.tgt = ?tgt;
@@ -2581,9 +2581,9 @@ test "mach.lang.be.codegen.mir.abi:incoming_copies_follow_all_parameter_captures
     ctx.f = ?f;
     ctx.param_vregs = ?pv[0];
     ctx.param_count = 3;
-    val new_vreg_r: res[u32, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
-    val new_vreg_r2: res[u32, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
-    val new_vreg_r3: res[u32, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
+    val new_vreg_r: res[mir.VRegId, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
+    val new_vreg_r2: res[mir.VRegId, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
+    val new_vreg_r3: res[mir.VRegId, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
     if (sel new_vreg_r.err) { ret 1; }
     if (sel new_vreg_r2.err) { ret 1; }
     if (sel new_vreg_r3.err) { ret 1; }
@@ -2594,7 +2594,7 @@ test "mach.lang.be.codegen.mir.abi:incoming_copies_follow_all_parameter_captures
     if (f.abi_input_count != 5 || f.abi_inputs[0].secret || f.abi_inputs[1].secret
         || f.abi_inputs[2].secret || f.abi_inputs[3].secret || f.abi_inputs[4].secret) { ret 4; }
     if (f.abi_inputs[0].width != 4 || f.abi_inputs[1].width != 8
-        || f.abi_inputs[1].reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)::u32
+        || mir.preg_regid(f.abi_inputs[1].reg) != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)
         || f.abi_inputs[2].location != mir.ABI_INPUT_ARG_STACK || f.abi_inputs[2].width != 4
         || f.abi_inputs[2].argument != 0 || f.abi_inputs[3].argument != 1
         || f.abi_inputs[4].argument != 2 || f.abi_inputs[4].width != 16) { ret 4; }
@@ -2669,7 +2669,7 @@ fun t_result_carrier_alignment(element_bits: u32, count: u32) i32 {
     if (sel regs.err) { ret 1; }
     f.vregs = regs.ok;
     f.vreg_cap = mir.INITIAL_VREG_CAP;
-    var iv: [1]u32 = [1]u32{0};
+    var iv: [1]mir.VRegId = [1]mir.VRegId{mir.vreg_id(0)};
     var ctx: context.LowerCtx;
     ctx.alloc = ?alloc;
     ctx.tgt = ?tgt;
@@ -2679,7 +2679,7 @@ fun t_result_carrier_alignment(element_bits: u32, count: u32) i32 {
     ctx.f = ?f;
     ctx.instr_vregs = ?iv[0];
     ctx.instr_count = 1;
-    val new_vreg_r: res[u32, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
+    val new_vreg_r: res[mir.VRegId, fail.Fail] = context.new_vreg(?ctx, mir.REG_CLASS_GP);
     if (sel new_vreg_r.err) { ret 1; }
     var callee: value.Value = value.fn(0, sig);
     var call: instruction.Instruction;
@@ -2838,7 +2838,7 @@ fun t_rec_transport(alloc: *A.Allocator, isa_name: str, os_name: str, abi_name: 
 fun t_piece_is(slot: *abi.ParamSlot, i: u32, kind: abi.PieceKind, reg: i32, width: u8, logical: u8) bool {
     if (i >= slot.piece_count) { ret false; }
     val p: *abi.ParamPiece = ?slot.pieces[i];
-    if (p.kind != kind || p.reg != reg || p.width != width) { ret false; }
+    if (p.kind != kind || mir.preg_regid(p.reg) != reg || p.width != width) { ret false; }
     val lw: res[u8, fail.Fail] = abi.piece_memory_width(slot, p);
     if (sel lw.err) { ret false; }
     ret lw.ok == logical;
@@ -2863,11 +2863,11 @@ fun t_leaf_split(slot: *abi.ParamSlot, kind0: abi.PieceKind, r0: i32, w0: u8, ki
 }
 
 fun t_byref(slot: *abi.ParamSlot, reg: i32) bool {
-    ret slot.class == abi.CLASS_BYREF && slot.reg == reg;
+    ret slot.class == abi.CLASS_BYREF && mir.preg_regid(slot.reg) == reg;
 }
 
 fun t_sret(slot: *abi.ParamSlot, reg: i32) bool {
-    ret slot.class == abi.CLASS_SRET && slot.reg == reg;
+    ret slot.class == abi.CLASS_SRET && mir.preg_regid(slot.reg) == reg;
 }
 
 val SYSV_RDI: i32 = 7;

--- a/src/lang/be/codegen/mir/bulk.mach
+++ b/src/lang/be/codegen/mir/bulk.mach
@@ -90,18 +90,18 @@ fun branch(e: *Expansion, bi: u32, target: u32) err[fail.Fail] {
     ret emit(e, bi, mir.MIR_BR, ?op, 1, e.ctx.tgt.model.pointer_width::u8);
 }
 
-fun conditional(e: *Expansion, bi: u32, cond: u32, yes: u32, no: u32) err[fail.Fail] {
+fun conditional(e: *Expansion, bi: u32, cond: mir.VRegId, yes: u32, no: u32) err[fail.Fail] {
     ret emit3(e, bi, mir.MIR_CBR, mir.op_vreg(cond), mir.op_block(e.ctx.f.blocks[yes].id),
                  mir.op_block(e.ctx.f.blocks[no].id), e.ctx.tgt.model.pointer_width::u8);
 }
 
-fun address(e: *Expansion, bi: u32, mem: mir.MirOperand) res[u32, fail.Fail] {
-    val rv: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+fun address(e: *Expansion, bi: u32, mem: mir.MirOperand) res[mir.VRegId, fail.Fail] {
+    val rv: res[mir.VRegId, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
     if (sel rv.err) { ret rv; }
-    val v: u32 = rv.ok;
+    val v: mir.VRegId = rv.ok;
     val er: err[fail.Fail] = emit2(e, bi, mir.MIR_GEP, mir.op_vreg(v), mem, e.ctx.tgt.model.pointer_width::u8);
-    if (sel er.err) { ret res[u32, fail.Fail].err{er.err}; }
-    ret res[u32, fail.Fail].ok{v};
+    if (sel er.err) { ret res[mir.VRegId, fail.Fail].err{er.err}; }
+    ret res[mir.VRegId, fail.Fail].ok{v};
 }
 
 fun piece_width(remaining: u64, mask: u32, word: u8) u8 {
@@ -122,17 +122,17 @@ fun piece_count(size: u64, mask: u32, word: u8) u32 {
 }
 
 fun small(e: *Expansion, bi: u32, dst: mir.MirOperand, src: mir.MirOperand, size: u64, copy: bool, mask: u32) err[fail.Fail] {
-    var values: [8]u32;
+    var values: [8]mir.VRegId;
     val word: u8 = e.ctx.tgt.model.gpr_width::u8;
     var off: u64 = 0;
     var pi: u32 = 0;
     if (copy) {
         for (off < size) {
             val width: u8 = piece_width(size - off, mask, word);
-            val rv: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+            val rv: res[mir.VRegId, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
             if (sel rv.err) { ret err[fail.Fail].err{rv.err}; }
             values[pi] = rv.ok;
-            e.ctx.f.vregs[values[pi]].secret = e.origin.writes_secret;
+            e.ctx.f.vregs[values[pi].n].secret = e.origin.writes_secret;
             val er: err[fail.Fail] = emit2(e, bi, mir.MIR_LOAD, mir.op_vreg(values[pi]), context.mem_at(src, off::i64), width);
             if (sel er.err) { ret er; }
             off = off + width::u64;
@@ -153,7 +153,7 @@ fun small(e: *Expansion, bi: u32, dst: mir.MirOperand, src: mir.MirOperand, size
     ret err[fail.Fail].ok{};
 }
 
-fun loop_path(e: *Expansion, dst: u32, src: u32, size: u64, copy: bool, backward: bool, width: u8, mask: u32, done: u32) res[u32, fail.Fail] {
+fun loop_path(e: *Expansion, dst: mir.VRegId, src: mir.VRegId, size: u64, copy: bool, backward: bool, width: u8, mask: u32, done: u32) res[u32, fail.Fail] {
     val rs: res[u32, fail.Fail] = fresh_block(e);
     if (sel rs.err) { ret rs; }
     val setup: u32 = rs.ok;
@@ -163,22 +163,22 @@ fun loop_path(e: *Expansion, dst: u32, src: u32, size: u64, copy: bool, backward
     val rt: res[u32, fail.Fail] = fresh_block(e);
     if (sel rt.err) { ret rt; }
     val tail: u32 = rt.ok;
-    val rd: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (sel rd.err) { ret rd; }
-    val d: u32 = rd.ok;
-    val rsrc: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (sel rsrc.err) { ret rsrc; }
-    val s: u32 = rsrc.ok;
-    val rc: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (sel rc.err) { ret rc; }
-    val count: u32 = rc.ok;
-    val rv: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (sel rv.err) { ret rv; }
-    val value: u32 = rv.ok;
-    e.ctx.f.vregs[value].secret = e.origin.writes_secret;
-    val rq: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (sel rq.err) { ret rq; }
-    val more: u32 = rq.ok;
+    val rd: res[mir.VRegId, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel rd.err) { ret res[u32, fail.Fail].err{rd.err}; }
+    val d: mir.VRegId = rd.ok;
+    val rsrc: res[mir.VRegId, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel rsrc.err) { ret res[u32, fail.Fail].err{rsrc.err}; }
+    val s: mir.VRegId = rsrc.ok;
+    val rc: res[mir.VRegId, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel rc.err) { ret res[u32, fail.Fail].err{rc.err}; }
+    val count: mir.VRegId = rc.ok;
+    val rv: res[mir.VRegId, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel rv.err) { ret res[u32, fail.Fail].err{rv.err}; }
+    val value: mir.VRegId = rv.ok;
+    e.ctx.f.vregs[value.n].secret = e.origin.writes_secret;
+    val rq: res[mir.VRegId, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel rq.err) { ret res[u32, fail.Fail].err{rq.err}; }
+    val more: mir.VRegId = rq.ok;
     val pw: u8 = e.ctx.tgt.model.pointer_width::u8;
     val remainder: u64 = size % width::u64;
     val whole: u64 = size - remainder;
@@ -262,13 +262,13 @@ fun expand_one(e: *Expansion, bi: u32) res[u32, fail.Fail] {
         ret res[u32, fail.Fail].ok{bi};
     }
     for (word::u64 > size) { word = word / 2; }
-    val rd: res[u32, fail.Fail] = address(e, bi, dst);
-    if (sel rd.err) { ret rd; }
-    val d: u32 = rd.ok;
-    var s: u32 = mir.MIR_VREG_NIL;
+    val rd: res[mir.VRegId, fail.Fail] = address(e, bi, dst);
+    if (sel rd.err) { ret res[u32, fail.Fail].err{rd.err}; }
+    val d: mir.VRegId = rd.ok;
+    var s: mir.VRegId = mir.MIR_VREG_NIL;
     if (copy) {
-        val rs: res[u32, fail.Fail] = address(e, bi, src);
-        if (sel rs.err) { ret rs; }
+        val rs: res[mir.VRegId, fail.Fail] = address(e, bi, src);
+        if (sel rs.err) { ret res[u32, fail.Fail].err{rs.err}; }
         s = rs.ok;
     }
     val re: res[u32, fail.Fail] = fresh_block(e);
@@ -285,18 +285,18 @@ fun expand_one(e: *Expansion, bi: u32) res[u32, fail.Fail] {
         }
         val rb: res[u32, fail.Fail] = loop_path(e, d, s, size, true, true, word, mask, done);
         if (sel rb.err) { ret rb; }
-        val rq: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-        if (sel rq.err) { ret rq; }
-        val before: u32 = rq.ok;
+        val rq: res[mir.VRegId, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+        if (sel rq.err) { ret res[u32, fail.Fail].err{rq.err}; }
+        val before: mir.VRegId = rq.ok;
         val ec: err[fail.Fail] = emit3(e, bi, mir.MIR_CMP_LT_U, mir.op_vreg(before), mir.op_vreg(d), mir.op_vreg(s), pw);
         if (sel ec.err) { ret res[u32, fail.Fail].err{ec.err}; }
         val ej: err[fail.Fail] = conditional(e, bi, before, rf.ok, rb.ok);
         if (sel ej.err) { ret res[u32, fail.Fail].err{ej.err}; }
         ret res[u32, fail.Fail].ok{done};
     }
-    val ra: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (sel ra.err) { ret ra; }
-    val unaligned: u32 = ra.ok;
+    val ra: res[mir.VRegId, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel ra.err) { ret res[u32, fail.Fail].err{ra.err}; }
+    val unaligned: mir.VRegId = ra.ok;
     var combined: mir.MirOperand = mir.op_vreg(d);
     if (copy) {
         val eo: err[fail.Fail] = emit3(e, bi, mir.MIR_OR, mir.op_vreg(unaligned), mir.op_vreg(d), mir.op_vreg(s), pw);
@@ -328,9 +328,9 @@ fun expand_one(e: *Expansion, bi: u32) res[u32, fail.Fail] {
     if (sel ef.err) { ret res[u32, fail.Fail].err{ef.err}; }
     val eb: err[fail.Fail] = conditional(e, backward, unaligned, rbackb.ok, rbackw.ok);
     if (sel eb.err) { ret res[u32, fail.Fail].err{eb.err}; }
-    val rq: res[u32, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
-    if (sel rq.err) { ret rq; }
-    val before: u32 = rq.ok;
+    val rq: res[mir.VRegId, fail.Fail] = context.new_vreg(e.ctx, mir.REG_CLASS_GP);
+    if (sel rq.err) { ret res[u32, fail.Fail].err{rq.err}; }
+    val before: mir.VRegId = rq.ok;
     val ec: err[fail.Fail] = emit3(e, bi, mir.MIR_CMP_LT_U, mir.op_vreg(before), mir.op_vreg(d), mir.op_vreg(s), pw);
     if (sel ec.err) { ret res[u32, fail.Fail].err{ec.err}; }
     val ej: err[fail.Fail] = conditional(e, bi, before, forward, backward);
@@ -503,11 +503,11 @@ fun t_setup(ctx: *context.LowerCtx, size: u64, copy: bool) err[fail.Fail] {
     origin.writes_secret = true;
     e.origin = ?origin;
     if (copy) {
-        val er: err[fail.Fail] = emit3(?e, 0, mir.MIR_MEMCPY, mir.op_mem_value(1, 0), mir.op_mem_value(0, 0), mir.op_imm(size::i64), ctx.tgt.model.pointer_width::u8);
+        val er: err[fail.Fail] = emit3(?e, 0, mir.MIR_MEMCPY, mir.op_mem_value(mir.vreg_id(1), 0), mir.op_mem_value(mir.vreg_id(0), 0), mir.op_imm(size::i64), ctx.tgt.model.pointer_width::u8);
         if (sel er.err) { ret er; }
     }
     or {
-        val er: err[fail.Fail] = emit2(?e, 0, mir.MIR_MEMZERO, mir.op_mem_value(1, 0), mir.op_imm(size::i64), ctx.tgt.model.pointer_width::u8);
+        val er: err[fail.Fail] = emit2(?e, 0, mir.MIR_MEMZERO, mir.op_mem_value(mir.vreg_id(1), 0), mir.op_imm(size::i64), ctx.tgt.model.pointer_width::u8);
         if (sel er.err) { ret er; }
     }
     ctx.f.blocks[0].instrs[0].writes_secret = true;
@@ -521,8 +521,8 @@ fun t_setup(ctx: *context.LowerCtx, size: u64, copy: bool) err[fail.Fail] {
 
 fun t_value(op: mir.MirOperand, regs: *u64) u64 {
     if (op.kind == mir.MIR_OP_IMM) { ret op.imm::u64; }
-    if (op.kind == mir.MIR_OP_MEM) { ret regs[op.vreg] + op.imm::u64; }
-    ret regs[op.vreg];
+    if (op.kind == mir.MIR_OP_MEM) { ret regs[op.vreg.n] + op.imm::u64; }
+    ret regs[op.vreg.n];
 }
 
 fun t_execute(f: *mir.MirFunction, bytes: *u8, src: u64, dst: u64, accesses: *u64, unaligned_widths: u32) i32 {
@@ -534,7 +534,7 @@ fun t_execute(f: *mir.MirFunction, bytes: *u8, src: u64, dst: u64, accesses: *u6
     var steps: u32 = 0;
     for (steps < 100000) {
         val mb: *mir.MirBlock = ?f.blocks[bi];
-        var next: u32 = mir.MIR_VREG_NIL;
+        var next: u32 = mir.MIR_VREG_NIL.n;
         var ii: u32 = 0;
         for (ii < mb.instr_count) {
             val mi: *mir.MirInstr = ?mb.instrs[ii];
@@ -561,7 +561,7 @@ fun t_execute(f: *mir.MirFunction, bytes: *u8, src: u64, dst: u64, accesses: *u6
                     or { bytes[at + j::u64] = (value >> (j * 8))::u8; }
                     j = j + 1;
                 }
-                if (op == mir.MIR_LOAD) { regs[mi.operands[0].vreg] = value; }
+                if (op == mir.MIR_LOAD) { regs[mi.operands[0].vreg.n] = value; }
             }
             or {
                 val a: u64 = t_value(mi.operands[1], ?regs[0]);
@@ -576,7 +576,7 @@ fun t_execute(f: *mir.MirFunction, bytes: *u8, src: u64, dst: u64, accesses: *u6
                 or (op == mir.MIR_CMP_LT_U) { result = (a < b)::u64; }
                 or (op != mir.MIR_MOV && op != mir.MIR_GEP) { ret 3; }
                 if (mi.width < 8) { result = result & ((1u64 << (mi.width::u32 * 8)) - 1); }
-                regs[mi.operands[0].vreg] = result;
+                regs[mi.operands[0].vreg.n] = result;
             }
             ii = ii + 1;
         }
@@ -700,7 +700,7 @@ test "mach.lang.be.codegen.mir.bulk:bounded_shape_secrecy_and_debug_ownership" {
                 if (mi.opcode != mir.MIR_RET && mi.inline_site != 19) { ret 8; }
                 if (mi.opcode == mir.MIR_LOAD) {
                     loads = loads + 1;
-                    if (!f.vregs[mi.operands[0].vreg].secret) { ret 9; }
+                    if (!f.vregs[mi.operands[0].vreg.n].secret) { ret 9; }
                     if (f.block_count == 1 && saw_store) { ret 10; }
                 }
                 if (mi.opcode == mir.MIR_STORE) { stores = stores + 1; saw_store = true; }
@@ -924,7 +924,7 @@ test "mach.lang.be.codegen.mir.bulk:common_copies_bound_live_pieces_and_large_co
                     if (mi.opcode == mir.MIR_LOAD) {
                         if (f.block_count == 1 && stored != 0) { ret 4; }
                         loaded = loaded + mi.width::u64;
-                        if (!mi.writes_secret || !f.vregs[mi.operands[0].vreg].secret) { ret 5; }
+                        if (!mi.writes_secret || !f.vregs[mi.operands[0].vreg.n].secret) { ret 5; }
                     }
                     if (mi.opcode == mir.MIR_STORE) {
                         stored = stored + mi.width::u64;

--- a/src/lang/be/codegen/mir/context.mach
+++ b/src/lang/be/codegen/mir/context.mach
@@ -38,16 +38,16 @@ pub rec LowerCtx {
     types:       *ir_type.IrTypeTable;
     fn:          *ir.Function;
     f:           *mir.MirFunction;
-    param_vregs: *u32;
+    param_vregs: *mir.VRegId;
     param_count: u32;
-    instr_vregs: *u32;
+    instr_vregs: *mir.VRegId;
 
-    slot_key_vregs: *u32;
+    slot_key_vregs: *mir.VRegId;
 
     instr_count: u32;
     interner:    *intern.Interner;
 
-    sret_vreg: u32;
+    sret_vreg: mir.VRegId;
 
     cur_loc: source.SrcLoc;
 
@@ -67,17 +67,17 @@ pub rec LowerCtx {
 pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) err[fail.Fail] {
     ctx.layout = target.layout_machine(tgt);
     if (ctx.param_count > 0) {
-        val res_params: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, ctx.param_count::usize);
+        val res_params: res[*mir.VRegId, A.Error] = A.allocate[mir.VRegId](ctx.alloc, ctx.param_count::usize);
         if (sel res_params.err) { ret err[fail.Fail].err{fail.refused(res_params.err)}; }
         ctx.param_vregs = res_params.ok;
     }
 
     if (ctx.instr_count > 0) {
-        val res_instrs: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, ctx.instr_count::usize);
+        val res_instrs: res[*mir.VRegId, A.Error] = A.allocate[mir.VRegId](ctx.alloc, ctx.instr_count::usize);
         if (sel res_instrs.err) { ret err[fail.Fail].err{fail.refused(res_instrs.err)}; }
         ctx.instr_vregs = res_instrs.ok;
 
-        val res_keys: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, ctx.instr_count::usize);
+        val res_keys: res[*mir.VRegId, A.Error] = A.allocate[mir.VRegId](ctx.alloc, ctx.instr_count::usize);
         if (sel res_keys.err) { ret err[fail.Fail].err{fail.refused(res_keys.err)}; }
         ctx.slot_key_vregs = res_keys.ok;
 
@@ -91,12 +91,12 @@ pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) err[fai
     var i: u32 = 0;
     for (i < ctx.param_count) {
         val reg_class: u32 = reg_class_of(ctx, tgt, fn.params[i].ty);
-        val res_vreg: res[u32, fail.Fail] = new_vreg_vec(ctx, reg_class, value_is_vector(ctx, fn.params[i].ty));
+        val res_vreg: res[mir.VRegId, fail.Fail] = new_vreg_vec(ctx, reg_class, value_is_vector(ctx, fn.params[i].ty));
         if (sel res_vreg.err) { ret err[fail.Fail].err{res_vreg.err}; }
-        val pv: u32 = res_vreg.ok;
+        val pv: mir.VRegId = res_vreg.ok;
         ctx.param_vregs[i] = pv;
-        ctx.f.vregs[pv].ty = fn.params[i].ty::u32;
-        if (fn.params[i].secret && !value_is_aggregate(ctx, fn.params[i].ty)) { ctx.f.vregs[pv].secret = true; }
+        ctx.f.vregs[pv.n].ty = fn.params[i].ty::u32;
+        if (fn.params[i].secret && !value_is_aggregate(ctx, fn.params[i].ty)) { ctx.f.vregs[pv.n].secret = true; }
         i = i + 1;
     }
 
@@ -106,14 +106,14 @@ pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) err[fai
         val inst: *instruction.Instruction = ?fn.instrs[i];
         if (defines_value(ctx, inst)) {
             val reg_class: u32 = reg_class_of(ctx, tgt, inst.ty);
-            val res_vreg: res[u32, fail.Fail] = new_vreg_vec(ctx, reg_class, value_is_vector(ctx, inst.ty));
+            val res_vreg: res[mir.VRegId, fail.Fail] = new_vreg_vec(ctx, reg_class, value_is_vector(ctx, inst.ty));
             if (sel res_vreg.err) { ret err[fail.Fail].err{res_vreg.err}; }
-            val rv: u32 = res_vreg.ok;
+            val rv: mir.VRegId = res_vreg.ok;
             ctx.instr_vregs[i] = rv;
-            ctx.f.vregs[rv].ty = inst.ty::u32;
+            ctx.f.vregs[rv.n].ty = inst.ty::u32;
             if (inst.secret && (inst.kind == instruction.OP_LOAD || inst.kind == instruction.OP_CALL)
                 && !value_is_aggregate(ctx, inst.ty)) {
-                ctx.f.vregs[rv].secret = true;
+                ctx.f.vregs[rv.n].secret = true;
             }
         }
         i = i + 1;
@@ -124,15 +124,15 @@ pub fun ctx_setup(ctx: *LowerCtx, tgt: *target.Target, fn: *ir.Function) err[fai
 
 pub fun ctx_dnit(ctx: *LowerCtx) {
     if (ctx.param_vregs != nil && ctx.param_count > 0) {
-        A.deallocate[u32](ctx.alloc, ctx.param_vregs, ctx.param_count::usize);
+        A.deallocate[mir.VRegId](ctx.alloc, ctx.param_vregs, ctx.param_count::usize);
         ctx.param_vregs = nil;
     }
     if (ctx.instr_vregs != nil && ctx.instr_count > 0) {
-        A.deallocate[u32](ctx.alloc, ctx.instr_vregs, ctx.instr_count::usize);
+        A.deallocate[mir.VRegId](ctx.alloc, ctx.instr_vregs, ctx.instr_count::usize);
         ctx.instr_vregs = nil;
     }
     if (ctx.slot_key_vregs != nil && ctx.instr_count > 0) {
-        A.deallocate[u32](ctx.alloc, ctx.slot_key_vregs, ctx.instr_count::usize);
+        A.deallocate[mir.VRegId](ctx.alloc, ctx.slot_key_vregs, ctx.instr_count::usize);
         ctx.slot_key_vregs = nil;
     }
     if (ctx.pending != nil && ctx.pending_cap > 0) {
@@ -179,12 +179,12 @@ pub fun values_convention(ctx: *LowerCtx) bool {
     ret ctx.tgt.abi.passing == abi.PASSING_VALUES;
 }
 
-pub fun new_vreg(ctx: *LowerCtx, reg_class: u32) res[u32, fail.Fail] {
+pub fun new_vreg(ctx: *LowerCtx, reg_class: u32) res[mir.VRegId, fail.Fail] {
     val f: *mir.MirFunction = ctx.f;
     if (f.vreg_count >= f.vreg_cap) {
         val new_cap: u32 = f.vreg_cap * 2;
         val res_vregs: res[*mir.MirVReg, A.Error] = A.reallocate[mir.MirVReg](ctx.alloc, f.vregs, f.vreg_cap::usize, new_cap::usize);
-        if (sel res_vregs.err) { ret res[u32, fail.Fail].err{fail.refused(res_vregs.err)}; }
+        if (sel res_vregs.err) { ret res[mir.VRegId, fail.Fail].err{fail.refused(res_vregs.err)}; }
         f.vregs    = res_vregs.ok;
         f.vreg_cap = new_cap;
     }
@@ -193,24 +193,24 @@ pub fun new_vreg(ctx: *LowerCtx, reg_class: u32) res[u32, fail.Fail] {
     if (values_convention(ctx)) { selected_class = mir.REG_CLASS_VALUE; }
     f.vregs[vid] = mir.vreg(vid, selected_class, false, false);
     f.vreg_count = f.vreg_count + 1;
-    ret res[u32, fail.Fail].ok{vid};
+    ret res[mir.VRegId, fail.Fail].ok{mir.vreg_id(vid)};
 }
 
-pub fun new_vreg_vec(ctx: *LowerCtx, reg_class: u32, vector: bool) res[u32, fail.Fail] {
-    val r: res[u32, fail.Fail] = new_vreg(ctx, reg_class);
+pub fun new_vreg_vec(ctx: *LowerCtx, reg_class: u32, vector: bool) res[mir.VRegId, fail.Fail] {
+    val r: res[mir.VRegId, fail.Fail] = new_vreg(ctx, reg_class);
     if (sel r.err) { ret r; }
-    ctx.f.vregs[r.ok].vector = vector;
+    ctx.f.vregs[r.ok.n].vector = vector;
     ret r;
 }
 
-pub fun instr_vreg(ctx: *LowerCtx, iid: id.InstructionId) u32 {
+pub fun instr_vreg(ctx: *LowerCtx, iid: id.InstructionId) mir.VRegId {
     if (iid == id.INSTR_NIL)         { ret mir.MIR_VREG_NIL; }
     if (ctx.instr_vregs == nil)      { ret mir.MIR_VREG_NIL; }
     if (iid::u32 >= ctx.instr_count) { ret mir.MIR_VREG_NIL; }
     ret ctx.instr_vregs[iid::u32];
 }
 
-pub fun slot_key_vreg(ctx: *LowerCtx, iid: id.InstructionId) u32 {
+pub fun slot_key_vreg(ctx: *LowerCtx, iid: id.InstructionId) mir.VRegId {
     if (iid == id.INSTR_NIL)         { ret mir.MIR_VREG_NIL; }
     if (ctx.slot_key_vregs == nil)   { ret mir.MIR_VREG_NIL; }
     if (iid::u32 >= ctx.instr_count) { ret mir.MIR_VREG_NIL; }
@@ -406,7 +406,7 @@ pub fun emit_store_to_w(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, 
     ret inst2(ctx, mb, mir.MIR_STORE, mem, src, width, width);
 }
 
-pub fun emit_load_from_w(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, mem: mir.MirOperand, width: u8) err[fail.Fail] {
+pub fun emit_load_from_w(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.VRegId, mem: mir.MirOperand, width: u8) err[fail.Fail] {
     ret inst2(ctx, mb, mir.MIR_LOAD, mir.op_vreg(dst), mem, width, width);
 }
 
@@ -452,10 +452,10 @@ pub fun store_subwidth_vector(ctx: *LowerCtx, mb: *mir.MirBlock, dest: mir.MirOp
         ret push_instr(ctx, mb, di);
     }
     val align: u32 = ir_type.byte_align_for_machine(ctx.types, ty, ctx.layout);
-    val skr: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+    val skr: res[mir.VRegId, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
     if (sel skr.err) { ret err[fail.Fail].err{skr.err}; }
-    val sk: u32 = skr.ok;
-    val ar: err[fail.Fail] = add_alloca_slot(ctx, sk, reg_w::u64, align, ty::u32);
+    val sk: mir.VRegId = skr.ok;
+    val ar: err[fail.Fail] = add_alloca_slot(ctx, sk.n, reg_w::u64, align, ty::u32);
     if (sel ar.err) { ret ar; }
 
     val psp: err[fail.Fail] = store_vector_register(ctx, mb, mir.op_mem_slot(sk, 0), value, ty);
@@ -465,9 +465,9 @@ pub fun store_subwidth_vector(ctx: *LowerCtx, mb: *mir.MirBlock, dest: mir.MirOp
     for (off::u32 < mem_w::u32) {
         val chunk: u8 = copy_chunk_width(ctx.tgt, (mem_w::u32 - off::u32)::u64);
 
-        val tr: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+        val tr: res[mir.VRegId, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
         if (sel tr.err) { ret err[fail.Fail].err{tr.err}; }
-        val tmp: u32 = tr.ok;
+        val tmp: mir.VRegId = tr.ok;
 
         val ld: err[fail.Fail] = emit_load_from_w(ctx, mb, tmp, mir.op_mem_slot(sk, off), chunk);
         if (sel ld.err) { ret ld; }
@@ -498,10 +498,10 @@ pub fun load_subwidth_vector(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOper
         ret push_instr(ctx, mb, di);
     }
     val align: u32 = ir_type.byte_align_for_machine(ctx.types, ty, ctx.layout);
-    val skr: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+    val skr: res[mir.VRegId, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
     if (sel skr.err) { ret err[fail.Fail].err{skr.err}; }
-    val sk: u32 = skr.ok;
-    val ar: err[fail.Fail] = add_alloca_slot(ctx, sk, reg_w::u64, align, ty::u32);
+    val sk: mir.VRegId = skr.ok;
+    val ar: err[fail.Fail] = add_alloca_slot(ctx, sk.n, reg_w::u64, align, ty::u32);
     if (sel ar.err) { ret ar; }
 
     var zoff: i64 = 0;
@@ -516,9 +516,9 @@ pub fun load_subwidth_vector(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.MirOper
     for (off::u32 < mem_w::u32) {
         val chunk: u8 = copy_chunk_width(ctx.tgt, (mem_w::u32 - off::u32)::u64);
 
-        val tr: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+        val tr: res[mir.VRegId, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
         if (sel tr.err) { ret err[fail.Fail].err{tr.err}; }
-        val tmp: u32 = tr.ok;
+        val tmp: mir.VRegId = tr.ok;
 
         val ld: err[fail.Fail] = emit_load_from_w(ctx, mb, tmp, mem_at(src, off), chunk);
         if (sel ld.err) { ret ld; }
@@ -554,18 +554,18 @@ pub fun copy_chunk_width(tgt: *target.Target, remaining: u64) u8 {
     ret 1;
 }
 
-pub fun emit_bin(ctx: *LowerCtx, mb: *mir.MirBlock, op: mir.MirOpcode, dst: u32, a: mir.MirOperand, b: mir.MirOperand) err[fail.Fail] {
+pub fun emit_bin(ctx: *LowerCtx, mb: *mir.MirBlock, op: mir.MirOpcode, dst: mir.VRegId, a: mir.MirOperand, b: mir.MirOperand) err[fail.Fail] {
     ret inst3(ctx, mb, op, mir.op_vreg(dst), a, b, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 }
 
-pub fun emit_lea_preg(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, base_preg: u32, disp: i64) err[fail.Fail] {
+pub fun emit_lea_preg(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.VRegId, base_preg: mir.PRegId, disp: i64) err[fail.Fail] {
     ret inst2(ctx, mb, mir.MIR_GEP, mir.op_vreg(dst), mir.op_mem_preg(base_preg, disp), ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
 }
 
-pub fun emit_lea_slot(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, out: *u32) err[fail.Fail] {
-    val res_vreg: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+pub fun emit_lea_slot(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, out: *mir.VRegId) err[fail.Fail] {
+    val res_vreg: res[mir.VRegId, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
     if (sel res_vreg.err) { ret err[fail.Fail].err{res_vreg.err}; }
-    val v: u32 = res_vreg.ok;
+    val v: mir.VRegId = res_vreg.ok;
 
     val res_emit: err[fail.Fail] = inst2(ctx, mb, mir.MIR_GEP, mir.op_vreg(v), mem, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
     if (sel res_emit.err) { ret res_emit; }
@@ -573,14 +573,14 @@ pub fun emit_lea_slot(ctx: *LowerCtx, mb: *mir.MirBlock, mem: mir.MirOperand, ou
     ret err[fail.Fail].ok{};
 }
 
-pub fun addr_to_vreg(ctx: *LowerCtx, mb: *mir.MirBlock, argop: mir.MirOperand, out_vreg: *u32) err[fail.Fail] {
+pub fun addr_to_vreg(ctx: *LowerCtx, mb: *mir.MirBlock, argop: mir.MirOperand, out_vreg: *mir.VRegId) err[fail.Fail] {
     if (argop.kind == mir.MIR_OP_VREG) {
         @out_vreg = argop.vreg;
         ret err[fail.Fail].ok{};
     }
-    val res_vreg: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+    val res_vreg: res[mir.VRegId, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
     if (sel res_vreg.err) { ret err[fail.Fail].err{res_vreg.err}; }
-    val v: u32 = res_vreg.ok;
+    val v: mir.VRegId = res_vreg.ok;
 
     val res_emit: err[fail.Fail] = inst2(ctx, mb, mir.MIR_GEP, mir.op_vreg(v), argop, ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
     if (sel res_emit.err) { ret res_emit; }
@@ -595,14 +595,14 @@ pub fun copy_aggregate(ctx: *LowerCtx, mb: *mir.MirBlock, dst_mem: mir.MirOperan
               ctx.tgt.model.pointer_width::u8, ctx.tgt.model.pointer_width::u8);
 }
 
-pub fun alloc_object_storage(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, ty: ir_type.IrTypeId) err[fail.Fail] {
-    val res_key: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+pub fun alloc_object_storage(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.VRegId, ty: ir_type.IrTypeId) err[fail.Fail] {
+    val res_key: res[mir.VRegId, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
     if (sel res_key.err) { ret err[fail.Fail].err{res_key.err}; }
-    val sk: u32 = res_key.ok;
+    val sk: mir.VRegId = res_key.ok;
 
     val size:  u64 = ir_type.byte_size_for_machine(ctx.types, ty, ctx.layout)::u64;
     val align: u32 = ir_type.byte_align_for_machine(ctx.types, ty, ctx.layout);
-    val res_slot: err[fail.Fail] = add_alloca_slot(ctx, sk, size, align, ty);
+    val res_slot: err[fail.Fail] = add_alloca_slot(ctx, sk.n, size, align, ty);
     if (sel res_slot.err) { ret res_slot; }
 
     ret inst2(ctx, mb, mir.MIR_ALLOCA, mir.op_vreg(dst), mir.op_mem_slot(sk, 0),
@@ -629,12 +629,12 @@ fun round_up_word(n: u64, word: u64) u64 {
     ret (n + word - 1) & ~(word - 1);
 }
 
-pub fun alloc_result_storage(ctx: *LowerCtx, mb: *mir.MirBlock, dst: u32, size: u64, align: u32) err[fail.Fail] {
-    val res_key: res[u32, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
+pub fun alloc_result_storage(ctx: *LowerCtx, mb: *mir.MirBlock, dst: mir.VRegId, size: u64, align: u32) err[fail.Fail] {
+    val res_key: res[mir.VRegId, fail.Fail] = new_vreg(ctx, mir.REG_CLASS_GP);
     if (sel res_key.err) { ret err[fail.Fail].err{res_key.err}; }
-    val sk: u32 = res_key.ok;
+    val sk: mir.VRegId = res_key.ok;
 
-    val res_slot: err[fail.Fail] = add_spill_slot_aligned(ctx, sk, size, align);
+    val res_slot: err[fail.Fail] = add_spill_slot_aligned(ctx, sk.n, size, align);
     if (sel res_slot.err) { ret res_slot; }
 
     ret inst2(ctx, mb, mir.MIR_ALLOCA, mir.op_vreg(dst), mir.op_mem_slot(sk, 0), ctx.tgt.model.gpr_width::u8, ctx.tgt.model.gpr_width::u8);
@@ -651,7 +651,7 @@ fun defines_value(ctx: *LowerCtx, inst: *instruction.Instruction) bool {
     ret true;
 }
 
-fun param_vreg(ctx: *LowerCtx, ix: u32) u32 {
+fun param_vreg(ctx: *LowerCtx, ix: u32) mir.VRegId {
     if (ctx.param_vregs == nil) { ret mir.MIR_VREG_NIL; }
     if (ix >= ctx.param_count)  { ret mir.MIR_VREG_NIL; }
     ret ctx.param_vregs[ix];
@@ -870,7 +870,7 @@ test "mach.lang.be.codegen.mir.context.vector_scaffolding" {
     if (!value_is_vector(?ctx, vecty))                           { ir_type.dnit(?types); ret 1; }
 
     var mb: mir.MirBlock;
-    val sr: err[fail.Fail] = store_vector_register(?ctx, ?mb, mir.op_mem_slot(1, 0), mir.op_vreg(2), narrowty);
+    val sr: err[fail.Fail] = store_vector_register(?ctx, ?mb, mir.op_mem_slot(mir.vreg_id(1), 0), mir.op_vreg(mir.vreg_id(2)), narrowty);
     if (sel sr.err)                                 { ir_type.dnit(?types); ret 1; }
     if (mb.instr_count != 1)                                     { ir_type.dnit(?types); ret 1; }
     if (mb.instrs[0].opcode != mir.MIR_STORE)                     { ir_type.dnit(?types); ret 1; }

--- a/src/lang/be/codegen/mir/lower.mach
+++ b/src/lang/be/codegen/mir/lower.mach
@@ -255,18 +255,18 @@ fun lower_phis(ctx: *lctx.LowerCtx, fn: *ir.Function) err[fail.Fail] {
 
 fun lower_block_phis(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block) err[fail.Fail] {
     val np: u32 = blk.phi_count;
-    val rd: res[*u32, A.Error] = A.allocate[u32](ctx.alloc, np::usize);
+    val rd: res[*mir.VRegId, A.Error] = A.allocate[mir.VRegId](ctx.alloc, np::usize);
     if (sel rd.err) { ret err[fail.Fail].err{fail.refused(rd.err)}; }
-    val dsts: *u32 = rd.ok;
+    val dsts: *mir.VRegId = rd.ok;
     val rs: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, np::usize);
     if (sel rs.err) {
-        A.deallocate[u32](ctx.alloc, dsts, np::usize);
+        A.deallocate[mir.VRegId](ctx.alloc, dsts, np::usize);
         ret err[fail.Fail].err{fail.refused(rs.err)};
     }
     val srcs: *mir.MirOperand = rs.ok;
     val rw: res[*u8, A.Error] = A.allocate[u8](ctx.alloc, np::usize);
     if (sel rw.err) {
-        A.deallocate[u32](ctx.alloc, dsts, np::usize);
+        A.deallocate[mir.VRegId](ctx.alloc, dsts, np::usize);
         A.deallocate[mir.MirOperand](ctx.alloc, srcs, np::usize);
         ret err[fail.Fail].err{fail.refused(rw.err)};
     }
@@ -299,8 +299,8 @@ fun lower_block_phis(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block) err[
                 cnt;
             }
             val phi: *instr.Instruction = phi_opt.some;
-            val dst_vreg: u32 = lctx.instr_vreg(ctx, blk.phis[hi]);
-            if (dst_vreg == mir.MIR_VREG_NIL) {
+            val dst_vreg: mir.VRegId = lctx.instr_vreg(ctx, blk.phis[hi]);
+            if (mir.vreg_is_nil(dst_vreg)) {
                 failure = err[fail.Fail].err{fail.message("mir.lower_ir: phi defines no result vreg")};
                 hi = hi + 1;
                 cnt;
@@ -332,17 +332,17 @@ fun lower_block_phis(ctx: *lctx.LowerCtx, fn: *ir.Function, blk: *ir.Block) err[
         pi = pi + 1;
     }
 
-    A.deallocate[u32](ctx.alloc, dsts, np::usize);
+    A.deallocate[mir.VRegId](ctx.alloc, dsts, np::usize);
     A.deallocate[mir.MirOperand](ctx.alloc, srcs, np::usize);
     A.deallocate[u8](ctx.alloc, wids, np::usize);
     ret failure;
 }
 
-fun phi_edge_err(ctx: *lctx.LowerCtx, block_id: u32, pred_id: u32, dst_vreg: u32) str {
+fun phi_edge_err(ctx: *lctx.LowerCtx, block_id: u32, pred_id: u32, dst_vreg: mir.VRegId) str {
     val fallback: str = "mir.lower_ir: phi has no incoming value for a predecessor edge";
     val rj: res[str, format.FormatError] = format.sprint(ctx.alloc,
         "mir.lower_ir: phi in block {} has no incoming value for predecessor block {} (result vreg {})",
-        block_id, pred_id, dst_vreg);
+        block_id, pred_id, dst_vreg.n);
     if (sel rj.err) { ret fallback; }
     ret rj.ok;
 }
@@ -360,7 +360,7 @@ fun mir_block_by_id(f: *mir.MirFunction, block_id: u32) *mir.MirBlock {
     ret nil;
 }
 
-fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, srcs: *mir.MirOperand, wids: *u8, n: u32) err[fail.Fail] {
+fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *mir.VRegId, srcs: *mir.MirOperand, wids: *u8, n: u32) err[fail.Fail] {
     val re: res[*bool, A.Error] = A.allocate[bool](ctx.alloc, n::usize);
     if (sel re.err) { ret err[fail.Fail].err{fail.refused(re.err)}; }
     val done: *bool = re.ok;
@@ -368,7 +368,7 @@ fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, sr
     var remaining: u32 = 0;
     var i: u32 = 0;
     for (i < n) {
-        if (srcs[i].kind == mir.MIR_OP_VREG && srcs[i].vreg == dsts[i]) {
+        if (srcs[i].kind == mir.MIR_OP_VREG && mir.vreg_same(srcs[i].vreg, dsts[i])) {
             done[i] = true;
         } or {
             done[i] = false;
@@ -396,18 +396,18 @@ fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, sr
         if (sel failure.ok && progressed == false && remaining > 0) {
             var c: u32 = 0;
             for (done[c]) { c = c + 1; }
-            val freed: u32 = dsts[c];
-            val cls: u32 = ctx.f.vregs[freed].class;
-            val tr: res[u32, fail.Fail] = lctx.new_vreg_vec(ctx, cls, ctx.f.vregs[freed].vector);
+            val freed: mir.VRegId = dsts[c];
+            val cls: u32 = ctx.f.vregs[freed.n].class;
+            val tr: res[mir.VRegId, fail.Fail] = lctx.new_vreg_vec(ctx, cls, ctx.f.vregs[freed.n].vector);
             if (sel tr.err) { failure = err[fail.Fail].err{tr.err}; cnt; }
-            val tmp: u32 = tr.ok;
-            ctx.f.vregs[tmp].ty = ctx.f.vregs[freed].ty;
+            val tmp: mir.VRegId = tr.ok;
+            ctx.f.vregs[tmp.n].ty = ctx.f.vregs[freed.n].ty;
             val sv: err[fail.Fail] = insert_mov_before_terminator(ctx, pred_mb,
                 mir.op_vreg(tmp), mir.op_vreg(freed), ctx.tgt.model.gpr_width::u8);
             if (sel sv.err) { failure = err[fail.Fail].err{sv.err}; cnt; }
             var d: u32 = 0;
             for (d < n) {
-                if (done[d] == false && srcs[d].kind == mir.MIR_OP_VREG && srcs[d].vreg == freed) {
+                if (done[d] == false && srcs[d].kind == mir.MIR_OP_VREG && mir.vreg_same(srcs[d].vreg, freed)) {
                     srcs[d] = mir.op_vreg(tmp);
                 }
                 d = d + 1;
@@ -419,10 +419,10 @@ fun emit_edge_copies(ctx: *lctx.LowerCtx, pred_mb: *mir.MirBlock, dsts: *u32, sr
     ret failure;
 }
 
-fun dst_is_pending_src(dsts: *u32, srcs: *mir.MirOperand, done: *bool, n: u32, v: u32) bool {
+fun dst_is_pending_src(dsts: *mir.VRegId, srcs: *mir.MirOperand, done: *bool, n: u32, v: mir.VRegId) bool {
     var i: u32 = 0;
     for (i < n) {
-        if (done[i] == false && srcs[i].kind == mir.MIR_OP_VREG && srcs[i].vreg == v) {
+        if (done[i] == false && srcs[i].kind == mir.MIR_OP_VREG && mir.vreg_same(srcs[i].vreg, v)) {
             ret true;
         }
         i = i + 1;
@@ -462,7 +462,7 @@ fun insert_mov_before_terminator(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mi
         mi.width     = iw;
         mi.src_width = iw;
     }
-    or (dst.kind == mir.MIR_OP_VREG && dst.vreg < ctx.f.vreg_count && ctx.f.vregs[dst.vreg].vector) {
+    or (dst.kind == mir.MIR_OP_VREG && dst.vreg.n < ctx.f.vreg_count && ctx.f.vregs[dst.vreg.n].vector) {
         mi.width     = 16;
         mi.src_width = 16;
     }
@@ -624,12 +624,12 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
         ret err[fail.Fail].ok{};
     }
     if (route == opdesc.LOWER_DBG) {
-        var vreg: u32 = mir.MIR_VREG_NIL;
+        var vreg: mir.VRegId = mir.MIR_VREG_NIL;
         if (inst.operand_count > 0) {
             val op: mir.MirOperand = lctx.lower_value(ctx, inst.operands[0]);
             if (op.kind == mir.MIR_OP_VREG) { vreg = op.vreg; }
         }
-        ret lctx.push_pending_dbg(ctx, iid::u32, vreg);
+        ret lctx.push_pending_dbg(ctx, iid::u32, vreg.n);
     }
     if (route == opdesc.LOWER_ALLOCA) {
         ret lower_alloca(ctx, mb, inst, iid);
@@ -656,7 +656,7 @@ fun lower_instr(ctx: *lctx.LowerCtx, fn: *ir.Function, mb: *mir.MirBlock, iid: i
         ret lower_vec_build(ctx, mb, inst, iid);
     }
     if (route == opdesc.LOWER_DECLASSIFY) {
-        val ddst: u32 = lctx.instr_vreg(ctx, iid);
+        val ddst: mir.VRegId = lctx.instr_vreg(ctx, iid);
         ret lctx.emit_declassify(ctx, mb, mir.op_vreg(ddst), lctx.lower_value(ctx, inst.operands[0]), lctx.op_width_of(ctx, inst.ty));
     }
     if (is_float_op(ctx, inst)) {
@@ -809,9 +809,9 @@ fun lower_cbr(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
 
     var cond: mir.MirOperand = lctx.lower_operand(ctx, inst, 0);
     if (cond.kind == mir.MIR_OP_IMM) {
-        val rv: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+        val rv: res[mir.VRegId, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
         if (sel rv.err) { ret err[fail.Fail].err{rv.err}; }
-        val creg: u32 = rv.ok;
+        val creg: mir.VRegId = rv.ok;
         val mv: err[fail.Fail] = lctx.emit_mov(ctx, mb, mir.op_vreg(creg), cond);
         if (sel mv.err) { ret mv; }
         cond = mir.op_vreg(creg);
@@ -870,15 +870,15 @@ fun lower_asm_instr(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, iid: id.InstructionI
         payload.binds = rb.ok;
         var k: u32 = 0;
         for (k < src.bind_count) {
-            var vreg: u32 = lctx.slot_key_vreg(ctx, src.binds[k].instr);
-            if (vreg == mir.MIR_VREG_NIL) { vreg = lctx.instr_vreg(ctx, src.binds[k].instr); }
-            if (vreg == mir.MIR_VREG_NIL) {
+            var vreg: mir.VRegId = lctx.slot_key_vreg(ctx, src.binds[k].instr);
+            if (mir.vreg_is_nil(vreg)) { vreg = lctx.instr_vreg(ctx, src.binds[k].instr); }
+            if (mir.vreg_is_nil(vreg)) {
                 val msg: str = asm_bind_message(ctx, "inline-asm local '", src.binds[k].name, "' has no addressable storage slot", "inline-asm local has no addressable storage slot");
                 A.deallocate[mir.MirAsmBind](ctx.alloc, payload.binds, src.bind_count::usize);
                 A.deallocate[mir.MirAsm](ctx.alloc, payload, 1::usize);
                 ret err[fail.Fail].err{fail.message(msg)};
             }
-            payload.binds[k] = mir.asm_bind(src.binds[k].name, vreg, src.binds[k].secret);
+            payload.binds[k] = mir.asm_bind(src.binds[k].name, vreg.n, src.binds[k].secret);
             k = k + 1;
         }
         payload.bind_count = src.bind_count;
@@ -901,9 +901,9 @@ fun narrow_shift_value(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Inst
     if (inst.kind == instr.OP_SHL) { ret res[mir.MirOperand, fail.Fail].ok{value}; }
     if (natural_w >= w)            { ret res[mir.MirOperand, fail.Fail].ok{value}; }
 
-    val vr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+    val vr: res[mir.VRegId, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
     if (sel vr.err) { ret res[mir.MirOperand, fail.Fail].err{vr.err}; }
-    val v: u32 = vr.ok;
+    val v: mir.VRegId = vr.ok;
 
     val pr: err[fail.Fail] = emit_promote(ctx, mb, mir.op_vreg(v), value, w, natural_w,
                                                inst.kind == instr.OP_SHR_S);
@@ -915,8 +915,8 @@ fun lower_shift(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
     if (inst.operand_count < 2) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: shift missing value or count operand")};
     }
-    val dst: u32 = lctx.instr_vreg(ctx, iid);
-    if (dst == mir.MIR_VREG_NIL) {
+    val dst: mir.VRegId = lctx.instr_vreg(ctx, iid);
+    if (mir.vreg_is_nil(dst)) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: shift defines no result vreg")};
     }
     val natural_w: u8 = lctx.op_width_of(ctx, inst.ty);
@@ -937,9 +937,9 @@ fun lower_shift(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
     if (count.kind != mir.MIR_OP_IMM) {
         val cnt_reg: i32 = ctx.tgt.model.shift_count_reg;
         if (cnt_reg >= 0) {
-            val mc: err[fail.Fail] = lctx.emit_mov_w(ctx, mb, mir.op_preg(cnt_reg::u32), count, w);
+            val mc: err[fail.Fail] = lctx.emit_mov_w(ctx, mb, mir.op_preg(mir.preg_id(cnt_reg)), count, w);
             if (sel mc.err) { ret mc; }
-            count_op = mir.op_preg(cnt_reg::u32);
+            count_op = mir.op_preg(mir.preg_id(cnt_reg));
         }
     }
 
@@ -957,8 +957,8 @@ fun lower_div(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     if (inst.operand_count < 2) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: division missing dividend or divisor operand")};
     }
-    val dst: u32 = lctx.instr_vreg(ctx, iid);
-    if (dst == mir.MIR_VREG_NIL) {
+    val dst: mir.VRegId = lctx.instr_vreg(ctx, iid);
+    if (mir.vreg_is_nil(dst)) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: division defines no result vreg")};
     }
     val acc_reg: i32 = ctx.tgt.model.div_reg;
@@ -975,14 +975,14 @@ fun lower_div(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     val dividend: mir.MirOperand = lctx.lower_value(ctx, inst.operands[0]);
     val divisor:  mir.MirOperand = lctx.lower_value(ctx, inst.operands[1]);
 
-    val mr: err[fail.Fail] = emit_promote(ctx, mb, mir.op_preg(acc_reg::u32), dividend, w, natural_w, signed);
+    val mr: err[fail.Fail] = emit_promote(ctx, mb, mir.op_preg(mir.preg_id(acc_reg)), dividend, w, natural_w, signed);
     if (sel mr.err) { ret mr; }
 
     var div_op: mir.MirOperand = divisor;
     if (natural_w < w || divisor.kind == mir.MIR_OP_IMM) {
-        val bvr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+        val bvr: res[mir.VRegId, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
         if (sel bvr.err) { ret err[fail.Fail].err{bvr.err}; }
-        val bv: u32 = bvr.ok;
+        val bv: mir.VRegId = bvr.ok;
         val ex: err[fail.Fail] = emit_promote(ctx, mb, mir.op_vreg(bv), divisor, w, natural_w, signed);
         if (sel ex.err) { ret ex; }
         div_op = mir.op_vreg(bv);
@@ -991,7 +991,7 @@ fun lower_div(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     val rop: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
     if (sel rop.err) { ret err[fail.Fail].err{fail.refused(rop.err)}; }
     val ops: *mir.MirOperand = rop.ok;
-    ops[0] = mir.op_preg(acc_reg::u32);
+    ops[0] = mir.op_preg(mir.preg_id(acc_reg));
     ops[1] = div_op;
     var mi: mir.MirInstr = mir.instr(inst.kind::u32, ops, 2, w, w);
     val pd: err[fail.Fail] = lctx.push_instr(ctx, mb, mi);
@@ -1001,11 +1001,11 @@ fun lower_div(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     if (inst.kind == instr.OP_REM_S || inst.kind == instr.OP_REM_U) {
         res_reg = hi_reg;
     }
-    ret lctx.emit_mov_w(ctx, mb, mir.op_vreg(dst), mir.op_preg(res_reg::u32), natural_w);
+    ret lctx.emit_mov_w(ctx, mb, mir.op_vreg(dst), mir.op_preg(mir.preg_id(res_reg)), natural_w);
 }
 
 fun lower_div_three_address(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction,
-                            iid: id.InstructionId, dst: u32) err[fail.Fail] {
+                            iid: id.InstructionId, dst: mir.VRegId) err[fail.Fail] {
     val signed: bool = inst.kind == instr.OP_DIV_S || inst.kind == instr.OP_REM_S;
 
     val natural_w: u8 = lctx.op_width_of(ctx, inst.ty);
@@ -1017,9 +1017,9 @@ fun lower_div_three_address(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr
 
     var n_op: mir.MirOperand = dividend;
     if (natural_w < w || dividend.kind == mir.MIR_OP_IMM) {
-        val nvr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+        val nvr: res[mir.VRegId, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
         if (sel nvr.err) { ret err[fail.Fail].err{nvr.err}; }
-        val nv: u32 = nvr.ok;
+        val nv: mir.VRegId = nvr.ok;
         val ne: err[fail.Fail] = emit_promote(ctx, mb, mir.op_vreg(nv), dividend, w, natural_w, signed);
         if (sel ne.err) { ret ne; }
         n_op = mir.op_vreg(nv);
@@ -1027,9 +1027,9 @@ fun lower_div_three_address(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr
 
     var m_op: mir.MirOperand = divisor;
     if (natural_w < w || divisor.kind == mir.MIR_OP_IMM) {
-        val mvr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+        val mvr: res[mir.VRegId, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
         if (sel mvr.err) { ret err[fail.Fail].err{mvr.err}; }
-        val mv: u32 = mvr.ok;
+        val mv: mir.VRegId = mvr.ok;
         val me: err[fail.Fail] = emit_promote(ctx, mb, mir.op_vreg(mv), divisor, w, natural_w, signed);
         if (sel me.err) { ret me; }
         m_op = mir.op_vreg(mv);
@@ -1075,8 +1075,8 @@ fun emit_promote(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, dst: mir.MirOperand, sr
 }
 
 fun lower_generic(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
-    val dst: u32 = lctx.instr_vreg(ctx, iid);
-    val has_dst: bool = dst != mir.MIR_VREG_NIL;
+    val dst: mir.VRegId = lctx.instr_vreg(ctx, iid);
+    val has_dst: bool = !mir.vreg_is_nil(dst);
     var total: u32 = inst.operand_count;
     if (has_dst) { total = total + 1; }
 
@@ -1097,15 +1097,15 @@ fun lower_generic(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructi
     for (k < inst.operand_count) {
         var op: mir.MirOperand = lctx.lower_operand(ctx, inst, k);
         if (op.kind == mir.MIR_OP_SYM) {
-            var av: u32 = mir.MIR_VREG_NIL;
+            var av: mir.VRegId = mir.MIR_VREG_NIL;
             val ar: err[fail.Fail] = lctx.addr_to_vreg(ctx, mb, op, ?av);
             if (sel ar.err) { ret ar; }
             op = mir.op_vreg(av);
         }
         if (op.kind == mir.MIR_OP_IMM && mir.operand_requires_reg(inst.kind::u32, base + k)) {
-            val cvr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+            val cvr: res[mir.VRegId, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
             if (sel cvr.err) { ret err[fail.Fail].err{cvr.err}; }
-            val cv: u32 = cvr.ok;
+            val cv: mir.VRegId = cvr.ok;
             val cw: u8 = lctx.op_width_of(ctx, inst.operands[k].ty);
             val ce: err[fail.Fail] = lctx.emit_mov_w(ctx, mb, mir.op_vreg(cv), op, cw);
             if (sel ce.err) { ret ce; }
@@ -1196,8 +1196,8 @@ fun lower_float_op(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruct
     if (inst.operand_count < 2) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: float op missing operand")};
     }
-    val dst: u32 = lctx.instr_vreg(ctx, iid);
-    if (dst == mir.MIR_VREG_NIL) {
+    val dst: mir.VRegId = lctx.instr_vreg(ctx, iid);
+    if (mir.vreg_is_nil(dst)) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: float op defines no result vreg")};
     }
 
@@ -1244,17 +1244,17 @@ fun bitcast_needs_frame(ctx: *lctx.LowerCtx, inst: *instr.Instruction) bool {
 }
 
 fun lower_bitcast_via_frame(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
-    val dst: u32 = lctx.instr_vreg(ctx, iid);
-    if (dst == mir.MIR_VREG_NIL) {
+    val dst: mir.VRegId = lctx.instr_vreg(ctx, iid);
+    if (mir.vreg_is_nil(dst)) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: cross-bank reinterpret defines no result vreg")};
     }
     val w: u8 = lctx.op_width_of(ctx, inst.ty);
 
-    val skr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+    val skr: res[mir.VRegId, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
     if (sel skr.err) { ret err[fail.Fail].err{skr.err}; }
-    val sk: u32 = skr.ok;
+    val sk: mir.VRegId = skr.ok;
 
-    val ar: err[fail.Fail] = lctx.add_spill_slot_aligned(ctx, sk, w::u64, w::u32);
+    val ar: err[fail.Fail] = lctx.add_spill_slot_aligned(ctx, sk.n, w::u64, w::u32);
     if (sel ar.err) { ret ar; }
 
     val sr: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
@@ -1279,8 +1279,8 @@ fun lower_float_neg(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruc
     if (inst.operand_count < 1) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: float negate missing operand")};
     }
-    val dst: u32 = lctx.instr_vreg(ctx, iid);
-    if (dst == mir.MIR_VREG_NIL) {
+    val dst: mir.VRegId = lctx.instr_vreg(ctx, iid);
+    if (mir.vreg_is_nil(dst)) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: float negate defines no result vreg")};
     }
 
@@ -1317,16 +1317,16 @@ fun lower_alloca(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructio
     val elem_align: u32 = ir_type.byte_align_for_machine(ctx.types, inst.aux_ty, ctx.layout);
     val total: u64 = elem_size::u64 * count;
 
-    val dst: u32 = lctx.instr_vreg(ctx, iid);
-    if (dst == mir.MIR_VREG_NIL) {
+    val dst: mir.VRegId = lctx.instr_vreg(ctx, iid);
+    if (mir.vreg_is_nil(dst)) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: alloca defines no result vreg")};
     }
 
-    val skr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+    val skr: res[mir.VRegId, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
     if (sel skr.err) { ret err[fail.Fail].err{skr.err}; }
-    val sk: u32 = skr.ok;
+    val sk: mir.VRegId = skr.ok;
 
-    val ar: err[fail.Fail] = lctx.add_alloca_slot(ctx, sk, total, elem_align, inst.aux_ty::u32);
+    val ar: err[fail.Fail] = lctx.add_alloca_slot(ctx, sk.n, total, elem_align, inst.aux_ty::u32);
     if (sel ar.err) { ret ar; }
 
     if (ctx.slot_key_vregs != nil && iid::u32 < ctx.instr_count) {
@@ -1344,8 +1344,8 @@ fun lower_alloca(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instructio
 }
 
 fun lower_vec_extract(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
-    val dst: u32 = lctx.instr_vreg(ctx, iid);
-    if (dst == mir.MIR_VREG_NIL) {
+    val dst: mir.VRegId = lctx.instr_vreg(ctx, iid);
+    if (mir.vreg_is_nil(dst)) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: vector lane read defines no result vreg")};
     }
     if (inst.operands[1].kind != value.VAL_CONST_INT) {
@@ -1364,8 +1364,8 @@ fun lower_vec_extract(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instr
 }
 
 fun lower_vec_insert(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
-    val dst: u32 = lctx.instr_vreg(ctx, iid);
-    if (dst == mir.MIR_VREG_NIL) {
+    val dst: mir.VRegId = lctx.instr_vreg(ctx, iid);
+    if (mir.vreg_is_nil(dst)) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: vector lane write defines no result vreg")};
     }
     if (inst.operands[1].kind != value.VAL_CONST_INT) {
@@ -1385,8 +1385,8 @@ fun lower_vec_insert(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instru
 }
 
 fun lower_vec_build(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, iid: id.InstructionId) err[fail.Fail] {
-    val dst: u32 = lctx.instr_vreg(ctx, iid);
-    if (dst == mir.MIR_VREG_NIL) {
+    val dst: mir.VRegId = lctx.instr_vreg(ctx, iid);
+    if (mir.vreg_is_nil(dst)) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: vector build defines no result vreg")};
     }
     if (inst.operand_count == 0) {
@@ -1412,13 +1412,13 @@ fun lower_load(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction,
     if (inst.operand_count == 0) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: load with no pointer operand")};
     }
-    val dst: u32 = lctx.instr_vreg(ctx, iid);
-    if (dst == mir.MIR_VREG_NIL) {
+    val dst: mir.VRegId = lctx.instr_vreg(ctx, iid);
+    if (mir.vreg_is_nil(dst)) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: load defines no result vreg")};
     }
     var mem: mir.MirOperand = lctx.mem_operand_of(ctx, inst.operands[0]);
     if (ctx.tgt.model.flat_addressing && mem.kind == mir.MIR_OP_SYM && lctx.value_is_float(ctx, inst.ty)) {
-        var base: u32 = mir.MIR_VREG_NIL;
+        var base: mir.VRegId = mir.MIR_VREG_NIL;
         val ar: err[fail.Fail] = lctx.addr_to_vreg(ctx, mb, mem, ?base);
         if (sel ar.err) { ret ar; }
         mem = mir.op_mem_value(base, 0);
@@ -1447,14 +1447,14 @@ fun lower_store(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction
     }
     var stored: mir.MirOperand = lctx.lower_value(ctx, inst.operands[0]);
     if (stored.kind == mir.MIR_OP_SYM) {
-        var addr: u32 = mir.MIR_VREG_NIL;
+        var addr: mir.VRegId = mir.MIR_VREG_NIL;
         val ar: err[fail.Fail] = lctx.addr_to_vreg(ctx, mb, stored, ?addr);
         if (sel ar.err) { ret ar; }
         stored = mir.op_vreg(addr);
     }
     var dest: mir.MirOperand = lctx.mem_operand_of(ctx, inst.operands[1]);
     if (ctx.tgt.model.flat_addressing && dest.kind == mir.MIR_OP_SYM && lctx.value_is_float(ctx, inst.operands[0].ty)) {
-        var dbase: u32 = mir.MIR_VREG_NIL;
+        var dbase: mir.VRegId = mir.MIR_VREG_NIL;
         val dr: err[fail.Fail] = lctx.addr_to_vreg(ctx, mb, dest, ?dbase);
         if (sel dr.err) { ret dr; }
         dest = mir.op_mem_value(dbase, 0);
@@ -1513,8 +1513,8 @@ fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     if (inst.operand_count == 0) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: gep with no base operand")};
     }
-    val dst: u32 = lctx.instr_vreg(ctx, iid);
-    if (dst == mir.MIR_VREG_NIL) {
+    val dst: mir.VRegId = lctx.instr_vreg(ctx, iid);
+    if (mir.vreg_is_nil(dst)) {
         ret err[fail.Fail].err{fail.message("mir.lower_ir: gep defines no result vreg")};
     }
 
@@ -1529,7 +1529,7 @@ fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
     }
 
     var disp:      i64 = 0;
-    var idx_vreg:  u32 = mir.MIR_VREG_NIL;
+    var idx_vreg:  mir.VRegId = mir.MIR_VREG_NIL;
     var idx_scale: u8  = 0;
     var cur_ty:    ir_type.IrTypeId = inst.aux_ty;
 
@@ -1583,7 +1583,7 @@ fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
         }
 
         var new_scale: u8 = 0;
-        val ir: res[u32, fail.Fail] = fold_runtime_index(ctx, mb, lctx.lower_value(ctx, v), stride, idx_vreg, idx_scale, ?new_scale);
+        val ir: res[mir.VRegId, fail.Fail] = fold_runtime_index(ctx, mb, lctx.lower_value(ctx, v), stride, idx_vreg, idx_scale, ?new_scale);
         if (sel ir.err) { ret err[fail.Fail].err{ir.err}; }
         idx_vreg  = ir.ok;
         idx_scale = new_scale;
@@ -1604,7 +1604,7 @@ fun lower_gep(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction, 
 }
 
 fun lower_gep_structural(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.Instruction,
-                         dst: u32, base: mir.MirOperand) err[fail.Fail] {
+                         dst: mir.VRegId, base: mir.MirOperand) err[fail.Fail] {
     val n: usize = (inst.operand_count + 1)::usize;
     val r: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, n);
     if (sel r.err) { ret err[fail.Fail].err{fail.refused(r.err)}; }
@@ -1622,86 +1622,83 @@ fun lower_gep_structural(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, inst: *instr.In
 }
 
 fun fold_runtime_index(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, idxop: mir.MirOperand, stride: u64,
-                       acc: u32, acc_scale: u8, scale_out: *u8) res[u32, fail.Fail] {
+                       acc: mir.VRegId, acc_scale: u8, scale_out: *u8) res[mir.VRegId, fail.Fail] {
     if (idxop.kind != mir.MIR_OP_VREG) {
-        ret res[u32, fail.Fail].err{fail.message("mir.lower_ir: gep runtime index is not a register value")};
+        ret res[mir.VRegId, fail.Fail].err{fail.message("mir.lower_ir: gep runtime index is not a register value")};
     }
-    val idxv: u32 = idxop.vreg;
+    val idxv: mir.VRegId = idxop.vreg;
 
-    if (acc == mir.MIR_VREG_NIL && is_sib_scale(stride)) {
+    if (mir.vreg_is_nil(acc) && is_sib_scale(stride)) {
         @scale_out = stride::u8;
-        ret res[u32, fail.Fail].ok{idxv};
+        ret res[mir.VRegId, fail.Fail].ok{idxv};
     }
 
-    val tr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-    if (sel tr.err) { ret res[u32, fail.Fail].err{tr.err}; }
-    val t: u32 = tr.ok;
+    val tr: res[mir.VRegId, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel tr.err) { ret res[mir.VRegId, fail.Fail].err{tr.err}; }
+    val t: mir.VRegId = tr.ok;
     val mr: err[fail.Fail] = lctx.emit_bin(ctx, mb, mir.MIR_MUL, t, mir.op_vreg(idxv), mir.op_imm(stride::i64));
-    if (sel mr.err) { ret res[u32, fail.Fail].err{mr.err}; }
+    if (sel mr.err) { ret res[mir.VRegId, fail.Fail].err{mr.err}; }
 
-    if (acc == mir.MIR_VREG_NIL) {
+    if (mir.vreg_is_nil(acc)) {
         @scale_out = 1;
-        ret res[u32, fail.Fail].ok{t};
+        ret res[mir.VRegId, fail.Fail].ok{t};
     }
 
-    var acc_term: u32 = acc;
+    var acc_term: mir.VRegId = acc;
     if (acc_scale > 1) {
-        val sr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-        if (sel sr.err) { ret res[u32, fail.Fail].err{sr.err}; }
+        val sr: res[mir.VRegId, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+        if (sel sr.err) { ret res[mir.VRegId, fail.Fail].err{sr.err}; }
         acc_term = sr.ok;
         val smr: err[fail.Fail] = lctx.emit_bin(ctx, mb, mir.MIR_MUL, acc_term, mir.op_vreg(acc), mir.op_imm(acc_scale::i64));
-        if (sel smr.err) { ret res[u32, fail.Fail].err{smr.err}; }
+        if (sel smr.err) { ret res[mir.VRegId, fail.Fail].err{smr.err}; }
     }
-    val ar: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
-    if (sel ar.err) { ret res[u32, fail.Fail].err{ar.err}; }
-    val sum: u32 = ar.ok;
+    val ar: res[mir.VRegId, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+    if (sel ar.err) { ret res[mir.VRegId, fail.Fail].err{ar.err}; }
+    val sum: mir.VRegId = ar.ok;
     val adr: err[fail.Fail] = lctx.emit_bin(ctx, mb, mir.MIR_ADD, sum, mir.op_vreg(acc_term), mir.op_vreg(t));
-    if (sel adr.err) { ret res[u32, fail.Fail].err{adr.err}; }
+    if (sel adr.err) { ret res[mir.VRegId, fail.Fail].err{adr.err}; }
     @scale_out = 1;
-    ret res[u32, fail.Fail].ok{sum};
+    ret res[mir.VRegId, fail.Fail].ok{sum};
 }
 
 fun is_sib_scale(s: u64) bool {
     ret s == 1 || s == 2 || s == 4 || s == 8;
 }
 
-fun fold_gep_mem(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, base: mir.MirOperand, idx_vreg: u32, idx_scale: u8, disp: i64) res[mir.MirOperand, fail.Fail] {
+fun fold_gep_mem(ctx: *lctx.LowerCtx, mb: *mir.MirBlock, base: mir.MirOperand, idx_vreg: mir.VRegId, idx_scale: u8, disp: i64) res[mir.MirOperand, fail.Fail] {
     var o: mir.MirOperand = base;
     if (base.kind == mir.MIR_OP_IMM) {
-        val vr: res[u32, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
+        val vr: res[mir.VRegId, fail.Fail] = lctx.new_vreg(ctx, mir.REG_CLASS_GP);
         if (sel vr.err) { ret res[mir.MirOperand, fail.Fail].err{vr.err}; }
-        val vbase: u32 = vr.ok;
+        val vbase: mir.VRegId = vr.ok;
         val mv: err[fail.Fail] = lctx.emit_mov(ctx, mb, mir.op_vreg(vbase), mir.op_imm(base.imm));
         if (sel mv.err) { ret res[mir.MirOperand, fail.Fail].err{mv.err}; }
         var m: mir.MirOperand = mir.op_mem_value(vbase, disp);
-        if (idx_vreg != mir.MIR_VREG_NIL) {
-            m.index         = idx_vreg;
-            m.scale         = idx_scale;
-            m.index_is_preg = false;
+        if (!mir.vreg_is_nil(idx_vreg)) {
+            m.index = mir.index_vreg(idx_vreg);
+            m.scale = idx_scale;
         }
         ret res[mir.MirOperand, fail.Fail].ok{m};
     }
     if (base.kind == mir.MIR_OP_MEM) {
         o.imm = base.imm + disp;
-        if (idx_vreg != mir.MIR_VREG_NIL) {
-            o.index         = idx_vreg;
-            o.scale         = idx_scale;
-            o.index_is_preg = false;
+        if (!mir.vreg_is_nil(idx_vreg)) {
+            o.index = mir.index_vreg(idx_vreg);
+            o.scale = idx_scale;
         }
         ret res[mir.MirOperand, fail.Fail].ok{o};
     }
     if (base.kind == mir.MIR_OP_SYM) {
-        if (idx_vreg == mir.MIR_VREG_NIL) {
+        if (mir.vreg_is_nil(idx_vreg)) {
             o.sym_off = base.sym_off + disp::i32;
             ret res[mir.MirOperand, fail.Fail].ok{o};
         }
-        var sbase: u32 = mir.MIR_VREG_NIL;
+        var sbase: mir.VRegId = mir.MIR_VREG_NIL;
         val ar: err[fail.Fail] = lctx.addr_to_vreg(ctx, mb, base, ?sbase);
         if (sel ar.err) { ret res[mir.MirOperand, fail.Fail].err{ar.err}; }
         var m: mir.MirOperand = mir.op_mem_value(sbase, disp);
-        m.index         = idx_vreg;
-        m.scale         = idx_scale;
-        m.index_is_preg = false;
+        m.index = mir.index_vreg(idx_vreg);
+        m.scale = idx_scale;
         ret res[mir.MirOperand, fail.Fail].ok{m};
     }
     ret res[mir.MirOperand, fail.Fail].err{fail.message("mir.lower_ir: gep base is neither a memory nor a symbol reference")};
@@ -1865,7 +1862,7 @@ test "mach.lang.be.codegen.mir.lower:volatile_memory_flags_follow_each_ir_instru
     tgt.model.flat_addressing = true;
     tgt.model.pointer_width = 8;
     tgt.model.gpr_width = 8;
-    var parameters: [1]u32 = [1]u32{0};
+    var parameters: [1]mir.VRegId = [1]mir.VRegId{mir.vreg_id(0)};
     var operands: [1]value.Value;
     operands[0] = value.param(0, ty);
     var instructions: [2]instr.Instruction;

--- a/src/lang/be/codegen/notes.mach
+++ b/src/lang/be/codegen/notes.mach
@@ -59,7 +59,7 @@ pub val NOTE_SEED_MAX: u32 = 16;
 # the same instruction, so a set keyed by register cannot say which
 pub rec NoteSeeds {
     count:      u32;
-    origin:     [NOTE_SEED_MAX]u32;
+    origin:     [NOTE_SEED_MAX]mir.VRegId;
     secret:     [NOTE_SEED_MAX]bool;
     # a writes_secret load: operand 0 is secret by declaration
     dst_secret: bool;
@@ -85,8 +85,8 @@ pub fun note_seeds(f: *mir.MirFunction, n: *AsmNote, out: *NoteSeeds) {
         # a dropped self-copy: the downgraded vreg names its own carrier
         out.count     = 1;
         out.origin[0] = mi.declassified;
-        out.secret[0] = mi.declassified != mir.MIR_VREG_NIL && mi.declassified < f.vreg_count
-                        && f.vregs[mi.declassified].secret;
+        out.secret[0] = !mir.vreg_is_nil(mi.declassified) && mi.declassified.n < f.vreg_count
+                        && f.vregs[mi.declassified.n].secret;
         ret;
     }
     val defines: bool = mi.operand_count > 0 && mir.instr_defines_shape(mi);
@@ -115,8 +115,8 @@ test "mach.lang.be.codegen.notes.note_seeds:declared_destination_slot_key_and_no
     f.vreg_count = 2;
 
     var ops: [2]mir.MirOperand;
-    ops[0] = mir.op_preg_of(3, 0);
-    ops[1] = mir.op_mem_preg(5, 16);
+    ops[0] = mir.op_preg_of(mir.preg_id(3), mir.vreg_id(0));
+    ops[1] = mir.op_mem_preg(mir.preg_id(5), 16);
     var load: mir.MirInstr = mir.instr(mir.MIR_LOAD, ?ops[0], 2, 8, 8);
     load.writes_secret = true;
     var n: AsmNote = note_blank();
@@ -124,8 +124,8 @@ test "mach.lang.be.codegen.notes.note_seeds:declared_destination_slot_key_and_no
     var seeds: NoteSeeds;
     note_seeds(?f, ?n, ?seeds);
     if (seeds.count != 2 || !seeds.dst_secret || seeds.barrier) { ret 1; }
-    if (seeds.origin[0] != 0 || !seeds.secret[0])               { ret 2; }
-    if (seeds.origin[1] != mir.MIR_VREG_NIL || seeds.secret[1]) { ret 3; }
+    if (seeds.origin[0].n != 0 || !seeds.secret[0])               { ret 2; }
+    if (!mir.vreg_is_nil(seeds.origin[1]) || seeds.secret[1]) { ret 3; }
 
     # without the declaration a public origin stays public
     load.writes_secret = false;
@@ -133,22 +133,22 @@ test "mach.lang.be.codegen.notes.note_seeds:declared_destination_slot_key_and_no
     if (seeds.dst_secret || seeds.secret[0]) { ret 4; }
 
     var sops: [2]mir.MirOperand;
-    sops[0] = mir.op_mem_slot(1, 0);
-    sops[1] = mir.op_preg(9);
+    sops[0] = mir.op_mem_slot(mir.vreg_id(1), 0);
+    sops[1] = mir.op_preg(mir.preg_id(9));
     var store: mir.MirInstr = mir.instr(mir.MIR_MOV, ?sops[0], 2, 8, 8);
     n.mi = ?store;
     note_seeds(?f, ?n, ?seeds);
     if (seeds.count != 2 || seeds.dst_secret)                   { ret 5; }
-    if (seeds.origin[0] != 1 || !seeds.secret[0])               { ret 6; }
-    if (seeds.origin[1] != mir.MIR_VREG_NIL || seeds.secret[1]) { ret 7; }
+    if (seeds.origin[0].n != 1 || !seeds.secret[0])               { ret 6; }
+    if (!mir.vreg_is_nil(seeds.origin[1]) || seeds.secret[1]) { ret 7; }
 
     var iops: [2]mir.MirOperand;
-    iops[0] = mir.op_preg_of(3, 1);
+    iops[0] = mir.op_preg_of(mir.preg_id(3), mir.vreg_id(1));
     iops[1] = mir.op_imm(4);
     var mov: mir.MirInstr = mir.instr(mir.MIR_MOV, ?iops[0], 2, 8, 8);
     n.mi = ?mov;
     note_seeds(?f, ?n, ?seeds);
-    if (seeds.count != 2 || seeds.origin[0] != 1 || !seeds.secret[0] || seeds.origin[1] != mir.MIR_VREG_NIL) { ret 8; }
+    if (seeds.count != 2 || seeds.origin[0].n != 1 || !seeds.secret[0] || !mir.vreg_is_nil(seeds.origin[1])) { ret 8; }
 
     n.mi = nil;
     note_seeds(?f, ?n, ?seeds);

--- a/src/lang/be/codegen/regalloc.mach
+++ b/src/lang/be/codegen/regalloc.mach
@@ -391,10 +391,10 @@ fun ctx_init(ctx: *AllocCtx, tgt: *target.Target, m: *mir.MirModule, f: *mir.Mir
     ctx.hints = rh.ok;
     var hi: u32 = 0;
     for (hi < f.vreg_count) {
-        ctx.hints[hi].src_vreg     = mir.MIR_VREG_NIL;
+        ctx.hints[hi].src_vreg     = mir.MIR_VREG_NIL.n;
         ctx.hints[hi].src_preg     = -1;
         ctx.hints[hi].copy_pos     = -1;
-        ctx.hints[hi].dst_vreg     = mir.MIR_VREG_NIL;
+        ctx.hints[hi].dst_vreg     = mir.MIR_VREG_NIL.n;
         ctx.hints[hi].dst_copy_pos = -1;
         ctx.hints[hi].sink_preg    = -1;
         hi = hi + 1;
@@ -807,11 +807,11 @@ fun flat_instr(ctx: *AllocCtx, pos: u32) *mir.MirInstr {
     ret ?ctx.f.blocks[fi.block].instrs[fi.instr];
 }
 
-fun touch(ctx: *AllocCtx, v: u32, pos: u32) {
-    if (v >= ctx.f.vreg_count) {
+fun touch(ctx: *AllocCtx, v: mir.VRegId, pos: u32) {
+    if (v.n >= ctx.f.vreg_count) {
         panic("regalloc: out-of-range vreg id in a MIR operand\n");
     }
-    val lr: *LiveRange = ?ctx.ranges[v];
+    val lr: *LiveRange = ?ctx.ranges[v.n];
     if (pos::i64 < lr.start)   { lr.start = pos::i64; }
     if (pos::i64 > lr.end_pos) { lr.end_pos = pos::i64; }
     lr.use_count = lr.use_count + 1;
@@ -826,11 +826,11 @@ fun build_ranges(ctx: *AllocCtx) {
             val op: *mir.MirOperand = ?mi.operands[k];
             if (op.kind == mir.MIR_OP_VREG) {
                 touch(ctx, op.vreg, pos);
-            } or (op.kind == mir.MIR_OP_MEM && op.vreg != mir.MIR_VREG_NIL) {
+            } or (op.kind == mir.MIR_OP_MEM && !mir.vreg_is_nil(op.vreg)) {
                 touch(ctx, op.vreg, pos);
             }
-            if (op.kind == mir.MIR_OP_MEM && !op.index_is_preg && op.index != mir.MIR_VREG_NIL) {
-                touch(ctx, op.index, pos);
+            if (sel op.index.vreg) {
+                touch(ctx, op.index.vreg, pos);
             }
             k = k + 1;
         }
@@ -869,12 +869,12 @@ fun tally_reads(ctx: *AllocCtx, reads: *u32, nv: u32) {
                 val op: *mir.MirOperand = ?mi.operands[k];
                 if (op.kind == mir.MIR_OP_VREG) {
                     val is_dst: bool = has_def && k == 0;
-                    if (!is_dst && op.vreg < nv) { reads[op.vreg] = reads[op.vreg] + 1; }
-                } or (op.kind == mir.MIR_OP_MEM && op.vreg != mir.MIR_VREG_NIL && op.vreg < nv) {
-                    reads[op.vreg] = reads[op.vreg] + 1;
+                    if (!is_dst && op.vreg.n < nv) { reads[op.vreg.n] = reads[op.vreg.n] + 1; }
+                } or (op.kind == mir.MIR_OP_MEM && !mir.vreg_is_nil(op.vreg) && op.vreg.n < nv) {
+                    reads[op.vreg.n] = reads[op.vreg.n] + 1;
                 }
-                if (op.kind == mir.MIR_OP_MEM && !op.index_is_preg && op.index != mir.MIR_VREG_NIL && op.index < nv) {
-                    reads[op.index] = reads[op.index] + 1;
+                if (sel op.index.vreg) {
+                    if (op.index.vreg.n < nv) { reads[op.index.vreg.n] = reads[op.index.vreg.n] + 1; }
                 }
                 k = k + 1;
             }
@@ -888,9 +888,9 @@ fun is_dead_mov(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr, reads: *
     if (!instr_is_reg_copy(tgt, mi)) { ret false; }
     val d: *mir.MirOperand = ?mi.operands[0];
     if (d.kind != mir.MIR_OP_VREG) { ret false; }
-    if (d.vreg >= nv)              { ret false; }
+    if (d.vreg.n >= nv)             { ret false; }
     if (vreg_has_slot(ctx, d.vreg)) { ret false; }
-    ret reads[d.vreg] == 0;
+    ret reads[d.vreg.n] == 0;
 }
 
 fun sweep_dead_movs(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
@@ -940,18 +940,18 @@ fun sweep_dead_movs(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
     ret err[fail.Fail].ok{};
 }
 
-fun instr_reads_vreg(mi: *mir.MirInstr, v: u32) bool {
+fun instr_reads_vreg(mi: *mir.MirInstr, v: mir.VRegId) bool {
     val has_def: bool = instr_defines(mi);
     var k: u32 = 0;
     for (k < mi.operand_count) {
         val op: *mir.MirOperand = ?mi.operands[k];
         if (op.kind == mir.MIR_OP_VREG) {
             val is_dst: bool = has_def && k == 0;
-            if (!is_dst && op.vreg == v) { ret true; }
+            if (!is_dst && mir.vreg_same(op.vreg, v)) { ret true; }
         }
         if (op.kind == mir.MIR_OP_MEM) {
-            if (op.vreg != mir.MIR_VREG_NIL && op.vreg == v)                        { ret true; }
-            if (!op.index_is_preg && op.index != mir.MIR_VREG_NIL && op.index == v) { ret true; }
+            if (!mir.vreg_is_nil(op.vreg) && mir.vreg_same(op.vreg, v))   { ret true; }
+            if (sel op.index.vreg) { if (mir.vreg_same(op.index.vreg, v)) { ret true; } }
         }
         k = k + 1;
     }
@@ -980,7 +980,7 @@ fun tally_defs(ctx: *AllocCtx, defs: *u32, nv: u32) {
             val mi: *mir.MirInstr = ?blk.instrs[ii];
             if (instr_defines(mi)) {
                 val d: *mir.MirOperand = ?mi.operands[0];
-                if (d.vreg < nv) { defs[d.vreg] = defs[d.vreg] + 1; }
+                if (d.vreg.n < nv) { defs[d.vreg.n] = defs[d.vreg.n] + 1; }
             }
             ii = ii + 1;
         }
@@ -995,10 +995,10 @@ fun try_coalesce(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
     val dop: *mir.MirOperand = ?mi.operands[0];
     val sop: *mir.MirOperand = ?mi.operands[1];
     if (dop.kind != mir.MIR_OP_VREG || sop.kind != mir.MIR_OP_VREG) { ret false; }
-    val d: u32 = dop.vreg;
-    val s: u32 = sop.vreg;
+    val d: u32 = dop.vreg.n;
+    val s: u32 = sop.vreg.n;
     if (d >= nv || s >= nv || d == s)                { ret false; }
-    if (vreg_has_slot(ctx, d) || vreg_has_slot(ctx, s)) { ret false; }
+    if (vreg_has_slot(ctx, dop.vreg) || vreg_has_slot(ctx, sop.vreg)) { ret false; }
 
     val dv: *mir.MirVReg = ?ctx.f.vregs[d];
     val sv: *mir.MirVReg = ?ctx.f.vregs[s];
@@ -1027,23 +1027,23 @@ fun rename_vregs(ctx: *AllocCtx, parent: *u32, nv: u32) {
             var k: u32 = 0;
             for (k < mi.operand_count) {
                 val op: *mir.MirOperand = ?mi.operands[k];
-                if (op.kind == mir.MIR_OP_VREG && op.vreg < nv) {
-                    op.vreg = web_find(parent, op.vreg);
+                if (op.kind == mir.MIR_OP_VREG && op.vreg.n < nv) {
+                    op.vreg = mir.vreg_id(web_find(parent, op.vreg.n));
                 } or (op.kind == mir.MIR_OP_MEM) {
-                    if (op.vreg != mir.MIR_VREG_NIL && op.vreg < nv) {
-                        op.vreg = web_find(parent, op.vreg);
+                    if (!mir.vreg_is_nil(op.vreg) && op.vreg.n < nv) {
+                        op.vreg = mir.vreg_id(web_find(parent, op.vreg.n));
                     }
-                    if (!op.index_is_preg && op.index != mir.MIR_VREG_NIL && op.index < nv) {
-                        op.index = web_find(parent, op.index);
-                    }
+                    var ix: u32 = nv;
+                    if (sel op.index.vreg) { ix = op.index.vreg.n; }
+                    if (ix < nv) { op.index = mir.index_vreg(mir.vreg_id(web_find(parent, ix))); }
                 }
                 k = k + 1;
             }
             var b: u32 = 0;
             for (b < mi.dbg_binding_count) {
                 val db: *mir.MirDbgBinding = ?mi.dbg_bindings[b];
-                if (db.vreg  != mir.MIR_VREG_NIL && db.vreg  < nv) { db.vreg  = web_find(parent, db.vreg); }
-                if (db.vreg2 != mir.MIR_VREG_NIL && db.vreg2 < nv) { db.vreg2 = web_find(parent, db.vreg2); }
+                if (db.vreg  != mir.MIR_VREG_NIL.n && db.vreg  < nv) { db.vreg  = web_find(parent, db.vreg); }
+                if (db.vreg2 != mir.MIR_VREG_NIL.n && db.vreg2 < nv) { db.vreg2 = web_find(parent, db.vreg2); }
                 b = b + 1;
             }
             ii = ii + 1;
@@ -1065,7 +1065,7 @@ fun drop_self_copies(tgt: *target.Target, ctx: *AllocCtx) {
             if (instr_is_reg_copy(tgt, mi)) {
                 val a: *mir.MirOperand = ?mi.operands[0];
                 val b: *mir.MirOperand = ?mi.operands[1];
-                drop = a.kind == mir.MIR_OP_VREG && b.kind == mir.MIR_OP_VREG && a.vreg == b.vreg;
+                drop = a.kind == mir.MIR_OP_VREG && b.kind == mir.MIR_OP_VREG && mir.vreg_same(a.vreg, b.vreg);
             }
             if (drop && mir.instr_declassifies(mi)) {
                 val marker: mir.MirInstr = mir.declassify_marker(mi, mi.operands[0].vreg);
@@ -1135,7 +1135,7 @@ fun coalesce_copies(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
 fun reads_in_window(ctx: *AllocCtx, d: u32, from: i64, to: i64) bool {
     var p: i64 = from + 1;
     for (p < to) {
-        if (instr_reads_vreg(flat_instr(ctx, p::u32), d)) { ret true; }
+        if (instr_reads_vreg(flat_instr(ctx, p::u32), mir.vreg_id(d))) { ret true; }
         p = p + 1;
     }
     ret false;
@@ -1149,16 +1149,16 @@ fun build_hints(tgt: *target.Target, ctx: *AllocCtx) {
         val mi: *mir.MirInstr = flat_instr(ctx, pos);
         if (instr_is_reg_copy(tgt, mi)) {
             val d: *mir.MirOperand = ?mi.operands[0];
-            if (d.kind == mir.MIR_OP_VREG && d.vreg < nv
-                && ctx.hints[d.vreg].src_vreg == mir.MIR_VREG_NIL
-                && ctx.hints[d.vreg].src_preg < 0) {
+            if (d.kind == mir.MIR_OP_VREG && d.vreg.n < nv
+                && ctx.hints[d.vreg.n].src_vreg == mir.MIR_VREG_NIL.n
+                && ctx.hints[d.vreg.n].src_preg < 0) {
                 val s: *mir.MirOperand = ?mi.operands[1];
-                if (s.kind == mir.MIR_OP_VREG && s.vreg != d.vreg) {
-                    ctx.hints[d.vreg].src_vreg = s.vreg;
-                    ctx.hints[d.vreg].copy_pos = pos::i64;
+                if (s.kind == mir.MIR_OP_VREG && !mir.vreg_same(s.vreg, d.vreg)) {
+                    ctx.hints[d.vreg.n].src_vreg = s.vreg.n;
+                    ctx.hints[d.vreg.n].copy_pos = pos::i64;
                 } or (s.kind == mir.MIR_OP_PREG) {
-                    ctx.hints[d.vreg].src_preg = s.preg::i32;
-                    ctx.hints[d.vreg].copy_pos = pos::i64;
+                    ctx.hints[d.vreg.n].src_preg = mir.preg_regid(s.preg);
+                    ctx.hints[d.vreg.n].copy_pos = pos::i64;
                 }
             }
             maybe_sink_hint(ctx, mi, pos, nv);
@@ -1180,35 +1180,35 @@ fun maybe_tie_hint(ctx: *AllocCtx, mi: *mir.MirInstr, pos: u32, nv: u32) {
     val d: *mir.MirOperand = ?mi.operands[0];
     val l: *mir.MirOperand = ?mi.operands[1];
     if (d.kind != mir.MIR_OP_VREG || l.kind != mir.MIR_OP_VREG) { ret; }
-    if (d.vreg >= nv || l.vreg >= nv || d.vreg == l.vreg)       { ret; }
-    if (ctx.hints[d.vreg].src_vreg != mir.MIR_VREG_NIL
-        || ctx.hints[d.vreg].src_preg >= 0)                     { ret; }
-    if (ctx.ranges[l.vreg].end_pos != pos::i64)                 { ret; }
-    if (ctx.ranges[d.vreg].start != pos::i64)                   { ret; }
-    ctx.hints[d.vreg].src_vreg = l.vreg;
-    ctx.hints[d.vreg].copy_pos = pos::i64;
+    if (d.vreg.n >= nv || l.vreg.n >= nv || mir.vreg_same(d.vreg, l.vreg)) { ret; }
+    if (ctx.hints[d.vreg.n].src_vreg != mir.MIR_VREG_NIL.n
+        || ctx.hints[d.vreg.n].src_preg >= 0)                   { ret; }
+    if (ctx.ranges[l.vreg.n].end_pos != pos::i64)               { ret; }
+    if (ctx.ranges[d.vreg.n].start != pos::i64)                 { ret; }
+    ctx.hints[d.vreg.n].src_vreg = l.vreg.n;
+    ctx.hints[d.vreg.n].copy_pos = pos::i64;
 }
 
 fun maybe_sink_hint(ctx: *AllocCtx, mi: *mir.MirInstr, pos: u32, nv: u32) {
     val d: *mir.MirOperand = ?mi.operands[0];
     val s: *mir.MirOperand = ?mi.operands[1];
     if (d.kind != mir.MIR_OP_PREG || s.kind != mir.MIR_OP_VREG) { ret; }
-    if (s.vreg >= nv)                                           { ret; }
+    if (s.vreg.n >= nv)                                         { ret; }
     if (mi.width < ctx.spill_width)                             { ret; }
-    val sv: u32 = s.vreg;
+    val sv: u32 = s.vreg.n;
     if (ctx.hints[sv].sink_preg >= 0)                           { ret; }
     if (ctx.ranges[sv].end_pos != pos::i64)                     { ret; }
-    ctx.hints[sv].sink_preg = d.preg::i32;
+    ctx.hints[sv].sink_preg = mir.preg_regid(d.preg);
 }
 
 fun maybe_reverse_hint(ctx: *AllocCtx, mi: *mir.MirInstr, pos: u32, nv: u32) {
     val d: *mir.MirOperand = ?mi.operands[0];
     val s: *mir.MirOperand = ?mi.operands[1];
     if (d.kind != mir.MIR_OP_VREG || s.kind != mir.MIR_OP_VREG) { ret; }
-    if (d.vreg >= nv || s.vreg >= nv || d.vreg == s.vreg)       { ret; }
-    val dv: u32 = d.vreg;
-    val sv: u32 = s.vreg;
-    if (ctx.hints[sv].dst_vreg != mir.MIR_VREG_NIL) { ret; }
+    if (d.vreg.n >= nv || s.vreg.n >= nv || mir.vreg_same(d.vreg, s.vreg)) { ret; }
+    val dv: u32 = d.vreg.n;
+    val sv: u32 = s.vreg.n;
+    if (ctx.hints[sv].dst_vreg != mir.MIR_VREG_NIL.n) { ret; }
 
     val p: i64 = pos::i64;
     val dr: *LiveRange = ?ctx.ranges[dv];
@@ -1354,12 +1354,12 @@ fun collect_references(ctx: *AllocCtx, l: *LiveScratch) {
                 val op: *mir.MirOperand = ?mi.operands[k];
                 if (op.kind == mir.MIR_OP_VREG || op.kind == mir.MIR_OP_MEM) {
                     val is_dst: bool = has_def && k == 0 && op.kind == mir.MIR_OP_VREG;
-                    if (!is_dst) { note_use(l, op.vreg, bi); }
+                    if (!is_dst) { note_use(l, op.vreg.n, bi); }
                 }
-                if (op.kind == mir.MIR_OP_MEM && !op.index_is_preg) { note_use(l, op.index, bi); }
+                if (sel op.index.vreg) { note_use(l, op.index.vreg.n, bi); }
                 k = k + 1;
             }
-            if (has_def) { note_def(l, mi.operands[0].vreg, bi); }
+            if (has_def) { note_def(l, mi.operands[0].vreg.n, bi); }
             ii = ii + 1;
         }
         bi = bi + 1;
@@ -1565,9 +1565,10 @@ fun linear_scan(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
     var oi: u32 = 0;
     for (oi < nv) {
         val v: u32 = order[oi];
+        val vid: mir.VRegId = mir.vreg_id(v);
         val lr: *LiveRange = ?ctx.ranges[v];
         if (lr.end_pos < 0) { oi = oi + 1; cnt; }
-        if (vreg_has_slot(ctx, v)) { oi = oi + 1; cnt; }
+        if (vreg_has_slot(ctx, vid)) { oi = oi + 1; cnt; }
 
         expire_active(ctx, lr.start);
         release_pins(ctx, lr.start);
@@ -1576,16 +1577,16 @@ fun linear_scan(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
         ctx.cur_end   = lr.end_pos;
 
         var preg: i32 = -1;
-        if (ctx.hints[v].src_vreg != mir.MIR_VREG_NIL || ctx.hints[v].src_preg >= 0) {
-            preg = pick_hint(ctx, v, lr);
+        if (ctx.hints[v].src_vreg != mir.MIR_VREG_NIL.n || ctx.hints[v].src_preg >= 0) {
+            preg = pick_hint(ctx, vid, lr);
         }
         if (preg < 0 && ctx.hints[v].sink_preg >= 0) {
-            preg = pick_sink_hint(ctx, v, lr);
+            preg = pick_sink_hint(ctx, vid, lr);
         }
-        if (preg < 0 && ctx.hints[v].dst_vreg != mir.MIR_VREG_NIL) {
-            val rr: i32 = pick_target_hint(ctx, v, lr);
+        if (preg < 0 && ctx.hints[v].dst_vreg != mir.MIR_VREG_NIL.n) {
+            val rr: i32 = pick_target_hint(ctx, vid, lr);
             if (rr >= 0) {
-                ctx.f.vregs[v].assigned = rr::u32;
+                ctx.f.vregs[v].assigned = mir.preg_id(rr);
                 val dv: u32 = ctx.hints[v].dst_vreg;
                 if (ctx.hints[v].dst_copy_pos > ctx.anchor_until[dv]) {
                     ctx.anchor_until[dv] = ctx.hints[v].dst_copy_pos;
@@ -1603,9 +1604,9 @@ fun linear_scan(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
         }
 
         if (preg >= 0) {
-            assign(ctx, v, preg::u32, lr.reg_class);
+            assign(ctx, vid, mir.preg_id(preg), lr.reg_class);
         } or {
-            val sr: err[fail.Fail] = spill_on_pressure(ctx, v);
+            val sr: err[fail.Fail] = spill_on_pressure(ctx, vid);
             if (sel sr.err) { A.deallocate[u32](ctx.alloc, order, nv::usize); ret sr; }
         }
         oi = oi + 1;
@@ -1627,7 +1628,7 @@ fun reserve_param_registers(ctx: *AllocCtx) {
             val d: *mir.MirOperand = ?mi.operands[0];
             val s: *mir.MirOperand = ?mi.operands[1];
             if ((d.kind == mir.MIR_OP_VREG || d.kind == mir.MIR_OP_MEM) && s.kind == mir.MIR_OP_PREG) {
-                val r: u32 = s.preg;
+                val r: u32 = s.preg.n;
                 if (isa.regid_class(r::i32) == isa.REG_CLASS_ID_GP) {
                     if (r < ctx.gp_count && pos::i64 > ctx.pinned_end[r]) {
                         ctx.pinned_end[r]    = pos::i64;
@@ -1672,7 +1673,7 @@ fun build_arg_reservations(ctx: *AllocCtx) err[fail.Fail] {
         val mi: *mir.MirInstr = flat_instr(ctx, pos);
         if (!instr_defines_preg(mi)) { pos = pos + 1; cnt; }
         val d: *mir.MirOperand = ?mi.operands[0];
-        val r: u32 = d.preg;
+        val r: u32 = d.preg.n;
 
         ctx.def_res_reg[ctx.def_res_count] = r;
         ctx.def_res_pos[ctx.def_res_count] = pos::i64;
@@ -1686,7 +1687,7 @@ fun build_arg_reservations(ctx: *AllocCtx) err[fail.Fail] {
                 found = true;
             } or {
                 val mj: *mir.MirInstr = flat_instr(ctx, c);
-                if (instr_defines_preg(mj) && mj.operands[0].preg == r) { killed = true; }
+                if (instr_defines_preg(mj) && mj.operands[0].preg.n == r) { killed = true; }
                 c = c + 1;
             }
         }
@@ -1772,9 +1773,9 @@ fun build_vreg_slot_flags(ctx: *AllocCtx) err[fail.Fail] {
     ret err[fail.Fail].ok{};
 }
 
-fun vreg_has_slot(ctx: *AllocCtx, v: u32) bool {
-    if (v >= ctx.f.vreg_count) { ret false; }
-    ret ctx.vreg_slot_flag[v];
+fun vreg_has_slot(ctx: *AllocCtx, v: mir.VRegId) bool {
+    if (v.n >= ctx.f.vreg_count) { ret false; }
+    ret ctx.vreg_slot_flag[v.n];
 }
 
 rec RangeKey {
@@ -1825,18 +1826,18 @@ fun expire_active(ctx: *AllocCtx, current_start: i64) {
             ctx.active[write] = v;
             write = write + 1;
         } or {
-            free_assigned(ctx, v);
+            free_assigned(ctx, mir.vreg_id(v));
         }
         read = read + 1;
     }
     ctx.active_count = write;
 }
 
-fun free_assigned(ctx: *AllocCtx, v: u32) {
-    val mv: *mir.MirVReg = ?ctx.f.vregs[v];
-    if (mv.assigned == mir.MIR_VREG_NIL) { ret; }
-    val lr: *LiveRange = ?ctx.ranges[v];
-    val index: u32 = isa.regid_index(mv.assigned::i32)::u32;
+fun free_assigned(ctx: *AllocCtx, v: mir.VRegId) {
+    val mv: *mir.MirVReg = ?ctx.f.vregs[v.n];
+    if (mir.preg_is_nil(mv.assigned)) { ret; }
+    val lr: *LiveRange = ?ctx.ranges[v.n];
+    val index: u32 = isa.regid_index(mir.preg_regid(mv.assigned))::u32;
     if (lr.reg_class == REG_CLASS_GP) {
         if (index < ctx.gp_count) { ctx.gp_busy[index] = false; }
     } or {
@@ -1844,17 +1845,17 @@ fun free_assigned(ctx: *AllocCtx, v: u32) {
     }
 }
 
-fun pick_hint(ctx: *AllocCtx, v: u32, lr: *LiveRange) i32 {
-    val h: *CopyHint = ?ctx.hints[v];
+fun pick_hint(ctx: *AllocCtx, v: mir.VRegId, lr: *LiveRange) i32 {
+    val h: *CopyHint = ?ctx.hints[v.n];
 
     var rid: i32 = -1;
     if (h.src_preg >= 0) {
         rid = h.src_preg;
-    } or (h.src_vreg != mir.MIR_VREG_NIL) {
-        val s: u32 = h.src_vreg;
-        if (s < ctx.f.vreg_count && !is_spilled(ctx, s) && !vreg_has_slot(ctx, s)) {
-            val a: u32 = ctx.f.vregs[s].assigned;
-            if (a != mir.MIR_VREG_NIL) { rid = a::i32; }
+    } or (h.src_vreg != mir.MIR_VREG_NIL.n) {
+        val s: mir.VRegId = mir.vreg_id(h.src_vreg);
+        if (s.n < ctx.f.vreg_count && !is_spilled(ctx, s) && !vreg_has_slot(ctx, s)) {
+            val a: mir.PRegId = ctx.f.vregs[s.n].assigned;
+            if (!mir.preg_is_nil(a)) { rid = mir.preg_regid(a); }
         }
     }
     if (rid < 0) { ret -1; }
@@ -1875,7 +1876,7 @@ fun pick_hint(ctx: *AllocCtx, v: u32, lr: *LiveRange) i32 {
             ret rid;
         }
         if (can_transfer(ctx, lr, h)) {
-            transfer_source_reg(ctx, h.src_vreg, rid::u32);
+            transfer_source_reg(ctx, mir.vreg_id(h.src_vreg), mir.preg_id(rid));
             ret rid;
         }
         ret -1;
@@ -1891,7 +1892,7 @@ fun pick_hint(ctx: *AllocCtx, v: u32, lr: *LiveRange) i32 {
             ret rid;
         }
         if (can_transfer(ctx, lr, h)) {
-            transfer_source_reg(ctx, h.src_vreg, rid::u32);
+            transfer_source_reg(ctx, mir.vreg_id(h.src_vreg), mir.preg_id(rid));
             ret rid;
         }
         ret -1;
@@ -1899,22 +1900,22 @@ fun pick_hint(ctx: *AllocCtx, v: u32, lr: *LiveRange) i32 {
 }
 
 fun can_transfer(ctx: *AllocCtx, lr: *LiveRange, h: *CopyHint) bool {
-    if (h.src_vreg == mir.MIR_VREG_NIL) { ret false; }
+    if (h.src_vreg == mir.MIR_VREG_NIL.n) { ret false; }
     if (h.copy_pos < 0)                 { ret false; }
     if (ctx.ranges[h.src_vreg].end_pos != h.copy_pos) { ret false; }
     if (lr.start != h.copy_pos)                       { ret false; }
     ret true;
 }
 
-fun transfer_source_reg(ctx: *AllocCtx, src: u32, rid: u32) {
-    if (!vreg_in_active(ctx, src) || ctx.f.vregs[src].assigned != rid) {
+fun transfer_source_reg(ctx: *AllocCtx, src: mir.VRegId, rid: mir.PRegId) {
+    if (!vreg_in_active(ctx, src) || !mir.preg_same(ctx.f.vregs[src.n].assigned, rid)) {
         panic("regalloc: copy-hint transfer source is not the live owner of its register\n");
     }
     remove_active(ctx, src);
 }
 
-fun pick_sink_hint(ctx: *AllocCtx, v: u32, lr: *LiveRange) i32 {
-    val rid: i32 = ctx.hints[v].sink_preg;
+fun pick_sink_hint(ctx: *AllocCtx, v: mir.VRegId, lr: *LiveRange) i32 {
+    val rid: i32 = ctx.hints[v.n].sink_preg;
     if (rid < 0) { ret -1; }
 
     val rclass: i32 = isa.regid_class(rid);
@@ -1938,14 +1939,14 @@ fun pick_sink_hint(ctx: *AllocCtx, v: u32, lr: *LiveRange) i32 {
     }
 }
 
-fun pick_target_hint(ctx: *AllocCtx, v: u32, lr: *LiveRange) i32 {
-    val d: u32 = ctx.hints[v].dst_vreg;
-    if (d >= ctx.f.vreg_count)                       { ret -1; }
+fun pick_target_hint(ctx: *AllocCtx, v: mir.VRegId, lr: *LiveRange) i32 {
+    val d: mir.VRegId = mir.vreg_id(ctx.hints[v.n].dst_vreg);
+    if (d.n >= ctx.f.vreg_count)                     { ret -1; }
     if (is_spilled(ctx, d) || vreg_has_slot(ctx, d)) { ret -1; }
-    val a: u32 = ctx.f.vregs[d].assigned;
-    if (a == mir.MIR_VREG_NIL)                       { ret -1; }
+    val a: mir.PRegId = ctx.f.vregs[d.n].assigned;
+    if (mir.preg_is_nil(a))                          { ret -1; }
 
-    val rid: i32 = a::i32;
+    val rid: i32 = mir.preg_regid(a);
     val rclass: i32 = isa.regid_class(rid);
     val idx: u32 = isa.regid_index(rid)::u32;
     if (lr.reg_class == REG_CLASS_GP) {
@@ -1956,10 +1957,10 @@ fun pick_target_hint(ctx: *AllocCtx, v: u32, lr: *LiveRange) i32 {
     ret rid;
 }
 
-fun vreg_in_active(ctx: *AllocCtx, v: u32) bool {
+fun vreg_in_active(ctx: *AllocCtx, v: mir.VRegId) bool {
     var i: u32 = 0;
     for (i < ctx.active_count) {
-        if (ctx.active[i] == v) { ret true; }
+        if (ctx.active[i] == v.n) { ret true; }
         i = i + 1;
     }
     ret false;
@@ -2057,8 +2058,8 @@ fun pick_fp(ctx: *AllocCtx, crosses_call: bool) i32 {
     ret -1;
 }
 
-fun assign(ctx: *AllocCtx, v: u32, preg: u32, reg_class: u32) {
-    val preg_class: i32 = isa.regid_class(preg::i32);
+fun assign(ctx: *AllocCtx, v: mir.VRegId, preg: mir.PRegId, reg_class: u32) {
+    val preg_class: i32 = isa.regid_class(mir.preg_regid(preg));
     if (reg_class == REG_CLASS_GP) {
         if (preg_class != isa.REG_CLASS_ID_GP) {
             panic("regalloc: GP vreg assigned a non-GP register\n");
@@ -2068,24 +2069,24 @@ fun assign(ctx: *AllocCtx, v: u32, preg: u32, reg_class: u32) {
             panic("regalloc: float vreg assigned a non-XMM register\n");
         }
     }
-    ctx.f.vregs[v].assigned = preg;
-    ctx.active[ctx.active_count] = v;
+    ctx.f.vregs[v.n].assigned = preg;
+    ctx.active[ctx.active_count] = v.n;
     ctx.active_count = ctx.active_count + 1;
 }
 
-fun spill_on_pressure(ctx: *AllocCtx, v: u32) err[fail.Fail] {
-    val lr: *LiveRange = ?ctx.ranges[v];
-    val victim: u32 = find_spill_victim(ctx, lr.reg_class);
-    if (victim == mir.MIR_VREG_NIL) {
+fun spill_on_pressure(ctx: *AllocCtx, v: mir.VRegId) err[fail.Fail] {
+    val lr: *LiveRange = ?ctx.ranges[v.n];
+    val victim: mir.VRegId = find_spill_victim(ctx, lr.reg_class);
+    if (mir.vreg_is_nil(victim)) {
         ret spill_vreg(ctx, v);
     }
 
-    val vr: *LiveRange = ?ctx.ranges[victim];
+    val vr: *LiveRange = ?ctx.ranges[victim.n];
     if (vr.end_pos < lr.end_pos) {
         ret spill_vreg(ctx, v);
     }
 
-    val freed: u32 = ctx.f.vregs[victim].assigned;
+    val freed: mir.PRegId = ctx.f.vregs[victim.n].assigned;
     val sr: err[fail.Fail] = spill_vreg(ctx, victim);
     if (sel sr.err) { ret sr; }
     free_assigned_id(ctx, victim, lr.reg_class, freed);
@@ -2098,14 +2099,14 @@ fun spill_on_pressure(ctx: *AllocCtx, v: u32) err[fail.Fail] {
         preg = pick_fp(ctx, lr.crosses_call);
     }
     if (preg >= 0) {
-        assign(ctx, v, preg::u32, lr.reg_class);
+        assign(ctx, v, mir.preg_id(preg), lr.reg_class);
         ret err[fail.Fail].ok{};
     }
     ret spill_vreg(ctx, v);
 }
 
-fun free_assigned_id(ctx: *AllocCtx, v: u32, reg_class: u32, preg: u32) {
-    val index: u32 = isa.regid_index(preg::i32)::u32;
+fun free_assigned_id(ctx: *AllocCtx, v: mir.VRegId, reg_class: u32, preg: mir.PRegId) {
+    val index: u32 = isa.regid_index(mir.preg_regid(preg))::u32;
     if (reg_class == REG_CLASS_GP) {
         if (index < ctx.gp_count) { ctx.gp_busy[index] = false; }
     } or {
@@ -2113,11 +2114,11 @@ fun free_assigned_id(ctx: *AllocCtx, v: u32, reg_class: u32, preg: u32) {
     }
 }
 
-fun remove_active(ctx: *AllocCtx, v: u32) {
+fun remove_active(ctx: *AllocCtx, v: mir.VRegId) {
     var write: u32 = 0;
     var read: u32 = 0;
     for (read < ctx.active_count) {
-        if (ctx.active[read] != v) {
+        if (ctx.active[read] != v.n) {
             ctx.active[write] = ctx.active[read];
             write = write + 1;
         }
@@ -2126,8 +2127,8 @@ fun remove_active(ctx: *AllocCtx, v: u32) {
     ctx.active_count = write;
 }
 
-fun find_spill_victim(ctx: *AllocCtx, reg_class: u32) u32 {
-    var best: u32 = mir.MIR_VREG_NIL;
+fun find_spill_victim(ctx: *AllocCtx, reg_class: u32) mir.VRegId {
+    var best: mir.VRegId = mir.MIR_VREG_NIL;
     var best_density: i64 = POS_MAX;
     var best_crosses: bool = true;
     var ai: u32 = 0;
@@ -2150,20 +2151,20 @@ fun find_spill_victim(ctx: *AllocCtx, reg_class: u32) u32 {
         if (better) {
             best_density = density;
             best_crosses = lr.crosses_call;
-            best = v;
+            best = mir.vreg_id(v);
         }
         ai = ai + 1;
     }
     ret best;
 }
 
-fun spill_vreg(ctx: *AllocCtx, v: u32) err[fail.Fail] {
-    val mv: *mir.MirVReg = ?ctx.f.vregs[v];
+fun spill_vreg(ctx: *AllocCtx, v: mir.VRegId) err[fail.Fail] {
+    val mv: *mir.MirVReg = ?ctx.f.vregs[v.n];
     if (mv.spill_slot >= 0) { ret err[fail.Fail].ok{}; }
-    mv.assigned = mir.MIR_VREG_NIL;
+    mv.assigned = mir.MIR_PREG_NIL;
 
-    val size: u32 = class_width(ctx, ?ctx.ranges[v]);
-    val sr: res[i32, fail.Fail] = add_spill_slot(ctx, v, size);
+    val size: u32 = class_width(ctx, ?ctx.ranges[v.n]);
+    val sr: res[i32, fail.Fail] = add_spill_slot(ctx, v.n, size);
     if (sel sr.err) { ret err[fail.Fail].err{sr.err}; }
     mv.spill_slot = sr.ok;
     ret err[fail.Fail].ok{};
@@ -2302,7 +2303,7 @@ fun function_uses_fp_scratch(f: *mir.MirFunction) bool {
                         ret true;
                     }
                     if (op.kind == mir.MIR_OP_PREG &&
-                        isa.regid_class(op.preg::i32) == isa.REG_CLASS_ID_XMM) {
+                        isa.regid_class(mir.preg_regid(op.preg)) == isa.REG_CLASS_ID_XMM) {
                         ret true;
                     }
                     k = k + 1;
@@ -2385,14 +2386,14 @@ fun spill_across_calls(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
         var v: u32 = 0;
         for (v < ctx.f.vreg_count) {
             val mv: *mir.MirVReg = ?ctx.f.vregs[v];
-            if (mv.assigned == mir.MIR_VREG_NIL) { v = v + 1; cnt; }
+            if (mir.preg_is_nil(mv.assigned)) { v = v + 1; cnt; }
             if (mv.spill_slot >= 0)              { v = v + 1; cnt; }
             val lr: *LiveRange = ?ctx.ranges[v];
             if (lr.start >= pos::i64 || lr.end_pos <= pos::i64) { v = v + 1; cnt; }
 
             var must_spill: bool = false;
             if (lr.reg_class != REG_CLASS_GP) {
-                val xidx: u32 = isa.regid_index(mv.assigned::i32)::u32;
+                val xidx: u32 = isa.regid_index(mir.preg_regid(mv.assigned))::u32;
                 if (xidx >= ctx.fp_count || !ctx.fp_callee_saved[xidx]) {
                     must_spill = true;
                 } or (mv.vector && !tgt.abi.fp_callee_saved_full_vector) {
@@ -2400,15 +2401,15 @@ fun spill_across_calls(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
                 } or (is_asm && (asm_fp & (1::u32 << xidx)) != 0) {
                     must_spill = true;
                 }
-            } or (isa.regid_index(mv.assigned::i32)::u32 < ctx.gp_count
-                  && !ctx.callee_saved[isa.regid_index(mv.assigned::i32)::u32]) {
+            } or (isa.regid_index(mir.preg_regid(mv.assigned))::u32 < ctx.gp_count
+                  && !ctx.callee_saved[isa.regid_index(mir.preg_regid(mv.assigned))::u32]) {
                 must_spill = true;
-            } or (is_asm && isa.regid_index(mv.assigned::i32)::u32 < ctx.gp_count
-                  && (asm_gp & (1::u32 << isa.regid_index(mv.assigned::i32)::u32)) != 0) {
+            } or (is_asm && isa.regid_index(mir.preg_regid(mv.assigned))::u32 < ctx.gp_count
+                  && (asm_gp & (1::u32 << isa.regid_index(mir.preg_regid(mv.assigned))::u32)) != 0) {
                 must_spill = true;
             }
             if (must_spill) {
-                val sr: err[fail.Fail] = spill_vreg(ctx, v);
+                val sr: err[fail.Fail] = spill_vreg(ctx, mir.vreg_id(v));
                 if (sel sr.err) { ret sr; }
             }
             v = v + 1;
@@ -2418,8 +2419,8 @@ fun spill_across_calls(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
     ret err[fail.Fail].ok{};
 }
 
-fun rewritten_preg_ok(tgt: *target.Target, preg: u32) bool {
-    val rid: i32 = preg::i32;
+fun rewritten_preg_ok(tgt: *target.Target, preg: mir.PRegId) bool {
+    val rid: i32 = mir.preg_regid(preg);
     val rclass: i32 = isa.regid_class(rid);
     val ridx: i32 = isa.regid_index(rid);
     if (ridx < 0) { ret false; }
@@ -2448,7 +2449,7 @@ fun special_gp_register(tgt: *target.Target, rid: i32) bool {
 }
 
 fun operand_bank_matches(op: *mir.MirOperand) bool {
-    val class: i32 = isa.regid_class(op.preg::i32);
+    val class: i32 = isa.regid_class(mir.preg_regid(op.preg));
     ret (op.required_bank == mir.BANK_GP && class == isa.REG_CLASS_ID_GP)
         || (op.required_bank == mir.BANK_FP && class == isa.REG_CLASS_ID_XMM);
 }
@@ -2473,12 +2474,12 @@ fun verify_rewritten_operands(tgt: *target.Target, f: *mir.MirFunction) err[fail
                     ret err[fail.Fail].err{fail.message("regalloc: a rewritten register operand violates its selected bank constraint")};
                 }
                 if (op.kind == mir.MIR_OP_MEM) {
-                    if (op.vreg == mir.MIR_VREG_NIL
-                        && (!rewritten_preg_ok(tgt, op.preg) || isa.regid_class(op.preg::i32) != isa.REG_CLASS_ID_GP)) {
+                    if (mir.vreg_is_nil(op.vreg)
+                        && (!rewritten_preg_ok(tgt, op.preg) || isa.regid_class(mir.preg_regid(op.preg)) != isa.REG_CLASS_ID_GP)) {
                         ret err[fail.Fail].err{fail.message("regalloc: a rewritten memory base is not a valid general-bank register")};
                     }
-                    if (op.index != mir.MIR_VREG_NIL && op.index_is_preg
-                        && (!rewritten_preg_ok(tgt, op.index) || isa.regid_class(op.index::i32) != isa.REG_CLASS_ID_GP)) {
+                    if (sel op.index.preg
+                        && (!rewritten_preg_ok(tgt, op.index.preg) || isa.regid_class(mir.preg_regid(op.index.preg)) != isa.REG_CLASS_ID_GP)) {
                         ret err[fail.Fail].err{fail.message("regalloc: a rewritten memory index is not a valid general-bank register")};
                     }
                 }
@@ -2495,10 +2496,10 @@ fun verify_allocation(tgt: *target.Target, ctx: *AllocCtx) err[fail.Fail] {
     var v: u32 = 0;
     for (v < ctx.f.vreg_count) {
         val mv: *mir.MirVReg = ?ctx.f.vregs[v];
-        if (mv.assigned == mir.MIR_VREG_NIL) { v = v + 1; cnt; }
+        if (mir.preg_is_nil(mv.assigned)) { v = v + 1; cnt; }
         val lr: *LiveRange = ?ctx.ranges[v];
 
-        val rid: i32 = mv.assigned::i32;
+        val rid: i32 = mir.preg_regid(mv.assigned);
         val rclass: i32 = isa.regid_class(rid);
         val ridx: i32 = isa.regid_index(rid);
 
@@ -2525,15 +2526,15 @@ fun record_callee_mask(tgt: *target.Target, ctx: *AllocCtx) {
     var v: u32 = 0;
     for (v < ctx.f.vreg_count) {
         val mv: *mir.MirVReg = ?ctx.f.vregs[v];
-        if (mv.assigned == mir.MIR_VREG_NIL) { v = v + 1; cnt; }
+        if (mir.preg_is_nil(mv.assigned)) { v = v + 1; cnt; }
         val lr: *LiveRange = ?ctx.ranges[v];
         if (lr.reg_class == REG_CLASS_GP) {
-            val gidx: u32 = isa.regid_index(mv.assigned::i32)::u32;
+            val gidx: u32 = isa.regid_index(mir.preg_regid(mv.assigned))::u32;
             if (gidx < ctx.gp_count && ctx.callee_saved[gidx] && !ctx.reserved[gidx]) {
                 mask = mask | (1::u32 << gidx);
             }
         } or {
-            val xidx: u32 = isa.regid_index(mv.assigned::i32)::u32;
+            val xidx: u32 = isa.regid_index(mir.preg_regid(mv.assigned))::u32;
             if (ctx.fp_callee_saved != nil && xidx < ctx.fp_count && ctx.fp_callee_saved[xidx]) {
                 fp_mask = fp_mask | (1::u32 << xidx);
             }
@@ -2566,7 +2567,7 @@ fun drop_self_copies_physical(tgt: *target.Target, ctx: *AllocCtx) {
             if (instr_is_reg_copy(tgt, mi)) {
                 val a: *mir.MirOperand = ?mi.operands[0];
                 val b: *mir.MirOperand = ?mi.operands[1];
-                drop = a.kind == mir.MIR_OP_PREG && b.kind == mir.MIR_OP_PREG && a.preg == b.preg;
+                drop = a.kind == mir.MIR_OP_PREG && b.kind == mir.MIR_OP_PREG && mir.preg_same(a.preg, b.preg);
             }
             if (drop && mir.instr_declassifies(mi)) {
                 val marker: mir.MirInstr = mir.declassify_marker(mi, mi.operands[0].vreg);
@@ -2656,28 +2657,28 @@ fun extra_movs(ctx: *AllocCtx, mi: *mir.MirInstr) u32 {
         val op: *mir.MirOperand = ?mi.operands[k];
         if (op.kind == mir.MIR_OP_VREG) {
             if (is_spilled(ctx, op.vreg)) { n = n + 1; }
-        } or (op.kind == mir.MIR_OP_MEM && op.vreg != mir.MIR_VREG_NIL) {
+        } or (op.kind == mir.MIR_OP_MEM && !mir.vreg_is_nil(op.vreg)) {
             if (is_spilled(ctx, op.vreg)) { n = n + 1; }
         }
-        if (op.kind == mir.MIR_OP_MEM && !op.index_is_preg && op.index != mir.MIR_VREG_NIL) {
-            if (is_spilled(ctx, op.index)) { n = n + 1; }
+        if (sel op.index.vreg) {
+            if (is_spilled(ctx, op.index.vreg)) { n = n + 1; }
         }
         k = k + 1;
     }
     ret n;
 }
 
-fun is_spilled(ctx: *AllocCtx, v: u32) bool {
-    if (v >= ctx.f.vreg_count) { ret false; }
-    ret ctx.f.vregs[v].spill_slot >= 0;
+fun is_spilled(ctx: *AllocCtx, v: mir.VRegId) bool {
+    if (v.n >= ctx.f.vreg_count) { ret false; }
+    ret ctx.f.vregs[v.n].spill_slot >= 0;
 }
 
-fun is_fp_vreg(ctx: *AllocCtx, v: u32) bool {
-    if (v >= ctx.f.vreg_count) { ret false; }
-    ret ctx.f.vregs[v].class != REG_CLASS_GP;
+fun is_fp_vreg(ctx: *AllocCtx, v: mir.VRegId) bool {
+    if (v.n >= ctx.f.vreg_count) { ret false; }
+    ret ctx.f.vregs[v.n].class != REG_CLASS_GP;
 }
 
-fun is_storage_slot(ctx: *AllocCtx, v: u32) bool {
+fun is_storage_slot(ctx: *AllocCtx, v: mir.VRegId) bool {
     if (is_spilled(ctx, v)) { ret false; }
     ret vreg_has_slot(ctx, v);
 }
@@ -2701,7 +2702,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
     var ci: u32 = 0;
     for (ci < 16) { claimed[ci] = -1; ci = ci + 1; }
 
-    var store_dst_vreg: u32 = mir.MIR_VREG_NIL;
+    var store_dst_vreg: mir.VRegId = mir.MIR_VREG_NIL;
     var store_dst_tmp: i32 = -1;
     var store_dst_reloaded: bool = false;
 
@@ -2709,7 +2710,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
     for (k < n) {
         val op: *mir.MirOperand = ?ops[k];
         if (op.kind == mir.MIR_OP_VREG) {
-            val v: u32 = op.vreg;
+            val v: mir.VRegId = op.vreg;
             if (has_def && k == 0) {
                 if (is_fp_vreg(ctx, v) && is_spilled(ctx, v)) {
                     ops[k] = mir.op_mem_slot(v, 0);
@@ -2720,7 +2721,7 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                         ret err[fail.Fail].err{fail.message(regalloc_msg(ctx, "regalloc: no free register for spilled destination in '", "'", "regalloc: no free register for spilled destination"))};
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    ops[k] = mir.op_preg_of(tmp::u32, v);
+                    ops[k] = mir.op_preg_of(mir.preg_id(tmp), v);
                     store_dst_vreg = v;
                     store_dst_tmp  = tmp;
                 } or {
@@ -2729,13 +2730,13 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
             } or {
                 if (is_fp_vreg(ctx, v) && is_spilled(ctx, v)) {
                     ops[k] = mir.op_mem_slot(v, 0);
-                } or (store_dst_tmp >= 0 && v == store_dst_vreg) {
+                } or (store_dst_tmp >= 0 && mir.vreg_same(v, store_dst_vreg)) {
                     if (!store_dst_reloaded) {
-                        val er: err[fail.Fail] = emit_reload(ctx, dst, wp, store_dst_tmp::u32, v, mi.loc, mi.inline_site);
+                        val er: err[fail.Fail] = emit_reload(ctx, dst, wp, mir.preg_id(store_dst_tmp), v, mi.loc, mi.inline_site);
                         if (sel er.err) { free_ops(ctx, ops, n); ret er; }
                         store_dst_reloaded = true;
                     }
-                    ops[k] = mir.op_preg_of(store_dst_tmp::u32, v);
+                    ops[k] = mir.op_preg_of(mir.preg_id(store_dst_tmp), v);
                 } or (is_spilled(ctx, v)) {
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, is_entry, src_pos);
                     if (tmp < 0) {
@@ -2743,16 +2744,16 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                         ret err[fail.Fail].err{fail.message(regalloc_msg(ctx, "regalloc: no free register for spilled source in '", "'", "regalloc: no free register for spilled source"))};
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    val er: err[fail.Fail] = emit_reload(ctx, dst, wp, tmp::u32, v, mi.loc, mi.inline_site);
+                    val er: err[fail.Fail] = emit_reload(ctx, dst, wp, mir.preg_id(tmp), v, mi.loc, mi.inline_site);
                     if (sel er.err) { free_ops(ctx, ops, n); ret er; }
-                    ops[k] = mir.op_preg_of(tmp::u32, v);
+                    ops[k] = mir.op_preg_of(mir.preg_id(tmp), v);
                 } or {
                     ops[k] = preg_of(ctx, v);
                 }
             }
         } or (op.kind == mir.MIR_OP_MEM) {
-            if (op.vreg != mir.MIR_VREG_NIL) {
-                val v: u32 = op.vreg;
+            if (!mir.vreg_is_nil(op.vreg)) {
+                val v: mir.VRegId = op.vreg;
                 if (is_storage_slot(ctx, v)) {
                 } or (is_spilled(ctx, v)) {
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, is_entry, src_pos);
@@ -2761,17 +2762,18 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                         ret err[fail.Fail].err{fail.message(regalloc_msg(ctx, "regalloc: no free register for spilled MEM base in '", "'", "regalloc: no free register for spilled MEM base"))};
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    val er: err[fail.Fail] = emit_reload(ctx, dst, wp, tmp::u32, v, mi.loc, mi.inline_site);
+                    val er: err[fail.Fail] = emit_reload(ctx, dst, wp, mir.preg_id(tmp), v, mi.loc, mi.inline_site);
                     if (sel er.err) { free_ops(ctx, ops, n); ret er; }
                     ops[k].vreg = mir.MIR_VREG_NIL;
-                    ops[k].preg = tmp::u32;
+                    ops[k].preg = mir.preg_id(tmp);
                 } or {
                     ops[k].vreg = mir.MIR_VREG_NIL;
                     ops[k].preg = assigned_preg(ctx, v);
                 }
             }
-            if (!ops[k].index_is_preg && ops[k].index != mir.MIR_VREG_NIL) {
-                val iv: u32 = ops[k].index;
+            var iv: mir.VRegId = mir.MIR_VREG_NIL;
+            if (sel ops[k].index.vreg) { iv = ops[k].index.vreg; }
+            if (!mir.vreg_is_nil(iv)) {
                 if (is_spilled(ctx, iv)) {
                     val tmp: i32 = reload_temp(ctx, ?claimed[0], claimed_count, is_entry, src_pos);
                     if (tmp < 0) {
@@ -2779,13 +2781,11 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
                         ret err[fail.Fail].err{fail.message(regalloc_msg(ctx, "regalloc: no free register for spilled MEM index in '", "'", "regalloc: no free register for spilled MEM index"))};
                     }
                     claimed[claimed_count] = tmp; claimed_count = claimed_count + 1;
-                    val er: err[fail.Fail] = emit_reload(ctx, dst, wp, tmp::u32, iv, mi.loc, mi.inline_site);
+                    val er: err[fail.Fail] = emit_reload(ctx, dst, wp, mir.preg_id(tmp), iv, mi.loc, mi.inline_site);
                     if (sel er.err) { free_ops(ctx, ops, n); ret er; }
-                    ops[k].index         = tmp::u32;
-                    ops[k].index_is_preg = true;
+                    ops[k].index = mir.index_preg(mir.preg_id(tmp));
                 } or {
-                    ops[k].index         = assigned_preg(ctx, iv);
-                    ops[k].index_is_preg = true;
+                    ops[k].index = mir.index_preg(assigned_preg(ctx, iv));
                 }
             }
         }
@@ -2793,11 +2793,11 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
         k = k + 1;
     }
 
-    if (store_dst_vreg == mir.MIR_VREG_NIL
+    if (mir.vreg_is_nil(store_dst_vreg)
         && mi.width >= ctx.spill_width
         && instr_is_reg_copy(tgt, mi)
         && ops[0].kind == mir.MIR_OP_PREG && ops[1].kind == mir.MIR_OP_PREG
-        && ops[0].preg == ops[1].preg
+        && mir.preg_same(ops[0].preg, ops[1].preg)
         && operand_bank_matches(?ops[0]) && operand_bank_matches(?ops[1])) {
         # a declassify keeps a zero-byte marker: the barrier must reach the
         # stream even when the move it selected to is a self-copy
@@ -2834,8 +2834,8 @@ fun rewrite_instr(tgt: *target.Target, ctx: *AllocCtx, mi: *mir.MirInstr,
         A.deallocate[mir.MirOperand](ctx.alloc, mi.operands, mi.operand_count::usize);
     }
 
-    if (store_dst_vreg != mir.MIR_VREG_NIL) {
-        val sr: err[fail.Fail] = emit_store(ctx, dst, wp, store_dst_vreg, store_dst_tmp::u32, mi.loc, mi.inline_site);
+    if (!mir.vreg_is_nil(store_dst_vreg)) {
+        val sr: err[fail.Fail] = emit_store(ctx, dst, wp, store_dst_vreg, mir.preg_id(store_dst_tmp), mi.loc, mi.inline_site);
         if (sel sr.err) { ret sr; }
     }
     ret err[fail.Fail].ok{};
@@ -2849,16 +2849,16 @@ fun instr_defines_ops(mi: *mir.MirInstr, ops: *mir.MirOperand, n: u32) bool {
 
 # the rewritten operand keeps its origin vreg as provenance: the seed the
 # physical secrecy walk reads at the instruction the notification names
-fun preg_of(ctx: *AllocCtx, v: u32) mir.MirOperand {
+fun preg_of(ctx: *AllocCtx, v: mir.VRegId) mir.MirOperand {
     ret mir.op_preg_of(assigned_preg(ctx, v), v);
 }
 
-fun assigned_preg(ctx: *AllocCtx, v: u32) u32 {
-    if (v >= ctx.f.vreg_count) {
+fun assigned_preg(ctx: *AllocCtx, v: mir.VRegId) mir.PRegId {
+    if (v.n >= ctx.f.vreg_count) {
         panic("regalloc: operand vreg id out of range during rewrite\n");
     }
-    val a: u32 = ctx.f.vregs[v].assigned;
-    if (a == mir.MIR_VREG_NIL) {
+    val a: mir.PRegId = ctx.f.vregs[v.n].assigned;
+    if (mir.preg_is_nil(a)) {
         panic("regalloc: unassigned vreg reached instruction rewrite\n");
     }
     ret a;
@@ -2891,8 +2891,8 @@ fun id_claimed(claimed: *i32, count: u32, id: i32) bool {
     ret false;
 }
 
-fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32, loc: source.SrcLoc, inline_site: u32) err[fail.Fail] {
-    if (isa.regid_class(tmp::i32) != isa.REG_CLASS_ID_GP) {
+fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: mir.PRegId, v: mir.VRegId, loc: source.SrcLoc, inline_site: u32) err[fail.Fail] {
+    if (isa.regid_class(mir.preg_regid(tmp)) != isa.REG_CLASS_ID_GP) {
         ret err[fail.Fail].err{fail.message("regalloc: spill transport requires a general-bank scratch register")};
     }
     val ro: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
@@ -2912,8 +2912,8 @@ fun emit_reload(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, tmp: u32, v: u32, 
     ret err[fail.Fail].ok{};
 }
 
-fun emit_store(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, v: u32, tmp: u32, loc: source.SrcLoc, inline_site: u32) err[fail.Fail] {
-    if (isa.regid_class(tmp::i32) != isa.REG_CLASS_ID_GP) {
+fun emit_store(ctx: *AllocCtx, dst: *mir.MirInstr, wp: *u32, v: mir.VRegId, tmp: mir.PRegId, loc: source.SrcLoc, inline_site: u32) err[fail.Fail] {
+    if (isa.regid_class(mir.preg_regid(tmp)) != isa.REG_CLASS_ID_GP) {
         ret err[fail.Fail].err{fail.message("regalloc: spill transport requires a general-bank scratch register")};
     }
     val ro: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](ctx.alloc, 2::usize);
@@ -3014,9 +3014,9 @@ test "mach.lang.be.codegen.regalloc.verify_allocation:accepts_a_well_formed_assi
 
     var vregs: [2]mir.MirVReg;
     vregs[0] = mir.vreg(0, REG_CLASS_GP, false, false);
-    vregs[0].assigned = isa.regid_make(isa.REG_CLASS_ID_GP, 0)::u32;
+    vregs[0].assigned = mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, 0));
     vregs[1] = mir.vreg(1, 1, false, false);
-    vregs[1].assigned = isa.regid_make(isa.REG_CLASS_ID_XMM, 0)::u32;
+    vregs[1].assigned = mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 0));
 
     var f: mir.MirFunction;
     f.vregs = ?vregs[0];
@@ -3058,7 +3058,7 @@ test "mach.lang.be.codegen.regalloc.verify_allocation:rejects_a_cross_class_regi
 
     var vregs: [1]mir.MirVReg;
     vregs[0] = mir.vreg(0, REG_CLASS_GP, false, false);
-    vregs[0].assigned = isa.regid_make(isa.REG_CLASS_ID_XMM, 0)::u32;
+    vregs[0].assigned = mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 0));
 
     var f: mir.MirFunction;
     f.vregs = ?vregs[0];
@@ -3100,7 +3100,7 @@ test "mach.lang.be.codegen.regalloc.verify_allocation:rejects_a_reserved_registe
 
     var vregs: [1]mir.MirVReg;
     vregs[0] = mir.vreg(0, REG_CLASS_GP, false, false);
-    vregs[0].assigned = isa.regid_make(isa.REG_CLASS_ID_GP, 2)::u32;
+    vregs[0].assigned = mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, 2));
 
     var f: mir.MirFunction;
     f.vregs = ?vregs[0];
@@ -3225,8 +3225,8 @@ test "mach.lang.be.codegen.regalloc.extend_range_for_block:in_out_matrix" {
 
 test "mach.lang.be.codegen.regalloc.instr_defines:fused_cbr_shape" {
     var ops: [4]mir.MirOperand;
-    ops[0] = mir.op_vreg(3);
-    ops[1] = mir.op_vreg(4);
+    ops[0] = mir.op_vreg(mir.vreg_id(3));
+    ops[1] = mir.op_vreg(mir.vreg_id(4));
     ops[2] = mir.op_block(1);
     ops[3] = mir.op_block(2);
 
@@ -3239,13 +3239,13 @@ test "mach.lang.be.codegen.regalloc.instr_defines:fused_cbr_shape" {
     ops[1] = mir.op_imm(0);
     if (instr_defines(?fused))                       { ret 1; }
 
-    ops[0] = mir.op_preg(7);
+    ops[0] = mir.op_preg(mir.preg_id(7));
     if (instr_defines_preg(?fused))                  { ret 1; }
 
     var cmp_ops: [3]mir.MirOperand;
-    cmp_ops[0] = mir.op_vreg(5);
-    cmp_ops[1] = mir.op_vreg(3);
-    cmp_ops[2] = mir.op_vreg(4);
+    cmp_ops[0] = mir.op_vreg(mir.vreg_id(5));
+    cmp_ops[1] = mir.op_vreg(mir.vreg_id(3));
+    cmp_ops[2] = mir.op_vreg(mir.vreg_id(4));
     var cmp: mir.MirInstr = mir.instr(mir.MIR_SEL_CMP_LT_S, ?cmp_ops[0], 3, 0, 0);
     if (!instr_defines(?cmp)) { ret 1; }
     ret 0;
@@ -3274,7 +3274,7 @@ test "mach.lang.be.codegen.regalloc.can_transfer:destination_born_guard" {
     if (can_transfer(?ctx, ?lr_born, ?h)) { ret 1; }
     ranges[1].end_pos = 10;
 
-    h.src_vreg = mir.MIR_VREG_NIL;
+    h.src_vreg = mir.MIR_VREG_NIL.n;
     h.src_preg = 5;
     if (can_transfer(?ctx, ?lr_born, ?h)) { ret 1; }
 
@@ -3303,23 +3303,23 @@ test "mach.lang.be.codegen.regalloc.is_dead_mov:physical_dest_and_read_guards" {
     reads[0] = 0; reads[1] = 1; reads[2] = 0;
 
     var ops: [2]mir.MirOperand;
-    ops[0] = mir.op_vreg(0);
-    ops[1] = mir.op_vreg(1);
+    ops[0] = mir.op_vreg(mir.vreg_id(0));
+    ops[1] = mir.op_vreg(mir.vreg_id(1));
     var mv: mir.MirInstr = mir.instr(mir.MIR_MOV, ?ops[0], 2, 8, 8);
     mv.asm_block     = nil;
 
     if (!is_dead_mov(?t, ?ctx, ?mv, ?reads[0], 3)) { ret 1; }
 
-    ops[0] = mir.op_vreg(1);
+    ops[0] = mir.op_vreg(mir.vreg_id(1));
     if (is_dead_mov(?t, ?ctx, ?mv, ?reads[0], 3)) { ret 1; }
 
-    ops[0] = mir.op_vreg(2);
+    ops[0] = mir.op_vreg(mir.vreg_id(2));
     if (is_dead_mov(?t, ?ctx, ?mv, ?reads[0], 3)) { ret 1; }
 
-    ops[0] = mir.op_preg(0);
+    ops[0] = mir.op_preg(mir.preg_id(0));
     if (is_dead_mov(?t, ?ctx, ?mv, ?reads[0], 3)) { ret 1; }
 
-    ops[0] = mir.op_vreg(0);
+    ops[0] = mir.op_vreg(mir.vreg_id(0));
     mv.src_width = 4;
     if (is_dead_mov(?t, ?ctx, ?mv, ?reads[0], 3)) { ret 1; }
 
@@ -3338,10 +3338,10 @@ test "mach.lang.be.codegen.regalloc.sweep_dead_movs:retallies_to_a_fixpoint" {
     t_vregs(?alloc, ?f, 3);
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 4);
-    t_mov(?alloc, ?b, 0, mir.op_vreg(0), mir.op_preg(3));
-    t_mov(?alloc, ?b, 1, mir.op_vreg(1), mir.op_vreg(0));
-    t_mov(?alloc, ?b, 2, mir.op_vreg(2), mir.op_preg(5));
-    t_mov(?alloc, ?b, 3, mir.op_preg(6), mir.op_vreg(2));
+    t_mov(?alloc, ?b, 0, mir.op_vreg(mir.vreg_id(0)), mir.op_preg(mir.preg_id(3)));
+    t_mov(?alloc, ?b, 1, mir.op_vreg(mir.vreg_id(1)), mir.op_vreg(mir.vreg_id(0)));
+    t_mov(?alloc, ?b, 2, mir.op_vreg(mir.vreg_id(2)), mir.op_preg(mir.preg_id(5)));
+    t_mov(?alloc, ?b, 3, mir.op_preg(mir.preg_id(6)), mir.op_vreg(mir.vreg_id(2)));
     f.blocks      = ?b;
     f.block_count = 1;
     f.block_cap   = 1;
@@ -3356,9 +3356,9 @@ test "mach.lang.be.codegen.regalloc.sweep_dead_movs:retallies_to_a_fixpoint" {
 
     if (b.instr_count != 2) { ret 1; }
     if (b.instrs[0].operands[0].kind != mir.MIR_OP_VREG)  { ret 1; }
-    if (b.instrs[0].operands[0].vreg != 2)                { ret 1; }
+    if (b.instrs[0].operands[0].vreg.n != 2)                { ret 1; }
     if (b.instrs[1].operands[0].kind != mir.MIR_OP_PREG)  { ret 1; }
-    if (b.instrs[1].operands[0].preg != 6)                { ret 1; }
+    if (b.instrs[1].operands[0].preg.n != 6)                { ret 1; }
 
     ret 0;
 }
@@ -3399,7 +3399,7 @@ fun t_vregs(alloc: *A.Allocator, f: *mir.MirFunction, n: u32) {
         f.vregs[i].id         = i;
         f.vregs[i].class      = REG_CLASS_GP;
         f.vregs[i].spill_slot = -1;
-        f.vregs[i].assigned   = mir.MIR_VREG_NIL;
+        f.vregs[i].assigned   = mir.MIR_PREG_NIL;
         f.vregs[i].vector     = false;
         f.vregs[i].secret     = false;
         i = i + 1;
@@ -3460,9 +3460,9 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:single_assignment_web_is_mer
     t_vregs(?alloc, ?f, 2);
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 3);
-    t_mov(?alloc, ?b, 0, mir.op_vreg(0), mir.op_preg(3));
-    t_mov(?alloc, ?b, 1, mir.op_vreg(1), mir.op_vreg(0));
-    t_mov(?alloc, ?b, 2, mir.op_preg(4), mir.op_vreg(1));
+    t_mov(?alloc, ?b, 0, mir.op_vreg(mir.vreg_id(0)), mir.op_preg(mir.preg_id(3)));
+    t_mov(?alloc, ?b, 1, mir.op_vreg(mir.vreg_id(1)), mir.op_vreg(mir.vreg_id(0)));
+    t_mov(?alloc, ?b, 2, mir.op_preg(mir.preg_id(4)), mir.op_vreg(mir.vreg_id(1)));
     f.blocks      = ?b;
     f.block_count = 1;
     f.block_cap   = 1;
@@ -3477,8 +3477,8 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:single_assignment_web_is_mer
 
     if (b.instr_count != 2) { ret 1; }
     if (b.instrs[1].operands[1].kind != mir.MIR_OP_VREG) { ret 1; }
-    if (b.instrs[1].operands[1].vreg != 0)               { ret 1; }
-    if (b.instrs[0].operands[0].vreg != 0)               { ret 1; }
+    if (b.instrs[1].operands[1].vreg.n != 0)               { ret 1; }
+    if (b.instrs[0].operands[0].vreg.n != 0)               { ret 1; }
 
     ret 0;
 }
@@ -3497,9 +3497,9 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:refuses_to_merge_a_secret_wi
     f.vregs[0].secret = true;
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 3);
-    t_mov(?alloc, ?b, 0, mir.op_vreg(0), mir.op_preg(3));
-    t_mov(?alloc, ?b, 1, mir.op_vreg(1), mir.op_vreg(0));
-    t_mov(?alloc, ?b, 2, mir.op_preg(4), mir.op_vreg(1));
+    t_mov(?alloc, ?b, 0, mir.op_vreg(mir.vreg_id(0)), mir.op_preg(mir.preg_id(3)));
+    t_mov(?alloc, ?b, 1, mir.op_vreg(mir.vreg_id(1)), mir.op_vreg(mir.vreg_id(0)));
+    t_mov(?alloc, ?b, 2, mir.op_preg(mir.preg_id(4)), mir.op_vreg(mir.vreg_id(1)));
     f.blocks      = ?b;
     f.block_count = 1;
     f.block_cap   = 1;
@@ -3510,7 +3510,7 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:refuses_to_merge_a_secret_wi
     val coalesce_copies_r: err[fail.Fail] = coalesce_copies(?t, ?ctx);
     if (sel coalesce_copies_r.err) { ret 1; }
     if (b.instr_count != 3) { ret 2; }
-    if (b.instrs[1].operands[0].vreg != 1 || b.instrs[1].operands[1].vreg != 0) { ret 3; }
+    if (b.instrs[1].operands[0].vreg.n != 1 || b.instrs[1].operands[1].vreg.n != 0) { ret 3; }
 
     # control: the same web with both sides secret merges
     var f2: mir.MirFunction;
@@ -3519,9 +3519,9 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:refuses_to_merge_a_secret_wi
     f2.vregs[1].secret = true;
     var b2: mir.MirBlock;
     t_block(?alloc, ?b2, 3);
-    t_mov(?alloc, ?b2, 0, mir.op_vreg(0), mir.op_preg(3));
-    t_mov(?alloc, ?b2, 1, mir.op_vreg(1), mir.op_vreg(0));
-    t_mov(?alloc, ?b2, 2, mir.op_preg(4), mir.op_vreg(1));
+    t_mov(?alloc, ?b2, 0, mir.op_vreg(mir.vreg_id(0)), mir.op_preg(mir.preg_id(3)));
+    t_mov(?alloc, ?b2, 1, mir.op_vreg(mir.vreg_id(1)), mir.op_vreg(mir.vreg_id(0)));
+    t_mov(?alloc, ?b2, 2, mir.op_preg(mir.preg_id(4)), mir.op_vreg(mir.vreg_id(1)));
     f2.blocks      = ?b2;
     f2.block_count = 1;
     f2.block_cap   = 1;
@@ -3546,9 +3546,9 @@ fun t_selected_copy(t: *target.Target, opcode: u32, copied: bool) bool {
     fin { mir.dnit_function(?alloc, ?f); }
     t_vregs(?alloc, ?f, 2);
     t_block(?alloc, ?b, 3);
-    t_mov(?alloc, ?b, 0, mir.op_vreg(0), mir.op_preg(10));
-    t_mov(?alloc, ?b, 1, mir.op_vreg(1), mir.op_vreg(0));
-    t_mov(?alloc, ?b, 2, mir.op_preg(11), mir.op_vreg(1));
+    t_mov(?alloc, ?b, 0, mir.op_vreg(mir.vreg_id(0)), mir.op_preg(mir.preg_id(10)));
+    t_mov(?alloc, ?b, 1, mir.op_vreg(mir.vreg_id(1)), mir.op_vreg(mir.vreg_id(0)));
+    t_mov(?alloc, ?b, 2, mir.op_preg(mir.preg_id(11)), mir.op_vreg(mir.vreg_id(1)));
     var i: u32 = 0;
     for (i < 3) {
         b.instrs[i].width = t.model.gpr_width::u8;
@@ -3573,7 +3573,7 @@ fun t_selected_copy(t: *target.Target, opcode: u32, copied: bool) bool {
     if (sel coalesce_copies_r.err) { ret false; }
     if (!copied) { ret b.instr_count == 3 && b.instrs[1].opcode == opcode; }
     ret b.instr_count == 2 && b.instrs[1].operands[1].kind == mir.MIR_OP_VREG &&
-        b.instrs[1].operands[1].vreg == 0;
+        b.instrs[1].operands[1].vreg.n == 0;
 }
 
 test "mach.lang.be.codegen.regalloc.coalesce_copies:rv32_guard_uses_each_selected_machine" {
@@ -3611,10 +3611,10 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:refuses_unsafe_shapes" {
     t_vregs(?alloc, ?f, 2);
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 4);
-    t_mov(?alloc, ?b, 0, mir.op_vreg(0), mir.op_preg(3));
-    t_mov(?alloc, ?b, 1, mir.op_vreg(1), mir.op_vreg(0));
-    t_mov(?alloc, ?b, 2, mir.op_vreg(1), mir.op_preg(5));
-    t_mov(?alloc, ?b, 3, mir.op_preg(4), mir.op_vreg(1));
+    t_mov(?alloc, ?b, 0, mir.op_vreg(mir.vreg_id(0)), mir.op_preg(mir.preg_id(3)));
+    t_mov(?alloc, ?b, 1, mir.op_vreg(mir.vreg_id(1)), mir.op_vreg(mir.vreg_id(0)));
+    t_mov(?alloc, ?b, 2, mir.op_vreg(mir.vreg_id(1)), mir.op_preg(mir.preg_id(5)));
+    t_mov(?alloc, ?b, 3, mir.op_preg(mir.preg_id(4)), mir.op_vreg(mir.vreg_id(1)));
     f.blocks      = ?b;
     f.block_count = 1;
     f.block_cap   = 1;
@@ -3632,11 +3632,11 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:refuses_unsafe_shapes" {
     t_vregs(?alloc, ?f2, 2);
     var b2: mir.MirBlock;
     t_block(?alloc, ?b2, 3);
-    t_mov(?alloc, ?b2, 0, mir.op_vreg(0), mir.op_preg(3));
-    t_mov(?alloc, ?b2, 1, mir.op_vreg(1), mir.op_vreg(0));
+    t_mov(?alloc, ?b2, 0, mir.op_vreg(mir.vreg_id(0)), mir.op_preg(mir.preg_id(3)));
+    t_mov(?alloc, ?b2, 1, mir.op_vreg(mir.vreg_id(1)), mir.op_vreg(mir.vreg_id(0)));
     b2.instrs[1].width     = 4;
     b2.instrs[1].src_width = 4;
-    t_mov(?alloc, ?b2, 2, mir.op_preg(4), mir.op_vreg(1));
+    t_mov(?alloc, ?b2, 2, mir.op_preg(mir.preg_id(4)), mir.op_vreg(mir.vreg_id(1)));
     f2.blocks      = ?b2;
     f2.block_count = 1;
     f2.block_cap   = 1;
@@ -3653,9 +3653,9 @@ test "mach.lang.be.codegen.regalloc.coalesce_copies:refuses_unsafe_shapes" {
     t_vregs(?alloc, ?f3, 2);
     var b3: mir.MirBlock;
     t_block(?alloc, ?b3, 3);
-    t_mov(?alloc, ?b3, 0, mir.op_vreg(0), mir.op_preg(3));
-    t_mov(?alloc, ?b3, 1, mir.op_vreg(1), mir.op_vreg(0));
-    t_mov(?alloc, ?b3, 2, mir.op_preg(4), mir.op_vreg(1));
+    t_mov(?alloc, ?b3, 0, mir.op_vreg(mir.vreg_id(0)), mir.op_preg(mir.preg_id(3)));
+    t_mov(?alloc, ?b3, 1, mir.op_vreg(mir.vreg_id(1)), mir.op_vreg(mir.vreg_id(0)));
+    t_mov(?alloc, ?b3, 2, mir.op_preg(mir.preg_id(4)), mir.op_vreg(mir.vreg_id(1)));
     f3.blocks      = ?b3;
     f3.block_count = 1;
     f3.block_cap   = 1;
@@ -3680,31 +3680,31 @@ test "mach.lang.be.codegen.regalloc.maybe_sink_hint:records_only_a_dying_full_wi
     ctx.spill_width = 8;
     var i: u32 = 0;
     for (i < 2) {
-        hints[i].src_vreg     = mir.MIR_VREG_NIL;
+        hints[i].src_vreg     = mir.MIR_VREG_NIL.n;
         hints[i].src_preg     = -1;
         hints[i].copy_pos     = -1;
-        hints[i].dst_vreg     = mir.MIR_VREG_NIL;
+        hints[i].dst_vreg     = mir.MIR_VREG_NIL.n;
         hints[i].dst_copy_pos = -1;
         hints[i].sink_preg    = -1;
         i = i + 1;
     }
 
     var ops: [2]mir.MirOperand;
-    ops[0] = mir.op_preg(7);
-    ops[1] = mir.op_vreg(1);
+    ops[0] = mir.op_preg(mir.preg_id(7));
+    ops[1] = mir.op_vreg(mir.vreg_id(1));
     var mv: mir.MirInstr = mir.instr(mir.MIR_MOV, ?ops[0], 2, 8, 8);
 
     ranges[1].end_pos = 10;
     maybe_sink_hint(?ctx, ?mv, 10, 2);
     if (hints[1].sink_preg != 7) { ret 1; }
 
-    ops[0] = mir.op_preg(6);
+    ops[0] = mir.op_preg(mir.preg_id(6));
     maybe_sink_hint(?ctx, ?mv, 10, 2);
     if (hints[1].sink_preg != 7) { ret 1; }
 
     hints[1].sink_preg = -1;
     ranges[1].end_pos  = 14;
-    ops[0] = mir.op_preg(7);
+    ops[0] = mir.op_preg(mir.preg_id(7));
     maybe_sink_hint(?ctx, ?mv, 10, 2);
     if (hints[1].sink_preg != -1) { ret 1; }
 
@@ -3716,7 +3716,7 @@ test "mach.lang.be.codegen.regalloc.maybe_sink_hint:records_only_a_dying_full_wi
 
     mv.width     = 8;
     mv.src_width = 8;
-    ops[0] = mir.op_vreg(0);
+    ops[0] = mir.op_vreg(mir.vreg_id(0));
     maybe_sink_hint(?ctx, ?mv, 10, 2);
     if (hints[1].sink_preg != -1) { ret 1; }
 
@@ -3731,19 +3731,19 @@ test "mach.lang.be.codegen.regalloc.maybe_tie_hint:ties_a_dying_left_operand" {
     ctx.hints  = ?hints[0];
     var i: u32 = 0;
     for (i < 3) {
-        hints[i].src_vreg     = mir.MIR_VREG_NIL;
+        hints[i].src_vreg     = mir.MIR_VREG_NIL.n;
         hints[i].src_preg     = -1;
         hints[i].copy_pos     = -1;
-        hints[i].dst_vreg     = mir.MIR_VREG_NIL;
+        hints[i].dst_vreg     = mir.MIR_VREG_NIL.n;
         hints[i].dst_copy_pos = -1;
         hints[i].sink_preg    = -1;
         i = i + 1;
     }
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_vreg(0);
-    ops[1] = mir.op_vreg(1);
-    ops[2] = mir.op_vreg(2);
+    ops[0] = mir.op_vreg(mir.vreg_id(0));
+    ops[1] = mir.op_vreg(mir.vreg_id(1));
+    ops[2] = mir.op_vreg(mir.vreg_id(2));
     var op: mir.MirInstr = mir.instr(mir.MIR_SEL_MUL, ?ops[0], 3, 0, 0);
 
     ranges[1].end_pos = 20;
@@ -3752,21 +3752,21 @@ test "mach.lang.be.codegen.regalloc.maybe_tie_hint:ties_a_dying_left_operand" {
     if (hints[0].src_vreg != 1)  { ret 1; }
     if (hints[0].copy_pos != 20) { ret 1; }
 
-    hints[0].src_vreg = mir.MIR_VREG_NIL;
+    hints[0].src_vreg = mir.MIR_VREG_NIL.n;
     hints[0].copy_pos = -1;
     ranges[1].end_pos = 24;
     maybe_tie_hint(?ctx, ?op, 20, 3);
-    if (hints[0].src_vreg != mir.MIR_VREG_NIL) { ret 1; }
+    if (hints[0].src_vreg != mir.MIR_VREG_NIL.n) { ret 1; }
 
     ranges[1].end_pos = 20;
     ranges[0].start   = 12;
     maybe_tie_hint(?ctx, ?op, 20, 3);
-    if (hints[0].src_vreg != mir.MIR_VREG_NIL) { ret 1; }
+    if (hints[0].src_vreg != mir.MIR_VREG_NIL.n) { ret 1; }
 
     ranges[0].start = 20;
     op.opcode = mir.MIR_SEL_CMP_EQ;
     maybe_tie_hint(?ctx, ?op, 20, 3);
-    if (hints[0].src_vreg != mir.MIR_VREG_NIL) { ret 1; }
+    if (hints[0].src_vreg != mir.MIR_VREG_NIL.n) { ret 1; }
 
     if (!is_two_address_op(mir.MIR_SEL_ADD))   { ret 1; }
     if (!is_two_address_op(mir.MIR_SEL_SHR_S)) { ret 1; }
@@ -3801,8 +3801,8 @@ fun t_self_copy_is_dropped(t: *target.Target, width: u8) bool {
     t_vregs(?alloc, ?f, 3);
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 2);
-    t_mov(?alloc, ?b, 0, mir.op_vreg(1), mir.op_vreg(1));
-    t_mov(?alloc, ?b, 1, mir.op_vreg(2), mir.op_vreg(0));
+    t_mov(?alloc, ?b, 0, mir.op_vreg(mir.vreg_id(1)), mir.op_vreg(mir.vreg_id(1)));
+    t_mov(?alloc, ?b, 1, mir.op_vreg(mir.vreg_id(2)), mir.op_vreg(mir.vreg_id(0)));
     b.instrs[0].width = width; b.instrs[0].src_width = width;
     b.instrs[1].width = width; b.instrs[1].src_width = width;
     f.blocks      = ?b;
@@ -3818,8 +3818,8 @@ fun t_self_copy_is_dropped(t: *target.Target, width: u8) bool {
 
     if (b.instr_count != 1) { ret false; }
     val kept: *mir.MirOperand = b.instrs[0].operands;
-    ret kept[0].kind == mir.MIR_OP_VREG && kept[0].vreg == 2 &&
-        kept[1].kind == mir.MIR_OP_VREG && kept[1].vreg == 0;
+    ret kept[0].kind == mir.MIR_OP_VREG && kept[0].vreg.n == 2 &&
+        kept[1].kind == mir.MIR_OP_VREG && kept[1].vreg.n == 0;
 }
 
 test "mach.lang.be.codegen.regalloc.drop_self_copies:width_is_not_a_gate" {
@@ -3864,9 +3864,9 @@ test "mach.lang.be.codegen.regalloc.drop_self_copies_physical:deletes_only_the_s
     t_vregs(?alloc, ?f, 1);
     var b: mir.MirBlock;
     t_block(?alloc, ?b, 3);
-    t_mov(?alloc, ?b, 0, mir.op_preg(3), mir.op_preg(3));
-    t_mov(?alloc, ?b, 1, mir.op_preg(4), mir.op_preg(5));
-    t_mov(?alloc, ?b, 2, mir.op_preg(6), mir.op_preg(6));
+    t_mov(?alloc, ?b, 0, mir.op_preg(mir.preg_id(3)), mir.op_preg(mir.preg_id(3)));
+    t_mov(?alloc, ?b, 1, mir.op_preg(mir.preg_id(4)), mir.op_preg(mir.preg_id(5)));
+    t_mov(?alloc, ?b, 2, mir.op_preg(mir.preg_id(6)), mir.op_preg(mir.preg_id(6)));
     f.blocks      = ?b;
     f.block_count = 1;
     f.block_cap   = 1;
@@ -3880,8 +3880,8 @@ test "mach.lang.be.codegen.regalloc.drop_self_copies_physical:deletes_only_the_s
 
     if (b.instr_count != 1) { ret 1; }
     val kept: *mir.MirOperand = b.instrs[0].operands;
-    if (kept[0].kind != mir.MIR_OP_PREG || kept[0].preg != 4) { ret 1; }
-    if (kept[1].kind != mir.MIR_OP_PREG || kept[1].preg != 5) { ret 1; }
+    if (kept[0].kind != mir.MIR_OP_PREG || kept[0].preg.n != 4) { ret 1; }
+    if (kept[1].kind != mir.MIR_OP_PREG || kept[1].preg.n != 5) { ret 1; }
     ret 0;
 }
 
@@ -4031,8 +4031,8 @@ test "mach.lang.be.codegen.regalloc.verify_rewritten_operands:walks_the_program_
     val gp: u32 = bank_count(?tgt, REG_CLASS_GP);
 
     var ops: [2]mir.MirOperand;
-    ops[0] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_GP, 1)::u32);
-    ops[1] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_GP, 3)::u32);
+    ops[0] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, 1)));
+    ops[1] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, 3)));
     var ins: [1]mir.MirInstr;
     ins[0] = mir.instr(mir.MIR_MOV, ?ops[0], 2, 8, 8);
     var blk: [1]mir.MirBlock;
@@ -4046,19 +4046,19 @@ test "mach.lang.be.codegen.regalloc.verify_rewritten_operands:walks_the_program_
     if (sel capture_operand_banks_r.err) { ret 1; }
     val verify_rewritten_operands_r: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
     if (sel verify_rewritten_operands_r.err) { ret 1; }
-    ops[1] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_GP, (gp + 40)::i32)::u32);
+    ops[1] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, (gp + 40)::i32)));
     val verify_rewritten_operands_r2: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
     if (sel verify_rewritten_operands_r2.ok)  { ret 2; }
-    ops[1] = mir.op_preg(isa.regid_make(7, 0)::u32);
+    ops[1] = mir.op_preg(mir.preg_id(isa.regid_make(7, 0)));
     val verify_rewritten_operands_r3: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
     if (sel verify_rewritten_operands_r3.ok)  { ret 3; }
-    ops[1] = mir.op_vreg(0);
+    ops[1] = mir.op_vreg(mir.vreg_id(0));
     val verify_rewritten_operands_r4: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
     if (sel verify_rewritten_operands_r4.ok)  { ret 4; }
-    ops[1] = mir.op_mem_preg(isa.regid_make(isa.REG_CLASS_ID_GP, (gp + 40)::i32)::u32, 0);
+    ops[1] = mir.op_mem_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, (gp + 40)::i32)), 0);
     val verify_rewritten_operands_r5: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
     if (sel verify_rewritten_operands_r5.ok)  { ret 5; }
-    ops[1] = mir.op_mem_preg(tgt.model.stack_ptr_reg::u32, 0);
+    ops[1] = mir.op_mem_preg(mir.preg_id(tgt.model.stack_ptr_reg), 0);
     val verify_rewritten_operands_r6: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
     if (sel verify_rewritten_operands_r6.err) { ret 6; }
     ret 0;
@@ -4094,13 +4094,13 @@ fun t_spilled_update(mode: u32) i32 {
     val ar: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?alloc, count::usize);
     if (sel ar.err) { ret 1; }
     val ops: *mir.MirOperand = ar.ok;
-    ops[0] = mir.op_vreg(0);
-    ops[1] = mir.op_vreg(0);
+    ops[0] = mir.op_vreg(mir.vreg_id(0));
+    ops[1] = mir.op_vreg(mir.vreg_id(0));
     ops[2] = mir.op_imm(8);
     var mi: mir.MirInstr = mir.instr(mir.MIR_SUB, ops, count, 8, 8);
     if (mode == 1) {
         mi.opcode = mir.MIR_ADD;
-        ops[2] = mir.op_vreg(0);
+        ops[2] = mir.op_vreg(mir.vreg_id(0));
     } or (mode == 2) {
         ops[1] = mir.op_imm(100);
     }
@@ -4115,10 +4115,10 @@ fun t_spilled_update(mode: u32) i32 {
             i = i + 1;
         }
     }
-    val wrong_scratch: u32 = isa.regid_make(isa.REG_CLASS_ID_XMM, 0)::u32;
-    val emit_reload_r: err[fail.Fail] = emit_reload(?ctx, ?dst[0], ?written, wrong_scratch, 0, mi.loc, 0);
+    val wrong_scratch: mir.PRegId = mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 0));
+    val emit_reload_r: err[fail.Fail] = emit_reload(?ctx, ?dst[0], ?written, wrong_scratch, mir.vreg_id(0), mi.loc, 0);
     if (sel emit_reload_r.ok) { free_ops(?ctx, ops, count); ret 9; }
-    val emit_store_r: err[fail.Fail] = emit_store(?ctx, ?dst[0], ?written, 0, wrong_scratch, mi.loc, 0);
+    val emit_store_r: err[fail.Fail] = emit_store(?ctx, ?dst[0], ?written, mir.vreg_id(0), wrong_scratch, mi.loc, 0);
     if (sel emit_store_r.ok) { free_ops(?ctx, ops, count); ret 9; }
     if (written != 0) { free_ops(?ctx, ops, count); ret 9; }
     val rr: err[fail.Fail] = rewrite_instr(?tgt, ?ctx, ?mi, ?dst[0], ?written, false, 0);
@@ -4138,24 +4138,24 @@ fun t_spilled_update(mode: u32) i32 {
         val a: *mir.MirOperand = ?ins.operands[0];
         val b: *mir.MirOperand = ?ins.operands[1];
         if (ins.opcode == mir.MIR_MOV) {
-            if (a.kind == mir.MIR_OP_PREG && b.kind == mir.MIR_OP_MEM && b.vreg == 0) {
+            if (a.kind == mir.MIR_OP_PREG && b.kind == mir.MIR_OP_MEM && b.vreg.n == 0) {
                 reg = slot;
                 loads = loads + 1;
-            } or (a.kind == mir.MIR_OP_MEM && a.vreg == 0 && b.kind == mir.MIR_OP_PREG) {
+            } or (a.kind == mir.MIR_OP_MEM && a.vreg.n == 0 && b.kind == mir.MIR_OP_PREG) {
                 slot = reg;
                 stores = stores + 1;
             } or { ret 3; }
         } or {
             val c: *mir.MirOperand = ?ins.operands[2];
-            if (a.kind != mir.MIR_OP_PREG || a.preg != 0) { ret 3; }
+            if (a.kind != mir.MIR_OP_PREG || a.preg.n != 0) { ret 3; }
             var left: i64 = b.imm;
             var right: i64 = c.imm;
             if (b.kind == mir.MIR_OP_PREG) {
-                if (b.preg != a.preg) { ret 4; }
+                if (!mir.preg_same(b.preg, a.preg)) { ret 4; }
                 left = reg;
             }
             if (c.kind == mir.MIR_OP_PREG) {
-                if (c.preg != a.preg) { ret 4; }
+                if (!mir.preg_same(c.preg, a.preg)) { ret 4; }
                 right = reg;
             }
             if (ins.opcode == mir.MIR_SUB) { reg = left - right; }
@@ -4194,7 +4194,7 @@ test "mach.lang.be.codegen.regalloc.rewrite_instr:a_spilled_secret_keeps_its_slo
     vregs[0] = mir.vreg(0, REG_CLASS_GP, false, true);
     vregs[0].spill_slot = 0;
     vregs[1] = mir.vreg(1, REG_CLASS_GP, false, false);
-    vregs[1].assigned = 7;
+    vregs[1].assigned = mir.preg_id(7);
     var f: mir.MirFunction;
     f.vregs = ?vregs[0];
     f.vreg_count = 2;
@@ -4210,9 +4210,9 @@ test "mach.lang.be.codegen.regalloc.rewrite_instr:a_spilled_secret_keeps_its_slo
     val ar: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?alloc, 3::usize);
     if (sel ar.err) { ret 1; }
     val ops: *mir.MirOperand = ar.ok;
-    ops[0] = mir.op_vreg(1);
-    ops[1] = mir.op_vreg(1);
-    ops[2] = mir.op_vreg(0);
+    ops[0] = mir.op_vreg(mir.vreg_id(1));
+    ops[1] = mir.op_vreg(mir.vreg_id(1));
+    ops[2] = mir.op_vreg(mir.vreg_id(0));
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ops, 3, 8, 8);
     val capture_operand_banks_r: err[fail.Fail] = rules.capture_operand_banks(?f, ?mi);
     if (sel capture_operand_banks_r.err) { ret 2; }
@@ -4229,22 +4229,22 @@ test "mach.lang.be.codegen.regalloc.rewrite_instr:a_spilled_secret_keeps_its_slo
     # the reload: the scratch is a physical alias of the secret for one instruction
     val reload: *mir.MirInstr = ?dst[0];
     if (reload.opcode != mir.MIR_MOV || reload.operand_count != 2) { ret 5; }
-    if (reload.operands[0].kind != mir.MIR_OP_PREG || reload.operands[0].preg != 9) { ret 6; }
-    if (reload.operands[1].kind != mir.MIR_OP_MEM || reload.operands[1].vreg != 0) { ret 7; }
-    if (!f.vregs[reload.operands[1].vreg].secret) { ret 8; }
+    if (reload.operands[0].kind != mir.MIR_OP_PREG || reload.operands[0].preg.n != 9) { ret 6; }
+    if (reload.operands[1].kind != mir.MIR_OP_MEM || reload.operands[1].vreg.n != 0) { ret 7; }
+    if (!f.vregs[reload.operands[1].vreg.n].secret) { ret 8; }
 
     # the use reads the scratch, and the vreg seed survives rewriting untouched
     val use: *mir.MirInstr = ?dst[1];
-    if (use.opcode != mir.MIR_ADD || use.operands[2].kind != mir.MIR_OP_PREG || use.operands[2].preg != 9) { ret 9; }
+    if (use.opcode != mir.MIR_ADD || use.operands[2].kind != mir.MIR_OP_PREG || use.operands[2].preg.n != 9) { ret 9; }
     if (!f.vregs[0].secret || f.vregs[1].secret) { ret 10; }
 
     # provenance: the scratch names the secret it aliases at both the reload
     # and the use, and the assigned register names its public vreg
-    if (mir.operand_origin(?reload.operands[0]) != 0 || !mir.operand_seed_secret(?f, ?reload.operands[0])) { ret 11; }
-    if (mir.operand_origin(?reload.operands[1]) != 0 || !mir.operand_seed_secret(?f, ?reload.operands[1])) { ret 12; }
-    if (mir.operand_origin(?use.operands[2]) != 0 || !mir.operand_seed_secret(?f, ?use.operands[2]))       { ret 13; }
-    if (mir.operand_origin(?use.operands[0]) != 1 || mir.operand_seed_secret(?f, ?use.operands[0]))        { ret 14; }
-    if (mir.operand_origin(?use.operands[1]) != 1 || mir.operand_seed_secret(?f, ?use.operands[1]))        { ret 15; }
+    if (mir.operand_origin(?reload.operands[0]).n != 0 || !mir.operand_seed_secret(?f, ?reload.operands[0])) { ret 11; }
+    if (mir.operand_origin(?reload.operands[1]).n != 0 || !mir.operand_seed_secret(?f, ?reload.operands[1])) { ret 12; }
+    if (mir.operand_origin(?use.operands[2]).n != 0 || !mir.operand_seed_secret(?f, ?use.operands[2]))       { ret 13; }
+    if (mir.operand_origin(?use.operands[0]).n != 1 || mir.operand_seed_secret(?f, ?use.operands[0]))        { ret 14; }
+    if (mir.operand_origin(?use.operands[1]).n != 1 || mir.operand_seed_secret(?f, ?use.operands[1]))        { ret 15; }
     ret 0;
 }
 
@@ -4265,7 +4265,7 @@ test "mach.lang.be.codegen.regalloc.rewrite_instr:a_spilled_secret_destination_k
     vregs[0] = mir.vreg(0, REG_CLASS_GP, false, true);
     vregs[0].spill_slot = 0;
     vregs[1] = mir.vreg(1, REG_CLASS_GP, false, false);
-    vregs[1].assigned = 7;
+    vregs[1].assigned = mir.preg_id(7);
     var f: mir.MirFunction;
     f.vregs = ?vregs[0];
     f.vreg_count = 2;
@@ -4281,8 +4281,8 @@ test "mach.lang.be.codegen.regalloc.rewrite_instr:a_spilled_secret_destination_k
     val ar: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?alloc, 2::usize);
     if (sel ar.err) { ret 1; }
     val ops: *mir.MirOperand = ar.ok;
-    ops[0] = mir.op_vreg(0);
-    ops[1] = mir.op_vreg(1);
+    ops[0] = mir.op_vreg(mir.vreg_id(0));
+    ops[1] = mir.op_vreg(mir.vreg_id(1));
     var mi: mir.MirInstr = mir.instr(mir.MIR_MOV, ops, 2, 8, 8);
     val capture_operand_banks_r: err[fail.Fail] = rules.capture_operand_banks(?f, ?mi);
     if (sel capture_operand_banks_r.err) { ret 2; }
@@ -4296,14 +4296,14 @@ test "mach.lang.be.codegen.regalloc.rewrite_instr:a_spilled_secret_destination_k
     if (sel rewrite_instr_r.err) { ret 3; }
     if (written != 2) { ret 4; }
     val mov: *mir.MirInstr = ?dst[0];
-    if (mov.operands[0].kind != mir.MIR_OP_PREG || mov.operands[0].preg != 9) { ret 5; }
-    if (mir.operand_origin(?mov.operands[0]) != 0 || !mir.operand_seed_secret(?f, ?mov.operands[0])) { ret 6; }
-    if (mir.operand_origin(?mov.operands[1]) != 1 || mir.operand_seed_secret(?f, ?mov.operands[1]))  { ret 7; }
+    if (mov.operands[0].kind != mir.MIR_OP_PREG || mov.operands[0].preg.n != 9) { ret 5; }
+    if (mir.operand_origin(?mov.operands[0]).n != 0 || !mir.operand_seed_secret(?f, ?mov.operands[0])) { ret 6; }
+    if (mir.operand_origin(?mov.operands[1]).n != 1 || mir.operand_seed_secret(?f, ?mov.operands[1]))  { ret 7; }
     val store: *mir.MirInstr = ?dst[1];
     if (store.opcode != mir.MIR_MOV || store.operands[0].kind != mir.MIR_OP_MEM) { ret 8; }
-    if (mir.operand_origin(?store.operands[0]) != 0 || !mir.operand_seed_secret(?f, ?store.operands[0])) { ret 9; }
-    if (store.operands[1].kind != mir.MIR_OP_PREG || store.operands[1].preg != 9) { ret 10; }
-    if (mir.operand_origin(?store.operands[1]) != 0 || !mir.operand_seed_secret(?f, ?store.operands[1])) { ret 11; }
+    if (mir.operand_origin(?store.operands[0]).n != 0 || !mir.operand_seed_secret(?f, ?store.operands[0])) { ret 9; }
+    if (store.operands[1].kind != mir.MIR_OP_PREG || store.operands[1].preg.n != 9) { ret 10; }
+    if (mir.operand_origin(?store.operands[1]).n != 0 || !mir.operand_seed_secret(?f, ?store.operands[1])) { ret 11; }
     ret 0;
 }
 
@@ -4326,7 +4326,7 @@ fun t_verify_bank_slots(tgt: *target.Target, opcode: mir.MirOpcode, bank0: mir.O
     for (k < count) {
         var class: i32 = isa.REG_CLASS_ID_GP;
         if (expected[k] == mir.BANK_FP) { class = isa.REG_CLASS_ID_XMM; }
-        ops[k] = mir.op_preg(isa.regid_make(class, 1 + k::i32)::u32);
+        ops[k] = mir.op_preg(mir.preg_id(isa.regid_make(class, 1 + k::i32)));
         k = k + 1;
     }
     var mi: mir.MirInstr = mir.instr(opcode, ?ops[0], count, 8, 8);
@@ -4341,10 +4341,10 @@ fun t_verify_bank_slots(tgt: *target.Target, opcode: mir.MirOpcode, bank0: mir.O
     if (sel verify_rewritten_operands_r.err) { ret 2; }
     k = 0;
     for (k < count) {
-        val original: u32 = ops[k].preg;
+        val original: mir.PRegId = ops[k].preg;
         var wrong: i32 = isa.REG_CLASS_ID_XMM;
         if (expected[k] == mir.BANK_FP) { wrong = isa.REG_CLASS_ID_GP; }
-        ops[k].preg = isa.regid_make(wrong, 1 + k::i32)::u32;
+        ops[k].preg = mir.preg_id(isa.regid_make(wrong, 1 + k::i32));
         val verify_rewritten_operands_r2: err[fail.Fail] = verify_rewritten_operands(tgt, ?f);
         if (sel verify_rewritten_operands_r2.ok) { ret 3; }
         ops[k].preg = original;
@@ -4373,7 +4373,7 @@ test "mach.lang.be.codegen.regalloc.verify_rewritten_operands:enforces_individua
     if (t_verify_bank_slots(?tgt, mir.MIR_MOV, mir.BANK_GP, mir.BANK_FP, mir.BANK_UNKNOWN, 2, false) != 0) { ret 8; }
     if (t_verify_bank_slots(?tgt, mir.MIR_ADD, mir.BANK_FP, mir.BANK_FP, mir.BANK_FP, 3, true) != 0) { ret 9; }
     var ops: [2]mir.MirOperand;
-    ops[0] = mir.op_preg(1); ops[1] = mir.op_mem_preg(tgt.model.stack_ptr_reg::u32, 0);
+    ops[0] = mir.op_preg(mir.preg_id(1)); ops[1] = mir.op_mem_preg(mir.preg_id(tgt.model.stack_ptr_reg), 0);
     var mi: mir.MirInstr = mir.instr(mir.MIR_MOV, ?ops[0], 2, 8, 8);
     var blk: mir.MirBlock; blk.instrs = ?mi; blk.instr_count = 1;
     var f: mir.MirFunction; f.blocks = ?blk; f.block_count = 1;
@@ -4381,17 +4381,16 @@ test "mach.lang.be.codegen.regalloc.verify_rewritten_operands:enforces_individua
     if (sel capture_operand_banks_r.err) { ret 10; }
     val verify_rewritten_operands_r: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
     if (sel verify_rewritten_operands_r.err) { ret 11; }
-    ops[1].preg = isa.regid_make(isa.REG_CLASS_ID_XMM, 1)::u32;
+    ops[1].preg = mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 1));
     val verify_rewritten_operands_r2: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
     if (sel verify_rewritten_operands_r2.ok) { ret 12; }
-    ops[1].preg = tgt.model.stack_ptr_reg::u32;
-    ops[1].index_is_preg = true;
-    ops[1].index = isa.regid_make(isa.REG_CLASS_ID_XMM, 1)::u32;
+    ops[1].preg = mir.preg_id(tgt.model.stack_ptr_reg);
+    ops[1].index = mir.index_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 1)));
     val verify_rewritten_operands_r3: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
     if (sel verify_rewritten_operands_r3.ok) { ret 13; }
     val alloc_function_r: err[fail.Fail] = alloc_function(?tgt, nil, ?f);
     if (sel alloc_function_r.ok) { ret 15; }
-    ops[1].index = 2;
+    ops[1].index = mir.index_preg(mir.preg_id(2));
     val verify_rewritten_operands_r4: err[fail.Fail] = verify_rewritten_operands(?tgt, ?f);
     if (sel verify_rewritten_operands_r4.err) { ret 14; }
     ret 0;
@@ -4486,17 +4485,17 @@ fun t_dense_liveness(ctx: *AllocCtx) err[fail.Fail] {
             var k: u32 = 0;
             for (k < mi.operand_count) {
                 val op: *mir.MirOperand = ?mi.operands[k];
-                var v: u32 = mir.MIR_VREG_NIL;
-                if (op.kind == mir.MIR_OP_VREG || op.kind == mir.MIR_OP_MEM) { v = op.vreg; }
+                var v: u32 = mir.MIR_VREG_NIL.n;
+                if (op.kind == mir.MIR_OP_VREG || op.kind == mir.MIR_OP_MEM) { v = op.vreg.n; }
                 if (v < nv && !(has_def && k == 0 && op.kind == mir.MIR_OP_VREG) && !defs[base + v::usize]) {
                     uses[base + v::usize] = true;
                 }
-                if (op.kind == mir.MIR_OP_MEM && !op.index_is_preg && op.index < nv && !defs[base + op.index::usize]) {
-                    uses[base + op.index::usize] = true;
+                if (sel op.index.vreg) {
+                    if (op.index.vreg.n < nv && !defs[base + op.index.vreg.n::usize]) { uses[base + op.index.vreg.n::usize] = true; }
                 }
                 k = k + 1;
             }
-            if (has_def && mi.operands[0].vreg < nv) { defs[base + mi.operands[0].vreg::usize] = true; }
+            if (has_def && mi.operands[0].vreg.n < nv) { defs[base + mi.operands[0].vreg.n::usize] = true; }
             ii = ii + 1;
         }
         bi = bi + 1;
@@ -4591,21 +4590,21 @@ fun t_sparse_liveness_case(sample: u32, ordinal: usize, attempts: *usize) i32 {
         var definition: u32 = 0;
         var use_index: u32 = 1;
         if ((sample & 2) != 0) { definition = 1; use_index = 0; }
-        operands[bi][definition][0] = mir.op_vreg(bi);
-        operands[bi][definition][1] = mir.op_preg(0);
+        operands[bi][definition][0] = mir.op_vreg(mir.vreg_id(bi));
+        operands[bi][definition][1] = mir.op_preg(mir.preg_id(0));
         instrs[bi][definition] = mir.instr(mir.MIR_MOV, ?operands[bi][definition][0], 2, 8, 8);
-        operands[bi][use_index][0] = mir.op_preg(0);
-        operands[bi][use_index][1] = mir.op_vreg((bi + sample) % 8);
+        operands[bi][use_index][0] = mir.op_preg(mir.preg_id(0));
+        operands[bi][use_index][1] = mir.op_vreg(mir.vreg_id((bi + sample) % 8));
         instrs[bi][use_index] = mir.instr(mir.MIR_MOV, ?operands[bi][use_index][0], 2, 8, 8);
         var destination: u32 = (bi + 1) % 8;
         if ((sample & 4) != 0) { destination = bi; }
         if ((sample & 3) == 3) { destination = (bi + 2) % 8; }
-        operands[bi][2][0] = mir.op_vreg(destination);
-        operands[bi][2][1] = mir.op_mem_value((bi + 2) % 8, 0);
-        operands[bi][2][1].index = (bi + 3) % 8;
-        operands[bi][2][1].index_is_preg = (sample & 1) != 0;
+        operands[bi][2][0] = mir.op_vreg(mir.vreg_id(destination));
+        operands[bi][2][1] = mir.op_mem_value(mir.vreg_id((bi + 2) % 8), 0);
+        if ((sample & 1) != 0) { operands[bi][2][1].index = mir.index_preg(mir.preg_id(((bi + 3) % 8)::i32)); }
+        or                     { operands[bi][2][1].index = mir.index_vreg(mir.vreg_id((bi + 3) % 8)); }
         instrs[bi][2] = mir.instr(mir.MIR_LOAD, ?operands[bi][2][0], 2, 8, 8);
-        operands[bi][3][0] = mir.op_vreg((bi + 4) % 8);
+        operands[bi][3][0] = mir.op_vreg(mir.vreg_id((bi + 4) % 8));
         operands[bi][3][1] = mir.op_block(40 - ((bi + 1) % 8) * 3);
         operands[bi][3][2] = mir.op_block(40 - ((bi + sample + 6) % 8) * 3);
         instrs[bi][3] = mir.instr(mir.MIR_CBR, ?operands[bi][3][0], 3, 8, 8);

--- a/src/lang/be/codegen/rules.mach
+++ b/src/lang/be/codegen/rules.mach
@@ -64,12 +64,12 @@ pub rec RulePack {
 
 fun typed_operand_bank(f: *mir.MirFunction, op: *mir.MirOperand) res[mir.OperandBank, fail.Fail] {
     if (op.kind == mir.MIR_OP_VREG) {
-        if (op.vreg >= f.vreg_count || f.vregs == nil) { ret res[mir.OperandBank, fail.Fail].err{fail.message("rules: operand bank refers to a missing virtual register")}; }
+        if (op.vreg.n >= f.vreg_count || f.vregs == nil) { ret res[mir.OperandBank, fail.Fail].err{fail.message("rules: operand bank refers to a missing virtual register")}; }
         if (mir.vreg_is_fp(f, op.vreg)) { ret res[mir.OperandBank, fail.Fail].ok{mir.BANK_FP}; }
         ret res[mir.OperandBank, fail.Fail].ok{mir.BANK_GP};
     }
     if (op.kind == mir.MIR_OP_PREG) {
-        val class: i32 = isa.regid_class(op.preg::i32);
+        val class: i32 = isa.regid_class(mir.preg_regid(op.preg));
         if (class == isa.REG_CLASS_ID_GP) { ret res[mir.OperandBank, fail.Fail].ok{mir.BANK_GP}; }
         if (class == isa.REG_CLASS_ID_XMM) { ret res[mir.OperandBank, fail.Fail].ok{mir.BANK_FP}; }
         ret res[mir.OperandBank, fail.Fail].err{fail.message("rules: operand bank refers to an unknown physical register class")};
@@ -213,7 +213,7 @@ fun gate_admits(gate: RuleGate, mi: *mir.MirInstr) bool {
 
 pub fun operand_rides_fp_bank(f: *mir.MirFunction, op: *mir.MirOperand) bool {
     if (op.kind == mir.MIR_OP_VREG) { ret mir.vreg_is_fp(f, op.vreg); }
-    if (op.kind == mir.MIR_OP_PREG) { ret isa.regid_class(op.preg::i32) == isa.REG_CLASS_ID_XMM; }
+    if (op.kind == mir.MIR_OP_PREG) { ret isa.regid_class(mir.preg_regid(op.preg)) == isa.REG_CLASS_ID_XMM; }
     ret false;
 }
 
@@ -240,15 +240,15 @@ fun count_vreg_refs(f: *mir.MirFunction, counts: *u32, nv: u32) {
             var k: u32 = 0;
             for (k < mi.operand_count) {
                 val op: *mir.MirOperand = ?mi.operands[k];
-                if (op.kind == mir.MIR_OP_VREG && op.vreg < nv) {
-                    counts[op.vreg] = counts[op.vreg] + 1;
+                if (op.kind == mir.MIR_OP_VREG && op.vreg.n < nv) {
+                    counts[op.vreg.n] = counts[op.vreg.n] + 1;
                 }
                 if (op.kind == mir.MIR_OP_MEM) {
-                    if (op.vreg != mir.MIR_VREG_NIL && op.vreg < nv) {
-                        counts[op.vreg] = counts[op.vreg] + 1;
+                    if (!mir.vreg_is_nil(op.vreg) && op.vreg.n < nv) {
+                        counts[op.vreg.n] = counts[op.vreg.n] + 1;
                     }
-                    if (!op.index_is_preg && op.index != mir.MIR_VREG_NIL && op.index < nv) {
-                        counts[op.index] = counts[op.index] + 1;
+                    if (sel op.index.vreg) {
+                        if (op.index.vreg.n < nv) { counts[op.index.vreg.n] = counts[op.index.vreg.n] + 1; }
                     }
                 }
                 k = k + 1;
@@ -259,9 +259,9 @@ fun count_vreg_refs(f: *mir.MirFunction, counts: *u32, nv: u32) {
     }
 }
 
-fun defines_vreg(mi: *mir.MirInstr, v: u32) bool {
+fun defines_vreg(mi: *mir.MirInstr, v: mir.VRegId) bool {
     if (!mir.instr_defines_shape(mi)) { ret false; }
-    ret mi.operands[0].kind == mir.MIR_OP_VREG && mi.operands[0].vreg == v;
+    ret mi.operands[0].kind == mir.MIR_OP_VREG && mir.vreg_same(mi.operands[0].vreg, v);
 }
 
 fun combine_cbr(pack: *RulePack, a: *A.Allocator, f: *mir.MirFunction) err[fail.Fail] {
@@ -320,7 +320,7 @@ fun fusable_cmp_index(pack: *RulePack, b: *mir.MirBlock, br: *mir.MirInstr,
     if (br.vec_lane != 0)                         { ret FUSE_NONE; }
     if (br.operand_count != 3)                    { ret FUSE_NONE; }
     if (br.operands[0].kind != mir.MIR_OP_VREG)   { ret FUSE_NONE; }
-    val v: u32 = br.operands[0].vreg;
+    val v: u32 = br.operands[0].vreg.n;
     if (v >= nv)                                  { ret FUSE_NONE; }
     if (counts[v] != 2)                           { ret FUSE_NONE; }
 
@@ -328,7 +328,7 @@ fun fusable_cmp_index(pack: *RulePack, b: *mir.MirBlock, br: *mir.MirInstr,
     var found: bool = false;
     for (k > 0 && !found) {
         k = k - 1;
-        if (defines_vreg(?b.instrs[k], v)) { found = true; }
+        if (defines_vreg(?b.instrs[k], mir.vreg_id(v))) { found = true; }
     }
     if (!found) { ret FUSE_NONE; }
 
@@ -371,7 +371,7 @@ fun fuse_pair(a: *A.Allocator, b: *mir.MirBlock, ci: u32, j: u32) err[fail.Fail]
         A.deallocate[mir.MirOperand](a, ops, 4::usize);
         ret res_dbg;
     }
-    rewrite_cond_bindings(br, br.operands[0].vreg, cmp);
+    rewrite_cond_bindings(br, br.operands[0].vreg.n, cmp);
 
     A.deallocate[mir.MirOperand](a, br.operands, br.operand_count::usize);
     br.opcode        = mir.fused_cbr_opcode(cmp.opcode);
@@ -401,22 +401,22 @@ fun rewrite_cond_bindings(br: *mir.MirInstr, cond_vreg: u32, cmp: *mir.MirInstr)
             val rhs: *mir.MirOperand = ?cmp.operands[2];
             if (lhs.kind == mir.MIR_OP_IMM) {
                 bind.lhs_is_imm = true;
-                bind.vreg       = mir.MIR_VREG_NIL;
+                bind.vreg       = mir.MIR_VREG_NIL.n;
                 bind.imm        = lhs.imm;
             }
             or {
                 bind.lhs_is_imm = false;
-                bind.vreg       = lhs.vreg;
+                bind.vreg       = lhs.vreg.n;
                 bind.imm        = 0;
             }
             if (rhs.kind == mir.MIR_OP_IMM) {
                 bind.rhs_is_imm = true;
-                bind.vreg2      = mir.MIR_VREG_NIL;
+                bind.vreg2      = mir.MIR_VREG_NIL.n;
                 bind.imm2       = rhs.imm;
             }
             or {
                 bind.rhs_is_imm = false;
-                bind.vreg2      = rhs.vreg;
+                bind.vreg2      = rhs.vreg.n;
                 bind.imm2       = 0;
             }
         }
@@ -638,7 +638,7 @@ fun write_opcode_ice(opcode: u32) {
 }
 
 fun t_operand_zero_is_preg_ten(tgt: *isa.BackendTarget, f: *mir.MirFunction, mi: *mir.MirInstr) bool {
-    ret mi.operands[0].kind == mir.MIR_OP_PREG && mi.operands[0].preg == 10;
+    ret mi.operands[0].kind == mir.MIR_OP_PREG && mi.operands[0].preg.n == 10;
 }
 
 fun t_expand_two_pieces(builder: *ExpansionBuilder) err[fail.Fail] {
@@ -686,8 +686,8 @@ test "mach.lang.be.codegen.rules.select:retag_pass_priority" {
     var ops:    [3][2]mir.MirOperand;
     var i:      u32 = 0;
     for (i < 3) {
-        ops[i][0] = mir.op_preg(10);
-        ops[i][1] = mir.op_preg(11);
+        ops[i][0] = mir.op_preg(mir.preg_id(10));
+        ops[i][1] = mir.op_preg(mir.preg_id(11));
         instrs[i].operands      = ?ops[i][0];
         instrs[i].operand_count = 2;
         instrs[i].width         = 8;
@@ -721,7 +721,7 @@ test "mach.lang.be.codegen.rules.select:retag_pass_priority" {
     if (instrs[1].opcode != 2)   { ret 1; }
     if (instrs[2].opcode != 101) { ret 1; }
     if (instrs[0].operand_count != 2)          { ret 1; }
-    if (instrs[0].operands[0].preg != 10)      { ret 1; }
+    if (instrs[0].operands[0].preg.n != 10)    { ret 1; }
     if (blk.instr_count != 3)                  { ret 1; }
     if (blk.instrs != ?instrs[0])              { ret 1; }
     ret 0;
@@ -733,10 +733,10 @@ test "mach.lang.be.codegen.rules.select:guard_routing" {
 
     var instrs: [2]mir.MirInstr;
     var ops:    [2][2]mir.MirOperand;
-    ops[0][0] = mir.op_preg(10);
-    ops[0][1] = mir.op_preg(11);
-    ops[1][0] = mir.op_preg(12);
-    ops[1][1] = mir.op_preg(11);
+    ops[0][0] = mir.op_preg(mir.preg_id(10));
+    ops[0][1] = mir.op_preg(mir.preg_id(11));
+    ops[1][0] = mir.op_preg(mir.preg_id(12));
+    ops[1][1] = mir.op_preg(mir.preg_id(11));
     var i: u32 = 0;
     for (i < 2) {
         instrs[i].opcode        = 7;
@@ -782,8 +782,8 @@ test "mach.lang.be.codegen.rules.select:gate_routing" {
     var ops:    [2][2]mir.MirOperand;
     var i:      u32 = 0;
     for (i < 2) {
-        ops[i][0] = mir.op_preg(10);
-        ops[i][1] = mir.op_preg(11);
+        ops[i][0] = mir.op_preg(mir.preg_id(10));
+        ops[i][1] = mir.op_preg(mir.preg_id(11));
         instrs[i].opcode        = 5;
         instrs[i].operands      = ?ops[i][0];
         instrs[i].operand_count = 2;
@@ -791,8 +791,8 @@ test "mach.lang.be.codegen.rules.select:gate_routing" {
         i = i + 1;
     }
     instrs[1].vec_lane = mir.vec_lane_make(mir.VEC_LANE_FLOAT, 4, 4);
-    ops[1][0] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, 0)::u32);
-    ops[1][1] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, 1)::u32);
+    ops[1][0] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 0)));
+    ops[1][1] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 1)));
 
     var rules_table: [2]Rule;
     rules_table[0].op   = 5;
@@ -829,8 +829,8 @@ test "mach.lang.be.codegen.rules.select:unmatched_opcode_fails" {
 
     var instrs: [1]mir.MirInstr;
     var ops:    [2]mir.MirOperand;
-    ops[0] = mir.op_preg(10);
-    ops[1] = mir.op_preg(11);
+    ops[0] = mir.op_preg(mir.preg_id(10));
+    ops[1] = mir.op_preg(mir.preg_id(11));
     instrs[0].opcode        = 40;
     instrs[0].operands      = ?ops[0];
     instrs[0].operand_count = 2;
@@ -867,14 +867,14 @@ test "mach.lang.be.codegen.rules.select:expansion_identity_carriage" {
     val res_exp_ops: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?backing, 2::usize);
     if (sel res_exp_ops.err) { ret 1; }
     val exp_ops: *mir.MirOperand = res_exp_ops.ok;
-    exp_ops[0] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, 0)::u32);
-    exp_ops[1] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, 1)::u32);
+    exp_ops[0] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 0)));
+    exp_ops[1] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 1)));
 
     var edge_ops: [2][2]mir.MirOperand;
-    edge_ops[0][0] = mir.op_preg(12);
-    edge_ops[0][1] = mir.op_preg(13);
-    edge_ops[1][0] = mir.op_preg(14);
-    edge_ops[1][1] = mir.op_preg(15);
+    edge_ops[0][0] = mir.op_preg(mir.preg_id(12));
+    edge_ops[0][1] = mir.op_preg(mir.preg_id(13));
+    edge_ops[1][0] = mir.op_preg(mir.preg_id(14));
+    edge_ops[1][1] = mir.op_preg(mir.preg_id(15));
 
     var bindings: [1]mir.MirDbgBinding;
     bindings[0].iid  = 7;
@@ -943,7 +943,7 @@ test "mach.lang.be.codegen.rules.select:expansion_identity_carriage" {
         if (blk.instrs[p].memory_flags != mir.MEMORY_VOLATILE) { ret 2; }
         if (blk.instrs[p].asm_block != nil)   { ret 1; }
         if (blk.instrs[p].operand_count != 2) { ret 1; }
-        if (blk.instrs[p].operands[0].preg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)::u32) { ret 1; }
+        if (mir.preg_regid(blk.instrs[p].operands[0].preg) != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
         if (blk.instrs[p].operands[0].required_bank != mir.BANK_FP) { ret 2; }
         p = p + 1;
     }
@@ -969,8 +969,8 @@ test "mach.lang.be.codegen.rules.select:expansion_length_mismatch_fails" {
     val res_ops: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?backing, 2::usize);
     if (sel res_ops.err) { ret 1; }
     val ops: *mir.MirOperand = res_ops.ok;
-    ops[0] = mir.op_preg(10);
-    ops[1] = mir.op_preg(11);
+    ops[0] = mir.op_preg(mir.preg_id(10));
+    ops[1] = mir.op_preg(mir.preg_id(11));
     instrs[0].opcode        = 9;
     instrs[0].operands      = ops;
     instrs[0].operand_count = 2;
@@ -1009,8 +1009,8 @@ test "mach.lang.be.codegen.rules.select:expansion_over_emission_fails" {
     val res_ops: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?backing, 2::usize);
     if (sel res_ops.err) { ret 1; }
     val ops: *mir.MirOperand = res_ops.ok;
-    ops[0] = mir.op_preg(10);
-    ops[1] = mir.op_preg(11);
+    ops[0] = mir.op_preg(mir.preg_id(10));
+    ops[1] = mir.op_preg(mir.preg_id(11));
     instrs[0].opcode        = 9;
     instrs[0].operands      = ops;
     instrs[0].operand_count = 2;
@@ -1065,9 +1065,9 @@ test "mach.lang.be.codegen.rules.combine_cbr:fuses_safe_shape" {
     val instrs: *mir.MirInstr = res_instrs.ok;
 
     var cmp_ops: [3]mir.MirOperand;
-    cmp_ops[0] = mir.op_vreg(2);
-    cmp_ops[1] = mir.op_vreg(0);
-    cmp_ops[2] = mir.op_vreg(1);
+    cmp_ops[0] = mir.op_vreg(mir.vreg_id(2));
+    cmp_ops[1] = mir.op_vreg(mir.vreg_id(0));
+    cmp_ops[2] = mir.op_vreg(mir.vreg_id(1));
     if (!t_heap_instr(?backing, ?instrs[0], mir.MIR_CMP_LT_S, ?cmp_ops[0], 3)) { ret 1; }
     instrs[0].width     = 4;
     instrs[0].src_width = 4;
@@ -1081,7 +1081,7 @@ test "mach.lang.be.codegen.rules.combine_cbr:fuses_safe_shape" {
     instrs[0].dbg_binding_count = 1;
 
     var br_ops: [3]mir.MirOperand;
-    br_ops[0] = mir.op_vreg(2);
+    br_ops[0] = mir.op_vreg(mir.vreg_id(2));
     br_ops[1] = mir.op_block(5);
     br_ops[2] = mir.op_block(9);
     if (!t_heap_instr(?backing, ?instrs[1], mir.MIR_CBR, ?br_ops[0], 3)) { ret 1; }
@@ -1129,8 +1129,8 @@ test "mach.lang.be.codegen.rules.combine_cbr:fuses_safe_shape" {
     val fused: *mir.MirInstr = ?blk.instrs[0];
     if (fused.opcode != mir.MIR_SEL_CBR_LT_S) { ret 1; }
     if (fused.operand_count != 4)             { ret 1; }
-    if (fused.operands[0].kind != mir.MIR_OP_VREG || fused.operands[0].vreg != 0) { ret 1; }
-    if (fused.operands[1].kind != mir.MIR_OP_VREG || fused.operands[1].vreg != 1) { ret 1; }
+    if (fused.operands[0].kind != mir.MIR_OP_VREG || fused.operands[0].vreg.n != 0) { ret 1; }
+    if (fused.operands[1].kind != mir.MIR_OP_VREG || fused.operands[1].vreg.n != 1) { ret 1; }
     if (fused.operands[2].kind != mir.MIR_OP_BLOCK || fused.operands[2].imm != 5) { ret 1; }
     if (fused.operands[3].kind != mir.MIR_OP_BLOCK || fused.operands[3].imm != 9) { ret 1; }
 
@@ -1170,17 +1170,17 @@ test "mach.lang.be.codegen.rules.combine_cbr:declines_unsafe_shapes" {
     pack.fused_cbr_cc_count = 6;
 
     var cmp_ops: [3]mir.MirOperand;
-    cmp_ops[0] = mir.op_vreg(2);
-    cmp_ops[1] = mir.op_vreg(0);
-    cmp_ops[2] = mir.op_vreg(1);
+    cmp_ops[0] = mir.op_vreg(mir.vreg_id(2));
+    cmp_ops[1] = mir.op_vreg(mir.vreg_id(0));
+    cmp_ops[2] = mir.op_vreg(mir.vreg_id(1));
     var use_ops: [2]mir.MirOperand;
-    use_ops[0] = mir.op_vreg(3);
-    use_ops[1] = mir.op_vreg(2);
+    use_ops[0] = mir.op_vreg(mir.vreg_id(3));
+    use_ops[1] = mir.op_vreg(mir.vreg_id(2));
     var redef_ops: [2]mir.MirOperand;
-    redef_ops[0] = mir.op_vreg(0);
+    redef_ops[0] = mir.op_vreg(mir.vreg_id(0));
     redef_ops[1] = mir.op_imm(4);
     var br_ops: [3]mir.MirOperand;
-    br_ops[0] = mir.op_vreg(2);
+    br_ops[0] = mir.op_vreg(mir.vreg_id(2));
     br_ops[1] = mir.op_block(5);
     br_ops[2] = mir.op_block(9);
 
@@ -1272,23 +1272,23 @@ test "mach.lang.be.codegen.rules.is_reg_move:membership" {
 
 test "mach.lang.be.codegen.rules.capture_operand_banks:checks_opcode_before_preserving_type" {
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(1); ops[1] = mir.op_preg(2); ops[2] = mir.op_preg(3);
+    ops[0] = mir.op_preg(mir.preg_id(1)); ops[1] = mir.op_preg(mir.preg_id(2)); ops[2] = mir.op_preg(mir.preg_id(3));
     var mi: mir.MirInstr = mir.instr(mir.MIR_FADD, ?ops[0], 3, 8, 8);
     var f: mir.MirFunction;
     val capture_operand_banks_r: err[fail.Fail] = capture_operand_banks(?f, ?mi);
     if (sel capture_operand_banks_r.ok) { ret 1; }
     var k: u32 = 0;
-    for (k < 3) { ops[k] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, k::i32)::u32); k = k + 1; }
+    for (k < 3) { ops[k] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, k::i32))); k = k + 1; }
     val capture_operand_banks_r2: err[fail.Fail] = capture_operand_banks(?f, ?mi);
     if (sel capture_operand_banks_r2.err) { ret 2; }
     mi.opcode = mir.MIR_FP_TO_SI; mi.operand_count = 2;
     val capture_operand_banks_r3: err[fail.Fail] = capture_operand_banks(?f, ?mi);
     if (sel capture_operand_banks_r3.ok) { ret 3; }
-    ops[0] = mir.op_preg(1);
+    ops[0] = mir.op_preg(mir.preg_id(1));
     val capture_operand_banks_r4: err[fail.Fail] = capture_operand_banks(?f, ?mi);
     if (sel capture_operand_banks_r4.err) { ret 4; }
     if (ops[0].required_bank != mir.BANK_GP || ops[1].required_bank != mir.BANK_FP) { ret 5; }
-    ops[0] = mir.op_vreg(0);
+    ops[0] = mir.op_vreg(mir.vreg_id(0));
     val capture_operand_banks_r5: err[fail.Fail] = capture_operand_banks(?f, ?mi);
     if (sel capture_operand_banks_r5.ok) { ret 6; }
     var vregs: [1]mir.MirVReg;
@@ -1321,7 +1321,7 @@ test "mach.lang.be.codegen.rules.emit:new_registers_require_explicit_bank_constr
         }
     }
     var ops: [2]mir.MirOperand;
-    ops[0] = mir.op_preg(1); ops[1] = mir.op_imm(0);
+    ops[0] = mir.op_preg(mir.preg_id(1)); ops[1] = mir.op_imm(0);
     val emit_r: res[*mir.MirInstr, fail.Fail] = emit_instr(?builder, 900, ?ops[0], 2);
     if (sel emit_r.ok) { ret 2; }
     if (builder.emitted != 0 || builder.cursor != 0) { ret 3; }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -16717,12 +16717,12 @@ fun ut_transport_moves_v(s: *session.Session, mm: *mir.MirModule, suffix: str, m
                     && mi.operands[0].kind == mir.MIR_OP_PREG && mi.operands[1].kind == mir.MIR_OP_VREG
                     && (!has_call || ii < last_call)) {
                     @moves = @moves + 1;
-                    if (mf.vregs[mi.operands[1].vreg].secret) { @secret = @secret + 1; }
+                    if (mf.vregs[mi.operands[1].vreg.n].secret) { @secret = @secret + 1; }
                 }
                 if (mi.opcode == mir.MIR_CBR || mir.is_fused_cbr(mi.opcode)) {
                     var k: u32 = 0;
                     for (k < mi.operand_count) {
-                        if (mi.operands[k].kind == mir.MIR_OP_VREG && mf.vregs[mi.operands[k].vreg].secret) { @branch_secret = true; }
+                        if (mi.operands[k].kind == mir.MIR_OP_VREG && mf.vregs[mi.operands[k].vreg.n].secret) { @branch_secret = true; }
                         k = k + 1;
                     }
                 }

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -10655,6 +10655,75 @@ test "mach.lang.driver:section_identity_is_not_another_identity_domain" {
     ret bad;
 }
 
+# the negative interchange check behind `mir.VRegId` / `mir.PRegId` (#2212,
+# the #3114 acceptance): a virtual register cannot be assigned where a
+# physical one is meant, a physical one cannot stand in for a virtual one, a
+# vreg number cannot become a memory index without naming its case, and
+# neither identity indexes a table without the unwrap. the records and the
+# tag mirror the operand's shape because a snippet project cannot import the
+# compiler's own modules; the rule pinned here is the one MirOperand rests on.
+test "mach.lang.driver:register_identity_is_not_another_identity_domain" {
+    var alloc: A.Allocator;
+    val make_r: err[A.Error] = page.make(?alloc);
+    if (sel make_r.err) { ret 1; }
+    var bad: i32 = 0;
+    val a_src: str = "pub rec VRegId { n: u32; }\npub rec PRegId { n: u32; }\npub tag MirIndex: u8 { none; vreg: VRegId; preg: PRegId; }\npub rec MirOperand { vreg: VRegId; preg: PRegId; index: MirIndex; }\npub fun vreg_id(n: u32) VRegId { var v: VRegId; v.n = n; ret v; }\npub fun preg_id(regid: i32) PRegId { var p: PRegId; p.n = regid::u32; ret p; }\n";
+
+    val sr: res[session.Session, fail.Fail] = session.init(?alloc);
+    if (sel sr.err) { ret 1; }
+    var s: session.Session = sr.ok;
+    val pr: res[project.Project, outcome.Fail] = ut_sema2(?s, ?alloc,
+        "use a: uniontest.a;\nfun main() i64 { var op: a.MirOperand; op.preg = op.vreg; ret 0; }\n", a_src);
+    if (!ut_project_was_rejected(pr)) { session.dnit(?s); ret 2; }
+    if (!ut_diag_has(?s.diags, "type mismatch: expected PRegId, found VRegId")) { bad = 1; }
+    session.dnit(?s);
+
+    val sr2: res[session.Session, fail.Fail] = session.init(?alloc);
+    if (sel sr2.err) { ret 1; }
+    var s2: session.Session = sr2.ok;
+    val pr2: res[project.Project, outcome.Fail] = ut_sema2(?s2, ?alloc,
+        "use a: uniontest.a;\nfun main() i64 { var op: a.MirOperand; op.vreg = a.preg_id(3); ret 0; }\n", a_src);
+    if (!ut_project_was_rejected(pr2)) { session.dnit(?s2); ret 3; }
+    if (!ut_diag_has(?s2.diags, "type mismatch: expected VRegId, found PRegId")) { bad = bad | 2; }
+    session.dnit(?s2);
+
+    val sr3: res[session.Session, fail.Fail] = session.init(?alloc);
+    if (sel sr3.err) { ret 1; }
+    var s3: session.Session = sr3.ok;
+    val pr3: res[project.Project, outcome.Fail] = ut_sema2(?s3, ?alloc,
+        "use a: uniontest.a;\nfun main() i64 { var op: a.MirOperand; val raw: u32 = 3; op.preg = raw; ret 0; }\n", a_src);
+    if (!ut_project_was_rejected(pr3)) { session.dnit(?s3); ret 4; }
+    if (!ut_diag_has(?s3.diags, "type mismatch: expected PRegId, found u32")) { bad = bad | 4; }
+    session.dnit(?s3);
+
+    val sr4: res[session.Session, fail.Fail] = session.init(?alloc);
+    if (sel sr4.err) { ret 1; }
+    var s4: session.Session = sr4.ok;
+    val pr4: res[project.Project, outcome.Fail] = ut_sema2(?s4, ?alloc,
+        "use a: uniontest.a;\nfun main() i64 { var op: a.MirOperand; op.index = op.vreg; ret 0; }\n", a_src);
+    if (!ut_project_was_rejected(pr4)) { session.dnit(?s4); ret 5; }
+    if (!ut_diag_has(?s4.diags, "type mismatch: expected MirIndex, found VRegId")) { bad = bad | 8; }
+    session.dnit(?s4);
+
+    val sr5: res[session.Session, fail.Fail] = session.init(?alloc);
+    if (sel sr5.err) { ret 1; }
+    var s5: session.Session = sr5.ok;
+    val pr5: res[project.Project, outcome.Fail] = ut_sema2(?s5, ?alloc,
+        "use a: uniontest.a;\nfun main() i64 { var op: a.MirOperand; var table: [4]u32; ret table[op.vreg]::i64; }\n", a_src);
+    if (!ut_project_was_rejected(pr5)) { session.dnit(?s5); ret 6; }
+    if (!ut_diag_has(?s5.diags, "index must be an integer")) { bad = bad | 16; }
+    session.dnit(?s5);
+
+    val sr6: res[session.Session, fail.Fail] = session.init(?alloc);
+    if (sel sr6.err) { ret 1; }
+    var s6: session.Session = sr6.ok;
+    val pr6: res[project.Project, outcome.Fail] = ut_sema2(?s6, ?alloc,
+        "use a: uniontest.a;\nfun main() i64 { var op: a.MirOperand; op.preg = a.preg_id(3); op.index = a.MirIndex.vreg{op.vreg}; var table: [4]u32; ret table[op.vreg.n]::i64; }\n", a_src);
+    if (ut_project_was_rejected(pr6)) { session.dnit(?s6); ret 7; }
+    session.dnit(?s6);
+    ret bad;
+}
+
 test "mach.lang.driver:distinct_name_type_mismatch_keeps_its_note" {
     var alloc: A.Allocator;
     val make_r: err[A.Error] = page.make(?alloc);

--- a/src/lang/fuzz/mir.mach
+++ b/src/lang/fuzz/mir.mach
@@ -98,14 +98,17 @@ pub fun answer(alloc: *A.Allocator, data: *u8, len: usize) verdict.Verdict {
                 for (o < OPERAND_COUNT) {
                     var op: mir.MirOperand;
                     op.kind          = byte(?c)::mir.MirOperandKind;
-                    op.vreg          = word(?c) % PREG_LIMIT;
-                    op.preg          = word(?c) % PREG_LIMIT;
+                    op.vreg          = mir.vreg_id(word(?c) % PREG_LIMIT);
+                    op.preg          = mir.preg_id((word(?c) % PREG_LIMIT)::i32);
                     op.imm           = dword(?c)::i64;
                     op.sym           = intern.STR_NIL;
                     op.sym_off       = word(?c)::i32;
-                    op.index         = word(?c);
+                    val index: u32   = word(?c);
                     op.scale         = byte(?c);
-                    op.index_is_preg = (byte(?c) & 1) == 1;
+                    val index_case: u8 = byte(?c) % 3;
+                    op.index         = mir.index_none();
+                    if (index_case == 1) { op.index = mir.index_vreg(mir.vreg_id(index)); }
+                    or (index_case == 2) { op.index = mir.index_preg(mir.preg_id(index::i32)); }
                     op.sym_got       = (byte(?c) & 1) == 1;
                     operands[f][b][i][o] = op;
                     o = o + 1;

--- a/src/lang/target.mach
+++ b/src/lang/target.mach
@@ -30,6 +30,7 @@ use A: std.allocator;
 
 use fp: mach.lang.build.fingerprint;
 use mach.lang.be.codegen.debug_input;
+use mach.lang.be.codegen.mir;
 use mach.lang.intern;
 use mach.lang.target.abi;
 use mach.lang.target.abi.aapcs64;
@@ -1483,14 +1484,14 @@ test "mach.lang.target.select:linux_riscv64" {
     val arg: abi.ArgPassingFn = t.abi.arg_passing;
     val ai: abi.ParamSlot = arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (ai.class != abi.CLASS_GP) { ret 1; }
-    if (ai.reg != 10)             { ret 1; }
+    if (mir.preg_regid(ai.reg) != 10)             { ret 1; }
     val af: abi.ParamSlot = arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (af.class != abi.CLASS_FP)                                  { ret 1; }
-    if (af.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 10))        { ret 1; }
+    if (mir.preg_regid(af.reg) != isa.regid_make(isa.REG_CLASS_ID_XMM, 10))        { ret 1; }
     val rp: abi.RetPassingFn = t.abi.ret_passing;
     val rr: abi.ParamSlot = rp(8, 8, false, 0, false, false, 0, 0, abi.agg_none());
     if (rr.class != abi.CLASS_GP) { ret 1; }
-    if (rr.reg != 10)             { ret 1; }
+    if (mir.preg_regid(rr.reg) != 10)             { ret 1; }
 
     ret 0;
 }
@@ -1545,10 +1546,10 @@ test "mach.lang.target.select:riscv32_freestanding_raw" {
     val arg: abi.ArgPassingFn = t.abi.arg_passing;
     val ai: abi.ParamSlot = arg(0, 4, 4, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (ai.class != abi.CLASS_GP) { ret 1; }
-    if (ai.reg != 10)             { ret 1; }
+    if (mir.preg_regid(ai.reg) != 10)             { ret 1; }
     val af: abi.ParamSlot = arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (af.class != abi.CLASS_FP)                           { ret 1; }
-    if (af.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 10)) { ret 1; }
+    if (mir.preg_regid(af.reg) != isa.regid_make(isa.REG_CLASS_ID_XMM, 10)) { ret 1; }
 
     if (t.of == nil)                         { ret 1; }
     if (!str_equals(t.os.default_of, "raw")) { ret 1; }
@@ -2146,7 +2147,7 @@ test "mach.lang.target.abi_vtable:granularity_matches_its_classifier" {
                 || vt.callee_saved != nil || vt.va_model != nil || vt.arg_passing == nil) { ret 2; }
             val classify: abi.ArgPassingFn = vt.arg_passing;
             val logical: abi.ParamSlot = classify(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
-            if (logical.class != abi.CLASS_VALUE || logical.piece_count != 0 || logical.size != 16 || logical.reg != -1) { ret 3; }
+            if (logical.class != abi.CLASS_VALUE || logical.piece_count != 0 || logical.size != 16 || !mir.preg_is_nil(logical.reg)) { ret 3; }
             i = i + 1;
             cnt;
         }

--- a/src/lang/target/abi.mach
+++ b/src/lang/target/abi.mach
@@ -18,6 +18,7 @@ use std.types.string.str_len;
 use A: std.allocator;
 
 use mach.lang.target.isa;
+use mach.lang.be.codegen.mir;
 
 pub val ABI_UNKNOWN: u32 = 0;
 pub val ABI_SYSV:    u32 = 1;
@@ -114,7 +115,7 @@ pub val PARAM_MAX_PIECES: u32 = 4;
 
 pub rec ParamPiece {
     kind:    PieceKind;
-    reg:     i32;
+    reg:     mir.PRegId;
     src_off: i64;
     stk_off: i64;
     # transport width, independent of bytes remaining in the logical object
@@ -125,9 +126,11 @@ pub rec AggField { is_float: bool; offset: u32; width: u8; }
 pub rec AggLayout { field_count: u8; fields: [2]AggField; }
 pub fun agg_none() AggLayout { var a: AggLayout; a.field_count = 0; ret a; }
 
+# reg is the physical register the slot rides, MIR_PREG_NIL for a stack slot;
+# the constructors take the isa regid the packs select (-1 for none)
 pub rec ParamSlot {
     class:          ParamClass;
-    reg:            i32;
+    reg:            mir.PRegId;
     offset:         i64;
     size:           u64;
     indirect_size:  u64;
@@ -559,7 +562,7 @@ fun piece_for_reg(reg: i32, src_off: i64, word: u32) ParamPiece {
 fun make_slot_base(class: ParamClass, reg: i32, offset: i64, size: u64, carrier_width: u8) ParamSlot {
     var s: ParamSlot;
     s.class          = class;
-    s.reg            = reg;
+    s.reg            = mir.preg_id(reg);
     s.offset         = offset;
     s.size           = size;
     s.indirect_size  = 0;
@@ -594,7 +597,7 @@ pub fun make_slot_indirect(class: ParamClass, reg: i32, offset: i64, size: u64,
 pub fun make_slot_value(size: u64) ParamSlot {
     var s: ParamSlot;
     s.class = CLASS_VALUE;
-    s.reg = -1;
+    s.reg = mir.MIR_PREG_NIL;
     s.size = size;
     ret s;
 }
@@ -603,7 +606,7 @@ pub fun make_slot_pair(class: ParamClass, reg: i32, reg2: i32, offset: i64, size
                        word: u32) ParamSlot {
     var s: ParamSlot;
     s.class       = class;
-    s.reg         = reg;
+    s.reg         = mir.preg_id(reg);
     s.offset      = offset;
     s.size        = size;
     s.indirect_size  = 0;
@@ -626,7 +629,7 @@ pub fun make_slot_hfa(base_reg: i32, count: u8, elem: u8, size: u64) ParamSlot {
     }
     var s: ParamSlot;
     s.class     = CLASS_FP;
-    s.reg       = base_reg;
+    s.reg       = mir.preg_id(base_reg);
     s.offset    = 0;
     s.size      = size;
     s.indirect_size  = 0;
@@ -645,7 +648,7 @@ pub fun make_slot_hfa(base_reg: i32, count: u8, elem: u8, size: u64) ParamSlot {
 pub fun make_piece(kind: PieceKind, reg: i32, src_off: i64, stk_off: i64, width: u8) ParamPiece {
     var p: ParamPiece;
     p.kind    = kind;
-    p.reg     = reg;
+    p.reg     = mir.preg_id(reg);
     p.src_off = src_off;
     p.stk_off = stk_off;
     p.width   = width;
@@ -658,7 +661,7 @@ pub fun make_slot_pieces(class: ParamClass, pieces: *ParamPiece, count: u32, siz
     }
     var s: ParamSlot;
     s.class     = class;
-    s.reg       = -1;
+    s.reg       = mir.MIR_PREG_NIL;
     s.offset    = 0;
     s.size      = size;
     s.indirect_size  = 0;
@@ -748,7 +751,7 @@ test "mach.lang.target.abi.make_slot_pair:geometry_is_the_conventions_word" {
     if (p4.piece_count != 2)       { ret 1; }
     if (p4.pieces[0].src_off != 0) { ret 1; }
     if (p4.pieces[0].width != 4)   { ret 1; }
-    if (p4.pieces[1].reg != 11)    { ret 1; }
+    if (mir.preg_regid(p4.pieces[1].reg) != 11)    { ret 1; }
     if (p4.pieces[1].src_off != 4) { ret 1; }
     if (p4.pieces[1].width != 4)   { ret 1; }
 

--- a/src/lang/target/abi/aapcs64.mach
+++ b/src/lang/target/abi/aapcs64.mach
@@ -9,6 +9,7 @@ use std.types.string.str;
 
 use mach.lang.target.abi;
 use mach.lang.target.isa;
+use mach.lang.be.codegen.mir;
 
 pub val REG_X0:  i32 = 0;
 pub val REG_X1:  i32 = 1;
@@ -216,10 +217,10 @@ pub fun register(reg: *abi.AbiRegistry) err[fail.Fail] {
 test "mach.lang.target.abi.aapcs64.classify_arg:scalar_register_banks" {
     val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
-    if (i.reg != REG_X0)         { ret 1; }
+    if (mir.preg_regid(i.reg) != REG_X0)         { ret 1; }
     val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)  { ret 1; }
-    if (f.reg != fp_param_reg(0)) { ret 1; }
+    if (mir.preg_regid(f.reg) != fp_param_reg(0)) { ret 1; }
     ret 0;
 }
 
@@ -227,19 +228,19 @@ test "mach.lang.target.abi.aapcs64.classify_arg:integer_aggregate_gp" {
     val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP)    { ret 1; }
     if (s.piece_count   != 2)       { ret 1; }
-    if (s.pieces[0].reg != REG_X0)  { ret 1; }
-    if (s.pieces[1].reg != REG_X1)  { ret 1; }
+    if (mir.preg_regid(s.pieces[0].reg) != REG_X0)  { ret 1; }
+    if (mir.preg_regid(s.pieces[1].reg) != REG_X1)  { ret 1; }
     val o: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (o.class != abi.CLASS_GP)    { ret 1; }
     if (o.piece_count   != 1)       { ret 1; }
-    if (o.pieces[0].reg != REG_X0)  { ret 1; }
+    if (mir.preg_regid(o.pieces[0].reg) != REG_X0)  { ret 1; }
     ret 0;
 }
 
 test "mach.lang.target.abi.aapcs64.classify_arg:large_aggregate_byref" {
     val s: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_BYREF) { ret 1; }
-    if (s.reg   != REG_X0)          { ret 1; }
+    if (mir.preg_regid(s.reg) != REG_X0)          { ret 1; }
     val e: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 8, 0, 0, 0, abi.agg_none());
     if (e.class != abi.CLASS_STACK_BYREF) { ret 1; }
     ret 0;
@@ -248,17 +249,17 @@ test "mach.lang.target.abi.aapcs64.classify_arg:large_aggregate_byref" {
 test "mach.lang.target.abi.aapcs64.classify_arg:hfa_v_run" {
     val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, false, 0, 0, 2, 4, abi.agg_none());
     if (s.piece_count     != 2)               { ret 1; }
-    if (s.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
+    if (mir.preg_regid(s.pieces[0].reg)   != fp_param_reg(0)) { ret 1; }
     if (s.pieces[0].width != 4)               { ret 1; }
-    if (s.pieces[1].reg   != fp_param_reg(1)) { ret 1; }
+    if (mir.preg_regid(s.pieces[1].reg)   != fp_param_reg(1)) { ret 1; }
     if (s.size != 8)                          { ret 1; }
     val q: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 0, 0, 4, 8, abi.agg_none());
     if (q.piece_count     != 4)               { ret 1; }
-    if (q.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
+    if (mir.preg_regid(q.pieces[0].reg)   != fp_param_reg(0)) { ret 1; }
     if (q.pieces[0].width != 8)               { ret 1; }
-    if (q.pieces[3].reg   != fp_param_reg(3)) { ret 1; }
+    if (mir.preg_regid(q.pieces[3].reg)   != fp_param_reg(3)) { ret 1; }
     val a: abi.ParamSlot = classify_arg(0, 8, 4, false, 0, true, false, 0, 5, 2, 4, abi.agg_none());
-    if (a.pieces[0].reg != fp_param_reg(5)) { ret 1; }
+    if (mir.preg_regid(a.pieces[0].reg) != fp_param_reg(5)) { ret 1; }
     val m: abi.ParamSlot = classify_arg(0, 12, 4, false, 0, true, false, 0, 6, 3, 4, abi.agg_none());
     if (m.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
@@ -267,16 +268,16 @@ test "mach.lang.target.abi.aapcs64.classify_arg:hfa_v_run" {
 test "mach.lang.target.abi.aapcs64.classify_arg:short_vector_hva" {
     val v: abi.ParamSlot = classify_arg(0, 16, 16, false, 0, false, true, 0, 0, 0, 0, abi.agg_none());
     if (v.class != abi.CLASS_FP)  { ret 1; }
-    if (v.reg != fp_param_reg(0)) { ret 1; }
+    if (mir.preg_regid(v.reg) != fp_param_reg(0)) { ret 1; }
     if (v.piece_count != 1)       { ret 1; }
     if (v.pieces[0].width != 16)  { ret 1; }
     val v2: abi.ParamSlot = classify_arg(1, 16, 16, false, 0, false, true, 0, 3, 0, 0, abi.agg_none());
-    if (v2.reg != fp_param_reg(3)) { ret 1; }
+    if (mir.preg_regid(v2.reg) != fp_param_reg(3)) { ret 1; }
     val vs: abi.ParamSlot = classify_arg(2, 16, 16, false, 0, false, true, 0, 8, 0, 0, abi.agg_none());
     if (vs.class != abi.CLASS_STACK) { ret 1; }
     val r: abi.ParamSlot = classify_return(16, 16, false, 0, false, true, 0, 0, abi.agg_none());
     if (r.class != abi.CLASS_FP)  { ret 1; }
-    if (r.reg != fp_param_reg(0)) { ret 1; }
+    if (mir.preg_regid(r.reg) != fp_param_reg(0)) { ret 1; }
     if (r.pieces[0].width != 16)  { ret 1; }
     ret 0;
 }
@@ -284,7 +285,7 @@ test "mach.lang.target.abi.aapcs64.classify_arg:short_vector_hva" {
 test "mach.lang.target.abi.aapcs64.classify:vector_piece_is_a_whole_v_register" {
     val d: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, true, 0, 0, 0, 0, abi.agg_none());
     if (d.class != abi.CLASS_FP)  { ret 1; }
-    if (d.reg != fp_param_reg(0)) { ret 1; }
+    if (mir.preg_regid(d.reg) != fp_param_reg(0)) { ret 1; }
     if (d.piece_count != 1)       { ret 1; }
     if (d.pieces[0].width != 16)  { ret 1; }
     if (d.size != 8)              { ret 1; }
@@ -302,7 +303,7 @@ test "mach.lang.target.abi.aapcs64.classify:vector_piece_is_a_whole_v_register" 
 
     val w: abi.ParamSlot = classify_arg(0, 32, 16, false, 0, false, true, 0, 0, 0, 0, abi.agg_none());
     if (w.class != abi.CLASS_BYREF) { ret 1; }
-    if (w.reg != gp_param_reg(0))   { ret 1; }
+    if (mir.preg_regid(w.reg) != gp_param_reg(0))   { ret 1; }
     if (w.size != 8)                { ret 1; }
 
     val ws: abi.ParamSlot = classify_arg(0, 32, 16, false, 0, false, true, GP_PARAM_COUNT, 0, 0, 0, abi.agg_none());
@@ -311,17 +312,17 @@ test "mach.lang.target.abi.aapcs64.classify:vector_piece_is_a_whole_v_register" 
 
     val wr: abi.ParamSlot = classify_return(32, 16, false, 0, false, true, 0, 0, abi.agg_none());
     if (wr.class != abi.CLASS_SRET) { ret 1; }
-    if (wr.reg != REG_X8)           { ret 1; }
+    if (mir.preg_regid(wr.reg) != REG_X8)           { ret 1; }
     ret 0;
 }
 
 test "mach.lang.target.abi.aapcs64.classify_arg:banks_independent" {
     val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 7, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
-    if (i.reg != REG_X7)         { ret 1; }
+    if (mir.preg_regid(i.reg) != REG_X7)         { ret 1; }
     val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 7, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)  { ret 1; }
-    if (f.reg != fp_param_reg(0)) { ret 1; }
+    if (mir.preg_regid(f.reg) != fp_param_reg(0)) { ret 1; }
     val s: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 8, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_STACK) { ret 1; }
     ret 0;
@@ -329,26 +330,26 @@ test "mach.lang.target.abi.aapcs64.classify_arg:banks_independent" {
 
 test "mach.lang.target.abi.aapcs64.classify_return:scalar_and_small_aggregate" {
     val v: abi.ParamSlot = classify_return(0, 0, false, 0, false, false, 0, 0, abi.agg_none());
-    if (v.class != abi.CLASS_GP || v.reg != -1) { ret 1; }
+    if (v.class != abi.CLASS_GP || !mir.preg_is_nil(v.reg)) { ret 1; }
     val i: abi.ParamSlot = classify_return(8, 8, false, 0, false, false, 0, 0, abi.agg_none());
-    if (i.reg != REG_X0) { ret 1; }
+    if (mir.preg_regid(i.reg) != REG_X0) { ret 1; }
     val f: abi.ParamSlot = classify_return(8, 8, true, 0, false, false, 0, 0, abi.agg_none());
-    if (f.class != abi.CLASS_FP || f.reg != fp_param_reg(0)) { ret 1; }
+    if (f.class != abi.CLASS_FP || mir.preg_regid(f.reg) != fp_param_reg(0)) { ret 1; }
     val a: abi.ParamSlot = classify_return(16, 8, false, 0, true, false, 0, 0, abi.agg_none());
-    if (a.pieces[0].reg != REG_X0 || a.pieces[1].reg != REG_X1) { ret 1; }
+    if (mir.preg_regid(a.pieces[0].reg) != REG_X0 || mir.preg_regid(a.pieces[1].reg) != REG_X1) { ret 1; }
     ret 0;
 }
 
 test "mach.lang.target.abi.aapcs64.classify_return:hfa_before_sret" {
     val s: abi.ParamSlot = classify_return(12, 4, false, 0, true, false, 3, 4, abi.agg_none());
     if (s.piece_count     != 3)               { ret 1; }
-    if (s.pieces[0].reg   != fp_param_reg(0)) { ret 1; }
+    if (mir.preg_regid(s.pieces[0].reg)   != fp_param_reg(0)) { ret 1; }
     if (s.pieces[0].width != 4)               { ret 1; }
-    if (s.pieces[2].reg   != fp_param_reg(2)) { ret 1; }
+    if (mir.preg_regid(s.pieces[2].reg)   != fp_param_reg(2)) { ret 1; }
     val q: abi.ParamSlot = classify_return(32, 8, false, 0, true, false, 4, 8, abi.agg_none());
     if (q.piece_count != 4)       { ret 1; }
     val r: abi.ParamSlot = classify_return(32, 8, false, 0, true, false, 0, 0, abi.agg_none());
-    if (r.class != abi.CLASS_SRET || r.reg != REG_X8) { ret 1; }
+    if (r.class != abi.CLASS_SRET || mir.preg_regid(r.reg) != REG_X8) { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/abi/riscv.mach
+++ b/src/lang/target/abi/riscv.mach
@@ -9,6 +9,7 @@ use std.types.string.str;
 
 use mach.lang.target.abi;
 use mach.lang.target.isa;
+use mach.lang.be.codegen.mir;
 
 pub rec RiscvAbi {
     id:                    u32;
@@ -523,25 +524,25 @@ test "mach.lang.target.abi.riscv.classify_arg_v:a_wide_scalar_takes_a_register_p
     val a: abi.ParamSlot = classify_arg_v(v_ilp32(), 0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (a.class       != abi.CLASS_GP) { ret 1; }
     if (a.piece_count != 2)            { ret 1; }
-    if (a.pieces[0].reg != REG_A0)     { ret 1; }
-    if (a.pieces[1].reg != REG_A1)     { ret 1; }
+    if (mir.preg_regid(a.pieces[0].reg) != REG_A0)     { ret 1; }
+    if (mir.preg_regid(a.pieces[1].reg) != REG_A1)     { ret 1; }
     if (a.pieces[1].src_off != 4)      { ret 1; }
 
     val b: abi.ParamSlot = classify_arg_v(v_ilp32(), 1, 8, 8, false, 0, false, false, 2, 0, 0, 0, abi.agg_none());
     if (b.piece_count   != 2)          { ret 1; }
-    if (b.pieces[0].reg != gp_param_reg(v_ilp32(), 2)) { ret 1; }
+    if (mir.preg_regid(b.pieces[0].reg) != gp_param_reg(v_ilp32(), 2)) { ret 1; }
 
     val w: abi.ParamSlot = classify_arg_v(v_ilp32(), 0, 4, 4, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (w.piece_count != 1)            { ret 1; }
 
     val odd: abi.ParamSlot = classify_arg_v(v_ilp32(), 1, 8, 8, false, 0, false, false, 1, 0, 0, 0, abi.agg_none());
     if (odd.piece_count   != 2)        { ret 1; }
-    if (odd.pieces[0].reg != gp_param_reg(v_ilp32(), 1)) { ret 1; }
-    if (odd.pieces[1].reg != gp_param_reg(v_ilp32(), 2)) { ret 1; }
+    if (mir.preg_regid(odd.pieces[0].reg) != gp_param_reg(v_ilp32(), 1)) { ret 1; }
+    if (mir.preg_regid(odd.pieces[1].reg) != gp_param_reg(v_ilp32(), 2)) { ret 1; }
 
     val l: abi.ParamSlot = classify_arg_v(v_lp64(), 0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (l.piece_count != 1)            { ret 1; }
-    if (l.reg         != REG_A0)       { ret 1; }
+    if (mir.preg_regid(l.reg)         != REG_A0)       { ret 1; }
     ret 0;
 }
 
@@ -568,7 +569,7 @@ test "mach.lang.target.abi.riscv.classify_arg_v:a_soft_double_takes_a_register_p
     val s: abi.ParamSlot = classify_arg_v(v_ilp32(), 0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class       != abi.CLASS_GP) { ret 1; }
     if (s.piece_count != 2)            { ret 1; }
-    if (s.pieces[1].reg != REG_A1)     { ret 1; }
+    if (mir.preg_regid(s.pieces[1].reg) != REG_A1)     { ret 1; }
 
     val f: abi.ParamSlot = classify_arg_v(v_ilp32f(), 0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (f.class       != abi.CLASS_GP) { ret 1; }
@@ -586,8 +587,8 @@ test "mach.lang.target.abi.riscv.classify_return_v:a_wide_scalar_returns_in_a_pa
     val a: abi.ParamSlot = classify_return_v(v_ilp32(), 8, 8, false, 0, false, false, 0, 0, abi.agg_none());
     if (a.class         != abi.CLASS_GP) { ret 1; }
     if (a.piece_count   != 2)            { ret 1; }
-    if (a.pieces[0].reg != REG_A0)       { ret 1; }
-    if (a.pieces[1].reg != REG_A1)       { ret 1; }
+    if (mir.preg_regid(a.pieces[0].reg) != REG_A0)       { ret 1; }
+    if (mir.preg_regid(a.pieces[1].reg) != REG_A1)       { ret 1; }
     if (a.pieces[1].src_off != 4)        { ret 1; }
 
     val w: abi.ParamSlot = classify_return_v(v_ilp32(), 4, 4, false, 0, false, false, 0, 0, abi.agg_none());
@@ -601,16 +602,16 @@ test "mach.lang.target.abi.riscv.classify_return_v:a_wide_scalar_returns_in_a_pa
 test "mach.lang.target.abi.riscv.classify_arg_v:same_double_three_banks" {
     val d: abi.ParamSlot  = classify_arg_v(v_lp64d(), 0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (d.class != abi.CLASS_FP)            { ret 1; }
-    if (d.reg   != fp_param_reg(v_lp64d(), 0)) { ret 1; }
+    if (mir.preg_regid(d.reg)   != fp_param_reg(v_lp64d(), 0)) { ret 1; }
     val f: abi.ParamSlot  = classify_arg_v(v_lp64f(), 0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_GP)            { ret 1; }
-    if (f.reg   != REG_A0)                  { ret 1; }
+    if (mir.preg_regid(f.reg)   != REG_A0)                  { ret 1; }
     val f32: abi.ParamSlot = classify_arg_v(v_lp64f(), 0, 4, 4, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (f32.class != abi.CLASS_FP)          { ret 1; }
-    if (f32.reg   != fp_param_reg(v_lp64f(), 0)) { ret 1; }
+    if (mir.preg_regid(f32.reg)   != fp_param_reg(v_lp64f(), 0)) { ret 1; }
     val s: abi.ParamSlot  = classify_arg_v(v_lp64(), 0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP)            { ret 1; }
-    if (s.reg   != REG_A0)                  { ret 1; }
+    if (mir.preg_regid(s.reg) != REG_A0)                  { ret 1; }
     val s32: abi.ParamSlot = classify_arg_v(v_lp64(), 0, 4, 4, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (s32.class != abi.CLASS_GP)          { ret 1; }
     ret 0;
@@ -653,12 +654,12 @@ test "mach.lang.target.abi.riscv.classify_arg_v:unnamed_float_takes_the_a_bank" 
     if (named.class != abi.CLASS_FP)          { ret 1; }
     val tail: abi.ParamSlot = classify_arg_v(v, 0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (tail.class != abi.CLASS_GP)           { ret 1; }
-    if (tail.reg   != REG_A0)                 { ret 1; }
+    if (mir.preg_regid(tail.reg)   != REG_A0)                 { ret 1; }
     val hfa: abi.ParamSlot = classify_arg_v(v, 0, 8, 8, false, 0, true, false, 0, 0, 1, 8, abi.agg_none());
     if (hfa.class != abi.CLASS_FP)            { ret 1; }
     val tagg: abi.ParamSlot = classify_arg_v(v, 0, 8, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (tagg.class != abi.CLASS_GP)           { ret 1; }
-    if (tagg.reg   != REG_A0)                 { ret 1; }
+    if (mir.preg_regid(tagg.reg)   != REG_A0)                 { ret 1; }
     val spill: abi.ParamSlot = classify_arg_v(v, 8, 8, 8, false, 0, false, false, 8, 0, 0, 0, abi.agg_none());
     if (spill.class != abi.CLASS_STACK)       { ret 1; }
     ret 0;
@@ -690,14 +691,14 @@ test "mach.lang.target.abi.riscv.register:refuses_a_member_with_no_variadic_rule
 test "mach.lang.target.abi.riscv.classify_arg_v:flatten_gated_on_member_width" {
     val d: abi.ParamSlot = classify_arg_v(v_lp64d(), 0, 16, 8, false, 0, true, false, 0, 0, 2, 8, abi.agg_none());
     if (d.piece_count   != 2)                    { ret 1; }
-    if (d.pieces[0].reg != fp_param_reg(v_lp64d(), 0)) { ret 1; }
+    if (mir.preg_regid(d.pieces[0].reg) != fp_param_reg(v_lp64d(), 0)) { ret 1; }
     val f: abi.ParamSlot = classify_arg_v(v_lp64f(), 0, 16, 8, false, 0, true, false, 0, 0, 2, 8, abi.agg_none());
     if (f.class           != abi.CLASS_GP) { ret 1; }
-    if (f.pieces[0].reg   != REG_A0)       { ret 1; }
-    if (f.pieces[1].reg   != REG_A1)       { ret 1; }
+    if (mir.preg_regid(f.pieces[0].reg)   != REG_A0)       { ret 1; }
+    if (mir.preg_regid(f.pieces[1].reg)   != REG_A1)       { ret 1; }
     val f32: abi.ParamSlot = classify_arg_v(v_lp64f(), 0, 8, 4, false, 0, true, false, 0, 0, 2, 4, abi.agg_none());
     if (f32.piece_count   != 2)                    { ret 1; }
-    if (f32.pieces[0].reg != fp_param_reg(v_lp64f(), 0)) { ret 1; }
+    if (mir.preg_regid(f32.pieces[0].reg) != fp_param_reg(v_lp64f(), 0)) { ret 1; }
     val s: abi.ParamSlot = classify_arg_v(v_lp64(), 0, 8, 4, false, 0, true, false, 0, 0, 2, 4, abi.agg_none());
     if (s.class != abi.CLASS_GP) { ret 1; }
     ret 0;
@@ -708,7 +709,7 @@ test "mach.lang.target.abi.riscv.classify_return_v:bank_matches_member" {
     if (d.class != abi.CLASS_FP) { ret 1; }
     val f: abi.ParamSlot = classify_return_v(v_lp64f(), 8, 8, true, 0, false, false, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_GP) { ret 1; }
-    if (f.reg   != REG_A0)       { ret 1; }
+    if (mir.preg_regid(f.reg)   != REG_A0)       { ret 1; }
     val f32: abi.ParamSlot = classify_return_v(v_lp64f(), 4, 4, true, 0, false, false, 0, 0, abi.agg_none());
     if (f32.class != abi.CLASS_FP) { ret 1; }
     val s: abi.ParamSlot = classify_return_v(v_lp64(), 8, 8, true, 0, false, false, 0, 0, abi.agg_none());
@@ -734,7 +735,7 @@ test "mach.lang.target.abi.riscv.classify_arg_v:descriptor_facts_are_read" {
     if (a6.class != abi.CLASS_STACK) { ret 1; }
     val ok: abi.ParamSlot = classify_arg_v(v_lp64d(), 6, 8, 8, false, 0, false, false, 6, 0, 0, 0, abi.agg_none());
     if (ok.class != abi.CLASS_GP)    { ret 1; }
-    if (ok.reg   != REG_A0 + 6)      { ret 1; }
+    if (mir.preg_regid(ok.reg)   != REG_A0 + 6)      { ret 1; }
     ret 0;
 }
 

--- a/src/lang/target/abi/sysv.mach
+++ b/src/lang/target/abi/sysv.mach
@@ -9,6 +9,7 @@ use std.types.string.str;
 
 use mach.lang.target.abi;
 use mach.lang.target.isa;
+use mach.lang.be.codegen.mir;
 
 pub val REG_RAX: i32 = 0;
 pub val REG_RCX: i32 = 1;
@@ -256,8 +257,8 @@ test "mach.lang.target.abi.sysv.classify_arg:all_float_16byte_rides_xmm_pair" {
     val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 3, true, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP)            { ret 1; }
     if (s.piece_count   != 2)               { ret 1; }
-    if (s.pieces[0].reg != fp_param_reg(0)) { ret 1; }
-    if (s.pieces[1].reg != fp_param_reg(1)) { ret 1; }
+    if (mir.preg_regid(s.pieces[0].reg) != fp_param_reg(0)) { ret 1; }
+    if (mir.preg_regid(s.pieces[1].reg) != fp_param_reg(1)) { ret 1; }
     ret 0;
 }
 
@@ -265,24 +266,24 @@ test "mach.lang.target.abi.sysv.classify_arg:all_float_8byte_rides_one_xmm" {
     val s: abi.ParamSlot = classify_arg(0, 8, 4, false, 1, true, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP)            { ret 1; }
     if (s.piece_count   != 1)               { ret 1; }
-    if (s.pieces[0].reg != fp_param_reg(0)) { ret 1; }
+    if (mir.preg_regid(s.pieces[0].reg) != fp_param_reg(0)) { ret 1; }
     ret 0;
 }
 
 test "mach.lang.target.abi.sysv.classify_arg:mixed_int_sse_rides_rdi_xmm" {
     val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 2, true, false, 0, 0, 0, 0, abi.agg_none());
-    if (s.pieces[0].reg != REG_RDI)         { ret 1; }
-    if (s.pieces[1].reg != fp_param_reg(0)) { ret 1; }
+    if (mir.preg_regid(s.pieces[0].reg) != REG_RDI)         { ret 1; }
+    if (mir.preg_regid(s.pieces[1].reg) != fp_param_reg(0)) { ret 1; }
     val r: abi.ParamSlot = classify_arg(0, 16, 8, false, 1, true, false, 0, 0, 0, 0, abi.agg_none());
-    if (r.pieces[0].reg != fp_param_reg(0)) { ret 1; }
-    if (r.pieces[1].reg != REG_RDI)         { ret 1; }
+    if (mir.preg_regid(r.pieces[0].reg) != fp_param_reg(0)) { ret 1; }
+    if (mir.preg_regid(r.pieces[1].reg) != REG_RDI)         { ret 1; }
     ret 0;
 }
 
 test "mach.lang.target.abi.sysv.classify_arg:all_integer_rides_gp_pair" {
     val s: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
-    if (s.pieces[0].reg != REG_RDI) { ret 1; }
-    if (s.pieces[1].reg != REG_RSI) { ret 1; }
+    if (mir.preg_regid(s.pieces[0].reg) != REG_RDI) { ret 1; }
+    if (mir.preg_regid(s.pieces[1].reg) != REG_RSI) { ret 1; }
     ret 0;
 }
 
@@ -295,29 +296,29 @@ test "mach.lang.target.abi.sysv.classify_arg:sse_bank_exhaustion_spills" {
 
 test "mach.lang.target.abi.sysv.classify_return:all_float_returns_xmm_pair" {
     val s: abi.ParamSlot = classify_return(16, 8, false, 3, true, false, 0, 0, abi.agg_none());
-    if (s.pieces[0].reg != REG_XMM0) { ret 1; }
-    if (s.pieces[1].reg != REG_XMM1) { ret 1; }
+    if (mir.preg_regid(s.pieces[0].reg) != REG_XMM0) { ret 1; }
+    if (mir.preg_regid(s.pieces[1].reg) != REG_XMM1) { ret 1; }
     val o: abi.ParamSlot = classify_return(8, 4, false, 1, true, false, 0, 0, abi.agg_none());
     if (o.piece_count   != 1)        { ret 1; }
-    if (o.pieces[0].reg != REG_XMM0) { ret 1; }
+    if (mir.preg_regid(o.pieces[0].reg) != REG_XMM0) { ret 1; }
     ret 0;
 }
 
 test "mach.lang.target.abi.sysv.classify_return:banks_fill_in_order" {
     val gp: abi.ParamSlot = classify_return(16, 8, false, 0, true, false, 0, 0, abi.agg_none());
-    if (gp.pieces[0].reg != REG_RAX || gp.pieces[1].reg != REG_RDX) { ret 1; }
+    if (mir.preg_regid(gp.pieces[0].reg) != REG_RAX || mir.preg_regid(gp.pieces[1].reg) != REG_RDX) { ret 1; }
     val mix: abi.ParamSlot = classify_return(16, 8, false, 2, true, false, 0, 0, abi.agg_none());
-    if (mix.pieces[0].reg != REG_RAX || mix.pieces[1].reg != REG_XMM0) { ret 1; }
+    if (mir.preg_regid(mix.pieces[0].reg) != REG_RAX || mir.preg_regid(mix.pieces[1].reg) != REG_XMM0) { ret 1; }
     ret 0;
 }
 
 test "mach.lang.target.abi.sysv.classify_arg:scalar_float_xmm_integer_gp" {
     val f: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (f.class != abi.CLASS_FP)    { ret 1; }
-    if (f.reg   != fp_param_reg(0)) { ret 1; }
+    if (mir.preg_regid(f.reg)   != fp_param_reg(0)) { ret 1; }
     val i: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (i.class != abi.CLASS_GP) { ret 1; }
-    if (i.reg   != REG_RDI)      { ret 1; }
+    if (mir.preg_regid(i.reg)   != REG_RDI)      { ret 1; }
     ret 0;
 }
 
@@ -338,17 +339,17 @@ test "mach.lang.target.abi.sysv.register:indirect_result_in_argfile" {
 test "mach.lang.target.abi.sysv.classify_arg:large_aggregate_memory_class_by_value" {
     val s0: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (s0.class != abi.CLASS_STACK) { ret 1; }
-    if (s0.reg   != -1)              { ret 1; }
+    if (!mir.preg_is_nil(s0.reg))              { ret 1; }
     if (s0.size  != 32)              { ret 1; }
 
     val s1: abi.ParamSlot = classify_arg(0, 32, 8, false, 0, true, false, 5, 0, 0, 0, abi.agg_none());
     if (s1.class != abi.CLASS_STACK) { ret 1; }
-    if (s1.reg   != -1)              { ret 1; }
+    if (!mir.preg_is_nil(s1.reg))              { ret 1; }
     if (s1.size  != 32)              { ret 1; }
 
     val s2: abi.ParamSlot = classify_arg(0, 17, 8, false, 0, true, false, 6, 0, 0, 0, abi.agg_none());
     if (s2.class != abi.CLASS_STACK) { ret 1; }
-    if (s2.reg   != -1)              { ret 1; }
+    if (!mir.preg_is_nil(s2.reg))              { ret 1; }
     if (s2.size  != 17)              { ret 1; }
     ret 0;
 }
@@ -356,53 +357,53 @@ test "mach.lang.target.abi.sysv.classify_arg:large_aggregate_memory_class_by_val
 test "mach.lang.target.abi.sysv.classify_arg:padding_only_eightbyte_consumes_no_register" {
     val s: abi.ParamSlot = classify_arg(0, 16, 16, false, abi.EB_EMPTY_HI, true, false, 0, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_GP || s.piece_count != 1) { ret 1; }
-    if (s.pieces[0].reg != REG_RDI || s.pieces[0].width != 8 || s.pieces[0].src_off != 0) { ret 2; }
+    if (mir.preg_regid(s.pieces[0].reg) != REG_RDI || s.pieces[0].width != 8 || s.pieces[0].src_off != 0) { ret 2; }
     if (s.size != 16) { ret 3; }
     val next: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, false, 1, 0, 0, 0, abi.agg_none());
-    if (next.reg != REG_RSI) { ret 4; }
+    if (mir.preg_regid(next.reg) != REG_RSI) { ret 4; }
     val lo: abi.ParamSlot = classify_arg(0, 16, 16, false, abi.EB_EMPTY_LO, true, false, 0, 0, 0, 0, abi.agg_none());
     if (lo.class != abi.CLASS_GP || lo.piece_count != 1) { ret 5; }
-    if (lo.pieces[0].reg != REG_RDI || lo.pieces[0].src_off != 8 || lo.pieces[0].width != 8) { ret 6; }
+    if (mir.preg_regid(lo.pieces[0].reg) != REG_RDI || lo.pieces[0].src_off != 8 || lo.pieces[0].width != 8) { ret 6; }
     val sse_hi: abi.ParamSlot = classify_arg(0, 16, 16, false, abi.EB_EMPTY_LO | abi.EB_SSE_HI, true, false, 0, 0, 0, 0, abi.agg_none());
-    if (sse_hi.piece_count != 1 || sse_hi.pieces[0].kind != abi.PIECE_FP || sse_hi.pieces[0].reg != fp_param_reg(0)) { ret 7; }
+    if (sse_hi.piece_count != 1 || sse_hi.pieces[0].kind != abi.PIECE_FP || mir.preg_regid(sse_hi.pieces[0].reg) != fp_param_reg(0)) { ret 7; }
     val spilled: abi.ParamSlot = classify_arg(0, 16, 16, false, abi.EB_EMPTY_HI, true, false, 6, 0, 0, 0, abi.agg_none());
     if (spilled.class != abi.CLASS_STACK) { ret 8; }
     val fits: abi.ParamSlot = classify_arg(0, 16, 16, false, abi.EB_EMPTY_HI, true, false, 5, 0, 0, 0, abi.agg_none());
-    if (fits.class != abi.CLASS_GP || fits.pieces[0].reg != REG_R9) { ret 9; }
+    if (fits.class != abi.CLASS_GP || mir.preg_regid(fits.pieces[0].reg) != REG_R9) { ret 9; }
     ret 0;
 }
 
 test "mach.lang.target.abi.sysv.classify_return:padding_only_eightbyte_returns_in_rax_alone" {
     val s: abi.ParamSlot = classify_return(16, 16, false, abi.EB_EMPTY_HI, true, false, 0, 0, abi.agg_none());
-    if (s.class != abi.CLASS_GP || s.piece_count != 1 || s.pieces[0].reg != REG_RAX || s.size != 16) { ret 1; }
+    if (s.class != abi.CLASS_GP || s.piece_count != 1 || mir.preg_regid(s.pieces[0].reg) != REG_RAX || s.size != 16) { ret 1; }
     val full: abi.ParamSlot = classify_return(16, 8, false, 0, true, false, 0, 0, abi.agg_none());
-    if (full.piece_count != 2 || full.pieces[1].reg != REG_RDX) { ret 2; }
+    if (full.piece_count != 2 || mir.preg_regid(full.pieces[1].reg) != REG_RDX) { ret 2; }
     val hi: abi.ParamSlot = classify_return(16, 16, false, abi.EB_EMPTY_LO, true, false, 0, 0, abi.agg_none());
-    if (hi.piece_count != 1 || hi.pieces[0].reg != REG_RAX || hi.pieces[0].src_off != 8) { ret 3; }
+    if (hi.piece_count != 1 || mir.preg_regid(hi.pieces[0].reg) != REG_RAX || hi.pieces[0].src_off != 8) { ret 3; }
     ret 0;
 }
 
 test "mach.lang.target.abi.sysv.classify_arg:unaligned_field_is_memory_class" {
     val s: abi.ParamSlot = classify_arg(0, 5, 1, false, abi.EB_UNALIGNED, true, false, 0, 0, 0, 0, abi.agg_none());
-    if (s.class != abi.CLASS_STACK || s.reg != -1 || s.size != 5) { ret 1; }
+    if (s.class != abi.CLASS_STACK || !mir.preg_is_nil(s.reg) || s.size != 5) { ret 1; }
     val two: abi.ParamSlot = classify_arg(0, 9, 1, false, abi.EB_UNALIGNED, true, false, 0, 0, 0, 0, abi.agg_none());
     if (two.class != abi.CLASS_STACK || two.size != 9) { ret 2; }
     val sse: abi.ParamSlot = classify_arg(0, 16, 1, false, abi.EB_UNALIGNED | abi.EB_SSE_LO | abi.EB_SSE_HI, true, false, 0, 0, 0, 0, abi.agg_none());
     if (sse.class != abi.CLASS_STACK) { ret 3; }
     val aligned: abi.ParamSlot = classify_arg(0, 12, 1, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (aligned.class != abi.CLASS_GP || aligned.piece_count != 2) { ret 4; }
-    if (aligned.pieces[0].reg != REG_RDI || aligned.pieces[1].reg != REG_RSI) { ret 5; }
+    if (mir.preg_regid(aligned.pieces[0].reg) != REG_RDI || mir.preg_regid(aligned.pieces[1].reg) != REG_RSI) { ret 5; }
     val next: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
-    if (next.reg != REG_RDI) { ret 6; }
+    if (mir.preg_regid(next.reg) != REG_RDI) { ret 6; }
     ret 0;
 }
 
 test "mach.lang.target.abi.sysv.classify_return:unaligned_field_returns_through_hidden_pointer" {
     val s: abi.ParamSlot = classify_return(5, 1, false, abi.EB_UNALIGNED, true, false, 0, 0, abi.agg_none());
-    if (s.class != abi.CLASS_SRET || s.reg != REG_RAX) { ret 1; }
+    if (s.class != abi.CLASS_SRET || mir.preg_regid(s.reg) != REG_RAX) { ret 1; }
     val two: abi.ParamSlot = classify_return(9, 1, false, abi.EB_UNALIGNED, true, false, 0, 0, abi.agg_none());
     if (two.class != abi.CLASS_SRET) { ret 2; }
     val aligned: abi.ParamSlot = classify_return(12, 1, false, 0, true, false, 0, 0, abi.agg_none());
-    if (aligned.class != abi.CLASS_GP || aligned.piece_count != 2 || aligned.pieces[1].reg != REG_RDX) { ret 3; }
+    if (aligned.class != abi.CLASS_GP || aligned.piece_count != 2 || mir.preg_regid(aligned.pieces[1].reg) != REG_RDX) { ret 3; }
     ret 0;
 }

--- a/src/lang/target/abi/win64.mach
+++ b/src/lang/target/abi/win64.mach
@@ -9,6 +9,7 @@ use std.types.string.str;
 
 use mach.lang.target.abi;
 use mach.lang.target.isa;
+use mach.lang.be.codegen.mir;
 use mach.lang.target.isa.x64;
 
 pub val REG_RAX: i32 = 0;
@@ -222,18 +223,18 @@ pub fun register_win64(reg: *abi.AbiRegistry) err[fail.Fail] {
 test "mach.lang.target.abi.win64.classify_arg:scalar_integers_then_spill" {
     val s0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (s0.class != abi.CLASS_GP) { ret 1; }
-    if (s0.reg   != REG_RCX)      { ret 1; }
+    if (mir.preg_regid(s0.reg)   != REG_RCX)      { ret 1; }
 
     val s1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, false, 1, 0, 0, 0, abi.agg_none());
-    if (s1.reg != REG_RDX) { ret 1; }
+    if (mir.preg_regid(s1.reg) != REG_RDX) { ret 1; }
     val s2: abi.ParamSlot = classify_arg(2, 8, 8, false, 0, false, false, 2, 0, 0, 0, abi.agg_none());
-    if (s2.reg != REG_R8) { ret 1; }
+    if (mir.preg_regid(s2.reg) != REG_R8) { ret 1; }
     val s3: abi.ParamSlot = classify_arg(3, 8, 8, false, 0, false, false, 3, 0, 0, 0, abi.agg_none());
-    if (s3.reg != REG_R9) { ret 1; }
+    if (mir.preg_regid(s3.reg) != REG_R9) { ret 1; }
 
     val s4: abi.ParamSlot = classify_arg(4, 8, 8, false, 0, false, false, 4, 0, 0, 0, abi.agg_none());
     if (s4.class != abi.CLASS_STACK) { ret 1; }
-    if (s4.reg   != -1)              { ret 1; }
+    if (!mir.preg_is_nil(s4.reg))              { ret 1; }
     if (s4.size  != 8)               { ret 1; }
     ret 0;
 }
@@ -241,11 +242,11 @@ test "mach.lang.target.abi.win64.classify_arg:scalar_integers_then_spill" {
 test "mach.lang.target.abi.win64.classify_arg:floats_then_spill" {
     val f0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
     if (f0.class != abi.CLASS_FP)                            { ret 1; }
-    if (f0.reg   != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
+    if (mir.preg_regid(f0.reg)   != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
 
     val f3: abi.ParamSlot = classify_arg(3, 4, 4, true, 0, false, false, 0, 3, 0, 0, abi.agg_none());
     if (f3.class != abi.CLASS_FP)                            { ret 1; }
-    if (f3.reg   != isa.regid_make(isa.REG_CLASS_ID_XMM, 3)) { ret 1; }
+    if (mir.preg_regid(f3.reg)   != isa.regid_make(isa.REG_CLASS_ID_XMM, 3)) { ret 1; }
 
     val f4: abi.ParamSlot = classify_arg(4, 8, 8, true, 0, false, false, 0, 4, 0, 0, abi.agg_none());
     if (f4.class != abi.CLASS_STACK) { ret 1; }
@@ -254,23 +255,23 @@ test "mach.lang.target.abi.win64.classify_arg:floats_then_spill" {
 
 test "mach.lang.target.abi.win64.classify_arg:shared_positional_slot" {
     val i0: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 0, 0, 0, 0, abi.agg_none());
-    if (i0.reg != REG_RCX) { ret 1; }
+    if (mir.preg_regid(i0.reg) != REG_RCX) { ret 1; }
     val f1: abi.ParamSlot = classify_arg(1, 8, 8, true, 0, false, false, 1, 0, 0, 0, abi.agg_none());
     if (f1.class != abi.CLASS_FP)                            { ret 1; }
-    if (f1.reg   != isa.regid_make(isa.REG_CLASS_ID_XMM, 1)) { ret 1; }
+    if (mir.preg_regid(f1.reg)   != isa.regid_make(isa.REG_CLASS_ID_XMM, 1)) { ret 1; }
 
     val g0: abi.ParamSlot = classify_arg(0, 8, 8, true, 0, false, false, 0, 0, 0, 0, abi.agg_none());
-    if (g0.reg != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
+    if (mir.preg_regid(g0.reg) != isa.regid_make(isa.REG_CLASS_ID_XMM, 0)) { ret 1; }
     val g1: abi.ParamSlot = classify_arg(1, 8, 8, false, 0, false, false, 0, 1, 0, 0, abi.agg_none());
     if (g1.class != abi.CLASS_GP) { ret 1; }
-    if (g1.reg   != REG_RDX)      { ret 1; }
+    if (mir.preg_regid(g1.reg)   != REG_RDX)      { ret 1; }
     ret 0;
 }
 
 test "mach.lang.target.abi.win64.classify_arg:aggregate_by_value_or_ref" {
     val by_val: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (by_val.class != abi.CLASS_GP) { ret 1; }
-    if (by_val.reg   != REG_RCX)      { ret 1; }
+    if (mir.preg_regid(by_val.reg)   != REG_RCX)      { ret 1; }
     if (by_val.size  != 8)            { ret 1; }
 
     val four: abi.ParamSlot = classify_arg(0, 4, 4, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
@@ -278,19 +279,19 @@ test "mach.lang.target.abi.win64.classify_arg:aggregate_by_value_or_ref" {
 
     val by_ref3: abi.ParamSlot = classify_arg(0, 3, 1, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (by_ref3.class != abi.CLASS_BYREF) { ret 1; }
-    if (by_ref3.reg   != REG_RCX)         { ret 1; }
+    if (mir.preg_regid(by_ref3.reg)   != REG_RCX)         { ret 1; }
     if (by_ref3.size  != 8)               { ret 1; }
 
     val by_ref16: abi.ParamSlot = classify_arg(0, 16, 8, false, 0, true, false, 0, 0, 0, 0, abi.agg_none());
     if (by_ref16.class != abi.CLASS_BYREF) { ret 1; }
-    if (by_ref16.reg   != REG_RCX)         { ret 1; }
+    if (mir.preg_regid(by_ref16.reg)   != REG_RCX)         { ret 1; }
     ret 0;
 }
 
 test "mach.lang.target.abi.win64.classify_arg:exhausted_byref_spills_pointer" {
     val s: abi.ParamSlot = classify_arg(4, 16, 8, false, 0, true, false, 4, 0, 0, 0, abi.agg_none());
     if (s.class != abi.CLASS_STACK_BYREF) { ret 1; }
-    if (s.reg   != -1)                    { ret 1; }
+    if (!mir.preg_is_nil(s.reg))                    { ret 1; }
     if (s.size  != 8)                     { ret 1; }
 
     val s3: abi.ParamSlot = classify_arg(4, 3, 1, false, 0, true, false, 4, 0, 0, 0, abi.agg_none());
@@ -306,7 +307,7 @@ test "mach.lang.target.abi.win64.classify_arg:exhausted_byref_spills_pointer" {
 test "mach.lang.target.abi.win64.classify_arg:vector_by_reference" {
     val e0: abi.ParamSlot = classify_arg(0, 16, 16, false, 0, false, true, 0, 0, 0, 0, abi.agg_none());
     if (e0.class != abi.CLASS_VEC_BYREF) { ret 1; }
-    if (e0.reg   != REG_RCX)             { ret 1; }
+    if (mir.preg_regid(e0.reg)   != REG_RCX)             { ret 1; }
     if (e0.size  != 8)                   { ret 1; }
     if (e0.indirect_size != 16)          { ret 1; }
     if (e0.indirect_align != 16)         { ret 1; }
@@ -319,11 +320,11 @@ test "mach.lang.target.abi.win64.classify_arg:vector_by_reference" {
 
     val e3: abi.ParamSlot = classify_arg(3, 16, 16, false, 0, false, true, 3, 0, 0, 0, abi.agg_none());
     if (e3.class != abi.CLASS_VEC_BYREF) { ret 1; }
-    if (e3.reg   != REG_R9)              { ret 1; }
+    if (mir.preg_regid(e3.reg)   != REG_R9)              { ret 1; }
 
     val es: abi.ParamSlot = classify_arg(4, 16, 16, false, 0, false, true, 4, 0, 0, 0, abi.agg_none());
     if (es.class != abi.CLASS_VEC_STACK_BYREF) { ret 1; }
-    if (es.reg   != -1)                        { ret 1; }
+    if (!mir.preg_is_nil(es.reg))                        { ret 1; }
     if (es.size  != 8)                         { ret 1; }
     if (es.indirect_size != 16)                { ret 1; }
     if (es.indirect_align != 16)               { ret 1; }
@@ -333,37 +334,37 @@ test "mach.lang.target.abi.win64.classify_arg:vector_by_reference" {
 test "mach.lang.target.abi.win64.classify_return:vector_xmm0" {
     val v: abi.ParamSlot = classify_return(16, 16, false, 0, false, true, 0, 0, abi.agg_none());
     if (v.class != abi.CLASS_FP) { ret 1; }
-    if (v.reg   != REG_XMM0)     { ret 1; }
+    if (mir.preg_regid(v.reg)   != REG_XMM0)     { ret 1; }
     ret 0;
 }
 
 test "mach.lang.target.abi.win64.classify_return:scalars" {
     val voidr: abi.ParamSlot = classify_return(0, 0, false, 0, false, false, 0, 0, abi.agg_none());
     if (voidr.class != abi.CLASS_GP) { ret 1; }
-    if (voidr.reg   != -1)           { ret 1; }
+    if (!mir.preg_is_nil(voidr.reg))           { ret 1; }
 
     val ir: abi.ParamSlot = classify_return(8, 8, false, 0, false, false, 0, 0, abi.agg_none());
     if (ir.class != abi.CLASS_GP) { ret 1; }
-    if (ir.reg   != REG_RAX)      { ret 1; }
+    if (mir.preg_regid(ir.reg)   != REG_RAX)      { ret 1; }
 
     val fr: abi.ParamSlot = classify_return(8, 8, true, 0, false, false, 0, 0, abi.agg_none());
     if (fr.class != abi.CLASS_FP) { ret 1; }
-    if (fr.reg   != REG_XMM0)     { ret 1; }
+    if (mir.preg_regid(fr.reg)   != REG_XMM0)     { ret 1; }
     ret 0;
 }
 
 test "mach.lang.target.abi.win64.classify_return:aggregate_rax_or_sret" {
     val small: abi.ParamSlot = classify_return(8, 8, false, 0, true, false, 0, 0, abi.agg_none());
     if (small.class != abi.CLASS_GP) { ret 1; }
-    if (small.reg   != REG_RAX)      { ret 1; }
+    if (mir.preg_regid(small.reg)   != REG_RAX)      { ret 1; }
 
     val fsmall: abi.ParamSlot = classify_return(8, 8, true, 1, true, false, 0, 0, abi.agg_none());
     if (fsmall.class != abi.CLASS_GP) { ret 1; }
-    if (fsmall.reg   != REG_RAX)      { ret 1; }
+    if (mir.preg_regid(fsmall.reg)   != REG_RAX)      { ret 1; }
 
     val big: abi.ParamSlot = classify_return(12, 4, false, 0, true, false, 0, 0, abi.agg_none());
     if (big.class != abi.CLASS_SRET) { ret 1; }
-    if (big.reg   != REG_RAX)        { ret 1; }
+    if (mir.preg_regid(big.reg)   != REG_RAX)        { ret 1; }
     ret 0;
 }
 
@@ -372,7 +373,7 @@ test "mach.lang.target.abi.win64.classify_return:sret_reserves_first_slot" {
     if (ret_slot.class != abi.CLASS_SRET) { ret 1; }
     val first_arg: abi.ParamSlot = classify_arg(0, 8, 8, false, 0, false, false, 1, 0, 0, 0, abi.agg_none());
     if (first_arg.class != abi.CLASS_GP) { ret 1; }
-    if (first_arg.reg   != REG_RDX)      { ret 1; }
+    if (mir.preg_regid(first_arg.reg)   != REG_RDX)      { ret 1; }
     ret 0;
 }
 
@@ -466,19 +467,19 @@ test "mach.lang.target.abi.win64:vector_extent_carriers" {
         val last: abi.ParamSlot = classify_arg(3, width, 1, false, 0, false, true, 3, 0, 0, 0, abi.agg_none());
         val stack: abi.ParamSlot = classify_arg(4, width, 1, false, 0, false, true, 4, 0, 0, 0, abi.agg_none());
         val result: abi.ParamSlot = classify_return(width, 1, false, 0, false, true, 0, 0, abi.agg_none());
-        if (first.reg != REG_RCX || last.reg != REG_R9 || stack.reg != -1) { ret 1; }
+        if (mir.preg_regid(first.reg) != REG_RCX || mir.preg_regid(last.reg) != REG_R9 || !mir.preg_is_nil(stack.reg)) { ret 1; }
         if (integer) {
             if (first.class != abi.CLASS_GP || last.class != abi.CLASS_GP || stack.class != abi.CLASS_STACK) { ret 2; }
             if (first.size != width || stack.size != width || first.indirect_size != 0) { ret 3; }
-            if (result.class != abi.CLASS_GP || result.reg != REG_RAX || result.size != width) { ret 4; }
+            if (result.class != abi.CLASS_GP || mir.preg_regid(result.reg) != REG_RAX || result.size != width) { ret 4; }
         } or {
             if (first.class != abi.CLASS_VEC_BYREF || last.class != abi.CLASS_VEC_BYREF || stack.class != abi.CLASS_VEC_STACK_BYREF) { ret 5; }
             if (first.size != 8 || stack.size != 8 || first.indirect_size != width || stack.indirect_size != width) { ret 6; }
             if (first.indirect_align != 16 || stack.indirect_align != 16) { ret 7; }
             if (width == 16) {
-                if (result.class != abi.CLASS_FP || result.reg != REG_XMM0 || result.size != 16) { ret 8; }
+                if (result.class != abi.CLASS_FP || mir.preg_regid(result.reg) != REG_XMM0 || result.size != 16) { ret 8; }
             } or {
-                if (result.class != abi.CLASS_SRET || result.reg != REG_RAX || result.size != 8) { ret 9; }
+                if (result.class != abi.CLASS_SRET || mir.preg_regid(result.reg) != REG_RAX || result.size != 8) { ret 9; }
             }
         }
         i = i + 1;

--- a/src/lang/target/isa.mach
+++ b/src/lang/target/isa.mach
@@ -95,7 +95,6 @@ pub rec Inst {
     src3:     Operand;
     size:     u8;
     flags:    u16;
-    clobbers: u32;
     src_line: u32;
     src_file: str;
 }
@@ -1949,7 +1948,6 @@ pub fun inst_blank() Inst {
     mi.src3     = make_none();
     mi.size     = 0;
     mi.flags    = 0;
-    mi.clobbers = 0;
     mi.src_line = 0;
     mi.src_file = nil;
     ret mi;

--- a/src/lang/target/isa/arm64/encode.mach
+++ b/src/lang/target/isa/arm64/encode.mach
@@ -1055,10 +1055,10 @@ fun emit_movewide_seq(st: *encode.EncodeState, rd: u32, value: u64, use64: bool)
 
 fun req_gpr(op: *mir.MirOperand) res[i32, fail.Fail] {
     if (op.kind == mir.MIR_OP_PREG) {
-        if (isa.regid_class(op.preg::i32) != isa.REG_CLASS_ID_GP) {
+        if (isa.regid_class(mir.preg_regid(op.preg)) != isa.REG_CLASS_ID_GP) {
             ret res[i32, fail.Fail].err{fail.message("internal compiler error: a float/vector register reached a general-purpose operand position")};
         }
-        ret res[i32, fail.Fail].ok{isa.regid_index(op.preg::i32)};
+        ret res[i32, fail.Fail].ok{isa.regid_index(mir.preg_regid(op.preg))};
     }
     if (op.kind == mir.MIR_OP_VREG) {
         ret res[i32, fail.Fail].err{fail.message("encode: virtual register survived register allocation")};
@@ -1112,16 +1112,16 @@ fun resolve_mem(f: *mir.MirFunction, op: *mir.MirOperand) res[A64Mem, fail.Fail]
     m.has_index = false;
     m.index     = 0;
     m.scale     = 0;
-    if (op.index != mir.MIR_VREG_NIL) {
-        if (!op.index_is_preg) {
-            ret res[A64Mem, fail.Fail].err{fail.message("encode: value vreg survived in a memory-operand index")};
-        }
+    if (sel op.index.vreg) {
+        ret res[A64Mem, fail.Fail].err{fail.message("encode: value vreg survived in a memory-operand index")};
+    }
+    if (sel op.index.preg) {
         m.has_index = true;
-        m.index     = op.index;
+        m.index     = mir.preg_regid(op.index.preg)::u32;
         m.scale     = op.scale;
     }
-    if (op.vreg != mir.MIR_VREG_NIL) {
-        val slot: opt[i64] = frame_slot_offset(f, op.vreg);
+    if (!mir.vreg_is_nil(op.vreg)) {
+        val slot: opt[i64] = frame_slot_offset(f, op.vreg.n);
         if (!sel slot.some) {
             ret res[A64Mem, fail.Fail].err{fail.message("encode: value vreg survived in a memory-operand base")};
         }
@@ -1129,7 +1129,7 @@ fun resolve_mem(f: *mir.MirFunction, op: *mir.MirOperand) res[A64Mem, fail.Fail]
         m.off  = slot.some + op.imm;
         ret res[A64Mem, fail.Fail].ok{m};
     }
-    m.base = op.preg;
+    m.base = mir.preg_regid(op.preg)::u32;
     m.off  = op.imm;
     ret res[A64Mem, fail.Fail].ok{m};
 }
@@ -1683,15 +1683,15 @@ fun is_float_width(w: u8) bool {
 }
 
 fun reg_is_vec(op: *mir.MirOperand) bool {
-    ret op.kind == mir.MIR_OP_PREG && isa.regid_class(op.preg::i32) == isa.REG_CLASS_ID_XMM;
+    ret op.kind == mir.MIR_OP_PREG && isa.regid_class(mir.preg_regid(op.preg)) == isa.REG_CLASS_ID_XMM;
 }
 
 fun req_vec(op: *mir.MirOperand) res[i32, fail.Fail] {
     if (op.kind == mir.MIR_OP_PREG) {
-        if (isa.regid_class(op.preg::i32) != isa.REG_CLASS_ID_XMM) {
+        if (isa.regid_class(mir.preg_regid(op.preg)) != isa.REG_CLASS_ID_XMM) {
             ret res[i32, fail.Fail].err{fail.message("internal compiler error: a general-purpose register reached a float/vector operand position")};
         }
-        ret res[i32, fail.Fail].ok{isa.regid_index(op.preg::i32)};
+        ret res[i32, fail.Fail].ok{isa.regid_index(mir.preg_regid(op.preg))};
     }
     if (op.kind == mir.MIR_OP_VREG) {
         ret res[i32, fail.Fail].err{fail.message("encode: virtual register survived register allocation")};
@@ -1737,7 +1737,7 @@ fun emit_fp_slot_load(st: *encode.EncodeState, f: *mir.MirFunction, memop: *mir.
 }
 
 fun is_fp_slot(f: *mir.MirFunction, op: *mir.MirOperand) bool {
-    ret op.kind == mir.MIR_OP_MEM && op.vreg != mir.MIR_VREG_NIL && mir.vreg_is_fp(f, op.vreg);
+    ret op.kind == mir.MIR_OP_MEM && !mir.vreg_is_nil(op.vreg) && mir.vreg_is_fp(f, op.vreg);
 }
 
 fun fmov_imm8(bits: u64, use64: bool) opt[u32] {
@@ -4094,7 +4094,7 @@ fun tbuf_interned(st: *encode.EncodeState, alloc: *A.Allocator, itn: *intern.Int
 }
 
 fun tvec(n: i32) mir.MirOperand {
-    ret mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, n)::u32);
+    ret mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, n)));
 }
 
 test "mach.lang.target.isa.arm64.encode:three_address_alu_register_forms" {
@@ -4132,8 +4132,8 @@ test "mach.lang.target.isa.arm64.encode:immediate_shifts" {
     tbuf(?st, ?alloc);
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(0);
-    ops[1] = mir.op_preg(1);
+    ops[0] = mir.op_preg(mir.preg_id(0));
+    ops[1] = mir.op_preg(mir.preg_id(1));
     ops[2] = mir.op_imm(3);
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 0, 0, 0);
     mi.operand_count = 3;
@@ -4227,9 +4227,9 @@ test "mach.lang.target.isa.arm64.encode:compare_with_an_immediate_lhs_materializ
     tbuf(?st, ?alloc);
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(0);
+    ops[0] = mir.op_preg(mir.preg_id(0));
     ops[1] = mir.op_imm(48);
-    ops[2] = mir.op_preg(1);
+    ops[2] = mir.op_preg(mir.preg_id(1));
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
     mi.opcode = mir.MIR_SEL_CMP_LE_U; mi.width = 1;
 
@@ -4271,7 +4271,7 @@ test "mach.lang.target.isa.arm64.encode:unsigned_divide_plus_div_by_zero_trap" {
     tbuf(?st, ?alloc);
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(0); ops[1] = mir.op_preg(1); ops[2] = mir.op_preg(2);
+    ops[0] = mir.op_preg(mir.preg_id(0)); ops[1] = mir.op_preg(mir.preg_id(1)); ops[2] = mir.op_preg(mir.preg_id(2));
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
     mi.opcode = mir.MIR_SEL_DIV_U; mi.width = 8;
 
@@ -4294,7 +4294,7 @@ test "mach.lang.target.isa.arm64.encode:signed_divide_plus_zero_overflow_traps" 
     tbuf(?st, ?alloc);
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(0); ops[1] = mir.op_preg(1); ops[2] = mir.op_preg(2);
+    ops[0] = mir.op_preg(mir.preg_id(0)); ops[1] = mir.op_preg(mir.preg_id(1)); ops[2] = mir.op_preg(mir.preg_id(2));
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
     mi.opcode = mir.MIR_SEL_DIV_S; mi.width = 8;
 
@@ -4323,7 +4323,7 @@ test "mach.lang.target.isa.arm64.encode:signed_remainder_plus_zero_overflow_trap
     tbuf(?st, ?alloc);
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(0); ops[1] = mir.op_preg(1); ops[2] = mir.op_preg(2);
+    ops[0] = mir.op_preg(mir.preg_id(0)); ops[1] = mir.op_preg(mir.preg_id(1)); ops[2] = mir.op_preg(mir.preg_id(2));
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
     mi.opcode = mir.MIR_SEL_REM_S; mi.width = 4;
 
@@ -4353,7 +4353,7 @@ test "mach.lang.target.isa.arm64.encode:unsigned_remainder_plus_div_by_zero_trap
     tbuf(?st, ?alloc);
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(0); ops[1] = mir.op_preg(1); ops[2] = mir.op_preg(2);
+    ops[0] = mir.op_preg(mir.preg_id(0)); ops[1] = mir.op_preg(mir.preg_id(1)); ops[2] = mir.op_preg(mir.preg_id(2));
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
     mi.opcode = mir.MIR_SEL_REM_U; mi.width = 8;
 
@@ -4512,15 +4512,15 @@ test "mach.lang.target.isa.arm64.encode:frame_slot_ldr_str_and_spill_reload_stor
     f.frame.slot_count = 1;
 
     var sops: [2]mir.MirOperand;
-    sops[0] = mir.op_mem_slot(100, 0);
-    sops[1] = mir.op_preg(9);
+    sops[0] = mir.op_mem_slot(mir.vreg_id(100), 0);
+    sops[1] = mir.op_preg(mir.preg_id(9));
     var sst: mir.MirInstr = mir.instr(mir.MIR_ADD, ?sops[0], 2, 8, 8);
     encode_store(?st, ?f, ?sst);
     if (read_word(?st.buf, 0) != 0xF81F83A9) { bad = 1; }
 
     var lops: [2]mir.MirOperand;
-    lops[0] = mir.op_preg(9);
-    lops[1] = mir.op_mem_slot(100, 0);
+    lops[0] = mir.op_preg(mir.preg_id(9));
+    lops[1] = mir.op_mem_slot(mir.vreg_id(100), 0);
     var lst: mir.MirInstr = mir.instr(mir.MIR_ADD, ?lops[0], 2, 8, 8);
     encode_load(?st, ?f, ?lst);
     if (read_word(?st.buf, 4) != 0xF85F83A9) { bad = 1; }
@@ -4614,9 +4614,9 @@ test "mach.lang.target.isa.arm64.encode.store:every_destination_kind_keeps_the_b
 
     val v_bit: u32 = 1 << 26;
     var vval: mir.MirOperand = tvec(2);
-    var gval: mir.MirOperand = mir.op_preg(2);
+    var gval: mir.MirOperand = mir.op_preg(mir.preg_id(2));
 
-    var pmem: mir.MirOperand = mir.op_mem_preg(1, 0);
+    var pmem: mir.MirOperand = mir.op_mem_preg(mir.preg_id(1), 0);
     st.buf.len = 0;
     emit_store_mem(?st, ?f, ?pmem, ?vval, 8);
     if ((read_word(?st.buf, 0) & v_bit) == 0) { bad = 1; }
@@ -4644,7 +4644,7 @@ test "mach.lang.target.isa.arm64.encode.store:every_destination_kind_keeps_the_b
 }
 
 test "mach.lang.target.isa.arm64.encode.resolvers:reject_the_wrong_bank" {
-    var gp:  mir.MirOperand = mir.op_preg(2);
+    var gp:  mir.MirOperand = mir.op_preg(mir.preg_id(2));
     var vec: mir.MirOperand = tvec(2);
 
     val g: res[i32, fail.Fail] = req_gpr(?gp);
@@ -4706,7 +4706,7 @@ test "mach.lang.target.isa.arm64.encode:float_width_refusals_emit_nothing" {
     if (!t_accepted(encode_fp_neg(?st, ?f, ?ng), ?st.buf)) { bad = 1; }
 
     var cops: [3]mir.MirOperand;
-    cops[0] = mir.op_preg(0); cops[1] = tvec(13); cops[2] = tvec(14);
+    cops[0] = mir.op_preg(mir.preg_id(0)); cops[1] = tvec(13); cops[2] = tvec(14);
     var cm: mir.MirInstr = mir.instr(mir.MIR_FCMP, ?cops[0], 3, 16, 0);
     cm.src_width = mir.FCC_EQ; st.buf.len = 0;
     if (!t_refused(encode_fp_cmp(?st, ?f, ?cm), ?st.buf)) { bad = 1; }
@@ -4722,7 +4722,7 @@ test "mach.lang.target.isa.arm64.encode:float_width_refusals_emit_nothing" {
     if (!t_accepted(encode_fp_conv(?st, ?f, ?cv), ?st.buf)) { bad = 1; }
 
     var iops: [2]mir.MirOperand;
-    iops[0] = tvec(12); iops[1] = mir.op_preg(1);
+    iops[0] = tvec(12); iops[1] = mir.op_preg(mir.preg_id(1));
     var i2f: mir.MirInstr = mir.instr(mir.MIR_SI_TO_FP, ?iops[0], 2, 16, 0);
     i2f.src_width = 8; st.buf.len = 0;
     if (!t_refused(encode_fp_conv(?st, ?f, ?i2f), ?st.buf)) { bad = 1; }
@@ -4730,7 +4730,7 @@ test "mach.lang.target.isa.arm64.encode:float_width_refusals_emit_nothing" {
     if (!t_accepted(encode_fp_conv(?st, ?f, ?i2f), ?st.buf)) { bad = 1; }
 
     var fops: [2]mir.MirOperand;
-    fops[0] = mir.op_preg(0); fops[1] = tvec(13);
+    fops[0] = mir.op_preg(mir.preg_id(0)); fops[1] = tvec(13);
     var f2i: mir.MirInstr = mir.instr(mir.MIR_FP_TO_SI, ?fops[0], 2, 8, 0);
     f2i.src_width = 16; st.buf.len = 0;
     if (!t_refused(encode_fp_conv(?st, ?f, ?f2i), ?st.buf)) { bad = 1; }
@@ -4831,7 +4831,7 @@ test "mach.lang.target.isa.arm64.encode:access_width_refusals_emit_nothing" {
 
     var lops: [2]mir.MirOperand;
     lops[0] = tvec(0);
-    lops[1] = mir.op_mem_preg(1, 0);
+    lops[1] = mir.op_mem_preg(mir.preg_id(1), 0);
     var ld: mir.MirInstr = mir.instr(mir.MIR_LOAD, ?lops[0], 2, 32, 0);
     ld.src_width = 32; st.buf.len = 0;
     if (!t_refused(encode_load(?st, ?f, ?ld), ?st.buf)) { bad = 1; }
@@ -4839,17 +4839,17 @@ test "mach.lang.target.isa.arm64.encode:access_width_refusals_emit_nothing" {
     if (!t_accepted(encode_load(?st, ?f, ?ld), ?st.buf)) { bad = 1; }
 
     var sops: [2]mir.MirOperand;
-    sops[0] = mir.op_mem_preg(1, 0);
+    sops[0] = mir.op_mem_preg(mir.preg_id(1), 0);
     sops[1] = tvec(0);
     st.buf.len = 0;
     if (!t_refused(emit_store_mem(?st, ?f, ?sops[0], ?sops[1], 32), ?st.buf)) { bad = 1; }
     st.buf.len = 0;
     if (!t_accepted(emit_store_mem(?st, ?f, ?sops[0], ?sops[1], 16), ?st.buf)) { bad = 1; }
 
-    var sym: mir.MirOperand = mir.op_preg(0);
+    var sym: mir.MirOperand = mir.op_preg(mir.preg_id(0));
     sym.kind = mir.MIR_OP_SYM;
     sym.sym  = 1;
-    var sgp: mir.MirOperand = mir.op_preg(0);
+    var sgp: mir.MirOperand = mir.op_preg(mir.preg_id(0));
     st.buf.len = 0;
     if (!t_refused(emit_global_load(?st, 0, ?sym, 16, false), ?st.buf)) { bad = 1; }
     st.buf.len = 0;
@@ -4883,7 +4883,7 @@ test "mach.lang.target.isa.arm64.encode:fcmp_plus_cset_float_condition_mapping" 
     var ops: [3]mir.MirOperand;
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
 
-    ops[0] = mir.op_preg(0); ops[1] = tvec(14); ops[2] = tvec(15);
+    ops[0] = mir.op_preg(mir.preg_id(0)); ops[1] = tvec(14); ops[2] = tvec(15);
     mi.opcode = mir.MIR_FCMP; mi.width = 8; mi.src_width = mir.FCC_EQ; st.buf.len = 0;
     encode_fp_cmp(?st, ?f, ?mi);
     if (read_word(?st.buf, 0) != 0x1E6F21C0) { bad = 1; }
@@ -4900,7 +4900,7 @@ test "mach.lang.target.isa.arm64.encode:fcmp_plus_cset_float_condition_mapping" 
     mi.src_width = mir.FCC_GE; st.buf.len = 0;
     encode_fp_cmp(?st, ?f, ?mi); if (read_word(?st.buf, 4) != 0x1A9FB7E0) { bad = 1; }
 
-    ops[0] = mir.op_preg(3); ops[1] = tvec(21); ops[2] = tvec(9);
+    ops[0] = mir.op_preg(mir.preg_id(3)); ops[1] = tvec(21); ops[2] = tvec(9);
     mi.width = 4; mi.src_width = mir.FCC_LT; st.buf.len = 0;
     encode_fp_cmp(?st, ?f, ?mi);
     if (read_word(?st.buf, 0) != 0x1E2922A0) { bad = 1; }
@@ -4919,7 +4919,7 @@ test "mach.lang.target.isa.arm64.encode:int_float_scvtf_ucvtf" {
     var ops: [2]mir.MirOperand;
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 2, 0, 0);
 
-    ops[0] = tvec(0); ops[1] = mir.op_preg(1);
+    ops[0] = tvec(0); ops[1] = mir.op_preg(mir.preg_id(1));
     mi.opcode = mir.MIR_SI_TO_FP;
     mi.width = 4; mi.src_width = 4; st.buf.len = 0;
     encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E220020) { bad = 1; }
@@ -4938,10 +4938,10 @@ test "mach.lang.target.isa.arm64.encode:int_float_scvtf_ucvtf" {
     encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E230020) { bad = 1; }
     mi.width = 8; mi.src_width = 8; st.buf.len = 0;
     encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E630020) { bad = 1; }
-    ops[0] = tvec(7); ops[1] = mir.op_preg(9);
+    ops[0] = tvec(7); ops[1] = mir.op_preg(mir.preg_id(9));
     mi.opcode = mir.MIR_SI_TO_FP; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
     encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E220127) { bad = 1; }
-    ops[0] = tvec(22); ops[1] = mir.op_preg(13);
+    ops[0] = tvec(22); ops[1] = mir.op_preg(mir.preg_id(13));
     mi.width = 8; mi.src_width = 8; st.buf.len = 0;
     encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E6201B6) { bad = 1; }
 
@@ -4958,7 +4958,7 @@ test "mach.lang.target.isa.arm64.encode:float_int_fcvtzs_fcvtzu" {
     var ops: [2]mir.MirOperand;
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 2, 0, 0);
 
-    ops[0] = mir.op_preg(0); ops[1] = tvec(1);
+    ops[0] = mir.op_preg(mir.preg_id(0)); ops[1] = tvec(1);
     mi.opcode = mir.MIR_FP_TO_SI;
     mi.width = 4; mi.src_width = 4; st.buf.len = 0;
     encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E380020) { bad = 1; }
@@ -4977,10 +4977,10 @@ test "mach.lang.target.isa.arm64.encode:float_int_fcvtzs_fcvtzu" {
     encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E790020) { bad = 1; }
     mi.width = 8; mi.src_width = 8; st.buf.len = 0;
     encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E790020) { bad = 1; }
-    ops[0] = mir.op_preg(9); ops[1] = tvec(7);
+    ops[0] = mir.op_preg(mir.preg_id(9)); ops[1] = tvec(7);
     mi.opcode = mir.MIR_FP_TO_SI; mi.width = 4; mi.src_width = 4; st.buf.len = 0;
     encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E3800E9) { bad = 1; }
-    ops[0] = mir.op_preg(13); ops[1] = tvec(22);
+    ops[0] = mir.op_preg(mir.preg_id(13)); ops[1] = tvec(22);
     mi.width = 8; mi.src_width = 8; st.buf.len = 0;
     encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E7802CD) { bad = 1; }
 
@@ -5003,12 +5003,12 @@ test "mach.lang.target.isa.arm64.encode:fcvt_s_d_and_gp_fp_bitcast_fmov" {
     mi.opcode = mir.MIR_FP_TRUNC; mi.width = 4; mi.src_width = 8; st.buf.len = 0;
     encode_fp_conv(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E624272) { bad = 1; }
 
-    ops[0] = tvec(0); ops[1] = mir.op_preg(1);
+    ops[0] = tvec(0); ops[1] = mir.op_preg(mir.preg_id(1));
     mi.opcode = arm64.FMOV::u32; mi.width = 4; st.buf.len = 0;
     encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E270020) { bad = 1; }
     mi.width = 8; st.buf.len = 0;
     encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x9E670020) { bad = 1; }
-    ops[0] = mir.op_preg(0); ops[1] = tvec(1);
+    ops[0] = mir.op_preg(mir.preg_id(0)); ops[1] = tvec(1);
     mi.width = 4; st.buf.len = 0;
     encode_fmov(?st, ?f, ?mi); if (read_word(?st.buf, 0) != 0x1E260020) { bad = 1; }
     mi.width = 8; st.buf.len = 0;
@@ -5187,13 +5187,13 @@ test "mach.lang.target.isa.arm64.encode:spilled_float_operands_route_through_fp_
     var ops: [3]mir.MirOperand;
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
 
-    ops[0] = tvec(0); ops[1] = mir.op_mem_slot(100, 0); ops[2] = tvec(2);
+    ops[0] = tvec(0); ops[1] = mir.op_mem_slot(mir.vreg_id(100), 0); ops[2] = tvec(2);
     mi.opcode = mir.MIR_FADD; mi.width = 8; mi.src_width = 8; st.buf.len = 0;
     encode_fp_arith(?st, ?f, ?mi);
     if (read_word(?st.buf, 0) != 0xFC5F83BF) { bad = 1; }
     if (read_word(?st.buf, 4) != 0x1E622BE0) { bad = 1; }
 
-    ops[0] = mir.op_mem_slot(100, 0); ops[1] = tvec(1); ops[2] = tvec(2);
+    ops[0] = mir.op_mem_slot(mir.vreg_id(100), 0); ops[1] = tvec(1); ops[2] = tvec(2);
     st.buf.len = 0;
     encode_fp_arith(?st, ?f, ?mi);
     if (read_word(?st.buf, 0) != 0x1E62283F) { bad = 1; }
@@ -5201,10 +5201,10 @@ test "mach.lang.target.isa.arm64.encode:spilled_float_operands_route_through_fp_
 
     var mops: [2]mir.MirOperand;
     var mv: mir.MirInstr = mir.instr(mir.MIR_MOV, ?mops[0], 2, 8, 0);
-    mops[0] = tvec(5); mops[1] = mir.op_mem_slot(100, 0);
+    mops[0] = tvec(5); mops[1] = mir.op_mem_slot(mir.vreg_id(100), 0);
     st.buf.len = 0;
     encode_fmov(?st, ?f, ?mv); if (read_word(?st.buf, 0) != 0xFC5F83A5) { bad = 1; }
-    mops[0] = mir.op_mem_slot(100, 0); mops[1] = tvec(5);
+    mops[0] = mir.op_mem_slot(mir.vreg_id(100), 0); mops[1] = tvec(5);
     st.buf.len = 0;
     encode_fmov(?st, ?f, ?mv); if (read_word(?st.buf, 0) != 0xFC1F83A5) { bad = 1; }
 
@@ -5261,25 +5261,25 @@ test "mach.lang.target.isa.arm64.encode:gep_alloca_address_arithmetic" {
     f.frame.slot_count = 1;
 
     var aops: [2]mir.MirOperand;
-    aops[0] = mir.op_preg(0);
-    aops[1] = mir.op_mem_slot(100, 0);
+    aops[0] = mir.op_preg(mir.preg_id(0));
+    aops[1] = mir.op_mem_slot(mir.vreg_id(100), 0);
     var al: mir.MirInstr = mir.instr(mir.MIR_ALLOCA, ?aops[0], 2, 0, 0);
     al.width = 8; al.src_width = 8;
     encode_addr(?st, ?f, ?al);
     if (read_word(?st.buf, 0) != 0xD10043A0) { bad = 1; }
 
     var g1ops: [2]mir.MirOperand;
-    g1ops[0] = mir.op_preg(0);
-    g1ops[1] = mir.op_mem_preg(29, 16);
+    g1ops[0] = mir.op_preg(mir.preg_id(0));
+    g1ops[1] = mir.op_mem_preg(mir.preg_id(29), 16);
     var g1: mir.MirInstr = mir.instr(mir.MIR_GEP, ?g1ops[0], 2, 0, 0);
     g1.width = 8; g1.src_width = 8;
     encode_addr(?st, ?f, ?g1);
     if (read_word(?st.buf, 4) != 0x910043A0) { bad = 1; }
 
     var g2ops: [2]mir.MirOperand;
-    g2ops[0] = mir.op_preg(0);
-    var m2: mir.MirOperand = mir.op_mem_preg(1, 0);
-    m2.index = 2; m2.scale = 8; m2.index_is_preg = true;
+    g2ops[0] = mir.op_preg(mir.preg_id(0));
+    var m2: mir.MirOperand = mir.op_mem_preg(mir.preg_id(1), 0);
+    m2.index = mir.index_preg(mir.preg_id(2)); m2.scale = 8;
     g2ops[1] = m2;
     var g2: mir.MirInstr = mir.instr(mir.MIR_GEP, ?g2ops[0], 2, 0, 0);
     g2.width = 8; g2.src_width = 8;
@@ -5297,8 +5297,8 @@ test "mach.lang.target.isa.arm64.encode:integer_conversions" {
     tbuf(?st, ?alloc);
 
     var ops: [2]mir.MirOperand;
-    ops[0] = mir.op_preg(0);
-    ops[1] = mir.op_preg(1);
+    ops[0] = mir.op_preg(mir.preg_id(0));
+    ops[1] = mir.op_preg(mir.preg_id(1));
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 2, 0, 0);
 
     mi.opcode = mir.MIR_SEXT; mi.width = 8; mi.src_width = 1;
@@ -5403,7 +5403,7 @@ test "mach.lang.target.isa.arm64.encode:branch_to_fallthrough_elided" {
     if (st.fixup_count != 1) { bad = 1; }
 
     var cops: [3]mir.MirOperand;
-    cops[0] = mir.op_preg(10); cops[1] = mir.op_block(3); cops[2] = mir.op_block(4);
+    cops[0] = mir.op_preg(mir.preg_id(10)); cops[1] = mir.op_block(3); cops[2] = mir.op_block(4);
     var cbr: mir.MirInstr = mir.instr(mir.MIR_SEL_CBR, ?cops[0], 3, 8, 0);
 
     st.has_next_block = false; st.buf.len = 0; st.fixup_count = 0;
@@ -5417,7 +5417,7 @@ test "mach.lang.target.isa.arm64.encode:branch_to_fallthrough_elided" {
     if (st.fixups[0].target_block != 3)     { bad = 1; }
 
     var ops: [4]mir.MirOperand;
-    ops[0] = mir.op_preg(11); ops[1] = mir.op_preg(12);
+    ops[0] = mir.op_preg(mir.preg_id(11)); ops[1] = mir.op_preg(mir.preg_id(12));
     ops[2] = mir.op_block(3); ops[3] = mir.op_block(4);
     var mi: mir.MirInstr = mir.instr(mir.MIR_SEL_CBR_EQ, ?ops[0], 4, 8, 0);
 
@@ -5470,9 +5470,9 @@ test "mach.lang.target.isa.arm64.encode:end_to_end_leaf_add_body" {
     tbuf(?st, ?alloc);
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(0);
-    ops[1] = mir.op_preg(0);
-    ops[2] = mir.op_preg(1);
+    ops[0] = mir.op_preg(mir.preg_id(0));
+    ops[1] = mir.op_preg(mir.preg_id(0));
+    ops[2] = mir.op_preg(mir.preg_id(1));
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 0, 0, 0);
     mi.operand_count = 3;
     mi.width = 4;
@@ -5540,7 +5540,7 @@ test "mach.lang.target.isa.arm64.encode:call_global_emitters_record_relocs_plus_
     }
 
     var iops: [1]mir.MirOperand;
-    iops[0] = mir.op_preg(9);
+    iops[0] = mir.op_preg(mir.preg_id(9));
     var ii: mir.MirInstr = mir.instr(mir.MIR_CALL, ?iops[0], 1, 0, 0);
     encode_call(?st, ?ii);
     if (read_word(?st.buf, 4) != 0xD63F0120) { bad = 1; }
@@ -5570,7 +5570,7 @@ test "mach.lang.target.isa.arm64.encode:call_global_emitters_record_relocs_plus_
     }
 
     var so: mir.MirOperand = mir.op_sym(sym, 0);
-    var sv: mir.MirOperand = mir.op_preg(1);
+    var sv: mir.MirOperand = mir.op_preg(mir.preg_id(1));
     emit_global_store(?st, ?f, ?so, ?sv, 4);
     if (read_word(?st.buf, 24) != 0x90000010) { bad = 1; }
     if (read_word(?st.buf, 28) != 0xB9000201) { bad = 1; }
@@ -5630,7 +5630,7 @@ test "mach.lang.target.isa.arm64.encode:got_indirect_emitters_record_relocs_plus
 
     var so: mir.MirOperand = mir.op_sym(sym, 0);
     so.sym_got = true;
-    var sv: mir.MirOperand = mir.op_preg(1);
+    var sv: mir.MirOperand = mir.op_preg(mir.preg_id(1));
     emit_global_store_got(?st, ?f, ?so, ?sv, 4);
     if (read_word(?st.buf, 20) != 0x90000010) { bad = 1; }
     if (read_word(?st.buf, 24) != 0xF9400210) { bad = 1; }
@@ -7193,7 +7193,7 @@ test "mach.lang.target.isa.arm64.encode:vec_lane_index_refuses_out_of_range" {
 
     var rops: [3]mir.MirOperand;
     var rmi: mir.MirInstr = mir.instr(mir.MIR_VEC_EXTRACT, ?rops[0], 3, 4, 0);
-    rops[0] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_GP, 0)::u32);
+    rops[0] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, 0)));
     rops[1] = tvec(1);
     rops[2] = mir.op_imm(3);
     rmi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 4, 4);
@@ -7212,7 +7212,7 @@ test "mach.lang.target.isa.arm64.encode:vec_lane_index_refuses_out_of_range" {
     wops[0] = tvec(0);
     wops[1] = tvec(1);
     wops[2] = mir.op_imm(3);
-    wops[3] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_GP, 0)::u32);
+    wops[3] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, 0)));
     wmi.vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 4, 4);
     st.buf.len = 0;
     val r_7111: err[fail.Fail] = encode_vec_lane_write(?st, ?f, ?wmi);
@@ -7969,14 +7969,14 @@ test "mach.lang.target.isa.arm64.encode.stream:notes_name_their_instruction_and_
 
     var vregs: [1]mir.MirVReg;
     vregs[0] = mir.vreg(0, mir.REG_CLASS_GP, false, true);
-    vregs[0].assigned = isa.regid_make(isa.REG_CLASS_ID_GP, 0)::u32;
+    vregs[0].assigned = mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, 0));
     var mov_ops: [2]mir.MirOperand;
-    mov_ops[0] = mir.op_preg_of(isa.regid_make(isa.REG_CLASS_ID_GP, 0)::u32, 0);
+    mov_ops[0] = mir.op_preg_of(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, 0)), mir.vreg_id(0));
     mov_ops[0].required_bank = mir.BANK_GP;
     mov_ops[1] = mir.op_imm(5);
     var instrs: [3]mir.MirInstr;
     instrs[0] = mir.instr(arm64.MOV::u32, ?mov_ops[0], 2, 8, 8);
-    instrs[1] = mir.declassify_marker(?instrs[0], 0);
+    instrs[1] = mir.declassify_marker(?instrs[0], mir.vreg_id(0));
     instrs[2] = mir.instr(arm64.RET::u32, nil, 0, 0, 0);
     var blk: mir.MirBlock;
     blk.id = 0; blk.instrs = ?instrs[0]; blk.instr_count = 3;
@@ -8009,9 +8009,9 @@ test "mach.lang.target.isa.arm64.encode.stream:notes_name_their_instruction_and_
 
     var seeds: encode.NoteSeeds;
     encode.note_seeds(?f, mov, ?seeds);
-    if (seeds.barrier || seeds.count != 2 || seeds.origin[0] != 0 || !seeds.secret[0] || seeds.secret[1]) { ret 12; }
+    if (seeds.barrier || seeds.count != 2 || seeds.origin[0].n != 0 || !seeds.secret[0] || seeds.secret[1]) { ret 12; }
     encode.note_seeds(?f, bar, ?seeds);
-    if (!seeds.barrier || seeds.count != 1 || seeds.origin[0] != 0 || !seeds.secret[0]) { ret 13; }
+    if (!seeds.barrier || seeds.count != 1 || seeds.origin[0].n != 0 || !seeds.secret[0]) { ret 13; }
     encode.note_seeds(?f, head, ?seeds);
     if (seeds.count != 0 || seeds.barrier) { ret 14; }
 

--- a/src/lang/target/isa/arm64/rules.mach
+++ b/src/lang/target/isa/arm64/rules.mach
@@ -221,7 +221,7 @@ fun guard_identity_copy(tgt: *isa.BackendTarget, f: *mir.MirFunction, mi: *mir.M
 }
 
 fun fp_preg(idx: i32) mir.MirOperand {
-    ret mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, idx)::u32);
+    ret mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, idx)));
 }
 
 test "mach.lang.target.isa.arm64.rules:opcode_rewrites" {
@@ -236,9 +236,9 @@ test "mach.lang.target.isa.arm64.rules:opcode_rewrites" {
     var ops:    [17][3]mir.MirOperand;
     var i:      u32 = 0;
     for (i < 17) {
-        ops[i][0] = mir.op_preg(10);
-        ops[i][1] = mir.op_preg(11);
-        ops[i][2] = mir.op_preg(12);
+        ops[i][0] = mir.op_preg(mir.preg_id(10));
+        ops[i][1] = mir.op_preg(mir.preg_id(11));
+        ops[i][2] = mir.op_preg(mir.preg_id(12));
         instrs[i].operands      = ?ops[i][0];
         instrs[i].operand_count = 3;
         instrs[i].width         = 8;
@@ -256,7 +256,7 @@ test "mach.lang.target.isa.arm64.rules:opcode_rewrites" {
     instrs[8].opcode  = mir.MIR_MOV;
     ops[8][0] = fp_preg(10); ops[8][1] = fp_preg(11);
     instrs[9].opcode  = mir.MIR_BITCAST;
-    ops[9][0] = fp_preg(10); ops[9][1] = mir.op_preg(11);
+    ops[9][0] = fp_preg(10); ops[9][1] = mir.op_preg(mir.preg_id(11));
     instrs[10].opcode = mir.MIR_BITCAST;
     instrs[11].opcode = mir.MIR_BR;
     instrs[12].opcode = mir.MIR_RET;
@@ -326,7 +326,7 @@ test "mach.lang.target.isa.arm64.rules:bitcast_bank_selects_fmov" {
     var vregs: [2]mir.MirVReg;
 
     var ops: [2]mir.MirOperand;
-    ops[0] = mir.op_vreg(0); ops[1] = mir.op_vreg(1);
+    ops[0] = mir.op_vreg(mir.vreg_id(0)); ops[1] = mir.op_vreg(mir.vreg_id(1));
 
     var instrs: [1]mir.MirInstr;
     instrs[0].operands      = ?ops[0];
@@ -401,9 +401,9 @@ test "mach.lang.target.isa.arm64.rules:generic_opcode_coverage" {
     reachable_vec[19] = mir.MIR_REM_U;
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(10);
-    ops[1] = mir.op_preg(11);
-    ops[2] = mir.op_preg(12);
+    ops[0] = mir.op_preg(mir.preg_id(10));
+    ops[1] = mir.op_preg(mir.preg_id(11));
+    ops[2] = mir.op_preg(mir.preg_id(12));
     var probe: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 8, 0);
 
     var f: mir.MirFunction;
@@ -530,9 +530,9 @@ test "mach.lang.target.isa.arm64.rules:vector_compare_swaps_operands" {
 
     if (blk.instrs[0].opcode != arm64.VEC_CMGT::u32) { ret 1; }
     if (blk.instrs[0].operand_count != 3)            { ret 1; }
-    if (blk.instrs[0].operands[0].preg != isa.regid_make(isa.REG_CLASS_ID_XMM, 20)::u32)        { ret 1; }
-    if (blk.instrs[0].operands[1].preg != isa.regid_make(isa.REG_CLASS_ID_XMM, 22)::u32)        { ret 1; }
-    if (blk.instrs[0].operands[2].preg != isa.regid_make(isa.REG_CLASS_ID_XMM, 21)::u32)        { ret 1; }
+    if (mir.preg_regid(blk.instrs[0].operands[0].preg) != isa.regid_make(isa.REG_CLASS_ID_XMM, 20))        { ret 1; }
+    if (mir.preg_regid(blk.instrs[0].operands[1].preg) != isa.regid_make(isa.REG_CLASS_ID_XMM, 22))        { ret 1; }
+    if (mir.preg_regid(blk.instrs[0].operands[2].preg) != isa.regid_make(isa.REG_CLASS_ID_XMM, 21))        { ret 1; }
 
     if (blk.instrs[0].width != 16)                                              { ret 1; }
     if (blk.instrs[0].src_width != 4)                                           { ret 1; }
@@ -631,9 +631,9 @@ fun vec_op_select_fails(opcode: u32, lane: u32) bool {
     val res_ops: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?backing, 3::usize);
     if (sel res_ops.err) { ret false; }
     val ops: *mir.MirOperand = res_ops.ok;
-    ops[0] = mir.op_preg(20);
-    ops[1] = mir.op_preg(21);
-    ops[2] = mir.op_preg(22);
+    ops[0] = mir.op_preg(mir.preg_id(20));
+    ops[1] = mir.op_preg(mir.preg_id(21));
+    ops[2] = mir.op_preg(mir.preg_id(22));
     if (lane != mir.VEC_LANE_NONE) {
         ops[0] = fp_preg(20);
         ops[1] = fp_preg(21);
@@ -688,8 +688,8 @@ test "mach.lang.target.isa.arm64.rules:identity_conversions_select_to_a_move" {
     var ops:    [8][2]mir.MirOperand;
     var i:      u32 = 0;
     for (i < 8) {
-        ops[i][0] = mir.op_preg(10);
-        ops[i][1] = mir.op_preg(11);
+        ops[i][0] = mir.op_preg(mir.preg_id(10));
+        ops[i][1] = mir.op_preg(mir.preg_id(11));
         instrs[i].operands      = ?ops[i][0];
         instrs[i].operand_count = 2;
         instrs[i].width         = 8;

--- a/src/lang/target/isa/riscv/encode.mach
+++ b/src/lang/target/isa/riscv/encode.mach
@@ -675,10 +675,10 @@ fun int_mem_funct3(width: u8, is_load: bool, xl: u8) res[u32, fail.Fail] {
 
 fun req_gpr(op: *mir.MirOperand) res[i32, fail.Fail] {
     if (op.kind == mir.MIR_OP_PREG) {
-        if (isa.regid_class(op.preg::i32) != isa.REG_CLASS_ID_GP) {
+        if (isa.regid_class(mir.preg_regid(op.preg)) != isa.REG_CLASS_ID_GP) {
             ret res[i32, fail.Fail].err{fail.message("internal compiler error: a float register reached a general-purpose operand position")};
         }
-        ret res[i32, fail.Fail].ok{isa.regid_index(op.preg::i32)};
+        ret res[i32, fail.Fail].ok{isa.regid_index(mir.preg_regid(op.preg))};
     }
     if (op.kind == mir.MIR_OP_VREG) {
         ret res[i32, fail.Fail].err{fail.message("encode: virtual register survived register allocation")};
@@ -808,16 +808,16 @@ fun resolve_mem(f: *mir.MirFunction, op: *mir.MirOperand) res[RvMem, fail.Fail] 
     m.has_index = false;
     m.index     = 0;
     m.scale     = 0;
-    if (op.index != mir.MIR_VREG_NIL) {
-        if (!op.index_is_preg) {
-            ret res[RvMem, fail.Fail].err{fail.message("encode: value vreg survived in a memory-operand index")};
-        }
+    if (sel op.index.vreg) {
+        ret res[RvMem, fail.Fail].err{fail.message("encode: value vreg survived in a memory-operand index")};
+    }
+    if (sel op.index.preg) {
         m.has_index = true;
-        m.index     = op.index;
+        m.index     = mir.preg_regid(op.index.preg)::u32;
         m.scale     = op.scale;
     }
-    if (op.vreg != mir.MIR_VREG_NIL) {
-        val slot: opt[i64] = frame_slot_offset(f, op.vreg);
+    if (!mir.vreg_is_nil(op.vreg)) {
+        val slot: opt[i64] = frame_slot_offset(f, op.vreg.n);
         if (!sel slot.some) {
             ret res[RvMem, fail.Fail].err{fail.message("encode: value vreg survived in a memory-operand base")};
         }
@@ -825,7 +825,7 @@ fun resolve_mem(f: *mir.MirFunction, op: *mir.MirOperand) res[RvMem, fail.Fail] 
         m.off  = slot.some + op.imm;
         ret res[RvMem, fail.Fail].ok{m};
     }
-    m.base = op.preg;
+    m.base = mir.preg_regid(op.preg)::u32;
     m.off  = op.imm;
     ret res[RvMem, fail.Fail].ok{m};
 }
@@ -1518,10 +1518,10 @@ fun encode_convert(st: *encode.EncodeState, mi: *mir.MirInstr) err[fail.Fail] {
 
 fun req_fpr(op: *mir.MirOperand) res[i32, fail.Fail] {
     if (op.kind == mir.MIR_OP_PREG) {
-        if (isa.regid_class(op.preg::i32) != isa.REG_CLASS_ID_XMM) {
+        if (isa.regid_class(mir.preg_regid(op.preg)) != isa.REG_CLASS_ID_XMM) {
             ret res[i32, fail.Fail].err{fail.message("internal compiler error: a general-purpose register reached a float operand position")};
         }
-        ret res[i32, fail.Fail].ok{isa.regid_index(op.preg::i32)};
+        ret res[i32, fail.Fail].ok{isa.regid_index(mir.preg_regid(op.preg))};
     }
     if (op.kind == mir.MIR_OP_VREG) {
         ret res[i32, fail.Fail].err{fail.message("encode: virtual register survived register allocation")};
@@ -1534,7 +1534,7 @@ fun is_float_width(w: u8) bool {
 }
 
 fun reg_is_fp(op: *mir.MirOperand) bool {
-    ret op.kind == mir.MIR_OP_PREG && isa.regid_class(op.preg::i32) == isa.REG_CLASS_ID_XMM;
+    ret op.kind == mir.MIR_OP_PREG && isa.regid_class(mir.preg_regid(op.preg)) == isa.REG_CLASS_ID_XMM;
 }
 
 fun fp_mem_funct3(width: u8, is_load: bool) res[u32, fail.Fail] {
@@ -1580,7 +1580,7 @@ fun emit_fp_slot_load(st: *encode.EncodeState, f: *mir.MirFunction, memop: *mir.
 }
 
 fun is_fp_slot(f: *mir.MirFunction, op: *mir.MirOperand) bool {
-    ret op.kind == mir.MIR_OP_MEM && op.vreg != mir.MIR_VREG_NIL && mir.vreg_is_fp(f, op.vreg);
+    ret op.kind == mir.MIR_OP_MEM && !mir.vreg_is_nil(op.vreg) && mir.vreg_is_fp(f, op.vreg);
 }
 
 fun fmv_i2f_funct7(width: u8) u32 {
@@ -3804,8 +3804,8 @@ test "mach.lang.target.isa.riscv.encode:mir_subword_load_store_widths" {
     st.reloc_cap   = 0;
 
     var ldops: [2]mir.MirOperand;
-    ldops[0] = mir.op_preg(10);
-    ldops[1] = mir.op_mem_preg(11, 0);
+    ldops[0] = mir.op_preg(mir.preg_id(10));
+    ldops[1] = mir.op_mem_preg(mir.preg_id(11), 0);
     var ld: mir.MirInstr = mir.instr(mir.MIR_LOAD, ?ldops[0], 2, 0, 0);
 
     ld.width = 4; ld.src_width = 1; encode_load(?st, nil, ?ld);
@@ -3818,8 +3818,8 @@ test "mach.lang.target.isa.riscv.encode:mir_subword_load_store_widths" {
     if (read_word(?st.buf, 0) != 0x0005B503) { bad = 1; }
 
     var srops: [2]mir.MirOperand;
-    srops[0] = mir.op_mem_preg(11, 0);
-    srops[1] = mir.op_preg(10);
+    srops[0] = mir.op_mem_preg(mir.preg_id(11), 0);
+    srops[1] = mir.op_preg(mir.preg_id(10));
     var sr: mir.MirInstr = mir.instr(mir.MIR_STORE, ?srops[0], 2, 0, 0);
 
     st.buf.len = 0; sr.width = 1; sr.src_width = 1; encode_store(?st, nil, ?sr);
@@ -3829,7 +3829,7 @@ test "mach.lang.target.isa.riscv.encode:mir_subword_load_store_widths" {
 
     st.buf.len = 0; st.reloc_count = 0;
     var glops: [2]mir.MirOperand;
-    glops[0] = mir.op_preg(10);
+    glops[0] = mir.op_preg(mir.preg_id(10));
     glops[1] = mir.op_sym(7::intern.StrId, 0);
     var gl: mir.MirInstr = mir.instr(mir.MIR_LOAD, ?glops[0], 2, 0, 0);
     gl.width = 4; gl.src_width = 1; encode_load(?st, nil, ?gl);
@@ -3851,7 +3851,7 @@ test "mach.lang.target.isa.riscv.encode:mir_alu_shift_mov_neg_not" {
     tbuf(?st, ?alloc);
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(10); ops[1] = mir.op_preg(11); ops[2] = mir.op_preg(12);
+    ops[0] = mir.op_preg(mir.preg_id(10)); ops[1] = mir.op_preg(mir.preg_id(11)); ops[2] = mir.op_preg(mir.preg_id(12));
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 0, 0);
 
     mi.width = 8; encode_addsub(?st, ?mi, false);
@@ -3877,7 +3877,7 @@ test "mach.lang.target.isa.riscv.encode:mir_alu_shift_mov_neg_not" {
 
     st.buf.len = 0;
     var mvo: [2]mir.MirOperand;
-    mvo[0] = mir.op_preg(10); mvo[1] = mir.op_preg(11);
+    mvo[0] = mir.op_preg(mir.preg_id(10)); mvo[1] = mir.op_preg(mir.preg_id(11));
     var mv: mir.MirInstr = mir.instr(mir.MIR_ADD, ?mvo[0], 2, 8, 0);
     encode_mov(?st, nil, ?mv);
     if (read_word(?st.buf, 0) != 0x00058513) { bad = 1; }
@@ -3897,9 +3897,9 @@ test "mach.lang.target.isa.riscv.encode:const_value_variable_shift_materializes"
     tbuf(?st, ?alloc);
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(10);
+    ops[0] = mir.op_preg(mir.preg_id(10));
     ops[1] = mir.op_imm(1);
-    ops[2] = mir.op_preg(12);
+    ops[2] = mir.op_preg(mir.preg_id(12));
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 8, 0);
 
     encode_shift(?st, ?mi, F3_SLL, false);
@@ -3933,7 +3933,7 @@ test "mach.lang.target.isa.riscv.encode:integer_compare_sequences" {
     tbuf(?st, ?alloc);
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(10); ops[1] = mir.op_preg(11); ops[2] = mir.op_preg(12);
+    ops[0] = mir.op_preg(mir.preg_id(10)); ops[1] = mir.op_preg(mir.preg_id(11)); ops[2] = mir.op_preg(mir.preg_id(12));
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 8, 0);
 
     mi.opcode = mir.MIR_SEL_CMP_EQ; encode_compare(?st, ?mi);
@@ -3988,8 +3988,8 @@ test "mach.lang.target.isa.riscv.encode:fused_cbr_sequences" {
     st.fixup_cap   = 0;
 
     var ops: [4]mir.MirOperand;
-    ops[0] = mir.op_preg(11);
-    ops[1] = mir.op_preg(12);
+    ops[0] = mir.op_preg(mir.preg_id(11));
+    ops[1] = mir.op_preg(mir.preg_id(12));
     ops[2] = mir.op_block(3);
     ops[3] = mir.op_block(4);
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 4, 8, 0);
@@ -4063,7 +4063,7 @@ test "mach.lang.target.isa.riscv.encode:branch_to_fallthrough_elided" {
     if (st.fixup_count != 1) { bad = 1; }
 
     var cops: [3]mir.MirOperand;
-    cops[0] = mir.op_preg(10); cops[1] = mir.op_block(3); cops[2] = mir.op_block(4);
+    cops[0] = mir.op_preg(mir.preg_id(10)); cops[1] = mir.op_block(3); cops[2] = mir.op_block(4);
     var cbr: mir.MirInstr = mir.instr(mir.MIR_SEL_CBR, ?cops[0], 3, 8, 0);
 
     st.has_next_block = false; st.buf.len = 0; st.fixup_count = 0;
@@ -4078,7 +4078,7 @@ test "mach.lang.target.isa.riscv.encode:branch_to_fallthrough_elided" {
     if (st.fixups[0].target_block != 3)     { bad = 1; }
 
     var ops: [4]mir.MirOperand;
-    ops[0] = mir.op_preg(11); ops[1] = mir.op_preg(12);
+    ops[0] = mir.op_preg(mir.preg_id(11)); ops[1] = mir.op_preg(mir.preg_id(12));
     ops[2] = mir.op_block(3); ops[3] = mir.op_block(4);
     var mi: mir.MirInstr = mir.instr(mir.MIR_SEL_CBR_EQ, ?ops[0], 4, 8, 0);
 
@@ -4270,7 +4270,7 @@ test "mach.lang.target.isa.riscv.encode:call_records_plt32_marker" {
     }
 
     var iops: [1]mir.MirOperand;
-    iops[0] = mir.op_preg(10);
+    iops[0] = mir.op_preg(mir.preg_id(10));
     var ii: mir.MirInstr = mir.instr(mir.MIR_CALL, ?iops[0], 1, 0, 0);
     encode_call(?st, ?ii);
     if (read_word(?st.buf, 8) != 0x000500E7) { bad = 1; }
@@ -4330,7 +4330,7 @@ test "mach.lang.target.isa.riscv.encode:global_la_sequences" {
 
     st.buf.len = 0; st.reloc_count = 0;
     var so: mir.MirOperand = mir.op_sym(sym, 0);
-    var sv: mir.MirOperand = mir.op_preg(11);
+    var sv: mir.MirOperand = mir.op_preg(mir.preg_id(11));
     emit_global_store(?st, ?so, ?sv, 8);
     if (read_word(?st.buf, 0) != 0x00000297) { bad = 1; }
     if (read_word(?st.buf, 4) != 0x00B2B023) { bad = 1; }
@@ -5474,7 +5474,7 @@ test "mach.lang.target.isa.riscv.encode:asm_relocation_modifiers" {
 }
 
 fun fp_op(idx: i32) mir.MirOperand {
-    ret mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, idx)::u32);
+    ret mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, idx)));
 }
 
 fun t_words_match(st: *encode.EncodeState, want: *u32, n: u32) bool {
@@ -5494,7 +5494,7 @@ test "mach.lang.target.isa.riscv.encode:divide_family" {
     tbuf(?st, ?alloc);
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(10); ops[1] = mir.op_preg(11); ops[2] = mir.op_preg(12);
+    ops[0] = mir.op_preg(mir.preg_id(10)); ops[1] = mir.op_preg(mir.preg_id(11)); ops[2] = mir.op_preg(mir.preg_id(12));
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 8, 0);
 
     var sdiv64: [10]u32;
@@ -5556,7 +5556,7 @@ test "mach.lang.target.isa.riscv.encode:integer_conversions" {
     tbuf(?st, ?alloc);
 
     var ops: [2]mir.MirOperand;
-    ops[0] = mir.op_preg(10); ops[1] = mir.op_preg(11);
+    ops[0] = mir.op_preg(mir.preg_id(10)); ops[1] = mir.op_preg(mir.preg_id(11));
     var mi: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 2, 0, 0);
 
     mi.opcode = mir.MIR_TRUNC; mi.width = 4; mi.src_width = 8;
@@ -5630,7 +5630,7 @@ test "mach.lang.target.isa.riscv.encode:float_arith_neg_cmp" {
 
     st.buf.len = 0;
     var cops: [3]mir.MirOperand;
-    cops[0] = mir.op_preg(10); cops[1] = fp_op(11); cops[2] = fp_op(12);
+    cops[0] = mir.op_preg(mir.preg_id(10)); cops[1] = fp_op(11); cops[2] = fp_op(12);
     var ci: mir.MirInstr = mir.instr(mir.MIR_FCMP, ?cops[0], 3, 8, 0);
     ci.src_width = mir.FCC_EQ; encode_fp_cmp(?st, nil, ?ci);
     if (read_word(?st.buf, 0) != 0xA2C5A553) { bad = 1; }
@@ -5666,7 +5666,7 @@ test "mach.lang.target.isa.riscv.encode:float_conversions" {
     if (read_word(?st.buf, 0) != 0x42058553) { bad = 1; }
 
     st.buf.len = 0;
-    ops[0] = fp_op(10); ops[1] = mir.op_preg(11);
+    ops[0] = fp_op(10); ops[1] = mir.op_preg(mir.preg_id(11));
     mi.opcode = mir.MIR_SI_TO_FP; mi.width = 8; mi.src_width = 8;
     encode_fp_conv(?st, nil, ?mi);
     if (read_word(?st.buf, 0) != 0xD225F553) { bad = 1; }
@@ -5675,7 +5675,7 @@ test "mach.lang.target.isa.riscv.encode:float_conversions" {
     if (read_word(?st.buf, 0) != 0xD2058553) { bad = 1; }
 
     st.buf.len = 0;
-    ops[0] = mir.op_preg(10); ops[1] = fp_op(11);
+    ops[0] = mir.op_preg(mir.preg_id(10)); ops[1] = fp_op(11);
     mi.opcode = mir.MIR_FP_TO_SI; mi.width = 8; mi.src_width = 8;
     encode_fp_conv(?st, nil, ?mi);
     if (read_word(?st.buf, 0) != 0xC2259553) { bad = 1; }
@@ -5706,12 +5706,12 @@ test "mach.lang.target.isa.riscv.encode:fmov_and_float_memory" {
     if (read_word(?st.buf, 0) != 0x22B58553) { bad = 1; }
 
     st.buf.len = 0;
-    ops[0] = fp_op(10); ops[1] = mir.op_preg(11);
+    ops[0] = fp_op(10); ops[1] = mir.op_preg(mir.preg_id(11));
     encode_fmov(?st, nil, ?mi);
     if (read_word(?st.buf, 0) != 0xF2058553) { bad = 1; }
 
     st.buf.len = 0;
-    ops[0] = mir.op_preg(10); ops[1] = fp_op(11);
+    ops[0] = mir.op_preg(mir.preg_id(10)); ops[1] = fp_op(11);
     encode_fmov(?st, nil, ?mi);
     if (read_word(?st.buf, 0) != 0xE2058553) { bad = 1; }
 
@@ -5723,12 +5723,12 @@ test "mach.lang.target.isa.riscv.encode:fmov_and_float_memory" {
     if (read_word(?st.buf, 0) != 0x20B58553) { bad = 1; }
 
     st.buf.len = 0;
-    ops[0] = fp_op(10); ops[1] = mir.op_preg(11);
+    ops[0] = fp_op(10); ops[1] = mir.op_preg(mir.preg_id(11));
     encode_fmov(?st, nil, ?mw);
     if (read_word(?st.buf, 0) != 0xF0058553) { bad = 1; }
 
     st.buf.len = 0;
-    ops[0] = mir.op_preg(10); ops[1] = fp_op(11);
+    ops[0] = mir.op_preg(mir.preg_id(10)); ops[1] = fp_op(11);
     encode_fmov(?st, nil, ?mw);
     if (read_word(?st.buf, 0) != 0xE0058553) { bad = 1; }
 
@@ -5810,7 +5810,7 @@ test "mach.lang.target.isa.riscv.encode:access_width_refusals_emit_nothing" {
 
     var lops: [2]mir.MirOperand;
     lops[0] = fp_op(10);
-    lops[1] = mir.op_mem_preg(11, 0);
+    lops[1] = mir.op_mem_preg(mir.preg_id(11), 0);
     var ld: mir.MirInstr = mir.instr(mir.MIR_LOAD, ?lops[0], 2, 16, 0);
     ld.src_width = 16; st.buf.len = 0;
     if (!t_refused(encode_load(?st, ?f, ?ld), ?st.buf)) { bad = 1; }
@@ -5818,17 +5818,17 @@ test "mach.lang.target.isa.riscv.encode:access_width_refusals_emit_nothing" {
     if (!t_accepted(encode_load(?st, ?f, ?ld), ?st.buf)) { bad = 1; }
 
     var sops: [2]mir.MirOperand;
-    sops[0] = mir.op_mem_preg(11, 0);
+    sops[0] = mir.op_mem_preg(mir.preg_id(11), 0);
     sops[1] = fp_op(10);
     st.buf.len = 0;
     if (!t_refused(emit_store_mem(?st, ?f, ?sops[0], ?sops[1], 16), ?st.buf)) { bad = 1; }
     st.buf.len = 0;
     if (!t_accepted(emit_store_mem(?st, ?f, ?sops[0], ?sops[1], 8), ?st.buf)) { bad = 1; }
 
-    var sym: mir.MirOperand = mir.op_preg(0);
+    var sym: mir.MirOperand = mir.op_preg(mir.preg_id(0));
     sym.kind = mir.MIR_OP_SYM;
     sym.sym  = 1;
-    var gv: mir.MirOperand = mir.op_preg(10);
+    var gv: mir.MirOperand = mir.op_preg(mir.preg_id(10));
     st.buf.len = 0;
     if (!t_refused(emit_global_load(?st, 10, ?sym, 16), ?st.buf)) { bad = 1; }
     st.buf.len = 0;
@@ -5877,7 +5877,7 @@ test "mach.lang.target.isa.riscv.encode:float_width_refusals_emit_nothing" {
     if (!t_accepted(encode_fp_neg(?st, nil, ?ng), ?st.buf)) { bad = 1; }
 
     var cops: [3]mir.MirOperand;
-    cops[0] = mir.op_preg(10); cops[1] = fp_op(11); cops[2] = fp_op(12);
+    cops[0] = mir.op_preg(mir.preg_id(10)); cops[1] = fp_op(11); cops[2] = fp_op(12);
     var cm: mir.MirInstr = mir.instr(mir.MIR_FCMP, ?cops[0], 3, 16, mir.FCC_EQ);
     cm.src_width = mir.FCC_EQ;
     st.buf.len = 0;
@@ -5895,7 +5895,7 @@ test "mach.lang.target.isa.riscv.encode:float_width_refusals_emit_nothing" {
     if (!t_accepted(encode_fp_conv(?st, nil, ?cv), ?st.buf)) { bad = 1; }
 
     var i2f: mir.MirInstr = mir.instr(mir.MIR_SI_TO_FP, ?ops[0], 2, 16, 0);
-    ops[0] = fp_op(10); ops[1] = mir.op_preg(11);
+    ops[0] = fp_op(10); ops[1] = mir.op_preg(mir.preg_id(11));
     i2f.src_width = 8;
     st.buf.len = 0;
     if (!t_refused(encode_fp_conv(?st, nil, ?i2f), ?st.buf)) { bad = 1; }
@@ -5903,7 +5903,7 @@ test "mach.lang.target.isa.riscv.encode:float_width_refusals_emit_nothing" {
     if (!t_accepted(encode_fp_conv(?st, nil, ?i2f), ?st.buf)) { bad = 1; }
 
     var f2i: mir.MirInstr = mir.instr(mir.MIR_FP_TO_SI, ?ops[0], 2, 8, 0);
-    ops[0] = mir.op_preg(10); ops[1] = fp_op(11);
+    ops[0] = mir.op_preg(mir.preg_id(10)); ops[1] = fp_op(11);
     f2i.src_width = 16;
     st.buf.len = 0;
     if (!t_refused(encode_fp_conv(?st, nil, ?f2i), ?st.buf)) { bad = 1; }
@@ -6617,14 +6617,14 @@ test "mach.lang.target.isa.riscv.encode.stream:notes_name_their_instruction_and_
 
     var vregs: [1]mir.MirVReg;
     vregs[0] = mir.vreg(0, mir.REG_CLASS_GP, false, true);
-    vregs[0].assigned = isa.regid_make(isa.REG_CLASS_ID_GP, 10)::u32;
+    vregs[0].assigned = mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, 10));
     var mov_ops: [2]mir.MirOperand;
-    mov_ops[0] = mir.op_preg_of(isa.regid_make(isa.REG_CLASS_ID_GP, 10)::u32, 0);
+    mov_ops[0] = mir.op_preg_of(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, 10)), mir.vreg_id(0));
     mov_ops[0].required_bank = mir.BANK_GP;
     mov_ops[1] = mir.op_imm(5);
     var instrs: [3]mir.MirInstr;
     instrs[0] = mir.instr(riscv.MOV::u32, ?mov_ops[0], 2, 8, 8);
-    instrs[1] = mir.declassify_marker(?instrs[0], 0);
+    instrs[1] = mir.declassify_marker(?instrs[0], mir.vreg_id(0));
     instrs[2] = mir.instr(riscv.RET::u32, nil, 0, 0, 0);
     var blk: mir.MirBlock;
     blk.id = 0; blk.instrs = ?instrs[0]; blk.instr_count = 3;
@@ -6657,9 +6657,9 @@ test "mach.lang.target.isa.riscv.encode.stream:notes_name_their_instruction_and_
 
     var seeds: encode.NoteSeeds;
     encode.note_seeds(?f, mov, ?seeds);
-    if (seeds.barrier || seeds.count != 2 || seeds.origin[0] != 0 || !seeds.secret[0] || seeds.secret[1]) { ret 12; }
+    if (seeds.barrier || seeds.count != 2 || seeds.origin[0].n != 0 || !seeds.secret[0] || seeds.secret[1]) { ret 12; }
     encode.note_seeds(?f, bar, ?seeds);
-    if (!seeds.barrier || seeds.count != 1 || seeds.origin[0] != 0 || !seeds.secret[0]) { ret 13; }
+    if (!seeds.barrier || seeds.count != 1 || seeds.origin[0].n != 0 || !seeds.secret[0]) { ret 13; }
     encode.note_seeds(?f, head, ?seeds);
     if (seeds.count != 0 || seeds.barrier) { ret 14; }
 
@@ -6784,7 +6784,7 @@ fun t_walk_rv_function(f: *mir.MirFunction) {
     f.frame.omit  = false;
     t_walk_inputs_rv[0].argument      = 0;
     t_walk_inputs_rv[0].location      = mir.ABI_INPUT_REGISTER;
-    t_walk_inputs_rv[0].reg           = isa.regid_make(isa.REG_CLASS_ID_GP, 10)::u32;
+    t_walk_inputs_rv[0].reg           = mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, 10));
     t_walk_inputs_rv[0].offset        = 0;
     t_walk_inputs_rv[0].width         = 8;
     t_walk_inputs_rv[0].logical_width = 8;

--- a/src/lang/target/isa/riscv/rules.mach
+++ b/src/lang/target/isa/riscv/rules.mach
@@ -144,7 +144,7 @@ fun guard_identity_copy(tgt: *isa.BackendTarget, f: *mir.MirFunction, mi: *mir.M
 }
 
 fun fp_preg(idx: i32) mir.MirOperand {
-    ret mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, idx)::u32);
+    ret mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, idx)));
 }
 
 test "mach.lang.target.isa.riscv.rules:opcode_rewrites" {
@@ -159,9 +159,9 @@ test "mach.lang.target.isa.riscv.rules:opcode_rewrites" {
     var ops:    [14][3]mir.MirOperand;
     var i:      u32 = 0;
     for (i < 14) {
-        ops[i][0] = mir.op_preg(10);
-        ops[i][1] = mir.op_preg(11);
-        ops[i][2] = mir.op_preg(12);
+        ops[i][0] = mir.op_preg(mir.preg_id(10));
+        ops[i][1] = mir.op_preg(mir.preg_id(11));
+        ops[i][2] = mir.op_preg(mir.preg_id(12));
         instrs[i].operands      = ?ops[i][0];
         instrs[i].operand_count = 3;
         instrs[i].width         = 8;
@@ -179,7 +179,7 @@ test "mach.lang.target.isa.riscv.rules:opcode_rewrites" {
     instrs[8].opcode  = mir.MIR_MOV;
     ops[8][0] = fp_preg(10); ops[8][1] = fp_preg(11);
     instrs[9].opcode  = mir.MIR_BITCAST;
-    ops[9][0] = fp_preg(10); ops[9][1] = mir.op_preg(11);
+    ops[9][0] = fp_preg(10); ops[9][1] = mir.op_preg(mir.preg_id(11));
     instrs[10].opcode = mir.MIR_BITCAST;
     instrs[13].opcode = mir.MIR_BITCAST;
     ops[13][0] = fp_preg(10); ops[13][1] = fp_preg(11);
@@ -243,9 +243,9 @@ test "mach.lang.target.isa.riscv.rules:generic_opcode_coverage" {
     mir.selection_eliminated(?eliminated[0]);
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(10);
-    ops[1] = mir.op_preg(11);
-    ops[2] = mir.op_preg(12);
+    ops[0] = mir.op_preg(mir.preg_id(10));
+    ops[1] = mir.op_preg(mir.preg_id(11));
+    ops[2] = mir.op_preg(mir.preg_id(12));
     var probe: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 8, 0);
 
     var f: mir.MirFunction;
@@ -307,8 +307,8 @@ test "mach.lang.target.isa.riscv.rules:identity_conversions_select_to_a_move" {
     var ops:    [7][2]mir.MirOperand;
     var i:      u32 = 0;
     for (i < 7) {
-        ops[i][0] = mir.op_preg(10);
-        ops[i][1] = mir.op_preg(11);
+        ops[i][0] = mir.op_preg(mir.preg_id(10));
+        ops[i][1] = mir.op_preg(mir.preg_id(11));
         instrs[i].operands      = ?ops[i][0];
         instrs[i].operand_count = 2;
         instrs[i].width         = 8;

--- a/src/lang/target/isa/spirv/cfg.mach
+++ b/src/lang/target/isa/spirv/cfg.mach
@@ -998,7 +998,7 @@ fun t_br(mi: *mir.MirInstr, ops: *mir.MirOperand, target: u32) {
 }
 
 fun t_cbr(mi: *mir.MirInstr, ops: *mir.MirOperand, t0: u32, t1: u32) {
-    ops[0]           = mir.op_vreg(0);
+    ops[0]           = mir.op_vreg(mir.vreg_id(0));
     ops[1]           = mir.op_block(t0);
     ops[2]           = mir.op_block(t1);
     mi.opcode        = mir.MIR_CBR;

--- a/src/lang/target/isa/spirv/emit.mach
+++ b/src/lang/target/isa/spirv/emit.mach
@@ -511,8 +511,8 @@ fun scan_fn_writes(e: *Emit, fx: u32, mf: *mir.MirFunction) err[fail.Fail] {
                 ii = ii + 1;
                 if (mi.opcode != mir.MIR_GEP || mi.operand_count < 2) { cnt; }
                 if (mi.operands[0].kind != mir.MIR_OP_VREG) { cnt; }
-                val dst: u32 = mi.operands[0].vreg;
-                if (origin == nil || dst == mir.MIR_VREG_NIL || dst >= n) { cnt; }
+                val dst: u32 = mi.operands[0].vreg.n;
+                if (origin == nil || dst == mir.MIR_VREG_NIL.n || dst >= n) { cnt; }
                 val g: u32 = operand_origin(e, origin, n, ?mi.operands[1]);
                 if (g == GL_NONE || origin[dst] == g) { cnt; }
                 if (origin[dst] != GL_NONE) {
@@ -569,8 +569,8 @@ fun operand_only_reads(mi: *mir.MirInstr, oi: u32) bool {
 fun operand_origin(e: *Emit, origin: *u32, n: u32, op: *mir.MirOperand) u32 {
     if (op.kind == mir.MIR_OP_SYM) { ret gl_lookup(e, op.sym); }
     if (op.kind != mir.MIR_OP_VREG && op.kind != mir.MIR_OP_MEM) { ret GL_NONE; }
-    if (origin == nil || op.vreg == mir.MIR_VREG_NIL || op.vreg >= n) { ret GL_NONE; }
-    ret origin[op.vreg];
+    if (origin == nil || mir.vreg_is_nil(op.vreg) || op.vreg.n >= n) { ret GL_NONE; }
+    ret origin[op.vreg.n];
 }
 
 fun mark_written(e: *Emit, fx: u32, mi: *mir.MirInstr, gix: u32) err[fail.Fail] {
@@ -1764,10 +1764,10 @@ fun address_origin(e: *Emit, mf: *mir.MirFunction, op: *mir.MirOperand, out_ix: 
         if (gx != GL_NONE) { @out_ix = gx; ret ADDR_GLOBAL; }
         ret ADDR_UNKNOWN;
     }
-    var base: u32 = mir.MIR_VREG_NIL;
-    if (op.kind == mir.MIR_OP_VREG) { base = op.vreg; }
-    or (op.kind == mir.MIR_OP_MEM) { base = op.vreg; }
-    if (base == mir.MIR_VREG_NIL) { ret ADDR_UNKNOWN; }
+    var base: u32 = mir.MIR_VREG_NIL.n;
+    if (op.kind == mir.MIR_OP_VREG) { base = op.vreg.n; }
+    or (op.kind == mir.MIR_OP_MEM) { base = op.vreg.n; }
+    if (base == mir.MIR_VREG_NIL.n) { ret ADDR_UNKNOWN; }
 
     val def: *mir.MirInstr = defining_instr(mf, base);
     if (def == nil) { ret ADDR_UNKNOWN; }
@@ -1787,7 +1787,7 @@ fun defining_instr(mf: *mir.MirFunction, vreg: u32) *mir.MirInstr {
         for (ii < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[ii];
             if (mir.instr_defines_shape(mi) && mi.operand_count > 0
-                && mi.operands[0].kind == mir.MIR_OP_VREG && mi.operands[0].vreg == vreg) {
+                && mi.operands[0].kind == mir.MIR_OP_VREG && mi.operands[0].vreg.n == vreg) {
                 ret mi;
             }
             ii = ii + 1;
@@ -1922,7 +1922,7 @@ fun emit_terminator(e: *Emit, mf: *mir.MirFunction, st: *cfg.Structure, ix: u32,
 
 fun read_condition(e: *Emit, vm: *VMaps, op: *mir.MirOperand) u32 {
     if (op.kind != mir.MIR_OP_VREG) { e.b.err = true; ret 0; }
-    val v: u32 = op.vreg;
+    val v: u32 = op.vreg.n;
     if (v >= vm.n) { e.b.err = true; ret 0; }
     val ty: u32 = vm.type_id[v];
     val raw: u32 = read_operand(e, vm, op, ty);
@@ -2080,13 +2080,13 @@ fun build_vmaps(e: *Emit, mf: *mir.MirFunction, irfn: *ir.Function, out: *VMaps)
             or (mi.opcode == mir.MIR_VALUE_CALL) {
                 if (mi.operand_count < 2) { ret emit_fail(e, "spirv.emit: malformed logical call"); }
                 dest = ?mi.operands[1];
-                if (dest.kind == mir.MIR_OP_VREG && dest.vreg < n) {
-                    ty = ir_value_spv_type(e, mf.vregs[dest.vreg].ty);
+                if (dest.kind == mir.MIR_OP_VREG && dest.vreg.n < n) {
+                    ty = ir_value_spv_type(e, mf.vregs[dest.vreg.n].ty);
                 }
             }
-            if (dest != nil && dest.kind == mir.MIR_OP_VREG && dest.vreg < n && ty != 0) {
-                out.type_id[dest.vreg] = ty;
-                out.is_bool[dest.vreg] = types.type_is_bool(e.tt, ty);
+            if (dest != nil && dest.kind == mir.MIR_OP_VREG && dest.vreg.n < n && ty != 0) {
+                out.type_id[dest.vreg.n] = ty;
+                out.is_bool[dest.vreg.n] = types.type_is_bool(e.tt, ty);
             }
             ei = ei + 1;
         }
@@ -2130,10 +2130,10 @@ fun declare_allocas(e: *Emit, mf: *mir.MirFunction, out: *VMaps) err[fail.Fail] 
             val mi: *mir.MirInstr = ?blk.instrs[ii];
             if (mi.opcode != mir.MIR_ALLOCA || mi.operand_count < 2
                 || mi.operands[0].kind != mir.MIR_OP_VREG) { ii = ii + 1; cnt; }
-            val dst: u32 = mi.operands[0].vreg;
+            val dst: u32 = mi.operands[0].vreg.n;
             if (dst >= out.n) { ii = ii + 1; cnt; }
 
-            val slot: *mir.MirSlot = find_slot(mf, mi.operands[1].vreg);
+            val slot: *mir.MirSlot = find_slot(mf, mi.operands[1].vreg.n);
             if (slot == nil || slot.ty == mir.SLOT_TY_NIL) {
                 ret unsupported(e, "a local allocation whose type was not recorded is not supported by the SPIR-V target: a shader variable needs a type, and a size and alignment do not determine one");
             }
@@ -2184,7 +2184,7 @@ fun type_computed_defs(e: *Emit, mf: *mir.MirFunction, out: *VMaps, skip_copies:
             if (mi.opcode == mir.MIR_GEP || mi.opcode == mir.MIR_ALLOCA) { ii = ii + 1; cnt; }
             if (mi.opcode == mir.MIR_LOAD && mi.operand_count == 2
                 && mi.operands[0].kind == mir.MIR_OP_VREG) {
-                val lv: u32 = mi.operands[0].vreg;
+                val lv: u32 = mi.operands[0].vreg.n;
                 var lt: u32 = interface_value_type(e, ?mi.operands[1]);
                 if (lt != 0 && types.is_composite(e.tt, lt)) {
                     val leaf: u32 = leading_leaf_type(e, lt);
@@ -2199,7 +2199,7 @@ fun type_computed_defs(e: *Emit, mf: *mir.MirFunction, out: *VMaps, skip_copies:
                 }
             }
             if (mir.instr_defines_shape(mi) && mi.operands[0].kind == mir.MIR_OP_VREG) {
-                val v: u32 = mi.operands[0].vreg;
+                val v: u32 = mi.operands[0].vreg.n;
                 if (v < out.n && out.type_id[v] == 0 && !(skip_copies && is_reg_copy(mi))) {
                     val boolean: bool = (mir.is_cmp_opcode(mi.opcode) || mi.opcode == mir.MIR_FCMP)
                                      && !mir.vec_lane_is_vector(mi.vec_lane);
@@ -2242,8 +2242,8 @@ fun propagate_copy_types(mf: *mir.MirFunction, out: *VMaps) {
                 val mi: *mir.MirInstr = ?blk.instrs[ii];
                 if (is_reg_copy(mi) && mi.operands[0].kind == mir.MIR_OP_VREG &&
                     mi.operands[1].kind == mir.MIR_OP_VREG) {
-                    val d:  u32 = mi.operands[0].vreg;
-                    val sv: u32 = mi.operands[1].vreg;
+                    val d:  u32 = mi.operands[0].vreg.n;
+                    val sv: u32 = mi.operands[1].vreg.n;
                     if (d < out.n && sv < out.n && out.type_id[d] == 0 && out.type_id[sv] != 0) {
                         out.type_id[d] = out.type_id[sv];
                         out.is_bool[d] = out.is_bool[sv];
@@ -2265,7 +2265,7 @@ fun seed_declared_copy_types(e: *Emit, mf: *mir.MirFunction, out: *VMaps) {
         for (ii < blk.instr_count) {
             val mi: *mir.MirInstr = ?blk.instrs[ii];
             if (is_reg_copy(mi) && mi.operands[0].kind == mir.MIR_OP_VREG) {
-                val v: u32 = mi.operands[0].vreg;
+                val v: u32 = mi.operands[0].vreg.n;
                 if (v < out.n && v < mf.vreg_count && out.type_id[v] == 0
                     && mf.vregs[v].ty != mir.VREG_TY_NIL) {
                     val t: u32 = ir_value_spv_type(e, mf.vregs[v].ty);
@@ -2579,7 +2579,7 @@ fun emit_global_load(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirIns
     var from_interface: bool = false;
     if (var_id == 0) { var_id = interface_target(e, ?mi.operands[1]); from_interface = true; }
     if (var_id == 0) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[1])); }
-    val dst: u32 = mi.operands[0].vreg;
+    val dst: u32 = mi.operands[0].vreg.n;
     if (dst >= vm.n || vm.type_id[dst] == 0) {
         ret emit_fail(e, "spirv.emit: interface load result vreg has no type");
     }
@@ -2621,7 +2621,7 @@ fun emit_global_store(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirIn
     if (var_id == 0) { ret unsupported(e, addressed_memory_refusal(e, mf, ?mi.operands[0])); }
     if (value_ty != 0 && types.is_composite(e.tt, value_ty) && stored_scalar(e, vm, mi, ?mi.operands[1])) {
         var want: u32 = 0;
-        if (mi.operands[1].kind == mir.MIR_OP_VREG) { want = vm.type_id[mi.operands[1].vreg]; }
+        if (mi.operands[1].kind == mir.MIR_OP_VREG) { want = vm.type_id[mi.operands[1].vreg.n]; }
         or {
             val leaf: u32 = leading_leaf_type(e, value_ty);
             if (mi.width != 0 && types.type_bits(e.tt, leaf) == mi.width::u32 * 8) { want = leaf; }
@@ -2642,8 +2642,8 @@ fun emit_global_store(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirIn
 # an immediate, or a vreg holding a scalar or vector rather than a composite's address
 fun stored_scalar(e: *Emit, vm: *VMaps, mi: *mir.MirInstr, op: *mir.MirOperand) bool {
     if (op.kind == mir.MIR_OP_IMM) { ret true; }
-    if (op.kind != mir.MIR_OP_VREG || op.vreg >= vm.n) { ret false; }
-    val ty: u32 = vm.type_id[op.vreg];
+    if (op.kind != mir.MIR_OP_VREG || op.vreg.n >= vm.n) { ret false; }
+    val ty: u32 = vm.type_id[op.vreg.n];
     ret ty != 0 && !types.is_composite(e.tt, ty);
 }
 
@@ -2709,7 +2709,7 @@ fun emit_access_chain(e: *Emit, mf: *mir.MirFunction, vm: *VMaps,
         ret unsupported(e, "pointer arithmetic across whole objects is not supported by the SPIR-V target: a logical pointer names one object, so a getelementptr's leading index may only be 0");
     }
 
-    val dst: u32 = mi.operands[0].vreg;
+    val dst: u32 = mi.operands[0].vreg.n;
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: access chain result vreg out of range"); }
 
     val count: u32 = mi.operand_count - 3;
@@ -2762,19 +2762,19 @@ fun emit_access_chain(e: *Emit, mf: *mir.MirFunction, vm: *VMaps,
 
 fun chain_target(vm: *VMaps, op: *mir.MirOperand, out_ty: *u32) u32 {
     @out_ty = 0;
-    var v: u32 = mir.MIR_VREG_NIL;
-    if (op.kind == mir.MIR_OP_VREG) { v = op.vreg; }
-    or (op.kind == mir.MIR_OP_MEM && op.imm == 0) { v = op.vreg; }
-    if (v == mir.MIR_VREG_NIL || v >= vm.n) { ret 0; }
+    var v: u32 = mir.MIR_VREG_NIL.n;
+    if (op.kind == mir.MIR_OP_VREG) { v = op.vreg.n; }
+    or (op.kind == mir.MIR_OP_MEM && op.imm == 0) { v = op.vreg.n; }
+    if (v == mir.MIR_VREG_NIL.n || v >= vm.n) { ret 0; }
     @out_ty = vm.chain_ty[v];
     ret vm.chain_id[v];
 }
 
 fun chain_storage(vm: *VMaps, op: *mir.MirOperand) u32 {
-    var v: u32 = mir.MIR_VREG_NIL;
-    if (op.kind == mir.MIR_OP_VREG) { v = op.vreg; }
-    or (op.kind == mir.MIR_OP_MEM && op.imm == 0) { v = op.vreg; }
-    if (v == mir.MIR_VREG_NIL || v >= vm.n) { ret 0; }
+    var v: u32 = mir.MIR_VREG_NIL.n;
+    if (op.kind == mir.MIR_OP_VREG) { v = op.vreg.n; }
+    or (op.kind == mir.MIR_OP_MEM && op.imm == 0) { v = op.vreg.n; }
+    if (v == mir.MIR_VREG_NIL.n || v >= vm.n) { ret 0; }
     ret vm.chain_sc[v];
 }
 
@@ -2835,7 +2835,7 @@ fun read_value(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, op: *mir.MirOperand,
         if (reference == 0 || actual != pointee || chain_storage(vm, op) != storage) {
             ret res[u32, fail.Fail].err{fail.message("SPIR-V Logical Shader reference arguments require a matching Function-storage object")};
         }
-        if (op.vreg >= vm.n || !vm.chain_object[op.vreg]) {
+        if (op.vreg.n >= vm.n || !vm.chain_object[op.vreg.n]) {
             ret res[u32, fail.Fail].err{fail.message("SPIR-V Logical Shader Function-storage reference arguments must name a memory object declaration, not a subobject access chain")};
         }
         ret res[u32, fail.Fail].ok{reference};
@@ -2862,13 +2862,13 @@ fun write_value(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, op: *mir.MirOperand,
     var storage: u32 = 0;
     val pointee: u32 = types.pointer_shape(e.tt, held_ty, ?storage);
     if (pointee != 0) {
-        if (op.kind != mir.MIR_OP_VREG || op.vreg >= vm.n || vm.type_id[op.vreg] != held_ty) {
+        if (op.kind != mir.MIR_OP_VREG || op.vreg.n >= vm.n || vm.type_id[op.vreg.n] != held_ty) {
             ret emit_fail(e, "spirv.emit: logical reference binding type mismatch");
         }
-        vm.chain_id[op.vreg] = held;
-        vm.chain_ty[op.vreg] = pointee;
-        vm.chain_sc[op.vreg] = storage;
-        vm.chain_object[op.vreg] = true;
+        vm.chain_id[op.vreg.n] = held;
+        vm.chain_ty[op.vreg.n] = pointee;
+        vm.chain_sc[op.vreg.n] = storage;
+        vm.chain_object[op.vreg.n] = true;
         ret err[fail.Fail].ok{};
     }
     if (op.kind == mir.MIR_OP_MEM) {
@@ -2880,10 +2880,10 @@ fun write_value(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, op: *mir.MirOperand,
         memory_store(e, dst, converted, flags);
         ret err[fail.Fail].ok{};
     }
-    if (op.kind != mir.MIR_OP_VREG || op.vreg >= vm.n || vm.type_id[op.vreg] != held_ty) {
+    if (op.kind != mir.MIR_OP_VREG || op.vreg.n >= vm.n || vm.type_id[op.vreg.n] != held_ty) {
         ret emit_fail(e, "spirv.emit: logical result type mismatch");
     }
-    ret store_vreg(e, vm, op.vreg, held);
+    ret store_vreg(e, vm, op.vreg.n, held);
 }
 
 fun emit_param(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr,
@@ -3037,7 +3037,7 @@ fun emit_call(e: *Emit, mf: *mir.MirFunction, vm: *VMaps, mi: *mir.MirInstr) err
     ops[1] = spirv.alloc_id(e.b);
     spirv.inst(e.b, ?e.b.functions, spirv.OP_FUNCTION_CALL, ops, count + 3);
     if (!returns_void) { ret write_value(e, mf, vm, ?mi.operands[1], ops[1], ret_ty, mi.memory_flags); }
-    if (mi.operands[1].kind != mir.MIR_OP_VREG || mi.operands[1].vreg != mir.MIR_VREG_NIL) {
+    if (mi.operands[1].kind != mir.MIR_OP_VREG || !mir.vreg_is_nil(mi.operands[1].vreg)) {
         ret emit_fail(e, "spirv.emit: void logical call names a result");
     }
     ret err[fail.Fail].ok{};
@@ -3154,7 +3154,7 @@ fun ir_function_record(irmod: *ir.Module, name: intern.StrId) *ir.Function {
 
 fun read_operand(e: *Emit, vm: *VMaps, op: *mir.MirOperand, want_ty: u32) u32 {
     if (op.kind == mir.MIR_OP_VREG) {
-        val v: u32 = op.vreg;
+        val v: u32 = op.vreg.n;
         if (v < vm.n && vm.opq_var[v] != 0) {
             val fresh: u32 = spirv.alloc_id(e.b);
             var ol: [3]u32;
@@ -3183,13 +3183,13 @@ fun read_operand(e: *Emit, vm: *VMaps, op: *mir.MirOperand, want_ty: u32) u32 {
 
 fun operand_carries_type(vm: *VMaps, op: *mir.MirOperand) bool {
     if (op.kind != mir.MIR_OP_VREG) { ret false; }
-    if (op.vreg >= vm.n || vm.type_id[op.vreg] == 0) { ret false; }
-    ret !vm.is_bool[op.vreg];
+    if (op.vreg.n >= vm.n || vm.type_id[op.vreg.n] == 0) { ret false; }
+    ret !vm.is_bool[op.vreg.n];
 }
 
 fun operand_matches_type(vm: *VMaps, op: *mir.MirOperand, want_ty: u32) bool {
     if (!operand_carries_type(vm, op)) { ret true; }
-    ret vm.type_id[op.vreg] == want_ty;
+    ret vm.type_id[op.vreg.n] == want_ty;
 }
 
 fun widen_bool(e: *Emit, boolean: u32, want_ty: u32) u32 {
@@ -3229,7 +3229,7 @@ fun emit_binary(e: *Emit, vm: *VMaps, mi: *mir.MirInstr, op_code: u32) err[fail.
     if (mi.operand_count != 3 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret emit_fail(e, "spirv.emit: malformed binary instruction");
     }
-    val dst: u32 = mi.operands[0].vreg;
+    val dst: u32 = mi.operands[0].vreg.n;
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: binary result vreg out of range"); }
     val ty: u32 = vm.type_id[dst];
     if (!operand_matches_type(vm, ?mi.operands[1], ty)
@@ -3250,7 +3250,7 @@ fun emit_unary(e: *Emit, vm: *VMaps, mi: *mir.MirInstr, op_code: u32) err[fail.F
     if (mi.operand_count != 2 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret emit_fail(e, "spirv.emit: malformed unary instruction");
     }
-    val dst: u32 = mi.operands[0].vreg;
+    val dst: u32 = mi.operands[0].vreg.n;
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: unary result vreg out of range"); }
     val a: u32 = read_operand(e, vm, ?mi.operands[1], vm.type_id[dst]);
     if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable operand in unary instruction"); }
@@ -3278,7 +3278,7 @@ fun emit_vector_compare(e: *Emit, vm: *VMaps, mi: *mir.MirInstr, op_code: u32) e
     if (mi.operand_count != 3 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret emit_fail(e, "spirv.emit: malformed vector comparison instruction");
     }
-    val dst: u32 = mi.operands[0].vreg;
+    val dst: u32 = mi.operands[0].vreg.n;
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: comparison result vreg out of range"); }
 
     val lanes: u32 = mir.vec_lane_count(mi.vec_lane);
@@ -3329,7 +3329,7 @@ fun emit_vec_extract(e: *Emit, vm: *VMaps, mi: *mir.MirInstr) err[fail.Fail] {
     if (mi.operands[2].kind != mir.MIR_OP_IMM) {
         ret unsupported(e, "a runtime vector lane index is not supported by the SPIR-V target");
     }
-    val dst: u32 = mi.operands[0].vreg;
+    val dst: u32 = mi.operands[0].vreg.n;
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: vector extract result vreg out of range"); }
     val vec_ty: u32 = operand_vector_type(e, vm, mi, ?mi.operands[1]);
     if (vec_ty == 0) { ret unsupported(e, unsupported_value_type(e, mi)); }
@@ -3350,7 +3350,7 @@ fun emit_vec_insert(e: *Emit, vm: *VMaps, mi: *mir.MirInstr) err[fail.Fail] {
     if (mi.operands[2].kind != mir.MIR_OP_IMM) {
         ret unsupported(e, "a runtime vector lane index is not supported by the SPIR-V target");
     }
-    val dst: u32 = mi.operands[0].vreg;
+    val dst: u32 = mi.operands[0].vreg.n;
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: vector insert result vreg out of range"); }
     val vec_ty: u32 = vm.type_id[dst];
     if (vec_ty == 0) { ret unsupported(e, unsupported_value_type(e, mi)); }
@@ -3373,7 +3373,7 @@ fun emit_vec_build(e: *Emit, vm: *VMaps, mi: *mir.MirInstr) err[fail.Fail] {
     if (mi.operand_count < 2 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret emit_fail(e, "spirv.emit: malformed vector build instruction");
     }
-    val dst: u32 = mi.operands[0].vreg;
+    val dst: u32 = mi.operands[0].vreg.n;
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: vector build result vreg out of range"); }
     val vec_ty: u32 = vm.type_id[dst];
     if (vec_ty == 0) { ret unsupported(e, unsupported_value_type(e, mi)); }
@@ -3407,8 +3407,8 @@ fun emit_vec_build(e: *Emit, vm: *VMaps, mi: *mir.MirInstr) err[fail.Fail] {
 }
 
 fun operand_vector_type(e: *Emit, vm: *VMaps, mi: *mir.MirInstr, op: *mir.MirOperand) u32 {
-    if (op.kind == mir.MIR_OP_VREG && op.vreg < vm.n && vm.type_id[op.vreg] != 0) {
-        ret vm.type_id[op.vreg];
+    if (op.kind == mir.MIR_OP_VREG && op.vreg.n < vm.n && vm.type_id[op.vreg.n] != 0) {
+        ret vm.type_id[op.vreg.n];
     }
     if (!mir.vec_lane_is_vector(mi.vec_lane)) { ret 0; }
     ret vector_type_of(e, mi.vec_lane, false);
@@ -3435,7 +3435,7 @@ fun emit_compare_typed(e: *Emit, vm: *VMaps, mi: *mir.MirInstr,
     if (mi.operand_count != 3 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret emit_fail(e, "spirv.emit: malformed comparison instruction");
     }
-    val dst: u32 = mi.operands[0].vreg;
+    val dst: u32 = mi.operands[0].vreg.n;
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: comparison result vreg out of range"); }
     if (!operand_matches_type(vm, ?mi.operands[1], operand_ty)
      || !operand_matches_type(vm, ?mi.operands[2], operand_ty)) {
@@ -3457,7 +3457,7 @@ fun emit_convert(e: *Emit, vm: *VMaps, mi: *mir.MirInstr,
     if (mi.operand_count != 2 || mi.operands[0].kind != mir.MIR_OP_VREG) {
         ret emit_fail(e, "spirv.emit: malformed conversion instruction");
     }
-    val dst: u32 = mi.operands[0].vreg;
+    val dst: u32 = mi.operands[0].vreg.n;
     if (dst >= vm.n) { ret emit_fail(e, "spirv.emit: conversion result vreg out of range"); }
     var src_ty: u32 = 0;
     if (!operand_carries_type(vm, ?mi.operands[1])) {
@@ -3484,25 +3484,25 @@ fun emit_mov(e: *Emit, vm: *VMaps, mi: *mir.MirInstr) err[fail.Fail] {
     val src: *mir.MirOperand = ?mi.operands[1];
 
     if (dst.kind == mir.MIR_OP_VREG) {
-        if (dst.vreg >= vm.n) { ret emit_fail(e, "spirv.emit: move destination vreg out of range"); }
+        if (dst.vreg.n >= vm.n) { ret emit_fail(e, "spirv.emit: move destination vreg out of range"); }
         var pointee: u32 = 0;
         val reference: u32 = chain_target(vm, src, ?pointee);
         if (reference != 0) {
-            vm.chain_id[dst.vreg] = reference;
-            vm.chain_ty[dst.vreg] = pointee;
-            vm.chain_sc[dst.vreg] = chain_storage(vm, src);
-            vm.chain_object[dst.vreg] = src.vreg < vm.n && vm.chain_object[src.vreg];
+            vm.chain_id[dst.vreg.n] = reference;
+            vm.chain_ty[dst.vreg.n] = pointee;
+            vm.chain_sc[dst.vreg.n] = chain_storage(vm, src);
+            vm.chain_object[dst.vreg.n] = src.vreg.n < vm.n && vm.chain_object[src.vreg.n];
             ret err[fail.Fail].ok{};
         }
-        val val_id: u32 = read_operand(e, vm, src, vm.type_id[dst.vreg]);
+        val val_id: u32 = read_operand(e, vm, src, vm.type_id[dst.vreg.n]);
         if (e.b.err) { ret emit_fail(e, "spirv.emit: unreadable move source"); }
-        ret store_vreg(e, vm, dst.vreg, val_id);
+        ret store_vreg(e, vm, dst.vreg.n, val_id);
     }
     ret unsupported(e, "memory-destination move is not yet supported by the SPIR-V target");
 }
 
 fun operand_is_bool(vm: *VMaps, op: *mir.MirOperand) bool {
-    if (op.kind == mir.MIR_OP_VREG) { ret op.vreg < vm.n && vm.is_bool[op.vreg]; }
+    if (op.kind == mir.MIR_OP_VREG) { ret op.vreg.n < vm.n && vm.is_bool[op.vreg.n]; }
     ret false;
 }
 
@@ -3672,8 +3672,8 @@ test "mach.lang.target.isa.spirv.emit:volatile_whole_object_self_copy_keeps_load
     vm.chain_ty = ?tys[0];
     var mf: mir.MirFunction;
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_mem_value(0, 0);
-    ops[1] = mir.op_mem_value(0, 0);
+    ops[0] = mir.op_mem_value(mir.vreg_id(0), 0);
+    ops[1] = mir.op_mem_value(mir.vreg_id(0), 0);
     ops[2] = mir.op_imm(16);
     var mi: mir.MirInstr = mir.instr(mir.MIR_MEMCPY, ?ops[0], 3, 8, 8);
     var mode: u32 = 0;
@@ -3728,7 +3728,7 @@ test "mach.lang.target.isa.spirv.emit:volatile_opaque_load_is_evaluated_once_at_
     vm.opq_var = ?deferred[0];
     var mf: mir.MirFunction;
     var ops: [2]mir.MirOperand;
-    ops[0] = mir.op_vreg(0);
+    ops[0] = mir.op_vreg(mir.vreg_id(0));
     ops[1] = mir.op_sym(1, 0);
     var mi: mir.MirInstr = mir.instr(mir.MIR_LOAD, ?ops[0], 2, 8, 8);
     mi.memory_flags = mir.MEMORY_VOLATILE;

--- a/src/lang/target/isa/x64/encode.mach
+++ b/src/lang/target/isa/x64/encode.mach
@@ -2662,7 +2662,7 @@ fun is_float_const_move(f: *mir.MirFunction, mi: *mir.MirInstr) bool {
     val src: *mir.MirOperand = ?mi.operands[1];
     if (src.kind != mir.MIR_OP_IMM)  { ret false; }
     if (dst.kind != mir.MIR_OP_PREG) { ret false; }
-    ret isa.regid_class(dst.preg::i32) == isa.REG_CLASS_ID_XMM;
+    ret isa.regid_class(mir.preg_regid(dst.preg)) == isa.REG_CLASS_ID_XMM;
 }
 
 fun encode_float_const_mov(st: *enc.EncodeState, f: *mir.MirFunction, mi: *mir.MirInstr) err[fail.Fail] {
@@ -2671,7 +2671,7 @@ fun encode_float_const_mov(st: *enc.EncodeState, f: *mir.MirFunction, mi: *mir.M
         ret err[fail.Fail].err{fail.message("internal compiler error: float constant move has a non-float operand width (expected 4 or 8)")};
     }
     ret emit_float_load(st, isa.make_imm(mi.operands[1].imm, w),
-                        mi.operands[0].preg::i32, w);
+                        mir.preg_regid(mi.operands[0].preg), w);
 }
 
 fun float_work_reg(dst: isa.Operand) i32 {
@@ -4057,7 +4057,7 @@ fun mir_to_inst(f: *mir.MirFunction, mi: *mir.MirInstr, inst: *isa.Inst) err[fai
 
 fun mir_to_operand(f: *mir.MirFunction, op: *mir.MirOperand, width: u8) res[isa.Operand, fail.Fail] {
     if (op.kind == mir.MIR_OP_PREG) {
-        ret res[isa.Operand, fail.Fail].ok{isa.make_reg(op.preg::i32, width)};
+        ret res[isa.Operand, fail.Fail].ok{isa.make_reg(mir.preg_regid(op.preg), width)};
     }
     if (op.kind == mir.MIR_OP_VREG) {
         ret res[isa.Operand, fail.Fail].err{fail.message("encode: virtual register survived register allocation")};
@@ -4068,22 +4068,22 @@ fun mir_to_operand(f: *mir.MirFunction, op: *mir.MirOperand, width: u8) res[isa.
     if (op.kind == mir.MIR_OP_MEM) {
         var index: i32 = -1;
         var scale: u8 = 0;
-        if (op.index != mir.MIR_VREG_NIL) {
-            if (!op.index_is_preg) {
-                ret res[isa.Operand, fail.Fail].err{fail.message("encode: value vreg survived in a memory-operand index")};
-            }
-            index = op.index::i32;
+        if (sel op.index.vreg) {
+            ret res[isa.Operand, fail.Fail].err{fail.message("encode: value vreg survived in a memory-operand index")};
+        }
+        if (sel op.index.preg) {
+            index = mir.preg_regid(op.index.preg);
             scale = op.scale;
         }
-        if (op.vreg != mir.MIR_VREG_NIL) {
-            val slot: opt[i64] = frame_slot_offset(f, op.vreg);
+        if (!mir.vreg_is_nil(op.vreg)) {
+            val slot: opt[i64] = frame_slot_offset(f, op.vreg.n);
             if (!sel slot.some) {
                 ret res[isa.Operand, fail.Fail].err{fail.message("encode: value vreg survived in a memory-operand base")};
             }
             val off: i64 = slot.some;
             ret res[isa.Operand, fail.Fail].ok{isa.make_mem(slot_base_reg(f), (off + op.imm)::i32, index, scale, width)};
         }
-        ret res[isa.Operand, fail.Fail].ok{isa.make_mem(op.preg::i32, op.imm::i32, index, scale, width)};
+        ret res[isa.Operand, fail.Fail].ok{isa.make_mem(mir.preg_regid(op.preg), op.imm::i32, index, scale, width)};
     }
     if (op.kind == mir.MIR_OP_SYM) {
         var sym: isa.Operand = isa.make_mem(-1, 0, -1, 0, width);
@@ -5871,7 +5871,7 @@ test "mach.lang.target.isa.x64.encode:branch_to_fallthrough_elided" {
     if (st.fixup_count != 1) { bad = 1; }
 
     var cops: [3]mir.MirOperand;
-    cops[0] = mir.op_preg(x64.RAX::u32); cops[1] = mir.op_block(3); cops[2] = mir.op_block(4);
+    cops[0] = mir.op_preg(mir.preg_id(x64.RAX)); cops[1] = mir.op_block(3); cops[2] = mir.op_block(4);
     var cbr: mir.MirInstr = mir.instr(mir.MIR_SEL_CBR, ?cops[0], 3, 8, 0);
 
     st.has_next_block = false; st.buf.len = 0; st.fixup_count = 0;
@@ -5885,7 +5885,7 @@ test "mach.lang.target.isa.x64.encode:branch_to_fallthrough_elided" {
     if (st.fixups[0].target_block != 3)     { bad = 1; }
 
     var ops: [4]mir.MirOperand;
-    ops[0] = mir.op_preg(x64.RCX::u32); ops[1] = mir.op_preg(x64.RDX::u32);
+    ops[0] = mir.op_preg(mir.preg_id(x64.RCX)); ops[1] = mir.op_preg(mir.preg_id(x64.RDX));
     ops[2] = mir.op_block(3); ops[3] = mir.op_block(4);
     var mi: mir.MirInstr = mir.instr(mir.MIR_SEL_CBR_EQ, ?ops[0], 4, 8, 0);
 
@@ -6593,7 +6593,7 @@ test "mach.lang.target.isa.x64.encode.check_accounted:rejects_unrendered_bytes" 
 }
 
 fun xmm_op(idx: i32) mir.MirOperand {
-    ret mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, idx)::u32);
+    ret mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, idx)));
 }
 
 test "mach.lang.target.isa.x64.encode.encode_float_arith:two_address_shapes" {
@@ -6654,7 +6654,7 @@ test "mach.lang.target.isa.x64.encode.encode_float_arith:two_address_shapes" {
 
     var dops: [3]mir.MirOperand;
     dops[0] = xmm_op(x64.XMM2); dops[1] = xmm_op(x64.XMM0);
-    dops[2] = mir.op_mem_preg(x64.RBP::u32, -8);
+    dops[2] = mir.op_mem_preg(mir.preg_id(x64.RBP), -8);
     var dv: mir.MirInstr = mir.instr(mir.MIR_FDIV, ?dops[0], 3, 8, 0);
     buf.len = 0;
     encode_float_arith(?st, ?f, ?dv);
@@ -6683,7 +6683,7 @@ test "mach.lang.target.isa.x64.encode.encode_float_cmp:operands_in_place" {
     var bad: i32 = 0;
 
     var gops: [3]mir.MirOperand;
-    gops[0] = mir.op_preg(x64.RAX::u32); gops[1] = xmm_op(x64.XMM0); gops[2] = xmm_op(x64.XMM1);
+    gops[0] = mir.op_preg(mir.preg_id(x64.RAX)); gops[1] = xmm_op(x64.XMM0); gops[2] = xmm_op(x64.XMM1);
     var gt: mir.MirInstr = mir.instr(mir.MIR_FCMP, ?gops[0], 3, 4, mir.FCC_GT);
     buf.len = 0;
     encode_float_cmp(?st, ?f, ?gt);
@@ -6693,7 +6693,7 @@ test "mach.lang.target.isa.x64.encode.encode_float_cmp:operands_in_place" {
     or (buf.data[2] != 0xC1)  { bad = 1; }
 
     var lops: [3]mir.MirOperand;
-    lops[0] = mir.op_preg(x64.RAX::u32); lops[1] = xmm_op(x64.XMM0); lops[2] = xmm_op(x64.XMM1);
+    lops[0] = mir.op_preg(mir.preg_id(x64.RAX)); lops[1] = xmm_op(x64.XMM0); lops[2] = xmm_op(x64.XMM1);
     var lt: mir.MirInstr = mir.instr(mir.MIR_FCMP, ?lops[0], 3, 4, mir.FCC_LT);
     buf.len = 0;
     encode_float_cmp(?st, ?f, ?lt);
@@ -6937,7 +6937,7 @@ test "mach.lang.target.isa.x64.encode:float_width_refusals_emit_nothing" {
     if (!t_accepted_n(encode_fp_mov(?mv, buf), buf)) { bad = 1; }
 
     var cops: [2]mir.MirOperand;
-    cops[0] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, x64.XMM3)::u32);
+    cops[0] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, x64.XMM3)));
     cops[1] = mir.op_imm(0);
     var cn: mir.MirInstr = mir.instr(x64.MOV::u32, ?cops[0], 2, 16, 0);
     buf.len = 0;
@@ -6968,7 +6968,7 @@ test "mach.lang.target.isa.x64.encode:float_width_refusals_emit_nothing" {
     if (!t_accepted(encode_float_neg(?st, ?f, ?ng), buf)) { bad = 1; }
 
     var mops: [3]mir.MirOperand;
-    mops[0] = mir.op_preg(x64.RAX::u32); mops[1] = xmm_op(x64.XMM0); mops[2] = xmm_op(x64.XMM1);
+    mops[0] = mir.op_preg(mir.preg_id(x64.RAX)); mops[1] = xmm_op(x64.XMM0); mops[2] = xmm_op(x64.XMM1);
     var cm: mir.MirInstr = mir.instr(mir.MIR_FCMP, ?mops[0], 3, 16, mir.FCC_GT);
     buf.len = 0;
     if (!t_refused(encode_float_cmp(?st, ?f, ?cm), buf)) { bad = 1; }
@@ -6986,7 +6986,7 @@ test "mach.lang.target.isa.x64.encode:float_width_refusals_emit_nothing" {
     if (!t_accepted(encode_float_conv(?st, ?f, ?cv), buf)) { bad = 1; }
 
     var iops: [2]mir.MirOperand;
-    iops[0] = xmm_op(x64.XMM2); iops[1] = mir.op_preg(x64.RCX::u32);
+    iops[0] = xmm_op(x64.XMM2); iops[1] = mir.op_preg(mir.preg_id(x64.RCX));
     var i2f: mir.MirInstr = mir.instr(mir.MIR_SI_TO_FP, ?iops[0], 2, 16, 0);
     i2f.src_width = 8; buf.len = 0;
     if (!t_refused(encode_float_conv(?st, ?f, ?i2f), buf)) { bad = 1; }
@@ -6994,7 +6994,7 @@ test "mach.lang.target.isa.x64.encode:float_width_refusals_emit_nothing" {
     if (!t_accepted(encode_float_conv(?st, ?f, ?i2f), buf)) { bad = 1; }
 
     var fops: [2]mir.MirOperand;
-    fops[0] = mir.op_preg(x64.RCX::u32); fops[1] = xmm_op(x64.XMM0);
+    fops[0] = mir.op_preg(mir.preg_id(x64.RCX)); fops[1] = xmm_op(x64.XMM0);
     var f2i: mir.MirInstr = mir.instr(mir.MIR_FP_TO_SI, ?fops[0], 2, 8, 0);
     f2i.src_width = 16; buf.len = 0;
     if (!t_refused(encode_float_conv(?st, ?f, ?f2i), buf)) { bad = 1; }
@@ -8035,14 +8035,14 @@ test "mach.lang.target.isa.x64.encode.stream:notes_name_their_instruction_and_ca
 
     var vregs: [1]mir.MirVReg;
     vregs[0] = mir.vreg(0, mir.REG_CLASS_GP, false, true);
-    vregs[0].assigned = isa.regid_make(isa.REG_CLASS_ID_GP, 0)::u32;
+    vregs[0].assigned = mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, 0));
     var mov_ops: [2]mir.MirOperand;
-    mov_ops[0] = mir.op_preg_of(isa.regid_make(isa.REG_CLASS_ID_GP, 0)::u32, 0);
+    mov_ops[0] = mir.op_preg_of(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_GP, 0)), mir.vreg_id(0));
     mov_ops[0].required_bank = mir.BANK_GP;
     mov_ops[1] = mir.op_imm(5);
     var instrs: [3]mir.MirInstr;
     instrs[0] = mir.instr(x64.MOV::u32, ?mov_ops[0], 2, 8, 8);
-    instrs[1] = mir.declassify_marker(?instrs[0], 0);
+    instrs[1] = mir.declassify_marker(?instrs[0], mir.vreg_id(0));
     instrs[2] = mir.instr(x64.RET::u32, nil, 0, 0, 0);
     var blk: mir.MirBlock;
     blk.id = 0; blk.instrs = ?instrs[0]; blk.instr_count = 3;
@@ -8075,9 +8075,9 @@ test "mach.lang.target.isa.x64.encode.stream:notes_name_their_instruction_and_ca
 
     var seeds: enc.NoteSeeds;
     enc.note_seeds(?f, mov, ?seeds);
-    if (seeds.barrier || seeds.count != 2 || seeds.origin[0] != 0 || !seeds.secret[0] || seeds.secret[1]) { ret 12; }
+    if (seeds.barrier || seeds.count != 2 || seeds.origin[0].n != 0 || !seeds.secret[0] || seeds.secret[1]) { ret 12; }
     enc.note_seeds(?f, bar, ?seeds);
-    if (!seeds.barrier || seeds.count != 1 || seeds.origin[0] != 0 || !seeds.secret[0]) { ret 13; }
+    if (!seeds.barrier || seeds.count != 1 || seeds.origin[0].n != 0 || !seeds.secret[0]) { ret 13; }
     enc.note_seeds(?f, head, ?seeds);
     if (seeds.count != 0 || seeds.barrier) { ret 14; }
 
@@ -8256,7 +8256,7 @@ fun t_walk_function(f: *mir.MirFunction) {
     f.frame.omit  = false;
     t_walk_inputs[0].argument      = 0;
     t_walk_inputs[0].location      = mir.ABI_INPUT_REGISTER;
-    t_walk_inputs[0].reg           = x64.RDI::u32;
+    t_walk_inputs[0].reg           = mir.preg_id(x64.RDI);
     t_walk_inputs[0].offset        = 0;
     t_walk_inputs[0].width         = 8;
     t_walk_inputs[0].logical_width = 8;
@@ -8541,11 +8541,11 @@ test "mach.lang.target.isa.x64.encode.walk:the_barrier_downgrades_the_carrier_it
     t_walk_function(?f);
     var vregs: [1]mir.MirVReg;
     vregs[0] = mir.vreg(0, mir.REG_CLASS_GP, false, true);
-    vregs[0].assigned = x64.RDI::u32;
+    vregs[0].assigned = mir.preg_id(x64.RDI);
     f.vregs = ?vregs[0];
     f.vreg_count = 1;
     var seed: mir.MirInstr = mir.instr(isa.ISA_USE::u32, nil, 0, 0, 0);
-    var marker: mir.MirInstr = mir.declassify_marker(?seed, 0);
+    var marker: mir.MirInstr = mir.declassify_marker(?seed, mir.vreg_id(0));
     var n: [8]enc.AsmNote;
     var at: u32 = t_note_head(?n[0]);
     n[at] = enc.note_blank(); n[at].kind = enc.ASM_NOTE_BARRIER; n[at].mi = ?marker; at = at + 1;
@@ -8555,7 +8555,7 @@ test "mach.lang.target.isa.x64.encode.walk:the_barrier_downgrades_the_carrier_it
     t_note_inst(?n[0], ?at, t_inst2(x64.RET, t_none(), t_none(), 0));
     if (t_walk(?n[0], at, ?f, nil) != 0) { ret 1; }
     # the same stream with the barrier naming another register
-    vregs[0].assigned = x64.RSI::u32;
+    vregs[0].assigned = mir.preg_id(x64.RSI);
     if (t_walk(?n[0], at, ?f, T_BRANCH) != 1) { ret 2; }
     ret 0;
 }

--- a/src/lang/target/isa/x64/rules.mach
+++ b/src/lang/target/isa/x64/rules.mach
@@ -192,9 +192,9 @@ test "mach.lang.target.isa.x64.rules:opcode_rewrites" {
     var ops:    [20][3]mir.MirOperand;
     var i:      u32 = 0;
     for (i < 20) {
-        ops[i][0] = mir.op_preg(10);
-        ops[i][1] = mir.op_preg(11);
-        ops[i][2] = mir.op_preg(12);
+        ops[i][0] = mir.op_preg(mir.preg_id(10));
+        ops[i][1] = mir.op_preg(mir.preg_id(11));
+        ops[i][2] = mir.op_preg(mir.preg_id(12));
         instrs[i].operands      = ?ops[i][0];
         instrs[i].operand_count = 3;
         instrs[i].width         = 8;
@@ -223,15 +223,15 @@ test "mach.lang.target.isa.x64.rules:opcode_rewrites" {
     instrs[18].opcode = mir.MIR_NOT; instrs[18].vec_lane = mir.vec_lane_make(mir.VEC_LANE_INT, 4, 4);
     instrs[19].opcode = mir.MIR_CALL;
     ops[4][1] = mir.op_block(0); ops[4][2] = mir.op_block(1);
-    ops[5][0] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, 0)::u32);
-    ops[5][1] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, 1)::u32);
-    ops[5][2] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, 2)::u32);
+    ops[5][0] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 0)));
+    ops[5][1] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 1)));
+    ops[5][2] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 2)));
     instrs[6].operand_count = 2;
-    ops[6][1] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, 1)::u32);
+    ops[6][1] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 1)));
     instrs[16].operand_count = 1; ops[16][0] = mir.op_block(0);
     instrs[17].operand_count = 0;
-    ops[18][0] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, 0)::u32);
-    ops[18][1] = mir.op_preg(isa.regid_make(isa.REG_CLASS_ID_XMM, 1)::u32);
+    ops[18][0] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 0)));
+    ops[18][1] = mir.op_preg(mir.preg_id(isa.regid_make(isa.REG_CLASS_ID_XMM, 1)));
     instrs[18].operand_count = 2;
     instrs[19].operand_count = 1;
 
@@ -288,14 +288,14 @@ test "mach.lang.target.isa.x64.rules:neg_not_expansion" {
     val res_neg_ops: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?backing, 2::usize);
     if (sel res_neg_ops.err) { ret 1; }
     val neg_ops: *mir.MirOperand = res_neg_ops.ok;
-    neg_ops[0] = mir.op_preg(10);
-    neg_ops[1] = mir.op_preg(11);
+    neg_ops[0] = mir.op_preg(mir.preg_id(10));
+    neg_ops[1] = mir.op_preg(mir.preg_id(11));
 
     val res_not_ops: res[*mir.MirOperand, A.Error] = A.allocate[mir.MirOperand](?backing, 2::usize);
     if (sel res_not_ops.err) { ret 1; }
     val not_ops: *mir.MirOperand = res_not_ops.ok;
-    not_ops[0] = mir.op_preg(12);
-    not_ops[1] = mir.op_preg(13);
+    not_ops[0] = mir.op_preg(mir.preg_id(12));
+    not_ops[1] = mir.op_preg(mir.preg_id(13));
 
     var bindings: [1]mir.MirDbgBinding;
     bindings[0].iid  = 9;
@@ -335,16 +335,16 @@ test "mach.lang.target.isa.x64.rules:neg_not_expansion" {
     if (blk.instr_cap != 4)   { ret 1; }
 
     if (blk.instrs[0].opcode != x64.XOR::u32)      { ret 1; }
-    if (blk.instrs[0].operands[0].preg != 10)      { ret 1; }
-    if (blk.instrs[0].operands[1].preg != 10)      { ret 1; }
+    if (blk.instrs[0].operands[0].preg.n != 10)      { ret 1; }
+    if (blk.instrs[0].operands[1].preg.n != 10)      { ret 1; }
     if (blk.instrs[1].opcode != x64.SUB::u32)      { ret 1; }
-    if (blk.instrs[1].operands[0].preg != 10)      { ret 1; }
-    if (blk.instrs[1].operands[1].preg != 11)      { ret 1; }
+    if (blk.instrs[1].operands[0].preg.n != 10)      { ret 1; }
+    if (blk.instrs[1].operands[1].preg.n != 11)      { ret 1; }
     if (blk.instrs[2].opcode != x64.MOV::u32)      { ret 1; }
-    if (blk.instrs[2].operands[0].preg != 12)      { ret 1; }
-    if (blk.instrs[2].operands[1].preg != 13)      { ret 1; }
+    if (blk.instrs[2].operands[0].preg.n != 12)      { ret 1; }
+    if (blk.instrs[2].operands[1].preg.n != 13)      { ret 1; }
     if (blk.instrs[3].opcode != x64.XOR::u32)      { ret 1; }
-    if (blk.instrs[3].operands[0].preg != 12)      { ret 1; }
+    if (blk.instrs[3].operands[0].preg.n != 12)      { ret 1; }
     if (blk.instrs[3].operands[1].kind != mir.MIR_OP_IMM) { ret 1; }
     if (blk.instrs[3].operands[1].imm != -1)       { ret 1; }
 
@@ -389,9 +389,9 @@ test "mach.lang.target.isa.x64.rules:generic_opcode_coverage" {
     mir.selection_eliminated(?eliminated[0]);
 
     var ops: [3]mir.MirOperand;
-    ops[0] = mir.op_preg(10);
-    ops[1] = mir.op_preg(11);
-    ops[2] = mir.op_preg(12);
+    ops[0] = mir.op_preg(mir.preg_id(10));
+    ops[1] = mir.op_preg(mir.preg_id(11));
+    ops[2] = mir.op_preg(mir.preg_id(12));
     var probe: mir.MirInstr = mir.instr(mir.MIR_ADD, ?ops[0], 3, 8, 0);
 
     var f: mir.MirFunction;


### PR DESCRIPTION
Section 10 items 3 and 4 of the #2212 census (doc/design/backend-census-2212.md), both recorded as section 11 amendments. References #2212 (the coordinator closes it when every remainder lane lands).

## Item 3: `isa.Inst.clobbers` deleted

N5 ruled implicit writes come from `asm.Mnemonic.implicit` and the opcode descriptors. The field had one writer (`inst_blank`, `= 0`) and no reader repo-wide, so its removal changes no byte and closes the fail-open shape a future reader would have inherited.

## Item 4: nominal `VRegId` / `PRegId`, tagged memory index

The #3113 error-driven tree-wide retype recipe: change the type, follow the compiler's errors, add no conversion helper that lets a vreg flow into a preg slot.

- `mir.VRegId` and `mir.PRegId` are single-field records (a `def` is a transparent alias and enforces nothing). `MIR_VREG_NIL` is a `VRegId`; `MIR_PREG_NIL` is new, so a physical slot never borrows the virtual sentinel. `mir.preg_id(regid)` / `mir.preg_regid(p)` are the one way in from and out to an isa regid (the census's "MIR preg to isa regid with no conversion function" gap).
- Threaded through `MirOperand.vreg/preg`, `MirVReg.assigned`, `MirInstr.declassified`, `MirAbiInput.reg`, `abi.ParamSlot.reg` and `ParamPiece.reg` (the ABI constructors still take the isa regid the packs select, so no pack changes), the lowering context (`new_vreg`, `instr_vreg`, the param/instr/slot-key tables, `addr_to_vreg`), the allocator helpers (`touch`, `assign`, `spill_vreg`, `preg_of`, `assigned_preg`, `emit_reload`/`emit_store`, `rewritten_preg_ok` and the rest), `op_preg_of` provenance, `operand_origin`, `notes.NoteSeeds.origin`, and every ISA's `req_gpr`/`req_vec`/`mir_to_operand`/`resolve_mem`, plus the SPIR-V emitter's reads.
- `MirOperand.index: MirIndex`, a `tag` with `none`, `vreg` and `preg` cases, replaces `index` plus `index_is_preg`; every reader is a `sel` guard, and the rewrite sites that reassign the operand rebind the payload first (the language refuses an assignment inside a guard).
- Allocator-internal tables (ranges, hints, webs, `active`, frame slot keys) stay indexed by the number and unwrap at the boundary with `.n`; `looprotate` gets its own `NONE` sentinel for its block/remap tables instead of borrowing `MIR_VREG_NIL`.

ISA-file hunks are the operand-type retype only (the parallel x64 table and registry lanes were merged in before final verification).

## Verification

- Negative test (the #3114 acceptance): `mach.lang.driver:register_identity_is_not_another_identity_domain` proves vreg to preg field, preg to vreg field, bare `u32` to either, vreg where the index tag is meant, and either identity as a table index are type errors, and that the tag-cased form compiles. Mutation controls: a wrong diagnostic needle fails it (exit 1) and a preg in the `vreg` tag case fails the accept arm (exit 7).
- Corpus layer B, run once at the end (owner rule 2), through the from-source compiler: x86_64-linux, aarch64-linux, riscv64-linux and spirv, 400 pass / 0 fail / 8 declared skips; no golden moved (byte-identical, owner rule 1 identity bar: a retype changes no bytes).
- Suite through the built compiler on the merged tree (dev 8d87f77fd, all four sibling #2212 lanes in): 3063 passed, 0 failed (dev baseline 3062 + this branch's 1, exact by name).
- `sh test/census.sh`: all ok.
- x86_64 link leg (`test/link/run.sh --leg x86_64-linux`): 142 pass / 0 fail.
- Fixpoint: A by the v5 stage, B by A, C by B, `cmp` byte-identical.