### PR TITLE
fix(#3317): host-independent driver, doc and dep unit tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -166,6 +166,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The dependency conflict diagnostic's example `[dep.<id>]` table escapes its `git`, `ref` and `path` values as the manifest writer does, so a host path with backslashes reparses as written (#3317).
+- Four unit tests that encoded an x86_64-linux host (a two-target union fixture with no default, an absolute out probed through a host-invalid joined path, and a fixture path written into a scaffolded `mach.toml` unescaped) are host-independent, and the aarch64-linux and x86_64-windows test legs pass again (#3317).
 - Test return values are constrained to a status in `0..255` across test protocols, preventing return codes of 256 or multiples of 256 from being masked as passing exit status 0 on Linux and Darwin (#3241).
 - A literal-shaped `ret` outside `0..255` in a test body is a compile error at the `ret` naming the value, such as `test result 256 is outside the status range 0..255` (#3241).
 - The test dispatcher folds runtime results outside `0..255` to `255` before exiting, ensuring failure reporting with identical status across every host (#3241).

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -608,17 +608,28 @@ fun selection_text(a: *A.Allocator, r: *DepReq) str {
     ret t2.ok;
 }
 
+# the example table is valid TOML as printed: values are escaped as the
+# manifest writer would write them
 fun conflict_text(a: *A.Allocator, subject: *DepReq, x: *DepReq, y: *DepReq) str {
     var decl: str = "";
     if (subject.is_git) {
-        val d: res[str, format.FormatError] = format.sprint(a,
-            "[dep.{}]\n    git = \"{}\"\n    ref = \"{}\"", subject.id, subject.url, subject.ref);
-        if (sel d.ok) { decl = d.ok; }
+        val url_r: res[str, outcome.Fail] = manifest.toml_escape_value(a, subject.url);
+        val ref_r: res[str, outcome.Fail] = manifest.toml_escape_value(a, subject.ref);
+        if (sel url_r.ok) {
+            if (sel ref_r.ok) {
+                val d: res[str, format.FormatError] = format.sprint(a,
+                    "[dep.{}]\n    git = \"{}\"\n    ref = \"{}\"", subject.id, url_r.ok, ref_r.ok);
+                if (sel d.ok) { decl = d.ok; }
+            }
+        }
     }
     or {
-        val d: res[str, format.FormatError] = format.sprint(a,
-            "[dep.{}]\n    path = \"{}\"", subject.id, subject.src_path);
-        if (sel d.ok) { decl = d.ok; }
+        val path_r: res[str, outcome.Fail] = manifest.toml_escape_value(a, subject.src_path);
+        if (sel path_r.ok) {
+            val d: res[str, format.FormatError] = format.sprint(a,
+                "[dep.{}]\n    path = \"{}\"", subject.id, path_r.ok);
+            if (sel d.ok) { decl = d.ok; }
+        }
     }
     val msg: res[str, format.FormatError] = format.sprint(a,
         "dependency conflict: project id '{}' is reached with two different selections:\n    {} requires {}\n    {} requires {}\n  the root decides by declaring the identity itself, for example:\n    {}",
@@ -1974,6 +1985,22 @@ test "mach.cli.cmd.dep.closure:one_identity_two_selections_names_both_chains" {
     if (!t_contains(text, "root -> c -> b")) { bad = 1; }
     if (!t_contains(text, "[dep.b]"))        { bad = 1; }
     if (!t_contains(text, fix_b2))           { bad = 1; }
+    # the example table is valid TOML for a host path with backslashes and quotes
+    var w: DepReq;
+    w.id        = "b";
+    w.url       = "C:\\Users\\fixture\\quoted\" repo";
+    w.src_path  = "";
+    w.ref       = "branch/main";
+    w.chain     = "root -> c -> b";
+    w.root_decl = false;
+    w.is_git    = true;
+    val win_text: str = conflict_text(?a, ?w, ?x, ?w);
+    if (!t_contains(win_text, "git = \"C:\\\\Users\\\\fixture\\\\quoted\\\" repo\"")) { bad = 2; }
+    w.url      = "";
+    w.src_path = "C:\\Users\\fixture\\local";
+    w.is_git   = false;
+    val win_path: str = conflict_text(?a, ?w, ?x, ?w);
+    if (!t_contains(win_path, "path = \"C:\\\\Users\\\\fixture\\\\local\"")) { bad = 3; }
 
     fs.remove_all(?a, outer);
     fs.remove_all(?a, fix_a);

--- a/src/cli/cmd/dep.mach
+++ b/src/cli/cmd/dep.mach
@@ -1692,6 +1692,19 @@ fun t_dep_table(a: *A.Allocator, name: str, url: str) str {
     ret t_dep_table_ref(a, name, url, "branch/main");
 }
 
+# a path table through the manifest writer, so a host path with backslashes
+# lands escaped
+fun t_dep_table_path(a: *A.Allocator, name: str, dir: str) str {
+    var spec: manifest.DepTableSpec;
+    spec.name   = name;
+    spec.source = manifest.DEP_SOURCE_PATH;
+    spec.value  = dir;
+    spec.ref    = "";
+    val r: res[str, outcome.Fail] = manifest.manifest_add_dep_table(a, "", ?spec);
+    if (sel r.err) { ret ""; }
+    ret r.ok;
+}
+
 fun t_dep_cli(a: *A.Allocator, argc: usize, argv: **u8) i64 {
     val parsed: res[args.ParsedInvocation, outcome.Fail] = args.parse_invocation(a, argc, argv);
     if (sel parsed.err) { ret -1; }
@@ -2654,9 +2667,9 @@ test "mach.cli.cmd.dep.pull:an_alias_key_is_refused_naming_the_removal" {
     if (str_empty(source)) { ret 2; }
     fin { fs.remove_all(?a, source); }
     if (!t_write(?a, source, MANIFEST, "[project]\nid = \"local\"\nversion = \"0.1.0\"\nsrc = \"src\"\nout = \"out\"\n[profile.debug]\ndefault = true\nopt = 0\ndebug = true\nsimd = \"scalarize\"\nvectorize = false\nfloat_reassoc = false\n[profile.release]\nopt = 2\ndebug = false\nsimd = \"scalarize\"\nvectorize = true\nfloat_reassoc = false\n") || !t_lib_module(?a, source)) { ret 3; }
-    val table_r: res[str, format.FormatError] = format.sprint(?a, "\n[dep.alias]\npath = \"{}\"\n", source);
-    if (sel table_r.err) { ret 4; }
-    val root: str = t_root_repo(?a, "mach_dep_alias_root", table_r.ok);
+    val table: str = t_dep_table_path(?a, "alias", source);
+    if (str_empty(table)) { ret 4; }
+    val root: str = t_root_repo(?a, "mach_dep_alias_root", table);
     if (str_empty(root)) { ret 5; }
     fin { fs.remove_all(?a, root); }
     var s:    session.Session;

--- a/src/cli/cmd/doc.mach
+++ b/src/cli/cmd/doc.mach
@@ -1,6 +1,7 @@
 use mach.lang.fail;
 use std.allocator.arena;
 use std.allocator.page;
+use std.collections.vector.Vector;
 use fs:       std.filesystem;
 use txn:      std.filesystem.transaction;
 use io_error: std.io.error;
@@ -990,15 +991,23 @@ test "mach.cli.cmd.doc.run:a_relative_out_is_project_rooted_and_an_absolute_out_
     if (sel exists_r.err)                  { ret 99; }
     if (!(sel exists_r.ok && exists_r.ok)) { bad = 2; }
 
+    # the project root's listing after the relative run is the reference: an
+    # absolute out that were project-rooted would add an entry to it, however
+    # the host spells the joined path
+    val before_r: res[Vector[str], fs.FsError] = fs.read_dir(?alloc, ?root[0]);
+    if (sel before_r.err) { ret 99; }
+    var before: Vector[str] = before_r.ok;
+
     val abs_out: str = t_join(?alloc, ?elsewhere[0], "api");
     av[5] = abs_out::*u8;
     if (t_doc_run(6, ?av[0]) != 0) { bad = 3; }
     val exists_r2: res[bool, io_error.Error] = fs.exists(t_join(?alloc, abs_out, "README.md"));
     if (sel exists_r2.err)                   { ret 99; }
     if (!(sel exists_r2.ok && exists_r2.ok)) { bad = 4; }
-    val exists_r3: res[bool, io_error.Error] = fs.exists(t_join(?alloc, ?root[0], abs_out));
-    if (sel exists_r3.err)                  { ret 99; }
-    if ((sel exists_r3.ok && exists_r3.ok)) { bad = 5; }
+    val after_r: res[Vector[str], fs.FsError] = fs.read_dir(?alloc, ?root[0]);
+    if (sel after_r.err) { ret 99; }
+    var after: Vector[str] = after_r.ok;
+    if (!t_same_names(?before, ?after)) { bad = 5; }
 
     fs.remove_all(?alloc, ?root[0]);
     fs.remove_all(?alloc, ?elsewhere[0]);
@@ -1115,6 +1124,23 @@ test "mach.cli.cmd.doc.generate:creates_missing_output_dirs" {
     session.dnit(?s);
     fs.remove_all(?alloc, ?root[0]);
     ret bad;
+}
+
+# two directory listings name the same entries
+fun t_same_names(a: *Vector[str], b: *Vector[str]) bool {
+    if (a.len != b.len) { ret false; }
+    var i: usize = 0;
+    for (i < a.len) {
+        var found: bool  = false;
+        var j:     usize = 0;
+        for (j < b.len) {
+            if (str_equals(a.data[i], b.data[j])) { found = true; }
+            j = j + 1;
+        }
+        if (!found) { ret false; }
+        i = i + 1;
+    }
+    ret true;
 }
 
 fun t_join(a: *A.Allocator, base: str, leaf: str) str {

--- a/src/lang/driver/tests.mach
+++ b/src/lang/driver/tests.mach
@@ -14262,7 +14262,7 @@ test "mach.lang.driver:float_type_compiles_x86_64" {
 }
 
 fun ut_float_union_manifest() str {
-    ret "[project]\nid = \"floatunion\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.rv32]\nisa = \"rv32imc\"\nos = \"freestanding\"\nabi = \"ilp32\"\n\n[artifact.floatunion]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/floatunion\"\ntargets = [\"*\"]\nlink = []\nneed = []\n[profile.debug]\ndefault = true\nopt = 0\ndebug = true\nsimd = \"scalarize\"\nvectorize = false\nfloat_reassoc = false\n[profile.release]\nopt = 2\ndebug = false\nsimd = \"scalarize\"\nvectorize = true\nfloat_reassoc = false\n";
+    ret "[project]\nid = \"floatunion\"\nversion = \"0.0.0\"\nsrc = \"src\"\nout = \"out/{target.name}/{profile.name}\"\n\n[target.linux]\ndefault = true\nisa = \"x86_64\"\nos = \"linux\"\nabi = \"sysv64\"\n\n[target.rv32]\nisa = \"rv32imc\"\nos = \"freestanding\"\nabi = \"ilp32\"\n\n[artifact.floatunion]\nkind = \"bin\"\nentry = \"main.mach\"\nout = \"bin/floatunion\"\ntargets = [\"*\"]\nlink = []\nneed = []\n[profile.debug]\ndefault = true\nopt = 0\ndebug = true\nsimd = \"scalarize\"\nvectorize = false\nfloat_reassoc = false\n[profile.release]\nopt = 2\ndebug = false\nsimd = \"scalarize\"\nvectorize = true\nfloat_reassoc = false\n";
 }
 
 test "mach.lang.driver:float_gated_out_of_a_freestanding_tuple" {

--- a/src/lang/manifest.mach
+++ b/src/lang/manifest.mach
@@ -4629,7 +4629,13 @@ fun hex_digit(v: u8) u8 {
     ret 'a'::u8 + (v - 10);
 }
 
-fun toml_escape_value(alloc: *A.Allocator, s: str) res[str, outcome.Fail] {
+# the body of a TOML basic string for a value: backslash, quote and control
+# bytes escaped so the text reparses to the same value
+# ---
+# alloc: owns the returned text
+# s:     the value
+# ret:   the escaped body, without the surrounding quotes
+pub fun toml_escape_value(alloc: *A.Allocator, s: str) res[str, outcome.Fail] {
     val n:      usize = str_len(s);
     var cap:    usize = 1;
     var offset: usize = 0;


### PR DESCRIPTION
Closes #3317

Four unit tests encoded the x86_64-linux host; one product defect of the same class was found beside them and fixed.

## Root causes

- `float_gated_out_of_a_freestanding_tuple`, `union_ctx_has_float_restored_across_divergent_tuple`: the union fixture declares `[target.linux]` (x86_64) and `[target.rv32]` and no default. On an x86_64-linux host `linux` matches the host and is the primary; on any other host `resolve_target` hits the "several targets, none matches the host, none is `default = true`" refusal and `build_project_union` fails before the test's assertion. The fixture now marks `linux` as `default = true`, which is a no-op on the linux host and selects it (with the native warning, not an error) everywhere else. The `mos6502` tuple it replaced sat behind the same rule, so this was latent until the tuple substitution.
- `doc.run:a_relative_out_is_project_rooted_and_an_absolute_out_is_used_as_given` (exit 99): the "not project-rooted" check probed `fs.exists(join(root, abs_out))`. On windows that is `C:\...\root\C:\Users\...\api`, which is `ERROR_INVALID_NAME` (mapped to `EIO`, not `ENOENT`), so `exists` refuses and the test bails with 99 instead of answering. The check is now a listing of the project root before and after the absolute run, which asks the real question (nothing new landed under the root) without spelling a path the host cannot name.
- `dep.pull:an_alias_key_is_refused_naming_the_removal` (exit 10): the test wrote the source path into the scaffolded `mach.toml` with a raw `path = "{}"`; a windows temp path's backslashes are invalid TOML escapes, so the scaffold was a syntax error and the refusal text never appeared. The fixture now goes through `manifest_add_dep_table` (new `t_dep_table_path` beside `t_dep_table`), which escapes like the writer does.
- Product: `conflict_text`'s example `[dep.<id>]` table interpolated `git`, `ref` and `path` raw, so on windows the suggested table was not valid TOML. `toml_escape_value` is now `pub` and the example escapes its values; the closure test gains a host-independent backslash-and-quote fixture for both the git and path shapes.

## Verification

- linux: `out/audit/mach test .` 3079 passed, 0 failed (same count as CI).
- aarch64: reproduced both driver failures under `qemu-aarch64` (`--target linux-arm64 --runner qemu-aarch64`) on origin/dev; both pass with the fix. The driver module under qemu is 517/518, the one failure (`floating remainder preserves signed zero`) spawns an aarch64 child with no binfmt here (child exit 127) and is a runner artifact; it passes in CI.
- windows under wine: the driver module failure set goes from 34 (origin/dev) to 32 (this branch), exactly the two driver tests; the remaining 32 are the same on both and are wine-only (they pass in CI's windows leg). The doc module is 16/17 on both, the one failure wine-only.
- The doc test cannot reproduce under wine: wine treats the mid-path `C:` as an ordinary name and answers `ENOENT`, so the fix there is reasoned from the log (exit 99) and from std's `win32_error` mapping. The dep test cannot run under wine at all (its scaffold needs `git.exe`, exit 5 both before and after); the mechanism is confirmed on linux by feeding a `path = "C:\Users\RUNNER~1\x"` manifest to `mach dep verify` (`toml: syntax error`), and the CI windows leg is the check.
- Mutation controls: fixture reverted, both driver tests fail under qemu; `path.is_abs` guard disabled in `doc.run`, the doc test exits 5; original raw `path = "{}"` fixture, the alias scaffold is a toml syntax error; `toml_escape_value` bypassed in `conflict_text`, the closure test exits 3.
- Cross-builds of the compiler for windows-x86_64, aarch64-linux and darwin-aarch64 succeed; `mach fmt . --check` clean.

The `targets on *` jobs are expected to keep failing on the link suite's std `branch/main` float-deps cell (R3), not part of this issue.
