### PR TITLE
fix(#3325): reserve a 16 MiB stack on windows-x86_64 for the parser's nesting bound

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,8 +83,6 @@ jobs:
         with:
           name: mach-${{ matrix.target }}
           path: artifact
-      # the release profile is linux-only until #3325: the fuzz corpus replay
-      # overflows the stack at O2 on windows
       - name: unit suite, debug and release
         shell: bash
         run: |
@@ -93,7 +91,7 @@ jobs:
           m=$PWD/artifact/mach; [ "$RUNNER_OS" = Windows ] && m=$m.exe
           "$m" dep pull .
           "$m" test .
-          [ "$RUNNER_OS" = Windows ] || "$m" test . --profile release
+          "$m" test . --profile release
       - name: formatter
         shell: bash
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -173,6 +173,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- The windows-x86_64 target reserves a 16 MiB stack, so the parser's 2048-level nesting bound (8.2 MiB of win64 release frames) is answered with a diagnostic instead of `STATUS_STACK_OVERFLOW`, and the release-profile unit suite runs on windows in CI again (#3325).
 - `mach fmt` and `mach init` keep the transaction layer's lock sentinel, claims directory and backup container under `out/.mach-txn/<relative path>` instead of beside the sources they rewrite, so a formatted tree gains no `.mach-txn-lock` or `.machtxn.*` entries (#3310).
 - `mach fmt --check` locks nothing and creates no control home, and `mach init` into an absent destination locks through an ephemeral home under the temporary directory so the parent directory receives no sentinel (#3310).
 - `.gitignore` covers `.mach-txn-lock` and `.machtxn.*` against a pre-fix formatter (#3310).

--- a/mach.toml
+++ b/mach.toml
@@ -24,9 +24,13 @@ isa  = "x86_64"
 os   = "windows"
 abi  = "win64"
 # the sweep cases in stack_probe_runtime recurse past the 1 MiB PE default,
-# and the compiler itself recurses on real inputs; reserve is address space,
-# not memory, so match the 8 MiB linux main-thread default (#3091).
-stack_reserve = 0x800000
+# and the compiler itself recurses on real inputs (#3091). the parser descends
+# MAX_NEST_DEPTH (2048) levels before it refuses, and at O2 one statement level
+# (parse_stmt, parse_stmt_body, parse_if_stmt, parse_block_stmt) costs 4208
+# bytes of win64 frame, 8.2 MiB in all, past the 8 MiB linux default that the
+# sysv frames (3568 bytes, 7.0 MiB) fit under. reserve is address space, not
+# memory, so hold twice the bound's worst case (#3325).
+stack_reserve = 0x1000000
 
 [target.darwin-x86_64]
 isa = "x86_64"

--- a/test/fuzz/README.md
+++ b/test/fuzz/README.md
@@ -13,3 +13,13 @@ value or a typed rejection, and a crash, a hang or an allocation past its cap is
 a finding. To retain a new input, put the file in its boundary's directory. A
 single candidate can be answered on its own with `MACH_FUZZ_INPUT` and
 `MACH_FUZZ_BOUNDARY` set for the `one_input_named_by_the_environment` test.
+
+The parser inputs named `unbounded-*` nest past `MAX_NEST_DEPTH` (2048, in
+`src/lang/fe/parser/state.mach`) and are answered by the depth refusal, so they
+descend the full bound before answering. Release frames are larger than debug
+ones and differ by ABI: at O2 one `if (1) {` level costs 3568 bytes on sysv64,
+3632 on aapcs64 and 4208 on win64, so the bound needs 7.0 MiB, 7.1 MiB and
+8.2 MiB of stack. Linux and darwin run on the 8 MiB main-thread default; the
+windows-x86_64 target reserves 16 MiB in `mach.toml` for it (#3325). Widening a
+frame in that cycle or raising the bound moves these numbers, and an input that
+answers in debug can still exhaust the stack in release.


### PR DESCRIPTION
Closes #3325

## Cause

The windows test binary already carried the 8 MiB reserve `[target.windows-x86_64]` declares (verified on the cross-built dispatcher: `SizeOfStackReserve 0x800000`), so this is not the 1 MiB PE default. The recursion is the parser's, and it is bounded: `MAX_NEST_DEPTH = 2048` (`src/lang/fe/parser/state.mach`), the last-resort stack guard. The failing input is `test/fuzz/corpus/parser/unbounded-block-recursion.mach` (`if (1) {` nested 18000 deep), which descends the full bound before the depth refusal answers. The bound times the release frame cost of one level exceeds 8 MiB on win64 and not on sysv64 or aapcs64.

One statement level is the cycle `parse_stmt -> parse_stmt_body -> parse_if_stmt -> parse_block_stmt -> parse_stmt`. Frame sizes read from the O2 prologues (`llvm-objdump -d` on `obj/mach/lang/fe/parser/grammar.o`, the `sub rsp` plus the pushed `rbp` and return address; callee saves sit inside the `sub`):

| ABI | parse_stmt | parse_stmt_body | parse_if_stmt | parse_block_stmt | per level | x 2048 | stack |
|---|---|---|---|---|---|---|---|
| win64 | 0x30 | 0xa60 | 0x350 | 0x250 | 4208 | 8,617,984 (8.22 MiB) | 8 MiB reserve: **overflows** |
| sysv64 | 0x10 | 0x8a0 | 0x2f0 | 0x210 | 3568 | 7,307,264 (6.97 MiB) | 8 MiB default: fits |
| aapcs64 | 0x10 | 0x930 | 0x2d0 | 0x1e0 | 3632 | 7,438,336 (7.09 MiB) | 8 MiB default: fits |

Cross-check on linux x86_64 release: bisecting `ulimit -s` on the candidate test (`MACH_FUZZ_INPUT`) puts that input's need at 7177 KiB, matching the sysv64 arithmetic plus the base frames. The next inputs are `unbounded-expression-recursion` (6377 KiB) and `unbounded-unary-recursion` (5674 KiB); the manifest reader is bounded at `MAX_VALUE_DEPTH = 64` and its deepest input needs 1422 KiB.

## Fix

`[target.windows-x86_64].stack_reserve = 0x1000000` (16 MiB): twice the bound's worst case. Reserve is address space, not memory. The cross-built release dispatcher and compiler both carry `SizeOfStackReserve 0x1000000`. `ci.yml` runs the release-profile unit suite on windows again (the linux-only condition is deleted). `test/fuzz/README.md` records the per-ABI numbers so the next frame widening in that cycle is checked against them.

## Mutation control

With the reserve back at `0x800000`, 8,617,984 > 8,388,608 again and the windows release replay is the crash in the issue (run 34738388197). wine does not reproduce in either direction (both binaries replay the corpus and exit 0 there, 4.7 s), so the PR's `test x86_64-windows` job is the check.

## Verification

- `mach test .` 3091/3091 and `mach test . --profile release` 3091/3091 (from-source compiler; no tests added, delta 0)
- `mach fmt . --check` clean
- cross-builds windows-x86_64 and darwin-aarch64 release
- no codegen or driver change, so no fixpoint run
